### PR TITLE
fix: Resolve boosted status routes and remote actor rendering

### DIFF
--- a/app/(timeline)/[actor]/[status]/page.test.ts
+++ b/app/(timeline)/[actor]/[status]/page.test.ts
@@ -1,0 +1,48 @@
+import { generateMetadata } from './page'
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn()
+}))
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn()
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn()
+}))
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn()
+}))
+
+jest.mock('./Header', () => ({
+  Header: () => null
+}))
+
+jest.mock('./RemoteStatusLoading', () => ({
+  RemoteStatusLoading: () => null
+}))
+
+jest.mock('./StatusBox', () => ({
+  StatusBox: () => null
+}))
+
+describe('#generateMetadata', () => {
+  it('does not throw when the actor route has malformed URI escapes', async () => {
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          actor: '%E0%A4%A',
+          status: 'status-id'
+        })
+      })
+    ).resolves.toEqual({
+      title: 'Activities.next: %E0%A4%A status'
+    })
+  })
+})

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -20,7 +20,7 @@ import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { Header } from './Header'
 import { RemoteStatusLoading } from './RemoteStatusLoading'
 import { StatusBox } from './StatusBox'
-import { resolveStatusFromPath } from './resolveStatusFromPath'
+import { decodePathParam, resolveStatusFromPath } from './resolveStatusFromPath'
 
 interface Props {
   params: Promise<{ actor: string; status: string }>
@@ -31,7 +31,7 @@ export const generateMetadata = async ({
 }: Props): Promise<Metadata> => {
   const { actor } = await params
   return {
-    title: `Activities.next: ${decodeURIComponent(actor)} status`
+    title: `Activities.next: ${decodePathParam(actor)} status`
   }
 }
 

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
+import { getRemoteStatus } from '@/lib/activities/getRemoteStatus'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from '@/lib/jobs/names'
@@ -56,7 +57,16 @@ const Page: FC<Props> = async ({ params }) => {
   })
   if (!resolvedStatus) return notFound()
 
-  const { fullStatusId, isStatusHash, status, statusId } = resolvedStatus
+  const { fullStatusId, isStatusHash } = resolvedStatus
+  let { status, statusId } = resolvedStatus
+
+  if (!status && !isStatusHash && fullStatusId) {
+    status = await getRemoteStatus({
+      statusId: fullStatusId,
+      signingActor: currentActor ?? undefined
+    })
+    statusId = status?.id ?? ''
+  }
 
   // Try to fetch remote status if not found and user is logged in
   if (!status && session && !isStatusHash) {

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -20,6 +20,7 @@ import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { Header } from './Header'
 import { RemoteStatusLoading } from './RemoteStatusLoading'
 import { StatusBox } from './StatusBox'
+import { resolveStatusFromPath } from './resolveStatusFromPath'
 
 interface Props {
   params: Promise<{ actor: string; status: string }>
@@ -48,60 +49,14 @@ const Page: FC<Props> = async ({ params }) => {
 
   const { actor, status: statusParam } = await params
   const currentTime = Date.now()
-  const decodedActor = decodeURIComponent(actor)
-  const decodedStatusParam = (() => {
-    try {
-      return decodeURIComponent(statusParam)
-    } catch {
-      return statusParam
-    }
-  })()
-
-  const parts = decodedActor.split('@').slice(1)
-  if (parts.length !== 2) {
-    return notFound()
-  }
-
-  const actorFromPath = await database.getActorFromUsername({
-    username: parts[0],
-    domain: parts[1]
+  const resolvedStatus = await resolveStatusFromPath({
+    database,
+    actorParam: actor,
+    statusParam
   })
-  const actorIdFromPath = actorFromPath?.id
-  const isStatusHash = /^[a-f0-9]{64}$/i.test(decodedStatusParam)
+  if (!resolvedStatus) return notFound()
 
-  const protocol = parts[1].startsWith('localhost') ? 'http' : 'https'
-  const isFullStatusUrl = /^https?:\/\//.test(decodedStatusParam)
-  const fullStatusId = isFullStatusUrl
-    ? decodedStatusParam
-    : `${protocol}://${parts[1]}/users/${parts[0]}/statuses/${decodedStatusParam}`
-
-  let status: Status | null = null
-  let statusId = ''
-
-  if (isStatusHash) {
-    status = await database.getStatusFromUrlHash({
-      urlHash: decodedStatusParam,
-      actorId: actorIdFromPath
-    })
-    statusId = status?.id ?? ''
-  }
-
-  // Try full URL format first (ActivityPub standard), then fallback to raw id (for legacy/mock data)
-  if (!status) {
-    status = await database.getStatus({
-      statusId: fullStatusId,
-      withReplies: false
-    })
-    statusId = fullStatusId
-  }
-
-  if (!status && !isFullStatusUrl) {
-    status = await database.getStatus({
-      statusId: decodedStatusParam,
-      withReplies: false
-    })
-    statusId = decodedStatusParam
-  }
+  const { fullStatusId, isStatusHash, status, statusId } = resolvedStatus
 
   // Try to fetch remote status if not found and user is logged in
   if (!status && session && !isStatusHash) {

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
@@ -6,6 +6,7 @@ import { resolveStatusFromPath } from './resolveStatusFromPath'
 describe('#resolveStatusFromPath', () => {
   const originalActorId = 'https://remote.example/users/original'
   const boosterActorId = 'https://boost.example/users/booster'
+  const secondBoosterActorId = 'https://other.example/users/booster'
   const originalUrl = 'https://remote.example/@original/123'
   const statusHash = getHashFromString(originalUrl)
 
@@ -34,34 +35,33 @@ describe('#resolveStatusFromPath', () => {
     tags: []
   } as Status
 
-  const boostedStatus = {
-    id: 'https://boost.example/users/booster/statuses/456/activity',
-    actorId: boosterActorId,
-    actor: {
-      username: 'booster',
-      domain: 'boost.example'
-    },
-    type: StatusType.enum.Announce,
-    to: [],
-    cc: [],
-    edits: [],
-    originalStatus,
-    isLocalActor: false,
-    createdAt: Date.now(),
-    updatedAt: Date.now()
-  } as Status
+  const createAnnounce = (actorId = boosterActorId) =>
+    ({
+      id: `${actorId}/statuses/456/activity`,
+      actorId,
+      actor: {
+        username: 'booster',
+        domain: new URL(actorId).host
+      },
+      type: StatusType.enum.Announce,
+      to: [],
+      cc: [],
+      edits: [],
+      originalStatus,
+      isLocalActor: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    }) as Status
 
-  it('resolves a hash route when the stored row actor is the booster and the path actor owns the original status', async () => {
-    const database = {
-      getActorFromUsername: jest
-        .fn()
-        .mockResolvedValue({ id: originalActorId }),
-      getStatusFromUrlHash: jest
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(boostedStatus),
-      getStatus: jest.fn().mockResolvedValue(null)
-    }
+  const createDatabase = () => ({
+    getActorFromUsername: jest.fn().mockResolvedValue({ id: originalActorId }),
+    getStatusFromUrlHash: jest.fn().mockResolvedValue(null),
+    getStatus: jest.fn().mockResolvedValue(null)
+  })
+
+  it('resolves a hash route from the scoped actor lookup', async () => {
+    const database = createDatabase()
+    database.getStatusFromUrlHash.mockResolvedValueOnce(originalStatus)
 
     await expect(
       resolveStatusFromPath({
@@ -70,11 +70,38 @@ describe('#resolveStatusFromPath', () => {
         statusParam: statusHash
       })
     ).resolves.toEqual({
-      fullStatusId:
-        'https://remote.example/users/original/statuses/' + statusHash,
+      fullStatusId: '',
       isStatusHash: true,
-      status: boostedStatus,
-      statusId: boostedStatus.id
+      status: originalStatus,
+      statusId: originalStatus.id
+    })
+
+    expect(database.getStatusFromUrlHash).toHaveBeenCalledTimes(1)
+    expect(database.getStatusFromUrlHash).toHaveBeenCalledWith({
+      urlHash: statusHash,
+      actorId: originalActorId
+    })
+    expect(database.getStatus).not.toHaveBeenCalled()
+  })
+
+  it('resolves a boosted hash route to the original status when the path actor owns it', async () => {
+    const database = createDatabase()
+    const boostedStatus = createAnnounce()
+    database.getStatusFromUrlHash
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(boostedStatus)
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: statusHash
+      })
+    ).resolves.toEqual({
+      fullStatusId: '',
+      isStatusHash: true,
+      status: originalStatus,
+      statusId: originalStatus.id
     })
 
     expect(database.getStatusFromUrlHash).toHaveBeenNthCalledWith(1, {
@@ -84,22 +111,15 @@ describe('#resolveStatusFromPath', () => {
     expect(database.getStatusFromUrlHash).toHaveBeenNthCalledWith(2, {
       urlHash: statusHash
     })
+    expect(database.getStatus).not.toHaveBeenCalled()
   })
 
-  it('does not resolve an unscoped hash when neither the status nor original status belongs to the path actor', async () => {
-    const database = {
-      getActorFromUsername: jest
-        .fn()
-        .mockResolvedValue({ id: originalActorId }),
-      getStatusFromUrlHash: jest
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({
-          ...originalStatus,
-          actorId: 'https://other.example/users/someone'
-        }),
-      getStatus: jest.fn().mockResolvedValue(null)
-    }
+  it('returns the original status when an unscoped hash lookup finds another boost of the same status', async () => {
+    const database = createDatabase()
+    const secondBoostedStatus = createAnnounce(secondBoosterActorId)
+    database.getStatusFromUrlHash
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(secondBoostedStatus)
 
     await expect(
       resolveStatusFromPath({
@@ -108,11 +128,146 @@ describe('#resolveStatusFromPath', () => {
         statusParam: statusHash
       })
     ).resolves.toEqual({
-      fullStatusId:
-        'https://remote.example/users/original/statuses/' + statusHash,
+      fullStatusId: '',
+      isStatusHash: true,
+      status: originalStatus,
+      statusId: originalStatus.id
+    })
+  })
+
+  it('does not resolve an unscoped hash when a note belongs to a different actor', async () => {
+    const database = createDatabase()
+    database.getStatusFromUrlHash
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        ...originalStatus,
+        actorId: 'https://other.example/users/someone'
+      })
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: statusHash
+      })
+    ).resolves.toEqual({
+      fullStatusId: '',
       isStatusHash: true,
       status: null,
       statusId: ''
+    })
+  })
+
+  it('does not resolve an unscoped hash when an announce original belongs to a different actor', async () => {
+    const database = createDatabase()
+    database.getStatusFromUrlHash
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        ...createAnnounce(),
+        originalStatus: {
+          ...originalStatus,
+          actorId: 'https://other.example/users/someone'
+        }
+      })
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: statusHash
+      })
+    ).resolves.toEqual({
+      fullStatusId: '',
+      isStatusHash: true,
+      status: null,
+      statusId: ''
+    })
+  })
+
+  it('returns null when the actor route is malformed', async () => {
+    const database = createDatabase()
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: 'plain-username',
+        statusParam: statusHash
+      })
+    ).resolves.toBeNull()
+
+    expect(database.getActorFromUsername).not.toHaveBeenCalled()
+    expect(database.getStatusFromUrlHash).not.toHaveBeenCalled()
+    expect(database.getStatus).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the actor route has malformed URI escapes', async () => {
+    const database = createDatabase()
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '%E0%A4%A',
+        statusParam: statusHash
+      })
+    ).resolves.toBeNull()
+
+    expect(database.getActorFromUsername).not.toHaveBeenCalled()
+    expect(database.getStatusFromUrlHash).not.toHaveBeenCalled()
+    expect(database.getStatus).not.toHaveBeenCalled()
+  })
+
+  it('falls back from full status id to raw id for non-hash status params', async () => {
+    const database = createDatabase()
+    database.getStatus
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(originalStatus)
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: '123'
+      })
+    ).resolves.toEqual({
+      fullStatusId: 'https://remote.example/users/original/statuses/123',
+      isStatusHash: false,
+      status: originalStatus,
+      statusId: originalStatus.id
+    })
+
+    expect(database.getStatusFromUrlHash).not.toHaveBeenCalled()
+    expect(database.getStatus).toHaveBeenNthCalledWith(1, {
+      statusId: 'https://remote.example/users/original/statuses/123',
+      withReplies: false
+    })
+    expect(database.getStatus).toHaveBeenNthCalledWith(2, {
+      statusId: '123',
+      withReplies: false
+    })
+  })
+
+  it('resolves full URL status params without raw id fallback', async () => {
+    const database = createDatabase()
+    database.getStatus.mockResolvedValueOnce(originalStatus)
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: originalStatus.id
+      })
+    ).resolves.toEqual({
+      fullStatusId: originalStatus.id,
+      isStatusHash: false,
+      status: originalStatus,
+      statusId: originalStatus.id
+    })
+
+    expect(database.getStatusFromUrlHash).not.toHaveBeenCalled()
+    expect(database.getStatus).toHaveBeenCalledTimes(1)
+    expect(database.getStatus).toHaveBeenCalledWith({
+      statusId: originalStatus.id,
+      withReplies: false
     })
   })
 })

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
@@ -1,0 +1,118 @@
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+
+import { resolveStatusFromPath } from './resolveStatusFromPath'
+
+describe('#resolveStatusFromPath', () => {
+  const originalActorId = 'https://remote.example/users/original'
+  const boosterActorId = 'https://boost.example/users/booster'
+  const originalUrl = 'https://remote.example/@original/123'
+  const statusHash = getHashFromString(originalUrl)
+
+  const originalStatus = {
+    id: 'https://remote.example/users/original/statuses/123',
+    url: originalUrl,
+    actorId: originalActorId,
+    actor: {
+      username: 'original',
+      domain: 'remote.example'
+    },
+    type: StatusType.enum.Note,
+    to: [],
+    cc: [],
+    edits: [],
+    isLocalActor: false,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    text: 'Original status',
+    reply: '',
+    replies: [],
+    actorAnnounceStatusId: null,
+    isActorLiked: false,
+    totalLikes: 0,
+    attachments: [],
+    tags: []
+  } as Status
+
+  const boostedStatus = {
+    id: 'https://boost.example/users/booster/statuses/456/activity',
+    actorId: boosterActorId,
+    actor: {
+      username: 'booster',
+      domain: 'boost.example'
+    },
+    type: StatusType.enum.Announce,
+    to: [],
+    cc: [],
+    edits: [],
+    originalStatus,
+    isLocalActor: false,
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  } as Status
+
+  it('resolves a hash route when the stored row actor is the booster and the path actor owns the original status', async () => {
+    const database = {
+      getActorFromUsername: jest
+        .fn()
+        .mockResolvedValue({ id: originalActorId }),
+      getStatusFromUrlHash: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(boostedStatus),
+      getStatus: jest.fn().mockResolvedValue(null)
+    }
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: statusHash
+      })
+    ).resolves.toEqual({
+      fullStatusId:
+        'https://remote.example/users/original/statuses/' + statusHash,
+      isStatusHash: true,
+      status: boostedStatus,
+      statusId: boostedStatus.id
+    })
+
+    expect(database.getStatusFromUrlHash).toHaveBeenNthCalledWith(1, {
+      urlHash: statusHash,
+      actorId: originalActorId
+    })
+    expect(database.getStatusFromUrlHash).toHaveBeenNthCalledWith(2, {
+      urlHash: statusHash
+    })
+  })
+
+  it('does not resolve an unscoped hash when neither the status nor original status belongs to the path actor', async () => {
+    const database = {
+      getActorFromUsername: jest
+        .fn()
+        .mockResolvedValue({ id: originalActorId }),
+      getStatusFromUrlHash: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...originalStatus,
+          actorId: 'https://other.example/users/someone'
+        }),
+      getStatus: jest.fn().mockResolvedValue(null)
+    }
+
+    await expect(
+      resolveStatusFromPath({
+        database,
+        actorParam: '@original@remote.example',
+        statusParam: statusHash
+      })
+    ).resolves.toEqual({
+      fullStatusId:
+        'https://remote.example/users/original/statuses/' + statusHash,
+      isStatusHash: true,
+      status: null,
+      statusId: ''
+    })
+  })
+})

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
@@ -1,0 +1,107 @@
+import { Database } from '@/lib/database/types'
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+interface ResolveStatusFromPathParams {
+  database: Pick<
+    Database,
+    'getActorFromUsername' | 'getStatus' | 'getStatusFromUrlHash'
+  >
+  actorParam: string
+  statusParam: string
+}
+
+interface ResolveStatusFromPathResult {
+  status: Status | null
+  statusId: string
+  fullStatusId: string
+  isStatusHash: boolean
+}
+
+const decodeParam = (param: string) => {
+  try {
+    return decodeURIComponent(param)
+  } catch {
+    return param
+  }
+}
+
+const getStatusOwnerActorId = (status: Status) =>
+  status.type === StatusType.enum.Announce
+    ? status.originalStatus.actorId
+    : status.actorId
+
+export const resolveStatusFromPath = async ({
+  database,
+  actorParam,
+  statusParam
+}: ResolveStatusFromPathParams): Promise<ResolveStatusFromPathResult | null> => {
+  const decodedActor = decodeURIComponent(actorParam)
+  const decodedStatusParam = decodeParam(statusParam)
+
+  const parts = decodedActor.split('@').slice(1)
+  if (parts.length !== 2) {
+    return null
+  }
+
+  const [username, domain] = parts
+  const actorFromPath = await database.getActorFromUsername({
+    username,
+    domain
+  })
+  const actorIdFromPath = actorFromPath?.id
+  const isStatusHash = /^[a-f0-9]{64}$/i.test(decodedStatusParam)
+
+  const protocol = domain.startsWith('localhost') ? 'http' : 'https'
+  const isFullStatusUrl = /^https?:\/\//.test(decodedStatusParam)
+  const fullStatusId = isFullStatusUrl
+    ? decodedStatusParam
+    : `${protocol}://${domain}/users/${username}/statuses/${decodedStatusParam}`
+
+  let status: Status | null = null
+  let statusId = ''
+
+  if (isStatusHash) {
+    status = await database.getStatusFromUrlHash({
+      urlHash: decodedStatusParam,
+      actorId: actorIdFromPath
+    })
+
+    if (!status && actorIdFromPath) {
+      const unscopedStatus = await database.getStatusFromUrlHash({
+        urlHash: decodedStatusParam
+      })
+
+      if (
+        unscopedStatus &&
+        getStatusOwnerActorId(unscopedStatus) === actorIdFromPath
+      ) {
+        status = unscopedStatus
+      }
+    }
+
+    statusId = status?.id ?? ''
+  }
+
+  if (!status) {
+    status = await database.getStatus({
+      statusId: fullStatusId,
+      withReplies: false
+    })
+    statusId = status?.id ?? ''
+  }
+
+  if (!status && !isFullStatusUrl) {
+    status = await database.getStatus({
+      statusId: decodedStatusParam,
+      withReplies: false
+    })
+    statusId = status?.id ?? ''
+  }
+
+  return {
+    status,
+    statusId,
+    fullStatusId,
+    isStatusHash
+  }
+}

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
@@ -25,17 +25,27 @@ const decodeParam = (param: string) => {
   }
 }
 
-const getStatusOwnerActorId = (status: Status) =>
-  status.type === StatusType.enum.Announce
-    ? status.originalStatus.actorId
-    : status.actorId
+const getStatusForPathActor = (status: Status, actorId: string) => {
+  if (status.actorId === actorId) return status
 
+  if (
+    status.type === StatusType.enum.Announce &&
+    status.originalStatus.actorId === actorId
+  ) {
+    return status.originalStatus
+  }
+
+  return null
+}
+
+// Returns null only when the actor route cannot be parsed. Lookup misses are
+// returned as { status: null } so callers can still queue remote fetches.
 export const resolveStatusFromPath = async ({
   database,
   actorParam,
   statusParam
 }: ResolveStatusFromPathParams): Promise<ResolveStatusFromPathResult | null> => {
-  const decodedActor = decodeURIComponent(actorParam)
+  const decodedActor = decodeParam(actorParam)
   const decodedStatusParam = decodeParam(statusParam)
 
   const parts = decodedActor.split('@').slice(1)
@@ -53,12 +63,13 @@ export const resolveStatusFromPath = async ({
 
   const protocol = domain.startsWith('localhost') ? 'http' : 'https'
   const isFullStatusUrl = /^https?:\/\//.test(decodedStatusParam)
-  const fullStatusId = isFullStatusUrl
-    ? decodedStatusParam
-    : `${protocol}://${domain}/users/${username}/statuses/${decodedStatusParam}`
+  const fullStatusId = isStatusHash
+    ? ''
+    : isFullStatusUrl
+      ? decodedStatusParam
+      : `${protocol}://${domain}/users/${username}/statuses/${decodedStatusParam}`
 
   let status: Status | null = null
-  let statusId = ''
 
   if (isStatusHash) {
     status = await database.getStatusFromUrlHash({
@@ -71,36 +82,29 @@ export const resolveStatusFromPath = async ({
         urlHash: decodedStatusParam
       })
 
-      if (
-        unscopedStatus &&
-        getStatusOwnerActorId(unscopedStatus) === actorIdFromPath
-      ) {
-        status = unscopedStatus
+      if (unscopedStatus) {
+        status = getStatusForPathActor(unscopedStatus, actorIdFromPath)
       }
     }
-
-    statusId = status?.id ?? ''
   }
 
-  if (!status) {
+  if (!status && !isStatusHash) {
     status = await database.getStatus({
       statusId: fullStatusId,
       withReplies: false
     })
-    statusId = status?.id ?? ''
   }
 
-  if (!status && !isFullStatusUrl) {
+  if (!status && !isStatusHash && !isFullStatusUrl) {
     status = await database.getStatus({
       statusId: decodedStatusParam,
       withReplies: false
     })
-    statusId = status?.id ?? ''
   }
 
   return {
     status,
-    statusId,
+    statusId: status?.id ?? '',
     fullStatusId,
     isStatusHash
   }

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
@@ -17,7 +17,7 @@ interface ResolveStatusFromPathResult {
   isStatusHash: boolean
 }
 
-const decodeParam = (param: string) => {
+export const decodePathParam = (param: string) => {
   try {
     return decodeURIComponent(param)
   } catch {
@@ -45,8 +45,8 @@ export const resolveStatusFromPath = async ({
   actorParam,
   statusParam
 }: ResolveStatusFromPathParams): Promise<ResolveStatusFromPathResult | null> => {
-  const decodedActor = decodeParam(actorParam)
-  const decodedStatusParam = decodeParam(statusParam)
+  const decodedActor = decodePathParam(actorParam)
+  const decodedStatusParam = decodePathParam(statusParam)
 
   const parts = decodedActor.split('@').slice(1)
   if (parts.length !== 2) {

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -8,6 +8,7 @@ import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
+import { getActorImageUrl } from '@/lib/utils/activitypubActor'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 
 type ProfileData = {
@@ -19,12 +20,6 @@ type ProfileData = {
   followersCount: number
   isInternalAccount: boolean
   hasFitnessData: boolean
-}
-
-const getImageUrl = (image: Actor['icon']) => {
-  if (!image) return ''
-  if (Array.isArray(image)) return image.find((item) => item.url)?.url || ''
-  return image.url
 }
 
 export const getProfileData = async (
@@ -84,8 +79,8 @@ export const getProfileData = async (
       actorId: person.id,
       name: person.name,
       summary: person.summary || '',
-      iconUrl: getImageUrl(person.icon),
-      headerImageUrl: getImageUrl(person.image),
+      iconUrl: getActorImageUrl(person.icon),
+      headerImageUrl: getActorImageUrl(person.image),
       publicKey: person.publicKey.publicKeyPem,
       followersUrl: person.followers,
       inboxUrl: person.inbox,

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -21,6 +21,12 @@ type ProfileData = {
   hasFitnessData: boolean
 }
 
+const getImageUrl = (image: Actor['icon']) => {
+  if (!image) return ''
+  if (Array.isArray(image)) return image.find((item) => item.url)?.url || ''
+  return image.url
+}
+
 export const getProfileData = async (
   database: Database,
   actorHandle: string,
@@ -78,8 +84,8 @@ export const getProfileData = async (
       actorId: person.id,
       name: person.name,
       summary: person.summary || '',
-      iconUrl: person.icon?.url || '',
-      headerImageUrl: person.image?.url || '',
+      iconUrl: getImageUrl(person.icon),
+      headerImageUrl: getImageUrl(person.image),
       publicKey: person.publicKey.publicKeyPem,
       followersUrl: person.followers,
       inboxUrl: person.inbox,

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -2,6 +2,7 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { Actor as ActivityPubActor } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 
@@ -16,6 +17,12 @@ export class BlockedFederationDomainError extends Error {
     super(`Federation with actor domain is blocked: ${actorId}`)
     this.name = 'BlockedFederationDomainError'
   }
+}
+
+const getImageUrl = (image: ActivityPubActor['icon']) => {
+  if (!image) return undefined
+  if (Array.isArray(image)) return image.find((item) => item.url)?.url
+  return image.url
 }
 
 export const assertActorCanFederate = async ({
@@ -62,6 +69,7 @@ export const recordActorIfNeeded = async ({
       signingActor: await getResolvedSigningActor()
     })
     if (!person) return
+    const iconUrl = getImageUrl(person.icon)
     const actor = await database.createActor({
       actorId,
       username: person.preferredUsername,
@@ -69,7 +77,7 @@ export const recordActorIfNeeded = async ({
       followersUrl: person.followers ?? '',
       inboxUrl: person.inbox,
       sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
-      ...(person.icon ? { iconUrl: person.icon.url } : {}),
+      ...(iconUrl ? { iconUrl } : {}),
       publicKey: person.publicKey.publicKeyPem || '',
       createdAt: new Date(person.published ?? Date.now()).getTime()
     })
@@ -84,12 +92,13 @@ export const recordActorIfNeeded = async ({
       signingActor: await getResolvedSigningActor()
     })
     if (!person) return undefined
+    const iconUrl = getImageUrl(person.icon)
     const actor = await database.updateActor({
       actorId,
       followersUrl: person.followers ?? '',
       inboxUrl: person.inbox,
       sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
-      ...(person.icon ? { iconUrl: person.icon.url } : {}),
+      ...(iconUrl ? { iconUrl } : {}),
       publicKey: person.publicKey.publicKeyPem || ''
     })
     return actor ?? undefined

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -2,8 +2,8 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
-import { Actor as ActivityPubActor } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
+import { getActorImageUrl } from '@/lib/utils/activitypubActor'
 import { logger } from '@/lib/utils/logger'
 
 interface RecordActorIfNeededParams {
@@ -17,12 +17,6 @@ export class BlockedFederationDomainError extends Error {
     super(`Federation with actor domain is blocked: ${actorId}`)
     this.name = 'BlockedFederationDomainError'
   }
-}
-
-const getImageUrl = (image: ActivityPubActor['icon']) => {
-  if (!image) return undefined
-  if (Array.isArray(image)) return image.find((item) => item.url)?.url
-  return image.url
 }
 
 export const assertActorCanFederate = async ({
@@ -69,7 +63,7 @@ export const recordActorIfNeeded = async ({
       signingActor: await getResolvedSigningActor()
     })
     if (!person) return
-    const iconUrl = getImageUrl(person.icon)
+    const iconUrl = getActorImageUrl(person.icon)
     const actor = await database.createActor({
       actorId,
       username: person.preferredUsername,
@@ -92,7 +86,7 @@ export const recordActorIfNeeded = async ({
       signingActor: await getResolvedSigningActor()
     })
     if (!person) return undefined
-    const iconUrl = getImageUrl(person.icon)
+    const iconUrl = getActorImageUrl(person.icon)
     const actor = await database.updateActor({
       actorId,
       followersUrl: person.followers ?? '',

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -3,8 +3,13 @@ import { enableFetchMocks } from 'jest-fetch-mock'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
+import { MockMastodonActivityPubNote } from '@/lib/stub/note'
+import { MockActivityPubPerson } from '@/lib/stub/person'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/activitypub'
+import { AnnounceAction } from '@/lib/types/activitypub/activities'
+import { StatusType } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 import { getActorPerson } from './getActorPerson'
 import { getActorPosts } from './getActorPosts'
@@ -69,5 +74,97 @@ describe('#getActorPosts', () => {
         }
       ]
     })
+  })
+
+  it('keeps the boost actor on Announce and does not assign it to the original status', async () => {
+    const boosterActorId = 'https://boost.example/users/booster'
+    const originalActorId = 'https://origin.example/users/original'
+    const originalStatusId = `${originalActorId}/statuses/original-1`
+    const announceStatusId = `${boosterActorId}/statuses/announce-1/activity`
+    const published = Date.now()
+
+    const boosterActor = await database.createActor({
+      actorId: boosterActorId,
+      username: 'booster',
+      domain: 'boost.example',
+      followersUrl: `${boosterActorId}/followers`,
+      inboxUrl: `${boosterActorId}/inbox`,
+      sharedInboxUrl: 'https://boost.example/inbox',
+      publicKey: 'public key',
+      createdAt: published
+    })
+    if (!boosterActor) throw new Error('Failed to create booster actor')
+
+    const person = MockActivityPubPerson({
+      id: boosterActorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${boosterActorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: `${boosterActorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === `${boosterActorId}/outbox?page=true`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox?page=true`,
+            type: 'OrderedCollectionPage',
+            partOf: `${boosterActorId}/outbox`,
+            orderedItems: [
+              {
+                id: announceStatusId,
+                type: AnnounceAction,
+                actor: boosterActorId,
+                published: new Date(published).toISOString(),
+                to: [ACTIVITY_STREAM_PUBLIC],
+                cc: [`${boosterActorId}/followers`],
+                object: originalStatusId
+              }
+            ]
+          })
+        }
+      }
+
+      if (req.url === originalStatusId) {
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockMastodonActivityPubNote({
+              id: originalStatusId,
+              from: originalActorId,
+              content: 'Original status text',
+              withContext: true
+            })
+          )
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    const announceStatus = response.statuses[0]
+
+    expect(announceStatus.type).toBe(StatusType.enum.Announce)
+    if (announceStatus.type !== StatusType.enum.Announce) {
+      throw new Error('Expected Announce status')
+    }
+
+    expect(announceStatus.actorId).toBe(boosterActorId)
+    expect(announceStatus.actor?.id).toBe(boosterActorId)
+    expect(announceStatus.originalStatus.actorId).toBe(originalActorId)
+    expect(announceStatus.originalStatus.actor?.id).not.toBe(boosterActorId)
+    expect(announceStatus.originalStatus.text).toBe('Original status text')
   })
 })

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -339,4 +339,73 @@ describe('#getActorPosts', () => {
       name: 'patak'
     })
   })
+
+  it('skips malformed remote outbox activities', async () => {
+    const actorId = 'https://malformed.example/users/actor'
+    const published = Date.now()
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 2,
+            first: `${actorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === `${actorId}/outbox?page=true`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${actorId}/outbox?page=true`,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            orderedItems: [
+              {
+                id: `${actorId}/statuses/bad-announce/activity`,
+                type: AnnounceAction,
+                actor: actorId,
+                published: new Date(published).toISOString(),
+                to: [ACTIVITY_STREAM_PUBLIC],
+                cc: []
+              },
+              {
+                id: `${actorId}/statuses/bad-create/activity`,
+                type: 'Create',
+                actor: actorId,
+                published: new Date(published).toISOString(),
+                object: {
+                  id: `${actorId}/statuses/bad-create`,
+                  type: 'Note',
+                  attributedTo: actorId,
+                  to: [ACTIVITY_STREAM_PUBLIC],
+                  cc: [],
+                  content: [],
+                  published: new Date(published).toISOString()
+                }
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+
+    expect(response).toMatchObject({
+      statusesCount: 2,
+      statuses: []
+    })
+  })
 })

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -167,4 +167,176 @@ describe('#getActorPosts', () => {
     expect(announceStatus.originalStatus.actor?.id).not.toBe(boosterActorId)
     expect(announceStatus.originalStatus.text).toBe('Original status text')
   })
+
+  it('loads boosted original actor profiles for opaque actor ids', async () => {
+    const boosterActorId = 'https://boost-bsky.example/users/booster'
+    const originalActorId =
+      'https://bsky.brid.gy/ap/did:plc:2gkh62xvzokhlf6li4ol3b3d'
+    const originalStatusId =
+      'https://bsky.brid.gy/convert/ap/at://did:plc:2gkh62xvzokhlf6li4ol3b3d/app.bsky.feed.post/3mknrszqses2y'
+    const announceStatusId = `${boosterActorId}/statuses/announce-bridgy/activity`
+    const published = Date.now()
+
+    const boosterActor = await database.createActor({
+      actorId: boosterActorId,
+      username: 'booster',
+      domain: 'boost-bsky.example',
+      followersUrl: `${boosterActorId}/followers`,
+      inboxUrl: `${boosterActorId}/inbox`,
+      sharedInboxUrl: 'https://boost-bsky.example/inbox',
+      publicKey: 'public key',
+      createdAt: published
+    })
+    if (!boosterActor) throw new Error('Failed to create booster actor')
+
+    await database.createActor({
+      actorId: originalActorId,
+      username: 'did:plc:2gkh62xvzokhlf6li4ol3b3d',
+      domain: 'bsky.brid.gy',
+      followersUrl: `${originalActorId}/followers`,
+      inboxUrl: `${originalActorId}/inbox`,
+      sharedInboxUrl: 'https://bsky.brid.gy/inbox',
+      publicKey: 'stale public key',
+      createdAt: published
+    })
+
+    const person = MockActivityPubPerson({
+      id: boosterActorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${boosterActorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: `${boosterActorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === `${boosterActorId}/outbox?page=true`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox?page=true`,
+            type: 'OrderedCollectionPage',
+            partOf: `${boosterActorId}/outbox`,
+            orderedItems: [
+              {
+                id: announceStatusId,
+                type: AnnounceAction,
+                actor: boosterActorId,
+                published: new Date(published).toISOString(),
+                to: [ACTIVITY_STREAM_PUBLIC],
+                cc: [`${boosterActorId}/followers`],
+                object: originalStatusId
+              }
+            ]
+          })
+        }
+      }
+
+      if (req.url === originalStatusId) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: originalStatusId,
+            type: 'Note',
+            url: [
+              'https://bsky.brid.gy/r/https://bsky.app/profile/did:plc:2gkh62xvzokhlf6li4ol3b3d/post/3mknrszqses2y',
+              {
+                href: 'at://did:plc:2gkh62xvzokhlf6li4ol3b3d/app.bsky.feed.post/3mknrszqses2y',
+                rel: 'canonical',
+                type: 'Link'
+              }
+            ],
+            attributedTo: originalActorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [`${originalActorId}/followers`],
+            content: 'Original Bridgy status text',
+            published: new Date(published).toISOString()
+          })
+        }
+      }
+
+      if (req.url === originalActorId) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: originalActorId,
+            type: 'Person',
+            following: `${originalActorId}/following`,
+            followers: `${originalActorId}/followers`,
+            inbox: `${originalActorId}/inbox`,
+            outbox: `${originalActorId}/outbox`,
+            featured: {
+              id: `${originalActorId}/collections/featured`,
+              type: 'OrderedCollection'
+            },
+            preferredUsername: 'patak.cat',
+            name: 'patak',
+            summary: '',
+            url: [
+              'https://bsky.brid.gy/r/https://bsky.app/profile/patak.cat',
+              {
+                href: 'https://patak.cat/',
+                rel: 'canonical',
+                type: 'Link'
+              },
+              'https://patak.cat/'
+            ],
+            image: [
+              {
+                type: 'Image',
+                url: 'https://cdn.example/header.jpg'
+              }
+            ],
+            tag: {
+              type: 'Hashtag',
+              href: 'https://bsky.brid.gy/tags/fedidev',
+              name: '#fedidev'
+            },
+            attachment: [
+              {
+                type: 'Link',
+                href: 'https://patak.cat/'
+              }
+            ],
+            published: new Date(published).toISOString(),
+            publicKey: {
+              id: `${originalActorId}#main-key`,
+              owner: originalActorId,
+              publicKeyPem: 'public key'
+            },
+            endpoints: {
+              sharedInbox: 'https://bsky.brid.gy/inbox'
+            }
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    const announceStatus = response.statuses[0]
+
+    expect(announceStatus.type).toBe(StatusType.enum.Announce)
+    if (announceStatus.type !== StatusType.enum.Announce) {
+      throw new Error('Expected Announce status')
+    }
+
+    expect(announceStatus.originalStatus.actorId).toBe(originalActorId)
+    expect(announceStatus.originalStatus.actor).toMatchObject({
+      id: originalActorId,
+      username: 'patak.cat',
+      domain: 'bsky.brid.gy',
+      name: 'patak'
+    })
+  })
 })

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -7,11 +7,12 @@ import {
   CreateAction
 } from '@/lib/types/activitypub/activities'
 import { Note } from '@/lib/types/activitypub/objects'
-import { Actor as DomainActor } from '@/lib/types/domain/actor'
+import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Status, fromAnnoucne, fromNote } from '@/lib/types/domain/status'
 import { getTracer } from '@/lib/utils/trace'
 
 import { getActorCollections } from './getActorCollections'
+import { getActorPerson } from './getActorPerson'
 
 type GetActorPostsFunction = (params: {
   database: Database
@@ -21,6 +22,54 @@ type GetActorPostsFunction = (params: {
   statusesCount: number
   statuses: Status[]
 }>
+
+const getActorDomain = (actorId: string) => {
+  try {
+    return new URL(actorId).host
+  } catch {
+    return actorId
+  }
+}
+
+const getActorIdUsername = (actorId: string) =>
+  decodeURIComponent(actorId.split('/').filter(Boolean).pop() || actorId)
+    .replace(/^@+/, '')
+    .trim()
+
+const isOpaqueActorUsername = (actorId: string, username: string) => {
+  const actorIdUsername = getActorIdUsername(actorId)
+  return (
+    username === actorIdUsername &&
+    (username.startsWith('did:') ||
+      /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(username))
+  )
+}
+
+const getImageUrl = (image: Actor['icon']) => {
+  if (!image) return undefined
+  if (Array.isArray(image)) return image.find((item) => item.url)?.url
+  return image.url
+}
+
+const getActorProfileFromPerson = (person: Actor): ActorProfile =>
+  ActorProfile.parse({
+    id: person.id,
+    username: person.preferredUsername,
+    domain: getActorDomain(person.id),
+    name: person.name,
+    summary: person.summary || undefined,
+    iconUrl: getImageUrl(person.icon),
+    headerImageUrl: getImageUrl(person.image),
+    manuallyApprovesFollowers: person.manuallyApprovesFollowers,
+    followersUrl: person.followers || `${person.id}/followers`,
+    inboxUrl: person.inbox,
+    sharedInboxUrl: person.endpoints?.sharedInbox || '',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: person.published ? new Date(person.published).getTime() : 0
+  })
 
 export const getActorPosts: GetActorPostsFunction = async ({
   database,
@@ -34,6 +83,36 @@ export const getActorPosts: GetActorPostsFunction = async ({
     },
     async (span) => {
       const actor = await database.getActorFromId({ id: person.id })
+      const actorProfileCache = new Map<string, Promise<ActorProfile | null>>()
+      const getActorProfile = (actorId: string) => {
+        let actorProfile = actorProfileCache.get(actorId)
+        if (!actorProfile) {
+          actorProfile = (async () => {
+            const persistedActor = await database.getActorFromId({
+              id: actorId
+            })
+            if (
+              persistedActor &&
+              !isOpaqueActorUsername(actorId, persistedActor.username)
+            ) {
+              return ActorProfile.parse(persistedActor)
+            }
+
+            const actorPerson = await getActorPerson({
+              actorId,
+              signingActor
+            })
+            if (!actorPerson) {
+              return persistedActor ? ActorProfile.parse(persistedActor) : null
+            }
+
+            return getActorProfileFromPerson(actorPerson)
+          })()
+          actorProfileCache.set(actorId, actorProfile)
+        }
+
+        return actorProfile
+      }
       const value = await getActorCollections({
         person,
         field: 'outbox',
@@ -62,6 +141,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
             })
             if (!note) return null
             const originalStatus = fromNote(note)
+            originalStatus.actor = await getActorProfile(originalStatus.actorId)
             const announceStatus = fromAnnoucne(
               item as unknown as AnnounceStatus,
               originalStatus

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -62,11 +62,12 @@ export const getActorPosts: GetActorPostsFunction = async ({
             })
             if (!note) return null
             const originalStatus = fromNote(note)
-            if (actor) originalStatus.actor = actor
-            return fromAnnoucne(
+            const announceStatus = fromAnnoucne(
               item as unknown as AnnounceStatus,
               originalStatus
             )
+            if (actor) announceStatus.actor = actor
+            return announceStatus
           }
 
           // Unsupported activity

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -8,7 +8,7 @@ import {
 } from '@/lib/types/activitypub/activities'
 import { Note } from '@/lib/types/activitypub/objects'
 import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
-import { Status, fromAnnoucne, fromNote } from '@/lib/types/domain/status'
+import { Status, fromAnnounce, fromNote } from '@/lib/types/domain/status'
 import {
   normalizeActivityPubAnnounce,
   normalizeActivityPubContent
@@ -17,6 +17,7 @@ import {
   getActorProfileFromPerson,
   isOpaqueActorUsername
 } from '@/lib/utils/activitypubActor'
+import { logger } from '@/lib/utils/logger'
 import { getTracer } from '@/lib/utils/trace'
 
 import { getActorCollections } from './getActorCollections'
@@ -31,10 +32,14 @@ type GetActorPostsFunction = (params: {
   statuses: Status[]
 }>
 
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
 const getStatusFromNote = (note: Note) => {
   try {
     return fromNote(note)
-  } catch {
+  } catch (error) {
+    logger.error(`[getActorPosts] ${getErrorMessage(error)}`)
     return null
   }
 }
@@ -121,7 +126,7 @@ export const getActorPosts: GetActorPostsFunction = async ({
             if (!originalStatus) return null
 
             originalStatus.actor = await getActorProfile(originalStatus.actorId)
-            const announceStatus = fromAnnoucne(announce, originalStatus)
+            const announceStatus = fromAnnounce(announce, originalStatus)
             if (actor) announceStatus.actor = actor
             return announceStatus
           }

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -1,14 +1,22 @@
 import { getNote } from '@/lib/activities'
-import { AnnounceStatus } from '@/lib/activities/announceStatus'
 import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/activitypub'
 import {
+  Announce,
   AnnounceAction,
   CreateAction
 } from '@/lib/types/activitypub/activities'
 import { Note } from '@/lib/types/activitypub/objects'
 import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Status, fromAnnoucne, fromNote } from '@/lib/types/domain/status'
+import {
+  normalizeActivityPubAnnounce,
+  normalizeActivityPubContent
+} from '@/lib/utils/activitypub'
+import {
+  getActorProfileFromPerson,
+  isOpaqueActorUsername
+} from '@/lib/utils/activitypubActor'
 import { getTracer } from '@/lib/utils/trace'
 
 import { getActorCollections } from './getActorCollections'
@@ -23,53 +31,13 @@ type GetActorPostsFunction = (params: {
   statuses: Status[]
 }>
 
-const getActorDomain = (actorId: string) => {
+const getStatusFromNote = (note: Note) => {
   try {
-    return new URL(actorId).host
+    return fromNote(note)
   } catch {
-    return actorId
+    return null
   }
 }
-
-const getActorIdUsername = (actorId: string) =>
-  decodeURIComponent(actorId.split('/').filter(Boolean).pop() || actorId)
-    .replace(/^@+/, '')
-    .trim()
-
-const isOpaqueActorUsername = (actorId: string, username: string) => {
-  const actorIdUsername = getActorIdUsername(actorId)
-  return (
-    username === actorIdUsername &&
-    (username.startsWith('did:') ||
-      /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(username))
-  )
-}
-
-const getImageUrl = (image: Actor['icon']) => {
-  if (!image) return undefined
-  if (Array.isArray(image)) return image.find((item) => item.url)?.url
-  return image.url
-}
-
-const getActorProfileFromPerson = (person: Actor): ActorProfile =>
-  ActorProfile.parse({
-    id: person.id,
-    username: person.preferredUsername,
-    domain: getActorDomain(person.id),
-    name: person.name,
-    summary: person.summary || undefined,
-    iconUrl: getImageUrl(person.icon),
-    headerImageUrl: getImageUrl(person.image),
-    manuallyApprovesFollowers: person.manuallyApprovesFollowers,
-    followersUrl: person.followers || `${person.id}/followers`,
-    inboxUrl: person.inbox,
-    sharedInboxUrl: person.endpoints?.sharedInbox || '',
-    followingCount: 0,
-    followersCount: 0,
-    statusCount: 0,
-    lastStatusAt: null,
-    createdAt: person.published ? new Date(person.published).getTime() : 0
-  })
 
 export const getActorPosts: GetActorPostsFunction = async ({
   database,
@@ -129,23 +97,31 @@ export const getActorPosts: GetActorPostsFunction = async ({
           // This should be impossible for status api
           if (typeof item === 'string') return null
           if (item.type === AnnounceAction) {
-            if (!item.object || typeof item.object !== 'string') return null
+            const announceResult = Announce.safeParse(
+              normalizeActivityPubAnnounce(item)
+            )
+            if (!announceResult.success) return null
+
+            const announce = announceResult.data
             const localStatus = await database.getStatus({
-              statusId: item.object
+              statusId: announce.object
             })
             if (localStatus) return localStatus
 
             const note = await getNote({
-              statusId: item.object,
+              statusId: announce.object,
               signingActor
             })
             if (!note) return null
-            const originalStatus = fromNote(note)
+
+            const noteResult = Note.safeParse(normalizeActivityPubContent(note))
+            if (!noteResult.success) return null
+
+            const originalStatus = getStatusFromNote(noteResult.data)
+            if (!originalStatus) return null
+
             originalStatus.actor = await getActorProfile(originalStatus.actorId)
-            const announceStatus = fromAnnoucne(
-              item as unknown as AnnounceStatus,
-              originalStatus
-            )
+            const announceStatus = fromAnnoucne(announce, originalStatus)
             if (actor) announceStatus.actor = actor
             return announceStatus
           }
@@ -157,7 +133,12 @@ export const getActorPosts: GetActorPostsFunction = async ({
           const obj = item.object as { type?: string; [key: string]: unknown }
           if (obj.type !== 'Note') return null
 
-          const status = fromNote(obj as unknown as Note)
+          const noteResult = Note.safeParse(normalizeActivityPubContent(obj))
+          if (!noteResult.success) return null
+
+          const status = getStatusFromNote(noteResult.data)
+          if (!status) return null
+
           if (actor) status.actor = actor
           return status
         })

--- a/lib/activities/getRemoteStatus.test.ts
+++ b/lib/activities/getRemoteStatus.test.ts
@@ -71,6 +71,74 @@ describe('#getRemoteStatus', () => {
     })
   })
 
+  it('fetches public remote statuses with object-shaped audience entries', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === STATUS_ID) {
+        return JSON.stringify({
+          id: STATUS_ID,
+          type: 'Note',
+          attributedTo: ACTOR_ID,
+          content: 'Hello with object audience',
+          to: [
+            {
+              id: PUBLIC_STREAM,
+              type: 'Collection'
+            }
+          ],
+          cc: [],
+          published: new Date('2026-04-30T12:00:00.000Z').toISOString()
+        })
+      }
+
+      if (req.url === ACTOR_ID) {
+        return { status: 503, body: 'Unavailable' }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    await expect(
+      getRemoteStatus({ statusId: STATUS_ID })
+    ).resolves.toMatchObject({
+      id: STATUS_ID,
+      actorId: ACTOR_ID,
+      actor: null,
+      text: 'Hello with object audience'
+    })
+  })
+
+  it('does not return non-Note remote objects', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        id: STATUS_ID,
+        type: 'Announce',
+        actor: ACTOR_ID,
+        object: `${ACTOR_ID}/statuses/2`,
+        to: [PUBLIC_STREAM],
+        cc: [],
+        published: new Date('2026-04-30T12:00:00.000Z').toISOString()
+      })
+    )
+
+    await expect(getRemoteStatus({ statusId: STATUS_ID })).resolves.toBeNull()
+  })
+
+  it('does not return malformed remote notes', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        id: STATUS_ID,
+        type: 'Note',
+        attributedTo: ACTOR_ID,
+        content: [],
+        to: [PUBLIC_STREAM],
+        cc: [],
+        published: new Date('2026-04-30T12:00:00.000Z').toISOString()
+      })
+    )
+
+    await expect(getRemoteStatus({ statusId: STATUS_ID })).resolves.toBeNull()
+  })
+
   it('does not return non-public remote statuses', async () => {
     fetchMock.mockResponseOnce(
       JSON.stringify({

--- a/lib/activities/getRemoteStatus.test.ts
+++ b/lib/activities/getRemoteStatus.test.ts
@@ -1,0 +1,90 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { getRemoteStatus } from './getRemoteStatus'
+
+enableFetchMocks()
+
+const PUBLIC_STREAM = 'https://www.w3.org/ns/activitystreams#Public'
+const ACTOR_ID = 'https://remote.example/users/alice'
+const STATUS_ID = 'https://remote.example/users/alice/statuses/1'
+
+describe('#getRemoteStatus', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('fetches a public remote status without persisting it', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === STATUS_ID) {
+        return JSON.stringify({
+          id: STATUS_ID,
+          type: 'Note',
+          url: [
+            'https://remote.example/@alice/1',
+            {
+              href: 'at://did:plc:alice/app.bsky.feed.post/1',
+              rel: 'canonical',
+              type: 'Link'
+            }
+          ],
+          attributedTo: ACTOR_ID,
+          content: 'Hello from a remote profile',
+          to: [PUBLIC_STREAM],
+          cc: [`${ACTOR_ID}/followers`],
+          published: new Date('2026-04-30T12:00:00.000Z').toISOString()
+        })
+      }
+
+      if (req.url === ACTOR_ID) {
+        return JSON.stringify({
+          id: ACTOR_ID,
+          type: 'Person',
+          preferredUsername: 'alice',
+          name: 'Alice',
+          inbox: `${ACTOR_ID}/inbox`,
+          outbox: `${ACTOR_ID}/outbox`,
+          followers: `${ACTOR_ID}/followers`,
+          publicKey: {
+            id: `${ACTOR_ID}#main-key`,
+            owner: ACTOR_ID,
+            publicKeyPem: 'public key'
+          }
+        })
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    await expect(
+      getRemoteStatus({ statusId: STATUS_ID })
+    ).resolves.toMatchObject({
+      id: STATUS_ID,
+      actorId: ACTOR_ID,
+      actor: {
+        id: ACTOR_ID,
+        username: 'alice',
+        domain: 'remote.example',
+        name: 'Alice'
+      },
+      text: 'Hello from a remote profile',
+      url: 'https://remote.example/@alice/1'
+    })
+  })
+
+  it('does not return non-public remote statuses', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        id: STATUS_ID,
+        type: 'Note',
+        attributedTo: ACTOR_ID,
+        content: 'Private remote status',
+        to: [ACTOR_ID],
+        cc: [],
+        published: new Date('2026-04-30T12:00:00.000Z').toISOString()
+      })
+    )
+
+    await expect(getRemoteStatus({ statusId: STATUS_ID })).resolves.toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/activities/getRemoteStatus.ts
+++ b/lib/activities/getRemoteStatus.ts
@@ -1,15 +1,15 @@
 import { getNote } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { Note } from '@/lib/types/activitypub/objects'
 import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
+import { getActorProfileFromPerson } from '@/lib/utils/activitypubActor'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
 import { logger } from '@/lib/utils/logger'
 
-import { Actor } from '../types/activitypub'
-import { Note } from '../types/activitypub/objects'
-import { ActorProfile, Actor as DomainActor } from '../types/domain/actor'
+import { Actor as DomainActor } from '../types/domain/actor'
 import { StatusNote, fromNote } from '../types/domain/status'
 
 type GetRemoteStatusParams = {
@@ -26,70 +26,52 @@ const publicStreams = [
 
 const hasPublicAudience = (value: Note['to'] | Note['cc']) => {
   const items = Array.isArray(value) ? value : [value]
-  return items.some(
-    (item): item is string =>
-      typeof item === 'string' && publicStreams.includes(item)
-  )
+  return items.some((item) => publicStreams.includes(item))
 }
 
-const getActorDomain = (actorId: string) => {
-  try {
-    return new URL(actorId).host
-  } catch {
-    return actorId
-  }
-}
-
-const getImageUrl = (image: Actor['icon']) => {
-  if (!image) return undefined
-  if (Array.isArray(image)) return image.find((item) => item.url)?.url
-  return image.url
-}
-
-const getActorProfileFromPerson = (person: Actor): ActorProfile =>
-  ActorProfile.parse({
-    id: person.id,
-    username: person.preferredUsername,
-    domain: getActorDomain(person.id),
-    name: person.name,
-    summary: person.summary || undefined,
-    iconUrl: getImageUrl(person.icon),
-    headerImageUrl: getImageUrl(person.image),
-    manuallyApprovesFollowers: person.manuallyApprovesFollowers,
-    followersUrl: person.followers || `${person.id}/followers`,
-    inboxUrl: person.inbox,
-    sharedInboxUrl: person.endpoints?.sharedInbox || '',
-    followingCount: 0,
-    followersCount: 0,
-    statusCount: 0,
-    lastStatusAt: null,
-    createdAt: person.published ? new Date(person.published).getTime() : 0
-  })
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
 
 export const getRemoteStatus = async ({
   statusId,
   signingActor
 }: GetRemoteStatusParams): Promise<StatusNote | null> => {
+  let remoteNote: Awaited<ReturnType<typeof getNote>>
   try {
-    const remoteNote = await getNote({ statusId, signingActor })
-    if (!remoteNote) return null
-
-    const note = normalizeActivityPubContent(remoteNote) as Note
-    if (!hasPublicAudience(note.to) && !hasPublicAudience(note.cc)) {
-      return null
-    }
-
-    const status = fromNote(note)
-    const actorPerson = await getActorPerson({
-      actorId: status.actorId,
-      signingActor
-    })
-    status.actor = actorPerson ? getActorProfileFromPerson(actorPerson) : null
-
-    return status
+    remoteNote = await getNote({ statusId, signingActor })
   } catch (error) {
-    const nodeError = error as NodeJS.ErrnoException
-    logger.error(`[getRemoteStatus] ${nodeError.message}`)
+    logger.error(`[getRemoteStatus] ${getErrorMessage(error)}`)
     return null
   }
+  if (!remoteNote) return null
+
+  const noteResult = Note.safeParse(normalizeActivityPubContent(remoteNote))
+  if (!noteResult.success) {
+    logger.error(`[getRemoteStatus] ${noteResult.error.message}`)
+    return null
+  }
+
+  const note = noteResult.data
+  if (!hasPublicAudience(note.to) && !hasPublicAudience(note.cc)) {
+    return null
+  }
+
+  let status: StatusNote
+  try {
+    status = fromNote(note)
+  } catch (error) {
+    logger.error(`[getRemoteStatus] ${getErrorMessage(error)}`)
+    return null
+  }
+
+  const actorPerson = await getActorPerson({
+    actorId: status.actorId,
+    signingActor
+  }).catch((error: unknown) => {
+    logger.error(`[getRemoteStatus.actor] ${getErrorMessage(error)}`)
+    return null
+  })
+  status.actor = actorPerson ? getActorProfileFromPerson(actorPerson) : null
+
+  return status
 }

--- a/lib/activities/getRemoteStatus.ts
+++ b/lib/activities/getRemoteStatus.ts
@@ -1,0 +1,95 @@
+import { getNote } from '@/lib/activities'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
+import { logger } from '@/lib/utils/logger'
+
+import { Actor } from '../types/activitypub'
+import { Note } from '../types/activitypub/objects'
+import { ActorProfile, Actor as DomainActor } from '../types/domain/actor'
+import { StatusNote, fromNote } from '../types/domain/status'
+
+type GetRemoteStatusParams = {
+  statusId: string
+  signingActor?: DomainActor
+}
+
+const publicStreams = [
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT,
+  'Public',
+  'as:Public'
+]
+
+const hasPublicAudience = (value: Note['to'] | Note['cc']) => {
+  const items = Array.isArray(value) ? value : [value]
+  return items.some(
+    (item): item is string =>
+      typeof item === 'string' && publicStreams.includes(item)
+  )
+}
+
+const getActorDomain = (actorId: string) => {
+  try {
+    return new URL(actorId).host
+  } catch {
+    return actorId
+  }
+}
+
+const getImageUrl = (image: Actor['icon']) => {
+  if (!image) return undefined
+  if (Array.isArray(image)) return image.find((item) => item.url)?.url
+  return image.url
+}
+
+const getActorProfileFromPerson = (person: Actor): ActorProfile =>
+  ActorProfile.parse({
+    id: person.id,
+    username: person.preferredUsername,
+    domain: getActorDomain(person.id),
+    name: person.name,
+    summary: person.summary || undefined,
+    iconUrl: getImageUrl(person.icon),
+    headerImageUrl: getImageUrl(person.image),
+    manuallyApprovesFollowers: person.manuallyApprovesFollowers,
+    followersUrl: person.followers || `${person.id}/followers`,
+    inboxUrl: person.inbox,
+    sharedInboxUrl: person.endpoints?.sharedInbox || '',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: person.published ? new Date(person.published).getTime() : 0
+  })
+
+export const getRemoteStatus = async ({
+  statusId,
+  signingActor
+}: GetRemoteStatusParams): Promise<StatusNote | null> => {
+  try {
+    const remoteNote = await getNote({ statusId, signingActor })
+    if (!remoteNote) return null
+
+    const note = normalizeActivityPubContent(remoteNote) as Note
+    if (!hasPublicAudience(note.to) && !hasPublicAudience(note.cc)) {
+      return null
+    }
+
+    const status = fromNote(note)
+    const actorPerson = await getActorPerson({
+      actorId: status.actorId,
+      signingActor
+    })
+    status.actor = actorPerson ? getActorProfileFromPerson(actorPerson) : null
+
+    return status
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException
+    logger.error(`[getRemoteStatus] ${nodeError.message}`)
+    return null
+  }
+}

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -2,10 +2,12 @@ import Link from 'next/link'
 import { FC } from 'react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { getMentionDomainFromActorID } from '@/lib/types/domain/actor'
+import type { ActorProfile } from '@/lib/types/domain/actor'
 import {
-  ActorProfile,
-  getMentionDomainFromActorID
-} from '@/lib/types/domain/actor'
+  getActorIdUsername,
+  isOpaqueActorUsernameValue
+} from '@/lib/utils/activitypubActor'
 
 interface Props {
   actor?: ActorProfile | null
@@ -31,20 +33,35 @@ const getActorMention = (actor: ActorProfile) =>
 const getStatusUrlHandle = (statusUrl?: string | null) => {
   if (!statusUrl) return null
   try {
-    const handle = new URL(statusUrl).pathname
+    const url = new URL(statusUrl)
+    const parts = url.pathname
       .split('/')
       .filter(Boolean)
-      .find((part) => part.startsWith('@') && part.length > 1)
-    if (!handle) return null
-    return `@${getDisplayUsername(handle)}`
+      .map(decodeURIComponent)
+
+    const handle = parts.find((part) => part.startsWith('@') && part.length > 1)
+    if (handle) return `@${getDisplayUsername(handle)}`
+
+    const profileIndex = parts.indexOf('profile')
+    const profileHandle = parts[profileIndex + 1]
+    const isBlueskyProfileUrl =
+      url.hostname === 'bsky.app' ||
+      url.hostname === 'bsky.brid.gy' ||
+      parts.includes('bsky.app')
+    if (
+      isBlueskyProfileUrl &&
+      profileIndex >= 0 &&
+      profileHandle &&
+      !isOpaqueActorUsernameValue(profileHandle)
+    ) {
+      return `@${getDisplayUsername(profileHandle)}`
+    }
+
+    return null
   } catch {
     return null
   }
 }
-
-const getActorIdHandle = (actorId: string, statusUrl?: string | null) =>
-  getStatusUrlHandle(statusUrl) ||
-  `@${getDisplayUsername(actorId.split('/').filter(Boolean).pop() || actorId)}`
 
 const getActorIdDomain = (actorId: string) => {
   try {
@@ -54,15 +71,53 @@ const getActorIdDomain = (actorId: string) => {
   }
 }
 
-export const getActorIdMention = (actorId: string, statusUrl?: string | null) =>
-  `${getActorIdHandle(actorId, statusUrl)}${getActorIdDomain(actorId)}`
+const getActorIdParts = (actorId: string, statusUrl?: string | null) => {
+  const statusHandle = getStatusUrlHandle(statusUrl)
+  if (statusHandle) {
+    const domain = getActorIdDomain(actorId)
+    return {
+      handle: statusHandle,
+      domain,
+      href: `/${statusHandle}${domain}`
+    }
+  }
+
+  const username = getDisplayUsername(getActorIdUsername(actorId))
+  if (isOpaqueActorUsernameValue(username)) {
+    const domain = getActorIdDomain(actorId)
+    return {
+      handle: domain || `@${username}`,
+      domain: '',
+      href: actorId
+    }
+  }
+
+  const handle = `@${username}`
+  const domain = getActorIdDomain(actorId)
+  return {
+    handle,
+    domain,
+    href: `/${handle}${domain}`
+  }
+}
+
+const getActorIdHandle = (actorId: string, statusUrl?: string | null) =>
+  getActorIdParts(actorId, statusUrl).handle
+
+export const getActorIdMention = (
+  actorId: string,
+  statusUrl?: string | null
+) => {
+  const { handle, domain } = getActorIdParts(actorId, statusUrl)
+  return `${handle}${domain}`
+}
 
 export const ActorAvatar: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
   const href = actor
     ? `/${getActorMention(actor)}`
-    : `/${getActorIdMention(actorId || '', statusUrl)}`
+    : getActorIdParts(actorId || '', statusUrl).href
   const initials = actor
     ? getInitials(actor.name || getDisplayUsername(actor.username) || '')
     : getInitials(getActorIdHandle(actorId || '', statusUrl))
@@ -81,9 +136,7 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
   if (!actor) {
-    const handle = getActorIdHandle(actorId || '', statusUrl)
-    const domain = getActorIdDomain(actorId || '')
-    const href = `/${getActorIdMention(actorId || '', statusUrl)}`
+    const { handle, domain, href } = getActorIdParts(actorId || '', statusUrl)
     return (
       <div
         className="flex items-center gap-1 min-w-0"

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -15,6 +15,12 @@ interface Props {
   statusUrl?: string | null
 }
 
+type ActorIdParts = {
+  handle: string
+  domain: string
+  href?: string
+}
+
 const getInitials = (value: string) =>
   value
     .replace(/^@/, '')
@@ -30,6 +36,43 @@ const getDisplayUsername = (username: string) =>
 const getActorMention = (actor: ActorProfile) =>
   `@${getDisplayUsername(actor.username)}@${actor.domain}`
 
+const getProfileHandleFromParts = (parts: string[]) => {
+  const profileIndex = parts.indexOf('profile')
+  const profileHandle = parts[profileIndex + 1]
+  if (
+    profileIndex >= 0 &&
+    profileHandle &&
+    !isOpaqueActorUsernameValue(profileHandle)
+  ) {
+    return `@${getDisplayUsername(profileHandle)}`
+  }
+  return null
+}
+
+const getBlueskyProfileHandle = (url: URL) => {
+  if (url.hostname === 'bsky.app') {
+    return getProfileHandleFromParts(
+      url.pathname.split('/').filter(Boolean).map(decodeURIComponent)
+    )
+  }
+
+  if (url.hostname !== 'bsky.brid.gy' || !url.pathname.startsWith('/r/')) {
+    return null
+  }
+
+  try {
+    const embeddedUrl = new URL(
+      decodeURIComponent(url.pathname.slice('/r/'.length))
+    )
+    if (embeddedUrl.hostname !== 'bsky.app') return null
+    return getProfileHandleFromParts(
+      embeddedUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent)
+    )
+  } catch {
+    return null
+  }
+}
+
 const getStatusUrlHandle = (statusUrl?: string | null) => {
   if (!statusUrl) return null
   try {
@@ -42,22 +85,7 @@ const getStatusUrlHandle = (statusUrl?: string | null) => {
     const handle = parts.find((part) => part.startsWith('@') && part.length > 1)
     if (handle) return `@${getDisplayUsername(handle)}`
 
-    const profileIndex = parts.indexOf('profile')
-    const profileHandle = parts[profileIndex + 1]
-    const isBlueskyProfileUrl =
-      url.hostname === 'bsky.app' ||
-      url.hostname === 'bsky.brid.gy' ||
-      parts.includes('bsky.app')
-    if (
-      isBlueskyProfileUrl &&
-      profileIndex >= 0 &&
-      profileHandle &&
-      !isOpaqueActorUsernameValue(profileHandle)
-    ) {
-      return `@${getDisplayUsername(profileHandle)}`
-    }
-
-    return null
+    return getBlueskyProfileHandle(url)
   } catch {
     return null
   }
@@ -71,7 +99,10 @@ const getActorIdDomain = (actorId: string) => {
   }
 }
 
-const getActorIdParts = (actorId: string, statusUrl?: string | null) => {
+const getActorIdParts = (
+  actorId: string,
+  statusUrl?: string | null
+): ActorIdParts => {
   const statusHandle = getStatusUrlHandle(statusUrl)
   if (statusHandle) {
     const domain = getActorIdDomain(actorId)
@@ -87,8 +118,7 @@ const getActorIdParts = (actorId: string, statusUrl?: string | null) => {
     const domain = getActorIdDomain(actorId)
     return {
       handle: domain || `@${username}`,
-      domain: '',
-      href: actorId
+      domain: ''
     }
   }
 
@@ -122,12 +152,20 @@ export const ActorAvatar: FC<Props> = ({ actor, actorId, statusUrl }) => {
     ? getInitials(actor.name || getDisplayUsername(actor.username) || '')
     : getInitials(getActorIdHandle(actorId || '', statusUrl))
 
+  const avatar = (
+    <Avatar className="h-10 w-10">
+      <AvatarImage src={actor?.iconUrl} />
+      <AvatarFallback>{initials}</AvatarFallback>
+    </Avatar>
+  )
+
+  if (!href) {
+    return <div onClick={(e) => e.stopPropagation()}>{avatar}</div>
+  }
+
   return (
     <Link href={href} onClick={(e) => e.stopPropagation()}>
-      <Avatar className="h-10 w-10">
-        <AvatarImage src={actor?.iconUrl} />
-        <AvatarFallback>{initials}</AvatarFallback>
-      </Avatar>
+      {avatar}
     </Link>
   )
 }
@@ -142,9 +180,13 @@ export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
         className="flex items-center gap-1 min-w-0"
         onClick={(e) => e.stopPropagation()}
       >
-        <Link href={href} className="font-semibold hover:underline truncate">
-          {handle}
-        </Link>
+        {href ? (
+          <Link href={href} className="font-semibold hover:underline truncate">
+            {handle}
+          </Link>
+        ) : (
+          <span className="font-semibold truncate">{handle}</span>
+        )}
         <span className="text-muted-foreground truncate">{domain}</span>
       </div>
     )

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -49,38 +49,53 @@ const getProfileHandleFromParts = (parts: string[]) => {
   return null
 }
 
+const getDecodedPathParts = (pathname: string) => {
+  try {
+    return pathname.split('/').filter(Boolean).map(decodeURIComponent)
+  } catch {
+    return null
+  }
+}
+
+const decodePathParam = (value: string) => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
 const getBlueskyProfileHandle = (url: URL) => {
   if (url.hostname === 'bsky.app') {
-    return getProfileHandleFromParts(
-      url.pathname.split('/').filter(Boolean).map(decodeURIComponent)
-    )
+    const parts = getDecodedPathParts(url.pathname)
+    return parts ? getProfileHandleFromParts(parts) : null
   }
 
   if (url.hostname !== 'bsky.brid.gy' || !url.pathname.startsWith('/r/')) {
     return null
   }
 
+  const embeddedUrlString = decodePathParam(url.pathname.slice('/r/'.length))
+  if (!embeddedUrlString) return null
+
+  let embeddedUrl: URL
   try {
-    const embeddedUrl = new URL(
-      decodeURIComponent(url.pathname.slice('/r/'.length))
-    )
-    if (embeddedUrl.hostname !== 'bsky.app') return null
-    return getProfileHandleFromParts(
-      embeddedUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent)
-    )
+    embeddedUrl = new URL(embeddedUrlString)
   } catch {
     return null
   }
+  if (embeddedUrl.hostname !== 'bsky.app') return null
+
+  const parts = getDecodedPathParts(embeddedUrl.pathname)
+  return parts ? getProfileHandleFromParts(parts) : null
 }
 
 const getStatusUrlHandle = (statusUrl?: string | null) => {
   if (!statusUrl) return null
   try {
     const url = new URL(statusUrl)
-    const parts = url.pathname
-      .split('/')
-      .filter(Boolean)
-      .map(decodeURIComponent)
+    const parts = getDecodedPathParts(url.pathname)
+    if (!parts) return null
 
     const handle = parts.find((part) => part.startsWith('@') && part.length > 1)
     if (handle) return `@${getDisplayUsername(handle)}`

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -4,9 +4,7 @@ import { FC } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import {
   ActorProfile,
-  getMention,
-  getMentionDomainFromActorID,
-  getMentionFromActorID
+  getMentionDomainFromActorID
 } from '@/lib/types/domain/actor'
 
 interface Props {
@@ -23,15 +21,35 @@ const getInitials = (value: string) =>
     .toUpperCase()
     .slice(0, 2)
 
+const getDisplayUsername = (username: string) =>
+  username.replace(/^@+/, '').split('@')[0]
+
+const getActorMention = (actor: ActorProfile) =>
+  `@${getDisplayUsername(actor.username)}@${actor.domain}`
+
+const getActorIdHandle = (actorId: string) =>
+  `@${getDisplayUsername(actorId.split('/').filter(Boolean).pop() || actorId)}`
+
+const getActorIdDomain = (actorId: string) => {
+  try {
+    return getMentionDomainFromActorID(actorId)
+  } catch {
+    return ''
+  }
+}
+
+export const getActorIdMention = (actorId: string) =>
+  `${getActorIdHandle(actorId)}${getActorIdDomain(actorId)}`
+
 export const ActorAvatar: FC<Props> = ({ actor, actorId }) => {
   if (!actor && !actorId) return null
 
   const href = actor
-    ? `/${getMention(actor, true)}`
-    : `/${getMentionFromActorID(actorId || '', true)}`
+    ? `/${getActorMention(actor)}`
+    : `/${getActorIdMention(actorId || '')}`
   const initials = actor
-    ? getInitials(actor.name || actor.username || '')
-    : getInitials(getMentionFromActorID(actorId || '', false))
+    ? getInitials(actor.name || getDisplayUsername(actor.username) || '')
+    : getInitials(getActorIdHandle(actorId || ''))
 
   return (
     <Link href={href} onClick={(e) => e.stopPropagation()}>
@@ -47,9 +65,9 @@ export const ActorInfo: FC<Props> = ({ actor, actorId }) => {
   if (!actor && !actorId) return null
 
   if (!actor) {
-    const handle = getMentionFromActorID(actorId || '', false)
-    const domain = getMentionDomainFromActorID(actorId || '')
-    const href = `/${getMentionFromActorID(actorId || '', true)}`
+    const handle = getActorIdHandle(actorId || '')
+    const domain = getActorIdDomain(actorId || '')
+    const href = `/${getActorIdMention(actorId || '')}`
     return (
       <div
         className="flex items-center gap-1 min-w-0"
@@ -69,13 +87,13 @@ export const ActorInfo: FC<Props> = ({ actor, actorId }) => {
       onClick={(e) => e.stopPropagation()}
     >
       <Link
-        href={`/${getMention(actor, true)}`}
+        href={`/${getActorMention(actor)}`}
         className="font-semibold hover:underline truncate"
       >
-        {actor.name || actor.username}
+        {actor.name || getDisplayUsername(actor.username)}
       </Link>
       <span className="text-muted-foreground truncate">
-        {getMention(actor, true)}
+        {getActorMention(actor)}
       </span>
     </div>
   )

--- a/lib/components/posts/actor.tsx
+++ b/lib/components/posts/actor.tsx
@@ -10,6 +10,7 @@ import {
 interface Props {
   actor?: ActorProfile | null
   actorId?: string
+  statusUrl?: string | null
 }
 
 const getInitials = (value: string) =>
@@ -27,7 +28,22 @@ const getDisplayUsername = (username: string) =>
 const getActorMention = (actor: ActorProfile) =>
   `@${getDisplayUsername(actor.username)}@${actor.domain}`
 
-const getActorIdHandle = (actorId: string) =>
+const getStatusUrlHandle = (statusUrl?: string | null) => {
+  if (!statusUrl) return null
+  try {
+    const handle = new URL(statusUrl).pathname
+      .split('/')
+      .filter(Boolean)
+      .find((part) => part.startsWith('@') && part.length > 1)
+    if (!handle) return null
+    return `@${getDisplayUsername(handle)}`
+  } catch {
+    return null
+  }
+}
+
+const getActorIdHandle = (actorId: string, statusUrl?: string | null) =>
+  getStatusUrlHandle(statusUrl) ||
   `@${getDisplayUsername(actorId.split('/').filter(Boolean).pop() || actorId)}`
 
 const getActorIdDomain = (actorId: string) => {
@@ -38,18 +54,18 @@ const getActorIdDomain = (actorId: string) => {
   }
 }
 
-export const getActorIdMention = (actorId: string) =>
-  `${getActorIdHandle(actorId)}${getActorIdDomain(actorId)}`
+export const getActorIdMention = (actorId: string, statusUrl?: string | null) =>
+  `${getActorIdHandle(actorId, statusUrl)}${getActorIdDomain(actorId)}`
 
-export const ActorAvatar: FC<Props> = ({ actor, actorId }) => {
+export const ActorAvatar: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
   const href = actor
     ? `/${getActorMention(actor)}`
-    : `/${getActorIdMention(actorId || '')}`
+    : `/${getActorIdMention(actorId || '', statusUrl)}`
   const initials = actor
     ? getInitials(actor.name || getDisplayUsername(actor.username) || '')
-    : getInitials(getActorIdHandle(actorId || ''))
+    : getInitials(getActorIdHandle(actorId || '', statusUrl))
 
   return (
     <Link href={href} onClick={(e) => e.stopPropagation()}>
@@ -61,13 +77,13 @@ export const ActorAvatar: FC<Props> = ({ actor, actorId }) => {
   )
 }
 
-export const ActorInfo: FC<Props> = ({ actor, actorId }) => {
+export const ActorInfo: FC<Props> = ({ actor, actorId, statusUrl }) => {
   if (!actor && !actorId) return null
 
   if (!actor) {
-    const handle = getActorIdHandle(actorId || '')
+    const handle = getActorIdHandle(actorId || '', statusUrl)
     const domain = getActorIdDomain(actorId || '')
-    const href = `/${getActorIdMention(actorId || '')}`
+    const href = `/${getActorIdMention(actorId || '', statusUrl)}`
     return (
       <div
         className="flex items-center gap-1 min-w-0"

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -275,10 +275,10 @@ describe('Post', () => {
       />
     )
 
-    expect(screen.getByRole('link', { name: '@hackers.pub' })).toHaveAttribute(
-      'href',
-      actorId
-    )
+    expect(screen.getByText('@hackers.pub')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: '@hackers.pub' })
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText('@019382d3-63d7-7cf7-86e8-91e2551c306c')
     ).not.toBeInTheDocument()
@@ -309,6 +309,32 @@ describe('Post', () => {
     expect(screen.getByText('@bsky.brid.gy')).toBeInTheDocument()
     expect(
       screen.queryByText('@did:plc:2gkh62xvzokhlf6li4ol3b3d')
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not infer bsky profile handles from unrelated status url paths', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actorId:
+              'https://hackers.pub/ap/actors/019382d3-63d7-7cf7-86e8-91e2551c306c',
+            actor: null,
+            url: 'https://example.com/posts/bsky.app/profile/notalice'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText('@hackers.pub')).toBeInTheDocument()
+    expect(screen.queryByText('@notalice')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: '@hackers.pub' })
     ).not.toBeInTheDocument()
   })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -253,4 +253,62 @@ describe('Post', () => {
       screen.queryByText('@019382d3-63d7-7cf7-86e8-91e2551c306c')
     ).not.toBeInTheDocument()
   })
+
+  it('falls back to the actor domain when opaque actor ids have no usable status handle', () => {
+    const actorId =
+      'https://hackers.pub/ap/actors/019382d3-63d7-7cf7-86e8-91e2551c306c'
+
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actorId,
+            actor: null,
+            url: 'https://hackers.pub/ap/notes/019dc9aa-ebc9-7059-8de2-f5850dbeea4e'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: '@hackers.pub' })).toHaveAttribute(
+      'href',
+      actorId
+    )
+    expect(
+      screen.queryByText('@019382d3-63d7-7cf7-86e8-91e2551c306c')
+    ).not.toBeInTheDocument()
+  })
+
+  it('uses bsky profile handles from bridgy status urls', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actorId: 'https://bsky.brid.gy/ap/did:plc:2gkh62xvzokhlf6li4ol3b3d',
+            actor: null,
+            url: 'https://bsky.brid.gy/r/https://bsky.app/profile/patak.cat/post/3mknrszqses2y'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: '@patak.cat' })).toHaveAttribute(
+      'href',
+      '/@patak.cat@bsky.brid.gy'
+    )
+    expect(screen.getByText('@bsky.brid.gy')).toBeInTheDocument()
+    expect(
+      screen.queryByText('@did:plc:2gkh62xvzokhlf6li4ol3b3d')
+    ).not.toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -224,4 +224,33 @@ describe('Post', () => {
       screen.queryByText('@@original@origin.example')
     ).not.toBeInTheDocument()
   })
+
+  it('uses the status url handle when actor ids are opaque', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actorId:
+              'https://hackers.pub/ap/actors/019382d3-63d7-7cf7-86e8-91e2551c306c',
+            actor: null,
+            url: 'https://hackers.pub/@hongminhee/019dc9aa-ebc9-7059-8de2-f5850dbeea4e'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: '@hongminhee' })).toHaveAttribute(
+      'href',
+      '/@hongminhee@hackers.pub'
+    )
+    expect(screen.getByText('@hackers.pub')).toBeInTheDocument()
+    expect(
+      screen.queryByText('@019382d3-63d7-7cf7-86e8-91e2551c306c')
+    ).not.toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -154,7 +154,11 @@ describe('Post', () => {
       <Post
         host="activities.local"
         currentTime={currentTime}
-        status={{ ...boostedStatus, actor: null }}
+        status={{
+          ...boostedStatus,
+          actor: null,
+          actorId: 'https://remote.example/@booster'
+        }}
         onShowAttachment={jest.fn()}
       />
     )
@@ -162,5 +166,62 @@ describe('Post', () => {
     expect(
       screen.getByText('Boosted by @booster@remote.example')
     ).toBeInTheDocument()
+  })
+
+  it('normalizes prefixed remote actor usernames in post handles', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actor: {
+              ...boostedStatus.originalStatus.actor!,
+              username: '@original',
+              name: undefined
+            }
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'original' })).toHaveAttribute(
+      'href',
+      '/@original@origin.example'
+    )
+    expect(screen.getByText('@original@origin.example')).toBeInTheDocument()
+    expect(
+      screen.queryByText('@@original@origin.example')
+    ).not.toBeInTheDocument()
+  })
+
+  it('normalizes actor id handles when the actor profile is absent', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actorId: 'https://origin.example/@original',
+            actor: null
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: '@original' })).toHaveAttribute(
+      'href',
+      '/@original@origin.example'
+    )
+    expect(screen.getByText('@origin.example')).toBeInTheDocument()
+    expect(
+      screen.queryByText('@@original@origin.example')
+    ).not.toBeInTheDocument()
   })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -312,6 +312,31 @@ describe('Post', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('ignores malformed bridgy embedded status urls', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...boostedStatus,
+          originalStatus: {
+            ...boostedStatus.originalStatus,
+            actorId: 'https://bsky.brid.gy/ap/did:plc:2gkh62xvzokhlf6li4ol3b3d',
+            actor: null,
+            url: 'https://bsky.brid.gy/r/%E0%A4%A'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText('@bsky.brid.gy')).toBeInTheDocument()
+    expect(screen.queryByText('@patak.cat')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: '@bsky.brid.gy' })
+    ).not.toBeInTheDocument()
+  })
+
   it('does not infer bsky profile handles from unrelated status url paths', () => {
     render(
       <Post

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -5,7 +5,11 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { ReactNode } from 'react'
 
-import { StatusNote, StatusType } from '@/lib/types/domain/status'
+import {
+  StatusAnnounce,
+  StatusNote,
+  StatusType
+} from '@/lib/types/domain/status'
 
 import { Post } from './post'
 
@@ -61,6 +65,55 @@ const status: StatusNote = {
   tags: []
 }
 
+const boostedStatus: StatusAnnounce = {
+  id: 'https://remote.example/users/booster/statuses/boost-1/activity',
+  actorId: 'https://remote.example/users/booster',
+  actor: {
+    id: 'https://remote.example/users/booster',
+    username: 'booster',
+    domain: 'remote.example',
+    name: 'Booster',
+    followersUrl: 'https://remote.example/users/booster/followers',
+    inboxUrl: 'https://remote.example/users/booster/inbox',
+    sharedInboxUrl: 'https://remote.example/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: currentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: false,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Announce,
+  originalStatus: {
+    ...status,
+    id: 'https://origin.example/users/original/statuses/post-1',
+    actorId: 'https://origin.example/users/original',
+    actor: {
+      id: 'https://origin.example/users/original',
+      username: 'original',
+      domain: 'origin.example',
+      name: 'Original',
+      followersUrl: 'https://origin.example/users/original/followers',
+      inboxUrl: 'https://origin.example/users/original/inbox',
+      sharedInboxUrl: 'https://origin.example/inbox',
+      followingCount: 0,
+      followersCount: 0,
+      statusCount: 0,
+      lastStatusAt: null,
+      createdAt: currentTime
+    },
+    isLocalActor: false,
+    url: 'https://origin.example/@original/post-1',
+    text: 'Original post',
+    summary: null
+  }
+}
+
 describe('Post', () => {
   it('does not nest long-post collapse inside expanded content warnings', () => {
     render(
@@ -77,5 +130,37 @@ describe('Post', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show content' }))
 
     expect(screen.queryByTestId('collapsible-content')).not.toBeInTheDocument()
+  })
+
+  it('renders boosts with the booster label and original post actor', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={boostedStatus}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText('Boosted by Booster')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Original' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Booster' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('falls back to the boost actor id when the actor profile is absent', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{ ...boostedStatus, actor: null }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText('Boosted by @booster@remote.example')
+    ).toBeInTheDocument()
   })
 })

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -219,6 +219,7 @@ export const Post: FC<PostProps> = (props) => {
           <ActorAvatar
             actor={actualStatus.actor}
             actorId={actualStatus.actorId}
+            statusUrl={actualStatus.url}
           />
         </div>
         <div className="flex-1 min-w-0">
@@ -226,6 +227,7 @@ export const Post: FC<PostProps> = (props) => {
             <ActorInfo
               actor={actualStatus.actor}
               actorId={actualStatus.actorId}
+              statusUrl={actualStatus.url}
             />
             <span className="text-muted-foreground">·</span>
             <span className="text-muted-foreground text-xs whitespace-nowrap">

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -4,7 +4,7 @@ import { Activity, ExternalLink, LoaderCircle, Repeat2 } from 'lucide-react'
 import { FC } from 'react'
 
 import { PostLineLimit } from '@/lib/types/database/rows'
-import { ActorProfile, getMentionFromActorID } from '@/lib/types/domain/actor'
+import { ActorProfile } from '@/lib/types/domain/actor'
 import { EditableStatus, Status, StatusType } from '@/lib/types/domain/status'
 import {
   formatFitnessDistance,
@@ -21,7 +21,7 @@ import {
 
 import { BrandedDeviceLink } from './BrandedDeviceLink'
 import { Actions } from './actions/actions'
-import { ActorAvatar, ActorInfo } from './actor'
+import { ActorAvatar, ActorInfo, getActorIdMention } from './actor'
 import { Attachments, OnMediaSelectedHandle } from './attachments'
 import { CollapsibleContent } from './collapsible-content'
 import { ContentWarning } from './content-warning'
@@ -52,7 +52,7 @@ export const BoostStatus: FC<BoostStatusProps> = ({ status }) => {
   const actorName =
     status.actor?.name ||
     status.actor?.username ||
-    getMentionFromActorID(status.actorId, true)
+    getActorIdMention(status.actorId)
 
   return (
     <div className="flex items-center gap-2 mb-1 text-sm text-muted-foreground ml-12">

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -4,7 +4,7 @@ import { Activity, ExternalLink, LoaderCircle, Repeat2 } from 'lucide-react'
 import { FC } from 'react'
 
 import { PostLineLimit } from '@/lib/types/database/rows'
-import { ActorProfile } from '@/lib/types/domain/actor'
+import { ActorProfile, getMentionFromActorID } from '@/lib/types/domain/actor'
 import { EditableStatus, Status, StatusType } from '@/lib/types/domain/status'
 import {
   formatFitnessDistance,
@@ -49,10 +49,15 @@ interface BoostStatusProps {
 
 export const BoostStatus: FC<BoostStatusProps> = ({ status }) => {
   if (status.type !== StatusType.enum.Announce) return null
+  const actorName =
+    status.actor?.name ||
+    status.actor?.username ||
+    getMentionFromActorID(status.actorId, true)
+
   return (
     <div className="flex items-center gap-2 mb-1 text-sm text-muted-foreground ml-12">
       <Repeat2 className="size-4" />
-      <span>Boosted by {status.actor?.name || status.actor?.username}</span>
+      <span>Boosted by {actorName}</span>
     </div>
   )
 }

--- a/lib/types/activitypub/actor.ts
+++ b/lib/types/activitypub/actor.ts
@@ -3,6 +3,12 @@ import { z } from 'zod'
 
 import { Emoji, HashTag, Image, PropertyValue } from './objects'
 
+const ActorImage = z.union([Image, Image.array()])
+const ActorCollectionReference = z.union([z.string().url(), z.looseObject({})])
+const ActorUrl = z.union([z.string(), z.looseObject({})])
+const ActorTag = z.union([Emoji, HashTag, z.looseObject({})])
+const ActorAttachment = z.union([PropertyValue, z.looseObject({})])
+
 // APActor - ActivityPub Actor (Person, Service, etc.)
 // Prefixed with "AP" to distinguish from domain Actor type
 export const APActor = z.object({
@@ -18,12 +24,12 @@ export const APActor = z.object({
   followers: z.string().url().optional(),
   inbox: z.string().url(),
   outbox: z.string().url(),
-  featured: z.string().url().optional(),
-  featuredTags: z.string().url().optional(),
+  featured: ActorCollectionReference.optional(),
+  featuredTags: ActorCollectionReference.optional(),
   preferredUsername: z.string(),
   name: z.string().optional(),
   summary: z.string().nullish(),
-  url: z.string().optional(),
+  url: z.union([ActorUrl, ActorUrl.array()]).optional(),
   published: z.string().nullish(),
   manuallyApprovesFollowers: z.boolean().optional(),
   discoverable: z.boolean().optional(),
@@ -43,10 +49,10 @@ export const APActor = z.object({
       sharedInbox: z.string().url().optional()
     })
     .optional(),
-  icon: Image.nullish(),
-  image: Image.nullish(),
-  attachment: z.array(PropertyValue).optional(),
-  tag: z.array(z.union([HashTag, Emoji])).optional(),
+  icon: ActorImage.nullish(),
+  image: ActorImage.nullish(),
+  attachment: z.union([ActorAttachment, ActorAttachment.array()]).optional(),
+  tag: z.union([ActorTag, ActorTag.array()]).optional(),
   generator: z
     .object({
       id: z.string().optional(),

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { AnnounceStatus } from '@/lib/activities/announceStatus'
 import { getContent, getReply, getSummary } from '@/lib/activities/note'
+import type { Announce as ActivityPubAnnounce } from '@/lib/types/activitypub/activities'
 import { Document } from '@/lib/types/activitypub/objects'
 import {
   ENTITY_TYPE_QUESTION,
@@ -211,7 +212,7 @@ export const fromNote = (note: Note): StatusNote => {
 }
 
 export const fromAnnoucne = (
-  announce: AnnounceStatus,
+  announce: AnnounceStatus | ActivityPubAnnounce,
   originalStatus: StatusNote
 ): StatusAnnounce => {
   const currentTime = Date.now()

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -211,7 +211,7 @@ export const fromNote = (note: Note): StatusNote => {
   })
 }
 
-export const fromAnnoucne = (
+export const fromAnnounce = (
   announce: AnnounceStatus | ActivityPubAnnounce,
   originalStatus: StatusNote
 ): StatusAnnounce => {
@@ -240,6 +240,8 @@ export const fromAnnoucne = (
     updatedAt: currentTime
   })
 }
+
+export const fromAnnoucne = fromAnnounce
 
 export const toActivityPubObject = (status: Status): Note | Question => {
   if (status.type === StatusType.enum.Poll) {

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -241,8 +241,6 @@ export const fromAnnounce = (
   })
 }
 
-export const fromAnnoucne = fromAnnounce
-
 export const toActivityPubObject = (status: Status): Note | Question => {
   if (status.type === StatusType.enum.Poll) {
     return Question.parse({

--- a/lib/utils/activitypubActor.test.ts
+++ b/lib/utils/activitypubActor.test.ts
@@ -1,6 +1,7 @@
 import {
   getActorIdUsername,
-  isOpaqueActorUsername
+  isOpaqueActorUsername,
+  isOpaqueActorUsernameValue
 } from '@/lib/utils/activitypubActor'
 
 describe('activitypubActor utils', () => {
@@ -27,6 +28,18 @@ describe('activitypubActor utils', () => {
     const actorId = 'https://bsky.brid.gy/ap/did:plc:alice'
 
     expect(isOpaqueActorUsername(actorId, 'did:plc:alice')).toBe(true)
+    expect(isOpaqueActorUsername(actorId, 'alice')).toBe(false)
     expect(isOpaqueActorUsername(actorId, 'alice.example')).toBe(false)
+  })
+
+  it('detects standalone opaque username values', () => {
+    expect(isOpaqueActorUsernameValue('did:plc:alice')).toBe(true)
+    expect(
+      isOpaqueActorUsernameValue('019382d3-63d7-7cf7-86e8-91e2551c306c')
+    ).toBe(true)
+    expect(
+      isOpaqueActorUsernameValue('aaaaaaaa-000000000000000000000000000')
+    ).toBe(false)
+    expect(isOpaqueActorUsernameValue('alice')).toBe(false)
   })
 })

--- a/lib/utils/activitypubActor.test.ts
+++ b/lib/utils/activitypubActor.test.ts
@@ -1,0 +1,32 @@
+import {
+  getActorIdUsername,
+  isOpaqueActorUsername
+} from '@/lib/utils/activitypubActor'
+
+describe('activitypubActor utils', () => {
+  it('detects strict UUID actor usernames only when they match the actor id', () => {
+    const actorId =
+      'https://hackers.pub/ap/actors/019382d3-63d7-7cf7-86e8-91e2551c306c'
+
+    expect(getActorIdUsername(actorId)).toBe(
+      '019382d3-63d7-7cf7-86e8-91e2551c306c'
+    )
+    expect(
+      isOpaqueActorUsername(actorId, '019382d3-63d7-7cf7-86e8-91e2551c306c')
+    ).toBe(true)
+    expect(
+      isOpaqueActorUsername(
+        'https://hackers.pub/ap/actors/aaaaaaaa-000000000000000000000000000',
+        'aaaaaaaa-000000000000000000000000000'
+      )
+    ).toBe(false)
+    expect(isOpaqueActorUsername(actorId, 'hongminhee')).toBe(false)
+  })
+
+  it('detects DID actor usernames only when they match the actor id', () => {
+    const actorId = 'https://bsky.brid.gy/ap/did:plc:alice'
+
+    expect(isOpaqueActorUsername(actorId, 'did:plc:alice')).toBe(true)
+    expect(isOpaqueActorUsername(actorId, 'alice.example')).toBe(false)
+  })
+})

--- a/lib/utils/activitypubActor.test.ts
+++ b/lib/utils/activitypubActor.test.ts
@@ -1,5 +1,6 @@
 import {
   getActorIdUsername,
+  getActorProfileFromPerson,
   isOpaqueActorUsername,
   isOpaqueActorUsernameValue
 } from '@/lib/utils/activitypubActor'
@@ -41,5 +42,24 @@ describe('activitypubActor utils', () => {
       isOpaqueActorUsernameValue('aaaaaaaa-000000000000000000000000000')
     ).toBe(false)
     expect(isOpaqueActorUsernameValue('alice')).toBe(false)
+  })
+
+  it('falls back to epoch time for invalid actor published dates', () => {
+    expect(
+      getActorProfileFromPerson({
+        id: 'https://example.com/users/alice',
+        type: 'Person',
+        preferredUsername: 'alice',
+        name: 'Alice',
+        inbox: 'https://example.com/users/alice/inbox',
+        outbox: 'https://example.com/users/alice/outbox',
+        published: 'not-a-date',
+        publicKey: {
+          id: 'https://example.com/users/alice#main-key',
+          owner: 'https://example.com/users/alice',
+          publicKeyPem: 'public-key'
+        }
+      }).createdAt
+    ).toBe(0)
   })
 })

--- a/lib/utils/activitypubActor.ts
+++ b/lib/utils/activitypubActor.ts
@@ -1,0 +1,54 @@
+import { Actor as ActivityPubActor } from '@/lib/types/activitypub'
+import { ActorProfile } from '@/lib/types/domain/actor'
+
+const UUID_USERNAME_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export const getActorDomain = (actorId: string) => {
+  try {
+    return new URL(actorId).host
+  } catch {
+    return actorId
+  }
+}
+
+export const getActorIdUsername = (actorId: string) =>
+  decodeURIComponent(actorId.split('/').filter(Boolean).pop() || actorId)
+    .replace(/^@+/, '')
+    .trim()
+
+export const isOpaqueActorUsernameValue = (username: string) =>
+  username.startsWith('did:') || UUID_USERNAME_PATTERN.test(username)
+
+export const isOpaqueActorUsername = (actorId: string, username: string) => {
+  const actorIdUsername = getActorIdUsername(actorId)
+  return username === actorIdUsername && isOpaqueActorUsernameValue(username)
+}
+
+export const getActorImageUrl = (image: ActivityPubActor['icon']) => {
+  if (!image) return undefined
+  if (Array.isArray(image)) return image.find((item) => item.url)?.url
+  return image.url
+}
+
+export const getActorProfileFromPerson = (
+  person: ActivityPubActor
+): ActorProfile =>
+  ActorProfile.parse({
+    id: person.id,
+    username: person.preferredUsername,
+    domain: getActorDomain(person.id),
+    name: person.name,
+    summary: person.summary || undefined,
+    iconUrl: getActorImageUrl(person.icon),
+    headerImageUrl: getActorImageUrl(person.image),
+    manuallyApprovesFollowers: person.manuallyApprovesFollowers,
+    followersUrl: person.followers || `${person.id}/followers`,
+    inboxUrl: person.inbox,
+    sharedInboxUrl: person.endpoints?.sharedInbox || '',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: person.published ? new Date(person.published).getTime() : 0
+  })

--- a/lib/utils/activitypubActor.ts
+++ b/lib/utils/activitypubActor.ts
@@ -31,6 +31,12 @@ export const getActorImageUrl = (image: ActivityPubActor['icon']) => {
   return image.url
 }
 
+const getActorCreatedAt = (published: string | null | undefined) => {
+  if (!published) return 0
+  const createdAt = Date.parse(published)
+  return Number.isFinite(createdAt) ? createdAt : 0
+}
+
 export const getActorProfileFromPerson = (
   person: ActivityPubActor
 ): ActorProfile =>
@@ -50,5 +56,5 @@ export const getActorProfileFromPerson = (
     followersCount: 0,
     statusCount: 0,
     lastStatusAt: null,
-    createdAt: person.published ? new Date(person.published).getTime() : 0
+    createdAt: getActorCreatedAt(person.published)
   })

--- a/lib/utils/getStatusDetailPath.test.ts
+++ b/lib/utils/getStatusDetailPath.test.ts
@@ -19,8 +19,9 @@ describe('#getStatusDetailPath', () => {
     )
   })
 
-  it('returns a hash-based path for announce status using original status', () => {
+  it('returns an id-based path for remote announce status using original status', () => {
     const url = 'https://remote.example/users/bob/statuses/456'
+    const id = 'https://remote.example/ap/statuses/456'
     const status = {
       type: StatusType.enum.Announce,
       originalStatus: {
@@ -28,12 +29,14 @@ describe('#getStatusDetailPath', () => {
           username: 'bob',
           domain: 'remote.example'
         },
+        id,
+        isLocalActor: false,
         url
       }
     } as Status
 
     expect(getStatusDetailPath(status)).toBe(
-      `/@bob@remote.example/${getHashFromString(url)}`
+      `/@bob@remote.example/${encodeURIComponent(id)}`
     )
   })
 

--- a/lib/utils/getStatusDetailPath.ts
+++ b/lib/utils/getStatusDetailPath.ts
@@ -7,5 +7,9 @@ export const getStatusDetailPath = (status: Status) => {
   const actualStatus = getActualStatus(status)
   if (!actualStatus.actor) return null
 
+  if (actualStatus.isLocalActor === false) {
+    return `/${getMention(actualStatus.actor, true)}/${encodeURIComponent(actualStatus.id)}`
+  }
+
   return `/${getMention(actualStatus.actor, true)}/${getHashFromString(actualStatus.url)}`
 }

--- a/lib/utils/getStatusDetailPathClient.test.ts
+++ b/lib/utils/getStatusDetailPathClient.test.ts
@@ -19,8 +19,9 @@ describe('#getStatusDetailPathClient', () => {
     )
   })
 
-  it('returns a hash-based path for announce status using original status', async () => {
+  it('returns an id-based path for remote announce status using original status', async () => {
     const url = 'https://remote.example/users/bob/statuses/456'
+    const id = 'https://remote.example/ap/statuses/456'
     const status = {
       type: StatusType.enum.Announce,
       originalStatus: {
@@ -28,12 +29,14 @@ describe('#getStatusDetailPathClient', () => {
           username: 'bob',
           domain: 'remote.example'
         },
+        id,
+        isLocalActor: false,
         url
       }
     } as Status
 
     expect(await getStatusDetailPathClient(status)).toBe(
-      `/@bob@remote.example/${await getHashFromStringClient(url)}`
+      `/@bob@remote.example/${encodeURIComponent(id)}`
     )
   })
 

--- a/lib/utils/getStatusDetailPathClient.ts
+++ b/lib/utils/getStatusDetailPathClient.ts
@@ -7,6 +7,10 @@ export const getStatusDetailPathClient = async (status: Status) => {
   const actualStatus = getActualStatus(status)
   if (!actualStatus.actor) return null
 
+  if (actualStatus.isLocalActor === false) {
+    return `/${getMention(actualStatus.actor, true)}/${encodeURIComponent(actualStatus.id)}`
+  }
+
   const urlHash = await getHashFromStringClient(actualStatus.url)
   return `/${getMention(actualStatus.actor, true)}/${urlHash}`
 }


### PR DESCRIPTION
## Summary

This PR fixes boosted status detail routes and timeline rendering where a boost row could be treated as if the booster were the original post owner.

The route lookup now lives in `resolveStatusFromPath`, keeps the scoped hash lookup first, and falls back to validated unscoped lookup only when the resolved status owner matches the actor in the path. Announce rows are unwrapped to their original status for owner checks and public detail links.

It also improves remote and opaque actor handling:
- fetches public remote statuses when a local row is missing
- normalizes ActivityPub actor/content helpers in shared utilities
- validates remote Note/Announce payloads before mapping to domain statuses
- avoids displaying UUID/DID actor IDs as usernames
- derives human handles from Mastodon-style and anchored Bluesky/Bridgy URLs
- avoids linking opaque actor fallbacks to raw ActivityPub JSON actor URLs
- keeps malformed remote data observable through logging instead of silent drops

## Root Cause

Boosted status links are generated from the actual/original status, but the persisted row for a boost belongs to the actor that boosted it. The old detail route scoped hash lookup to the actor parsed from the URL, so original-owner boost links could miss the stored booster row and return 404.

Timeline rendering had the same ownership confusion in remote outbox mapping: the original status actor could be overwritten with the booster actor, producing empty boost text and the wrong displayed owner.

## Production Investigation

The originally reported hash `c137613b93abd541592aa6ad69e94e7d315962c38a4cd324d63b87cf649f8ad6` was not found in the production statuses table by `urlHash`, status `id`, or `url`, so that exact URL still depends on the underlying production row/data existing.

Known production-data examples for `@cheeaun@mastodon.social`, Bridgy Bluesky, Hackers.pub, and Hollo-style remote IDs were used to verify the corrected route/link shapes locally without mutating production data.

## Notes

`getProfileData` now uses the shared `getActorImageUrl` helper. This does not change image-clearing behavior in the current SQL adapter: `database.updateActor` only writes icon/header settings when the value is truthy, so both the previous empty string and the new `undefined` leave any persisted value unchanged.

## Validation

- `yarn run prettier --write`
- `yarn test --runTestsByPath lib/utils/activitypubActor.test.ts lib/components/posts/post.test.tsx lib/activities/getActorPosts.test.ts`
- `git diff --check`
- `yarn lint` (0 errors; existing 12 warnings remain)
- `yarn build`
- Earlier branch validation also included the resolver/path tests and full `yarn test`