### PR TITLE
feat: make public statuses publicly readable

### DIFF
--- a/app/api/users/[username]/statuses/[statusId]/route.test.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.test.ts
@@ -138,6 +138,12 @@ describe('GET /api/users/[username]/statuses/[statusId]', () => {
       params: Promise.resolve({ username: 'test', statusId: '123' })
     })
 
+    expect(mockDatabase.getStatusReplies).toHaveBeenCalledWith({
+      statusId: 'https://example.com/users/test/statuses/123',
+      url: 'https://example.com/users/test/statuses/123',
+      publicOnly: true,
+      limit: 100
+    })
     expect(mockToActivityPubObject).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [publicReply]

--- a/app/api/users/[username]/statuses/[statusId]/route.test.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.test.ts
@@ -1,11 +1,13 @@
 import { NextRequest } from 'next/server'
 
 import { type Actor } from '@/lib/types/domain/actor'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 import { GET } from './route'
 
 const mockDatabase = {
-  getStatus: jest.fn()
+  getStatus: jest.fn(),
+  getStatusReplies: jest.fn()
 }
 const mockActor: Actor = {
   id: 'https://example.com/users/test',
@@ -33,10 +35,14 @@ jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
       handle(mockDatabase, mockActor, req, query)
 }))
 
-jest.mock('@/lib/types/domain/status', () => ({
-  toActivityPubObject: (...params: unknown[]) =>
-    mockToActivityPubObject(...params)
-}))
+jest.mock('@/lib/types/domain/status', () => {
+  const actual = jest.requireActual('@/lib/types/domain/status')
+  return {
+    ...actual,
+    toActivityPubObject: (...params: unknown[]) =>
+      mockToActivityPubObject(...params)
+  }
+})
 
 const createRequest = (accept: string) =>
   new NextRequest('https://example.com/api/users/test/statuses/123', {
@@ -48,8 +54,13 @@ describe('GET /api/users/[username]/statuses/[statusId]', () => {
     jest.clearAllMocks()
     mockDatabase.getStatus.mockResolvedValue({
       id: 'https://example.com/users/test/statuses/123',
+      url: 'https://example.com/users/test/statuses/123',
+      type: 'Note',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
       actor: { domain: 'example.com' }
     })
+    mockDatabase.getStatusReplies.mockResolvedValue([])
     mockToActivityPubObject.mockReturnValue({
       id: 'https://example.com/users/test/statuses/123',
       type: 'Note',
@@ -67,7 +78,7 @@ describe('GET /api/users/[username]/statuses/[statusId]', () => {
     expect(response.headers.get('content-type')).toBe('application/json')
     expect(mockDatabase.getStatus).toHaveBeenCalledWith({
       statusId: 'https://example.com/users/test/statuses/123',
-      withReplies: true
+      withReplies: false
     })
 
     const data = await response.json()
@@ -89,5 +100,48 @@ describe('GET /api/users/[username]/statuses/[statusId]', () => {
     )
     expect(response.headers.get('server')).toBe('activities.next')
     expect(response.headers.get('vary')).toBe('Accept')
+  })
+
+  it('returns not found for a non-public ActivityPub object request', async () => {
+    mockDatabase.getStatus.mockResolvedValue({
+      id: 'https://example.com/users/test/statuses/123',
+      url: 'https://example.com/users/test/statuses/123',
+      type: 'Note',
+      to: ['https://example.com/users/test/followers'],
+      cc: [],
+      actor: { domain: 'example.com' }
+    })
+
+    const response = await GET(createRequest('application/activity+json'), {
+      params: Promise.resolve({ username: 'test', statusId: '123' })
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.getStatusReplies).not.toHaveBeenCalled()
+    expect(mockToActivityPubObject).not.toHaveBeenCalled()
+  })
+
+  it('filters non-public replies from public ActivityPub object responses', async () => {
+    const publicReply = {
+      id: 'https://example.com/users/other/statuses/public-reply',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    }
+    const privateReply = {
+      id: 'https://example.com/users/other/statuses/private-reply',
+      to: ['https://example.com/users/other/followers'],
+      cc: []
+    }
+    mockDatabase.getStatusReplies.mockResolvedValue([publicReply, privateReply])
+
+    await GET(createRequest('application/activity+json'), {
+      params: Promise.resolve({ username: 'test', statusId: '123' })
+    })
+
+    expect(mockToActivityPubObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [publicReply]
+      })
+    )
   })
 })

--- a/app/api/users/[username]/statuses/[statusId]/route.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.ts
@@ -23,6 +23,8 @@ type StatusParams = OnlyLocalUserGuardHandle & {
   statusId: string
 }
 
+const ACTIVITYPUB_REPLIES_LIMIT = 100
+
 export const GET = traceApiRoute(
   'getActorStatus',
   OnlyLocalUserGuard(async (database, actor, req, query: unknown) => {
@@ -43,7 +45,9 @@ export const GET = traceApiRoute(
             replies: (
               await database.getStatusReplies({
                 statusId: status.id,
-                url: status.url
+                url: status.url,
+                publicOnly: true,
+                limit: ACTIVITYPUB_REPLIES_LIMIT
               })
             ).filter(
               (reply): reply is StatusNote | StatusPoll =>

--- a/app/api/users/[username]/statuses/[statusId]/route.ts
+++ b/app/api/users/[username]/statuses/[statusId]/route.ts
@@ -3,7 +3,13 @@ import {
   OnlyLocalUserGuardHandle
 } from '@/lib/services/guards/OnlyLocalUserGuard'
 import { AppRouterParams } from '@/lib/services/guards/types'
-import { toActivityPubObject } from '@/lib/types/domain/status'
+import { isStatusPubliclyReadable } from '@/lib/services/statusAccess'
+import {
+  StatusNote,
+  StatusPoll,
+  StatusType,
+  toActivityPubObject
+} from '@/lib/types/domain/status'
 import {
   activityPubRedirectResponse,
   activityPubResponse,
@@ -22,11 +28,32 @@ export const GET = traceApiRoute(
   OnlyLocalUserGuard(async (database, actor, req, query: unknown) => {
     const { statusId } = await (query as AppRouterParams<StatusParams>).params
     const id = `${actor.id}/statuses/${statusId}`
-    const status = await database.getStatus({ statusId: id, withReplies: true })
+    const status = await database.getStatus({
+      statusId: id,
+      withReplies: false
+    })
     if (!status) return apiErrorResponse(404)
+    if (!isStatusPubliclyReadable(status)) return apiErrorResponse(404)
 
-    const note = toActivityPubObject(status)
-    if (!note) return apiErrorResponse(404)
+    const statusWithPublicReplies =
+      status.type === StatusType.enum.Announce
+        ? status
+        : {
+            ...status,
+            replies: (
+              await database.getStatusReplies({
+                statusId: status.id,
+                url: status.url
+              })
+            ).filter(
+              (reply): reply is StatusNote | StatusPoll =>
+                reply.type !== StatusType.enum.Announce &&
+                isStatusPubliclyReadable(reply)
+            )
+          }
+
+    const activityPubObject = toActivityPubObject(statusWithPublicReplies)
+    if (!activityPubObject) return apiErrorResponse(404)
 
     const contentType = negotiateActivityPubContentType(
       req.headers.get('accept')
@@ -34,7 +61,7 @@ export const GET = traceApiRoute(
     if (contentType) {
       return activityPubResponse({
         req,
-        data: { '@context': ACTIVITY_STREAM_URL, ...note },
+        data: { '@context': ACTIVITY_STREAM_URL, ...activityPubObject },
         contentType
       })
     }

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -7,6 +7,7 @@ import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { seedActor3 } from '@/lib/stub/seed/actor3'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { type Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -273,6 +274,60 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
 
     expect(uris).toEqual([publicStatusId])
     expect(uris).not.toContain(unreadableAnnounceId)
+  })
+
+  it('caps scanning when batches contain no readable statuses', async () => {
+    const now = Date.now() + 20_000
+    const privateOriginal = {
+      id: `${ACTOR2_ID}/statuses/account-private-original-scan-cap`,
+      url: `${ACTOR2_ID}/statuses/account-private-original-scan-cap`,
+      actorId: ACTOR2_ID,
+      actor: null,
+      type: StatusType.enum.Note,
+      to: [`${ACTOR2_ID}/followers`],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: now,
+      updatedAt: now,
+      text: 'Private original for scan cap',
+      summary: '',
+      reply: '',
+      replies: [],
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      totalLikes: 0,
+      attachments: [],
+      tags: []
+    } as Status
+    const unreadableAnnounce = {
+      id: `${ACTOR1_ID}/statuses/account-unreadable-announce-scan-cap`,
+      actorId: ACTOR1_ID,
+      actor: null,
+      type: StatusType.enum.Announce,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: now + 1,
+      updatedAt: now + 1,
+      originalStatus: privateOriginal
+    } as Status
+    const getActorStatuses = jest
+      .spyOn(database, 'getActorStatuses')
+      .mockResolvedValue([unreadableAnnounce])
+
+    try {
+      const response = await GET(createRequest('?limit=1'), {
+        params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+      })
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual([])
+      expect(getActorStatuses).toHaveBeenCalledTimes(10)
+    } finally {
+      getActorStatuses.mockRestore()
+    }
   })
 
   it('returns bad request for invalid query params', async () => {

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -1,0 +1,164 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const createRequest = (query = '') =>
+  new NextRequest(
+    `https://llun.test/api/v1/accounts/${urlToId(ACTOR1_ID)}/statuses${query}`
+  )
+
+describe('GET /api/v1/accounts/[id]/statuses', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+  })
+
+  it('allows anonymous reads but only returns public and unlisted statuses', async () => {
+    const publicStatusId = `${ACTOR1_ID}/statuses/account-public-read`
+    const unlistedStatusId = `${ACTOR1_ID}/statuses/account-unlisted-read`
+    const privateStatusId = `${ACTOR1_ID}/statuses/account-private-read`
+    const directStatusId = `${ACTOR1_ID}/statuses/account-direct-read`
+
+    await database.createNote({
+      id: publicStatusId,
+      url: publicStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account public read',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createNote({
+      id: unlistedStatusId,
+      url: unlistedStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account unlisted read',
+      to: [`${ACTOR1_ID}/followers`],
+      cc: [ACTIVITY_STREAM_PUBLIC]
+    })
+    await database.createNote({
+      id: privateStatusId,
+      url: privateStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account private read',
+      to: [`${ACTOR1_ID}/followers`],
+      cc: []
+    })
+    await database.createNote({
+      id: directStatusId,
+      url: directStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account direct read',
+      to: [ACTOR2_ID],
+      cc: []
+    })
+
+    const response = await GET(createRequest('?limit=50'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(200)
+
+    const data = (await response.json()) as Array<{ uri: string }>
+    const uris = data.map((status) => status.uri)
+
+    expect(uris).toContain(publicStatusId)
+    expect(uris).toContain(unlistedStatusId)
+    expect(uris).not.toContain(privateStatusId)
+    expect(uris).not.toContain(directStatusId)
+  })
+
+  it('allows the owner to read their non-public account statuses', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+
+    const privateStatusId = `${ACTOR1_ID}/statuses/account-private-owner-read`
+    const directStatusId = `${ACTOR1_ID}/statuses/account-direct-owner-read`
+
+    await database.createNote({
+      id: privateStatusId,
+      url: privateStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account private owner read',
+      to: [`${ACTOR1_ID}/followers`],
+      cc: []
+    })
+    await database.createNote({
+      id: directStatusId,
+      url: directStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account direct owner read',
+      to: [ACTOR2_ID],
+      cc: []
+    })
+
+    const response = await GET(createRequest('?limit=50'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(200)
+
+    const data = (await response.json()) as Array<{ uri: string }>
+    const uris = data.map((status) => status.uri)
+
+    expect(uris).toContain(privateStatusId)
+    expect(uris).toContain(directStatusId)
+  })
+
+  it('returns bad request for invalid query params', async () => {
+    const response = await GET(createRequest('?limit=0'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -229,6 +229,52 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
     expect(uris).not.toContain(privateStatusId)
   })
 
+  it('continues scanning when a public announce wraps a non-public original', async () => {
+    const now = Date.now() + 10_000
+    const publicStatusId = `${ACTOR1_ID}/statuses/account-public-after-unreadable-announce`
+    const privateOriginalStatusId = `${ACTOR2_ID}/statuses/account-private-original-for-announce`
+    const unreadableAnnounceId = `${ACTOR1_ID}/statuses/account-unreadable-announce`
+
+    await database.createNote({
+      id: publicStatusId,
+      url: publicStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account public after unreadable announce',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      createdAt: now
+    })
+    await database.createNote({
+      id: privateOriginalStatusId,
+      url: privateOriginalStatusId,
+      actorId: ACTOR2_ID,
+      text: 'Private original for unreadable announce',
+      to: [`${ACTOR2_ID}/followers`],
+      cc: [],
+      createdAt: now + 1
+    })
+    await database.createAnnounce({
+      id: unreadableAnnounceId,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      originalStatusId: privateOriginalStatusId,
+      createdAt: now + 2
+    })
+
+    const response = await GET(createRequest('?limit=1'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(200)
+
+    const data = (await response.json()) as Array<{ uri: string }>
+    const uris = data.map((status) => status.uri)
+
+    expect(uris).toEqual([publicStatusId])
+    expect(uris).not.toContain(unreadableAnnounceId)
+  })
+
   it('returns bad request for invalid query params', async () => {
     const response = await GET(createRequest('?limit=0'), {
       params: Promise.resolve({ id: urlToId(ACTOR1_ID) })

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -1,9 +1,12 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
-import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { seedActor3 } from '@/lib/stub/seed/actor3'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -152,6 +155,78 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
 
     expect(uris).toContain(privateStatusId)
     expect(uris).toContain(directStatusId)
+  })
+
+  it('allows accepted followers to read followers-only account statuses', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+
+    await database.createFollow({
+      actorId: ACTOR2_ID,
+      targetActorId: ACTOR1_ID,
+      inbox: `${ACTOR2_ID}/inbox`,
+      sharedInbox: `https://${TEST_DOMAIN}/inbox`,
+      status: FollowStatus.enum.Accepted
+    })
+
+    const privateStatusId = `${ACTOR1_ID}/statuses/account-private-follower-read`
+    await database.createNote({
+      id: privateStatusId,
+      url: privateStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account private follower read',
+      to: [`${ACTOR1_ID}/followers`],
+      cc: []
+    })
+
+    const response = await GET(createRequest('?limit=50'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(200)
+
+    const data = (await response.json()) as Array<{ uri: string }>
+    const uris = data.map((status) => status.uri)
+
+    expect(uris).toContain(privateStatusId)
+  })
+
+  it('applies account visibility filtering before limiting results', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor3.email }
+    })
+
+    const publicStatusId = `${ACTOR1_ID}/statuses/account-visible-before-limit`
+    const privateStatusId = `${ACTOR1_ID}/statuses/account-hidden-before-limit`
+    await database.createNote({
+      id: publicStatusId,
+      url: publicStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account visible before limit',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createNote({
+      id: privateStatusId,
+      url: privateStatusId,
+      actorId: ACTOR1_ID,
+      text: 'Account hidden before limit',
+      to: [`${ACTOR1_ID}/followers`],
+      cc: []
+    })
+
+    const response = await GET(createRequest('?limit=1'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(200)
+
+    const data = (await response.json()) as Array<{ uri: string }>
+    const uris = data.map((status) => status.uri)
+
+    expect(uris).toEqual([publicStatusId])
+    expect(uris).not.toContain(privateStatusId)
   })
 
   it('returns bad request for invalid query params', async () => {

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -105,7 +105,7 @@ export const GET = traceApiRoute(
     const isFollower =
       currentActor && currentActor.id !== id
         ? follow?.status === FollowStatus.enum.Accepted
-        : undefined
+        : false
     const isOwner = currentActor?.id === id
     const statuses = await database.getActorStatuses({
       actorId: id,
@@ -113,14 +113,14 @@ export const GET = traceApiRoute(
       minStatusId: minId || sinceId,
       limit,
       publicOnly: currentActor === null,
-      visibleToActorId: currentActor && !isOwner ? currentActor.id : undefined,
+      visibleToActorId: currentActor && !isOwner ? currentActor.id : null,
       includeFollowersOnly: isFollower,
       followersAudience: actor.followersUrl
     })
     const followerStateByActorId = currentActor
       ? new Map<string, boolean>()
       : undefined
-    if (currentActor && !isOwner && isFollower !== undefined) {
+    if (currentActor && !isOwner) {
       followerStateByActorId?.set(id, isFollower)
     }
     const originalAuthorIds = currentActor
@@ -147,10 +147,9 @@ export const GET = traceApiRoute(
           actorId: currentActor.id,
           targetActorId
         })
-        followerStateByActorId?.set(
-          targetActorId,
+        const originalIsFollower =
           originalFollow?.status === FollowStatus.enum.Accepted
-        )
+        followerStateByActorId?.set(targetActorId, originalIsFollower)
       })
     )
     const readableStatuses = (

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -7,7 +7,7 @@ import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
-import { StatusType } from '@/lib/types/domain/status'
+import { type Status, StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -107,72 +107,90 @@ export const GET = traceApiRoute(
         ? follow?.status === FollowStatus.enum.Accepted
         : false
     const isOwner = currentActor?.id === id
-    const statuses = await database.getActorStatuses({
-      actorId: id,
-      maxStatusId: maxId,
-      minStatusId: minId || sinceId,
-      limit,
-      publicOnly: currentActor === null,
-      visibleToActorId: currentActor && !isOwner ? currentActor.id : null,
-      includeFollowersOnly: isFollower,
-      followersAudience: actor.followersUrl
-    })
     const followerStateByActorId = currentActor
       ? new Map<string, boolean>()
       : undefined
     if (currentActor && !isOwner) {
       followerStateByActorId?.set(id, isFollower)
     }
-    const originalAuthorIds = currentActor
-      ? [
-          ...new Set(
-            statuses
-              .flatMap((status) =>
-                status.type === StatusType.enum.Announce
-                  ? [status.originalStatus.actorId]
-                  : []
-              )
-              .filter(
-                (actorId) =>
-                  actorId !== currentActor.id &&
-                  !followerStateByActorId?.has(actorId)
-              )
-          )
-        ]
-      : []
-    await Promise.all(
-      originalAuthorIds.map(async (targetActorId) => {
-        if (!currentActor) return
-        const originalFollow = await database.getAcceptedOrRequestedFollow({
-          actorId: currentActor.id,
-          targetActorId
-        })
-        const originalIsFollower =
-          originalFollow?.status === FollowStatus.enum.Accepted
-        followerStateByActorId?.set(targetActorId, originalIsFollower)
+
+    const readableStatuses: Status[] = []
+    let nextMaxId = maxId
+
+    while (readableStatuses.length < limit) {
+      const statuses = await database.getActorStatuses({
+        actorId: id,
+        maxStatusId: nextMaxId,
+        minStatusId: minId || sinceId,
+        limit,
+        publicOnly: currentActor === null,
+        visibleToActorId: currentActor && !isOwner ? currentActor.id : null,
+        includeFollowersOnly: isFollower,
+        followersAudience: actor.followersUrl
       })
-    )
-    const readableStatuses = (
+
+      if (statuses.length === 0) break
+
+      const originalAuthorIds: string[] = []
+      if (currentActor) {
+        const seen = new Set<string>()
+        for (const status of statuses) {
+          if (status.type !== StatusType.enum.Announce) continue
+
+          const { actorId } = status.originalStatus
+          if (
+            actorId !== currentActor.id &&
+            !followerStateByActorId?.has(actorId) &&
+            !seen.has(actorId)
+          ) {
+            seen.add(actorId)
+            originalAuthorIds.push(actorId)
+          }
+        }
+      }
+
       await Promise.all(
-        statuses.map(async (status) =>
-          (await canActorReadStatus({
-            database,
-            status,
-            currentActor,
-            isFollower,
-            followerStateByActorId
-          }))
-            ? status
-            : null
-        )
+        originalAuthorIds.map(async (targetActorId) => {
+          if (!currentActor) return
+          const originalFollow = await database.getAcceptedOrRequestedFollow({
+            actorId: currentActor.id,
+            targetActorId
+          })
+          const originalIsFollower =
+            originalFollow?.status === FollowStatus.enum.Accepted
+          followerStateByActorId?.set(targetActorId, originalIsFollower)
+        })
       )
-    ).filter((status): status is (typeof statuses)[number] => status !== null)
+
+      const readableBatch = (
+        await Promise.all(
+          statuses.map(async (status) =>
+            (await canActorReadStatus({
+              database,
+              status,
+              currentActor,
+              isFollower,
+              followerStateByActorId
+            }))
+              ? status
+              : null
+          )
+        )
+      ).filter((status): status is Status => status !== null)
+
+      readableStatuses.push(...readableBatch)
+
+      if (statuses.length < limit) break
+      nextMaxId = statuses[statuses.length - 1].id
+    }
 
     const mastodonStatuses = (
       await Promise.all(
-        readableStatuses.map((status) =>
-          getMastodonStatus(database, status, currentActor?.id)
-        )
+        readableStatuses
+          .slice(0, limit)
+          .map((status) =>
+            getMastodonStatus(database, status, currentActor?.id)
+          )
       )
     ).filter((status): status is Mastodon.Status => status !== null)
 

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod'
 
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -49,7 +50,7 @@ const StatusQueryParams = z.object({
 
 export const GET = traceApiRoute(
   'getAccountStatuses',
-  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
+  OptionalOAuthGuard<Params>([Scope.enum.read], async (req, context) => {
     const { database, currentActor, params } = context
     const encodedAccountId = (await params).id
     if (!encodedAccountId) {
@@ -74,7 +75,16 @@ export const GET = traceApiRoute(
 
     const url = new URL(req.url)
     const queryParams = Object.fromEntries(url.searchParams.entries())
-    const parsedParams = StatusQueryParams.parse(queryParams)
+    const parsed = StatusQueryParams.safeParse(queryParams)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+    const parsedParams = parsed.data
 
     const {
       limit = 20,
@@ -87,13 +97,27 @@ export const GET = traceApiRoute(
       actorId: id,
       maxStatusId: maxId,
       minStatusId: minId || sinceId,
-      limit
+      limit,
+      publicOnly: currentActor === null
     })
+    const readableStatuses = (
+      await Promise.all(
+        statuses.map(async (status) =>
+          (await canActorReadStatus({
+            database,
+            status,
+            currentActor
+          }))
+            ? status
+            : null
+        )
+      )
+    ).filter((status): status is (typeof statuses)[number] => status !== null)
 
     const mastodonStatuses = (
       await Promise.all(
-        statuses.map((status) =>
-          getMastodonStatus(database, status, currentActor.id)
+        readableStatuses.map((status) =>
+          getMastodonStatus(database, status, currentActor?.id)
         )
       )
     ).filter((status): status is Mastodon.Status => status !== null)

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -7,6 +7,7 @@ import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -64,7 +65,7 @@ export const GET = traceApiRoute(
     }
     const id = idToUrl(encodedAccountId)
 
-    const actor = await database.getMastodonActorFromId({ id })
+    const actor = await database.getActorFromId({ id })
     if (!actor) {
       return apiResponse({
         req,
@@ -113,8 +114,45 @@ export const GET = traceApiRoute(
       limit,
       publicOnly: currentActor === null,
       visibleToActorId: currentActor && !isOwner ? currentActor.id : undefined,
-      includeFollowersOnly: isFollower
+      includeFollowersOnly: isFollower,
+      followersAudience: actor.followersUrl
     })
+    const followerStateByActorId = currentActor
+      ? new Map<string, boolean>()
+      : undefined
+    if (currentActor && !isOwner && isFollower !== undefined) {
+      followerStateByActorId?.set(id, isFollower)
+    }
+    const originalAuthorIds = currentActor
+      ? [
+          ...new Set(
+            statuses
+              .flatMap((status) =>
+                status.type === StatusType.enum.Announce
+                  ? [status.originalStatus.actorId]
+                  : []
+              )
+              .filter(
+                (actorId) =>
+                  actorId !== currentActor.id &&
+                  !followerStateByActorId?.has(actorId)
+              )
+          )
+        ]
+      : []
+    await Promise.all(
+      originalAuthorIds.map(async (targetActorId) => {
+        if (!currentActor) return
+        const originalFollow = await database.getAcceptedOrRequestedFollow({
+          actorId: currentActor.id,
+          targetActorId
+        })
+        followerStateByActorId?.set(
+          targetActorId,
+          originalFollow?.status === FollowStatus.enum.Accepted
+        )
+      })
+    )
     const readableStatuses = (
       await Promise.all(
         statuses.map(async (status) =>
@@ -122,7 +160,8 @@ export const GET = traceApiRoute(
             database,
             status,
             currentActor,
-            isFollower
+            isFollower,
+            followerStateByActorId
           }))
             ? status
             : null

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -19,6 +19,7 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const MAX_STATUS_SCAN_BATCHES = 10
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -116,8 +117,14 @@ export const GET = traceApiRoute(
 
     const readableStatuses: Status[] = []
     let nextMaxId = maxId
+    let scannedBatches = 0
 
-    while (readableStatuses.length < limit) {
+    while (
+      readableStatuses.length < limit &&
+      scannedBatches < MAX_STATUS_SCAN_BATCHES
+    ) {
+      scannedBatches += 1
+
       const statuses = await database.getActorStatuses({
         actorId: id,
         maxStatusId: nextMaxId,

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -6,6 +6,7 @@ import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -100,13 +101,25 @@ export const GET = traceApiRoute(
       limit,
       publicOnly: currentActor === null
     })
+    const follow =
+      currentActor && currentActor.id !== id
+        ? await database.getAcceptedOrRequestedFollow({
+            actorId: currentActor.id,
+            targetActorId: id
+          })
+        : null
+    const isFollower =
+      currentActor && currentActor.id !== id
+        ? follow?.status === FollowStatus.enum.Accepted
+        : undefined
     const readableStatuses = (
       await Promise.all(
         statuses.map(async (status) =>
           (await canActorReadStatus({
             database,
             status,
-            currentActor
+            currentActor,
+            isFollower
           }))
             ? status
             : null

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -94,13 +94,6 @@ export const GET = traceApiRoute(
       since_id: sinceId
     } = parsedParams
 
-    const statuses = await database.getActorStatuses({
-      actorId: id,
-      maxStatusId: maxId,
-      minStatusId: minId || sinceId,
-      limit,
-      publicOnly: currentActor === null
-    })
     const follow =
       currentActor && currentActor.id !== id
         ? await database.getAcceptedOrRequestedFollow({
@@ -112,6 +105,16 @@ export const GET = traceApiRoute(
       currentActor && currentActor.id !== id
         ? follow?.status === FollowStatus.enum.Accepted
         : undefined
+    const isOwner = currentActor?.id === id
+    const statuses = await database.getActorStatuses({
+      actorId: id,
+      maxStatusId: maxId,
+      minStatusId: minId || sinceId,
+      limit,
+      publicOnly: currentActor === null,
+      visibleToActorId: currentActor && !isOwner ? currentActor.id : undefined,
+      includeFollowersOnly: isFollower
+    })
     const readableStatuses = (
       await Promise.all(
         statuses.map(async (status) =>

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -207,6 +207,34 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(response.status).toBe(404)
     })
 
+    it('allows direct recipients to read direct statuses', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-direct-recipient-read`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Direct recipient read target',
+        to: [ACTOR2_ID],
+        cc: []
+      })
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.visibility).toBe('direct')
+    })
+
     it('returns status with correct Mastodon format', async () => {
       const statusId = `${ACTOR1_ID}/statuses/post-1`
       const status = (await database.getStatus({ statusId })) as Status

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -7,11 +7,12 @@ import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
-import { PUT } from './route'
+import { GET, PUT } from './route'
 
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
@@ -77,6 +78,135 @@ describe('GET /api/v1/statuses/[id]', () => {
   })
 
   describe('status retrieval and format', () => {
+    it('allows anonymous reads for public statuses', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/post-1`
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data).toMatchObject({
+        id: urlToId(statusId),
+        uri: statusId,
+        visibility: 'public'
+      })
+    })
+
+    it('returns not found for anonymous reads of followers-only statuses', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-private-anonymous-read`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Private anonymous read target',
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(404)
+    })
+
+    it('allows the status owner to read followers-only statuses', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-private-owner-read`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Private owner read target',
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.visibility).toBe('private')
+    })
+
+    it('allows accepted followers to read followers-only statuses', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      await database.createFollow({
+        actorId: ACTOR2_ID,
+        targetActorId: ACTOR1_ID,
+        inbox: `${ACTOR1_ID}/inbox`,
+        sharedInbox: `https://${TEST_DOMAIN}/inbox`,
+        status: FollowStatus.enum.Accepted
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-private-follower-read`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Private follower read target',
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.visibility).toBe('private')
+    })
+
+    it('returns not found for authenticated non-recipients of direct statuses', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-direct-non-recipient-read`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Direct non-recipient read target',
+        to: ['https://llun.test/users/third-user'],
+        cc: []
+      })
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(404)
+    })
+
     it('returns status with correct Mastodon format', async () => {
       const statusId = `${ACTOR1_ID}/statuses/post-1`
       const status = (await database.getStatus({ statusId })) as Status

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -3,8 +3,12 @@ import { z } from 'zod'
 import { deleteStatusFromUserInput } from '@/lib/actions/deleteStatus'
 import { updateNoteFromUserInput } from '@/lib/actions/updateNote'
 import { updateNoteVisibilityFromUserInput } from '@/lib/actions/updateNoteVisibility'
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import {
+  OAuthGuard,
+  OptionalOAuthGuard
+} from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -35,7 +39,7 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute(
   'getStatus',
-  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
+  OptionalOAuthGuard<Params>([Scope.enum.read], async (req, context) => {
     const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
@@ -47,8 +51,24 @@ export const GET = traceApiRoute(
       })
     const statusId = idToUrl(encodedStatusId)
 
-    const status = await database.getStatus({ statusId })
+    const status = await database.getStatus({
+      statusId,
+      currentActorId: currentActor?.id
+    })
     if (!status)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+
+    const hasAccess = await canActorReadStatus({
+      database,
+      status,
+      currentActor
+    })
+    if (!hasAccess)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
@@ -59,7 +79,7 @@ export const GET = traceApiRoute(
     const mastodonStatus = await getMastodonStatus(
       database,
       status,
-      currentActor.id
+      currentActor?.id
     )
     if (!mastodonStatus)
       return apiResponse({

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -324,6 +324,29 @@ describe('StatusDatabase', () => {
       })
     })
 
+    describe('getActorStatuses followers audience fallback', () => {
+      it('includes fallback actor followers audience for followers-only reads', async () => {
+        const statusId = `${primaryActorId}/statuses/fallback-followers-${Date.now()}`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: primaryActorId,
+          to: [`${primaryActorId}/followers`],
+          cc: [],
+          text: 'Fallback followers audience'
+        })
+
+        const statuses = await database.getActorStatuses({
+          actorId: primaryActorId,
+          includeFollowersOnly: true,
+          followersAudience: `${primaryActorId}/followers-updated`,
+          limit: 50
+        })
+
+        expect(statuses.map((status) => status.id)).toContain(statusId)
+      })
+    })
+
     describe('getStatusReplies', () => {
       it('returns replies for specific status', async () => {
         const replies = await database.getStatusReplies({

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -712,22 +712,35 @@ export const StatusSQLDatabaseMixin = (
     minStatusId,
     maxStatusId,
     limit = PER_PAGE_LIMIT,
-    publicOnly = false
+    publicOnly = false,
+    visibleToActorId,
+    includeFollowersOnly = false
   }: GetActorStatusesParams) {
     let query = database('statuses')
       .where('actorId', actorId)
       .orderBy('createdAt', 'desc')
       .limit(limit)
 
-    if (publicOnly) {
+    const recipientActorIds =
+      publicOnly || visibleToActorId || includeFollowersOnly
+        ? [ACTIVITY_STREAM_PUBLIC, ACTIVITY_STREAM_PUBLIC_COMPACT]
+        : null
+
+    if (recipientActorIds) {
+      if (!publicOnly) {
+        if (includeFollowersOnly) {
+          recipientActorIds.push(`${actorId}/followers`)
+        }
+        if (visibleToActorId) {
+          recipientActorIds.push(visibleToActorId)
+        }
+      }
+
       query = query.whereIn(
         'statuses.id',
         database('recipients')
           .select('statusId')
-          .whereIn('recipients.actorId', [
-            ACTIVITY_STREAM_PUBLIC,
-            ACTIVITY_STREAM_PUBLIC_COMPACT
-          ])
+          .whereIn('recipients.actorId', recipientActorIds)
       )
     }
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -714,7 +714,8 @@ export const StatusSQLDatabaseMixin = (
     limit = PER_PAGE_LIMIT,
     publicOnly = false,
     visibleToActorId,
-    includeFollowersOnly = false
+    includeFollowersOnly = false,
+    followersAudience
   }: GetActorStatusesParams) {
     let query = database('statuses')
       .where('actorId', actorId)
@@ -729,7 +730,7 @@ export const StatusSQLDatabaseMixin = (
     if (recipientActorIds) {
       if (!publicOnly) {
         if (includeFollowersOnly) {
-          recipientActorIds.push(`${actorId}/followers`)
+          recipientActorIds.push(followersAudience ?? `${actorId}/followers`)
         }
         if (visibleToActorId) {
           recipientActorIds.push(visibleToActorId)

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -52,7 +52,10 @@ import {
   StatusType
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
-import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
 import { getAttachmentMediaPath } from '@/lib/utils/getAttachmentMediaPath'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
@@ -708,12 +711,25 @@ export const StatusSQLDatabaseMixin = (
     actorId,
     minStatusId,
     maxStatusId,
-    limit = PER_PAGE_LIMIT
+    limit = PER_PAGE_LIMIT,
+    publicOnly = false
   }: GetActorStatusesParams) {
     let query = database('statuses')
       .where('actorId', actorId)
       .orderBy('createdAt', 'desc')
       .limit(limit)
+
+    if (publicOnly) {
+      query = query.whereIn(
+        'statuses.id',
+        database('recipients')
+          .select('statusId')
+          .whereIn('recipients.actorId', [
+            ACTIVITY_STREAM_PUBLIC,
+            ACTIVITY_STREAM_PUBLIC_COMPACT
+          ])
+      )
+    }
 
     if (minStatusId) {
       const minStatus = await database('statuses')

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -652,8 +652,13 @@ export const StatusSQLDatabaseMixin = (
     return getStatusWithAttachmentsFromData(status, currentActorId, withReplies)
   }
 
-  async function getStatusReplies({ statusId, url }: GetStatusRepliesParams) {
-    const statuses = await database('statuses')
+  async function getStatusReplies({
+    statusId,
+    url,
+    limit,
+    publicOnly = false
+  }: GetStatusRepliesParams) {
+    let query = database('statuses')
       .where((builder) => {
         builder.where('reply', statusId)
         if (url) {
@@ -661,6 +666,24 @@ export const StatusSQLDatabaseMixin = (
         }
       })
       .orderBy('createdAt', 'desc')
+
+    if (publicOnly) {
+      query = query.whereIn(
+        'statuses.id',
+        database('recipients')
+          .select('statusId')
+          .whereIn('recipients.actorId', [
+            ACTIVITY_STREAM_PUBLIC,
+            ACTIVITY_STREAM_PUBLIC_COMPACT
+          ])
+      )
+    }
+
+    if (limit) {
+      query = query.limit(limit)
+    }
+
+    const statuses = await query
     const statusesWithAttachments = (
       await Promise.all(
         statuses.map((item) => getStatusWithAttachmentsFromData(item))

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -753,7 +753,11 @@ export const StatusSQLDatabaseMixin = (
     if (recipientActorIds) {
       if (!publicOnly) {
         if (includeFollowersOnly) {
-          recipientActorIds.push(followersAudience ?? `${actorId}/followers`)
+          recipientActorIds.push(
+            ...[followersAudience, `${actorId}/followers`].filter(
+              (audience): audience is string => Boolean(audience)
+            )
+          )
         }
         if (visibleToActorId) {
           recipientActorIds.push(visibleToActorId)
@@ -764,7 +768,7 @@ export const StatusSQLDatabaseMixin = (
         'statuses.id',
         database('recipients')
           .select('statusId')
-          .whereIn('recipients.actorId', recipientActorIds)
+          .whereIn('recipients.actorId', [...new Set(recipientActorIds)])
       )
     }
 

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -11,7 +11,11 @@ import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { logger } from '@/lib/utils/logger'
 import { apiErrorResponse } from '@/lib/utils/response'
 
-import { AppRouterParams, AuthenticatedApiHandle } from './types'
+import {
+  AppRouterParams,
+  AuthenticatedApiHandle,
+  OptionalAuthenticatedApiHandle
+} from './types'
 
 // better-auth stores tokens as SHA-256 base64url (matching its defaultHasher)
 const hashToken = (token: string): string => {
@@ -51,138 +55,183 @@ export const getTokenFromHeader = (
 
 type ScopeMatchMode = 'all' | 'any'
 
-const createOAuthGuard =
-  (matchMode: ScopeMatchMode) =>
-  <P>(scopes: Scope[], handle: AuthenticatedApiHandle<P>) =>
-  async (req: NextRequest, context: AppRouterParams<P>) => {
-    const database = getDatabase()
-    if (!database) {
-      return apiErrorResponse(500)
+type GuardContext<P> = {
+  currentActor: Actor
+  database: NonNullable<ReturnType<typeof getDatabase>>
+  params: Promise<P>
+  grantedScopes?: string[]
+}
+
+const resolveAuthenticatedContext = async <P>({
+  req,
+  context,
+  scopes,
+  matchMode
+}: {
+  req: NextRequest
+  context: AppRouterParams<P>
+  scopes: Scope[]
+  matchMode: ScopeMatchMode
+}): Promise<
+  | { authenticated: true; context: GuardContext<P> }
+  | { authenticated: false; response?: Response }
+> => {
+  const database = getDatabase()
+  if (!database) {
+    return { authenticated: false, response: apiErrorResponse(500) }
+  }
+
+  const session = await getServerAuthSession()
+  if (session?.user?.email) {
+    const currentActor = await getActorFromSession(database, session)
+    if (!currentActor) {
+      return { authenticated: false, response: apiErrorResponse(401) }
+    }
+    return {
+      authenticated: true,
+      context: { currentActor, database, params: context.params }
+    }
+  }
+
+  const authorizationToken = req.headers.get('Authorization')
+  const token = getTokenFromHeader(authorizationToken)
+  if (!token) {
+    if (authorizationToken) {
+      return { authenticated: false, response: apiErrorResponse(401) }
+    }
+    return { authenticated: false }
+  }
+
+  const baseURL = getBaseURL()
+  const jwksUrl = `${baseURL}/api/auth/jwks`
+
+  // Distinguish JWT from opaque tokens by format: JWTs have three
+  // dot-separated segments. This prevents tampered/expired JWTs from
+  // falling through to the opaque DB lookup path.
+  let jwtPayload: Record<string, unknown> | null = null
+  let grantedScopes: string[] = []
+
+  if (isJwtFormat(token)) {
+    try {
+      jwtPayload = (await verifyAccessToken(token, {
+        jwksUrl,
+        // For 'any' mode, skip scope checking in verifyAccessToken
+        // and do it manually below
+        scopes: matchMode === 'all' ? scopes : [],
+        verifyOptions: {
+          issuer: baseURL,
+          audience: baseURL
+        }
+      })) as Record<string, unknown>
+    } catch {
+      // JWT verification failed (expired, invalid signature, wrong scope,
+      // etc.) — reject immediately, do NOT fall through to opaque lookup
+      return { authenticated: false, response: apiErrorResponse(401) }
     }
 
-    const session = await getServerAuthSession()
-    if (session?.user?.email) {
-      const currentActor = await getActorFromSession(database, session)
-      if (!currentActor) return apiErrorResponse(401)
-      return handle(req, { currentActor, database, params: context.params })
-    }
+    const jwtScope = jwtPayload.scope as string | undefined
+    const jwtScopes = jwtScope ? jwtScope.split(' ') : []
+    grantedScopes = jwtScopes
 
-    const authorizationToken = req.headers.get('Authorization')
-    const token = getTokenFromHeader(authorizationToken)
-    if (!token) {
-      return apiErrorResponse(401)
-    }
-
-    const baseURL = getBaseURL()
-    const jwksUrl = `${baseURL}/api/auth/jwks`
-
-    // Distinguish JWT from opaque tokens by format: JWTs have three
-    // dot-separated segments. This prevents tampered/expired JWTs from
-    // falling through to the opaque DB lookup path.
-    let jwtPayload: Record<string, unknown> | null = null
-    let grantedScopes: string[] = []
-
-    if (isJwtFormat(token)) {
-      try {
-        jwtPayload = (await verifyAccessToken(token, {
-          jwksUrl,
-          // For 'any' mode, skip scope checking in verifyAccessToken
-          // and do it manually below
-          scopes: matchMode === 'all' ? scopes : [],
-          verifyOptions: {
-            issuer: baseURL,
-            audience: baseURL
-          }
-        })) as Record<string, unknown>
-      } catch {
-        // JWT verification failed (expired, invalid signature, wrong scope,
-        // etc.) — reject immediately, do NOT fall through to opaque lookup
-        return apiErrorResponse(401)
+    if (matchMode === 'all') {
+      // Defense-in-depth: explicitly verify JWT scope claims in case
+      // verifyAccessToken's scope checking changes in a future version
+      for (const scope of scopes) {
+        if (!jwtScopes.includes(scope)) {
+          return { authenticated: false, response: apiErrorResponse(401) }
+        }
       }
+    } else {
+      // 'any' mode: at least one required scope must be present
+      const hasAny = scopes.some((scope) => jwtScopes.includes(scope))
+      if (!hasAny) {
+        return { authenticated: false, response: apiErrorResponse(401) }
+      }
+    }
+  }
 
-      const jwtScope = jwtPayload.scope as string | undefined
-      const jwtScopes = jwtScope ? jwtScope.split(' ') : []
-      grantedScopes = jwtScopes
+  try {
+    // Verify the token exists in DB (revocation check for JWTs,
+    // primary auth check for opaque tokens).
+    // better-auth's storeToken() hashes ALL token types (JWT and opaque)
+    // via defaultHasher (SHA-256 base64url) before storing in the
+    // oauthAccessToken.token column.
+    // See: @better-auth/oauth-provider/dist/utils-DgozotLg.mjs storeToken()
+    const db = getKnex()
+    const storedToken = await db('oauthAccessToken')
+      .where('token', hashToken(token))
+      .first()
+    if (!storedToken) {
+      return { authenticated: false, response: apiErrorResponse(401) }
+    }
+
+    // For opaque tokens, check expiration and scopes manually
+    // (JWT verification already handles these for JWT tokens)
+    if (!jwtPayload) {
+      if (new Date(storedToken.expiresAt) < new Date()) {
+        return { authenticated: false, response: apiErrorResponse(401) }
+      }
+      const storedScopes = parseStoredScopes(storedToken.scopes as string)
+      grantedScopes = storedScopes
 
       if (matchMode === 'all') {
-        // Defense-in-depth: explicitly verify JWT scope claims in case
-        // verifyAccessToken's scope checking changes in a future version
         for (const scope of scopes) {
-          if (!jwtScopes.includes(scope)) {
-            return apiErrorResponse(401)
+          if (!storedScopes.includes(scope)) {
+            return { authenticated: false, response: apiErrorResponse(401) }
           }
         }
       } else {
-        // 'any' mode: at least one required scope must be present
-        const hasAny = scopes.some((scope) => jwtScopes.includes(scope))
+        const hasAny = scopes.some((scope) => storedScopes.includes(scope))
         if (!hasAny) {
-          return apiErrorResponse(401)
+          return { authenticated: false, response: apiErrorResponse(401) }
         }
       }
     }
 
-    try {
-      // Verify the token exists in DB (revocation check for JWTs,
-      // primary auth check for opaque tokens).
-      // better-auth's storeToken() hashes ALL token types (JWT and opaque)
-      // via defaultHasher (SHA-256 base64url) before storing in the
-      // oauthAccessToken.token column.
-      // See: @better-auth/oauth-provider/dist/utils-DgozotLg.mjs storeToken()
-      const db = getKnex()
-      const storedToken = await db('oauthAccessToken')
-        .where('token', hashToken(token))
-        .first()
-      if (!storedToken) {
-        return apiErrorResponse(401)
-      }
+    // Extract actorId: from JWT claims or from stored referenceId (opaque)
+    const actorId = jwtPayload
+      ? (jwtPayload.actorId as string | null)
+      : (storedToken.referenceId as string | null)
 
-      // For opaque tokens, check expiration and scopes manually
-      // (JWT verification already handles these for JWT tokens)
-      if (!jwtPayload) {
-        if (new Date(storedToken.expiresAt) < new Date()) {
-          return apiErrorResponse(401)
-        }
-        const storedScopes = parseStoredScopes(storedToken.scopes as string)
-        grantedScopes = storedScopes
+    if (!actorId) {
+      return { authenticated: false, response: apiErrorResponse(401) }
+    }
 
-        if (matchMode === 'all') {
-          for (const scope of scopes) {
-            if (!storedScopes.includes(scope)) {
-              return apiErrorResponse(401)
-            }
-          }
-        } else {
-          const hasAny = scopes.some((scope) => storedScopes.includes(scope))
-          if (!hasAny) {
-            return apiErrorResponse(401)
-          }
-        }
-      }
+    const actor = await database.getActorFromId({ id: actorId })
+    if (!actor) {
+      return { authenticated: false, response: apiErrorResponse(401) }
+    }
 
-      // Extract actorId: from JWT claims or from stored referenceId (opaque)
-      const actorId = jwtPayload
-        ? (jwtPayload.actorId as string | null)
-        : (storedToken.referenceId as string | null)
-
-      if (!actorId) {
-        return apiErrorResponse(401)
-      }
-
-      const actor = await database.getActorFromId({ id: actorId })
-      if (!actor) {
-        return apiErrorResponse(401)
-      }
-
-      return handle(req, {
+    return {
+      authenticated: true,
+      context: {
         currentActor: Actor.parse(actor),
         database,
         params: context.params,
         grantedScopes
-      })
-    } catch (e) {
-      logger.error(e as Error)
-      return apiErrorResponse(500)
+      }
     }
+  } catch (e) {
+    logger.error(e as Error)
+    return { authenticated: false, response: apiErrorResponse(500) }
+  }
+}
+
+const createOAuthGuard =
+  (matchMode: ScopeMatchMode) =>
+  <P>(scopes: Scope[], handle: AuthenticatedApiHandle<P>) =>
+  async (req: NextRequest, context: AppRouterParams<P>) => {
+    const result = await resolveAuthenticatedContext({
+      req,
+      context,
+      scopes,
+      matchMode
+    })
+    if (!result.authenticated) {
+      return result.response ?? apiErrorResponse(401)
+    }
+
+    return handle(req, result.context)
   }
 
 /**
@@ -194,3 +243,33 @@ export const OAuthGuard = createOAuthGuard('all')
  * Requires at least ONE of the specified scopes to be present on the token.
  */
 export const OAuthGuardAnyScope = createOAuthGuard('any')
+
+export const OptionalOAuthGuard =
+  <P>(scopes: Scope[], handle: OptionalAuthenticatedApiHandle<P>) =>
+  async (req: NextRequest, context: AppRouterParams<P>) => {
+    const result = await resolveAuthenticatedContext({
+      req,
+      context,
+      scopes,
+      matchMode: 'all'
+    })
+
+    if (result.authenticated) {
+      return handle(req, result.context)
+    }
+
+    if (result.response) {
+      return result.response
+    }
+
+    const database = getDatabase()
+    if (!database) {
+      return apiErrorResponse(500)
+    }
+
+    return handle(req, {
+      currentActor: null,
+      database,
+      params: context.params
+    })
+  }

--- a/lib/services/guards/types.ts
+++ b/lib/services/guards/types.ts
@@ -15,6 +15,16 @@ export type AuthenticatedApiHandle<P> = (
   }
 ) => Promise<Response> | Response
 
+export type OptionalAuthenticatedApiHandle<P> = (
+  request: NextRequest,
+  context: {
+    database: Database
+    currentActor: Actor | null
+    params: Promise<P>
+    grantedScopes?: string[]
+  }
+) => Promise<Response> | Response
+
 export type ActivityPubVerifiedSenderHandle<P> = (
   request: NextRequest,
   context: { database: Database; params: Promise<P> }

--- a/lib/services/statusAccess.test.ts
+++ b/lib/services/statusAccess.test.ts
@@ -107,6 +107,47 @@ describe('status access helpers', () => {
     ).resolves.toBe(true)
   })
 
+  it('does not allow requested followers to read followers-only statuses', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn().mockResolvedValue({
+        status: FollowStatus.enum.Requested
+      })
+    }
+    const status = note({
+      id: `${ACTOR_ID}/statuses/private-for-requested-follower`,
+      to: [FOLLOWERS_URL],
+      cc: []
+    })
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status,
+        currentActor: actor
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('allows direct recipients to read direct statuses', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn()
+    }
+    const status = note({
+      id: `${ACTOR_ID}/statuses/direct-for-recipient`,
+      to: [FOLLOWER_ID],
+      cc: []
+    })
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status,
+        currentActor: actor
+      })
+    ).resolves.toBe(true)
+    expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
+
   it('uses pre-fetched follower state when provided', async () => {
     const database = {
       getAcceptedOrRequestedFollow: jest.fn()

--- a/lib/services/statusAccess.test.ts
+++ b/lib/services/statusAccess.test.ts
@@ -152,6 +152,53 @@ describe('status access helpers', () => {
     expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
   })
 
+  it('allows direct recipients to read followers-only statuses', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn()
+    }
+    const status = note({
+      id: `${ACTOR_ID}/statuses/private-direct-recipient`,
+      to: [FOLLOWERS_URL],
+      cc: [FOLLOWER_ID]
+    })
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status,
+        currentActor: actor
+      })
+    ).resolves.toBe(true)
+    expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
+
+  it('recognizes the fallback actor followers audience', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn().mockResolvedValue({
+        status: FollowStatus.enum.Accepted
+      })
+    }
+    const status = {
+      ...note({
+        id: `${ACTOR_ID}/statuses/private-fallback-followers`,
+        to: [FOLLOWERS_URL],
+        cc: []
+      }),
+      actor: {
+        id: ACTOR_ID,
+        followersUrl: `${ACTOR_ID}/followers-updated`
+      }
+    } as Status
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status,
+        currentActor: actor
+      })
+    ).resolves.toBe(true)
+  })
+
   it('uses pre-fetched follower state when provided', async () => {
     const database = {
       getAcceptedOrRequestedFollow: jest.fn()

--- a/lib/services/statusAccess.test.ts
+++ b/lib/services/statusAccess.test.ts
@@ -17,6 +17,10 @@ const note = ({ id, to, cc }: { id: string; to: string[]; cc: string[] }) =>
   ({
     id,
     actorId: ACTOR_ID,
+    actor: {
+      id: ACTOR_ID,
+      followersUrl: FOLLOWERS_URL
+    },
     type: StatusType.enum.Note,
     to,
     cc
@@ -164,6 +168,39 @@ describe('status access helpers', () => {
         status,
         currentActor: actor,
         isFollower: true
+      })
+    ).resolves.toBe(true)
+    expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
+
+  it('uses pre-fetched follower state for announced originals', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn()
+    }
+    const originalStatus = note({
+      id: `${ACTOR_ID}/statuses/private-original-for-announce`,
+      to: [FOLLOWERS_URL],
+      cc: []
+    })
+    const announce = {
+      id: `${FOLLOWER_ID}/statuses/announce-private-original`,
+      actorId: FOLLOWER_ID,
+      actor: {
+        id: FOLLOWER_ID,
+        followersUrl: `${FOLLOWER_ID}/followers`
+      },
+      type: StatusType.enum.Announce,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      originalStatus
+    } as Status
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status: announce,
+        currentActor: actor,
+        followerStateByActorId: new Map([[ACTOR_ID, true]])
       })
     ).resolves.toBe(true)
     expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()

--- a/lib/services/statusAccess.test.ts
+++ b/lib/services/statusAccess.test.ts
@@ -1,0 +1,109 @@
+import { Actor } from '@/lib/types/domain/actor'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import { canActorReadStatus, isStatusPubliclyReadable } from './statusAccess'
+
+const ACTOR_ID = 'https://example.com/users/author'
+const FOLLOWER_ID = 'https://example.com/users/follower'
+const FOLLOWERS_URL = `${ACTOR_ID}/followers`
+
+const actor = {
+  id: FOLLOWER_ID
+} as Actor
+
+const note = ({ id, to, cc }: { id: string; to: string[]; cc: string[] }) =>
+  ({
+    id,
+    actorId: ACTOR_ID,
+    type: StatusType.enum.Note,
+    to,
+    cc
+  }) as Status
+
+describe('status access helpers', () => {
+  it('treats public and unlisted statuses as publicly readable', () => {
+    expect(
+      isStatusPubliclyReadable(
+        note({
+          id: `${ACTOR_ID}/statuses/public`,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+      )
+    ).toBe(true)
+
+    expect(
+      isStatusPubliclyReadable(
+        note({
+          id: `${ACTOR_ID}/statuses/unlisted`,
+          to: [FOLLOWERS_URL],
+          cc: [ACTIVITY_STREAM_PUBLIC]
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('does not treat followers-only or direct statuses as publicly readable', () => {
+    expect(
+      isStatusPubliclyReadable(
+        note({
+          id: `${ACTOR_ID}/statuses/private`,
+          to: [FOLLOWERS_URL],
+          cc: []
+        })
+      )
+    ).toBe(false)
+
+    expect(
+      isStatusPubliclyReadable(
+        note({
+          id: `${ACTOR_ID}/statuses/direct`,
+          to: [FOLLOWER_ID],
+          cc: []
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('requires both an announce and its original status to be public', () => {
+    const privateOriginal = note({
+      id: `${ACTOR_ID}/statuses/private-original`,
+      to: [FOLLOWERS_URL],
+      cc: []
+    })
+
+    const announce = {
+      id: `${FOLLOWER_ID}/statuses/announce`,
+      actorId: FOLLOWER_ID,
+      type: StatusType.enum.Announce,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      originalStatus: privateOriginal
+    } as Status
+
+    expect(isStatusPubliclyReadable(announce)).toBe(false)
+  })
+
+  it('allows accepted followers to read followers-only statuses', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn().mockResolvedValue({
+        status: FollowStatus.enum.Accepted
+      })
+    }
+    const status = note({
+      id: `${ACTOR_ID}/statuses/private-for-follower`,
+      to: [FOLLOWERS_URL],
+      cc: []
+    })
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status,
+        currentActor: actor
+      })
+    ).resolves.toBe(true)
+  })
+})

--- a/lib/services/statusAccess.test.ts
+++ b/lib/services/statusAccess.test.ts
@@ -106,4 +106,25 @@ describe('status access helpers', () => {
       })
     ).resolves.toBe(true)
   })
+
+  it('uses pre-fetched follower state when provided', async () => {
+    const database = {
+      getAcceptedOrRequestedFollow: jest.fn()
+    }
+    const status = note({
+      id: `${ACTOR_ID}/statuses/private-prefetched-follower`,
+      to: [FOLLOWERS_URL],
+      cc: []
+    })
+
+    await expect(
+      canActorReadStatus({
+        database: database as never,
+        status,
+        currentActor: actor,
+        isFollower: true
+      })
+    ).resolves.toBe(true)
+    expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
 })

--- a/lib/services/statusAccess.ts
+++ b/lib/services/statusAccess.ts
@@ -1,0 +1,80 @@
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { getVisibility } from '@/lib/utils/getVisibility'
+
+const isPublicOrUnlisted = (status: Status): boolean => {
+  const visibility = getVisibility(status.to, status.cc)
+  return visibility === 'public' || visibility === 'unlisted'
+}
+
+const hasFollowersAudience = (status: Status): boolean =>
+  [...status.to, ...status.cc].some((item) => item.endsWith('/followers'))
+
+const isDirectRecipient = (status: Status, actor: Actor): boolean =>
+  status.to.includes(actor.id) || status.cc.includes(actor.id)
+
+export const isStatusPubliclyReadable = (status: Status): boolean => {
+  if (!isPublicOrUnlisted(status)) return false
+
+  if (status.type === StatusType.enum.Announce) {
+    return isStatusPubliclyReadable(status.originalStatus)
+  }
+
+  return true
+}
+
+const canActorReadSingleStatus = async ({
+  database,
+  status,
+  currentActor
+}: {
+  database: Database
+  status: Status
+  currentActor: Actor
+}): Promise<boolean> => {
+  if (isPublicOrUnlisted(status)) return true
+  if (currentActor.id === status.actorId) return true
+
+  if (hasFollowersAudience(status)) {
+    const follow = await database.getAcceptedOrRequestedFollow({
+      actorId: currentActor.id,
+      targetActorId: status.actorId
+    })
+    return follow?.status === FollowStatus.enum.Accepted
+  }
+
+  return isDirectRecipient(status, currentActor)
+}
+
+export const canActorReadStatus = async ({
+  database,
+  status,
+  currentActor
+}: {
+  database: Database
+  status: Status
+  currentActor: Actor | null
+}): Promise<boolean> => {
+  if (isStatusPubliclyReadable(status)) return true
+  if (!currentActor) return false
+
+  if (status.type === StatusType.enum.Announce) {
+    const canReadAnnounce = await canActorReadSingleStatus({
+      database,
+      status,
+      currentActor
+    })
+
+    if (!canReadAnnounce) return false
+
+    return canActorReadStatus({
+      database,
+      status: status.originalStatus,
+      currentActor
+    })
+  }
+
+  return canActorReadSingleStatus({ database, status, currentActor })
+}

--- a/lib/services/statusAccess.ts
+++ b/lib/services/statusAccess.ts
@@ -28,16 +28,20 @@ export const isStatusPubliclyReadable = (status: Status): boolean => {
 const canActorReadSingleStatus = async ({
   database,
   status,
-  currentActor
+  currentActor,
+  isFollower
 }: {
   database: Database
   status: Status
   currentActor: Actor
+  isFollower?: boolean
 }): Promise<boolean> => {
   if (isPublicOrUnlisted(status)) return true
   if (currentActor.id === status.actorId) return true
 
   if (hasFollowersAudience(status)) {
+    if (isFollower !== undefined) return isFollower
+
     const follow = await database.getAcceptedOrRequestedFollow({
       actorId: currentActor.id,
       targetActorId: status.actorId
@@ -51,11 +55,13 @@ const canActorReadSingleStatus = async ({
 export const canActorReadStatus = async ({
   database,
   status,
-  currentActor
+  currentActor,
+  isFollower
 }: {
   database: Database
   status: Status
   currentActor: Actor | null
+  isFollower?: boolean
 }): Promise<boolean> => {
   if (isStatusPubliclyReadable(status)) return true
   if (!currentActor) return false
@@ -64,7 +70,8 @@ export const canActorReadStatus = async ({
     const canReadAnnounce = await canActorReadSingleStatus({
       database,
       status,
-      currentActor
+      currentActor,
+      isFollower
     })
 
     if (!canReadAnnounce) return false
@@ -76,5 +83,10 @@ export const canActorReadStatus = async ({
     })
   }
 
-  return canActorReadSingleStatus({ database, status, currentActor })
+  return canActorReadSingleStatus({
+    database,
+    status,
+    currentActor,
+    isFollower
+  })
 }

--- a/lib/services/statusAccess.ts
+++ b/lib/services/statusAccess.ts
@@ -9,17 +9,14 @@ const isPublicOrUnlisted = (status: Status): boolean => {
   return visibility === 'public' || visibility === 'unlisted'
 }
 
-const getFollowersAudienceCandidates = (status: Status): Set<string> =>
-  new Set(
-    [status.actor?.followersUrl, `${status.actorId}/followers`].filter(
-      (audience): audience is string => Boolean(audience)
-    )
-  )
-
 const hasFollowersAudience = (status: Status): boolean => {
-  const followersAudiences = getFollowersAudienceCandidates(status)
-  return [...status.to, ...status.cc].some((recipient) =>
-    followersAudiences.has(recipient)
+  const followersUrl = status.actor?.followersUrl
+  const fallbackFollowersUrl = `${status.actorId}/followers`
+  const isFollowersAudience = (recipient: string) =>
+    recipient === followersUrl || recipient === fallbackFollowersUrl
+
+  return (
+    status.to.some(isFollowersAudience) || status.cc.some(isFollowersAudience)
   )
 }
 

--- a/lib/services/statusAccess.ts
+++ b/lib/services/statusAccess.ts
@@ -10,7 +10,9 @@ const isPublicOrUnlisted = (status: Status): boolean => {
 }
 
 const hasFollowersAudience = (status: Status): boolean =>
-  [...status.to, ...status.cc].some((item) => item.endsWith('/followers'))
+  [...status.to, ...status.cc].includes(
+    status.actor?.followersUrl ?? `${status.actorId}/followers`
+  )
 
 const isDirectRecipient = (status: Status, actor: Actor): boolean =>
   status.to.includes(actor.id) || status.cc.includes(actor.id)
@@ -29,18 +31,22 @@ const canActorReadSingleStatus = async ({
   database,
   status,
   currentActor,
-  isFollower
+  isFollower,
+  followerStateByActorId
 }: {
   database: Database
   status: Status
   currentActor: Actor
   isFollower?: boolean
+  followerStateByActorId?: ReadonlyMap<string, boolean>
 }): Promise<boolean> => {
   if (isPublicOrUnlisted(status)) return true
   if (currentActor.id === status.actorId) return true
 
   if (hasFollowersAudience(status)) {
-    if (isFollower !== undefined) return isFollower
+    const prefetchedIsFollower =
+      isFollower ?? followerStateByActorId?.get(status.actorId)
+    if (prefetchedIsFollower !== undefined) return prefetchedIsFollower
 
     const follow = await database.getAcceptedOrRequestedFollow({
       actorId: currentActor.id,
@@ -56,12 +62,14 @@ export const canActorReadStatus = async ({
   database,
   status,
   currentActor,
-  isFollower
+  isFollower,
+  followerStateByActorId
 }: {
   database: Database
   status: Status
   currentActor: Actor | null
   isFollower?: boolean
+  followerStateByActorId?: ReadonlyMap<string, boolean>
 }): Promise<boolean> => {
   if (isStatusPubliclyReadable(status)) return true
   if (!currentActor) return false
@@ -71,7 +79,8 @@ export const canActorReadStatus = async ({
       database,
       status,
       currentActor,
-      isFollower
+      isFollower,
+      followerStateByActorId
     })
 
     if (!canReadAnnounce) return false
@@ -79,7 +88,8 @@ export const canActorReadStatus = async ({
     return canActorReadStatus({
       database,
       status: status.originalStatus,
-      currentActor
+      currentActor,
+      followerStateByActorId
     })
   }
 
@@ -87,6 +97,7 @@ export const canActorReadStatus = async ({
     database,
     status,
     currentActor,
-    isFollower
+    isFollower,
+    followerStateByActorId
   })
 }

--- a/lib/services/statusAccess.ts
+++ b/lib/services/statusAccess.ts
@@ -9,10 +9,19 @@ const isPublicOrUnlisted = (status: Status): boolean => {
   return visibility === 'public' || visibility === 'unlisted'
 }
 
-const hasFollowersAudience = (status: Status): boolean =>
-  [...status.to, ...status.cc].includes(
-    status.actor?.followersUrl ?? `${status.actorId}/followers`
+const getFollowersAudienceCandidates = (status: Status): Set<string> =>
+  new Set(
+    [status.actor?.followersUrl, `${status.actorId}/followers`].filter(
+      (audience): audience is string => Boolean(audience)
+    )
   )
+
+const hasFollowersAudience = (status: Status): boolean => {
+  const followersAudiences = getFollowersAudienceCandidates(status)
+  return [...status.to, ...status.cc].some((recipient) =>
+    followersAudiences.has(recipient)
+  )
+}
 
 const isDirectRecipient = (status: Status, actor: Actor): boolean =>
   status.to.includes(actor.id) || status.cc.includes(actor.id)
@@ -42,6 +51,7 @@ const canActorReadSingleStatus = async ({
 }): Promise<boolean> => {
   if (isPublicOrUnlisted(status)) return true
   if (currentActor.id === status.actorId) return true
+  if (isDirectRecipient(status, currentActor)) return true
 
   if (hasFollowersAudience(status)) {
     const prefetchedIsFollower =
@@ -55,7 +65,7 @@ const canActorReadSingleStatus = async ({
     return follow?.status === FollowStatus.enum.Accepted
   }
 
-  return isDirectRecipient(status, currentActor)
+  return false
 }
 
 export const canActorReadStatus = async ({

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -440,6 +440,8 @@ export type GetActorStatusesParams = {
   maxStatusId?: string | null
   limit?: number
   publicOnly?: boolean
+  visibleToActorId?: string | null
+  includeFollowersOnly?: boolean
 }
 export type GetStatusesByIdsParams = {
   statusIds: string[]

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -442,6 +442,7 @@ export type GetActorStatusesParams = {
   publicOnly?: boolean
   visibleToActorId?: string | null
   includeFollowersOnly?: boolean
+  followersAudience?: string | null
 }
 export type GetStatusesByIdsParams = {
   statusIds: string[]

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -390,6 +390,8 @@ export type GetStatusParams = BaseStatusParams & {
 }
 export type GetStatusRepliesParams = BaseStatusParams & {
   url?: string
+  limit?: number
+  publicOnly?: boolean
 }
 export type DeleteStatusParams = BaseStatusParams
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -439,6 +439,7 @@ export type GetActorStatusesParams = {
   minStatusId?: string | null
   maxStatusId?: string | null
   limit?: number
+  publicOnly?: boolean
 }
 export type GetStatusesByIdsParams = {
   statusIds: string[]


### PR DESCRIPTION
## Summary
- Allow anonymous reads of public and unlisted statuses through Mastodon status endpoints.
- Keep followers-only and direct statuses restricted to owners, accepted followers, or direct recipients.
- Stop ActivityPub object fetches from exposing non-public statuses or non-public replies.

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test
