### PR TITLE
feat: fix actor profile boosts and pagination

### DIFF
--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -234,4 +234,38 @@ describe('ActorTimelines', () => {
     })
     expect(screen.getByRole('button', { name: 'Load more' })).toBeEnabled()
   })
+
+  it('stops loading when an empty outbox page repeats the same cursor', async () => {
+    const repeatedPageUrl =
+      'https://remote.example/users/actor/outbox?page=true&max_id=1'
+
+    getActorStatusesMock.mockResolvedValueOnce({
+      statuses: [],
+      statusesCount: 3,
+      nextPageUrl: repeatedPageUrl,
+      prevPageUrl: 'https://remote.example/users/actor/outbox?page=true'
+    })
+
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/newer')]}
+        attachments={[]}
+        statusPagination={{
+          nextPageUrl: repeatedPageUrl,
+          prevPageUrl: null
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getActorStatusesMock).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Load more' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -172,4 +172,39 @@ describe('ActorTimelines', () => {
       screen.getAllByText('https://remote.example/statuses/oldest')
     ).toHaveLength(2)
   })
+
+  it('shows load more when the initial actor page has no renderable statuses', async () => {
+    getActorStatusesMock.mockResolvedValue({
+      statuses: [createStatus('https://remote.example/statuses/first-post')],
+      statusesCount: 3,
+      nextPageUrl: null,
+      prevPageUrl: 'https://remote.example/users/actor/outbox?page=true'
+    })
+
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[]}
+        attachments={[]}
+        statusPagination={{
+          nextPageUrl:
+            'https://remote.example/users/actor/outbox?page=true&max_id=1',
+          prevPageUrl: null
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getActorStatusesMock).toHaveBeenCalledWith({
+        actorId: 'https://remote.example/users/actor',
+        pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
+      })
+    })
+    expect(
+      screen.getAllByText('https://remote.example/statuses/first-post')
+    ).toHaveLength(2)
+  })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { getActorStatuses } from '@/lib/client'
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+import { ActorTimelines } from './ActorTimelines'
+
+jest.mock('@/lib/client', () => ({
+  getActorStatuses: jest.fn()
+}))
+
+jest.mock('@/lib/components/posts/posts', () => ({
+  Posts: ({ statuses }: { statuses: Status[] }) => (
+    <div>
+      {statuses.map((status) => (
+        <div key={status.id}>{status.id}</div>
+      ))}
+    </div>
+  )
+}))
+
+jest.mock('./ActorMediaGallery', () => ({
+  ActorMediaGallery: () => null
+}))
+
+jest.mock('@/lib/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: ReactNode }) => (
+    <button>{children}</button>
+  )
+}))
+
+jest.mock('@/lib/components/ui/button', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick
+  }: {
+    children: ReactNode
+    disabled?: boolean
+    onClick?: () => void
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  )
+}))
+
+const createStatus = (id: string): Status => {
+  const now = new Date('2026-04-30T10:00:00.000Z').getTime()
+  return {
+    id,
+    actorId: 'https://remote.example/users/actor',
+    actor: null,
+    to: [],
+    cc: [],
+    edits: [],
+    isLocalActor: false,
+    createdAt: now,
+    updatedAt: now,
+    type: StatusType.enum.Note,
+    url: id,
+    text: id,
+    summary: null,
+    reply: '',
+    replies: [],
+    actorAnnounceStatusId: null,
+    isActorLiked: false,
+    totalLikes: 0,
+    attachments: [],
+    tags: []
+  }
+}
+
+describe('ActorTimelines', () => {
+  const getActorStatusesMock = getActorStatuses as jest.Mock
+
+  beforeEach(() => {
+    getActorStatusesMock.mockReset()
+  })
+
+  it('loads and appends older actor statuses from the next outbox page', async () => {
+    getActorStatusesMock.mockResolvedValue({
+      statuses: [createStatus('https://remote.example/statuses/older')],
+      statusesCount: 2,
+      nextPageUrl: null,
+      prevPageUrl: 'https://remote.example/users/actor/outbox?page=true'
+    })
+
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/newer')]}
+        attachments={[]}
+        statusPagination={{
+          nextPageUrl:
+            'https://remote.example/users/actor/outbox?page=true&max_id=1',
+          prevPageUrl: null
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getActorStatusesMock).toHaveBeenCalledWith({
+        actorId: 'https://remote.example/users/actor',
+        pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
+      })
+    })
+    expect(
+      screen.getAllByText('https://remote.example/statuses/older')
+    ).toHaveLength(2)
+    expect(
+      screen.queryByRole('button', { name: 'Load more' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('continues to the next cursor when an outbox page has no renderable statuses', async () => {
+    getActorStatusesMock
+      .mockResolvedValueOnce({
+        statuses: [],
+        statusesCount: 3,
+        nextPageUrl:
+          'https://remote.example/users/actor/outbox?page=true&max_id=2',
+        prevPageUrl: 'https://remote.example/users/actor/outbox?page=true'
+      })
+      .mockResolvedValueOnce({
+        statuses: [createStatus('https://remote.example/statuses/oldest')],
+        statusesCount: 3,
+        nextPageUrl: null,
+        prevPageUrl:
+          'https://remote.example/users/actor/outbox?page=true&max_id=1'
+      })
+
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/newer')]}
+        attachments={[]}
+        statusPagination={{
+          nextPageUrl:
+            'https://remote.example/users/actor/outbox?page=true&max_id=1',
+          prevPageUrl: null
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getActorStatusesMock).toHaveBeenCalledTimes(2)
+    })
+    expect(getActorStatusesMock).toHaveBeenNthCalledWith(1, {
+      actorId: 'https://remote.example/users/actor',
+      pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=1'
+    })
+    expect(getActorStatusesMock).toHaveBeenNthCalledWith(2, {
+      actorId: 'https://remote.example/users/actor',
+      pageUrl: 'https://remote.example/users/actor/outbox?page=true&max_id=2'
+    })
+    expect(
+      screen.getAllByText('https://remote.example/statuses/oldest')
+    ).toHaveLength(2)
+  })
+})

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -207,4 +207,31 @@ describe('ActorTimelines', () => {
       screen.getAllByText('https://remote.example/statuses/first-post')
     ).toHaveLength(2)
   })
+
+  it('shows a retryable error when loading older statuses fails', async () => {
+    getActorStatusesMock.mockRejectedValueOnce(new Error('Network error'))
+
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/newer')]}
+        attachments={[]}
+        statusPagination={{
+          nextPageUrl:
+            'https://remote.example/users/actor/outbox?page=true&max_id=1',
+          prevPageUrl: null
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Failed to load more posts. Please try again.'
+      )
+    })
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeEnabled()
+  })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -95,18 +95,27 @@ export const ActorTimelines: FC<Props> = ({
       let pageUrl: string | null = nextPageUrl
       let prevPageUrl: string | null = currentStatusPagination.prevPageUrl
       let nextStatuses: Status[] = []
+      const visitedPageUrls = new Set<string>()
 
       for (
         let loadedPages = 0;
         pageUrl && loadedPages < LOAD_MORE_PAGE_LIMIT;
         loadedPages += 1
       ) {
+        if (visitedPageUrls.has(pageUrl)) {
+          pageUrl = null
+          break
+        }
+        visitedPageUrls.add(pageUrl)
         const result = await getActorStatuses({
           actorId,
           pageUrl
         })
 
-        pageUrl = result.nextPageUrl
+        pageUrl =
+          result.nextPageUrl && !visitedPageUrls.has(result.nextPageUrl)
+            ? result.nextPageUrl
+            : null
         prevPageUrl = result.prevPageUrl
         if (result.statuses.length > 0) {
           nextStatuses = result.statuses

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { FC } from 'react'
+import { FC, useCallback, useEffect, useRef, useState } from 'react'
 
+import { getActorStatuses } from '@/lib/client'
 import { Posts } from '@/lib/components/posts/posts'
+import { Button } from '@/lib/components/ui/button'
 import {
   Tabs,
   TabsContent,
@@ -20,8 +22,14 @@ interface Props {
   actorId: string
   statuses: Status[]
   attachments: Attachment[]
+  statusPagination?: {
+    nextPageUrl: string | null
+    prevPageUrl: string | null
+  }
   postLineLimit?: PostLineLimit
 }
+
+const LOAD_MORE_PAGE_LIMIT = 5
 
 const isReply = (status: Status) => {
   switch (status.type) {
@@ -35,16 +43,112 @@ const isReply = (status: Status) => {
   }
 }
 
+const appendUniqueStatuses = (
+  previousStatuses: Status[],
+  nextStatuses: Status[]
+) => {
+  const statusIds = new Set(previousStatuses.map((status) => status.id))
+  return [
+    ...previousStatuses,
+    ...nextStatuses.filter((status) => {
+      if (statusIds.has(status.id)) return false
+      statusIds.add(status.id)
+      return true
+    })
+  ]
+}
+
 export const ActorTimelines: FC<Props> = ({
   host,
   actorId,
   statuses,
   attachments,
+  statusPagination,
   postLineLimit
 }) => {
   const currentTime = Date.now()
+  const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
+  const [currentStatusPagination, setCurrentStatusPagination] = useState({
+    nextPageUrl: statusPagination?.nextPageUrl ?? null,
+    prevPageUrl: statusPagination?.prevPageUrl ?? null
+  })
+  const [isLoadingMoreStatuses, setLoadingMoreStatuses] =
+    useState<boolean>(false)
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+  const isLoadingRef = useRef<boolean>(false)
 
-  const postStatuses = statuses.filter((status) => !isReply(status))
+  const postStatuses = currentStatuses.filter((status) => !isReply(status))
+
+  const loadMoreStatuses = useCallback(async () => {
+    const nextPageUrl = currentStatusPagination.nextPageUrl
+    if (isLoadingRef.current || !nextPageUrl) return
+
+    isLoadingRef.current = true
+    setLoadingMoreStatuses(true)
+    try {
+      let pageUrl: string | null = nextPageUrl
+      let prevPageUrl: string | null = currentStatusPagination.prevPageUrl
+      let nextStatuses: Status[] = []
+
+      for (
+        let loadedPages = 0;
+        pageUrl && loadedPages < LOAD_MORE_PAGE_LIMIT;
+        loadedPages += 1
+      ) {
+        const result = await getActorStatuses({
+          actorId,
+          pageUrl
+        })
+
+        pageUrl = result.nextPageUrl
+        prevPageUrl = result.prevPageUrl
+        if (result.statuses.length > 0) {
+          nextStatuses = result.statuses
+          break
+        }
+      }
+
+      setCurrentStatusPagination({
+        nextPageUrl: pageUrl,
+        prevPageUrl
+      })
+      if (nextStatuses.length > 0) {
+        setCurrentStatuses((previousStatuses) =>
+          appendUniqueStatuses(previousStatuses, nextStatuses)
+        )
+      }
+    } catch (_error) {
+      // Error loading more - user can retry by clicking the button
+    } finally {
+      isLoadingRef.current = false
+      setLoadingMoreStatuses(false)
+    }
+  }, [actorId, currentStatusPagination.nextPageUrl])
+
+  useEffect(() => {
+    const loadMoreElement = loadMoreRef.current
+    if (!loadMoreElement) return
+    if (typeof IntersectionObserver === 'undefined') return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries
+        if (entry.isIntersecting) {
+          loadMoreStatuses()
+        }
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.1
+      }
+    )
+
+    observer.observe(loadMoreElement)
+    return () => {
+      observer.disconnect()
+    }
+  }, [loadMoreStatuses])
 
   return (
     <Tabs defaultValue="posts" className="w-full">
@@ -88,7 +192,7 @@ export const ActorTimelines: FC<Props> = ({
           host={host}
           className="mt-0"
           currentTime={currentTime}
-          statuses={statuses}
+          statuses={currentStatuses}
           postLineLimit={postLineLimit}
         />
       </TabsContent>
@@ -107,6 +211,17 @@ export const ActorTimelines: FC<Props> = ({
           </p>
         )}
       </TabsContent>
+      {currentStatusPagination.nextPageUrl && currentStatuses.length > 0 && (
+        <div ref={loadMoreRef} className="border-t p-4 text-center">
+          <Button
+            variant="outline"
+            disabled={isLoadingMoreStatuses}
+            onClick={loadMoreStatuses}
+          >
+            {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
+          </Button>
+        </div>
+      )}
     </Tabs>
   )
 }

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -30,6 +30,7 @@ interface Props {
 }
 
 const LOAD_MORE_PAGE_LIMIT = 5
+const LOAD_MORE_ERROR_MESSAGE = 'Failed to load more posts. Please try again.'
 
 const isReply = (status: Status) => {
   switch (status.type) {
@@ -74,6 +75,7 @@ export const ActorTimelines: FC<Props> = ({
   })
   const [isLoadingMoreStatuses, setLoadingMoreStatuses] =
     useState<boolean>(false)
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
   const loadMoreRef = useRef<HTMLDivElement>(null)
   const isLoadingRef = useRef<boolean>(false)
 
@@ -88,6 +90,7 @@ export const ActorTimelines: FC<Props> = ({
 
     isLoadingRef.current = true
     setLoadingMoreStatuses(true)
+    setLoadMoreError(null)
     try {
       let pageUrl: string | null = nextPageUrl
       let prevPageUrl: string | null = currentStatusPagination.prevPageUrl
@@ -121,12 +124,16 @@ export const ActorTimelines: FC<Props> = ({
         )
       }
     } catch (_error) {
-      // Error loading more - user can retry by clicking the button
+      setLoadMoreError(LOAD_MORE_ERROR_MESSAGE)
     } finally {
       isLoadingRef.current = false
       setLoadingMoreStatuses(false)
     }
-  }, [actorId, currentStatusPagination.nextPageUrl])
+  }, [
+    actorId,
+    currentStatusPagination.nextPageUrl,
+    currentStatusPagination.prevPageUrl
+  ])
 
   useEffect(() => {
     const loadMoreElement = loadMoreRef.current
@@ -216,6 +223,11 @@ export const ActorTimelines: FC<Props> = ({
       </TabsContent>
       {currentStatusPagination.nextPageUrl && (
         <div ref={loadMoreRef} className="border-t p-4 text-center">
+          {loadMoreError && (
+            <p className="mb-3 text-sm text-destructive" role="alert">
+              {loadMoreError}
+            </p>
+          )}
           <Button
             variant="outline"
             disabled={isLoadingMoreStatuses}

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, useCallback, useEffect, useRef, useState } from 'react'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { getActorStatuses } from '@/lib/client'
 import { Posts } from '@/lib/components/posts/posts'
@@ -77,7 +77,10 @@ export const ActorTimelines: FC<Props> = ({
   const loadMoreRef = useRef<HTMLDivElement>(null)
   const isLoadingRef = useRef<boolean>(false)
 
-  const postStatuses = currentStatuses.filter((status) => !isReply(status))
+  const postStatuses = useMemo(
+    () => currentStatuses.filter((status) => !isReply(status)),
+    [currentStatuses]
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     const nextPageUrl = currentStatusPagination.nextPageUrl
@@ -211,7 +214,7 @@ export const ActorTimelines: FC<Props> = ({
           </p>
         )}
       </TabsContent>
-      {currentStatusPagination.nextPageUrl && currentStatuses.length > 0 && (
+      {currentStatusPagination.nextPageUrl && (
         <div ref={loadMoreRef} className="border-t p-4 text-center">
           <Button
             variant="outline"

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -202,6 +202,25 @@ describe('getProfileData', () => {
       })
     })
 
+    it('passes the requested remote status page cursor to the outbox loader', async () => {
+      await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true,
+        undefined,
+        {
+          statusPageUrl:
+            'https://remote.com/users/remoteuser/outbox?page=true&max_id=1'
+        }
+      )
+
+      expect(getActorPosts).toHaveBeenCalledWith({
+        database: mockDatabase,
+        person: mockPerson,
+        pageUrl: 'https://remote.com/users/remoteuser/outbox?page=true&max_id=1'
+      })
+    })
+
     it('should return hasFitnessData as false for remote actors', async () => {
       const result = await getProfileData(
         mockDatabase,

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -15,6 +15,10 @@ type ProfileData = {
   person: Actor
   statuses: Status[]
   statusesCount: number
+  statusPagination: {
+    nextPageUrl: string | null
+    prevPageUrl: string | null
+  }
   attachments: Attachment[]
   followingCount: number
   followersCount: number
@@ -22,11 +26,16 @@ type ProfileData = {
   hasFitnessData: boolean
 }
 
+type ProfileDataOptions = {
+  statusPageUrl?: string
+}
+
 export const getProfileData = async (
   database: Database,
   actorHandle: string,
   isLoggedIn: boolean = true,
-  signingActor?: DomainActor
+  signingActor?: DomainActor,
+  options: ProfileDataOptions = {}
 ): Promise<ProfileData | null> => {
   const [username, domain] = actorHandle.split('@').slice(1)
   const persistedActor = await database.getActorFromUsername({
@@ -54,6 +63,10 @@ export const getProfileData = async (
       person: getPersonFromActor(persistedActor),
       statuses,
       statusesCount,
+      statusPagination: {
+        nextPageUrl: null,
+        prevPageUrl: null
+      },
       attachments,
       followingCount,
       followersCount,
@@ -94,7 +107,12 @@ export const getProfileData = async (
     actorFollowingResponse,
     actorFollowersResponse
   ] = await Promise.all([
-    getActorPosts({ database, person, ...signingParams }),
+    getActorPosts({
+      database,
+      person,
+      pageUrl: options.statusPageUrl,
+      ...signingParams
+    }),
     database.getAttachmentsForActor({ actorId: person.id }),
     getActorFollowing({ person, ...signingParams }),
     getActorFollowers({ person, ...signingParams })
@@ -103,6 +121,10 @@ export const getProfileData = async (
   return {
     ...actorPostsResponse,
     person,
+    statusPagination: {
+      nextPageUrl: actorPostsResponse.nextPageUrl ?? null,
+      prevPageUrl: actorPostsResponse.prevPageUrl ?? null
+    },
     attachments,
     followingCount: actorFollowingResponse.followingCount,
     followersCount: actorFollowersResponse.followerCount,

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -18,18 +18,17 @@ import { getProfileData } from './getProfileData'
 
 interface Props {
   params: Promise<{ actor: string }>
-  searchParams: Promise<{
-    status_page?: string | string[]
-  }>
 }
 
-const getSearchParam = (value?: string | string[]) =>
-  Array.isArray(value) ? value[0] : value
-
-const getStatusPageHref = (profilePath: string, pageUrl: string | null) =>
-  pageUrl
-    ? `${profilePath}?status_page=${encodeURIComponent(pageUrl)}`
-    : profilePath
+const getInitials = (name: string, fallback: string) =>
+  (name || fallback)
+    .trim()
+    .split(/\s+/)
+    .map((part) => Array.from(part)[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
 
 export const generateMetadata = async ({
   params
@@ -40,7 +39,7 @@ export const generateMetadata = async ({
   }
 }
 
-const Page: FC<Props> = async ({ params, searchParams }) => {
+const Page: FC<Props> = async ({ params }) => {
   const { host } = getConfig()
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
@@ -61,16 +60,11 @@ const Page: FC<Props> = async ({ params, searchParams }) => {
     ? await database.getActorSettings({ actorId: currentActor.id })
     : undefined
 
-  const statusPageUrl = getSearchParam((await searchParams).status_page)
-
   const actorProfile = await getProfileData(
     database,
     decodedActorHandle,
     isLoggedIn,
-    currentActor ?? undefined,
-    {
-      statusPageUrl
-    }
+    currentActor ?? undefined
   )
   if (!actorProfile) {
     return notFound()
@@ -88,11 +82,7 @@ const Page: FC<Props> = async ({ params, searchParams }) => {
 
   const isCurrentUser = currentActor?.id === person.id
 
-  const initials = (person.name || '')
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
+  const initials = getInitials(person.name || '', person.preferredUsername)
 
   const getHeaderImage = () => {
     if (!person.image) return null
@@ -120,9 +110,6 @@ const Page: FC<Props> = async ({ params, searchParams }) => {
   const headerImageUrl = headerImage?.url ?? null
   const headerImageMediaType = headerImage?.mediaType ?? null
   const iconImageUrl = getIconImage()
-  const profilePath = `/@${person.preferredUsername}@${actorDomain}`
-  const showStatusPagination =
-    Boolean(statusPageUrl) || Boolean(statusPagination.nextPageUrl)
 
   return (
     <div className="space-y-6">
@@ -186,38 +173,9 @@ const Page: FC<Props> = async ({ params, searchParams }) => {
           actorId={person.id}
           statuses={statuses}
           attachments={attachments}
+          statusPagination={statusPagination}
           postLineLimit={actorSettings?.postLineLimit}
         />
-        {showStatusPagination && (
-          <div className="flex items-center justify-between gap-3 border-t p-4">
-            <div>
-              {statusPageUrl && (
-                <Button variant="outline" asChild>
-                  <Link
-                    href={getStatusPageHref(
-                      profilePath,
-                      statusPagination.prevPageUrl
-                    )}
-                  >
-                    Newer posts
-                  </Link>
-                </Button>
-              )}
-            </div>
-            {statusPagination.nextPageUrl && (
-              <Button variant="outline" asChild>
-                <Link
-                  href={getStatusPageHref(
-                    profilePath,
-                    statusPagination.nextPageUrl
-                  )}
-                >
-                  Older posts
-                </Link>
-              </Button>
-            )}
-          </div>
-        )}
       </section>
     </div>
   )

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -18,7 +18,18 @@ import { getProfileData } from './getProfileData'
 
 interface Props {
   params: Promise<{ actor: string }>
+  searchParams: Promise<{
+    status_page?: string | string[]
+  }>
 }
+
+const getSearchParam = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value
+
+const getStatusPageHref = (profilePath: string, pageUrl: string | null) =>
+  pageUrl
+    ? `${profilePath}?status_page=${encodeURIComponent(pageUrl)}`
+    : profilePath
 
 export const generateMetadata = async ({
   params
@@ -29,7 +40,7 @@ export const generateMetadata = async ({
   }
 }
 
-const Page: FC<Props> = async ({ params }) => {
+const Page: FC<Props> = async ({ params, searchParams }) => {
   const { host } = getConfig()
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
@@ -50,11 +61,16 @@ const Page: FC<Props> = async ({ params }) => {
     ? await database.getActorSettings({ actorId: currentActor.id })
     : undefined
 
+  const statusPageUrl = getSearchParam((await searchParams).status_page)
+
   const actorProfile = await getProfileData(
     database,
     decodedActorHandle,
     isLoggedIn,
-    currentActor ?? undefined
+    currentActor ?? undefined,
+    {
+      statusPageUrl
+    }
   )
   if (!actorProfile) {
     return notFound()
@@ -65,6 +81,7 @@ const Page: FC<Props> = async ({ params }) => {
     statuses,
     attachments,
     statusesCount,
+    statusPagination,
     followingCount,
     followersCount
   } = actorProfile
@@ -103,6 +120,9 @@ const Page: FC<Props> = async ({ params }) => {
   const headerImageUrl = headerImage?.url ?? null
   const headerImageMediaType = headerImage?.mediaType ?? null
   const iconImageUrl = getIconImage()
+  const profilePath = `/@${person.preferredUsername}@${actorDomain}`
+  const showStatusPagination =
+    Boolean(statusPageUrl) || Boolean(statusPagination.nextPageUrl)
 
   return (
     <div className="space-y-6">
@@ -168,6 +188,36 @@ const Page: FC<Props> = async ({ params }) => {
           attachments={attachments}
           postLineLimit={actorSettings?.postLineLimit}
         />
+        {showStatusPagination && (
+          <div className="flex items-center justify-between gap-3 border-t p-4">
+            <div>
+              {statusPageUrl && (
+                <Button variant="outline" asChild>
+                  <Link
+                    href={getStatusPageHref(
+                      profilePath,
+                      statusPagination.prevPageUrl
+                    )}
+                  >
+                    Newer posts
+                  </Link>
+                </Button>
+              )}
+            </div>
+            {statusPagination.nextPageUrl && (
+              <Button variant="outline" asChild>
+                <Link
+                  href={getStatusPageHref(
+                    profilePath,
+                    statusPagination.nextPageUrl
+                  )}
+                >
+                  Older posts
+                </Link>
+              </Button>
+            )}
+          </div>
+        )}
       </section>
     </div>
   )

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -169,6 +169,7 @@ const Page: FC<Props> = async ({ params }) => {
 
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         <ActorTimelines
+          key={person.id}
           host={host}
           actorId={person.id}
           statuses={statuses}

--- a/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from 'next/server'
+
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { StatusType } from '@/lib/types/domain/status'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockDatabase = {}
+const mockCurrentActor = {
+  id: 'https://local.example/users/me'
+}
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (_scopes: unknown, handle: CallableFunction) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        database: mockDatabase,
+        params: context.params
+      })
+}))
+
+jest.mock('@/lib/activities/getActorPerson')
+jest.mock('@/lib/activities/getActorPosts')
+
+const actorId = 'https://remote.example/users/actor'
+const pageUrl = 'https://remote.example/users/actor/outbox?page=true&max_id=1'
+
+const createRequest = (query = '') =>
+  new NextRequest(
+    `https://local.example/api/v1/accounts/${urlToId(actorId)}/remote-statuses${query}`
+  )
+
+describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getActorPerson as jest.Mock).mockResolvedValue({
+      id: actorId,
+      type: 'Person',
+      preferredUsername: 'actor',
+      outbox: `${actorId}/outbox`
+    })
+    ;(getActorPosts as jest.Mock).mockResolvedValue({
+      statuses: [
+        {
+          id: `${actorId}/statuses/older`,
+          actorId,
+          actor: null,
+          to: [],
+          cc: [],
+          edits: [],
+          isLocalActor: false,
+          createdAt: 1,
+          updatedAt: 1,
+          type: StatusType.enum.Note,
+          url: `${actorId}/statuses/older`,
+          text: 'Older status',
+          summary: null,
+          reply: '',
+          replies: [],
+          actorAnnounceStatusId: null,
+          isActorLiked: false,
+          totalLikes: 0,
+          attachments: [],
+          tags: []
+        }
+      ],
+      statusesCount: 30,
+      nextPageUrl: null,
+      prevPageUrl: `${actorId}/outbox?page=true`
+    })
+  })
+
+  it('returns remote actor statuses for a requested outbox page', async () => {
+    const response = await GET(
+      createRequest(`?page_url=${encodeURIComponent(pageUrl)}`),
+      {
+        params: Promise.resolve({ id: urlToId(actorId) })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      statuses: [{ id: `${actorId}/statuses/older` }],
+      statusesCount: 30,
+      nextPageUrl: null,
+      prevPageUrl: `${actorId}/outbox?page=true`
+    })
+    expect(getActorPerson).toHaveBeenCalledWith({
+      actorId,
+      signingActor: mockCurrentActor
+    })
+    expect(getActorPosts).toHaveBeenCalledWith({
+      database: mockDatabase,
+      person: expect.objectContaining({ id: actorId }),
+      signingActor: mockCurrentActor,
+      pageUrl
+    })
+  })
+
+  it('returns bad request for invalid page urls', async () => {
+    const response = await GET(createRequest('?page_url=not-a-url'), {
+      params: Promise.resolve({ id: urlToId(actorId) })
+    })
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
@@ -108,4 +108,20 @@ describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
 
     expect(response.status).toBe(400)
   })
+
+  it('returns bad request for page urls outside the actor outbox', async () => {
+    const response = await GET(
+      createRequest(
+        `?page_url=${encodeURIComponent(
+          'https://attacker.example/users/actor/outbox?page=true'
+        )}`
+      ),
+      {
+        params: Promise.resolve({ id: urlToId(actorId) })
+      }
+    )
+
+    expect(response.status).toBe(400)
+    expect(getActorPosts).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/accounts/[id]/remote-statuses/route.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod'
+
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { cleanJson } from '@/lib/utils/cleanJson'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import {
+  ERROR_400,
+  ERROR_404,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+const StatusQueryParams = z.object({
+  page_url: z.string().url().optional()
+})
+
+export const GET = traceApiRoute(
+  'getRemoteAccountStatuses',
+  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
+    const { database, currentActor, params } = context
+    const encodedAccountId = (await params).id
+    if (!encodedAccountId) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const url = new URL(req.url)
+    const parsed = StatusQueryParams.safeParse(
+      Object.fromEntries(url.searchParams.entries())
+    )
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const actorId = idToUrl(encodedAccountId)
+    const person = await getActorPerson({
+      actorId,
+      signingActor: currentActor
+    })
+    if (!person) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+    }
+
+    const result = await getActorPosts({
+      database,
+      person,
+      signingActor: currentActor,
+      pageUrl: parsed.data.page_url
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: {
+        statuses: result.statuses.map((status) => cleanJson(status)),
+        statusesCount: result.statusesCount,
+        nextPageUrl: result.nextPageUrl,
+        prevPageUrl: result.prevPageUrl
+      }
+    })
+  }),
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { accountId: params?.id || 'unknown' }
+    }
+  }
+)

--- a/app/api/v1/accounts/[id]/remote-statuses/route.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { isCollectionPageUrl } from '@/lib/activities/getActorCollections'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
@@ -65,6 +66,19 @@ export const GET = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: ERROR_404,
         responseStatusCode: 404
+      })
+    }
+
+    if (
+      parsed.data.page_url &&
+      (!person.outbox ||
+        !isCollectionPageUrl(parsed.data.page_url, person.outbox))
+    ) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
       })
     }
 

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -21,12 +21,14 @@ const isCollectionPageUrl = (pageUrl: string, collectionUrl: string) => {
   try {
     const page = new URL(pageUrl)
     const collection = new URL(collectionUrl)
+    const pagePath = page.pathname.replace(/\/$/, '') || '/'
+    const collectionPath = collection.pathname.replace(/\/$/, '') || '/'
+    const collectionPrefix = collectionPath === '/' ? '/' : `${collectionPath}/`
 
     return (
       page.protocol === collection.protocol &&
       page.host === collection.host &&
-      page.pathname.replace(/\/$/, '') ===
-        collection.pathname.replace(/\/$/, '')
+      (pagePath === collectionPath || pagePath.startsWith(collectionPrefix))
     )
   } catch {
     return false

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -17,7 +17,7 @@ interface Params {
   pageUrl?: string
 }
 
-const isCollectionPageUrl = (pageUrl: string, collectionUrl: string) => {
+export const isCollectionPageUrl = (pageUrl: string, collectionUrl: string) => {
   try {
     const page = new URL(pageUrl)
     const collection = new URL(collectionUrl)

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -14,12 +14,30 @@ interface Params {
   person: Actor
   field: 'following' | 'followers' | 'outbox'
   signingActor?: DomainActor
+  pageUrl?: string
+}
+
+const isCollectionPageUrl = (pageUrl: string, collectionUrl: string) => {
+  try {
+    const page = new URL(pageUrl)
+    const collection = new URL(collectionUrl)
+
+    return (
+      page.protocol === collection.protocol &&
+      page.host === collection.host &&
+      page.pathname.replace(/\/$/, '') ===
+        collection.pathname.replace(/\/$/, '')
+    )
+  } catch {
+    return false
+  }
 }
 
 export const getActorCollections = async ({
   person,
   field,
-  signingActor
+  signingActor,
+  pageUrl
 }: Params) => {
   return getTracer().startActiveSpan(
     `activities.${field}`,
@@ -53,12 +71,16 @@ export const getActorCollections = async ({
       }
 
       const collection = JSON.parse(fieldResponse.body) as OrderedCollection
-      const pageUrl = getOrderCollectionFirstPage(collection)
+      const firstPageUrl = getOrderCollectionFirstPage(collection)
+      const collectionPageUrl =
+        pageUrl && isCollectionPageUrl(pageUrl, person[field])
+          ? pageUrl
+          : firstPageUrl
 
       // Return totalItems even if page URL is not available
       // This is common for remote actors where Mastodon only provides totalItems
       // without exposing the actual list of followers/following
-      if (!pageUrl) {
+      if (!collectionPageUrl) {
         span.end()
         return {
           page: null,
@@ -68,15 +90,15 @@ export const getActorCollections = async ({
 
       try {
         const response = await request({
-          url: pageUrl,
+          url: collectionPageUrl,
           headers: activityPubRequestHeaders({
-            url: pageUrl,
+            url: collectionPageUrl,
             signingActor
           })
         })
         if (response.statusCode !== 200) {
           span.setAttributes({
-            url: pageUrl,
+            url: collectionPageUrl,
             status: response.statusCode
           })
           span.recordException(

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -261,7 +261,7 @@ describe('#getActorPosts', () => {
   it('fetches a requested remote outbox page and returns pagination cursors', async () => {
     const actorId = 'https://paged.example/users/actor'
     const olderStatusId = `${actorId}/statuses/older`
-    const nextPageUrl = `${actorId}/outbox?page=true&max_id=older`
+    const nextPageUrl = `${actorId}/outbox/page/older`
     const prevPageUrl = `${actorId}/outbox?page=true&min_id=first`
     const published = Date.now()
     const person = MockActivityPubPerson({

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -258,6 +258,118 @@ describe('#getActorPosts', () => {
     )
   })
 
+  it('does not mutate cached original statuses when resolving boost actor profiles', async () => {
+    const boosterActorId = 'https://boost-no-mutate.example/users/booster'
+    const originalActorId = 'https://origin-no-mutate.example/users/original'
+    const originalStatusId = `${originalActorId}/statuses/original`
+    const announceStatusId = `${boosterActorId}/statuses/announce/activity`
+    const published = Date.now()
+
+    await database.createActor({
+      actorId: boosterActorId,
+      username: 'booster',
+      domain: 'boost-no-mutate.example',
+      followersUrl: `${boosterActorId}/followers`,
+      inboxUrl: `${boosterActorId}/inbox`,
+      sharedInboxUrl: 'https://boost-no-mutate.example/inbox',
+      publicKey: 'public key',
+      createdAt: published
+    })
+    await database.createActor({
+      actorId: originalActorId,
+      username: 'original',
+      domain: 'origin-no-mutate.example',
+      followersUrl: `${originalActorId}/followers`,
+      inboxUrl: `${originalActorId}/inbox`,
+      sharedInboxUrl: 'https://origin-no-mutate.example/inbox',
+      publicKey: 'public key',
+      createdAt: published
+    })
+    await database.createNote({
+      id: originalStatusId,
+      url: originalStatusId,
+      actorId: originalActorId,
+      text: 'Cached original status',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [`${originalActorId}/followers`],
+      reply: '',
+      createdAt: published - 1
+    })
+
+    const cachedOriginalStatus = await database.getStatus({
+      statusId: originalStatusId
+    })
+    if (!cachedOriginalStatus) {
+      throw new Error('Failed to load cached original status')
+    }
+    cachedOriginalStatus.actor = null
+
+    const getStatusSpy = jest
+      .spyOn(database, 'getStatus')
+      .mockResolvedValue(cachedOriginalStatus)
+
+    const person = MockActivityPubPerson({
+      id: boosterActorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${boosterActorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: `${boosterActorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === `${boosterActorId}/outbox?page=true`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox?page=true`,
+            type: 'OrderedCollectionPage',
+            partOf: `${boosterActorId}/outbox`,
+            orderedItems: [
+              {
+                id: announceStatusId,
+                type: AnnounceAction,
+                actor: boosterActorId,
+                published: new Date(published).toISOString(),
+                to: [ACTIVITY_STREAM_PUBLIC],
+                cc: [`${boosterActorId}/followers`],
+                object: originalStatusId
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    try {
+      const response = await getActorPosts({ database, person })
+      const announceStatus = response.statuses[0]
+
+      expect(announceStatus.type).toBe(StatusType.enum.Announce)
+      if (announceStatus.type !== StatusType.enum.Announce) {
+        throw new Error('Expected Announce status')
+      }
+
+      expect(announceStatus.originalStatus.actor).toMatchObject({
+        id: originalActorId
+      })
+      expect(cachedOriginalStatus.actor).toBeNull()
+    } finally {
+      getStatusSpy.mockRestore()
+    }
+  })
+
   it('fetches a requested remote outbox page and returns pagination cursors', async () => {
     const actorId = 'https://paged.example/users/actor'
     const olderStatusId = `${actorId}/statuses/older`

--- a/lib/activities/getActorPosts.test.ts
+++ b/lib/activities/getActorPosts.test.ts
@@ -168,6 +168,163 @@ describe('#getActorPosts', () => {
     expect(announceStatus.originalStatus.text).toBe('Original status text')
   })
 
+  it('keeps Announce statuses when the boosted original status is already cached', async () => {
+    const boosterActorId = 'https://boost-cached.example/users/booster'
+    const originalActorId = 'https://origin-cached.example/users/original'
+    const originalStatusId = `${originalActorId}/statuses/original-reply`
+    const announceStatusId = `${boosterActorId}/statuses/announce-cached/activity`
+    const published = Date.now()
+
+    const boosterActor = await database.createActor({
+      actorId: boosterActorId,
+      username: 'booster',
+      domain: 'boost-cached.example',
+      followersUrl: `${boosterActorId}/followers`,
+      inboxUrl: `${boosterActorId}/inbox`,
+      sharedInboxUrl: 'https://boost-cached.example/inbox',
+      publicKey: 'public key',
+      createdAt: published
+    })
+    if (!boosterActor) throw new Error('Failed to create booster actor')
+
+    await database.createNote({
+      id: originalStatusId,
+      url: originalStatusId,
+      actorId: originalActorId,
+      text: 'Cached original reply',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [`${originalActorId}/followers`],
+      reply: `${originalActorId}/statuses/root`,
+      createdAt: published - 1
+    })
+
+    const person = MockActivityPubPerson({
+      id: boosterActorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${boosterActorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 1,
+            first: `${boosterActorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === `${boosterActorId}/outbox?page=true`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${boosterActorId}/outbox?page=true`,
+            type: 'OrderedCollectionPage',
+            partOf: `${boosterActorId}/outbox`,
+            orderedItems: [
+              {
+                id: announceStatusId,
+                type: AnnounceAction,
+                actor: boosterActorId,
+                published: new Date(published).toISOString(),
+                to: [ACTIVITY_STREAM_PUBLIC],
+                cc: [`${boosterActorId}/followers`],
+                object: originalStatusId
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({ database, person })
+    const announceStatus = response.statuses[0]
+
+    expect(announceStatus.type).toBe(StatusType.enum.Announce)
+    if (announceStatus.type !== StatusType.enum.Announce) {
+      throw new Error('Expected Announce status')
+    }
+
+    expect(announceStatus.id).toBe(announceStatusId)
+    expect(announceStatus.actorId).toBe(boosterActorId)
+    expect(announceStatus.originalStatus.id).toBe(originalStatusId)
+    expect(announceStatus.originalStatus.reply).toBe(
+      `${originalActorId}/statuses/root`
+    )
+  })
+
+  it('fetches a requested remote outbox page and returns pagination cursors', async () => {
+    const actorId = 'https://paged.example/users/actor'
+    const olderStatusId = `${actorId}/statuses/older`
+    const nextPageUrl = `${actorId}/outbox?page=true&max_id=older`
+    const prevPageUrl = `${actorId}/outbox?page=true&min_id=first`
+    const published = Date.now()
+    const person = MockActivityPubPerson({
+      id: actorId,
+      withContext: true
+    }) as Actor
+
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === `${actorId}/outbox`) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: `${actorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 30,
+            first: `${actorId}/outbox?page=true`
+          })
+        }
+      }
+
+      if (req.url === nextPageUrl) {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            id: nextPageUrl,
+            type: 'OrderedCollectionPage',
+            partOf: `${actorId}/outbox`,
+            prev: prevPageUrl,
+            orderedItems: [
+              {
+                id: `${olderStatusId}/activity`,
+                type: 'Create',
+                actor: actorId,
+                published: new Date(published).toISOString(),
+                object: MockMastodonActivityPubNote({
+                  id: olderStatusId,
+                  from: actorId,
+                  content: 'Older page status',
+                  withContext: true
+                })
+              }
+            ]
+          })
+        }
+      }
+
+      return { status: 404, body: 'Not Found' }
+    })
+
+    const response = await getActorPosts({
+      database,
+      person,
+      pageUrl: nextPageUrl
+    })
+
+    expect(response.statusesCount).toBe(30)
+    expect(response.nextPageUrl).toBeNull()
+    expect(response.prevPageUrl).toBe(prevPageUrl)
+    expect(response.statuses).toHaveLength(1)
+    expect(response.statuses[0].id).toBe(olderStatusId)
+  })
+
   it('loads boosted original actor profiles for opaque actor ids', async () => {
     const boosterActorId = 'https://boost-bsky.example/users/booster'
     const originalActorId =

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -154,10 +154,14 @@ export const getActorPosts: GetActorPostsFunction = async ({
                 if (!originalStatus) return null
               }
 
-              originalStatus.actor = await getActorProfile(
-                originalStatus.actorId
+              const originalStatusWithActor = {
+                ...originalStatus,
+                actor: await getActorProfile(originalStatus.actorId)
+              }
+              const announceStatus = fromAnnounce(
+                announce,
+                originalStatusWithActor
               )
-              const announceStatus = fromAnnounce(announce, originalStatus)
               if (actor) announceStatus.actor = actor
               return announceStatus
             }

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -64,119 +64,130 @@ export const getActorPosts: GetActorPostsFunction = async ({
       attributes: { actorId: person.id }
     },
     async (span) => {
-      const actor = await database.getActorFromId({ id: person.id })
-      const actorProfileCache = new Map<string, Promise<ActorProfile | null>>()
-      const getActorProfile = (actorId: string) => {
-        let actorProfile = actorProfileCache.get(actorId)
-        if (!actorProfile) {
-          actorProfile = (async () => {
-            const persistedActor = await database.getActorFromId({
-              id: actorId
-            })
-            if (
-              persistedActor &&
-              !isOpaqueActorUsername(actorId, persistedActor.username)
-            ) {
-              return ActorProfile.parse(persistedActor)
-            }
+      try {
+        const actor = await database.getActorFromId({ id: person.id })
+        const actorProfileCache = new Map<
+          string,
+          Promise<ActorProfile | null>
+        >()
+        const getActorProfile = (actorId: string) => {
+          let actorProfile = actorProfileCache.get(actorId)
+          if (!actorProfile) {
+            actorProfile = (async () => {
+              const persistedActor = await database.getActorFromId({
+                id: actorId
+              })
+              if (
+                persistedActor &&
+                !isOpaqueActorUsername(actorId, persistedActor.username)
+              ) {
+                return ActorProfile.parse(persistedActor)
+              }
 
-            const actorPerson = await getActorPerson({
-              actorId,
-              signingActor
-            })
-            if (!actorPerson) {
-              return persistedActor ? ActorProfile.parse(persistedActor) : null
-            }
-
-            return getActorProfileFromPerson(actorPerson)
-          })()
-          actorProfileCache.set(actorId, actorProfile)
-        }
-
-        return actorProfile
-      }
-      const value = await getActorCollections({
-        person,
-        field: 'outbox',
-        signingActor,
-        pageUrl
-      })
-      if (!value) {
-        span.end()
-        return {
-          statusesCount: 0,
-          statuses: [],
-          nextPageUrl: null,
-          prevPageUrl: null
-        }
-      }
-
-      const items = value.page?.orderedItems ?? []
-      const statuses = await Promise.all(
-        items.map(async (item) => {
-          // This should be impossible for status api
-          if (typeof item === 'string') return null
-          if (item.type === AnnounceAction) {
-            const announceResult = Announce.safeParse(
-              normalizeActivityPubAnnounce(item)
-            )
-            if (!announceResult.success) return null
-
-            const announce = announceResult.data
-            const localStatus = await database.getStatus({
-              statusId: announce.object
-            })
-
-            let originalStatus =
-              localStatus?.type !== StatusType.enum.Announce
-                ? localStatus
-                : null
-
-            if (!originalStatus) {
-              const note = await getNote({
-                statusId: announce.object,
+              const actorPerson = await getActorPerson({
+                actorId,
                 signingActor
               })
-              if (!note) return null
+              if (!actorPerson) {
+                return persistedActor
+                  ? ActorProfile.parse(persistedActor)
+                  : null
+              }
 
-              const noteResult = Note.safeParse(
-                normalizeActivityPubContent(note)
-              )
-              if (!noteResult.success) return null
-
-              originalStatus = getStatusFromNote(noteResult.data)
-              if (!originalStatus) return null
-            }
-
-            originalStatus.actor = await getActorProfile(originalStatus.actorId)
-            const announceStatus = fromAnnounce(announce, originalStatus)
-            if (actor) announceStatus.actor = actor
-            return announceStatus
+              return getActorProfileFromPerson(actorPerson)
+            })()
+            actorProfileCache.set(actorId, actorProfile)
           }
 
-          // Unsupported activity
-          if (item.type !== CreateAction) return null
-          // Unsupported Object
-          if (!item.object || typeof item.object === 'string') return null
-          const obj = item.object as { type?: string; [key: string]: unknown }
-          if (obj.type !== 'Note') return null
+          return actorProfile
+        }
 
-          const noteResult = Note.safeParse(normalizeActivityPubContent(obj))
-          if (!noteResult.success) return null
-
-          const status = getStatusFromNote(noteResult.data)
-          if (!status) return null
-
-          if (actor) status.actor = actor
-          return status
+        const value = await getActorCollections({
+          person,
+          field: 'outbox',
+          signingActor,
+          pageUrl
         })
-      )
+        if (!value) {
+          return {
+            statusesCount: 0,
+            statuses: [],
+            nextPageUrl: null,
+            prevPageUrl: null
+          }
+        }
 
-      return {
-        statusesCount: value.totalItems ?? 0,
-        statuses: statuses.filter((item) => item !== null),
-        nextPageUrl: value.page?.next ?? null,
-        prevPageUrl: value.page?.prev ?? null
+        const items = value.page?.orderedItems ?? []
+        const statuses = await Promise.all(
+          items.map(async (item) => {
+            // This should be impossible for status api
+            if (typeof item === 'string') return null
+            if (item.type === AnnounceAction) {
+              const announceResult = Announce.safeParse(
+                normalizeActivityPubAnnounce(item)
+              )
+              if (!announceResult.success) return null
+
+              const announce = announceResult.data
+              const localStatus = await database.getStatus({
+                statusId: announce.object
+              })
+
+              let originalStatus =
+                localStatus?.type !== StatusType.enum.Announce
+                  ? localStatus
+                  : null
+
+              if (!originalStatus) {
+                const note = await getNote({
+                  statusId: announce.object,
+                  signingActor
+                })
+                if (!note) return null
+
+                const noteResult = Note.safeParse(
+                  normalizeActivityPubContent(note)
+                )
+                if (!noteResult.success) return null
+
+                originalStatus = getStatusFromNote(noteResult.data)
+                if (!originalStatus) return null
+              }
+
+              originalStatus.actor = await getActorProfile(
+                originalStatus.actorId
+              )
+              const announceStatus = fromAnnounce(announce, originalStatus)
+              if (actor) announceStatus.actor = actor
+              return announceStatus
+            }
+
+            // Unsupported activity
+            if (item.type !== CreateAction) return null
+            // Unsupported Object
+            if (!item.object || typeof item.object === 'string') return null
+            const obj = item.object as { type?: string; [key: string]: unknown }
+            if (obj.type !== 'Note') return null
+
+            const noteResult = Note.safeParse(normalizeActivityPubContent(obj))
+            if (!noteResult.success) return null
+
+            const status = getStatusFromNote(noteResult.data)
+            if (!status) return null
+
+            if (actor) status.actor = actor
+            return status
+          })
+        )
+
+        return {
+          statusesCount: value.totalItems ?? 0,
+          statuses: statuses.filter((item) => item !== null),
+          nextPageUrl: value.page?.next ?? null,
+          prevPageUrl: value.page?.prev ?? null
+        }
+      } finally {
+        span.end()
       }
     }
   )

--- a/lib/activities/getActorPosts.ts
+++ b/lib/activities/getActorPosts.ts
@@ -8,7 +8,12 @@ import {
 } from '@/lib/types/activitypub/activities'
 import { Note } from '@/lib/types/activitypub/objects'
 import { ActorProfile, Actor as DomainActor } from '@/lib/types/domain/actor'
-import { Status, fromAnnounce, fromNote } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  fromAnnounce,
+  fromNote
+} from '@/lib/types/domain/status'
 import {
   normalizeActivityPubAnnounce,
   normalizeActivityPubContent
@@ -27,9 +32,12 @@ type GetActorPostsFunction = (params: {
   database: Database
   person: Actor
   signingActor?: DomainActor
+  pageUrl?: string
 }) => Promise<{
   statusesCount: number
   statuses: Status[]
+  nextPageUrl: string | null
+  prevPageUrl: string | null
 }>
 
 const getErrorMessage = (error: unknown) =>
@@ -47,7 +55,8 @@ const getStatusFromNote = (note: Note) => {
 export const getActorPosts: GetActorPostsFunction = async ({
   database,
   person,
-  signingActor
+  signingActor,
+  pageUrl
 }) =>
   getTracer().startActiveSpan(
     'activities.getActorPosts',
@@ -89,11 +98,17 @@ export const getActorPosts: GetActorPostsFunction = async ({
       const value = await getActorCollections({
         person,
         field: 'outbox',
-        signingActor
+        signingActor,
+        pageUrl
       })
       if (!value) {
         span.end()
-        return { statusesCount: 0, statuses: [] }
+        return {
+          statusesCount: 0,
+          statuses: [],
+          nextPageUrl: null,
+          prevPageUrl: null
+        }
       }
 
       const items = value.page?.orderedItems ?? []
@@ -111,19 +126,27 @@ export const getActorPosts: GetActorPostsFunction = async ({
             const localStatus = await database.getStatus({
               statusId: announce.object
             })
-            if (localStatus) return localStatus
 
-            const note = await getNote({
-              statusId: announce.object,
-              signingActor
-            })
-            if (!note) return null
+            let originalStatus =
+              localStatus?.type !== StatusType.enum.Announce
+                ? localStatus
+                : null
 
-            const noteResult = Note.safeParse(normalizeActivityPubContent(note))
-            if (!noteResult.success) return null
+            if (!originalStatus) {
+              const note = await getNote({
+                statusId: announce.object,
+                signingActor
+              })
+              if (!note) return null
 
-            const originalStatus = getStatusFromNote(noteResult.data)
-            if (!originalStatus) return null
+              const noteResult = Note.safeParse(
+                normalizeActivityPubContent(note)
+              )
+              if (!noteResult.success) return null
+
+              originalStatus = getStatusFromNote(noteResult.data)
+              if (!originalStatus) return null
+            }
 
             originalStatus.actor = await getActorProfile(originalStatus.actorId)
             const announceStatus = fromAnnounce(announce, originalStatus)
@@ -151,7 +174,9 @@ export const getActorPosts: GetActorPostsFunction = async ({
 
       return {
         statusesCount: value.totalItems ?? 0,
-        statuses: statuses.filter((item) => item !== null)
+        statuses: statuses.filter((item) => item !== null),
+        nextPageUrl: value.page?.next ?? null,
+        prevPageUrl: value.page?.prev ?? null
       }
     }
   )

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -1,6 +1,6 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
-import { updateNote } from './client'
+import { getActorStatuses, updateNote } from './client'
 
 enableFetchMocks()
 
@@ -33,5 +33,32 @@ describe('client updateNote', () => {
         })
       })
     )
+  })
+})
+
+describe('client getActorStatuses', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        origin: 'https://local.example'
+      }
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window')
+  })
+
+  it('throws when the remote statuses request fails', async () => {
+    fetchMock.mockResponseOnce('', { status: 500 })
+
+    await expect(
+      getActorStatuses({
+        actorId: 'https://remote.example/users/actor',
+        pageUrl: 'https://remote.example/users/actor/outbox?page=true'
+      })
+    ).rejects.toThrow('Failed to load actor statuses: 500')
   })
 })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -493,6 +493,46 @@ export const getHashtagTimeline = async ({
   return data.statuses as Status[]
 }
 
+interface GetActorStatusesParams {
+  actorId: string
+  pageUrl?: string | null
+}
+
+export interface GetActorStatusesResult {
+  statuses: Status[]
+  statusesCount: number
+  nextPageUrl: string | null
+  prevPageUrl: string | null
+}
+
+export const getActorStatuses = async ({
+  actorId,
+  pageUrl
+}: GetActorStatusesParams): Promise<GetActorStatusesResult> => {
+  const path = `/api/v1/accounts/${urlToId(actorId)}/remote-statuses`
+  const url = new URL(`${window.origin}${path}`)
+  if (pageUrl) {
+    url.searchParams.append('page_url', pageUrl)
+  }
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return {
+      statuses: [],
+      statusesCount: 0,
+      nextPageUrl: null,
+      prevPageUrl: null
+    }
+  }
+
+  return (await response.json()) as GetActorStatusesResult
+}
+
 interface DeleteSessionParams {
   token: string
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -522,12 +522,7 @@ export const getActorStatuses = async ({
     }
   })
   if (response.status !== 200) {
-    return {
-      statuses: [],
-      statusesCount: 0,
-      nextPageUrl: null,
-      prevPageUrl: null
-    }
+    throw new Error(`Failed to load actor statuses: ${response.status}`)
   }
 
   return (await response.json()) as GetActorStatusesResult

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -213,7 +213,7 @@ export const fromNote = (note: Note): StatusNote => {
 
 export const fromAnnounce = (
   announce: AnnounceStatus | ActivityPubAnnounce,
-  originalStatus: StatusNote
+  originalStatus: StatusNote | StatusPoll
 ): StatusAnnounce => {
   const currentTime = Date.now()
   return StatusAnnounce.parse({


### PR DESCRIPTION
## Summary
- Keep remote profile boosts as `Announce` statuses even when the boosted original status is already cached locally.
- Add remote outbox page cursor support and profile Older/Newer pagination links.
- Validate requested outbox page URLs against the actor outbox URL before fetching.

## Root cause
Cached boosted statuses were returned as the original cached status instead of being wrapped back into the actor's `Announce`. Boosted replies could then be filtered out of the profile Posts tab as replies.

## Tests
- `yarn run prettier --write .`
- `yarn lint`
- `yarn build`
- `yarn test`
