### PR TITLE
feat: add region filter to fitness heatmap page

### DIFF
--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -13,6 +13,10 @@ import {
   CalendarMetric,
   FitnessCalendarHeatmap
 } from '@/lib/components/fitness/FitnessCalendarHeatmap'
+import {
+  HEATMAP_REGIONS,
+  serializeRegions
+} from '@/lib/services/fitness-files/regions'
 
 type PeriodType = 'all_time' | 'yearly' | 'monthly'
 
@@ -85,6 +89,7 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
   const [periodKey, setPeriodKey] = useState<string>('all')
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)
   const [calendarMetric, setCalendarMetric] = useState<CalendarMetric>('count')
+  const [selectedRegions, setSelectedRegions] = useState<string[]>([])
 
   const [heatmapData, setHeatmapData] = useState<FitnessHeatmapData | null>(
     null
@@ -107,6 +112,11 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
     return periodKey
   }, [periodType, selectedYear, periodKey])
 
+  const serializedRegions = useMemo(
+    () => serializeRegions(selectedRegions),
+    [selectedRegions]
+  )
+
   const fetchData = useCallback(async () => {
     setIsLoading(true)
     setError(null)
@@ -123,7 +133,8 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
           actorId,
           activityType,
           periodType,
-          periodKey: effectivePeriodKey
+          periodKey: effectivePeriodKey,
+          regions: serializedRegions || undefined
         }),
         getFitnessCalendarData({
           actorId,
@@ -140,7 +151,7 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
     } finally {
       setIsLoading(false)
     }
-  }, [actorId, selectedType, periodType, effectivePeriodKey])
+  }, [actorId, selectedType, periodType, effectivePeriodKey, serializedRegions])
 
   useEffect(() => {
     fetchData()
@@ -175,6 +186,19 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
       setPeriodKey(options.includes(newKey) ? newKey : options[0])
     }
   }
+
+  const addRegion = (regionId: string) => {
+    if (!regionId || selectedRegions.includes(regionId)) return
+    setSelectedRegions((prev) => [...prev, regionId])
+  }
+
+  const removeRegion = (regionId: string) => {
+    setSelectedRegions((prev) => prev.filter((r) => r !== regionId))
+  }
+
+  const availableRegions = HEATMAP_REGIONS.filter(
+    (r) => !selectedRegions.includes(r.id)
+  )
 
   return (
     <div className="space-y-6 p-2 sm:p-4">
@@ -248,6 +272,63 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
         )}
       </div>
 
+      {/* Region filter */}
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground">Region</span>
+          <select
+            value=""
+            onChange={(e) => {
+              addRegion(e.target.value)
+              e.target.value = ''
+            }}
+            className="rounded border bg-background px-2 py-1 text-sm"
+          >
+            <option value="">
+              {selectedRegions.length === 0
+                ? 'Worldwide (add region...)'
+                : 'Add region...'}
+            </option>
+            {availableRegions.map((region) => (
+              <option key={region.id} value={region.id}>
+                {region.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {selectedRegions.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {selectedRegions.map((regionId) => {
+              const region = HEATMAP_REGIONS.find((r) => r.id === regionId)
+              return (
+                <span
+                  key={regionId}
+                  className="flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary"
+                >
+                  {region?.label ?? regionId}
+                  <button
+                    type="button"
+                    onClick={() => removeRegion(regionId)}
+                    className="ml-0.5 rounded-full p-0.5 hover:bg-primary/20"
+                    aria-label={`Remove ${region?.label ?? regionId}`}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 14 14"
+                      fill="currentColor"
+                      className="h-3 w-3"
+                    >
+                      <path d="M10.95 3.05a.75.75 0 0 0-1.06 0L7 5.94 4.11 3.05A.75.75 0 0 0 3.05 4.11L5.94 7l-2.89 2.89a.75.75 0 1 0 1.06 1.06L7 8.06l2.89 2.89a.75.75 0 0 0 1.06-1.06L8.06 7l2.89-2.89a.75.75 0 0 0 0-1.06Z" />
+                    </svg>
+                  </button>
+                </span>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
       {isLoading && (
         <p className="text-center text-muted-foreground">Loading...</p>
       )}
@@ -301,7 +382,8 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
               heatmapData.status === 'completed' &&
               !heatmapData.imagePath && (
                 <p className="py-8 text-center text-sm text-muted-foreground">
-                  No route data available for this period.
+                  No route data available for this period
+                  {selectedRegions.length > 0 ? ' and region' : ''}.
                 </p>
               )}
           </div>

--- a/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
@@ -147,7 +147,7 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
 
     expect(response.status).toBe(200)
     const data = await response.json()
-    expect(data).toEqual({
+    expect(data).toMatchObject({
       id: 'heatmap-1',
       activityType: 'running',
       periodType: 'yearly',
@@ -161,7 +161,8 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
       actorId: ACTOR1_ID,
       activityType: 'running',
       periodType: 'yearly',
-      periodKey: '2025'
+      periodKey: '2025',
+      regions: ''
     })
   })
 
@@ -195,7 +196,8 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
       actorId: ACTOR1_ID,
       activityType: null,
       periodType: 'all_time',
-      periodKey: 'all'
+      periodKey: 'all',
+      regions: ''
     })
   })
 

--- a/app/api/v1/accounts/[id]/fitness-heatmap/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmap/route.ts
@@ -3,6 +3,10 @@ import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import {
+  HEATMAP_REGION_MAP,
+  serializeRegions
+} from '@/lib/services/fitness-files/regions'
 import { AppRouterParams } from '@/lib/services/guards/types'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -26,10 +30,25 @@ interface Params {
   id: string
 }
 
+const validRegionIds = Array.from(HEATMAP_REGION_MAP.keys())
+
 const FitnessHeatmapQueryParams = z.object({
   activity_type: z.string().optional(),
   period_type: z.enum(['all_time', 'yearly', 'monthly']),
-  period_key: z.string()
+  period_key: z.string(),
+  /**
+   * Comma-separated list of region IDs, e.g. "singapore,netherlands".
+   * Empty or absent means worldwide (no region filter).
+   */
+  regions: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) return ''
+      const ids = val.split(',').filter(Boolean)
+      const valid = ids.filter((id) => validRegionIds.includes(id))
+      return serializeRegions(valid)
+    })
 })
 
 export const GET = traceApiRoute(
@@ -100,14 +119,16 @@ export const GET = traceApiRoute(
     const {
       activity_type: activityType,
       period_type: periodType,
-      period_key: periodKey
+      period_key: periodKey,
+      regions
     } = parsed.data
 
     const heatmap = await database.getFitnessHeatmapByKey({
       actorId: id,
       activityType: activityType ?? null,
       periodType,
-      periodKey
+      periodKey,
+      regions
     })
 
     if (!heatmap) {
@@ -127,6 +148,7 @@ export const GET = traceApiRoute(
         activityType: heatmap.activityType,
         periodType: heatmap.periodType,
         periodKey: heatmap.periodKey,
+        regions: heatmap.regions,
         status: heatmap.status,
         imagePath: heatmap.imagePath,
         activityCount: heatmap.activityCount

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1126,6 +1126,8 @@ export interface FitnessHeatmapData {
   activityType?: string
   periodType: string
   periodKey: string
+  /** Sorted comma-separated region IDs. Empty string means worldwide. */
+  regions: string
   status: string
   imagePath?: string
   activityCount: number
@@ -1142,12 +1144,15 @@ export const getFitnessHeatmap = async ({
   actorId,
   activityType,
   periodType,
-  periodKey
+  periodKey,
+  regions
 }: {
   actorId: string
   activityType?: string
   periodType: string
   periodKey: string
+  /** Sorted comma-separated region IDs. Empty string or absent means worldwide. */
+  regions?: string
 }): Promise<FitnessHeatmapData | null> => {
   const encodedId = urlToId(actorId)
   const url = new URL(
@@ -1157,6 +1162,9 @@ export const getFitnessHeatmap = async ({
   url.searchParams.append('period_key', periodKey)
   if (activityType) {
     url.searchParams.append('activity_type', activityType)
+  }
+  if (regions) {
+    url.searchParams.append('regions', regions)
   }
   const response = await fetch(url.toString(), {
     method: 'GET',

--- a/lib/database/sql/fitnessHeatmap.ts
+++ b/lib/database/sql/fitnessHeatmap.ts
@@ -14,6 +14,8 @@ export interface CreateFitnessHeatmapParams {
   activityType?: string | null
   periodType: FitnessHeatmapPeriodType
   periodKey: string
+  /** Sorted comma-separated region IDs. Empty string means worldwide. */
+  regions?: string
   periodStart?: Date | null
   periodEnd?: Date | null
 }
@@ -27,6 +29,8 @@ export interface GetFitnessHeatmapByKeyParams {
   activityType?: string | null
   periodType: FitnessHeatmapPeriodType
   periodKey: string
+  /** Sorted comma-separated region IDs. Empty string means worldwide. */
+  regions?: string
   includeDeleted?: boolean
 }
 
@@ -77,6 +81,7 @@ const parseSQLFitnessHeatmap = (row: SQLFitnessHeatmap): FitnessHeatmap => ({
   activityType: row.activityType ?? undefined,
   periodType: row.periodType as FitnessHeatmapPeriodType,
   periodKey: row.periodKey,
+  regions: row.regions ?? '',
   periodStart: row.periodStart ? getCompatibleTime(row.periodStart) : undefined,
   periodEnd: row.periodEnd ? getCompatibleTime(row.periodEnd) : undefined,
   imagePath: row.imagePath ?? undefined,
@@ -101,6 +106,7 @@ export const FitnessHeatmapSQLDatabaseMixin = (
       activityType: params.activityType ?? null,
       periodType: params.periodType,
       periodKey: params.periodKey,
+      regions: params.regions ?? '',
       periodStart: params.periodStart ?? null,
       periodEnd: params.periodEnd ?? null,
       imagePath: null,
@@ -131,12 +137,14 @@ export const FitnessHeatmapSQLDatabaseMixin = (
     activityType,
     periodType,
     periodKey,
+    regions,
     includeDeleted
   }: GetFitnessHeatmapByKeyParams) {
     let query = database<SQLFitnessHeatmap>('fitness_heatmaps')
       .where('actorId', actorId)
       .where('periodType', periodType)
       .where('periodKey', periodKey)
+      .where('regions', regions ?? '')
 
     if (!includeDeleted) {
       query = query.whereNull('deletedAt')

--- a/lib/jobs/generateFitnessHeatmapJob.ts
+++ b/lib/jobs/generateFitnessHeatmapJob.ts
@@ -9,6 +9,12 @@ import {
   parseFitnessFile
 } from '@/lib/services/fitness-files/parseFitnessFile'
 import type { FitnessCoordinate } from '@/lib/services/fitness-files/parseFitnessFile'
+import {
+  filterCoordinatesToBounds,
+  getRegionBounds,
+  parseRegionsString,
+  serializeRegions
+} from '@/lib/services/fitness-files/regions'
 import { deleteMediaFile, saveMedia } from '@/lib/services/medias'
 import { getAttachmentMediaPath } from '@/lib/utils/getAttachmentMediaPath'
 import { logger } from '@/lib/utils/logger'
@@ -19,7 +25,9 @@ const JobData = z.object({
   actorId: z.string(),
   activityType: z.string().nullable(),
   periodType: z.enum(['all_time', 'yearly', 'monthly']),
-  periodKey: z.string()
+  periodKey: z.string(),
+  /** Sorted comma-separated region IDs. Empty string means worldwide. */
+  regions: z.string().optional().default('')
 })
 
 const getPeriodRange = (
@@ -76,9 +84,12 @@ const getFitnessFileBuffer = async (
 export const generateFitnessHeatmapJob = createJobHandle(
   GENERATE_FITNESS_HEATMAP_JOB_NAME,
   async (database, message) => {
-    const { actorId, activityType, periodType, periodKey } = JobData.parse(
-      message.data
-    )
+    const { actorId, activityType, periodType, periodKey, regions } =
+      JobData.parse(message.data)
+
+    const normalizedRegions = serializeRegions(parseRegionsString(regions))
+    const regionIds = parseRegionsString(normalizedRegions)
+    const regionBounds = getRegionBounds(regionIds)
 
     const { periodStart, periodEnd } = getPeriodRange(periodType, periodKey)
 
@@ -96,6 +107,7 @@ export const generateFitnessHeatmapJob = createJobHandle(
         activityType,
         periodType,
         periodKey,
+        regions: normalizedRegions,
         includeDeleted: true
       })
 
@@ -113,6 +125,7 @@ export const generateFitnessHeatmapJob = createJobHandle(
           activityType,
           periodType,
           periodKey,
+          regions: normalizedRegions,
           periodStart,
           periodEnd
         })
@@ -177,7 +190,12 @@ export const generateFitnessHeatmapJob = createJobHandle(
         }
       }
 
-      if (allRouteSegments.length === 0) {
+      // When regions are selected, filter to only keep coordinates within bounds
+      const filteredSegments = regionBounds
+        ? filterCoordinatesToBounds(allRouteSegments, regionBounds)
+        : allRouteSegments
+
+      if (filteredSegments.length === 0) {
         await database.updateFitnessHeatmapStatus({
           id: heatmapId,
           status: 'completed',
@@ -205,14 +223,15 @@ export const generateFitnessHeatmapJob = createJobHandle(
       }
 
       const imageBuffer = await generateHeatmapImage({
-        routeSegments: allRouteSegments
+        routeSegments: filteredSegments,
+        ...(regionBounds ? { regionBounds } : {})
       })
 
       if (!imageBuffer) {
         await database.updateFitnessHeatmapStatus({
           id: heatmapId,
           status: 'completed',
-          activityCount: allRouteSegments.length,
+          activityCount: filteredSegments.length,
           imagePath: null
         })
 
@@ -230,7 +249,8 @@ export const generateFitnessHeatmapJob = createJobHandle(
 
       const imageBytes = new Uint8Array(imageBuffer)
       const activityTypePath = activityType ?? 'all'
-      const fileName = `heatmap-${activityTypePath}-${periodType}_${periodKey}.png`
+      const regionsSuffix = normalizedRegions ? `-${normalizedRegions}` : ''
+      const fileName = `heatmap-${activityTypePath}-${periodType}_${periodKey}${regionsSuffix}.png`
 
       const storedMedia = await saveMedia(database, actor, {
         file: new File([imageBytes], fileName, { type: 'image/png' }),
@@ -247,7 +267,7 @@ export const generateFitnessHeatmapJob = createJobHandle(
         id: heatmapId,
         status: 'completed',
         imagePath,
-        activityCount: allRouteSegments.length
+        activityCount: filteredSegments.length
       })
 
       // Clean up previous heatmap image to avoid orphaned files

--- a/lib/services/fitness-files/generateHeatmapImage.ts
+++ b/lib/services/fitness-files/generateHeatmapImage.ts
@@ -3,7 +3,7 @@ import sharp from 'sharp'
 import { downsamplePrivacySegments } from '@/lib/services/fitness-files/privacy'
 import type { PrivacySegment } from '@/lib/services/fitness-files/privacy'
 
-import type { FitnessCoordinate } from './mapUtils'
+import type { CoordinateBounds, FitnessCoordinate } from './mapUtils'
 import {
   TILE_SIZE,
   calculateBounds,
@@ -16,6 +16,11 @@ export interface GenerateHeatmapImageParams {
   routeSegments: FitnessCoordinate[][]
   width?: number
   height?: number
+  /**
+   * When provided, the map viewport is forced to these bounds instead of
+   * being auto-fitted to the route data. Used for region-based heatmaps.
+   */
+  regionBounds?: CoordinateBounds
 }
 
 const DEFAULT_WIDTH = 1200
@@ -51,7 +56,8 @@ const downsampleRoute = (
 export const generateHeatmapImage = async ({
   routeSegments,
   width = DEFAULT_WIDTH,
-  height = DEFAULT_HEIGHT
+  height = DEFAULT_HEIGHT,
+  regionBounds
 }: GenerateHeatmapImageParams): Promise<Buffer | null> => {
   const validRoutes = routeSegments.filter((route) => route.length >= 2)
   if (validRoutes.length === 0) return null
@@ -59,7 +65,7 @@ export const generateHeatmapImage = async ({
   const allCoordinates = validRoutes.flat()
   if (allCoordinates.length < 2) return null
 
-  const bounds = calculateBounds(allCoordinates)
+  const bounds = regionBounds ?? calculateBounds(allCoordinates)
   if (
     !Number.isFinite(bounds.minLat) ||
     !Number.isFinite(bounds.maxLat) ||

--- a/lib/services/fitness-files/regions.ts
+++ b/lib/services/fitness-files/regions.ts
@@ -1,0 +1,230 @@
+import type { CoordinateBounds } from './mapUtils'
+
+export interface HeatmapRegion {
+  id: string
+  label: string
+  bounds: CoordinateBounds
+}
+
+export const HEATMAP_REGIONS: HeatmapRegion[] = [
+  {
+    id: 'europe',
+    label: 'Europe',
+    bounds: { minLat: 34.0, maxLat: 72.0, minLng: -25.0, maxLng: 45.0 }
+  },
+  {
+    id: 'southeast_asia',
+    label: 'Southeast Asia',
+    bounds: { minLat: -11.0, maxLat: 28.0, minLng: 92.0, maxLng: 141.0 }
+  },
+  {
+    id: 'east_asia',
+    label: 'East Asia',
+    bounds: { minLat: 18.0, maxLat: 53.0, minLng: 100.0, maxLng: 146.0 }
+  },
+  {
+    id: 'south_asia',
+    label: 'South Asia',
+    bounds: { minLat: 5.0, maxLat: 37.0, minLng: 60.0, maxLng: 97.0 }
+  },
+  {
+    id: 'north_america',
+    label: 'North America',
+    bounds: { minLat: 15.0, maxLat: 83.0, minLng: -168.0, maxLng: -52.0 }
+  },
+  {
+    id: 'south_america',
+    label: 'South America',
+    bounds: { minLat: -56.0, maxLat: 13.0, minLng: -82.0, maxLng: -34.0 }
+  },
+  {
+    id: 'africa',
+    label: 'Africa',
+    bounds: { minLat: -35.0, maxLat: 38.0, minLng: -18.0, maxLng: 52.0 }
+  },
+  {
+    id: 'oceania',
+    label: 'Australia / Oceania',
+    bounds: { minLat: -47.0, maxLat: -10.0, minLng: 112.0, maxLng: 180.0 }
+  },
+  {
+    id: 'singapore',
+    label: 'Singapore',
+    bounds: { minLat: 1.15, maxLat: 1.48, minLng: 103.59, maxLng: 104.09 }
+  },
+  {
+    id: 'indonesia',
+    label: 'Indonesia',
+    bounds: { minLat: -11.0, maxLat: 6.0, minLng: 95.0, maxLng: 141.0 }
+  },
+  {
+    id: 'malaysia',
+    label: 'Malaysia',
+    bounds: { minLat: 0.85, maxLat: 7.4, minLng: 99.6, maxLng: 119.3 }
+  },
+  {
+    id: 'thailand',
+    label: 'Thailand',
+    bounds: { minLat: 5.5, maxLat: 20.5, minLng: 97.3, maxLng: 105.7 }
+  },
+  {
+    id: 'vietnam',
+    label: 'Vietnam',
+    bounds: { minLat: 8.3, maxLat: 23.4, minLng: 102.1, maxLng: 109.5 }
+  },
+  {
+    id: 'philippines',
+    label: 'Philippines',
+    bounds: { minLat: 4.5, maxLat: 21.1, minLng: 116.9, maxLng: 126.6 }
+  },
+  {
+    id: 'japan',
+    label: 'Japan',
+    bounds: { minLat: 30.0, maxLat: 46.0, minLng: 129.0, maxLng: 146.0 }
+  },
+  {
+    id: 'south_korea',
+    label: 'South Korea',
+    bounds: { minLat: 33.1, maxLat: 38.7, minLng: 125.9, maxLng: 129.6 }
+  },
+  {
+    id: 'china',
+    label: 'China',
+    bounds: { minLat: 18.0, maxLat: 53.5, minLng: 73.5, maxLng: 135.1 }
+  },
+  {
+    id: 'netherlands',
+    label: 'Netherlands',
+    bounds: { minLat: 50.75, maxLat: 53.57, minLng: 3.35, maxLng: 7.23 }
+  },
+  {
+    id: 'germany',
+    label: 'Germany',
+    bounds: { minLat: 47.2, maxLat: 55.1, minLng: 5.9, maxLng: 15.1 }
+  },
+  {
+    id: 'france',
+    label: 'France',
+    bounds: { minLat: 41.3, maxLat: 51.1, minLng: -5.2, maxLng: 9.6 }
+  },
+  {
+    id: 'uk',
+    label: 'United Kingdom',
+    bounds: { minLat: 49.8, maxLat: 60.9, minLng: -8.2, maxLng: 2.0 }
+  },
+  {
+    id: 'spain',
+    label: 'Spain',
+    bounds: { minLat: 35.9, maxLat: 43.8, minLng: -9.3, maxLng: 4.4 }
+  },
+  {
+    id: 'italy',
+    label: 'Italy',
+    bounds: { minLat: 36.6, maxLat: 47.1, minLng: 6.6, maxLng: 18.5 }
+  },
+  {
+    id: 'switzerland',
+    label: 'Switzerland',
+    bounds: { minLat: 45.8, maxLat: 47.8, minLng: 5.9, maxLng: 10.5 }
+  },
+  {
+    id: 'usa',
+    label: 'United States',
+    bounds: { minLat: 24.4, maxLat: 49.4, minLng: -125.0, maxLng: -66.9 }
+  },
+  {
+    id: 'canada',
+    label: 'Canada',
+    bounds: { minLat: 41.7, maxLat: 83.1, minLng: -141.0, maxLng: -52.6 }
+  },
+  {
+    id: 'australia',
+    label: 'Australia',
+    bounds: { minLat: -43.7, maxLat: -10.7, minLng: 113.3, maxLng: 153.6 }
+  },
+  {
+    id: 'new_zealand',
+    label: 'New Zealand',
+    bounds: { minLat: -47.3, maxLat: -34.4, minLng: 166.4, maxLng: 178.6 }
+  }
+]
+
+export const HEATMAP_REGION_MAP = new Map<string, HeatmapRegion>(
+  HEATMAP_REGIONS.map((r) => [r.id, r])
+)
+
+/**
+ * Convert a sorted, comma-separated regions string to an array of region IDs.
+ * Empty string means no region filter (worldwide).
+ */
+export const parseRegionsString = (regions: string): string[] => {
+  if (!regions) return []
+  return regions.split(',').filter(Boolean)
+}
+
+/**
+ * Convert an array of region IDs to a normalized, sorted comma-separated string
+ * for storage in the database.
+ */
+export const serializeRegions = (regionIds: string[]): string =>
+  [...regionIds].sort().join(',')
+
+/**
+ * Compute the union bounding box for a list of region IDs.
+ * Returns null if no valid regions are found (meaning no filter / worldwide).
+ */
+export const getRegionBounds = (
+  regionIds: string[]
+): CoordinateBounds | null => {
+  if (regionIds.length === 0) return null
+
+  const validRegions = regionIds
+    .map((id) => HEATMAP_REGION_MAP.get(id))
+    .filter((r): r is HeatmapRegion => r !== undefined)
+
+  if (validRegions.length === 0) return null
+
+  const bounds: CoordinateBounds = {
+    minLat: Number.POSITIVE_INFINITY,
+    maxLat: Number.NEGATIVE_INFINITY,
+    minLng: Number.POSITIVE_INFINITY,
+    maxLng: Number.NEGATIVE_INFINITY
+  }
+
+  for (const region of validRegions) {
+    bounds.minLat = Math.min(bounds.minLat, region.bounds.minLat)
+    bounds.maxLat = Math.max(bounds.maxLat, region.bounds.maxLat)
+    bounds.minLng = Math.min(bounds.minLng, region.bounds.minLng)
+    bounds.maxLng = Math.max(bounds.maxLng, region.bounds.maxLng)
+  }
+
+  return bounds
+}
+
+/**
+ * Filter route segments to only keep coordinates within the given bounds,
+ * splitting on gaps where points leave the region.
+ */
+export const filterCoordinatesToBounds = <
+  T extends { lat: number; lng: number }
+>(
+  segments: T[][],
+  bounds: CoordinateBounds
+): T[][] => {
+  const result: T[][] = []
+
+  for (const segment of segments) {
+    const filtered = segment.filter(
+      (p) =>
+        p.lat >= bounds.minLat &&
+        p.lat <= bounds.maxLat &&
+        p.lng >= bounds.minLng &&
+        p.lng <= bounds.maxLng
+    )
+    if (filtered.length >= 2) {
+      result.push(filtered)
+    }
+  }
+
+  return result
+}

--- a/lib/types/database/fitnessHeatmap.ts
+++ b/lib/types/database/fitnessHeatmap.ts
@@ -11,6 +11,7 @@ export interface SQLFitnessHeatmap {
   activityType: string | null
   periodType: string
   periodKey: string
+  regions: string
   periodStart: Date | string | number | null
   periodEnd: Date | string | number | null
   imagePath: string | null
@@ -28,6 +29,8 @@ export interface FitnessHeatmap {
   activityType?: string
   periodType: FitnessHeatmapPeriodType
   periodKey: string
+  /** Sorted comma-separated region IDs. Empty string means worldwide (no filter). */
+  regions: string
   periodStart?: number
   periodEnd?: number
   imagePath?: string

--- a/migrations/20260407010000_add_regions_to_fitness_heatmaps.js
+++ b/migrations/20260407010000_add_regions_to_fitness_heatmaps.js
@@ -1,0 +1,42 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  // Add the regions column (sorted comma-separated region IDs, empty = worldwide)
+  await knex.schema.alterTable('fitness_heatmaps', function (table) {
+    table.string('regions').notNullable().defaultTo('')
+  })
+
+  // Drop the old unique constraint and recreate with regions included.
+  // SQLite does not support DROP CONSTRAINT, so we use dropUnique which maps
+  // to DROP INDEX in SQLite and ALTER TABLE DROP CONSTRAINT in Postgres.
+  await knex.schema.alterTable('fitness_heatmaps', function (table) {
+    table.dropUnique(['actorId', 'activityType', 'periodType', 'periodKey'])
+    table.unique([
+      'actorId',
+      'activityType',
+      'periodType',
+      'periodKey',
+      'regions'
+    ])
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable('fitness_heatmaps', function (table) {
+    table.dropUnique([
+      'actorId',
+      'activityType',
+      'periodType',
+      'periodKey',
+      'regions'
+    ])
+    table.unique(['actorId', 'activityType', 'periodType', 'periodKey'])
+    table.dropColumn('regions')
+  })
+}


### PR DESCRIPTION
Add a multi-select region dropdown to the heatmap page that restricts
the map viewport and route data to one or more geographic regions
(e.g. Singapore, Netherlands, Europe, Southeast Asia).

- Define 28 predefined regions with bounding boxes in regions.ts
- Add `regions` column to fitness_heatmaps table (migration)
- Filter route coordinates to region bounds before generating the image
- Override the map viewport to the union of selected region bounds
- Store the normalized (sorted, comma-joined) region key as part of the
  unique heatmap record so each region combination is cached separately
- Expose `regions` param in the GET /fitness-heatmap API route
- Add tag-based multi-select UI to the heatmap page

https://claude.ai/code/session_01653P9xpk4GKyG42SYyuK4g