### PR TITLE
feat: harden WebFinger discovery

### DIFF
--- a/app/api/well-known/webfinger/route.test.ts
+++ b/app/api/well-known/webfinger/route.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+
+import { GET } from './route'
+
+type MockDatabase = Pick<Database, 'getActorFromUsername'>
+
+let mockDatabase: MockDatabase | null = null
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('GET /api/well-known/webfinger', () => {
+  const database: jest.Mocked<MockDatabase> = {
+    getActorFromUsername: jest.fn()
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase = database
+  })
+
+  it('returns WebFinger JRD for a local actor', async () => {
+    database.getActorFromUsername.mockResolvedValue({
+      id: 'https://example.com/users/test',
+      username: 'test',
+      domain: 'example.com',
+      privateKey: 'key'
+    } as never)
+
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/.well-known/webfinger?resource=acct:test@example.com'
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toStartWith(
+      'application/jrd+json'
+    )
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      subject: 'acct:test@example.com',
+      aliases: ['https://example.com/@test', 'https://example.com/users/test']
+    })
+  })
+
+  it('returns 404 when the resource is missing', async () => {
+    const response = await GET(
+      new NextRequest('https://example.com/.well-known/webfinger'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(404)
+    expect(database.getActorFromUsername).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 for cached remote actors', async () => {
+    database.getActorFromUsername.mockResolvedValue({
+      id: 'https://remote.example/users/test',
+      username: 'test',
+      domain: 'remote.example',
+      privateKey: null
+    } as never)
+
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/.well-known/webfinger?resource=acct:test@remote.example'
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/well-known/webfinger/route.ts
+++ b/app/api/well-known/webfinger/route.ts
@@ -14,6 +14,7 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 export const dynamic = 'force-dynamic'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const WEBFINGER_CONTENT_TYPE = 'application/jrd+json; charset=utf-8'
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -51,5 +52,10 @@ export const GET = traceApiRoute('webfinger', async (req: NextRequest) => {
       responseStatusCode: 404
     })
 
-  return apiResponse({ req, allowedMethods: CORS_HEADERS, data: response })
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: response,
+    additionalHeaders: [['Content-Type', WEBFINGER_CONTENT_TYPE]]
+  })
 })

--- a/lib/activities/getWebfingerSelf.test.ts
+++ b/lib/activities/getWebfingerSelf.test.ts
@@ -22,6 +22,15 @@ describe('#getWebfingerSelf', () => {
     expect(selfUrl).toBeNull()
   })
 
+  it('does not request malformed account names', async () => {
+    const selfUrl = await getWebfingerSelf({
+      account: 'user@example.com@evil.test'
+    })
+
+    expect(selfUrl).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('returns self href from webfinger without aliases (Misskey format)', async () => {
     // Misskey doesn't include aliases in webfinger response
     fetchMock.mockResponseOnce(
@@ -43,5 +52,19 @@ describe('#getWebfingerSelf', () => {
     )
     const selfUrl = await getWebfingerSelf({ account: 'user@misskey.test' })
     expect(selfUrl).toEqual('https://misskey.test/users/abc123')
+  })
+
+  it('requests a JRD response using an encoded acct resource', async () => {
+    const selfUrl = await getWebfingerSelf({ account: 'test1@llun.test' })
+
+    expect(selfUrl).toEqual('https://llun.test/users/test1')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://llun.test/.well-known/webfinger?resource=acct%3Atest1%40llun.test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'application/jrd+json, application/json'
+        })
+      })
+    )
   })
 })

--- a/lib/activities/getWebfingerSelf.ts
+++ b/lib/activities/getWebfingerSelf.ts
@@ -12,17 +12,24 @@ export const getWebfingerSelf: GetWebfingerSelfFunction = async ({ account }) =>
     'activities.getWebfingerSelf',
     { attributes: { account } },
     async (span) => {
-      const [user, domain] = account.split('@')
+      const [user, domain, ...rest] = account.split('@')
       if (!user || !domain) {
+        span.end()
+        return null
+      }
+      if (rest.length > 0) {
         span.end()
         return null
       }
 
       try {
+        const url = new URL(`https://${domain}/.well-known/webfinger`)
+        url.searchParams.set('resource', `acct:${account}`)
+
         const { statusCode, body } = await request({
-          url: `https://${domain}/.well-known/webfinger?resource=acct:${account}`,
+          url: url.toString(),
           headers: {
-            Accept: 'application/json'
+            Accept: 'application/jrd+json, application/json'
           }
         })
         if (statusCode !== 200) {

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -147,6 +147,16 @@ describe('#getWebFingerResponse', () => {
     expect(result).toBeNull()
   })
 
+  it('returns null when account resource contains multiple at signs', async () => {
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'acct:user@example.com@elsewhere.test'
+    })
+
+    expect(result).toBeNull()
+    expect(mockDatabase.getActorFromUsername).not.toHaveBeenCalled()
+  })
+
   it('returns null when actor not found', async () => {
     mockDatabase.getActorFromUsername.mockResolvedValue(null)
 
@@ -224,6 +234,56 @@ describe('#getWebFingerResponse', () => {
     })
   })
 
+  it('uses the requested domain casing before falling back to normalized domain casing', async () => {
+    mockDatabase.getActorFromUsername
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'https://example.com/users/user',
+        username: 'user',
+        domain: 'example.com',
+        privateKey: 'key'
+      })
+
+    await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'ACCT:user@EXAMPLE.COM'
+    })
+
+    expect(mockDatabase.getActorFromUsername).toHaveBeenNthCalledWith(1, {
+      username: 'user',
+      domain: 'EXAMPLE.COM'
+    })
+    expect(mockDatabase.getActorFromUsername).toHaveBeenNthCalledWith(2, {
+      username: 'user',
+      domain: 'example.com'
+    })
+  })
+
+  it('preserves stored domain casing when the exact lookup matches', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://Example.COM/users/user',
+      username: 'user',
+      domain: 'Example.COM',
+      privateKey: 'key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'ACCT:user@Example.COM'
+    })
+
+    expect(mockDatabase.getActorFromUsername).toHaveBeenCalledTimes(1)
+    expect(mockDatabase.getActorFromUsername).toHaveBeenCalledWith({
+      username: 'user',
+      domain: 'Example.COM'
+    })
+    expect(result?.subject).toBe('acct:user@Example.COM')
+    expect(result?.aliases).toEqual([
+      'https://Example.COM/@user',
+      'https://Example.COM/users/user'
+    ])
+  })
+
   it('handles resource without acct: prefix', async () => {
     mockDatabase.getActorFromUsername.mockResolvedValue({
       id: 'https://example.com/users/user',
@@ -240,6 +300,40 @@ describe('#getWebFingerResponse', () => {
     expect(mockDatabase.getActorFromUsername).toHaveBeenCalledWith({
       username: 'user',
       domain: 'example.com'
+    })
+  })
+
+  it('returns aliases and self links from the canonical actor id', async () => {
+    mockDatabase.getActorFromUsername.mockResolvedValue({
+      id: 'https://fitness.example/users/runner',
+      username: 'runner',
+      domain: 'fitness.example',
+      privateKey: 'key'
+    })
+
+    const result = await getWebFingerResponse({
+      database: mockDatabase as unknown as Database,
+      resource: 'acct:runner@fitness.example'
+    })
+
+    expect(result).toMatchObject({
+      subject: 'acct:runner@fitness.example',
+      aliases: [
+        'https://fitness.example/@runner',
+        'https://fitness.example/users/runner'
+      ],
+      links: expect.arrayContaining([
+        expect.objectContaining({
+          rel: 'self',
+          type: 'application/activity+json',
+          href: 'https://fitness.example/users/runner'
+        }),
+        expect.objectContaining({
+          rel: 'self',
+          type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+          href: 'https://fitness.example/users/runner'
+        })
+      ])
     })
   })
 })

--- a/lib/services/wellknown/webfinger.ts
+++ b/lib/services/wellknown/webfinger.ts
@@ -18,41 +18,67 @@ interface GetWebFingerParams {
   resource: string
 }
 
+const getAccountFromResource = (resource: string) => {
+  const trimmedResource = resource.trim()
+  const account = trimmedResource.toLowerCase().startsWith('acct:')
+    ? trimmedResource.slice('acct:'.length)
+    : trimmedResource
+  const parts = account.split('@')
+
+  if (parts.length !== 2) return null
+
+  const [username, domain] = parts.map((part) => part.trim())
+  if (!username || !domain) return null
+
+  return {
+    username,
+    domain,
+    normalizedDomain: domain.toLowerCase()
+  }
+}
+
 export const getWebFingerResponse = async ({
   database,
   resource
 }: GetWebFingerParams): Promise<WebFingerResponse | null> => {
-  const account = resource.startsWith('acct:') ? resource.slice(5) : resource
+  const account = getAccountFromResource(resource)
+  if (!account) return null
 
-  const [username, domain] = account.split('@')
-  if (!domain) return null
-
-  const actor = await database.getActorFromUsername({ username, domain })
+  const actor =
+    (await database.getActorFromUsername({
+      username: account.username,
+      domain: account.domain
+    })) ??
+    (account.domain === account.normalizedDomain
+      ? null
+      : await database.getActorFromUsername({
+          username: account.username,
+          domain: account.normalizedDomain
+        }))
 
   // This is not local actors
   if (!actor?.privateKey) return null
 
+  const profilePageUrl = `https://${actor.domain}/@${actor.username}`
+
   return {
-    subject: `acct:${username}@${domain}`,
-    aliases: [
-      `https://${domain}/@${username}`,
-      `https://${domain}/users/${username}`
-    ],
+    subject: `acct:${actor.username}@${actor.domain}`,
+    aliases: [profilePageUrl, actor.id],
     links: [
       {
         rel: 'http://webfinger.net/rel/profile-page',
         type: 'text/html',
-        href: `https://${domain}/@${username}`
+        href: profilePageUrl
       },
       {
         rel: 'self',
         type: 'application/activity+json',
-        href: `https://${domain}/users/${username}`
+        href: actor.id
       },
       {
         rel: 'self',
         type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-        href: `https://${domain}/users/${username}`
+        href: actor.id
       }
     ]
   }

--- a/lib/utils/response.test.ts
+++ b/lib/utils/response.test.ts
@@ -8,6 +8,7 @@ import {
   ERROR_422,
   ERROR_500,
   HTTP_STATUS,
+  apiResponse,
   codeMap,
   defaultStatusOption,
   statusText
@@ -74,6 +75,24 @@ describe('response utilities', () => {
         status: 404,
         statusText: 'Not Found'
       })
+    })
+  })
+
+  describe('#apiResponse', () => {
+    it('preserves explicit content type headers', async () => {
+      const response = apiResponse({
+        req: new Request('https://example.com') as never,
+        allowedMethods: ['GET'],
+        data: { ok: true },
+        additionalHeaders: [
+          ['Content-Type', 'application/jrd+json; charset=utf-8']
+        ]
+      })
+
+      expect(response.headers.get('content-type')).toBe(
+        'application/jrd+json; charset=utf-8'
+      )
+      expect(await response.json()).toEqual({ ok: true })
     })
   })
 })

--- a/lib/utils/response.ts
+++ b/lib/utils/response.ts
@@ -150,12 +150,19 @@ export const apiResponse = ({
     }
   }
 
-  return Response.json(data, {
+  const headers = new Headers([
+    ['Server', SERVICE_NAME],
+    ...Object.entries(getCORSHeaders(allowedMethods, req.headers)),
+    ...additionalHeaders
+  ])
+  const responseOptions = {
     ...defaultStatusOption(responseStatusCode),
-    headers: new Headers([
-      ['Server', SERVICE_NAME],
-      ...Object.entries(getCORSHeaders(allowedMethods, req.headers)),
-      ...additionalHeaders
-    ])
-  })
+    headers
+  }
+
+  if (headers.has('content-type')) {
+    return new Response(JSON.stringify(data) ?? 'null', responseOptions)
+  }
+
+  return Response.json(data, responseOptions)
 }


### PR DESCRIPTION
## Summary
- harden WebFinger resource parsing and canonical actor aliases/self links
- return successful WebFinger responses as application/jrd+json while keeping CORS apiResponse handling
- encode outbound acct WebFinger lookups and request JRD responses
- add service, route, outbound lookup, and response utility coverage

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test

## Notes
- No database migration needed. The running activities.local container is mounted to /Users/llun/Documents/llun/activities.next, not this Codex worktree, so I validated the branch with unit/route/build checks rather than mutating that checkout.