### PR TITLE
Add Poll type support to getMastodonStatus

### DIFF
--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -694,7 +694,6 @@ export const StatusSQLDatabaseMixin = (
     }
     if (data.type === StatusType.enum.Poll) {
       const pollChoices = await getPollChoices(data.id)
-      console.log(data.content)
       return StatusPoll.parse({
         ...base,
         choices: pollChoices,


### PR DESCRIPTION
This PR adds support for Poll type statuses in the getMastodonStatus function and refactors the code to use StatusType enum instead of string literals. It also adds tests for the Poll type handling.