### PR TITLE
minor: add heatmap list with status, retry, and error display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ backups/
 .gemini
 .playwright-mcp
 AGENTS.override.md
+
+# Git worktrees
+.worktrees/

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -292,16 +292,21 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
     async (h: FitnessHeatmapData) => {
       setGenerationPending(true)
       try {
-        await triggerFitnessHeatmap({
+        const success = await triggerFitnessHeatmap({
           actorId,
           activityType: h.activityType,
           periodType: h.periodType as PeriodType,
           periodKey: h.periodKey,
-          region: h.region || null
+          region: h.region || undefined
         })
-      } catch {
+        if (!success) {
+          throw new Error('Failed to enqueue retry. Please try again.')
+        }
+      } catch (err) {
         setGenerationPending(false)
-        throw new Error('Failed to enqueue retry. Please try again.')
+        throw err instanceof Error
+          ? err
+          : new Error('Failed to enqueue retry. Please try again.')
       }
       getFitnessHeatmaps({ actorId })
         .then(setHeatmaps)
@@ -454,6 +459,10 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
                     setIsDetailRetrying(true)
                     try {
                       await handleRetry(heatmapData)
+                    } catch (err) {
+                      setError(
+                        err instanceof Error ? err.message : 'Retry failed.'
+                      )
                     } finally {
                       setIsDetailRetrying(false)
                     }

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { RefreshCw } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
@@ -8,14 +9,16 @@ import {
   getDistinctFitnessActivityTypes,
   getFitnessCalendarData,
   getFitnessHeatmap,
+  getFitnessHeatmaps,
   triggerFitnessHeatmap
 } from '@/lib/client'
 import {
   CalendarMetric,
   FitnessCalendarHeatmap
 } from '@/lib/components/fitness/FitnessCalendarHeatmap'
+import { FitnessHeatmapList } from '@/lib/components/fitness/FitnessHeatmapList'
 import { RegionSelector } from '@/lib/components/fitness/RegionSelector'
-import { serializeRegions } from '@/lib/fitness/regions'
+import { deserializeRegions, serializeRegions } from '@/lib/fitness/regions'
 
 type PeriodType = 'all_time' | 'yearly' | 'monthly'
 
@@ -101,6 +104,14 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
   // don't fire duplicate POST requests on every fetchData re-run.
   const generationKeyRef = useRef<string | null>(null)
 
+  const [heatmaps, setHeatmaps] = useState<FitnessHeatmapData[]>([])
+  const [currentTime, setCurrentTime] = useState<number>(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setCurrentTime(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+
   useEffect(() => {
     getDistinctFitnessActivityTypes({ actorId })
       .then(setActivityTypes)
@@ -133,7 +144,7 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
         effectivePeriodKey
       )
 
-      const [heatmap, calendar] = await Promise.all([
+      const [heatmap, calendar, allHeatmaps] = await Promise.all([
         getFitnessHeatmap({
           actorId,
           activityType,
@@ -146,11 +157,13 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
           startDate,
           endDate,
           activityType
-        })
+        }),
+        getFitnessHeatmaps({ actorId })
       ])
 
       setHeatmapData(heatmap)
       setCalendarDays(calendar)
+      setHeatmaps(allHeatmaps)
 
       // If no heatmap exists yet and a region filter is active, trigger
       // on-demand generation (only once per unique param combination).
@@ -184,7 +197,11 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
   // Poll every 5 s while a generation job is in flight (either we triggered it
   // ourselves, or the server already has it in "generating" status).
   useEffect(() => {
-    if (!generationPending && heatmapData?.status !== 'generating') return
+    const hasInFlight =
+      generationPending ||
+      heatmapData?.status === 'generating' ||
+      heatmaps.some((h) => h.status === 'generating' || h.status === 'pending')
+    if (!hasInFlight) return
 
     const id = setInterval(() => {
       getFitnessHeatmap({
@@ -203,12 +220,16 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
         .catch(() => {
           // Ignore transient poll errors
         })
+      getFitnessHeatmaps({ actorId })
+        .then(setHeatmaps)
+        .catch(() => {})
     }, 5000)
 
     return () => clearInterval(id)
   }, [
     generationPending,
     heatmapData?.status,
+    heatmaps,
     actorId,
     selectedType,
     periodType,
@@ -245,6 +266,32 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
       setPeriodKey(options.includes(newKey) ? newKey : options[0])
     }
   }
+
+  const handleSelectHeatmap = useCallback((h: FitnessHeatmapData) => {
+    setSelectedType(h.activityType ?? '')
+    setPeriodType(h.periodType as PeriodType)
+    setPeriodKey(h.periodKey)
+    if (h.periodType === 'yearly') setSelectedYear(parseInt(h.periodKey, 10))
+    if (h.periodType === 'monthly')
+      setSelectedYear(parseInt(h.periodKey.split('-')[0], 10))
+    setSelectedRegionIds(h.region ? deserializeRegions(h.region) : [])
+  }, [])
+
+  const handleRetry = useCallback(
+    async (h: FitnessHeatmapData) => {
+      await triggerFitnessHeatmap({
+        actorId,
+        activityType: h.activityType,
+        periodType: h.periodType as PeriodType,
+        periodKey: h.periodKey,
+        region: h.region || null
+      })
+      getFitnessHeatmaps({ actorId })
+        .then(setHeatmaps)
+        .catch(() => {})
+    },
+    [actorId]
+  )
 
   return (
     <div className="space-y-6 p-2 sm:p-4">
@@ -329,6 +376,17 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
         </div>
       </div>
 
+      {/* Heatmap list */}
+      <div className="space-y-2">
+        <h2 className="text-lg font-medium">Heatmaps</h2>
+        <FitnessHeatmapList
+          heatmaps={heatmaps}
+          onSelect={handleSelectHeatmap}
+          onRetry={handleRetry}
+          currentTime={currentTime}
+        />
+      </div>
+
       {isLoading && (
         <p className="text-center text-muted-foreground">Loading...</p>
       )}
@@ -364,9 +422,23 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
               </p>
             )}
             {heatmapData && heatmapData.status === 'failed' && (
-              <p className="py-8 text-center text-sm text-red-600 dark:text-red-400">
-                Heatmap generation failed. Try regenerating.
-              </p>
+              <div className="py-4 text-center text-sm">
+                <p className="text-red-600 dark:text-red-400">
+                  Heatmap generation failed.
+                </p>
+                {heatmapData.error && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {heatmapData.error}
+                  </p>
+                )}
+                <button
+                  onClick={() => handleRetry(heatmapData)}
+                  className="mt-2 inline-flex items-center gap-1 rounded border px-2 py-1 text-xs hover:bg-muted"
+                >
+                  <RefreshCw className="size-3" />
+                  Retry
+                </button>
+              </div>
             )}
             {heatmapData &&
               heatmapData.status === 'completed' &&

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -106,6 +106,7 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
 
   const [heatmaps, setHeatmaps] = useState<FitnessHeatmapData[]>([])
   const [currentTime, setCurrentTime] = useState<number>(() => Date.now())
+  const [isDetailRetrying, setIsDetailRetrying] = useState(false)
 
   useEffect(() => {
     const id = setInterval(() => setCurrentTime(Date.now()), 60_000)
@@ -194,13 +195,23 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
     fetchData()
   }, [fetchData])
 
+  // Stable boolean: true when any list entry is still in-flight.
+  // Using a derived primitive prevents the polling effect from tearing down
+  // its interval on every setHeatmaps call.
+  const hasAnyListInFlight = useMemo(
+    () =>
+      heatmaps.some((h) => h.status === 'generating' || h.status === 'pending'),
+    [heatmaps]
+  )
+
   // Poll every 5 s while a generation job is in flight (either we triggered it
-  // ourselves, or the server already has it in "generating" status).
+  // ourselves, or the server already has it in "generating"/"pending" status).
   useEffect(() => {
     const hasInFlight =
       generationPending ||
       heatmapData?.status === 'generating' ||
-      heatmaps.some((h) => h.status === 'generating' || h.status === 'pending')
+      heatmapData?.status === 'pending' ||
+      hasAnyListInFlight
     if (!hasInFlight) return
 
     const id = setInterval(() => {
@@ -229,7 +240,7 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
   }, [
     generationPending,
     heatmapData?.status,
-    heatmaps,
+    hasAnyListInFlight,
     actorId,
     selectedType,
     periodType,
@@ -432,10 +443,20 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
                   </p>
                 )}
                 <button
-                  onClick={() => handleRetry(heatmapData)}
-                  className="mt-2 inline-flex items-center gap-1 rounded border px-2 py-1 text-xs hover:bg-muted"
+                  disabled={isDetailRetrying}
+                  onClick={async () => {
+                    setIsDetailRetrying(true)
+                    try {
+                      await handleRetry(heatmapData)
+                    } finally {
+                      setIsDetailRetrying(false)
+                    }
+                  }}
+                  className="mt-2 inline-flex items-center gap-1 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
                 >
-                  <RefreshCw className="size-3" />
+                  <RefreshCw
+                    className={`size-3${isDetailRetrying ? ' animate-spin' : ''}`}
+                  />
                   Retry
                 </button>
               </div>

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -290,13 +290,19 @@ export const FitnessHeatmapView: FC<Props> = ({ actorId }) => {
 
   const handleRetry = useCallback(
     async (h: FitnessHeatmapData) => {
-      await triggerFitnessHeatmap({
-        actorId,
-        activityType: h.activityType,
-        periodType: h.periodType as PeriodType,
-        periodKey: h.periodKey,
-        region: h.region || null
-      })
+      setGenerationPending(true)
+      try {
+        await triggerFitnessHeatmap({
+          actorId,
+          activityType: h.activityType,
+          periodType: h.periodType as PeriodType,
+          periodKey: h.periodKey,
+          region: h.region || null
+        })
+      } catch {
+        setGenerationPending(false)
+        throw new Error('Failed to enqueue retry. Please try again.')
+      }
       getFitnessHeatmaps({ actorId })
         .then(setHeatmaps)
         .catch(() => {})

--- a/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
@@ -123,6 +123,8 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
   })
 
   it('returns 200 with heatmap data for valid request', async () => {
+    const createdTime = Date.now()
+    const updatedTime = Date.now() + 1000
     const heatmapData = {
       id: 'heatmap-1',
       actorId: ACTOR1_ID,
@@ -133,8 +135,8 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
       status: 'completed' as const,
       imagePath: 'heatmaps/actor1/yearly_2025.png',
       activityCount: 42,
-      createdAt: Date.now(),
-      updatedAt: Date.now()
+      createdAt: createdTime,
+      updatedAt: updatedTime
     }
 
     mockDb.getFitnessHeatmapByKey.mockResolvedValue(heatmapData)
@@ -156,7 +158,10 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
       region: '',
       status: 'completed',
       imagePath: 'heatmaps/actor1/yearly_2025.png',
-      activityCount: 42
+      activityCount: 42,
+      error: null,
+      createdAt: createdTime,
+      updatedAt: updatedTime
     })
 
     expect(mockDb.getFitnessHeatmapByKey).toHaveBeenCalledWith({
@@ -287,5 +292,35 @@ describe('GET /api/v1/accounts/[id]/fitness-heatmap', () => {
     expect(response.status).toBe(500)
 
     mockDatabase = mockDb
+  })
+
+  it('returns error message from failed heatmap', async () => {
+    const heatmapData = {
+      id: 'heatmap-5',
+      actorId: ACTOR1_ID,
+      activityType: 'running',
+      periodType: 'yearly' as const,
+      periodKey: '2025',
+      region: '',
+      status: 'failed' as const,
+      imagePath: null,
+      activityCount: 0,
+      error: 'OOM while rendering',
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    }
+
+    mockDb.getFitnessHeatmapByKey.mockResolvedValue(heatmapData)
+
+    const request = new NextRequest(
+      `${baseUrl}?period_type=yearly&period_key=2025&activity_type=running`
+    )
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.error).toBe('OOM while rendering')
   })
 })

--- a/app/api/v1/accounts/[id]/fitness-heatmap/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmap/route.ts
@@ -149,7 +149,10 @@ export const GET = traceApiRoute(
         region: heatmap.region,
         status: heatmap.status,
         imagePath: heatmap.imagePath,
-        activityCount: heatmap.activityCount
+        activityCount: heatmap.activityCount,
+        error: heatmap.error ?? null,
+        createdAt: heatmap.createdAt,
+        updatedAt: heatmap.updatedAt
       }
     })
   },

--- a/app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts
@@ -1,0 +1,186 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+const mockGetActorFromSession = jest.fn()
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: (...args: unknown[]) => mockGetActorFromSession(...args)
+}))
+
+type MockDatabase = Pick<Database, 'getFitnessHeatmapsForActor'>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('GET /api/v1/accounts/[id]/fitness-heatmaps', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getFitnessHeatmapsForActor: jest.fn()
+  }
+
+  const encodedId = ACTOR1_ID.replace('https://', '').replaceAll('/', ':')
+  const baseUrl = `http://llun.test/api/v1/accounts/${encodedId}/fitness-heatmaps`
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockGetActorFromSession.mockResolvedValue({
+      ...seedActor1,
+      id: ACTOR1_ID
+    })
+    mockDb.getFitnessHeatmapsForActor.mockResolvedValue([])
+  })
+
+  it('returns 401 when not logged in', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 401 when session has no actor', async () => {
+    mockGetActorFromSession.mockResolvedValue(null)
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 403 when requesting another actors data', async () => {
+    mockGetActorFromSession.mockResolvedValue({
+      ...seedActor1,
+      id: 'https://llun.test/users/other'
+    })
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+    expect(response.status).toBe(403)
+  })
+
+  it('returns 200 with empty heatmaps array', async () => {
+    mockDb.getFitnessHeatmapsForActor.mockResolvedValue([])
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual({ heatmaps: [] })
+  })
+
+  it('returns 200 with full heatmap list including error field', async () => {
+    const createdTime = Date.now()
+    const updatedTime = Date.now() + 1000
+
+    const heatmaps = [
+      {
+        id: 'heatmap-1',
+        actorId: ACTOR1_ID,
+        activityType: 'running',
+        periodType: 'yearly' as const,
+        periodKey: '2025',
+        region: '',
+        status: 'completed' as const,
+        imagePath: 'heatmaps/actor1/yearly_2025.png',
+        activityCount: 42,
+        error: null,
+        createdAt: createdTime,
+        updatedAt: updatedTime
+      },
+      {
+        id: 'heatmap-2',
+        actorId: ACTOR1_ID,
+        activityType: 'cycling',
+        periodType: 'monthly' as const,
+        periodKey: '2025-03',
+        region: 'netherlands',
+        status: 'failed' as const,
+        imagePath: null,
+        activityCount: 0,
+        error: 'boom',
+        createdAt: createdTime,
+        updatedAt: updatedTime
+      }
+    ]
+
+    mockDb.getFitnessHeatmapsForActor.mockResolvedValue(heatmaps)
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual({
+      heatmaps: [
+        {
+          id: 'heatmap-1',
+          activityType: 'running',
+          periodType: 'yearly',
+          periodKey: '2025',
+          region: '',
+          status: 'completed',
+          imagePath: 'heatmaps/actor1/yearly_2025.png',
+          activityCount: 42,
+          error: null,
+          createdAt: createdTime,
+          updatedAt: updatedTime
+        },
+        {
+          id: 'heatmap-2',
+          activityType: 'cycling',
+          periodType: 'monthly',
+          periodKey: '2025-03',
+          region: 'netherlands',
+          status: 'failed',
+          imagePath: null,
+          activityCount: 0,
+          error: 'boom',
+          createdAt: createdTime,
+          updatedAt: updatedTime
+        }
+      ]
+    })
+
+    expect(mockDb.getFitnessHeatmapsForActor).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID
+    })
+  })
+
+  it('returns 500 when database is not available', async () => {
+    mockDatabase = null
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+    expect(response.status).toBe(500)
+
+    mockDatabase = mockDb
+  })
+})

--- a/app/api/v1/accounts/[id]/fitness-heatmaps/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmaps/route.ts
@@ -1,0 +1,99 @@
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { AppRouterParams } from '@/lib/services/guards/types'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_401,
+  ERROR_403,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const GET = traceApiRoute(
+  'getAccountFitnessHeatmaps',
+  async (req, params: AppRouterParams<Params>) => {
+    const session = await getServerAuthSession()
+    if (!session?.user?.email) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const currentActor = await getActorFromSession(database, session)
+    if (!currentActor) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const { id: encodedAccountId } = await params.params
+    const id = idToUrl(encodedAccountId)
+
+    if (currentActor.id !== id) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: 403
+      })
+    }
+
+    const heatmaps = await database.getFitnessHeatmapsForActor({
+      actorId: id
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: {
+        heatmaps: heatmaps.map((h) => ({
+          id: h.id,
+          activityType: h.activityType,
+          periodType: h.periodType,
+          periodKey: h.periodKey,
+          region: h.region,
+          status: h.status,
+          imagePath: h.imagePath,
+          activityCount: h.activityCount,
+          error: h.error ?? null,
+          createdAt: h.createdAt,
+          updatedAt: h.updatedAt
+        }))
+      }
+    })
+  },
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { accountId: params?.id || 'unknown' }
+    }
+  }
+)

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1130,6 +1130,9 @@ export interface FitnessHeatmapData {
   status: string
   imagePath?: string
   activityCount: number
+  error?: string | null
+  createdAt: number
+  updatedAt: number
 }
 
 export interface FitnessCalendarDay {
@@ -1202,6 +1205,24 @@ export const triggerFitnessHeatmap = async ({
     }
   )
   return response.ok
+}
+
+export const getFitnessHeatmaps = async ({
+  actorId
+}: {
+  actorId: string
+}): Promise<FitnessHeatmapData[]> => {
+  const encodedId = urlToId(actorId)
+  const response = await fetch(
+    `${window.origin}/api/v1/accounts/${encodedId}/fitness-heatmaps`,
+    {
+      method: 'GET',
+      headers: { Accept: 'application/json' }
+    }
+  )
+  if (!response.ok) return []
+  const json = await response.json()
+  return json.heatmaps as FitnessHeatmapData[]
 }
 
 export const getFitnessCalendarData = async ({

--- a/lib/components/fitness/FitnessHeatmapList.test.tsx
+++ b/lib/components/fitness/FitnessHeatmapList.test.tsx
@@ -102,8 +102,8 @@ describe('FitnessHeatmapList', () => {
       />
     )
 
-    // Click the row — it's a div[role=button] containing "All · 2025"
-    const rowButton = screen.getByText('All · 2025').closest('[role="button"]')
+    // Click the row — it's a button containing "All · 2025"
+    const rowButton = screen.getByText('All · 2025').closest('button')
     expect(rowButton).not.toBeNull()
     fireEvent.click(rowButton!)
 

--- a/lib/components/fitness/FitnessHeatmapList.test.tsx
+++ b/lib/components/fitness/FitnessHeatmapList.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+import { FitnessHeatmapData } from '@/lib/client'
+
+import { FitnessHeatmapList } from './FitnessHeatmapList'
+
+const makeMockHeatmap = (
+  overrides: Partial<FitnessHeatmapData> = {}
+): FitnessHeatmapData => ({
+  id: 'heatmap-1',
+  periodType: 'yearly',
+  periodKey: '2025',
+  region: '',
+  status: 'completed',
+  activityCount: 10,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  ...overrides
+})
+
+const CURRENT_TIME = 1_700_000_060_000
+
+describe('FitnessHeatmapList', () => {
+  it('renders empty state when no heatmaps', () => {
+    render(
+      <FitnessHeatmapList
+        heatmaps={[]}
+        onSelect={jest.fn()}
+        onRetry={jest.fn()}
+        currentTime={CURRENT_TIME}
+      />
+    )
+    expect(screen.getByText('No heatmaps yet.')).toBeInTheDocument()
+  })
+
+  it('shows active section with in-progress and failed heatmaps', () => {
+    const generating = makeMockHeatmap({
+      id: 'heatmap-gen',
+      status: 'generating'
+    })
+    const failed = makeMockHeatmap({ id: 'heatmap-fail', status: 'failed' })
+
+    render(
+      <FitnessHeatmapList
+        heatmaps={[generating, failed]}
+        onSelect={jest.fn()}
+        onRetry={jest.fn()}
+        currentTime={CURRENT_TIME}
+      />
+    )
+
+    expect(screen.getByText('In Progress & Failed')).toBeInTheDocument()
+    expect(screen.getByText('Generating…')).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+  })
+
+  it('completed section is collapsed by default and can be toggled', () => {
+    const completed = makeMockHeatmap({
+      id: 'heatmap-done',
+      status: 'completed',
+      periodKey: '2025'
+    })
+
+    render(
+      <FitnessHeatmapList
+        heatmaps={[completed]}
+        onSelect={jest.fn()}
+        onRetry={jest.fn()}
+        currentTime={CURRENT_TIME}
+      />
+    )
+
+    // Completed section button should be present
+    const toggleBtn = screen.getByRole('button', { name: /Completed/i })
+    expect(toggleBtn).toBeInTheDocument()
+
+    // The row content (display name) should NOT be visible initially
+    // The row buttons are rendered inside the toggle, so "All · 2025" text should be absent
+    expect(screen.queryByText('All · 2025')).not.toBeInTheDocument()
+
+    // Toggle open
+    fireEvent.click(toggleBtn)
+
+    // Now the row should be visible
+    expect(screen.getByText('All · 2025')).toBeInTheDocument()
+  })
+
+  it('clicking a row calls onSelect with that heatmap', () => {
+    const onSelect = jest.fn()
+    const heatmap = makeMockHeatmap({ id: 'heatmap-active', status: 'pending' })
+
+    render(
+      <FitnessHeatmapList
+        heatmaps={[heatmap]}
+        onSelect={onSelect}
+        onRetry={jest.fn()}
+        currentTime={CURRENT_TIME}
+      />
+    )
+
+    // Click the row — it's a div[role=button] containing "All · 2025"
+    const rowButton = screen.getByText('All · 2025').closest('[role="button"]')
+    expect(rowButton).not.toBeNull()
+    fireEvent.click(rowButton!)
+
+    expect(onSelect).toHaveBeenCalledWith(heatmap)
+  })
+
+  it('clicking retry button calls onRetry and not onSelect', async () => {
+    const onSelect = jest.fn()
+    const onRetry = jest.fn().mockResolvedValue(undefined)
+    const heatmap = makeMockHeatmap({
+      id: 'heatmap-fail',
+      status: 'failed',
+      error: 'Something went wrong'
+    })
+
+    render(
+      <FitnessHeatmapList
+        heatmaps={[heatmap]}
+        onSelect={onSelect}
+        onRetry={onRetry}
+        currentTime={CURRENT_TIME}
+      />
+    )
+
+    // The Retry button is a real <button> element (not a div[role=button] row)
+    const retryBtn = screen
+      .getAllByRole('button')
+      .find(
+        (el) =>
+          el.tagName === 'BUTTON' && el.textContent?.trim().includes('Retry')
+      )
+    expect(retryBtn).toBeDefined()
+
+    await act(async () => {
+      fireEvent.click(retryBtn!)
+    })
+
+    expect(onRetry).toHaveBeenCalledWith(heatmap)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('generating row shows animate-spin icon label', () => {
+    const heatmap = makeMockHeatmap({
+      id: 'heatmap-gen',
+      status: 'generating'
+    })
+
+    render(
+      <FitnessHeatmapList
+        heatmaps={[heatmap]}
+        onSelect={jest.fn()}
+        onRetry={jest.fn()}
+        currentTime={CURRENT_TIME}
+      />
+    )
+
+    expect(screen.getByText('Generating…')).toBeInTheDocument()
+  })
+})

--- a/lib/components/fitness/FitnessHeatmapList.tsx
+++ b/lib/components/fitness/FitnessHeatmapList.tsx
@@ -65,8 +65,9 @@ const RetryButton: FC<RetryButtonProps> = ({ heatmap, onRetry }) => {
           try {
             await onRetry(heatmap)
           } catch {
-            setIsRetrying(false)
             setError('Retry failed. Please try again.')
+          } finally {
+            setIsRetrying(false)
           }
         }}
       >
@@ -132,37 +133,31 @@ const HeatmapRow: FC<HeatmapRowProps> = ({
   })()
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      className="w-full text-left p-2 rounded hover:bg-muted flex flex-col gap-1 cursor-pointer"
-      onClick={() => onSelect(heatmap)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onSelect(heatmap)
-        }
-      }}
-    >
-      <div className="flex items-center gap-1.5 text-xs">
-        {statusIcon}
-        {statusLabel}
-        <span className="text-muted-foreground ml-auto">
-          {formatRelativeTime(currentTime - heatmap.updatedAt)}
-        </span>
-      </div>
-      <div className="text-sm">
-        {formatActivityType(heatmap.activityType)} ·{' '}
-        {formatPeriod(heatmap.periodType, heatmap.periodKey)}
-      </div>
-      {regionLabel && (
-        <span className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-          {regionLabel}
-        </span>
-      )}
-      {heatmap.status === 'failed' && heatmap.error && (
-        <p className="text-xs text-destructive">{heatmap.error}</p>
-      )}
+    <div className="flex items-start gap-2 rounded p-2 hover:bg-muted">
+      <button
+        className="flex flex-1 flex-col gap-1 text-left"
+        onClick={() => onSelect(heatmap)}
+      >
+        <div className="flex items-center gap-1.5 text-xs">
+          {statusIcon}
+          {statusLabel}
+          <span className="ml-auto text-muted-foreground">
+            {formatRelativeTime(currentTime - heatmap.updatedAt)}
+          </span>
+        </div>
+        <div className="text-sm">
+          {formatActivityType(heatmap.activityType)} ·{' '}
+          {formatPeriod(heatmap.periodType, heatmap.periodKey)}
+        </div>
+        {regionLabel && (
+          <span className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+            {regionLabel}
+          </span>
+        )}
+        {heatmap.status === 'failed' && heatmap.error && (
+          <p className="text-xs text-destructive">{heatmap.error}</p>
+        )}
+      </button>
       {heatmap.status === 'failed' && (
         <RetryButton heatmap={heatmap} onRetry={onRetry} />
       )}

--- a/lib/components/fitness/FitnessHeatmapList.tsx
+++ b/lib/components/fitness/FitnessHeatmapList.tsx
@@ -138,24 +138,26 @@ const HeatmapRow: FC<HeatmapRowProps> = ({
         className="flex flex-1 flex-col gap-1 text-left"
         onClick={() => onSelect(heatmap)}
       >
-        <div className="flex items-center gap-1.5 text-xs">
+        <span className="flex items-center gap-1.5 text-xs">
           {statusIcon}
           {statusLabel}
           <span className="ml-auto text-muted-foreground">
             {formatRelativeTime(currentTime - heatmap.updatedAt)}
           </span>
-        </div>
-        <div className="text-sm">
+        </span>
+        <span className="text-sm">
           {formatActivityType(heatmap.activityType)} ·{' '}
           {formatPeriod(heatmap.periodType, heatmap.periodKey)}
-        </div>
+        </span>
         {regionLabel && (
           <span className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
             {regionLabel}
           </span>
         )}
         {heatmap.status === 'failed' && heatmap.error && (
-          <p className="text-xs text-destructive">{heatmap.error}</p>
+          <span className="block text-xs text-destructive">
+            {heatmap.error}
+          </span>
         )}
       </button>
       {heatmap.status === 'failed' && (

--- a/lib/components/fitness/FitnessHeatmapList.tsx
+++ b/lib/components/fitness/FitnessHeatmapList.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  RefreshCw
+} from 'lucide-react'
+import { FC, useState } from 'react'
+
+import { FitnessHeatmapData } from '@/lib/client'
+import { REGION_MAP } from '@/lib/fitness/regions'
+import { cn } from '@/lib/utils'
+
+interface FitnessHeatmapListProps {
+  heatmaps: FitnessHeatmapData[]
+  onSelect: (heatmap: FitnessHeatmapData) => void
+  onRetry: (heatmap: FitnessHeatmapData) => Promise<void>
+  currentTime: number
+}
+
+const formatActivityType = (type?: string): string =>
+  type
+    ? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : 'All'
+
+const formatPeriod = (periodType: string, periodKey: string): string => {
+  if (periodType === 'all_time') return 'All time'
+  return periodKey
+}
+
+const formatRelativeTime = (diffMs: number): string => {
+  if (diffMs < 60_000) return 'just now'
+  if (diffMs < 3_600_000) return `${Math.floor(diffMs / 60_000)}m ago`
+  if (diffMs < 86_400_000) return `${Math.floor(diffMs / 3_600_000)}h ago`
+  return `${Math.floor(diffMs / 86_400_000)}d ago`
+}
+
+interface RetryButtonProps {
+  heatmap: FitnessHeatmapData
+  onRetry: (heatmap: FitnessHeatmapData) => Promise<void>
+}
+
+const RetryButton: FC<RetryButtonProps> = ({ heatmap, onRetry }) => {
+  const [isRetrying, setIsRetrying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  return (
+    <span className="inline-flex flex-col gap-0.5">
+      <button
+        className={cn(
+          'inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium',
+          'text-muted-foreground hover:bg-muted hover:text-foreground transition-colors',
+          isRetrying && 'pointer-events-none opacity-50'
+        )}
+        disabled={isRetrying}
+        onClick={async (e) => {
+          e.stopPropagation()
+          e.preventDefault()
+          setIsRetrying(true)
+          setError(null)
+          try {
+            await onRetry(heatmap)
+          } catch {
+            setIsRetrying(false)
+            setError('Retry failed. Please try again.')
+          }
+        }}
+      >
+        <RefreshCw className={cn('size-3', isRetrying && 'animate-spin')} />
+        Retry
+      </button>
+      {error && <span className="text-destructive text-xs">{error}</span>}
+    </span>
+  )
+}
+
+interface HeatmapRowProps {
+  heatmap: FitnessHeatmapData
+  onSelect: (heatmap: FitnessHeatmapData) => void
+  onRetry: (heatmap: FitnessHeatmapData) => Promise<void>
+  currentTime: number
+}
+
+const HeatmapRow: FC<HeatmapRowProps> = ({
+  heatmap,
+  onSelect,
+  onRetry,
+  currentTime
+}) => {
+  const regionLabel =
+    heatmap.region && heatmap.region !== ''
+      ? heatmap.region
+          .split(',')
+          .map((id) => REGION_MAP.get(id.trim())?.name ?? id.trim())
+          .join(', ')
+      : null
+
+  const statusIcon = (() => {
+    switch (heatmap.status) {
+      case 'pending':
+        return <Clock className="size-3" />
+      case 'generating':
+        return <Loader2 className="size-3 animate-spin" />
+      case 'completed':
+        return <CheckCircle2 className="size-3" />
+      case 'failed':
+        return <AlertCircle className="size-3 text-destructive" />
+      default:
+        return null
+    }
+  })()
+
+  const statusLabel = (() => {
+    switch (heatmap.status) {
+      case 'pending':
+        return <span className="text-muted-foreground">Queued</span>
+      case 'generating':
+        return (
+          <span className="text-blue-600 dark:text-blue-400">Generating…</span>
+        )
+      case 'completed':
+        return <span className="text-muted-foreground">Completed</span>
+      case 'failed':
+        return <span className="text-destructive">Failed</span>
+      default:
+        return null
+    }
+  })()
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className="w-full text-left p-2 rounded hover:bg-muted flex flex-col gap-1 cursor-pointer"
+      onClick={() => onSelect(heatmap)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect(heatmap)
+        }
+      }}
+    >
+      <div className="flex items-center gap-1.5 text-xs">
+        {statusIcon}
+        {statusLabel}
+        <span className="text-muted-foreground ml-auto">
+          {formatRelativeTime(currentTime - heatmap.updatedAt)}
+        </span>
+      </div>
+      <div className="text-sm">
+        {formatActivityType(heatmap.activityType)} ·{' '}
+        {formatPeriod(heatmap.periodType, heatmap.periodKey)}
+      </div>
+      {regionLabel && (
+        <span className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+          {regionLabel}
+        </span>
+      )}
+      {heatmap.status === 'failed' && heatmap.error && (
+        <p className="text-xs text-destructive">{heatmap.error}</p>
+      )}
+      {heatmap.status === 'failed' && (
+        <RetryButton heatmap={heatmap} onRetry={onRetry} />
+      )}
+    </div>
+  )
+}
+
+export const FitnessHeatmapList: FC<FitnessHeatmapListProps> = ({
+  heatmaps,
+  onSelect,
+  onRetry,
+  currentTime
+}) => {
+  const [isCompletedOpen, setIsCompletedOpen] = useState(false)
+
+  const active = heatmaps
+    .filter((h) => ['pending', 'generating', 'failed'].includes(h.status))
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+
+  const completed = heatmaps
+    .filter((h) => h.status === 'completed')
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+
+  if (active.length === 0 && completed.length === 0) {
+    return <p className="text-sm text-muted-foreground">No heatmaps yet.</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {active.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium text-muted-foreground">
+            In Progress &amp; Failed
+          </p>
+          {active.map((heatmap) => (
+            <HeatmapRow
+              key={heatmap.id}
+              heatmap={heatmap}
+              onSelect={onSelect}
+              onRetry={onRetry}
+              currentTime={currentTime}
+            />
+          ))}
+        </div>
+      )}
+
+      {completed.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <button
+            className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setIsCompletedOpen((prev) => !prev)}
+          >
+            {isCompletedOpen ? (
+              <ChevronDown className="size-3" />
+            ) : (
+              <ChevronRight className="size-3" />
+            )}
+            Completed ({completed.length})
+          </button>
+          {isCompletedOpen &&
+            completed.map((heatmap) => (
+              <HeatmapRow
+                key={heatmap.id}
+                heatmap={heatmap}
+                onSelect={onSelect}
+                onRetry={onRetry}
+                currentTime={currentTime}
+              />
+            ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a **Heatmaps list section** to the fitness heatmap page showing all generated heatmaps (active/failed always visible, completed in a collapsible section)
- Each row shows status icon + label (Queued / Generating… / Completed / Failed), activity type, period, region, and relative timestamp
- **Failed heatmaps** show the error message inline and a Retry button (reuses the existing idempotent POST endpoint)
- The **detail view** also shows the error message and a Retry button when the currently-viewed heatmap has failed
- Clicking a list row sets the selectors (activity, period, region) to match that heatmap, loading it into the existing view
- List polls every 5s while any heatmap is in-progress
- Error logging already existed (`logger.error` in `generateFitnessHeatmapJob`); this PR just surfaces the already-stored `error` field through the API and UI

## New endpoints

- `GET /api/v1/accounts/[id]/fitness-heatmaps` — returns all heatmaps for the actor with `error`, `createdAt`, `updatedAt`
- `GET /api/v1/accounts/[id]/fitness-heatmap` — now also returns `error`, `createdAt`, `updatedAt`

## New files

- `lib/components/fitness/FitnessHeatmapList.tsx` — list component
- `lib/components/fitness/FitnessHeatmapList.test.tsx` — 6 RTL tests
- `app/api/v1/accounts/[id]/fitness-heatmaps/route.ts` — list endpoint
- `app/api/v1/accounts/[id]/fitness-heatmaps/route.test.ts` — 6 route tests

## Test plan

- [ ] All 1525 tests pass (`yarn test`)
- [ ] Build succeeds (`yarn build`)
- [ ] Lint clean (`yarn lint`)
- [ ] Navigate to `/@<actor>/fitness/heatmap` — "Heatmaps" section appears below selectors
- [ ] Completed heatmaps appear in collapsed "Completed (N)" section; clicking the header expands it
- [ ] Clicking a completed row loads that heatmap into the detail view (selectors snap to match)
- [ ] Trigger a region-filtered heatmap — it appears in "In Progress & Failed" as "Generating…" and transitions to "Completed" after polling
- [ ] If a heatmap fails, the row shows the error message and a Retry button; clicking Retry re-enqueues the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)