### PR TITLE
fix: Safari post line limit spacing

### DIFF
--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -8,13 +8,38 @@ import { CollapsibleContent } from './collapsible-content'
 
 const COLLAPSED_HEIGHT_REM = `${5 * 1.4375}rem`
 
+let resizeObserverInstances: ResizeObserverMock[] = []
+let originalResizeObserver: unknown
+let originalScrollHeightDescriptor: PropertyDescriptor | undefined
+
 class ResizeObserverMock {
-  observe = jest.fn()
+  observedElements: Element[] = []
+
+  constructor(
+    private readonly callback: (entries: never[], observer: unknown) => void
+  ) {
+    resizeObserverInstances.push(this)
+  }
+
+  observe = jest.fn((element: Element) => {
+    this.observedElements.push(element)
+  })
+
   disconnect = jest.fn()
+
+  trigger() {
+    this.callback([], this)
+  }
 }
 
 describe('CollapsibleContent', () => {
   beforeEach(() => {
+    resizeObserverInstances = []
+    originalResizeObserver = global.ResizeObserver
+    originalScrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    )
     document.documentElement.style.fontSize = '16px'
 
     Object.defineProperty(global, 'ResizeObserver', {
@@ -26,6 +51,27 @@ describe('CollapsibleContent', () => {
       configurable: true,
       get: () => 300
     })
+  })
+
+  afterEach(() => {
+    if (originalResizeObserver) {
+      Object.defineProperty(global, 'ResizeObserver', {
+        configurable: true,
+        value: originalResizeObserver
+      })
+    } else {
+      Reflect.deleteProperty(global, 'ResizeObserver')
+    }
+
+    if (originalScrollHeightDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollHeight',
+        originalScrollHeightDescriptor
+      )
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight')
+    }
   })
 
   it('uses a fixed collapsed layout height for overflowing content', async () => {
@@ -41,11 +87,44 @@ describe('CollapsibleContent', () => {
       ).toBeInTheDocument()
     })
 
-    const content = screen.getByText(
-      'Long status content that exceeds the timeline line limit.'
+    const button = screen.getByRole('button', { name: 'Show more content' })
+    const content = document.getElementById(
+      button.getAttribute('aria-controls')!
     )
+
     expect(content).toHaveClass('overflow-hidden')
-    expect(content.style.height).toBe(COLLAPSED_HEIGHT_REM)
-    expect(content.style.maxHeight).toBe('')
+    expect(content?.style.height).toBe(COLLAPSED_HEIGHT_REM)
+    expect(content?.style.maxHeight).toBe('')
+  })
+
+  it('observes natural content size while the collapsed container has fixed height', async () => {
+    render(
+      <CollapsibleContent maxLines={5}>
+        Long status content that exceeds the timeline line limit.
+      </CollapsibleContent>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Show more content' })
+      ).toBeInTheDocument()
+    })
+
+    const button = screen.getByRole('button', { name: 'Show more content' })
+    const collapsedContainer = document.getElementById(
+      button.getAttribute('aria-controls')!
+    )
+    const observedElements = resizeObserverInstances.flatMap(
+      (instance) => instance.observedElements
+    )
+
+    expect(observedElements).not.toContain(collapsedContainer)
+    expect(
+      observedElements.some((element) =>
+        element.textContent?.includes(
+          'Long status content that exceeds the timeline line limit.'
+        )
+      )
+    ).toBe(true)
   })
 })

--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -128,10 +128,11 @@ describe('CollapsibleContent', () => {
     ).toBe(true)
   })
 
-  it('preserves markdown content selectors on the measured wrapper', async () => {
+  it('applies caller-provided content classes to the measured wrapper', async () => {
     render(
       <CollapsibleContent
-        className="mt-1 text-sm leading-relaxed break-words markdown-content"
+        className="mt-1 text-sm leading-relaxed break-words"
+        contentClassName="markdown-content"
         maxLines={5}
       >
         <p>Long status content that exceeds the timeline line limit.</p>
@@ -147,10 +148,15 @@ describe('CollapsibleContent', () => {
     const observedElements = resizeObserverInstances.flatMap(
       (instance) => instance.observedElements
     )
+    const button = screen.getByRole('button', { name: 'Show more content' })
+    const collapsedContainer = document.getElementById(
+      button.getAttribute('aria-controls')!
+    )
     const measuredMarkdownContent = observedElements.find((element) =>
       element.classList.contains('markdown-content')
     )
 
+    expect(collapsedContainer).not.toHaveClass('markdown-content')
     expect(measuredMarkdownContent).toBeDefined()
     expect(
       measuredMarkdownContent?.querySelector(':scope > p')

--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -127,4 +127,35 @@ describe('CollapsibleContent', () => {
       )
     ).toBe(true)
   })
+
+  it('preserves markdown content selectors on the measured wrapper', async () => {
+    render(
+      <CollapsibleContent
+        className="mt-1 text-sm leading-relaxed break-words markdown-content"
+        maxLines={5}
+      >
+        <p>Long status content that exceeds the timeline line limit.</p>
+      </CollapsibleContent>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Show more content' })
+      ).toBeInTheDocument()
+    })
+
+    const observedElements = resizeObserverInstances.flatMap(
+      (instance) => instance.observedElements
+    )
+    const measuredMarkdownContent = observedElements.find((element) =>
+      element.classList.contains('markdown-content')
+    )
+
+    expect(measuredMarkdownContent).toBeDefined()
+    expect(
+      measuredMarkdownContent?.querySelector(':scope > p')
+    ).toHaveTextContent(
+      'Long status content that exceeds the timeline line limit.'
+    )
+  })
 })

--- a/lib/components/posts/collapsible-content.test.tsx
+++ b/lib/components/posts/collapsible-content.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { CollapsibleContent } from './collapsible-content'
+
+const COLLAPSED_HEIGHT_REM = `${5 * 1.4375}rem`
+
+class ResizeObserverMock {
+  observe = jest.fn()
+  disconnect = jest.fn()
+}
+
+describe('CollapsibleContent', () => {
+  beforeEach(() => {
+    document.documentElement.style.fontSize = '16px'
+
+    Object.defineProperty(global, 'ResizeObserver', {
+      configurable: true,
+      value: ResizeObserverMock
+    })
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => 300
+    })
+  })
+
+  it('uses a fixed collapsed layout height for overflowing content', async () => {
+    render(
+      <CollapsibleContent maxLines={5}>
+        Long status content that exceeds the timeline line limit.
+      </CollapsibleContent>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Show more content' })
+      ).toBeInTheDocument()
+    })
+
+    const content = screen.getByText(
+      'Long status content that exceeds the timeline line limit.'
+    )
+    expect(content).toHaveClass('overflow-hidden')
+    expect(content.style.height).toBe(COLLAPSED_HEIGHT_REM)
+    expect(content.style.maxHeight).toBe('')
+  })
+})

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -26,7 +26,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   className,
   maxLines = 5
 }) => {
-  const contentRef = useRef<HTMLDivElement>(null)
+  const measuredContentRef = useRef<HTMLDivElement>(null)
   const [isOverflowing, setIsOverflowing] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const contentId = useId()
@@ -34,7 +34,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   const maxHeightRem = maxLines * LINE_HEIGHT_REM
 
   const checkOverflow = useCallback(() => {
-    const el = contentRef.current
+    const el = measuredContentRef.current
     if (!el) return
 
     const maxHeightPx =
@@ -48,7 +48,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   }, [children, checkOverflow])
 
   useEffect(() => {
-    const el = contentRef.current
+    const el = measuredContentRef.current
     if (!el) return
 
     const observer = new ResizeObserver(() => {
@@ -64,11 +64,10 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
     <div className="relative">
       <div
         id={contentId}
-        ref={contentRef}
         className={cn(className, needsCollapse && 'overflow-hidden')}
         style={needsCollapse ? { height: `${maxHeightRem}rem` } : undefined}
       >
-        {children}
+        <div ref={measuredContentRef}>{children}</div>
       </div>
       {needsCollapse && (
         <div className="absolute bottom-0 left-0 right-0 flex items-end justify-center bg-gradient-to-t from-background to-transparent pt-8 pb-0">

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -16,16 +16,16 @@ import { cn } from '@/lib/utils'
 interface CollapsibleContentProps {
   children: ReactNode
   className?: string
+  contentClassName?: string
   maxLines?: number
 }
 
 const LINE_HEIGHT_REM = 1.4375 // ~line height for text-sm leading-relaxed
-const hasClassToken = (className: string | undefined, token: string) =>
-  className?.split(/\s+/).includes(token) ?? false
 
 export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   children,
   className,
+  contentClassName,
   maxLines = 5
 }) => {
   const measuredContentRef = useRef<HTMLDivElement>(null)
@@ -61,9 +61,6 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   }, [checkOverflow])
 
   const needsCollapse = isOverflowing && !isExpanded
-  const measuredContentClassName = hasClassToken(className, 'markdown-content')
-    ? 'markdown-content'
-    : undefined
 
   return (
     <div className="relative">
@@ -72,7 +69,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
         className={cn(className, needsCollapse && 'overflow-hidden')}
         style={needsCollapse ? { height: `${maxHeightRem}rem` } : undefined}
       >
-        <div ref={measuredContentRef} className={measuredContentClassName}>
+        <div ref={measuredContentRef} className={contentClassName}>
           {children}
         </div>
       </div>

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -20,6 +20,8 @@ interface CollapsibleContentProps {
 }
 
 const LINE_HEIGHT_REM = 1.4375 // ~line height for text-sm leading-relaxed
+const hasClassToken = (className: string | undefined, token: string) =>
+  className?.split(/\s+/).includes(token) ?? false
 
 export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   children,
@@ -59,6 +61,9 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
   }, [checkOverflow])
 
   const needsCollapse = isOverflowing && !isExpanded
+  const measuredContentClassName = hasClassToken(className, 'markdown-content')
+    ? 'markdown-content'
+    : undefined
 
   return (
     <div className="relative">
@@ -67,7 +72,9 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
         className={cn(className, needsCollapse && 'overflow-hidden')}
         style={needsCollapse ? { height: `${maxHeightRem}rem` } : undefined}
       >
-        <div ref={measuredContentRef}>{children}</div>
+        <div ref={measuredContentRef} className={measuredContentClassName}>
+          {children}
+        </div>
       </div>
       {needsCollapse && (
         <div className="absolute bottom-0 left-0 right-0 flex items-end justify-center bg-gradient-to-t from-background to-transparent pt-8 pb-0">

--- a/lib/components/posts/collapsible-content.tsx
+++ b/lib/components/posts/collapsible-content.tsx
@@ -66,7 +66,7 @@ export const CollapsibleContent: FC<CollapsibleContentProps> = ({
         id={contentId}
         ref={contentRef}
         className={cn(className, needsCollapse && 'overflow-hidden')}
-        style={needsCollapse ? { maxHeight: `${maxHeightRem}rem` } : undefined}
+        style={needsCollapse ? { height: `${maxHeightRem}rem` } : undefined}
       >
         {children}
       </div>

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -103,7 +103,8 @@ export const Post: FC<PostProps> = (props) => {
     <>
       {collapsible && postLineLimit !== 0 && !summary ? (
         <CollapsibleContent
-          className="mt-1 text-sm leading-relaxed break-words markdown-content"
+          className="mt-1 text-sm leading-relaxed break-words"
+          contentClassName="markdown-content"
           maxLines={postLineLimit}
         >
           {processedAndCleanedText}


### PR DESCRIPTION
## Summary
- Fix timeline collapsed post layout by using a fixed collapsed height instead of only `max-height`.
- Add a regression test for overflowing collapsed content so the layout contract stays explicit.

## Root Cause
Safari/WebKit can visually clip overflowed timeline status content while still allowing the row to reserve the original content height when collapse is expressed only with `max-height`. Using an explicit collapsed `height` makes the post occupy the configured line-limit height.

## Test Plan
- `yarn run prettier --write .`
- `yarn lint` (0 errors; existing warnings remain in unrelated files)
- `yarn build`
- `yarn test`