### PR TITLE
Remove runtime config

### DIFF
--- a/app/(nosidebar)/[actor]/ActorTimelines.tsx
+++ b/app/(nosidebar)/[actor]/ActorTimelines.tsx
@@ -9,12 +9,14 @@ import { AttachmentData } from '@/lib/models/attachment'
 import { StatusData } from '@/lib/models/status'
 
 interface Props {
+  host: string
   currentTime: Date
   statuses: StatusData[]
   attachments: AttachmentData[]
 }
 
 export const ActorTimelines: FC<Props> = ({
+  host,
   currentTime,
   statuses,
   attachments
@@ -31,6 +33,7 @@ export const ActorTimelines: FC<Props> = ({
       )}
       {currentTab === ActorTab.Posts && (
         <Posts
+          host={host}
           className={attachments.length > 0 ? 'mt-2' : 'mt-4'}
           currentTime={currentTime}
           statuses={statuses}

--- a/app/(nosidebar)/[actor]/[status]/StatusBox.tsx
+++ b/app/(nosidebar)/[actor]/[status]/StatusBox.tsx
@@ -9,16 +9,18 @@ import { AttachmentData } from '@/lib/models/attachment'
 import { StatusData } from '@/lib/models/status'
 
 interface Props {
+  host: string
   currentTime: Date
   status: StatusData
 }
 
-export const StatusBox: FC<Props> = ({ currentTime, status }) => {
+export const StatusBox: FC<Props> = ({ host, currentTime, status }) => {
   const [modalMedia, setModalMedia] = useState<AttachmentData>()
 
   return (
     <>
       <Post
+        host={host}
         currentTime={currentTime}
         status={status}
         onShowAttachment={(attachment: AttachmentData) =>

--- a/app/(nosidebar)/[actor]/[status]/page.tsx
+++ b/app/(nosidebar)/[actor]/[status]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
 import { Posts } from '@/lib/components/Posts/Posts'
+import { getConfig } from '@/lib/config'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMACT
@@ -25,6 +26,7 @@ export const generateMetadata = async ({
 }
 
 const Page: FC<Props> = async ({ params }) => {
+  const { host } = getConfig()
   const storage = await getStorage()
   if (!storage) throw new Error('Storage is not available')
 
@@ -74,13 +76,23 @@ const Page: FC<Props> = async ({ params }) => {
 
   return (
     <>
-      <Posts className="mt-4" currentTime={currentTime} statuses={previouses} />
+      <Posts
+        className="mt-4"
+        currentTime={currentTime}
+        host={host}
+        statuses={previouses}
+      />
       <section className={styles.highlight}>
-        <StatusBox currentTime={currentTime} status={status.toJson()} />
+        <StatusBox
+          host={host}
+          currentTime={currentTime}
+          status={status.toJson()}
+        />
       </section>
       <Posts
         className="mt-4"
         currentTime={currentTime}
+        host={host}
         statuses={replies.map((reply) => reply.toJson())}
       />
     </>

--- a/app/(nosidebar)/[actor]/page.tsx
+++ b/app/(nosidebar)/[actor]/page.tsx
@@ -7,6 +7,7 @@ import { FC } from 'react'
 import { authOptions } from '@/app/api/auth/[...nextauth]/authOptions'
 import { FollowAction } from '@/lib/components/FollowAction'
 import { Profile } from '@/lib/components/Profile'
+import { getConfig } from '@/lib/config'
 import { getStorage } from '@/lib/storage'
 
 import { ActorTimelines } from './ActorTimelines'
@@ -26,6 +27,7 @@ export const generateMetadata = async ({
 }
 
 const Page: FC<Props> = async ({ params }) => {
+  const { host } = getConfig()
   const [storage, session] = await Promise.all([
     getStorage(),
     getServerSession(authOptions)
@@ -78,6 +80,7 @@ const Page: FC<Props> = async ({ params }) => {
         </div>
       </section>
       <ActorTimelines
+        host={host}
         currentTime={new Date()}
         statuses={statuses}
         attachments={attachments}

--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -7,6 +7,7 @@ import { FC } from 'react'
 
 import { authOptions } from '@/app/api/auth/[...nextauth]/authOptions'
 import { Posts } from '@/lib/components/Posts/Posts'
+import { getConfig } from '@/lib/config'
 import { getStorage } from '@/lib/storage'
 import { Timeline } from '@/lib/timelines/types'
 
@@ -18,6 +19,7 @@ export const metadata: Metadata = {
 }
 
 const Page: FC = async () => {
+  const { host } = getConfig()
   const [storage, providers, session] = await Promise.all([
     getStorage(),
     getProviders(),
@@ -51,6 +53,7 @@ const Page: FC = async () => {
         <div>
           <h2 className="mb-4">Local public timeline</h2>
           <Posts
+            host={host}
             className="mt-4"
             currentTime={new Date()}
             statuses={statuses?.map((status) => status.toJson())}

--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -105,6 +105,7 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
         }}
       />
       <Posts
+        host={host}
         className="mt-4"
         currentTime={new Date()}
         statuses={currentStatuses}

--- a/app/api/v1/medias/apple/[token]/utils.ts
+++ b/app/api/v1/medias/apple/[token]/utils.ts
@@ -1,6 +1,6 @@
-import getConfig from 'next/config'
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
 import { headerHost } from '@/lib/services/guards/headerHost'
 
 export const allowOrigin = (request: NextRequest) => {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -38,16 +38,10 @@ jest.mock('./lib/config', () => {
     getConfig: jest.fn().mockReturnValue({
       serviceName: 'activities.next',
       host,
-      secretPhase
+      secretPhase,
+      email: {
+        serviceFromAddress: 'test@llun.dev'
+      }
     })
   }
-})
-
-jest.mock('next/config', () => {
-  const host = jest.requireActual('./lib/stub/const').TEST_DOMAIN
-  return jest.fn().mockReturnValue({
-    publicRuntimeConfig: {
-      host
-    }
-  })
 })

--- a/lib/actions/acceptFollowRequest.test.ts
+++ b/lib/actions/acceptFollowRequest.test.ts
@@ -18,16 +18,6 @@ import { acceptFollowRequest } from './acceptFollowRequest'
 
 enableFetchMocks()
 
-jest.mock('../config', () => {
-  return {
-    getConfig: jest.fn().mockReturnValue({
-      serviceName: 'activities.next',
-      email: {
-        serviceFromAddress: 'test@llun.dev'
-      }
-    })
-  }
-})
 jest.mock('../services/email', () => ({
   sendMail: jest.fn()
 }))

--- a/lib/actions/announce.test.ts
+++ b/lib/actions/announce.test.ts
@@ -13,8 +13,6 @@ import { announce, userAnnounce } from './announce'
 
 enableFetchMocks()
 
-jest.mock('../config')
-
 describe('Announce action', () => {
   const storage = new SqlStorage({
     client: 'better-sqlite3',

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -5,6 +5,7 @@ import { Actor } from '../models/actor'
 import { StatusType } from '../models/status'
 import { SqlStorage } from '../storage/sql'
 import { expectCall, mockRequests } from '../stub/activities'
+import { TEST_DOMAIN } from '../stub/const'
 import { MockImageDocument } from '../stub/imageDocument'
 import { MockLitepubNote, MockMastodonNote } from '../stub/note'
 import { seedActor1 } from '../stub/seed/actor1'
@@ -15,7 +16,6 @@ import { formatText } from '../utils/text/formatText'
 import { createNote, createNoteFromUserInput } from './createNote'
 
 enableFetchMocks()
-jest.mock('../config')
 
 // Actor id for testing pulling actor information when create status
 const FRIEND_ACTOR_ID = 'https://somewhere.test/actors/friend'
@@ -246,7 +246,7 @@ How are you?
       })
 
       const note = getNoteFromStatusData(status.data)
-      expect(note?.content).toEqual(formatText(text))
+      expect(note?.content).toEqual(formatText(TEST_DOMAIN, text))
       expect(note?.tag).toHaveLength(1)
       expect(note?.tag).toContainValue({
         type: 'Mention',
@@ -290,7 +290,7 @@ How are you?
       ])
 
       const note = getNoteFromStatusData(status.data)
-      expect(note?.content).toEqual(formatText(text))
+      expect(note?.content).toEqual(formatText(TEST_DOMAIN, text))
       expect(note?.tag).toHaveLength(2)
       expect(note?.tag).toContainValue({
         type: 'Mention',

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 
 import { getContent, getSummary, getTags } from '../activities/entities/note'
 import { Question, QuestionEntity } from '../activities/entities/question'
+import { getConfig } from '../config'
 import { compact } from '../jsonld'
 import { ACTIVITY_STREAM_URL } from '../jsonld/activitystream'
 import { Actor } from '../models/actor'
@@ -107,6 +108,7 @@ export const createPollFromUserInput = async ({
   storage,
   endAt
 }: CreatePollFromUserInputParams) => {
+  const config = getConfig()
   const span = getSpan('actions', 'createPollFromUser', {
     replyStatusId
   })
@@ -127,7 +129,7 @@ export const createPollFromUserInput = async ({
       currentActor.domain
     }/${currentActor.getMention()}/${postId}`,
     actorId: currentActor.id,
-    text: formatText(text),
+    text: formatText(config.host, text),
     summary: '',
     to,
     cc,

--- a/lib/actions/like.test.ts
+++ b/lib/actions/like.test.ts
@@ -11,8 +11,6 @@ import { likeRequest } from './like'
 
 enableFetchMocks()
 
-jest.mock('../config')
-
 describe('Accept follow action', () => {
   const storage = new SqlStorage({
     client: 'better-sqlite3',

--- a/lib/actions/rejectFollowRequest.test.ts
+++ b/lib/actions/rejectFollowRequest.test.ts
@@ -11,8 +11,6 @@ import { rejectFollowRequest } from './rejectFollowRequest'
 
 enableFetchMocks()
 
-jest.mock('../config')
-
 describe('Accept follow action', () => {
   const storage = new SqlStorage({
     client: 'better-sqlite3',

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -9,7 +9,6 @@ import { seedStorage } from '../stub/storage'
 import { updateNoteFromUserInput } from './updateNote'
 
 enableFetchMocks()
-jest.mock('../config')
 
 describe('Update note action', () => {
   const storage = new SqlStorage({

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -5,6 +5,7 @@ import {
   getContent,
   getSummary
 } from '../activities/entities/note'
+import { getConfig } from '../config'
 import { compact } from '../jsonld'
 import {
   ACTIVITY_STREAM_PUBLIC,
@@ -67,6 +68,7 @@ export const updateNoteFromUserInput = async ({
   summary,
   storage
 }: UpdateNoteFromUserInput) => {
+  const config = getConfig()
   const span = getSpan('actions', 'updateNoteFromUser', { statusId })
   const status = await storage.getStatus({ statusId })
   if (
@@ -81,7 +83,7 @@ export const updateNoteFromUserInput = async ({
   const updatedStatus = await storage.updateNote({
     statusId,
     summary,
-    text: formatText(text)
+    text: formatText(config.host, text)
   })
   if (!updatedStatus) {
     span.end()

--- a/lib/activities/index.test.ts
+++ b/lib/activities/index.test.ts
@@ -18,7 +18,6 @@ import { TEST_SHARED_INBOX, seedStorage } from '../stub/storage'
 import { CreateStatus } from './actions/createStatus'
 
 enableFetchMocks()
-jest.mock('../config')
 
 describe('activities', () => {
   const storage = new SqlStorage({

--- a/lib/components/PostBox/PostBox.tsx
+++ b/lib/components/PostBox/PostBox.tsx
@@ -292,7 +292,7 @@ export const PostBox: FC<Props> = ({
 
   return (
     <div>
-      <ReplyPreview status={replyStatus} onClose={onCloseReply} />
+      <ReplyPreview host={host} status={replyStatus} onClose={onCloseReply} />
       <form ref={formRef} onSubmit={onPost}>
         <div className="mb-3">
           <textarea

--- a/lib/components/PostBox/ReplyPreview.tsx
+++ b/lib/components/PostBox/ReplyPreview.tsx
@@ -10,6 +10,7 @@ import { Poll } from '../Posts/Poll'
 import styles from './ReplyPreview.module.scss'
 
 interface Props {
+  host: string
   status?: StatusData
   onClose?: () => void
 }
@@ -36,7 +37,7 @@ const getTags = (statusData: StatusData) => {
   }
 }
 
-export const ReplyPreview: FC<Props> = ({ status, onClose }) => {
+export const ReplyPreview: FC<Props> = ({ host, status, onClose }) => {
   if (!status) return null
   return (
     <section
@@ -51,7 +52,9 @@ export const ReplyPreview: FC<Props> = ({ status, onClose }) => {
     >
       <div>
         <Actor actorId={status.actorId || ''} />
-        {cleanClassName(convertTextContent(getText(status), getTags(status)))}
+        {cleanClassName(
+          convertTextContent(host, getText(status), getTags(status))
+        )}
         <Poll status={status} currentTime={new Date()} />
       </div>
       <CloseButton className={cn(styles.close)} onClick={() => onClose?.()} />

--- a/lib/components/Posts/Actions.tsx
+++ b/lib/components/Posts/Actions.tsx
@@ -15,6 +15,7 @@ interface Props extends PostProps {
 }
 
 export const Actions: FC<Props> = ({
+  host,
   currentActor,
   status,
   showDeleteAction = false,
@@ -42,6 +43,7 @@ export const Actions: FC<Props> = ({
           status={status.originalStatus}
         />
         <EditHistoryButton
+          host={host}
           status={status.originalStatus}
           onShowEdits={onShowEdits}
         />
@@ -63,7 +65,11 @@ export const Actions: FC<Props> = ({
         status={status}
         onPostDeleted={onPostDeleted}
       />
-      <EditHistoryButton status={status} onShowEdits={onShowEdits} />
+      <EditHistoryButton
+        status={status}
+        host={host}
+        onShowEdits={onShowEdits}
+      />
       <EditButton
         status={status}
         className={cn({ 'd-none': !showDeleteAction })}

--- a/lib/components/Posts/Actions/EditHistoryButton.tsx
+++ b/lib/components/Posts/Actions/EditHistoryButton.tsx
@@ -9,11 +9,12 @@ import { Button } from '../../Button'
 import styles from './EditHistoryButton.module.scss'
 
 interface Props {
+  host: string
   status: StatusNote | StatusPoll
   onShowEdits?: (status: StatusData) => void
 }
 
-export const EditHistoryButton: FC<Props> = ({ status, onShowEdits }) => {
+export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
   const [showHistory, setShowHistory] = useState<boolean>(false)
 
   if (status.edits.length === 0) return null
@@ -47,7 +48,9 @@ export const EditHistoryButton: FC<Props> = ({ status, onShowEdits }) => {
                     {formatDistance(edit.createdAt, Date.now())}
                   </div>
                   <div className="me-auto text-start">
-                    {cleanClassName(convertTextContent(edit.text, status.tags))}
+                    {cleanClassName(
+                      convertTextContent(host, edit.text, status.tags)
+                    )}
                   </div>
                 </li>
               )

--- a/lib/components/Posts/Post.tsx
+++ b/lib/components/Posts/Post.tsx
@@ -14,6 +14,7 @@ import { Poll } from './Poll'
 import styles from './Post.module.scss'
 
 export interface PostProps {
+  host: string
   currentActor?: ActorProfile
   currentTime: Date
   status: StatusData
@@ -54,7 +55,7 @@ const BoostStatus: FC<BoostStatusProps> = ({ status }) => {
 }
 
 export const Post: FC<PostProps> = (props) => {
-  const { status, currentTime, onShowAttachment } = props
+  const { host, status, currentTime, onShowAttachment } = props
   const actualStatus = getActualStatus(status)
 
   return (
@@ -74,7 +75,7 @@ export const Post: FC<PostProps> = (props) => {
       </div>
       <div className={'me-1 text-break'}>
         {cleanClassName(
-          convertTextContent(actualStatus.text, actualStatus.tags)
+          convertTextContent(host, actualStatus.text, actualStatus.tags)
         )}
       </div>
       <Poll status={actualStatus} currentTime={currentTime} />

--- a/lib/components/Posts/Posts.tsx
+++ b/lib/components/Posts/Posts.tsx
@@ -12,6 +12,7 @@ import { Post } from './Post'
 import styles from './Posts.module.scss'
 
 interface Props {
+  host: string
   className?: string
   currentActor?: ActorProfile
   showActions?: boolean
@@ -23,6 +24,7 @@ interface Props {
 }
 
 export const Posts: FC<Props> = ({
+  host,
   className,
   currentActor,
   showActions = false,
@@ -41,6 +43,7 @@ export const Posts: FC<Props> = ({
       {statuses.map((status, index) => (
         <div key={`${index}-${status.id}`} className={cn(styles.block)}>
           <Post
+            host={host}
             currentTime={currentTime}
             currentActor={currentActor}
             status={status}

--- a/lib/models/status.test.ts
+++ b/lib/models/status.test.ts
@@ -14,7 +14,6 @@ import { Actor } from './actor'
 import { Status, StatusType } from './status'
 
 enableFetchMocks()
-jest.mock('../config')
 
 describe('Status', () => {
   const storage = new SqlStorage({

--- a/lib/storage/storage.test.ts
+++ b/lib/storage/storage.test.ts
@@ -15,8 +15,6 @@ import { FirestoreStorage } from './firestore'
 import { SqlStorage } from './sql'
 import { Storage } from './types'
 
-jest.mock('../config')
-
 const TEST_SHARED_INBOX = `https://${TEST_DOMAIN}/inbox`
 const TEST_PASSWORD_HASH = 'password_hash'
 

--- a/lib/stub/storage.ts
+++ b/lib/stub/storage.ts
@@ -3,6 +3,7 @@ import { Actor } from '../models/actor'
 import { FollowStatus } from '../models/follow'
 import { Storage } from '../storage/types'
 import { linkifyText } from '../utils/text/linkifyText'
+import { TEST_DOMAIN } from './const'
 import { seedActor1 } from './seed/actor1'
 import { seedActor2 } from './seed/actor2'
 import { seedActor3 } from './seed/actor3'
@@ -149,7 +150,7 @@ export const seedStorage = async (storage: Storage) => {
     actorId: actors[1].id,
     to: [ACTIVITY_STREAM_PUBLIC, actors[0].id],
     cc: [`${actors[1].id}/followers`],
-    text: linkifyText('@test1@llun.test This is Actor1 post'),
+    text: linkifyText(TEST_DOMAIN)('@test1@llun.test This is Actor1 post'),
     reply: `${actors[0].id}/statuses/post-1`
   })
   await storage.createTag({

--- a/lib/utils/getNoteFromStatusData.ts
+++ b/lib/utils/getNoteFromStatusData.ts
@@ -1,4 +1,5 @@
 import { Note } from '../activities/entities/note'
+import { getConfig } from '../config'
 import { Attachment } from '../models/attachment'
 import { StatusData, StatusType } from '../models/status'
 import { Tag } from '../models/tag'
@@ -21,7 +22,7 @@ export const getNoteFromStatusData = (status: StatusData): Note | null => {
     to: actualStatus.to,
     cc: actualStatus.cc,
     inReplyTo: actualStatus.reply || null,
-    content: formatText(actualStatus.text),
+    content: formatText(getConfig().host, actualStatus.text),
     attachment: actualStatus.attachments.map((attachment) =>
       new Attachment(attachment).toObject()
     ),

--- a/lib/utils/signature.test.ts
+++ b/lib/utils/signature.test.ts
@@ -1,7 +1,5 @@
 import { parse, verify } from './signature'
 
-jest.mock('../config')
-
 describe('#parse', () => {
   test('split signature into parts', async () => {
     const signature =

--- a/lib/utils/text/convertTextContent.test.ts
+++ b/lib/utils/text/convertTextContent.test.ts
@@ -1,8 +1,12 @@
+import { TEST_DOMAIN } from '@/lib/stub/const'
+
 import { convertTextContent } from './convertTextContent'
 
 describe('#convertTextContent', () => {
   it('produces html from markdown text', () => {
-    expect(convertTextContent('sample text')).toEqual('<p>sample text</p>')
+    expect(convertTextContent(TEST_DOMAIN, 'sample text')).toEqual(
+      '<p>sample text</p>'
+    )
   })
 
   it('auto detect link', () => {
@@ -11,14 +15,14 @@ This is a text with link
 
 https://www.llun.dev
     `.trim()
-    expect(convertTextContent(text)).toEqual(
+    expect(convertTextContent(TEST_DOMAIN, text)).toEqual(
       '<p>This is a text with link</p>\n<p><a href="https://https//www.llun.dev%3C/p%3E" target="_blank" rel="nofollow noopener noreferrer">https//www.llun.dev%3C/p%3E</a>'
     )
   })
 
   it('auto detech mention', () => {
     const text = `@null@llun.dev test mention`
-    expect(convertTextContent(text)).toEqual(
+    expect(convertTextContent(TEST_DOMAIN, text)).toEqual(
       '<p><span class="h-card"><a href="https://test.llun.dev/@null@llun.dev" target="_blank" class="u-url mention">@<span>null</span></a></span> test mention</p>'
     )
   })

--- a/lib/utils/text/convertTextContent.ts
+++ b/lib/utils/text/convertTextContent.ts
@@ -7,11 +7,15 @@ import { convertMarkdownText } from './convertMarkdownText'
 import { linkifyText } from './linkifyText'
 import { SANITIZED_OPTION } from './sanitizeText'
 
-export const convertTextContent = (text: string, tags: TagData[] = []) =>
+export const convertTextContent = (
+  host: string,
+  text: string,
+  tags: TagData[] = []
+) =>
   _.chain(text)
     .thru((text) => sanitizeHtml(text, SANITIZED_OPTION))
     .thru(convertMarkdownText)
-    .thru(linkifyText)
+    .thru(linkifyText(host))
     .thru(_.curryRight(convertEmojisToImages)(tags))
     .value()
     .trim()

--- a/lib/utils/text/formatText.ts
+++ b/lib/utils/text/formatText.ts
@@ -3,5 +3,9 @@ import _ from 'lodash'
 import { convertMarkdownText } from './convertMarkdownText'
 import { sanitizeText } from './sanitizeText'
 
-export const formatText = (text: string) =>
-  _.chain(text).thru(convertMarkdownText).thru(sanitizeText).value().trim()
+export const formatText = (host: string, text: string) =>
+  _.chain(text)
+    .thru(convertMarkdownText)
+    .thru(sanitizeText(host))
+    .value()
+    .trim()

--- a/lib/utils/text/linkifyText.test.ts
+++ b/lib/utils/text/linkifyText.test.ts
@@ -1,3 +1,5 @@
+import { TEST_DOMAIN } from '@/lib/stub/const'
+
 import { getConfig } from '../../config'
 import { linkifyText } from './linkifyText'
 
@@ -5,7 +7,7 @@ describe('#linkifyText', () => {
   const config = getConfig()
 
   it('links mention with user url', async () => {
-    const message = linkifyText('@test1@somewhere.test')
+    const message = linkifyText(TEST_DOMAIN)('@test1@somewhere.test')
     expect(message).toEqual(
       `<span class="h-card"><a href="https://${
         getConfig().host
@@ -14,7 +16,7 @@ describe('#linkifyText', () => {
   })
 
   it('links multiple mentions with user url', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'With multiple mentions @test1@somewhere.test and @test2@llun.test tags'
     )
     expect(message).toEqual(
@@ -23,7 +25,7 @@ describe('#linkifyText', () => {
   })
 
   it('linkify http link', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'Test linkify string https://www.llun.me/posts/dev/2023-01-07-my-wrong-assumptions-with-activity-pub/ with url'
     )
     expect(message).toEqual(
@@ -32,7 +34,7 @@ describe('#linkifyText', () => {
   })
 
   it('linkify link without protocol and pathname', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'Test linkify string llun.me, without protocol and pathname'
     )
     expect(message).toEqual(
@@ -41,7 +43,7 @@ describe('#linkifyText', () => {
   })
 
   it('linkify link without protocol', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'Test linkify string llun.me/pathname, without pathname'
     )
     expect(message).toEqual(
@@ -50,7 +52,7 @@ describe('#linkifyText', () => {
   })
 
   it('linkify link without protocol with very long pathname', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'Test linkify string www.llun.me/posts/dev/2023-01-07-my-wrong-assumptions-with-activity-pub/, without pathname'
     )
     expect(message).toEqual(
@@ -59,7 +61,7 @@ describe('#linkifyText', () => {
   })
 
   it('linkify link include query', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'Test linkify with query in url https://www.youtube.com/watch?v=mroK84Y2GwM'
     )
     expect(message).toEqual(
@@ -68,7 +70,7 @@ describe('#linkifyText', () => {
   })
 
   it('linkify cuts query short', async () => {
-    const message = linkifyText(
+    const message = linkifyText(TEST_DOMAIN)(
       'Linkify with long query https://www.google.com/search?q=noreferrer&sourceid=chrome&ie=UTF-8'
     )
     expect(message).toEqual(

--- a/lib/utils/text/linkifyText.ts
+++ b/lib/utils/text/linkifyText.ts
@@ -1,13 +1,10 @@
 import * as linkify from 'linkifyjs'
-import getConfig from 'next/config'
 
 import { linkBody } from './linkBody'
 import './linkify-mention'
 import { mentionBody } from './mentionBody'
 
-export const linkifyText = (text: string) => {
-  const { publicRuntimeConfig } = getConfig()
-  const { host } = publicRuntimeConfig
+export const linkifyText = (host: string) => (text: string) => {
   const tokens = linkify.tokenize(text)
   const texts = tokens.map((item) => {
     if (item.t === 'mention') {

--- a/lib/utils/text/sanitizeText.ts
+++ b/lib/utils/text/sanitizeText.ts
@@ -32,11 +32,11 @@ export const SANITIZED_OPTION = {
 
 // Support the same tags as Mastodon here
 // https://github.com/mastodon/mastodon/blob/eae5c7334ae61c463edd2e3cd03115b897f6e92b/lib/sanitize_ext/sanitize_config.rb
-export const sanitizeText = (text: string) =>
+export const sanitizeText = (host: string) => (text: string) =>
   sanitizeHtml(text, {
     ...SANITIZED_OPTION,
     textFilter: (text, tagName) => {
       if (['code', 'pre', 'a'].includes(tagName)) return text
-      return linkifyText(text)
+      return linkifyText(host)(text)
     }
   })


### PR DESCRIPTION
This PR is removing `next/config` runtime configuration because the feature is deprecated https://nextjs.org/docs/pages/api-reference/next-config-js/runtime-configuration and cause error when linkify because the host value is failed to spread from the configuration.