### PR TITLE
feat: add content warning support

### DIFF
--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -272,7 +272,7 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
               <Posts
                 host={host}
                 className="mt-0"
-                currentTime={new Date()}
+                currentTime={Date.now()}
                 statuses={currentStatuses}
                 currentActor={profile}
                 showActions

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -42,7 +42,7 @@ export const ActorTimelines: FC<Props> = ({
   attachments,
   postLineLimit
 }) => {
-  const currentTime = new Date()
+  const currentTime = Date.now()
 
   const postStatuses = statuses.filter((status) => !isReply(status))
 

--- a/app/(timeline)/[actor]/[status]/StatusBox.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.tsx
@@ -18,7 +18,7 @@ import { StatusLikes } from './StatusLikes'
 interface Props {
   host: string
   mapboxAccessToken?: string
-  currentTime: Date
+  currentTime: number
   currentActor?: ActorProfile | null
   status: Status
   variant?: 'detail' | 'comment'

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -47,7 +47,7 @@ const Page: FC<Props> = async ({ params }) => {
     : null
 
   const { actor, status: statusParam } = await params
-  const currentTime = new Date()
+  const currentTime = Date.now()
   const decodedActor = decodeURIComponent(actor)
   const decodedStatusParam = (() => {
     try {

--- a/app/(timeline)/admin/tags/[tag]/AdminHashtagPosts.tsx
+++ b/app/(timeline)/admin/tags/[tag]/AdminHashtagPosts.tsx
@@ -12,7 +12,7 @@ interface Props {
 export const AdminHashtagPosts = ({ host, statuses, currentTime }: Props) => (
   <Posts
     host={host}
-    currentTime={new Date(currentTime)}
+    currentTime={currentTime}
     statuses={statuses}
     showActions={false}
   />

--- a/app/(timeline)/tags/[tag]/HashtagTimeline.tsx
+++ b/app/(timeline)/tags/[tag]/HashtagTimeline.tsx
@@ -127,7 +127,7 @@ export const HashtagTimeline: FC<HashtagTimelineProps> = ({
           <Posts
             host={host}
             className="mt-0"
-            currentTime={new Date(currentTime)}
+            currentTime={currentTime}
             statuses={currentStatuses}
             currentActor={currentActor}
             showActions={Boolean(currentActor)}

--- a/app/api/v1/accounts/outbox/route.test.ts
+++ b/app/api/v1/accounts/outbox/route.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server'
+
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { DELETE, POST } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => ({})
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn().mockResolvedValue(seedActor1)
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: () => undefined
+  })
+}))
+
+describe('POST /api/v1/accounts/outbox', () => {
+  beforeEach(() => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('returns 400 for invalid JSON', async () => {
+    const req = new NextRequest('http://localhost/api/v1/accounts/outbox', {
+      method: 'POST',
+      body: '{',
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const res = await POST(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('DELETE /api/v1/accounts/outbox', () => {
+  beforeEach(() => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('returns 400 for invalid JSON', async () => {
+    const req = new NextRequest('http://localhost/api/v1/accounts/outbox', {
+      method: 'DELETE',
+      body: '{',
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const res = await DELETE(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/v1/accounts/outbox/route.ts
+++ b/app/api/v1/accounts/outbox/route.ts
@@ -33,8 +33,8 @@ export const POST = traceApiRoute(
   'getAccountOutbox',
   AuthenticatedGuard(async (req, context) => {
     const { currentActor, database } = context
-    const body = await req.json()
     try {
+      const body = await req.json()
       const parsed = PostRequest.safeParse(body)
       if (!parsed.success) {
         return apiResponse({
@@ -136,8 +136,8 @@ export const DELETE = traceApiRoute(
   'deleteAccountOutbox',
   AuthenticatedGuard(async (req, context) => {
     const { currentActor, database } = context
-    const body = await req.json()
     try {
+      const body = await req.json()
       const parsed = DeleteStatusRequest.safeParse(body)
       if (!parsed.success) {
         return apiResponse({

--- a/app/api/v1/accounts/outbox/route.ts
+++ b/app/api/v1/accounts/outbox/route.ts
@@ -35,11 +35,21 @@ export const POST = traceApiRoute(
     const { currentActor, database } = context
     const body = await req.json()
     try {
-      const request = PostRequest.parse(body)
+      const parsed = PostRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const request = parsed.data
       switch (request.type) {
         case 'note': {
           const {
             message,
+            contentWarning,
             replyStatus,
             attachments,
             fitnessFileId,
@@ -48,6 +58,7 @@ export const POST = traceApiRoute(
           const status = await createNoteFromUserInput({
             currentActor,
             text: message,
+            summary: contentWarning,
             replyNoteId: replyStatus?.id,
             attachments,
             fitnessFileId,
@@ -74,6 +85,7 @@ export const POST = traceApiRoute(
         case 'poll': {
           const {
             message,
+            contentWarning,
             replyStatus,
             choices,
             durationInSeconds,
@@ -84,6 +96,7 @@ export const POST = traceApiRoute(
           await createPollFromUserInput({
             currentActor,
             text: message,
+            summary: contentWarning,
             replyStatusId: replyStatus?.id,
             choices,
             endAt,
@@ -125,7 +138,16 @@ export const DELETE = traceApiRoute(
     const { currentActor, database } = context
     const body = await req.json()
     try {
-      const request = DeleteStatusRequest.parse(body)
+      const parsed = DeleteStatusRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const request = parsed.data
       await deleteStatusFromUserInput({
         currentActor,
         database,

--- a/app/api/v1/accounts/outbox/types.ts
+++ b/app/api/v1/accounts/outbox/types.ts
@@ -8,6 +8,7 @@ import { MastodonVisibility } from '@/lib/utils/getVisibility'
 export const CreateNoteRequest = z.object({
   type: z.literal('note'),
   message: z.string(),
+  contentWarning: z.string().optional(),
   replyStatus: Status.optional(),
   attachments: PostBoxAttachment.array().optional(),
   fitnessFileId: z.string().optional(),
@@ -20,6 +21,7 @@ export type CreateNoteRequest = z.infer<typeof CreateNoteRequest>
 export const CreatePollRequest = z.object({
   type: z.literal('poll'),
   message: z.string(),
+  contentWarning: z.string().optional(),
   choices: z.string().array(),
   pollType: z.enum(['oneOf', 'anyOf']).optional(),
   durationInSeconds: z

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getQueue } from '@/lib/services/queue'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
@@ -69,6 +70,7 @@ describe('GET /api/v1/statuses/[id]', () => {
   })
 
   beforeEach(() => {
+    jest.clearAllMocks()
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
@@ -362,6 +364,7 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(updatedStatus?.summary).toBeNull()
       expect(updatedStatus?.to).toEqual([`${ACTOR1_ID}/followers`])
       expect(updatedStatus?.cc).toEqual([])
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -6,7 +6,7 @@ import { getQueue } from '@/lib/services/queue'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
-import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
@@ -365,6 +365,49 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(updatedStatus?.to).toEqual([`${ACTOR1_ID}/followers`])
       expect(updatedStatus?.cc).toEqual([])
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not partially apply visibility when content update is forbidden', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-forbidden-combined`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public edit target',
+        summary: 'Existing warning',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              visibility: 'private',
+              spoiler_text: ''
+            }),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      const updatedStatus = await database.getStatus({ statusId })
+
+      expect(response.status).toBe(403)
+      expect(updatedStatus?.summary).toBe('Existing warning')
+      expect(updatedStatus?.to).toEqual([ACTIVITY_STREAM_PUBLIC])
+      expect(updatedStatus?.cc).toEqual([`${ACTOR1_ID}/followers`])
+      expect(getQueue().publish).not.toHaveBeenCalled()
     })
   })
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1,15 +1,50 @@
+import { NextRequest } from 'next/server'
+
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
-import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
+import { PUT } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn().mockReturnValue({
+    publish: jest.fn().mockResolvedValue(undefined)
+  })
+}))
+
 jest.mock('@/lib/config', () => ({
-  getConfig: jest.fn().mockReturnValue({ host: 'llun.test' })
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
 }))
 
 /**
@@ -24,11 +59,19 @@ describe('GET /api/v1/statuses/[id]', () => {
   beforeAll(async () => {
     await database.migrate()
     await seedDatabase(database)
+    mockDatabase = database
   })
 
   afterAll(async () => {
     if (!database) return
+    mockDatabase = null
     await database.destroy()
+  })
+
+  beforeEach(() => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
   })
 
   describe('status retrieval and format', () => {
@@ -275,6 +318,50 @@ describe('GET /api/v1/statuses/[id]', () => {
 
       expect(mastodonStatus?.sensitive).toBe(true)
       expect(mastodonStatus?.spoiler_text).toBe('CW: Sensitive topic')
+    })
+  })
+
+  describe('status update', () => {
+    it('applies visibility updates when spoiler_text is also present', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-visibility-with-cw`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public edit target',
+        summary: 'Existing warning',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              visibility: 'private',
+              spoiler_text: ''
+            }),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      const updatedStatus = await database.getStatus({ statusId })
+
+      expect(data.visibility).toBe('private')
+      expect(data.spoiler_text).toBe('')
+      expect(updatedStatus?.summary).toBeNull()
+      expect(updatedStatus?.to).toEqual([`${ACTOR1_ID}/followers`])
+      expect(updatedStatus?.cc).toEqual([])
     })
   })
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -367,6 +367,44 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
     })
 
+    it('clears content warning when spoiler_text is null', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-null-cw`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Content warning target',
+        summary: 'Existing warning',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              spoiler_text: null
+            }),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      const updatedStatus = await database.getStatus({ statusId })
+
+      expect(data.spoiler_text).toBe('')
+      expect(updatedStatus?.summary).toBeNull()
+    })
+
     it('does not partially apply visibility when content update is forbidden', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor2.email }

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -80,7 +80,6 @@ export const GET = traceApiRoute(
 const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().optional(),
-  sensitive: z.boolean().optional(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
 })
 
@@ -113,21 +112,20 @@ export const PUT = traceApiRoute(
 
       let updatedNote
 
-      if (
-        changes.visibility !== undefined &&
-        changes.status === undefined &&
-        changes.spoiler_text === undefined
-      ) {
-        updatedNote = await updateNoteVisibilityFromUserInput({
-          statusId,
-          currentActor,
-          visibility: changes.visibility,
-          database
+      const shouldUpdateContent =
+        changes.status !== undefined || changes.spoiler_text !== undefined
+      const visibility = changes.visibility
+
+      if (!shouldUpdateContent && visibility === undefined) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
         })
-      } else if (
-        changes.status !== undefined ||
-        changes.spoiler_text !== undefined
-      ) {
+      }
+
+      if (shouldUpdateContent) {
         updatedNote = await updateNoteFromUserInput({
           statusId,
           currentActor,
@@ -135,12 +133,21 @@ export const PUT = traceApiRoute(
           summary: changes.spoiler_text,
           database
         })
-      } else {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
+        if (!updatedNote)
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_403,
+            responseStatusCode: 403
+          })
+      }
+
+      if (visibility !== undefined) {
+        updatedNote = await updateNoteVisibilityFromUserInput({
+          statusId,
+          currentActor,
+          visibility,
+          database
         })
       }
 

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -79,7 +79,7 @@ export const GET = traceApiRoute(
 
 const EditNoteSchema = z.object({
   status: z.string().optional(),
-  spoiler_text: z.string().optional(),
+  spoiler_text: z.string().nullish(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
 })
 
@@ -145,6 +145,7 @@ export const PUT = traceApiRoute(
           currentActor,
           visibility,
           publish: !shouldUpdateContent,
+          status: existingStatus,
           database
         })
         if (!updatedNote)
@@ -163,6 +164,10 @@ export const PUT = traceApiRoute(
           text: changes.status,
           summary: changes.spoiler_text,
           publish: true,
+          status:
+            updatedNote?.type === StatusType.enum.Note
+              ? updatedNote
+              : existingStatus,
           database
         })
         if (!updatedNote)

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -80,6 +80,7 @@ export const GET = traceApiRoute(
 const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().optional(),
+  sensitive: z.boolean().optional(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
 })
 
@@ -99,18 +100,34 @@ export const PUT = traceApiRoute(
     const { database, currentActor } = context
     const statusId = idToUrl(encodedStatusId)
     try {
-      const changes = EditNoteSchema.parse(await req.json())
+      const parsed = EditNoteSchema.safeParse(await req.json())
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const changes = parsed.data
 
       let updatedNote
 
-      if (changes.visibility !== undefined && changes.status === undefined) {
+      if (
+        changes.visibility !== undefined &&
+        changes.status === undefined &&
+        changes.spoiler_text === undefined
+      ) {
         updatedNote = await updateNoteVisibilityFromUserInput({
           statusId,
           currentActor,
           visibility: changes.visibility,
           database
         })
-      } else if (changes.status !== undefined) {
+      } else if (
+        changes.status !== undefined ||
+        changes.spoiler_text !== undefined
+      ) {
         updatedNote = await updateNoteFromUserInput({
           statusId,
           currentActor,

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -125,12 +125,12 @@ export const PUT = traceApiRoute(
         })
       }
 
-      if (shouldUpdateContent) {
-        updatedNote = await updateNoteFromUserInput({
+      if (visibility !== undefined) {
+        updatedNote = await updateNoteVisibilityFromUserInput({
           statusId,
           currentActor,
-          text: changes.status,
-          summary: changes.spoiler_text,
+          visibility,
+          publish: !shouldUpdateContent,
           database
         })
         if (!updatedNote)
@@ -142,13 +142,22 @@ export const PUT = traceApiRoute(
           })
       }
 
-      if (visibility !== undefined) {
-        updatedNote = await updateNoteVisibilityFromUserInput({
+      if (shouldUpdateContent) {
+        updatedNote = await updateNoteFromUserInput({
           statusId,
           currentActor,
-          visibility,
+          text: changes.status,
+          summary: changes.spoiler_text,
+          publish: true,
           database
         })
+        if (!updatedNote)
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_403,
+            responseStatusCode: 403
+          })
       }
 
       if (!updatedNote)

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -125,6 +125,20 @@ export const PUT = traceApiRoute(
         })
       }
 
+      const existingStatus = await database.getStatus({ statusId })
+      if (
+        !existingStatus ||
+        existingStatus.type !== StatusType.enum.Note ||
+        existingStatus.actorId !== currentActor.id
+      ) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_403,
+          responseStatusCode: 403
+        })
+      }
+
       if (visibility !== undefined) {
         updatedNote = await updateNoteVisibilityFromUserInput({
           statusId,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -24,7 +24,6 @@ const NoteSchema = z.object({
   status: z.string(),
   in_reply_to_id: z.string().optional(),
   spoiler_text: z.string().optional(),
-  sensitive: z.boolean().optional(),
   media_ids: z.array(z.string()).optional(),
   visibility: VisibilitySchema.optional()
 })

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -24,6 +24,7 @@ const NoteSchema = z.object({
   status: z.string(),
   in_reply_to_id: z.string().optional(),
   spoiler_text: z.string().optional(),
+  sensitive: z.boolean().optional(),
   media_ids: z.array(z.string()).optional(),
   visibility: VisibilitySchema.optional()
 })
@@ -34,10 +35,20 @@ export const POST = traceApiRoute(
     const { currentActor, database } = context
     try {
       const content = await req.json()
-      const note = NoteSchema.parse(content)
+      const parsed = NoteSchema.safeParse(content)
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const note = parsed.data
       const status = await createNoteFromUserInput({
         currentActor,
         text: note.status,
+        summary: note.spoiler_text,
         replyNoteId: note.in_reply_to_id,
         visibility: note.visibility,
         attachments: [],

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -89,6 +89,20 @@ describe('Create note action', () => {
       )
     })
 
+    it('stores content warning text as note summary', async () => {
+      const status = (await createNoteFromUserInput({
+        text: 'Hidden behind a warning',
+        summary: 'Movie spoilers',
+        currentActor: actor1,
+        database
+      })) as StatusNote
+
+      expect(status.summary).toBe('Movie spoilers')
+
+      const note = getNoteFromStatus(status) as Note
+      expect(note.summary).toBe('Movie spoilers')
+    })
+
     it('set reply to replyStatus id', async () => {
       const status = (await createNoteFromUserInput({
         text: 'Hello',

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -153,6 +153,7 @@ export const getVisibilityFromReplyStatus = (
 
 interface CreateNoteFromUserInputParams {
   text: string
+  summary?: string | null
   replyNoteId?: string
   currentActor: Actor
   attachments?: PostBoxAttachment[]
@@ -162,6 +163,7 @@ interface CreateNoteFromUserInputParams {
 }
 export const createNoteFromUserInput = async ({
   text,
+  summary,
   replyNoteId,
   currentActor,
   attachments = [],
@@ -219,7 +221,7 @@ export const createNoteFromUserInput = async ({
     actorId: currentActor.id,
 
     text,
-    summary: null,
+    summary: summary?.trim() || null,
 
     to,
     cc,

--- a/lib/actions/createPoll.test.ts
+++ b/lib/actions/createPoll.test.ts
@@ -67,6 +67,24 @@ describe('Create poll action', () => {
       expect(poll?.cc).toContain(`${actor1.id}/followers`)
     })
 
+    it('stores content warning text as poll summary', async () => {
+      await createPollFromUserInput({
+        text: 'Choose the culprit',
+        summary: 'Mystery spoilers',
+        currentActor: actor1,
+        choices: ['Butler', 'Gardener'],
+        database,
+        endAt: Date.now() + 24 * 60 * 60 * 1000
+      })
+
+      const statuses = await database.getActorStatuses({
+        actorId: actor1.id
+      })
+      const poll = statuses.find((s) => s.text.includes('Choose the culprit'))
+
+      expect(poll?.summary).toBe('Mystery spoilers')
+    })
+
     it('creates a poll with mentions in cc', async () => {
       await createPollFromUserInput({
         text: `@${actor2.username}@${actor2.domain} What do you think?`,

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -16,6 +16,7 @@ import { getSpan } from '@/lib/utils/trace'
 
 interface CreatePollFromUserInputParams {
   text: string
+  summary?: string | null
   replyStatusId?: string
   currentActor: Actor
   choices: string[]
@@ -26,6 +27,7 @@ interface CreatePollFromUserInputParams {
 }
 export const createPollFromUserInput = async ({
   text,
+  summary,
   replyStatusId,
   currentActor,
   choices = [],
@@ -71,7 +73,7 @@ export const createPollFromUserInput = async ({
     url: `https://${currentActor.domain}/${getMention(currentActor)}/${postId}`,
     actorId: currentActor.id,
     text: convertMarkdownText(config.host)(text),
-    summary: '',
+    summary: summary?.trim() || null,
     to,
     cc,
     reply: replyStatus?.id || '',

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -4,6 +4,7 @@ import { updateNoteFromUserInput } from '@/lib/actions/updateNote'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import * as timelinesService from '@/lib/services/timelines'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
@@ -18,6 +19,10 @@ jest.mock('@/lib/services/queue', () => ({
   getQueue: jest.fn().mockReturnValue({
     publish: jest.fn().mockResolvedValue(undefined)
   })
+}))
+
+jest.mock('@/lib/services/timelines', () => ({
+  addStatusToTimelines: jest.fn().mockResolvedValue(undefined)
 }))
 
 describe('Update note action', () => {
@@ -73,6 +78,10 @@ describe('Update note action', () => {
           statusId
         }
       })
+      expect(timelinesService.addStatusToTimelines).toHaveBeenCalledWith(
+        database,
+        status
+      )
     })
 
     it('format text when updating text', async () => {
@@ -134,6 +143,10 @@ describe('Update note action', () => {
       expect(status).toMatchObject({
         summary: 'Draft warning'
       })
+      expect(timelinesService.addStatusToTimelines).toHaveBeenCalledWith(
+        database,
+        status
+      )
       expect(getQueue().publish).not.toHaveBeenCalled()
     })
   })

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -89,5 +89,24 @@ describe('Update note action', () => {
         text: 'This is markdown **text** that should get format'
       })
     })
+
+    it('updates content warning without changing text', async () => {
+      if (!actor1) fail('Actor1 is required')
+      const statusId = `${actor1.id}/statuses/post-1`
+      const before = await database.getStatus({ statusId })
+      if (!before || before.type !== 'Note') fail('Note is required')
+
+      const status = (await updateNoteFromUserInput({
+        statusId,
+        currentActor: actor1,
+        database,
+        summary: 'Updated warning'
+      })) as Status
+
+      expect(status).toMatchObject({
+        text: before.text,
+        summary: 'Updated warning'
+      })
+    })
   })
 })

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -107,6 +107,34 @@ describe('Update note action', () => {
         text: before.text,
         summary: 'Updated warning'
       })
+
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
+      expect(getQueue().publish).toHaveBeenCalledWith({
+        id: getHashFromString(statusId),
+        name: SEND_UPDATE_NOTE_JOB_NAME,
+        data: {
+          actorId: actor1.id,
+          statusId
+        }
+      })
+    })
+
+    it('does not publish when publish is false', async () => {
+      if (!actor1) fail('Actor1 is required')
+      const statusId = `${actor1.id}/statuses/post-1`
+
+      const status = (await updateNoteFromUserInput({
+        statusId,
+        currentActor: actor1,
+        database,
+        summary: 'Draft warning',
+        publish: false
+      })) as Status
+
+      expect(status).toMatchObject({
+        summary: 'Draft warning'
+      })
+      expect(getQueue().publish).not.toHaveBeenCalled()
     })
   })
 })

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -1,6 +1,7 @@
 import { Database } from '@/lib/database/types'
 import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Actor } from '@/lib/types/domain/actor'
 import { StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
@@ -43,6 +44,8 @@ export const updateNoteFromUserInput = async ({
     span.end()
     return null
   }
+
+  await addStatusToTimelines(database, updatedStatus)
 
   if (publish) {
     await getQueue().publish({

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -9,8 +9,8 @@ import { getSpan } from '@/lib/utils/trace'
 interface UpdateNoteFromUserInput {
   statusId: string
   currentActor: Actor
-  text: string
-  summary?: string
+  text?: string
+  summary?: string | null
   database: Database
 }
 
@@ -34,8 +34,8 @@ export const updateNoteFromUserInput = async ({
 
   const updatedStatus = await database.updateNote({
     statusId,
-    summary,
-    text
+    summary: summary === undefined ? status.summary : summary?.trim() || null,
+    text: text ?? status.text
   })
   if (!updatedStatus) {
     span.end()

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -11,6 +11,7 @@ interface UpdateNoteFromUserInput {
   currentActor: Actor
   text?: string
   summary?: string | null
+  publish?: boolean
   database: Database
 }
 
@@ -19,6 +20,7 @@ export const updateNoteFromUserInput = async ({
   currentActor,
   text,
   summary,
+  publish = true,
   database
 }: UpdateNoteFromUserInput) => {
   const span = getSpan('actions', 'updateNoteFromUser', { statusId })
@@ -42,14 +44,16 @@ export const updateNoteFromUserInput = async ({
     return null
   }
 
-  await getQueue().publish({
-    id: getHashFromString(statusId),
-    name: SEND_UPDATE_NOTE_JOB_NAME,
-    data: {
-      actorId: currentActor.id,
-      statusId
-    }
-  })
+  if (publish) {
+    await getQueue().publish({
+      id: getHashFromString(statusId),
+      name: SEND_UPDATE_NOTE_JOB_NAME,
+      data: {
+        actorId: currentActor.id,
+        statusId
+      }
+    })
+  }
 
   span.end()
   return updatedStatus

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -3,7 +3,7 @@ import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Actor } from '@/lib/types/domain/actor'
-import { StatusType } from '@/lib/types/domain/status'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getSpan } from '@/lib/utils/trace'
 
@@ -13,6 +13,7 @@ interface UpdateNoteFromUserInput {
   text?: string
   summary?: string | null
   publish?: boolean
+  status?: StatusNote
   database: Database
 }
 
@@ -22,12 +23,14 @@ export const updateNoteFromUserInput = async ({
   text,
   summary,
   publish = true,
+  status: preloadedStatus,
   database
 }: UpdateNoteFromUserInput) => {
   const span = getSpan('actions', 'updateNoteFromUser', { statusId })
-  const status = await database.getStatus({ statusId })
+  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
   if (
     !status ||
+    status.id !== statusId ||
     status.type !== StatusType.enum.Note ||
     status.actorId !== currentActor.id
   ) {

--- a/lib/actions/updateNoteVisibility.ts
+++ b/lib/actions/updateNoteVisibility.ts
@@ -8,7 +8,7 @@ import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Mention } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
-import { StatusType } from '@/lib/types/domain/status'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { getMentionFromTag } from '@/lib/types/domain/tag'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
@@ -19,6 +19,7 @@ interface UpdateNoteVisibilityFromUserInput {
   currentActor: Actor
   visibility: MastodonVisibility
   publish?: boolean
+  status?: StatusNote
   database: Database
 }
 
@@ -27,12 +28,14 @@ export const updateNoteVisibilityFromUserInput = async ({
   currentActor,
   visibility,
   publish = true,
+  status: preloadedStatus,
   database
 }: UpdateNoteVisibilityFromUserInput) => {
   const span = getSpan('actions', 'updateNoteVisibilityFromUser', { statusId })
-  const status = await database.getStatus({ statusId })
+  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
   if (
     !status ||
+    status.id !== statusId ||
     status.type !== StatusType.enum.Note ||
     status.actorId !== currentActor.id
   ) {

--- a/lib/actions/updateNoteVisibility.ts
+++ b/lib/actions/updateNoteVisibility.ts
@@ -18,6 +18,7 @@ interface UpdateNoteVisibilityFromUserInput {
   statusId: string
   currentActor: Actor
   visibility: MastodonVisibility
+  publish?: boolean
   database: Database
 }
 
@@ -25,6 +26,7 @@ export const updateNoteVisibilityFromUserInput = async ({
   statusId,
   currentActor,
   visibility,
+  publish = true,
   database
 }: UpdateNoteVisibilityFromUserInput) => {
   const span = getSpan('actions', 'updateNoteVisibilityFromUser', { statusId })
@@ -61,11 +63,13 @@ export const updateNoteVisibilityFromUserInput = async ({
 
   await addStatusToTimelines(database, updatedStatus)
 
-  await getQueue().publish({
-    id: getHashFromString(statusId),
-    name: SEND_UPDATE_NOTE_JOB_NAME,
-    data: { actorId: currentActor.id, statusId }
-  })
+  if (publish) {
+    await getQueue().publish({
+      id: getHashFromString(statusId),
+      name: SEND_UPDATE_NOTE_JOB_NAME,
+      data: { actorId: currentActor.id, statusId }
+    })
+  }
 
   span.end()
   return updatedStatus

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -1,0 +1,37 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { updateNote } from './client'
+
+enableFetchMocks()
+
+describe('client updateNote', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(
+      JSON.stringify({
+        id: '123',
+        content: '',
+        created_at: '2026-04-26T10:00:00.000Z',
+        edited_at: null,
+        in_reply_to_id: null
+      })
+    )
+  })
+
+  it('omits empty status text for content-warning-only edits', async () => {
+    await updateNote({
+      statusId: '123',
+      message: '',
+      contentWarning: 'Updated warning'
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/statuses/123',
+      expect.objectContaining({
+        body: JSON.stringify({
+          spoiler_text: 'Updated warning'
+        })
+      })
+    )
+  })
+})

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -65,7 +65,7 @@ export const createNote = async ({
 
 export interface UpdateNoteParams {
   statusId: string
-  message: string
+  message?: string
   contentWarning?: string
 }
 export const updateNote = async ({
@@ -73,7 +73,10 @@ export const updateNote = async ({
   message,
   contentWarning
 }: UpdateNoteParams) => {
-  if (message.trim().length === 0) {
+  if (message === undefined && contentWarning === undefined) {
+    throw new Error('Message or content warning must be provided')
+  }
+  if (message !== undefined && message.trim().length === 0) {
     throw new Error('Message must not be empty')
   }
 
@@ -83,8 +86,8 @@ export const updateNote = async ({
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      status: message,
-      spoiler_text: contentWarning
+      ...(message !== undefined ? { status: message } : {}),
+      ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {})
     })
   })
   if (response.status !== 200) {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -15,6 +15,7 @@ import { urlToId } from '@/lib/utils/urlToId'
 
 export interface CreateNoteParams {
   message: string
+  contentWarning?: string
   replyStatus?: Status
   attachments?: PostBoxAttachment[]
   fitnessFileId?: string
@@ -22,6 +23,7 @@ export interface CreateNoteParams {
 }
 export const createNote = async ({
   message,
+  contentWarning,
   replyStatus,
   attachments = [],
   fitnessFileId,
@@ -44,6 +46,7 @@ export const createNote = async ({
       type: 'note',
       replyStatus,
       message,
+      contentWarning,
       attachments,
       fitnessFileId,
       visibility
@@ -63,8 +66,13 @@ export const createNote = async ({
 export interface UpdateNoteParams {
   statusId: string
   message: string
+  contentWarning?: string
 }
-export const updateNote = async ({ statusId, message }: UpdateNoteParams) => {
+export const updateNote = async ({
+  statusId,
+  message,
+  contentWarning
+}: UpdateNoteParams) => {
   if (message.trim().length === 0) {
     throw new Error('Message must not be empty')
   }
@@ -75,7 +83,8 @@ export const updateNote = async ({ statusId, message }: UpdateNoteParams) => {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      status: message
+      status: message,
+      spoiler_text: contentWarning
     })
   })
   if (response.status !== 200) {
@@ -122,6 +131,7 @@ export const updateStatusVisibility = async ({
 
 export interface CreatePollParams {
   message: string
+  contentWarning?: string
   choices: string[]
   durationInSeconds: Duration
   pollType?: 'oneOf' | 'anyOf'
@@ -131,6 +141,7 @@ export interface CreatePollParams {
 
 export const createPoll = async ({
   message,
+  contentWarning,
   choices,
   durationInSeconds,
   pollType,
@@ -157,6 +168,7 @@ export const createPoll = async ({
       type: 'poll',
       replyStatus,
       message,
+      contentWarning,
       durationInSeconds,
       pollType,
       choices,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -73,11 +73,11 @@ export const updateNote = async ({
   message,
   contentWarning
 }: UpdateNoteParams) => {
-  if (message === undefined && contentWarning === undefined) {
+  const normalizedMessage =
+    message !== undefined && message.trim().length > 0 ? message : undefined
+
+  if (normalizedMessage === undefined && contentWarning === undefined) {
     throw new Error('Message or content warning must be provided')
-  }
-  if (message !== undefined && message.trim().length === 0) {
-    throw new Error('Message must not be empty')
   }
 
   const response = await fetch(`/api/v1/statuses/${statusId}`, {
@@ -86,7 +86,7 @@ export const updateNote = async ({
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      ...(message !== undefined ? { status: message } : {}),
+      ...(normalizedMessage !== undefined ? { status: normalizedMessage } : {}),
       ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {})
     })
   })

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -171,14 +171,14 @@ export const PostBox: FC<Props> = ({
       }
 
       if (editStatus) {
-        const { content } = await updateNote({
+        await updateNote({
           statusId: urlToId(editStatus.id),
           message,
           contentWarning
         })
         onPostUpdated({
           ...editStatus,
-          text: content,
+          text: message,
           summary: contentWarning.trim() || null
         })
         dispatch(resetExtension())

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -1,4 +1,4 @@
-import { Activity, BarChart3, Loader2, X } from 'lucide-react'
+import { Activity, AlertTriangle, BarChart3, Loader2, X } from 'lucide-react'
 import {
   FC,
   FormEvent,
@@ -56,6 +56,8 @@ import {
   removePollChoice,
   resetExtension,
   setAttachments,
+  setContentWarning,
+  setContentWarningVisibility,
   setFitnessFile,
   setFitnessFileUploaded,
   setFitnessFileUploading,
@@ -149,6 +151,7 @@ export const PostBox: FC<Props> = ({
         const poll = postExtension.poll
         await createPoll({
           message,
+          contentWarning: postExtension.contentWarning,
           choices: poll.choices.map((item) => item.text),
           durationInSeconds: poll.durationInSeconds,
           pollType: poll.pollType,
@@ -164,9 +167,11 @@ export const PostBox: FC<Props> = ({
       if (editStatus) {
         const { content } = await updateNote({
           statusId: urlToId(editStatus.id),
-          message
+          message,
+          contentWarning: postExtension.contentWarning
         })
         editStatus.text = content
+        editStatus.summary = postExtension.contentWarning.trim() || null
         onPostUpdated(editStatus)
         dispatch(resetExtension())
 
@@ -281,6 +286,7 @@ export const PostBox: FC<Props> = ({
 
       const response = await createNote({
         message,
+        contentWarning: postExtension.contentWarning,
         replyStatus,
         attachments,
         fitnessFileId,
@@ -364,18 +370,42 @@ export const PostBox: FC<Props> = ({
 
   const onTextChange = (value: string) => {
     setText(value)
+    textRef.current = value
     if (value.trim().length === 0) {
       setAllowPost(Boolean(postExtensionRef.current.fitnessFile))
       return
     }
     if (
       editStatus &&
-      value === sanitizeHtml(editStatus.text, { allowedTags: [] })
+      value === sanitizeHtml(editStatus.text, { allowedTags: [] }) &&
+      postExtensionRef.current.contentWarning === (editStatus.summary ?? '')
     ) {
       setAllowPost(false)
       return
     }
     setAllowPost(true)
+  }
+
+  const onContentWarningChange = (value: string) => {
+    dispatch(setContentWarning(value))
+    if (!editStatus) return
+
+    setAllowPost(
+      value !== (editStatus.summary ?? '') ||
+        textRef.current !== sanitizeHtml(editStatus.text, { allowedTags: [] })
+    )
+  }
+
+  const onToggleContentWarning = () => {
+    const nextVisible = !postExtension.contentWarningVisible
+    dispatch(setContentWarningVisibility(nextVisible))
+    if (!editStatus) return
+
+    const nextContentWarning = nextVisible ? postExtension.contentWarning : ''
+    setAllowPost(
+      nextContentWarning !== (editStatus.summary ?? '') ||
+        textRef.current !== sanitizeHtml(editStatus.text, { allowedTags: [] })
+    )
   }
 
   /**
@@ -436,6 +466,8 @@ export const PostBox: FC<Props> = ({
   useEffect(() => {
     if (editStatus) {
       setText(editStatus.text)
+      dispatch(setContentWarning(editStatus.summary ?? ''))
+      dispatch(setContentWarningVisibility(Boolean(editStatus.summary)))
       setAllowPost(false) // Initial state for edit is disabled until changed? Or should we check?
       // Original logic in onTextChange checked if text === editStatus.text.
       // So if we set text to editStatus.text, allowPost should be false.
@@ -443,6 +475,8 @@ export const PostBox: FC<Props> = ({
       return
     } else {
       setText('')
+      dispatch(setContentWarning(''))
+      dispatch(setContentWarningVisibility(false))
       setAllowPost(false)
     }
 
@@ -501,6 +535,18 @@ export const PostBox: FC<Props> = ({
               onClose={onCloseReply}
             />
             <Tabs value={currentTab} onValueChange={setCurrentTab}>
+              {postExtension.contentWarningVisible ? (
+                <input
+                  className="mb-3 flex h-9 w-full rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                  aria-label="Content warning"
+                  name="contentWarning"
+                  placeholder="Write your warning here"
+                  value={postExtension.contentWarning}
+                  onChange={(event) =>
+                    onContentWarningChange(event.target.value)
+                  }
+                />
+              ) : null}
               <TabsList className="mb-3">
                 <TabsTrigger value="write">Write</TabsTrigger>
                 <TabsTrigger value="preview">Preview</TabsTrigger>
@@ -567,6 +613,21 @@ export const PostBox: FC<Props> = ({
                 dispatch(setVisibility(visibility))
               }
             />
+            <Button
+              type="button"
+              variant={
+                postExtension.contentWarningVisible ? 'secondary' : 'link'
+              }
+              aria-label={
+                postExtension.contentWarningVisible
+                  ? 'Remove content warning'
+                  : 'Add content warning'
+              }
+              title="Content warning"
+              onClick={onToggleContentWarning}
+            >
+              <AlertTriangle className="size-4" />
+            </Button>
             <Button
               type="button"
               variant="link"

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -104,7 +104,10 @@ export const PostBox: FC<Props> = ({
   const postBoxRef = useRef<HTMLTextAreaElement>(null)
   const formRef = useRef<HTMLFormElement>(null)
   const textRef = useRef(text)
-  const fitnessCleanupInFlightRef = useRef<string | null>(null)
+  const fitnessCleanupInFlightRef = useRef<{
+    uploadedId: string
+    promise: Promise<boolean>
+  } | null>(null)
 
   const [postExtension, dispatch] = useReducer(
     statusExtensionReducer,
@@ -327,40 +330,59 @@ export const PostBox: FC<Props> = ({
   }
 
   const onRemoveFitnessFile = useCallback(async () => {
-    const fitnessFile = postExtension.fitnessFile
+    const fitnessFile = postExtensionRef.current.fitnessFile
     if (!fitnessFile) {
-      return
+      return true
+    }
+
+    const clearFitnessFile = () => {
+      dispatch(removeFitnessFile())
+      postExtensionRef.current = {
+        ...postExtensionRef.current,
+        fitnessFile: undefined
+      }
+      setAllowPost(textRef.current.trim().length > 0)
     }
 
     if (!fitnessFile.uploadedId) {
-      dispatch(removeFitnessFile())
-      setAllowPost(textRef.current.trim().length > 0)
-      return
+      clearFitnessFile()
+      return true
     }
 
-    if (fitnessCleanupInFlightRef.current === fitnessFile.uploadedId) {
-      return
+    const inFlight = fitnessCleanupInFlightRef.current
+    if (inFlight?.uploadedId === fitnessFile.uploadedId) {
+      return inFlight.promise
     }
 
-    fitnessCleanupInFlightRef.current = fitnessFile.uploadedId
+    const uploadedId = fitnessFile.uploadedId
 
-    try {
-      setWarningMsg(null)
-      await deleteFitnessFile(fitnessFile.uploadedId)
-      dispatch(removeFitnessFile())
-      setAllowPost(textRef.current.trim().length > 0)
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error && error.message
-          ? error.message
-          : 'Failed to delete uploaded fitness file'
-      setWarningMsg(errorMessage)
-    } finally {
-      if (fitnessCleanupInFlightRef.current === fitnessFile.uploadedId) {
-        fitnessCleanupInFlightRef.current = null
+    const cleanupPromise = (async () => {
+      try {
+        setWarningMsg(null)
+        await deleteFitnessFile(uploadedId)
+        clearFitnessFile()
+        return true
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error && error.message
+            ? error.message
+            : 'Failed to delete uploaded fitness file'
+        setWarningMsg(errorMessage)
+        return false
+      } finally {
+        if (fitnessCleanupInFlightRef.current?.uploadedId === uploadedId) {
+          fitnessCleanupInFlightRef.current = null
+        }
       }
+    })()
+
+    fitnessCleanupInFlightRef.current = {
+      uploadedId,
+      promise: cleanupPromise
     }
-  }, [postExtension.fitnessFile])
+
+    return cleanupPromise
+  }, [])
 
   const onQuickPost = async (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (!(event.metaKey || event.ctrlKey)) return
@@ -660,6 +682,7 @@ export const PostBox: FC<Props> = ({
                 setWarningMsg('Some files are already selected')
               }
               onUploadStart={() => setWarningMsg(null)}
+              onBeforeAddAttachments={onRemoveFitnessFile}
             />
           </div>
           <div>

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -140,6 +140,9 @@ export const PostBox: FC<Props> = ({
     setIsPosting(true)
     setWarningMsg(null)
     const message = text
+    const contentWarning = postExtension.contentWarningVisible
+      ? postExtension.contentWarning
+      : ''
     try {
       if (postExtension.poll.showing && postExtension.fitnessFile) {
         setWarningMsg(
@@ -154,7 +157,7 @@ export const PostBox: FC<Props> = ({
         const poll = postExtension.poll
         await createPoll({
           message,
-          contentWarning: postExtension.contentWarning,
+          contentWarning,
           choices: poll.choices.map((item) => item.text),
           durationInSeconds: poll.durationInSeconds,
           pollType: poll.pollType,
@@ -171,12 +174,12 @@ export const PostBox: FC<Props> = ({
         const { content } = await updateNote({
           statusId: urlToId(editStatus.id),
           message,
-          contentWarning: postExtension.contentWarning
+          contentWarning
         })
         onPostUpdated({
           ...editStatus,
           text: content,
-          summary: postExtension.contentWarning.trim() || null
+          summary: contentWarning.trim() || null
         })
         dispatch(resetExtension())
 
@@ -291,7 +294,7 @@ export const PostBox: FC<Props> = ({
 
       const response = await createNote({
         message,
-        contentWarning: postExtension.contentWarning,
+        contentWarning,
         replyStatus,
         attachments,
         fitnessFileId,

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -564,6 +564,7 @@ export const PostBox: FC<Props> = ({
             <Tabs value={currentTab} onValueChange={setCurrentTab}>
               {postExtension.contentWarningVisible ? (
                 <input
+                  type="text"
                   className="mb-3 flex h-9 w-full rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                   aria-label="Content warning"
                   name="contentWarning"

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -170,9 +170,11 @@ export const PostBox: FC<Props> = ({
           message,
           contentWarning: postExtension.contentWarning
         })
-        editStatus.text = content
-        editStatus.summary = postExtension.contentWarning.trim() || null
-        onPostUpdated(editStatus)
+        onPostUpdated({
+          ...editStatus,
+          text: content,
+          summary: postExtension.contentWarning.trim() || null
+        })
         dispatch(resetExtension())
 
         setText('')

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -171,14 +171,15 @@ export const PostBox: FC<Props> = ({
       }
 
       if (editStatus) {
+        const updateMessage = message.trim().length > 0 ? message : undefined
         await updateNote({
           statusId: urlToId(editStatus.id),
-          message,
+          message: updateMessage,
           contentWarning
         })
         onPostUpdated({
           ...editStatus,
-          text: message,
+          text: updateMessage ?? editStatus.text,
           summary: contentWarning.trim() || null
         })
         dispatch(resetExtension())

--- a/lib/components/post-box/reducers.test.ts
+++ b/lib/components/post-box/reducers.test.ts
@@ -44,7 +44,7 @@ describe('post-box reducers', () => {
     expect(nextState.contentWarningVisible).toBe(true)
   })
 
-  it('clears content warning when visibility is turned off', () => {
+  it('keeps content warning text when visibility is turned off', () => {
     const stateWithWarning = statusExtensionReducer(
       DEFAULT_STATE,
       setContentWarning('Spoilers')
@@ -55,7 +55,7 @@ describe('post-box reducers', () => {
       setContentWarningVisibility(false)
     )
 
-    expect(nextState.contentWarning).toBe('')
+    expect(nextState.contentWarning).toBe('Spoilers')
     expect(nextState.contentWarningVisible).toBe(false)
   })
 

--- a/lib/components/post-box/reducers.test.ts
+++ b/lib/components/post-box/reducers.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_STATE,
+  addAttachment,
   setAttachments,
   setContentWarning,
   setContentWarningVisibility,
@@ -83,7 +84,7 @@ describe('post-box reducers', () => {
     expect(nextState.fitnessFile).toBe(stateWithFitnessFile.fitnessFile)
   })
 
-  it('clears poll and fitness state when attachments are added', () => {
+  it('clears poll and fitness state when entering attachment mode', () => {
     const stateWithPoll = {
       ...DEFAULT_STATE,
       poll: {
@@ -112,6 +113,84 @@ describe('post-box reducers', () => {
           height: 100
         }
       ])
+    )
+
+    expect(nextState.attachments).toHaveLength(1)
+    expect(nextState.poll.showing).toBe(false)
+    expect(nextState.fitnessFile).toBeUndefined()
+  })
+
+  it('preserves state when managing an existing attachment list', () => {
+    const stateWithAttachments = {
+      ...DEFAULT_STATE,
+      attachments: [
+        {
+          type: 'upload' as const,
+          id: 'media-1',
+          mediaType: 'image/png',
+          url: 'https://llun.test/media-1.png',
+          width: 100,
+          height: 100
+        },
+        {
+          type: 'upload' as const,
+          id: 'media-2',
+          mediaType: 'image/png',
+          url: 'https://llun.test/media-2.png',
+          width: 100,
+          height: 100
+        }
+      ],
+      contentWarning: 'Spoilers',
+      contentWarningVisible: true,
+      fitnessFile: {
+        file: {
+          name: 'activity.fit',
+          size: 2048,
+          type: 'application/vnd.ant.fit'
+        } as File,
+        uploading: false
+      }
+    }
+
+    const nextState = statusExtensionReducer(
+      stateWithAttachments,
+      setAttachments(stateWithAttachments.attachments.slice(0, 1))
+    )
+
+    expect(nextState.attachments).toHaveLength(1)
+    expect(nextState.contentWarning).toBe('Spoilers')
+    expect(nextState.contentWarningVisible).toBe(true)
+    expect(nextState.fitnessFile).toBe(stateWithAttachments.fitnessFile)
+  })
+
+  it('clears poll and fitness state when adding an attachment', () => {
+    const stateWithPoll = {
+      ...DEFAULT_STATE,
+      poll: {
+        ...DEFAULT_STATE.poll,
+        showing: true
+      },
+      fitnessFile: {
+        file: {
+          name: 'activity.fit',
+          size: 2048,
+          type: 'application/vnd.ant.fit'
+        } as File,
+        uploading: false
+      }
+    }
+
+    const nextState = statusExtensionReducer(
+      stateWithPoll,
+      addAttachment({
+        type: 'upload',
+        id: 'media-id',
+        mediaType: 'image/png',
+        url: 'https://llun.test/media.png',
+        width: 100,
+        height: 100
+      })
     )
 
     expect(nextState.attachments).toHaveLength(1)

--- a/lib/components/post-box/reducers.test.ts
+++ b/lib/components/post-box/reducers.test.ts
@@ -120,7 +120,7 @@ describe('post-box reducers', () => {
     expect(nextState.fitnessFile).toBeUndefined()
   })
 
-  it('preserves state when managing an existing attachment list', () => {
+  it('clears incompatible modes while managing an existing attachment list', () => {
     const stateWithAttachments = {
       ...DEFAULT_STATE,
       attachments: [
@@ -161,7 +161,7 @@ describe('post-box reducers', () => {
     expect(nextState.attachments).toHaveLength(1)
     expect(nextState.contentWarning).toBe('Spoilers')
     expect(nextState.contentWarningVisible).toBe(true)
-    expect(nextState.fitnessFile).toBe(stateWithAttachments.fitnessFile)
+    expect(nextState.fitnessFile).toBeUndefined()
   })
 
   it('clears poll and fitness state when adding an attachment', () => {

--- a/lib/components/post-box/reducers.test.ts
+++ b/lib/components/post-box/reducers.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_STATE,
+  setAttachments,
   setContentWarning,
   setContentWarningVisibility,
   setFitnessFile,
@@ -55,5 +56,66 @@ describe('post-box reducers', () => {
 
     expect(nextState.contentWarning).toBe('')
     expect(nextState.contentWarningVisible).toBe(false)
+  })
+
+  it('preserves compatible composer state when attachments are updated', () => {
+    const file = {
+      name: 'activity.fit',
+      size: 2048,
+      type: 'application/vnd.ant.fit'
+    } as File
+    const stateWithFitnessFile = statusExtensionReducer(
+      {
+        ...DEFAULT_STATE,
+        contentWarning: 'Spoilers',
+        contentWarningVisible: true
+      },
+      setFitnessFile(file)
+    )
+
+    const nextState = statusExtensionReducer(
+      stateWithFitnessFile,
+      setAttachments([])
+    )
+
+    expect(nextState.contentWarning).toBe('Spoilers')
+    expect(nextState.contentWarningVisible).toBe(true)
+    expect(nextState.fitnessFile).toBe(stateWithFitnessFile.fitnessFile)
+  })
+
+  it('clears poll and fitness state when attachments are added', () => {
+    const stateWithPoll = {
+      ...DEFAULT_STATE,
+      poll: {
+        ...DEFAULT_STATE.poll,
+        showing: true
+      },
+      fitnessFile: {
+        file: {
+          name: 'activity.fit',
+          size: 2048,
+          type: 'application/vnd.ant.fit'
+        } as File,
+        uploadedId: 'fitness-file-id'
+      }
+    }
+
+    const nextState = statusExtensionReducer(
+      stateWithPoll,
+      setAttachments([
+        {
+          type: 'upload',
+          id: 'media-id',
+          mediaType: 'image/png',
+          url: 'https://llun.test/media.png',
+          width: 100,
+          height: 100
+        }
+      ])
+    )
+
+    expect(nextState.attachments).toHaveLength(1)
+    expect(nextState.poll.showing).toBe(false)
+    expect(nextState.fitnessFile).toBeUndefined()
   })
 })

--- a/lib/components/post-box/reducers.test.ts
+++ b/lib/components/post-box/reducers.test.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_STATE,
+  setContentWarning,
+  setContentWarningVisibility,
   setFitnessFile,
   statusExtensionReducer
 } from './reducers'
@@ -28,5 +30,30 @@ describe('post-box reducers', () => {
     expect(nextState.poll.showing).toBe(false)
     expect(nextState.fitnessFile?.file).toBe(file)
     expect(nextState.visibility).toBe('private')
+  })
+
+  it('shows content warning input when text is set', () => {
+    const nextState = statusExtensionReducer(
+      DEFAULT_STATE,
+      setContentWarning('Spoilers')
+    )
+
+    expect(nextState.contentWarning).toBe('Spoilers')
+    expect(nextState.contentWarningVisible).toBe(true)
+  })
+
+  it('clears content warning when visibility is turned off', () => {
+    const stateWithWarning = statusExtensionReducer(
+      DEFAULT_STATE,
+      setContentWarning('Spoilers')
+    )
+
+    const nextState = statusExtensionReducer(
+      stateWithWarning,
+      setContentWarningVisibility(false)
+    )
+
+    expect(nextState.contentWarning).toBe('')
+    expect(nextState.contentWarningVisible).toBe(false)
   })
 })

--- a/lib/components/post-box/reducers.ts
+++ b/lib/components/post-box/reducers.ts
@@ -183,13 +183,16 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
       return DEFAULT_STATE
     }
     case 'setAttachments': {
-      // Preserve visibility when loading attachments (e.g., when editing)
+      const hasAttachments = action.attachments.length > 0
       return {
-        ...DEFAULT_STATE,
+        ...state,
         attachments: action.attachments,
-        contentWarning: state.contentWarning,
-        contentWarningVisible: state.contentWarningVisible,
-        visibility: state.visibility
+        fitnessFile: hasAttachments ? undefined : state.fitnessFile,
+        poll: hasAttachments
+          ? {
+              ...DEFAULT_STATE.poll
+            }
+          : state.poll
       }
     }
     case 'setPollVisibility': {

--- a/lib/components/post-box/reducers.ts
+++ b/lib/components/post-box/reducers.ts
@@ -183,12 +183,13 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
       return DEFAULT_STATE
     }
     case 'setAttachments': {
-      const hasAttachments = action.attachments.length > 0
+      const isEnteringAttachmentMode =
+        state.attachments.length === 0 && action.attachments.length > 0
       return {
         ...state,
         attachments: action.attachments,
-        fitnessFile: hasAttachments ? undefined : state.fitnessFile,
-        poll: hasAttachments
+        fitnessFile: isEnteringAttachmentMode ? undefined : state.fitnessFile,
+        poll: isEnteringAttachmentMode
           ? {
               ...DEFAULT_STATE.poll
             }
@@ -277,7 +278,11 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
       if (state.attachments.length >= MAX_ATTACHMENTS) return state
       return {
         ...state,
-        attachments: [...state.attachments, action.attachment]
+        attachments: [...state.attachments, action.attachment],
+        fitnessFile: undefined,
+        poll: {
+          ...DEFAULT_STATE.poll
+        }
       }
     }
     case 'updateAttachment': {

--- a/lib/components/post-box/reducers.ts
+++ b/lib/components/post-box/reducers.ts
@@ -230,7 +230,6 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
     case 'setContentWarningVisibility': {
       return {
         ...state,
-        contentWarning: action.visible ? state.contentWarning : '',
         contentWarningVisible: action.visible
       }
     }

--- a/lib/components/post-box/reducers.ts
+++ b/lib/components/post-box/reducers.ts
@@ -8,6 +8,8 @@ import { Choice, DEFAULT_DURATION, Duration } from './poll-choices'
 
 interface StatusExtension {
   attachments: PostBoxAttachment[]
+  contentWarning: string
+  contentWarningVisible: boolean
   poll: {
     showing: boolean
     choices: Choice[]
@@ -36,6 +38,20 @@ export const setPollVisibility = (visible: boolean) => ({
   visible
 })
 type ActionSetPollVisibility = ReturnType<typeof setPollVisibility>
+
+export const setContentWarning = (contentWarning: string) => ({
+  type: 'setContentWarning' as const,
+  contentWarning
+})
+type ActionSetContentWarning = ReturnType<typeof setContentWarning>
+
+export const setContentWarningVisibility = (visible: boolean) => ({
+  type: 'setContentWarningVisibility' as const,
+  visible
+})
+type ActionSetContentWarningVisibility = ReturnType<
+  typeof setContentWarningVisibility
+>
 
 export const addPollChoice = {
   type: 'addPollChoice' as const
@@ -117,6 +133,8 @@ type Actions =
   | ActionReset
   | ActionSetAttachments
   | ActionSetPollVisibility
+  | ActionSetContentWarning
+  | ActionSetContentWarningVisibility
   | ActionAddPollChoice
   | ActionRemovePollChoice
   | ActionSetPollDurationInSeconds
@@ -139,6 +157,8 @@ export const DEFAULT_CHOICES = [
 
 export const DEFAULT_STATE: StatusExtension = {
   attachments: [],
+  contentWarning: '',
+  contentWarningVisible: false,
   poll: {
     showing: false,
     choices: DEFAULT_CHOICES,
@@ -167,6 +187,8 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
       return {
         ...DEFAULT_STATE,
         attachments: action.attachments,
+        contentWarning: state.contentWarning,
+        contentWarningVisible: state.contentWarningVisible,
         visibility: state.visibility
       }
     }
@@ -183,13 +205,29 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
         : state.poll.durationInSeconds
       // Preserve visibility when toggling poll mode
       return {
+        ...state,
         attachments: [],
+        fitnessFile: action.visible ? undefined : state.fitnessFile,
         poll: {
           ...state.poll,
           showing: action.visible,
           durationInSeconds: duration
-        },
-        visibility: state.visibility
+        }
+      }
+    }
+    case 'setContentWarning': {
+      return {
+        ...state,
+        contentWarning: action.contentWarning,
+        contentWarningVisible:
+          state.contentWarningVisible || action.contentWarning.length > 0
+      }
+    }
+    case 'setContentWarningVisibility': {
+      return {
+        ...state,
+        contentWarning: action.visible ? state.contentWarning : '',
+        contentWarningVisible: action.visible
       }
     }
     case 'addPollChoice': {

--- a/lib/components/post-box/reducers.ts
+++ b/lib/components/post-box/reducers.ts
@@ -183,13 +183,12 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
       return DEFAULT_STATE
     }
     case 'setAttachments': {
-      const isEnteringAttachmentMode =
-        state.attachments.length === 0 && action.attachments.length > 0
+      const hasAttachments = action.attachments.length > 0
       return {
         ...state,
         attachments: action.attachments,
-        fitnessFile: isEnteringAttachmentMode ? undefined : state.fitnessFile,
-        poll: isEnteringAttachmentMode
+        fitnessFile: hasAttachments ? undefined : state.fitnessFile,
+        poll: hasAttachments
           ? {
               ...DEFAULT_STATE.poll
             }

--- a/lib/components/post-box/upload-media-button.test.tsx
+++ b/lib/components/post-box/upload-media-button.test.tsx
@@ -29,13 +29,14 @@ describe('UploadMediaButton', () => {
   const mockOnAddAttachment = jest.fn()
   const mockOnDuplicateError = jest.fn()
   const mockOnUploadStart = jest.fn()
+  const mockOnBeforeAddAttachments = jest.fn()
 
   const createMockFile = (name: string, type = 'image/jpeg') => {
     return new File(['test'], name, { type })
   }
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
     mockResizeImage.mockImplementation((file) => Promise.resolve(file))
 
     // Mock crypto.randomUUID
@@ -192,6 +193,35 @@ describe('UploadMediaButton', () => {
   })
 
   describe('async file processing', () => {
+    it('does not add processed files when the before-add hook returns false', async () => {
+      mockOnBeforeAddAttachments.mockResolvedValue(false)
+
+      render(
+        <UploadMediaButton
+          isMediaUploadEnabled={true}
+          attachments={[]}
+          onAddAttachment={mockOnAddAttachment}
+          onDuplicateError={mockOnDuplicateError}
+          onUploadStart={mockOnUploadStart}
+          onBeforeAddAttachments={mockOnBeforeAddAttachments}
+        />
+      )
+
+      const input =
+        document.querySelector<HTMLInputElement>('input[type="file"]')!
+      const file = createMockFile('file1.jpg')
+
+      fireEvent.change(input, { target: { files: [file] } })
+
+      await waitFor(() => {
+        expect(mockOnBeforeAddAttachments).toHaveBeenCalledTimes(1)
+      })
+
+      expect(mockResizeImage).toHaveBeenCalledTimes(1)
+      expect(mockOnAddAttachment).not.toHaveBeenCalled()
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test-url')
+    })
+
     it('awaits all file processing before completing', async () => {
       const processingOrder: string[] = []
 

--- a/lib/components/post-box/upload-media-button.tsx
+++ b/lib/components/post-box/upload-media-button.tsx
@@ -20,6 +20,7 @@ interface Props {
   onAddAttachment: (attachment: PostBoxAttachment) => void
   onDuplicateError: () => void
   onUploadStart: () => void
+  onBeforeAddAttachments?: () => boolean | void | Promise<boolean | void>
 }
 
 export const UploadMediaButton: FC<Props> = ({
@@ -27,7 +28,8 @@ export const UploadMediaButton: FC<Props> = ({
   attachments = [],
   onAddAttachment,
   onDuplicateError,
-  onUploadStart
+  onUploadStart,
+  onBeforeAddAttachments
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const onOpenFile = () => {
@@ -41,53 +43,73 @@ export const UploadMediaButton: FC<Props> = ({
     if (!event.currentTarget.files) return
     if (!event.currentTarget.files.length) return
 
+    const selectedFiles = Array.from(event.currentTarget.files)
     onUploadStart()
 
     const availableSlots = MAX_ATTACHMENTS - attachments.length
     if (availableSlots <= 0) return
 
-    const filteredFiles = Array.from(event.currentTarget.files).filter(
-      (file) => {
-        return !attachments.some((attachment) => attachment.name === file.name)
-      }
-    )
+    const filteredFiles = selectedFiles.filter((file) => {
+      return !attachments.some((attachment) => attachment.name === file.name)
+    })
 
-    if (filteredFiles.length !== event.currentTarget.files.length) {
+    if (filteredFiles.length !== selectedFiles.length) {
       onDuplicateError()
     }
 
     const files = filteredFiles.slice(0, availableSlots)
 
-    await Promise.all(
-      files.map(async (targetFile) => {
-        const previewUrl = URL.createObjectURL(targetFile)
-        try {
-          const tempId = crypto.randomUUID()
-          const file = await resizeImage(targetFile, MAX_WIDTH, MAX_HEIGHT)
-          onAddAttachment({
-            type: MEDIA_TYPE,
-            id: tempId,
-            mediaType: targetFile.type,
-            url: previewUrl,
-            width: 0,
-            height: 0,
-            name: targetFile.name,
-            file
-          })
-        } catch (error) {
-          logger.error(
-            {
-              error,
-              fileName: targetFile.name,
-              fileType: targetFile.type
-            },
-            'Failed to process file'
-          )
-          // Revoke the blob URL if processing fails
-          URL.revokeObjectURL(previewUrl)
+    const processedAttachments = (
+      await Promise.all(
+        files.map(async (targetFile): Promise<PostBoxAttachment | null> => {
+          const previewUrl = URL.createObjectURL(targetFile)
+          try {
+            const tempId = crypto.randomUUID()
+            const file = await resizeImage(targetFile, MAX_WIDTH, MAX_HEIGHT)
+            return {
+              type: MEDIA_TYPE,
+              id: tempId,
+              mediaType: targetFile.type,
+              url: previewUrl,
+              width: 0,
+              height: 0,
+              name: targetFile.name,
+              file
+            }
+          } catch (error) {
+            logger.error(
+              {
+                error,
+                fileName: targetFile.name,
+                fileType: targetFile.type
+              },
+              'Failed to process file'
+            )
+            // Revoke the blob URL if processing fails
+            URL.revokeObjectURL(previewUrl)
+            return null
+          }
+        })
+      )
+    ).filter(
+      (attachment): attachment is PostBoxAttachment => attachment !== null
+    )
+
+    if (!processedAttachments.length) return
+
+    const shouldAddAttachments = await onBeforeAddAttachments?.()
+    if (shouldAddAttachments === false) {
+      processedAttachments.forEach((attachment) => {
+        if (attachment.url.startsWith('blob:')) {
+          URL.revokeObjectURL(attachment.url)
         }
       })
-    )
+      return
+    }
+
+    processedAttachments.forEach((attachment) => {
+      onAddAttachment(attachment)
+    })
   }
 
   if (!isMediaUploadEnabled) {

--- a/lib/components/posts/content-warning.test.tsx
+++ b/lib/components/posts/content-warning.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { ContentWarning } from './content-warning'
+
+describe('ContentWarning', () => {
+  it('hides content until expanded', () => {
+    render(
+      <ContentWarning summary="Spoilers">
+        <p>Hidden details</p>
+      </ContentWarning>
+    )
+
+    expect(screen.getByText('Spoilers')).toBeInTheDocument()
+    expect(screen.queryByText('Hidden details')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+
+    expect(screen.getByText('Hidden details')).toBeInTheDocument()
+  })
+})

--- a/lib/components/posts/content-warning.test.tsx
+++ b/lib/components/posts/content-warning.test.tsx
@@ -17,8 +17,19 @@ describe('ContentWarning', () => {
     expect(screen.getByText('Spoilers')).toBeInTheDocument()
     expect(screen.queryByText('Hidden details')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+    const showButton = screen.getByRole('button', { name: 'Show content' })
+    expect(showButton).toHaveAttribute('aria-expanded', 'false')
+    expect(showButton).toHaveAttribute('aria-controls')
+
+    fireEvent.click(showButton)
 
     expect(screen.getByText('Hidden details')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Hide content' })
+    ).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide content' }))
+
+    expect(screen.queryByText('Hidden details')).not.toBeInTheDocument()
   })
 })

--- a/lib/components/posts/content-warning.test.tsx
+++ b/lib/components/posts/content-warning.test.tsx
@@ -8,10 +8,13 @@ import { ContentWarning } from './content-warning'
 
 describe('ContentWarning', () => {
   it('hides content until expanded', () => {
+    const onParentClick = jest.fn()
     render(
-      <ContentWarning summary="Spoilers">
-        <p>Hidden details</p>
-      </ContentWarning>
+      <div onClick={onParentClick}>
+        <ContentWarning summary="Spoilers">
+          <p>Hidden details</p>
+        </ContentWarning>
+      </div>
     )
 
     expect(screen.getByText('Spoilers')).toBeInTheDocument()
@@ -19,7 +22,7 @@ describe('ContentWarning', () => {
 
     const showButton = screen.getByRole('button', { name: 'Show content' })
     expect(showButton).toHaveAttribute('aria-expanded', 'false')
-    expect(showButton).toHaveAttribute('aria-controls')
+    expect(showButton).not.toHaveAttribute('aria-controls')
 
     fireEvent.click(showButton)
 
@@ -27,6 +30,10 @@ describe('ContentWarning', () => {
     expect(
       screen.getByRole('button', { name: 'Hide content' })
     ).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      screen.getByRole('button', { name: 'Hide content' })
+    ).toHaveAttribute('aria-controls')
+    expect(onParentClick).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Hide content' }))
 

--- a/lib/components/posts/content-warning.tsx
+++ b/lib/components/posts/content-warning.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import { FC, ReactNode, useState } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+
+interface Props {
+  children: ReactNode
+  summary: string
+}
+
+export const ContentWarning: FC<Props> = ({ children, summary }) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <div className="mt-2 rounded-md border border-border/70 bg-muted/30 px-3 py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <AlertTriangle className="size-4 shrink-0 text-muted-foreground" />
+          <span className="break-words text-sm font-medium">{summary}</span>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            setIsExpanded(!isExpanded)
+          }}
+          aria-expanded={isExpanded}
+        >
+          {isExpanded ? 'Hide' : 'Show'}
+        </Button>
+      </div>
+      {isExpanded ? <div className="mt-2">{children}</div> : null}
+    </div>
+  )
+}

--- a/lib/components/posts/content-warning.tsx
+++ b/lib/components/posts/content-warning.tsx
@@ -3,8 +3,6 @@
 import { AlertTriangle } from 'lucide-react'
 import { FC, ReactNode, useId, useState } from 'react'
 
-import { Button } from '@/lib/components/ui/button'
-
 interface Props {
   children: ReactNode
   summary: string
@@ -16,26 +14,28 @@ export const ContentWarning: FC<Props> = ({ children, summary }) => {
 
   return (
     <div className="mt-2 rounded-md border border-border/70 bg-muted/30 px-3 py-2">
-      <div className="flex items-center justify-between gap-3">
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-center justify-between gap-3 text-left"
+        onClick={(event) => {
+          event.stopPropagation()
+          setIsExpanded(!isExpanded)
+        }}
+        aria-expanded={isExpanded}
+        aria-controls={isExpanded ? contentId : undefined}
+        aria-label={isExpanded ? 'Hide content' : 'Show content'}
+      >
         <div className="flex min-w-0 items-center gap-2">
           <AlertTriangle className="size-4 shrink-0 text-muted-foreground" />
           <span className="break-words text-sm font-medium">{summary}</span>
         </div>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={(event) => {
-            event.stopPropagation()
-            setIsExpanded(!isExpanded)
-          }}
-          aria-expanded={isExpanded}
-          aria-controls={contentId}
-          aria-label={isExpanded ? 'Hide content' : 'Show content'}
+        <span
+          className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-input bg-secondary px-3 text-sm font-medium text-secondary-foreground shadow-xs"
+          aria-hidden="true"
         >
           {isExpanded ? 'Hide' : 'Show'}
-        </Button>
-      </div>
+        </span>
+      </button>
       {isExpanded ? (
         <div id={contentId} className="mt-2">
           {children}

--- a/lib/components/posts/content-warning.tsx
+++ b/lib/components/posts/content-warning.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AlertTriangle } from 'lucide-react'
-import { FC, ReactNode, useState } from 'react'
+import { FC, ReactNode, useId, useState } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
 
@@ -12,6 +12,7 @@ interface Props {
 
 export const ContentWarning: FC<Props> = ({ children, summary }) => {
   const [isExpanded, setIsExpanded] = useState(false)
+  const contentId = useId()
 
   return (
     <div className="mt-2 rounded-md border border-border/70 bg-muted/30 px-3 py-2">
@@ -29,11 +30,17 @@ export const ContentWarning: FC<Props> = ({ children, summary }) => {
             setIsExpanded(!isExpanded)
           }}
           aria-expanded={isExpanded}
+          aria-controls={contentId}
+          aria-label={isExpanded ? 'Hide content' : 'Show content'}
         >
           {isExpanded ? 'Hide' : 'Show'}
         </Button>
       </div>
-      {isExpanded ? <div className="mt-2">{children}</div> : null}
+      {isExpanded ? (
+        <div id={contentId} className="mt-2">
+          {children}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -65,7 +65,7 @@ describe('Poll', () => {
     jest.useRealTimers()
   })
 
-  it('updates poll availability after the initial render time expires', () => {
+  it('updates poll availability when the poll reaches its end time', () => {
     render(
       <Poll
         status={pollStatus}
@@ -75,16 +75,18 @@ describe('Poll', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Vote' })).toBeInTheDocument()
+    expect(jest.getTimerCount()).toBe(1)
 
     act(() => {
-      jest.setSystemTime(new Date(currentTime.getTime() + 60_000))
-      jest.advanceTimersByTime(60_000)
+      jest.setSystemTime(new Date(pollStatus.endAt))
+      jest.advanceTimersByTime(pollStatus.endAt - currentTime.getTime())
     })
 
     expect(screen.getByText('Poll closed')).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Vote' })
     ).not.toBeInTheDocument()
+    expect(jest.getTimerCount()).toBe(0)
   })
 
   it('does not start a timer for already closed polls', () => {

--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -86,4 +86,20 @@ describe('Poll', () => {
       screen.queryByRole('button', { name: 'Vote' })
     ).not.toBeInTheDocument()
   })
+
+  it('does not start a timer for already closed polls', () => {
+    render(
+      <Poll
+        status={{
+          ...pollStatus,
+          endAt: currentTime.getTime() - 1_000
+        }}
+        currentTime={currentTime}
+        currentActorId="https://activities.local/actors/llun"
+      />
+    )
+
+    expect(screen.getByText('Poll closed')).toBeInTheDocument()
+    expect(jest.getTimerCount()).toBe(0)
+  })
 })

--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, render, screen } from '@testing-library/react'
+
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+
+import { Poll } from './poll'
+
+jest.mock('@/lib/client', () => ({
+  votePoll: jest.fn()
+}))
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z')
+
+const pollStatus: StatusPoll = {
+  id: 'https://activities.local/statuses/poll-1',
+  actorId: 'https://activities.local/actors/llun',
+  actor: null,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime.getTime(),
+  updatedAt: currentTime.getTime(),
+  type: StatusType.enum.Poll,
+  url: 'https://activities.local/@llun/poll-1',
+  text: 'Question',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  attachments: [],
+  tags: [],
+  choices: [
+    {
+      statusId: 'https://activities.local/statuses/poll-1',
+      title: 'First',
+      totalVotes: 0,
+      createdAt: currentTime.getTime(),
+      updatedAt: currentTime.getTime()
+    },
+    {
+      statusId: 'https://activities.local/statuses/poll-1',
+      title: 'Second',
+      totalVotes: 0,
+      createdAt: currentTime.getTime(),
+      updatedAt: currentTime.getTime()
+    }
+  ],
+  endAt: currentTime.getTime() + 30_000,
+  pollType: 'oneOf'
+}
+
+describe('Poll', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(currentTime)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('updates poll availability after the initial render time expires', () => {
+    render(
+      <Poll
+        status={pollStatus}
+        currentTime={currentTime}
+        currentActorId="https://activities.local/actors/llun"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Vote' })).toBeInTheDocument()
+
+    act(() => {
+      jest.setSystemTime(new Date(currentTime.getTime() + 60_000))
+      jest.advanceTimersByTime(60_000)
+    })
+
+    expect(screen.getByText('Poll closed')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Vote' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/lib/components/posts/poll.test.tsx
+++ b/lib/components/posts/poll.test.tsx
@@ -12,7 +12,7 @@ jest.mock('@/lib/client', () => ({
   votePoll: jest.fn()
 }))
 
-const currentTime = new Date('2026-04-26T10:00:00.000Z')
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
 
 const pollStatus: StatusPoll = {
   id: 'https://activities.local/statuses/poll-1',
@@ -22,8 +22,8 @@ const pollStatus: StatusPoll = {
   cc: [],
   edits: [],
   isLocalActor: true,
-  createdAt: currentTime.getTime(),
-  updatedAt: currentTime.getTime(),
+  createdAt: currentTime,
+  updatedAt: currentTime,
   type: StatusType.enum.Poll,
   url: 'https://activities.local/@llun/poll-1',
   text: 'Question',
@@ -40,25 +40,25 @@ const pollStatus: StatusPoll = {
       statusId: 'https://activities.local/statuses/poll-1',
       title: 'First',
       totalVotes: 0,
-      createdAt: currentTime.getTime(),
-      updatedAt: currentTime.getTime()
+      createdAt: currentTime,
+      updatedAt: currentTime
     },
     {
       statusId: 'https://activities.local/statuses/poll-1',
       title: 'Second',
       totalVotes: 0,
-      createdAt: currentTime.getTime(),
-      updatedAt: currentTime.getTime()
+      createdAt: currentTime,
+      updatedAt: currentTime
     }
   ],
-  endAt: currentTime.getTime() + 30_000,
+  endAt: currentTime + 30_000,
   pollType: 'oneOf'
 }
 
 describe('Poll', () => {
   beforeEach(() => {
     jest.useFakeTimers()
-    jest.setSystemTime(currentTime)
+    jest.setSystemTime(new Date(currentTime))
   })
 
   afterEach(() => {
@@ -79,7 +79,7 @@ describe('Poll', () => {
 
     act(() => {
       jest.setSystemTime(new Date(pollStatus.endAt))
-      jest.advanceTimersByTime(pollStatus.endAt - currentTime.getTime())
+      jest.advanceTimersByTime(pollStatus.endAt - currentTime)
     })
 
     expect(screen.getByText('Poll closed')).toBeInTheDocument()
@@ -89,12 +89,37 @@ describe('Poll', () => {
     expect(jest.getTimerCount()).toBe(0)
   })
 
+  it('syncs poll availability when currentTime prop changes', () => {
+    const { rerender } = render(
+      <Poll
+        status={pollStatus}
+        currentTime={currentTime}
+        currentActorId="https://activities.local/actors/llun"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Vote' })).toBeInTheDocument()
+
+    rerender(
+      <Poll
+        status={pollStatus}
+        currentTime={pollStatus.endAt}
+        currentActorId="https://activities.local/actors/llun"
+      />
+    )
+
+    expect(screen.getByText('Poll closed')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Vote' })
+    ).not.toBeInTheDocument()
+  })
+
   it('does not start a timer for already closed polls', () => {
     render(
       <Poll
         status={{
           ...pollStatus,
-          endAt: currentTime.getTime() - 1_000
+          endAt: currentTime - 1_000
         }}
         currentTime={currentTime}
         currentActorId="https://activities.local/actors/llun"

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -8,7 +8,7 @@ import { Status, StatusType } from '@/lib/types/domain/status'
 
 interface Props {
   status: Status
-  currentTime: Date
+  currentTime: number
   currentActorId?: string
 }
 
@@ -25,15 +25,19 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
   )
 
   useEffect(() => {
+    setNow(currentTime)
+  }, [currentTime])
+
+  useEffect(() => {
     if (pollEndAt === undefined) return
 
-    const nextNow = new Date()
+    const nextNow = Date.now()
     setNow(nextNow)
-    if (nextNow.getTime() >= pollEndAt) return
+    if (nextNow >= pollEndAt) return
 
     const timeout = setTimeout(() => {
-      setNow(new Date())
-    }, pollEndAt - nextNow.getTime())
+      setNow(Date.now())
+    }, pollEndAt - nextNow)
 
     return () => {
       clearTimeout(timeout)
@@ -43,7 +47,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
   if (status.type !== StatusType.enum.Poll) return null
   if (!status.choices) return null
 
-  const isPollClosed = now.getTime() >= status.endAt
+  const isPollClosed = now >= status.endAt
   const choices = status.choices
   const totalVotes =
     choices.reduce((sum, choice) => sum + choice.totalVotes, 0) || 1

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { formatDistance } from 'date-fns'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 
 import { votePoll } from '@/lib/client'
 import { Status, StatusType } from '@/lib/types/domain/status'
@@ -13,6 +13,7 @@ interface Props {
 }
 
 export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
+  const [now, setNow] = useState(currentTime)
   const [selectedChoices, setSelectedChoices] = useState<number[]>([])
   const [isVoting, setIsVoting] = useState(false)
   const [votedChoices, setVotedChoices] = useState<number[]>(
@@ -21,10 +22,23 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
       : []
   )
 
+  useEffect(() => {
+    if (status.type !== StatusType.enum.Poll) return
+
+    setNow(new Date())
+    const interval = window.setInterval(() => {
+      setNow(new Date())
+    }, 60_000)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [status.id, status.type])
+
   if (status.type !== StatusType.enum.Poll) return null
   if (!status.choices) return null
 
-  const isPollClosed = currentTime.getTime() > status.endAt
+  const isPollClosed = now.getTime() > status.endAt
   const choices = status.choices
   const totalVotes =
     choices.reduce((sum, choice) => sum + choice.totalVotes, 0) || 1
@@ -123,7 +137,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
       {isPollClosed ? <div className="text-sm">Poll closed</div> : null}
       {!isPollClosed ? (
         <div className="text-sm">
-          Poll close in {formatDistance(status.endAt, currentTime)}
+          Poll close in {formatDistance(status.endAt, now)}
         </div>
       ) : null}
     </div>

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -13,6 +13,8 @@ interface Props {
 }
 
 export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
+  const pollEndAt =
+    status.type === StatusType.enum.Poll ? status.endAt : undefined
   const [now, setNow] = useState(currentTime)
   const [selectedChoices, setSelectedChoices] = useState<number[]>([])
   const [isVoting, setIsVoting] = useState(false)
@@ -23,17 +25,24 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
   )
 
   useEffect(() => {
-    if (status.type !== StatusType.enum.Poll) return
+    if (pollEndAt === undefined) return
 
-    setNow(new Date())
+    const nextNow = new Date()
+    setNow(nextNow)
+    if (nextNow.getTime() > pollEndAt) return
+
     const interval = setInterval(() => {
-      setNow(new Date())
+      const nextNow = new Date()
+      setNow(nextNow)
+      if (nextNow.getTime() > pollEndAt) {
+        clearInterval(interval)
+      }
     }, 60_000)
 
     return () => {
       clearInterval(interval)
     }
-  }, [status.id, status.type])
+  }, [pollEndAt, status.id])
 
   if (status.type !== StatusType.enum.Poll) return null
   if (!status.choices) return null

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -26,12 +26,12 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
     if (status.type !== StatusType.enum.Poll) return
 
     setNow(new Date())
-    const interval = window.setInterval(() => {
+    const interval = setInterval(() => {
       setNow(new Date())
     }, 60_000)
 
     return () => {
-      window.clearInterval(interval)
+      clearInterval(interval)
     }
   }, [status.id, status.type])
 

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -29,25 +29,21 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
 
     const nextNow = new Date()
     setNow(nextNow)
-    if (nextNow.getTime() > pollEndAt) return
+    if (nextNow.getTime() >= pollEndAt) return
 
-    const interval = setInterval(() => {
-      const nextNow = new Date()
-      setNow(nextNow)
-      if (nextNow.getTime() > pollEndAt) {
-        clearInterval(interval)
-      }
-    }, 60_000)
+    const timeout = setTimeout(() => {
+      setNow(new Date())
+    }, pollEndAt - nextNow.getTime())
 
     return () => {
-      clearInterval(interval)
+      clearTimeout(timeout)
     }
   }, [pollEndAt, status.id])
 
   if (status.type !== StatusType.enum.Poll) return null
   if (!status.choices) return null
 
-  const isPollClosed = now.getTime() > status.endAt
+  const isPollClosed = now.getTime() >= status.endAt
   const choices = status.choices
   const totalVotes =
     choices.reduce((sum, choice) => sum + choice.totalVotes, 0) || 1

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
+
+import { Post } from './post'
+
+jest.mock('./collapsible-content', () => ({
+  CollapsibleContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="collapsible-content">{children}</div>
+  )
+}))
+
+jest.mock('./poll', () => ({
+  Poll: () => null
+}))
+
+jest.mock('./attachments', () => ({
+  Attachments: () => null
+}))
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const status: StatusNote = {
+  id: 'https://activities.local/users/llun/statuses/post-1',
+  actorId: 'https://activities.local/users/llun',
+  actor: {
+    id: 'https://activities.local/users/llun',
+    username: 'llun',
+    domain: 'activities.local',
+    name: 'Llun',
+    followersUrl: 'https://activities.local/users/llun/followers',
+    inboxUrl: 'https://activities.local/users/llun/inbox',
+    sharedInboxUrl: 'https://activities.local/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: currentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://activities.local/@llun/post-1',
+  text: 'Long content',
+  summary: 'Spoilers',
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  attachments: [],
+  tags: []
+}
+
+describe('Post', () => {
+  it('does not nest long-post collapse inside expanded content warnings', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={status}
+        collapsible
+        postLineLimit={1}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show content' }))
+
+    expect(screen.queryByTestId('collapsible-content')).not.toBeInTheDocument()
+  })
+})

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -93,9 +93,10 @@ export const Post: FC<PostProps> = (props) => {
   const isOwner =
     Boolean(actualStatus.isLocalActor) &&
     props.currentActor?.id === actualStatus.actorId
+  const summary = actualStatus.summary?.trim()
   const statusBody = (
     <>
-      {collapsible && postLineLimit !== 0 ? (
+      {collapsible && postLineLimit !== 0 && !summary ? (
         <CollapsibleContent
           className="mt-1 text-sm leading-relaxed break-words markdown-content"
           maxLines={postLineLimit}
@@ -204,7 +205,6 @@ export const Post: FC<PostProps> = (props) => {
       <Attachments status={actualStatus} onMediaSelected={onShowAttachment} />
     </>
   )
-  const summary = actualStatus.summary?.trim()
 
   return (
     <div className="flex flex-col gap-1">

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -198,7 +198,7 @@ export const Post: FC<PostProps> = (props) => {
 
       <Poll
         status={actualStatus}
-        currentTime={new Date()}
+        currentTime={props.currentTime}
         currentActorId={props.currentActor?.id}
       />
       <Attachments status={actualStatus} onMediaSelected={onShowAttachment} />

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -24,6 +24,7 @@ import { Actions } from './actions/actions'
 import { ActorAvatar, ActorInfo } from './actor'
 import { Attachments, OnMediaSelectedHandle } from './attachments'
 import { CollapsibleContent } from './collapsible-content'
+import { ContentWarning } from './content-warning'
 import { Poll } from './poll'
 import { RetryFitnessButton } from './retry-fitness-button'
 
@@ -92,6 +93,118 @@ export const Post: FC<PostProps> = (props) => {
   const isOwner =
     Boolean(actualStatus.isLocalActor) &&
     props.currentActor?.id === actualStatus.actorId
+  const statusBody = (
+    <>
+      {collapsible && postLineLimit !== 0 ? (
+        <CollapsibleContent
+          className="mt-1 text-sm leading-relaxed break-words markdown-content"
+          maxLines={postLineLimit}
+        >
+          {processedAndCleanedText}
+        </CollapsibleContent>
+      ) : (
+        <div className="mt-1 text-sm leading-relaxed break-words markdown-content">
+          {processedAndCleanedText}
+        </div>
+      )}
+      {fitnessFile ? (
+        <div className="mt-2 max-w-full rounded-md border bg-muted/30 px-3 py-2 text-xs">
+          <div className="flex max-w-full items-center gap-2">
+            <Activity className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 font-medium text-muted-foreground">
+              Fitness
+            </span>
+            <a
+              href={fitnessFile.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(event) => event.stopPropagation()}
+              className="truncate text-foreground underline-offset-2 hover:underline"
+              title={fitnessFile.fileName}
+            >
+              {fitnessFile.fileName}
+            </a>
+            <span className="shrink-0 text-muted-foreground uppercase">
+              {fitnessFile.fileType}
+            </span>
+          </div>
+
+          {isFitnessProcessing ? (
+            <div className="mt-2 inline-flex items-center gap-2 text-muted-foreground">
+              <LoaderCircle className="size-3.5 animate-spin" />
+              <span>Processing fitness activity...</span>
+            </div>
+          ) : null}
+
+          {isFitnessFailed ? (
+            isOwner ? (
+              <RetryFitnessButton statusId={actualStatus.id} />
+            ) : (
+              <div className="mt-2 flex items-center gap-2 text-destructive">
+                <span>
+                  Processing failed. The original activity file is still
+                  available.
+                </span>
+              </div>
+            )
+          ) : null}
+
+          {isFitnessCompleted ? (
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
+              {fitnessDistance ? (
+                <span>
+                  Distance:{' '}
+                  <strong className="text-foreground">{fitnessDistance}</strong>
+                </span>
+              ) : null}
+              {fitnessDuration ? (
+                <span>
+                  Duration:{' '}
+                  <strong className="text-foreground">{fitnessDuration}</strong>
+                </span>
+              ) : null}
+              {fitnessPaceOrSpeed ? (
+                <span>
+                  {fitnessPaceOrSpeed.label}:{' '}
+                  <strong className="text-foreground">
+                    {fitnessPaceOrSpeed.value}
+                  </strong>
+                </span>
+              ) : null}
+              {fitnessElevation ? (
+                <span>
+                  Elevation:{' '}
+                  <strong className="text-foreground">
+                    {fitnessElevation}
+                  </strong>
+                </span>
+              ) : null}
+              {getDeviceDisplayLabel(
+                fitnessFile.deviceName,
+                fitnessFile.deviceManufacturer
+              ) ? (
+                <span className="text-muted-foreground">
+                  Via:{' '}
+                  <BrandedDeviceLink
+                    deviceName={fitnessFile.deviceName}
+                    deviceManufacturer={fitnessFile.deviceManufacturer}
+                  />
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <Poll
+        status={actualStatus}
+        currentTime={new Date()}
+        currentActorId={props.currentActor?.id}
+      />
+      <Attachments status={actualStatus} onMediaSelected={onShowAttachment} />
+    </>
+  )
+  const summary = actualStatus.summary?.trim()
 
   return (
     <div className="flex flex-col gap-1">
@@ -128,120 +241,11 @@ export const Post: FC<PostProps> = (props) => {
             )}
           </div>
 
-          {collapsible && postLineLimit !== 0 ? (
-            <CollapsibleContent
-              className="mt-1 text-sm leading-relaxed break-words markdown-content"
-              maxLines={postLineLimit}
-            >
-              {processedAndCleanedText}
-            </CollapsibleContent>
+          {summary ? (
+            <ContentWarning summary={summary}>{statusBody}</ContentWarning>
           ) : (
-            <div className="mt-1 text-sm leading-relaxed break-words markdown-content">
-              {processedAndCleanedText}
-            </div>
+            statusBody
           )}
-          {fitnessFile ? (
-            <div className="mt-2 max-w-full rounded-md border bg-muted/30 px-3 py-2 text-xs">
-              <div className="flex max-w-full items-center gap-2">
-                <Activity className="size-3.5 shrink-0 text-muted-foreground" />
-                <span className="shrink-0 font-medium text-muted-foreground">
-                  Fitness
-                </span>
-                <a
-                  href={fitnessFile.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(event) => event.stopPropagation()}
-                  className="truncate text-foreground underline-offset-2 hover:underline"
-                  title={fitnessFile.fileName}
-                >
-                  {fitnessFile.fileName}
-                </a>
-                <span className="shrink-0 text-muted-foreground uppercase">
-                  {fitnessFile.fileType}
-                </span>
-              </div>
-
-              {isFitnessProcessing ? (
-                <div className="mt-2 inline-flex items-center gap-2 text-muted-foreground">
-                  <LoaderCircle className="size-3.5 animate-spin" />
-                  <span>Processing fitness activity...</span>
-                </div>
-              ) : null}
-
-              {isFitnessFailed ? (
-                isOwner ? (
-                  <RetryFitnessButton statusId={actualStatus.id} />
-                ) : (
-                  <div className="mt-2 flex items-center gap-2 text-destructive">
-                    <span>
-                      Processing failed. The original activity file is still
-                      available.
-                    </span>
-                  </div>
-                )
-              ) : null}
-
-              {isFitnessCompleted ? (
-                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
-                  {fitnessDistance ? (
-                    <span>
-                      Distance:{' '}
-                      <strong className="text-foreground">
-                        {fitnessDistance}
-                      </strong>
-                    </span>
-                  ) : null}
-                  {fitnessDuration ? (
-                    <span>
-                      Duration:{' '}
-                      <strong className="text-foreground">
-                        {fitnessDuration}
-                      </strong>
-                    </span>
-                  ) : null}
-                  {fitnessPaceOrSpeed ? (
-                    <span>
-                      {fitnessPaceOrSpeed.label}:{' '}
-                      <strong className="text-foreground">
-                        {fitnessPaceOrSpeed.value}
-                      </strong>
-                    </span>
-                  ) : null}
-                  {fitnessElevation ? (
-                    <span>
-                      Elevation:{' '}
-                      <strong className="text-foreground">
-                        {fitnessElevation}
-                      </strong>
-                    </span>
-                  ) : null}
-                  {getDeviceDisplayLabel(
-                    fitnessFile.deviceName,
-                    fitnessFile.deviceManufacturer
-                  ) ? (
-                    <span className="text-muted-foreground">
-                      Via:{' '}
-                      <BrandedDeviceLink
-                        deviceName={fitnessFile.deviceName}
-                        deviceManufacturer={fitnessFile.deviceManufacturer}
-                      />
-                    </span>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-
-          <Poll
-            status={actualStatus}
-            currentTime={new Date()}
-            currentActorId={props.currentActor?.id}
-          />
-          <Attachments
-            status={actualStatus}
-            onMediaSelected={onShowAttachment}
-          />
 
           <div onClick={(e) => e.stopPropagation()}>
             <Actions {...props} />

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -31,7 +31,7 @@ import { RetryFitnessButton } from './retry-fitness-button'
 export interface PostProps {
   host: string
   currentActor?: ActorProfile
-  currentTime: Date
+  currentTime: number
   status: Status
   editable?: boolean
   showActions?: boolean

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -19,7 +19,7 @@ interface Props {
   className?: string
   currentActor?: ActorProfile
   showActions?: boolean
-  currentTime: Date
+  currentTime: number
   statuses: Status[]
   isMediaUploadEnabled?: boolean
   postLineLimit?: PostLineLimit

--- a/lib/components/posts/status-reply-box.test.tsx
+++ b/lib/components/posts/status-reply-box.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { createNote } from '@/lib/client'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
+
+import { StatusReplyBox } from './status-reply-box'
+
+jest.mock('@/lib/client', () => ({
+  createNote: jest.fn(),
+  uploadAttachment: jest.fn()
+}))
+
+const createNoteMock = createNote as jest.MockedFunction<typeof createNote>
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const profile: ActorProfile = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  domain: 'activities.local',
+  name: 'Llun',
+  followersUrl: 'https://activities.local/users/llun/followers',
+  inboxUrl: 'https://activities.local/users/llun/inbox',
+  sharedInboxUrl: 'https://activities.local/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: currentTime
+}
+
+const replyStatus: StatusNote = {
+  id: 'https://activities.local/users/llun/statuses/post-1',
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://activities.local/@llun/post-1',
+  text: 'Original status',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  attachments: [],
+  tags: []
+}
+
+describe('StatusReplyBox', () => {
+  beforeEach(() => {
+    createNoteMock.mockResolvedValue({
+      status: replyStatus,
+      attachments: []
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not submit hidden content warning text', async () => {
+    render(
+      <StatusReplyBox
+        profile={profile}
+        replyStatus={replyStatus}
+        onCancel={jest.fn()}
+        onPostCreated={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Reply to Llun...'), {
+      target: { value: 'Reply body' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add content warning' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Content warning' }), {
+      target: { value: 'Spoilers' }
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove content warning' })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }))
+
+    await waitFor(() => {
+      expect(createNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contentWarning: ''
+        })
+      )
+    })
+  })
+})

--- a/lib/components/posts/status-reply-box.test.tsx
+++ b/lib/components/posts/status-reply-box.test.tsx
@@ -94,7 +94,7 @@ describe('StatusReplyBox', () => {
     await waitFor(() => {
       expect(createNoteMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          contentWarning: ''
+          contentWarning: undefined
         })
       )
     })

--- a/lib/components/posts/status-reply-box.tsx
+++ b/lib/components/posts/status-reply-box.tsx
@@ -146,7 +146,7 @@ export const StatusReplyBox: FC<Props> = ({
     const message = text
     const contentWarning = postExtension.contentWarningVisible
       ? postExtension.contentWarning
-      : ''
+      : undefined
 
     try {
       const uploadResults = await Promise.all(

--- a/lib/components/posts/status-reply-box.tsx
+++ b/lib/components/posts/status-reply-box.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Loader2 } from 'lucide-react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
 import {
   FC,
   FormEvent,
@@ -17,6 +17,8 @@ import {
   addAttachment,
   resetExtension,
   setAttachments,
+  setContentWarning,
+  setContentWarningVisibility,
   statusExtensionReducer,
   updateAttachment
 } from '@/lib/components/post-box/reducers'
@@ -206,6 +208,7 @@ export const StatusReplyBox: FC<Props> = ({
 
       const response = await createNote({
         message,
+        contentWarning: postExtension.contentWarning,
         replyStatus,
         attachments
       })
@@ -296,6 +299,19 @@ export const StatusReplyBox: FC<Props> = ({
               value={text}
             />
 
+            {postExtension.contentWarningVisible ? (
+              <input
+                className="mt-2 flex h-8 w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                aria-label="Content warning"
+                name="contentWarning"
+                placeholder="Write your warning here"
+                value={postExtension.contentWarning}
+                onChange={(event) =>
+                  dispatch(setContentWarning(event.target.value))
+                }
+              />
+            ) : null}
+
             {postExtension.attachments.length > 0 && (
               <div className="grid gap-2 grid-cols-8 mt-2">
                 {postExtension.attachments.map((item, index) => (
@@ -322,6 +338,28 @@ export const StatusReplyBox: FC<Props> = ({
             ) : null}
 
             <div className="flex items-center mt-2">
+              <Button
+                type="button"
+                variant={
+                  postExtension.contentWarningVisible ? 'secondary' : 'link'
+                }
+                size="icon-sm"
+                aria-label={
+                  postExtension.contentWarningVisible
+                    ? 'Remove content warning'
+                    : 'Add content warning'
+                }
+                title="Content warning"
+                onClick={() =>
+                  dispatch(
+                    setContentWarningVisibility(
+                      !postExtension.contentWarningVisible
+                    )
+                  )
+                }
+              >
+                <AlertTriangle className="size-4" />
+              </Button>
               <UploadMediaButton
                 isMediaUploadEnabled={isMediaUploadEnabled}
                 attachments={postExtension.attachments}

--- a/lib/components/posts/status-reply-box.tsx
+++ b/lib/components/posts/status-reply-box.tsx
@@ -144,6 +144,9 @@ export const StatusReplyBox: FC<Props> = ({
     setWarningMsg(null)
     removedAttachmentIdsRef.current.clear()
     const message = text
+    const contentWarning = postExtension.contentWarningVisible
+      ? postExtension.contentWarning
+      : ''
 
     try {
       const uploadResults = await Promise.all(
@@ -208,7 +211,7 @@ export const StatusReplyBox: FC<Props> = ({
 
       const response = await createNote({
         message,
-        contentWarning: postExtension.contentWarning,
+        contentWarning,
         replyStatus,
         attachments
       })
@@ -301,6 +304,7 @@ export const StatusReplyBox: FC<Props> = ({
 
             {postExtension.contentWarningVisible ? (
               <input
+                type="text"
                 className="mt-2 flex h-8 w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                 aria-label="Content warning"
                 name="contentWarning"


### PR DESCRIPTION
## Summary

- Add content warning composition support for notes, replies, polls, and status edits.
- Map custom outbox `contentWarning` and Mastodon API `spoiler_text` to the existing status `summary` field.
- Collapse status text, polls, fitness details, and attachments behind the summary until expanded.

## Validation

- `yarn run prettier --write`
- `git diff --check`
- `yarn lint` (passes with existing `no-explicit-any` warnings in auth adapter and fitness parser files)
- `yarn build`
- `yarn test`
- Browser check on `https://activities.local/`: content warning composer input appears and toggles correctly. I did not submit a local timeline test post without explicit confirmation.

No database migration was needed because the existing `summary` field already stores this data.