### PR TITLE
Fix edit status functionality

### DIFF
--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -81,7 +81,13 @@ export const PUT = OAuthGuard<Params>(
       created_at: getISOTimeUTC(updatedNote.createdAt),
       in_reply_to_id: updatedNote.reply,
       edited_at: getISOTimeUTC(updatedNote.updatedAt),
-      content: updatedNote.text
+      content: updatedNote.text,
+      type: updatedNote.type,
+      actor_id: updatedNote.actorId,
+      to: updatedNote.to,
+      cc: updatedNote.cc,
+      summary: updatedNote.summary,
+      tags: updatedNote.tags
     })
   }
 )

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -67,7 +67,19 @@ export const updateNote = async ({ statusId, message }: UpdateNoteParams) => {
     throw new Error('Fail to create a new note')
   }
 
-  return response.json()
+  const updatedStatus = await response.json()
+  return {
+    content: updatedStatus.content,
+    status: {
+      ...updatedStatus,
+      text: updatedStatus.content,
+      createdAt: new Date(updatedStatus.created_at),
+      updatedAt: updatedStatus.edited_at
+        ? new Date(updatedStatus.edited_at)
+        : undefined,
+      reply: updatedStatus.in_reply_to_id || ''
+    }
+  }
 }
 
 export interface CreatePollParams {

--- a/lib/components/PostBox/PostBox.tsx
+++ b/lib/components/PostBox/PostBox.tsx
@@ -23,6 +23,7 @@ import {
   StatusNote,
   StatusType
 } from '@/lib/models/status'
+import { urlToId } from '@/lib/utils/urlToId'
 
 import { Duration, PollChoices } from './PollChoices'
 import styles from './PostBox.module.scss'
@@ -92,13 +93,18 @@ export const PostBox: FC<Props> = ({
       }
 
       if (editStatus) {
-        const uuid = new URL(editStatus.id).pathname.split('/').pop()
-        if (!uuid) return
-
         // TODO: Update updateNote api to return full status?
-        const { content } = await updateNote({ statusId: uuid, message })
-        editStatus.text = content
-        onPostUpdated(editStatus)
+        const { content, status: updatedStatus } = await updateNote({
+          statusId: urlToId(editStatus.id),
+          message
+        })
+
+        // Use the full updated status object instead of just updating the text
+        onPostUpdated({
+          ...editStatus,
+          ...updatedStatus,
+          text: content
+        })
         dispatch(resetExtension())
 
         postBoxRef.current.value = ''


### PR DESCRIPTION
# Fix Edit Status Functionality

## Problem

When editing a status in the PostBox component, the current implementation has several issues:

1. It directly mutates the `editStatus` prop by setting `editStatus.text = content`, which is against React best practices
2. It only updates the text property, ignoring other properties that might have changed
3. The API response from `updateNote` doesn't return the full status object, only partial information

## Solution

This PR fixes the edit status functionality by:

1. Enhancing the `updateNote` client function to return a more complete status object
2. Updating the PostBox component to properly handle the updated status without direct prop mutation
3. Expanding the API response in the PUT handler to include more status information

## Changes

1. In `lib/client.ts`:

   - Modified the `updateNote` function to return a more complete status object with properly formatted fields

2. In `lib/components/PostBox/PostBox.tsx`:

   - Updated the edit status handling to use the full status object returned from `updateNote`
   - Removed direct mutation of the `editStatus` prop
   - Used object spreading to merge the existing status with the updated properties

3. In `app/api/v1/statuses/[id]/route.ts`:
   - Enhanced the PUT handler response to include more status information (type, actor_id, to, cc, summary, tags)

## Testing

The changes have been tested by:

- Editing a status and verifying that all properties are properly updated
- Ensuring the UI correctly reflects the updated status
- Confirming that the status is properly updated in the database

## Screenshots

N/A
