### PR TITLE
feat: add actor route heatmap recreation script

### DIFF
--- a/lib/database/sql/fitnessFile.test.ts
+++ b/lib/database/sql/fitnessFile.test.ts
@@ -58,6 +58,53 @@ describe('FitnessFileDatabase', () => {
         })
         expect(actorFiles.some((item) => item.id === created!.id)).toBe(true)
       })
+
+      it('uses a deterministic id tiebreaker when files share createdAt', async () => {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2030-01-01T00:00:00.000Z'))
+
+        try {
+          const first = await database.createFitnessFile({
+            actorId: actors.extra.id,
+            path: 'fitness/same-created-at-1.fit',
+            fileName: 'same-created-at-1.fit',
+            fileType: 'fit',
+            mimeType: 'application/vnd.ant.fit',
+            bytes: 1024
+          })
+          const second = await database.createFitnessFile({
+            actorId: actors.extra.id,
+            path: 'fitness/same-created-at-2.fit',
+            fileName: 'same-created-at-2.fit',
+            fileType: 'fit',
+            mimeType: 'application/vnd.ant.fit',
+            bytes: 1024
+          })
+          const third = await database.createFitnessFile({
+            actorId: actors.extra.id,
+            path: 'fitness/same-created-at-3.fit',
+            fileName: 'same-created-at-3.fit',
+            fileType: 'fit',
+            mimeType: 'application/vnd.ant.fit',
+            bytes: 1024
+          })
+
+          expect(first).toBeDefined()
+          expect(second).toBeDefined()
+          expect(third).toBeDefined()
+
+          const actorFiles = await database.getFitnessFilesByActor({
+            actorId: actors.extra.id,
+            limit: 3
+          })
+
+          expect(actorFiles.map((item) => item.id)).toEqual(
+            [first!.id, second!.id, third!.id].sort().reverse()
+          )
+        } finally {
+          jest.useRealTimers()
+        }
+      })
     })
 
     describe('getFitnessFileByStatus/updateFitnessFileStatus', () => {

--- a/lib/database/sql/fitnessFile.ts
+++ b/lib/database/sql/fitnessFile.ts
@@ -374,6 +374,7 @@ export const FitnessFileSQLDatabaseMixin = (
 
     const rows = await query
       .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
       .limit(limit)
       .offset(offset)
 

--- a/lib/database/sql/fitnessRouteHeatmap.test.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.test.ts
@@ -252,6 +252,22 @@ describe('FitnessRouteHeatmapDatabase', () => {
             actorId: actors.replyAuthor.id
           })
         ).resolves.toEqual(expect.arrayContaining(['netherlands', 'singapore']))
+
+        await database.deleteFitnessRouteHeatmapsForActor({
+          actorId: actors.replyAuthor.id
+        })
+
+        await expect(
+          database.getDistinctRouteHeatmapRegionsForActor({
+            actorId: actors.replyAuthor.id
+          })
+        ).resolves.toEqual([])
+        await expect(
+          database.getDistinctRouteHeatmapRegionsForActor({
+            actorId: actors.replyAuthor.id,
+            includeDeleted: true
+          })
+        ).resolves.toEqual(expect.arrayContaining(['netherlands', 'singapore']))
       })
     })
 

--- a/lib/database/sql/fitnessRouteHeatmap.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.ts
@@ -88,6 +88,7 @@ export interface FitnessRouteHeatmapDatabase {
   ): Promise<string[]>
   getDistinctRouteHeatmapRegionsForActor(params: {
     actorId: string
+    includeDeleted?: boolean
   }): Promise<string[]>
   deleteFitnessRouteHeatmapsForActor(params: {
     actorId: string
@@ -385,13 +386,16 @@ export const FitnessRouteHeatmapSQLDatabaseMixin = (
     return rows.map((row: { activityType: string }) => row.activityType)
   },
 
-  async getDistinctRouteHeatmapRegionsForActor({ actorId }) {
-    const rows = await database('fitness_route_heatmaps')
+  async getDistinctRouteHeatmapRegionsForActor({ actorId, includeDeleted }) {
+    let query = database('fitness_route_heatmaps')
       .where('actorId', actorId)
-      .whereNull('deletedAt')
       .whereNot('region', '')
-      .distinct('region')
-      .orderBy('region', 'asc')
+
+    if (!includeDeleted) {
+      query = query.whereNull('deletedAt')
+    }
+
+    const rows = await query.distinct('region').orderBy('region', 'asc')
 
     return rows.map((row: { region: string }) => row.region)
   },

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
@@ -1,0 +1,167 @@
+import { GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME } from '@/lib/jobs/names'
+import { recreateFitnessRouteHeatmapJobs } from '@/lib/jobs/recreateFitnessRouteHeatmapJobs'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+
+const mockPublish = jest.fn()
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn(() => ({
+    publish: mockPublish
+  }))
+}))
+
+const makeFitnessFile = (
+  overrides: Partial<FitnessFile> = {}
+): FitnessFile => ({
+  id: overrides.id ?? 'fitness-file-1',
+  actorId: overrides.actorId ?? 'actor-1',
+  path: overrides.path ?? 'fitness-file.fit',
+  fileName: overrides.fileName ?? 'fitness-file.fit',
+  fileType: overrides.fileType ?? 'fit',
+  mimeType: overrides.mimeType ?? 'application/octet-stream',
+  bytes: overrides.bytes ?? 1024,
+  processingStatus: overrides.processingStatus ?? 'completed',
+  isPrimary: overrides.isPrimary ?? true,
+  activityType: overrides.activityType,
+  activityStartTime: overrides.activityStartTime,
+  createdAt: overrides.createdAt ?? Date.UTC(2026, 0, 1),
+  updatedAt: overrides.updatedAt ?? Date.UTC(2026, 0, 1)
+})
+
+describe('recreateFitnessRouteHeatmapJobs', () => {
+  beforeEach(() => {
+    mockPublish.mockClear()
+  })
+
+  it('deletes existing heatmaps and queues every discoverable actor variant', async () => {
+    const getFitnessFilesByActor = jest
+      .fn()
+      .mockResolvedValueOnce([
+        makeFitnessFile({
+          id: 'run-2026-01',
+          activityType: 'run',
+          activityStartTime: Date.UTC(2026, 0, 15, 8)
+        }),
+        makeFitnessFile({
+          id: 'cycle-2026-02',
+          activityType: 'cycle',
+          activityStartTime: Date.UTC(2026, 1, 3, 10)
+        })
+      ])
+      .mockResolvedValueOnce([])
+    const database = {
+      getDistinctRouteHeatmapRegionsForActor: jest
+        .fn()
+        .mockResolvedValue(['encoded-region']),
+      getFitnessFilesByActor,
+      deleteFitnessRouteHeatmapsForActor: jest.fn().mockResolvedValue(3)
+    }
+
+    const result = await recreateFitnessRouteHeatmapJobs({
+      database,
+      actorId: 'actor-1',
+      runId: 'test-run'
+    })
+
+    expect(
+      database.getDistinctRouteHeatmapRegionsForActor
+    ).toHaveBeenCalledWith({
+      actorId: 'actor-1'
+    })
+    expect(getFitnessFilesByActor).toHaveBeenNthCalledWith(1, {
+      actorId: 'actor-1',
+      processingStatus: 'completed',
+      isPrimary: true,
+      limit: 500,
+      offset: 0
+    })
+    expect(database.deleteFitnessRouteHeatmapsForActor).toHaveBeenCalledWith({
+      actorId: 'actor-1'
+    })
+
+    expect(result.deletedCount).toBe(3)
+    expect(result.queuedCount).toBe(20)
+    expect(result.failedCount).toBe(0)
+    expect(result.variants).toEqual(
+      expect.arrayContaining([
+        {
+          activityType: null,
+          periodType: 'all_time',
+          periodKey: 'all'
+        },
+        {
+          activityType: null,
+          periodType: 'yearly',
+          periodKey: '2026'
+        },
+        {
+          activityType: null,
+          periodType: 'monthly',
+          periodKey: '2026-01'
+        },
+        {
+          activityType: 'run',
+          periodType: 'monthly',
+          periodKey: '2026-01'
+        },
+        {
+          activityType: 'cycle',
+          periodType: 'monthly',
+          periodKey: '2026-02',
+          region: 'encoded-region'
+        }
+      ])
+    )
+    expect(mockPublish).toHaveBeenCalledTimes(20)
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          activityType: 'run',
+          periodType: 'monthly',
+          periodKey: '2026-01'
+        }
+      })
+    )
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          activityType: 'cycle',
+          periodType: 'monthly',
+          periodKey: '2026-02',
+          region: 'encoded-region'
+        }
+      })
+    )
+  })
+
+  it('skips deletion and publishing in dry-run mode', async () => {
+    const database = {
+      getDistinctRouteHeatmapRegionsForActor: jest.fn().mockResolvedValue([]),
+      getFitnessFilesByActor: jest
+        .fn()
+        .mockResolvedValueOnce([
+          makeFitnessFile({
+            activityStartTime: Date.UTC(2026, 4, 1)
+          })
+        ])
+        .mockResolvedValueOnce([]),
+      deleteFitnessRouteHeatmapsForActor: jest.fn()
+    }
+
+    const result = await recreateFitnessRouteHeatmapJobs({
+      database,
+      actorId: 'actor-1',
+      dryRun: true
+    })
+
+    expect(result.deletedCount).toBe(0)
+    expect(result.queuedCount).toBe(0)
+    expect(result.variants).toHaveLength(3)
+    expect(database.deleteFitnessRouteHeatmapsForActor).not.toHaveBeenCalled()
+    expect(mockPublish).not.toHaveBeenCalled()
+  })
+})

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
@@ -1,13 +1,23 @@
 import { GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME } from '@/lib/jobs/names'
-import { recreateFitnessRouteHeatmapJobs } from '@/lib/jobs/recreateFitnessRouteHeatmapJobs'
+import {
+  buildRecreateFitnessRouteHeatmapVariants,
+  recreateFitnessRouteHeatmapJobs
+} from '@/lib/jobs/recreateFitnessRouteHeatmapJobs'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
+import { logger } from '@/lib/utils/logger'
 
 const mockPublish = jest.fn()
+const mockWarn = logger.warn as jest.Mock
 
 jest.mock('@/lib/services/queue', () => ({
   getQueue: jest.fn(() => ({
     publish: mockPublish
   }))
+}))
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: jest.fn()
+  }
 }))
 
 const makeFitnessFile = (
@@ -30,7 +40,9 @@ const makeFitnessFile = (
 
 describe('recreateFitnessRouteHeatmapJobs', () => {
   beforeEach(() => {
-    mockPublish.mockClear()
+    mockPublish.mockReset()
+    mockPublish.mockResolvedValue(undefined)
+    mockWarn.mockReset()
   })
 
   it('deletes existing heatmaps and queues every discoverable actor variant', async () => {
@@ -66,7 +78,8 @@ describe('recreateFitnessRouteHeatmapJobs', () => {
     expect(
       database.getDistinctRouteHeatmapRegionsForActor
     ).toHaveBeenCalledWith({
-      actorId: 'actor-1'
+      actorId: 'actor-1',
+      includeDeleted: true
     })
     expect(getFitnessFilesByActor).toHaveBeenNthCalledWith(1, {
       actorId: 'actor-1',
@@ -163,5 +176,143 @@ describe('recreateFitnessRouteHeatmapJobs', () => {
     expect(result.variants).toHaveLength(3)
     expect(database.deleteFitnessRouteHeatmapsForActor).not.toHaveBeenCalled()
     expect(mockPublish).not.toHaveBeenCalled()
+  })
+
+  it('normalizes regions and collapses blank activity types into the all-activity bucket', () => {
+    const variants = buildRecreateFitnessRouteHeatmapVariants({
+      fitnessFiles: [
+        makeFitnessFile({
+          activityType: '  ',
+          activityStartTime: undefined
+        })
+      ],
+      regions: ['  region-b  ', '', 'region-a', 'region-a']
+    })
+
+    expect(variants).toEqual([
+      {
+        activityType: null,
+        periodType: 'all_time',
+        periodKey: 'all'
+      },
+      {
+        activityType: null,
+        periodType: 'all_time',
+        periodKey: 'all',
+        region: 'region-a'
+      },
+      {
+        activityType: null,
+        periodType: 'all_time',
+        periodKey: 'all',
+        region: 'region-b'
+      }
+    ])
+  })
+
+  it('paginates completed primary fitness files while deriving variants', async () => {
+    const firstPage = Array.from({ length: 500 }, (_value, index) =>
+      makeFitnessFile({
+        id: `run-${index}`,
+        activityType: 'run',
+        activityStartTime: Date.UTC(2026, 0, 1)
+      })
+    )
+    const getFitnessFilesByActor = jest
+      .fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([
+        makeFitnessFile({
+          id: 'ride-501',
+          activityType: 'ride',
+          activityStartTime: Date.UTC(2026, 1, 1)
+        })
+      ])
+    const database = {
+      getDistinctRouteHeatmapRegionsForActor: jest.fn().mockResolvedValue([]),
+      getFitnessFilesByActor,
+      deleteFitnessRouteHeatmapsForActor: jest.fn()
+    }
+
+    const result = await recreateFitnessRouteHeatmapJobs({
+      database,
+      actorId: 'actor-1',
+      dryRun: true
+    })
+
+    expect(getFitnessFilesByActor).toHaveBeenNthCalledWith(1, {
+      actorId: 'actor-1',
+      processingStatus: 'completed',
+      isPrimary: true,
+      limit: 500,
+      offset: 0
+    })
+    expect(getFitnessFilesByActor).toHaveBeenNthCalledWith(2, {
+      actorId: 'actor-1',
+      processingStatus: 'completed',
+      isPrimary: true,
+      limit: 500,
+      offset: 500
+    })
+    expect(result.variants).toEqual(
+      expect.arrayContaining([
+        {
+          activityType: 'run',
+          periodType: 'monthly',
+          periodKey: '2026-01'
+        },
+        {
+          activityType: 'ride',
+          periodType: 'monthly',
+          periodKey: '2026-02'
+        }
+      ])
+    )
+  })
+
+  it('records per-variant publish failures without blocking other variants', async () => {
+    mockPublish.mockImplementation((message) => {
+      return message.data.periodType === 'monthly'
+        ? Promise.reject(new Error('queue unavailable'))
+        : Promise.resolve()
+    })
+    const database = {
+      getDistinctRouteHeatmapRegionsForActor: jest.fn().mockResolvedValue([]),
+      getFitnessFilesByActor: jest
+        .fn()
+        .mockResolvedValueOnce([
+          makeFitnessFile({
+            activityStartTime: Date.UTC(2026, 4, 1)
+          })
+        ])
+        .mockResolvedValueOnce([]),
+      deleteFitnessRouteHeatmapsForActor: jest.fn().mockResolvedValue(1)
+    }
+
+    const result = await recreateFitnessRouteHeatmapJobs({
+      database,
+      actorId: 'actor-1',
+      runId: 'test-run'
+    })
+
+    expect(result.queuedCount).toBe(2)
+    expect(result.failedCount).toBe(1)
+    expect(result.errors).toEqual([
+      {
+        variant: {
+          activityType: null,
+          periodType: 'monthly',
+          periodKey: '2026-05'
+        },
+        error: 'queue unavailable'
+      }
+    ])
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Failed to publish route heatmap recreation job',
+        actorId: 'actor-1',
+        error: 'queue unavailable'
+      })
+    )
   })
 })

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
@@ -315,4 +315,78 @@ describe('recreateFitnessRouteHeatmapJobs', () => {
       })
     )
   })
+
+  it('limits concurrent route heatmap publishes', async () => {
+    const releasePublish: Array<() => void> = []
+    let activePublishCount = 0
+    let maxActivePublishCount = 0
+    const expectedPublishCount = 26
+    mockPublish.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          activePublishCount += 1
+          maxActivePublishCount = Math.max(
+            maxActivePublishCount,
+            activePublishCount
+          )
+          releasePublish.push(() => {
+            activePublishCount -= 1
+            resolve()
+          })
+        })
+    )
+    const database = {
+      getDistinctRouteHeatmapRegionsForActor: jest.fn().mockResolvedValue([]),
+      getFitnessFilesByActor: jest
+        .fn()
+        .mockResolvedValueOnce(
+          Array.from({ length: 6 }, (_value, index) =>
+            makeFitnessFile({
+              id: `fitness-file-${index}`,
+              activityType: `activity-${index}`,
+              activityStartTime: Date.UTC(2026, index, 1)
+            })
+          )
+        )
+        .mockResolvedValueOnce([]),
+      deleteFitnessRouteHeatmapsForActor: jest.fn().mockResolvedValue(1)
+    }
+
+    const resultPromise = recreateFitnessRouteHeatmapJobs({
+      database,
+      actorId: 'actor-1',
+      runId: 'test-run'
+    })
+
+    for (
+      let guard = 0;
+      guard < 10 && mockPublish.mock.calls.length < 4;
+      guard += 1
+    ) {
+      await Promise.resolve()
+    }
+
+    expect(mockPublish).toHaveBeenCalledTimes(4)
+    expect(maxActivePublishCount).toBe(4)
+
+    for (
+      let guard = 0;
+      guard < 100 &&
+      (mockPublish.mock.calls.length < expectedPublishCount ||
+        activePublishCount > 0);
+      guard += 1
+    ) {
+      const release = releasePublish.shift()
+      release?.()
+      await Promise.resolve()
+
+      expect(maxActivePublishCount).toBeLessThanOrEqual(4)
+    }
+
+    const result = await resultPromise
+
+    expect(mockPublish).toHaveBeenCalledTimes(expectedPublishCount)
+    expect(result.queuedCount).toBe(expectedPublishCount)
+    expect(result.failedCount).toBe(0)
+  })
 })

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
@@ -1,10 +1,12 @@
-import crypto from 'crypto'
+import { randomUUID } from 'node:crypto'
 
+import type { Database } from '@/lib/database/types'
 import { GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
-import { FitnessFile } from '@/lib/types/database/fitnessFile'
-import { FitnessRouteHeatmapPeriodType } from '@/lib/types/database/fitnessRouteHeatmap'
+import type { FitnessFile } from '@/lib/types/database/fitnessFile'
+import type { FitnessRouteHeatmapPeriodType } from '@/lib/types/database/fitnessRouteHeatmap'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { logger } from '@/lib/utils/logger'
 
 const FITNESS_FILE_PAGE_SIZE = 500
 
@@ -15,21 +17,12 @@ export interface RecreateFitnessRouteHeatmapVariant {
   region?: string
 }
 
-export interface RecreateFitnessRouteHeatmapJobsDatabase {
-  getDistinctRouteHeatmapRegionsForActor(params: {
-    actorId: string
-  }): Promise<string[]>
-  getFitnessFilesByActor(params: {
-    actorId: string
-    processingStatus: 'completed'
-    isPrimary: true
-    limit: number
-    offset: number
-  }): Promise<FitnessFile[]>
-  deleteFitnessRouteHeatmapsForActor(params: {
-    actorId: string
-  }): Promise<number>
-}
+export type RecreateFitnessRouteHeatmapJobsDatabase = Pick<
+  Database,
+  | 'getDistinctRouteHeatmapRegionsForActor'
+  | 'getFitnessFilesByActor'
+  | 'deleteFitnessRouteHeatmapsForActor'
+>
 
 export interface RecreateFitnessRouteHeatmapJobsParams {
   database: RecreateFitnessRouteHeatmapJobsDatabase
@@ -112,6 +105,8 @@ const addFileVariants = (
   }
 
   if (!activityDate) {
+    // Scoped route-heatmap generation filters by activityStartTime; files
+    // without one cannot contribute to yearly/monthly caches.
     return
   }
 
@@ -148,6 +143,25 @@ const normalizeRegions = (regions: string[]) =>
     new Set(regions.map((region) => region.trim()).filter(Boolean))
   ).sort()
 
+const buildVariantsFromBaseMap = ({
+  baseVariants,
+  regions
+}: {
+  baseVariants: Map<string, RecreateFitnessRouteHeatmapVariant>
+  regions: string[]
+}): RecreateFitnessRouteHeatmapVariant[] => {
+  const variants = new Map(baseVariants)
+  const baseVariantValues = Array.from(baseVariants.values())
+
+  for (const region of normalizeRegions(regions)) {
+    for (const variant of baseVariantValues) {
+      addVariant(variants, { ...variant, region })
+    }
+  }
+
+  return Array.from(variants.values()).sort(sortVariants)
+}
+
 export const buildRecreateFitnessRouteHeatmapVariants = ({
   fitnessFiles,
   regions
@@ -161,29 +175,14 @@ export const buildRecreateFitnessRouteHeatmapVariants = ({
     addFileVariants(baseVariants, file)
   }
 
-  const sortedBaseVariants = Array.from(baseVariants.values()).sort(
-    sortVariants
-  )
-  const variants = new Map<string, RecreateFitnessRouteHeatmapVariant>()
-
-  for (const variant of sortedBaseVariants) {
-    addVariant(variants, variant)
-  }
-
-  for (const region of normalizeRegions(regions)) {
-    for (const variant of sortedBaseVariants) {
-      addVariant(variants, { ...variant, region })
-    }
-  }
-
-  return Array.from(variants.values()).sort(sortVariants)
+  return buildVariantsFromBaseMap({ baseVariants, regions })
 }
 
-const getCompletedPrimaryFitnessFilesForActor = async (
+const getCompletedPrimaryFitnessFileVariantsForActor = async (
   database: RecreateFitnessRouteHeatmapJobsDatabase,
   actorId: string
 ) => {
-  const fitnessFiles: FitnessFile[] = []
+  const variants = new Map<string, RecreateFitnessRouteHeatmapVariant>()
   let offset = 0
 
   while (true) {
@@ -195,7 +194,9 @@ const getCompletedPrimaryFitnessFilesForActor = async (
       offset
     })
 
-    fitnessFiles.push(...page)
+    for (const file of page) {
+      addFileVariants(variants, file)
+    }
 
     if (page.length < FITNESS_FILE_PAGE_SIZE) {
       break
@@ -204,7 +205,7 @@ const getCompletedPrimaryFitnessFilesForActor = async (
     offset += page.length
   }
 
-  return fitnessFiles
+  return variants
 }
 
 const buildJobId = ({
@@ -232,16 +233,16 @@ export const recreateFitnessRouteHeatmapJobs = async ({
   database,
   actorId,
   dryRun = false,
-  runId = crypto.randomUUID()
+  runId = randomUUID()
 }: RecreateFitnessRouteHeatmapJobsParams): Promise<RecreateFitnessRouteHeatmapJobsResult> => {
-  const [regions, fitnessFiles] = await Promise.all([
-    database.getDistinctRouteHeatmapRegionsForActor({ actorId }),
-    getCompletedPrimaryFitnessFilesForActor(database, actorId)
+  const [regions, baseVariants] = await Promise.all([
+    database.getDistinctRouteHeatmapRegionsForActor({
+      actorId,
+      includeDeleted: true
+    }),
+    getCompletedPrimaryFitnessFileVariantsForActor(database, actorId)
   ])
-  const variants = buildRecreateFitnessRouteHeatmapVariants({
-    fitnessFiles,
-    regions
-  })
+  const variants = buildVariantsFromBaseMap({ baseVariants, regions })
 
   if (dryRun) {
     return {
@@ -260,9 +261,9 @@ export const recreateFitnessRouteHeatmapJobs = async ({
   const errors: RecreateFitnessRouteHeatmapJobError[] = []
   let queuedCount = 0
 
-  for (const variant of variants) {
-    try {
-      await queue.publish({
+  const publishResults = await Promise.allSettled(
+    variants.map((variant) =>
+      queue.publish({
         id: buildJobId({ runId, actorId, variant }),
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
         data: {
@@ -273,14 +274,34 @@ export const recreateFitnessRouteHeatmapJobs = async ({
           ...(variant.region ? { region: variant.region } : {})
         }
       })
+    )
+  )
+
+  publishResults.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
       queuedCount += 1
-    } catch (error) {
+      return
+    }
+
+    const variant = variants[index]
+    const error =
+      result.reason instanceof Error
+        ? result.reason.message
+        : String(result.reason)
+
+    logger.warn({
+      message: 'Failed to publish route heatmap recreation job',
+      actorId,
+      error,
+      variant
+    })
+    if (variant) {
       errors.push({
         variant,
-        error: (error as Error).message
+        error
       })
     }
-  }
+  })
 
   return {
     variants,

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
@@ -3,12 +3,14 @@ import { randomUUID } from 'node:crypto'
 import type { Database } from '@/lib/database/types'
 import { GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import type { Queue } from '@/lib/services/queue/type'
 import type { FitnessFile } from '@/lib/types/database/fitnessFile'
 import type { FitnessRouteHeatmapPeriodType } from '@/lib/types/database/fitnessRouteHeatmap'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
 const FITNESS_FILE_PAGE_SIZE = 500
+const ROUTE_HEATMAP_RECREATE_PUBLISH_CONCURRENCY = 4
 
 export interface RecreateFitnessRouteHeatmapVariant {
   activityType: string | null
@@ -229,6 +231,73 @@ const buildJobId = ({
     ].join(':')
   )
 
+const publishRouteHeatmapVariant = ({
+  queue,
+  runId,
+  actorId,
+  variant
+}: {
+  queue: Queue
+  runId: string
+  actorId: string
+  variant: RecreateFitnessRouteHeatmapVariant
+}) =>
+  queue.publish({
+    id: buildJobId({ runId, actorId, variant }),
+    name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+    data: {
+      actorId,
+      activityType: variant.activityType,
+      periodType: variant.periodType,
+      periodKey: variant.periodKey,
+      ...(variant.region ? { region: variant.region } : {})
+    }
+  })
+
+const publishRouteHeatmapVariants = async ({
+  queue,
+  runId,
+  actorId,
+  variants
+}: {
+  queue: Queue
+  runId: string
+  actorId: string
+  variants: RecreateFitnessRouteHeatmapVariant[]
+}): Promise<PromiseSettledResult<void>[]> => {
+  const results: PromiseSettledResult<void>[] = []
+  let nextIndex = 0
+  const workerCount = Math.min(
+    ROUTE_HEATMAP_RECREATE_PUBLISH_CONCURRENCY,
+    variants.length
+  )
+
+  const publishNextVariant = async () => {
+    while (nextIndex < variants.length) {
+      const index = nextIndex
+      nextIndex += 1
+
+      try {
+        await publishRouteHeatmapVariant({
+          queue,
+          runId,
+          actorId,
+          variant: variants[index]
+        })
+        results[index] = { status: 'fulfilled', value: undefined }
+      } catch (error) {
+        results[index] = { status: 'rejected', reason: error }
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: workerCount }, () => publishNextVariant())
+  )
+
+  return results
+}
+
 export const recreateFitnessRouteHeatmapJobs = async ({
   database,
   actorId,
@@ -261,21 +330,12 @@ export const recreateFitnessRouteHeatmapJobs = async ({
   const errors: RecreateFitnessRouteHeatmapJobError[] = []
   let queuedCount = 0
 
-  const publishResults = await Promise.allSettled(
-    variants.map((variant) =>
-      queue.publish({
-        id: buildJobId({ runId, actorId, variant }),
-        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
-          actorId,
-          activityType: variant.activityType,
-          periodType: variant.periodType,
-          periodKey: variant.periodKey,
-          ...(variant.region ? { region: variant.region } : {})
-        }
-      })
-    )
-  )
+  const publishResults = await publishRouteHeatmapVariants({
+    queue,
+    runId,
+    actorId,
+    variants
+  })
 
   publishResults.forEach((result, index) => {
     if (result.status === 'fulfilled') {

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
@@ -1,0 +1,292 @@
+import crypto from 'crypto'
+
+import { GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+import { FitnessRouteHeatmapPeriodType } from '@/lib/types/database/fitnessRouteHeatmap'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+
+const FITNESS_FILE_PAGE_SIZE = 500
+
+export interface RecreateFitnessRouteHeatmapVariant {
+  activityType: string | null
+  periodType: FitnessRouteHeatmapPeriodType
+  periodKey: string
+  region?: string
+}
+
+export interface RecreateFitnessRouteHeatmapJobsDatabase {
+  getDistinctRouteHeatmapRegionsForActor(params: {
+    actorId: string
+  }): Promise<string[]>
+  getFitnessFilesByActor(params: {
+    actorId: string
+    processingStatus: 'completed'
+    isPrimary: true
+    limit: number
+    offset: number
+  }): Promise<FitnessFile[]>
+  deleteFitnessRouteHeatmapsForActor(params: {
+    actorId: string
+  }): Promise<number>
+}
+
+export interface RecreateFitnessRouteHeatmapJobsParams {
+  database: RecreateFitnessRouteHeatmapJobsDatabase
+  actorId: string
+  dryRun?: boolean
+  runId?: string
+}
+
+export interface RecreateFitnessRouteHeatmapJobError {
+  variant: RecreateFitnessRouteHeatmapVariant
+  error: string
+}
+
+export interface RecreateFitnessRouteHeatmapJobsResult {
+  variants: RecreateFitnessRouteHeatmapVariant[]
+  deletedCount: number
+  queuedCount: number
+  failedCount: number
+  errors: RecreateFitnessRouteHeatmapJobError[]
+}
+
+const PeriodTypeOrder: Record<FitnessRouteHeatmapPeriodType, number> = {
+  all_time: 0,
+  yearly: 1,
+  monthly: 2
+}
+
+const getVariantKey = ({
+  activityType,
+  periodType,
+  periodKey,
+  region
+}: RecreateFitnessRouteHeatmapVariant) =>
+  `${activityType ?? ''}\u0000${periodType}\u0000${periodKey}\u0000${region ?? ''}`
+
+const sortVariants = (
+  left: RecreateFitnessRouteHeatmapVariant,
+  right: RecreateFitnessRouteHeatmapVariant
+) =>
+  (left.region ?? '').localeCompare(right.region ?? '') ||
+  (left.activityType ?? '').localeCompare(right.activityType ?? '') ||
+  PeriodTypeOrder[left.periodType] - PeriodTypeOrder[right.periodType] ||
+  left.periodKey.localeCompare(right.periodKey)
+
+const addVariant = (
+  variants: Map<string, RecreateFitnessRouteHeatmapVariant>,
+  variant: RecreateFitnessRouteHeatmapVariant
+) => {
+  variants.set(getVariantKey(variant), variant)
+}
+
+const getActivityDate = (file: FitnessFile): Date | null => {
+  if (typeof file.activityStartTime !== 'number') {
+    return null
+  }
+
+  const date = new Date(file.activityStartTime)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+const addFileVariants = (
+  variants: Map<string, RecreateFitnessRouteHeatmapVariant>,
+  file: FitnessFile
+) => {
+  const activityType = file.activityType?.trim() || null
+  const activityDate = getActivityDate(file)
+
+  addVariant(variants, {
+    activityType: null,
+    periodType: 'all_time',
+    periodKey: 'all'
+  })
+
+  if (activityType) {
+    addVariant(variants, {
+      activityType,
+      periodType: 'all_time',
+      periodKey: 'all'
+    })
+  }
+
+  if (!activityDate) {
+    return
+  }
+
+  const year = activityDate.getUTCFullYear().toString()
+  const month = `${year}-${String(activityDate.getUTCMonth() + 1).padStart(2, '0')}`
+
+  addVariant(variants, {
+    activityType: null,
+    periodType: 'yearly',
+    periodKey: year
+  })
+  addVariant(variants, {
+    activityType: null,
+    periodType: 'monthly',
+    periodKey: month
+  })
+
+  if (activityType) {
+    addVariant(variants, {
+      activityType,
+      periodType: 'yearly',
+      periodKey: year
+    })
+    addVariant(variants, {
+      activityType,
+      periodType: 'monthly',
+      periodKey: month
+    })
+  }
+}
+
+const normalizeRegions = (regions: string[]) =>
+  Array.from(
+    new Set(regions.map((region) => region.trim()).filter(Boolean))
+  ).sort()
+
+export const buildRecreateFitnessRouteHeatmapVariants = ({
+  fitnessFiles,
+  regions
+}: {
+  fitnessFiles: FitnessFile[]
+  regions: string[]
+}): RecreateFitnessRouteHeatmapVariant[] => {
+  const baseVariants = new Map<string, RecreateFitnessRouteHeatmapVariant>()
+
+  for (const file of fitnessFiles) {
+    addFileVariants(baseVariants, file)
+  }
+
+  const sortedBaseVariants = Array.from(baseVariants.values()).sort(
+    sortVariants
+  )
+  const variants = new Map<string, RecreateFitnessRouteHeatmapVariant>()
+
+  for (const variant of sortedBaseVariants) {
+    addVariant(variants, variant)
+  }
+
+  for (const region of normalizeRegions(regions)) {
+    for (const variant of sortedBaseVariants) {
+      addVariant(variants, { ...variant, region })
+    }
+  }
+
+  return Array.from(variants.values()).sort(sortVariants)
+}
+
+const getCompletedPrimaryFitnessFilesForActor = async (
+  database: RecreateFitnessRouteHeatmapJobsDatabase,
+  actorId: string
+) => {
+  const fitnessFiles: FitnessFile[] = []
+  let offset = 0
+
+  while (true) {
+    const page = await database.getFitnessFilesByActor({
+      actorId,
+      processingStatus: 'completed',
+      isPrimary: true,
+      limit: FITNESS_FILE_PAGE_SIZE,
+      offset
+    })
+
+    fitnessFiles.push(...page)
+
+    if (page.length < FITNESS_FILE_PAGE_SIZE) {
+      break
+    }
+
+    offset += page.length
+  }
+
+  return fitnessFiles
+}
+
+const buildJobId = ({
+  runId,
+  actorId,
+  variant
+}: {
+  runId: string
+  actorId: string
+  variant: RecreateFitnessRouteHeatmapVariant
+}) =>
+  getHashFromString(
+    [
+      'recreate-route-heatmap',
+      runId,
+      actorId,
+      variant.activityType ?? 'all',
+      variant.periodType,
+      variant.periodKey,
+      variant.region ?? ''
+    ].join(':')
+  )
+
+export const recreateFitnessRouteHeatmapJobs = async ({
+  database,
+  actorId,
+  dryRun = false,
+  runId = crypto.randomUUID()
+}: RecreateFitnessRouteHeatmapJobsParams): Promise<RecreateFitnessRouteHeatmapJobsResult> => {
+  const [regions, fitnessFiles] = await Promise.all([
+    database.getDistinctRouteHeatmapRegionsForActor({ actorId }),
+    getCompletedPrimaryFitnessFilesForActor(database, actorId)
+  ])
+  const variants = buildRecreateFitnessRouteHeatmapVariants({
+    fitnessFiles,
+    regions
+  })
+
+  if (dryRun) {
+    return {
+      variants,
+      deletedCount: 0,
+      queuedCount: 0,
+      failedCount: 0,
+      errors: []
+    }
+  }
+
+  const deletedCount = await database.deleteFitnessRouteHeatmapsForActor({
+    actorId
+  })
+  const queue = getQueue()
+  const errors: RecreateFitnessRouteHeatmapJobError[] = []
+  let queuedCount = 0
+
+  for (const variant of variants) {
+    try {
+      await queue.publish({
+        id: buildJobId({ runId, actorId, variant }),
+        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+        data: {
+          actorId,
+          activityType: variant.activityType,
+          periodType: variant.periodType,
+          periodKey: variant.periodKey,
+          ...(variant.region ? { region: variant.region } : {})
+        }
+      })
+      queuedCount += 1
+    } catch (error) {
+      errors.push({
+        variant,
+        error: (error as Error).message
+      })
+    }
+  }
+
+  return {
+    variants,
+    deletedCount,
+    queuedCount,
+    failedCount: errors.length,
+    errors
+  }
+}

--- a/scripts/recreateFitnessRouteHeatmaps.test.ts
+++ b/scripts/recreateFitnessRouteHeatmaps.test.ts
@@ -1,0 +1,31 @@
+import { parseArgs } from './recreateFitnessRouteHeatmaps'
+
+describe('recreateFitnessRouteHeatmaps parseArgs', () => {
+  it('accepts bare, inline, and space-separated dry-run values', () => {
+    expect(parseArgs(['--actor-id', 'actor-1', '--dry-run'])).toEqual({
+      actorId: 'actor-1',
+      dryRun: true
+    })
+    expect(parseArgs(['--actor-id', 'actor-1', '--dry-run=false'])).toEqual({
+      actorId: 'actor-1',
+      dryRun: false
+    })
+    expect(parseArgs(['--actor-id', 'actor-1', '--dry-run', 'false'])).toEqual({
+      actorId: 'actor-1',
+      dryRun: false
+    })
+  })
+
+  it('leaves the next option available when dry-run has no value', () => {
+    expect(parseArgs(['--dry-run', '--actor-id', 'actor-1'])).toEqual({
+      actorId: 'actor-1',
+      dryRun: true
+    })
+  })
+
+  it('rejects invalid dry-run values with a targeted error', () => {
+    expect(() =>
+      parseArgs(['--actor-id', 'actor-1', '--dry-run', 'maybe'])
+    ).toThrow('Invalid value for --dry-run: maybe. Use true or false.')
+  })
+})

--- a/scripts/recreateFitnessRouteHeatmaps.ts
+++ b/scripts/recreateFitnessRouteHeatmaps.ts
@@ -34,7 +34,7 @@ const CliArgs = z.object({
 
 const USAGE = `Usage: NODE_ENV=production scripts/recreateFitnessRouteHeatmaps.ts \\
   --actor-id https://yourdomain.com/users/username \\
-  [--dry-run]`
+  [--dry-run [true|false]]`
 
 const parseDryRunValue = (value?: string) => {
   if (value === undefined) {
@@ -52,7 +52,7 @@ const parseDryRunValue = (value?: string) => {
   throw new Error(`Invalid value for --dry-run: ${value}. Use true or false.`)
 }
 
-const parseArgs = (args: string[]) => {
+export const parseArgs = (args: string[]) => {
   const parsedArgs: Record<string, string | boolean> = {}
 
   for (let index = 0; index < args.length; index += 1) {
@@ -63,7 +63,19 @@ const parseArgs = (args: string[]) => {
 
     const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
     if (rawKey === 'dry-run') {
-      parsedArgs[rawKey] = parseDryRunValue(inlineValue)
+      const nextValue = args[index + 1]
+      if (inlineValue !== undefined) {
+        parsedArgs[rawKey] = parseDryRunValue(inlineValue)
+        continue
+      }
+
+      if (nextValue && !nextValue.startsWith('--')) {
+        parsedArgs[rawKey] = parseDryRunValue(nextValue)
+        index += 1
+        continue
+      }
+
+      parsedArgs[rawKey] = parseDryRunValue()
       continue
     }
 

--- a/scripts/recreateFitnessRouteHeatmaps.ts
+++ b/scripts/recreateFitnessRouteHeatmaps.ts
@@ -36,6 +36,22 @@ const USAGE = `Usage: NODE_ENV=production scripts/recreateFitnessRouteHeatmaps.t
   --actor-id https://yourdomain.com/users/username \\
   [--dry-run]`
 
+const parseDryRunValue = (value?: string) => {
+  if (value === undefined) {
+    return true
+  }
+
+  if (value === 'true') {
+    return true
+  }
+
+  if (value === 'false') {
+    return false
+  }
+
+  throw new Error(`Invalid value for --dry-run: ${value}. Use true or false.`)
+}
+
 const parseArgs = (args: string[]) => {
   const parsedArgs: Record<string, string | boolean> = {}
 
@@ -47,7 +63,7 @@ const parseArgs = (args: string[]) => {
 
     const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
     if (rawKey === 'dry-run') {
-      parsedArgs[rawKey] = inlineValue === undefined ? true : inlineValue
+      parsedArgs[rawKey] = parseDryRunValue(inlineValue)
       continue
     }
 
@@ -103,47 +119,51 @@ async function recreateFitnessRouteHeatmaps(args = process.argv.slice(2)) {
     return 1
   }
 
-  const actor = await database.getActorFromId({ id: input.actorId })
-  if (!actor) {
-    console.error(`Error: Actor not found: ${input.actorId}`)
-    return 1
-  }
+  try {
+    const actor = await database.getActorFromId({ id: input.actorId })
+    if (!actor) {
+      console.error(`Error: Actor not found: ${input.actorId}`)
+      return 1
+    }
 
-  const result = await recreateFitnessRouteHeatmapJobs({
-    database,
-    actorId: actor.id,
-    dryRun: input.dryRun
-  })
+    const result = await recreateFitnessRouteHeatmapJobs({
+      database,
+      actorId: actor.id,
+      dryRun: input.dryRun
+    })
 
-  if (input.dryRun) {
+    if (input.dryRun) {
+      console.log(
+        `Dry run: found ${result.variants.length} route heatmap variant(s) for ${actor.id}.`
+      )
+
+      for (const variant of result.variants) {
+        console.log(`  - ${formatVariant(variant)}`)
+      }
+
+      return 0
+    }
+
     console.log(
-      `Dry run: found ${result.variants.length} route heatmap variant(s) for ${actor.id}.`
+      `Deleted ${result.deletedCount} existing route heatmap cache row(s) for ${actor.id}.`
+    )
+    console.log(
+      `Queued ${result.queuedCount} of ${result.variants.length} route heatmap generation job(s).`
     )
 
-    for (const variant of result.variants) {
-      console.log(`  - ${formatVariant(variant)}`)
+    if (result.failedCount > 0) {
+      console.error(
+        `Failed to queue ${result.failedCount} route heatmap generation job(s):`
+      )
+      for (const { variant, error } of result.errors) {
+        console.error(`  - ${formatVariant(variant)}: ${error}`)
+      }
     }
 
-    return 0
+    return result.failedCount > 0 ? 1 : 0
+  } finally {
+    await database.destroy()
   }
-
-  console.log(
-    `Deleted ${result.deletedCount} existing route heatmap cache row(s) for ${actor.id}.`
-  )
-  console.log(
-    `Queued ${result.queuedCount} of ${result.variants.length} route heatmap generation job(s).`
-  )
-
-  if (result.failedCount > 0) {
-    console.error(
-      `Failed to queue ${result.failedCount} route heatmap generation job(s):`
-    )
-    for (const { variant, error } of result.errors) {
-      console.error(`  - ${formatVariant(variant)}: ${error}`)
-    }
-  }
-
-  return result.failedCount > 0 ? 1 : 0
 }
 
 if (require.main === module) {

--- a/scripts/recreateFitnessRouteHeatmaps.ts
+++ b/scripts/recreateFitnessRouteHeatmaps.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env -S node -r @swc-node/register
+/**
+ * Recreates every discoverable route heatmap cache variant for one actor.
+ *
+ * The script soft-deletes existing route heatmap cache rows before queueing
+ * fresh generation jobs with unique recreate IDs, so failed prior attempts do
+ * not block the rebuild through queue deduplication.
+ *
+ * Usage:
+ *   NODE_ENV=production scripts/recreateFitnessRouteHeatmaps.ts \
+ *     --actor-id https://yourdomain.com/users/username
+ *
+ * Preview without deleting or queueing:
+ *   NODE_ENV=production scripts/recreateFitnessRouteHeatmaps.ts \
+ *     --actor-id https://yourdomain.com/users/username \
+ *     --dry-run
+ */
+import { loadEnvConfig } from '@next/env'
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import {
+  RecreateFitnessRouteHeatmapVariant,
+  recreateFitnessRouteHeatmapJobs
+} from '@/lib/jobs/recreateFitnessRouteHeatmapJobs'
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
+
+const CliArgs = z.object({
+  actorId: z.string().min(1),
+  dryRun: z.boolean().default(false)
+})
+
+const USAGE = `Usage: NODE_ENV=production scripts/recreateFitnessRouteHeatmaps.ts \\
+  --actor-id https://yourdomain.com/users/username \\
+  [--dry-run]`
+
+const parseArgs = (args: string[]) => {
+  const parsedArgs: Record<string, string | boolean> = {}
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
+    if (rawKey === 'dry-run') {
+      parsedArgs[rawKey] = inlineValue === undefined ? true : inlineValue
+      continue
+    }
+
+    const nextValue = inlineValue ?? args[index + 1]
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`Missing value for --${rawKey}`)
+    }
+
+    if (inlineValue === undefined) {
+      index += 1
+    }
+
+    parsedArgs[rawKey] = nextValue
+  }
+
+  return CliArgs.parse({
+    actorId: parsedArgs['actor-id'],
+    dryRun: parsedArgs['dry-run'] ?? false
+  })
+}
+
+const formatVariant = ({
+  activityType,
+  periodType,
+  periodKey,
+  region
+}: RecreateFitnessRouteHeatmapVariant) =>
+  [
+    activityType ?? 'all activities',
+    `${periodType}:${periodKey}`,
+    ...(region ? [`region:${region}`] : [])
+  ].join(' | ')
+
+async function recreateFitnessRouteHeatmaps(args = process.argv.slice(2)) {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE)
+    return 0
+  }
+
+  let input: z.infer<typeof CliArgs>
+  try {
+    input = parseArgs(args)
+  } catch (error) {
+    const nodeError = error as Error
+    console.error(nodeError.message)
+    console.error(USAGE)
+    return 1
+  }
+
+  const database = getDatabase()
+  if (!database) {
+    console.error('Error: Database is not available')
+    return 1
+  }
+
+  const actor = await database.getActorFromId({ id: input.actorId })
+  if (!actor) {
+    console.error(`Error: Actor not found: ${input.actorId}`)
+    return 1
+  }
+
+  const result = await recreateFitnessRouteHeatmapJobs({
+    database,
+    actorId: actor.id,
+    dryRun: input.dryRun
+  })
+
+  if (input.dryRun) {
+    console.log(
+      `Dry run: found ${result.variants.length} route heatmap variant(s) for ${actor.id}.`
+    )
+
+    for (const variant of result.variants) {
+      console.log(`  - ${formatVariant(variant)}`)
+    }
+
+    return 0
+  }
+
+  console.log(
+    `Deleted ${result.deletedCount} existing route heatmap cache row(s) for ${actor.id}.`
+  )
+  console.log(
+    `Queued ${result.queuedCount} of ${result.variants.length} route heatmap generation job(s).`
+  )
+
+  if (result.failedCount > 0) {
+    console.error(
+      `Failed to queue ${result.failedCount} route heatmap generation job(s):`
+    )
+    for (const { variant, error } of result.errors) {
+      console.error(`  - ${formatVariant(variant)}: ${error}`)
+    }
+  }
+
+  return result.failedCount > 0 ? 1 : 0
+}
+
+if (require.main === module) {
+  recreateFitnessRouteHeatmaps()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Script failed:', error)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary
- Add a reusable route heatmap recreation helper that enumerates every discoverable all-time, yearly, and monthly variant for an actor.
- Mirror known cached region variants, soft-delete existing route heatmap rows, and publish fresh unique generation jobs so failed prior attempts do not block recreation.
- Add `scripts/recreateFitnessRouteHeatmaps.ts` with `--actor-id` and `--dry-run` support.

## Validation
- `node -v && yarn run prettier --write .`
- `node -v && yarn lint` (0 errors; existing warnings remain)
- `node -v && yarn build`
- `node -v && yarn test`