### PR TITLE
feat: add headless federation signing actor

### DIFF
--- a/app/api/users/[username]/followers/route.test.ts
+++ b/app/api/users/[username]/followers/route.test.ts
@@ -27,14 +27,22 @@ const mockActor: Actor = {
 
 jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
   OnlyLocalUserGuard:
-    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
-    (req: NextRequest, query: unknown) =>
-      handle(mockDatabase, mockActor, req, query)
+    (
+      handle: (...params: unknown[]) => Promise<Response> | Response,
+      options?: { allowFederationSigningActor?: boolean }
+    ) =>
+    (req: NextRequest, query: unknown) => {
+      if (!options?.allowFederationSigningActor) {
+        return new Response(null, { status: 404 })
+      }
+
+      return handle(mockDatabase, mockActor, req, query)
+    }
 }))
 
 describe('GET /api/users/[username]/followers', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    mockDatabase.getActorFollowersCount.mockClear()
     mockDatabase.getActorFollowersCount.mockResolvedValue(2)
   })
 

--- a/app/api/users/[username]/followers/route.ts
+++ b/app/api/users/[username]/followers/route.ts
@@ -5,20 +5,25 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActorFollowers',
-  OnlyLocalUserGuard(async (database, actor, req) => {
-    const followerId = `${actor.id}/followers`
+  OnlyLocalUserGuard(
+    async (database, actor, req) => {
+      const followerId = `${actor.id}/followers`
 
-    const totalItems = await database.getActorFollowersCount({
-      actorId: actor.id
-    })
-    return activityPubResponse({
-      req,
-      data: {
-        '@context': ACTIVITY_STREAM_URL,
-        id: followerId,
-        type: 'OrderedCollection',
-        totalItems
-      }
-    })
-  })
+      const totalItems = await database.getActorFollowersCount({
+        actorId: actor.id
+      })
+      return activityPubResponse({
+        req,
+        data: {
+          '@context': ACTIVITY_STREAM_URL,
+          id: followerId,
+          type: 'OrderedCollection',
+          totalItems
+        }
+      })
+    },
+    {
+      allowFederationSigningActor: true
+    }
+  )
 )

--- a/app/api/users/[username]/following/route.test.ts
+++ b/app/api/users/[username]/following/route.test.ts
@@ -27,14 +27,22 @@ const mockActor: Actor = {
 
 jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
   OnlyLocalUserGuard:
-    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
-    (req: NextRequest, query: unknown) =>
-      handle(mockDatabase, mockActor, req, query)
+    (
+      handle: (...params: unknown[]) => Promise<Response> | Response,
+      options?: { allowFederationSigningActor?: boolean }
+    ) =>
+    (req: NextRequest, query: unknown) => {
+      if (!options?.allowFederationSigningActor) {
+        return new Response(null, { status: 404 })
+      }
+
+      return handle(mockDatabase, mockActor, req, query)
+    }
 }))
 
 describe('GET /api/users/[username]/following', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    mockDatabase.getActorFollowingCount.mockClear()
     mockDatabase.getActorFollowingCount.mockResolvedValue(4)
   })
 

--- a/app/api/users/[username]/following/route.ts
+++ b/app/api/users/[username]/following/route.ts
@@ -5,19 +5,24 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActorFollowing',
-  OnlyLocalUserGuard(async (database, actor, req) => {
-    const followingId = `${actor.id}/following`
-    const totalItems = await database.getActorFollowingCount({
-      actorId: actor.id
-    })
-    return activityPubResponse({
-      req,
-      data: {
-        '@context': ACTIVITY_STREAM_URL,
-        id: followingId,
-        type: 'OrderedCollection',
-        totalItems
-      }
-    })
-  })
+  OnlyLocalUserGuard(
+    async (database, actor, req) => {
+      const followingId = `${actor.id}/following`
+      const totalItems = await database.getActorFollowingCount({
+        actorId: actor.id
+      })
+      return activityPubResponse({
+        req,
+        data: {
+          '@context': ACTIVITY_STREAM_URL,
+          id: followingId,
+          type: 'OrderedCollection',
+          totalItems
+        }
+      })
+    },
+    {
+      allowFederationSigningActor: true
+    }
+  )
 )

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -6,6 +6,17 @@ const mockCanFederateWithDomain = jest.fn()
 const mockCreateFollower = jest.fn()
 const mockVerifyAllows = jest.fn()
 const mockDatabase = {}
+type MockActor = {
+  id: string
+  username: string
+  type: string
+  privateKey?: string
+}
+let mockActor: MockActor = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  type: 'Person'
+}
 
 jest.mock('@/lib/services/federation/domainPolicy', () => ({
   canFederateWithDomain: (...params: unknown[]) =>
@@ -43,18 +54,22 @@ jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
     (
       handle: (
         database: typeof mockDatabase,
-        actor: { id: string },
+        actor: typeof mockActor,
         req: NextRequest,
         query: { params: Promise<{ username: string }> }
-      ) => Promise<Response> | Response
+      ) => Promise<Response> | Response,
+      options?: { allowFederationSigningActor?: boolean }
     ) =>
-    (req: NextRequest, query: { params: Promise<{ username: string }> }) =>
-      handle(
-        mockDatabase,
-        { id: 'https://activities.local/users/llun' },
-        req,
-        query
-      )
+    (req: NextRequest, query: { params: Promise<{ username: string }> }) => {
+      if (
+        mockActor.username === '__instance__' &&
+        !options?.allowFederationSigningActor
+      ) {
+        return new Response(null, { status: 404 })
+      }
+
+      return handle(mockDatabase, mockActor, req, query)
+    }
 }))
 
 jest.mock('@/lib/actions/acceptFollowRequest', () => ({
@@ -77,26 +92,49 @@ jest.mock('@/lib/actions/undoFollowRequest', () => ({
   undoFollowRequest: jest.fn()
 }))
 
-const createFollowRequest = () =>
-  new NextRequest('https://activities.local/api/users/llun/inbox', {
+const createFollowRequest = (username = 'llun') =>
+  new NextRequest(`https://activities.local/api/users/${username}/inbox`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       id: 'https://remote.test/users/alice/follows/1',
       type: 'Follow',
       actor: 'https://remote.test/users/alice',
-      object: 'https://activities.local/users/llun'
+      object: `https://activities.local/users/${username}`
     })
   })
 
 describe('POST /api/users/[username]/inbox', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockActor = {
+      id: 'https://activities.local/users/llun',
+      username: 'llun',
+      type: 'Person'
+    }
     mockVerifyAllows.mockResolvedValue(true)
     mockCanFederateWithDomain.mockResolvedValue(true)
     mockCreateFollower.mockResolvedValue({
       object: 'https://activities.local/users/llun'
     })
+  })
+
+  it('accepts verified deliveries to the headless signer inbox without creating state', async () => {
+    mockActor = {
+      id: 'https://activities.local/users/__instance__',
+      username: '__instance__',
+      type: 'Service',
+      privateKey: 'private-key'
+    }
+
+    const response = await POST(createFollowRequest('__instance__'), {
+      params: Promise.resolve({ username: '__instance__' })
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockVerifyAllows).toHaveBeenCalled()
+    expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
+    expect(mockCreateFollower).not.toHaveBeenCalled()
   })
 
   it('rejects requests before processing when sender verification fails', async () => {

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -9,6 +9,7 @@ import { FollowRequest } from '@/lib/activities/followAction'
 import { UndoFollow } from '@/lib/activities/undoFollow'
 import { UndoLike } from '@/lib/activities/undoLike'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { isFederationSigningActor } from '@/lib/services/federation/instanceActor'
 import { ActivityPubVerifySenderGuard } from '@/lib/services/guards/ActivityPubVerifyGuard'
 import {
   OnlyLocalUserGuard,
@@ -35,10 +36,155 @@ export const POST = traceApiRoute(
   'actorInbox',
   ActivityPubVerifySenderGuard<OnlyLocalUserGuardParams>(
     (req, context) =>
-      OnlyLocalUserGuard(async (database, _, req) => {
-        try {
-          const parsed = Activity.safeParse(await req.json())
-          if (!parsed.success) {
+      OnlyLocalUserGuard(
+        async (database, actor, req) => {
+          try {
+            if (isFederationSigningActor(actor)) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: DEFAULT_202,
+                responseStatusCode: 202
+              })
+            }
+
+            const parsed = Activity.safeParse(await req.json())
+            if (!parsed.success) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: ERROR_400,
+                responseStatusCode: 400
+              })
+            }
+
+            const activity = parsed.data
+            if (!(await canFederateWithDomain(database, activity.actor))) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: ERROR_403,
+                responseStatusCode: 403
+              })
+            }
+
+            switch (activity.type) {
+              case 'Accept': {
+                const follow = await acceptFollowRequest({ activity, database })
+                if (!follow)
+                  return apiResponse({
+                    req,
+                    allowedMethods: CORS_HEADERS,
+                    data: ERROR_404,
+                    responseStatusCode: 404
+                  })
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: DEFAULT_202,
+                  responseStatusCode: 202
+                })
+              }
+              case 'Reject': {
+                const follow = await rejectFollowRequest({ activity, database })
+                if (!follow)
+                  return apiResponse({
+                    req,
+                    allowedMethods: CORS_HEADERS,
+                    data: ERROR_404,
+                    responseStatusCode: 404
+                  })
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: DEFAULT_202,
+                  responseStatusCode: 202
+                })
+              }
+              case 'Follow': {
+                const follow = await createFollower({
+                  followRequest: activity as FollowRequest,
+                  database
+                })
+                if (!follow)
+                  return apiResponse({
+                    req,
+                    allowedMethods: CORS_HEADERS,
+                    data: ERROR_404,
+                    responseStatusCode: 404
+                  })
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: { target: follow.object },
+                  responseStatusCode: 202
+                })
+              }
+              case 'Like': {
+                await likeRequest({ activity, database })
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: DEFAULT_202,
+                  responseStatusCode: 202
+                })
+              }
+              case 'Undo': {
+                const undoRequest = activity as UndoFollow | UndoLike
+                switch (undoRequest.object.type) {
+                  case 'Follow': {
+                    const result = await undoFollowRequest({
+                      database,
+                      request: undoRequest as UndoFollow
+                    })
+                    if (!result)
+                      return apiResponse({
+                        req,
+                        allowedMethods: CORS_HEADERS,
+                        data: ERROR_404,
+                        responseStatusCode: 404
+                      })
+                    return apiResponse({
+                      req,
+                      allowedMethods: CORS_HEADERS,
+                      data: { target: undoRequest.object.object },
+                      responseStatusCode: 202
+                    })
+                  }
+                  case 'Like': {
+                    await database.deleteLike({
+                      actorId: undoRequest.object.actor,
+                      statusId:
+                        typeof undoRequest.object.object === 'string'
+                          ? undoRequest.object.object
+                          : undoRequest.object.object.id
+                    })
+                    return apiResponse({
+                      req,
+                      allowedMethods: CORS_HEADERS,
+                      data: DEFAULT_202,
+                      responseStatusCode: 202
+                    })
+                  }
+                  default: {
+                    return apiResponse({
+                      req,
+                      allowedMethods: CORS_HEADERS,
+                      data: DEFAULT_202,
+                      responseStatusCode: 202
+                    })
+                  }
+                }
+              }
+              default:
+                return apiResponse({
+                  req,
+                  allowedMethods: CORS_HEADERS,
+                  data: DEFAULT_202,
+                  responseStatusCode: 202
+                })
+            }
+          } catch {
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,
@@ -46,142 +192,9 @@ export const POST = traceApiRoute(
               responseStatusCode: 400
             })
           }
-
-          const activity = parsed.data
-          if (!(await canFederateWithDomain(database, activity.actor))) {
-            return apiResponse({
-              req,
-              allowedMethods: CORS_HEADERS,
-              data: ERROR_403,
-              responseStatusCode: 403
-            })
-          }
-
-          switch (activity.type) {
-            case 'Accept': {
-              const follow = await acceptFollowRequest({ activity, database })
-              if (!follow)
-                return apiResponse({
-                  req,
-                  allowedMethods: CORS_HEADERS,
-                  data: ERROR_404,
-                  responseStatusCode: 404
-                })
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: DEFAULT_202,
-                responseStatusCode: 202
-              })
-            }
-            case 'Reject': {
-              const follow = await rejectFollowRequest({ activity, database })
-              if (!follow)
-                return apiResponse({
-                  req,
-                  allowedMethods: CORS_HEADERS,
-                  data: ERROR_404,
-                  responseStatusCode: 404
-                })
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: DEFAULT_202,
-                responseStatusCode: 202
-              })
-            }
-            case 'Follow': {
-              const follow = await createFollower({
-                followRequest: activity as FollowRequest,
-                database
-              })
-              if (!follow)
-                return apiResponse({
-                  req,
-                  allowedMethods: CORS_HEADERS,
-                  data: ERROR_404,
-                  responseStatusCode: 404
-                })
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: { target: follow.object },
-                responseStatusCode: 202
-              })
-            }
-            case 'Like': {
-              await likeRequest({ activity, database })
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: DEFAULT_202,
-                responseStatusCode: 202
-              })
-            }
-            case 'Undo': {
-              const undoRequest = activity as UndoFollow | UndoLike
-              switch (undoRequest.object.type) {
-                case 'Follow': {
-                  const result = await undoFollowRequest({
-                    database,
-                    request: undoRequest as UndoFollow
-                  })
-                  if (!result)
-                    return apiResponse({
-                      req,
-                      allowedMethods: CORS_HEADERS,
-                      data: ERROR_404,
-                      responseStatusCode: 404
-                    })
-                  return apiResponse({
-                    req,
-                    allowedMethods: CORS_HEADERS,
-                    data: { target: undoRequest.object.object },
-                    responseStatusCode: 202
-                  })
-                }
-                case 'Like': {
-                  await database.deleteLike({
-                    actorId: undoRequest.object.actor,
-                    statusId:
-                      typeof undoRequest.object.object === 'string'
-                        ? undoRequest.object.object
-                        : undoRequest.object.object.id
-                  })
-                  return apiResponse({
-                    req,
-                    allowedMethods: CORS_HEADERS,
-                    data: DEFAULT_202,
-                    responseStatusCode: 202
-                  })
-                }
-                default: {
-                  return apiResponse({
-                    req,
-                    allowedMethods: CORS_HEADERS,
-                    data: DEFAULT_202,
-                    responseStatusCode: 202
-                  })
-                }
-              }
-            }
-            default:
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: DEFAULT_202,
-                responseStatusCode: 202
-              })
-          }
-        } catch {
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: ERROR_400,
-            responseStatusCode: 400
-          })
-        }
-      })(req, context),
+        },
+        { allowFederationSigningActor: true }
+      )(req, context),
     CORS_HEADERS
   )
 )

--- a/app/api/users/[username]/outbox/route.test.ts
+++ b/app/api/users/[username]/outbox/route.test.ts
@@ -27,14 +27,22 @@ const mockActor: Actor = {
 
 jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
   OnlyLocalUserGuard:
-    (handle: (...params: unknown[]) => Promise<Response> | Response) =>
-    (req: NextRequest, query: unknown) =>
-      handle(mockDatabase, mockActor, req, query)
+    (
+      handle: (...params: unknown[]) => Promise<Response> | Response,
+      options?: { allowFederationSigningActor?: boolean }
+    ) =>
+    (req: NextRequest, query: unknown) => {
+      if (!options?.allowFederationSigningActor) {
+        return new Response(null, { status: 404 })
+      }
+
+      return handle(mockDatabase, mockActor, req, query)
+    }
 }))
 
 describe('GET /api/users/[username]/outbox', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    mockDatabase.getActorStatuses.mockClear()
   })
 
   it('negotiates collection responses with the shared ActivityPub helper', async () => {

--- a/app/api/users/[username]/outbox/route.ts
+++ b/app/api/users/[username]/outbox/route.ts
@@ -12,58 +12,63 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActorOutbox',
-  OnlyLocalUserGuard(async (database, actor, req) => {
-    const url = new URL(req.url)
-    const pageParam = url.searchParams.get('page')
-    if (!pageParam) {
-      const outboxId = `${actor.id}/outbox`
-      return activityPubResponse({
-        req,
-        data: {
-          '@context': ACTIVITY_STREAM_URL,
-          id: outboxId,
-          type: 'OrderedCollection',
-          totalItems: actor.statusCount,
-          first: `${outboxId}?page=true`,
-          last: `${outboxId}?min_id=0&page=true`
-        }
-      })
-    }
+  OnlyLocalUserGuard(
+    async (database, actor, req) => {
+      const url = new URL(req.url)
+      const pageParam = url.searchParams.get('page')
+      if (!pageParam) {
+        const outboxId = `${actor.id}/outbox`
+        return activityPubResponse({
+          req,
+          data: {
+            '@context': ACTIVITY_STREAM_URL,
+            id: outboxId,
+            type: 'OrderedCollection',
+            totalItems: actor.statusCount,
+            first: `${outboxId}?page=true`,
+            last: `${outboxId}?min_id=0&page=true`
+          }
+        })
+      }
 
-    const statuses = await database.getActorStatuses({ actorId: actor.id })
-    const items = statuses.map((status) => {
-      if (status.type === StatusType.enum.Announce) {
+      const statuses = await database.getActorStatuses({ actorId: actor.id })
+      const items = statuses.map((status) => {
+        if (status.type === StatusType.enum.Announce) {
+          return {
+            id: status.id,
+            type: AnnounceAction,
+            actor: actor.id,
+            published: getISOTimeUTC(status.createdAt),
+            ...(status.to ? { to: status.to } : null),
+            ...(status.cc ? { cc: status.cc } : null),
+            object: status.originalStatus.id
+          }
+        }
+
         return {
-          id: status.id,
-          type: AnnounceAction,
+          id: `${status.id}/activity`,
+          type: CreateAction,
           actor: actor.id,
           published: getISOTimeUTC(status.createdAt),
           ...(status.to ? { to: status.to } : null),
           ...(status.cc ? { cc: status.cc } : null),
-          object: status.originalStatus.id
+          object: cleanJson(status)
         }
-      }
+      })
 
-      return {
-        id: `${status.id}/activity`,
-        type: CreateAction,
-        actor: actor.id,
-        published: getISOTimeUTC(status.createdAt),
-        ...(status.to ? { to: status.to } : null),
-        ...(status.cc ? { cc: status.cc } : null),
-        object: cleanJson(status)
-      }
-    })
-
-    return activityPubResponse({
-      req,
-      data: {
-        '@context': ACTIVITY_STREAM_URL,
-        id: `${actor.id}/outbox?page=true`,
-        type: 'OrderedCollectionPage',
-        partOf: `${actor.id}/outbox`,
-        orderedItems: items
-      }
-    })
-  })
+      return activityPubResponse({
+        req,
+        data: {
+          '@context': ACTIVITY_STREAM_URL,
+          id: `${actor.id}/outbox?page=true`,
+          type: 'OrderedCollectionPage',
+          partOf: `${actor.id}/outbox`,
+          orderedItems: items
+        }
+      })
+    },
+    {
+      allowFederationSigningActor: true
+    }
+  )
 )

--- a/app/api/users/[username]/route.test.ts
+++ b/app/api/users/[username]/route.test.ts
@@ -5,7 +5,7 @@ import { type Actor } from '@/lib/types/domain/actor'
 import { GET } from './route'
 
 const mockDatabase = {}
-const mockActor: Actor = {
+let mockActor: Actor = {
   id: 'https://example.com/users/test',
   username: 'test',
   domain: 'example.com',
@@ -36,6 +36,26 @@ const createRequest = (accept: string) =>
   })
 
 describe('GET /api/users/[username]', () => {
+  beforeEach(() => {
+    mockActor = {
+      id: 'https://example.com/users/test',
+      username: 'test',
+      domain: 'example.com',
+      name: 'Test Actor',
+      summary: '',
+      followersUrl: 'https://example.com/users/test/followers',
+      inboxUrl: 'https://example.com/users/test/inbox',
+      sharedInboxUrl: 'https://example.com/inbox',
+      followingCount: 0,
+      followersCount: 0,
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: 1,
+      updatedAt: 1,
+      publicKey: 'public-key'
+    }
+  })
+
   it('returns ActivityPub JSON for combined weighted Accept headers', async () => {
     const response = await GET(
       createRequest(
@@ -92,5 +112,77 @@ describe('GET /api/users/[username]', () => {
     expect(response.headers.get('location')).toBe('https://example.com/@test')
     expect(response.headers.get('server')).toBe('activities.next')
     expect(response.headers.get('vary')).toBe('Accept')
+  })
+
+  it('returns a Service actor for the headless instance actor', async () => {
+    mockActor = {
+      ...mockActor,
+      id: 'https://example.com/users/__instance__',
+      type: 'Service',
+      username: '__instance__',
+      name: 'Instance actor',
+      privateKey: 'private-key'
+    }
+
+    const response = await GET(createRequest('application/activity+json'), {
+      params: Promise.resolve({ username: '__instance__' })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({
+      id: 'https://example.com/users/__instance__',
+      type: 'Service',
+      preferredUsername: '__instance__',
+      url: 'https://example.com/users/__instance__'
+    })
+  })
+
+  it('does not redirect the headless instance actor to itself when HTML is preferred', async () => {
+    mockActor = {
+      ...mockActor,
+      id: 'https://example.com/users/__instance__',
+      type: 'Service',
+      username: '__instance__',
+      name: 'Instance actor',
+      privateKey: 'private-key'
+    }
+
+    const response = await GET(
+      createRequest('text/html, application/xhtml+xml, */*;q=0.8'),
+      { params: Promise.resolve({ username: '__instance__' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'application/activity+json'
+    )
+
+    const data = await response.json()
+    expect(data).toMatchObject({
+      id: 'https://example.com/users/__instance__',
+      type: 'Service',
+      preferredUsername: '__instance__'
+    })
+  })
+
+  it('redirects generic Service actors that are not the headless signer', async () => {
+    mockActor = {
+      ...mockActor,
+      id: 'https://example.com/users/service',
+      type: 'Service',
+      username: 'service',
+      name: 'Service actor'
+    }
+
+    const response = await GET(
+      createRequest('text/html, application/xhtml+xml, */*;q=0.8'),
+      { params: Promise.resolve({ username: 'service' }) }
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/@service'
+    )
   })
 })

--- a/app/api/users/[username]/route.ts
+++ b/app/api/users/[username]/route.ts
@@ -1,3 +1,4 @@
+import { isFederationSigningActor } from '@/lib/services/federation/instanceActor'
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
 import {
   activityPubRedirectResponse,
@@ -9,20 +10,30 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 export const GET = traceApiRoute(
   'getActor',
-  OnlyLocalUserGuard(async (_, actor, req) => {
-    const contentType = negotiateActivityPubContentType(
-      req.headers.get('accept')
-    )
-    if (contentType) {
-      return activityPubResponse({
-        req,
-        data: getPersonFromActor(actor),
-        contentType
-      })
-    }
+  OnlyLocalUserGuard(
+    async (_, actor, req) => {
+      const contentType = negotiateActivityPubContentType(
+        req.headers.get('accept')
+      )
+      if (contentType) {
+        return activityPubResponse({
+          req,
+          data: getPersonFromActor(actor),
+          contentType
+        })
+      }
 
-    return activityPubRedirectResponse(
-      `https://${actor.domain}/@${actor.username}`
-    )
-  })
+      if (isFederationSigningActor(actor)) {
+        return activityPubResponse({
+          req,
+          data: getPersonFromActor(actor)
+        })
+      }
+
+      return activityPubRedirectResponse(
+        `https://${actor.domain}/@${actor.username}`
+      )
+    },
+    { allowFederationSigningActor: true }
+  )
 )

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -2,6 +2,7 @@ import { follow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -48,9 +49,10 @@ export const POST = traceApiRoute(
     }
 
     // Check if target actor exists
+    const signingActor = await getFederationSigningActor(database)
     const person = await getActorPerson({
       actorId: targetActorId,
-      signingActor: currentActor
+      signingActor
     })
     if (!person)
       return apiResponse({
@@ -74,7 +76,7 @@ export const POST = traceApiRoute(
         inbox: `${currentActor.id}/inbox`,
         sharedInbox: `https://${currentActor.domain}/inbox`
       })
-      await follow(followItem.id, currentActor, targetActorId)
+      await follow(followItem.id, currentActor, targetActorId, signingActor)
     }
 
     const relationship = await getRelationship({

--- a/app/api/v1/accounts/[id]/unfollow/route.ts
+++ b/app/api/v1/accounts/[id]/unfollow/route.ts
@@ -1,6 +1,7 @@
 import { unfollow } from '@/lib/activities'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -39,8 +40,13 @@ export const POST = traceApiRoute(
 
     if (existingFollow) {
       const canFederate = await canFederateWithDomain(database, targetActorId)
+      const signingActor = canFederate
+        ? await getFederationSigningActor(database)
+        : undefined
       await Promise.all([
-        canFederate ? unfollow(currentActor, existingFollow) : undefined,
+        canFederate
+          ? unfollow(currentActor, existingFollow, signingActor)
+          : undefined,
         database.updateFollowStatus({
           followId: existingFollow.id,
           status: FollowStatus.enum.Undo

--- a/app/api/v1/accounts/follow/route.test.ts
+++ b/app/api/v1/accounts/follow/route.test.ts
@@ -2,21 +2,30 @@ import { NextRequest } from 'next/server'
 
 import { FollowStatus } from '@/lib/types/domain/follow'
 
-import { DELETE } from './route'
+import { DELETE, POST } from './route'
 
+const mockFollow = jest.fn()
 const mockUnfollow = jest.fn()
 const mockCanFederateWithDomain = jest.fn()
 const mockCurrentActor = {
   id: 'https://llun.test/users/llun',
   domain: 'llun.test'
 }
+const mockSigningActor = {
+  id: 'https://llun.test/users/__instance__',
+  type: 'Service',
+  username: '__instance__',
+  domain: 'llun.test',
+  privateKey: 'instance-key'
+}
 const mockDatabase = {
   getAcceptedOrRequestedFollow: jest.fn(),
-  updateFollowStatus: jest.fn()
+  updateFollowStatus: jest.fn(),
+  getFederationSigningActor: jest.fn()
 }
 
 jest.mock('@/lib/activities', () => ({
-  follow: jest.fn(),
+  follow: (...params: unknown[]) => mockFollow(...params),
   unfollow: (...params: unknown[]) => mockUnfollow(...params)
 }))
 
@@ -58,6 +67,7 @@ describe('DELETE /api/v1/accounts/follow', () => {
       targetActorId: 'https://blocked.test/users/alice'
     })
     mockDatabase.updateFollowStatus.mockResolvedValue(undefined)
+    mockDatabase.getFederationSigningActor.mockResolvedValue(mockSigningActor)
   })
 
   const createRequest = () =>
@@ -66,6 +76,37 @@ describe('DELETE /api/v1/accounts/follow', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ target: 'https://blocked.test/users/alice' })
     })
+
+  const createInvalidJsonRequest = (method: 'POST' | 'DELETE') =>
+    new NextRequest('https://llun.test/api/v1/accounts/follow', {
+      method,
+      headers: { 'content-type': 'application/json' },
+      body: '{'
+    })
+
+  it('returns 400 for invalid JSON on follow', async () => {
+    const response = await POST(createInvalidJsonRequest('POST'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid JSON body'
+    })
+    expect(mockFollow).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid JSON on unfollow', async () => {
+    const response = await DELETE(createInvalidJsonRequest('DELETE'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid JSON body'
+    })
+    expect(mockUnfollow).not.toHaveBeenCalled()
+  })
 
   it('updates local state without sending Undo to blocked domains', async () => {
     mockCanFederateWithDomain.mockResolvedValue(false)
@@ -90,10 +131,14 @@ describe('DELETE /api/v1/accounts/follow', () => {
     })
 
     expect(response.status).toBe(202)
-    expect(mockUnfollow).toHaveBeenCalledWith(mockCurrentActor, {
-      id: 'follow-1',
-      actorId: mockCurrentActor.id,
-      targetActorId: 'https://blocked.test/users/alice'
-    })
+    expect(mockUnfollow).toHaveBeenCalledWith(
+      mockCurrentActor,
+      {
+        id: 'follow-1',
+        actorId: mockCurrentActor.id,
+        targetActorId: 'https://blocked.test/users/alice'
+      },
+      mockSigningActor
+    )
   })
 })

--- a/app/api/v1/accounts/follow/route.ts
+++ b/app/api/v1/accounts/follow/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from 'next/server'
+
 /**
 
  * @deprecated Use POST /api/v1/accounts/:id/follow and /unfollow instead
@@ -6,6 +8,7 @@
 import { follow, unfollow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -28,6 +31,50 @@ const CORS_HEADERS = [
 ]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const getJsonBody = async (req: NextRequest) => {
+  try {
+    return await req.json()
+  } catch {
+    return undefined
+  }
+}
+
+const invalidJsonBodyResponse = (req: NextRequest) =>
+  apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: { error: 'Invalid JSON body' },
+    responseStatusCode: HTTP_STATUS.BAD_REQUEST
+  })
+
+const invalidFollowRequestResponse = (req: NextRequest) =>
+  apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: { error: 'Invalid input' },
+    responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+  })
+
+type ParseFollowRequestBodyResult =
+  | { ok: true; data: FollowRequest }
+  | { ok: false; response: Response }
+
+const parseFollowRequestBody = async (
+  req: NextRequest
+): Promise<ParseFollowRequestBodyResult> => {
+  const body = await getJsonBody(req)
+  if (body === undefined) {
+    return { ok: false, response: invalidJsonBodyResponse(req) }
+  }
+
+  const parsed = FollowRequest.safeParse(body)
+  if (!parsed.success) {
+    return { ok: false, response: invalidFollowRequestResponse(req) }
+  }
+
+  return { ok: true, data: parsed.data }
+}
 
 export const GET = traceApiRoute(
   'getFollowFromUrl',
@@ -55,8 +102,10 @@ export const POST = traceApiRoute(
   'followAccountFromUrl',
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
-    const body = await req.json()
-    const { target } = FollowRequest.parse(body)
+    const parsed = await parseFollowRequestBody(req)
+    if (!parsed.ok) return parsed.response
+
+    const { target } = parsed.data
     if (!(await canFederateWithDomain(database, target))) {
       return apiResponse({
         req,
@@ -66,9 +115,10 @@ export const POST = traceApiRoute(
       })
     }
 
+    const signingActor = await getFederationSigningActor(database)
     const person = await getActorPerson({
       actorId: target,
-      signingActor: currentActor
+      signingActor
     })
     if (!person)
       return apiResponse({
@@ -84,7 +134,7 @@ export const POST = traceApiRoute(
       inbox: `${currentActor.id}/inbox`,
       sharedInbox: `https://${currentActor.domain}/inbox`
     })
-    await follow(followItem.id, currentActor, target)
+    await follow(followItem.id, currentActor, target, signingActor)
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
@@ -98,8 +148,10 @@ export const DELETE = traceApiRoute(
   'unfollowAccountFromUrl',
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
-    const body = await req.json()
-    const { target } = FollowRequest.parse(body)
+    const parsed = await parseFollowRequestBody(req)
+    if (!parsed.ok) return parsed.response
+
+    const { target } = parsed.data
     const follow = await database.getAcceptedOrRequestedFollow({
       actorId: currentActor.id,
       targetActorId: target
@@ -112,8 +164,11 @@ export const DELETE = traceApiRoute(
         responseStatusCode: 404
       })
     const canFederate = await canFederateWithDomain(database, target)
+    const signingActor = canFederate
+      ? await getFederationSigningActor(database)
+      : undefined
     await Promise.all([
-      canFederate ? unfollow(currentActor, follow) : undefined,
+      canFederate ? unfollow(currentActor, follow, signingActor) : undefined,
       database.updateFollowStatus({
         followId: follow.id,
         status: FollowStatus.enum.Undo

--- a/app/api/v1/accounts/types.test.ts
+++ b/app/api/v1/accounts/types.test.ts
@@ -1,0 +1,27 @@
+import { FEDERATION_SIGNING_ACTOR_USERNAME } from '@/lib/services/federation/instanceActor'
+
+import { CreateAccountRequest } from './types'
+
+describe('CreateAccountRequest', () => {
+  it('rejects the reserved federation signing actor username', () => {
+    const parsed = CreateAccountRequest.safeParse({
+      username: FEDERATION_SIGNING_ACTOR_USERNAME,
+      name: '',
+      email: 'test@example.com',
+      password: 'password123'
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects usernames in the federation signing actor namespace', () => {
+    const parsed = CreateAccountRequest.safeParse({
+      username: `${FEDERATION_SIGNING_ACTOR_USERNAME}abc`,
+      name: '',
+      email: 'test@example.com',
+      password: 'password123'
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/app/api/v1/accounts/types.ts
+++ b/app/api/v1/accounts/types.ts
@@ -1,7 +1,15 @@
 import { z } from 'zod'
 
+import { isFederationSigningActorUsername } from '@/lib/services/federation/instanceActor'
+
 export const CreateAccountRequest = z.object({
-  username: z.string().regex(/\w+/).trim(),
+  username: z
+    .string()
+    .regex(/\w+/)
+    .trim()
+    .refine((username) => !isFederationSigningActorUsername(username), {
+      message: 'Username is reserved'
+    }),
   name: z.string().trim().max(255).optional(),
   email: z.string().email().trim(),
   password: z.string().min(8).trim()

--- a/app/api/v1/actors/route.test.ts
+++ b/app/api/v1/actors/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { FEDERATION_SIGNING_ACTOR_USERNAME } from '@/lib/services/federation/instanceActor'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 
@@ -116,5 +117,35 @@ describe('POST /api/v1/actors', () => {
     const data = await response.json()
     expect(response.status).toBe(400)
     expect(data.error).toBe('Domain is not allowed')
+  })
+
+  it('rejects the reserved federation signing actor username', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [],
+      allowActorDomains: ['llun.test']
+    })
+
+    const response = await POST(
+      createRequest({ username: FEDERATION_SIGNING_ACTOR_USERNAME }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects usernames in the federation signing actor namespace', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [],
+      allowActorDomains: ['llun.test']
+    })
+
+    const response = await POST(
+      createRequest({ username: `${FEDERATION_SIGNING_ACTOR_USERNAME}abc` }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(400)
   })
 })

--- a/app/api/v1/actors/route.ts
+++ b/app/api/v1/actors/route.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util'
 import { z } from 'zod'
 
 import { getConfig } from '@/lib/config'
+import { isFederationSigningActorUsername } from '@/lib/services/federation/instanceActor'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
@@ -15,7 +16,13 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 const generateKeyPair = promisify(crypto.generateKeyPair)
 
 const CreateActorRequest = z.object({
-  username: z.string().min(1).max(50),
+  username: z
+    .string()
+    .min(1)
+    .max(50)
+    .refine((username) => !isFederationSigningActorUsername(username), {
+      message: 'Username is reserved'
+    }),
   domain: z.string().min(1).optional()
 })
 

--- a/app/api/well-known/webfinger/route.test.ts
+++ b/app/api/well-known/webfinger/route.test.ts
@@ -49,6 +49,35 @@ describe('GET /api/well-known/webfinger', () => {
     })
   })
 
+  it('returns WebFinger JRD for the headless instance actor without a profile page link', async () => {
+    database.getActorFromUsername.mockResolvedValue({
+      id: 'https://example.com/users/__instance__',
+      type: 'Service',
+      username: '__instance__',
+      domain: 'example.com',
+      privateKey: 'key'
+    } as never)
+
+    const response = await GET(
+      new NextRequest(
+        'https://example.com/.well-known/webfinger?resource=acct:__instance__@example.com'
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({
+      subject: 'acct:__instance__@example.com',
+      aliases: ['https://example.com/users/__instance__']
+    })
+    expect(data.links).not.toContainEqual(
+      expect.objectContaining({
+        rel: 'http://webfinger.net/rel/profile-page'
+      })
+    )
+  })
+
   it('returns 404 when the resource is missing', async () => {
     const response = await GET(
       new NextRequest('https://example.com/.well-known/webfinger'),

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -26,6 +26,7 @@ const customJestConfig = {
     '\\.(js|mjs|jsx|ts|tsx)$': ['@swc/jest']
   },
   extensionsToTreatAsEsm: ['.ts'],
+  testTimeout: 30000,
   moduleNameMapper: {
     '^@/app/(.*)$': '<rootDir>/app/$1',
     '^@/lib/(.*)$': '<rootDir>/lib/$1',

--- a/lib/actions/utils.test.ts
+++ b/lib/actions/utils.test.ts
@@ -1,6 +1,15 @@
+import knex from 'knex'
+
+import { getSQLDatabase } from '@/lib/database/sql'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 
 import { BlockedFederationDomainError, recordActorIfNeeded } from './utils'
+
+const mockGetActorPerson = jest.fn()
+
+jest.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: (...params: unknown[]) => mockGetActorPerson(...params)
+}))
 
 describe('recordActorIfNeeded', () => {
   const database = getTestSQLDatabase()
@@ -11,6 +20,10 @@ describe('recordActorIfNeeded', () => {
 
   afterAll(async () => {
     await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
   })
 
   it('rejects actors from blocked domains before fetching them', async () => {
@@ -25,5 +38,63 @@ describe('recordActorIfNeeded', () => {
         database
       })
     ).rejects.toThrow(BlockedFederationDomainError)
+  })
+
+  it('refreshes the persisted actor type for stale remote actors', async () => {
+    const sql = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(sql)
+    await database.migrate()
+
+    try {
+      const actorId = 'https://remote-service.test/users/service'
+      const oldTime = new Date(Date.now() - 4 * 86_400_000)
+      await database.createActor({
+        actorId,
+        type: 'Person',
+        username: 'service',
+        domain: 'remote-service.test',
+        followersUrl: `${actorId}/followers`,
+        inboxUrl: `${actorId}/inbox`,
+        sharedInboxUrl: 'https://remote-service.test/inbox',
+        publicKey: 'old-public-key',
+        createdAt: oldTime.getTime()
+      })
+      await sql('actors').where('id', actorId).update({ updatedAt: oldTime })
+
+      mockGetActorPerson.mockResolvedValue({
+        id: actorId,
+        type: 'Service',
+        preferredUsername: 'service',
+        followers: `${actorId}/followers`,
+        inbox: `${actorId}/inbox`,
+        outbox: `${actorId}/outbox`,
+        publicKey: {
+          id: `${actorId}#main-key`,
+          owner: actorId,
+          publicKeyPem: 'new-public-key'
+        },
+        endpoints: {
+          sharedInbox: 'https://remote-service.test/inbox'
+        }
+      })
+
+      const actor = await recordActorIfNeeded({ actorId, database })
+
+      expect(actor?.type).toBe('Service')
+      await expect(
+        database.getActorFromId({ id: actorId })
+      ).resolves.toMatchObject({
+        type: 'Service',
+        publicKey: 'new-public-key'
+      })
+    } finally {
+      await database.destroy()
+    }
   })
 })

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -66,6 +66,7 @@ export const recordActorIfNeeded = async ({
     const iconUrl = getActorImageUrl(person.icon)
     const actor = await database.createActor({
       actorId,
+      type: person.type,
       username: person.preferredUsername,
       domain: new URL(person.id).hostname,
       followersUrl: person.followers ?? '',
@@ -89,6 +90,7 @@ export const recordActorIfNeeded = async ({
     const iconUrl = getActorImageUrl(person.icon)
     const actor = await database.updateActor({
       actorId,
+      type: person.type,
       followersUrl: person.followers ?? '',
       inboxUrl: person.inbox,
       sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -379,7 +379,8 @@ export const undoAnnounce = async ({
 export const follow = async (
   id: string,
   currentActor: Actor,
-  targetActorId: string
+  targetActorId: string,
+  signingActor?: Actor
 ) =>
   getTracer().startActiveSpan(
     'activities.follow',
@@ -400,7 +401,7 @@ export const follow = async (
       }
       const person = await getActorPerson({
         actorId: targetActorId,
-        signingActor: currentActor
+        signingActor
       })
       const targetInbox = person?.inbox
       if (!targetInbox) {
@@ -433,7 +434,11 @@ export const follow = async (
     }
   )
 
-export const unfollow = async (currentActor: Actor, follow: Follow) =>
+export const unfollow = async (
+  currentActor: Actor,
+  follow: Follow,
+  signingActor?: Actor
+) =>
   getTracer().startActiveSpan(
     'activities.unfollow',
     {
@@ -458,7 +463,7 @@ export const unfollow = async (currentActor: Actor, follow: Follow) =>
 
       const person = await getActorPerson({
         actorId: follow.targetActorId,
-        signingActor: currentActor
+        signingActor
       })
       const targetInbox = person?.inbox ?? `${follow.targetActorId}/inbox`
 

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -97,6 +97,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       })
       await trx('actors').insert({
         id: actorId,
+        type: 'Person',
         accountId,
         username,
         domain,
@@ -377,6 +378,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
 
     await database('actors').insert({
       id: actorId,
+      type: 'Person',
       accountId,
       username,
       domain,
@@ -429,6 +431,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
 
       const actor = Actor.parse({
         id: sqlActor.id,
+        type: sqlActor.type ?? 'Person',
         username: sqlActor.username,
         domain: sqlActor.domain,
         ...(sqlActor.name ? { name: sqlActor.name } : null),

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -1,11 +1,18 @@
 import crypto from 'crypto'
 
+import { type SQLActorDatabase } from '@/lib/database/sql/actor'
 import {
   databaseBeforeAll,
   getTestDatabaseTable,
   getTestSQLDatabase
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
+import {
+  FEDERATION_SIGNING_ACTOR_TYPE,
+  FEDERATION_SIGNING_ACTOR_USERNAME,
+  getFederationSigningActorId,
+  getFederationSigningActorUsername
+} from '@/lib/services/federation/instanceActor'
 import {
   EXTERNAL_ACTORS,
   TEST_DOMAIN,
@@ -86,6 +93,35 @@ describe('ActorDatabase', () => {
       })
     })
 
+    describe('#getActor', () => {
+      it('falls back to Person for unknown persisted actor types', () => {
+        const actor = (database as SQLActorDatabase).getActor(
+          {
+            id: `https://${TEST_DOMAIN}/users/unknown-type`,
+            type: 'UnknownType' as never,
+            username: 'unknown-type',
+            domain: TEST_DOMAIN,
+            accountId: null,
+            publicKey: 'public-key',
+            privateKey: '',
+            settings: JSON.stringify({
+              followersUrl: `https://${TEST_DOMAIN}/users/unknown-type/followers`,
+              inboxUrl: `https://${TEST_DOMAIN}/users/unknown-type/inbox`,
+              sharedInboxUrl: `https://${TEST_DOMAIN}/inbox`
+            }),
+            createdAt: Date.now(),
+            updatedAt: Date.now()
+          },
+          0,
+          0,
+          0,
+          0
+        )
+
+        expect(actor.type).toBe('Person')
+      })
+    })
+
     describe('deprecated actor', () => {
       it('returns actor from id', async () => {
         const id = `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`
@@ -148,18 +184,34 @@ describe('ActorDatabase', () => {
     })
 
     describe('#getFederationSigningActor', () => {
-      it('returns a local actor with a private key', async () => {
+      it('creates a dedicated headless instance actor with a private key', async () => {
         const actor = await database.getFederationSigningActor()
 
         expect(actor).toMatchObject({
+          id: getFederationSigningActorId(TEST_DOMAIN),
+          type: FEDERATION_SIGNING_ACTOR_TYPE,
+          username: FEDERATION_SIGNING_ACTOR_USERNAME,
           domain: TEST_DOMAIN,
           privateKey: expect.toBeString(),
           publicKey: expect.toBeString()
         })
-        expect(actor?.account).toBeDefined()
+        expect(actor?.account).toBeUndefined()
       })
 
-      it('returns null when no local actor has a private key', async () => {
+      it('returns one signer for concurrent first-run bootstrap calls', async () => {
+        await withFreshDatabase(async (database) => {
+          const [first, second] = await Promise.all([
+            database.getFederationSigningActor(),
+            database.getFederationSigningActor()
+          ])
+
+          expect(first?.id).toBe(getFederationSigningActorId(TEST_DOMAIN))
+          expect(second?.id).toBe(first?.id)
+          expect(second?.privateKey).toBe(first?.privateKey)
+        })
+      })
+
+      it('creates the headless actor when no user actors exist', async () => {
         await withFreshDatabase(async (database) => {
           await database.createActor({
             actorId: EXTERNAL_ACTORS[0].id,
@@ -179,24 +231,69 @@ describe('ActorDatabase', () => {
             domain: TEST_DOMAIN_2
           })
 
-          await expect(database.getFederationSigningActor()).resolves.toBeNull()
+          const actor = await database.getFederationSigningActor()
+          expect(actor).toMatchObject({
+            id: getFederationSigningActorId(TEST_DOMAIN),
+            type: FEDERATION_SIGNING_ACTOR_TYPE
+          })
+          expect(actor?.account).toBeUndefined()
         })
       })
 
-      it('skips actors scheduled for deletion', async () => {
+      it('uses an alternate headless actor instead of a real user actor when the reserved id is unavailable', async () => {
         await withFreshDatabase(async (database) => {
           const username = 'deleting-signer'
           await createSigningAccount(database, username)
-          await database.scheduleActorDeletion({
-            actorId: `https://${TEST_DOMAIN}/users/${username}`,
-            scheduledAt: null
+
+          await database.createActor({
+            actorId: getFederationSigningActorId(TEST_DOMAIN),
+            type: FEDERATION_SIGNING_ACTOR_TYPE,
+            username: FEDERATION_SIGNING_ACTOR_USERNAME,
+            domain: TEST_DOMAIN,
+            followersUrl: `${getFederationSigningActorId(TEST_DOMAIN)}/followers`,
+            inboxUrl: `${getFederationSigningActorId(TEST_DOMAIN)}/inbox`,
+            sharedInboxUrl: `https://${TEST_DOMAIN}/inbox`,
+            publicKey: '',
+            createdAt: Date.now()
           })
 
-          await expect(database.getFederationSigningActor()).resolves.toBeNull()
+          const actor = await database.getFederationSigningActor()
+          const fallbackUsername = getFederationSigningActorUsername(1)
+
+          expect(actor).toMatchObject({
+            id: getFederationSigningActorId(TEST_DOMAIN, fallbackUsername),
+            type: FEDERATION_SIGNING_ACTOR_TYPE,
+            username: fallbackUsername,
+            domain: TEST_DOMAIN,
+            privateKey: expect.toBeString()
+          })
+          expect(actor?.account).toBeUndefined()
         })
       })
 
-      it('deterministically returns the oldest eligible actor', async () => {
+      it('does not reuse arbitrary service actors as the federation signer', async () => {
+        await withFreshDatabase(async (database) => {
+          await database.createActor({
+            actorId: `https://${TEST_DOMAIN}/users/not-the-instance`,
+            type: FEDERATION_SIGNING_ACTOR_TYPE,
+            username: 'not-the-instance',
+            domain: TEST_DOMAIN,
+            followersUrl: `https://${TEST_DOMAIN}/users/not-the-instance/followers`,
+            inboxUrl: `https://${TEST_DOMAIN}/users/not-the-instance/inbox`,
+            sharedInboxUrl: `https://${TEST_DOMAIN}/inbox`,
+            publicKey: 'public-key',
+            privateKey: 'private-key',
+            createdAt: Date.now()
+          })
+
+          const actor = await database.getFederationSigningActor()
+
+          expect(actor?.id).toBe(getFederationSigningActorId(TEST_DOMAIN))
+          expect(actor?.username).toBe(FEDERATION_SIGNING_ACTOR_USERNAME)
+        })
+      })
+
+      it('deterministically returns the reserved headless actor', async () => {
         await withFreshDatabase(async (database) => {
           await createSigningAccount(database, 'older-signer')
           await new Promise((resolve) => setTimeout(resolve, 5))
@@ -205,8 +302,9 @@ describe('ActorDatabase', () => {
           const first = await database.getFederationSigningActor()
           const second = await database.getFederationSigningActor()
 
-          expect(first?.id).toBe(`https://${TEST_DOMAIN}/users/older-signer`)
+          expect(first?.id).toBe(getFederationSigningActorId(TEST_DOMAIN))
           expect(second?.id).toBe(first?.id)
+          expect(second?.privateKey).toBe(first?.privateKey)
         })
       })
     })
@@ -303,6 +401,79 @@ describe('ActorDatabase', () => {
           statuses_count: 0,
           followers_count: 0,
           following_count: 0
+        })
+      })
+
+      it('returns local headless signer as undiscoverable bot account', async () => {
+        await withFreshDatabase(async (database) => {
+          const signingActor = await database.getFederationSigningActor()
+          expect(signingActor).toBeTruthy()
+
+          const actor = await database.getMastodonActorFromId({
+            id: signingActor!.id
+          })
+
+          expect(actor).toMatchObject({
+            username: FEDERATION_SIGNING_ACTOR_USERNAME,
+            bot: true,
+            group: false,
+            discoverable: false,
+            noindex: true,
+            statuses_count: 0,
+            followers_count: 0,
+            following_count: 0
+          })
+        })
+      })
+
+      it('maps remote ActivityPub actor types to Mastodon fields', async () => {
+        await withFreshDatabase(async (database) => {
+          const suffix = crypto.randomUUID().slice(0, 8)
+          const serviceActorId = `https://remote-${suffix}.example/users/service`
+          const groupActorId = `https://remote-${suffix}.example/users/group`
+
+          await database.createActor({
+            actorId: serviceActorId,
+            type: 'Service',
+            username: 'service',
+            domain: `remote-${suffix}.example`,
+            followersUrl: `${serviceActorId}/followers`,
+            inboxUrl: `${serviceActorId}/inbox`,
+            sharedInboxUrl: `${serviceActorId}/inbox`,
+            publicKey: 'servicePublicKey',
+            createdAt: Date.now()
+          })
+          await database.createActor({
+            actorId: groupActorId,
+            type: 'Group',
+            username: 'group',
+            domain: `remote-${suffix}.example`,
+            followersUrl: `${groupActorId}/followers`,
+            inboxUrl: `${groupActorId}/inbox`,
+            sharedInboxUrl: `${groupActorId}/inbox`,
+            publicKey: 'groupPublicKey',
+            createdAt: Date.now()
+          })
+
+          const serviceActor = await database.getMastodonActorFromId({
+            id: serviceActorId
+          })
+          const groupActor = await database.getMastodonActorFromId({
+            id: groupActorId
+          })
+
+          expect(serviceActor).toMatchObject({
+            bot: true,
+            group: false,
+            discoverable: true,
+            noindex: false
+          })
+          expect(groupActor).toMatchObject({
+            bot: false,
+            group: true,
+            discoverable: true,
+            noindex: false
+          })
         })
       })
     })
@@ -444,6 +615,39 @@ describe('ActorDatabase', () => {
           privateKey: expect.toBeString()
         })
       })
+
+      it('updates actor type for refreshed remote actors', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `remote-service-${suffix}`
+        const domain = `remote-service-${suffix}.test`
+        const actorId = `https://${domain}/users/${username}`
+
+        await database.createActor({
+          actorId,
+          type: 'Person',
+          username,
+          domain,
+          followersUrl: `${actorId}/followers`,
+          inboxUrl: `${actorId}/inbox`,
+          sharedInboxUrl: `https://${domain}/inbox`,
+          publicKey: 'public-key',
+          createdAt: Date.now()
+        })
+
+        await database.updateActor({
+          actorId,
+          type: 'Service'
+        })
+
+        const actor = await database.getActorFromId({ id: actorId })
+        expect(actor?.type).toBe('Service')
+
+        const mastodonActor = await database.getMastodonActorFromUsername({
+          username,
+          domain
+        })
+        expect(mastodonActor?.bot).toBeTrue()
+      })
     })
 
     describe('#getActorSettings', () => {
@@ -522,6 +726,38 @@ describe('ActorDatabase', () => {
           actorId: `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`
         })
         expect(result).toBeTrue()
+      })
+
+      it('returns true for the headless instance actor', async () => {
+        const actor = await database.getFederationSigningActor()
+        if (!actor) fail('Expected federation signing actor')
+
+        const result = await database.isInternalActor({
+          actorId: actor.id
+        })
+        expect(result).toBeTrue()
+      })
+
+      it('returns false for non-signer accountless local service actors', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `local-service-${suffix}`
+        const actorId = `https://${TEST_DOMAIN}/users/${username}`
+
+        await database.createActor({
+          actorId,
+          type: 'Service',
+          username,
+          domain: TEST_DOMAIN,
+          followersUrl: `${actorId}/followers`,
+          inboxUrl: `${actorId}/inbox`,
+          sharedInboxUrl: `https://${TEST_DOMAIN}/inbox`,
+          publicKey: 'public-key',
+          privateKey: 'private-key',
+          createdAt: Date.now()
+        })
+
+        const result = await database.isInternalActor({ actorId })
+        expect(result).toBeFalse()
       })
 
       it('returns false when actor is external', async () => {

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -13,6 +13,14 @@ import {
 } from '@/lib/database/sql/utils/counter'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  FEDERATION_SIGNING_ACTOR_TYPE,
+  FEDERATION_SIGNING_ACTOR_USERNAME,
+  getFederationSigningActorId,
+  getFederationSigningActorUsername,
+  isFederationSigningActor,
+  isFederationSigningActorUsername
+} from '@/lib/services/federation/instanceActor'
 import { Mastodon } from '@/lib/types/activitypub'
 import {
   ActorDatabase,
@@ -35,9 +43,10 @@ import {
 } from '@/lib/types/database/operations'
 import { ActorSettings, SQLAccount, SQLActor } from '@/lib/types/database/rows'
 import { Account } from '@/lib/types/domain/account'
-import { Actor } from '@/lib/types/domain/actor'
+import { Actor, ActorType } from '@/lib/types/domain/actor'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { generateKeyPair } from '@/lib/utils/signature'
 import { urlToId } from '@/lib/utils/urlToId'
 
 export interface SQLActorDatabase extends ActorDatabase {
@@ -95,9 +104,45 @@ const getConfiguredActorDomain = () => {
   return host.includes('://') ? new URL(host).host : host
 }
 
+const getFederationSigningActorSettings = (
+  actorId: string,
+  domain: string
+) => ({
+  followersUrl: `${actorId}/followers`,
+  inboxUrl: `${actorId}/inbox`,
+  sharedInboxUrl: `https://${domain}/inbox`
+})
+
+const isValidFederationSigningSQLActor = (
+  sqlActor: SQLActor | undefined,
+  domain: string
+): sqlActor is SQLActor =>
+  Boolean(
+    sqlActor &&
+    sqlActor.type === FEDERATION_SIGNING_ACTOR_TYPE &&
+    sqlActor.domain === domain &&
+    sqlActor.accountId == null &&
+    sqlActor.privateKey &&
+    !sqlActor.deletionStatus &&
+    isFederationSigningActorUsername(sqlActor.username)
+  )
+
+const FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN = `${FEDERATION_SIGNING_ACTOR_USERNAME.replace(/[\\%_]/g, '\\$&')}%`
+
+const federationSigningActorCreationLocks = new Map<
+  string,
+  Promise<Actor | null>
+>()
+// Process-local only; cross-process races still rely on the actor id unique
+// constraint plus insert recovery below.
+
+const isMastodonBotActorType = (type: SQLActor['type']) =>
+  type === 'Service' || type === 'Application' || type === 'Organization'
+
 export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
   async createActor({
     actorId,
+    type = 'Person',
 
     username,
     domain,
@@ -125,6 +170,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     }
     await database('actors').insert({
       id: actorId,
+      type,
       username,
       domain,
       name,
@@ -140,6 +186,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
   async createMastodonActor({
     actorId,
+    type = 'Person',
 
     username,
     domain,
@@ -167,6 +214,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     }
     await database('actors').insert({
       id: actorId,
+      type,
       username,
       domain,
       name,
@@ -271,18 +319,105 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
   },
 
   async getFederationSigningActor() {
-    const persistedActor = await database<SQLActor>('actors')
-      .where('domain', getConfiguredActorDomain())
-      .whereNotNull('accountId')
-      .whereNotNull('privateKey')
-      .where('privateKey', '<>', '')
-      .whereNull('deletionStatus')
-      .orderBy('createdAt', 'asc')
-      .orderBy('id', 'asc')
-      .first<{ id: string }>('id')
-    if (!persistedActor) return null
+    const domain = getConfiguredActorDomain()
+    const actorId = getFederationSigningActorId(domain)
+    const getActorFromRow = (sqlActor: SQLActor | undefined) => {
+      if (!isValidFederationSigningSQLActor(sqlActor, domain)) return null
 
-    return this.getActorFromId({ id: persistedActor.id })
+      return this.getActor(sqlActor, 0, 0, 0, 0)
+    }
+    const getExistingHeadlessActor = async () => {
+      const localServiceActors = await database<SQLActor>('actors')
+        .where('domain', domain)
+        .andWhere('type', FEDERATION_SIGNING_ACTOR_TYPE)
+        .whereRaw("?? LIKE ? ESCAPE '\\'", [
+          'username',
+          FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
+        ])
+        .whereNull('accountId')
+        .whereNotNull('privateKey')
+        .where('privateKey', '<>', '')
+        .whereNull('deletionStatus')
+        .orderBy('createdAt', 'asc')
+        .orderBy('id', 'asc')
+
+      for (const sqlActor of localServiceActors) {
+        const actor = getActorFromRow(sqlActor)
+        if (actor) return actor
+      }
+
+      return null
+    }
+
+    const pendingActor = federationSigningActorCreationLocks.get(domain)
+    if (pendingActor) return pendingActor
+
+    const createSigningActor = async () => {
+      const reservedActor = getActorFromRow(
+        await database<SQLActor>('actors').where('id', actorId).first()
+      )
+      if (reservedActor) return reservedActor
+
+      const existingHeadlessActor = await getExistingHeadlessActor()
+      if (existingHeadlessActor) return existingHeadlessActor
+
+      const usedUsernames = new Set(
+        (
+          await database<SQLActor>('actors')
+            .where('domain', domain)
+            .whereRaw("?? LIKE ? ESCAPE '\\'", [
+              'username',
+              FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
+            ])
+            .select('username')
+        ).map((actor) => actor.username)
+      )
+      let username = FEDERATION_SIGNING_ACTOR_USERNAME
+      for (let index = 0; usedUsernames.has(username); index += 1) {
+        username = getFederationSigningActorUsername(index + 1)
+      }
+      const signingActorId = getFederationSigningActorId(domain, username)
+
+      const currentTime = new Date()
+      const keyPair = await generateKeyPair(getConfig().secretPhase)
+      try {
+        await database<SQLActor>('actors').insert({
+          id: signingActorId,
+          type: FEDERATION_SIGNING_ACTOR_TYPE,
+          username,
+          domain,
+          name: 'Instance actor',
+          summary: 'Service actor used for ActivityPub federation signing.',
+          accountId: null,
+          settings: JSON.stringify(
+            getFederationSigningActorSettings(signingActorId, domain)
+          ),
+          publicKey: keyPair.publicKey,
+          privateKey: keyPair.privateKey,
+          createdAt: currentTime,
+          updatedAt: currentTime
+        })
+      } catch (error) {
+        const actor = await getExistingHeadlessActor()
+        if (actor) return actor
+        throw error
+      }
+
+      const sqlActor = await database<SQLActor>('actors')
+        .where('id', signingActorId)
+        .first()
+      return getActorFromRow(sqlActor)
+    }
+
+    const creatingActor = createSigningActor()
+    federationSigningActorCreationLocks.set(domain, creatingActor)
+    try {
+      return await creatingActor
+    } finally {
+      if (federationSigningActorCreationLocks.get(domain) === creatingActor) {
+        federationSigningActorCreationLocks.delete(domain)
+      }
+    }
   },
 
   async getMastodonActorFromUsername({
@@ -400,6 +535,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       : null
     return Actor.parse({
       id: sqlActor.id,
+      type: ActorType.catch(ActorType.enum.Person).parse(sqlActor.type),
       username: sqlActor.username,
       domain: sqlActor.domain,
       ...(sqlActor.name ? { name: sqlActor.name } : null),
@@ -450,6 +586,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
     const settings = getCompatibleJSON(sqlActor.settings)
     const lastStatusCreatedAt = lastStatus?.createdAt ? lastStatus.createdAt : 0
+    const isLocalHeadlessSigner = isValidFederationSigningSQLActor(
+      sqlActor,
+      getConfiguredActorDomain()
+    )
     return Mastodon.Account.parse({
       id: urlToId(sqlActor.id),
       username: sqlActor.username,
@@ -467,10 +607,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       emojis: [],
 
       locked: settings.manuallyApprovesFollowers ?? true,
-      bot: false,
-      group: false,
-      discoverable: true,
-      noindex: false,
+      bot: isMastodonBotActorType(sqlActor.type),
+      group: sqlActor.type === 'Group',
+      discoverable: !isLocalHeadlessSigner,
+      noindex: isLocalHeadlessSigner,
 
       source: {
         note: '',
@@ -494,6 +634,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
   async updateActor({
     actorId,
+    type,
     name,
     summary,
     iconUrl,
@@ -536,6 +677,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     await database<SQLActor>('actors')
       .where('id', actorId)
       .update({
+        ...(type ? { type } : null),
         ...(name ? { name } : null),
         ...(summary ? { summary } : null),
 
@@ -610,7 +752,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       .where('id', actorId)
       .first()
     if (!persistedActor) return false
-    return Boolean(persistedActor.accountId)
+    if (persistedActor.accountId) return true
+
+    return (
+      persistedActor.domain === getConfiguredActorDomain() &&
+      isFederationSigningActor(this.getActor(persistedActor, 0, 0, 0, 0))
+    )
   },
 
   async getActorSettings({ actorId }: GetActorSettingsParams) {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -48,6 +48,7 @@ describe('StatusDatabase', () => {
             id: primaryActorId,
             username: actors.primary.username,
             domain: actors.primary.domain,
+            type: 'Person',
             followersUrl: `${primaryActorId}/followers`,
             inboxUrl: `${primaryActorId}/inbox`,
             sharedInboxUrl: `https://${actors.primary.domain}/inbox`,

--- a/lib/services/federation/getFederationSigningActor.test.ts
+++ b/lib/services/federation/getFederationSigningActor.test.ts
@@ -1,0 +1,48 @@
+import { Database } from '@/lib/database/types'
+import {
+  FEDERATION_SIGNING_ACTOR_TYPE,
+  FEDERATION_SIGNING_ACTOR_USERNAME
+} from '@/lib/services/federation/instanceActor'
+import { Actor } from '@/lib/types/domain/actor'
+
+import { getFederationSigningActor } from './getFederationSigningActor'
+
+const serviceActor = {
+  id: 'https://example.com/users/__instance__',
+  type: FEDERATION_SIGNING_ACTOR_TYPE,
+  username: FEDERATION_SIGNING_ACTOR_USERNAME,
+  domain: 'example.com',
+  privateKey: 'service-private-key'
+} as Actor
+
+const userActor = {
+  id: 'https://example.com/users/alice',
+  type: 'Person',
+  username: 'alice',
+  domain: 'example.com',
+  privateKey: 'user-private-key'
+} as Actor
+
+describe('getFederationSigningActor', () => {
+  it('reuses an already resolved headless instance actor', async () => {
+    const database = {
+      getFederationSigningActor: jest.fn()
+    } as unknown as Database
+
+    await expect(
+      getFederationSigningActor(database, serviceActor)
+    ).resolves.toBe(serviceActor)
+    expect(database.getFederationSigningActor).not.toHaveBeenCalled()
+  })
+
+  it('does not reuse a real user actor as the federation signing actor', async () => {
+    const database = {
+      getFederationSigningActor: jest.fn().mockResolvedValue(serviceActor)
+    } as unknown as Database
+
+    await expect(getFederationSigningActor(database, userActor)).resolves.toBe(
+      serviceActor
+    )
+    expect(database.getFederationSigningActor).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/services/federation/getFederationSigningActor.ts
+++ b/lib/services/federation/getFederationSigningActor.ts
@@ -1,11 +1,19 @@
 import { Database } from '@/lib/database/types'
+import { isFederationSigningActor } from '@/lib/services/federation/instanceActor'
 import { Actor } from '@/lib/types/domain/actor'
 
+/**
+ * Returns the dedicated headless federation signer.
+ *
+ * The optional actor is only a short-circuit for callers that already resolved
+ * the headless signer earlier in the same flow. User actors are intentionally
+ * ignored so federation fetches never fall back to signing as a person.
+ */
 export const getFederationSigningActor = async (
   database: Database,
-  preferredActor?: Actor
+  candidateActor?: Actor
 ): Promise<Actor | undefined> => {
-  if (preferredActor?.privateKey) return preferredActor
+  if (isFederationSigningActor(candidateActor)) return candidateActor
 
   return (await database.getFederationSigningActor()) ?? undefined
 }

--- a/lib/services/federation/instanceActor.ts
+++ b/lib/services/federation/instanceActor.ts
@@ -1,0 +1,23 @@
+import { type Actor } from '@/lib/types/domain/actor'
+
+export const FEDERATION_SIGNING_ACTOR_USERNAME = '__instance__'
+export const FEDERATION_SIGNING_ACTOR_TYPE = 'Service'
+
+export const getFederationSigningActorUsername = (index = 0) =>
+  index === 0 ? FEDERATION_SIGNING_ACTOR_USERNAME : `__instance__${index}`
+
+export const isFederationSigningActorUsername = (username: string) =>
+  username.startsWith(FEDERATION_SIGNING_ACTOR_USERNAME)
+
+export const getFederationSigningActorId = (
+  domain: string,
+  username = FEDERATION_SIGNING_ACTOR_USERNAME
+) => `https://${domain}/users/${username}`
+
+export const isFederationSigningActor = (actor?: Actor | null) =>
+  Boolean(
+    actor?.privateKey &&
+    actor.type === FEDERATION_SIGNING_ACTOR_TYPE &&
+    isFederationSigningActorUsername(actor.username) &&
+    !actor.account
+  )

--- a/lib/services/guards/OnlyLocalUserGuard.test.ts
+++ b/lib/services/guards/OnlyLocalUserGuard.test.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { FEDERATION_SIGNING_ACTOR_USERNAME } from '@/lib/services/federation/instanceActor'
+import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 
@@ -48,6 +50,38 @@ describe('OnlyLocalUserGuard', () => {
       const req = createRequest()
       const response = await guard(req, {
         params: Promise.resolve({ username: seedActor1.username })
+      })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+    })
+
+    it('returns 404 for the headless instance actor by default', async () => {
+      await database.getFederationSigningActor()
+
+      const guard = OnlyLocalUserGuard(mockHandler)
+      const req = createRequest(TEST_DOMAIN)
+      const response = await guard(req, {
+        params: Promise.resolve({
+          username: FEDERATION_SIGNING_ACTOR_USERNAME
+        })
+      })
+
+      expect(response.status).toBe(404)
+      expect(mockHandler).not.toHaveBeenCalled()
+    })
+
+    it('calls handler for the headless instance actor when explicitly allowed', async () => {
+      await database.getFederationSigningActor()
+
+      const guard = OnlyLocalUserGuard(mockHandler, {
+        allowFederationSigningActor: true
+      })
+      const req = createRequest(TEST_DOMAIN)
+      const response = await guard(req, {
+        params: Promise.resolve({
+          username: FEDERATION_SIGNING_ACTOR_USERNAME
+        })
       })
 
       expect(response.status).toBe(200)

--- a/lib/services/guards/OnlyLocalUserGuard.ts
+++ b/lib/services/guards/OnlyLocalUserGuard.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
 import { Database } from '@/lib/database/types'
+import { isFederationSigningActor } from '@/lib/services/federation/instanceActor'
 import { Actor } from '@/lib/types/domain/actor'
 import { apiErrorResponse } from '@/lib/utils/response'
 
@@ -19,8 +20,12 @@ export type OnlyLocalUserGuardHandle = (
   query: AppRouterParams<OnlyLocalUserGuardParams>
 ) => Promise<Response> | Response
 
+export type OnlyLocalUserGuardOptions = {
+  allowFederationSigningActor?: boolean
+}
+
 export const OnlyLocalUserGuard =
-  (handle: OnlyLocalUserGuardHandle) =>
+  (handle: OnlyLocalUserGuardHandle, options: OnlyLocalUserGuardOptions = {}) =>
   async (
     req: NextRequest,
     query: AppRouterParams<OnlyLocalUserGuardParams>
@@ -32,7 +37,10 @@ export const OnlyLocalUserGuard =
     const host = headerHost(req.headers)
     const id = `https://${host}/users/${username}`
     const actor = await database.getActorFromId({ id })
-    if (!actor || !actor.account) {
+    const isAllowedActor =
+      actor?.account ||
+      (options.allowFederationSigningActor && isFederationSigningActor(actor))
+    if (!actor || !isAllowedActor) {
       return apiErrorResponse(404)
     }
 

--- a/lib/services/wellknown/webfinger.ts
+++ b/lib/services/wellknown/webfinger.ts
@@ -59,17 +59,26 @@ export const getWebFingerResponse = async ({
   // This is not local actors
   if (!actor?.privateKey) return null
 
-  const profilePageUrl = `https://${actor.domain}/@${actor.username}`
+  const profilePageUrl =
+    actor.type === 'Service'
+      ? actor.id
+      : `https://${actor.domain}/@${actor.username}`
+  const profilePageLink =
+    actor.type === 'Service'
+      ? []
+      : [
+          {
+            rel: 'http://webfinger.net/rel/profile-page',
+            type: 'text/html',
+            href: profilePageUrl
+          }
+        ]
 
   return {
     subject: `acct:${actor.username}@${actor.domain}`,
-    aliases: [profilePageUrl, actor.id],
+    aliases: actor.type === 'Service' ? [actor.id] : [profilePageUrl, actor.id],
     links: [
-      {
-        rel: 'http://webfinger.net/rel/profile-page',
-        type: 'text/html',
-        href: profilePageUrl
-      },
+      ...profilePageLink,
       {
         rel: 'self',
         type: 'application/activity+json',

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { Timeline } from '@/lib/services/timelines/types'
 import { ActorSettings, PostLineLimit } from '@/lib/types/database/rows'
 import { Account } from '@/lib/types/domain/account'
-import { Actor } from '@/lib/types/domain/actor'
+import { Actor, ActorType } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 import { Session } from '@/lib/types/domain/session'
@@ -29,6 +29,7 @@ export interface BaseDatabase {
 
 export type CreateActorParams = {
   actorId: string
+  type?: ActorType
 
   username: string
   domain: string
@@ -55,6 +56,7 @@ export type IsCurrentActorFollowingParams = {
 }
 export type UpdateActorParams = {
   actorId: string
+  type?: ActorType
 
   name?: string
   summary?: string

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -1,3 +1,5 @@
+import { type ActorType } from '@/lib/types/domain/actor'
+
 // SQL row types - Types returned directly from database queries
 
 export const POST_LINE_LIMIT_VALUES = [5, 10, 0] as const
@@ -35,11 +37,12 @@ export type ActorDeletionStatus = 'scheduled' | 'deleting' | null
 
 export interface SQLActor {
   id: string
+  type?: ActorType
   username: string
   domain: string
   name?: string
   summary?: string
-  accountId: string
+  accountId: string | null
 
   publicKey: string
   privateKey: string

--- a/lib/types/domain/actor.ts
+++ b/lib/types/domain/actor.ts
@@ -3,8 +3,20 @@ import { z } from 'zod'
 import { Account } from '@/lib/types/domain/account'
 import { logger } from '@/lib/utils/logger'
 
+export const ACTOR_TYPES = [
+  'Person',
+  'Service',
+  'Application',
+  'Group',
+  'Organization'
+] as const
+
+export const ActorType = z.enum(ACTOR_TYPES)
+export type ActorType = z.infer<typeof ActorType>
+
 export const ActorProfile = z.object({
   id: z.string(),
+  type: ActorType.optional(),
   username: z.string(),
   domain: z.string(),
   name: z.string().optional(),

--- a/lib/utils/getPersonFromActor.ts
+++ b/lib/utils/getPersonFromActor.ts
@@ -5,6 +5,11 @@ import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 export const getPersonFromActor = (
   actor: Actor
 ): ActivityPubActor & { '@context': string[] } => {
+  const actorType = actor.type ?? 'Person'
+  const profileUrl =
+    actorType === 'Service'
+      ? actor.id
+      : `https://${actor.domain}/@${actor.username}`
   const icon = actor.iconUrl
     ? {
         icon: {
@@ -26,15 +31,15 @@ export const getPersonFromActor = (
 
   const person = ActivityPubActor.parse({
     id: actor.id,
-    type: 'Person',
-    following: `https://${actor.domain}/users/${actor.username}/following`,
-    followers: `https://${actor.domain}/users/${actor.username}/followers`,
-    inbox: `https://${actor.domain}/users/${actor.username}/inbox`,
-    outbox: `https://${actor.domain}/users/${actor.username}/outbox`,
+    type: actorType,
+    following: `${actor.id}/following`,
+    followers: actor.followersUrl,
+    inbox: actor.inboxUrl,
+    outbox: `${actor.id}/outbox`,
     preferredUsername: actor.username,
     name: actor.name || '',
     summary: actor.summary || '',
-    url: `https://${actor.domain}/@${actor.username}`,
+    url: profileUrl,
     published: getISOTimeUTC(actor.createdAt),
     publicKey: {
       id: `${actor.id}#main-key`,
@@ -42,7 +47,7 @@ export const getPersonFromActor = (
       publicKeyPem: actor.publicKey
     },
     endpoints: {
-      sharedInbox: `https://${actor.domain}/inbox`
+      sharedInbox: actor.sharedInboxUrl
     },
     ...icon,
     ...headerImage

--- a/migrations/20260428120000_add_actor_type.js
+++ b/migrations/20260428120000_add_actor_type.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('actors', function (table) {
+    table.string('type').notNullable().defaultTo('Person')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('actors', function (table) {
+    table.dropColumn('type')
+  })
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -52,6 +52,7 @@ CREATE TABLE
 CREATE TABLE
     public.actors (
         id character varying(255),
+        type character varying(255) DEFAULT 'Person'::character varying NOT NULL,
         username character varying(255),
         "accountId" character varying(255),
         name character varying(255),


### PR DESCRIPTION
## Summary
- add a dedicated accountless Service actor for federation HTTP-signature GETs
- persist ActivityPub actor type in the actors table and preserve remote actor types
- keep the headless instance actor out of profile-page redirects and profile WebFinger aliases

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test
- env ACTIVITIES_DATABASE_CLIENT=pg ACTIVITIES_DATABASE_PG_HOST=127.0.0.1 ACTIVITIES_DATABASE_PG_PORT=5432 ACTIVITIES_DATABASE_PG_USER=postgres ACTIVITIES_DATABASE_PG_PASSWORD=postgres ACTIVITIES_DATABASE_PG_DATABASE=activities yarn migrate

Follow-up to https://github.com/llun/activities.next/pull/605#issuecomment-4332428064