### PR TITLE
feat: add federation domain rules

### DIFF
--- a/app/(timeline)/admin/federation/actions.ts
+++ b/app/(timeline)/admin/federation/actions.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/services/federation/domainRules'
 import { DomainBlockSeverity } from '@/lib/types/database/operations'
 import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+import { logger } from '@/lib/utils/logger'
 
 const ADMIN_FEDERATION_PATH = '/admin/federation'
 
@@ -108,7 +109,12 @@ export async function importKnownDomainBlocklistAction(formData: FormData) {
     created = result.created
     updated = result.updated
     skipped = result.skipped
-  } catch {
+  } catch (error) {
+    logger.error({
+      message: 'Failed to import known domain blocklist',
+      sourceId,
+      error
+    })
     redirectWithStatus('import-failed')
   }
 

--- a/app/(timeline)/admin/federation/actions.ts
+++ b/app/(timeline)/admin/federation/actions.ts
@@ -1,0 +1,108 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import {
+  KnownDomainBlocklistSourceId,
+  fetchKnownDomainBlocklist
+} from '@/lib/services/federation/blocklistSources'
+import {
+  DEFAULT_DOMAIN_BLOCK_SEVERITY,
+  normalizeDomain
+} from '@/lib/services/federation/domainRules'
+import { DomainBlockSeverity } from '@/lib/types/database/operations'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+const ADMIN_FEDERATION_PATH = '/admin/federation'
+
+const getAdminDatabase = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) redirect('/')
+
+  return database
+}
+
+const redirectWithStatus = (status: string): never => {
+  revalidatePath(ADMIN_FEDERATION_PATH)
+  redirect(`${ADMIN_FEDERATION_PATH}?status=${encodeURIComponent(status)}`)
+}
+
+const getText = (formData: FormData, key: string): string =>
+  String(formData.get(key) ?? '').trim()
+
+const getCheckbox = (formData: FormData, key: string): boolean =>
+  formData.get(key) === 'on'
+
+const getSeverity = (value: string): DomainBlockSeverity =>
+  value === 'noop' || value === 'silence' || value === 'suspend'
+    ? value
+    : DEFAULT_DOMAIN_BLOCK_SEVERITY
+
+export async function createDomainBlockAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const domain = normalizeDomain(getText(formData, 'domain'))
+  const normalizedDomain = domain ?? redirectWithStatus('invalid-block-domain')
+
+  await database.createDomainBlock({
+    domain: normalizedDomain,
+    severity: getSeverity(getText(formData, 'severity')),
+    rejectMedia: getCheckbox(formData, 'rejectMedia'),
+    rejectReports: getCheckbox(formData, 'rejectReports'),
+    privateComment: getText(formData, 'privateComment') || null,
+    publicComment: getText(formData, 'publicComment') || null,
+    obfuscate: getCheckbox(formData, 'obfuscate'),
+    source: null
+  })
+
+  redirectWithStatus('block-saved')
+}
+
+export async function deleteDomainBlockAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const id = getText(formData, 'id')
+  if (id) await database.deleteDomainBlock(id)
+
+  redirectWithStatus('block-deleted')
+}
+
+export async function createDomainAllowAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const domain = normalizeDomain(getText(formData, 'domain'))
+  const normalizedDomain = domain ?? redirectWithStatus('invalid-allow-domain')
+
+  await database.createDomainAllow({ domain: normalizedDomain })
+
+  redirectWithStatus('allow-saved')
+}
+
+export async function deleteDomainAllowAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const id = getText(formData, 'id')
+  if (id) await database.deleteDomainAllow(id)
+
+  redirectWithStatus('allow-deleted')
+}
+
+export async function importKnownDomainBlocklistAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const source = KnownDomainBlocklistSourceId.safeParse(
+    getText(formData, 'source')
+  )
+  const sourceId = source.success
+    ? source.data
+    : redirectWithStatus('invalid-source')
+
+  const blocks = await fetchKnownDomainBlocklist(sourceId)
+  const result = await database.importDomainBlocks({ blocks })
+
+  redirectWithStatus(
+    `imported-${result.created}-${result.updated}-${result.skipped}`
+  )
+}

--- a/app/(timeline)/admin/federation/actions.ts
+++ b/app/(timeline)/admin/federation/actions.ts
@@ -7,7 +7,7 @@ import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import {
   KnownDomainBlocklistSourceId,
-  fetchKnownDomainBlocklist
+  downloadKnownDomainBlocklist
 } from '@/lib/services/federation/blocklistSources'
 import {
   DEFAULT_DOMAIN_BLOCK_SEVERITY,
@@ -103,7 +103,7 @@ export async function importKnownDomainBlocklistAction(formData: FormData) {
   let updated = 0
   let skipped = 0
   try {
-    const blocks = await fetchKnownDomainBlocklist(sourceId)
+    const blocks = await downloadKnownDomainBlocklist(sourceId)
     const result = await database.importDomainBlocks({ blocks })
     created = result.created
     updated = result.updated

--- a/app/(timeline)/admin/federation/actions.ts
+++ b/app/(timeline)/admin/federation/actions.ts
@@ -99,10 +99,18 @@ export async function importKnownDomainBlocklistAction(formData: FormData) {
     ? source.data
     : redirectWithStatus('invalid-source')
 
-  const blocks = await fetchKnownDomainBlocklist(sourceId)
-  const result = await database.importDomainBlocks({ blocks })
+  let created = 0
+  let updated = 0
+  let skipped = 0
+  try {
+    const blocks = await fetchKnownDomainBlocklist(sourceId)
+    const result = await database.importDomainBlocks({ blocks })
+    created = result.created
+    updated = result.updated
+    skipped = result.skipped
+  } catch {
+    redirectWithStatus('import-failed')
+  }
 
-  redirectWithStatus(
-    `imported-${result.created}-${result.updated}-${result.skipped}`
-  )
+  redirectWithStatus(`imported-${created}-${updated}-${skipped}`)
 }

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -1,4 +1,12 @@
-import { Download, ShieldBan, ShieldCheck, Trash2 } from 'lucide-react'
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ShieldBan,
+  ShieldCheck,
+  Trash2
+} from 'lucide-react'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import {
@@ -18,7 +26,7 @@ import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { KNOWN_DOMAIN_BLOCKLIST_SOURCES } from '@/lib/services/federation/blocklistSources'
-import { toPublicDomainBlock } from '@/lib/services/federation/domainRules'
+import { cn } from '@/lib/utils'
 import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
 
 export const dynamic = 'force-dynamic'
@@ -38,6 +46,13 @@ const STATUS_MESSAGES: Record<string, string> = {
   'import-failed': 'Unable to import the blocklist'
 }
 
+const ERROR_STATUSES = new Set([
+  'invalid-block-domain',
+  'invalid-allow-domain',
+  'invalid-source',
+  'import-failed'
+])
+
 const ADMIN_FEDERATION_PAGE_SIZE = 100
 
 const getStatusMessage = (status?: string): string | null => {
@@ -50,6 +65,87 @@ const getStatusMessage = (status?: string): string | null => {
   return `Imported ${match[1]} new block${match[1] === '1' ? '' : 's'}, updated ${match[2]}, skipped ${match[3]}`
 }
 
+const getOffset = (value?: string): number => {
+  const offset = Number(value ?? 0)
+  return Number.isInteger(offset) && offset > 0 ? offset : 0
+}
+
+const getPaginationHref = ({
+  blockOffset,
+  allowOffset
+}: {
+  blockOffset: number
+  allowOffset: number
+}): string => {
+  const params = new URLSearchParams()
+  if (blockOffset > 0) params.set('blockOffset', String(blockOffset))
+  if (allowOffset > 0) params.set('allowOffset', String(allowOffset))
+
+  const query = params.toString()
+  return query ? `/admin/federation?${query}` : '/admin/federation'
+}
+
+const getNextOffset = (offset: number, count: number): number => offset + count
+
+const getPreviousOffset = (offset: number): number =>
+  Math.max(0, offset - ADMIN_FEDERATION_PAGE_SIZE)
+
+const getPaginationLabel = (
+  noun: string,
+  offset: number,
+  count: number,
+  total: number
+): string => {
+  if (count === 0) return `Showing 0 of ${total} ${noun}`
+  return `Showing ${offset + 1}-${offset + count} of ${total} ${noun}`
+}
+
+const PaginationControls = ({
+  label,
+  previousHref,
+  nextHref,
+  hasPrevious,
+  hasNext
+}: {
+  label: string
+  previousHref: string
+  nextHref: string
+  hasPrevious: boolean
+  hasNext: boolean
+}) => (
+  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <p className="text-sm text-muted-foreground">{label}</p>
+    <div className="flex gap-2">
+      {hasPrevious ? (
+        <Button asChild variant="outline" size="sm">
+          <Link href={previousHref}>
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Link>
+        </Button>
+      ) : (
+        <Button disabled variant="outline" size="sm">
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </Button>
+      )}
+      {hasNext ? (
+        <Button asChild variant="outline" size="sm">
+          <Link href={nextHref}>
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </Button>
+      ) : (
+        <Button disabled variant="outline" size="sm">
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  </div>
+)
+
 const Page = async ({ searchParams }: Props) => {
   const database = getDatabase()
   if (!database) throw new Error('Failed to load database')
@@ -58,16 +154,35 @@ const Page = async ({ searchParams }: Props) => {
   const admin = await getAdminFromSession(database, session)
   if (!admin) return redirect('/')
 
-  const [{ status }, blocks, allows, stats] = await Promise.all([
-    searchParams,
-    database.getDomainBlocks({ limit: ADMIN_FEDERATION_PAGE_SIZE }),
-    database.getDomainAllows({ limit: ADMIN_FEDERATION_PAGE_SIZE }),
+  const params = await searchParams
+  const { status } = params
+  const blockOffset = getOffset(params.blockOffset)
+  const allowOffset = getOffset(params.allowOffset)
+
+  const [blocks, allows, stats] = await Promise.all([
+    database.getDomainBlocks({
+      limit: ADMIN_FEDERATION_PAGE_SIZE,
+      offset: blockOffset
+    }),
+    database.getDomainAllows({
+      limit: ADMIN_FEDERATION_PAGE_SIZE,
+      offset: allowOffset
+    }),
     database.getDomainFederationRuleStats()
   ])
   const statusMessage = getStatusMessage(status)
+  const isErrorStatus = status ? ERROR_STATUSES.has(status) : false
   const sourceCounts = new Map(Object.entries(stats.sourceCounts))
   const config = getConfig()
   const federationMode = config.federationMode ?? 'open'
+  const hasPreviousBlocks = blockOffset > 0
+  const hasNextBlocks =
+    blocks.length > 0 &&
+    getNextOffset(blockOffset, blocks.length) < stats.blocks
+  const hasPreviousAllows = allowOffset > 0
+  const hasNextAllows =
+    allows.length > 0 &&
+    getNextOffset(allowOffset, allows.length) < stats.allows
 
   return (
     <div className="space-y-6">
@@ -81,7 +196,14 @@ const Page = async ({ searchParams }: Props) => {
       </div>
 
       {statusMessage && (
-        <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-100">
+        <div
+          className={cn(
+            'rounded-lg border px-4 py-3 text-sm',
+            isErrorStatus
+              ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100'
+              : 'border-green-200 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-100'
+          )}
+        >
           {statusMessage}
         </div>
       )}
@@ -176,6 +298,14 @@ const Page = async ({ searchParams }: Props) => {
                 rows={2}
               />
             </div>
+            <div className="space-y-1">
+              <Label htmlFor="block-private-comment">Private comment</Label>
+              <Textarea
+                id="block-private-comment"
+                name="privateComment"
+                rows={2}
+              />
+            </div>
             <div className="grid gap-3 sm:grid-cols-3">
               <Label>
                 <Checkbox name="rejectMedia" />
@@ -213,54 +343,59 @@ const Page = async ({ searchParams }: Props) => {
 
       <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">Domain Blocks</h2>
-        {stats.blocks > blocks.length && (
-          <p className="mb-3 text-sm text-muted-foreground">
-            Showing first {blocks.length} of {stats.blocks} blocked domains.
-          </p>
-        )}
         <div className="space-y-2">
           {blocks.length === 0 ? (
             <p className="text-sm text-muted-foreground">No domains blocked</p>
           ) : (
-            blocks.map((block) => {
-              const publicBlock = toPublicDomainBlock(block)
-              return (
-                <div
-                  key={block.id}
-                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate font-medium">{block.domain}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {block.severity}
-                      {publicBlock.comment ? ` - ${publicBlock.comment}` : ''}
-                    </p>
-                  </div>
-                  <form action={deleteDomainBlockAction}>
-                    <input type="hidden" name="id" value={block.id} />
-                    <Button
-                      type="submit"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Delete block for ${block.domain}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </form>
+            blocks.map((block) => (
+              <div
+                key={block.id}
+                className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <p className="truncate font-medium">{block.domain}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {block.severity}
+                    {block.publicComment ? ` - ${block.publicComment}` : ''}
+                  </p>
                 </div>
-              )
-            })
+                <form action={deleteDomainBlockAction}>
+                  <input type="hidden" name="id" value={block.id} />
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Delete block for ${block.domain}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </form>
+              </div>
+            ))
           )}
         </div>
+        <PaginationControls
+          label={getPaginationLabel(
+            'blocked domains',
+            blockOffset,
+            blocks.length,
+            stats.blocks
+          )}
+          previousHref={getPaginationHref({
+            blockOffset: getPreviousOffset(blockOffset),
+            allowOffset
+          })}
+          nextHref={getPaginationHref({
+            blockOffset: getNextOffset(blockOffset, blocks.length),
+            allowOffset
+          })}
+          hasPrevious={hasPreviousBlocks}
+          hasNext={hasNextBlocks}
+        />
       </section>
 
       <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">Domain Allows</h2>
-        {stats.allows > allows.length && (
-          <p className="mb-3 text-sm text-muted-foreground">
-            Showing first {allows.length} of {stats.allows} allowed domains.
-          </p>
-        )}
         <div className="space-y-2">
           {allows.length === 0 ? (
             <p className="text-sm text-muted-foreground">No domains allowed</p>
@@ -286,6 +421,24 @@ const Page = async ({ searchParams }: Props) => {
             ))
           )}
         </div>
+        <PaginationControls
+          label={getPaginationLabel(
+            'allowed domains',
+            allowOffset,
+            allows.length,
+            stats.allows
+          )}
+          previousHref={getPaginationHref({
+            blockOffset,
+            allowOffset: getPreviousOffset(allowOffset)
+          })}
+          nextHref={getPaginationHref({
+            blockOffset,
+            allowOffset: getNextOffset(allowOffset, allows.length)
+          })}
+          hasPrevious={hasPreviousAllows}
+          hasNext={hasNextAllows}
+        />
       </section>
     </div>
   )

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -34,7 +34,8 @@ const STATUS_MESSAGES: Record<string, string> = {
   'allow-deleted': 'Domain allow deleted',
   'invalid-block-domain': 'Enter a valid domain to block',
   'invalid-allow-domain': 'Enter a valid domain to allow',
-  'invalid-source': 'Choose a known blocklist source'
+  'invalid-source': 'Choose a known blocklist source',
+  'import-failed': 'Unable to import the blocklist'
 }
 
 const ADMIN_FEDERATION_PAGE_SIZE = 100

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -1,0 +1,283 @@
+import { Download, ShieldBan, ShieldCheck, Trash2 } from 'lucide-react'
+import { redirect } from 'next/navigation'
+
+import {
+  createDomainAllowAction,
+  createDomainBlockAction,
+  deleteDomainAllowAction,
+  deleteDomainBlockAction,
+  importKnownDomainBlocklistAction
+} from '@/app/(timeline)/admin/federation/actions'
+import { Button } from '@/lib/components/ui/button'
+import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { KNOWN_DOMAIN_BLOCKLIST_SOURCES } from '@/lib/services/federation/blocklistSources'
+import { toPublicDomainBlock } from '@/lib/services/federation/domainRules'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+interface Props {
+  searchParams: Promise<Record<string, string | undefined>>
+}
+
+const STATUS_MESSAGES: Record<string, string> = {
+  'block-saved': 'Domain block saved',
+  'block-deleted': 'Domain block deleted',
+  'allow-saved': 'Domain allow saved',
+  'allow-deleted': 'Domain allow deleted',
+  'invalid-block-domain': 'Enter a valid domain to block',
+  'invalid-allow-domain': 'Enter a valid domain to allow',
+  'invalid-source': 'Choose a known blocklist source'
+}
+
+const getStatusMessage = (status?: string): string | null => {
+  if (!status) return null
+  if (STATUS_MESSAGES[status]) return STATUS_MESSAGES[status]
+
+  const match = /^imported-(\d+)-(\d+)-(\d+)$/.exec(status)
+  if (!match) return null
+
+  return `Imported ${match[1]} new block${match[1] === '1' ? '' : 's'}, updated ${match[2]}, skipped ${match[3]}`
+}
+
+const Page = async ({ searchParams }: Props) => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const [{ status }, blocks, allows] = await Promise.all([
+    searchParams,
+    database.getDomainBlocks({ limit: 10_000 }),
+    database.getDomainAllows({ limit: 10_000 })
+  ])
+  const statusMessage = getStatusMessage(status)
+  const sourceCounts = new Map<string, number>()
+  blocks.forEach((block) => {
+    if (!block.source) return
+    sourceCounts.set(block.source, (sourceCounts.get(block.source) ?? 0) + 1)
+  })
+  const config = getConfig()
+  const federationMode = config.federationMode ?? 'open'
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Federation</h1>
+        <p className="text-sm text-muted-foreground">
+          {federationMode === 'allowlist'
+            ? 'Limited federation mode'
+            : 'Open federation mode'}
+        </p>
+      </div>
+
+      {statusMessage && (
+        <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-100">
+          {statusMessage}
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <ShieldBan className="h-5 w-5 text-destructive" />
+            <div>
+              <p className="text-sm text-muted-foreground">Blocked domains</p>
+              <p className="text-2xl font-bold">{blocks.length}</p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <ShieldCheck className="h-5 w-5 text-green-600" />
+            <div>
+              <p className="text-sm text-muted-foreground">Allowed domains</p>
+              <p className="text-2xl font-bold">{allows.length}</p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
+          <p className="text-sm text-muted-foreground">Shared-list entries</p>
+          <p className="text-2xl font-bold">
+            {blocks.filter((block) => block.source).length}
+          </p>
+        </div>
+      </div>
+
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">Known Blocklist</h2>
+            <p className="text-sm text-muted-foreground">
+              Import a Mastodon-compatible CSV source.
+            </p>
+          </div>
+        </div>
+        <div className="space-y-3">
+          {KNOWN_DOMAIN_BLOCKLIST_SOURCES.map((source) => (
+            <form
+              key={source.id}
+              action={importKnownDomainBlocklistAction}
+              className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <input type="hidden" name="source" value={source.id} />
+              <div>
+                <p className="font-medium">{source.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {sourceCounts.get(source.id) ?? 0} imported entries
+                </p>
+              </div>
+              <Button type="submit" className="sm:w-auto">
+                <Download className="h-4 w-4" />
+                Import
+              </Button>
+            </form>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold">Add Domain Block</h2>
+          <form action={createDomainBlockAction} className="space-y-4">
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium">Domain</span>
+              <input
+                required
+                name="domain"
+                placeholder="example.social"
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium">Severity</span>
+              <select
+                name="severity"
+                defaultValue="suspend"
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              >
+                <option value="suspend">Suspend</option>
+                <option value="silence">Silence</option>
+                <option value="noop">Noop</option>
+              </select>
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium">
+                Public comment
+              </span>
+              <textarea
+                name="publicComment"
+                rows={2}
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              />
+            </label>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="flex items-center gap-2 text-sm">
+                <input name="rejectMedia" type="checkbox" />
+                Reject media
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input name="rejectReports" type="checkbox" />
+                Reject reports
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input name="obfuscate" type="checkbox" />
+                Obfuscate
+              </label>
+            </div>
+            <Button type="submit">Save block</Button>
+          </form>
+        </div>
+
+        <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold">Add Domain Allow</h2>
+          <form action={createDomainAllowAction} className="space-y-4">
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium">Domain</span>
+              <input
+                required
+                name="domain"
+                placeholder="trusted.social"
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              />
+            </label>
+            <Button type="submit">Save allow</Button>
+          </form>
+        </div>
+      </section>
+
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold">Domain Blocks</h2>
+        <div className="space-y-2">
+          {blocks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No domains blocked</p>
+          ) : (
+            blocks.map((block) => {
+              const publicBlock = toPublicDomainBlock(block)
+              return (
+                <div
+                  key={block.id}
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{block.domain}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {block.severity}
+                      {publicBlock.comment ? ` - ${publicBlock.comment}` : ''}
+                    </p>
+                  </div>
+                  <form action={deleteDomainBlockAction}>
+                    <input type="hidden" name="id" value={block.id} />
+                    <Button
+                      type="submit"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Delete block for ${block.domain}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </form>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold">Domain Allows</h2>
+        <div className="space-y-2">
+          {allows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No domains allowed</p>
+          ) : (
+            allows.map((allow) => (
+              <div
+                key={allow.id}
+                className="flex items-center justify-between gap-3 rounded-lg border p-4"
+              >
+                <p className="min-w-0 truncate font-medium">{allow.domain}</p>
+                <form action={deleteDomainAllowAction}>
+                  <input type="hidden" name="id" value={allow.id} />
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Delete allow for ${allow.domain}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </form>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default Page

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -289,6 +289,10 @@ const Page = async ({ searchParams }: Props) => {
                 <option value="silence">Silence</option>
                 <option value="noop">Noop</option>
               </Select>
+              <p className="text-xs text-muted-foreground">
+                Only Suspend rejects federation. Silence and Noop are stored for
+                Mastodon-compatible metadata.
+              </p>
             </div>
             <div className="space-y-1">
               <Label htmlFor="block-public-comment">Public comment</Label>

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -9,6 +9,11 @@ import {
   importKnownDomainBlocklistAction
 } from '@/app/(timeline)/admin/federation/actions'
 import { Button } from '@/lib/components/ui/button'
+import { Checkbox } from '@/lib/components/ui/checkbox'
+import { Input } from '@/lib/components/ui/input'
+import { Label } from '@/lib/components/ui/label'
+import { Select } from '@/lib/components/ui/select'
+import { Textarea } from '@/lib/components/ui/textarea'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -32,6 +37,8 @@ const STATUS_MESSAGES: Record<string, string> = {
   'invalid-source': 'Choose a known blocklist source'
 }
 
+const ADMIN_FEDERATION_PAGE_SIZE = 100
+
 const getStatusMessage = (status?: string): string | null => {
   if (!status) return null
   if (STATUS_MESSAGES[status]) return STATUS_MESSAGES[status]
@@ -50,17 +57,14 @@ const Page = async ({ searchParams }: Props) => {
   const admin = await getAdminFromSession(database, session)
   if (!admin) return redirect('/')
 
-  const [{ status }, blocks, allows] = await Promise.all([
+  const [{ status }, blocks, allows, stats] = await Promise.all([
     searchParams,
-    database.getDomainBlocks({ limit: 10_000 }),
-    database.getDomainAllows({ limit: 10_000 })
+    database.getDomainBlocks({ limit: ADMIN_FEDERATION_PAGE_SIZE }),
+    database.getDomainAllows({ limit: ADMIN_FEDERATION_PAGE_SIZE }),
+    database.getDomainFederationRuleStats()
   ])
   const statusMessage = getStatusMessage(status)
-  const sourceCounts = new Map<string, number>()
-  blocks.forEach((block) => {
-    if (!block.source) return
-    sourceCounts.set(block.source, (sourceCounts.get(block.source) ?? 0) + 1)
-  })
+  const sourceCounts = new Map(Object.entries(stats.sourceCounts))
   const config = getConfig()
   const federationMode = config.federationMode ?? 'open'
 
@@ -87,7 +91,7 @@ const Page = async ({ searchParams }: Props) => {
             <ShieldBan className="h-5 w-5 text-destructive" />
             <div>
               <p className="text-sm text-muted-foreground">Blocked domains</p>
-              <p className="text-2xl font-bold">{blocks.length}</p>
+              <p className="text-2xl font-bold">{stats.blocks}</p>
             </div>
           </div>
         </div>
@@ -96,15 +100,13 @@ const Page = async ({ searchParams }: Props) => {
             <ShieldCheck className="h-5 w-5 text-green-600" />
             <div>
               <p className="text-sm text-muted-foreground">Allowed domains</p>
-              <p className="text-2xl font-bold">{allows.length}</p>
+              <p className="text-2xl font-bold">{stats.allows}</p>
             </div>
           </div>
         </div>
         <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
           <p className="text-sm text-muted-foreground">Shared-list entries</p>
-          <p className="text-2xl font-bold">
-            {blocks.filter((block) => block.source).length}
-          </p>
+          <p className="text-2xl font-bold">{stats.sourceBlocks}</p>
         </div>
       </div>
 
@@ -144,50 +146,48 @@ const Page = async ({ searchParams }: Props) => {
         <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
           <h2 className="mb-4 text-lg font-semibold">Add Domain Block</h2>
           <form action={createDomainBlockAction} className="space-y-4">
-            <label className="block">
-              <span className="mb-1 block text-sm font-medium">Domain</span>
-              <input
+            <div className="space-y-1">
+              <Label htmlFor="block-domain">Domain</Label>
+              <Input
+                id="block-domain"
                 required
                 name="domain"
                 placeholder="example.social"
-                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
               />
-            </label>
-            <label className="block">
-              <span className="mb-1 block text-sm font-medium">Severity</span>
-              <select
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="block-severity">Severity</Label>
+              <Select
+                id="block-severity"
                 name="severity"
                 defaultValue="suspend"
-                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
               >
                 <option value="suspend">Suspend</option>
                 <option value="silence">Silence</option>
                 <option value="noop">Noop</option>
-              </select>
-            </label>
-            <label className="block">
-              <span className="mb-1 block text-sm font-medium">
-                Public comment
-              </span>
-              <textarea
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="block-public-comment">Public comment</Label>
+              <Textarea
+                id="block-public-comment"
                 name="publicComment"
                 rows={2}
-                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
               />
-            </label>
+            </div>
             <div className="grid gap-3 sm:grid-cols-3">
-              <label className="flex items-center gap-2 text-sm">
-                <input name="rejectMedia" type="checkbox" />
+              <Label>
+                <Checkbox name="rejectMedia" />
                 Reject media
-              </label>
-              <label className="flex items-center gap-2 text-sm">
-                <input name="rejectReports" type="checkbox" />
+              </Label>
+              <Label>
+                <Checkbox name="rejectReports" />
                 Reject reports
-              </label>
-              <label className="flex items-center gap-2 text-sm">
-                <input name="obfuscate" type="checkbox" />
+              </Label>
+              <Label>
+                <Checkbox name="obfuscate" />
                 Obfuscate
-              </label>
+              </Label>
             </div>
             <Button type="submit">Save block</Button>
           </form>
@@ -196,15 +196,15 @@ const Page = async ({ searchParams }: Props) => {
         <div className="rounded-xl border bg-background/80 p-5 shadow-sm">
           <h2 className="mb-4 text-lg font-semibold">Add Domain Allow</h2>
           <form action={createDomainAllowAction} className="space-y-4">
-            <label className="block">
-              <span className="mb-1 block text-sm font-medium">Domain</span>
-              <input
+            <div className="space-y-1">
+              <Label htmlFor="allow-domain">Domain</Label>
+              <Input
+                id="allow-domain"
                 required
                 name="domain"
                 placeholder="trusted.social"
-                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
               />
-            </label>
+            </div>
             <Button type="submit">Save allow</Button>
           </form>
         </div>
@@ -212,6 +212,11 @@ const Page = async ({ searchParams }: Props) => {
 
       <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">Domain Blocks</h2>
+        {stats.blocks > blocks.length && (
+          <p className="mb-3 text-sm text-muted-foreground">
+            Showing first {blocks.length} of {stats.blocks} blocked domains.
+          </p>
+        )}
         <div className="space-y-2">
           {blocks.length === 0 ? (
             <p className="text-sm text-muted-foreground">No domains blocked</p>
@@ -250,6 +255,11 @@ const Page = async ({ searchParams }: Props) => {
 
       <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">Domain Allows</h2>
+        {stats.allows > allows.length && (
+          <p className="mb-3 text-sm text-muted-foreground">
+            Showing first {allows.length} of {stats.allows} allowed domains.
+          </p>
+        )}
         <div className="space-y-2">
           {allows.length === 0 ? (
             <p className="text-sm text-muted-foreground">No domains allowed</p>

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -25,6 +25,7 @@ const Layout: FC<Props> = ({ children }) => {
     { name: 'Overview', url: '/admin' },
     { name: 'Accounts', url: '/admin/accounts' },
     { name: 'Hashtags', url: '/admin/tags' },
+    { name: 'Federation', url: '/admin/federation' },
     { name: 'System', url: '/admin/system' }
   ]
 

--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockCanFederateWithDomain = jest.fn()
+const mockDatabase = {}
+const mockPublish = jest.fn()
+
+jest.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: (...params: unknown[]) =>
+    mockCanFederateWithDomain(...params)
+}))
+
+jest.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
+  ActivityPubVerifySenderGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: { database: typeof mockDatabase; params: Promise<{}> }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, { database: mockDatabase, params: context.params })
+}))
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: () => ({ publish: mockPublish })
+}))
+
+const createRequest = (actor: string) =>
+  new NextRequest('https://activities.local/api/inbox', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: `${actor}/activities/create-1`,
+      type: 'Create',
+      actor,
+      object: {
+        id: `${actor}/statuses/1`,
+        type: 'Note'
+      }
+    })
+  })
+
+describe('POST /api/inbox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rejects activities from blocked actor domains', async () => {
+    mockCanFederateWithDomain.mockResolvedValue(false)
+
+    const response = await POST(createRequest('https://blocked.test/users/a'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockPublish).not.toHaveBeenCalled()
+  })
+
+  it('enqueues activities from allowed actor domains', async () => {
+    mockCanFederateWithDomain.mockResolvedValue(true)
+
+    const response = await POST(createRequest('https://allowed.test/users/a'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'CreateNoteJob' })
+    )
+  })
+})

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -1,10 +1,12 @@
 import { StatusActivity } from '@/lib/activities/statusAction'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { ActivityPubVerifySenderGuard } from '@/lib/services/guards/ActivityPubVerifyGuard'
 import { getQueue } from '@/lib/services/queue'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   DEFAULT_202,
   ERROR_400,
+  ERROR_403,
   ERROR_404,
   apiResponse,
   defaultOptions
@@ -22,7 +24,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 export const POST = traceApiRoute(
   'sharedInbox',
-  ActivityPubVerifySenderGuard(async (request) => {
+  ActivityPubVerifySenderGuard(async (request, { database }) => {
     const body = await request.json()
     if (
       !isRecord(body) ||
@@ -37,6 +39,15 @@ export const POST = traceApiRoute(
       })
     }
     const activity = body as unknown as StatusActivity
+    if (!(await canFederateWithDomain(database, activity.actor))) {
+      return apiResponse({
+        req: request,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: 403
+      })
+    }
+
     const jobMessage = getJobMessage(activity)
     if (!jobMessage) {
       return apiResponse({

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -8,6 +8,7 @@ import { undoFollowRequest } from '@/lib/actions/undoFollowRequest'
 import { FollowRequest } from '@/lib/activities/followAction'
 import { UndoFollow } from '@/lib/activities/undoFollow'
 import { UndoLike } from '@/lib/activities/undoLike'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
 import { Accept, Follow, Like, Reject, Undo } from '@/lib/types/activitypub'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -30,6 +31,15 @@ export const POST = traceApiRoute(
   OnlyLocalUserGuard(async (database, _, req) => {
     try {
       const activity = Activity.parse(await req.json())
+      if (!(await canFederateWithDomain(database, activity.actor))) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: { status: 'Forbidden' },
+          responseStatusCode: 403
+        })
+      }
+
       switch (activity.type) {
         case 'Accept': {
           const follow = await acceptFollowRequest({ activity, database })

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -1,6 +1,7 @@
 import { follow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getRelationship } from '@/lib/services/accounts/relationship'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -8,6 +9,7 @@ import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
   ERROR_404,
+  HTTP_STATUS,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -36,6 +38,14 @@ export const POST = traceApiRoute(
       })
 
     const targetActorId = idToUrl(encodedAccountId)
+    if (!(await canFederateWithDomain(database, targetActorId))) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { status: 'Forbidden' },
+        responseStatusCode: HTTP_STATUS.FORBIDDEN
+      })
+    }
 
     // Check if target actor exists
     const person = await getActorPerson({ actorId: targetActorId })

--- a/app/api/v1/accounts/[id]/unfollow/route.ts
+++ b/app/api/v1/accounts/[id]/unfollow/route.ts
@@ -1,5 +1,6 @@
 import { unfollow } from '@/lib/activities'
 import { getRelationship } from '@/lib/services/accounts/relationship'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -37,8 +38,9 @@ export const POST = traceApiRoute(
     })
 
     if (existingFollow) {
+      const canFederate = await canFederateWithDomain(database, targetActorId)
       await Promise.all([
-        unfollow(currentActor, existingFollow),
+        canFederate ? unfollow(currentActor, existingFollow) : undefined,
         database.updateFollowStatus({
           followId: existingFollow.id,
           status: FollowStatus.enum.Undo

--- a/app/api/v1/accounts/follow/route.test.ts
+++ b/app/api/v1/accounts/follow/route.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server'
+
+import { FollowStatus } from '@/lib/types/domain/follow'
+
+import { DELETE } from './route'
+
+const mockUnfollow = jest.fn()
+const mockCanFederateWithDomain = jest.fn()
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun',
+  domain: 'llun.test'
+}
+const mockDatabase = {
+  getAcceptedOrRequestedFollow: jest.fn(),
+  updateFollowStatus: jest.fn()
+}
+
+jest.mock('@/lib/activities', () => ({
+  follow: jest.fn(),
+  unfollow: (...params: unknown[]) => mockUnfollow(...params)
+}))
+
+jest.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: jest.fn()
+}))
+
+jest.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: (...params: unknown[]) =>
+    mockCanFederateWithDomain(...params)
+}))
+
+jest.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+describe('DELETE /api/v1/accounts/follow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue({
+      id: 'follow-1',
+      actorId: mockCurrentActor.id,
+      targetActorId: 'https://blocked.test/users/alice'
+    })
+    mockDatabase.updateFollowStatus.mockResolvedValue(undefined)
+  })
+
+  const createRequest = () =>
+    new NextRequest('https://llun.test/api/v1/accounts/follow', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target: 'https://blocked.test/users/alice' })
+    })
+
+  it('updates local state without sending Undo to blocked domains', async () => {
+    mockCanFederateWithDomain.mockResolvedValue(false)
+
+    const response = await DELETE(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockUnfollow).not.toHaveBeenCalled()
+    expect(mockDatabase.updateFollowStatus).toHaveBeenCalledWith({
+      followId: 'follow-1',
+      status: FollowStatus.enum.Undo
+    })
+  })
+
+  it('sends Undo when the target domain is allowed', async () => {
+    mockCanFederateWithDomain.mockResolvedValue(true)
+
+    const response = await DELETE(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockUnfollow).toHaveBeenCalledWith(mockCurrentActor, {
+      id: 'follow-1',
+      actorId: mockCurrentActor.id,
+      targetActorId: 'https://blocked.test/users/alice'
+    })
+  })
+})

--- a/app/api/v1/accounts/follow/route.ts
+++ b/app/api/v1/accounts/follow/route.ts
@@ -108,8 +108,9 @@ export const DELETE = traceApiRoute(
         data: ERROR_404,
         responseStatusCode: 404
       })
+    const canFederate = await canFederateWithDomain(database, target)
     await Promise.all([
-      unfollow(currentActor, follow),
+      canFederate ? unfollow(currentActor, follow) : undefined,
       database.updateFollowStatus({
         followId: follow.id,
         status: FollowStatus.enum.Undo

--- a/app/api/v1/accounts/follow/route.ts
+++ b/app/api/v1/accounts/follow/route.ts
@@ -5,6 +5,7 @@
  */
 import { follow, unfollow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -56,6 +57,15 @@ export const POST = traceApiRoute(
     const { database, currentActor } = context
     const body = await req.json()
     const { target } = FollowRequest.parse(body)
+    if (!(await canFederateWithDomain(database, target))) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { status: 'Forbidden' },
+        responseStatusCode: HTTP_STATUS.FORBIDDEN
+      })
+    }
+
     const person = await getActorPerson({ actorId: target })
     if (!person)
       return apiResponse({

--- a/app/api/v1/admin/domain_allows/[id]/route.ts
+++ b/app/api/v1/admin/domain_allows/[id]/route.ts
@@ -1,0 +1,66 @@
+import { toAdminDomainAllow } from '@/lib/services/federation/domainRules'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_404,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+type Params = {
+  id: string
+}
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.DELETE
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminGetDomainAllow',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const allow = await database.getDomainAllowById(id)
+    if (!allow) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminDomainAllow(allow)
+    })
+  })
+)
+
+export const DELETE = traceApiRoute(
+  'adminDeleteDomainAllow',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const allow = await database.deleteDomainAllow(id)
+    if (!allow) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminDomainAllow(allow)
+    })
+  })
+)

--- a/app/api/v1/admin/domain_allows/route.test.ts
+++ b/app/api/v1/admin/domain_allows/route.test.ts
@@ -1,8 +1,10 @@
 import { NextRequest } from 'next/server'
 
-import { POST } from './route'
+import { GET, POST } from './route'
 
 const mockDatabase = {
+  getDomainAllows: jest.fn(),
+  getDomainFederationRuleStats: jest.fn(),
   createDomainAllow: jest.fn()
 }
 
@@ -29,7 +31,48 @@ jest.mock('@/lib/config', () => ({
 
 describe('/api/v1/admin/domain_allows', () => {
   beforeEach(() => {
+    mockDatabase.getDomainAllows.mockReset()
+    mockDatabase.getDomainFederationRuleStats.mockReset()
     mockDatabase.createDomainAllow.mockReset()
+  })
+
+  it('lists admin domain allows with pagination', async () => {
+    mockDatabase.getDomainAllows.mockResolvedValue([
+      {
+        id: 'allow-1',
+        type: 'allow',
+        domain: 'trusted.test',
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+    mockDatabase.getDomainFederationRuleStats.mockResolvedValue({
+      blocks: 0,
+      allows: 12,
+      sourceBlocks: 0,
+      sourceCounts: {}
+    })
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/admin/domain_allows?limit=10&offset=2'
+      ),
+      { params: Promise.resolve({}) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-total-count')).toBe('12')
+    expect(response.headers.get('x-offset')).toBe('2')
+    expect(response.headers.get('x-limit')).toBe('10')
+    expect(mockDatabase.getDomainAllows).toHaveBeenCalledWith({
+      limit: 10,
+      offset: 2
+    })
+    expect(data[0]).toMatchObject({
+      id: 'allow-1',
+      domain: 'trusted.test'
+    })
   })
 
   it('rejects invalid JSON bodies', async () => {

--- a/app/api/v1/admin/domain_allows/route.test.ts
+++ b/app/api/v1/admin/domain_allows/route.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  createDomainAllow: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue({
+    user: { email: 'admin@llun.test' }
+  })
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: jest.fn().mockResolvedValue({
+    id: 'admin',
+    email: 'admin@llun.test'
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'llun.test', allowEmails: [] })
+}))
+
+describe('/api/v1/admin/domain_allows', () => {
+  beforeEach(() => {
+    mockDatabase.createDomainAllow.mockReset()
+  })
+
+  it('rejects invalid JSON bodies', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/admin/domain_allows', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{'
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockDatabase.createDomainAllow).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/admin/domain_allows/route.ts
+++ b/app/api/v1/admin/domain_allows/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server'
+
+import {
+  DomainAllowRequest,
+  readRequestData
+} from '@/app/api/v1/admin/domain_allows/schema'
+import { toAdminDomainAllow } from '@/lib/services/federation/domainRules'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.POST
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminListDomainAllows',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const allows = await database.getDomainAllows({ limit: 10_000 })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: allows.map(toAdminDomainAllow)
+    })
+  })
+)
+
+export const POST = traceApiRoute(
+  'adminCreateDomainAllow',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const parsed = DomainAllowRequest.safeParse(await readRequestData(req))
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const allow = await database.createDomainAllow({
+      domain: parsed.data.domain
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminDomainAllow(allow)
+    })
+  })
+)

--- a/app/api/v1/admin/domain_allows/route.ts
+++ b/app/api/v1/admin/domain_allows/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
-import {
-  DomainAllowRequest,
-  readRequestData
-} from '@/app/api/v1/admin/domain_allows/schema'
+import { DomainAllowRequest } from '@/app/api/v1/admin/domain_allows/schema'
 import { toAdminDomainAllow } from '@/lib/services/federation/domainRules'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import {
   ERROR_400,
   ERROR_422,
@@ -67,7 +65,7 @@ export const POST = traceApiRoute(
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
     let data: unknown
     try {
-      data = await readRequestData(req)
+      data = await getRequestBody(req)
     } catch {
       return apiResponse({
         req,

--- a/app/api/v1/admin/domain_allows/route.ts
+++ b/app/api/v1/admin/domain_allows/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
 
 import {
   DomainAllowRequest,
@@ -21,18 +22,42 @@ const CORS_HEADERS = [
   HttpMethod.enum.GET,
   HttpMethod.enum.POST
 ]
+const DomainRuleListQueryParams = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(100),
+  offset: z.coerce.number().int().min(0).default(0)
+})
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute(
   'adminListDomainAllows',
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
-    const allows = await database.getDomainAllows({ limit: 10_000 })
+    const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+    const parsedParams = DomainRuleListQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const { limit, offset } = parsedParams.data
+    const [allows, stats] = await Promise.all([
+      database.getDomainAllows({ limit, offset }),
+      database.getDomainFederationRuleStats()
+    ])
 
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: allows.map(toAdminDomainAllow)
+      data: allows.map(toAdminDomainAllow),
+      additionalHeaders: [
+        ['X-Total-Count', `${stats.allows}`],
+        ['X-Offset', `${offset}`],
+        ['X-Limit', `${limit}`]
+      ]
     })
   })
 )

--- a/app/api/v1/admin/domain_allows/route.ts
+++ b/app/api/v1/admin/domain_allows/route.ts
@@ -8,6 +8,7 @@ import { toAdminDomainAllow } from '@/lib/services/federation/domainRules'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
+  ERROR_400,
   ERROR_422,
   HTTP_STATUS,
   apiResponse,
@@ -39,7 +40,19 @@ export const GET = traceApiRoute(
 export const POST = traceApiRoute(
   'adminCreateDomainAllow',
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
-    const parsed = DomainAllowRequest.safeParse(await readRequestData(req))
+    let data: unknown
+    try {
+      data = await readRequestData(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const parsed = DomainAllowRequest.safeParse(data)
     if (!parsed.success) {
       return apiResponse({
         req,

--- a/app/api/v1/admin/domain_allows/schema.ts
+++ b/app/api/v1/admin/domain_allows/schema.ts
@@ -10,13 +10,3 @@ export const DomainAllowRequest = z.object({
     .max(255)
     .refine((value) => normalizeDomain(value) !== null)
 })
-
-export const readRequestData = async (req: Request) => {
-  const contentType = req.headers.get('content-type') ?? ''
-  if (contentType.includes('application/json')) {
-    return req.json()
-  }
-
-  const formData = await req.formData()
-  return Object.fromEntries(formData.entries())
-}

--- a/app/api/v1/admin/domain_allows/schema.ts
+++ b/app/api/v1/admin/domain_allows/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+import { normalizeDomain } from '@/lib/services/federation/domainRules'
+
+export const DomainAllowRequest = z.object({
+  domain: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .refine((value) => normalizeDomain(value) !== null)
+})
+
+export const readRequestData = async (req: Request) => {
+  const contentType = req.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    return req.json()
+  }
+
+  const formData = await req.formData()
+  return Object.fromEntries(formData.entries())
+}

--- a/app/api/v1/admin/domain_blocks/[id]/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.test.ts
@@ -1,9 +1,10 @@
 import { NextRequest } from 'next/server'
 
-import { DELETE } from './route'
+import { DELETE, PUT } from './route'
 
 const mockDatabase = {
-  deleteDomainBlock: jest.fn()
+  deleteDomainBlock: jest.fn(),
+  updateDomainBlock: jest.fn()
 }
 
 jest.mock('@/lib/database', () => ({
@@ -30,23 +31,80 @@ jest.mock('@/lib/config', () => ({
 describe('/api/v1/admin/domain_blocks/:id', () => {
   beforeEach(() => {
     mockDatabase.deleteDomainBlock.mockReset()
+    mockDatabase.updateDomainBlock.mockReset()
+  })
+
+  const domainBlock = {
+    id: 'block-1',
+    type: 'block',
+    domain: 'blocked.test',
+    severity: 'suspend',
+    rejectMedia: false,
+    rejectReports: false,
+    privateComment: null,
+    publicComment: null,
+    obfuscate: false,
+    source: null,
+    createdAt: 0,
+    updatedAt: 0
+  }
+
+  it('updates only provided domain block fields', async () => {
+    mockDatabase.updateDomainBlock.mockResolvedValue({
+      ...domainBlock,
+      publicComment: 'Updated comment'
+    })
+
+    const response = await PUT(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/block-1', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ public_comment: 'Updated comment' })
+      }),
+      { params: Promise.resolve({ id: 'block-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateDomainBlock).toHaveBeenCalledWith({
+      id: 'block-1',
+      severity: undefined,
+      rejectMedia: undefined,
+      rejectReports: undefined,
+      privateComment: undefined,
+      publicComment: 'Updated comment',
+      obfuscate: undefined
+    })
+  })
+
+  it('clears comments when provided as blank strings', async () => {
+    mockDatabase.updateDomainBlock.mockResolvedValue(domainBlock)
+
+    const response = await PUT(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/block-1', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          private_comment: ' ',
+          public_comment: ''
+        })
+      }),
+      { params: Promise.resolve({ id: 'block-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateDomainBlock).toHaveBeenCalledWith({
+      id: 'block-1',
+      severity: undefined,
+      rejectMedia: undefined,
+      rejectReports: undefined,
+      privateComment: null,
+      publicComment: null,
+      obfuscate: undefined
+    })
   })
 
   it('returns the deleted domain block', async () => {
-    mockDatabase.deleteDomainBlock.mockResolvedValue({
-      id: 'block-1',
-      type: 'block',
-      domain: 'blocked.test',
-      severity: 'suspend',
-      rejectMedia: false,
-      rejectReports: false,
-      privateComment: null,
-      publicComment: null,
-      obfuscate: false,
-      source: null,
-      createdAt: 0,
-      updatedAt: 0
-    })
+    mockDatabase.deleteDomainBlock.mockResolvedValue(domainBlock)
 
     const response = await DELETE(
       new NextRequest('https://llun.test/api/v1/admin/domain_blocks/block-1', {

--- a/app/api/v1/admin/domain_blocks/[id]/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.test.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from 'next/server'
+
+import { DELETE } from './route'
+
+const mockDatabase = {
+  deleteDomainBlock: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue({
+    user: { email: 'admin@llun.test' }
+  })
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: jest.fn().mockResolvedValue({
+    id: 'admin',
+    email: 'admin@llun.test'
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'llun.test', allowEmails: [] })
+}))
+
+describe('/api/v1/admin/domain_blocks/:id', () => {
+  beforeEach(() => {
+    mockDatabase.deleteDomainBlock.mockReset()
+  })
+
+  it('returns the deleted domain block', async () => {
+    mockDatabase.deleteDomainBlock.mockResolvedValue({
+      id: 'block-1',
+      type: 'block',
+      domain: 'blocked.test',
+      severity: 'suspend',
+      rejectMedia: false,
+      rejectReports: false,
+      privateComment: null,
+      publicComment: null,
+      obfuscate: false,
+      source: null,
+      createdAt: 0,
+      updatedAt: 0
+    })
+
+    const response = await DELETE(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/block-1', {
+        method: 'DELETE'
+      }),
+      { params: Promise.resolve({ id: 'block-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toMatchObject({
+      id: 'block-1',
+      domain: 'blocked.test',
+      severity: 'suspend'
+    })
+  })
+})

--- a/app/api/v1/admin/domain_blocks/[id]/route.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest } from 'next/server'
 
-import {
-  DomainBlockUpdateRequest,
-  readRequestData
-} from '@/app/api/v1/admin/domain_blocks/schema'
+import { DomainBlockUpdateRequest } from '@/app/api/v1/admin/domain_blocks/schema'
 import { toAdminDomainBlock } from '@/lib/services/federation/domainRules'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import {
   ERROR_400,
   ERROR_404,
@@ -59,7 +57,7 @@ export const PUT = traceApiRoute(
     async (req: NextRequest, { database, params }) => {
       let data: unknown
       try {
-        data = await readRequestData(req)
+        data = await getRequestBody(req)
       } catch {
         return apiResponse({
           req,

--- a/app/api/v1/admin/domain_blocks/[id]/route.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.ts
@@ -124,7 +124,7 @@ export const DELETE = traceApiRoute(
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: {}
+      data: toAdminDomainBlock(block)
     })
   })
 )

--- a/app/api/v1/admin/domain_blocks/[id]/route.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from 'next/server'
+
+import {
+  DomainBlockUpdateRequest,
+  readRequestData
+} from '@/app/api/v1/admin/domain_blocks/schema'
+import { toAdminDomainBlock } from '@/lib/services/federation/domainRules'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_404,
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+type Params = {
+  id: string
+}
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PUT,
+  HttpMethod.enum.DELETE
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminGetDomainBlock',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const block = await database.getDomainBlockById(id)
+    if (!block) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminDomainBlock(block)
+    })
+  })
+)
+
+export const PUT = traceApiRoute(
+  'adminUpdateDomainBlock',
+  AdminApiGuard<Params>(
+    CORS_HEADERS,
+    async (req: NextRequest, { database, params }) => {
+      const parsed = DomainBlockUpdateRequest.safeParse(
+        await readRequestData(req)
+      )
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        })
+      }
+
+      const { id } = await params
+      const block = await database.updateDomainBlock({
+        id,
+        severity: parsed.data.severity,
+        rejectMedia: parsed.data.reject_media,
+        rejectReports: parsed.data.reject_reports,
+        privateComment: parsed.data.private_comment,
+        publicComment: parsed.data.public_comment,
+        obfuscate: parsed.data.obfuscate
+      })
+      if (!block) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: HTTP_STATUS.NOT_FOUND
+        })
+      }
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: toAdminDomainBlock(block)
+      })
+    }
+  )
+)
+
+export const DELETE = traceApiRoute(
+  'adminDeleteDomainBlock',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const block = await database.deleteDomainBlock(id)
+    if (!block) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: {}
+    })
+  })
+)

--- a/app/api/v1/admin/domain_blocks/[id]/route.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.ts
@@ -8,6 +8,7 @@ import { toAdminDomainBlock } from '@/lib/services/federation/domainRules'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
+  ERROR_400,
   ERROR_404,
   ERROR_422,
   HTTP_STATUS,
@@ -56,9 +57,19 @@ export const PUT = traceApiRoute(
   AdminApiGuard<Params>(
     CORS_HEADERS,
     async (req: NextRequest, { database, params }) => {
-      const parsed = DomainBlockUpdateRequest.safeParse(
-        await readRequestData(req)
-      )
+      let data: unknown
+      try {
+        data = await readRequestData(req)
+      } catch {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: HTTP_STATUS.BAD_REQUEST
+        })
+      }
+
+      const parsed = DomainBlockUpdateRequest.safeParse(data)
       if (!parsed.success) {
         return apiResponse({
           req,

--- a/app/api/v1/admin/domain_blocks/import/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/import/route.test.ts
@@ -5,7 +5,7 @@ import { POST } from './route'
 const mockDatabase = {
   importDomainBlocks: jest.fn()
 }
-const mockFetchKnownDomainBlocklist = jest.fn()
+const mockDownloadKnownDomainBlocklist = jest.fn()
 
 jest.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
@@ -35,19 +35,68 @@ jest.mock('@/lib/services/federation/blocklistSources', () => {
 
   return {
     ...actual,
-    fetchKnownDomainBlocklist: (...params: unknown[]) =>
-      mockFetchKnownDomainBlocklist(...params)
+    downloadKnownDomainBlocklist: (...params: unknown[]) =>
+      mockDownloadKnownDomainBlocklist(...params)
   }
 })
 
 describe('/api/v1/admin/domain_blocks/import', () => {
   beforeEach(() => {
     mockDatabase.importDomainBlocks.mockReset()
-    mockFetchKnownDomainBlocklist.mockReset()
+    mockDownloadKnownDomainBlocklist.mockReset()
+  })
+
+  it('imports a known blocklist source', async () => {
+    mockDownloadKnownDomainBlocklist.mockResolvedValue([
+      {
+        domain: 'bad.test',
+        severity: 'suspend',
+        rejectMedia: false,
+        rejectReports: false,
+        publicComment: 'spam',
+        privateComment: null,
+        obfuscate: false,
+        source: 'oliphant-tier0'
+      }
+    ])
+    mockDatabase.importDomainBlocks.mockResolvedValue({
+      created: 1,
+      updated: 0,
+      skipped: 0
+    })
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/import', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ source: 'oliphant-tier0' })
+      }),
+      { params: Promise.resolve({}) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockDownloadKnownDomainBlocklist).toHaveBeenCalledWith(
+      'oliphant-tier0'
+    )
+    expect(mockDatabase.importDomainBlocks).toHaveBeenCalledWith({
+      blocks: expect.arrayContaining([
+        expect.objectContaining({ domain: 'bad.test' })
+      ])
+    })
+    expect(data).toEqual({
+      source: 'oliphant-tier0',
+      fetched: 1,
+      created: 1,
+      updated: 0,
+      skipped: 0
+    })
   })
 
   it('returns bad request when import fails', async () => {
-    mockFetchKnownDomainBlocklist.mockRejectedValue(new Error('fetch failed'))
+    mockDownloadKnownDomainBlocklist.mockRejectedValue(
+      new Error('download failed')
+    )
 
     const response = await POST(
       new NextRequest('https://llun.test/api/v1/admin/domain_blocks/import', {

--- a/app/api/v1/admin/domain_blocks/import/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/import/route.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  importDomainBlocks: jest.fn()
+}
+const mockFetchKnownDomainBlocklist = jest.fn()
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue({
+    user: { email: 'admin@llun.test' }
+  })
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: jest.fn().mockResolvedValue({
+    id: 'admin',
+    email: 'admin@llun.test'
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'llun.test', allowEmails: [] })
+}))
+
+jest.mock('@/lib/services/federation/blocklistSources', () => {
+  const actual = jest.requireActual(
+    '@/lib/services/federation/blocklistSources'
+  )
+
+  return {
+    ...actual,
+    fetchKnownDomainBlocklist: (...params: unknown[]) =>
+      mockFetchKnownDomainBlocklist(...params)
+  }
+})
+
+describe('/api/v1/admin/domain_blocks/import', () => {
+  beforeEach(() => {
+    mockDatabase.importDomainBlocks.mockReset()
+    mockFetchKnownDomainBlocklist.mockReset()
+  })
+
+  it('returns bad request when import fails', async () => {
+    mockFetchKnownDomainBlocklist.mockRejectedValue(new Error('fetch failed'))
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/import', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ source: 'oliphant-tier0' })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockDatabase.importDomainBlocks).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/admin/domain_blocks/import/route.ts
+++ b/app/api/v1/admin/domain_blocks/import/route.ts
@@ -7,6 +7,7 @@ import {
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
+  ERROR_400,
   ERROR_422,
   HTTP_STATUS,
   apiResponse,
@@ -21,8 +22,23 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 export const POST = traceApiRoute(
   'adminImportDomainBlocks',
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
-    const body = await req.json().catch(() => ({}))
-    const parsed = KnownDomainBlocklistSourceId.safeParse(body.source)
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const source =
+      typeof body === 'object' && body !== null && 'source' in body
+        ? body.source
+        : undefined
+    const parsed = KnownDomainBlocklistSourceId.safeParse(source)
     if (!parsed.success) {
       return apiResponse({
         req,

--- a/app/api/v1/admin/domain_blocks/import/route.ts
+++ b/app/api/v1/admin/domain_blocks/import/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+
+import {
+  KnownDomainBlocklistSourceId,
+  fetchKnownDomainBlocklist
+} from '@/lib/services/federation/blocklistSources'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const POST = traceApiRoute(
+  'adminImportDomainBlocks',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const body = await req.json().catch(() => ({}))
+    const parsed = KnownDomainBlocklistSourceId.safeParse(body.source)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const blocks = await fetchKnownDomainBlocklist(parsed.data)
+    const result = await database.importDomainBlocks({ blocks })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: {
+        source: parsed.data,
+        fetched: blocks.length,
+        ...result
+      }
+    })
+  })
+)

--- a/app/api/v1/admin/domain_blocks/import/route.ts
+++ b/app/api/v1/admin/domain_blocks/import/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server'
 
 import {
   KnownDomainBlocklistSourceId,
-  fetchKnownDomainBlocklist
+  downloadKnownDomainBlocklist
 } from '@/lib/services/federation/blocklistSources'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -48,10 +48,10 @@ export const POST = traceApiRoute(
       })
     }
 
-    let blocks: Awaited<ReturnType<typeof fetchKnownDomainBlocklist>>
+    let blocks: Awaited<ReturnType<typeof downloadKnownDomainBlocklist>>
     let result: Awaited<ReturnType<typeof database.importDomainBlocks>>
     try {
-      blocks = await fetchKnownDomainBlocklist(parsed.data)
+      blocks = await downloadKnownDomainBlocklist(parsed.data)
       result = await database.importDomainBlocks({ blocks })
     } catch {
       return apiResponse({

--- a/app/api/v1/admin/domain_blocks/import/route.ts
+++ b/app/api/v1/admin/domain_blocks/import/route.ts
@@ -48,8 +48,19 @@ export const POST = traceApiRoute(
       })
     }
 
-    const blocks = await fetchKnownDomainBlocklist(parsed.data)
-    const result = await database.importDomainBlocks({ blocks })
+    let blocks: Awaited<ReturnType<typeof fetchKnownDomainBlocklist>>
+    let result: Awaited<ReturnType<typeof database.importDomainBlocks>>
+    try {
+      blocks = await fetchKnownDomainBlocklist(parsed.data)
+      result = await database.importDomainBlocks({ blocks })
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
 
     return apiResponse({
       req,

--- a/app/api/v1/admin/domain_blocks/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/route.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from 'next/server'
+
+import { GET, POST } from './route'
+
+const mockDatabase = {
+  getDomainBlocks: jest.fn(),
+  createDomainBlock: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue({
+    user: { email: 'admin@llun.test' }
+  })
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: jest.fn().mockResolvedValue({
+    id: 'admin',
+    email: 'admin@llun.test'
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'llun.test', allowEmails: [] })
+}))
+
+describe('/api/v1/admin/domain_blocks', () => {
+  beforeEach(() => {
+    mockDatabase.getDomainBlocks.mockReset()
+    mockDatabase.createDomainBlock.mockReset()
+  })
+
+  it('lists admin domain blocks', async () => {
+    mockDatabase.getDomainBlocks.mockResolvedValue([
+      {
+        id: 'block-1',
+        type: 'block',
+        domain: 'blocked.test',
+        severity: 'suspend',
+        rejectMedia: true,
+        rejectReports: false,
+        privateComment: null,
+        publicComment: 'spam',
+        obfuscate: false,
+        source: null,
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks'),
+      { params: Promise.resolve({}) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data[0]).toMatchObject({
+      id: 'block-1',
+      domain: 'blocked.test',
+      severity: 'suspend',
+      reject_media: true,
+      public_comment: 'spam'
+    })
+  })
+
+  it('creates domain blocks from JSON bodies', async () => {
+    mockDatabase.createDomainBlock.mockResolvedValue({
+      id: 'block-2',
+      type: 'block',
+      domain: 'new.test',
+      severity: 'silence',
+      rejectMedia: false,
+      rejectReports: true,
+      privateComment: null,
+      publicComment: null,
+      obfuscate: false,
+      source: null,
+      createdAt: 0,
+      updatedAt: 0
+    })
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          domain: 'new.test',
+          severity: 'silence',
+          reject_reports: true
+        })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.createDomainBlock).toHaveBeenCalledWith({
+      domain: 'new.test',
+      severity: 'silence',
+      rejectMedia: false,
+      rejectReports: true,
+      privateComment: null,
+      publicComment: null,
+      obfuscate: false,
+      source: null
+    })
+  })
+})

--- a/app/api/v1/admin/domain_blocks/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/route.test.ts
@@ -109,4 +109,57 @@ describe('/api/v1/admin/domain_blocks', () => {
       source: null
     })
   })
+
+  it('creates domain blocks from checkbox-style values', async () => {
+    mockDatabase.createDomainBlock.mockResolvedValue({
+      id: 'block-3',
+      type: 'block',
+      domain: 'form.test',
+      severity: 'suspend',
+      rejectMedia: true,
+      rejectReports: false,
+      privateComment: null,
+      publicComment: null,
+      obfuscate: true,
+      source: null,
+      createdAt: 0,
+      updatedAt: 0
+    })
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          domain: 'form.test',
+          reject_media: 'on',
+          obfuscate: 'on'
+        })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.createDomainBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'form.test',
+        rejectMedia: true,
+        obfuscate: true
+      })
+    )
+  })
+
+  it('rejects invalid JSON bodies', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{'
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockDatabase.createDomainBlock).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/admin/domain_blocks/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/route.test.ts
@@ -4,6 +4,7 @@ import { GET, POST } from './route'
 
 const mockDatabase = {
   getDomainBlocks: jest.fn(),
+  getDomainFederationRuleStats: jest.fn(),
   createDomainBlock: jest.fn()
 }
 
@@ -31,6 +32,7 @@ jest.mock('@/lib/config', () => ({
 describe('/api/v1/admin/domain_blocks', () => {
   beforeEach(() => {
     mockDatabase.getDomainBlocks.mockReset()
+    mockDatabase.getDomainFederationRuleStats.mockReset()
     mockDatabase.createDomainBlock.mockReset()
   })
 
@@ -51,14 +53,29 @@ describe('/api/v1/admin/domain_blocks', () => {
         updatedAt: 0
       }
     ])
+    mockDatabase.getDomainFederationRuleStats.mockResolvedValue({
+      blocks: 42,
+      allows: 0,
+      sourceBlocks: 0,
+      sourceCounts: {}
+    })
 
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/admin/domain_blocks'),
+      new NextRequest(
+        'https://llun.test/api/v1/admin/domain_blocks?limit=25&offset=5'
+      ),
       { params: Promise.resolve({}) }
     )
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    expect(response.headers.get('x-total-count')).toBe('42')
+    expect(response.headers.get('x-offset')).toBe('5')
+    expect(response.headers.get('x-limit')).toBe('25')
+    expect(mockDatabase.getDomainBlocks).toHaveBeenCalledWith({
+      limit: 25,
+      offset: 5
+    })
     expect(data[0]).toMatchObject({
       id: 'block-1',
       domain: 'blocked.test',

--- a/app/api/v1/admin/domain_blocks/route.ts
+++ b/app/api/v1/admin/domain_blocks/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
 
 import {
   DomainBlockRequest,
@@ -21,18 +22,42 @@ const CORS_HEADERS = [
   HttpMethod.enum.GET,
   HttpMethod.enum.POST
 ]
+const DomainRuleListQueryParams = z.object({
+  limit: z.coerce.number().int().min(1).max(200).default(100),
+  offset: z.coerce.number().int().min(0).default(0)
+})
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute(
   'adminListDomainBlocks',
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
-    const blocks = await database.getDomainBlocks({ limit: 10_000 })
+    const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+    const parsedParams = DomainRuleListQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const { limit, offset } = parsedParams.data
+    const [blocks, stats] = await Promise.all([
+      database.getDomainBlocks({ limit, offset }),
+      database.getDomainFederationRuleStats()
+    ])
 
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: blocks.map(toAdminDomainBlock)
+      data: blocks.map(toAdminDomainBlock),
+      additionalHeaders: [
+        ['X-Total-Count', `${stats.blocks}`],
+        ['X-Offset', `${offset}`],
+        ['X-Limit', `${limit}`]
+      ]
     })
   })
 )

--- a/app/api/v1/admin/domain_blocks/route.ts
+++ b/app/api/v1/admin/domain_blocks/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
-import {
-  DomainBlockRequest,
-  readRequestData
-} from '@/app/api/v1/admin/domain_blocks/schema'
+import { DomainBlockRequest } from '@/app/api/v1/admin/domain_blocks/schema'
 import { toAdminDomainBlock } from '@/lib/services/federation/domainRules'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import {
   ERROR_400,
   ERROR_422,
@@ -67,7 +65,7 @@ export const POST = traceApiRoute(
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
     let data: unknown
     try {
-      data = await readRequestData(req)
+      data = await getRequestBody(req)
     } catch {
       return apiResponse({
         req,

--- a/app/api/v1/admin/domain_blocks/route.ts
+++ b/app/api/v1/admin/domain_blocks/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from 'next/server'
+
+import {
+  DomainBlockRequest,
+  readRequestData
+} from '@/app/api/v1/admin/domain_blocks/schema'
+import { toAdminDomainBlock } from '@/lib/services/federation/domainRules'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.POST
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminListDomainBlocks',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const blocks = await database.getDomainBlocks({ limit: 10_000 })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: blocks.map(toAdminDomainBlock)
+    })
+  })
+)
+
+export const POST = traceApiRoute(
+  'adminCreateDomainBlock',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const parsed = DomainBlockRequest.safeParse(await readRequestData(req))
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const block = await database.createDomainBlock({
+      domain: parsed.data.domain,
+      severity: parsed.data.severity,
+      rejectMedia: parsed.data.reject_media,
+      rejectReports: parsed.data.reject_reports,
+      privateComment: parsed.data.private_comment,
+      publicComment: parsed.data.public_comment,
+      obfuscate: parsed.data.obfuscate,
+      source: null
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminDomainBlock(block)
+    })
+  })
+)

--- a/app/api/v1/admin/domain_blocks/route.ts
+++ b/app/api/v1/admin/domain_blocks/route.ts
@@ -8,6 +8,7 @@ import { toAdminDomainBlock } from '@/lib/services/federation/domainRules'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
+  ERROR_400,
   ERROR_422,
   HTTP_STATUS,
   apiResponse,
@@ -39,7 +40,19 @@ export const GET = traceApiRoute(
 export const POST = traceApiRoute(
   'adminCreateDomainBlock',
   AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
-    const parsed = DomainBlockRequest.safeParse(await readRequestData(req))
+    let data: unknown
+    try {
+      data = await readRequestData(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const parsed = DomainBlockRequest.safeParse(data)
     if (!parsed.success) {
       return apiResponse({
         req,

--- a/app/api/v1/admin/domain_blocks/schema.ts
+++ b/app/api/v1/admin/domain_blocks/schema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+import { normalizeDomain } from '@/lib/services/federation/domainRules'
+import { DomainBlockSeverity } from '@/lib/types/database/operations'
+
+const Booleanish = z.union([z.boolean(), z.string()]).transform((value) => {
+  if (typeof value === 'boolean') return value
+  return value.toLowerCase() === 'true' || value === '1'
+})
+
+export const DomainBlockRequest = z.object({
+  domain: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .refine((value) => normalizeDomain(value) !== null),
+  severity: DomainBlockSeverity.default('suspend'),
+  reject_media: Booleanish.default(false),
+  reject_reports: Booleanish.default(false),
+  private_comment: z
+    .string()
+    .trim()
+    .max(10_000)
+    .optional()
+    .transform((value) => value || null),
+  public_comment: z
+    .string()
+    .trim()
+    .max(10_000)
+    .optional()
+    .transform((value) => value || null),
+  obfuscate: Booleanish.default(false)
+})
+
+export const DomainBlockUpdateRequest = DomainBlockRequest.omit({
+  domain: true
+}).partial()
+
+export const readRequestData = async (req: Request) => {
+  const contentType = req.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    return req.json()
+  }
+
+  const formData = await req.formData()
+  return Object.fromEntries(formData.entries())
+}

--- a/app/api/v1/admin/domain_blocks/schema.ts
+++ b/app/api/v1/admin/domain_blocks/schema.ts
@@ -5,7 +5,8 @@ import { DomainBlockSeverity } from '@/lib/types/database/operations'
 
 const Booleanish = z.union([z.boolean(), z.string()]).transform((value) => {
   if (typeof value === 'boolean') return value
-  return value.toLowerCase() === 'true' || value === '1'
+  const normalized = value.toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'on'
 })
 
 export const DomainBlockRequest = z.object({

--- a/app/api/v1/admin/domain_blocks/schema.ts
+++ b/app/api/v1/admin/domain_blocks/schema.ts
@@ -9,6 +9,10 @@ const Booleanish = z.union([z.boolean(), z.string()]).transform((value) => {
   return normalized === 'true' || normalized === '1' || normalized === 'on'
 })
 
+const Comment = z.string().trim().max(10_000)
+const CreateComment = Comment.optional().transform((value) => value || null)
+const UpdateComment = Comment.transform((value) => value || null).optional()
+
 export const DomainBlockRequest = z.object({
   domain: z
     .string()
@@ -19,21 +23,16 @@ export const DomainBlockRequest = z.object({
   severity: DomainBlockSeverity.default('suspend'),
   reject_media: Booleanish.default(false),
   reject_reports: Booleanish.default(false),
-  private_comment: z
-    .string()
-    .trim()
-    .max(10_000)
-    .optional()
-    .transform((value) => value || null),
-  public_comment: z
-    .string()
-    .trim()
-    .max(10_000)
-    .optional()
-    .transform((value) => value || null),
+  private_comment: CreateComment,
+  public_comment: CreateComment,
   obfuscate: Booleanish.default(false)
 })
 
-export const DomainBlockUpdateRequest = DomainBlockRequest.omit({
-  domain: true
-}).partial()
+export const DomainBlockUpdateRequest = z.object({
+  severity: DomainBlockSeverity.optional(),
+  reject_media: Booleanish.optional(),
+  reject_reports: Booleanish.optional(),
+  private_comment: UpdateComment,
+  public_comment: UpdateComment,
+  obfuscate: Booleanish.optional()
+})

--- a/app/api/v1/admin/domain_blocks/schema.ts
+++ b/app/api/v1/admin/domain_blocks/schema.ts
@@ -37,13 +37,3 @@ export const DomainBlockRequest = z.object({
 export const DomainBlockUpdateRequest = DomainBlockRequest.omit({
   domain: true
 }).partial()
-
-export const readRequestData = async (req: Request) => {
-  const contentType = req.headers.get('content-type') ?? ''
-  if (contentType.includes('application/json')) {
-    return req.json()
-  }
-
-  const formData = await req.formData()
-  return Object.fromEntries(formData.entries())
-}

--- a/app/api/v1/instance/domain_blocks/route.test.ts
+++ b/app/api/v1/instance/domain_blocks/route.test.ts
@@ -12,33 +12,51 @@ jest.mock('@/lib/config', () => ({
 }))
 
 describe('GET /api/v1/instance/domain_blocks', () => {
-  it('returns public Mastodon-shaped domain blocks', async () => {
+  beforeEach(() => {
+    mockGetDatabase.mockReset()
+  })
+
+  it('returns paginated public Mastodon-shaped domain blocks', async () => {
+    const getDomainBlocks = jest.fn().mockResolvedValue([
+      {
+        id: '1',
+        type: 'block',
+        domain: 'blocked.test',
+        severity: 'suspend',
+        rejectMedia: false,
+        rejectReports: false,
+        privateComment: 'internal',
+        publicComment: 'spam',
+        obfuscate: false,
+        source: null,
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+    const getDomainFederationRuleStats = jest.fn().mockResolvedValue({
+      blocks: 42,
+      allows: 0
+    })
+
     mockGetDatabase.mockReturnValue({
-      getDomainBlocks: jest.fn().mockResolvedValue([
-        {
-          id: '1',
-          type: 'block',
-          domain: 'blocked.test',
-          severity: 'suspend',
-          rejectMedia: false,
-          rejectReports: false,
-          privateComment: 'internal',
-          publicComment: 'spam',
-          obfuscate: false,
-          source: null,
-          createdAt: 0,
-          updatedAt: 0
-        }
-      ])
+      getDomainBlocks,
+      getDomainFederationRuleStats
     })
 
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/instance/domain_blocks'),
+      new NextRequest(
+        'https://llun.test/api/v1/instance/domain_blocks?limit=25&offset=5'
+      ),
       { params: Promise.resolve({}) }
     )
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    expect(getDomainBlocks).toHaveBeenCalledWith({ limit: 25, offset: 5 })
+    expect(getDomainFederationRuleStats).toHaveBeenCalledTimes(1)
+    expect(response.headers.get('X-Total-Count')).toBe('42')
+    expect(response.headers.get('X-Offset')).toBe('5')
+    expect(response.headers.get('X-Limit')).toBe('25')
     expect(data).toEqual([
       {
         domain: 'blocked.test',
@@ -48,5 +66,23 @@ describe('GET /api/v1/instance/domain_blocks', () => {
         comment: 'spam'
       }
     ])
+  })
+
+  it('rejects invalid pagination parameters', async () => {
+    const getDomainBlocks = jest.fn()
+    mockGetDatabase.mockReturnValue({
+      getDomainBlocks,
+      getDomainFederationRuleStats: jest.fn()
+    })
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/instance/domain_blocks?limit=1001'
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(getDomainBlocks).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/instance/domain_blocks/route.test.ts
+++ b/app/api/v1/instance/domain_blocks/route.test.ts
@@ -35,6 +35,7 @@ describe('GET /api/v1/instance/domain_blocks', () => {
     ])
     const getDomainFederationRuleStats = jest.fn().mockResolvedValue({
       blocks: 42,
+      suspendBlocks: 7,
       allows: 0
     })
 
@@ -52,9 +53,13 @@ describe('GET /api/v1/instance/domain_blocks', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(getDomainBlocks).toHaveBeenCalledWith({ limit: 25, offset: 5 })
+    expect(getDomainBlocks).toHaveBeenCalledWith({
+      limit: 25,
+      offset: 5,
+      severity: 'suspend'
+    })
     expect(getDomainFederationRuleStats).toHaveBeenCalledTimes(1)
-    expect(response.headers.get('X-Total-Count')).toBe('42')
+    expect(response.headers.get('X-Total-Count')).toBe('7')
     expect(response.headers.get('X-Offset')).toBe('5')
     expect(response.headers.get('X-Limit')).toBe('25')
     expect(data).toEqual([

--- a/app/api/v1/instance/domain_blocks/route.test.ts
+++ b/app/api/v1/instance/domain_blocks/route.test.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockGetDatabase = jest.fn()
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockGetDatabase()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'llun.test', allowEmails: [] })
+}))
+
+describe('GET /api/v1/instance/domain_blocks', () => {
+  it('returns public Mastodon-shaped domain blocks', async () => {
+    mockGetDatabase.mockReturnValue({
+      getDomainBlocks: jest.fn().mockResolvedValue([
+        {
+          id: '1',
+          type: 'block',
+          domain: 'blocked.test',
+          severity: 'suspend',
+          rejectMedia: false,
+          rejectReports: false,
+          privateComment: 'internal',
+          publicComment: 'spam',
+          obfuscate: false,
+          source: null,
+          createdAt: 0,
+          updatedAt: 0
+        }
+      ])
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/domain_blocks'),
+      { params: Promise.resolve({}) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual([
+      {
+        domain: 'blocked.test',
+        digest:
+          'cc5ac927c0bbef58bde4777f9afc52f3ed6c8d0652af02e650d33035030398f2',
+        severity: 'suspend',
+        comment: 'spam'
+      }
+    ])
+  })
+})

--- a/app/api/v1/instance/domain_blocks/route.ts
+++ b/app/api/v1/instance/domain_blocks/route.ts
@@ -1,5 +1,29 @@
+import { NextRequest } from 'next/server'
+
+import { getDatabase } from '@/lib/database'
+import { toPublicDomainBlock } from '@/lib/services/federation/domainRules'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { HTTP_STATUS, apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
-export const GET = traceApiRoute('getInstanceDomainBlocks', async () => {
-  return Response.json([])
+const CORS_HEADERS = [HttpMethod.enum.GET]
+
+export const GET = traceApiRoute('getInstanceDomainBlocks', async (req) => {
+  const database = getDatabase()
+  if (!database) {
+    return apiResponse({
+      req: req as NextRequest,
+      allowedMethods: CORS_HEADERS,
+      data: { error: 'Database unavailable' },
+      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+    })
+  }
+
+  const blocks = await database.getDomainBlocks({ limit: 10_000 })
+
+  return apiResponse({
+    req: req as NextRequest,
+    allowedMethods: CORS_HEADERS,
+    data: blocks.map(toPublicDomainBlock)
+  })
 })

--- a/app/api/v1/instance/domain_blocks/route.ts
+++ b/app/api/v1/instance/domain_blocks/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
 import { toPublicDomainBlock } from '@/lib/services/federation/domainRules'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { HTTP_STATUS, apiResponse } from '@/lib/utils/response'
+import { ERROR_400, HTTP_STATUS, apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.GET]
+const DomainBlockListQueryParams = z.object({
+  limit: z.coerce.number().int().min(1).max(1000).default(100),
+  offset: z.coerce.number().int().min(0).default(0)
+})
 
 export const GET = traceApiRoute('getInstanceDomainBlocks', async (req) => {
   const database = getDatabase()
@@ -19,11 +24,31 @@ export const GET = traceApiRoute('getInstanceDomainBlocks', async (req) => {
     })
   }
 
-  const blocks = await database.getDomainBlocks({ limit: 10_000 })
+  const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+  const parsedParams = DomainBlockListQueryParams.safeParse(queryParams)
+  if (!parsedParams.success) {
+    return apiResponse({
+      req: req as NextRequest,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_400,
+      responseStatusCode: HTTP_STATUS.BAD_REQUEST
+    })
+  }
+
+  const { limit, offset } = parsedParams.data
+  const [blocks, stats] = await Promise.all([
+    database.getDomainBlocks({ limit, offset }),
+    database.getDomainFederationRuleStats()
+  ])
 
   return apiResponse({
     req: req as NextRequest,
     allowedMethods: CORS_HEADERS,
-    data: blocks.map(toPublicDomainBlock)
+    data: blocks.map(toPublicDomainBlock),
+    additionalHeaders: [
+      ['X-Total-Count', `${stats.blocks}`],
+      ['X-Offset', `${offset}`],
+      ['X-Limit', `${limit}`]
+    ]
   })
 })

--- a/app/api/v1/instance/domain_blocks/route.ts
+++ b/app/api/v1/instance/domain_blocks/route.ts
@@ -13,42 +13,45 @@ const DomainBlockListQueryParams = z.object({
   offset: z.coerce.number().int().min(0).default(0)
 })
 
-export const GET = traceApiRoute('getInstanceDomainBlocks', async (req) => {
-  const database = getDatabase()
-  if (!database) {
+export const GET = traceApiRoute(
+  'getInstanceDomainBlocks',
+  async (req: NextRequest) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Database unavailable' },
+        responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
+
+    const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+    const parsedParams = DomainBlockListQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const { limit, offset } = parsedParams.data
+    const [blocks, stats] = await Promise.all([
+      database.getDomainBlocks({ limit, offset, severity: 'suspend' }),
+      database.getDomainFederationRuleStats()
+    ])
+
     return apiResponse({
-      req: req as NextRequest,
+      req,
       allowedMethods: CORS_HEADERS,
-      data: { error: 'Database unavailable' },
-      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      data: blocks.map(toPublicDomainBlock),
+      additionalHeaders: [
+        ['X-Total-Count', `${stats.suspendBlocks}`],
+        ['X-Offset', `${offset}`],
+        ['X-Limit', `${limit}`]
+      ]
     })
   }
-
-  const queryParams = Object.fromEntries(new URL(req.url).searchParams)
-  const parsedParams = DomainBlockListQueryParams.safeParse(queryParams)
-  if (!parsedParams.success) {
-    return apiResponse({
-      req: req as NextRequest,
-      allowedMethods: CORS_HEADERS,
-      data: ERROR_400,
-      responseStatusCode: HTTP_STATUS.BAD_REQUEST
-    })
-  }
-
-  const { limit, offset } = parsedParams.data
-  const [blocks, stats] = await Promise.all([
-    database.getDomainBlocks({ limit, offset }),
-    database.getDomainFederationRuleStats()
-  ])
-
-  return apiResponse({
-    req: req as NextRequest,
-    allowedMethods: CORS_HEADERS,
-    data: blocks.map(toPublicDomainBlock),
-    additionalHeaders: [
-      ['X-Total-Count', `${stats.blocks}`],
-      ['X-Offset', `${offset}`],
-      ['X-Limit', `${limit}`]
-    ]
-  })
-})
+)

--- a/lib/actions/utils.test.ts
+++ b/lib/actions/utils.test.ts
@@ -1,0 +1,29 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
+import { BlockedFederationDomainError, recordActorIfNeeded } from './utils'
+
+describe('recordActorIfNeeded', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  it('rejects actors from blocked domains before fetching them', async () => {
+    await database.createDomainBlock({
+      domain: 'blocked-record.test',
+      severity: 'suspend'
+    })
+
+    await expect(
+      recordActorIfNeeded({
+        actorId: 'https://blocked-record.test/users/alice',
+        database
+      })
+    ).rejects.toThrow(BlockedFederationDomainError)
+  })
+})

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -7,13 +7,28 @@ interface RecordActorIfNeededParams {
   actorId: string
   database: Database
 }
+
+export class BlockedFederationDomainError extends Error {
+  constructor(actorId: string) {
+    super(`Federation with actor domain is blocked: ${actorId}`)
+    this.name = 'BlockedFederationDomainError'
+  }
+}
+
+export const assertActorCanFederate = async ({
+  actorId,
+  database
+}: RecordActorIfNeededParams): Promise<void> => {
+  if (!(await canFederateWithDomain(database, actorId))) {
+    throw new BlockedFederationDomainError(actorId)
+  }
+}
+
 export const recordActorIfNeeded = async ({
   actorId,
   database
 }: RecordActorIfNeededParams): Promise<Actor | undefined> => {
-  if (!(await canFederateWithDomain(database, actorId))) {
-    return undefined
-  }
+  await assertActorCanFederate({ actorId, database })
 
   const existingActor = await database.getActorFromId({
     id: actorId

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -1,5 +1,6 @@
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { Actor } from '@/lib/types/domain/actor'
 
 interface RecordActorIfNeededParams {
@@ -10,6 +11,10 @@ export const recordActorIfNeeded = async ({
   actorId,
   database
 }: RecordActorIfNeededParams): Promise<Actor | undefined> => {
+  if (!(await canFederateWithDomain(database, actorId))) {
+    return undefined
+  }
+
   const existingActor = await database.getActorFromId({
     id: actorId
   })

--- a/lib/components/ui/select.tsx
+++ b/lib/components/ui/select.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Select({ className, ...props }: React.ComponentProps<'select'>) {
+  return (
+    <select
+      data-slot="select"
+      className={cn(
+        'border-input bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Select }

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -21,6 +21,8 @@ import { PushConfig, getPushConfig } from './push'
 import { QueueConfig, getQueueConfig } from './queue'
 import { RequestConfig, getRequestConfig } from './request'
 
+const FederationMode = z.enum(['open', 'allowlist'])
+
 const Config = z.object({
   host: z.string(),
   serviceName: z.string().nullish(),
@@ -33,6 +35,7 @@ const Config = z.object({
   secretPhase: z.string(),
   allowMediaDomains: z.string().array().optional(),
   allowActorDomains: z.string().array().optional(),
+  federationMode: FederationMode.default('open'),
   auth: AuthConfig.optional(),
   email: z
     .union([SMTPConfig, LambdaConfig, ResendConfig, SESConfig])
@@ -79,6 +82,7 @@ const getConfigFromEnvironment = () => {
       allowActorDomains: JSON.parse(
         process.env.ACTIVITIES_ALLOW_ACTOR_DOMAINS || '[]'
       ),
+      federationMode: process.env.ACTIVITIES_FEDERATION_MODE || 'open',
       ...getEmailConfig(),
       ...getAuthConfig(),
       ...getDatabaseConfig(),

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -224,8 +224,11 @@ describe('AdminDatabase', () => {
         })
 
         await expect(
-          database.getDomainBlockForDomain(`sub.${domain}`)
+          database.getDomainBlockForDomain(domain)
         ).resolves.toMatchObject({ id: block.id })
+        await expect(
+          database.getDomainBlockForDomain(`sub.${domain}`)
+        ).resolves.toBeNull()
 
         const updated = await database.updateDomainBlock({
           id: block.id,
@@ -304,12 +307,12 @@ describe('AdminDatabase', () => {
         expect(suspendDomains.has(noopDomain)).toBe(false)
       })
 
-      it('matches the most specific domain rule in SQL', async () => {
+      it('matches exact domains before wildcard rules in SQL', async () => {
         const suffix = crypto.randomUUID().slice(0, 8)
         const parentDomain = `parent-${suffix}.test`
         const childDomain = `sub.${parentDomain}`
-        const parent = await database.createDomainBlock({
-          domain: parentDomain,
+        const wildcard = await database.createDomainBlock({
+          domain: `*.${parentDomain}`,
           severity: 'silence'
         })
         const child = await database.createDomainBlock({
@@ -318,19 +321,22 @@ describe('AdminDatabase', () => {
         })
 
         await expect(
-          database.getDomainBlockForDomain(`deep.${childDomain}`)
+          database.getDomainBlockForDomain(childDomain)
         ).resolves.toMatchObject({ id: child.id })
         await expect(
+          database.getDomainBlockForDomain(`deep.${childDomain}`)
+        ).resolves.toMatchObject({ id: wildcard.id })
+        await expect(
           database.getDomainBlockForDomain(parentDomain)
-        ).resolves.toMatchObject({ id: parent.id })
+        ).resolves.toBeNull()
       })
 
       it('matches domain rules for multiple domains in one batch', async () => {
         const suffix = crypto.randomUUID().slice(0, 8)
         const parentDomain = `batch-parent-${suffix}.test`
         const childDomain = `sub.${parentDomain}`
-        const parent = await database.createDomainBlock({
-          domain: parentDomain,
+        const wildcardParent = await database.createDomainBlock({
+          domain: `*.${parentDomain}`,
           severity: 'silence'
         })
         const child = await database.createDomainBlock({
@@ -343,16 +349,18 @@ describe('AdminDatabase', () => {
         })
 
         const blockMatches = await database.getDomainBlocksForDomains([
+          childDomain,
           `deep.${childDomain}`,
           parentDomain,
           `unknown-${suffix}.test`
         ])
-        expect(blockMatches[`deep.${childDomain}`]).toMatchObject({
+        expect(blockMatches[childDomain]).toMatchObject({
           id: child.id
         })
-        expect(blockMatches[parentDomain]).toMatchObject({
-          id: parent.id
+        expect(blockMatches[`deep.${childDomain}`]).toMatchObject({
+          id: wildcardParent.id
         })
+        expect(blockMatches[parentDomain]).toBeNull()
         expect(blockMatches[`unknown-${suffix}.test`]).toBeNull()
 
         const allowMatches = await database.getDomainAllowsForDomains([
@@ -389,8 +397,11 @@ describe('AdminDatabase', () => {
 
         expect(second.id).toBe(first.id)
         await expect(
-          database.getDomainAllowForDomain(`sub.${domain}`)
+          database.getDomainAllowForDomain(domain)
         ).resolves.toMatchObject({ id: first.id })
+        await expect(
+          database.getDomainAllowForDomain(`sub.${domain}`)
+        ).resolves.toBeNull()
 
         await expect(
           database.deleteDomainAllow(first.id)

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -349,6 +349,39 @@ describe('AdminDatabase', () => {
           })
         })
       })
+
+      it('imports domain blocks in batches', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const existingDomain = `batch-existing-${suffix}.test`
+        await database.createDomainBlock({
+          domain: existingDomain,
+          severity: 'silence',
+          source: 'manual'
+        })
+
+        const result = await database.importDomainBlocks({
+          blocks: [
+            {
+              domain: existingDomain,
+              severity: 'suspend',
+              source: 'oliphant-tier0'
+            },
+            ...Array.from({ length: 60 }, (_, index) => ({
+              domain: `batch-${index}-${suffix}.test`,
+              severity: 'suspend' as const,
+              source: 'oliphant-tier0'
+            }))
+          ]
+        })
+
+        expect(result).toEqual({ created: 60, updated: 1, skipped: 0 })
+        await expect(
+          database.getDomainBlockForDomain(existingDomain)
+        ).resolves.toMatchObject({
+          severity: 'suspend',
+          source: 'oliphant-tier0'
+        })
+      })
     })
   })
 })

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto'
+
 import {
   databaseBeforeAll,
   getTestDatabaseTable
@@ -197,6 +199,111 @@ describe('AdminDatabase', () => {
         ourTags.forEach((h) => {
           expect(h.latestPostAt).not.toBeNull()
           expect(typeof h.latestPostAt).toBe('number')
+        })
+      })
+    })
+
+    describe('domain federation rules', () => {
+      it('creates, matches, updates, and deletes domain blocks', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const domain = `blocked-${suffix}.test`
+        const block = await database.createDomainBlock({
+          domain: `https://${domain}/path`,
+          severity: 'suspend',
+          rejectMedia: true,
+          publicComment: 'spam source',
+          obfuscate: true
+        })
+
+        expect(block).toMatchObject({
+          domain,
+          severity: 'suspend',
+          rejectMedia: true,
+          publicComment: 'spam source',
+          obfuscate: true
+        })
+
+        await expect(
+          database.getDomainBlockForDomain(`sub.${domain}`)
+        ).resolves.toMatchObject({ id: block.id })
+
+        const updated = await database.updateDomainBlock({
+          id: block.id,
+          severity: 'silence',
+          rejectMedia: false,
+          publicComment: 'limited'
+        })
+        expect(updated).toMatchObject({
+          severity: 'silence',
+          rejectMedia: false,
+          publicComment: 'limited'
+        })
+
+        await expect(
+          database.deleteDomainBlock(block.id)
+        ).resolves.toMatchObject({
+          id: block.id
+        })
+        await expect(database.getDomainBlockById(block.id)).resolves.toBeNull()
+      })
+
+      it('creates and deletes domain allows idempotently', async () => {
+        const domain = `allowed-${crypto.randomUUID().slice(0, 8)}.test`
+
+        const first = await database.createDomainAllow({ domain })
+        const second = await database.createDomainAllow({
+          domain: `https://${domain}/users/a`
+        })
+
+        expect(second.id).toBe(first.id)
+        await expect(
+          database.getDomainAllowForDomain(`sub.${domain}`)
+        ).resolves.toMatchObject({ id: first.id })
+
+        await expect(
+          database.deleteDomainAllow(first.id)
+        ).resolves.toMatchObject({
+          id: first.id
+        })
+        await expect(database.getDomainAllowById(first.id)).resolves.toBeNull()
+      })
+
+      it('imports domain blocks with create, update, and skip counts', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const existingDomain = `existing-${suffix}.test`
+        const newDomain = `new-${suffix}.test`
+        await database.createDomainBlock({
+          domain: existingDomain,
+          severity: 'silence',
+          source: 'manual'
+        })
+
+        const result = await database.importDomainBlocks({
+          blocks: [
+            {
+              domain: existingDomain,
+              severity: 'suspend',
+              source: 'oliphant-tier0'
+            },
+            {
+              domain: newDomain,
+              severity: 'suspend',
+              source: 'oliphant-tier0'
+            },
+            {
+              domain: '',
+              severity: 'suspend',
+              source: 'oliphant-tier0'
+            }
+          ]
+        })
+
+        expect(result).toEqual({ created: 1, updated: 1, skipped: 1 })
+        await expect(
+          database.getDomainBlockForDomain(existingDomain)
+        ).resolves.toMatchObject({
+          severity: 'suspend',
+          source: 'oliphant-tier0'
         })
       })
     })

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -474,7 +474,7 @@ describe('AdminDatabase', () => {
               severity: 'suspend',
               source: 'oliphant-tier0'
             },
-            ...Array.from({ length: 60 }, (_, index) => ({
+            ...Array.from({ length: 510 }, (_, index) => ({
               domain: `batch-${index}-${suffix}.test`,
               severity: 'suspend' as const,
               source: 'oliphant-tier0'
@@ -482,7 +482,7 @@ describe('AdminDatabase', () => {
           ]
         })
 
-        expect(result).toEqual({ created: 60, updated: 1, skipped: 0 })
+        expect(result).toEqual({ created: 510, updated: 1, skipped: 0 })
         await expect(
           database.getDomainBlockForDomain(existingDomain)
         ).resolves.toMatchObject({

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -373,6 +373,35 @@ describe('AdminDatabase', () => {
         expect(allowMatches[allowDomain]).toBeNull()
       })
 
+      it('matches domain rules for large domain batches', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const blockDomain = `large-block-${suffix}.test`
+        const allowDomain = `large-allow-${suffix}.test`
+        const block = await database.createDomainBlock({
+          domain: blockDomain,
+          severity: 'suspend'
+        })
+        const allow = await database.createDomainAllow({
+          domain: allowDomain
+        })
+        const domains = [
+          blockDomain,
+          allowDomain,
+          ...Array.from(
+            { length: 1100 },
+            (_, index) => `large-${index}-${suffix}.test`
+          )
+        ]
+
+        const blockMatches = await database.getDomainBlocksForDomains(domains)
+        const allowMatches = await database.getDomainAllowsForDomains(domains)
+
+        expect(blockMatches[blockDomain]).toMatchObject({ id: block.id })
+        expect(allowMatches[allowDomain]).toMatchObject({ id: allow.id })
+        expect(blockMatches[domains[2]]).toBeNull()
+        expect(allowMatches[domains[2]]).toBeNull()
+      })
+
       it('does not match wildcard rules against the parent domain', async () => {
         const domain = `wild-${crypto.randomUUID().slice(0, 8)}.test`
         const wildcard = await database.createDomainAllow({

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -268,6 +268,46 @@ describe('AdminDatabase', () => {
         ).resolves.toMatchObject({ id: parent.id })
       })
 
+      it('matches domain rules for multiple domains in one batch', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const parentDomain = `batch-parent-${suffix}.test`
+        const childDomain = `sub.${parentDomain}`
+        const parent = await database.createDomainBlock({
+          domain: parentDomain,
+          severity: 'silence'
+        })
+        const child = await database.createDomainBlock({
+          domain: childDomain,
+          severity: 'suspend'
+        })
+        const allowDomain = `batch-allow-${suffix}.test`
+        const wildcardAllow = await database.createDomainAllow({
+          domain: `*.${allowDomain}`
+        })
+
+        const blockMatches = await database.getDomainBlocksForDomains([
+          `deep.${childDomain}`,
+          parentDomain,
+          `unknown-${suffix}.test`
+        ])
+        expect(blockMatches[`deep.${childDomain}`]).toMatchObject({
+          id: child.id
+        })
+        expect(blockMatches[parentDomain]).toMatchObject({
+          id: parent.id
+        })
+        expect(blockMatches[`unknown-${suffix}.test`]).toBeNull()
+
+        const allowMatches = await database.getDomainAllowsForDomains([
+          `sub.${allowDomain}`,
+          allowDomain
+        ])
+        expect(allowMatches[`sub.${allowDomain}`]).toMatchObject({
+          id: wildcardAllow.id
+        })
+        expect(allowMatches[allowDomain]).toBeNull()
+      })
+
       it('does not match wildcard rules against the parent domain', async () => {
         const domain = `wild-${crypto.randomUUID().slice(0, 8)}.test`
         const wildcard = await database.createDomainAllow({

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -247,6 +247,41 @@ describe('AdminDatabase', () => {
         await expect(database.getDomainBlockById(block.id)).resolves.toBeNull()
       })
 
+      it('matches the most specific domain rule in SQL', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const parentDomain = `parent-${suffix}.test`
+        const childDomain = `sub.${parentDomain}`
+        const parent = await database.createDomainBlock({
+          domain: parentDomain,
+          severity: 'silence'
+        })
+        const child = await database.createDomainBlock({
+          domain: childDomain,
+          severity: 'suspend'
+        })
+
+        await expect(
+          database.getDomainBlockForDomain(`deep.${childDomain}`)
+        ).resolves.toMatchObject({ id: child.id })
+        await expect(
+          database.getDomainBlockForDomain(parentDomain)
+        ).resolves.toMatchObject({ id: parent.id })
+      })
+
+      it('does not match wildcard rules against the parent domain', async () => {
+        const domain = `wild-${crypto.randomUUID().slice(0, 8)}.test`
+        const wildcard = await database.createDomainAllow({
+          domain: `*.${domain}`
+        })
+
+        await expect(
+          database.getDomainAllowForDomain(`sub.${domain}`)
+        ).resolves.toMatchObject({ id: wildcard.id })
+        await expect(
+          database.getDomainAllowForDomain(domain)
+        ).resolves.toBeNull()
+      })
+
       it('creates and deletes domain allows idempotently', async () => {
         const domain = `allowed-${crypto.randomUUID().slice(0, 8)}.test`
 
@@ -304,6 +339,14 @@ describe('AdminDatabase', () => {
         ).resolves.toMatchObject({
           severity: 'suspend',
           source: 'oliphant-tier0'
+        })
+
+        await expect(
+          database.getDomainFederationRuleStats()
+        ).resolves.toMatchObject({
+          sourceCounts: expect.objectContaining({
+            'oliphant-tier0': expect.any(Number)
+          })
         })
       })
     })

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -247,6 +247,63 @@ describe('AdminDatabase', () => {
         await expect(database.getDomainBlockById(block.id)).resolves.toBeNull()
       })
 
+      it('upserts domain blocks by domain and type', async () => {
+        const domain = `upsert-${crypto.randomUUID().slice(0, 8)}.test`
+        const first = await database.createDomainBlock({
+          domain,
+          severity: 'suspend',
+          publicComment: 'first'
+        })
+        const second = await database.createDomainBlock({
+          domain,
+          severity: 'silence',
+          publicComment: 'second'
+        })
+
+        expect(second.id).toBe(first.id)
+        expect(second).toMatchObject({
+          domain,
+          severity: 'silence',
+          publicComment: 'second'
+        })
+      })
+
+      it('filters domain blocks by severity and counts suspend blocks', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const suspendDomain = `000-suspend-${suffix}.test`
+        const silenceDomain = `000-silence-${suffix}.test`
+        const noopDomain = `000-noop-${suffix}.test`
+        const before = await database.getDomainFederationRuleStats()
+
+        await database.createDomainBlock({
+          domain: suspendDomain,
+          severity: 'suspend'
+        })
+        await database.createDomainBlock({
+          domain: silenceDomain,
+          severity: 'silence'
+        })
+        await database.createDomainBlock({
+          domain: noopDomain,
+          severity: 'noop'
+        })
+
+        const after = await database.getDomainFederationRuleStats()
+        expect(after.blocks).toBe(before.blocks + 3)
+        expect(after.suspendBlocks).toBe(before.suspendBlocks + 1)
+
+        const suspendBlocks = await database.getDomainBlocks({
+          limit: 1000,
+          severity: 'suspend'
+        })
+        const suspendDomains = new Set(
+          suspendBlocks.map((block) => block.domain)
+        )
+        expect(suspendDomains.has(suspendDomain)).toBe(true)
+        expect(suspendDomains.has(silenceDomain)).toBe(false)
+        expect(suspendDomains.has(noopDomain)).toBe(false)
+      })
+
       it('matches the most specific domain rule in SQL', async () => {
         const suffix = crypto.randomUUID().slice(0, 8)
         const parentDomain = `parent-${suffix}.test`

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -111,6 +111,18 @@ const getDomainRuleCandidates = (domain: string): string[] => {
   return [...new Set([...exactCandidates, ...wildcardCandidates, '*'])]
 }
 
+const SQL_BATCH_SIZE = 50
+
+const chunkArray = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = []
+
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+
+  return chunks
+}
+
 const buildDomainBlockInsert = (
   params: CreateDomainBlockParams,
   now: Date,
@@ -559,34 +571,57 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     let created = 0
     let updated = 0
     let skipped = 0
+    const normalizedBlocks = new Map<string, CreateDomainBlockParams>()
+
+    blocks.forEach((block) => {
+      const normalized = normalizeDomain(block.domain)
+      if (!normalized) {
+        skipped++
+        return
+      }
+
+      normalizedBlocks.set(normalized, { ...block, domain: normalized })
+    })
+
+    const normalizedDomains = [...normalizedBlocks.keys()]
+    if (normalizedDomains.length === 0) {
+      return { created, updated, skipped }
+    }
 
     await database.transaction(async (trx) => {
-      for (const block of blocks) {
-        const normalized = normalizeDomain(block.domain)
-        if (!normalized) {
-          skipped++
-          continue
-        }
-
-        const now = new Date()
-        const existing = await trx<SQLDomainFederationRule>(
+      const existingDomains = new Set<string>()
+      for (const domainChunk of chunkArray(normalizedDomains, SQL_BATCH_SIZE)) {
+        const rows = await trx<SQLDomainFederationRule>(
           'domain_federation_rules'
         )
-          .where({ type: 'block', domain: normalized })
-          .first()
+          .select('domain')
+          .where('type', 'block')
+          .whereIn('domain', domainChunk)
 
-        if (existing) {
-          await trx<SQLDomainFederationRule>('domain_federation_rules')
-            .where('id', existing.id)
-            .update(buildDomainBlockUpdate(block, now))
-          updated++
-          continue
-        }
+        rows.forEach((row) => existingDomains.add(row.domain))
+      }
 
-        await trx('domain_federation_rules').insert(
-          buildDomainBlockInsert(block, now)
-        )
-        created++
+      const now = new Date()
+      const rows = [...normalizedBlocks.values()].map((block) =>
+        buildDomainBlockInsert(block, now)
+      )
+      created = rows.filter((row) => !existingDomains.has(row.domain)).length
+      updated = rows.length - created
+
+      for (const rowChunk of chunkArray(rows, SQL_BATCH_SIZE)) {
+        await trx('domain_federation_rules')
+          .insert(rowChunk)
+          .onConflict(['type', 'domain'])
+          .merge([
+            'severity',
+            'rejectMedia',
+            'rejectReports',
+            'privateComment',
+            'publicComment',
+            'obfuscate',
+            'source',
+            'updatedAt'
+          ])
       }
     })
 

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -105,12 +105,14 @@ const getDomainRuleCandidates = (domain: string): string[] => {
   if (domain === '*') return ['*']
 
   const parts = domain.split('.')
-  const exactCandidates = parts.map((_, index) => parts.slice(index).join('.'))
-  const wildcardCandidates = exactCandidates
+  const parentCandidates = parts
     .slice(1)
-    .map((candidate) => `*.${candidate}`)
+    .map((_, index) => parts.slice(index + 1).join('.'))
+  const wildcardCandidates = parentCandidates.map(
+    (candidate) => `*.${candidate}`
+  )
 
-  return [...new Set([...exactCandidates, ...wildcardCandidates, '*'])]
+  return [...new Set([domain, ...wildcardCandidates, '*'])]
 }
 
 const normalizeDomains = (domains: string[]): string[] => [
@@ -129,12 +131,14 @@ const compareDomainRuleRows = (
   if (left.domain === '*') return 1
   if (right.domain === '*') return -1
 
+  const wildcardDiff =
+    Number(left.domain.startsWith('*.')) - Number(right.domain.startsWith('*.'))
+  if (wildcardDiff !== 0) return wildcardDiff
+
   const lengthDiff = right.domain.length - left.domain.length
   if (lengthDiff !== 0) return lengthDiff
 
-  return (
-    Number(left.domain.startsWith('*.')) - Number(right.domain.startsWith('*.'))
-  )
+  return 0
 }
 
 const resolveDomainRuleMatches = <T extends DomainBlock | DomainAllow>(
@@ -453,8 +457,10 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     )
       .where('type', 'block')
       .whereIn('domain', getDomainRuleCandidates(normalized))
+      .orderByRaw(
+        "case when domain = '*' or domain like '*.%' then 1 else 0 end asc"
+      )
       .orderByRaw('length(domain) DESC')
-      .orderByRaw("case when domain like '*.%' then 1 else 0 end asc")
       .first()
 
     return row ? toDomainBlock(row) : null
@@ -484,8 +490,10 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     )
       .where('type', 'allow')
       .whereIn('domain', getDomainRuleCandidates(normalized))
+      .orderByRaw(
+        "case when domain = '*' or domain like '*.%' then 1 else 0 end asc"
+      )
       .orderByRaw('length(domain) DESC')
-      .orderByRaw("case when domain like '*.%' then 1 else 0 end asc")
       .first()
 
     return row ? toDomainAllow(row) : null

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -159,7 +159,7 @@ const resolveDomainRuleMatches = <T extends DomainBlock | DomainAllow>(
   )
 }
 
-const SQL_BATCH_SIZE = 50
+const SQL_BATCH_SIZE = 500
 
 const chunkArray = <T>(items: T[], size: number): T[][] => {
   const chunks: T[][] = []

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -12,7 +12,6 @@ import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { toDomainAccount } from '@/lib/database/sql/utils/toDomainAccount'
 import {
   DEFAULT_DOMAIN_BLOCK_SEVERITY,
-  findMatchingDomainRule,
   normalizeDomain
 } from '@/lib/services/federation/domainRules'
 import {
@@ -98,6 +97,18 @@ const normalizeOrThrow = (domain: string): string => {
   const normalized = normalizeDomain(domain)
   if (!normalized) throw new Error('Invalid domain')
   return normalized
+}
+
+const getDomainRuleCandidates = (domain: string): string[] => {
+  if (domain === '*') return ['*']
+
+  const parts = domain.split('.')
+  const exactCandidates = parts.map((_, index) => parts.slice(index).join('.'))
+  const wildcardCandidates = exactCandidates
+    .slice(1)
+    .map((candidate) => `*.${candidate}`)
+
+  return [...new Set([...exactCandidates, ...wildcardCandidates, '*'])]
 }
 
 const buildDomainBlockInsert = (
@@ -377,16 +388,70 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     const normalized = normalizeDomain(domain)
     if (!normalized) return null
 
-    const blocks = await this.getDomainBlocks({ limit: 10_000 })
-    return findMatchingDomainRule(normalized, blocks)
+    const row = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', 'block')
+      .whereIn('domain', getDomainRuleCandidates(normalized))
+      .orderByRaw('length(domain) DESC')
+      .orderByRaw("case when domain like '*.%' then 1 else 0 end asc")
+      .first()
+
+    return row ? toDomainBlock(row) : null
   },
 
   async getDomainAllowForDomain(domain: string) {
     const normalized = normalizeDomain(domain)
     if (!normalized) return null
 
-    const allows = await this.getDomainAllows({ limit: 10_000 })
-    return findMatchingDomainRule(normalized, allows)
+    const row = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', 'allow')
+      .whereIn('domain', getDomainRuleCandidates(normalized))
+      .orderByRaw('length(domain) DESC')
+      .orderByRaw("case when domain like '*.%' then 1 else 0 end asc")
+      .first()
+
+    return row ? toDomainAllow(row) : null
+  },
+
+  async getDomainFederationRuleStats() {
+    const [blockCount, allowCount, sourceRows] = await Promise.all([
+      database('domain_federation_rules')
+        .where('type', 'block')
+        .count<{ count: string | number }>('id as count')
+        .first(),
+      database('domain_federation_rules')
+        .where('type', 'allow')
+        .count<{ count: string | number }>('id as count')
+        .first(),
+      database('domain_federation_rules')
+        .select('source')
+        .where('type', 'block')
+        .whereNotNull('source')
+        .groupBy('source')
+        .count<{ source: string; count: string | number }>('id as count')
+    ])
+    const sourceCounts = Object.fromEntries(
+      (
+        sourceRows as unknown as {
+          source: string
+          count: string | number
+        }[]
+      ).map((row) => [row.source, Number(row.count)])
+    )
+    const sourceBlocks = Object.values(sourceCounts).reduce(
+      (total, count) => total + count,
+      0
+    )
+
+    return {
+      blocks: Number(blockCount?.count ?? 0),
+      allows: Number(allowCount?.count ?? 0),
+      sourceBlocks,
+      sourceCounts
+    }
   },
 
   async createDomainBlock(params) {

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -18,6 +18,8 @@ import {
   AdminDatabase,
   AdminHashtag,
   CreateDomainBlockParams,
+  DomainAllow,
+  DomainBlock,
   GetAccountWithActorsParams,
   GetAllAccountsParams,
   GetAllHashtagsParams,
@@ -67,7 +69,7 @@ const toDomainActor = (row: SQLActor): Actor => {
 const toBoolean = (value: boolean | number | undefined | null): boolean =>
   value === true || value === 1
 
-const toDomainBlock = (row: SQLDomainFederationRule) => ({
+const toDomainBlock = (row: SQLDomainFederationRule): DomainBlock => ({
   id: row.id,
   domain: row.domain,
   type: 'block' as const,
@@ -85,7 +87,7 @@ const toDomainBlock = (row: SQLDomainFederationRule) => ({
   updatedAt: getCompatibleTime(row.updatedAt)
 })
 
-const toDomainAllow = (row: SQLDomainFederationRule) => ({
+const toDomainAllow = (row: SQLDomainFederationRule): DomainAllow => ({
   id: row.id,
   domain: row.domain,
   type: 'allow' as const,
@@ -109,6 +111,48 @@ const getDomainRuleCandidates = (domain: string): string[] => {
     .map((candidate) => `*.${candidate}`)
 
   return [...new Set([...exactCandidates, ...wildcardCandidates, '*'])]
+}
+
+const normalizeDomains = (domains: string[]): string[] => [
+  ...new Set(
+    domains
+      .map((domain) => normalizeDomain(domain))
+      .filter((domain): domain is string => domain !== null)
+  )
+]
+
+const compareDomainRuleRows = (
+  left: SQLDomainFederationRule,
+  right: SQLDomainFederationRule
+) => {
+  if (left.domain === right.domain) return 0
+  if (left.domain === '*') return 1
+  if (right.domain === '*') return -1
+
+  const lengthDiff = right.domain.length - left.domain.length
+  if (lengthDiff !== 0) return lengthDiff
+
+  return (
+    Number(left.domain.startsWith('*.')) - Number(right.domain.startsWith('*.'))
+  )
+}
+
+const resolveDomainRuleMatches = <T extends DomainBlock | DomainAllow>(
+  domains: string[],
+  rows: SQLDomainFederationRule[],
+  toDomainRule: (row: SQLDomainFederationRule) => T
+): Record<string, T | null> => {
+  const sortedRows = [...rows].sort(compareDomainRuleRows)
+
+  return Object.fromEntries(
+    domains.map((domain) => {
+      const candidates = new Set(getDomainRuleCandidates(domain))
+      const row =
+        sortedRows.find((candidate) => candidates.has(candidate.domain)) ?? null
+
+      return [domain, row ? toDomainRule(row) : null]
+    })
+  )
 }
 
 const SQL_BATCH_SIZE = 50
@@ -412,6 +456,21 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     return row ? toDomainBlock(row) : null
   },
 
+  async getDomainBlocksForDomains(domains: string[]) {
+    const normalizedDomains = normalizeDomains(domains)
+    if (normalizedDomains.length === 0) return {}
+
+    const rows = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', 'block')
+      .whereIn('domain', [
+        ...new Set(normalizedDomains.flatMap(getDomainRuleCandidates))
+      ])
+
+    return resolveDomainRuleMatches(normalizedDomains, rows, toDomainBlock)
+  },
+
   async getDomainAllowForDomain(domain: string) {
     const normalized = normalizeDomain(domain)
     if (!normalized) return null
@@ -426,6 +485,21 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
       .first()
 
     return row ? toDomainAllow(row) : null
+  },
+
+  async getDomainAllowsForDomains(domains: string[]) {
+    const normalizedDomains = normalizeDomains(domains)
+    if (normalizedDomains.length === 0) return {}
+
+    const rows = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', 'allow')
+      .whereIn('domain', [
+        ...new Set(normalizedDomains.flatMap(getDomainRuleCandidates))
+      ])
+
+    return resolveDomainRuleMatches(normalizedDomains, rows, toDomainAllow)
   },
 
   async getDomainFederationRuleStats() {

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import { Knex } from 'knex'
 
 import {
@@ -10,15 +11,27 @@ import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { toDomainAccount } from '@/lib/database/sql/utils/toDomainAccount'
 import {
+  DEFAULT_DOMAIN_BLOCK_SEVERITY,
+  findMatchingDomainRule,
+  normalizeDomain
+} from '@/lib/services/federation/domainRules'
+import {
   AdminDatabase,
   AdminHashtag,
+  CreateDomainBlockParams,
   GetAccountWithActorsParams,
   GetAllAccountsParams,
   GetAllHashtagsParams,
   GetServiceStatsBucketsParams,
-  HashtagSortOrder
+  HashtagSortOrder,
+  UpdateDomainBlockParams
 } from '@/lib/types/database/operations'
-import { ActorSettings, SQLAccount, SQLActor } from '@/lib/types/database/rows'
+import {
+  ActorSettings,
+  SQLAccount,
+  SQLActor,
+  SQLDomainFederationRule
+} from '@/lib/types/database/rows'
 import { Actor } from '@/lib/types/domain/actor'
 import { StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
@@ -51,6 +64,74 @@ const toDomainActor = (row: SQLActor): Actor => {
         : null
   })
 }
+
+const toBoolean = (value: boolean | number | undefined | null): boolean =>
+  value === true || value === 1
+
+const toDomainBlock = (row: SQLDomainFederationRule) => ({
+  id: row.id,
+  domain: row.domain,
+  type: 'block' as const,
+  severity:
+    row.severity === 'noop' || row.severity === 'silence'
+      ? row.severity
+      : DEFAULT_DOMAIN_BLOCK_SEVERITY,
+  rejectMedia: toBoolean(row.rejectMedia),
+  rejectReports: toBoolean(row.rejectReports),
+  privateComment: row.privateComment ?? null,
+  publicComment: row.publicComment ?? null,
+  obfuscate: toBoolean(row.obfuscate),
+  source: row.source ?? null,
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+const toDomainAllow = (row: SQLDomainFederationRule) => ({
+  id: row.id,
+  domain: row.domain,
+  type: 'allow' as const,
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+const normalizeOrThrow = (domain: string): string => {
+  const normalized = normalizeDomain(domain)
+  if (!normalized) throw new Error('Invalid domain')
+  return normalized
+}
+
+const buildDomainBlockInsert = (
+  params: CreateDomainBlockParams,
+  now: Date,
+  id = crypto.randomUUID()
+) => ({
+  id,
+  domain: normalizeOrThrow(params.domain),
+  type: 'block',
+  severity: params.severity ?? DEFAULT_DOMAIN_BLOCK_SEVERITY,
+  rejectMedia: params.rejectMedia ?? false,
+  rejectReports: params.rejectReports ?? false,
+  privateComment: params.privateComment ?? null,
+  publicComment: params.publicComment ?? null,
+  obfuscate: params.obfuscate ?? false,
+  source: params.source ?? null,
+  createdAt: now,
+  updatedAt: now
+})
+
+const buildDomainBlockUpdate = (
+  params: UpdateDomainBlockParams | CreateDomainBlockParams,
+  now: Date
+) => ({
+  severity: params.severity ?? DEFAULT_DOMAIN_BLOCK_SEVERITY,
+  rejectMedia: params.rejectMedia ?? false,
+  rejectReports: params.rejectReports ?? false,
+  privateComment: params.privateComment ?? null,
+  publicComment: params.publicComment ?? null,
+  obfuscate: params.obfuscate ?? false,
+  source: params.source ?? null,
+  updatedAt: now
+})
 
 export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
   async getAllAccounts({ limit, offset }: GetAllAccountsParams) {
@@ -246,5 +327,204 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
       hashtags,
       total: parseInt(String(countResult?.count ?? '0'), 10)
     }
+  },
+
+  async getDomainBlocks({ limit = 100, offset = 0 } = {}) {
+    const rows = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', 'block')
+      .orderBy('domain', 'asc')
+      .limit(limit)
+      .offset(offset)
+
+    return rows.map(toDomainBlock)
+  },
+
+  async getDomainAllows({ limit = 100, offset = 0 } = {}) {
+    const rows = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', 'allow')
+      .orderBy('domain', 'asc')
+      .limit(limit)
+      .offset(offset)
+
+    return rows.map(toDomainAllow)
+  },
+
+  async getDomainBlockById(id: string) {
+    const row = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where({ id, type: 'block' })
+      .first()
+
+    return row ? toDomainBlock(row) : null
+  },
+
+  async getDomainAllowById(id: string) {
+    const row = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where({ id, type: 'allow' })
+      .first()
+
+    return row ? toDomainAllow(row) : null
+  },
+
+  async getDomainBlockForDomain(domain: string) {
+    const normalized = normalizeDomain(domain)
+    if (!normalized) return null
+
+    const blocks = await this.getDomainBlocks({ limit: 10_000 })
+    return findMatchingDomainRule(normalized, blocks)
+  },
+
+  async getDomainAllowForDomain(domain: string) {
+    const normalized = normalizeDomain(domain)
+    if (!normalized) return null
+
+    const allows = await this.getDomainAllows({ limit: 10_000 })
+    return findMatchingDomainRule(normalized, allows)
+  },
+
+  async createDomainBlock(params) {
+    const now = new Date()
+    const row = buildDomainBlockInsert(params, now)
+    const existing = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where({ type: 'block', domain: row.domain })
+      .first()
+
+    if (existing) {
+      await database<SQLDomainFederationRule>('domain_federation_rules')
+        .where('id', existing.id)
+        .update(buildDomainBlockUpdate(params, now))
+      const updated = await this.getDomainBlockById(existing.id)
+      if (!updated) throw new Error('Failed to update domain block')
+      return updated
+    }
+
+    await database('domain_federation_rules').insert(row)
+    const created = await this.getDomainBlockById(row.id)
+    if (!created) throw new Error('Failed to create domain block')
+    return created
+  },
+
+  async updateDomainBlock(params) {
+    const existing = await this.getDomainBlockById(params.id)
+    if (!existing) return null
+
+    await database<SQLDomainFederationRule>('domain_federation_rules')
+      .where({ id: params.id, type: 'block' })
+      .update({
+        severity: params.severity ?? existing.severity,
+        rejectMedia: params.rejectMedia ?? existing.rejectMedia,
+        rejectReports: params.rejectReports ?? existing.rejectReports,
+        privateComment:
+          params.privateComment === undefined
+            ? existing.privateComment
+            : params.privateComment,
+        publicComment:
+          params.publicComment === undefined
+            ? existing.publicComment
+            : params.publicComment,
+        obfuscate: params.obfuscate ?? existing.obfuscate,
+        source: params.source === undefined ? existing.source : params.source,
+        updatedAt: new Date()
+      })
+
+    return this.getDomainBlockById(params.id)
+  },
+
+  async deleteDomainBlock(id: string) {
+    const existing = await this.getDomainBlockById(id)
+    if (!existing) return null
+
+    await database('domain_federation_rules')
+      .where({ id, type: 'block' })
+      .delete()
+    return existing
+  },
+
+  async createDomainAllow({ domain }) {
+    const normalized = normalizeOrThrow(domain)
+    const existing = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where({ type: 'allow', domain: normalized })
+      .first()
+    if (existing) return toDomainAllow(existing)
+
+    const now = new Date()
+    const row = {
+      id: crypto.randomUUID(),
+      domain: normalized,
+      type: 'allow',
+      severity: null,
+      rejectMedia: false,
+      rejectReports: false,
+      privateComment: null,
+      publicComment: null,
+      obfuscate: false,
+      source: null,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    await database('domain_federation_rules').insert(row)
+    const created = await this.getDomainAllowById(row.id)
+    if (!created) throw new Error('Failed to create domain allow')
+    return created
+  },
+
+  async deleteDomainAllow(id: string) {
+    const existing = await this.getDomainAllowById(id)
+    if (!existing) return null
+
+    await database('domain_federation_rules')
+      .where({ id, type: 'allow' })
+      .delete()
+    return existing
+  },
+
+  async importDomainBlocks({ blocks }) {
+    let created = 0
+    let updated = 0
+    let skipped = 0
+
+    await database.transaction(async (trx) => {
+      for (const block of blocks) {
+        const normalized = normalizeDomain(block.domain)
+        if (!normalized) {
+          skipped++
+          continue
+        }
+
+        const now = new Date()
+        const existing = await trx<SQLDomainFederationRule>(
+          'domain_federation_rules'
+        )
+          .where({ type: 'block', domain: normalized })
+          .first()
+
+        if (existing) {
+          await trx<SQLDomainFederationRule>('domain_federation_rules')
+            .where('id', existing.id)
+            .update(buildDomainBlockUpdate(block, now))
+          updated++
+          continue
+        }
+
+        await trx('domain_federation_rules').insert(
+          buildDomainBlockInsert(block, now)
+        )
+        created++
+      }
+    })
+
+    return { created, updated, skipped }
   }
 })

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -396,14 +396,18 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     }
   },
 
-  async getDomainBlocks({ limit = 100, offset = 0 } = {}) {
-    const rows = await database<SQLDomainFederationRule>(
-      'domain_federation_rules'
-    )
+  async getDomainBlocks({ limit = 100, offset = 0, severity } = {}) {
+    const query = database<SQLDomainFederationRule>('domain_federation_rules')
       .where('type', 'block')
       .orderBy('domain', 'asc')
       .limit(limit)
       .offset(offset)
+
+    if (severity) {
+      query.where('severity', severity)
+    }
+
+    const rows = await query
 
     return rows.map(toDomainBlock)
   },
@@ -503,22 +507,30 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
   },
 
   async getDomainFederationRuleStats() {
-    const [blockCount, allowCount, sourceRows] = await Promise.all([
-      database('domain_federation_rules')
-        .where('type', 'block')
-        .count<{ count: string | number }>('id as count')
-        .first(),
-      database('domain_federation_rules')
-        .where('type', 'allow')
-        .count<{ count: string | number }>('id as count')
-        .first(),
-      database('domain_federation_rules')
-        .select('source')
-        .where('type', 'block')
-        .whereNotNull('source')
-        .groupBy('source')
-        .count<{ source: string; count: string | number }>('id as count')
-    ])
+    const [blockCount, suspendBlockCount, allowCount, sourceRows] =
+      await Promise.all([
+        database('domain_federation_rules')
+          .where('type', 'block')
+          .count<{ count: string | number }>('id as count')
+          .first(),
+        database('domain_federation_rules')
+          .where({
+            type: 'block',
+            severity: DEFAULT_DOMAIN_BLOCK_SEVERITY
+          })
+          .count<{ count: string | number }>('id as count')
+          .first(),
+        database('domain_federation_rules')
+          .where('type', 'allow')
+          .count<{ count: string | number }>('id as count')
+          .first(),
+        database('domain_federation_rules')
+          .select('source')
+          .where('type', 'block')
+          .whereNotNull('source')
+          .groupBy('source')
+          .count<{ source: string; count: string | number }>('id as count')
+      ])
     const sourceCounts = Object.fromEntries(
       (
         sourceRows as unknown as {
@@ -534,6 +546,7 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
 
     return {
       blocks: Number(blockCount?.count ?? 0),
+      suspendBlocks: Number(suspendBlockCount?.count ?? 0),
       allows: Number(allowCount?.count ?? 0),
       sourceBlocks,
       sourceCounts
@@ -543,25 +556,19 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
   async createDomainBlock(params) {
     const now = new Date()
     const row = buildDomainBlockInsert(params, now)
-    const existing = await database<SQLDomainFederationRule>(
+
+    await database('domain_federation_rules')
+      .insert(row)
+      .onConflict(['type', 'domain'])
+      .merge(buildDomainBlockUpdate(params, now))
+
+    const upserted = await database<SQLDomainFederationRule>(
       'domain_federation_rules'
     )
       .where({ type: 'block', domain: row.domain })
       .first()
-
-    if (existing) {
-      await database<SQLDomainFederationRule>('domain_federation_rules')
-        .where('id', existing.id)
-        .update(buildDomainBlockUpdate(params, now))
-      const updated = await this.getDomainBlockById(existing.id)
-      if (!updated) throw new Error('Failed to update domain block')
-      return updated
-    }
-
-    await database('domain_federation_rules').insert(row)
-    const created = await this.getDomainBlockById(row.id)
-    if (!created) throw new Error('Failed to create domain block')
-    return created
+    if (!upserted) throw new Error('Failed to upsert domain block')
+    return toDomainBlock(upserted)
   },
 
   async updateDomainBlock(params) {
@@ -602,13 +609,6 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
 
   async createDomainAllow({ domain }) {
     const normalized = normalizeOrThrow(domain)
-    const existing = await database<SQLDomainFederationRule>(
-      'domain_federation_rules'
-    )
-      .where({ type: 'allow', domain: normalized })
-      .first()
-    if (existing) return toDomainAllow(existing)
-
     const now = new Date()
     const row = {
       id: randomUUID(),
@@ -625,10 +625,18 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
       updatedAt: now
     }
 
-    await database('domain_federation_rules').insert(row)
-    const created = await this.getDomainAllowById(row.id)
-    if (!created) throw new Error('Failed to create domain allow')
-    return created
+    await database('domain_federation_rules')
+      .insert(row)
+      .onConflict(['type', 'domain'])
+      .ignore()
+
+    const upserted = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where({ type: 'allow', domain: normalized })
+      .first()
+    if (!upserted) throw new Error('Failed to create domain allow')
+    return toDomainAllow(upserted)
   },
 
   async deleteDomainAllow(id: string) {

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto'
 import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
 
 import {
   CounterKey,
@@ -126,7 +126,7 @@ const chunkArray = <T>(items: T[], size: number): T[][] => {
 const buildDomainBlockInsert = (
   params: CreateDomainBlockParams,
   now: Date,
-  id = crypto.randomUUID()
+  id = randomUUID()
 ) => ({
   id,
   domain: normalizeOrThrow(params.domain),
@@ -537,7 +537,7 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
 
     const now = new Date()
     const row = {
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       domain: normalized,
       type: 'allow',
       severity: null,

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -20,6 +20,7 @@ import {
   CreateDomainBlockParams,
   DomainAllow,
   DomainBlock,
+  DomainFederationRuleType,
   GetAccountWithActorsParams,
   GetAllAccountsParams,
   GetAllHashtagsParams,
@@ -169,6 +170,26 @@ const chunkArray = <T>(items: T[], size: number): T[][] => {
   }
 
   return chunks
+}
+
+const getDomainRuleCandidateRows = async (
+  database: Knex,
+  type: DomainFederationRuleType,
+  domains: string[]
+): Promise<SQLDomainFederationRule[]> => {
+  const candidates = [...new Set(domains.flatMap(getDomainRuleCandidates))]
+  const rows: SQLDomainFederationRule[] = []
+
+  for (const domainChunk of chunkArray(candidates, SQL_BATCH_SIZE)) {
+    const chunkRows = await database<SQLDomainFederationRule>(
+      'domain_federation_rules'
+    )
+      .where('type', type)
+      .whereIn('domain', domainChunk)
+    rows.push(...chunkRows)
+  }
+
+  return rows
 }
 
 const buildDomainBlockInsert = (
@@ -470,13 +491,11 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     const normalizedDomains = normalizeDomains(domains)
     if (normalizedDomains.length === 0) return {}
 
-    const rows = await database<SQLDomainFederationRule>(
-      'domain_federation_rules'
+    const rows = await getDomainRuleCandidateRows(
+      database,
+      'block',
+      normalizedDomains
     )
-      .where('type', 'block')
-      .whereIn('domain', [
-        ...new Set(normalizedDomains.flatMap(getDomainRuleCandidates))
-      ])
 
     return resolveDomainRuleMatches(normalizedDomains, rows, toDomainBlock)
   },
@@ -503,13 +522,11 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     const normalizedDomains = normalizeDomains(domains)
     if (normalizedDomains.length === 0) return {}
 
-    const rows = await database<SQLDomainFederationRule>(
-      'domain_federation_rules'
+    const rows = await getDomainRuleCandidateRows(
+      database,
+      'allow',
+      normalizedDomains
     )
-      .where('type', 'allow')
-      .whereIn('domain', [
-        ...new Set(normalizedDomains.flatMap(getDomainRuleCandidates))
-      ])
 
     return resolveDomainRuleMatches(normalizedDomains, rows, toDomainAllow)
   },

--- a/lib/jobs/createAnnounceJob.test.ts
+++ b/lib/jobs/createAnnounceJob.test.ts
@@ -53,6 +53,33 @@ describe('Announce action', () => {
     expect(status.originalStatus).toEqual(boostedStatus)
   })
 
+  it('does not create announces from blocked actor domains', async () => {
+    const statusId = 'https://blocked-announce.test/statuses/boost-1'
+    const announceStatusId =
+      'https://somewhere.test/statuses/blocked-announce-target'
+    await database.createDomainBlock({
+      domain: 'blocked-announce.test',
+      severity: 'suspend'
+    })
+
+    await expect(
+      createAnnounceJob(database, {
+        id: 'id',
+        name: CREATE_ANNOUNCE_JOB_NAME,
+        data: MockAnnounceStatus({
+          actorId: 'https://blocked-announce.test/actors/bad',
+          statusId,
+          announceStatusId
+        })
+      })
+    ).rejects.toThrow('Federation with actor domain is blocked')
+
+    await expect(
+      database.getStatus({ statusId: `${statusId}/activity` })
+    ).resolves.toBeNull()
+    expect(fetchMock).not.toHaveBeenCalledWith(announceStatusId)
+  })
+
   it('accepts announce object with id field', async () => {
     const statusId = stubNoteId()
     const announceStatusId =

--- a/lib/jobs/createAnnounceJob.ts
+++ b/lib/jobs/createAnnounceJob.ts
@@ -1,4 +1,7 @@
-import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  assertActorCanFederate,
+  recordActorIfNeeded
+} from '@/lib/actions/utils'
 import { getNote } from '@/lib/activities'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { createNoteJob } from '@/lib/jobs/createNoteJob'
@@ -27,6 +30,8 @@ export const createAnnounceJob: JobHandle = createJobHandle(
     } else {
       return
     }
+
+    await assertActorCanFederate({ actorId: status.actor, database })
 
     const existingStatus = await database.getStatus({
       statusId: object,

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -158,6 +158,29 @@ describe('createNoteJob', () => {
     })
   })
 
+  it('does not create notes from blocked actor domains', async () => {
+    const actorId = 'https://blocked-note.test/actors/bad'
+    const note = MockMastodonActivityPubNote({
+      id: 'https://blocked-note.test/statuses/1',
+      from: actorId,
+      content: '<p>Blocked</p>'
+    })
+    await database.createDomainBlock({
+      domain: 'blocked-note.test',
+      severity: 'suspend'
+    })
+
+    await expect(
+      createNoteJob(database, {
+        id: 'id',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note
+      })
+    ).rejects.toThrow('Federation with actor domain is blocked')
+
+    await expect(database.getStatus({ statusId: note.id })).resolves.toBeNull()
+  })
+
   it('adds note with single content map when contentMap is array', async () => {
     const note = MockMastodonActivityPubNote({
       content: '<p>Hello</p>',

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod'
 
-import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  assertActorCanFederate,
+  recordActorIfNeeded
+} from '@/lib/actions/utils'
 import {
   BaseNote,
   getAttachments,
@@ -60,6 +63,11 @@ export const createNoteJob = createJobHandle(
     const summary = getSummary(note)
 
     const publishedAt = new Date(note.published).getTime()
+
+    await assertActorCanFederate({
+      actorId: note.attributedTo,
+      database
+    })
 
     const [, status] = await Promise.all([
       recordActorIfNeeded({ actorId: note.attributedTo, database }),

--- a/lib/jobs/createPollJob.test.ts
+++ b/lib/jobs/createPollJob.test.ts
@@ -137,6 +137,29 @@ describe('createPollJob', () => {
     expect(status?.cc).toEqual(question.cc)
   })
 
+  it('does not create polls from blocked actor domains', async () => {
+    const question = MockActivityPubQuestion({
+      id: 'https://blocked-poll.test/questions/1',
+      from: 'https://blocked-poll.test/actors/pollcreator'
+    })
+    await database.createDomainBlock({
+      domain: 'blocked-poll.test',
+      severity: 'suspend'
+    })
+
+    await expect(
+      createPollJob(database, {
+        id: 'id',
+        name: CREATE_POLL_JOB_NAME,
+        data: question
+      })
+    ).rejects.toThrow('Federation with actor domain is blocked')
+
+    await expect(
+      database.getStatus({ statusId: question.id })
+    ).resolves.toBeNull()
+  })
+
   it('creates poll with oneOf choices', async () => {
     const question = MockActivityPubQuestion({
       oneOf: [createOption('Option A'), createOption('Option B')]

--- a/lib/jobs/createPollJob.ts
+++ b/lib/jobs/createPollJob.ts
@@ -1,4 +1,7 @@
-import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  assertActorCanFederate,
+  recordActorIfNeeded
+} from '@/lib/actions/utils'
 import {
   getContent,
   getReply,
@@ -47,6 +50,11 @@ export const createPollJob = createJobHandle(
       question.oneOf?.map((item) => item.name) ??
       question.anyOf?.map((item) => item.name) ??
       []
+
+    await assertActorCanFederate({
+      actorId: question.attributedTo,
+      database
+    })
 
     const [, status] = await Promise.all([
       recordActorIfNeeded({

--- a/lib/jobs/createPollVoteJob.ts
+++ b/lib/jobs/createPollVoteJob.ts
@@ -1,4 +1,7 @@
-import { recordActorIfNeeded } from '@/lib/actions/utils'
+import {
+  assertActorCanFederate,
+  recordActorIfNeeded
+} from '@/lib/actions/utils'
 import { ENTITY_TYPE_NOTE, Note } from '@/lib/types/activitypub'
 import { StatusType } from '@/lib/types/domain/status'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
@@ -52,6 +55,11 @@ export const createPollVoteJob = createJobHandle(
     if (choiceIndex === -1) {
       return
     }
+
+    await assertActorCanFederate({
+      actorId: note.attributedTo,
+      database
+    })
 
     await recordActorIfNeeded({
       actorId: note.attributedTo,

--- a/lib/jobs/fetchRemoteStatusJob.ts
+++ b/lib/jobs/fetchRemoteStatusJob.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { getNote } from '@/lib/activities'
 import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { Note } from '@/lib/types/activitypub/objects'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
@@ -17,6 +18,7 @@ const fetchRemoteStatus = async (
   depth = 0
 ): Promise<Status | null> => {
   if (depth > 3) return null
+  if (!(await canFederateWithDomain(database, statusId))) return null
 
   // 1. Check if already in database
   const existing = await database.getStatus({ statusId })
@@ -107,6 +109,7 @@ export const fetchRemoteStatusJob = createJobHandle(
 
     const client = {
       fetch: async (url: string) => {
+        if (!(await canFederateWithDomain(database, url))) return null
         const { body, statusCode } = await request({
           url,
           headers: { Accept: 'application/activity+json' }
@@ -174,6 +177,15 @@ export const fetchRemoteStatusJob = createJobHandle(
           const sanitizedReply = normalizeActivityPubContent(
             activityOrNote
           ) as Note
+          if (
+            !(await canFederateWithDomain(
+              database,
+              sanitizedReply.attributedTo
+            ))
+          ) {
+            return
+          }
+
           const actor = await recordActorIfNeeded({
             actorId: sanitizedReply.attributedTo,
             database

--- a/lib/jobs/sendAnnounceJob.ts
+++ b/lib/jobs/sendAnnounceJob.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { sendAnnounce } from '@/lib/activities'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { SEND_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
+import { filterFederatedUrls } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
 import { getTracer } from '@/lib/utils/trace'
 
@@ -36,8 +37,9 @@ export const sendAnnounceJob: JobHandle = createJobHandle(
       const inboxes = await database.getFollowersInbox({
         targetActorId: actorId
       })
+      const federatedInboxes = await filterFederatedUrls(database, inboxes)
       await Promise.all(
-        inboxes.map((inbox) =>
+        federatedInboxes.map((inbox) =>
           sendAnnounce({ currentActor: actor, inbox, status })
         )
       )

--- a/lib/jobs/sendNoteJob.test.ts
+++ b/lib/jobs/sendNoteJob.test.ts
@@ -102,6 +102,41 @@ describe('sendNoteJob', () => {
     // Job should complete without error
   })
 
+  it('does not send notes to suspended domains', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    await database.createDomainBlock({
+      domain: 'somewhere.test',
+      severity: 'suspend'
+    })
+
+    const statusId = `${actor1.id}/statuses/blocked-note-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`${actor1.id}/followers`],
+      text: 'Blocked domain should not receive this',
+      createdAt: Date.now()
+    })
+
+    await sendNoteJob(database, {
+      id: 'job-blocked',
+      name: SEND_NOTE_JOB_NAME,
+      data: {
+        actorId: actor1.id,
+        statusId
+      }
+    })
+
+    expect(
+      fetchMock.mock.calls.some(
+        (call) => call[0] === 'https://somewhere.test/inbox'
+      )
+    ).toBe(false)
+  })
+
   it('handles note with mentions', async () => {
     if (!actor1) fail('Actor1 is required')
 

--- a/lib/jobs/sendNoteJob.ts
+++ b/lib/jobs/sendNoteJob.ts
@@ -4,6 +4,7 @@ import { sendNote } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { SEND_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { filterFederatedUrls } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
@@ -96,9 +97,10 @@ export const sendNoteJob: JobHandle = createJobHandle(
       const inboxes = Array.from(
         new Set([...remoteActorsInbox, ...followersInbox])
       )
+      const federatedInboxes = await filterFederatedUrls(database, inboxes)
 
       await Promise.all(
-        inboxes.map(async (inbox) => {
+        federatedInboxes.map(async (inbox) => {
           try {
             await sendNote({
               currentActor: actor,

--- a/lib/jobs/sendUndoAnnounceJob.ts
+++ b/lib/jobs/sendUndoAnnounceJob.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { undoAnnounce } from '@/lib/activities'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { SEND_UNDO_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
+import { filterFederatedUrls } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
 import { StatusType } from '@/lib/types/domain/status'
 import { getTracer } from '@/lib/utils/trace'
@@ -39,8 +40,9 @@ export const sendUndoAnnounceJob: JobHandle = createJobHandle(
       const inboxes = await database.getFollowersInbox({
         targetActorId: actorId
       })
+      const federatedInboxes = await filterFederatedUrls(database, inboxes)
       await Promise.all(
-        inboxes.map((inbox) =>
+        federatedInboxes.map((inbox) =>
           undoAnnounce({ currentActor: actor, inbox, announce: status })
         )
       )

--- a/lib/jobs/sendUpdateNoteJob.ts
+++ b/lib/jobs/sendUpdateNoteJob.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { sendUpdateNote } from '@/lib/activities'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { filterFederatedUrls } from '@/lib/services/federation/domainPolicy'
 import { JobHandle } from '@/lib/services/queue/type'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
@@ -86,7 +87,7 @@ export const sendUpdateNoteJob: JobHandle = createJobHandle(
         .map((actor) => actor.sharedInboxUrl || actor.inboxUrl)
       inboxes.push(...toInboxes)
 
-      const uniqueInboxes = [...new Set(inboxes)]
+      const uniqueInboxes = await filterFederatedUrls(database, inboxes)
       await Promise.all(
         uniqueInboxes.map(async (inbox) => {
           try {

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -1,4 +1,6 @@
 import {
+  KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES,
+  KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS,
   fetchKnownDomainBlocklist,
   parseCsvLine,
   parseCsvRecords,
@@ -58,25 +60,53 @@ describe('blocklistSources', () => {
   })
 
   it('fetches a known source and parses the response', async () => {
-    const fetchImpl = jest.fn().mockResolvedValue({
-      ok: true,
-      text: async () =>
-        'domain,severity,reject_media,reject_reports,public_comment,obfuscate\nbad.test,suspend,False,False,spam,False'
+    const requestImpl = jest.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: 'domain,severity,reject_media,reject_reports,public_comment,obfuscate\nbad.test,suspend,False,False,spam,False'
     })
 
     const blocks = await fetchKnownDomainBlocklist(
       'oliphant-tier0',
-      fetchImpl as unknown as typeof fetch
+      requestImpl
     )
 
-    expect(fetchImpl).toHaveBeenCalledWith(
-      'https://codeberg.org/oliphant/blocklists/raw/branch/main/blocklists/_unified_tier0_blocklist.csv'
-    )
+    expect(requestImpl).toHaveBeenCalledWith({
+      url: 'https://codeberg.org/oliphant/blocklists/raw/branch/main/blocklists/_unified_tier0_blocklist.csv',
+      responseTimeout: KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS,
+      numberOfRetry: 0
+    })
     expect(blocks).toHaveLength(1)
     expect(blocks[0]).toMatchObject({
       domain: 'bad.test',
       severity: 'suspend',
       source: 'oliphant-tier0'
     })
+  })
+
+  it('rejects oversized known source responses by content length', async () => {
+    const requestImpl = jest.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: {
+        'content-length': String(KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES + 1)
+      },
+      body: ''
+    })
+
+    await expect(
+      fetchKnownDomainBlocklist('oliphant-tier0', requestImpl)
+    ).rejects.toThrow('Blocklist response too large')
+  })
+
+  it('rejects oversized known source response bodies', async () => {
+    const requestImpl = jest.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: 'a'.repeat(KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES + 1)
+    })
+
+    await expect(
+      fetchKnownDomainBlocklist('oliphant-tier0', requestImpl)
+    ).rejects.toThrow('Blocklist response too large')
   })
 })

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -1,0 +1,73 @@
+import {
+  fetchKnownDomainBlocklist,
+  parseCsvLine,
+  parseDomainBlockCsv
+} from './blocklistSources'
+
+describe('blocklistSources', () => {
+  it('parses quoted CSV fields', () => {
+    expect(parseCsvLine('a,"b, c","d ""quoted"""')).toEqual([
+      'a',
+      'b, c',
+      'd "quoted"'
+    ])
+  })
+
+  it('parses Mastodon-compatible domain block CSV rows', () => {
+    const blocks = parseDomainBlockCsv(
+      [
+        '#domain,severity,reject_media,reject_reports,public_comment,obfuscate',
+        'Example.Social,suspend,True,False,"spam, abuse",False',
+        'example.social,silence,False,False,duplicate,False',
+        'bad.test,noop,False,True,,True'
+      ].join('\n'),
+      'test-source'
+    )
+
+    expect(blocks).toEqual([
+      {
+        domain: 'example.social',
+        severity: 'silence',
+        rejectMedia: false,
+        rejectReports: false,
+        publicComment: 'duplicate',
+        privateComment: null,
+        obfuscate: false,
+        source: 'test-source'
+      },
+      {
+        domain: 'bad.test',
+        severity: 'noop',
+        rejectMedia: false,
+        rejectReports: true,
+        publicComment: null,
+        privateComment: null,
+        obfuscate: true,
+        source: 'test-source'
+      }
+    ])
+  })
+
+  it('fetches a known source and parses the response', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        'domain,severity,reject_media,reject_reports,public_comment,obfuscate\nbad.test,suspend,False,False,spam,False'
+    })
+
+    const blocks = await fetchKnownDomainBlocklist(
+      'oliphant-tier0',
+      fetchImpl as unknown as typeof fetch
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://codeberg.org/oliphant/blocklists/raw/branch/main/blocklists/_unified_tier0_blocklist.csv'
+    )
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({
+      domain: 'bad.test',
+      severity: 'suspend',
+      source: 'oliphant-tier0'
+    })
+  })
+})

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -1,7 +1,7 @@
 import {
   KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES,
   KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS,
-  fetchKnownDomainBlocklist,
+  downloadKnownDomainBlocklist,
   parseCsvLine,
   parseCsvRecords,
   parseDomainBlockCsv
@@ -66,7 +66,7 @@ describe('blocklistSources', () => {
       body: 'domain,severity,reject_media,reject_reports,public_comment,obfuscate\nbad.test,suspend,False,False,spam,False'
     })
 
-    const blocks = await fetchKnownDomainBlocklist(
+    const blocks = await downloadKnownDomainBlocklist(
       'oliphant-tier0',
       requestImpl
     )
@@ -74,7 +74,8 @@ describe('blocklistSources', () => {
     expect(requestImpl).toHaveBeenCalledWith({
       url: 'https://codeberg.org/oliphant/blocklists/raw/branch/main/blocklists/_unified_tier0_blocklist.csv',
       responseTimeout: KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS,
-      numberOfRetry: 0
+      numberOfRetry: 0,
+      maxResponseSize: KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES
     })
     expect(blocks).toHaveLength(1)
     expect(blocks[0]).toMatchObject({
@@ -94,7 +95,7 @@ describe('blocklistSources', () => {
     })
 
     await expect(
-      fetchKnownDomainBlocklist('oliphant-tier0', requestImpl)
+      downloadKnownDomainBlocklist('oliphant-tier0', requestImpl)
     ).rejects.toThrow('Blocklist response too large')
   })
 
@@ -106,7 +107,7 @@ describe('blocklistSources', () => {
     })
 
     await expect(
-      fetchKnownDomainBlocklist('oliphant-tier0', requestImpl)
+      downloadKnownDomainBlocklist('oliphant-tier0', requestImpl)
     ).rejects.toThrow('Blocklist response too large')
   })
 })

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -16,6 +16,13 @@ describe('blocklistSources', () => {
     ])
   })
 
+  it('keeps quotes literal when they do not start a field', () => {
+    expect(parseCsvLine('bad.test,spam "quote" marker')).toEqual([
+      'bad.test',
+      'spam "quote" marker'
+    ])
+  })
+
   it('parses quoted CSV fields with newlines', () => {
     expect(parseCsvRecords('a,b\none,"two\nlines"\nthree,four')).toEqual([
       ['a', 'b'],
@@ -83,6 +90,20 @@ describe('blocklistSources', () => {
       severity: 'suspend',
       source: 'oliphant-tier0'
     })
+  })
+
+  it('includes response error details when downloading a known source fails', async () => {
+    const requestImpl = jest.fn().mockResolvedValue({
+      statusCode: 500,
+      headers: {},
+      body: '{"message":"upstream unavailable"}'
+    })
+
+    await expect(
+      downloadKnownDomainBlocklist('oliphant-tier0', requestImpl)
+    ).rejects.toThrow(
+      'Failed to download Oliphant unified tier 0: upstream unavailable'
+    )
   })
 
   it('rejects oversized known source responses by content length', async () => {

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -25,7 +25,7 @@ describe('blocklistSources', () => {
   it('parses Mastodon-compatible domain block CSV rows', () => {
     const blocks = parseDomainBlockCsv(
       [
-        '#domain,severity,reject_media,reject_reports,public_comment,obfuscate',
+        '#Domain,Severity,Reject_Media,Reject_Reports,Public_Comment,Obfuscate',
         'Example.Social,suspend,True,False,"spam, abuse",False',
         'example.social,silence,False,False,duplicate,False',
         'bad.test,noop,False,True,,True'

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -1,6 +1,7 @@
 import {
   fetchKnownDomainBlocklist,
   parseCsvLine,
+  parseCsvRecords,
   parseDomainBlockCsv
 } from './blocklistSources'
 
@@ -10,6 +11,14 @@ describe('blocklistSources', () => {
       'a',
       'b, c',
       'd "quoted"'
+    ])
+  })
+
+  it('parses quoted CSV fields with newlines', () => {
+    expect(parseCsvRecords('a,b\none,"two\nlines"\nthree,four')).toEqual([
+      ['a', 'b'],
+      ['one', 'two\nlines'],
+      ['three', 'four']
     ])
   })
 

--- a/lib/services/federation/blocklistSources.test.ts
+++ b/lib/services/federation/blocklistSources.test.ts
@@ -31,6 +31,12 @@ describe('blocklistSources', () => {
     ])
   })
 
+  it('allows records with different column counts', () => {
+    expect(
+      parseCsvRecords('domain,severity\nbad.test\nworse.test,suspend')
+    ).toEqual([['domain', 'severity'], ['bad.test'], ['worse.test', 'suspend']])
+  })
+
   it('parses Mastodon-compatible domain block CSV rows', () => {
     const blocks = parseDomainBlockCsv(
       [

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -1,3 +1,4 @@
+import { parse } from 'csv-parse/sync'
 import { Buffer } from 'node:buffer'
 import { z } from 'zod'
 
@@ -49,69 +50,14 @@ export const parseCsvLine = (line: string): string[] => {
 }
 
 export const parseCsvRecords = (csv: string): string[][] => {
-  const records: string[][] = []
-  let fields: string[] = []
-  let field = ''
-  let inQuotes = false
-  let atFieldStart = true
+  const records = parse(csv, {
+    bom: true,
+    relax_column_count: true,
+    relax_quotes: true,
+    skip_empty_lines: true
+  }) as string[][]
 
-  const pushRecord = () => {
-    fields.push(field)
-    if (fields.some((value) => value.trim())) {
-      records.push(fields)
-    }
-    fields = []
-    field = ''
-    atFieldStart = true
-  }
-
-  const pushField = () => {
-    fields.push(field)
-    field = ''
-    atFieldStart = true
-  }
-
-  for (let i = 0; i < csv.length; i++) {
-    const char = csv[i]
-    const next = csv[i + 1]
-
-    if (char === '"' && inQuotes && next === '"') {
-      field += '"'
-      i++
-      continue
-    }
-
-    if (char === '"' && atFieldStart) {
-      inQuotes = true
-      atFieldStart = false
-      continue
-    }
-
-    if (char === '"' && inQuotes) {
-      inQuotes = false
-      continue
-    }
-
-    if (char === ',' && !inQuotes) {
-      pushField()
-      continue
-    }
-
-    if ((char === '\n' || char === '\r') && !inQuotes) {
-      if (char === '\r' && next === '\n') i++
-      pushRecord()
-      continue
-    }
-
-    field += char
-    atFieldStart = false
-  }
-
-  if (field || fields.length) {
-    pushRecord()
-  }
-
-  return records
+  return records.filter((fields) => fields.some((value) => value.trim()))
 }
 
 const getDownloadErrorDetail = (body: string): string => {

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -53,6 +53,7 @@ export const parseCsvRecords = (csv: string): string[][] => {
   let fields: string[] = []
   let field = ''
   let inQuotes = false
+  let atFieldStart = true
 
   const pushRecord = () => {
     fields.push(field)
@@ -61,6 +62,13 @@ export const parseCsvRecords = (csv: string): string[][] => {
     }
     fields = []
     field = ''
+    atFieldStart = true
+  }
+
+  const pushField = () => {
+    fields.push(field)
+    field = ''
+    atFieldStart = true
   }
 
   for (let i = 0; i < csv.length; i++) {
@@ -73,14 +81,19 @@ export const parseCsvRecords = (csv: string): string[][] => {
       continue
     }
 
-    if (char === '"') {
-      inQuotes = !inQuotes
+    if (char === '"' && atFieldStart) {
+      inQuotes = true
+      atFieldStart = false
+      continue
+    }
+
+    if (char === '"' && inQuotes) {
+      inQuotes = false
       continue
     }
 
     if (char === ',' && !inQuotes) {
-      fields.push(field)
-      field = ''
+      pushField()
       continue
     }
 
@@ -91,6 +104,7 @@ export const parseCsvRecords = (csv: string): string[][] => {
     }
 
     field += char
+    atFieldStart = false
   }
 
   if (field || fields.length) {
@@ -98,6 +112,25 @@ export const parseCsvRecords = (csv: string): string[][] => {
   }
 
   return records
+}
+
+const getDownloadErrorDetail = (body: string): string => {
+  const trimmed = body.trim()
+  if (!trimmed) return ''
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const message = Reflect.get(parsed, 'message')
+      if (typeof message === 'string') return message
+      const error = Reflect.get(parsed, 'error')
+      if (typeof error === 'string') return error
+    }
+  } catch {
+    // Fall back to raw response text below.
+  }
+
+  return trimmed.slice(0, 1000)
 }
 
 export const parseDomainBlockCsv = (
@@ -155,7 +188,12 @@ export const downloadKnownDomainBlocklist = async (
     maxResponseSize: KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES
   })
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw new Error(`Failed to download ${source.name}`)
+    const detail = getDownloadErrorDetail(response.body)
+    throw new Error(
+      detail
+        ? `Failed to download ${source.name}: ${detail}`
+        : `Failed to download ${source.name}`
+    )
   }
 
   const contentLength = response.headers['content-length']

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -9,7 +9,7 @@ import {
   DomainBlockSeverity,
   ImportDomainBlockParams
 } from '@/lib/types/database/operations'
-import { RequestOptions, request } from '@/lib/utils/request'
+import { RequestOptions, RequestResult, request } from '@/lib/utils/request'
 
 export const KnownDomainBlocklistSourceId = z.enum(['oliphant-tier0'])
 export type KnownDomainBlocklistSourceId = z.infer<
@@ -27,16 +27,12 @@ export const KNOWN_DOMAIN_BLOCKLIST_SOURCES = [
 export const KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS = 30_000
 export const KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES = 10 * 1024 * 1024
 
-type BlocklistResponse = {
-  statusCode: number
-  headers: Record<string, string | string[] | undefined>
-  body: string
+type BlocklistRequest = (options: RequestOptions) => Promise<RequestResult>
+
+const defaultBlocklistRequest: BlocklistRequest = async (options) => {
+  const { statusCode, headers, body } = await request(options)
+  return { statusCode, headers, body }
 }
-
-type BlocklistRequest = (options: RequestOptions) => Promise<BlocklistResponse>
-
-const defaultBlocklistRequest: BlocklistRequest = async (options) =>
-  request(options)
 
 const parseBoolean = (value: string | undefined): boolean =>
   value?.trim().toLowerCase() === 'true'
@@ -143,7 +139,7 @@ export const parseDomainBlockCsv = (
   return [...blocks.values()]
 }
 
-export const fetchKnownDomainBlocklist = async (
+export const downloadKnownDomainBlocklist = async (
   sourceId: KnownDomainBlocklistSourceId,
   requestImpl: BlocklistRequest = defaultBlocklistRequest
 ): Promise<ImportDomainBlockParams[]> => {
@@ -155,10 +151,11 @@ export const fetchKnownDomainBlocklist = async (
   const response = await requestImpl({
     url: source.url,
     responseTimeout: KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS,
-    numberOfRetry: 0
+    numberOfRetry: 0,
+    maxResponseSize: KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES
   })
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw new Error(`Failed to fetch ${source.name}`)
+    throw new Error(`Failed to download ${source.name}`)
   }
 
   const contentLength = response.headers['content-length']

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { z } from 'zod'
 
 import {
@@ -8,6 +9,7 @@ import {
   DomainBlockSeverity,
   ImportDomainBlockParams
 } from '@/lib/types/database/operations'
+import { RequestOptions, request } from '@/lib/utils/request'
 
 export const KnownDomainBlocklistSourceId = z.enum(['oliphant-tier0'])
 export type KnownDomainBlocklistSourceId = z.infer<
@@ -22,7 +24,19 @@ export const KNOWN_DOMAIN_BLOCKLIST_SOURCES = [
   }
 ] as const
 
-type FetchLike = typeof fetch
+export const KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS = 30_000
+export const KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES = 10 * 1024 * 1024
+
+type BlocklistResponse = {
+  statusCode: number
+  headers: Record<string, string | string[] | undefined>
+  body: string
+}
+
+type BlocklistRequest = (options: RequestOptions) => Promise<BlocklistResponse>
+
+const defaultBlocklistRequest: BlocklistRequest = async (options) =>
+  request(options)
 
 const parseBoolean = (value: string | undefined): boolean =>
   value?.trim().toLowerCase() === 'true'
@@ -131,18 +145,35 @@ export const parseDomainBlockCsv = (
 
 export const fetchKnownDomainBlocklist = async (
   sourceId: KnownDomainBlocklistSourceId,
-  fetchImpl: FetchLike = fetch
+  requestImpl: BlocklistRequest = defaultBlocklistRequest
 ): Promise<ImportDomainBlockParams[]> => {
   const source = KNOWN_DOMAIN_BLOCKLIST_SOURCES.find(
     (item) => item.id === sourceId
   )
   if (!source) throw new Error('Unknown domain blocklist source')
 
-  const response = await fetchImpl(source.url)
-  if (!response.ok) {
+  const response = await requestImpl({
+    url: source.url,
+    responseTimeout: KNOWN_DOMAIN_BLOCKLIST_TIMEOUT_MS,
+    numberOfRetry: 0
+  })
+  if (response.statusCode < 200 || response.statusCode >= 300) {
     throw new Error(`Failed to fetch ${source.name}`)
   }
 
-  const csv = await response.text()
+  const contentLength = response.headers['content-length']
+  const contentLengthValue = Array.isArray(contentLength)
+    ? contentLength[0]
+    : contentLength
+  const expectedBytes = Number(contentLengthValue ?? 0)
+  if (expectedBytes > KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES) {
+    throw new Error('Blocklist response too large')
+  }
+
+  const csv = response.body
+  if (Buffer.byteLength(csv, 'utf8') > KNOWN_DOMAIN_BLOCKLIST_MAX_BYTES) {
+    throw new Error('Blocklist response too large')
+  }
+
   return parseDomainBlockCsv(csv, source.id)
 }

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -97,7 +97,9 @@ export const parseDomainBlockCsv = (
   const [headerFields, ...rows] = parseCsvRecords(csv)
   if (!headerFields) return []
 
-  const headers = headerFields.map((field) => field.trim().replace(/^#/, ''))
+  const headers = headerFields.map((field) =>
+    field.trim().toLowerCase().replace(/^#/, '')
+  )
   const domainIndex = headers.indexOf('domain')
   if (domainIndex < 0) return []
 

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -35,16 +35,30 @@ const parseSeverity = (value: string | undefined): DomainBlockSeverity => {
 }
 
 export const parseCsvLine = (line: string): string[] => {
-  const fields: string[] = []
-  let current = ''
+  return parseCsvRecords(line)[0] ?? []
+}
+
+export const parseCsvRecords = (csv: string): string[][] => {
+  const records: string[][] = []
+  let fields: string[] = []
+  let field = ''
   let inQuotes = false
 
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i]
-    const next = line[i + 1]
+  const pushRecord = () => {
+    fields.push(field)
+    if (fields.some((value) => value.trim())) {
+      records.push(fields)
+    }
+    fields = []
+    field = ''
+  }
+
+  for (let i = 0; i < csv.length; i++) {
+    const char = csv[i]
+    const next = csv[i + 1]
 
     if (char === '"' && inQuotes && next === '"') {
-      current += '"'
+      field += '"'
       i++
       continue
     }
@@ -55,32 +69,35 @@ export const parseCsvLine = (line: string): string[] => {
     }
 
     if (char === ',' && !inQuotes) {
-      fields.push(current)
-      current = ''
+      fields.push(field)
+      field = ''
       continue
     }
 
-    current += char
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && next === '\n') i++
+      pushRecord()
+      continue
+    }
+
+    field += char
   }
 
-  fields.push(current)
-  return fields
+  if (field || fields.length) {
+    pushRecord()
+  }
+
+  return records
 }
 
 export const parseDomainBlockCsv = (
   csv: string,
   source: string
 ): ImportDomainBlockParams[] => {
-  const lines = csv
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line)
-  const [headerLine, ...rows] = lines
-  if (!headerLine) return []
+  const [headerFields, ...rows] = parseCsvRecords(csv)
+  if (!headerFields) return []
 
-  const headers = parseCsvLine(headerLine).map((field) =>
-    field.trim().replace(/^#/, '')
-  )
+  const headers = headerFields.map((field) => field.trim().replace(/^#/, ''))
   const domainIndex = headers.indexOf('domain')
   if (domainIndex < 0) return []
 
@@ -91,8 +108,7 @@ export const parseDomainBlockCsv = (
 
   const blocks = new Map<string, ImportDomainBlockParams>()
 
-  for (const row of rows) {
-    const fields = parseCsvLine(row)
+  for (const fields of rows) {
     const domain = normalizeDomain(fields[domainIndex] ?? '')
     if (!domain) continue
 

--- a/lib/services/federation/blocklistSources.ts
+++ b/lib/services/federation/blocklistSources.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod'
+
+import {
+  DEFAULT_DOMAIN_BLOCK_SEVERITY,
+  normalizeDomain
+} from '@/lib/services/federation/domainRules'
+import {
+  DomainBlockSeverity,
+  ImportDomainBlockParams
+} from '@/lib/types/database/operations'
+
+export const KnownDomainBlocklistSourceId = z.enum(['oliphant-tier0'])
+export type KnownDomainBlocklistSourceId = z.infer<
+  typeof KnownDomainBlocklistSourceId
+>
+
+export const KNOWN_DOMAIN_BLOCKLIST_SOURCES = [
+  {
+    id: KnownDomainBlocklistSourceId.enum['oliphant-tier0'],
+    name: 'Oliphant unified tier 0',
+    url: 'https://codeberg.org/oliphant/blocklists/raw/branch/main/blocklists/_unified_tier0_blocklist.csv'
+  }
+] as const
+
+type FetchLike = typeof fetch
+
+const parseBoolean = (value: string | undefined): boolean =>
+  value?.trim().toLowerCase() === 'true'
+
+const parseSeverity = (value: string | undefined): DomainBlockSeverity => {
+  const severity = value?.trim().toLowerCase()
+  return severity === 'noop' || severity === 'silence' || severity === 'suspend'
+    ? severity
+    : DEFAULT_DOMAIN_BLOCK_SEVERITY
+}
+
+export const parseCsvLine = (line: string): string[] => {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
+    const next = line[i + 1]
+
+    if (char === '"' && inQuotes && next === '"') {
+      current += '"'
+      i++
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = !inQuotes
+      continue
+    }
+
+    if (char === ',' && !inQuotes) {
+      fields.push(current)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  fields.push(current)
+  return fields
+}
+
+export const parseDomainBlockCsv = (
+  csv: string,
+  source: string
+): ImportDomainBlockParams[] => {
+  const lines = csv
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line)
+  const [headerLine, ...rows] = lines
+  if (!headerLine) return []
+
+  const headers = parseCsvLine(headerLine).map((field) =>
+    field.trim().replace(/^#/, '')
+  )
+  const domainIndex = headers.indexOf('domain')
+  if (domainIndex < 0) return []
+
+  const getField = (fields: string[], name: string): string | undefined => {
+    const index = headers.indexOf(name)
+    return index >= 0 ? fields[index] : undefined
+  }
+
+  const blocks = new Map<string, ImportDomainBlockParams>()
+
+  for (const row of rows) {
+    const fields = parseCsvLine(row)
+    const domain = normalizeDomain(fields[domainIndex] ?? '')
+    if (!domain) continue
+
+    blocks.set(domain, {
+      domain,
+      severity: parseSeverity(getField(fields, 'severity')),
+      rejectMedia: parseBoolean(getField(fields, 'reject_media')),
+      rejectReports: parseBoolean(getField(fields, 'reject_reports')),
+      publicComment: getField(fields, 'public_comment')?.trim() || null,
+      privateComment: getField(fields, 'private_comment')?.trim() || null,
+      obfuscate: parseBoolean(getField(fields, 'obfuscate')),
+      source
+    })
+  }
+
+  return [...blocks.values()]
+}
+
+export const fetchKnownDomainBlocklist = async (
+  sourceId: KnownDomainBlocklistSourceId,
+  fetchImpl: FetchLike = fetch
+): Promise<ImportDomainBlockParams[]> => {
+  const source = KNOWN_DOMAIN_BLOCKLIST_SOURCES.find(
+    (item) => item.id === sourceId
+  )
+  if (!source) throw new Error('Unknown domain blocklist source')
+
+  const response = await fetchImpl(source.url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${source.name}`)
+  }
+
+  const csv = await response.text()
+  return parseDomainBlockCsv(csv, source.id)
+}

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -1,0 +1,90 @@
+import { Database } from '@/lib/database/types'
+
+import { canFederateWithDomain, isDomainAllowed } from './domainPolicy'
+
+const mockGetConfig = jest.fn()
+jest.mock('@/lib/config', () => ({
+  getConfig: () => mockGetConfig()
+}))
+
+const createDatabase = (params: { blocks?: string[]; allows?: string[] }) =>
+  ({
+    getDomainBlockForDomain: async (domain: string) =>
+      params.blocks?.some(
+        (block) => domain === block || domain.endsWith(`.${block}`)
+      )
+        ? {
+            id: 'block',
+            type: 'block',
+            domain,
+            severity: 'suspend',
+            rejectMedia: false,
+            rejectReports: false,
+            privateComment: null,
+            publicComment: null,
+            obfuscate: false,
+            source: null,
+            createdAt: 0,
+            updatedAt: 0
+          }
+        : null,
+    getDomainAllows: async () =>
+      (params.allows ?? []).map((domain, index) => ({
+        id: String(index),
+        type: 'allow',
+        domain,
+        createdAt: 0,
+        updatedAt: 0
+      }))
+  }) as unknown as Database
+
+describe('domainPolicy', () => {
+  beforeEach(() => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: [],
+      federationMode: 'open'
+    })
+  })
+
+  it('rejects suspended blocked domains in open federation mode', async () => {
+    const database = createDatabase({ blocks: ['blocked.test'] })
+
+    await expect(
+      canFederateWithDomain(database, 'https://blocked.test/users/a')
+    ).resolves.toBe(false)
+    await expect(
+      canFederateWithDomain(database, 'https://allowed.test/users/a')
+    ).resolves.toBe(true)
+  })
+
+  it('requires allow entries in allowlist mode', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: [],
+      federationMode: 'allowlist'
+    })
+    const database = createDatabase({ allows: ['trusted.test'] })
+
+    await expect(
+      canFederateWithDomain(database, 'https://trusted.test/users/a')
+    ).resolves.toBe(true)
+    await expect(
+      canFederateWithDomain(database, 'https://other.test/users/a')
+    ).resolves.toBe(false)
+  })
+
+  it('always allows local actor domains', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: ['alias.test'],
+      federationMode: 'allowlist'
+    })
+    const database = createDatabase({})
+
+    await expect(isDomainAllowed(database, 'alias.test')).resolves.toBe(true)
+    await expect(
+      canFederateWithDomain(database, 'https://alias.test/users/a')
+    ).resolves.toBe(true)
+  })
+})

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -1,6 +1,10 @@
 import { Database } from '@/lib/database/types'
 
-import { canFederateWithDomain, isDomainAllowed } from './domainPolicy'
+import {
+  canFederateWithDomain,
+  filterFederatedUrls,
+  isDomainAllowed
+} from './domainPolicy'
 
 const mockGetConfig = jest.fn()
 jest.mock('@/lib/config', () => ({
@@ -93,5 +97,20 @@ describe('domainPolicy', () => {
     await expect(
       canFederateWithDomain(database, 'https://alias.test/users/a')
     ).resolves.toBe(true)
+  })
+
+  it('filters URLs with one lookup per unique domain', async () => {
+    const database = createDatabase({ blocks: ['blocked.test'] })
+    const blockLookup = jest.spyOn(database, 'getDomainBlockForDomain')
+
+    await expect(
+      filterFederatedUrls(database, [
+        'https://blocked.test/users/a/inbox',
+        'https://blocked.test/users/b/inbox',
+        'https://ok.test/users/a/inbox',
+        'https://ok.test/users/a/inbox'
+      ])
+    ).resolves.toEqual(['https://ok.test/users/a/inbox'])
+    expect(blockLookup).toHaveBeenCalledTimes(2)
   })
 })

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -3,7 +3,8 @@ import { Database } from '@/lib/database/types'
 import {
   canFederateWithDomain,
   filterFederatedUrls,
-  isDomainAllowed
+  isDomainAllowed,
+  isLocalFederationDomain
 } from './domainPolicy'
 
 const mockGetConfig = jest.fn()
@@ -97,6 +98,26 @@ describe('domainPolicy', () => {
     await expect(
       canFederateWithDomain(database, 'https://alias.test/users/a')
     ).resolves.toBe(true)
+  })
+
+  it('treats only exact local domains and configured wildcards as local', () => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: ['alias.test', '*.trusted.test'],
+      federationMode: 'open'
+    })
+
+    expect(isLocalFederationDomain('https://local.test/users/a')).toBe(true)
+    expect(isLocalFederationDomain('https://evil.local.test/users/a')).toBe(
+      false
+    )
+    expect(isLocalFederationDomain('https://alias.test/users/a')).toBe(true)
+    expect(isLocalFederationDomain('https://sub.alias.test/users/a')).toBe(
+      false
+    )
+    expect(isLocalFederationDomain('https://sub.trusted.test/users/a')).toBe(
+      true
+    )
   })
 
   it('filters URLs with one lookup per unique domain', async () => {

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -12,43 +12,57 @@ jest.mock('@/lib/config', () => ({
   getConfig: () => mockGetConfig()
 }))
 
-const createDatabase = (params: { blocks?: string[]; allows?: string[] }) =>
-  ({
-    getDomainBlockForDomain: async (domain: string) =>
-      params.blocks?.some(
-        (block) => domain === block || domain.endsWith(`.${block}`)
-      )
-        ? {
-            id: 'block',
-            type: 'block',
-            domain,
-            severity: 'suspend',
-            rejectMedia: false,
-            rejectReports: false,
-            privateComment: null,
-            publicComment: null,
-            obfuscate: false,
-            source: null,
-            createdAt: 0,
-            updatedAt: 0
-          }
-        : null,
-    getDomainAllowForDomain: async (domain: string) => {
-      const allow = params.allows?.find(
-        (rule) => domain === rule || domain.endsWith(`.${rule}`)
-      )
+const createDatabase = (params: { blocks?: string[]; allows?: string[] }) => {
+  const findBlock = (domain: string) =>
+    params.blocks?.some(
+      (block) => domain === block || domain.endsWith(`.${block}`)
+    )
+      ? {
+          id: 'block',
+          type: 'block' as const,
+          domain,
+          severity: 'suspend' as const,
+          rejectMedia: false,
+          rejectReports: false,
+          privateComment: null,
+          publicComment: null,
+          obfuscate: false,
+          source: null,
+          createdAt: 0,
+          updatedAt: 0
+        }
+      : null
+  const findAllow = (domain: string) => {
+    const allow = params.allows?.find(
+      (rule) => domain === rule || domain.endsWith(`.${rule}`)
+    )
 
-      return allow
-        ? {
-            id: 'allow',
-            type: 'allow',
-            domain: allow,
-            createdAt: 0,
-            updatedAt: 0
-          }
-        : null
-    }
-  }) as unknown as Database
+    return allow
+      ? {
+          id: 'allow',
+          type: 'allow' as const,
+          domain: allow,
+          createdAt: 0,
+          updatedAt: 0
+        }
+      : null
+  }
+
+  return {
+    getDomainBlockForDomain: jest.fn(async (domain: string) =>
+      findBlock(domain)
+    ),
+    getDomainAllowForDomain: jest.fn(async (domain: string) =>
+      findAllow(domain)
+    ),
+    getDomainBlocksForDomains: jest.fn(async (domains: string[]) =>
+      Object.fromEntries(domains.map((domain) => [domain, findBlock(domain)]))
+    ),
+    getDomainAllowsForDomains: jest.fn(async (domains: string[]) =>
+      Object.fromEntries(domains.map((domain) => [domain, findAllow(domain)]))
+    )
+  } as unknown as Database
+}
 
 describe('domainPolicy', () => {
   beforeEach(() => {
@@ -120,9 +134,8 @@ describe('domainPolicy', () => {
     )
   })
 
-  it('filters URLs with one lookup per unique domain', async () => {
+  it('filters URLs with a batched block lookup', async () => {
     const database = createDatabase({ blocks: ['blocked.test'] })
-    const blockLookup = jest.spyOn(database, 'getDomainBlockForDomain')
 
     await expect(
       filterFederatedUrls(database, [
@@ -132,6 +145,36 @@ describe('domainPolicy', () => {
         'https://ok.test/users/a/inbox'
       ])
     ).resolves.toEqual(['https://ok.test/users/a/inbox'])
-    expect(blockLookup).toHaveBeenCalledTimes(2)
+    expect(database.getDomainBlocksForDomains).toHaveBeenCalledWith([
+      'blocked.test',
+      'ok.test'
+    ])
+    expect(database.getDomainBlockForDomain).not.toHaveBeenCalled()
+  })
+
+  it('filters URLs with batched allow lookups in allowlist mode', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: [],
+      federationMode: 'allowlist'
+    })
+    const database = createDatabase({ allows: ['trusted.test'] })
+
+    await expect(
+      filterFederatedUrls(database, [
+        'https://trusted.test/users/a/inbox',
+        'https://other.test/users/a/inbox',
+        'https://trusted.test/users/a/inbox'
+      ])
+    ).resolves.toEqual(['https://trusted.test/users/a/inbox'])
+    expect(database.getDomainBlocksForDomains).toHaveBeenCalledWith([
+      'trusted.test',
+      'other.test'
+    ])
+    expect(database.getDomainAllowsForDomains).toHaveBeenCalledWith([
+      'trusted.test',
+      'other.test'
+    ])
+    expect(database.getDomainAllowForDomain).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -28,14 +28,21 @@ const createDatabase = (params: { blocks?: string[]; allows?: string[] }) =>
             updatedAt: 0
           }
         : null,
-    getDomainAllows: async () =>
-      (params.allows ?? []).map((domain, index) => ({
-        id: String(index),
-        type: 'allow',
-        domain,
-        createdAt: 0,
-        updatedAt: 0
-      }))
+    getDomainAllowForDomain: async (domain: string) => {
+      const allow = params.allows?.find(
+        (rule) => domain === rule || domain.endsWith(`.${rule}`)
+      )
+
+      return allow
+        ? {
+            id: 'allow',
+            type: 'allow',
+            domain: allow,
+            createdAt: 0,
+            updatedAt: 0
+          }
+        : null
+    }
   }) as unknown as Database
 
 describe('domainPolicy', () => {

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -70,6 +70,44 @@ export const canFederateWithDomain = async (
   return true
 }
 
+const getFederationDecisionsForDomains = async (
+  database: Database,
+  domains: string[]
+): Promise<Map<string, boolean>> => {
+  const uniqueDomains = [...new Set(domains)]
+  const decisions = new Map<string, boolean>()
+  const remoteDomains: string[] = []
+
+  for (const domain of uniqueDomains) {
+    if (isLocalFederationDomain(domain)) {
+      decisions.set(domain, true)
+    } else {
+      remoteDomains.push(domain)
+    }
+  }
+
+  if (remoteDomains.length === 0) return decisions
+
+  const blockRules = await database.getDomainBlocksForDomains(remoteDomains)
+  const unblockedDomains = remoteDomains.filter((domain) => {
+    const block = blockRules[domain] ?? null
+    const isBlocked = block ? shouldSuspendDomainBlock(block) : false
+    decisions.set(domain, !isBlocked)
+    return !isBlocked
+  })
+
+  if (getFederationMode() !== 'allowlist' || unblockedDomains.length === 0) {
+    return decisions
+  }
+
+  const allowRules = await database.getDomainAllowsForDomains(unblockedDomains)
+  for (const domain of unblockedDomains) {
+    decisions.set(domain, Boolean(allowRules[domain]))
+  }
+
+  return decisions
+}
+
 export const filterFederatedUrls = async (
   database: Database,
   urls: string[]
@@ -82,20 +120,10 @@ export const filterFederatedUrls = async (
         .filter((domain): domain is string => domain !== null)
     )
   ]
-  const domainResults = await Promise.all(
-    domains.map(async (domain) => ({
-      domain,
-      allowed: await canFederateWithDomain(database, domain)
-    }))
-  )
-  const allowedDomains = new Set(
-    domainResults
-      .filter((result) => result.allowed)
-      .map((result) => result.domain)
-  )
+  const decisions = await getFederationDecisionsForDomains(database, domains)
 
   return uniqueUrls.filter((url) => {
     const domain = getDomainFromUrl(url)
-    return domain ? allowedDomains.has(domain) : false
+    return domain ? decisions.get(domain) === true : false
   })
 }

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -1,0 +1,84 @@
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+
+import {
+  FederationMode,
+  domainMatchesRule,
+  findMatchingDomainRule,
+  normalizeDomain,
+  shouldSuspendDomainBlock
+} from './domainRules'
+
+export const getDomainFromUrl = (value: string): string | null =>
+  normalizeDomain(value)
+
+export const getFederationMode = (): FederationMode =>
+  getConfig().federationMode ?? 'open'
+
+export const isLocalFederationDomain = (value: string): boolean => {
+  const domain = getDomainFromUrl(value)
+  if (!domain) return false
+
+  const config = getConfig()
+  const localDomains = config.allowActorDomains?.length
+    ? config.allowActorDomains
+    : [config.host]
+
+  return localDomains.some((localDomain) =>
+    domainMatchesRule(domain, localDomain)
+  )
+}
+
+export const isDomainBlocked = async (
+  database: Database,
+  value: string
+): Promise<boolean> => {
+  const domain = getDomainFromUrl(value)
+  if (!domain) return false
+
+  const block = await database.getDomainBlockForDomain(domain)
+  return block ? shouldSuspendDomainBlock(block) : false
+}
+
+export const isDomainAllowed = async (
+  database: Database,
+  value: string
+): Promise<boolean> => {
+  const domain = getDomainFromUrl(value)
+  if (!domain) return false
+  if (isLocalFederationDomain(domain)) return true
+
+  const allows = await database.getDomainAllows()
+  return Boolean(findMatchingDomainRule(domain, allows))
+}
+
+export const canFederateWithDomain = async (
+  database: Database,
+  value: string
+): Promise<boolean> => {
+  const domain = getDomainFromUrl(value)
+  if (!domain) return false
+  if (isLocalFederationDomain(domain)) return true
+
+  if (await isDomainBlocked(database, domain)) return false
+
+  if (getFederationMode() === 'allowlist') {
+    return isDomainAllowed(database, domain)
+  }
+
+  return true
+}
+
+export const filterFederatedUrls = async (
+  database: Database,
+  urls: string[]
+): Promise<string[]> => {
+  const uniqueUrls = [...new Set(urls)]
+  const allowed = await Promise.all(
+    uniqueUrls.map(async (url) =>
+      (await canFederateWithDomain(database, url)) ? url : null
+    )
+  )
+
+  return allowed.filter((url): url is string => url !== null)
+}

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -72,11 +72,27 @@ export const filterFederatedUrls = async (
   urls: string[]
 ): Promise<string[]> => {
   const uniqueUrls = [...new Set(urls)]
-  const allowed = await Promise.all(
-    uniqueUrls.map(async (url) =>
-      (await canFederateWithDomain(database, url)) ? url : null
+  const domains = [
+    ...new Set(
+      uniqueUrls
+        .map((url) => getDomainFromUrl(url))
+        .filter((domain): domain is string => domain !== null)
     )
+  ]
+  const domainResults = await Promise.all(
+    domains.map(async (domain) => ({
+      domain,
+      allowed: await canFederateWithDomain(database, domain)
+    }))
+  )
+  const allowedDomains = new Set(
+    domainResults
+      .filter((result) => result.allowed)
+      .map((result) => result.domain)
   )
 
-  return allowed.filter((url): url is string => url !== null)
+  return uniqueUrls.filter((url) => {
+    const domain = getDomainFromUrl(url)
+    return domain ? allowedDomains.has(domain) : false
+  })
 }

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -19,13 +19,16 @@ export const isLocalFederationDomain = (value: string): boolean => {
   if (!domain) return false
 
   const config = getConfig()
-  const localDomains = config.allowActorDomains?.length
-    ? config.allowActorDomains
-    : [config.host]
+  const host = normalizeDomain(config.host)
+  if (domain === host) return true
 
-  return localDomains.some((localDomain) =>
-    domainMatchesRule(domain, localDomain)
-  )
+  return (config.allowActorDomains ?? []).some((localDomain) => {
+    const normalized = normalizeDomain(localDomain)
+    if (!normalized) return false
+    if (normalized.startsWith('*.'))
+      return domainMatchesRule(domain, normalized)
+    return domain === normalized
+  })
 }
 
 export const isDomainBlocked = async (

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -4,7 +4,6 @@ import { Database } from '@/lib/database/types'
 import {
   FederationMode,
   domainMatchesRule,
-  findMatchingDomainRule,
   normalizeDomain,
   shouldSuspendDomainBlock
 } from './domainRules'
@@ -48,8 +47,7 @@ export const isDomainAllowed = async (
   if (!domain) return false
   if (isLocalFederationDomain(domain)) return true
 
-  const allows = await database.getDomainAllows()
-  return Boolean(findMatchingDomainRule(domain, allows))
+  return Boolean(await database.getDomainAllowForDomain(domain))
 }
 
 export const canFederateWithDomain = async (

--- a/lib/services/federation/domainRules.test.ts
+++ b/lib/services/federation/domainRules.test.ts
@@ -14,6 +14,9 @@ describe('domainRules', () => {
     )
     expect(normalizeDomain('*.Example.Social')).toBe('*.example.social')
     expect(normalizeDomain('')).toBeNull()
+    expect(
+      normalizeDomain(Array.from({ length: 5 }, () => 'a'.repeat(63)).join('.'))
+    ).toBeNull()
   })
 
   it('matches exact domains and wildcard subdomains', () => {

--- a/lib/services/federation/domainRules.test.ts
+++ b/lib/services/federation/domainRules.test.ts
@@ -1,0 +1,60 @@
+import {
+  domainDigest,
+  domainMatchesRule,
+  findMatchingDomainRule,
+  normalizeDomain,
+  toPublicDomainBlock
+} from './domainRules'
+
+describe('domainRules', () => {
+  it('normalizes domains from bare domains and URLs', () => {
+    expect(normalizeDomain('Example.Social')).toBe('example.social')
+    expect(normalizeDomain('https://Sub.Example.Social/path')).toBe(
+      'sub.example.social'
+    )
+    expect(normalizeDomain('')).toBeNull()
+  })
+
+  it('matches exact domains, subdomains, and wildcard allows', () => {
+    expect(domainMatchesRule('example.social', 'example.social')).toBe(true)
+    expect(domainMatchesRule('sub.example.social', 'example.social')).toBe(true)
+    expect(domainMatchesRule('example.social', '*.example.social')).toBe(false)
+    expect(domainMatchesRule('sub.example.social', '*.example.social')).toBe(
+      true
+    )
+    expect(domainMatchesRule('anything.test', '*')).toBe(true)
+  })
+
+  it('finds the most specific matching rule', () => {
+    const match = findMatchingDomainRule('sub.example.social', [
+      { id: '1', type: 'block' as const, domain: 'example.social' },
+      { id: '2', type: 'block' as const, domain: 'sub.example.social' }
+    ])
+
+    expect(match?.id).toBe('2')
+  })
+
+  it('obfuscates public domain blocks with the digest', () => {
+    const publicBlock = toPublicDomainBlock({
+      id: '1',
+      type: 'block',
+      domain: 'blocked.test',
+      severity: 'suspend',
+      rejectMedia: false,
+      rejectReports: false,
+      privateComment: null,
+      publicComment: 'spam',
+      obfuscate: true,
+      source: null,
+      createdAt: 0,
+      updatedAt: 0
+    })
+
+    expect(publicBlock).toEqual({
+      domain: domainDigest('blocked.test'),
+      digest: domainDigest('blocked.test'),
+      severity: 'suspend',
+      comment: 'spam'
+    })
+  })
+})

--- a/lib/services/federation/domainRules.test.ts
+++ b/lib/services/federation/domainRules.test.ts
@@ -12,6 +12,7 @@ describe('domainRules', () => {
     expect(normalizeDomain('https://Sub.Example.Social/path')).toBe(
       'sub.example.social'
     )
+    expect(normalizeDomain('*.Example.Social')).toBe('*.example.social')
     expect(normalizeDomain('')).toBeNull()
   })
 

--- a/lib/services/federation/domainRules.test.ts
+++ b/lib/services/federation/domainRules.test.ts
@@ -16,9 +16,11 @@ describe('domainRules', () => {
     expect(normalizeDomain('')).toBeNull()
   })
 
-  it('matches exact domains, subdomains, and wildcard allows', () => {
+  it('matches exact domains and wildcard subdomains', () => {
     expect(domainMatchesRule('example.social', 'example.social')).toBe(true)
-    expect(domainMatchesRule('sub.example.social', 'example.social')).toBe(true)
+    expect(domainMatchesRule('sub.example.social', 'example.social')).toBe(
+      false
+    )
     expect(domainMatchesRule('example.social', '*.example.social')).toBe(false)
     expect(domainMatchesRule('sub.example.social', '*.example.social')).toBe(
       true
@@ -29,6 +31,7 @@ describe('domainRules', () => {
   it('finds the most specific matching rule', () => {
     const match = findMatchingDomainRule('sub.example.social', [
       { id: '1', type: 'block' as const, domain: 'example.social' },
+      { id: '3', type: 'block' as const, domain: '*.example.social' },
       { id: '2', type: 'block' as const, domain: 'sub.example.social' }
     ])
 

--- a/lib/services/federation/domainRules.ts
+++ b/lib/services/federation/domainRules.ts
@@ -1,0 +1,92 @@
+import crypto from 'crypto'
+
+import {
+  DomainAllow,
+  DomainBlock,
+  DomainBlockSeverity,
+  DomainFederationRuleType
+} from '@/lib/types/database/operations'
+
+export const FEDERATION_MODE_VALUES = ['open', 'allowlist'] as const
+export type FederationMode = (typeof FEDERATION_MODE_VALUES)[number]
+
+export const DEFAULT_DOMAIN_BLOCK_SEVERITY: DomainBlockSeverity = 'suspend'
+
+export const normalizeDomain = (value: string): string | null => {
+  const trimmed = value.trim().toLowerCase()
+  if (!trimmed) return null
+  if (trimmed === '*') return '*'
+
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`
+
+  try {
+    const url = new URL(withScheme)
+    return url.hostname.replace(/\.$/, '') || null
+  } catch {
+    return null
+  }
+}
+
+export const domainDigest = (domain: string): string =>
+  crypto.createHash('sha256').update(domain).digest('hex')
+
+export const domainMatchesRule = (
+  domain: string,
+  ruleDomain: string
+): boolean => {
+  const normalizedDomain = normalizeDomain(domain)
+  const normalizedRule = normalizeDomain(ruleDomain)
+  if (!normalizedDomain || !normalizedRule) return false
+  if (normalizedRule === '*') return true
+  if (normalizedRule.startsWith('*.')) {
+    const parent = normalizedRule.slice(2)
+    return normalizedDomain.endsWith(`.${parent}`)
+  }
+
+  return (
+    normalizedDomain === normalizedRule ||
+    normalizedDomain.endsWith(`.${normalizedRule}`)
+  )
+}
+
+export const findMatchingDomainRule = <
+  T extends { domain: string; type: DomainFederationRuleType }
+>(
+  domain: string,
+  rules: T[]
+): T | null =>
+  rules
+    .filter((rule) => domainMatchesRule(domain, rule.domain))
+    .sort((a, b) => b.domain.length - a.domain.length)[0] ?? null
+
+export const shouldSuspendDomainBlock = (block: DomainBlock): boolean =>
+  block.severity === 'suspend'
+
+export const toPublicDomainBlock = (block: DomainBlock) => ({
+  domain: block.obfuscate ? domainDigest(block.domain) : block.domain,
+  digest: domainDigest(block.domain),
+  severity: block.severity,
+  comment: block.publicComment
+})
+
+export const toAdminDomainBlock = (block: DomainBlock) => ({
+  id: block.id,
+  domain: block.domain,
+  digest: domainDigest(block.domain),
+  created_at: new Date(block.createdAt).toISOString(),
+  severity: block.severity,
+  reject_media: block.rejectMedia,
+  reject_reports: block.rejectReports,
+  private_comment: block.privateComment,
+  public_comment: block.publicComment,
+  obfuscate: block.obfuscate,
+  source: block.source
+})
+
+export const toAdminDomainAllow = (allow: DomainAllow) => ({
+  id: allow.id,
+  domain: allow.domain,
+  created_at: new Date(allow.createdAt).toISOString()
+})

--- a/lib/services/federation/domainRules.ts
+++ b/lib/services/federation/domainRules.ts
@@ -17,13 +17,17 @@ export const normalizeDomain = (value: string): string | null => {
   if (!trimmed) return null
   if (trimmed === '*') return '*'
 
-  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`
+  const hasWildcard = trimmed.startsWith('*.')
+  const domainToParse = hasWildcard ? trimmed.slice(2) : trimmed
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(domainToParse)
+    ? domainToParse
+    : `https://${domainToParse}`
 
   try {
     const url = new URL(withScheme)
-    return url.hostname.replace(/\.$/, '') || null
+    const normalized = url.hostname.replace(/\.$/, '')
+    if (!normalized) return null
+    return hasWildcard ? `*.${normalized}` : normalized
   } catch {
     return null
   }

--- a/lib/services/federation/domainRules.ts
+++ b/lib/services/federation/domainRules.ts
@@ -49,10 +49,7 @@ export const domainMatchesRule = (
     return normalizedDomain.endsWith(`.${parent}`)
   }
 
-  return (
-    normalizedDomain === normalizedRule ||
-    normalizedDomain.endsWith(`.${normalizedRule}`)
-  )
+  return normalizedDomain === normalizedRule
 }
 
 export const findMatchingDomainRule = <
@@ -63,7 +60,14 @@ export const findMatchingDomainRule = <
 ): T | null =>
   rules
     .filter((rule) => domainMatchesRule(domain, rule.domain))
-    .sort((a, b) => b.domain.length - a.domain.length)[0] ?? null
+    .sort((a, b) => {
+      const wildcardDiff =
+        Number(a.domain.startsWith('*.') || a.domain === '*') -
+        Number(b.domain.startsWith('*.') || b.domain === '*')
+      if (wildcardDiff !== 0) return wildcardDiff
+
+      return b.domain.length - a.domain.length
+    })[0] ?? null
 
 export const shouldSuspendDomainBlock = (block: DomainBlock): boolean =>
   block.severity === 'suspend'

--- a/lib/services/federation/domainRules.ts
+++ b/lib/services/federation/domainRules.ts
@@ -27,7 +27,10 @@ export const normalizeDomain = (value: string): string | null => {
     const url = new URL(withScheme)
     const normalized = url.hostname.replace(/\.$/, '')
     if (!normalized) return null
-    return hasWildcard ? `*.${normalized}` : normalized
+    const domain = hasWildcard ? `*.${normalized}` : normalized
+    if (domain.length > 255) return null
+
+    return domain
   } catch {
     return null
   }

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { apiErrorResponse } from '@/lib/utils/response'
 import { parse, verify } from '@/lib/utils/signature'
 
@@ -19,6 +20,10 @@ export const ActivityPubVerifySenderGuard =
 
     const signatureParts = await parse(requestSignature)
     if (!signatureParts.keyId) return apiErrorResponse(400)
+
+    if (!(await canFederateWithDomain(database, signatureParts.keyId))) {
+      return apiErrorResponse(403)
+    }
 
     const host = headerHost(request.headers)
     const requestUrl = new URL(request.url, `http://${host}`)

--- a/lib/services/guards/AdminApiGuard.test.ts
+++ b/lib/services/guards/AdminApiGuard.test.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { Scope } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+
+import { AdminApiGuard } from './AdminApiGuard'
+
+const mockDatabase = {} as Database
+const mockGetServerSession = jest.fn()
+const mockGetAdminFromSession = jest.fn()
+const mockOAuthGuard = jest.fn()
+let mockOAuthActor = {
+  account: { role: 'admin' }
+} as Actor
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: (...params: unknown[]) =>
+    mockGetAdminFromSession(...params)
+}))
+
+jest.mock('./OAuthGuard', () => ({
+  OAuthGuard: (...params: unknown[]) => mockOAuthGuard(...params)
+}))
+
+describe('AdminApiGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockOAuthActor = {
+      account: { role: 'admin' }
+    } as Actor
+    mockGetServerSession.mockResolvedValue(null)
+    mockGetAdminFromSession.mockResolvedValue(null)
+    mockOAuthGuard.mockImplementation(
+      (
+        _scopes: Scope[],
+        handle: (
+          req: NextRequest,
+          context: {
+            currentActor: Actor
+            database: Database
+            params: Promise<{}>
+          }
+        ) => Promise<Response> | Response
+      ) =>
+        (req: NextRequest, context: { params: Promise<{}> }) =>
+          handle(req, {
+            currentActor: mockOAuthActor,
+            database: mockDatabase,
+            params: context.params
+          })
+    )
+  })
+
+  const handle = jest.fn(() => NextResponse.json({ ok: true }))
+
+  it('allows an admin cookie session', async () => {
+    const session = { user: { email: 'admin@llun.test' } }
+    mockGetServerSession.mockResolvedValue(session)
+    mockGetAdminFromSession.mockResolvedValue({ role: 'admin' })
+
+    const guard = AdminApiGuard([HttpMethod.enum.GET], handle)
+    const response = await guard(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(handle).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      expect.objectContaining({ database: mockDatabase })
+    )
+    expect(mockOAuthGuard).not.toHaveBeenCalled()
+  })
+
+  it('allows an admin OAuth bearer token for read routes', async () => {
+    const guard = AdminApiGuard([HttpMethod.enum.GET], handle)
+    const response = await guard(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks', {
+        headers: { Authorization: 'Bearer token' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockOAuthGuard).toHaveBeenCalledWith(
+      [Scope.enum.read],
+      expect.any(Function)
+    )
+  })
+
+  it('requires write scope for non-GET admin routes', async () => {
+    const guard = AdminApiGuard([HttpMethod.enum.POST], handle)
+    await guard(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(mockOAuthGuard).toHaveBeenCalledWith(
+      [Scope.enum.write],
+      expect.any(Function)
+    )
+  })
+
+  it('rejects a non-admin OAuth bearer token', async () => {
+    mockOAuthActor = {
+      account: { role: 'user' }
+    } as Actor
+
+    const guard = AdminApiGuard([HttpMethod.enum.GET], handle)
+    const response = await guard(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks', {
+        headers: { Authorization: 'Bearer token' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects requests without session or bearer token', async () => {
+    const guard = AdminApiGuard([HttpMethod.enum.GET], handle)
+    const response = await guard(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(403)
+    expect(mockOAuthGuard).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/guards/AdminApiGuard.ts
+++ b/lib/services/guards/AdminApiGuard.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { getDatabase } from '@/lib/database'
 import { Database } from '@/lib/database/types'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { Scope } from '@/lib/types/database/operations'
 import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { HTTP_STATUS, apiResponse } from '@/lib/utils/response'
@@ -16,6 +17,9 @@ type AdminApiHandle<P> = (
     params: Promise<P>
   }
 ) => Promise<Response> | Response
+
+const getRequiredOAuthScopes = (method: string): Scope[] =>
+  method === HttpMethod.enum.GET ? [Scope.enum.read] : [Scope.enum.write]
 
 export const AdminApiGuard =
   <P>(allowedMethods: HttpMethod[], handle: AdminApiHandle<P>) =>
@@ -32,7 +36,11 @@ export const AdminApiGuard =
 
     const session = await getServerAuthSession()
     const admin = await getAdminFromSession(database, session)
-    if (!admin) {
+    if (admin) {
+      return handle(req, { database, params: context.params })
+    }
+
+    if (!req.headers.get('Authorization')) {
       return apiResponse({
         req,
         allowedMethods,
@@ -41,5 +49,20 @@ export const AdminApiGuard =
       })
     }
 
-    return handle(req, { database, params: context.params })
+    const { OAuthGuard } = await import('./OAuthGuard')
+    return OAuthGuard<P>(
+      getRequiredOAuthScopes(req.method),
+      async (oauthReq, { currentActor, database: oauthDatabase, params }) => {
+        if (currentActor.account?.role !== 'admin') {
+          return apiResponse({
+            req: oauthReq,
+            allowedMethods,
+            data: { error: 'Forbidden' },
+            responseStatusCode: HTTP_STATUS.FORBIDDEN
+          })
+        }
+
+        return handle(oauthReq, { database: oauthDatabase, params })
+      }
+    )(req, context)
   }

--- a/lib/services/guards/AdminApiGuard.ts
+++ b/lib/services/guards/AdminApiGuard.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from 'next/server'
+
+import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { HTTP_STATUS, apiResponse } from '@/lib/utils/response'
+
+import { AppRouterParams } from './types'
+
+type AdminApiHandle<P> = (
+  request: NextRequest,
+  context: {
+    database: Database
+    params: Promise<P>
+  }
+) => Promise<Response> | Response
+
+export const AdminApiGuard =
+  <P>(allowedMethods: HttpMethod[], handle: AdminApiHandle<P>) =>
+  async (req: NextRequest, context: AppRouterParams<P>) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods,
+        data: { error: 'Database unavailable' },
+        responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
+
+    const session = await getServerAuthSession()
+    const admin = await getAdminFromSession(database, session)
+    if (!admin) {
+      return apiResponse({
+        req,
+        allowedMethods,
+        data: { error: 'Forbidden' },
+        responseStatusCode: HTTP_STATUS.FORBIDDEN
+      })
+    }
+
+    return handle(req, { database, params: context.params })
+  }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1036,6 +1036,69 @@ export interface GetAllHashtagsResult {
   total: number
 }
 
+export const DomainFederationRuleType = z.enum(['block', 'allow'])
+export type DomainFederationRuleType = z.infer<typeof DomainFederationRuleType>
+
+export const DomainBlockSeverity = z.enum(['noop', 'silence', 'suspend'])
+export type DomainBlockSeverity = z.infer<typeof DomainBlockSeverity>
+
+export interface DomainFederationRule {
+  id: string
+  domain: string
+  type: DomainFederationRuleType
+  createdAt: number
+  updatedAt: number
+}
+
+export interface DomainBlock extends DomainFederationRule {
+  type: 'block'
+  severity: DomainBlockSeverity
+  rejectMedia: boolean
+  rejectReports: boolean
+  privateComment: string | null
+  publicComment: string | null
+  obfuscate: boolean
+  source: string | null
+}
+
+export interface DomainAllow extends DomainFederationRule {
+  type: 'allow'
+}
+
+export type ListDomainFederationRulesParams = {
+  type: DomainFederationRuleType
+  limit?: number
+  offset?: number
+}
+
+export type CreateDomainBlockParams = {
+  domain: string
+  severity?: DomainBlockSeverity
+  rejectMedia?: boolean
+  rejectReports?: boolean
+  privateComment?: string | null
+  publicComment?: string | null
+  obfuscate?: boolean
+  source?: string | null
+}
+
+export type UpdateDomainBlockParams = {
+  id: string
+  severity?: DomainBlockSeverity
+  rejectMedia?: boolean
+  rejectReports?: boolean
+  privateComment?: string | null
+  publicComment?: string | null
+  obfuscate?: boolean
+  source?: string | null
+}
+
+export type CreateDomainAllowParams = {
+  domain: string
+}
+
+export type ImportDomainBlockParams = CreateDomainBlockParams
+
 export interface AdminDatabase {
   getAllAccounts(params: GetAllAccountsParams): Promise<GetAllAccountsResult>
   getAccountWithActors(
@@ -1046,4 +1109,26 @@ export interface AdminDatabase {
     params: GetServiceStatsBucketsParams
   ): Promise<ServiceStatsBucket[]>
   getAllHashtags(params: GetAllHashtagsParams): Promise<GetAllHashtagsResult>
+  getDomainBlocks(params?: {
+    limit?: number
+    offset?: number
+  }): Promise<DomainBlock[]>
+  getDomainAllows(params?: {
+    limit?: number
+    offset?: number
+  }): Promise<DomainAllow[]>
+  getDomainBlockById(id: string): Promise<DomainBlock | null>
+  getDomainAllowById(id: string): Promise<DomainAllow | null>
+  getDomainBlockForDomain(domain: string): Promise<DomainBlock | null>
+  getDomainAllowForDomain(domain: string): Promise<DomainAllow | null>
+  createDomainBlock(params: CreateDomainBlockParams): Promise<DomainBlock>
+  updateDomainBlock(
+    params: UpdateDomainBlockParams
+  ): Promise<DomainBlock | null>
+  deleteDomainBlock(id: string): Promise<DomainBlock | null>
+  createDomainAllow(params: CreateDomainAllowParams): Promise<DomainAllow>
+  deleteDomainAllow(id: string): Promise<DomainAllow | null>
+  importDomainBlocks(params: {
+    blocks: ImportDomainBlockParams[]
+  }): Promise<{ created: number; updated: number; skipped: number }>
 }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1128,6 +1128,12 @@ export interface AdminDatabase {
   getDomainAllowById(id: string): Promise<DomainAllow | null>
   getDomainBlockForDomain(domain: string): Promise<DomainBlock | null>
   getDomainAllowForDomain(domain: string): Promise<DomainAllow | null>
+  getDomainBlocksForDomains(
+    domains: string[]
+  ): Promise<Record<string, DomainBlock | null>>
+  getDomainAllowsForDomains(
+    domains: string[]
+  ): Promise<Record<string, DomainAllow | null>>
   getDomainFederationRuleStats(): Promise<DomainFederationRuleStats>
   createDomainBlock(params: CreateDomainBlockParams): Promise<DomainBlock>
   updateDomainBlock(

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1099,6 +1099,13 @@ export type CreateDomainAllowParams = {
 
 export type ImportDomainBlockParams = CreateDomainBlockParams
 
+export type DomainFederationRuleStats = {
+  blocks: number
+  allows: number
+  sourceBlocks: number
+  sourceCounts: Record<string, number>
+}
+
 export interface AdminDatabase {
   getAllAccounts(params: GetAllAccountsParams): Promise<GetAllAccountsResult>
   getAccountWithActors(
@@ -1121,6 +1128,7 @@ export interface AdminDatabase {
   getDomainAllowById(id: string): Promise<DomainAllow | null>
   getDomainBlockForDomain(domain: string): Promise<DomainBlock | null>
   getDomainAllowForDomain(domain: string): Promise<DomainAllow | null>
+  getDomainFederationRuleStats(): Promise<DomainFederationRuleStats>
   createDomainBlock(params: CreateDomainBlockParams): Promise<DomainBlock>
   updateDomainBlock(
     params: UpdateDomainBlockParams

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1101,6 +1101,7 @@ export type ImportDomainBlockParams = CreateDomainBlockParams
 
 export type DomainFederationRuleStats = {
   blocks: number
+  suspendBlocks: number
   allows: number
   sourceBlocks: number
   sourceCounts: Record<string, number>
@@ -1119,6 +1120,7 @@ export interface AdminDatabase {
   getDomainBlocks(params?: {
     limit?: number
     offset?: number
+    severity?: DomainBlockSeverity
   }): Promise<DomainBlock[]>
   getDomainAllows(params?: {
     limit?: number

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -73,3 +73,18 @@ export interface SQLAccount {
   updatedAt: number | Date
   verifiedAt?: number | Date
 }
+
+export interface SQLDomainFederationRule {
+  id: string
+  domain: string
+  type: string
+  severity?: string | null
+  rejectMedia: boolean | number
+  rejectReports: boolean | number
+  privateComment?: string | null
+  publicComment?: string | null
+  obfuscate: boolean | number
+  source?: string | null
+  createdAt: number | Date
+  updatedAt: number | Date
+}

--- a/lib/utils/request.test.ts
+++ b/lib/utils/request.test.ts
@@ -46,7 +46,11 @@ jest.mock('got', () => {
 
         void (async () => {
           try {
-            const { response, body } = await readResponse(url, options)
+            const response = await fetch(url, {
+              method: options.method,
+              body: options.body,
+              headers: options.headers
+            })
             const headers: Record<string, string> = {}
             response.headers.forEach((value, key) => {
               headers[key] = value
@@ -56,6 +60,11 @@ jest.mock('got', () => {
               statusCode: response.status,
               headers
             })
+            if (stream.destroyed) return
+
+            const body = await response.text()
+            if (stream.destroyed) return
+
             stream.push(Buffer.from(body))
             stream.push(null)
           } catch (error) {
@@ -75,9 +84,12 @@ jest.mock('got', () => {
 
 enableFetchMocks()
 
-const createTestServer = async (body: string) => {
+const createTestServer = async (
+  body: string,
+  headers: Record<string, string> = {}
+) => {
   const server = createServer((_request, response) => {
-    response.writeHead(200, { 'content-type': 'text/plain' })
+    response.writeHead(200, { 'content-type': 'text/plain', ...headers })
     response.end(body)
   })
 
@@ -209,6 +221,25 @@ describe('request utility', () => {
     it('rejects a streamed response over the response size limit', async () => {
       fetchMock.dontMock()
       const { server, url } = await createTestServer('x'.repeat(32))
+
+      try {
+        await expect(
+          request({
+            url,
+            numberOfRetry: 0,
+            maxResponseSize: 8
+          })
+        ).rejects.toThrow('Response body too large')
+      } finally {
+        await closeServer(server)
+      }
+    })
+
+    it('rejects a streamed response with an oversized content length', async () => {
+      fetchMock.dontMock()
+      const { server, url } = await createTestServer('small body', {
+        'content-length': '32'
+      })
 
       try {
         await expect(

--- a/lib/utils/request.test.ts
+++ b/lib/utils/request.test.ts
@@ -1,8 +1,106 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+import { type Server, createServer } from 'node:http'
+import { type AddressInfo } from 'node:net'
 
 import { request } from './request'
 
+jest.mock('got', () => {
+  type GotMockOptions = {
+    method?: string
+    body?: string
+    headers?: Record<string, string>
+  }
+
+  const { Buffer } = jest.requireActual(
+    'node:buffer'
+  ) as typeof import('node:buffer')
+  const { Readable } = jest.requireActual(
+    'node:stream'
+  ) as typeof import('node:stream')
+
+  const readResponse = async (url: string, options: GotMockOptions) => {
+    const response = await fetch(url, {
+      method: options.method,
+      body: options.body,
+      headers: options.headers
+    })
+    const body = await response.text()
+
+    return { response, body }
+  }
+
+  const gotMock = Object.assign(
+    async (url: string, options: GotMockOptions) => {
+      const { response, body } = await readResponse(url, options)
+
+      return {
+        statusCode: response.status,
+        body
+      }
+    },
+    {
+      stream: (url: string, options: GotMockOptions) => {
+        const stream = new Readable({
+          read() {}
+        })
+
+        void (async () => {
+          try {
+            const { response, body } = await readResponse(url, options)
+            const headers: Record<string, string> = {}
+            response.headers.forEach((value, key) => {
+              headers[key] = value
+            })
+
+            stream.emit('response', {
+              statusCode: response.status,
+              headers
+            })
+            stream.push(Buffer.from(body))
+            stream.push(null)
+          } catch (error) {
+            stream.destroy(
+              error instanceof Error ? error : new Error(String(error))
+            )
+          }
+        })()
+
+        return stream
+      }
+    }
+  )
+
+  return gotMock
+})
+
 enableFetchMocks()
+
+const createTestServer = async (body: string) => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/plain' })
+    response.end(body)
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const { port } = server.address() as AddressInfo
+  return { server, url: `http://127.0.0.1:${port}` }
+}
+
+const closeServer = async (server: Server) => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
 
 describe('request utility', () => {
   beforeEach(() => {
@@ -88,6 +186,41 @@ describe('request utility', () => {
           method: 'GET'
         })
       )
+    })
+
+    it('returns a streamed response within the response size limit', async () => {
+      fetchMock.dontMock()
+      const { server, url } = await createTestServer('small body')
+
+      try {
+        const response = await request({
+          url,
+          numberOfRetry: 0,
+          maxResponseSize: 64
+        })
+
+        expect(response.statusCode).toBe(200)
+        expect(response.body).toBe('small body')
+      } finally {
+        await closeServer(server)
+      }
+    })
+
+    it('rejects a streamed response over the response size limit', async () => {
+      fetchMock.dontMock()
+      const { server, url } = await createTestServer('x'.repeat(32))
+
+      try {
+        await expect(
+          request({
+            url,
+            numberOfRetry: 0,
+            maxResponseSize: 8
+          })
+        ).rejects.toThrow('Response body too large')
+      } finally {
+        await closeServer(server)
+      }
     })
   })
 })

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -1,4 +1,5 @@
-import got, { Headers, Method } from 'got'
+import got, { Headers, Method, OptionsInit } from 'got'
+import { Buffer } from 'node:buffer'
 
 import { getConfig } from '@/lib/config'
 import packageJson from '@/package.json'
@@ -18,16 +19,22 @@ export interface RequestOptions {
   body?: string
   responseTimeout?: number
   numberOfRetry?: number
+  maxResponseSize?: number
 }
 
-export const request = ({
-  url,
+export interface RequestResult {
+  statusCode: number
+  headers: Record<string, string | string[] | undefined>
+  body: string
+}
+
+const getGotOptions = ({
   method = 'GET',
   headers,
   body,
   responseTimeout,
   numberOfRetry
-}: RequestOptions) => {
+}: Omit<RequestOptions, 'url' | 'maxResponseSize'>): OptionsInit => {
   const config = getConfig()
   const retryLimit = config.request?.numberOfRetry ?? MAX_RETRY_LIMIT
   const retryNoise = config.request?.retryNoise
@@ -35,7 +42,8 @@ export const request = ({
     responseTimeout ||
     config.request?.timeoutInMilliseconds ||
     DEFAULT_RESPONSE_TIMEOUT
-  return got(url, {
+
+  return {
     headers: {
       ...SHARED_HEADERS,
       ...headers
@@ -50,5 +58,66 @@ export const request = ({
     throwHttpErrors: false,
     method: method as Method,
     body
+  }
+}
+
+const requestWithResponseSizeLimit = (
+  url: string,
+  options: OptionsInit,
+  maxResponseSize: number
+): Promise<RequestResult> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let bodyBytes = 0
+    let statusCode = 0
+    let headers: Record<string, string | string[] | undefined> = {}
+    const stream = got.stream(url, options)
+
+    stream.on('response', (response) => {
+      statusCode = response.statusCode
+      headers = response.headers
+    })
+    stream.on('data', (chunk) => {
+      const buffer = Buffer.from(chunk)
+      bodyBytes += buffer.byteLength
+
+      if (bodyBytes > maxResponseSize) {
+        stream.destroy(new Error('Response body too large'))
+        return
+      }
+
+      chunks.push(buffer)
+    })
+    stream.on('end', () => {
+      resolve({
+        statusCode,
+        headers,
+        body: Buffer.concat(chunks).toString('utf8')
+      })
+    })
+    stream.on('error', reject)
   })
+
+export const request = ({
+  url,
+  method = 'GET',
+  headers,
+  body,
+  responseTimeout,
+  numberOfRetry,
+  maxResponseSize
+}: RequestOptions) => {
+  const options = getGotOptions({
+    method,
+    headers,
+    body,
+    responseTimeout,
+    numberOfRetry
+  })
+
+  if (typeof maxResponseSize === 'number') {
+    return requestWithResponseSizeLimit(url, options, maxResponseSize)
+  }
+
+  return got(url, options)
 }

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -76,6 +76,15 @@ const requestWithResponseSizeLimit = (
     stream.on('response', (response) => {
       statusCode = response.statusCode
       headers = response.headers
+
+      const declaredLengthHeader = response.headers['content-length']
+      const declaredLengthValue = Array.isArray(declaredLengthHeader)
+        ? declaredLengthHeader[0]
+        : declaredLengthHeader
+      const declaredLength = Number(declaredLengthValue ?? 0)
+      if (Number.isFinite(declaredLength) && declaredLength > maxResponseSize) {
+        stream.destroy(new Error('Response body too large'))
+      }
     })
     stream.on('data', (chunk) => {
       const buffer = Buffer.from(chunk)

--- a/migrations/20260426180000_add_domain_federation_rules.js
+++ b/migrations/20260426180000_add_domain_federation_rules.js
@@ -1,0 +1,34 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable('domain_federation_rules', function (table) {
+    table.string('id').primary()
+    table.string('domain').notNullable()
+    table.string('type').notNullable()
+    table.string('severity').nullable()
+    table.boolean('rejectMedia').notNullable().defaultTo(false)
+    table.boolean('rejectReports').notNullable().defaultTo(false)
+    table.text('privateComment').nullable()
+    table.text('publicComment').nullable()
+    table.boolean('obfuscate').notNullable().defaultTo(false)
+    table.string('source').nullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['type', 'domain'], {
+      indexName: 'domain_federation_rules_type_domain_unique'
+    })
+    table.index(['type', 'createdAt'], 'domain_federation_rules_type_idx')
+    table.index(['source'], 'domain_federation_rules_source_idx')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable('domain_federation_rules')
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "content-type": "^1.0.5",
+    "csv-parse": "^6.2.1",
     "date-fns": "^4.1.0",
     "fast-xml-parser": "^5.7.2",
     "fit-file-parser": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5641,6 +5641,7 @@ __metadata:
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
     content-type: "npm:^1.0.5"
+    csv-parse: "npm:^6.2.1"
     date-fns: "npm:^4.1.0"
     dotenv-flow: "npm:^4.1.0"
     eslint: "npm:^10.2.1"
@@ -6740,6 +6741,13 @@ __metadata:
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
+  languageName: node
+  linkType: hard
+
+"csv-parse@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "csv-parse@npm:6.2.1"
+  checksum: 10c0/8b6f14b244ca62476d4217aac721131ba0ada3e4ed7614e43ebc99203807564dcb054144d1de4ef22ee8b0c63b431640f75d46a0e1e0f72853a954b279ba1c61
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add Mastodon-like domain block and allow rules with storage, admin APIs, and a federation admin UI.
- Enforce federation policy for inbound ActivityPub, remote fetches, follows, actor recording, and outbound delivery fanout.
- Add import support for the Oliphant unified tier 0 known blocklist source and expose public instance domain blocks.

## Verification
- yarn prettier
- yarn lint
- yarn build
- yarn test
- Browser check: verified https://activities.local/admin/federation with block/allow create flows and accessible delete actions.