### PR TITLE
Don't return status when account is null

### DIFF
--- a/app/api/v1/statuses/[id]/context/route.ts
+++ b/app/api/v1/statuses/[id]/context/route.ts
@@ -40,7 +40,13 @@ export const GET = OAuthGuard<Params>(
               status ? getMastodonStatus(database, status) : null
             )
         : Promise.resolve(null),
-      database.getStatusReplies({ statusId })
+      database
+        .getStatusReplies({ statusId })
+        .then((statuses) =>
+          Promise.all(
+            statuses.map((status) => getMastodonStatus(database, status))
+          )
+        )
     ])
 
     return apiResponse({
@@ -48,9 +54,7 @@ export const GET = OAuthGuard<Params>(
       allowedMethods: CORS_HEADERS,
       data: {
         ancestors: ancestor ? [ancestor] : [],
-        descendants: await Promise.all(
-          descendants.map((status) => getMastodonStatus(database, status))
-        )
+        descendants: descendants.filter(Boolean)
       }
     })
   }

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -38,10 +38,13 @@ export const GET = OAuthGuard<Params>(
     const status = await database.getStatus({ statusId })
     if (!status) return apiErrorResponse(404)
 
+    const mastodonStatus = await getMastodonStatus(database, status)
+    if (!mastodonStatus) return apiErrorResponse(404)
+
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: await getMastodonStatus(database, status)
+      data: mastodonStatus
     })
   }
 )

--- a/app/api/v1/timelines/[timeline]/route.ts
+++ b/app/api/v1/timelines/[timeline]/route.ts
@@ -74,13 +74,14 @@ export const GET = OAuthGuard<Params>(
         ? `<https://${host}/api/v1/timelines/${timeline}?limit=20&min_id=${urlToId(statuses[0].id)}>; rel="prev"`
         : null
     const links = [nextLink, prevLink].filter(Boolean).join(', ')
+    const mastodonStatuses = await Promise.all(
+      statuses.map((item) => getMastodonStatus(database, item))
+    )
 
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: await Promise.all(
-        statuses.map((item) => getMastodonStatus(database, item))
-      ),
+      data: mastodonStatuses.filter(Boolean),
       additionalHeaders: [
         ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
       ]

--- a/app/api/v1/timelines/public/route.ts
+++ b/app/api/v1/timelines/public/route.ts
@@ -15,5 +15,5 @@ export const GET = async () => {
   const mastodonStatuses = await Promise.all(
     statuses.map((status) => getMastodonStatus(database, status))
   )
-  return Response.json(mastodonStatuses)
+  return Response.json(mastodonStatuses.filter(Boolean))
 }

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -1,5 +1,6 @@
 import { getActorPerson } from '@/lib/activities/requests/getActorPerson'
 import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/models/actor'
 
 interface RecordActorIfNeededParams {
   actorId: string
@@ -8,7 +9,7 @@ interface RecordActorIfNeededParams {
 export const recordActorIfNeeded = async ({
   actorId,
   database
-}: RecordActorIfNeededParams) => {
+}: RecordActorIfNeededParams): Promise<Actor | undefined> => {
   const existingActor = await database.getActorFromId({
     id: actorId
   })

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -9,8 +9,11 @@ import { urlToId } from '@/lib/utils/urlToId'
 export const getMastodonStatus = async (
   database: Database,
   status: Status
-): Promise<Mastodon.Status> => {
+): Promise<Mastodon.Status | null> => {
   const account = await database.getMastodonActorFromId({ id: status.actorId })
+  if (!account) {
+    return null
+  }
   const baseData = {
     // Identifiers & timestamps
     id: urlToId(status.id),


### PR DESCRIPTION
This PR fixing timelines error when status that received from the activity pub api doesn't have account in the database yet (because it fail to fetch from the mastodon server or other reason) which causing the timeline api return 500 errors.