### PR TITLE
Fix missing mentions and tags in Mastodon status

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@date-fns/utc": "^2.1.0",
     "@google-cloud/firestore": "^7.11.0",
     "@jmondi/oauth2-server": "^4.0.2",
-    "@llun/activities.schema": "^0.2.30",
+    "@llun/activities.schema": "^0.2.31",
     "@opentelemetry/api": "^1.9.0",
     "@upstash/qstash": "2.7.22",
     "bcrypt": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,12 +2027,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@llun/activities.schema@npm:^0.2.30":
-  version: 0.2.30
-  resolution: "@llun/activities.schema@npm:0.2.30"
+"@llun/activities.schema@npm:^0.2.31":
+  version: 0.2.31
+  resolution: "@llun/activities.schema@npm:0.2.31"
   dependencies:
     zod: "npm:^3.24.2"
-  checksum: 10c0/4af832d9a6b9818eabe7cf7ca20782ba2cc105e4538cfc039198f89563a031dba1fa277584677fe3d1136213263e12f5ea5dfb47009a21e30e10760b6b3e5aa1
+  checksum: 10c0/f136b142c8c9cddacb7e1a6662153302e65ddc42ea7c3a4c313cb49f7a1e730aab1ce88e9b9603a47a4a860146afaa300e2eac0cde4d73fce4fc90215dcc0180
   languageName: node
   linkType: hard
 
@@ -4189,7 +4189,7 @@ __metadata:
     "@date-fns/utc": "npm:^2.1.0"
     "@google-cloud/firestore": "npm:^7.11.0"
     "@jmondi/oauth2-server": "npm:^4.0.2"
-    "@llun/activities.schema": "npm:^0.2.30"
+    "@llun/activities.schema": "npm:^0.2.31"
     "@next/env": "npm:15.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     "@swc-node/register": "npm:^1.10.10"


### PR DESCRIPTION
## Summary
- Updated activities.schema dependency to v0.2.31 to fix missing mentions and tags in Mastodon status

## Test plan
- Verify that mentions and tags appear correctly in Mastodon status

🤖 Generated with [Claude Code](https://claude.ai/code)