### PR TITLE
feat: verify all inbox requests

### DIFF
--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -65,5 +65,5 @@ export const POST = traceApiRoute(
       data: DEFAULT_202,
       responseStatusCode: 202
     })
-  })
+  }, CORS_HEADERS)
 )

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -1,0 +1,133 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockCanFederateWithDomain = jest.fn()
+const mockCreateFollower = jest.fn()
+const mockVerifyAllows = jest.fn()
+const mockDatabase = {}
+
+jest.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: (...params: unknown[]) =>
+    mockCanFederateWithDomain(...params)
+}))
+
+jest.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
+  ActivityPubVerifySenderGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          params: Promise<{ username: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    async (
+      req: NextRequest,
+      context: { params: Promise<{ username: string }> }
+    ) => {
+      if (!(await mockVerifyAllows(req, context))) {
+        return Response.json({ status: 'Bad Request' }, { status: 400 })
+      }
+
+      return handle(req, {
+        database: mockDatabase,
+        params: context.params
+      })
+    }
+}))
+
+jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
+  OnlyLocalUserGuard:
+    (
+      handle: (
+        database: typeof mockDatabase,
+        actor: { id: string },
+        req: NextRequest,
+        query: { params: Promise<{ username: string }> }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, query: { params: Promise<{ username: string }> }) =>
+      handle(
+        mockDatabase,
+        { id: 'https://activities.local/users/llun' },
+        req,
+        query
+      )
+}))
+
+jest.mock('@/lib/actions/acceptFollowRequest', () => ({
+  acceptFollowRequest: jest.fn()
+}))
+
+jest.mock('@/lib/actions/createFollower', () => ({
+  createFollower: (...params: unknown[]) => mockCreateFollower(...params)
+}))
+
+jest.mock('@/lib/actions/like', () => ({
+  likeRequest: jest.fn()
+}))
+
+jest.mock('@/lib/actions/rejectFollowRequest', () => ({
+  rejectFollowRequest: jest.fn()
+}))
+
+jest.mock('@/lib/actions/undoFollowRequest', () => ({
+  undoFollowRequest: jest.fn()
+}))
+
+const createFollowRequest = () =>
+  new NextRequest('https://activities.local/api/users/llun/inbox', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: 'https://remote.test/users/alice/follows/1',
+      type: 'Follow',
+      actor: 'https://remote.test/users/alice',
+      object: 'https://activities.local/users/llun'
+    })
+  })
+
+describe('POST /api/users/[username]/inbox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockVerifyAllows.mockResolvedValue(true)
+    mockCanFederateWithDomain.mockResolvedValue(true)
+    mockCreateFollower.mockResolvedValue({
+      object: 'https://activities.local/users/llun'
+    })
+  })
+
+  it('rejects requests before processing when sender verification fails', async () => {
+    mockVerifyAllows.mockResolvedValue(false)
+
+    const response = await POST(createFollowRequest(), {
+      params: Promise.resolve({ username: 'llun' })
+    })
+
+    expect(response.status).toBe(400)
+    expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
+    expect(mockCreateFollower).not.toHaveBeenCalled()
+  })
+
+  it('processes verified actor inbox requests', async () => {
+    const response = await POST(createFollowRequest(), {
+      params: Promise.resolve({ username: 'llun' })
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockVerifyAllows).toHaveBeenCalled()
+    expect(mockCanFederateWithDomain).toHaveBeenCalledWith(
+      mockDatabase,
+      'https://remote.test/users/alice'
+    )
+    expect(mockCreateFollower).toHaveBeenCalledWith({
+      database: mockDatabase,
+      followRequest: expect.objectContaining({
+        actor: 'https://remote.test/users/alice',
+        type: 'Follow'
+      })
+    })
+  })
+})

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -19,6 +19,7 @@ import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   DEFAULT_202,
   ERROR_400,
+  ERROR_403,
   ERROR_404,
   apiResponse,
   defaultOptions
@@ -51,7 +52,7 @@ export const POST = traceApiRoute(
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,
-              data: { status: 'Forbidden' },
+              data: ERROR_403,
               responseStatusCode: 403
             })
           }

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -9,7 +9,11 @@ import { FollowRequest } from '@/lib/activities/followAction'
 import { UndoFollow } from '@/lib/activities/undoFollow'
 import { UndoLike } from '@/lib/activities/undoLike'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
-import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
+import { ActivityPubVerifySenderGuard } from '@/lib/services/guards/ActivityPubVerifyGuard'
+import {
+  OnlyLocalUserGuard,
+  OnlyLocalUserGuardParams
+} from '@/lib/services/guards/OnlyLocalUserGuard'
 import { Accept, Follow, Like, Reject, Undo } from '@/lib/types/activitypub'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -28,88 +32,34 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const POST = traceApiRoute(
   'actorInbox',
-  OnlyLocalUserGuard(async (database, _, req) => {
-    try {
-      const activity = Activity.parse(await req.json())
-      if (!(await canFederateWithDomain(database, activity.actor))) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: { status: 'Forbidden' },
-          responseStatusCode: 403
-        })
-      }
+  ActivityPubVerifySenderGuard<OnlyLocalUserGuardParams>(
+    (req, context) =>
+      OnlyLocalUserGuard(async (database, _, req) => {
+        try {
+          const parsed = Activity.safeParse(await req.json())
+          if (!parsed.success) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_400,
+              responseStatusCode: 400
+            })
+          }
 
-      switch (activity.type) {
-        case 'Accept': {
-          const follow = await acceptFollowRequest({ activity, database })
-          if (!follow)
+          const activity = parsed.data
+          if (!(await canFederateWithDomain(database, activity.actor))) {
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,
-              data: ERROR_404,
-              responseStatusCode: 404
+              data: { status: 'Forbidden' },
+              responseStatusCode: 403
             })
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: DEFAULT_202,
-            responseStatusCode: 202
-          })
-        }
-        case 'Reject': {
-          const follow = await rejectFollowRequest({ activity, database })
-          if (!follow)
-            return apiResponse({
-              req,
-              allowedMethods: CORS_HEADERS,
-              data: ERROR_404,
-              responseStatusCode: 404
-            })
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: DEFAULT_202,
-            responseStatusCode: 202
-          })
-        }
-        case 'Follow': {
-          const follow = await createFollower({
-            followRequest: activity as FollowRequest,
-            database
-          })
-          if (!follow)
-            return apiResponse({
-              req,
-              allowedMethods: CORS_HEADERS,
-              data: ERROR_404,
-              responseStatusCode: 404
-            })
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: { target: follow.object },
-            responseStatusCode: 202
-          })
-        }
-        case 'Like': {
-          await likeRequest({ activity, database })
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: DEFAULT_202,
-            responseStatusCode: 202
-          })
-        }
-        case 'Undo': {
-          const undoRequest = activity as UndoFollow | UndoLike
-          switch (undoRequest.object.type) {
-            case 'Follow': {
-              const result = await undoFollowRequest({
-                database,
-                request: undoRequest as UndoFollow
-              })
-              if (!result)
+          }
+
+          switch (activity.type) {
+            case 'Accept': {
+              const follow = await acceptFollowRequest({ activity, database })
+              if (!follow)
                 return apiResponse({
                   req,
                   allowedMethods: CORS_HEADERS,
@@ -119,18 +69,47 @@ export const POST = traceApiRoute(
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,
-                data: { target: undoRequest.object.object },
+                data: DEFAULT_202,
+                responseStatusCode: 202
+              })
+            }
+            case 'Reject': {
+              const follow = await rejectFollowRequest({ activity, database })
+              if (!follow)
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: ERROR_404,
+                  responseStatusCode: 404
+                })
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: DEFAULT_202,
+                responseStatusCode: 202
+              })
+            }
+            case 'Follow': {
+              const follow = await createFollower({
+                followRequest: activity as FollowRequest,
+                database
+              })
+              if (!follow)
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: ERROR_404,
+                  responseStatusCode: 404
+                })
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: { target: follow.object },
                 responseStatusCode: 202
               })
             }
             case 'Like': {
-              await database.deleteLike({
-                actorId: undoRequest.object.actor,
-                statusId:
-                  typeof undoRequest.object.object === 'string'
-                    ? undoRequest.object.object
-                    : undoRequest.object.object.id
-              })
+              await likeRequest({ activity, database })
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,
@@ -138,31 +117,70 @@ export const POST = traceApiRoute(
                 responseStatusCode: 202
               })
             }
-            default: {
+            case 'Undo': {
+              const undoRequest = activity as UndoFollow | UndoLike
+              switch (undoRequest.object.type) {
+                case 'Follow': {
+                  const result = await undoFollowRequest({
+                    database,
+                    request: undoRequest as UndoFollow
+                  })
+                  if (!result)
+                    return apiResponse({
+                      req,
+                      allowedMethods: CORS_HEADERS,
+                      data: ERROR_404,
+                      responseStatusCode: 404
+                    })
+                  return apiResponse({
+                    req,
+                    allowedMethods: CORS_HEADERS,
+                    data: { target: undoRequest.object.object },
+                    responseStatusCode: 202
+                  })
+                }
+                case 'Like': {
+                  await database.deleteLike({
+                    actorId: undoRequest.object.actor,
+                    statusId:
+                      typeof undoRequest.object.object === 'string'
+                        ? undoRequest.object.object
+                        : undoRequest.object.object.id
+                  })
+                  return apiResponse({
+                    req,
+                    allowedMethods: CORS_HEADERS,
+                    data: DEFAULT_202,
+                    responseStatusCode: 202
+                  })
+                }
+                default: {
+                  return apiResponse({
+                    req,
+                    allowedMethods: CORS_HEADERS,
+                    data: DEFAULT_202,
+                    responseStatusCode: 202
+                  })
+                }
+              }
+            }
+            default:
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,
                 data: DEFAULT_202,
                 responseStatusCode: 202
               })
-            }
           }
-        }
-        default:
+        } catch {
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,
-            data: DEFAULT_202,
-            responseStatusCode: 202
+            data: ERROR_400,
+            responseStatusCode: 400
           })
-      }
-    } catch {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_400,
-        responseStatusCode: 400
-      })
-    }
-  })
+        }
+      })(req, context),
+    CORS_HEADERS
+  )
 )

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -1,0 +1,83 @@
+import { NextRequest } from 'next/server'
+
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+
+import { ActivityPubVerifySenderGuard } from './ActivityPubVerifyGuard'
+
+const mockDatabase = {}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('ActivityPubVerifySenderGuard', () => {
+  it('returns CORS headers on verification errors when methods are provided', async () => {
+    const handler = jest.fn()
+    const guard = ActivityPubVerifySenderGuard(handler, [
+      HttpMethod.enum.OPTIONS,
+      HttpMethod.enum.POST
+    ])
+
+    const response = await guard(
+      new NextRequest('https://activities.local/api/inbox', {
+        method: 'POST',
+        headers: {
+          host: 'activities.local',
+          origin: 'https://remote.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://remote.test'
+    )
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe(
+      'OPTIONS,POST'
+    )
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('rejects stale signed dates', async () => {
+    const handler = jest.fn()
+    const guard = ActivityPubVerifySenderGuard(handler)
+
+    const response = await guard(
+      new NextRequest('https://activities.local/api/inbox', {
+        method: 'POST',
+        headers: {
+          date: 'Wed, 09 Nov 2022 18:28:37 GMT',
+          signature:
+            'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="signature"'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('rejects mismatched signed digest headers', async () => {
+    const handler = jest.fn()
+    const guard = ActivityPubVerifySenderGuard(handler)
+
+    const response = await guard(
+      new NextRequest('https://activities.local/api/inbox', {
+        method: 'POST',
+        headers: {
+          date: new Date().toUTCString(),
+          digest: 'SHA-256=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+          signature:
+            'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="signature"'
+        },
+        body: JSON.stringify({ type: 'Follow' })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -1,16 +1,46 @@
 import { NextRequest } from 'next/server'
+import crypto from 'node:crypto'
 
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 
 import { ActivityPubVerifySenderGuard } from './ActivityPubVerifyGuard'
 
+const mockCanFederateWithDomain = jest.fn()
 const mockDatabase = {}
+const mockGetSenderPublicKey = jest.fn()
+const mockVerify = jest.fn()
 
 jest.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
 }))
 
+jest.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: (...params: unknown[]) =>
+    mockCanFederateWithDomain(...params)
+}))
+
+jest.mock('@/lib/services/guards/getSenderPublicKey', () => ({
+  getSenderPublicKey: (...params: unknown[]) =>
+    mockGetSenderPublicKey(...params)
+}))
+
+jest.mock('@/lib/utils/signature', () => {
+  const actual = jest.requireActual('@/lib/utils/signature')
+
+  return {
+    ...actual,
+    verify: (...params: unknown[]) => mockVerify(...params)
+  }
+})
+
 describe('ActivityPubVerifySenderGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCanFederateWithDomain.mockResolvedValue(true)
+    mockGetSenderPublicKey.mockResolvedValue('public-key')
+    mockVerify.mockResolvedValue(true)
+  })
+
   it('returns CORS headers on verification errors when methods are provided', async () => {
     const handler = jest.fn()
     const guard = ActivityPubVerifySenderGuard(handler, [
@@ -79,5 +109,29 @@ describe('ActivityPubVerifySenderGuard', () => {
 
     expect(response.status).toBe(400)
     expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('accepts a matching sha-256 value from a multi-value signed digest header', async () => {
+    const handler = jest.fn().mockResolvedValue(Response.json({ ok: true }))
+    const guard = ActivityPubVerifySenderGuard(handler)
+    const body = JSON.stringify({ type: 'Follow' })
+    const digest = crypto.createHash('sha256').update(body).digest('base64')
+
+    const response = await guard(
+      new NextRequest('https://activities.local/api/inbox', {
+        method: 'POST',
+        headers: {
+          date: new Date().toUTCString(),
+          digest: `SHA-512=ignored, SHA-256=${digest}`,
+          signature:
+            'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="signature"'
+        },
+        body
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(handler).toHaveBeenCalled()
   })
 })

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -89,6 +89,28 @@ describe('ActivityPubVerifySenderGuard', () => {
     expect(handler).not.toHaveBeenCalled()
   })
 
+  it('rejects POST requests without a digest header', async () => {
+    const handler = jest.fn()
+    const guard = ActivityPubVerifySenderGuard(handler)
+
+    const response = await guard(
+      new NextRequest('https://activities.local/api/inbox', {
+        method: 'POST',
+        headers: {
+          date: new Date().toUTCString(),
+          signature:
+            'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="signature"'
+        },
+        body: JSON.stringify({ type: 'Follow' })
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(handler).not.toHaveBeenCalled()
+    expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
+  })
+
   it('rejects mismatched signed digest headers', async () => {
     const handler = jest.fn()
     const guard = ActivityPubVerifySenderGuard(handler)

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -1,28 +1,111 @@
+import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
-import { apiErrorResponse } from '@/lib/utils/response'
+import { getHeadersValue } from '@/lib/services/guards/getHeaderValue'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  StatusCode,
+  apiErrorResponse,
+  apiResponse,
+  codeMap
+} from '@/lib/utils/response'
 import { parse, verify } from '@/lib/utils/signature'
 
 import { getSenderPublicKey } from './getSenderPublicKey'
 import { headerHost } from './headerHost'
 import { ActivityPubVerifiedSenderHandle, AppRouterParams } from './types'
 
+const SIGNATURE_CLOCK_SKEW_MS = 12 * 60 * 60 * 1000
+
+const guardErrorResponse = (
+  request: NextRequest,
+  statusCode: StatusCode,
+  allowedMethods?: HttpMethod[]
+) => {
+  if (!allowedMethods) return apiErrorResponse(statusCode)
+
+  return apiResponse({
+    req: request,
+    allowedMethods,
+    data: codeMap[statusCode],
+    responseStatusCode: statusCode
+  })
+}
+
+const getSignedHeaders = (signatureParts: Record<string, string>) =>
+  (signatureParts.headers ?? '').toLowerCase().split(/\s+/).filter(Boolean)
+
+const isDateHeaderFresh = (
+  headers: Headers,
+  signedHeaders: string[],
+  now = Date.now()
+) => {
+  if (!signedHeaders.includes('date')) return false
+
+  const dateHeader = getHeadersValue(headers, 'date')
+  if (!dateHeader || Array.isArray(dateHeader)) return false
+
+  const signedAt = Date.parse(dateHeader)
+  if (Number.isNaN(signedAt)) return false
+
+  return Math.abs(now - signedAt) <= SIGNATURE_CLOCK_SKEW_MS
+}
+
+const digestMatches = async (request: NextRequest, signedHeaders: string[]) => {
+  const digestHeader = getHeadersValue(request.headers, 'digest')
+  if (!digestHeader) return true
+  if (Array.isArray(digestHeader)) return false
+  if (!signedHeaders.includes('digest')) return false
+
+  const separatorIndex = digestHeader.indexOf('=')
+  if (separatorIndex === -1) return false
+
+  const algorithm = digestHeader.slice(0, separatorIndex).toLowerCase()
+  const expectedDigest = digestHeader.slice(separatorIndex + 1)
+  if (algorithm !== 'sha-256') return false
+
+  const body = await request.clone().text()
+  const actualDigest = crypto.createHash('sha256').update(body).digest('base64')
+
+  const actualDigestBuffer = Buffer.from(actualDigest, 'base64')
+  const expectedDigestBuffer = Buffer.from(expectedDigest, 'base64')
+
+  if (actualDigestBuffer.length !== expectedDigestBuffer.length) return false
+
+  return crypto.timingSafeEqual(actualDigestBuffer, expectedDigestBuffer)
+}
+
 export const ActivityPubVerifySenderGuard =
-  <P>(handle: ActivityPubVerifiedSenderHandle<P>) =>
+  <P>(
+    handle: ActivityPubVerifiedSenderHandle<P>,
+    allowedMethods?: HttpMethod[]
+  ) =>
   async (request: NextRequest, context: AppRouterParams<P>) => {
     const database = getDatabase()
-    if (!database) return apiErrorResponse(500)
+    if (!database) return guardErrorResponse(request, 500, allowedMethods)
 
     const requestSignature = request.headers.get('signature')
-    if (!requestSignature) return apiErrorResponse(400)
+    if (!requestSignature)
+      return guardErrorResponse(request, 400, allowedMethods)
 
     const signatureParts = await parse(requestSignature)
-    if (!signatureParts.keyId) return apiErrorResponse(400)
+    if (!signatureParts.keyId) {
+      return guardErrorResponse(request, 400, allowedMethods)
+    }
+    const signedHeaders = getSignedHeaders(signatureParts)
+
+    if (!isDateHeaderFresh(request.headers, signedHeaders)) {
+      return guardErrorResponse(request, 400, allowedMethods)
+    }
+
+    if (!(await digestMatches(request, signedHeaders))) {
+      return guardErrorResponse(request, 400, allowedMethods)
+    }
 
     if (!(await canFederateWithDomain(database, signatureParts.keyId))) {
-      return apiErrorResponse(403)
+      return guardErrorResponse(request, 403, allowedMethods)
     }
 
     const host = headerHost(request.headers)
@@ -35,7 +118,7 @@ export const ActivityPubVerifySenderGuard =
         publicKey
       ))
     ) {
-      return apiErrorResponse(400)
+      return guardErrorResponse(request, 400, allowedMethods)
     }
 
     return handle(request, { database, params: context.params })

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -71,7 +71,8 @@ const isDateHeaderFresh = (
 
 const digestMatches = async (request: NextRequest, signedHeaders: string[]) => {
   const digestHeader = getHeadersValue(request.headers, 'digest')
-  if (!digestHeader) return true
+  if (!digestHeader)
+    return ['GET', 'HEAD'].includes(request.method.toUpperCase())
   if (Array.isArray(digestHeader)) return false
   if (!signedHeaders.includes('digest')) return false
 

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto'
 import { NextRequest } from 'next/server'
+import crypto from 'node:crypto'
 
 import { getDatabase } from '@/lib/database'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
@@ -17,7 +17,7 @@ import { getSenderPublicKey } from './getSenderPublicKey'
 import { headerHost } from './headerHost'
 import { ActivityPubVerifiedSenderHandle, AppRouterParams } from './types'
 
-const SIGNATURE_CLOCK_SKEW_MS = 12 * 60 * 60 * 1000
+const SIGNATURE_CLOCK_SKEW_MS = 5 * 60 * 1000
 
 const guardErrorResponse = (
   request: NextRequest,
@@ -36,6 +36,22 @@ const guardErrorResponse = (
 
 const getSignedHeaders = (signatureParts: Record<string, string>) =>
   (signatureParts.headers ?? '').toLowerCase().split(/\s+/).filter(Boolean)
+
+const getExpectedSha256Digest = (digestHeader: string) =>
+  digestHeader
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const separatorIndex = part.indexOf('=')
+      if (separatorIndex === -1) return null
+
+      return {
+        algorithm: part.slice(0, separatorIndex).trim().toLowerCase(),
+        value: part.slice(separatorIndex + 1).trim()
+      }
+    })
+    .find((part) => part?.algorithm === 'sha-256')?.value
 
 const isDateHeaderFresh = (
   headers: Headers,
@@ -59,15 +75,14 @@ const digestMatches = async (request: NextRequest, signedHeaders: string[]) => {
   if (Array.isArray(digestHeader)) return false
   if (!signedHeaders.includes('digest')) return false
 
-  const separatorIndex = digestHeader.indexOf('=')
-  if (separatorIndex === -1) return false
+  const expectedDigest = getExpectedSha256Digest(digestHeader)
+  if (!expectedDigest) return false
 
-  const algorithm = digestHeader.slice(0, separatorIndex).toLowerCase()
-  const expectedDigest = digestHeader.slice(separatorIndex + 1)
-  if (algorithm !== 'sha-256') return false
-
-  const body = await request.clone().text()
-  const actualDigest = crypto.createHash('sha256').update(body).digest('base64')
+  const bodyBuffer = Buffer.from(await request.clone().arrayBuffer())
+  const actualDigest = crypto
+    .createHash('sha256')
+    .update(bodyBuffer)
+    .digest('base64')
 
   const actualDigestBuffer = Buffer.from(actualDigest, 'base64')
   const expectedDigestBuffer = Buffer.from(expectedDigest, 'base64')


### PR DESCRIPTION
## Summary
- require ActivityPub sender verification on actor-specific inbox requests
- add Date freshness and Digest body validation to the inbox verification guard
- return CORS-aware guard errors for CORS-enabled inbox routes
- add focused coverage for actor inbox guard enforcement and guard error behavior

## Validation
- yarn run prettier --write .
- yarn lint (0 errors; existing no-explicit-any warnings remain)
- yarn build
- yarn test