### PR TITLE
Add deduplication ID to QStash jobs

### DIFF
--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -18,12 +18,10 @@ import {
   UPDATE_NOTE_JOB_NAME,
   UPDATE_POLL_JOB_NAME
 } from '@/lib/jobs/names'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 export const getJobMessage = (activity: StatusActivity) => {
-  const deduplicationId = crypto
-    .createHash('sha256')
-    .update(JSON.stringify(activity.id))
-    .digest('hex')
+  const deduplicationId = getHashFromString(activity.id)
   if (
     isMatch(activity, {
       type: CreateAction,

--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -1,6 +1,5 @@
 import { ENTITY_TYPE_NOTE, ENTITY_TYPE_QUESTION } from '@llun/activities.schema'
 import isMatch from 'lodash/isMatch'
-import crypto from 'node:crypto'
 
 import { StatusActivity } from '@/lib/activities/actions/status'
 import {

--- a/lib/actions/announce.test.ts
+++ b/lib/actions/announce.test.ts
@@ -9,7 +9,6 @@ import * as timelinesService from '@/lib/services/timelines'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { urlToId } from '@/lib/utils/urlToId'
 
 jest.mock('../services/queue', () => ({
   getQueue: jest.fn().mockReturnValue({

--- a/lib/actions/announce.test.ts
+++ b/lib/actions/announce.test.ts
@@ -8,6 +8,7 @@ import { getQueue } from '@/lib/services/queue'
 import * as timelinesService from '@/lib/services/timelines'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { urlToId } from '@/lib/utils/urlToId'
 
 jest.mock('../services/queue', () => ({
@@ -60,7 +61,7 @@ describe('Announce action', () => {
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `announce-${urlToId(status!.id)}`,
+        id: getHashFromString(status!.id),
         name: SEND_ANNOUNCE_JOB_NAME,
         data: JobData.parse({
           actorId: actor1.id,

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -5,9 +5,9 @@ import { SEND_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { Actor } from '@/lib/models/actor'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/jsonld/activitystream'
 import { getTracer } from '@/lib/utils/trace'
-import { urlToId } from '@/lib/utils/urlToId'
 
 interface UserAnnounceParams {
   currentActor: Actor
@@ -48,7 +48,7 @@ export const userAnnounce = async ({
     }
     await addStatusToTimelines(database, status)
     await getQueue().publish({
-      id: `announce-${urlToId(status.id)}`,
+      id: getHashFromString(status.id),
       name: SEND_ANNOUNCE_JOB_NAME,
       data: {
         actorId: currentActor.id,

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -17,7 +17,6 @@ import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/jsonld/activitystream'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
-import { urlToId } from '@/lib/utils/urlToId'
 
 enableFetchMocks()
 

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -13,6 +13,7 @@ import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/jsonld/activitystream'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
@@ -75,7 +76,7 @@ describe('Create note action', () => {
       })
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `send-note-${urlToId(status.id)}`,
+        id: getHashFromString(status.id),
         name: SEND_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,
@@ -103,7 +104,7 @@ describe('Create note action', () => {
       })
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `send-note-${urlToId(status.id)}`,
+        id: getHashFromString(status.id),
         name: SEND_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,
@@ -142,7 +143,7 @@ How are you?
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `send-note-${urlToId(status.id)}`,
+        id: getHashFromString(status.id),
         name: SEND_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,
@@ -190,7 +191,7 @@ How are you?
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `send-note-${urlToId(status.id)}`,
+        id: getHashFromString(status.id),
         name: SEND_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,
@@ -228,7 +229,7 @@ How are you?
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `send-note-${urlToId(status.id)}`,
+        id: getHashFromString(status.id),
         name: SEND_NOTE_JOB_NAME,
         data: {
           actorId: actor1.id,

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -8,13 +8,13 @@ import { PostBoxAttachment } from '@/lib/models/attachment'
 import { Status, StatusNote } from '@/lib/models/status'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMACT
 } from '@/lib/utils/jsonld/activitystream'
 import { getMentions } from '@/lib/utils/text/getMentions'
 import { getSpan } from '@/lib/utils/trace'
-import { urlToId } from '@/lib/utils/urlToId'
 
 // TODO: Support status visibility public, unlist, followers only, mentions only
 export const statusRecipientsTo = (
@@ -130,7 +130,7 @@ export const createNoteFromUserInput = async ({
   }
 
   await getQueue().publish({
-    id: `send-note-${urlToId(status.id)}`,
+    id: getHashFromString(status.id),
     name: SEND_NOTE_JOB_NAME,
     data: {
       actorId: currentActor.id,

--- a/lib/actions/undoAnnounce.test.ts
+++ b/lib/actions/undoAnnounce.test.ts
@@ -7,6 +7,7 @@ import { getQueue } from '@/lib/services/queue'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { seedActor2 } from '@/lib/stub/seed/actor2'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { urlToId } from '@/lib/utils/urlToId'
 
 // Mock the queue
@@ -52,7 +53,7 @@ describe('Undo Announce action', () => {
 
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
       expect(getQueue().publish).toHaveBeenCalledWith({
-        id: `undo-announce-${urlToId(status!.id)}`,
+        id: getHashFromString(status!.id),
         name: SEND_UNDO_ANNOUNCE_JOB_NAME,
         data: JobData.parse({
           actorId: actor2.id,

--- a/lib/actions/undoAnnounce.test.ts
+++ b/lib/actions/undoAnnounce.test.ts
@@ -8,7 +8,6 @@ import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { seedActor2 } from '@/lib/stub/seed/actor2'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { urlToId } from '@/lib/utils/urlToId'
 
 // Mock the queue
 jest.mock('../services/queue', () => ({

--- a/lib/actions/undoAnnounce.ts
+++ b/lib/actions/undoAnnounce.ts
@@ -3,8 +3,8 @@ import { SEND_UNDO_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { Actor } from '@/lib/models/actor'
 import { StatusType } from '@/lib/models/status'
 import { getQueue } from '@/lib/services/queue'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getTracer } from '@/lib/utils/trace'
-import { urlToId } from '@/lib/utils/urlToId'
 
 interface UserUndoAnnounceParams {
   currentActor: Actor
@@ -32,7 +32,7 @@ export const userUndoAnnounce = async ({
 
     await database.deleteStatus({ statusId })
     await getQueue().publish({
-      id: `undo-announce-${urlToId(status.id)}`,
+      id: getHashFromString(status.id),
       name: SEND_UNDO_ANNOUNCE_JOB_NAME,
       data: {
         actorId: currentActor.id,

--- a/lib/utils/getHashFromString.test.ts
+++ b/lib/utils/getHashFromString.test.ts
@@ -1,0 +1,41 @@
+import { getHashFromString } from './getHashFromString'
+
+describe('getHashFromString', () => {
+  it('should generate consistent hash for the same input', () => {
+    const input = 'test string'
+    const firstHash = getHashFromString(input)
+    const secondHash = getHashFromString(input)
+    expect(firstHash).toBe(secondHash)
+  })
+
+  it('should generate different hashes for different inputs', () => {
+    const input1 = 'test string 1'
+    const input2 = 'test string 2'
+    const hash1 = getHashFromString(input1)
+    const hash2 = getHashFromString(input2)
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it('should handle empty string', () => {
+    const input = ''
+    const hash = getHashFromString(input)
+    // SHA-256 hash of empty string
+    expect(hash).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    )
+  })
+
+  it('should handle special characters', () => {
+    const input = '!@#$%^&*()_+'
+    const hash = getHashFromString(input)
+    expect(hash).toHaveLength(64) // SHA-256 produces 64 character hex string
+    expect(hash).toMatch(/^[a-f0-9]{64}$/) // Should be hexadecimal
+  })
+
+  it('should handle unicode characters', () => {
+    const input = '你好世界'
+    const hash = getHashFromString(input)
+    expect(hash).toHaveLength(64)
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+})

--- a/lib/utils/getHashFromString.ts
+++ b/lib/utils/getHashFromString.ts
@@ -1,0 +1,5 @@
+import crypto from 'crypto'
+
+export const getHashFromString = (str: string) => {
+  return crypto.createHash('sha256').update(str).digest('hex')
+}


### PR DESCRIPTION
## Summary
- Adds SHA-256 hash utility function for generating consistent deduplication IDs
- Implements QStash job deduplication using activity/status IDs as the source
- Updates all job creation in action files to include deduplication IDs

## Test plan
- Verified deduplication works by submitting identical jobs
- All tests for hash function and job creation pass

🤖 Generated with [Claude Code](https://claude.ai/code)