### PR TITLE
Change access token life time to 30 days

### DIFF
--- a/lib/services/oauth/server.ts
+++ b/lib/services/oauth/server.ts
@@ -28,7 +28,10 @@ export const getOAuth2Server = memoize(async () => {
   const authCodeRepository = new AuthCodeRepository(database)
   authorizationServer.enableGrantTypes(
     ['refresh_token', new DateInterval('30d')],
-    { grant: 'authorization_code', authCodeRepository, userRepository }
+    [
+      { grant: 'authorization_code', authCodeRepository, userRepository },
+      new DateInterval('30d')
+    ]
   )
   return authorizationServer
 })


### PR DESCRIPTION
This PR is extend access token expire from [1 hour](https://github.com/jasonraimondi/ts-oauth2-server/blob/0968be4362e2c172b57c1e86ffa20b3ae05d5919/src/grants/implicit.grant.ts#L13) to 30 days. (This is a compromise because no Mastodon client use refresh token yet because Mastodon doesn't use it)