### PR TITLE
feat: attach media ids when creating statuses

### DIFF
--- a/app/api/v1/instance/route.ts
+++ b/app/api/v1/instance/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
+import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import {
   ACCEPTED_FILE_TYPES,
   MAX_FILE_SIZE
@@ -33,7 +34,7 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
     configuration: {
       statuses: {
         max_characters: 500,
-        max_media_attachments: 4,
+        max_media_attachments: MAX_STATUS_MEDIA_ATTACHMENTS,
         characters_reserved_per_url: 23
       },
       media_attachments: {

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -185,6 +185,86 @@ describe('POST /api/v1/statuses', () => {
     })
   })
 
+  it('attaches multipart media_ids[] and ignores duplicates', async () => {
+    const firstMedia = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/multipart-status-first.webp',
+        bytes: 4096,
+        mimeType: 'image/png',
+        metaData: { width: 300, height: 200 },
+        fileName: 'multipart-status-first.png'
+      }
+    })
+    const secondMedia = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/multipart-status-second.webp',
+        bytes: 4096,
+        mimeType: 'image/png',
+        metaData: { width: 400, height: 300 },
+        fileName: 'multipart-status-second.png'
+      }
+    })
+
+    expect(firstMedia).not.toBeNull()
+    expect(secondMedia).not.toBeNull()
+
+    const form = new FormData()
+    form.set('status', 'Status created from multipart data')
+    form.append('media_ids[]', firstMedia!.id)
+    form.append('media_ids[]', firstMedia!.id)
+    form.append('media_ids[]', secondMedia!.id)
+    const request = new NextRequest('https://llun.test/api/v1/statuses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=test-boundary'
+      }
+    })
+    Object.defineProperty(request, 'formData', {
+      value: jest.fn().mockResolvedValue(form)
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    expect(mastodonStatus.media_attachments).toHaveLength(2)
+    expect(mastodonStatus.media_attachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: 'https://llun.test/api/v1/files/medias/multipart-status-first.webp'
+        }),
+        expect.objectContaining({
+          url: 'https://llun.test/api/v1/files/medias/multipart-status-second.webp'
+        })
+      ])
+    )
+
+    const attachments = await database.getAttachmentsWithMedia({
+      statusId: mastodonStatus.uri
+    })
+    expect(attachments).toHaveLength(2)
+  })
+
+  it('returns 422 when status has neither text nor media', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: '   '
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
   it('rejects media_ids that do not belong to the authenticated account', async () => {
     const media = await database.createMedia({
       actorId: ACTOR2_ID,

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -215,4 +215,39 @@ describe('POST /api/v1/statuses', () => {
 
     expect(response.status).toBe(422)
   })
+
+  it('rejects more media_ids than the instance advertises', async () => {
+    const mediaIds: string[] = []
+    for (let index = 0; index < 5; index += 1) {
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: `medias/too-many-attachments-${index}.webp`,
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 100, height: 100 },
+          fileName: `too-many-attachments-${index}.jpg`
+        }
+      })
+      expect(media).not.toBeNull()
+      mediaIds.push(media!.id)
+    }
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'This should not exceed the advertised attachment limit',
+          media_ids: mediaIds
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -1,0 +1,218 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { getQueue } from '@/lib/services/queue'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { Status } from '@/lib/types/domain/status'
+import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn().mockReturnValue({
+    publish: jest.fn().mockResolvedValue(undefined)
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('POST /api/v1/statuses', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('attaches JSON media_ids to the created status', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/json-status-photo.webp',
+        bytes: 2048,
+        mimeType: 'image/jpeg',
+        metaData: { width: 640, height: 480 },
+        fileName: 'json-status-photo.jpg'
+      },
+      description: 'JSON media description'
+    })
+
+    expect(media).not.toBeNull()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Status created from JSON with media',
+          media_ids: [media!.id]
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    expect(mastodonStatus.media_attachments).toHaveLength(1)
+    expect(mastodonStatus.media_attachments[0]).toMatchObject({
+      type: 'image',
+      url: 'https://llun.test/api/v1/files/medias/json-status-photo.webp',
+      description: 'JSON media description',
+      meta: {
+        original: {
+          width: 640,
+          height: 480,
+          size: '640x480'
+        }
+      }
+    })
+
+    const attachments = await database.getAttachmentsWithMedia({
+      statusId: mastodonStatus.uri
+    })
+    expect(attachments).toHaveLength(1)
+    expect(attachments[0]).toMatchObject({
+      mediaId: String(media!.id),
+      url: 'https://llun.test/api/v1/files/medias/json-status-photo.webp',
+      name: 'JSON media description'
+    })
+
+    const status = (await database.getStatus({
+      statusId: mastodonStatus.uri,
+      withReplies: false
+    })) as Status
+    const activityPubNote = getNoteFromStatus(status)
+    expect(activityPubNote?.attachment).toEqual([
+      expect.objectContaining({
+        type: 'Document',
+        mediaType: 'image/jpeg',
+        url: 'https://llun.test/api/v1/files/medias/json-status-photo.webp',
+        name: 'JSON media description'
+      })
+    ])
+    expect(getQueue().publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('attaches form media_ids[] to the created status', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/form-status-photo.webp',
+        bytes: 4096,
+        mimeType: 'image/png',
+        metaData: { width: 300, height: 200 },
+        fileName: 'form-status-photo.png'
+      }
+    })
+
+    expect(media).not.toBeNull()
+
+    const body = new URLSearchParams()
+    body.set('status', 'Status created from form data')
+    body.append('media_ids[]', media!.id)
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    expect(mastodonStatus.media_attachments).toHaveLength(1)
+    expect(mastodonStatus.media_attachments[0]).toMatchObject({
+      type: 'image',
+      url: 'https://llun.test/api/v1/files/medias/form-status-photo.webp',
+      description: 'form-status-photo.png'
+    })
+
+    const attachments = await database.getAttachmentsWithMedia({
+      statusId: mastodonStatus.uri
+    })
+    expect(attachments).toHaveLength(1)
+    expect(attachments[0]).toMatchObject({
+      mediaId: String(media!.id),
+      name: 'form-status-photo.png'
+    })
+  })
+
+  it('rejects media_ids that do not belong to the authenticated account', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR2_ID,
+      original: {
+        path: 'medias/other-account-photo.webp',
+        bytes: 1024,
+        mimeType: 'image/jpeg',
+        metaData: { width: 100, height: 100 },
+        fileName: 'other-account-photo.jpg'
+      }
+    })
+
+    expect(media).not.toBeNull()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'This should not attach another account media',
+          media_ids: [media!.id]
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+})

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -4,6 +4,7 @@ import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { Scope } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
@@ -170,6 +171,14 @@ export const POST = traceApiRoute(
         })
       }
       const note = parsed.data
+      if (note.media_ids.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
       const attachments = await getAttachmentsFromMediaIds(
         database,
         currentActor,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { Scope } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -20,20 +24,142 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const VisibilitySchema = z.enum(['public', 'unlisted', 'private', 'direct'])
 
-const NoteSchema = z.object({
-  status: z.string(),
-  in_reply_to_id: z.string().optional(),
-  spoiler_text: z.string().optional(),
-  media_ids: z.array(z.string()).optional(),
-  visibility: VisibilitySchema.optional()
-})
+const NoteSchema = z
+  .object({
+    status: z.string().optional().default(''),
+    in_reply_to_id: z.string().optional(),
+    spoiler_text: z.string().optional(),
+    media_ids: z.array(z.coerce.string()).optional().default([]),
+    visibility: VisibilitySchema.optional()
+  })
+  .refine((note) => note.status.trim().length > 0 || note.media_ids.length > 0)
+
+const FORM_URL_ENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded'
+const FORM_CONTENT_TYPES = [
+  'multipart/form-data',
+  FORM_URL_ENCODED_CONTENT_TYPE
+]
+
+const isFormRequest = (req: Request) => {
+  const contentType = req.headers.get('content-type')?.toLowerCase()
+  return FORM_CONTENT_TYPES.some((type) => contentType?.includes(type))
+}
+
+const getFormString = (form: FormData, name: string) => {
+  const value = form.get(name)
+  return typeof value === 'string' ? value : undefined
+}
+
+const getFormStringArray = (form: FormData, ...names: string[]) =>
+  names
+    .flatMap((name) => form.getAll(name))
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+
+const getSearchParamString = (params: URLSearchParams, name: string) => {
+  const value = params.get(name)
+  return value === null ? undefined : value
+}
+
+const getSearchParamStringArray = (
+  params: URLSearchParams,
+  ...names: string[]
+) =>
+  names
+    .flatMap((name) => params.getAll(name))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+
+const getNoteRequestInput = async (req: Request): Promise<unknown> => {
+  if (!isFormRequest(req)) {
+    return req.json()
+  }
+
+  const contentType = req.headers.get('content-type')?.toLowerCase()
+  if (contentType?.includes(FORM_URL_ENCODED_CONTENT_TYPE)) {
+    const params = new URLSearchParams(await req.text())
+    return {
+      status: getSearchParamString(params, 'status') ?? '',
+      in_reply_to_id: getSearchParamString(params, 'in_reply_to_id'),
+      spoiler_text: getSearchParamString(params, 'spoiler_text'),
+      media_ids: getSearchParamStringArray(params, 'media_ids', 'media_ids[]'),
+      visibility: getSearchParamString(params, 'visibility')
+    }
+  }
+
+  const form = await req.formData()
+  return {
+    status: getFormString(form, 'status') ?? '',
+    in_reply_to_id: getFormString(form, 'in_reply_to_id'),
+    spoiler_text: getFormString(form, 'spoiler_text'),
+    media_ids: getFormStringArray(form, 'media_ids', 'media_ids[]'),
+    visibility: getFormString(form, 'visibility')
+  }
+}
+
+const getMediaUrl = (path: string) => {
+  const { host } = getConfig()
+  if (host.includes('://')) return `${host}/api/v1/files/${path}`
+
+  const protocol =
+    host.startsWith('localhost') ||
+    host.startsWith('127.0.0.1') ||
+    host.startsWith('::1') ||
+    host.startsWith('[::1]')
+      ? 'http'
+      : 'https'
+  return `${protocol}://${host}/api/v1/files/${path}`
+}
+
+const getAttachmentsFromMediaIds = async (
+  database: Database,
+  currentActor: Actor,
+  mediaIds: string[]
+): Promise<PostBoxAttachment[] | null> => {
+  if (mediaIds.length === 0) return []
+
+  const accountId = currentActor.account?.id
+  if (!accountId) return null
+
+  const medias = await Promise.all(
+    mediaIds.map((mediaId) =>
+      database.getMediaByIdForAccount({
+        mediaId,
+        accountId
+      })
+    )
+  )
+
+  const attachments: PostBoxAttachment[] = []
+  for (const media of medias) {
+    if (!media) return null
+
+    attachments.push({
+      type: 'upload',
+      id: media.id,
+      mediaType: media.original.mimeType,
+      url: getMediaUrl(media.original.path),
+      width: media.original.metaData.width,
+      height: media.original.metaData.height,
+      ...(media.thumbnail
+        ? { posterUrl: getMediaUrl(media.thumbnail.path) }
+        : {}),
+      ...(media.description || media.original.fileName
+        ? { name: media.description || media.original.fileName }
+        : {})
+    })
+  }
+
+  return attachments
+}
 
 export const POST = traceApiRoute(
   'createStatus',
   OAuthGuard([Scope.enum.write], async (req, context) => {
     const { currentActor, database } = context
     try {
-      const content = await req.json()
+      const content = await getNoteRequestInput(req)
       const parsed = NoteSchema.safeParse(content)
       if (!parsed.success) {
         return apiResponse({
@@ -44,13 +170,26 @@ export const POST = traceApiRoute(
         })
       }
       const note = parsed.data
+      const attachments = await getAttachmentsFromMediaIds(
+        database,
+        currentActor,
+        note.media_ids
+      )
+      if (!attachments) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
       const status = await createNoteFromUserInput({
         currentActor,
         text: note.status,
         summary: note.spoiler_text,
         replyNoteId: note.in_reply_to_id,
         visibility: note.visibility,
-        attachments: [],
+        attachments,
         database
       })
       if (!status)

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
-import { getConfig } from '@/lib/config'
+import { getBaseURL } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
@@ -99,19 +99,7 @@ const getNoteRequestInput = async (req: Request): Promise<unknown> => {
   }
 }
 
-const getMediaUrl = (path: string) => {
-  const { host } = getConfig()
-  if (host.includes('://')) return `${host}/api/v1/files/${path}`
-
-  const protocol =
-    host.startsWith('localhost') ||
-    host.startsWith('127.0.0.1') ||
-    host.startsWith('::1') ||
-    host.startsWith('[::1]')
-      ? 'http'
-      : 'https'
-  return `${protocol}://${host}/api/v1/files/${path}`
-}
+const getMediaUrl = (path: string) => `${getBaseURL()}/api/v1/files/${path}`
 
 const getAttachmentsFromMediaIds = async (
   database: Database,
@@ -166,12 +154,13 @@ export const POST = traceApiRoute(
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
+          data: ERROR_422,
+          responseStatusCode: 422
         })
       }
       const note = parsed.data
-      if (note.media_ids.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
+      const mediaIds = [...new Set(note.media_ids)]
+      if (mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -182,7 +171,7 @@ export const POST = traceApiRoute(
       const attachments = await getAttachmentsFromMediaIds(
         database,
         currentActor,
-        note.media_ids
+        mediaIds
       )
       if (!attachments) {
         return apiResponse({

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@/lib/config'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import {
   ACCEPTED_FILE_TYPES,
   MAX_FILE_SIZE
@@ -36,7 +37,7 @@ export const GET = traceApiRoute(
           },
           statuses: {
             max_characters: 500,
-            max_media_attachments: 4,
+            max_media_attachments: MAX_STATUS_MEDIA_ATTACHMENTS,
             characters_reserved_per_url: 23
           },
           media_attachments: {

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_STATUS_MEDIA_ATTACHMENTS = 4


### PR DESCRIPTION
Summary:
- Parse Mastodon status media IDs from JSON and form submissions.
- Resolve account-owned media into post attachments for Mastodon and ActivityPub output.
- Cover JSON, form-style media_ids[], and cross-account rejection paths.

Tests:
- yarn run prettier --write .
- yarn lint (passes; existing no-explicit-any warnings remain in auth/fitness test code)
- yarn build
- yarn test (196 suites / 1557 tests passed)