### PR TITLE
feat: support signed authorized fetches

### DIFF
--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -48,7 +48,10 @@ export const POST = traceApiRoute(
     }
 
     // Check if target actor exists
-    const person = await getActorPerson({ actorId: targetActorId })
+    const person = await getActorPerson({
+      actorId: targetActorId,
+      signingActor: currentActor
+    })
     if (!person)
       return apiResponse({
         req,

--- a/app/api/v1/accounts/follow/route.ts
+++ b/app/api/v1/accounts/follow/route.ts
@@ -66,7 +66,10 @@ export const POST = traceApiRoute(
       })
     }
 
-    const person = await getActorPerson({ actorId: target })
+    const person = await getActorPerson({
+      actorId: target,
+      signingActor: currentActor
+    })
     if (!person)
       return apiResponse({
         req,

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -6,6 +6,7 @@ import { Actor } from '@/lib/types/domain/actor'
 interface RecordActorIfNeededParams {
   actorId: string
   database: Database
+  signingActor?: Actor
 }
 
 export class BlockedFederationDomainError extends Error {
@@ -26,7 +27,8 @@ export const assertActorCanFederate = async ({
 
 export const recordActorIfNeeded = async ({
   actorId,
-  database
+  database,
+  signingActor
 }: RecordActorIfNeededParams): Promise<Actor | undefined> => {
   await assertActorCanFederate({ actorId, database })
 
@@ -38,7 +40,7 @@ export const recordActorIfNeeded = async ({
     return existingActor
   }
   if (!existingActor) {
-    const person = await getActorPerson({ actorId })
+    const person = await getActorPerson({ actorId, signingActor })
     if (!person) return
     const actor = await database.createActor({
       actorId,
@@ -57,7 +59,7 @@ export const recordActorIfNeeded = async ({
   const currentTime = Date.now()
   // Update actor if it's older than 3 day
   if (currentTime - existingActor.updatedAt > 3 * 86_400_000) {
-    const person = await getActorPerson({ actorId })
+    const person = await getActorPerson({ actorId, signingActor })
     if (!person) return undefined
     const actor = await database.updateActor({
       actorId,

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -43,8 +43,10 @@ export const recordActorIfNeeded = async ({
   }
 
   const getResolvedSigningActor = async () => {
-    const resolvedSigningActor =
-      signingActor ?? (await getFederationSigningActor(database))
+    const resolvedSigningActor = await getFederationSigningActor(
+      database,
+      signingActor
+    )
     if (!resolvedSigningActor) {
       logger.warn({
         message: 'Fetching remote actor without a federation signing actor',

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -1,7 +1,9 @@
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { Actor } from '@/lib/types/domain/actor'
+import { logger } from '@/lib/utils/logger'
 
 interface RecordActorIfNeededParams {
   actorId: string
@@ -39,8 +41,24 @@ export const recordActorIfNeeded = async ({
   if (existingActor?.privateKey) {
     return existingActor
   }
+
+  const getResolvedSigningActor = async () => {
+    const resolvedSigningActor =
+      signingActor ?? (await getFederationSigningActor(database))
+    if (!resolvedSigningActor) {
+      logger.warn({
+        message: 'Fetching remote actor without a federation signing actor',
+        actorId
+      })
+    }
+    return resolvedSigningActor
+  }
+
   if (!existingActor) {
-    const person = await getActorPerson({ actorId, signingActor })
+    const person = await getActorPerson({
+      actorId,
+      signingActor: await getResolvedSigningActor()
+    })
     if (!person) return
     const actor = await database.createActor({
       actorId,
@@ -59,7 +77,10 @@ export const recordActorIfNeeded = async ({
   const currentTime = Date.now()
   // Update actor if it's older than 3 day
   if (currentTime - existingActor.updatedAt > 3 * 86_400_000) {
-    const person = await getActorPerson({ actorId, signingActor })
+    const person = await getActorPerson({
+      actorId,
+      signingActor: await getResolvedSigningActor()
+    })
     if (!person) return undefined
     const actor = await database.updateActor({
       actorId,

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -27,7 +27,7 @@ export const getActorCollections = async ({
     url: string
   ): Record<string, string> => ({
     Accept: DEFAULT_ACCEPT,
-    ...(actor ? signedHeaders(actor, 'get', url) : {})
+    ...(actor ? signedHeaders(actor, 'GET', url) : {})
   })
 
   return getTracer().startActiveSpan(

--- a/lib/activities/getActorPerson.test.ts
+++ b/lib/activities/getActorPerson.test.ts
@@ -1,6 +1,7 @@
 import { enableFetchMocks } from 'jest-fetch-mock'
 
 import { mockRequests } from '@/lib/stub/activities'
+import { MockActor } from '@/lib/stub/actor'
 import { MockActivityPubPerson } from '@/lib/stub/person'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 
@@ -33,5 +34,23 @@ describe('#getActorPerson', () => {
       actorId: 'notexist'
     })
     expect(person).toBeNull()
+  })
+
+  it('signs GET requests when a signing actor is provided', async () => {
+    const remoteActorId = 'https://remote.test/users/signed'
+    const person = await getActorPerson({
+      actorId: remoteActorId,
+      signingActor: MockActor({ id: 'https://llun.test/users/local' })
+    })
+
+    expect(person).not.toBeNull()
+
+    const call = fetchMock.mock.calls.find(([url]) => url === remoteActorId)
+    expect(call).toBeDefined()
+    const request = call?.[1]
+    expect(request?.headers).toMatchObject({
+      host: 'remote.test',
+      signature: expect.stringContaining('headers="(request-target) host date"')
+    })
   })
 })

--- a/lib/activities/getActorPerson.ts
+++ b/lib/activities/getActorPerson.ts
@@ -23,7 +23,7 @@ export const getActorPerson: GetActorPersonFunction = ({
 
       // Add signed headers if a signing actor is provided
       if (signingActor) {
-        const signatureHeaders = signedHeaders(signingActor, 'get', actorId)
+        const signatureHeaders = signedHeaders(signingActor, 'GET', actorId)
         Object.assign(headers, signatureHeaders)
       }
 

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -56,7 +56,10 @@ export const getActorPosts: GetActorPostsFunction = async ({
             })
             if (localStatus) return localStatus
 
-            const note = await getNote({ statusId: item.object })
+            const note = await getNote({
+              statusId: item.object,
+              signingActor
+            })
             if (!note) return null
             const originalStatus = fromNote(note)
             if (actor) originalStatus.actor = actor

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -42,9 +42,11 @@ import { getTracer } from '@/lib/utils/trace'
 
 interface GetNoteParams {
   statusId: string
+  signingActor?: Actor
 }
 export const getNote = async ({
-  statusId
+  statusId,
+  signingActor
 }: GetNoteParams): Promise<Note | null> =>
   getTracer().startActiveSpan(
     'activities.getNote',
@@ -53,7 +55,12 @@ export const getNote = async ({
       try {
         const { statusCode, body } = await request({
           url: statusId,
-          headers: { Accept: DEFAULT_ACCEPT }
+          headers: {
+            Accept: DEFAULT_ACCEPT,
+            ...(signingActor
+              ? signedHeaders(signingActor, 'get', statusId)
+              : {})
+          }
         })
         if (statusCode !== 200) return null
         return JSON.parse(body)
@@ -409,7 +416,10 @@ export const follow = async (
         actor: currentActor.id,
         object: targetActorId
       }
-      const person = await getActorPerson({ actorId: targetActorId })
+      const person = await getActorPerson({
+        actorId: targetActorId,
+        signingActor: currentActor
+      })
       const targetInbox = person?.inbox
       if (!targetInbox) {
         span.end()
@@ -467,7 +477,10 @@ export const unfollow = async (currentActor: Actor, follow: Follow) =>
         }
       }
 
-      const person = await getActorPerson({ actorId: follow.targetActorId })
+      const person = await getActorPerson({
+        actorId: follow.targetActorId,
+        signingActor: currentActor
+      })
       const targetInbox = person?.inbox ?? `${follow.targetActorId}/inbox`
 
       const method = 'POST'

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -58,7 +58,7 @@ export const getNote = async ({
           headers: {
             Accept: DEFAULT_ACCEPT,
             ...(signingActor
-              ? signedHeaders(signingActor, 'get', statusId)
+              ? signedHeaders(signingActor, 'GET', statusId)
               : {})
           }
         })
@@ -111,12 +111,7 @@ export const sendNote = async ({ currentActor, inbox, note }: SendNoteParams) =>
           url: inbox,
           method,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              inbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, inbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           body: JSON.stringify(activity)
@@ -177,12 +172,7 @@ export const sendUpdateNote = async ({
           url: inbox,
           method,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              inbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, inbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           body: JSON.stringify(activity)
@@ -241,12 +231,7 @@ export const sendAnnounce = async ({
         await request({
           url: inbox,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              inbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, inbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           method,
@@ -302,12 +287,7 @@ export const deleteStatus = async ({
         await request({
           url: inbox,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              inbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, inbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           method,
@@ -369,12 +349,7 @@ export const undoAnnounce = async ({
           url: inbox,
           method,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              inbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, inbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           body: JSON.stringify(activity)
@@ -432,12 +407,7 @@ export const follow = async (
           url: targetInbox,
           method,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              targetInbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, targetInbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           body: JSON.stringify(activity)
@@ -488,12 +458,7 @@ export const unfollow = async (currentActor: Actor, follow: Follow) =>
         const { statusCode } = await request({
           url: targetInbox,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              targetInbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, targetInbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           method,
@@ -543,12 +508,7 @@ export const acceptFollow = async (
           url: followingInbox,
           method,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              followingInbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, followingInbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           body: JSON.stringify(activity)
@@ -597,12 +557,7 @@ export const rejectFollow = async (
           url: followingInbox,
           method,
           headers: {
-            ...signedHeaders(
-              currentActor,
-              method.toLowerCase(),
-              followingInbox,
-              activity
-            ),
+            ...signedHeaders(currentActor, method, followingInbox, activity),
             Accept: DEFAULT_ACCEPT
           },
           body: JSON.stringify(activity)
@@ -648,7 +603,7 @@ export const sendLike = async ({ currentActor, status }: LikeParams) =>
           headers: {
             ...signedHeaders(
               currentActor,
-              method.toLowerCase(),
+              method,
               status.actor.inboxUrl,
               activity
             ),
@@ -697,7 +652,7 @@ export const sendUndoLike = async ({ currentActor, status }: UndoLikeParams) =>
           headers: {
             ...signedHeaders(
               currentActor,
-              method.toLowerCase(),
+              method,
               status.actor.inboxUrl,
               activity
             ),
@@ -775,7 +730,7 @@ export const sendPollVotes = async ({
             headers: {
               ...signedHeaders(
                 currentActor,
-                method.toLowerCase(),
+                method,
                 status.actor.inboxUrl,
                 activity
               ),

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -2,11 +2,14 @@ import crypto from 'crypto'
 
 import {
   databaseBeforeAll,
-  getTestDatabaseTable
+  getTestDatabaseTable,
+  getTestSQLDatabase
 } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
 import {
   EXTERNAL_ACTORS,
   TEST_DOMAIN,
+  TEST_DOMAIN_2,
   TEST_EMAIL,
   TEST_PASSWORD_HASH,
   TEST_USERNAME3
@@ -14,6 +17,40 @@ import {
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const createSigningAccount = async (
+  database: Database,
+  username: string,
+  {
+    domain = TEST_DOMAIN,
+    privateKey = `privateKey-${username}`,
+    publicKey = `publicKey-${username}`
+  }: {
+    domain?: string
+    privateKey?: string
+    publicKey?: string
+  } = {}
+) =>
+  database.createAccount({
+    email: `${username}@${domain}`,
+    username,
+    passwordHash: TEST_PASSWORD_HASH,
+    domain,
+    privateKey,
+    publicKey
+  })
 
 describe('ActorDatabase', () => {
   const table = getTestDatabaseTable()
@@ -120,6 +157,57 @@ describe('ActorDatabase', () => {
           publicKey: expect.toBeString()
         })
         expect(actor?.account).toBeDefined()
+      })
+
+      it('returns null when no local actor has a private key', async () => {
+        await withFreshDatabase(async (database) => {
+          await database.createActor({
+            actorId: EXTERNAL_ACTORS[0].id,
+            username: EXTERNAL_ACTORS[0].username,
+            domain: EXTERNAL_ACTORS[0].domain,
+            followersUrl: EXTERNAL_ACTORS[0].followers_url,
+            inboxUrl: EXTERNAL_ACTORS[0].inbox_url,
+            sharedInboxUrl: EXTERNAL_ACTORS[0].inbox_url,
+            publicKey: 'publicKey',
+            createdAt: Date.now()
+          })
+
+          await createSigningAccount(database, 'empty-key-signer', {
+            privateKey: ''
+          })
+          await createSigningAccount(database, 'wrong-domain-signer', {
+            domain: TEST_DOMAIN_2
+          })
+
+          await expect(database.getFederationSigningActor()).resolves.toBeNull()
+        })
+      })
+
+      it('skips actors scheduled for deletion', async () => {
+        await withFreshDatabase(async (database) => {
+          const username = 'deleting-signer'
+          await createSigningAccount(database, username)
+          await database.scheduleActorDeletion({
+            actorId: `https://${TEST_DOMAIN}/users/${username}`,
+            scheduledAt: null
+          })
+
+          await expect(database.getFederationSigningActor()).resolves.toBeNull()
+        })
+      })
+
+      it('deterministically returns the oldest eligible actor', async () => {
+        await withFreshDatabase(async (database) => {
+          await createSigningAccount(database, 'older-signer')
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          await createSigningAccount(database, 'newer-signer')
+
+          const first = await database.getFederationSigningActor()
+          const second = await database.getFederationSigningActor()
+
+          expect(first?.id).toBe(`https://${TEST_DOMAIN}/users/older-signer`)
+          expect(second?.id).toBe(first?.id)
+        })
       })
     })
 

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -110,6 +110,19 @@ describe('ActorDatabase', () => {
       })
     })
 
+    describe('#getFederationSigningActor', () => {
+      it('returns a local actor with a private key', async () => {
+        const actor = await database.getFederationSigningActor()
+
+        expect(actor).toMatchObject({
+          domain: TEST_DOMAIN,
+          privateKey: expect.toBeString(),
+          publicKey: expect.toBeString()
+        })
+        expect(actor?.account).toBeDefined()
+      })
+    })
+
     describe('mastodon actor', () => {
       it('returns mastodon actor from id', async () => {
         const actor = await database.getMastodonActorFromId({

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex'
 
+import { getConfig } from '@/lib/config'
 import {
   CounterKey,
   decreaseCounterValue,
@@ -88,6 +89,11 @@ const parseStatusContent = (
 }
 
 const getStatusUrlHash = (url: string): string => getHashFromString(url)
+
+const getConfiguredActorDomain = () => {
+  const host = getConfig().host
+  return host.includes('://') ? new URL(host).host : host
+}
 
 export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
   async createActor({
@@ -266,11 +272,13 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
   async getFederationSigningActor() {
     const persistedActor = await database<SQLActor>('actors')
+      .where('domain', getConfiguredActorDomain())
       .whereNotNull('accountId')
       .whereNotNull('privateKey')
       .where('privateKey', '<>', '')
       .whereNull('deletionStatus')
       .orderBy('createdAt', 'asc')
+      .orderBy('id', 'asc')
       .first<{ id: string }>('id')
     if (!persistedActor) return null
 

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -264,6 +264,19 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     )
   },
 
+  async getFederationSigningActor() {
+    const persistedActor = await database<SQLActor>('actors')
+      .whereNotNull('accountId')
+      .whereNotNull('privateKey')
+      .where('privateKey', '<>', '')
+      .whereNull('deletionStatus')
+      .orderBy('createdAt', 'asc')
+      .first<{ id: string }>('id')
+    if (!persistedActor) return null
+
+    return this.getActorFromId({ id: persistedActor.id })
+  },
+
   async getMastodonActorFromUsername({
     username,
     domain

--- a/lib/jobs/createAnnounceJob.ts
+++ b/lib/jobs/createAnnounceJob.ts
@@ -9,6 +9,7 @@ import {
   CREATE_ANNOUNCE_JOB_NAME,
   CREATE_NOTE_JOB_NAME
 } from '@/lib/jobs/names'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Announce } from '@/lib/types/activitypub'
@@ -32,13 +33,14 @@ export const createAnnounceJob: JobHandle = createJobHandle(
     }
 
     await assertActorCanFederate({ actorId: status.actor, database })
+    const signingActor = await getFederationSigningActor(database)
 
     const existingStatus = await database.getStatus({
       statusId: object,
       withReplies: false
     })
     if (!existingStatus) {
-      const boostedStatus = await getNote({ statusId: object })
+      const boostedStatus = await getNote({ statusId: object, signingActor })
       if (!boostedStatus) {
         return
       }
@@ -56,7 +58,7 @@ export const createAnnounceJob: JobHandle = createJobHandle(
       return
     }
     const [, announce] = await Promise.all([
-      recordActorIfNeeded({ actorId: status.actor, database }),
+      recordActorIfNeeded({ actorId: status.actor, database, signingActor }),
       database.createAnnounce({
         id: status.id,
         actorId: status.actor,

--- a/lib/jobs/fetchRemoteStatusJob.test.ts
+++ b/lib/jobs/fetchRemoteStatusJob.test.ts
@@ -202,4 +202,91 @@ describe('fetchRemoteStatusJob', () => {
     expect(reply).toBeDefined()
     expect(reply?.reply).toBe(STATUS_ID)
   })
+
+  it('uses signed GET requests for remote status, actor, and replies fetches', async () => {
+    const STATUS_ID = `${REMOTE_STATUS_ID}/signed`
+    const REMOTE_SIGNED_ACTOR_ID =
+      'https://mastodon.social/users/signedFetchUser'
+    const REPLIES_ID = `${STATUS_ID}/replies`
+    const REPLY_ITEM_ID =
+      'https://mastodon.social/users/otherUser/statuses/signed-reply'
+    const signedFetches: string[] = []
+
+    fetchMock.mockResponse(async (req) => {
+      if (
+        req.url === STATUS_ID ||
+        req.url === REMOTE_SIGNED_ACTOR_ID ||
+        req.url === REPLIES_ID ||
+        req.url === REPLY_ITEM_ID
+      ) {
+        expect(req.headers.get('signature')).toContain(
+          'headers="(request-target) host date"'
+        )
+        signedFetches.push(req.url)
+      }
+
+      if (req.url === REMOTE_SIGNED_ACTOR_ID) {
+        return JSON.stringify({
+          ...MOCK_ACTOR,
+          id: REMOTE_SIGNED_ACTOR_ID,
+          preferredUsername: 'signedFetchUser',
+          inbox: `${REMOTE_SIGNED_ACTOR_ID}/inbox`,
+          outbox: `${REMOTE_SIGNED_ACTOR_ID}/outbox`,
+          publicKey: {
+            ...MOCK_ACTOR.publicKey,
+            id: `${REMOTE_SIGNED_ACTOR_ID}#main-key`,
+            owner: REMOTE_SIGNED_ACTOR_ID
+          }
+        })
+      }
+      if (req.url === STATUS_ID) {
+        return JSON.stringify({
+          id: STATUS_ID,
+          type: 'Note',
+          attributedTo: REMOTE_SIGNED_ACTOR_ID,
+          content: 'Signed Main Post',
+          to: [PUBLIC_STREAM],
+          replies: REPLIES_ID,
+          published: new Date().toISOString()
+        })
+      }
+      if (req.url === REPLIES_ID) {
+        return JSON.stringify({
+          id: REPLIES_ID,
+          type: 'Collection',
+          first: {
+            type: 'CollectionPage',
+            items: [REPLY_ITEM_ID]
+          }
+        })
+      }
+      if (req.url === REPLY_ITEM_ID) {
+        return JSON.stringify({
+          id: REPLY_ITEM_ID,
+          type: 'Note',
+          attributedTo: REMOTE_SIGNED_ACTOR_ID,
+          content: 'A signed reply',
+          inReplyTo: STATUS_ID,
+          to: [PUBLIC_STREAM],
+          published: new Date().toISOString()
+        })
+      }
+      return JSON.stringify({})
+    })
+
+    await fetchRemoteStatusJob(database, {
+      id: 'job-id',
+      name: FETCH_REMOTE_STATUS_JOB_NAME,
+      data: { statusId: STATUS_ID }
+    })
+
+    expect(signedFetches).toEqual(
+      expect.arrayContaining([
+        STATUS_ID,
+        REMOTE_SIGNED_ACTOR_ID,
+        REPLIES_ID,
+        REPLY_ITEM_ID
+      ])
+    )
+  })
 })

--- a/lib/jobs/fetchRemoteStatusJob.test.ts
+++ b/lib/jobs/fetchRemoteStatusJob.test.ts
@@ -3,7 +3,9 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { fetchRemoteStatusJob } from '@/lib/jobs/fetchRemoteStatusJob'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from '@/lib/jobs/names'
+import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { StatusType } from '@/lib/types/domain/status'
 
 enableFetchMocks()
@@ -32,6 +34,12 @@ describe('fetchRemoteStatusJob', () => {
   beforeAll(async () => {
     await database.migrate()
     await seedDatabase(database)
+    await database.createAccount({
+      ...seedActor1,
+      email: `signed-fetch-signer@${TEST_DOMAIN}`,
+      username: 'signed-fetch-signer',
+      domain: TEST_DOMAIN
+    })
   })
 
   afterAll(async () => {
@@ -288,5 +296,6 @@ describe('fetchRemoteStatusJob', () => {
         REPLY_ITEM_ID
       ])
     )
+    expect(signedFetches.filter((url) => url === STATUS_ID)).toHaveLength(1)
   })
 })

--- a/lib/jobs/fetchRemoteStatusJob.ts
+++ b/lib/jobs/fetchRemoteStatusJob.ts
@@ -15,18 +15,23 @@ import { signedHeaders } from '@/lib/utils/signature'
 import { createJobHandle } from './createJobHandle'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from './names'
 
+interface FetchRemoteStatusResult {
+  status: Status
+  note?: Note
+}
+
 const fetchRemoteStatus = async (
   database: Database,
   statusId: string,
   depth = 0,
   signingActor?: Actor
-): Promise<Status | null> => {
+): Promise<FetchRemoteStatusResult | null> => {
   if (depth > 3) return null
   if (!(await canFederateWithDomain(database, statusId))) return null
 
   // 1. Check if already in database
   const existing = await database.getStatus({ statusId })
-  if (existing) return existing
+  if (existing) return { status: existing }
 
   // 2. Fetch the Note
   const note = await getNote({ statusId, signingActor })
@@ -97,7 +102,9 @@ const fetchRemoteStatus = async (
     await fetchRemoteStatus(database, status.reply, depth + 1, signingActor)
   }
 
-  return status
+  if (!status) return null
+
+  return { status, note: sanitizedNote }
 }
 
 export const fetchRemoteStatusJob = createJobHandle(
@@ -106,11 +113,11 @@ export const fetchRemoteStatusJob = createJobHandle(
     const { statusId } = z.object({ statusId: z.string() }).parse(message.data)
     const signingActor = await getFederationSigningActor(database)
 
-    const status = await fetchRemoteStatus(database, statusId, 0, signingActor)
-    if (!status) return
+    const result = await fetchRemoteStatus(database, statusId, 0, signingActor)
+    if (!result) return
 
     // 8. Fetch replies (up to 100)
-    const note = await getNote({ statusId, signingActor })
+    const note = result.note ?? (await getNote({ statusId, signingActor }))
     if (!note) return
 
     const client = {
@@ -120,7 +127,7 @@ export const fetchRemoteStatusJob = createJobHandle(
           url,
           headers: {
             Accept: 'application/activity+json',
-            ...(signingActor ? signedHeaders(signingActor, 'get', url) : {})
+            ...(signingActor ? signedHeaders(signingActor, 'GET', url) : {})
           }
         })
         if (statusCode !== 200) return null

--- a/lib/jobs/fetchRemoteStatusJob.ts
+++ b/lib/jobs/fetchRemoteStatusJob.ts
@@ -4,10 +4,13 @@ import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { getNote } from '@/lib/activities'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { Note } from '@/lib/types/activitypub/objects'
+import { Actor } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
 import { request } from '@/lib/utils/request'
+import { signedHeaders } from '@/lib/utils/signature'
 
 import { createJobHandle } from './createJobHandle'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from './names'
@@ -15,7 +18,8 @@ import { FETCH_REMOTE_STATUS_JOB_NAME } from './names'
 const fetchRemoteStatus = async (
   database: Database,
   statusId: string,
-  depth = 0
+  depth = 0,
+  signingActor?: Actor
 ): Promise<Status | null> => {
   if (depth > 3) return null
   if (!(await canFederateWithDomain(database, statusId))) return null
@@ -25,7 +29,7 @@ const fetchRemoteStatus = async (
   if (existing) return existing
 
   // 2. Fetch the Note
-  const note = await getNote({ statusId })
+  const note = await getNote({ statusId, signingActor })
   if (!note) return null
 
   // 3. Check if public
@@ -48,7 +52,8 @@ const fetchRemoteStatus = async (
   const sanitizedNote = normalizeActivityPubContent(note) as Note
   const actor = await recordActorIfNeeded({
     actorId: sanitizedNote.attributedTo,
-    database
+    database,
+    signingActor
   })
   if (!actor) return null
 
@@ -89,7 +94,7 @@ const fetchRemoteStatus = async (
 
   // 7. Fetch parent (if any)
   if (status && status.type !== StatusType.enum.Announce && status.reply) {
-    await fetchRemoteStatus(database, status.reply, depth + 1)
+    await fetchRemoteStatus(database, status.reply, depth + 1, signingActor)
   }
 
   return status
@@ -99,12 +104,13 @@ export const fetchRemoteStatusJob = createJobHandle(
   FETCH_REMOTE_STATUS_JOB_NAME,
   async (database, message) => {
     const { statusId } = z.object({ statusId: z.string() }).parse(message.data)
+    const signingActor = await getFederationSigningActor(database)
 
-    const status = await fetchRemoteStatus(database, statusId)
+    const status = await fetchRemoteStatus(database, statusId, 0, signingActor)
     if (!status) return
 
     // 8. Fetch replies (up to 100)
-    const note = await getNote({ statusId })
+    const note = await getNote({ statusId, signingActor })
     if (!note) return
 
     const client = {
@@ -112,7 +118,10 @@ export const fetchRemoteStatusJob = createJobHandle(
         if (!(await canFederateWithDomain(database, url))) return null
         const { body, statusCode } = await request({
           url,
-          headers: { Accept: 'application/activity+json' }
+          headers: {
+            Accept: 'application/activity+json',
+            ...(signingActor ? signedHeaders(signingActor, 'get', url) : {})
+          }
         })
         if (statusCode !== 200) return null
         return JSON.parse(body)
@@ -188,7 +197,8 @@ export const fetchRemoteStatusJob = createJobHandle(
 
           const actor = await recordActorIfNeeded({
             actorId: sanitizedReply.attributedTo,
-            database
+            database,
+            signingActor
           })
           if (!actor) return
 

--- a/lib/services/federation/getFederationSigningActor.ts
+++ b/lib/services/federation/getFederationSigningActor.ts
@@ -1,0 +1,11 @@
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+
+export const getFederationSigningActor = async (
+  database: Database,
+  preferredActor?: Actor
+): Promise<Actor | undefined> => {
+  if (preferredActor?.privateKey) return preferredActor
+
+  return (await database.getFederationSigningActor()) ?? undefined
+}

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -156,4 +156,31 @@ describe('ActivityPubVerifySenderGuard', () => {
     expect(response.status).toBe(200)
     expect(handler).toHaveBeenCalled()
   })
+
+  it('includes query strings when verifying GET request targets', async () => {
+    const handler = jest.fn().mockResolvedValue(Response.json({ ok: true }))
+    const guard = ActivityPubVerifySenderGuard(handler)
+
+    const response = await guard(
+      new NextRequest(
+        'https://activities.local/api/users/alice/outbox?page=true&min_id=0',
+        {
+          method: 'GET',
+          headers: {
+            date: new Date().toUTCString(),
+            signature:
+              'keyId="https://remote.test/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="signature"'
+          }
+        }
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockVerify).toHaveBeenCalledWith(
+      'get /api/users/alice/outbox?page=true&min_id=0',
+      expect.any(Headers),
+      'public-key'
+    )
+  })
 })

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -126,14 +126,9 @@ export const ActivityPubVerifySenderGuard =
 
     const host = headerHost(request.headers)
     const requestUrl = new URL(request.url, `http://${host}`)
+    const requestTarget = `${request.method.toLowerCase()} ${requestUrl.pathname}${requestUrl.search}`
     const publicKey = await getSenderPublicKey(database, signatureParts.keyId)
-    if (
-      !(await verify(
-        `${request.method.toLowerCase()} ${requestUrl.pathname}`,
-        request.headers,
-        publicKey
-      ))
-    ) {
+    if (!(await verify(requestTarget, request.headers, publicKey))) {
       return guardErrorResponse(request, 400, allowedMethods)
     }
 

--- a/lib/services/guards/getSenderPublicKey.test.ts
+++ b/lib/services/guards/getSenderPublicKey.test.ts
@@ -3,6 +3,7 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { getSenderPublicKey } from '@/lib/services/guards/getSenderPublicKey'
 import { mockRequests } from '@/lib/stub/activities'
+import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 
@@ -14,6 +15,12 @@ describe('getSenderPublicKey', () => {
   beforeAll(async () => {
     await database.migrate()
     await seedDatabase(database)
+    await database.createAccount({
+      ...seedActor1,
+      email: `signed-key-signer@${TEST_DOMAIN}`,
+      username: 'signed-key-signer',
+      domain: TEST_DOMAIN
+    })
   })
 
   afterAll(async () => {

--- a/lib/services/guards/getSenderPublicKey.test.ts
+++ b/lib/services/guards/getSenderPublicKey.test.ts
@@ -38,11 +38,25 @@ describe('getSenderPublicKey', () => {
   })
 
   it('returns public key from remote actor', async () => {
-    // Test with a non-existent local actor (will try to fetch remotely)
-    const actorId = 'https://llun.test/users/test1'
+    const actorId = 'https://remote.test/users/test1'
     const publicKey = await getSenderPublicKey(database, actorId)
-    // The mock returns a public key
+
     expect(publicKey).toBeTruthy()
+  })
+
+  it('signs remote public key fetches with a local actor', async () => {
+    const actorId = 'https://remote.test/users/signed-key'
+    const publicKey = await getSenderPublicKey(database, actorId)
+
+    expect(publicKey).toBeTruthy()
+
+    const call = fetchMock.mock.calls.find(([url]) => url === actorId)
+    expect(call).toBeDefined()
+    const request = call?.[1]
+    expect(request?.headers).toMatchObject({
+      host: 'remote.test',
+      signature: expect.stringContaining('headers="(request-target) host date"')
+    })
   })
 
   it('returns empty string when remote actor not found', async () => {

--- a/lib/services/guards/getSenderPublicKey.ts
+++ b/lib/services/guards/getSenderPublicKey.ts
@@ -2,6 +2,7 @@ import { HTTPError } from 'got'
 
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { getTracer } from '@/lib/utils/trace'
 
 export async function getSenderPublicKey(database: Database, actorId: string) {
@@ -17,7 +18,8 @@ export async function getSenderPublicKey(database: Database, actorId: string) {
       }
 
       try {
-        const sender = await getActorPerson({ actorId })
+        const signingActor = await getFederationSigningActor(database)
+        const sender = await getActorPerson({ actorId, signingActor })
         return sender?.publicKey.publicKeyPem ?? ''
       } catch (error) {
         const nodeError = error as NodeJS.ErrnoException
@@ -28,7 +30,8 @@ export async function getSenderPublicKey(database: Database, actorId: string) {
         if (nodeError.response.statusCode === 410) {
           const url = new URL(actorId)
           const sender = await getActorPerson({
-            actorId: `${url.protocol}//${url.host}/actor#main-key`
+            actorId: `${url.protocol}//${url.host}/actor#main-key`,
+            signingActor: await getFederationSigningActor(database)
           })
           return sender?.publicKey.publicKeyPem ?? ''
         }

--- a/lib/services/guards/getSenderPublicKey.ts
+++ b/lib/services/guards/getSenderPublicKey.ts
@@ -17,8 +17,8 @@ export async function getSenderPublicKey(database: Database, actorId: string) {
         return localActor.publicKey
       }
 
+      const signingActor = await getFederationSigningActor(database)
       try {
-        const signingActor = await getFederationSigningActor(database)
         const sender = await getActorPerson({ actorId, signingActor })
         return sender?.publicKey.publicKeyPem ?? ''
       } catch (error) {
@@ -31,7 +31,7 @@ export async function getSenderPublicKey(database: Database, actorId: string) {
           const url = new URL(actorId)
           const sender = await getActorPerson({
             actorId: `${url.protocol}//${url.host}/actor#main-key`,
-            signingActor: await getFederationSigningActor(database)
+            signingActor
           })
           return sender?.publicKey.publicKeyPem ?? ''
         }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -123,6 +123,7 @@ export interface ActorDatabase {
   getActorFromUsername(
     params: GetActorFromUsernameParams
   ): Promise<Actor | null>
+  getFederationSigningActor(): Promise<Actor | null>
   getMastodonActorFromEmail(
     params: GetActorFromEmailParams
   ): Promise<Mastodon.Account | null>

--- a/lib/utils/signature.test.ts
+++ b/lib/utils/signature.test.ts
@@ -214,4 +214,38 @@ describe('#signedHeaders', () => {
     )
     expect(verifyResult).toBeTruthy()
   }, 15000)
+
+  it('includes query strings in GET request targets', async () => {
+    const actor = {
+      id: 'https://test.com/actor',
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey
+    } as Actor
+
+    const headers = signedHeaders(
+      actor,
+      'GET',
+      'https://target.com/outbox?page=true&min_id=0'
+    )
+
+    const verifyResult = await verify(
+      'get /outbox?page=true&min_id=0',
+      {
+        ...headers,
+        signature: headers.signature as string
+      },
+      keyPair.publicKey
+    )
+    expect(verifyResult).toBeTruthy()
+
+    const missingQueryVerifyResult = await verify(
+      'get /outbox',
+      {
+        ...headers,
+        signature: headers.signature as string
+      },
+      keyPair.publicKey
+    )
+    expect(missingQueryVerifyResult).toBeFalsy()
+  }, 15000)
 })

--- a/lib/utils/signature.test.ts
+++ b/lib/utils/signature.test.ts
@@ -169,7 +169,7 @@ describe('#signedHeaders', () => {
       publicKey: keyPair.publicKey
     } as Actor
 
-    const headers = signedHeaders(actor, 'post', 'https://target.com/inbox', {
+    const headers = signedHeaders(actor, 'POST', 'https://target.com/inbox', {
       type: 'Note',
       content: 'test'
     })
@@ -198,7 +198,7 @@ describe('#signedHeaders', () => {
       publicKey: keyPair.publicKey
     } as Actor
 
-    const headers = signedHeaders(actor, 'get', 'https://target.com/inbox')
+    const headers = signedHeaders(actor, 'GET', 'https://target.com/inbox')
 
     expect(headers.digest).toBeUndefined()
     expect(headers['content-type']).toBeUndefined()
@@ -206,6 +206,26 @@ describe('#signedHeaders', () => {
 
     const verifyResult = await verify(
       'get /inbox',
+      {
+        ...headers,
+        signature: headers.signature as string
+      },
+      keyPair.publicKey
+    )
+    expect(verifyResult).toBeTruthy()
+  }, 15000)
+
+  it('uses only the path for GET request targets without query strings', async () => {
+    const actor = {
+      id: 'https://test.com/actor',
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey
+    } as Actor
+
+    const headers = signedHeaders(actor, 'GET', 'https://target.com/outbox')
+
+    const verifyResult = await verify(
+      'get /outbox',
       {
         ...headers,
         signature: headers.signature as string

--- a/lib/utils/signature.ts
+++ b/lib/utils/signature.ts
@@ -75,6 +75,7 @@ export function signedHeaders(
   const url = new URL(targetUrl)
   const host = url.host
   const date = new Date().toUTCString()
+  const requestTargetPath = `${url.pathname}${url.search}`
   const headers: Record<string, string> = {
     host,
     date
@@ -99,7 +100,7 @@ export function signedHeaders(
   const signedString = headerKeys
     .map((key) => {
       if (key === '(request-target)') {
-        return `(request-target): ${method} ${url.pathname}`
+        return `(request-target): ${method.toLowerCase()} ${requestTargetPath}`
       }
       return `${key}: ${headers[key]}`
     })

--- a/lib/utils/signature.ts
+++ b/lib/utils/signature.ts
@@ -12,6 +12,8 @@ interface StringMap {
   [key: string]: string
 }
 
+type SignedHttpMethod = 'GET' | 'POST'
+
 export async function parse(signature: string): Promise<StringMap> {
   try {
     const result: StringMap = {}
@@ -68,7 +70,7 @@ export async function verify(
 
 export function signedHeaders(
   currentActor: Actor,
-  method: string,
+  method: SignedHttpMethod,
   targetUrl: string,
   content?: unknown
 ) {
@@ -76,6 +78,7 @@ export function signedHeaders(
   const host = url.host
   const date = new Date().toUTCString()
   const requestTargetPath = `${url.pathname}${url.search}`
+  const requestTargetMethod = method.toLowerCase()
   const headers: Record<string, string> = {
     host,
     date
@@ -100,7 +103,7 @@ export function signedHeaders(
   const signedString = headerKeys
     .map((key) => {
       if (key === '(request-target)') {
-        return `(request-target): ${method.toLowerCase()} ${requestTargetPath}`
+        return `(request-target): ${requestTargetMethod} ${requestTargetPath}`
       }
       return `${key}: ${headers[key]}`
     })


### PR DESCRIPTION
## Summary
- Sign outbound ActivityPub GET requests for note, actor, reply collection, boost, and follow-resolution fetches using the current actor or a local fallback signer.
- Include query strings in HTTP Signature `(request-target)` values so authorized fetch signatures verify correctly.
- Add database support for selecting a local federation signing actor and tests for signed GET coverage.

## Validation
- yarn run prettier --write .
- yarn lint (passes with existing warnings in auth/fitness files)
- yarn build
- yarn test

## Notes
- No migration was needed; this reuses existing actor private keys.