### PR TITLE
feat: implement robust ActivityPub content negotiation

### DIFF
--- a/app/api/users/[username]/followers/route.test.ts
+++ b/app/api/users/[username]/followers/route.test.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from 'next/server'
+
+import { type Actor } from '@/lib/types/domain/actor'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getActorFollowersCount: jest.fn()
+}
+const mockActor: Actor = {
+  id: 'https://example.com/users/test',
+  username: 'test',
+  domain: 'example.com',
+  name: 'Test Actor',
+  summary: '',
+  followersUrl: 'https://example.com/users/test/followers',
+  inboxUrl: 'https://example.com/users/test/inbox',
+  sharedInboxUrl: 'https://example.com/inbox',
+  followingCount: 0,
+  followersCount: 2,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+  publicKey: 'public-key'
+}
+
+jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
+  OnlyLocalUserGuard:
+    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
+    (req: NextRequest, query: unknown) =>
+      handle(mockDatabase, mockActor, req, query)
+}))
+
+describe('GET /api/users/[username]/followers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getActorFollowersCount.mockResolvedValue(2)
+  })
+
+  it('uses ActivityPub negotiation for followers collections', async () => {
+    const response = await GET(
+      new NextRequest('https://example.com/api/users/test/followers', {
+        headers: { accept: 'application/json' }
+      }),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('application/json')
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      id: 'https://example.com/users/test/followers',
+      type: 'OrderedCollection',
+      totalItems: 2
+    })
+  })
+})

--- a/app/api/users/[username]/followers/route.ts
+++ b/app/api/users/[username]/followers/route.ts
@@ -1,20 +1,24 @@
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
+import { activityPubResponse } from '@/lib/utils/activityPubContentNegotiation'
 import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActorFollowers',
-  OnlyLocalUserGuard(async (database, actor) => {
+  OnlyLocalUserGuard(async (database, actor, req) => {
     const followerId = `${actor.id}/followers`
 
     const totalItems = await database.getActorFollowersCount({
       actorId: actor.id
     })
-    return Response.json({
-      '@context': ACTIVITY_STREAM_URL,
-      id: followerId,
-      type: 'OrderedCollection',
-      totalItems
+    return activityPubResponse({
+      req,
+      data: {
+        '@context': ACTIVITY_STREAM_URL,
+        id: followerId,
+        type: 'OrderedCollection',
+        totalItems
+      }
     })
   })
 )

--- a/app/api/users/[username]/following/route.test.ts
+++ b/app/api/users/[username]/following/route.test.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from 'next/server'
+
+import { type Actor } from '@/lib/types/domain/actor'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getActorFollowingCount: jest.fn()
+}
+const mockActor: Actor = {
+  id: 'https://example.com/users/test',
+  username: 'test',
+  domain: 'example.com',
+  name: 'Test Actor',
+  summary: '',
+  followersUrl: 'https://example.com/users/test/followers',
+  inboxUrl: 'https://example.com/users/test/inbox',
+  sharedInboxUrl: 'https://example.com/inbox',
+  followingCount: 4,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+  publicKey: 'public-key'
+}
+
+jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
+  OnlyLocalUserGuard:
+    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
+    (req: NextRequest, query: unknown) =>
+      handle(mockDatabase, mockActor, req, query)
+}))
+
+describe('GET /api/users/[username]/following', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getActorFollowingCount.mockResolvedValue(4)
+  })
+
+  it('uses ActivityPub negotiation for following collections', async () => {
+    const response = await GET(
+      new NextRequest('https://example.com/api/users/test/following', {
+        headers: { accept: 'application/activity+json' }
+      }),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/activity+json'
+    )
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      id: 'https://example.com/users/test/following',
+      type: 'OrderedCollection',
+      totalItems: 4
+    })
+  })
+})

--- a/app/api/users/[username]/following/route.ts
+++ b/app/api/users/[username]/following/route.ts
@@ -1,19 +1,23 @@
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
+import { activityPubResponse } from '@/lib/utils/activityPubContentNegotiation'
 import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActorFollowing',
-  OnlyLocalUserGuard(async (database, actor) => {
+  OnlyLocalUserGuard(async (database, actor, req) => {
     const followingId = `${actor.id}/following`
     const totalItems = await database.getActorFollowingCount({
       actorId: actor.id
     })
-    return Response.json({
-      '@context': ACTIVITY_STREAM_URL,
-      id: followingId,
-      type: 'OrderedCollection',
-      totalItems
+    return activityPubResponse({
+      req,
+      data: {
+        '@context': ACTIVITY_STREAM_URL,
+        id: followingId,
+        type: 'OrderedCollection',
+        totalItems
+      }
     })
   })
 )

--- a/app/api/users/[username]/outbox/route.test.ts
+++ b/app/api/users/[username]/outbox/route.test.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server'
+
+import { type Actor } from '@/lib/types/domain/actor'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getActorStatuses: jest.fn()
+}
+const mockActor: Actor = {
+  id: 'https://example.com/users/test',
+  username: 'test',
+  domain: 'example.com',
+  name: 'Test Actor',
+  summary: '',
+  followersUrl: 'https://example.com/users/test/followers',
+  inboxUrl: 'https://example.com/users/test/inbox',
+  sharedInboxUrl: 'https://example.com/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 3,
+  lastStatusAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+  publicKey: 'public-key'
+}
+
+jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
+  OnlyLocalUserGuard:
+    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
+    (req: NextRequest, query: unknown) =>
+      handle(mockDatabase, mockActor, req, query)
+}))
+
+describe('GET /api/users/[username]/outbox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('negotiates collection responses with the shared ActivityPub helper', async () => {
+    const response = await GET(
+      new NextRequest('https://example.com/api/users/test/outbox', {
+        headers: {
+          accept:
+            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        }
+      }),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: 'https://example.com/users/test/outbox',
+      type: 'OrderedCollection',
+      totalItems: 3,
+      first: 'https://example.com/users/test/outbox?page=true'
+    })
+  })
+})

--- a/app/api/users/[username]/outbox/route.ts
+++ b/app/api/users/[username]/outbox/route.ts
@@ -4,6 +4,7 @@ import {
   CreateAction
 } from '@/lib/types/activitypub/activities'
 import { StatusType } from '@/lib/types/domain/status'
+import { activityPubResponse } from '@/lib/utils/activityPubContentNegotiation'
 import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
@@ -16,13 +17,16 @@ export const GET = traceApiRoute(
     const pageParam = url.searchParams.get('page')
     if (!pageParam) {
       const outboxId = `${actor.id}/outbox`
-      return Response.json({
-        '@context': ACTIVITY_STREAM_URL,
-        id: outboxId,
-        type: 'OrderedCollection',
-        totalItems: actor.statusCount,
-        first: `${outboxId}?page=true`,
-        last: `${outboxId}?min_id=0&page=true`
+      return activityPubResponse({
+        req,
+        data: {
+          '@context': ACTIVITY_STREAM_URL,
+          id: outboxId,
+          type: 'OrderedCollection',
+          totalItems: actor.statusCount,
+          first: `${outboxId}?page=true`,
+          last: `${outboxId}?min_id=0&page=true`
+        }
       })
     }
 
@@ -51,12 +55,15 @@ export const GET = traceApiRoute(
       }
     })
 
-    return Response.json({
-      '@context': ACTIVITY_STREAM_URL,
-      id: `${actor.id}/outbox?page=true`,
-      type: 'OrderedCollectionPage',
-      partOf: `${actor.id}/outbox`,
-      orderedItems: items
+    return activityPubResponse({
+      req,
+      data: {
+        '@context': ACTIVITY_STREAM_URL,
+        id: `${actor.id}/outbox?page=true`,
+        type: 'OrderedCollectionPage',
+        partOf: `${actor.id}/outbox`,
+        orderedItems: items
+      }
     })
   })
 )

--- a/app/api/users/[username]/route.test.ts
+++ b/app/api/users/[username]/route.test.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from 'next/server'
+
+import { type Actor } from '@/lib/types/domain/actor'
+
+import { GET } from './route'
+
+const mockDatabase = {}
+const mockActor: Actor = {
+  id: 'https://example.com/users/test',
+  username: 'test',
+  domain: 'example.com',
+  name: 'Test Actor',
+  summary: '',
+  followersUrl: 'https://example.com/users/test/followers',
+  inboxUrl: 'https://example.com/users/test/inbox',
+  sharedInboxUrl: 'https://example.com/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+  publicKey: 'public-key'
+}
+
+jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
+  OnlyLocalUserGuard:
+    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
+    (req: NextRequest, query: unknown) =>
+      handle(mockDatabase, mockActor, req, query)
+}))
+
+const createRequest = (accept: string) =>
+  new NextRequest('https://example.com/api/users/test', {
+    headers: { accept }
+  })
+
+describe('GET /api/users/[username]', () => {
+  it('returns ActivityPub JSON for combined weighted Accept headers', async () => {
+    const response = await GET(
+      createRequest(
+        'application/json;q=0.9, application/activity+json;q=1, text/html;q=0.8'
+      ),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/activity+json'
+    )
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      id: 'https://example.com/users/test',
+      type: 'Person',
+      preferredUsername: 'test'
+    })
+  })
+
+  it('returns JSON-LD when the ActivityStreams profile is requested', async () => {
+    const response = await GET(
+      createRequest(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      ),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+  })
+
+  it('returns ActivityPub JSON for wildcard Accept headers', async () => {
+    const response = await GET(createRequest('*/*'), {
+      params: Promise.resolve({ username: 'test' })
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/activity+json'
+    )
+  })
+
+  it('redirects to the profile page when HTML is preferred', async () => {
+    const response = await GET(
+      createRequest('text/html, application/xhtml+xml, */*;q=0.8'),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://example.com/@test')
+  })
+})

--- a/app/api/users/[username]/route.test.ts
+++ b/app/api/users/[username]/route.test.ts
@@ -90,6 +90,7 @@ describe('GET /api/users/[username]', () => {
 
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toBe('https://example.com/@test')
+    expect(response.headers.get('server')).toBe('activities.next')
     expect(response.headers.get('vary')).toBe('Accept')
   })
 })

--- a/app/api/users/[username]/route.test.ts
+++ b/app/api/users/[username]/route.test.ts
@@ -90,5 +90,6 @@ describe('GET /api/users/[username]', () => {
 
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toBe('https://example.com/@test')
+    expect(response.headers.get('vary')).toBe('Accept')
   })
 })

--- a/app/api/users/[username]/route.ts
+++ b/app/api/users/[username]/route.ts
@@ -1,5 +1,6 @@
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
 import {
+  activityPubRedirectResponse,
   activityPubResponse,
   negotiateActivityPubContentType
 } from '@/lib/utils/activityPubContentNegotiation'
@@ -20,6 +21,8 @@ export const GET = traceApiRoute(
       })
     }
 
-    return Response.redirect(`https://${actor.domain}/@${actor.username}`)
+    return activityPubRedirectResponse(
+      `https://${actor.domain}/@${actor.username}`
+    )
   })
 )

--- a/app/api/users/[username]/route.ts
+++ b/app/api/users/[username]/route.ts
@@ -1,20 +1,22 @@
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
+import {
+  activityPubResponse,
+  negotiateActivityPubContentType
+} from '@/lib/utils/activityPubContentNegotiation'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActor',
   OnlyLocalUserGuard(async (_, actor, req) => {
-    const acceptHeader = req.headers.get('accept')
-    if (acceptHeader?.startsWith('application/ld+json')) {
-      return Response.json(getPersonFromActor(actor), {
-        headers: { 'content-type': 'application/ld+json' }
-      })
-    }
-
-    if (acceptHeader?.startsWith('application/activity+json')) {
-      return Response.json(getPersonFromActor(actor), {
-        headers: { 'content-type': 'application/activity+json' }
+    const contentType = negotiateActivityPubContentType(
+      req.headers.get('accept')
+    )
+    if (contentType) {
+      return activityPubResponse({
+        req,
+        data: getPersonFromActor(actor),
+        contentType
       })
     }
 

--- a/app/api/users/[username]/statuses/[statusId]/route.test.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.test.ts
@@ -87,6 +87,7 @@ describe('GET /api/users/[username]/statuses/[statusId]', () => {
     expect(response.headers.get('location')).toBe(
       'https://example.com/@test/123'
     )
+    expect(response.headers.get('server')).toBe('activities.next')
     expect(response.headers.get('vary')).toBe('Accept')
   })
 })

--- a/app/api/users/[username]/statuses/[statusId]/route.test.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.test.ts
@@ -1,0 +1,91 @@
+import { NextRequest } from 'next/server'
+
+import { type Actor } from '@/lib/types/domain/actor'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getStatus: jest.fn()
+}
+const mockActor: Actor = {
+  id: 'https://example.com/users/test',
+  username: 'test',
+  domain: 'example.com',
+  name: 'Test Actor',
+  summary: '',
+  followersUrl: 'https://example.com/users/test/followers',
+  inboxUrl: 'https://example.com/users/test/inbox',
+  sharedInboxUrl: 'https://example.com/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+  publicKey: 'public-key'
+}
+const mockToActivityPubObject = jest.fn()
+
+jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
+  OnlyLocalUserGuard:
+    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
+    (req: NextRequest, query: unknown) =>
+      handle(mockDatabase, mockActor, req, query)
+}))
+
+jest.mock('@/lib/types/domain/status', () => ({
+  toActivityPubObject: (...params: unknown[]) =>
+    mockToActivityPubObject(...params)
+}))
+
+const createRequest = (accept: string) =>
+  new NextRequest('https://example.com/api/users/test/statuses/123', {
+    headers: { accept }
+  })
+
+describe('GET /api/users/[username]/statuses/[statusId]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getStatus.mockResolvedValue({
+      id: 'https://example.com/users/test/statuses/123',
+      actor: { domain: 'example.com' }
+    })
+    mockToActivityPubObject.mockReturnValue({
+      id: 'https://example.com/users/test/statuses/123',
+      type: 'Note',
+      attributedTo: 'https://example.com/users/test'
+    })
+  })
+
+  it('returns generic JSON when that is the negotiated ActivityPub type', async () => {
+    const response = await GET(
+      createRequest('application/json, text/html;q=0.5'),
+      { params: Promise.resolve({ username: 'test', statusId: '123' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('application/json')
+    expect(mockDatabase.getStatus).toHaveBeenCalledWith({
+      statusId: 'https://example.com/users/test/statuses/123',
+      withReplies: true
+    })
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: 'https://example.com/users/test/statuses/123',
+      type: 'Note'
+    })
+  })
+
+  it('redirects to the status page when HTML is preferred', async () => {
+    const response = await GET(createRequest('text/html, */*;q=0.8'), {
+      params: Promise.resolve({ username: 'test', statusId: '123' })
+    })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/@test/123'
+    )
+  })
+})

--- a/app/api/users/[username]/statuses/[statusId]/route.test.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.test.ts
@@ -87,5 +87,6 @@ describe('GET /api/users/[username]/statuses/[statusId]', () => {
     expect(response.headers.get('location')).toBe(
       'https://example.com/@test/123'
     )
+    expect(response.headers.get('vary')).toBe('Accept')
   })
 })

--- a/app/api/users/[username]/statuses/[statusId]/route.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.ts
@@ -4,6 +4,10 @@ import {
 } from '@/lib/services/guards/OnlyLocalUserGuard'
 import { AppRouterParams } from '@/lib/services/guards/types'
 import { toActivityPubObject } from '@/lib/types/domain/status'
+import {
+  activityPubResponse,
+  negotiateActivityPubContentType
+} from '@/lib/utils/activityPubContentNegotiation'
 import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
 import { apiErrorResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -23,19 +27,15 @@ export const GET = traceApiRoute(
     const note = toActivityPubObject(status)
     if (!note) return apiErrorResponse(404)
 
-    const acceptHeader = req.headers.get('accept')
-    if (acceptHeader?.startsWith('application/ld+json')) {
-      return Response.json(
-        { '@context': ACTIVITY_STREAM_URL, ...note },
-        { headers: { 'content-type': 'application/ld+json' } }
-      )
-    }
-
-    if (acceptHeader?.startsWith('application/activity+json')) {
-      return Response.json(
-        { '@context': ACTIVITY_STREAM_URL, ...note },
-        { headers: { 'content-type': 'activity+json' } }
-      )
+    const contentType = negotiateActivityPubContentType(
+      req.headers.get('accept')
+    )
+    if (contentType) {
+      return activityPubResponse({
+        req,
+        data: { '@context': ACTIVITY_STREAM_URL, ...note },
+        contentType
+      })
     }
 
     return Response.redirect(

--- a/app/api/users/[username]/statuses/[statusId]/route.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.ts
@@ -5,6 +5,7 @@ import {
 import { AppRouterParams } from '@/lib/services/guards/types'
 import { toActivityPubObject } from '@/lib/types/domain/status'
 import {
+  activityPubRedirectResponse,
   activityPubResponse,
   negotiateActivityPubContentType
 } from '@/lib/utils/activityPubContentNegotiation'
@@ -38,7 +39,7 @@ export const GET = traceApiRoute(
       })
     }
 
-    return Response.redirect(
+    return activityPubRedirectResponse(
       `https://${status.actor?.domain}/@${actor.username}/${statusId}`
     )
   })

--- a/lib/utils/acceptContentTypes.test.ts
+++ b/lib/utils/acceptContentTypes.test.ts
@@ -1,4 +1,7 @@
-import { acceptContentTypes } from './acceptContentTypes'
+import {
+  acceptContentTypes,
+  parseAcceptContentTypes
+} from './acceptContentTypes'
 
 describe('#acceptContentTypes', () => {
   it('returns list of content types that client send in', () => {
@@ -21,5 +24,22 @@ describe('#acceptContentTypes', () => {
     const value =
       'not-a-media-type, application/json;q=0, application/activity+json;q=0.8'
     expect(acceptContentTypes(value)).toEqual(['application/activity+json'])
+  })
+
+  it('keeps escaped quotes inside quoted parameter values', () => {
+    const value =
+      'application/json; note="escaped\\",still quoted";q=0.9, text/html;q=0.8'
+
+    expect(parseAcceptContentTypes(value)).toMatchObject([
+      {
+        type: 'application/json',
+        parameters: { note: 'escaped",still quoted' },
+        quality: 0.9
+      },
+      {
+        type: 'text/html',
+        quality: 0.8
+      }
+    ])
   })
 })

--- a/lib/utils/acceptContentTypes.test.ts
+++ b/lib/utils/acceptContentTypes.test.ts
@@ -8,11 +8,18 @@ describe('#acceptContentTypes', () => {
 
   it('returns multiple content types order by quality factor', () => {
     const value =
-      'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", text/html;q=0.1'
+      'application/json;q=0.9, application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", text/html;q=0.1'
     expect(acceptContentTypes(value)).toEqual([
       'application/activity+json',
       'application/ld+json',
+      'application/json',
       'text/html'
     ])
+  })
+
+  it('ignores invalid and explicitly unacceptable content types', () => {
+    const value =
+      'not-a-media-type, application/json;q=0, application/activity+json;q=0.8'
+    expect(acceptContentTypes(value)).toEqual(['application/activity+json'])
   })
 })

--- a/lib/utils/acceptContentTypes.test.ts
+++ b/lib/utils/acceptContentTypes.test.ts
@@ -42,4 +42,16 @@ describe('#acceptContentTypes', () => {
       }
     ])
   })
+
+  it('unescapes generic quoted-pair parameter values', () => {
+    const value = String.raw`application/json; note="a\\b\t\"quoted";q=0.9`
+
+    expect(parseAcceptContentTypes(value)).toMatchObject([
+      {
+        type: 'application/json',
+        parameters: { note: 'a\\bt"quoted' },
+        quality: 0.9
+      }
+    ])
+  })
 })

--- a/lib/utils/acceptContentTypes.ts
+++ b/lib/utils/acceptContentTypes.ts
@@ -84,10 +84,8 @@ export const parseAcceptContentTypes = (
           const value = parameter.slice(equalsIndex + 1)
           if (!name) return params
 
-          return {
-            ...params,
-            [name]: unquote(value)
-          }
+          params[name] = unquote(value)
+          return params
         },
         {}
       )

--- a/lib/utils/acceptContentTypes.ts
+++ b/lib/utils/acceptContentTypes.ts
@@ -44,7 +44,25 @@ const splitHeaderValue = (value: string, delimiter: ',' | ';') => {
 const unquote = (value: string) => {
   const trimmed = value.trim()
   if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return trimmed.slice(1, -1).replace(/\\"/g, '"')
+    let unquoted = ''
+    let escaped = false
+
+    for (const character of trimmed.slice(1, -1)) {
+      if (escaped) {
+        unquoted += character
+        escaped = false
+        continue
+      }
+
+      if (character === '\\') {
+        escaped = true
+        continue
+      }
+
+      unquoted += character
+    }
+
+    return escaped ? `${unquoted}\\` : unquoted
   }
 
   return trimmed

--- a/lib/utils/acceptContentTypes.ts
+++ b/lib/utils/acceptContentTypes.ts
@@ -1,8 +1,106 @@
-import contentType from 'content-type'
+export type AcceptedContentType = {
+  type: string
+  parameters: Record<string, string>
+  quality: number
+  specificity: number
+  index: number
+}
+
+const splitHeaderValue = (value: string, delimiter: ',' | ';') => {
+  const items: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (const character of value) {
+    if (character === '"') {
+      inQuotes = !inQuotes
+    }
+
+    if (character === delimiter && !inQuotes) {
+      items.push(current)
+      current = ''
+    } else {
+      current += character
+    }
+  }
+
+  items.push(current)
+  return items
+}
+
+const unquote = (value: string) => {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\"/g, '"')
+  }
+
+  return trimmed
+}
+
+const parseQuality = (value: string | undefined) => {
+  if (value === undefined) return 1
+
+  const quality = Number.parseFloat(value)
+  if (!Number.isFinite(quality) || quality < 0 || quality > 1) return null
+
+  return quality
+}
+
+const specificityFor = (type: string) => {
+  const [, subtype] = type.split('/')
+  if (type === '*/*') return 0
+  if (subtype === '*') return 1
+  return 2
+}
+
+export const parseAcceptContentTypes = (
+  acceptHeaderValue: string
+): AcceptedContentType[] => {
+  return splitHeaderValue(acceptHeaderValue, ',')
+    .map((item, index) => {
+      const [rawType, ...rawParameters] = splitHeaderValue(item, ';')
+      const type = rawType.trim().toLowerCase()
+      if (!/^[^\s/;]+\/[^\s/;]+$/.test(type)) return null
+
+      const parameters = rawParameters.reduce<Record<string, string>>(
+        (params, parameter) => {
+          const equalsIndex = parameter.indexOf('=')
+          if (equalsIndex === -1) return params
+
+          const name = parameter.slice(0, equalsIndex).trim().toLowerCase()
+          const value = parameter.slice(equalsIndex + 1)
+          if (!name) return params
+
+          return {
+            ...params,
+            [name]: unquote(value)
+          }
+        },
+        {}
+      )
+      const quality = parseQuality(parameters.q)
+      if (quality === null || quality === 0) return null
+
+      const { q: _quality, ...contentParameters } = parameters
+
+      return {
+        type,
+        parameters: contentParameters,
+        quality,
+        specificity: specificityFor(type),
+        index
+      }
+    })
+    .filter((item): item is AcceptedContentType => item !== null)
+    .sort((left, right) => {
+      if (left.quality !== right.quality) return right.quality - left.quality
+      if (left.specificity !== right.specificity) {
+        return right.specificity - left.specificity
+      }
+      return left.index - right.index
+    })
+}
 
 export const acceptContentTypes = (acceptHeaderValue: string) => {
-  return acceptHeaderValue
-    .split(',')
-    .map((item) => item.trim())
-    .map((item) => contentType.parse(item).type)
+  return parseAcceptContentTypes(acceptHeaderValue).map((item) => item.type)
 }

--- a/lib/utils/acceptContentTypes.ts
+++ b/lib/utils/acceptContentTypes.ts
@@ -10,8 +10,21 @@ const splitHeaderValue = (value: string, delimiter: ',' | ';') => {
   const items: string[] = []
   let current = ''
   let inQuotes = false
+  let escaped = false
 
   for (const character of value) {
+    if (escaped) {
+      current += character
+      escaped = false
+      continue
+    }
+
+    if (character === '\\' && inQuotes) {
+      current += character
+      escaped = true
+      continue
+    }
+
     if (character === '"') {
       inQuotes = !inQuotes
     }

--- a/lib/utils/activityPubContentNegotiation.test.ts
+++ b/lib/utils/activityPubContentNegotiation.test.ts
@@ -23,6 +23,14 @@ describe('#negotiateActivityPubContentType', () => {
     ).toBe(ACTIVITYSTREAM_LD_CONTENT_TYPE)
   })
 
+  it('recognizes ActivityStreams JSON-LD profile requests with multiple profile tokens', () => {
+    expect(
+      negotiateActivityPubContentType(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams https://example.com/other"'
+      )
+    ).toBe(ACTIVITYSTREAM_LD_CONTENT_TYPE)
+  })
+
   it('does not treat blank JSON-LD profiles as ActivityStreams requests', () => {
     expect(
       negotiateActivityPubContentType('application/ld+json; profile=""')
@@ -46,6 +54,15 @@ describe('#negotiateActivityPubContentType', () => {
       negotiateActivityPubContentType(
         'text/html, application/xhtml+xml, */*;q=0.8'
       )
+    ).toBeNull()
+  })
+
+  it('uses header order to break equal preference ties between ActivityPub and HTML', () => {
+    expect(
+      negotiateActivityPubContentType('application/activity+json, text/html')
+    ).toBe(ACTIVITYPUB_CONTENT_TYPE)
+    expect(
+      negotiateActivityPubContentType('text/html, application/activity+json')
     ).toBeNull()
   })
 

--- a/lib/utils/activityPubContentNegotiation.test.ts
+++ b/lib/utils/activityPubContentNegotiation.test.ts
@@ -2,6 +2,7 @@ import {
   ACTIVITYPUB_CONTENT_TYPE,
   ACTIVITYSTREAM_LD_CONTENT_TYPE,
   JSON_CONTENT_TYPE,
+  activityPubResponse,
   negotiateActivityPubContentType
 } from './activityPubContentNegotiation'
 
@@ -20,6 +21,12 @@ describe('#negotiateActivityPubContentType', () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
     ).toBe(ACTIVITYSTREAM_LD_CONTENT_TYPE)
+  })
+
+  it('does not treat blank JSON-LD profiles as ActivityStreams requests', () => {
+    expect(
+      negotiateActivityPubContentType('application/ld+json; profile=""')
+    ).toBeNull()
   })
 
   it('recognizes generic JSON requests', () => {
@@ -44,5 +51,32 @@ describe('#negotiateActivityPubContentType', () => {
 
   it('treats a missing Accept header as accepting ActivityPub JSON', () => {
     expect(negotiateActivityPubContentType(null)).toBe(ACTIVITYPUB_CONTENT_TYPE)
+  })
+})
+
+describe('#activityPubResponse', () => {
+  it('marks negotiated responses as varying by Accept', () => {
+    const response = activityPubResponse({
+      req: new Request('https://example.com', {
+        headers: { accept: 'application/activity+json' }
+      }) as never,
+      data: { ok: true }
+    })
+
+    expect(response.headers.get('vary')).toBe('Accept')
+  })
+
+  it('allows callers to override CORS methods', () => {
+    const response = activityPubResponse({
+      req: new Request('https://example.com', {
+        headers: { accept: 'application/activity+json' }
+      }) as never,
+      data: { ok: true },
+      allowedMethods: ['GET', 'POST']
+    })
+
+    expect(response.headers.get('access-control-allow-methods')).toBe(
+      'GET,POST'
+    )
   })
 })

--- a/lib/utils/activityPubContentNegotiation.test.ts
+++ b/lib/utils/activityPubContentNegotiation.test.ts
@@ -1,0 +1,48 @@
+import {
+  ACTIVITYPUB_CONTENT_TYPE,
+  ACTIVITYSTREAM_LD_CONTENT_TYPE,
+  JSON_CONTENT_TYPE,
+  negotiateActivityPubContentType
+} from './activityPubContentNegotiation'
+
+describe('#negotiateActivityPubContentType', () => {
+  it('returns the most preferred ActivityPub content type from weighted headers', () => {
+    expect(
+      negotiateActivityPubContentType(
+        'application/json;q=0.9, application/activity+json;q=1, text/html;q=0.8'
+      )
+    ).toBe(ACTIVITYPUB_CONTENT_TYPE)
+  })
+
+  it('recognizes ActivityStreams JSON-LD profile requests', () => {
+    expect(
+      negotiateActivityPubContentType(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    ).toBe(ACTIVITYSTREAM_LD_CONTENT_TYPE)
+  })
+
+  it('recognizes generic JSON requests', () => {
+    expect(negotiateActivityPubContentType('application/json')).toBe(
+      JSON_CONTENT_TYPE
+    )
+  })
+
+  it('recognizes wildcard requests as ActivityPub JSON', () => {
+    expect(negotiateActivityPubContentType('*/*')).toBe(
+      ACTIVITYPUB_CONTENT_TYPE
+    )
+  })
+
+  it('lets a preferred HTML representation win over wildcard JSON', () => {
+    expect(
+      negotiateActivityPubContentType(
+        'text/html, application/xhtml+xml, */*;q=0.8'
+      )
+    ).toBeNull()
+  })
+
+  it('treats a missing Accept header as accepting ActivityPub JSON', () => {
+    expect(negotiateActivityPubContentType(null)).toBe(ACTIVITYPUB_CONTENT_TYPE)
+  })
+})

--- a/lib/utils/activityPubContentNegotiation.ts
+++ b/lib/utils/activityPubContentNegotiation.ts
@@ -18,7 +18,8 @@ type ActivityPubCandidate = {
 }
 
 const isActivityStreamsProfile = (profile: string | undefined) => {
-  if (!profile) return true
+  if (profile === undefined) return true
+  if (!profile.trim()) return false
 
   return profile
     .split(/\s+/)
@@ -104,11 +105,13 @@ export const negotiateActivityPubContentType = (
 export const activityPubResponse = ({
   req,
   data,
-  contentType
+  contentType,
+  allowedMethods = [HttpMethod.enum.GET]
 }: {
   req: NextRequest
   data: unknown
   contentType?: string | null
+  allowedMethods?: HttpMethod[]
 }) => {
   const responseContentType =
     contentType ??
@@ -117,8 +120,11 @@ export const activityPubResponse = ({
 
   return apiResponse({
     req,
-    allowedMethods: [HttpMethod.enum.GET],
+    allowedMethods,
     data,
-    additionalHeaders: [['Content-Type', responseContentType]]
+    additionalHeaders: [
+      ['Content-Type', responseContentType],
+      ['Vary', 'Accept']
+    ]
   })
 }

--- a/lib/utils/activityPubContentNegotiation.ts
+++ b/lib/utils/activityPubContentNegotiation.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from 'next/server'
+
+import {
+  type AcceptedContentType,
+  parseAcceptContentTypes
+} from '@/lib/utils/acceptContentTypes'
+import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { apiResponse } from '@/lib/utils/response'
+
+export const ACTIVITYPUB_CONTENT_TYPE = 'application/activity+json'
+export const ACTIVITYSTREAM_LD_CONTENT_TYPE = `application/ld+json; profile="${ACTIVITY_STREAM_URL}"`
+export const JSON_CONTENT_TYPE = 'application/json'
+
+type ActivityPubCandidate = {
+  accepted: AcceptedContentType
+  responseContentType: string
+}
+
+const isActivityStreamsProfile = (profile: string | undefined) => {
+  if (!profile) return true
+
+  return profile
+    .split(/\s+/)
+    .map((item) => item.trim())
+    .includes(ACTIVITY_STREAM_URL)
+}
+
+const isHtmlType = ({ type }: AcceptedContentType) =>
+  type === 'text/html' || type === 'application/xhtml+xml'
+
+const isMorePreferred = (
+  left: AcceptedContentType,
+  right: AcceptedContentType
+) => {
+  if (left.quality !== right.quality) return left.quality > right.quality
+  if (left.specificity !== right.specificity) {
+    return left.specificity > right.specificity
+  }
+
+  return left.index < right.index
+}
+
+const getActivityPubCandidate = (
+  accepted: AcceptedContentType
+): ActivityPubCandidate | null => {
+  if (accepted.type === ACTIVITYPUB_CONTENT_TYPE) {
+    return {
+      accepted,
+      responseContentType: ACTIVITYPUB_CONTENT_TYPE
+    }
+  }
+
+  if (
+    accepted.type === 'application/ld+json' &&
+    isActivityStreamsProfile(accepted.parameters.profile)
+  ) {
+    return {
+      accepted,
+      responseContentType: ACTIVITYSTREAM_LD_CONTENT_TYPE
+    }
+  }
+
+  if (accepted.type === JSON_CONTENT_TYPE) {
+    return {
+      accepted,
+      responseContentType: JSON_CONTENT_TYPE
+    }
+  }
+
+  if (accepted.type === 'application/*' || accepted.type === '*/*') {
+    return {
+      accepted,
+      responseContentType: ACTIVITYPUB_CONTENT_TYPE
+    }
+  }
+
+  return null
+}
+
+export const negotiateActivityPubContentType = (
+  acceptHeaderValue: string | null
+) => {
+  if (!acceptHeaderValue?.trim()) return ACTIVITYPUB_CONTENT_TYPE
+
+  const acceptedContentTypes = parseAcceptContentTypes(acceptHeaderValue)
+  const activityPubCandidate = acceptedContentTypes
+    .map(getActivityPubCandidate)
+    .find((candidate): candidate is ActivityPubCandidate => candidate !== null)
+
+  if (!activityPubCandidate) return null
+
+  const htmlCandidate = acceptedContentTypes.find(isHtmlType)
+  if (
+    htmlCandidate &&
+    isMorePreferred(htmlCandidate, activityPubCandidate.accepted)
+  ) {
+    return null
+  }
+
+  return activityPubCandidate.responseContentType
+}
+
+export const activityPubResponse = ({
+  req,
+  data,
+  contentType
+}: {
+  req: NextRequest
+  data: unknown
+  contentType?: string | null
+}) => {
+  const responseContentType =
+    contentType ??
+    negotiateActivityPubContentType(req.headers.get('accept')) ??
+    ACTIVITYPUB_CONTENT_TYPE
+
+  return apiResponse({
+    req,
+    allowedMethods: [HttpMethod.enum.GET],
+    data,
+    additionalHeaders: [['Content-Type', responseContentType]]
+  })
+}

--- a/lib/utils/activityPubContentNegotiation.ts
+++ b/lib/utils/activityPubContentNegotiation.ts
@@ -21,10 +21,7 @@ const isActivityStreamsProfile = (profile: string | undefined) => {
   if (profile === undefined) return true
   if (!profile.trim()) return false
 
-  return profile
-    .split(/\s+/)
-    .map((item) => item.trim())
-    .includes(ACTIVITY_STREAM_URL)
+  return profile.trim().split(/\s+/).includes(ACTIVITY_STREAM_URL)
 }
 
 const isHtmlType = ({ type }: AcceptedContentType) =>

--- a/lib/utils/activityPubContentNegotiation.ts
+++ b/lib/utils/activityPubContentNegotiation.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { SERVICE_NAME } from '@/lib/constants'
 import {
   type AcceptedContentType,
   parseAcceptContentTypes
@@ -132,6 +133,7 @@ export const activityPubRedirectResponse = (url: string) => {
     status: 302,
     headers: {
       Location: url,
+      Server: SERVICE_NAME,
       Vary: 'Accept'
     }
   })

--- a/lib/utils/activityPubContentNegotiation.ts
+++ b/lib/utils/activityPubContentNegotiation.ts
@@ -19,9 +19,10 @@ type ActivityPubCandidate = {
 
 const isActivityStreamsProfile = (profile: string | undefined) => {
   if (profile === undefined) return true
-  if (!profile.trim()) return false
+  const trimmed = profile.trim()
+  if (!trimmed) return false
 
-  return profile.trim().split(/\s+/).includes(ACTIVITY_STREAM_URL)
+  return trimmed.split(/\s+/).includes(ACTIVITY_STREAM_URL)
 }
 
 const isHtmlType = ({ type }: AcceptedContentType) =>
@@ -123,5 +124,15 @@ export const activityPubResponse = ({
       ['Content-Type', responseContentType],
       ['Vary', 'Accept']
     ]
+  })
+}
+
+export const activityPubRedirectResponse = (url: string) => {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: url,
+      Vary: 'Accept'
+    }
   })
 }


### PR DESCRIPTION
## Summary
- Add robust Accept header parsing with q-value sorting, parameters, wildcards, and invalid-entry tolerance.
- Add ActivityPub negotiation/response helpers for activity+json, ActivityStreams JSON-LD, generic JSON, and wildcard requests.
- Apply the helper to actor, status, followers, following, and outbox ActivityPub GET routes while preserving HTML redirects when HTML is preferred.
- Add route and utility coverage for weighted combined headers, JSON-LD profile requests, generic JSON, wildcard requests, collection responses, and HTML fallback.

## Validation
- yarn run prettier --write .
- yarn lint (passes with existing warnings in auth/fitness files)
- yarn build
- yarn test --runTestsByPath lib/utils/acceptContentTypes.test.ts lib/utils/activityPubContentNegotiation.test.ts app/api/users/[username]/route.test.ts app/api/users/[username]/statuses/[statusId]/route.test.ts app/api/users/[username]/followers/route.test.ts app/api/users/[username]/following/route.test.ts app/api/users/[username]/outbox/route.test.ts
- yarn test --runInBand (215 suites, 1645 tests passed)

Note: the normal parallel yarn test command hit unrelated Jest worker SIGSEGV crashes in different pre-existing suites on two local runs; rerunning the named files and then the full suite serially passed.