### PR TITLE
feat: share ActivityPub signed request headers

### DIFF
--- a/lib/activities/activityPubHeaders.test.ts
+++ b/lib/activities/activityPubHeaders.test.ts
@@ -1,0 +1,80 @@
+import { MOCK_SECRET_PHASES } from '@/lib/stub/actor'
+import { Actor } from '@/lib/types/domain/actor'
+import { generateKeyPair, verify } from '@/lib/utils/signature'
+
+import { activityPubRequestHeaders } from './activityPubHeaders'
+
+describe('#activityPubRequestHeaders', () => {
+  let signingActor: Actor
+
+  beforeAll(async () => {
+    const keyPair = await generateKeyPair(MOCK_SECRET_PHASES)
+    signingActor = {
+      id: 'https://local.test/users/signer',
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey
+    } as Actor
+  }, 15000)
+
+  it('returns default ActivityPub Accept headers without a signing actor', () => {
+    const headers = activityPubRequestHeaders({
+      url: 'https://remote.test/users/alice'
+    })
+
+    expect(headers).toEqual({
+      Accept: 'application/activity+json, application/ld+json'
+    })
+  })
+
+  it('adds signed GET headers when a signing actor is provided', async () => {
+    const headers = activityPubRequestHeaders({
+      url: 'https://remote.test/users/alice/outbox?page=true',
+      signingActor
+    })
+
+    expect(headers).toMatchObject({
+      Accept: 'application/activity+json, application/ld+json',
+      host: 'remote.test',
+      signature: expect.stringContaining('headers="(request-target) host date"')
+    })
+
+    const verified = await verify(
+      'get /users/alice/outbox?page=true',
+      {
+        ...headers,
+        signature: headers.signature
+      },
+      signingActor.publicKey
+    )
+    expect(verified).toBeTruthy()
+  }, 15000)
+
+  it('adds digest headers for signed POST content', async () => {
+    const content = { type: 'Follow', object: 'https://remote.test/users/bob' }
+    const headers = activityPubRequestHeaders({
+      url: 'https://remote.test/inbox',
+      method: 'POST',
+      signingActor,
+      content
+    })
+
+    expect(headers).toMatchObject({
+      Accept: 'application/activity+json, application/ld+json',
+      'content-type': 'application/activity+json',
+      digest: expect.stringMatching(/^SHA-256=/),
+      signature: expect.stringContaining(
+        'headers="(request-target) host date digest content-type"'
+      )
+    })
+
+    const verified = await verify(
+      'post /inbox',
+      {
+        ...headers,
+        signature: headers.signature
+      },
+      signingActor.publicKey
+    )
+    expect(verified).toBeTruthy()
+  }, 15000)
+})

--- a/lib/activities/activityPubHeaders.test.ts
+++ b/lib/activities/activityPubHeaders.test.ts
@@ -22,7 +22,18 @@ describe('#activityPubRequestHeaders', () => {
     })
 
     expect(headers).toEqual({
-      Accept: 'application/activity+json, application/ld+json'
+      accept: 'application/activity+json, application/ld+json'
+    })
+  })
+
+  it('uses a custom ActivityPub Accept header when provided', () => {
+    const headers = activityPubRequestHeaders({
+      url: 'https://remote.test/users/alice',
+      accept: 'application/activity+json'
+    })
+
+    expect(headers).toEqual({
+      accept: 'application/activity+json'
     })
   })
 
@@ -33,7 +44,7 @@ describe('#activityPubRequestHeaders', () => {
     })
 
     expect(headers).toMatchObject({
-      Accept: 'application/activity+json, application/ld+json',
+      accept: 'application/activity+json, application/ld+json',
       host: 'remote.test',
       signature: expect.stringContaining('headers="(request-target) host date"')
     })
@@ -56,7 +67,7 @@ describe('#activityPubRequestHeaders', () => {
     })
 
     expect(headers).toMatchObject({
-      Accept: 'application/activity+json, application/ld+json',
+      accept: 'application/activity+json, application/ld+json',
       'content-type': 'application/activity+json',
       digest: expect.stringMatching(/^SHA-256=/),
       signature: expect.stringContaining(

--- a/lib/activities/activityPubHeaders.test.ts
+++ b/lib/activities/activityPubHeaders.test.ts
@@ -40,10 +40,7 @@ describe('#activityPubRequestHeaders', () => {
 
     const verified = await verify(
       'get /users/alice/outbox?page=true',
-      {
-        ...headers,
-        signature: headers.signature
-      },
+      headers,
       signingActor.publicKey
     )
     expect(verified).toBeTruthy()
@@ -69,10 +66,7 @@ describe('#activityPubRequestHeaders', () => {
 
     const verified = await verify(
       'post /inbox',
-      {
-        ...headers,
-        signature: headers.signature
-      },
+      headers,
       signingActor.publicKey
     )
     expect(verified).toBeTruthy()

--- a/lib/activities/activityPubHeaders.ts
+++ b/lib/activities/activityPubHeaders.ts
@@ -1,14 +1,14 @@
 import { DEFAULT_ACCEPT } from '@/lib/activities/constants'
 import { Actor } from '@/lib/types/domain/actor'
-import { signedHeaders } from '@/lib/utils/signature'
+import { type SignedHttpMethod, signedHeaders } from '@/lib/utils/signature'
 
-type ActivityPubMethod = Parameters<typeof signedHeaders>[1]
+type ActivityPubRequestContent = object
 
 interface ActivityPubRequestHeadersParams {
   url: string
-  method?: ActivityPubMethod
+  method?: SignedHttpMethod
   signingActor?: Actor | null
-  content?: unknown
+  content?: ActivityPubRequestContent
   accept?: string
 }
 
@@ -20,5 +20,5 @@ export const activityPubRequestHeaders = ({
   accept = DEFAULT_ACCEPT
 }: ActivityPubRequestHeadersParams): Record<string, string> => ({
   ...(signingActor ? signedHeaders(signingActor, method, url, content) : {}),
-  Accept: accept
+  accept
 })

--- a/lib/activities/activityPubHeaders.ts
+++ b/lib/activities/activityPubHeaders.ts
@@ -2,7 +2,7 @@ import { DEFAULT_ACCEPT } from '@/lib/activities/constants'
 import { Actor } from '@/lib/types/domain/actor'
 import { signedHeaders } from '@/lib/utils/signature'
 
-type ActivityPubMethod = 'GET' | 'POST'
+type ActivityPubMethod = Parameters<typeof signedHeaders>[1]
 
 interface ActivityPubRequestHeadersParams {
   url: string

--- a/lib/activities/activityPubHeaders.ts
+++ b/lib/activities/activityPubHeaders.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_ACCEPT } from '@/lib/activities/constants'
+import { Actor } from '@/lib/types/domain/actor'
+import { signedHeaders } from '@/lib/utils/signature'
+
+type ActivityPubMethod = 'GET' | 'POST'
+
+interface ActivityPubRequestHeadersParams {
+  url: string
+  method?: ActivityPubMethod
+  signingActor?: Actor | null
+  content?: unknown
+  accept?: string
+}
+
+export const activityPubRequestHeaders = ({
+  url,
+  method = 'GET',
+  signingActor,
+  content,
+  accept = DEFAULT_ACCEPT
+}: ActivityPubRequestHeadersParams): Record<string, string> => ({
+  ...(signingActor ? signedHeaders(signingActor, method, url, content) : {}),
+  Accept: accept
+})

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ACCEPT } from '@/lib/activities/constants'
+import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
 import {
   OrderedCollection,
   OrderedCollectionPage,
@@ -8,7 +8,6 @@ import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { signedHeaders } from '@/lib/utils/signature'
 import { getTracer } from '@/lib/utils/trace'
 
 interface Params {
@@ -22,14 +21,6 @@ export const getActorCollections = async ({
   field,
   signingActor
 }: Params) => {
-  const createHeaders = (
-    actor: DomainActor | undefined,
-    url: string
-  ): Record<string, string> => ({
-    Accept: DEFAULT_ACCEPT,
-    ...(actor ? signedHeaders(actor, 'GET', url) : {})
-  })
-
   return getTracer().startActiveSpan(
     `activities.${field}`,
     {
@@ -44,7 +35,10 @@ export const getActorCollections = async ({
 
       const fieldResponse = await request({
         url: person[field],
-        headers: createHeaders(signingActor, person[field])
+        headers: activityPubRequestHeaders({
+          url: person[field],
+          signingActor
+        })
       })
       if (fieldResponse.statusCode !== 200) {
         span.setAttributes({
@@ -75,7 +69,10 @@ export const getActorCollections = async ({
       try {
         const response = await request({
           url: pageUrl,
-          headers: createHeaders(signingActor, pageUrl)
+          headers: activityPubRequestHeaders({
+            url: pageUrl,
+            signingActor
+          })
         })
         if (response.statusCode !== 200) {
           span.setAttributes({

--- a/lib/activities/getActorPerson.ts
+++ b/lib/activities/getActorPerson.ts
@@ -1,9 +1,8 @@
-import { DEFAULT_ACCEPT } from '@/lib/activities/constants'
+import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { signedHeaders } from '@/lib/utils/signature'
 import { getTracer } from '@/lib/utils/trace'
 
 export type GetActorPersonFunction = (params: {
@@ -19,17 +18,12 @@ export const getActorPerson: GetActorPersonFunction = ({
 }) =>
   getTracer().startActiveSpan('activities.getActorProfile', async (span) => {
     try {
-      const headers: Record<string, string> = { Accept: DEFAULT_ACCEPT }
-
-      // Add signed headers if a signing actor is provided
-      if (signingActor) {
-        const signatureHeaders = signedHeaders(signingActor, 'GET', actorId)
-        Object.assign(headers, signatureHeaders)
-      }
-
       const { statusCode, body } = await request({
         url: actorId,
-        headers,
+        headers: activityPubRequestHeaders({
+          url: actorId,
+          signingActor
+        }),
         // Use default retry by set it to undefined, otherwise 0 retry
         numberOfRetry: withNetworkRetry ? undefined : 0
       })

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto'
 
 import { AcceptFollow } from '@/lib/activities/acceptFollow'
+import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
 import { AnnounceStatus } from '@/lib/activities/announceStatus'
-import { DEFAULT_ACCEPT } from '@/lib/activities/constants'
 import { CreateStatus } from '@/lib/activities/createStatus'
 import { DeleteStatus } from '@/lib/activities/deleteStatus'
 import { FollowRequest } from '@/lib/activities/followAction'
@@ -37,7 +37,6 @@ import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { logger } from '@/lib/utils/logger'
 import { request } from '@/lib/utils/request'
-import { signedHeaders } from '@/lib/utils/signature'
 import { getTracer } from '@/lib/utils/trace'
 
 interface GetNoteParams {
@@ -55,12 +54,10 @@ export const getNote = async ({
       try {
         const { statusCode, body } = await request({
           url: statusId,
-          headers: {
-            Accept: DEFAULT_ACCEPT,
-            ...(signingActor
-              ? signedHeaders(signingActor, 'GET', statusId)
-              : {})
-          }
+          headers: activityPubRequestHeaders({
+            url: statusId,
+            signingActor
+          })
         })
         if (statusCode !== 200) return null
         return JSON.parse(body)
@@ -110,10 +107,12 @@ export const sendNote = async ({ currentActor, inbox, note }: SendNoteParams) =>
         await request({
           url: inbox,
           method,
-          headers: {
-            ...signedHeaders(currentActor, method, inbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: inbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -171,10 +170,12 @@ export const sendUpdateNote = async ({
         await request({
           url: inbox,
           method,
-          headers: {
-            ...signedHeaders(currentActor, method, inbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: inbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -230,11 +231,13 @@ export const sendAnnounce = async ({
       try {
         await request({
           url: inbox,
-          headers: {
-            ...signedHeaders(currentActor, method, inbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
           method,
+          headers: activityPubRequestHeaders({
+            url: inbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -286,11 +289,13 @@ export const deleteStatus = async ({
       try {
         await request({
           url: inbox,
-          headers: {
-            ...signedHeaders(currentActor, method, inbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
           method,
+          headers: activityPubRequestHeaders({
+            url: inbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -348,10 +353,12 @@ export const undoAnnounce = async ({
         await request({
           url: inbox,
           method,
-          headers: {
-            ...signedHeaders(currentActor, method, inbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: inbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -406,10 +413,12 @@ export const follow = async (
         const { statusCode } = await request({
           url: targetInbox,
           method,
-          headers: {
-            ...signedHeaders(currentActor, method, targetInbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: targetInbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
         return statusCode === 202
@@ -457,11 +466,13 @@ export const unfollow = async (currentActor: Actor, follow: Follow) =>
       try {
         const { statusCode } = await request({
           url: targetInbox,
-          headers: {
-            ...signedHeaders(currentActor, method, targetInbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
           method,
+          headers: activityPubRequestHeaders({
+            url: targetInbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
         return statusCode === 202
@@ -507,10 +518,12 @@ export const acceptFollow = async (
         const { statusCode } = await request({
           url: followingInbox,
           method,
-          headers: {
-            ...signedHeaders(currentActor, method, followingInbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: followingInbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
         return statusCode === 202
@@ -556,10 +569,12 @@ export const rejectFollow = async (
         const { statusCode } = await request({
           url: followingInbox,
           method,
-          headers: {
-            ...signedHeaders(currentActor, method, followingInbox, activity),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: followingInbox,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
         return statusCode === 202
@@ -600,15 +615,12 @@ export const sendLike = async ({ currentActor, status }: LikeParams) =>
         await request({
           method,
           url: status.actor.inboxUrl,
-          headers: {
-            ...signedHeaders(
-              currentActor,
-              method,
-              status.actor.inboxUrl,
-              activity
-            ),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: status.actor.inboxUrl,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -649,15 +661,12 @@ export const sendUndoLike = async ({ currentActor, status }: UndoLikeParams) =>
         await request({
           method,
           url: status.actor.inboxUrl,
-          headers: {
-            ...signedHeaders(
-              currentActor,
-              method,
-              status.actor.inboxUrl,
-              activity
-            ),
-            Accept: DEFAULT_ACCEPT
-          },
+          headers: activityPubRequestHeaders({
+            url: status.actor.inboxUrl,
+            method,
+            signingActor: currentActor,
+            content: activity
+          }),
           body: JSON.stringify(activity)
         })
       } catch (error) {
@@ -727,15 +736,12 @@ export const sendPollVotes = async ({
           await request({
             url: status.actor.inboxUrl,
             method,
-            headers: {
-              ...signedHeaders(
-                currentActor,
-                method,
-                status.actor.inboxUrl,
-                activity
-              ),
-              Accept: DEFAULT_ACCEPT
-            },
+            headers: activityPubRequestHeaders({
+              url: status.actor.inboxUrl,
+              method,
+              signingActor: currentActor,
+              content: activity
+            }),
             body: JSON.stringify(activity)
           })
         } catch (error) {

--- a/lib/jobs/fetchRemoteStatusJob.ts
+++ b/lib/jobs/fetchRemoteStatusJob.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { getNote } from '@/lib/activities'
+import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
@@ -10,7 +11,6 @@ import { Actor } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
 import { request } from '@/lib/utils/request'
-import { signedHeaders } from '@/lib/utils/signature'
 
 import { createJobHandle } from './createJobHandle'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from './names'
@@ -125,10 +125,11 @@ export const fetchRemoteStatusJob = createJobHandle(
         if (!(await canFederateWithDomain(database, url))) return null
         const { body, statusCode } = await request({
           url,
-          headers: {
-            Accept: 'application/activity+json',
-            ...(signingActor ? signedHeaders(signingActor, 'GET', url) : {})
-          }
+          headers: activityPubRequestHeaders({
+            url,
+            signingActor,
+            accept: 'application/activity+json'
+          })
         })
         if (statusCode !== 200) return null
         return JSON.parse(body)

--- a/lib/utils/signature.ts
+++ b/lib/utils/signature.ts
@@ -12,7 +12,7 @@ interface StringMap {
   [key: string]: string
 }
 
-type SignedHttpMethod = 'GET' | 'POST'
+export type SignedHttpMethod = 'GET' | 'POST'
 
 export async function parse(signature: string): Promise<StringMap> {
   try {


### PR DESCRIPTION
## Summary
- Add a shared ActivityPub request-header helper for default Accept headers plus optional HTTP Signature headers.
- Use the helper for signed GET fetches and signed POST ActivityPub sends.
- Add helper tests covering unsigned defaults, signed GET query-string targets, and signed POST digest headers.

## Validation
- yarn run prettier --write .
- yarn lint (passes with existing warnings in auth and fitness parsing files)
- yarn build
- yarn test

## Notes
- No migrations or config changes required.