### PR TITLE
fix: make status navigation timestamp-only

### DIFF
--- a/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
@@ -6,10 +6,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { votePoll } from '@/lib/client'
-import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+import {
+  pollStatusCurrentTime,
+  pollStatusFixture
+} from '@/lib/components/posts/__fixtures__/poll-status'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 
 import { StatusBox } from './StatusBox'
+
+const mockPush = jest.fn()
 
 jest.mock('@/lib/components/posts/collapsible-content', () => ({
   CollapsibleContent: ({ children }: { children: ReactNode }) => (
@@ -40,65 +45,8 @@ jest.mock('@/lib/utils/getStatusDetailPathClient', () => ({
   getStatusDetailPathClient: jest.fn()
 }))
 
-const mockPush = jest.fn()
 const mockVotePoll = jest.mocked(votePoll)
 const mockGetStatusDetailPathClient = jest.mocked(getStatusDetailPathClient)
-
-const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
-
-const pollStatus: StatusPoll = {
-  id: 'https://activities.local/users/llun/statuses/poll-1',
-  actorId: 'https://activities.local/users/llun',
-  actor: {
-    id: 'https://activities.local/users/llun',
-    username: 'llun',
-    domain: 'activities.local',
-    name: 'Llun',
-    followersUrl: 'https://activities.local/users/llun/followers',
-    inboxUrl: 'https://activities.local/users/llun/inbox',
-    sharedInboxUrl: 'https://activities.local/inbox',
-    followingCount: 0,
-    followersCount: 0,
-    statusCount: 0,
-    lastStatusAt: null,
-    createdAt: currentTime
-  },
-  to: [],
-  cc: [],
-  edits: [],
-  isLocalActor: true,
-  createdAt: currentTime,
-  updatedAt: currentTime,
-  type: StatusType.enum.Poll,
-  url: 'https://activities.local/@llun/poll-1',
-  text: 'Question',
-  summary: null,
-  reply: '',
-  replies: [],
-  actorAnnounceStatusId: null,
-  isActorLiked: false,
-  totalLikes: 0,
-  totalShares: 0,
-  tags: [],
-  endAt: new Date('2026-12-31T10:00:00.000Z').getTime(),
-  choices: [
-    {
-      title: 'Option A',
-      totalVotes: 2,
-      statusId: 'https://activities.local/users/llun/statuses/poll-1',
-      createdAt: currentTime,
-      updatedAt: currentTime
-    },
-    {
-      title: 'Option B',
-      totalVotes: 1,
-      statusId: 'https://activities.local/users/llun/statuses/poll-1',
-      createdAt: currentTime,
-      updatedAt: currentTime
-    }
-  ],
-  pollType: 'oneOf'
-}
 
 describe('StatusBox', () => {
   beforeEach(() => {
@@ -111,14 +59,18 @@ describe('StatusBox', () => {
     render(
       <StatusBox
         host="activities.local"
-        currentActor={pollStatus.actor}
-        currentTime={currentTime}
-        status={pollStatus}
+        currentActor={pollStatusFixture.actor}
+        currentTime={pollStatusCurrentTime}
+        status={pollStatusFixture}
         variant="comment"
       />
     )
 
     const option = screen.getByLabelText('Option A')
+
+    fireEvent.click(screen.getByText('Question'))
+    expect(mockGetStatusDetailPathClient).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
 
     fireEvent.click(option)
 

--- a/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { votePoll } from '@/lib/client'
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
+
+import { StatusBox } from './StatusBox'
+
+jest.mock('@/lib/components/posts/collapsible-content', () => ({
+  CollapsibleContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  )
+}))
+
+jest.mock('./FitnessStatusDetail', () => ({
+  FitnessStatusDetail: () => null
+}))
+
+jest.mock('./StatusLikes', () => ({
+  StatusLikes: () => null
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: jest.fn()
+  })
+}))
+
+jest.mock('@/lib/client', () => ({
+  votePoll: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getStatusDetailPathClient', () => ({
+  getStatusDetailPathClient: jest.fn()
+}))
+
+const mockPush = jest.fn()
+const mockVotePoll = jest.mocked(votePoll)
+const mockGetStatusDetailPathClient = jest.mocked(getStatusDetailPathClient)
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const pollStatus: StatusPoll = {
+  id: 'https://activities.local/users/llun/statuses/poll-1',
+  actorId: 'https://activities.local/users/llun',
+  actor: {
+    id: 'https://activities.local/users/llun',
+    username: 'llun',
+    domain: 'activities.local',
+    name: 'Llun',
+    followersUrl: 'https://activities.local/users/llun/followers',
+    inboxUrl: 'https://activities.local/users/llun/inbox',
+    sharedInboxUrl: 'https://activities.local/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: currentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Poll,
+  url: 'https://activities.local/@llun/poll-1',
+  text: 'Question',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  tags: [],
+  endAt: new Date('2026-12-31T10:00:00.000Z').getTime(),
+  choices: [
+    {
+      title: 'Option A',
+      totalVotes: 2,
+      statusId: 'https://activities.local/users/llun/statuses/poll-1',
+      createdAt: currentTime,
+      updatedAt: currentTime
+    },
+    {
+      title: 'Option B',
+      totalVotes: 1,
+      statusId: 'https://activities.local/users/llun/statuses/poll-1',
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
+  ],
+  pollType: 'oneOf'
+}
+
+describe('StatusBox', () => {
+  beforeEach(() => {
+    mockPush.mockClear()
+    mockVotePoll.mockReset()
+    mockGetStatusDetailPathClient.mockResolvedValue('/@llun/poll-1')
+  })
+
+  it('only opens comment status detail pages from the timestamp', async () => {
+    render(
+      <StatusBox
+        host="activities.local"
+        currentActor={pollStatus.actor}
+        currentTime={currentTime}
+        status={pollStatus}
+        variant="comment"
+      />
+    )
+
+    const option = screen.getByLabelText('Option A')
+
+    fireEvent.click(option)
+
+    expect(option).toBeChecked()
+    expect(mockGetStatusDetailPathClient).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /Open status by Llun/ }))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/@llun/poll-1')
+    })
+  })
+})

--- a/app/(timeline)/[actor]/[status]/StatusBox.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.tsx
@@ -67,9 +67,9 @@ export const StatusBox: FC<Props> = ({
     )
   }
 
-  const openStatus = () => {
+  const openStatus = (statusToOpen: Status) => {
     void (async () => {
-      const detailPath = await getStatusDetailPathClient(status)
+      const detailPath = await getStatusDetailPathClient(statusToOpen)
       if (detailPath) router.push(detailPath)
     })()
   }

--- a/app/(timeline)/[actor]/[status]/StatusBox.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.tsx
@@ -9,7 +9,6 @@ import { StatusReplyBox } from '@/lib/components/posts/status-reply-box'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
-import { cn } from '@/lib/utils'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 
 import { FitnessStatusDetail } from './FitnessStatusDetail'
@@ -68,21 +67,16 @@ export const StatusBox: FC<Props> = ({
     )
   }
 
+  const openStatus = () => {
+    void (async () => {
+      const detailPath = await getStatusDetailPathClient(status)
+      if (detailPath) router.push(detailPath)
+    })()
+  }
+
   return (
     <>
-      <article
-        className={cn(
-          'p-4 transition-colors',
-          variant === 'comment' && 'cursor-pointer hover:bg-muted/40'
-        )}
-        onClick={() => {
-          if (variant === 'detail') return
-          void (async () => {
-            const detailPath = await getStatusDetailPathClient(status)
-            if (detailPath) router.push(detailPath)
-          })()
-        }}
-      >
+      <article className="p-4 transition-colors">
         <Post
           host={host}
           currentActor={currentActor ?? undefined}
@@ -95,6 +89,7 @@ export const StatusBox: FC<Props> = ({
               ? (s) => setReplyTarget(s)
               : undefined
           }
+          onOpenStatus={variant === 'comment' ? openStatus : undefined}
           onShowAttachment={(allMedias, index) => {
             setModalMedias({ medias: allMedias, initialSelection: index })
           }}

--- a/lib/components/posts/__fixtures__/poll-status.ts
+++ b/lib/components/posts/__fixtures__/poll-status.ts
@@ -1,0 +1,60 @@
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+
+export const pollStatusCurrentTime = new Date(
+  '2026-04-26T10:00:00.000Z'
+).getTime()
+
+export const pollStatusFixture: StatusPoll = {
+  id: 'https://activities.local/users/llun/statuses/poll-1',
+  actorId: 'https://activities.local/users/llun',
+  actor: {
+    id: 'https://activities.local/users/llun',
+    username: 'llun',
+    domain: 'activities.local',
+    name: 'Llun',
+    followersUrl: 'https://activities.local/users/llun/followers',
+    inboxUrl: 'https://activities.local/users/llun/inbox',
+    sharedInboxUrl: 'https://activities.local/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: pollStatusCurrentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  attachments: [],
+  isLocalActor: true,
+  createdAt: pollStatusCurrentTime,
+  updatedAt: pollStatusCurrentTime,
+  type: StatusType.enum.Poll,
+  url: 'https://activities.local/@llun/poll-1',
+  text: 'Question',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  tags: [],
+  endAt: new Date('2026-12-31T10:00:00.000Z').getTime(),
+  choices: [
+    {
+      title: 'Option A',
+      totalVotes: 2,
+      statusId: 'https://activities.local/users/llun/statuses/poll-1',
+      createdAt: pollStatusCurrentTime,
+      updatedAt: pollStatusCurrentTime
+    },
+    {
+      title: 'Option B',
+      totalVotes: 1,
+      statusId: 'https://activities.local/users/llun/statuses/poll-1',
+      createdAt: pollStatusCurrentTime,
+      updatedAt: pollStatusCurrentTime
+    }
+  ],
+  pollType: 'oneOf'
+}

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -38,6 +38,7 @@ export interface PostProps {
   onReply?: (status: Status) => void
   onEdit?: (status: EditableStatus) => void
   onPostDeleted?: (status: Status) => void
+  onOpenStatus?: () => void
   onShowAttachment: OnMediaSelectedHandle
   collapsible?: boolean
   postLineLimit?: PostLineLimit
@@ -68,6 +69,12 @@ export const Post: FC<PostProps> = (props) => {
   const externalStatusUrl = actualStatus.url || actualStatus.id
   const showExternalLink =
     !actualStatus.isLocalActor && Boolean(externalStatusUrl)
+  const relativeCreatedAt = formatDistanceToNow(actualStatus.createdAt)
+  const actorName =
+    actualStatus.actor?.name ||
+    actualStatus.actor?.username ||
+    getActorIdMention(actualStatus.actorId)
+  const openStatusLabel = `Open status by ${actorName} from ${relativeCreatedAt}`
 
   const processedAndCleanedText = _.chain(actualStatus)
     .thru((s) => processStatusText(host, s))
@@ -231,9 +238,23 @@ export const Post: FC<PostProps> = (props) => {
               statusUrl={actualStatus.url}
             />
             <span className="text-muted-foreground">·</span>
-            <span className="text-muted-foreground text-xs whitespace-nowrap">
-              {formatDistanceToNow(actualStatus.createdAt)}
-            </span>
+            {props.onOpenStatus ? (
+              <button
+                type="button"
+                className="text-muted-foreground text-xs whitespace-nowrap hover:underline"
+                aria-label={openStatusLabel}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  props.onOpenStatus?.()
+                }}
+              >
+                {relativeCreatedAt}
+              </button>
+            ) : (
+              <span className="text-muted-foreground text-xs whitespace-nowrap">
+                {relativeCreatedAt}
+              </span>
+            )}
             {showExternalLink && (
               <a
                 href={externalStatusUrl}

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -1,4 +1,4 @@
-import { formatDistanceToNow } from 'date-fns'
+import { formatDistance } from 'date-fns'
 import _ from 'lodash'
 import { Activity, ExternalLink, LoaderCircle, Repeat2 } from 'lucide-react'
 import { FC } from 'react'
@@ -38,7 +38,7 @@ export interface PostProps {
   onReply?: (status: Status) => void
   onEdit?: (status: EditableStatus) => void
   onPostDeleted?: (status: Status) => void
-  onOpenStatus?: () => void
+  onOpenStatus?: (status: Status) => void
   onShowAttachment: OnMediaSelectedHandle
   collapsible?: boolean
   postLineLimit?: PostLineLimit
@@ -69,12 +69,17 @@ export const Post: FC<PostProps> = (props) => {
   const externalStatusUrl = actualStatus.url || actualStatus.id
   const showExternalLink =
     !actualStatus.isLocalActor && Boolean(externalStatusUrl)
-  const relativeCreatedAt = formatDistanceToNow(actualStatus.createdAt)
-  const actorName =
-    actualStatus.actor?.name ||
-    actualStatus.actor?.username ||
-    getActorIdMention(actualStatus.actorId)
-  const openStatusLabel = `Open status by ${actorName} from ${relativeCreatedAt}`
+  const relativeCreatedAt = formatDistance(
+    actualStatus.createdAt,
+    props.currentTime
+  )
+  const actorName = actualStatus.actor
+    ? actualStatus.actor.name || actualStatus.actor.username
+    : null
+  const openStatusLabel = actorName
+    ? `Open status by ${actorName}, posted ${relativeCreatedAt} ago`
+    : `Open status, posted ${relativeCreatedAt} ago`
+  const timestampClassName = 'text-muted-foreground text-xs whitespace-nowrap'
 
   const processedAndCleanedText = _.chain(actualStatus)
     .thru((s) => processStatusText(host, s))
@@ -132,7 +137,6 @@ export const Post: FC<PostProps> = (props) => {
               href={fitnessFile.url}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={(event) => event.stopPropagation()}
               className="truncate text-foreground underline-offset-2 hover:underline"
               title={fitnessFile.fileName}
             >
@@ -241,26 +245,22 @@ export const Post: FC<PostProps> = (props) => {
             {props.onOpenStatus ? (
               <button
                 type="button"
-                className="text-muted-foreground text-xs whitespace-nowrap hover:underline"
+                className={`${timestampClassName} -mx-1 inline-flex min-h-8 items-center rounded-sm px-1 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50`}
                 aria-label={openStatusLabel}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  props.onOpenStatus?.()
+                onClick={() => {
+                  props.onOpenStatus?.(status)
                 }}
               >
                 {relativeCreatedAt}
               </button>
             ) : (
-              <span className="text-muted-foreground text-xs whitespace-nowrap">
-                {relativeCreatedAt}
-              </span>
+              <span className={timestampClassName}>{relativeCreatedAt}</span>
             )}
             {showExternalLink && (
               <a
                 href={externalStatusUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={(event) => event.stopPropagation()}
                 className="ml-1 inline-flex items-center text-muted-foreground hover:text-foreground"
                 aria-label="Open original post"
                 title="Open original post"
@@ -276,7 +276,7 @@ export const Post: FC<PostProps> = (props) => {
             statusBody
           )}
 
-          <div onClick={(e) => e.stopPropagation()}>
+          <div>
             <Actions {...props} />
           </div>
         </div>

--- a/lib/components/posts/posts.test.tsx
+++ b/lib/components/posts/posts.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { votePoll } from '@/lib/client'
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
+
+import { Posts } from './posts'
+
+jest.mock('./collapsible-content', () => ({
+  CollapsibleContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  )
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush
+  })
+}))
+
+jest.mock('@/lib/client', () => ({
+  votePoll: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getStatusDetailPathClient', () => ({
+  getStatusDetailPathClient: jest.fn()
+}))
+
+const mockPush = jest.fn()
+const mockVotePoll = jest.mocked(votePoll)
+const mockGetStatusDetailPathClient = jest.mocked(getStatusDetailPathClient)
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const pollStatus: StatusPoll = {
+  id: 'https://activities.local/users/llun/statuses/poll-1',
+  actorId: 'https://activities.local/users/llun',
+  actor: {
+    id: 'https://activities.local/users/llun',
+    username: 'llun',
+    domain: 'activities.local',
+    name: 'Llun',
+    followersUrl: 'https://activities.local/users/llun/followers',
+    inboxUrl: 'https://activities.local/users/llun/inbox',
+    sharedInboxUrl: 'https://activities.local/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: currentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Poll,
+  url: 'https://activities.local/@llun/poll-1',
+  text: 'Question',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  tags: [],
+  endAt: new Date('2026-12-31T10:00:00.000Z').getTime(),
+  choices: [
+    {
+      title: 'Option A',
+      totalVotes: 2,
+      statusId: 'https://activities.local/users/llun/statuses/poll-1',
+      createdAt: currentTime,
+      updatedAt: currentTime
+    },
+    {
+      title: 'Option B',
+      totalVotes: 1,
+      statusId: 'https://activities.local/users/llun/statuses/poll-1',
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
+  ],
+  pollType: 'oneOf'
+}
+
+describe('Posts', () => {
+  beforeEach(() => {
+    mockPush.mockClear()
+    mockVotePoll.mockReset()
+    mockGetStatusDetailPathClient.mockResolvedValue('/@llun/poll-1')
+  })
+
+  it('does not open the status detail page when poll content is clicked', async () => {
+    render(
+      <Posts
+        host="activities.local"
+        currentActor={pollStatus.actor ?? undefined}
+        currentTime={currentTime}
+        statuses={[pollStatus]}
+      />
+    )
+
+    const option = screen.getByLabelText('Option A')
+
+    fireEvent.click(option)
+
+    expect(option).toBeChecked()
+    expect(mockGetStatusDetailPathClient).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('opens the status detail page from the timestamp', async () => {
+    render(
+      <Posts
+        host="activities.local"
+        currentTime={currentTime}
+        statuses={[pollStatus]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Open status by Llun/ }))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/@llun/poll-1')
+    })
+  })
+})

--- a/lib/components/posts/posts.test.tsx
+++ b/lib/components/posts/posts.test.tsx
@@ -6,10 +6,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { votePoll } from '@/lib/client'
-import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+import {
+  pollStatusCurrentTime,
+  pollStatusFixture
+} from '@/lib/components/posts/__fixtures__/poll-status'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 
 import { Posts } from './posts'
+
+const mockPush = jest.fn()
 
 jest.mock('./collapsible-content', () => ({
   CollapsibleContent: ({ children }: { children: ReactNode }) => (
@@ -31,65 +36,8 @@ jest.mock('@/lib/utils/getStatusDetailPathClient', () => ({
   getStatusDetailPathClient: jest.fn()
 }))
 
-const mockPush = jest.fn()
 const mockVotePoll = jest.mocked(votePoll)
 const mockGetStatusDetailPathClient = jest.mocked(getStatusDetailPathClient)
-
-const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
-
-const pollStatus: StatusPoll = {
-  id: 'https://activities.local/users/llun/statuses/poll-1',
-  actorId: 'https://activities.local/users/llun',
-  actor: {
-    id: 'https://activities.local/users/llun',
-    username: 'llun',
-    domain: 'activities.local',
-    name: 'Llun',
-    followersUrl: 'https://activities.local/users/llun/followers',
-    inboxUrl: 'https://activities.local/users/llun/inbox',
-    sharedInboxUrl: 'https://activities.local/inbox',
-    followingCount: 0,
-    followersCount: 0,
-    statusCount: 0,
-    lastStatusAt: null,
-    createdAt: currentTime
-  },
-  to: [],
-  cc: [],
-  edits: [],
-  isLocalActor: true,
-  createdAt: currentTime,
-  updatedAt: currentTime,
-  type: StatusType.enum.Poll,
-  url: 'https://activities.local/@llun/poll-1',
-  text: 'Question',
-  summary: null,
-  reply: '',
-  replies: [],
-  actorAnnounceStatusId: null,
-  isActorLiked: false,
-  totalLikes: 0,
-  totalShares: 0,
-  tags: [],
-  endAt: new Date('2026-12-31T10:00:00.000Z').getTime(),
-  choices: [
-    {
-      title: 'Option A',
-      totalVotes: 2,
-      statusId: 'https://activities.local/users/llun/statuses/poll-1',
-      createdAt: currentTime,
-      updatedAt: currentTime
-    },
-    {
-      title: 'Option B',
-      totalVotes: 1,
-      statusId: 'https://activities.local/users/llun/statuses/poll-1',
-      createdAt: currentTime,
-      updatedAt: currentTime
-    }
-  ],
-  pollType: 'oneOf'
-}
 
 describe('Posts', () => {
   beforeEach(() => {
@@ -102,13 +50,17 @@ describe('Posts', () => {
     render(
       <Posts
         host="activities.local"
-        currentActor={pollStatus.actor ?? undefined}
-        currentTime={currentTime}
-        statuses={[pollStatus]}
+        currentActor={pollStatusFixture.actor ?? undefined}
+        currentTime={pollStatusCurrentTime}
+        statuses={[pollStatusFixture]}
       />
     )
 
     const option = screen.getByLabelText('Option A')
+
+    fireEvent.click(screen.getByText('Question'))
+    expect(mockGetStatusDetailPathClient).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
 
     fireEvent.click(option)
 
@@ -121,8 +73,8 @@ describe('Posts', () => {
     render(
       <Posts
         host="activities.local"
-        currentTime={currentTime}
-        statuses={[pollStatus]}
+        currentTime={pollStatusCurrentTime}
+        statuses={[pollStatusFixture]}
       />
     )
 

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -73,6 +73,13 @@ export const Posts: FC<Props> = ({
     setReplyingToStatusId(null)
   }
 
+  const openStatus = (status: Status) => {
+    void (async () => {
+      const detailPath = await getStatusDetailPathClient(status)
+      if (detailPath) router.push(detailPath)
+    })()
+  }
+
   return (
     <section className={cn('w-full grid grid-cols-1', className)}>
       {statuses.map((status, index) => (
@@ -80,32 +87,23 @@ export const Posts: FC<Props> = ({
           key={`${index}-${status.id}`}
           className="border-b border-border/60 p-4 last:border-b-0"
         >
-          <div
-            className="cursor-pointer transition-colors hover:bg-muted/40 -m-4 p-4"
-            onClick={() => {
-              void (async () => {
-                const detailPath = await getStatusDetailPathClient(status)
-                if (detailPath) router.push(detailPath)
-              })()
+          <Post
+            host={host}
+            currentTime={currentTime}
+            currentActor={currentActor}
+            status={status}
+            showActions={showActions}
+            editable={currentActor?.id === status.actorId}
+            collapsible
+            postLineLimit={postLineLimit}
+            onReply={handleReply}
+            onEdit={onEdit}
+            onPostDeleted={onPostDeleted}
+            onOpenStatus={() => openStatus(status)}
+            onShowAttachment={(allMedias, index) => {
+              setModalMedias({ medias: allMedias, initialSelection: index })
             }}
-          >
-            <Post
-              host={host}
-              currentTime={currentTime}
-              currentActor={currentActor}
-              status={status}
-              showActions={showActions}
-              editable={currentActor?.id === status.actorId}
-              collapsible
-              postLineLimit={postLineLimit}
-              onReply={handleReply}
-              onEdit={onEdit}
-              onPostDeleted={onPostDeleted}
-              onShowAttachment={(allMedias, index) => {
-                setModalMedias({ medias: allMedias, initialSelection: index })
-              }}
-            />
-          </div>
+          />
           {replyingToStatusId === status.id && currentActor && (
             <div onClick={(e) => e.stopPropagation()}>
               <StatusReplyBox

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -82,9 +82,9 @@ export const Posts: FC<Props> = ({
 
   return (
     <section className={cn('w-full grid grid-cols-1', className)}>
-      {statuses.map((status, index) => (
+      {statuses.map((status) => (
         <article
-          key={`${index}-${status.id}`}
+          key={status.id}
           className="border-b border-border/60 p-4 last:border-b-0"
         >
           <Post
@@ -99,21 +99,19 @@ export const Posts: FC<Props> = ({
             onReply={handleReply}
             onEdit={onEdit}
             onPostDeleted={onPostDeleted}
-            onOpenStatus={() => openStatus(status)}
+            onOpenStatus={openStatus}
             onShowAttachment={(allMedias, index) => {
               setModalMedias({ medias: allMedias, initialSelection: index })
             }}
           />
           {replyingToStatusId === status.id && currentActor && (
-            <div onClick={(e) => e.stopPropagation()}>
-              <StatusReplyBox
-                profile={currentActor}
-                replyStatus={status}
-                isMediaUploadEnabled={isMediaUploadEnabled}
-                onCancel={handleCancelReply}
-                onPostCreated={handleReplyCreated}
-              />
-            </div>
+            <StatusReplyBox
+              profile={currentActor}
+              replyStatus={status}
+              isMediaUploadEnabled={isMediaUploadEnabled}
+              onCancel={handleCancelReply}
+              onPostCreated={handleReplyCreated}
+            />
           )}
         </article>
       ))}

--- a/lib/utils/getHashFromStringClient.test.ts
+++ b/lib/utils/getHashFromStringClient.test.ts
@@ -24,4 +24,24 @@ describe('getHashFromStringClient', () => {
     expect(hash).toHaveLength(64)
     expect(hash).toMatch(/^[a-f0-9]{64}$/)
   })
+
+  it('falls back when Web Crypto subtle digest is unavailable', async () => {
+    const originalCrypto = globalThis.crypto
+
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: {}
+    })
+
+    try {
+      await expect(getHashFromStringClient('test string')).resolves.toBe(
+        'd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+      )
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: originalCrypto
+      })
+    }
+  })
 })

--- a/lib/utils/getHashFromStringClient.test.ts
+++ b/lib/utils/getHashFromStringClient.test.ts
@@ -26,22 +26,31 @@ describe('getHashFromStringClient', () => {
   })
 
   it('falls back when Web Crypto subtle digest is unavailable', async () => {
-    const originalCrypto = globalThis.crypto
+    const originalSubtleDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis.crypto,
+      'subtle'
+    )
 
-    Object.defineProperty(globalThis, 'crypto', {
+    Object.defineProperty(globalThis.crypto, 'subtle', {
       configurable: true,
-      value: {}
+      value: undefined
     })
 
     try {
+      // SHA-256('test string')
       await expect(getHashFromStringClient('test string')).resolves.toBe(
         'd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
       )
     } finally {
-      Object.defineProperty(globalThis, 'crypto', {
-        configurable: true,
-        value: originalCrypto
-      })
+      if (originalSubtleDescriptor) {
+        Object.defineProperty(
+          globalThis.crypto,
+          'subtle',
+          originalSubtleDescriptor
+        )
+      } else {
+        Reflect.deleteProperty(globalThis.crypto, 'subtle')
+      }
     }
   })
 })

--- a/lib/utils/getHashFromStringClient.ts
+++ b/lib/utils/getHashFromStringClient.ts
@@ -101,6 +101,7 @@ export const getHashFromStringClient = async (str: string) => {
   const bytes = encoder.encode(str)
 
   if (!globalThis.crypto?.subtle) {
+    // activities.local browser verification can run over HTTP, where Web Crypto is unavailable.
     return getHashFromBytes(bytes)
   }
 

--- a/lib/utils/getHashFromStringClient.ts
+++ b/lib/utils/getHashFromStringClient.ts
@@ -1,7 +1,110 @@
 const encoder = new TextEncoder()
 
+const SHA_256_INITIAL_HASH = [
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+  0x1f83d9ab, 0x5be0cd19
+]
+
+const SHA_256_ROUND_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+]
+
+const rotateRight = (value: number, bits: number) =>
+  (value >>> bits) | (value << (32 - bits))
+
+const toHex = (value: number) => value.toString(16).padStart(8, '0')
+
+const getHashFromBytes = (bytes: Uint8Array) => {
+  const bitLength = bytes.length * 8
+  const paddedLength = Math.ceil((bytes.length + 1 + 8) / 64) * 64
+  const data = new Uint8Array(paddedLength)
+  data.set(bytes)
+  data[bytes.length] = 0x80
+
+  const dataView = new DataView(data.buffer)
+  dataView.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000))
+  dataView.setUint32(paddedLength - 4, bitLength >>> 0)
+
+  const hash = [...SHA_256_INITIAL_HASH]
+  const words = new Uint32Array(64)
+
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      words[index] = dataView.getUint32(offset + index * 4)
+    }
+
+    for (let index = 16; index < 64; index += 1) {
+      const s0 =
+        rotateRight(words[index - 15], 7) ^
+        rotateRight(words[index - 15], 18) ^
+        (words[index - 15] >>> 3)
+      const s1 =
+        rotateRight(words[index - 2], 17) ^
+        rotateRight(words[index - 2], 19) ^
+        (words[index - 2] >>> 10)
+      words[index] = (words[index - 16] + s0 + words[index - 7] + s1) >>> 0
+    }
+
+    let a = hash[0]
+    let b = hash[1]
+    let c = hash[2]
+    let d = hash[3]
+    let e = hash[4]
+    let f = hash[5]
+    let g = hash[6]
+    let h = hash[7]
+
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)
+      const choice = (e & f) ^ (~e & g)
+      const temp1 =
+        (h + sum1 + choice + SHA_256_ROUND_CONSTANTS[index] + words[index]) >>>
+        0
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22)
+      const majority = (a & b) ^ (a & c) ^ (b & c)
+      const temp2 = (sum0 + majority) >>> 0
+
+      h = g
+      g = f
+      f = e
+      e = (d + temp1) >>> 0
+      d = c
+      c = b
+      b = a
+      a = (temp1 + temp2) >>> 0
+    }
+
+    hash[0] = (hash[0] + a) >>> 0
+    hash[1] = (hash[1] + b) >>> 0
+    hash[2] = (hash[2] + c) >>> 0
+    hash[3] = (hash[3] + d) >>> 0
+    hash[4] = (hash[4] + e) >>> 0
+    hash[5] = (hash[5] + f) >>> 0
+    hash[6] = (hash[6] + g) >>> 0
+    hash[7] = (hash[7] + h) >>> 0
+  }
+
+  return hash.map(toHex).join('')
+}
+
 export const getHashFromStringClient = async (str: string) => {
-  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(str))
+  const bytes = encoder.encode(str)
+
+  if (!globalThis.crypto?.subtle) {
+    return getHashFromBytes(bytes)
+  }
+
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
   return Array.from(new Uint8Array(digest))
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('')


### PR DESCRIPTION
## Summary

- Move status-detail navigation from the whole timeline/comment container to the timestamp control.
- Keep poll/body clicks local to the post so poll interaction no longer opens the status page.
- Add regression coverage for timeline posts and status-detail comment boxes.
- Add a client SHA-256 fallback for non-secure local hosts where `crypto.subtle` is unavailable, which keeps timestamp status links working on `activities.local` over HTTP.

## Root Cause

Timeline posts and comment status boxes attached `router.push` to the outer post container. Poll clicks bubbled to that container, so clicking poll content opened the status detail page.

## Validation

- `yarn run prettier --write .`
- `yarn lint` (0 errors; existing warnings only)
- `yarn build`
- `yarn test` (247 suites, 1843 tests)
- `yarn migrate` against a local SQLite dev DB
- Browser verified on `http://activities.local:3000`: clicking poll content stayed on the profile page, clicking the timestamp opened the status detail page.