### PR TITLE
feat: Add production archive scripts

### DIFF
--- a/scripts/downloadProductionArchive.ts
+++ b/scripts/downloadProductionArchive.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S node -r @swc-node/register
+/**
+ * Downloads a read-only production snapshot into a local archive.
+ *
+ * Usage:
+ *   NODE_ENV=production scripts/downloadProductionArchive.ts
+ *
+ * The default archive includes database rows plus database-referenced media and
+ * fitness files. Use --storage-scope all to include every object in the
+ * configured storage locations.
+ */
+import { downloadProductionArchive } from './productionArchive'
+
+if (require.main === module) {
+  downloadProductionArchive()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Archive download failed:', error)
+      process.exit(1)
+    })
+}

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -1,5 +1,9 @@
+import { execFile } from 'child_process'
+import fs from 'fs/promises'
+import knex from 'knex'
 import os from 'os'
 import path from 'path'
+import { promisify } from 'util'
 
 import { FitnessStorageType } from '@/lib/config/fitnessStorage'
 import { MediaStorageType } from '@/lib/config/mediaStorage'
@@ -10,10 +14,15 @@ import {
   isLocalDatabaseConfig,
   isLocalDatabaseConnection,
   isSafeArchiveEntryPath,
+  isSafeTarArchiveVerboseEntry,
   parseDownloadArgs,
   parseRestoreArgs,
-  sortTablesForRestore
+  sortTablesForRestore,
+  truncateTables,
+  validateTarArchivePaths
 } from './productionArchive'
+
+const execFileAsync = promisify(execFile)
 
 describe('production archive scripts', () => {
   describe('parseDownloadArgs', () => {
@@ -86,9 +95,17 @@ describe('production archive scripts', () => {
       expect(isLocalDatabaseConnection({ host: '127.0.0.1' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '::1' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: 'postgres' })).toBe(true)
-      expect(isLocalDatabaseConnection({ filename: './dev.sqlite3' })).toBe(
+      expect(isLocalDatabaseConnection({ host: '/var/run/postgresql' })).toBe(
         true
       )
+      expect(
+        isLocalDatabaseConnection('postgresql:///activity?host=/var/run')
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://%2Fvar%2Frun%2Fpostgresql/activity'
+        )
+      ).toBe(true)
     })
 
     it('rejects remote database hosts', () => {
@@ -120,6 +137,24 @@ describe('production archive scripts', () => {
           connection: { host: 'localhost' }
         })
       ).toBe(true)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: { host: '/var/run/postgresql' }
+        })
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: 'postgresql:///activity?host=/var/run/postgresql'
+        })
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'mysql2',
+          connection: { socketPath: '/tmp/mysql.sock' }
+        })
+      ).toBe(true)
     })
 
     it('rejects database configs without explicit local targets', () => {
@@ -133,6 +168,18 @@ describe('production archive scripts', () => {
         isLocalDatabaseConfig({
           client: 'pg',
           connection: { host: 'prod-db.example.com' }
+        })
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: { filename: './dev.sqlite3' }
+        })
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: { socketPath: '/tmp/mysql.sock' }
         })
       ).toBe(false)
     })
@@ -321,6 +368,94 @@ describe('production archive scripts', () => {
       expect(isSafeArchiveEntryPath('../x')).toBe(false)
       expect(isSafeArchiveEntryPath('/x')).toBe(false)
       expect(isSafeArchiveEntryPath('storage/../../x')).toBe(false)
+      expect(isSafeArchiveEntryPath('..\\..\\etc\\passwd')).toBe(false)
+      expect(isSafeArchiveEntryPath('storage\\..\\..\\x')).toBe(false)
+      expect(isSafeArchiveEntryPath('\\absolute')).toBe(false)
+    })
+  })
+
+  describe('validateTarArchivePaths', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'production-archive-test-')
+      )
+    })
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { force: true, recursive: true })
+    })
+
+    it('rejects symlink and hardlink archive entries', async () => {
+      const sourceDir = path.join(tempDir, 'source')
+      await fs.mkdir(sourceDir)
+      await fs.writeFile(path.join(sourceDir, 'file.txt'), 'content')
+      await fs.symlink('/etc/passwd', path.join(sourceDir, 'link'))
+      await fs.link(
+        path.join(sourceDir, 'file.txt'),
+        path.join(sourceDir, 'hardlink')
+      )
+      const archivePath = path.join(tempDir, 'archive.tar.gz')
+
+      await execFileAsync('tar', ['-czf', archivePath, '-C', sourceDir, '.'])
+
+      await expect(validateTarArchivePaths(archivePath)).rejects.toThrow(
+        'unsupported entry type'
+      )
+    })
+  })
+
+  describe('isSafeTarArchiveVerboseEntry', () => {
+    it('rejects tar symlink and hardlink listings', () => {
+      expect(
+        isSafeTarArchiveVerboseEntry(
+          'lrwxr-xr-x  0 llun staff 0 May  9 21:02 ./link -> /etc/passwd'
+        )
+      ).toBe(false)
+      expect(
+        isSafeTarArchiveVerboseEntry(
+          'hrw-r--r--  0 llun staff 0 May  9 21:02 ./hard link to ./file'
+        )
+      ).toBe(false)
+      expect(
+        isSafeTarArchiveVerboseEntry(
+          '-rw-r--r--  0 llun staff 7 May  9 21:02 ./file.txt'
+        )
+      ).toBe(true)
+    })
+  })
+
+  describe('truncateTables', () => {
+    it('uses one SQLite connection while foreign keys are disabled', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+
+      try {
+        await database.schema.createTable('parents', (table) => {
+          table.integer('id').primary()
+        })
+        await database.schema.createTable('children', (table) => {
+          table.integer('id').primary()
+          table.integer('parentId').references('parents.id')
+        })
+        await database('parents').insert({ id: 1 })
+        await database('children').insert({ id: 1, parentId: 1 })
+
+        await truncateTables(
+          database,
+          ['parents', 'children'],
+          ['children', 'parents']
+        )
+
+        await expect(database('parents')).resolves.toEqual([])
+        await expect(database('children')).resolves.toEqual([])
+      } finally {
+        await database.destroy()
+      }
     })
   })
 })

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -1,8 +1,10 @@
+import { S3Client } from '@aws-sdk/client-s3'
 import { execFile } from 'child_process'
 import fs from 'fs/promises'
 import knex from 'knex'
 import os from 'os'
 import path from 'path'
+import { Readable } from 'stream'
 import { promisify } from 'util'
 
 import { FitnessStorageType } from '@/lib/config/fitnessStorage'
@@ -10,12 +12,14 @@ import { MediaStorageType } from '@/lib/config/mediaStorage'
 
 import {
   PUBLIC_STORAGE_FETCH_TIMEOUT_MS,
+  archiveStorage,
   assertArchiveTableFilesReadable,
   assertMatchingMigrations,
   assertSafeDirectoryToReplace,
   buildStoragePlan,
   createPublicStorageFetchInit,
   createS3Client,
+  exportDatabase,
   fetchPublicStorageResponse,
   getDatabaseTableNames,
   getReferencedStoragePaths,
@@ -103,6 +107,11 @@ describe('production archive scripts', () => {
 
   describe('isLocalDatabaseConnection', () => {
     it('allows localhost, loopback, and socket hosts', () => {
+      expect(isLocalDatabaseConnection('localhost')).toBe(true)
+      expect(isLocalDatabaseConnection('127.0.0.1')).toBe(true)
+      expect(isLocalDatabaseConnection('::1')).toBe(true)
+      expect(isLocalDatabaseConnection('[::1]')).toBe(true)
+      expect(isLocalDatabaseConnection('/var/run/postgresql')).toBe(true)
       expect(isLocalDatabaseConnection({ host: 'localhost' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '127.0.0.1' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '::1' })).toBe(true)
@@ -152,6 +161,7 @@ describe('production archive scripts', () => {
         false
       )
       expect(isLocalDatabaseConnection({ host: 'postgres' })).toBe(false)
+      expect(isLocalDatabaseConnection('prod-db.example.com')).toBe(false)
       expect(isLocalDatabaseConnection('postgresql://postgres/activity')).toBe(
         false
       )
@@ -554,6 +564,274 @@ describe('production archive scripts', () => {
     })
   })
 
+  describe('exportDatabase', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'production-archive-export-test-')
+      )
+    })
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { force: true, recursive: true })
+    })
+
+    it('uses SQLite rowid keyset pagination without exporting rowid', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+      const statements: string[] = []
+      database.on('query', (query) => {
+        statements.push(query.sql)
+      })
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      try {
+        await database.schema.createTable('events', (table) => {
+          table.string('name')
+        })
+        await database.batchInsert(
+          'events',
+          Array.from({ length: 1005 }, (_, index) => ({
+            name: `event-${index}`
+          })),
+          200
+        )
+
+        const result = await exportDatabase(database, tempDir, {
+          includeReferencedStoragePaths: false
+        })
+
+        expect(result.manifest.tables).toEqual([
+          { name: 'events', rowCount: 1005 }
+        ])
+
+        const payload = await fs.readFile(
+          path.join(tempDir, 'database', 'events.jsonl'),
+          'utf-8'
+        )
+        const rows = payload
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+
+        expect(rows).toHaveLength(1005)
+        expect(rows[0]).toEqual({ name: 'event-0' })
+        expect(rows[1004]).toEqual({ name: 'event-1004' })
+        expect(rows.every((row) => !('rowid' in row))).toBe(true)
+        expect(
+          rows.every((row) => {
+            return !Object.keys(row).some((key) => {
+              return key.startsWith('__activitynext_archive_cursor_')
+            })
+          })
+        ).toBe(true)
+
+        const tableExportStatements = statements.filter((statement) => {
+          return statement.includes('from `events`')
+        })
+        expect(
+          tableExportStatements.every((statement) => {
+            return !statement.toLowerCase().includes('offset')
+          })
+        ).toBe(true)
+        expect(
+          tableExportStatements.some((statement) => {
+            return (
+              statement.includes('`rowid` as') &&
+              statement.includes('`rowid` > ?')
+            )
+          })
+        ).toBe(true)
+      } finally {
+        logSpy.mockRestore()
+        await database.destroy()
+      }
+    })
+
+    it('uses an unshadowed SQLite rowid cursor for no-primary-key tables', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+      const statements: string[] = []
+      database.on('query', (query) => {
+        statements.push(query.sql)
+      })
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      try {
+        await database.schema.createTable('events', (table) => {
+          table.string('rowid')
+          table.string('name')
+        })
+        await database.batchInsert(
+          'events',
+          Array.from({ length: 1005 }, (_, index) => ({
+            name: `event-${index}`,
+            rowid: 'duplicate-user-value'
+          })),
+          200
+        )
+
+        await exportDatabase(database, tempDir, {
+          includeReferencedStoragePaths: false
+        })
+
+        const payload = await fs.readFile(
+          path.join(tempDir, 'database', 'events.jsonl'),
+          'utf-8'
+        )
+        const rows = payload
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+
+        expect(rows).toHaveLength(1005)
+        expect(rows[1004]).toEqual({
+          name: 'event-1004',
+          rowid: 'duplicate-user-value'
+        })
+        expect(
+          statements.some((statement) => {
+            return (
+              statement.includes('`_rowid_` as') &&
+              statement.includes('`_rowid_` > ?')
+            )
+          })
+        ).toBe(true)
+      } finally {
+        logSpy.mockRestore()
+        await database.destroy()
+      }
+    })
+
+    it('treats SQLite rowid cursor shadowing as case-insensitive', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+      const statements: string[] = []
+      database.on('query', (query) => {
+        statements.push(query.sql)
+      })
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      try {
+        await database.schema.createTable('events', (table) => {
+          table.string('ROWID')
+          table.string('name')
+        })
+        await database.batchInsert(
+          'events',
+          Array.from({ length: 1005 }, (_, index) => ({
+            name: `event-${index}`,
+            ROWID: 'duplicate-user-value'
+          })),
+          200
+        )
+
+        await exportDatabase(database, tempDir, {
+          includeReferencedStoragePaths: false
+        })
+
+        const payload = await fs.readFile(
+          path.join(tempDir, 'database', 'events.jsonl'),
+          'utf-8'
+        )
+        const rows = payload
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+
+        expect(rows).toHaveLength(1005)
+        expect(rows[1004]).toEqual({
+          ROWID: 'duplicate-user-value',
+          name: 'event-1004'
+        })
+        expect(
+          statements.some((statement) => {
+            return (
+              statement.includes('`_rowid_` as') &&
+              statement.includes('`_rowid_` > ?')
+            )
+          })
+        ).toBe(true)
+      } finally {
+        logSpy.mockRestore()
+        await database.destroy()
+      }
+    })
+
+    it('uses a non-colliding private cursor alias for SQLite rowid export', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+      const statements: string[] = []
+      database.on('query', (query) => {
+        statements.push(query.sql)
+      })
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      try {
+        await database.schema.createTable('events', (table) => {
+          table.string('__activitynext_archive_cursor')
+          table.string('__ACTIVITYNEXT_ARCHIVE_CURSOR_1')
+          table.string('name')
+        })
+        await database.batchInsert(
+          'events',
+          Array.from({ length: 1005 }, (_, index) => ({
+            __ACTIVITYNEXT_ARCHIVE_CURSOR_1: `upper-real-${index}`,
+            __activitynext_archive_cursor: `real-${index}`,
+            name: `event-${index}`
+          })),
+          200
+        )
+
+        await exportDatabase(database, tempDir, {
+          includeReferencedStoragePaths: false
+        })
+
+        const payload = await fs.readFile(
+          path.join(tempDir, 'database', 'events.jsonl'),
+          'utf-8'
+        )
+        const rows = payload
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+
+        expect(rows).toHaveLength(1005)
+        expect(rows[1004]).toEqual({
+          __ACTIVITYNEXT_ARCHIVE_CURSOR_1: 'upper-real-1004',
+          __activitynext_archive_cursor: 'real-1004',
+          name: 'event-1004'
+        })
+        expect(
+          rows.every((row) => {
+            return !('__activitynext_archive_cursor_2' in row)
+          })
+        ).toBe(true)
+        expect(
+          statements.some((statement) => {
+            return statement.includes('as `__activitynext_archive_cursor_2`')
+          })
+        ).toBe(true)
+      } finally {
+        logSpy.mockRestore()
+        await database.destroy()
+      }
+    })
+  })
+
   describe('createS3Client', () => {
     it('uses the configured hostname as the S3-compatible endpoint', async () => {
       expect(normalizeStorageHostname('https://storage.example.com/')).toBe(
@@ -651,6 +929,94 @@ describe('production archive scripts', () => {
         })
       )
       expect(jest.getTimerCount()).toBe(0)
+    })
+  })
+
+  describe('archiveStorage', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'production-archive-storage-test-')
+      )
+    })
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { force: true, recursive: true })
+    })
+
+    it('removes partial files for allowed missing storage downloads', async () => {
+      const sendSpy = jest
+        .spyOn(S3Client.prototype, 'send')
+        .mockImplementation((async (command: { input?: { Key?: string } }) => {
+          if (command.input?.Key === 'bad.txt') {
+            return {
+              Body: Readable.from(
+                (async function* streamPartialThenFail() {
+                  yield Buffer.from('partial')
+                  throw new Error('stream failed')
+                })()
+              )
+            }
+          }
+
+          return { Body: Readable.from([Buffer.from('ok')]) }
+        }) as typeof S3Client.prototype.send)
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      try {
+        await fs.mkdir(path.join(tempDir, 'storage', 'media', 'files'), {
+          recursive: true
+        })
+        await fs.writeFile(
+          path.join(tempDir, 'storage', 'media', 'files', 'bad.txt'),
+          'stale partial'
+        )
+
+        const manifest = await archiveStorage(
+          [
+            {
+              destination: 'media',
+              files: ['bad.txt', 'good.txt'],
+              source: {
+                bucket: 'activitynext',
+                kind: 's3',
+                region: 'auto'
+              }
+            }
+          ],
+          tempDir,
+          { allowMissingStorage: true }
+        )
+
+        expect(manifest).toEqual([
+          expect.objectContaining({
+            destination: 'media',
+            failedFiles: [
+              expect.objectContaining({
+                error: expect.stringContaining('stream failed'),
+                path: 'bad.txt'
+              })
+            ],
+            fileCount: 1,
+            totalBytes: 2
+          })
+        ])
+        await expect(
+          fs.readFile(
+            path.join(tempDir, 'storage', 'media', 'files', 'good.txt'),
+            'utf-8'
+          )
+        ).resolves.toBe('ok')
+        await expect(
+          fs.access(path.join(tempDir, 'storage', 'media', 'files', 'bad.txt'))
+        ).rejects.toThrow()
+      } finally {
+        sendSpy.mockRestore()
+        logSpy.mockRestore()
+        errorSpy.mockRestore()
+      }
     })
   })
 

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -1,0 +1,160 @@
+import { FitnessStorageType } from '@/lib/config/fitnessStorage'
+import { MediaStorageType } from '@/lib/config/mediaStorage'
+
+import {
+  buildStoragePlan,
+  isLocalDatabaseConnection,
+  parseDownloadArgs,
+  parseRestoreArgs,
+  sortTablesForRestore
+} from './productionArchive'
+
+describe('production archive scripts', () => {
+  describe('parseDownloadArgs', () => {
+    it('uses production-safe defaults', () => {
+      expect(parseDownloadArgs([])).toEqual({
+        allowMissingStorage: false,
+        envFile: '.env.production',
+        outputDir: 'backups/production-archives',
+        skipDatabase: false,
+        skipStorage: false,
+        storageScope: 'referenced'
+      })
+    })
+
+    it('accepts explicit output and all-storage mode', () => {
+      expect(
+        parseDownloadArgs([
+          '--env-file',
+          '.env.prod.snapshot',
+          '--output-dir=tmp/archive',
+          '--storage-scope',
+          'all',
+          '--allow-missing-storage',
+          '--skip-storage'
+        ])
+      ).toEqual({
+        allowMissingStorage: true,
+        envFile: '.env.prod.snapshot',
+        outputDir: 'tmp/archive',
+        skipDatabase: false,
+        skipStorage: true,
+        storageScope: 'all'
+      })
+    })
+  })
+
+  describe('parseRestoreArgs', () => {
+    it('requires an archive and an explicit confirmation', () => {
+      expect(() => parseRestoreArgs(['--archive', 'backup.tar.gz'])).toThrow(
+        'Restoring replaces local data. Pass --yes to continue.'
+      )
+    })
+
+    it('accepts a local restore target', () => {
+      expect(
+        parseRestoreArgs([
+          '--archive',
+          'backup.tar.gz',
+          '--env-file',
+          '.env.local',
+          '--yes',
+          '--preserve-files'
+        ])
+      ).toEqual({
+        allowNonLocalDatabase: false,
+        archive: 'backup.tar.gz',
+        databaseOnly: false,
+        envFile: '.env.local',
+        filesOnly: false,
+        preserveFiles: true,
+        yes: true
+      })
+    })
+  })
+
+  describe('isLocalDatabaseConnection', () => {
+    it('allows localhost, loopback, and docker postgres hosts', () => {
+      expect(isLocalDatabaseConnection({ host: 'localhost' })).toBe(true)
+      expect(isLocalDatabaseConnection({ host: '127.0.0.1' })).toBe(true)
+      expect(isLocalDatabaseConnection({ host: '::1' })).toBe(true)
+      expect(isLocalDatabaseConnection({ host: 'postgres' })).toBe(true)
+    })
+
+    it('rejects remote database hosts', () => {
+      expect(isLocalDatabaseConnection({ host: 'prod-db.example.com' })).toBe(
+        false
+      )
+    })
+  })
+
+  describe('buildStoragePlan', () => {
+    it('downloads referenced media and fitness files without duplicating a shared fitness prefix', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: ['2026-01-01/activity.fit'],
+        mediaFilePaths: ['medias/image.webp', 'fitness/legacy.fit'],
+        scope: 'referenced',
+        mediaStorage: {
+          type: MediaStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          region: 'auto'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          region: 'auto',
+          prefix: 'fitness/'
+        }
+      })
+
+      expect(plan).toEqual([
+        {
+          destination: 'media',
+          files: ['medias/image.webp'],
+          source: {
+            bucket: 'activitynext',
+            kind: 's3',
+            prefix: undefined,
+            region: 'auto'
+          }
+        },
+        {
+          destination: 'fitness',
+          files: ['2026-01-01/activity.fit'],
+          source: {
+            bucket: 'activitynext',
+            kind: 's3',
+            prefix: 'fitness/',
+            region: 'auto'
+          }
+        }
+      ])
+    })
+  })
+
+  describe('sortTablesForRestore', () => {
+    it('orders parent tables before dependent tables', () => {
+      expect(
+        sortTablesForRestore(
+          ['attachments', 'actors', 'statuses'],
+          [
+            { fromTable: 'statuses', toTable: 'actors' },
+            { fromTable: 'attachments', toTable: 'statuses' }
+          ]
+        )
+      ).toEqual(['actors', 'statuses', 'attachments'])
+    })
+
+    it('keeps self references from creating cycles', () => {
+      expect(
+        sortTablesForRestore(
+          ['statuses', 'actors'],
+          [
+            { fromTable: 'statuses', toTable: 'statuses' },
+            { fromTable: 'statuses', toTable: 'actors' }
+          ]
+        )
+      ).toEqual(['actors', 'statuses'])
+    })
+  })
+})

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -9,12 +9,18 @@ import { FitnessStorageType } from '@/lib/config/fitnessStorage'
 import { MediaStorageType } from '@/lib/config/mediaStorage'
 
 import {
+  PUBLIC_STORAGE_FETCH_TIMEOUT_MS,
+  assertMatchingMigrations,
   assertSafeDirectoryToReplace,
   buildStoragePlan,
+  createPublicStorageFetchInit,
+  createS3Client,
+  getReferencedStoragePaths,
   isLocalDatabaseConfig,
   isLocalDatabaseConnection,
   isSafeArchiveEntryPath,
   isSafeTarArchiveVerboseEntry,
+  normalizeStorageHostname,
   parseDownloadArgs,
   parseRestoreArgs,
   sortTablesForRestore,
@@ -101,6 +107,7 @@ describe('production archive scripts', () => {
       expect(
         isLocalDatabaseConnection('postgresql:///activity?host=/var/run')
       ).toBe(true)
+      expect(isLocalDatabaseConnection('postgresql:///activity')).toBe(true)
       expect(
         isLocalDatabaseConnection(
           'postgresql://%2Fvar%2Frun%2Fpostgresql/activity'
@@ -147,6 +154,12 @@ describe('production archive scripts', () => {
         isLocalDatabaseConfig({
           client: 'pg',
           connection: 'postgresql:///activity?host=/var/run/postgresql'
+        })
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: 'postgresql:///activity'
         })
       ).toBe(true)
       expect(
@@ -228,6 +241,34 @@ describe('production archive scripts', () => {
       ])
     })
 
+    it('preserves object storage hostnames for S3-compatible clients', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: ['2026-01-01/activity.fit'],
+        mediaFilePaths: ['medias/image.webp'],
+        scope: 'referenced',
+        mediaStorage: {
+          type: MediaStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'media-storage.example.com',
+          region: 'auto'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'fitness-storage.example.com',
+          prefix: 'fitness/',
+          region: 'auto'
+        }
+      })
+
+      expect(plan[0].source).toMatchObject({
+        hostname: 'media-storage.example.com'
+      })
+      expect(plan[1].source).toMatchObject({
+        hostname: 'fitness-storage.example.com'
+      })
+    })
+
     it('filters referenced media files inside a shared local fitness directory', () => {
       const plan = buildStoragePlan({
         fitnessFilePaths: ['2026-01-01/activity.fit'],
@@ -289,6 +330,93 @@ describe('production archive scripts', () => {
     })
   })
 
+  describe('getReferencedStoragePaths', () => {
+    it('collects media and fitness paths with keyset pagination', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+      const mediaCount = 1005
+      const fitnessCount = 1005
+
+      try {
+        await database.schema.createTable('medias', (table) => {
+          table.increments('id').primary()
+          table.string('original')
+          table.string('thumbnail')
+        })
+        await database.schema.createTable('fitness_files', (table) => {
+          table.string('id').primary()
+          table.string('path')
+          table.string('mapImagePath')
+        })
+
+        await database.batchInsert(
+          'medias',
+          Array.from({ length: mediaCount }, (_, index) => ({
+            original: `medias/original-${index}.webp`,
+            thumbnail: index % 2 === 0 ? `medias/thumb-${index}.webp` : null
+          })),
+          200
+        )
+        await database.batchInsert(
+          'fitness_files',
+          Array.from({ length: fitnessCount }, (_, index) => ({
+            id: `fitness-${String(index).padStart(4, '0')}`,
+            mapImagePath: index % 2 === 0 ? `medias/map-${index}.webp` : null,
+            path: `fitness/${index}.fit`
+          })),
+          200
+        )
+
+        const paths = await getReferencedStoragePaths(database)
+
+        expect(paths.fitnessFilePaths).toHaveLength(fitnessCount)
+        expect(paths.mediaFilePaths).toHaveLength(
+          mediaCount + Math.ceil(mediaCount / 2) + Math.ceil(fitnessCount / 2)
+        )
+        expect(paths.fitnessFilePaths).toContain('fitness/1004.fit')
+        expect(paths.mediaFilePaths).toContain('medias/original-1004.webp')
+        expect(paths.mediaFilePaths).toContain('medias/map-1004.webp')
+      } finally {
+        await database.destroy()
+      }
+    })
+  })
+
+  describe('createS3Client', () => {
+    it('uses the configured hostname as the S3-compatible endpoint', async () => {
+      expect(normalizeStorageHostname('https://storage.example.com/')).toBe(
+        'storage.example.com'
+      )
+
+      const client = createS3Client({
+        bucket: 'bucket',
+        hostname: 'https://storage.example.com/',
+        kind: 's3',
+        region: 'auto'
+      })
+
+      try {
+        const endpoint = await client.config.endpoint!()
+        expect(endpoint.hostname).toBe('storage.example.com')
+        expect(endpoint.protocol).toBe('https:')
+      } finally {
+        client.destroy()
+      }
+    })
+  })
+
+  describe('createPublicStorageFetchInit', () => {
+    it('sets a timeout signal for public storage downloads', () => {
+      const init = createPublicStorageFetchInit()
+
+      expect(PUBLIC_STORAGE_FETCH_TIMEOUT_MS).toBe(30_000)
+      expect(init.signal).toBeInstanceOf(AbortSignal)
+    })
+  })
+
   describe('sortTablesForRestore', () => {
     it('orders parent tables before dependent tables', () => {
       expect(
@@ -324,6 +452,26 @@ describe('production archive scripts', () => {
           ]
         )
       ).toThrow('foreign-key cycle')
+    })
+  })
+
+  describe('assertMatchingMigrations', () => {
+    it('compares migration sets without depending on order', () => {
+      expect(() =>
+        assertMatchingMigrations(
+          ['002_second.js', '001_first.js'],
+          ['001_first.js', '002_second.js']
+        )
+      ).not.toThrow()
+    })
+
+    it('reports real migration differences', () => {
+      expect(() =>
+        assertMatchingMigrations(
+          ['001_first.js'],
+          ['001_first.js', '002_second.js']
+        )
+      ).toThrow('Extra locally: 002_second.js')
     })
   })
 

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -102,21 +102,47 @@ describe('production archive scripts', () => {
   })
 
   describe('isLocalDatabaseConnection', () => {
-    it('allows localhost, loopback, and docker postgres hosts', () => {
+    it('allows localhost, loopback, and socket hosts', () => {
       expect(isLocalDatabaseConnection({ host: 'localhost' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '127.0.0.1' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '::1' })).toBe(true)
-      expect(isLocalDatabaseConnection({ host: 'postgres' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '/var/run/postgresql' })).toBe(
         true
       )
       expect(
         isLocalDatabaseConnection('postgresql:///activity?host=/var/run')
       ).toBe(true)
-      expect(isLocalDatabaseConnection('postgresql:///activity')).toBe(true)
+      expect(
+        isLocalDatabaseConnection('postgresql:///activity?host=localhost')
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=/var/run&host=localhost'
+        )
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=/var/run,localhost'
+        )
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=localhost&hostaddr=127.0.0.1'
+        )
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://localhost/activity?hostaddr=127.0.0.1'
+        )
+      ).toBe(true)
       expect(
         isLocalDatabaseConnection(
           'postgresql://%2Fvar%2Frun%2Fpostgresql/activity'
+        )
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://%2Fvar%2Frun%2Fpostgresql,localhost/activity'
         )
       ).toBe(true)
     })
@@ -125,6 +151,59 @@ describe('production archive scripts', () => {
       expect(isLocalDatabaseConnection({ host: 'prod-db.example.com' })).toBe(
         false
       )
+      expect(isLocalDatabaseConnection({ host: 'postgres' })).toBe(false)
+      expect(isLocalDatabaseConnection('postgresql://postgres/activity')).toBe(
+        false
+      )
+      expect(isLocalDatabaseConnection('postgresql:///activity')).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=prod-db.example.com'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://localhost/activity?host=prod-db.example.com'
+        )
+      ).toBe(false)
+      expect(isLocalDatabaseConnection('postgresql:///activity?host=')).toBe(
+        false
+      )
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=/var/run&host=prod-db.example.com'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=/var/run,prod-db.example.com'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://%2Fvar%2Frun%2Fpostgresql,prod-db.example.com/activity'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://%2Fvar%2Frun%2Fpostgresql%2Cprod-db.example.com/activity'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql:///activity?host=localhost&hostaddr=203.0.113.10'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection(
+          'postgresql://prod-db.example.com/activity?hostaddr=127.0.0.1'
+        )
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConnection({
+          host: '/var/run/postgresql,prod-db.example.com'
+        })
+      ).toBe(false)
     })
 
     it('fails closed for missing or empty connection hosts', () => {
@@ -165,7 +244,7 @@ describe('production archive scripts', () => {
       expect(
         isLocalDatabaseConfig({
           client: 'pg',
-          connection: 'postgresql:///activity'
+          connection: 'postgresql://%2Fvar%2Frun%2Fpostgresql/activity'
         })
       ).toBe(true)
       expect(
@@ -193,6 +272,12 @@ describe('production archive scripts', () => {
         isLocalDatabaseConfig({
           client: 'pg',
           connection: { filename: './dev.sqlite3' }
+        })
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: 'postgresql:///activity'
         })
       ).toBe(false)
       expect(
@@ -656,6 +741,21 @@ describe('production archive scripts', () => {
         assertSafeDirectoryToReplace('/tmp/activitynext/uploads', '/tmp')
       ).toBe('/tmp/activitynext/uploads')
     })
+
+    it('allows the safe storage root itself as the restore target', () => {
+      expect(
+        assertSafeDirectoryToReplace(
+          '/tmp/activitynext/uploads',
+          '/tmp/activitynext/uploads'
+        )
+      ).toBe('/tmp/activitynext/uploads')
+    })
+
+    it('still rejects unsafe directories when they match the safe root', () => {
+      expect(() =>
+        assertSafeDirectoryToReplace(os.tmpdir(), os.tmpdir())
+      ).toThrow('unsafe directory')
+    })
   })
 
   describe('isSafeArchiveEntryPath', () => {
@@ -703,6 +803,24 @@ describe('production archive scripts', () => {
       await expect(validateTarArchivePaths(archivePath)).rejects.toThrow(
         'unsupported entry type'
       )
+    })
+
+    it('accepts a safe archive from a relative path', async () => {
+      const sourceDir = path.join(tempDir, 'relative-source')
+      await fs.mkdir(sourceDir)
+      await fs.writeFile(path.join(sourceDir, 'file.txt'), 'content')
+      const archivePath = path.join(tempDir, 'relative-archive.tar.gz')
+      const previousCwd = process.cwd()
+
+      await execFileAsync('tar', ['-czf', archivePath, '-C', sourceDir, '.'])
+      process.chdir(tempDir)
+      try {
+        await expect(
+          validateTarArchivePaths('relative-archive.tar.gz')
+        ).resolves.toBeUndefined()
+      } finally {
+        process.chdir(previousCwd)
+      }
     })
   })
 

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -1,9 +1,15 @@
+import os from 'os'
+import path from 'path'
+
 import { FitnessStorageType } from '@/lib/config/fitnessStorage'
 import { MediaStorageType } from '@/lib/config/mediaStorage'
 
 import {
+  assertSafeDirectoryToReplace,
   buildStoragePlan,
+  isLocalDatabaseConfig,
   isLocalDatabaseConnection,
+  isSafeArchiveEntryPath,
   parseDownloadArgs,
   parseRestoreArgs,
   sortTablesForRestore
@@ -68,6 +74,7 @@ describe('production archive scripts', () => {
         envFile: '.env.local',
         filesOnly: false,
         preserveFiles: true,
+        safeStorageRoot: '.',
         yes: true
       })
     })
@@ -79,12 +86,55 @@ describe('production archive scripts', () => {
       expect(isLocalDatabaseConnection({ host: '127.0.0.1' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: '::1' })).toBe(true)
       expect(isLocalDatabaseConnection({ host: 'postgres' })).toBe(true)
+      expect(isLocalDatabaseConnection({ filename: './dev.sqlite3' })).toBe(
+        true
+      )
     })
 
     it('rejects remote database hosts', () => {
       expect(isLocalDatabaseConnection({ host: 'prod-db.example.com' })).toBe(
         false
       )
+    })
+
+    it('fails closed for missing or empty connection hosts', () => {
+      expect(isLocalDatabaseConnection(null)).toBe(false)
+      expect(isLocalDatabaseConnection(undefined)).toBe(false)
+      expect(isLocalDatabaseConnection({})).toBe(false)
+      expect(isLocalDatabaseConnection({ host: '' })).toBe(false)
+      expect(isLocalDatabaseConnection({ host: '   ' })).toBe(false)
+    })
+  })
+
+  describe('isLocalDatabaseConfig', () => {
+    it('allows sqlite database files and local network database hosts', () => {
+      expect(
+        isLocalDatabaseConfig({
+          client: 'better-sqlite3',
+          connection: { filename: './dev.sqlite3' }
+        })
+      ).toBe(true)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: { host: 'localhost' }
+        })
+      ).toBe(true)
+    })
+
+    it('rejects database configs without explicit local targets', () => {
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: {}
+        })
+      ).toBe(false)
+      expect(
+        isLocalDatabaseConfig({
+          client: 'pg',
+          connection: { host: 'prod-db.example.com' }
+        })
+      ).toBe(false)
     })
   })
 
@@ -130,6 +180,66 @@ describe('production archive scripts', () => {
         }
       ])
     })
+
+    it('filters referenced media files inside a shared local fitness directory', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: ['2026-01-01/activity.fit'],
+        mediaFilePaths: [
+          'images/photo.webp',
+          'fitness/legacy.fit',
+          'fitness/maps/map.webp'
+        ],
+        scope: 'referenced',
+        mediaStorage: {
+          type: MediaStorageType.LocalFile,
+          path: '/tmp/activitynext/uploads'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.LocalFile,
+          path: '/tmp/activitynext/uploads/fitness'
+        }
+      })
+
+      expect(plan).toEqual([
+        {
+          destination: 'media',
+          files: ['images/photo.webp'],
+          source: {
+            kind: 'local',
+            path: '/tmp/activitynext/uploads'
+          }
+        },
+        {
+          destination: 'fitness',
+          files: ['2026-01-01/activity.fit'],
+          source: {
+            kind: 'local',
+            path: '/tmp/activitynext/uploads/fitness'
+          }
+        }
+      ])
+    })
+
+    it('sets shared local fitness exclusions once for all-storage mode', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: [],
+        mediaFilePaths: [],
+        scope: 'all',
+        mediaStorage: {
+          type: MediaStorageType.LocalFile,
+          path: '/tmp/activitynext/uploads'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.LocalFile,
+          path: '/tmp/activitynext/uploads/fitness'
+        }
+      })
+
+      expect(plan[0]).toMatchObject({
+        destination: 'media',
+        excludePrefixes: ['fitness']
+      })
+    })
   })
 
   describe('sortTablesForRestore', () => {
@@ -155,6 +265,62 @@ describe('production archive scripts', () => {
           ]
         )
       ).toEqual(['actors', 'statuses'])
+    })
+
+    it('throws when tables have a foreign-key cycle', () => {
+      expect(() =>
+        sortTablesForRestore(
+          ['actors', 'statuses'],
+          [
+            { fromTable: 'actors', toTable: 'statuses' },
+            { fromTable: 'statuses', toTable: 'actors' }
+          ]
+        )
+      ).toThrow('foreign-key cycle')
+    })
+  })
+
+  describe('assertSafeDirectoryToReplace', () => {
+    it('rejects broad filesystem and workspace paths', () => {
+      expect(() => assertSafeDirectoryToReplace('')).toThrow(
+        'empty directory path'
+      )
+      expect(() => assertSafeDirectoryToReplace('/')).toThrow(
+        'unsafe directory'
+      )
+      expect(() => assertSafeDirectoryToReplace(os.homedir())).toThrow(
+        'unsafe directory'
+      )
+      expect(() =>
+        assertSafeDirectoryToReplace(path.join(os.homedir(), 'Documents'))
+      ).toThrow('unsafe directory')
+      expect(() => assertSafeDirectoryToReplace(process.cwd())).toThrow(
+        'unsafe directory'
+      )
+      expect(() =>
+        assertSafeDirectoryToReplace(
+          path.join(os.homedir(), 'Documents', 'uploads')
+        )
+      ).toThrow('outside safe storage root')
+    })
+
+    it('allows child directories under the safe storage root', () => {
+      expect(
+        assertSafeDirectoryToReplace('/tmp/activitynext/uploads', '/tmp')
+      ).toBe('/tmp/activitynext/uploads')
+    })
+  })
+
+  describe('isSafeArchiveEntryPath', () => {
+    it('accepts archive-relative paths', () => {
+      expect(isSafeArchiveEntryPath('./manifest.json')).toBe(true)
+      expect(isSafeArchiveEntryPath('storage/media/files/a.jpg')).toBe(true)
+    })
+
+    it('rejects archive paths that can escape the extraction directory', () => {
+      expect(isSafeArchiveEntryPath('../x')).toBe(false)
+      expect(isSafeArchiveEntryPath('/x')).toBe(false)
+      expect(isSafeArchiveEntryPath('storage/../../x')).toBe(false)
     })
   })
 })

--- a/scripts/productionArchive.test.ts
+++ b/scripts/productionArchive.test.ts
@@ -10,18 +10,24 @@ import { MediaStorageType } from '@/lib/config/mediaStorage'
 
 import {
   PUBLIC_STORAGE_FETCH_TIMEOUT_MS,
+  assertArchiveTableFilesReadable,
   assertMatchingMigrations,
   assertSafeDirectoryToReplace,
   buildStoragePlan,
   createPublicStorageFetchInit,
   createS3Client,
+  fetchPublicStorageResponse,
+  getDatabaseTableNames,
   getReferencedStoragePaths,
+  getRestoreInsertBatchSize,
+  getStorageEndpoint,
   isLocalDatabaseConfig,
   isLocalDatabaseConnection,
   isSafeArchiveEntryPath,
   isSafeTarArchiveVerboseEntry,
   normalizeStorageHostname,
   parseDownloadArgs,
+  parseEnvFile,
   parseRestoreArgs,
   sortTablesForRestore,
   truncateTables,
@@ -269,6 +275,84 @@ describe('production archive scripts', () => {
       })
     })
 
+    it('does not deduplicate S3 fitness files from a different hostname', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: ['2026-01-01/activity.fit'],
+        mediaFilePaths: ['medias/image.webp', 'fitness/legacy.fit'],
+        scope: 'referenced',
+        mediaStorage: {
+          type: MediaStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'media-storage.example.com',
+          region: 'auto'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'fitness-storage.example.com',
+          prefix: 'fitness/',
+          region: 'auto'
+        }
+      })
+
+      expect(plan[0]).toMatchObject({
+        destination: 'media',
+        files: ['fitness/legacy.fit', 'medias/image.webp']
+      })
+    })
+
+    it('does not deduplicate S3 fitness files from a different endpoint scheme', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: ['2026-01-01/activity.fit'],
+        mediaFilePaths: ['medias/image.webp', 'fitness/legacy.fit'],
+        scope: 'referenced',
+        mediaStorage: {
+          type: MediaStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'http://storage.example.com',
+          region: 'auto'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'https://storage.example.com',
+          prefix: 'fitness/',
+          region: 'auto'
+        }
+      })
+
+      expect(plan[0]).toMatchObject({
+        destination: 'media',
+        files: ['fitness/legacy.fit', 'medias/image.webp']
+      })
+    })
+
+    it('deduplicates S3 fitness files when hostnames normalize to the same endpoint', () => {
+      const plan = buildStoragePlan({
+        fitnessFilePaths: ['2026-01-01/activity.fit'],
+        mediaFilePaths: ['medias/image.webp', 'fitness/legacy.fit'],
+        scope: 'referenced',
+        mediaStorage: {
+          type: MediaStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'https://storage.example.com/',
+          region: 'auto'
+        },
+        fitnessStorage: {
+          type: FitnessStorageType.ObjectStorage,
+          bucket: 'activitynext',
+          hostname: 'storage.example.com',
+          prefix: 'fitness/',
+          region: 'auto'
+        }
+      })
+
+      expect(plan[0]).toMatchObject({
+        destination: 'media',
+        files: ['medias/image.webp']
+      })
+    })
+
     it('filters referenced media files inside a shared local fitness directory', () => {
       const plan = buildStoragePlan({
         fitnessFilePaths: ['2026-01-01/activity.fit'],
@@ -390,10 +474,13 @@ describe('production archive scripts', () => {
       expect(normalizeStorageHostname('https://storage.example.com/')).toBe(
         'storage.example.com'
       )
+      expect(getStorageEndpoint('http://localhost:9000/')).toBe(
+        'http://localhost:9000'
+      )
 
       const client = createS3Client({
         bucket: 'bucket',
-        hostname: 'https://storage.example.com/',
+        hostname: 'http://storage.example.com/',
         kind: 's3',
         region: 'auto'
       })
@@ -401,19 +488,84 @@ describe('production archive scripts', () => {
       try {
         const endpoint = await client.config.endpoint!()
         expect(endpoint.hostname).toBe('storage.example.com')
-        expect(endpoint.protocol).toBe('https:')
+        expect(endpoint.protocol).toBe('http:')
       } finally {
         client.destroy()
       }
     })
   })
 
+  describe('parseEnvFile', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'production-archive-env-test-')
+      )
+    })
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { force: true, recursive: true })
+    })
+
+    it('parses multiline and quoted dotenv values', async () => {
+      const envPath = path.join(tempDir, '.env.production')
+      await fs.writeFile(
+        envPath,
+        [
+          'export SIMPLE=value # comment',
+          'MULTILINE="line one',
+          'line two"',
+          'ESCAPED_NEWLINE="line one\\nline two"',
+          "SINGLE='literal # hash'"
+        ].join('\n')
+      )
+
+      expect(parseEnvFile(envPath)).toEqual({
+        ESCAPED_NEWLINE: 'line one\nline two',
+        MULTILINE: 'line one\nline two',
+        SIMPLE: 'value',
+        SINGLE: 'literal # hash'
+      })
+    })
+  })
+
   describe('createPublicStorageFetchInit', () => {
     it('sets a timeout signal for public storage downloads', () => {
-      const init = createPublicStorageFetchInit()
+      const controller = new AbortController()
+      const init = createPublicStorageFetchInit(controller.signal)
 
-      expect(PUBLIC_STORAGE_FETCH_TIMEOUT_MS).toBe(30_000)
-      expect(init.signal).toBeInstanceOf(AbortSignal)
+      expect(PUBLIC_STORAGE_FETCH_TIMEOUT_MS).toBe(60_000)
+      expect(init.signal).toBe(controller.signal)
+    })
+  })
+
+  describe('fetchPublicStorageResponse', () => {
+    const originalFetch = global.fetch
+
+    afterEach(() => {
+      global.fetch = originalFetch
+      jest.useRealTimers()
+    })
+
+    it('clears the response timeout after the public storage request starts', async () => {
+      jest.useFakeTimers()
+      global.fetch = jest.fn(async () => {
+        return new Response('ok')
+      }) as typeof fetch
+
+      const response = await fetchPublicStorageResponse(
+        'https://storage.example.com/file.txt'
+      )
+
+      expect(response.ok).toBe(true)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://storage.example.com/file.txt',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal)
+        })
+      )
+      expect(jest.getTimerCount()).toBe(0)
     })
   })
 
@@ -571,6 +723,94 @@ describe('production archive scripts', () => {
           '-rw-r--r--  0 llun staff 7 May  9 21:02 ./file.txt'
         )
       ).toBe(true)
+      expect(
+        isSafeTarArchiveVerboseEntry(
+          '  -rw-r--r--  0 llun staff 7 May  9 21:02 ./file.txt'
+        )
+      ).toBe(true)
+      expect(
+        isSafeTarArchiveVerboseEntry(
+          '  lrwxr-xr-x  0 llun staff 0 May  9 21:02 ./link -> /etc/passwd'
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('getDatabaseTableNames', () => {
+    it('excludes SQLite internal and Knex lock tables', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+
+      try {
+        await database.schema.createTable('app_data', (table) => {
+          table.integer('id').primary()
+        })
+        await database.schema.createTable('knex_migrations_lock', (table) => {
+          table.integer('index').primary()
+          table.integer('is_locked')
+        })
+
+        await database('app_data').insert({ id: 1 })
+
+        await expect(getDatabaseTableNames(database)).resolves.toEqual([
+          'app_data'
+        ])
+      } finally {
+        await database.destroy()
+      }
+    })
+  })
+
+  describe('getRestoreInsertBatchSize', () => {
+    it('uses a conservative SQLite batch size based on column count', async () => {
+      const database = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true
+      })
+
+      try {
+        expect(
+          getRestoreInsertBatchSize(database, {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: 5
+          })
+        ).toBe(199)
+      } finally {
+        await database.destroy()
+      }
+    })
+  })
+
+  describe('assertArchiveTableFilesReadable', () => {
+    let tempDir: string
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'production-archive-db-test-')
+      )
+      await fs.mkdir(path.join(tempDir, 'database'))
+    })
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { force: true, recursive: true })
+    })
+
+    it('fails before restore when an archived table payload is missing', async () => {
+      await fs.writeFile(path.join(tempDir, 'database', 'users.jsonl'), '{}\n')
+
+      await expect(
+        assertArchiveTableFilesReadable(tempDir, [
+          { name: 'users', rowCount: 1 },
+          { name: 'statuses', rowCount: 1 }
+        ])
+      ).rejects.toThrow('missing database payload for statuses')
     })
   })
 

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -4,6 +4,7 @@ import {
   S3Client
 } from '@aws-sdk/client-s3'
 import { execFile, spawn } from 'child_process'
+import dotenvFlow from 'dotenv-flow'
 import { createReadStream, createWriteStream } from 'fs'
 import fs from 'fs/promises'
 import knex, { Knex } from 'knex'
@@ -38,8 +39,10 @@ const MIGRATIONS_DIR = 'migrations'
 const STORAGE_DIR = 'storage'
 const MANIFEST_FILE = 'manifest.json'
 const DATABASE_PAGE_SIZE = 1000
-export const PUBLIC_STORAGE_FETCH_TIMEOUT_MS = 30_000
+export const PUBLIC_STORAGE_FETCH_TIMEOUT_MS = 60_000
 const INSERT_BATCH_SIZE = 250
+const SQLITE_INSERT_PARAMETER_LIMIT = 999
+const KNEX_MIGRATIONS_LOCK_TABLE = 'knex_migrations_lock'
 
 export type StorageScope = 'referenced' | 'all'
 export type StorageDestination = 'media' | 'fitness'
@@ -534,6 +537,12 @@ const getSharedS3FitnessPrefix = (
 
   if (mediaStorage.bucket !== fitnessStorage.bucket) return null
   if (mediaStorage.region !== fitnessStorage.region) return null
+  if (
+    getStorageEndpointIdentity(mediaStorage.hostname) !==
+    getStorageEndpointIdentity(fitnessStorage.hostname)
+  ) {
+    return null
+  }
   return fitnessStorage.prefix || null
 }
 
@@ -575,50 +584,11 @@ const isS3FitnessStorage = (
   storage.type === FitnessStorageType.ObjectStorage ||
   storage.type === FitnessStorageType.S3Storage
 
-const parseEnvFile = (content: string) => {
-  const values: Record<string, string> = {}
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim()
-    if (!line || line.startsWith('#')) continue
-
-    const normalizedLine = line.startsWith('export ')
-      ? line.slice('export '.length).trim()
-      : line
-    const separatorIndex = normalizedLine.indexOf('=')
-    if (separatorIndex < 1) continue
-
-    const key = normalizedLine.slice(0, separatorIndex).trim()
-    const rawValue = normalizedLine.slice(separatorIndex + 1).trim()
-
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue
-    values[key] = parseEnvValue(rawValue)
-  }
-
-  return values
-}
-
-const parseEnvValue = (rawValue: string) => {
-  if (
-    (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
-    (rawValue.startsWith("'") && rawValue.endsWith("'"))
-  ) {
-    const quote = rawValue[0]
-    const unquoted = rawValue.slice(1, -1)
-    if (quote === "'") return unquoted
-    return unquoted
-      .replaceAll('\\n', '\n')
-      .replaceAll('\\"', '"')
-      .replaceAll('\\\\', '\\')
-  }
-
-  return rawValue.replace(/\s+#.*$/, '')
-}
+export const parseEnvFile = (envPath: string) => dotenvFlow.parse(envPath)
 
 const loadEnvFile = async (envFile: string) => {
   const envPath = path.resolve(process.cwd(), envFile)
-  const content = await fs.readFile(envPath, 'utf-8')
-  const values = parseEnvFile(content)
+  const values = parseEnvFile(envPath)
 
   for (const [key, value] of Object.entries(values)) {
     process.env[key] = value
@@ -658,17 +628,21 @@ const getQueryRows = <T>(result: unknown): T[] => {
   return result as T[]
 }
 
-const getDatabaseTableNames = async (database: Knex) => {
+export const getDatabaseTableNames = async (database: Knex) => {
   const client = getKnexClientName(database)
 
   if (client === 'pg' || client === 'pg-native') {
-    const result = await database.raw(`
+    const result = await database.raw(
+      `
       select table_name as name
       from information_schema.tables
       where table_schema = 'public'
         and table_type = 'BASE TABLE'
+        and table_name <> ?
       order by table_name asc
-    `)
+    `,
+      [KNEX_MIGRATIONS_LOCK_TABLE]
+    )
     return getQueryRows<{ name: string }>(result).map((row) => row.name)
   }
 
@@ -677,6 +651,7 @@ const getDatabaseTableNames = async (database: Knex) => {
       .select('name')
       .where('type', 'table')
       .whereNot('name', 'sqlite_sequence')
+      .whereNot('name', KNEX_MIGRATIONS_LOCK_TABLE)
       .orderBy('name', 'asc')
     return rows.map((row: { name: string }) => row.name)
   }
@@ -996,6 +971,17 @@ export const getReferencedStoragePaths = async (
 export const normalizeStorageHostname = (hostname: string) =>
   hostname.replace(/^https?:\/\//i, '').replace(/\/+$/, '')
 
+export const getStorageEndpoint = (hostname: string) => {
+  const trimmedHostname = hostname.trim().replace(/\/+$/, '')
+  if (/^https?:\/\//i.test(trimmedHostname)) return trimmedHostname
+  return `https://${trimmedHostname}`
+}
+
+const getStorageEndpointIdentity = (hostname: string | undefined) => {
+  if (!hostname?.trim()) return ''
+  return getStorageEndpoint(hostname)
+}
+
 export const createS3Client = (
   source: Extract<StorageSource, { kind: 's3' }>
 ) =>
@@ -1003,7 +989,7 @@ export const createS3Client = (
     region: source.region,
     ...(source.hostname
       ? {
-          endpoint: `https://${normalizeStorageHostname(source.hostname)}`,
+          endpoint: getStorageEndpoint(source.hostname),
           forcePathStyle: true
         }
       : null)
@@ -1185,11 +1171,9 @@ const downloadPublicStorageFile = async ({
   hostname: string
   key: string
 }) => {
-  const normalizedHostname = normalizeStorageHostname(hostname)
   const encodedKey = key.split('/').map(encodeURIComponent).join('/')
-  const response = await fetch(
-    `https://${normalizedHostname}/${encodedKey}`,
-    createPublicStorageFetchInit()
+  const response = await fetchPublicStorageResponse(
+    `${getStorageEndpoint(hostname)}/${encodedKey}`
   )
 
   if (!response.ok) {
@@ -1217,9 +1201,24 @@ const downloadPublicStorageFile = async ({
   return (await fs.stat(archiveFilePath)).size
 }
 
-export const createPublicStorageFetchInit = (): RequestInit => ({
-  signal: AbortSignal.timeout(PUBLIC_STORAGE_FETCH_TIMEOUT_MS)
+export const createPublicStorageFetchInit = (
+  signal: AbortSignal
+): RequestInit => ({
+  signal
 })
+
+export const fetchPublicStorageResponse = async (url: string) => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => {
+    controller.abort()
+  }, PUBLIC_STORAGE_FETCH_TIMEOUT_MS)
+
+  try {
+    return await fetch(url, createPublicStorageFetchInit(controller.signal))
+  } finally {
+    clearTimeout(timeout)
+  }
+}
 
 const archiveStorage = async (
   plan: StoragePlanEntry[],
@@ -1334,8 +1333,9 @@ export const isSafeArchiveEntryPath = (entry: string) => {
 }
 
 export const isSafeTarArchiveVerboseEntry = (entry: string) => {
-  if (!entry) return true
-  return entry[0] === '-' || entry[0] === 'd'
+  const trimmedEntry = entry.trimStart()
+  if (!trimmedEntry) return true
+  return trimmedEntry[0] === '-' || trimmedEntry[0] === 'd'
 }
 
 const readTarArchiveLines = async (
@@ -1622,6 +1622,57 @@ const ensureArchiveSchemaMatchesLocal = async (
   assertMatchingMigrations(archiveMigrations, await getMigrationNames(database))
 }
 
+export const getRestoreInsertBatchSize = (
+  database: Knex,
+  row: Record<string, unknown>
+) => {
+  const client = getKnexClientName(database)
+  if (client !== 'better-sqlite3' && client !== 'sqlite3') {
+    return INSERT_BATCH_SIZE
+  }
+
+  const columnCount = Math.max(Object.keys(row).length, 1)
+  return Math.max(
+    1,
+    Math.min(
+      INSERT_BATCH_SIZE,
+      Math.floor(SQLITE_INSERT_PARAMETER_LIMIT / columnCount)
+    )
+  )
+}
+
+export const assertArchiveTableFilesReadable = async (
+  archiveDir: string,
+  tables: ArchiveTableManifest[]
+) => {
+  for (const table of tables) {
+    const tableFilePath = path.join(
+      archiveDir,
+      DATABASE_DIR,
+      tableFileName(table.name)
+    )
+
+    const stat = await fs.stat(tableFilePath).catch((error) => {
+      const nodeError = error as NodeJS.ErrnoException
+      if (nodeError.code !== 'ENOENT') throw error
+      throw new Error(
+        `Archive is missing database payload for ${table.name}: ` +
+          tableFilePath
+      )
+    })
+
+    if (!stat.isFile()) {
+      throw new Error(
+        `Archive database payload is not a file for ${table.name}: ` +
+          tableFilePath
+      )
+    }
+
+    const file = await fs.open(tableFilePath, 'r')
+    await file.close()
+  }
+}
+
 const restoreTableFromJsonLines = async (
   database: Knex,
   tableName: string,
@@ -1633,21 +1684,30 @@ const restoreTableFromJsonLines = async (
     input
   })
   let batch: Record<string, unknown>[] = []
+  let batchSize = INSERT_BATCH_SIZE
   let rowCount = 0
 
   const flushBatch = async () => {
     if (batch.length === 0) return
-    await database.batchInsert(tableName, batch, INSERT_BATCH_SIZE)
+    await database.batchInsert(tableName, batch, batchSize)
     rowCount += batch.length
     batch = []
+    batchSize = INSERT_BATCH_SIZE
   }
 
   try {
     for await (const line of lines) {
       if (!line.trim()) continue
 
-      batch.push(JSON.parse(line) as Record<string, unknown>)
-      if (batch.length >= INSERT_BATCH_SIZE) {
+      const row = JSON.parse(line) as Record<string, unknown>
+      const rowBatchSize = getRestoreInsertBatchSize(database, row)
+      if (batch.length > 0 && batch.length >= rowBatchSize) {
+        await flushBatch()
+      }
+
+      batchSize = Math.min(batchSize, rowBatchSize)
+      batch.push(row)
+      if (batch.length >= batchSize) {
         await flushBatch()
       }
     }
@@ -1731,6 +1791,8 @@ const restoreDatabase = async (
       `Local database is missing archived table(s): ${missingTables.join(', ')}`
     )
   }
+
+  await assertArchiveTableFilesReadable(archiveDir, manifest.database.tables)
 
   const foreignKeys = await getForeignKeyReferences(database, tableNames)
   const orderedTables = sortTablesForRestore(tableNames, foreignKeys)

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -4,11 +4,12 @@ import {
   S3Client
 } from '@aws-sdk/client-s3'
 import { execFile } from 'child_process'
-import { createWriteStream } from 'fs'
+import { createReadStream, createWriteStream } from 'fs'
 import fs from 'fs/promises'
 import knex, { Knex } from 'knex'
 import os from 'os'
 import path from 'path'
+import { createInterface } from 'readline'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
 import type { ReadableStream as NodeReadableStream } from 'stream/web'
@@ -28,13 +29,14 @@ import {
 
 const execFileAsync = promisify(execFile)
 
-const ARCHIVE_VERSION = 1
+const ARCHIVE_VERSION = 2
 const DEFAULT_OUTPUT_DIR = 'backups/production-archives'
 const DEFAULT_DOWNLOAD_ENV_FILE = '.env.production'
 const DEFAULT_RESTORE_ENV_FILE = '.env.local'
 const DATABASE_DIR = 'database'
 const STORAGE_DIR = 'storage'
 const MANIFEST_FILE = 'manifest.json'
+const DATABASE_PAGE_SIZE = 1000
 const INSERT_BATCH_SIZE = 250
 
 export type StorageScope = 'referenced' | 'all'
@@ -56,6 +58,7 @@ export interface RestoreArgs {
   envFile: string
   filesOnly: boolean
   preserveFiles: boolean
+  safeStorageRoot: string
   yes: boolean
 }
 
@@ -113,6 +116,7 @@ interface ArchiveManifest {
   createdAt: string
   database: {
     client: string
+    migrations: string[]
     tables: ArchiveTableManifest[]
   } | null
   source: {
@@ -141,6 +145,7 @@ const RESTORE_USAGE = `Usage: scripts/restoreProductionArchive.ts \\
   --archive backups/production-archives/activitynext-production-<timestamp>.tar.gz \\
   --yes \\
   [--env-file .env.local] \\
+  [--safe-storage-root .] \\
   [--database-only] \\
   [--files-only] \\
   [--preserve-files] \\
@@ -242,6 +247,7 @@ export const parseRestoreArgs = (args: string[]): RestoreArgs => {
     envFile: getStringArg(parsed, 'env-file', DEFAULT_RESTORE_ENV_FILE)!,
     filesOnly,
     preserveFiles: getBooleanArg(parsed, 'preserve-files'),
+    safeStorageRoot: getStringArg(parsed, 'safe-storage-root', '.')!,
     yes
   }
 }
@@ -255,11 +261,38 @@ export const isLocalDatabaseConnection = (connection: unknown): boolean => {
     }
   }
 
-  if (!connection || typeof connection !== 'object') return true
+  if (!connection || typeof connection !== 'object') return false
+
+  const filename = (connection as { filename?: unknown }).filename
+  if (typeof filename === 'string' && filename.trim().length > 0) return true
 
   const host = (connection as { host?: unknown }).host
-  if (typeof host !== 'string' || host.trim().length === 0) return true
+  if (typeof host !== 'string' || host.trim().length === 0) return false
   return isLocalHost(host)
+}
+
+export const isLocalDatabaseConfig = (databaseConfig: Knex.Config) => {
+  const client = String(databaseConfig.client)
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const connection = databaseConfig.connection
+    if (typeof connection === 'string') return connection.trim().length > 0
+    if (!connection || typeof connection !== 'object') return false
+
+    const filename = (connection as { filename?: unknown }).filename
+    return typeof filename === 'string' && filename.trim().length > 0
+  }
+
+  if (
+    client === 'pg' ||
+    client === 'pg-native' ||
+    client === 'mysql' ||
+    client === 'mysql2'
+  ) {
+    return isLocalDatabaseConnection(databaseConfig.connection)
+  }
+
+  return false
 }
 
 export const sortTablesForRestore = (
@@ -292,8 +325,10 @@ export const sortTablesForRestore = (
     })
 
     if (ready.length === 0) {
-      ordered.push(...remaining)
-      break
+      throw new Error(
+        'Cannot determine restore order because archived tables have a ' +
+          `foreign-key cycle: ${[...remaining].sort().join(', ')}`
+      )
     }
 
     for (const table of ready) {
@@ -321,23 +356,26 @@ export const buildStoragePlan = ({
     mediaStorage,
     fitnessStorage
   )
+  const sharedFitnessPrefixes = uniqueSortedPaths([
+    sharedLocalFitnessPrefix,
+    sharedS3FitnessPrefix
+  ])
 
   if (mediaStorage) {
     const mediaFiles =
       scope === 'referenced'
         ? uniqueSortedPaths(mediaFilePaths).filter((filePath) => {
-            if (!sharedS3FitnessPrefix) return true
-            return !filePath.startsWith(sharedS3FitnessPrefix)
+            return !sharedFitnessPrefixes.some((prefix) => {
+              return isStoragePathInsidePrefix(filePath, prefix)
+            })
           })
         : undefined
+    const excludePrefixes = scope === 'all' ? sharedFitnessPrefixes : []
 
     plan.push({
       destination: 'media',
-      ...(scope === 'all' && sharedLocalFitnessPrefix
-        ? { excludePrefixes: [sharedLocalFitnessPrefix] }
-        : null),
-      ...(scope === 'all' && sharedS3FitnessPrefix
-        ? { excludePrefixes: [sharedS3FitnessPrefix] }
+      ...(excludePrefixes.length > 0
+        ? { excludePrefixes }
         : null),
       ...(mediaFiles ? { files: mediaFiles } : null),
       source: storageSourceFromMediaConfig(mediaStorage)
@@ -359,7 +397,6 @@ export const buildStoragePlan = ({
 
 const isLocalHost = (host: string) =>
   [
-    '',
     'localhost',
     '127.0.0.1',
     '::1',
@@ -369,14 +406,26 @@ const isLocalHost = (host: string) =>
     'host.docker.internal'
   ].includes(host.trim().toLowerCase())
 
-const uniqueSortedPaths = (filePaths: string[]) =>
+const uniqueSortedPaths = (filePaths: (string | null | undefined)[]) =>
   [...new Set(filePaths.map(normalizeStoragePath).filter(Boolean))].sort()
 
 const normalizeStoragePath = (filePath: string | null | undefined) => {
   if (!filePath) return ''
-  const normalized = filePath.replaceAll('\\', '/').replace(/^\/+/, '')
+  const normalized = filePath
+    .replaceAll('\\', '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
   if (normalized.includes('..')) return ''
   return normalized
+}
+
+const isStoragePathInsidePrefix = (filePath: string, prefix: string) => {
+  const normalizedPrefix = normalizeStoragePath(prefix)
+  if (!normalizedPrefix) return false
+  return (
+    filePath === normalizedPrefix ||
+    filePath.startsWith(`${normalizedPrefix}/`)
+  )
 }
 
 const storageSourceFromMediaConfig = (
@@ -392,7 +441,7 @@ const storageSourceFromMediaConfig = (
     case MediaStorageType.S3Storage:
       return {
         bucket: storage.bucket,
-        hostname: storage.hostname,
+        ...(storage.hostname ? { hostname: storage.hostname } : null),
         kind: 's3',
         prefix: undefined,
         region: storage.region
@@ -413,7 +462,7 @@ const storageSourceFromFitnessConfig = (
     case FitnessStorageType.S3Storage:
       return {
         bucket: storage.bucket,
-        hostname: storage.hostname,
+        ...(storage.hostname ? { hostname: storage.hostname } : null),
         kind: 's3',
         prefix: storage.prefix,
         region: storage.region
@@ -521,11 +570,6 @@ const loadEnvFile = async (envFile: string) => {
   for (const [key, value] of Object.entries(values)) {
     process.env[key] = value
   }
-
-  const memoizedGetConfig = getConfig as typeof getConfig & {
-    cache?: { clear?: () => void }
-  }
-  memoizedGetConfig.cache?.clear?.()
 }
 
 const createArchiveName = () => {
@@ -540,7 +584,7 @@ const quoteIdentifier = (identifier: string) =>
   `"${identifier.replaceAll('"', '""')}"`
 
 const tableFileName = (tableName: string) =>
-  `${encodeURIComponent(tableName)}.json`
+  `${encodeURIComponent(tableName)}.jsonl`
 
 const assertRelativeFilePath = (filePath: string) => {
   const normalized = normalizeStoragePath(filePath)
@@ -587,25 +631,69 @@ const getDatabaseTableNames = async (database: Knex) => {
   throw new Error(`Unsupported database client for archive: ${client}`)
 }
 
+const getMigrationNames = async (database: Knex) => {
+  if (!(await database.schema.hasTable('knex_migrations'))) return []
+
+  const rows = await database('knex_migrations')
+    .select('name')
+    .orderBy('id', 'asc')
+
+  return rows
+    .map((row: { name?: unknown }) => row.name)
+    .filter((name): name is string => typeof name === 'string')
+}
+
+const createTableRowsStream = (
+  database: Knex,
+  tableName: string,
+  onRow: () => void
+) => {
+  async function* rowsToJsonLines() {
+    let offset = 0
+
+    for (;;) {
+      const rows = await database(tableName)
+        .select('*')
+        .limit(DATABASE_PAGE_SIZE)
+        .offset(offset)
+
+      if (rows.length === 0) return
+
+      for (const row of rows) {
+        onRow()
+        yield `${JSON.stringify(row)}\n`
+      }
+
+      offset += rows.length
+    }
+  }
+
+  return Readable.from(rowsToJsonLines())
+}
+
 const exportDatabase = async (database: Knex, outputDir: string) => {
   const databaseDir = path.join(outputDir, DATABASE_DIR)
   await fs.mkdir(databaseDir, { recursive: true })
 
   const tableNames = await getDatabaseTableNames(database)
+  const migrations = await getMigrationNames(database)
   const tables: ArchiveTableManifest[] = []
 
   for (const tableName of tableNames) {
-    const rows = await database(tableName).select('*')
-    await fs.writeFile(
-      path.join(databaseDir, tableFileName(tableName)),
-      `${JSON.stringify(rows, null, 2)}\n`
+    let rowCount = 0
+    await pipeline(
+      createTableRowsStream(database, tableName, () => {
+        rowCount += 1
+      }),
+      createWriteStream(path.join(databaseDir, tableFileName(tableName)))
     )
-    tables.push({ name: tableName, rowCount: rows.length })
-    console.log(`Database: exported ${rows.length} row(s) from ${tableName}`)
+    tables.push({ name: tableName, rowCount })
+    console.log(`Database: exported ${rowCount} row(s) from ${tableName}`)
   }
 
   return {
     client: getKnexClientName(database),
+    migrations,
     tables
   }
 }
@@ -620,20 +708,46 @@ const getReferencedStoragePaths = async (
   const fitnessFilePaths: string[] = []
 
   if (await tableExists(database, 'medias')) {
-    const mediaRows = await database('medias').select('original', 'thumbnail')
-    for (const row of mediaRows) {
-      mediaFilePaths.push(row.original, row.thumbnail)
+    let offset = 0
+    for (;;) {
+      const mediaRows = await database('medias')
+        .select('original', 'thumbnail')
+        .orderBy('id', 'asc')
+        .limit(DATABASE_PAGE_SIZE)
+        .offset(offset)
+
+      if (mediaRows.length === 0) break
+
+      for (const row of mediaRows) {
+        if (typeof row.original === 'string') mediaFilePaths.push(row.original)
+        if (typeof row.thumbnail === 'string') {
+          mediaFilePaths.push(row.thumbnail)
+        }
+      }
+
+      offset += mediaRows.length
     }
   }
 
   if (await tableExists(database, 'fitness_files')) {
-    const fitnessRows = await database('fitness_files').select(
-      'path',
-      'mapImagePath'
-    )
-    for (const row of fitnessRows) {
-      fitnessFilePaths.push(row.path)
-      mediaFilePaths.push(row.mapImagePath)
+    let offset = 0
+    for (;;) {
+      const fitnessRows = await database('fitness_files')
+        .select('path', 'mapImagePath')
+        .orderBy('id', 'asc')
+        .limit(DATABASE_PAGE_SIZE)
+        .offset(offset)
+
+      if (fitnessRows.length === 0) break
+
+      for (const row of fitnessRows) {
+        if (typeof row.path === 'string') fitnessFilePaths.push(row.path)
+        if (typeof row.mapImagePath === 'string') {
+          mediaFilePaths.push(row.mapImagePath)
+        }
+      }
+
+      offset += fitnessRows.length
     }
   }
 
@@ -646,8 +760,10 @@ const getReferencedStoragePaths = async (
 const createS3Client = (source: Extract<StorageSource, { kind: 's3' }>) =>
   new S3Client({ region: source.region })
 
-const listS3Files = async (source: Extract<StorageSource, { kind: 's3' }>) => {
-  const client = createS3Client(source)
+const listS3Files = async (
+  source: Extract<StorageSource, { kind: 's3' }>,
+  client: S3Client
+) => {
   const files: string[] = []
   let continuationToken: string | undefined
 
@@ -710,19 +826,18 @@ const shouldExcludeStorageFile = (
 ) =>
   Boolean(
     excludePrefixes?.some((prefix) => {
-      const normalizedPrefix = normalizeStoragePath(prefix)
-      return (
-        filePath === normalizedPrefix ||
-        filePath.startsWith(`${normalizedPrefix}/`)
-      )
+      return isStoragePathInsidePrefix(filePath, prefix)
     })
   )
 
-const getStorageFiles = async (entry: StoragePlanEntry) => {
+const getStorageFiles = async (
+  entry: StoragePlanEntry,
+  s3Client?: S3Client
+) => {
   const allFiles =
     entry.files ??
     (entry.source.kind === 's3'
-      ? await listS3Files(entry.source)
+      ? await listS3Files(entry.source, s3Client ?? createS3Client(entry.source))
       : await listLocalFiles(path.resolve(entry.source.path)))
 
   return allFiles.filter((filePath) => {
@@ -747,17 +862,18 @@ const copyLocalStorageFile = async ({
 
 const downloadS3StorageFile = async ({
   archiveFilePath,
+  client,
   relativeFilePath,
   source
 }: {
   archiveFilePath: string
+  client: S3Client
   relativeFilePath: string
   source: Extract<StorageSource, { kind: 's3' }>
 }) => {
   const key = source.prefix
     ? `${source.prefix}${relativeFilePath}`
     : relativeFilePath
-  const client = createS3Client(source)
   let response
 
   try {
@@ -854,72 +970,79 @@ const archiveStorage = async (
   const storageManifests: ArchiveStorageManifest[] = []
 
   for (const entry of plan) {
-    const files = await getStorageFiles(entry)
-    let totalBytes = 0
-    let downloadedCount = 0
-    const failedFiles: { error: string; path: string }[] = []
+    const s3Client =
+      entry.source.kind === 's3' ? createS3Client(entry.source) : undefined
+    try {
+      const files = await getStorageFiles(entry, s3Client)
+      let totalBytes = 0
+      let downloadedCount = 0
+      const failedFiles: { error: string; path: string }[] = []
 
-    for (const filePath of files) {
-      const relativeFilePath = assertRelativeFilePath(filePath)
-      const archiveFilePath = path.join(
-        stagingDir,
-        STORAGE_DIR,
-        entry.destination,
-        'files',
-        relativeFilePath
+      for (const filePath of files) {
+        const relativeFilePath = assertRelativeFilePath(filePath)
+        const archiveFilePath = path.join(
+          stagingDir,
+          STORAGE_DIR,
+          entry.destination,
+          'files',
+          relativeFilePath
+        )
+
+        let size: number
+        try {
+          size =
+            entry.source.kind === 's3'
+              ? await downloadS3StorageFile({
+                  archiveFilePath,
+                  client: s3Client!,
+                  relativeFilePath,
+                  source: entry.source
+                })
+              : await copyLocalStorageFile({
+                  archiveFilePath,
+                  relativeFilePath,
+                  source: entry.source
+                })
+        } catch (error) {
+          const nodeError = error as Error
+          if (!options.allowMissingStorage) throw error
+
+          failedFiles.push({
+            error: nodeError.message,
+            path: relativeFilePath
+          })
+          console.error(
+            `Storage: failed to download ${entry.destination} file ` +
+              `${relativeFilePath}: ${nodeError.message}`
+          )
+          continue
+        }
+
+        totalBytes += size
+        downloadedCount += 1
+
+        if (downloadedCount % 25 === 0) {
+          console.log(
+            `Storage: downloaded ${downloadedCount}/${files.length} ` +
+              `${entry.destination} file(s)`
+          )
+        }
+      }
+
+      console.log(
+        `Storage: downloaded ${downloadedCount} ${entry.destination} file(s)`
       )
 
-      let size: number
-      try {
-        size =
-          entry.source.kind === 's3'
-            ? await downloadS3StorageFile({
-                archiveFilePath,
-                relativeFilePath,
-                source: entry.source
-              })
-            : await copyLocalStorageFile({
-                archiveFilePath,
-                relativeFilePath,
-                source: entry.source
-              })
-      } catch (error) {
-        const nodeError = error as Error
-        if (!options.allowMissingStorage) throw error
-
-        failedFiles.push({
-          error: nodeError.message,
-          path: relativeFilePath
-        })
-        console.error(
-          `Storage: failed to download ${entry.destination} file ` +
-            `${relativeFilePath}: ${nodeError.message}`
-        )
-        continue
-      }
-
-      totalBytes += size
-      downloadedCount += 1
-
-      if (downloadedCount % 25 === 0) {
-        console.log(
-          `Storage: downloaded ${downloadedCount}/${files.length} ` +
-            `${entry.destination} file(s)`
-        )
-      }
+      storageManifests.push({
+        destination: entry.destination,
+        failedFiles,
+        fileCount: downloadedCount,
+        source: redactStorageSource(entry.source),
+        totalBytes
+      })
+    } finally {
+      s3Client?.destroy()
     }
-
-    console.log(
-      `Storage: downloaded ${downloadedCount} ${entry.destination} file(s)`
-    )
-
-    storageManifests.push({
-      destination: entry.destination,
-      failedFiles,
-      fileCount: downloadedCount,
-      source: redactStorageSource(entry.source),
-      totalBytes
-    })
   }
 
   return storageManifests
@@ -942,8 +1065,30 @@ const createTarArchive = async (stagingDir: string, archivePath: string) => {
   await execFileAsync('tar', ['-czf', archivePath, '-C', stagingDir, '.'])
 }
 
+export const isSafeArchiveEntryPath = (entry: string) => {
+  if (!entry) return false
+  if (path.posix.isAbsolute(entry)) return false
+
+  const normalized = path.posix.normalize(entry)
+  return normalized !== '..' && !normalized.startsWith('../')
+}
+
+const validateTarArchivePaths = async (archivePath: string) => {
+  const { stdout } = await execFileAsync('tar', ['-tzf', archivePath], {
+    maxBuffer: 64 * 1024 * 1024
+  })
+
+  for (const entry of stdout.split(/\r?\n/)) {
+    if (!entry) continue
+    if (!isSafeArchiveEntryPath(entry)) {
+      throw new Error(`Archive contains unsafe path: ${entry}`)
+    }
+  }
+}
+
 const extractTarArchive = async (archivePath: string, outputDir: string) => {
   await fs.mkdir(outputDir, { recursive: true })
+  await validateTarArchivePaths(archivePath)
   await execFileAsync('tar', ['-xzf', archivePath, '-C', outputDir])
 }
 
@@ -981,8 +1126,7 @@ const ensureRestoreTargetIsLocal = (
     )
   }
 
-  const connection = config.database.connection
-  if (!isLocalDatabaseConnection(connection)) {
+  if (!isLocalDatabaseConfig(config.database)) {
     throw new Error(
       'Refusing to restore to a non-local database host. ' +
         'Pass --allow-non-local-database only if this is intentional.'
@@ -1039,7 +1183,7 @@ const truncateTables = async (database: Knex, tableNames: string[]) => {
 
   if (client === 'pg' || client === 'pg-native') {
     const tables = tableNames.map(quoteIdentifier).join(', ')
-    await database.raw(`truncate table ${tables} restart identity cascade`)
+    await database.raw(`truncate table ${tables} restart identity`)
     return
   }
 
@@ -1059,6 +1203,81 @@ const truncateTables = async (database: Knex, tableNames: string[]) => {
   }
 
   throw new Error(`Unsupported database client for restore: ${client}`)
+}
+
+const assertMatchingMigrations = (
+  archiveMigrations: string[],
+  localMigrations: string[]
+) => {
+  const archiveValue = JSON.stringify(archiveMigrations)
+  const localValue = JSON.stringify(localMigrations)
+  if (archiveValue === localValue) return
+
+  const archiveSet = new Set(archiveMigrations)
+  const localSet = new Set(localMigrations)
+  const missingLocally = archiveMigrations.filter((name) => !localSet.has(name))
+  const extraLocally = localMigrations.filter((name) => !archiveSet.has(name))
+
+  throw new Error(
+    'Local database migration state does not match the archive. ' +
+      'Restore with code that matches the archive before replacing data. ' +
+      `Missing locally: ${missingLocally.join(', ') || 'none'}. ` +
+      `Extra locally: ${extraLocally.join(', ') || 'none'}.`
+  )
+}
+
+const ensureArchiveSchemaMatchesLocal = async (
+  database: Knex,
+  archiveMigrations: string[]
+) => {
+  const migrationsBeforeLatest = await getMigrationNames(database)
+
+  if (migrationsBeforeLatest.length > 0) {
+    assertMatchingMigrations(archiveMigrations, migrationsBeforeLatest)
+    return
+  }
+
+  await database.migrate.latest()
+  assertMatchingMigrations(archiveMigrations, await getMigrationNames(database))
+}
+
+const restoreTableFromJsonLines = async (
+  database: Knex,
+  tableName: string,
+  tableFilePath: string
+) => {
+  const input = createReadStream(tableFilePath, { encoding: 'utf-8' })
+  const lines = createInterface({
+    crlfDelay: Infinity,
+    input
+  })
+  let batch: Record<string, unknown>[] = []
+  let rowCount = 0
+
+  const flushBatch = async () => {
+    if (batch.length === 0) return
+    await database.batchInsert(tableName, batch, INSERT_BATCH_SIZE)
+    rowCount += batch.length
+    batch = []
+  }
+
+  try {
+    for await (const line of lines) {
+      if (!line.trim()) continue
+
+      batch.push(JSON.parse(line) as Record<string, unknown>)
+      if (batch.length >= INSERT_BATCH_SIZE) {
+        await flushBatch()
+      }
+    }
+
+    await flushBatch()
+  } finally {
+    lines.close()
+    input.destroy()
+  }
+
+  return rowCount
 }
 
 const resetPostgresSequences = async (database: Knex, tableNames: string[]) => {
@@ -1121,7 +1340,7 @@ const restoreDatabase = async (
     return
   }
 
-  await database.migrate.latest()
+  await ensureArchiveSchemaMatchesLocal(database, manifest.database.migrations)
 
   const tableNames = manifest.database.tables.map((table) => table.name)
   const localTables = new Set(await getDatabaseTableNames(database))
@@ -1138,18 +1357,13 @@ const restoreDatabase = async (
   await truncateTables(database, tableNames)
 
   for (const tableName of orderedTables) {
-    const rows = JSON.parse(
-      await fs.readFile(
-        path.join(archiveDir, DATABASE_DIR, tableFileName(tableName)),
-        'utf-8'
-      )
-    ) as Record<string, unknown>[]
+    const rowCount = await restoreTableFromJsonLines(
+      database,
+      tableName,
+      path.join(archiveDir, DATABASE_DIR, tableFileName(tableName))
+    )
 
-    if (rows.length > 0) {
-      await database.batchInsert(tableName, rows, INSERT_BATCH_SIZE)
-    }
-
-    console.log(`Database: restored ${rows.length} row(s) into ${tableName}`)
+    console.log(`Database: restored ${rowCount} row(s) into ${tableName}`)
   }
 
   await resetPostgresSequences(database, tableNames)
@@ -1172,42 +1386,130 @@ const resolveLocalStoragePath = (
   return config.fitnessStorage.path
 }
 
-const assertSafeDirectoryToReplace = (directoryPath: string) => {
+const pathIsInside = (childPath: string, parentPath: string) => {
+  const relativePath = path.relative(parentPath, childPath)
+  return (
+    relativePath.length > 0 &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  )
+}
+
+export const assertSafeDirectoryToReplace = (
+  directoryPath: string,
+  safeStorageRoot = '.'
+) => {
+  if (!directoryPath.trim()) {
+    throw new Error('Refusing to replace empty directory path.')
+  }
+
+  if (!safeStorageRoot.trim()) {
+    throw new Error('Refusing to use empty safe storage root.')
+  }
+
   const resolved = path.resolve(directoryPath)
+  const resolvedSafeRoot = path.resolve(safeStorageRoot)
   const root = path.parse(resolved).root
-  if (resolved === root || resolved === os.homedir()) {
+  const homeDir = os.homedir()
+  const cwd = process.cwd()
+  const unsafePaths = new Set([
+    root,
+    homeDir,
+    cwd,
+    path.join(homeDir, 'Desktop'),
+    path.join(homeDir, 'Documents'),
+    path.join(homeDir, 'Downloads'),
+    path.join(homeDir, 'Movies'),
+    path.join(homeDir, 'Music'),
+    path.join(homeDir, 'Pictures'),
+    os.tmpdir()
+  ])
+
+  if (unsafePaths.has(resolved)) {
     throw new Error(`Refusing to replace unsafe directory: ${resolved}`)
   }
+
+  if (!pathIsInside(resolved, resolvedSafeRoot)) {
+    throw new Error(
+      `Refusing to replace directory outside safe storage root: ` +
+        `${resolved}. Safe root: ${resolvedSafeRoot}`
+    )
+  }
+
   return resolved
 }
 
 const emptyDirectory = async (directoryPath: string) => {
-  const resolved = assertSafeDirectoryToReplace(directoryPath)
-  await fs.rm(resolved, { force: true, recursive: true })
-  await fs.mkdir(resolved, { recursive: true })
+  await fs.rm(directoryPath, { force: true, recursive: true })
+  await fs.mkdir(directoryPath, { recursive: true })
 }
 
-const copyDirectoryContents = async (fromDir: string, toDir: string) => {
-  try {
-    const entries = await fs.readdir(fromDir, { withFileTypes: true })
-    await fs.mkdir(toDir, { recursive: true })
+const copyDirectoryContents = async (
+  fromDir: string,
+  toDir: string
+): Promise<number> => {
+  const entries = await fs.readdir(fromDir, { withFileTypes: true })
+  await fs.mkdir(toDir, { recursive: true })
+  let copiedCount = 0
 
-    for (const entry of entries) {
-      const sourcePath = path.join(fromDir, entry.name)
-      const destinationPath = path.join(toDir, entry.name)
+  for (const entry of entries) {
+    const sourcePath = path.join(fromDir, entry.name)
+    const destinationPath = path.join(toDir, entry.name)
 
-      if (entry.isDirectory()) {
-        await copyDirectoryContents(sourcePath, destinationPath)
-      } else if (entry.isFile()) {
-        await fs.mkdir(path.dirname(destinationPath), { recursive: true })
-        await fs.copyFile(sourcePath, destinationPath)
-      }
+    if (entry.isDirectory()) {
+      copiedCount += await copyDirectoryContents(sourcePath, destinationPath)
+    } else if (entry.isFile()) {
+      await fs.mkdir(path.dirname(destinationPath), { recursive: true })
+      await fs.copyFile(sourcePath, destinationPath)
+      copiedCount += 1
     }
-  } catch (error) {
-    const nodeError = error as NodeJS.ErrnoException
-    if (nodeError.code !== 'ENOENT') throw error
+  }
+
+  return copiedCount
+}
+
+const getStoragePayloadDir = (
+  archiveDir: string,
+  destination: StorageDestination
+) => path.join(archiveDir, STORAGE_DIR, destination, 'files')
+
+const assertStoragePayloadsExist = async (
+  archiveDir: string,
+  storageManifest: ArchiveStorageManifest[]
+) => {
+  for (const storage of storageManifest) {
+    if (storage.fileCount === 0) continue
+
+    const payloadDir = getStoragePayloadDir(archiveDir, storage.destination)
+    const stat = await fs.stat(payloadDir).catch((error) => {
+      const nodeError = error as NodeJS.ErrnoException
+      if (nodeError.code !== 'ENOENT') throw error
+      throw new Error(
+        `Archive is missing ${storage.destination} storage payload: ` +
+          payloadDir
+      )
+    })
+
+    if (!stat.isDirectory()) {
+      throw new Error(
+        `Archive storage payload is not a directory: ${payloadDir}`
+      )
+    }
   }
 }
+
+const getRestoreStorageTargets = (
+  manifest: ArchiveManifest,
+  config: ReturnType<typeof getConfig>,
+  safeStorageRoot: string
+) =>
+  manifest.storage.map((storage) => ({
+    destinationPath: assertSafeDirectoryToReplace(
+      resolveLocalStoragePath(storage.destination, config),
+      safeStorageRoot
+    ),
+    storage
+  }))
 
 const restoreStorage = async (
   archiveDir: string,
@@ -1215,19 +1517,34 @@ const restoreStorage = async (
   config: ReturnType<typeof getConfig>,
   args: RestoreArgs
 ) => {
-  for (const storage of manifest.storage) {
-    const destinationPath = resolveLocalStoragePath(storage.destination, config)
+  await assertStoragePayloadsExist(archiveDir, manifest.storage)
+  const restoreTargets = getRestoreStorageTargets(
+    manifest,
+    config,
+    args.safeStorageRoot
+  )
 
+  for (const { destinationPath, storage } of restoreTargets) {
     if (!args.preserveFiles) {
       await emptyDirectory(destinationPath)
     } else {
       await fs.mkdir(destinationPath, { recursive: true })
     }
 
-    await copyDirectoryContents(
-      path.join(archiveDir, STORAGE_DIR, storage.destination, 'files'),
-      destinationPath
-    )
+    const copiedCount =
+      storage.fileCount > 0
+        ? await copyDirectoryContents(
+            getStoragePayloadDir(archiveDir, storage.destination),
+            destinationPath
+          )
+        : 0
+
+    if (copiedCount !== storage.fileCount) {
+      throw new Error(
+        `Archive ${storage.destination} storage payload expected ` +
+          `${storage.fileCount} file(s), copied ${copiedCount}.`
+      )
+    }
 
     console.log(
       `Storage: restored ${storage.fileCount} ` +

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -272,11 +272,25 @@ export const isLocalDatabaseConnection = (connection: unknown): boolean => {
   if (typeof connection === 'string') {
     try {
       const url = new URL(connection)
-      const socketHost = url.searchParams.get('host')
-      if (isLocalSocketPath(socketHost)) return true
-      if (isLocalSocketPath(url.hostname)) return true
-      if (isLocalPostgresSocketUrl(url)) return true
-      return isLocalHost(url.hostname)
+      const postgresHosts = getConnectionParameterList(url, 'host')
+      const postgresHostAddresses = getConnectionParameterList(url, 'hostaddr')
+      if (postgresHosts.length > 0) {
+        return (
+          postgresHosts.every(isLocalDatabaseHost) &&
+          postgresHostAddresses.every(isLocalNetworkHost)
+        )
+      }
+
+      if (postgresHostAddresses.length > 0) {
+        return (
+          isLocalDatabaseHost(url.hostname) &&
+          postgresHostAddresses.every(isLocalNetworkHost)
+        )
+      }
+
+      return getConnectionParameterValues(url.hostname).every(
+        isLocalDatabaseHost
+      )
     } catch {
       return false
     }
@@ -285,9 +299,8 @@ export const isLocalDatabaseConnection = (connection: unknown): boolean => {
   if (!connection || typeof connection !== 'object') return false
 
   const host = (connection as { host?: unknown }).host
-  if (typeof host !== 'string' || host.trim().length === 0) return false
-  if (isLocalSocketPath(host)) return true
-  return isLocalHost(host)
+  if (typeof host !== 'string') return false
+  return getConnectionParameterValues(host).every(isLocalDatabaseHost)
 }
 
 const isLocalSqliteConnection = (connection: unknown) => {
@@ -441,9 +454,33 @@ const isLocalHost = (host: string) =>
     '::1',
     '[::1]',
     '0.0.0.0',
-    'postgres',
     'host.docker.internal'
   ].includes(host.trim().toLowerCase())
+
+const isLocalNetworkHost = (host: string) => {
+  if (host.trim().length === 0) return false
+  return isLocalHost(host)
+}
+
+const isLocalDatabaseHost = (host: string) => {
+  if (host.trim().length === 0) return false
+  if (isLocalSocketPath(host)) return true
+  return isLocalHost(host)
+}
+
+const getConnectionParameterValues = (value: string) => {
+  let decodedValue = value
+  try {
+    decodedValue = decodeURIComponent(value)
+  } catch {
+    decodedValue = value
+  }
+
+  return decodedValue.split(',').map((entry) => entry.trim())
+}
+
+const getConnectionParameterList = (url: URL, key: string) =>
+  url.searchParams.getAll(key).flatMap(getConnectionParameterValues)
 
 const isLocalSocketPath = (socketPath: unknown) =>
   typeof socketPath === 'string' &&
@@ -457,11 +494,6 @@ const isLocalSocketPath = (socketPath: unknown) =>
       return path.isAbsolute(trimmed)
     }
   })()
-
-const isLocalPostgresSocketUrl = (url: URL) =>
-  (url.protocol === 'postgresql:' || url.protocol === 'postgres:') &&
-  url.hostname === '' &&
-  url.host === ''
 
 const uniqueSortedPaths = (filePaths: (string | null | undefined)[]) =>
   [...new Set(filePaths.map(normalizeStoragePath).filter(Boolean))].sort()
@@ -1394,15 +1426,25 @@ const readTarArchiveLines = async (
 }
 
 export const validateTarArchivePaths = async (archivePath: string) => {
-  await readTarArchiveLines(archivePath, ['-tzf', archivePath], (entry) => {
-    if (!entry || isSafeArchiveEntryPath(entry)) return
-    throw new Error(`Archive contains unsafe path: ${entry}`)
-  })
+  const resolvedArchivePath = path.resolve(archivePath)
 
-  await readTarArchiveLines(archivePath, ['-tvzf', archivePath], (entry) => {
-    if (isSafeTarArchiveVerboseEntry(entry)) return
-    throw new Error(`Archive contains unsupported entry type: ${entry}`)
-  })
+  await readTarArchiveLines(
+    resolvedArchivePath,
+    ['-tzf', resolvedArchivePath],
+    (entry) => {
+      if (!entry || isSafeArchiveEntryPath(entry)) return
+      throw new Error(`Archive contains unsafe path: ${entry}`)
+    }
+  )
+
+  await readTarArchiveLines(
+    resolvedArchivePath,
+    ['-tvzf', resolvedArchivePath],
+    (entry) => {
+      if (isSafeTarArchiveVerboseEntry(entry)) return
+      throw new Error(`Archive contains unsupported entry type: ${entry}`)
+    }
+  )
 }
 
 const extractTarArchive = async (archivePath: string, outputDir: string) => {
@@ -1832,9 +1874,8 @@ const resolveLocalStoragePath = (
 const pathIsInside = (childPath: string, parentPath: string) => {
   const relativePath = path.relative(parentPath, childPath)
   return (
-    relativePath.length > 0 &&
-    !relativePath.startsWith('..') &&
-    !path.isAbsolute(relativePath)
+    relativePath.length === 0 ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
   )
 }
 

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -3,7 +3,7 @@ import {
   ListObjectsV2Command,
   S3Client
 } from '@aws-sdk/client-s3'
-import { execFile } from 'child_process'
+import { execFile, spawn } from 'child_process'
 import { createReadStream, createWriteStream } from 'fs'
 import fs from 'fs/promises'
 import knex, { Knex } from 'knex'
@@ -34,6 +34,7 @@ const DEFAULT_OUTPUT_DIR = 'backups/production-archives'
 const DEFAULT_DOWNLOAD_ENV_FILE = '.env.production'
 const DEFAULT_RESTORE_ENV_FILE = '.env.local'
 const DATABASE_DIR = 'database'
+const MIGRATIONS_DIR = 'migrations'
 const STORAGE_DIR = 'storage'
 const MANIFEST_FILE = 'manifest.json'
 const DATABASE_PAGE_SIZE = 1000
@@ -131,6 +132,17 @@ interface ArchiveManifest {
 interface ReferencedStoragePaths {
   fitnessFilePaths: string[]
   mediaFilePaths: string[]
+}
+
+interface DatabaseExportResult {
+  manifest: NonNullable<ArchiveManifest['database']>
+  referencedStoragePaths?: ReferencedStoragePaths
+}
+
+interface TableExportOrder {
+  columns: string[]
+  keyset: boolean
+  raw: boolean
 }
 
 const DOWNLOAD_USAGE = `Usage: NODE_ENV=production scripts/downloadProductionArchive.ts \\
@@ -255,7 +267,11 @@ export const parseRestoreArgs = (args: string[]): RestoreArgs => {
 export const isLocalDatabaseConnection = (connection: unknown): boolean => {
   if (typeof connection === 'string') {
     try {
-      return isLocalHost(new URL(connection).hostname)
+      const url = new URL(connection)
+      const socketHost = url.searchParams.get('host')
+      if (isLocalSocketPath(socketHost)) return true
+      if (isLocalSocketPath(url.hostname)) return true
+      return isLocalHost(url.hostname)
     } catch {
       return false
     }
@@ -263,33 +279,53 @@ export const isLocalDatabaseConnection = (connection: unknown): boolean => {
 
   if (!connection || typeof connection !== 'object') return false
 
-  const filename = (connection as { filename?: unknown }).filename
-  if (typeof filename === 'string' && filename.trim().length > 0) return true
-
   const host = (connection as { host?: unknown }).host
   if (typeof host !== 'string' || host.trim().length === 0) return false
+  if (isLocalSocketPath(host)) return true
   return isLocalHost(host)
+}
+
+const isLocalSqliteConnection = (connection: unknown) => {
+  if (typeof connection === 'string') return connection.trim().length > 0
+  if (!connection || typeof connection !== 'object') return false
+
+  const filename = (connection as { filename?: unknown }).filename
+  return typeof filename === 'string' && filename.trim().length > 0
+}
+
+const isLocalMysqlConnection = (connection: unknown) => {
+  if (typeof connection === 'string') {
+    try {
+      const url = new URL(connection)
+      const socketPath = url.searchParams.get('socketPath')
+      if (isLocalSocketPath(socketPath)) return true
+      if (isLocalSocketPath(url.hostname)) return true
+      return isLocalHost(url.hostname)
+    } catch {
+      return false
+    }
+  }
+
+  if (!connection || typeof connection !== 'object') return false
+
+  const socketPath = (connection as { socketPath?: unknown }).socketPath
+  if (isLocalSocketPath(socketPath)) return true
+  return isLocalDatabaseConnection(connection)
 }
 
 export const isLocalDatabaseConfig = (databaseConfig: Knex.Config) => {
   const client = String(databaseConfig.client)
 
   if (client === 'better-sqlite3' || client === 'sqlite3') {
-    const connection = databaseConfig.connection
-    if (typeof connection === 'string') return connection.trim().length > 0
-    if (!connection || typeof connection !== 'object') return false
-
-    const filename = (connection as { filename?: unknown }).filename
-    return typeof filename === 'string' && filename.trim().length > 0
+    return isLocalSqliteConnection(databaseConfig.connection)
   }
 
-  if (
-    client === 'pg' ||
-    client === 'pg-native' ||
-    client === 'mysql' ||
-    client === 'mysql2'
-  ) {
+  if (client === 'pg' || client === 'pg-native') {
     return isLocalDatabaseConnection(databaseConfig.connection)
+  }
+
+  if (client === 'mysql' || client === 'mysql2') {
+    return isLocalMysqlConnection(databaseConfig.connection)
   }
 
   return false
@@ -374,9 +410,7 @@ export const buildStoragePlan = ({
 
     plan.push({
       destination: 'media',
-      ...(excludePrefixes.length > 0
-        ? { excludePrefixes }
-        : null),
+      ...(excludePrefixes.length > 0 ? { excludePrefixes } : null),
       ...(mediaFiles ? { files: mediaFiles } : null),
       source: storageSourceFromMediaConfig(mediaStorage)
     })
@@ -406,6 +440,19 @@ const isLocalHost = (host: string) =>
     'host.docker.internal'
   ].includes(host.trim().toLowerCase())
 
+const isLocalSocketPath = (socketPath: unknown) =>
+  typeof socketPath === 'string' &&
+  (() => {
+    const trimmed = socketPath.trim()
+    if (!trimmed) return false
+
+    try {
+      return path.isAbsolute(decodeURIComponent(trimmed))
+    } catch {
+      return path.isAbsolute(trimmed)
+    }
+  })()
+
 const uniqueSortedPaths = (filePaths: (string | null | undefined)[]) =>
   [...new Set(filePaths.map(normalizeStoragePath).filter(Boolean))].sort()
 
@@ -423,8 +470,7 @@ const isStoragePathInsidePrefix = (filePath: string, prefix: string) => {
   const normalizedPrefix = normalizeStoragePath(prefix)
   if (!normalizedPrefix) return false
   return (
-    filePath === normalizedPrefix ||
-    filePath.startsWith(`${normalizedPrefix}/`)
+    filePath === normalizedPrefix || filePath.startsWith(`${normalizedPrefix}/`)
   )
 }
 
@@ -631,6 +677,73 @@ const getDatabaseTableNames = async (database: Knex) => {
   throw new Error(`Unsupported database client for archive: ${client}`)
 }
 
+const getTablePrimaryKeyColumns = async (database: Knex, tableName: string) => {
+  const client = getKnexClientName(database)
+
+  if (client === 'pg' || client === 'pg-native') {
+    const result = await database.raw(
+      `
+      select kcu.column_name as name
+      from information_schema.table_constraints tc
+      join information_schema.key_column_usage kcu
+        on tc.constraint_name = kcu.constraint_name
+        and tc.table_schema = kcu.table_schema
+      where tc.constraint_type = 'PRIMARY KEY'
+        and tc.table_schema = 'public'
+        and tc.table_name = ?
+      order by kcu.ordinal_position asc
+    `,
+      [tableName]
+    )
+    return getQueryRows<{ name: string }>(result).map((row) => row.name)
+  }
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const rows = await database.raw(
+      `PRAGMA table_info(${quoteIdentifier(tableName)})`
+    )
+    return getQueryRows<{ name: string; pk: number }>(rows)
+      .filter((row) => row.pk > 0)
+      .sort((left, right) => left.pk - right.pk)
+      .map((row) => row.name)
+  }
+
+  throw new Error(`Unsupported database client for export: ${client}`)
+}
+
+const getTableExportOrder = async (
+  database: Knex,
+  tableName: string
+): Promise<TableExportOrder> => {
+  const primaryKeyColumns = await getTablePrimaryKeyColumns(database, tableName)
+  if (primaryKeyColumns.length > 0) {
+    return {
+      columns: primaryKeyColumns,
+      keyset: true,
+      raw: false
+    }
+  }
+
+  const client = getKnexClientName(database)
+  if (client === 'pg' || client === 'pg-native') {
+    return {
+      columns: ['ctid'],
+      keyset: false,
+      raw: true
+    }
+  }
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    return {
+      columns: ['rowid'],
+      keyset: false,
+      raw: true
+    }
+  }
+
+  throw new Error(`Unsupported database client for export: ${client}`)
+}
+
 const getMigrationNames = async (database: Knex) => {
   if (!(await database.schema.hasTable('knex_migrations'))) return []
 
@@ -643,19 +756,73 @@ const getMigrationNames = async (database: Knex) => {
     .filter((name): name is string => typeof name === 'string')
 }
 
+const configureExportTransaction = async (database: Knex) => {
+  const client = getKnexClientName(database)
+  if (client !== 'pg' && client !== 'pg-native') return
+
+  await database.raw(
+    'set transaction isolation level repeatable read read only'
+  )
+}
+
+const withDatabaseReadSnapshot = async <T>(
+  database: Knex,
+  callback: (transaction: Knex) => Promise<T>
+) => {
+  return database.transaction(async (transaction) => {
+    const snapshot = transaction as Knex
+    await configureExportTransaction(snapshot)
+    return callback(snapshot)
+  })
+}
+
 const createTableRowsStream = (
   database: Knex,
   tableName: string,
+  order: TableExportOrder,
   onRow: () => void
 ) => {
   async function* rowsToJsonLines() {
+    let lastRow: Record<string, unknown> | null = null
     let offset = 0
 
     for (;;) {
-      const rows = await database(tableName)
-        .select('*')
-        .limit(DATABASE_PAGE_SIZE)
-        .offset(offset)
+      const query = database(tableName).select('*').limit(DATABASE_PAGE_SIZE)
+
+      for (const column of order.columns) {
+        if (order.raw) {
+          query.orderByRaw(`${column} asc`)
+        } else {
+          query.orderBy(column, 'asc')
+        }
+      }
+
+      if (order.keyset && lastRow) {
+        query.where(function () {
+          for (let index = 0; index < order.columns.length; index += 1) {
+            this.orWhere(function () {
+              for (
+                let previousIndex = 0;
+                previousIndex < index;
+                previousIndex += 1
+              ) {
+                const previousColumn = order.columns[previousIndex]
+                this.where(
+                  previousColumn,
+                  lastRow![previousColumn] as Knex.Value
+                )
+              }
+
+              const column = order.columns[index]
+              this.where(column, '>', lastRow![column] as Knex.Value)
+            })
+          }
+        })
+      } else if (!order.keyset) {
+        query.offset(offset)
+      }
+
+      const rows = await query
 
       if (rows.length === 0) return
 
@@ -664,6 +831,7 @@ const createTableRowsStream = (
         yield `${JSON.stringify(row)}\n`
       }
 
+      lastRow = rows[rows.length - 1]
       offset += rows.length
     }
   }
@@ -671,31 +839,47 @@ const createTableRowsStream = (
   return Readable.from(rowsToJsonLines())
 }
 
-const exportDatabase = async (database: Knex, outputDir: string) => {
+const exportDatabase = async (
+  database: Knex,
+  outputDir: string,
+  options: { includeReferencedStoragePaths: boolean }
+): Promise<DatabaseExportResult> => {
   const databaseDir = path.join(outputDir, DATABASE_DIR)
   await fs.mkdir(databaseDir, { recursive: true })
 
-  const tableNames = await getDatabaseTableNames(database)
-  const migrations = await getMigrationNames(database)
-  const tables: ArchiveTableManifest[] = []
+  return withDatabaseReadSnapshot(database, async (transaction) => {
+    const tableNames = await getDatabaseTableNames(transaction)
+    const migrations = await getMigrationNames(transaction)
+    const tables: ArchiveTableManifest[] = []
 
-  for (const tableName of tableNames) {
-    let rowCount = 0
-    await pipeline(
-      createTableRowsStream(database, tableName, () => {
-        rowCount += 1
-      }),
-      createWriteStream(path.join(databaseDir, tableFileName(tableName)))
-    )
-    tables.push({ name: tableName, rowCount })
-    console.log(`Database: exported ${rowCount} row(s) from ${tableName}`)
-  }
+    for (const tableName of tableNames) {
+      const order = await getTableExportOrder(transaction, tableName)
+      let rowCount = 0
+      await pipeline(
+        createTableRowsStream(transaction, tableName, order, () => {
+          rowCount += 1
+        }),
+        createWriteStream(path.join(databaseDir, tableFileName(tableName)))
+      )
+      tables.push({ name: tableName, rowCount })
+      console.log(`Database: exported ${rowCount} row(s) from ${tableName}`)
+    }
 
-  return {
-    client: getKnexClientName(database),
-    migrations,
-    tables
-  }
+    const manifest = {
+      client: getKnexClientName(transaction),
+      migrations,
+      tables
+    }
+
+    return {
+      manifest,
+      ...(options.includeReferencedStoragePaths
+        ? {
+            referencedStoragePaths: await getReferencedStoragePaths(transaction)
+          }
+        : null)
+    }
+  })
 }
 
 const tableExists = async (database: Knex, tableName: string) =>
@@ -837,7 +1021,10 @@ const getStorageFiles = async (
   const allFiles =
     entry.files ??
     (entry.source.kind === 's3'
-      ? await listS3Files(entry.source, s3Client ?? createS3Client(entry.source))
+      ? await listS3Files(
+          entry.source,
+          s3Client ?? createS3Client(entry.source)
+        )
       : await listLocalFiles(path.resolve(entry.source.path)))
 
   return allFiles.filter((filePath) => {
@@ -1067,29 +1254,96 @@ const createTarArchive = async (stagingDir: string, archivePath: string) => {
 
 export const isSafeArchiveEntryPath = (entry: string) => {
   if (!entry) return false
-  if (path.posix.isAbsolute(entry)) return false
+  const normalizedEntry = entry.replaceAll('\\', '/')
+  if (path.posix.isAbsolute(normalizedEntry)) return false
 
-  const normalized = path.posix.normalize(entry)
+  const normalized = path.posix.normalize(normalizedEntry)
   return normalized !== '..' && !normalized.startsWith('../')
 }
 
-const validateTarArchivePaths = async (archivePath: string) => {
-  const { stdout } = await execFileAsync('tar', ['-tzf', archivePath], {
-    maxBuffer: 64 * 1024 * 1024
+export const isSafeTarArchiveVerboseEntry = (entry: string) => {
+  if (!entry) return true
+  return entry[0] === '-' || entry[0] === 'd'
+}
+
+const readTarArchiveLines = async (
+  archivePath: string,
+  args: string[],
+  onLine: (entry: string) => void
+) => {
+  await new Promise<void>((resolve, reject) => {
+    const tar = spawn('tar', args, {
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    const lines = createInterface({ input: tar.stdout })
+    let settled = false
+    let stderr = ''
+    const stderrLimit = 64 * 1024
+
+    const finish = (error?: Error) => {
+      if (settled) return
+      settled = true
+      lines.close()
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    }
+
+    lines.on('line', (entry) => {
+      try {
+        onLine(entry)
+      } catch (error) {
+        tar.kill()
+        finish(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+    tar.stderr.on('data', (chunk) => {
+      stderr = (stderr + String(chunk)).slice(-stderrLimit)
+    })
+    tar.on('error', (error) => {
+      finish(error)
+    })
+    tar.on('close', (code) => {
+      if (settled) return
+      if (code === 0) {
+        finish()
+        return
+      }
+
+      finish(
+        new Error(
+          `Failed to list archive contents: ${stderr.trim() || `tar ${code}`}`
+        )
+      )
+    })
+  })
+}
+
+export const validateTarArchivePaths = async (archivePath: string) => {
+  await readTarArchiveLines(archivePath, ['-tzf', archivePath], (entry) => {
+    if (!entry || isSafeArchiveEntryPath(entry)) return
+    throw new Error(`Archive contains unsafe path: ${entry}`)
   })
 
-  for (const entry of stdout.split(/\r?\n/)) {
-    if (!entry) continue
-    if (!isSafeArchiveEntryPath(entry)) {
-      throw new Error(`Archive contains unsafe path: ${entry}`)
-    }
-  }
+  await readTarArchiveLines(archivePath, ['-tvzf', archivePath], (entry) => {
+    if (isSafeTarArchiveVerboseEntry(entry)) return
+    throw new Error(`Archive contains unsupported entry type: ${entry}`)
+  })
 }
 
 const extractTarArchive = async (archivePath: string, outputDir: string) => {
   await fs.mkdir(outputDir, { recursive: true })
   await validateTarArchivePaths(archivePath)
-  await execFileAsync('tar', ['-xzf', archivePath, '-C', outputDir])
+  await execFileAsync('tar', [
+    '-xzf',
+    archivePath,
+    '--no-same-owner',
+    '--no-same-permissions',
+    '-C',
+    outputDir
+  ])
 }
 
 const readManifest = async (archiveDir: string): Promise<ArchiveManifest> => {
@@ -1177,27 +1431,54 @@ const getForeignKeyReferences = async (
   throw new Error(`Unsupported database client for restore: ${client}`)
 }
 
-const truncateTables = async (database: Knex, tableNames: string[]) => {
+export const truncateTables = async (
+  database: Knex,
+  tableNames: string[],
+  orderedTables: string[]
+) => {
   const client = getKnexClientName(database)
   if (tableNames.length === 0) return
 
   if (client === 'pg' || client === 'pg-native') {
     const tables = tableNames.map(quoteIdentifier).join(', ')
-    await database.raw(`truncate table ${tables} restart identity`)
+    try {
+      await database.raw(`truncate table ${tables} restart identity`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        'Failed to truncate archived tables without CASCADE. This usually ' +
+          'means a local table outside the archive has a foreign key into an ' +
+          'archived table; regenerate the archive after schema changes. ' +
+          `Original error: ${message}`
+      )
+    }
     return
   }
 
   if (client === 'better-sqlite3' || client === 'sqlite3') {
-    await database.raw('PRAGMA foreign_keys = OFF')
+    const connection = await database.client.acquireConnection()
+
     try {
-      for (const tableName of tableNames) {
-        await database(tableName).delete()
-      }
-      if (await database.schema.hasTable('sqlite_sequence')) {
-        await database('sqlite_sequence').whereIn('name', tableNames).delete()
+      await database.raw('PRAGMA foreign_keys = OFF').connection(connection)
+      try {
+        for (const tableName of [...orderedTables].reverse()) {
+          await database(tableName).connection(connection).delete()
+        }
+        if (
+          await database.schema
+            .connection(connection)
+            .hasTable('sqlite_sequence')
+        ) {
+          await database('sqlite_sequence')
+            .connection(connection)
+            .whereIn('name', tableNames)
+            .delete()
+        }
+      } finally {
+        await database.raw('PRAGMA foreign_keys = ON').connection(connection)
       }
     } finally {
-      await database.raw('PRAGMA foreign_keys = ON')
+      await database.client.releaseConnection(connection)
     }
     return
   }
@@ -1226,10 +1507,31 @@ const assertMatchingMigrations = (
   )
 }
 
+const getLocalMigrationFileNames = async () => {
+  const entries = await fs.readdir(
+    path.resolve(process.cwd(), MIGRATIONS_DIR),
+    {
+      withFileTypes: true
+    }
+  )
+
+  return entries
+    .filter((entry) => {
+      return entry.isFile() && /\.(cjs|js|mjs|ts)$/.test(entry.name)
+    })
+    .map((entry) => entry.name)
+    .sort()
+}
+
 const ensureArchiveSchemaMatchesLocal = async (
   database: Knex,
   archiveMigrations: string[]
 ) => {
+  assertMatchingMigrations(
+    archiveMigrations,
+    await getLocalMigrationFileNames()
+  )
+
   const migrationsBeforeLatest = await getMigrationNames(database)
 
   if (migrationsBeforeLatest.length > 0) {
@@ -1354,7 +1656,7 @@ const restoreDatabase = async (
   const foreignKeys = await getForeignKeyReferences(database, tableNames)
   const orderedTables = sortTablesForRestore(tableNames, foreignKeys)
 
-  await truncateTables(database, tableNames)
+  await truncateTables(database, tableNames, orderedTables)
 
   for (const tableName of orderedTables) {
     const rowCount = await restoreTableFromJsonLines(
@@ -1579,14 +1881,20 @@ export const downloadProductionArchive = async (
   const database = createDatabase()
 
   try {
-    const databaseManifest = args.skipDatabase
+    const needsReferencedStoragePaths =
+      !args.skipStorage && args.storageScope === 'referenced'
+    const databaseExport = args.skipDatabase
       ? null
-      : await exportDatabase(database, stagingDir)
+      : await exportDatabase(database, stagingDir, {
+          includeReferencedStoragePaths: needsReferencedStoragePaths
+        })
+    const databaseManifest = databaseExport?.manifest ?? null
 
     const storagePaths =
       args.skipStorage || args.storageScope === 'all'
         ? { fitnessFilePaths: [], mediaFilePaths: [] }
-        : await getReferencedStoragePaths(database)
+        : (databaseExport?.referencedStoragePaths ??
+          (await withDatabaseReadSnapshot(database, getReferencedStoragePaths)))
 
     const storageManifest = args.skipStorage
       ? []

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -144,6 +144,7 @@ interface DatabaseExportResult {
 }
 
 interface TableExportOrder {
+  aliases?: string[]
   columns: string[]
   keyset: boolean
   raw: boolean
@@ -270,6 +271,10 @@ export const parseRestoreArgs = (args: string[]): RestoreArgs => {
 
 export const isLocalDatabaseConnection = (connection: unknown): boolean => {
   if (typeof connection === 'string') {
+    if (getConnectionParameterValues(connection).every(isLocalDatabaseHost)) {
+      return true
+    }
+
     try {
       const url = new URL(connection)
       const postgresHosts = getConnectionParameterList(url, 'host')
@@ -725,6 +730,60 @@ const getTablePrimaryKeyColumns = async (database: Knex, tableName: string) => {
   throw new Error(`Unsupported database client for export: ${client}`)
 }
 
+const getTableColumnNames = async (database: Knex, tableName: string) => {
+  const client = getKnexClientName(database)
+
+  if (client === 'pg' || client === 'pg-native') {
+    const result = await database.raw(
+      `
+      select column_name as name
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = ?
+      order by ordinal_position asc
+    `,
+      [tableName]
+    )
+    return getQueryRows<{ name: string }>(result).map((row) => row.name)
+  }
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const rows = await database.raw(
+      `PRAGMA table_info(${quoteIdentifier(tableName)})`
+    )
+    return getQueryRows<{ name: string }>(rows).map((row) => row.name)
+  }
+
+  throw new Error(`Unsupported database client for column discovery: ${client}`)
+}
+
+const getAvailableColumnName = (
+  existingColumns: Set<string>,
+  baseName: string
+) => {
+  const normalizedExistingColumns = new Set(
+    [...existingColumns].map((columnName) => columnName.toLowerCase())
+  )
+  let index = 0
+
+  for (;;) {
+    const candidate = index === 0 ? baseName : `${baseName}_${index}`
+    if (!normalizedExistingColumns.has(candidate.toLowerCase())) {
+      return candidate
+    }
+    index += 1
+  }
+}
+
+const getSqliteRowIdColumn = (columnNames: string[]) => {
+  const existingColumns = new Set(
+    columnNames.map((columnName) => columnName.toLowerCase())
+  )
+  return ['rowid', '_rowid_', 'oid'].find((column) => {
+    return !existingColumns.has(column)
+  })
+}
+
 const getTableExportOrder = async (
   database: Knex,
   tableName: string
@@ -739,6 +798,7 @@ const getTableExportOrder = async (
   }
 
   const client = getKnexClientName(database)
+  const columnNames = await getTableColumnNames(database, tableName)
   if (client === 'pg' || client === 'pg-native') {
     return {
       columns: ['ctid'],
@@ -748,9 +808,25 @@ const getTableExportOrder = async (
   }
 
   if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const rowIdColumn = getSqliteRowIdColumn(columnNames)
+    if (!rowIdColumn) {
+      return {
+        columns: ['rowid'],
+        keyset: false,
+        raw: true
+      }
+    }
+
+    const existingColumns = new Set(columnNames)
+    const cursorAlias = getAvailableColumnName(
+      existingColumns,
+      '__activitynext_archive_cursor'
+    )
+
     return {
-      columns: ['rowid'],
-      keyset: false,
+      aliases: [cursorAlias],
+      columns: [rowIdColumn],
+      keyset: true,
       raw: true
     }
   }
@@ -790,7 +866,35 @@ const withDatabaseReadSnapshot = async <T>(
   })
 }
 
-const createTableRowsStream = (
+const rawCursorAlias = (order: TableExportOrder, index: number) => {
+  return order.aliases?.[index] ?? `__activitynext_archive_cursor_${index}`
+}
+
+const getOrderColumnValue = (
+  row: Record<string, unknown>,
+  order: TableExportOrder,
+  index: number
+) => {
+  const column = order.columns[index]
+  return order.raw && order.keyset
+    ? row[rawCursorAlias(order, index)]
+    : row[column]
+}
+
+const serializeArchiveRow = (
+  row: Record<string, unknown>,
+  order: TableExportOrder
+) => {
+  if (!order.raw || !order.keyset) return row
+
+  const archiveRow = { ...row }
+  for (let index = 0; index < order.columns.length; index += 1) {
+    delete archiveRow[rawCursorAlias(order, index)]
+  }
+  return archiveRow
+}
+
+export const createTableRowsStream = (
   database: Knex,
   tableName: string,
   order: TableExportOrder,
@@ -803,9 +907,17 @@ const createTableRowsStream = (
     for (;;) {
       const query = database(tableName).select('*').limit(DATABASE_PAGE_SIZE)
 
+      if (order.raw && order.keyset) {
+        order.columns.forEach((column, index) => {
+          query.select(
+            database.raw('?? as ??', [column, rawCursorAlias(order, index)])
+          )
+        })
+      }
+
       for (const column of order.columns) {
         if (order.raw) {
-          query.orderByRaw(`${column} asc`)
+          query.orderByRaw('?? asc', [column])
         } else {
           query.orderBy(column, 'asc')
         }
@@ -821,14 +933,28 @@ const createTableRowsStream = (
                 previousIndex += 1
               ) {
                 const previousColumn = order.columns[previousIndex]
-                this.where(
-                  previousColumn,
-                  lastRow![previousColumn] as Knex.Value
+                const previousValue = getOrderColumnValue(
+                  lastRow!,
+                  order,
+                  previousIndex
                 )
+                if (order.raw) {
+                  this.whereRaw('?? = ?', [
+                    previousColumn,
+                    previousValue as Knex.Value
+                  ])
+                } else {
+                  this.where(previousColumn, previousValue as Knex.Value)
+                }
               }
 
               const column = order.columns[index]
-              this.where(column, '>', lastRow![column] as Knex.Value)
+              const value = getOrderColumnValue(lastRow!, order, index)
+              if (order.raw) {
+                this.whereRaw('?? > ?', [column, value as Knex.Value])
+              } else {
+                this.where(column, '>', value as Knex.Value)
+              }
             })
           }
         })
@@ -842,7 +968,7 @@ const createTableRowsStream = (
 
       for (const row of rows) {
         onRow()
-        yield `${JSON.stringify(row)}\n`
+        yield `${JSON.stringify(serializeArchiveRow(row, order))}\n`
       }
 
       lastRow = rows[rows.length - 1]
@@ -853,7 +979,7 @@ const createTableRowsStream = (
   return Readable.from(rowsToJsonLines())
 }
 
-const exportDatabase = async (
+export const exportDatabase = async (
   database: Knex,
   outputDir: string,
   options: { includeReferencedStoragePaths: boolean }
@@ -1252,7 +1378,7 @@ export const fetchPublicStorageResponse = async (url: string) => {
   }
 }
 
-const archiveStorage = async (
+export const archiveStorage = async (
   plan: StoragePlanEntry[],
   stagingDir: string,
   options: { allowMissingStorage: boolean }
@@ -1297,6 +1423,7 @@ const archiveStorage = async (
           const nodeError = error as Error
           if (!options.allowMissingStorage) throw error
 
+          await fs.rm(archiveFilePath, { force: true })
           failedFiles.push({
             error: nodeError.message,
             path: relativeFilePath

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -38,6 +38,7 @@ const MIGRATIONS_DIR = 'migrations'
 const STORAGE_DIR = 'storage'
 const MANIFEST_FILE = 'manifest.json'
 const DATABASE_PAGE_SIZE = 1000
+export const PUBLIC_STORAGE_FETCH_TIMEOUT_MS = 30_000
 const INSERT_BATCH_SIZE = 250
 
 export type StorageScope = 'referenced' | 'all'
@@ -271,6 +272,7 @@ export const isLocalDatabaseConnection = (connection: unknown): boolean => {
       const socketHost = url.searchParams.get('host')
       if (isLocalSocketPath(socketHost)) return true
       if (isLocalSocketPath(url.hostname)) return true
+      if (isLocalPostgresSocketUrl(url)) return true
       return isLocalHost(url.hostname)
     } catch {
       return false
@@ -452,6 +454,11 @@ const isLocalSocketPath = (socketPath: unknown) =>
       return path.isAbsolute(trimmed)
     }
   })()
+
+const isLocalPostgresSocketUrl = (url: URL) =>
+  (url.protocol === 'postgresql:' || url.protocol === 'postgres:') &&
+  url.hostname === '' &&
+  url.host === ''
 
 const uniqueSortedPaths = (filePaths: (string | null | undefined)[]) =>
   [...new Set(filePaths.map(normalizeStoragePath).filter(Boolean))].sort()
@@ -885,54 +892,99 @@ const exportDatabase = async (
 const tableExists = async (database: Knex, tableName: string) =>
   database.schema.hasTable(tableName)
 
-const getReferencedStoragePaths = async (
+const isKeysetValue = (value: unknown): value is Knex.Value =>
+  typeof value === 'number' ||
+  typeof value === 'string' ||
+  value instanceof Date
+
+const forEachKeysetRow = async <T extends { id: unknown }>({
+  columns,
+  database,
+  onRow,
+  tableName
+}: {
+  columns: string[]
+  database: Knex
+  onRow: (row: T) => void
+  tableName: string
+}) => {
+  let lastId: Knex.Value | null = null
+
+  for (;;) {
+    const query = database(tableName)
+      .select(['id', ...columns])
+      .orderBy('id', 'asc')
+      .limit(DATABASE_PAGE_SIZE)
+
+    if (lastId !== null) {
+      query.where('id', '>', lastId)
+    }
+
+    const rows = (await query) as T[]
+    if (rows.length === 0) break
+
+    for (const row of rows) {
+      onRow(row)
+    }
+
+    const nextLastId = rows[rows.length - 1]?.id
+    if (!isKeysetValue(nextLastId)) {
+      throw new Error(
+        `Cannot paginate ${tableName}: id must be a string, number, or Date.`
+      )
+    }
+
+    if (lastId !== null && Object.is(nextLastId, lastId)) {
+      throw new Error(`Cannot paginate ${tableName}: id did not advance.`)
+    }
+
+    lastId = nextLastId
+    if (rows.length < DATABASE_PAGE_SIZE) break
+  }
+}
+
+export const getReferencedStoragePaths = async (
   database: Knex
 ): Promise<ReferencedStoragePaths> => {
   const mediaFilePaths: string[] = []
   const fitnessFilePaths: string[] = []
 
   if (await tableExists(database, 'medias')) {
-    let offset = 0
-    for (;;) {
-      const mediaRows = await database('medias')
-        .select('original', 'thumbnail')
-        .orderBy('id', 'asc')
-        .limit(DATABASE_PAGE_SIZE)
-        .offset(offset)
-
-      if (mediaRows.length === 0) break
-
-      for (const row of mediaRows) {
-        if (typeof row.original === 'string') mediaFilePaths.push(row.original)
+    await forEachKeysetRow<{
+      id: number
+      original?: unknown
+      thumbnail?: unknown
+    }>({
+      columns: ['original', 'thumbnail'],
+      database,
+      onRow: (row) => {
+        if (typeof row.original === 'string') {
+          mediaFilePaths.push(row.original)
+        }
         if (typeof row.thumbnail === 'string') {
           mediaFilePaths.push(row.thumbnail)
         }
-      }
-
-      offset += mediaRows.length
-    }
+      },
+      tableName: 'medias'
+    })
   }
 
   if (await tableExists(database, 'fitness_files')) {
-    let offset = 0
-    for (;;) {
-      const fitnessRows = await database('fitness_files')
-        .select('path', 'mapImagePath')
-        .orderBy('id', 'asc')
-        .limit(DATABASE_PAGE_SIZE)
-        .offset(offset)
-
-      if (fitnessRows.length === 0) break
-
-      for (const row of fitnessRows) {
+    await forEachKeysetRow<{
+      id: string
+      mapImagePath?: unknown
+      path?: unknown
+    }>({
+      columns: ['path', 'mapImagePath'],
+      database,
+      onRow: (row) => {
         if (typeof row.path === 'string') fitnessFilePaths.push(row.path)
         if (typeof row.mapImagePath === 'string') {
           mediaFilePaths.push(row.mapImagePath)
         }
-      }
-
-      offset += fitnessRows.length
-    }
+      },
+      tableName: 'fitness_files'
+    })
   }
 
   return {
@@ -941,8 +993,21 @@ const getReferencedStoragePaths = async (
   }
 }
 
-const createS3Client = (source: Extract<StorageSource, { kind: 's3' }>) =>
-  new S3Client({ region: source.region })
+export const normalizeStorageHostname = (hostname: string) =>
+  hostname.replace(/^https?:\/\//i, '').replace(/\/+$/, '')
+
+export const createS3Client = (
+  source: Extract<StorageSource, { kind: 's3' }>
+) =>
+  new S3Client({
+    region: source.region,
+    ...(source.hostname
+      ? {
+          endpoint: `https://${normalizeStorageHostname(source.hostname)}`,
+          forcePathStyle: true
+        }
+      : null)
+  })
 
 const listS3Files = async (
   source: Extract<StorageSource, { kind: 's3' }>,
@@ -1120,9 +1185,12 @@ const downloadPublicStorageFile = async ({
   hostname: string
   key: string
 }) => {
-  const normalizedHostname = hostname.replace(/^https?:\/\//, '')
+  const normalizedHostname = normalizeStorageHostname(hostname)
   const encodedKey = key.split('/').map(encodeURIComponent).join('/')
-  const response = await fetch(`https://${normalizedHostname}/${encodedKey}`)
+  const response = await fetch(
+    `https://${normalizedHostname}/${encodedKey}`,
+    createPublicStorageFetchInit()
+  )
 
   if (!response.ok) {
     throw new Error(
@@ -1148,6 +1216,10 @@ const downloadPublicStorageFile = async ({
 
   return (await fs.stat(archiveFilePath)).size
 }
+
+export const createPublicStorageFetchInit = (): RequestInit => ({
+  signal: AbortSignal.timeout(PUBLIC_STORAGE_FETCH_TIMEOUT_MS)
+})
 
 const archiveStorage = async (
   plan: StoragePlanEntry[],
@@ -1486,13 +1558,20 @@ export const truncateTables = async (
   throw new Error(`Unsupported database client for restore: ${client}`)
 }
 
-const assertMatchingMigrations = (
+export const assertMatchingMigrations = (
   archiveMigrations: string[],
   localMigrations: string[]
 ) => {
-  const archiveValue = JSON.stringify(archiveMigrations)
-  const localValue = JSON.stringify(localMigrations)
-  if (archiveValue === localValue) return
+  const sortedArchiveMigrations = [...archiveMigrations].sort()
+  const sortedLocalMigrations = [...localMigrations].sort()
+  if (
+    sortedArchiveMigrations.length === sortedLocalMigrations.length &&
+    sortedArchiveMigrations.every((name, index) => {
+      return name === sortedLocalMigrations[index]
+    })
+  ) {
+    return
+  }
 
   const archiveSet = new Set(archiveMigrations)
   const localSet = new Set(localMigrations)

--- a/scripts/productionArchive.ts
+++ b/scripts/productionArchive.ts
@@ -1,0 +1,1346 @@
+import {
+  GetObjectCommand,
+  ListObjectsV2Command,
+  S3Client
+} from '@aws-sdk/client-s3'
+import { execFile } from 'child_process'
+import { createWriteStream } from 'fs'
+import fs from 'fs/promises'
+import knex, { Knex } from 'knex'
+import os from 'os'
+import path from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import type { ReadableStream as NodeReadableStream } from 'stream/web'
+import { promisify } from 'util'
+
+import { getConfig } from '@/lib/config'
+import {
+  FitnessStorageConfig,
+  FitnessStorageS3Config,
+  FitnessStorageType
+} from '@/lib/config/fitnessStorage'
+import {
+  MediaStorageConfig,
+  MediaStorageS3Config,
+  MediaStorageType
+} from '@/lib/config/mediaStorage'
+
+const execFileAsync = promisify(execFile)
+
+const ARCHIVE_VERSION = 1
+const DEFAULT_OUTPUT_DIR = 'backups/production-archives'
+const DEFAULT_DOWNLOAD_ENV_FILE = '.env.production'
+const DEFAULT_RESTORE_ENV_FILE = '.env.local'
+const DATABASE_DIR = 'database'
+const STORAGE_DIR = 'storage'
+const MANIFEST_FILE = 'manifest.json'
+const INSERT_BATCH_SIZE = 250
+
+export type StorageScope = 'referenced' | 'all'
+export type StorageDestination = 'media' | 'fitness'
+
+export interface DownloadArgs {
+  allowMissingStorage: boolean
+  envFile: string
+  outputDir: string
+  skipDatabase: boolean
+  skipStorage: boolean
+  storageScope: StorageScope
+}
+
+export interface RestoreArgs {
+  allowNonLocalDatabase: boolean
+  archive: string
+  databaseOnly: boolean
+  envFile: string
+  filesOnly: boolean
+  preserveFiles: boolean
+  yes: boolean
+}
+
+export interface ForeignKeyReference {
+  fromTable: string
+  toTable: string
+}
+
+export type StorageSource =
+  | {
+      kind: 'local'
+      path: string
+      prefix?: string
+    }
+  | {
+      bucket: string
+      hostname?: string
+      kind: 's3'
+      prefix?: string
+      region: string
+    }
+
+export interface StoragePlanEntry {
+  destination: StorageDestination
+  excludePrefixes?: string[]
+  files?: string[]
+  source: StorageSource
+}
+
+interface BuildStoragePlanParams {
+  fitnessFilePaths: string[]
+  fitnessStorage?: FitnessStorageConfig | null
+  mediaFilePaths: string[]
+  mediaStorage?: MediaStorageConfig | null
+  scope: StorageScope
+}
+
+interface ArchiveTableManifest {
+  name: string
+  rowCount: number
+}
+
+interface ArchiveStorageManifest {
+  destination: StorageDestination
+  failedFiles: { error: string; path: string }[]
+  fileCount: number
+  source: {
+    kind: StorageSource['kind']
+    prefix?: string
+  }
+  totalBytes: number
+}
+
+interface ArchiveManifest {
+  createdAt: string
+  database: {
+    client: string
+    tables: ArchiveTableManifest[]
+  } | null
+  source: {
+    host: string
+    nodeEnv: string | undefined
+  }
+  storage: ArchiveStorageManifest[]
+  storageScope: StorageScope
+  version: number
+}
+
+interface ReferencedStoragePaths {
+  fitnessFilePaths: string[]
+  mediaFilePaths: string[]
+}
+
+const DOWNLOAD_USAGE = `Usage: NODE_ENV=production scripts/downloadProductionArchive.ts \\
+  [--env-file .env.production] \\
+  [--output-dir backups/production-archives] \\
+  [--storage-scope referenced|all] \\
+  [--allow-missing-storage] \\
+  [--skip-database] \\
+  [--skip-storage]`
+
+const RESTORE_USAGE = `Usage: scripts/restoreProductionArchive.ts \\
+  --archive backups/production-archives/activitynext-production-<timestamp>.tar.gz \\
+  --yes \\
+  [--env-file .env.local] \\
+  [--database-only] \\
+  [--files-only] \\
+  [--preserve-files] \\
+  [--allow-non-local-database]`
+
+const parseKeyValueArgs = (args: string[]) => {
+  const parsed = new Map<string, string | true>()
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const [key, inlineValue] = argument.slice(2).split('=', 2)
+    if (inlineValue !== undefined) {
+      parsed.set(key, inlineValue)
+      continue
+    }
+
+    const nextValue = args[index + 1]
+    if (!nextValue || nextValue.startsWith('--')) {
+      parsed.set(key, true)
+      continue
+    }
+
+    parsed.set(key, nextValue)
+    index += 1
+  }
+
+  return parsed
+}
+
+const getStringArg = (
+  args: Map<string, string | true>,
+  key: string,
+  defaultValue?: string
+) => {
+  const value = args.get(key)
+  if (value === undefined) return defaultValue
+  if (value === true) throw new Error(`Missing value for --${key}`)
+  return value
+}
+
+const getBooleanArg = (args: Map<string, string | true>, key: string) => {
+  const value = args.get(key)
+  if (value === undefined) return false
+  if (value === true) return true
+  if (value === 'true') return true
+  if (value === 'false') return false
+  throw new Error(`Invalid value for --${key}: ${value}. Use true or false.`)
+}
+
+export const parseDownloadArgs = (args: string[]): DownloadArgs => {
+  const parsed = parseKeyValueArgs(args)
+  const storageScope = getStringArg(
+    parsed,
+    'storage-scope',
+    'referenced'
+  ) as StorageScope
+
+  if (storageScope !== 'referenced' && storageScope !== 'all') {
+    throw new Error(
+      `Invalid value for --storage-scope: ${storageScope}. ` +
+        'Use referenced or all.'
+    )
+  }
+
+  return {
+    allowMissingStorage: getBooleanArg(parsed, 'allow-missing-storage'),
+    envFile: getStringArg(parsed, 'env-file', DEFAULT_DOWNLOAD_ENV_FILE)!,
+    outputDir: getStringArg(parsed, 'output-dir', DEFAULT_OUTPUT_DIR)!,
+    skipDatabase: getBooleanArg(parsed, 'skip-database'),
+    skipStorage: getBooleanArg(parsed, 'skip-storage'),
+    storageScope
+  }
+}
+
+export const parseRestoreArgs = (args: string[]): RestoreArgs => {
+  const parsed = parseKeyValueArgs(args)
+  const archive = getStringArg(parsed, 'archive')
+  if (!archive) throw new Error('Missing required --archive path.')
+
+  const yes = getBooleanArg(parsed, 'yes')
+  if (!yes) {
+    throw new Error('Restoring replaces local data. Pass --yes to continue.')
+  }
+
+  const databaseOnly = getBooleanArg(parsed, 'database-only')
+  const filesOnly = getBooleanArg(parsed, 'files-only')
+  if (databaseOnly && filesOnly) {
+    throw new Error('Use only one of --database-only or --files-only.')
+  }
+
+  return {
+    allowNonLocalDatabase: getBooleanArg(parsed, 'allow-non-local-database'),
+    archive,
+    databaseOnly,
+    envFile: getStringArg(parsed, 'env-file', DEFAULT_RESTORE_ENV_FILE)!,
+    filesOnly,
+    preserveFiles: getBooleanArg(parsed, 'preserve-files'),
+    yes
+  }
+}
+
+export const isLocalDatabaseConnection = (connection: unknown): boolean => {
+  if (typeof connection === 'string') {
+    try {
+      return isLocalHost(new URL(connection).hostname)
+    } catch {
+      return false
+    }
+  }
+
+  if (!connection || typeof connection !== 'object') return true
+
+  const host = (connection as { host?: unknown }).host
+  if (typeof host !== 'string' || host.trim().length === 0) return true
+  return isLocalHost(host)
+}
+
+export const sortTablesForRestore = (
+  tables: string[],
+  foreignKeys: ForeignKeyReference[]
+) => {
+  const tableSet = new Set(tables)
+  const dependencies = new Map<string, Set<string>>()
+
+  for (const table of tables) {
+    dependencies.set(table, new Set())
+  }
+
+  for (const foreignKey of foreignKeys) {
+    if (foreignKey.fromTable === foreignKey.toTable) continue
+    if (!tableSet.has(foreignKey.fromTable)) continue
+    if (!tableSet.has(foreignKey.toTable)) continue
+    dependencies.get(foreignKey.fromTable)?.add(foreignKey.toTable)
+  }
+
+  const ordered: string[] = []
+  const remaining = new Set(tables)
+
+  while (remaining.size > 0) {
+    const ready = [...remaining].filter((table) => {
+      const tableDependencies = dependencies.get(table) ?? new Set()
+      return [...tableDependencies].every((dependency) => {
+        return !remaining.has(dependency)
+      })
+    })
+
+    if (ready.length === 0) {
+      ordered.push(...remaining)
+      break
+    }
+
+    for (const table of ready) {
+      ordered.push(table)
+      remaining.delete(table)
+    }
+  }
+
+  return ordered
+}
+
+export const buildStoragePlan = ({
+  fitnessFilePaths,
+  fitnessStorage,
+  mediaFilePaths,
+  mediaStorage,
+  scope
+}: BuildStoragePlanParams): StoragePlanEntry[] => {
+  const plan: StoragePlanEntry[] = []
+  const sharedS3FitnessPrefix = getSharedS3FitnessPrefix(
+    mediaStorage,
+    fitnessStorage
+  )
+  const sharedLocalFitnessPrefix = getSharedLocalFitnessPrefix(
+    mediaStorage,
+    fitnessStorage
+  )
+
+  if (mediaStorage) {
+    const mediaFiles =
+      scope === 'referenced'
+        ? uniqueSortedPaths(mediaFilePaths).filter((filePath) => {
+            if (!sharedS3FitnessPrefix) return true
+            return !filePath.startsWith(sharedS3FitnessPrefix)
+          })
+        : undefined
+
+    plan.push({
+      destination: 'media',
+      ...(scope === 'all' && sharedLocalFitnessPrefix
+        ? { excludePrefixes: [sharedLocalFitnessPrefix] }
+        : null),
+      ...(scope === 'all' && sharedS3FitnessPrefix
+        ? { excludePrefixes: [sharedS3FitnessPrefix] }
+        : null),
+      ...(mediaFiles ? { files: mediaFiles } : null),
+      source: storageSourceFromMediaConfig(mediaStorage)
+    })
+  }
+
+  if (fitnessStorage) {
+    plan.push({
+      destination: 'fitness',
+      ...(scope === 'referenced'
+        ? { files: uniqueSortedPaths(fitnessFilePaths) }
+        : null),
+      source: storageSourceFromFitnessConfig(fitnessStorage)
+    })
+  }
+
+  return plan
+}
+
+const isLocalHost = (host: string) =>
+  [
+    '',
+    'localhost',
+    '127.0.0.1',
+    '::1',
+    '[::1]',
+    '0.0.0.0',
+    'postgres',
+    'host.docker.internal'
+  ].includes(host.trim().toLowerCase())
+
+const uniqueSortedPaths = (filePaths: string[]) =>
+  [...new Set(filePaths.map(normalizeStoragePath).filter(Boolean))].sort()
+
+const normalizeStoragePath = (filePath: string | null | undefined) => {
+  if (!filePath) return ''
+  const normalized = filePath.replaceAll('\\', '/').replace(/^\/+/, '')
+  if (normalized.includes('..')) return ''
+  return normalized
+}
+
+const storageSourceFromMediaConfig = (
+  storage: MediaStorageConfig
+): StorageSource => {
+  switch (storage.type) {
+    case MediaStorageType.LocalFile:
+      return {
+        kind: 'local',
+        path: storage.path
+      }
+    case MediaStorageType.ObjectStorage:
+    case MediaStorageType.S3Storage:
+      return {
+        bucket: storage.bucket,
+        hostname: storage.hostname,
+        kind: 's3',
+        prefix: undefined,
+        region: storage.region
+      }
+  }
+}
+
+const storageSourceFromFitnessConfig = (
+  storage: FitnessStorageConfig
+): StorageSource => {
+  switch (storage.type) {
+    case FitnessStorageType.LocalFile:
+      return {
+        kind: 'local',
+        path: storage.path
+      }
+    case FitnessStorageType.ObjectStorage:
+    case FitnessStorageType.S3Storage:
+      return {
+        bucket: storage.bucket,
+        hostname: storage.hostname,
+        kind: 's3',
+        prefix: storage.prefix,
+        region: storage.region
+      }
+  }
+}
+
+const getSharedS3FitnessPrefix = (
+  mediaStorage?: MediaStorageConfig | null,
+  fitnessStorage?: FitnessStorageConfig | null
+) => {
+  if (!mediaStorage || !fitnessStorage) return null
+  if (!isS3MediaStorage(mediaStorage) || !isS3FitnessStorage(fitnessStorage)) {
+    return null
+  }
+
+  if (mediaStorage.bucket !== fitnessStorage.bucket) return null
+  if (mediaStorage.region !== fitnessStorage.region) return null
+  return fitnessStorage.prefix || null
+}
+
+const getSharedLocalFitnessPrefix = (
+  mediaStorage?: MediaStorageConfig | null,
+  fitnessStorage?: FitnessStorageConfig | null
+) => {
+  if (!mediaStorage || !fitnessStorage) return null
+  if (
+    mediaStorage.type !== MediaStorageType.LocalFile ||
+    fitnessStorage.type !== FitnessStorageType.LocalFile
+  ) {
+    return null
+  }
+
+  const mediaPath = path.resolve(mediaStorage.path)
+  const fitnessPath = path.resolve(fitnessStorage.path)
+  const relativeFitnessPath = path.relative(mediaPath, fitnessPath)
+
+  if (
+    relativeFitnessPath.startsWith('..') ||
+    path.isAbsolute(relativeFitnessPath)
+  ) {
+    return null
+  }
+
+  return normalizeStoragePath(relativeFitnessPath)
+}
+
+const isS3MediaStorage = (
+  storage: MediaStorageConfig
+): storage is MediaStorageS3Config =>
+  storage.type === MediaStorageType.ObjectStorage ||
+  storage.type === MediaStorageType.S3Storage
+
+const isS3FitnessStorage = (
+  storage: FitnessStorageConfig
+): storage is FitnessStorageS3Config =>
+  storage.type === FitnessStorageType.ObjectStorage ||
+  storage.type === FitnessStorageType.S3Storage
+
+const parseEnvFile = (content: string) => {
+  const values: Record<string, string> = {}
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const normalizedLine = line.startsWith('export ')
+      ? line.slice('export '.length).trim()
+      : line
+    const separatorIndex = normalizedLine.indexOf('=')
+    if (separatorIndex < 1) continue
+
+    const key = normalizedLine.slice(0, separatorIndex).trim()
+    const rawValue = normalizedLine.slice(separatorIndex + 1).trim()
+
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue
+    values[key] = parseEnvValue(rawValue)
+  }
+
+  return values
+}
+
+const parseEnvValue = (rawValue: string) => {
+  if (
+    (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+    (rawValue.startsWith("'") && rawValue.endsWith("'"))
+  ) {
+    const quote = rawValue[0]
+    const unquoted = rawValue.slice(1, -1)
+    if (quote === "'") return unquoted
+    return unquoted
+      .replaceAll('\\n', '\n')
+      .replaceAll('\\"', '"')
+      .replaceAll('\\\\', '\\')
+  }
+
+  return rawValue.replace(/\s+#.*$/, '')
+}
+
+const loadEnvFile = async (envFile: string) => {
+  const envPath = path.resolve(process.cwd(), envFile)
+  const content = await fs.readFile(envPath, 'utf-8')
+  const values = parseEnvFile(content)
+
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value
+  }
+
+  const memoizedGetConfig = getConfig as typeof getConfig & {
+    cache?: { clear?: () => void }
+  }
+  memoizedGetConfig.cache?.clear?.()
+}
+
+const createArchiveName = () => {
+  const timestamp = new Date()
+    .toISOString()
+    .replaceAll(':', '')
+    .replaceAll('.', '')
+  return `activitynext-production-${timestamp}.tar.gz`
+}
+
+const quoteIdentifier = (identifier: string) =>
+  `"${identifier.replaceAll('"', '""')}"`
+
+const tableFileName = (tableName: string) =>
+  `${encodeURIComponent(tableName)}.json`
+
+const assertRelativeFilePath = (filePath: string) => {
+  const normalized = normalizeStoragePath(filePath)
+  if (!normalized || normalized.startsWith('../') || normalized === '..') {
+    throw new Error(`Invalid archive file path: ${filePath}`)
+  }
+  return normalized
+}
+
+const getKnexClientName = (database: Knex) =>
+  String(database.client.config.client)
+
+const getQueryRows = <T>(result: unknown): T[] => {
+  if (result && typeof result === 'object' && 'rows' in result) {
+    return (result as { rows: T[] }).rows
+  }
+
+  return result as T[]
+}
+
+const getDatabaseTableNames = async (database: Knex) => {
+  const client = getKnexClientName(database)
+
+  if (client === 'pg' || client === 'pg-native') {
+    const result = await database.raw(`
+      select table_name as name
+      from information_schema.tables
+      where table_schema = 'public'
+        and table_type = 'BASE TABLE'
+      order by table_name asc
+    `)
+    return getQueryRows<{ name: string }>(result).map((row) => row.name)
+  }
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const rows = await database('sqlite_master')
+      .select('name')
+      .where('type', 'table')
+      .whereNot('name', 'sqlite_sequence')
+      .orderBy('name', 'asc')
+    return rows.map((row: { name: string }) => row.name)
+  }
+
+  throw new Error(`Unsupported database client for archive: ${client}`)
+}
+
+const exportDatabase = async (database: Knex, outputDir: string) => {
+  const databaseDir = path.join(outputDir, DATABASE_DIR)
+  await fs.mkdir(databaseDir, { recursive: true })
+
+  const tableNames = await getDatabaseTableNames(database)
+  const tables: ArchiveTableManifest[] = []
+
+  for (const tableName of tableNames) {
+    const rows = await database(tableName).select('*')
+    await fs.writeFile(
+      path.join(databaseDir, tableFileName(tableName)),
+      `${JSON.stringify(rows, null, 2)}\n`
+    )
+    tables.push({ name: tableName, rowCount: rows.length })
+    console.log(`Database: exported ${rows.length} row(s) from ${tableName}`)
+  }
+
+  return {
+    client: getKnexClientName(database),
+    tables
+  }
+}
+
+const tableExists = async (database: Knex, tableName: string) =>
+  database.schema.hasTable(tableName)
+
+const getReferencedStoragePaths = async (
+  database: Knex
+): Promise<ReferencedStoragePaths> => {
+  const mediaFilePaths: string[] = []
+  const fitnessFilePaths: string[] = []
+
+  if (await tableExists(database, 'medias')) {
+    const mediaRows = await database('medias').select('original', 'thumbnail')
+    for (const row of mediaRows) {
+      mediaFilePaths.push(row.original, row.thumbnail)
+    }
+  }
+
+  if (await tableExists(database, 'fitness_files')) {
+    const fitnessRows = await database('fitness_files').select(
+      'path',
+      'mapImagePath'
+    )
+    for (const row of fitnessRows) {
+      fitnessFilePaths.push(row.path)
+      mediaFilePaths.push(row.mapImagePath)
+    }
+  }
+
+  return {
+    fitnessFilePaths: uniqueSortedPaths(fitnessFilePaths),
+    mediaFilePaths: uniqueSortedPaths(mediaFilePaths)
+  }
+}
+
+const createS3Client = (source: Extract<StorageSource, { kind: 's3' }>) =>
+  new S3Client({ region: source.region })
+
+const listS3Files = async (source: Extract<StorageSource, { kind: 's3' }>) => {
+  const client = createS3Client(source)
+  const files: string[] = []
+  let continuationToken: string | undefined
+
+  do {
+    const response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: source.bucket,
+        ContinuationToken: continuationToken,
+        Prefix: source.prefix
+      })
+    )
+
+    for (const object of response.Contents ?? []) {
+      if (!object.Key) continue
+      const relativePath = source.prefix
+        ? object.Key.slice(source.prefix.length)
+        : object.Key
+      files.push(relativePath)
+    }
+
+    continuationToken = response.NextContinuationToken
+  } while (continuationToken)
+
+  return uniqueSortedPaths(files)
+}
+
+const listLocalFiles = async (basePath: string) => {
+  const files: string[] = []
+
+  async function traverse(currentPath: string, relativePath = '') {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry.name)
+      const nextRelativePath = relativePath
+        ? path.join(relativePath, entry.name)
+        : entry.name
+
+      if (entry.isDirectory()) {
+        await traverse(fullPath, nextRelativePath)
+      } else if (entry.isFile()) {
+        files.push(nextRelativePath)
+      }
+    }
+  }
+
+  try {
+    await traverse(basePath)
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException
+    if (nodeError.code !== 'ENOENT') throw error
+  }
+
+  return uniqueSortedPaths(files)
+}
+
+const shouldExcludeStorageFile = (
+  filePath: string,
+  excludePrefixes?: string[]
+) =>
+  Boolean(
+    excludePrefixes?.some((prefix) => {
+      const normalizedPrefix = normalizeStoragePath(prefix)
+      return (
+        filePath === normalizedPrefix ||
+        filePath.startsWith(`${normalizedPrefix}/`)
+      )
+    })
+  )
+
+const getStorageFiles = async (entry: StoragePlanEntry) => {
+  const allFiles =
+    entry.files ??
+    (entry.source.kind === 's3'
+      ? await listS3Files(entry.source)
+      : await listLocalFiles(path.resolve(entry.source.path)))
+
+  return allFiles.filter((filePath) => {
+    return !shouldExcludeStorageFile(filePath, entry.excludePrefixes)
+  })
+}
+
+const copyLocalStorageFile = async ({
+  archiveFilePath,
+  relativeFilePath,
+  source
+}: {
+  archiveFilePath: string
+  relativeFilePath: string
+  source: Extract<StorageSource, { kind: 'local' }>
+}) => {
+  const sourcePath = path.resolve(source.path, relativeFilePath)
+  await fs.mkdir(path.dirname(archiveFilePath), { recursive: true })
+  await fs.copyFile(sourcePath, archiveFilePath)
+  return (await fs.stat(archiveFilePath)).size
+}
+
+const downloadS3StorageFile = async ({
+  archiveFilePath,
+  relativeFilePath,
+  source
+}: {
+  archiveFilePath: string
+  relativeFilePath: string
+  source: Extract<StorageSource, { kind: 's3' }>
+}) => {
+  const key = source.prefix
+    ? `${source.prefix}${relativeFilePath}`
+    : relativeFilePath
+  const client = createS3Client(source)
+  let response
+
+  try {
+    response = await client.send(
+      new GetObjectCommand({
+        Bucket: source.bucket,
+        Key: key
+      })
+    )
+  } catch (error) {
+    if (!source.hostname) throw error
+    return downloadPublicStorageFile({
+      archiveFilePath,
+      hostname: source.hostname,
+      key
+    })
+  }
+
+  if (!response.Body) {
+    throw new Error(`S3 object has no body: ${key}`)
+  }
+
+  await fs.mkdir(path.dirname(archiveFilePath), { recursive: true })
+
+  const body = response.Body as Readable & {
+    transformToByteArray?: () => Promise<Uint8Array>
+    transformToWebStream?: () => ReadableStream<Uint8Array>
+  }
+
+  if (typeof body.transformToWebStream === 'function') {
+    await pipeline(
+      Readable.fromWeb(
+        body.transformToWebStream() as unknown as NodeReadableStream<Uint8Array>
+      ),
+      createWriteStream(archiveFilePath)
+    )
+  } else if (typeof body.pipe === 'function') {
+    await pipeline(body, createWriteStream(archiveFilePath))
+  } else if (typeof body.transformToByteArray === 'function') {
+    await fs.writeFile(
+      archiveFilePath,
+      Buffer.from(await body.transformToByteArray())
+    )
+  } else {
+    throw new Error(`Unsupported S3 body stream for ${key}`)
+  }
+
+  return (await fs.stat(archiveFilePath)).size
+}
+
+const downloadPublicStorageFile = async ({
+  archiveFilePath,
+  hostname,
+  key
+}: {
+  archiveFilePath: string
+  hostname: string
+  key: string
+}) => {
+  const normalizedHostname = hostname.replace(/^https?:\/\//, '')
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+  const response = await fetch(`https://${normalizedHostname}/${encodedKey}`)
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${key} from public storage: HTTP ${response.status}`
+    )
+  }
+
+  await fs.mkdir(path.dirname(archiveFilePath), { recursive: true })
+
+  if (response.body) {
+    await pipeline(
+      Readable.fromWeb(
+        response.body as unknown as NodeReadableStream<Uint8Array>
+      ),
+      createWriteStream(archiveFilePath)
+    )
+  } else {
+    await fs.writeFile(
+      archiveFilePath,
+      Buffer.from(await response.arrayBuffer())
+    )
+  }
+
+  return (await fs.stat(archiveFilePath)).size
+}
+
+const archiveStorage = async (
+  plan: StoragePlanEntry[],
+  stagingDir: string,
+  options: { allowMissingStorage: boolean }
+): Promise<ArchiveStorageManifest[]> => {
+  const storageManifests: ArchiveStorageManifest[] = []
+
+  for (const entry of plan) {
+    const files = await getStorageFiles(entry)
+    let totalBytes = 0
+    let downloadedCount = 0
+    const failedFiles: { error: string; path: string }[] = []
+
+    for (const filePath of files) {
+      const relativeFilePath = assertRelativeFilePath(filePath)
+      const archiveFilePath = path.join(
+        stagingDir,
+        STORAGE_DIR,
+        entry.destination,
+        'files',
+        relativeFilePath
+      )
+
+      let size: number
+      try {
+        size =
+          entry.source.kind === 's3'
+            ? await downloadS3StorageFile({
+                archiveFilePath,
+                relativeFilePath,
+                source: entry.source
+              })
+            : await copyLocalStorageFile({
+                archiveFilePath,
+                relativeFilePath,
+                source: entry.source
+              })
+      } catch (error) {
+        const nodeError = error as Error
+        if (!options.allowMissingStorage) throw error
+
+        failedFiles.push({
+          error: nodeError.message,
+          path: relativeFilePath
+        })
+        console.error(
+          `Storage: failed to download ${entry.destination} file ` +
+            `${relativeFilePath}: ${nodeError.message}`
+        )
+        continue
+      }
+
+      totalBytes += size
+      downloadedCount += 1
+
+      if (downloadedCount % 25 === 0) {
+        console.log(
+          `Storage: downloaded ${downloadedCount}/${files.length} ` +
+            `${entry.destination} file(s)`
+        )
+      }
+    }
+
+    console.log(
+      `Storage: downloaded ${downloadedCount} ${entry.destination} file(s)`
+    )
+
+    storageManifests.push({
+      destination: entry.destination,
+      failedFiles,
+      fileCount: downloadedCount,
+      source: redactStorageSource(entry.source),
+      totalBytes
+    })
+  }
+
+  return storageManifests
+}
+
+const redactStorageSource = (source: StorageSource) => ({
+  kind: source.kind,
+  ...(source.prefix ? { prefix: source.prefix } : null)
+})
+
+const writeManifest = async (stagingDir: string, manifest: ArchiveManifest) => {
+  await fs.writeFile(
+    path.join(stagingDir, MANIFEST_FILE),
+    `${JSON.stringify(manifest, null, 2)}\n`
+  )
+}
+
+const createTarArchive = async (stagingDir: string, archivePath: string) => {
+  await fs.mkdir(path.dirname(archivePath), { recursive: true })
+  await execFileAsync('tar', ['-czf', archivePath, '-C', stagingDir, '.'])
+}
+
+const extractTarArchive = async (archivePath: string, outputDir: string) => {
+  await fs.mkdir(outputDir, { recursive: true })
+  await execFileAsync('tar', ['-xzf', archivePath, '-C', outputDir])
+}
+
+const readManifest = async (archiveDir: string): Promise<ArchiveManifest> => {
+  const manifest = JSON.parse(
+    await fs.readFile(path.join(archiveDir, MANIFEST_FILE), 'utf-8')
+  ) as ArchiveManifest
+
+  if (manifest.version !== ARCHIVE_VERSION) {
+    throw new Error(
+      `Unsupported archive version: ${manifest.version}. ` +
+        `Expected ${ARCHIVE_VERSION}.`
+    )
+  }
+
+  return manifest
+}
+
+const ensureRestoreTargetIsLocal = (
+  config: ReturnType<typeof getConfig>,
+  args: RestoreArgs
+) => {
+  if (args.allowNonLocalDatabase) return
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'Refusing to restore while NODE_ENV=production. ' +
+        'Unset NODE_ENV or pass --allow-non-local-database.'
+    )
+  }
+
+  if (path.basename(args.envFile) === '.env.production') {
+    throw new Error(
+      'Refusing to restore using .env.production. Use .env.local instead.'
+    )
+  }
+
+  const connection = config.database.connection
+  if (!isLocalDatabaseConnection(connection)) {
+    throw new Error(
+      'Refusing to restore to a non-local database host. ' +
+        'Pass --allow-non-local-database only if this is intentional.'
+    )
+  }
+}
+
+const getForeignKeyReferences = async (
+  database: Knex,
+  tables: string[]
+): Promise<ForeignKeyReference[]> => {
+  const client = getKnexClientName(database)
+
+  if (client === 'pg' || client === 'pg-native') {
+    const result = await database.raw(`
+      select
+        tc.table_name as "fromTable",
+        ccu.table_name as "toTable"
+      from information_schema.table_constraints tc
+      join information_schema.key_column_usage kcu
+        on tc.constraint_name = kcu.constraint_name
+        and tc.table_schema = kcu.table_schema
+      join information_schema.constraint_column_usage ccu
+        on ccu.constraint_name = tc.constraint_name
+        and ccu.table_schema = tc.table_schema
+      where tc.constraint_type = 'FOREIGN KEY'
+        and tc.table_schema = 'public'
+    `)
+    return getQueryRows<ForeignKeyReference>(result)
+  }
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const references: ForeignKeyReference[] = []
+    for (const table of tables) {
+      const rows = await database.raw(
+        `PRAGMA foreign_key_list(${quoteIdentifier(table)})`
+      )
+      for (const row of getQueryRows<{ table: string }>(rows)) {
+        references.push({
+          fromTable: table,
+          toTable: row.table
+        })
+      }
+    }
+    return references
+  }
+
+  throw new Error(`Unsupported database client for restore: ${client}`)
+}
+
+const truncateTables = async (database: Knex, tableNames: string[]) => {
+  const client = getKnexClientName(database)
+  if (tableNames.length === 0) return
+
+  if (client === 'pg' || client === 'pg-native') {
+    const tables = tableNames.map(quoteIdentifier).join(', ')
+    await database.raw(`truncate table ${tables} restart identity cascade`)
+    return
+  }
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    await database.raw('PRAGMA foreign_keys = OFF')
+    try {
+      for (const tableName of tableNames) {
+        await database(tableName).delete()
+      }
+      if (await database.schema.hasTable('sqlite_sequence')) {
+        await database('sqlite_sequence').whereIn('name', tableNames).delete()
+      }
+    } finally {
+      await database.raw('PRAGMA foreign_keys = ON')
+    }
+    return
+  }
+
+  throw new Error(`Unsupported database client for restore: ${client}`)
+}
+
+const resetPostgresSequences = async (database: Knex, tableNames: string[]) => {
+  const client = getKnexClientName(database)
+  if (client !== 'pg' && client !== 'pg-native') return
+
+  for (const tableName of tableNames) {
+    const result = await database.raw(
+      `
+      select
+        a.attname as "columnName",
+        pg_get_serial_sequence(
+          format('%I.%I', n.nspname, c.relname),
+          a.attname
+        ) as "sequenceName"
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      join pg_attribute a on a.attrelid = c.oid
+      where n.nspname = 'public'
+        and c.relname = ?
+        and a.attnum > 0
+        and not a.attisdropped
+        and pg_get_serial_sequence(
+          format('%I.%I', n.nspname, c.relname),
+          a.attname
+        ) is not null
+    `,
+      [tableName]
+    )
+
+    for (const row of getQueryRows<{
+      columnName: string
+      sequenceName: string
+    }>(result)) {
+      await database.raw(
+        `
+        select setval(
+          ?,
+          coalesce(
+            (select max(${quoteIdentifier(row.columnName)})
+             from ${quoteIdentifier(tableName)}),
+            1
+          ),
+          exists(select 1 from ${quoteIdentifier(tableName)})
+        )
+      `,
+        [row.sequenceName]
+      )
+    }
+  }
+}
+
+const restoreDatabase = async (
+  database: Knex,
+  archiveDir: string,
+  manifest: ArchiveManifest
+) => {
+  if (!manifest.database) {
+    console.log('Database: archive has no database payload, skipping.')
+    return
+  }
+
+  await database.migrate.latest()
+
+  const tableNames = manifest.database.tables.map((table) => table.name)
+  const localTables = new Set(await getDatabaseTableNames(database))
+  const missingTables = tableNames.filter((table) => !localTables.has(table))
+  if (missingTables.length > 0) {
+    throw new Error(
+      `Local database is missing archived table(s): ${missingTables.join(', ')}`
+    )
+  }
+
+  const foreignKeys = await getForeignKeyReferences(database, tableNames)
+  const orderedTables = sortTablesForRestore(tableNames, foreignKeys)
+
+  await truncateTables(database, tableNames)
+
+  for (const tableName of orderedTables) {
+    const rows = JSON.parse(
+      await fs.readFile(
+        path.join(archiveDir, DATABASE_DIR, tableFileName(tableName)),
+        'utf-8'
+      )
+    ) as Record<string, unknown>[]
+
+    if (rows.length > 0) {
+      await database.batchInsert(tableName, rows, INSERT_BATCH_SIZE)
+    }
+
+    console.log(`Database: restored ${rows.length} row(s) into ${tableName}`)
+  }
+
+  await resetPostgresSequences(database, tableNames)
+}
+
+const resolveLocalStoragePath = (
+  destination: StorageDestination,
+  config: ReturnType<typeof getConfig>
+) => {
+  if (destination === 'media') {
+    if (config.mediaStorage?.type !== MediaStorageType.LocalFile) {
+      throw new Error('Local restore requires media storage type fs.')
+    }
+    return config.mediaStorage.path
+  }
+
+  if (config.fitnessStorage?.type !== FitnessStorageType.LocalFile) {
+    throw new Error('Local restore requires fitness storage type fs.')
+  }
+  return config.fitnessStorage.path
+}
+
+const assertSafeDirectoryToReplace = (directoryPath: string) => {
+  const resolved = path.resolve(directoryPath)
+  const root = path.parse(resolved).root
+  if (resolved === root || resolved === os.homedir()) {
+    throw new Error(`Refusing to replace unsafe directory: ${resolved}`)
+  }
+  return resolved
+}
+
+const emptyDirectory = async (directoryPath: string) => {
+  const resolved = assertSafeDirectoryToReplace(directoryPath)
+  await fs.rm(resolved, { force: true, recursive: true })
+  await fs.mkdir(resolved, { recursive: true })
+}
+
+const copyDirectoryContents = async (fromDir: string, toDir: string) => {
+  try {
+    const entries = await fs.readdir(fromDir, { withFileTypes: true })
+    await fs.mkdir(toDir, { recursive: true })
+
+    for (const entry of entries) {
+      const sourcePath = path.join(fromDir, entry.name)
+      const destinationPath = path.join(toDir, entry.name)
+
+      if (entry.isDirectory()) {
+        await copyDirectoryContents(sourcePath, destinationPath)
+      } else if (entry.isFile()) {
+        await fs.mkdir(path.dirname(destinationPath), { recursive: true })
+        await fs.copyFile(sourcePath, destinationPath)
+      }
+    }
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException
+    if (nodeError.code !== 'ENOENT') throw error
+  }
+}
+
+const restoreStorage = async (
+  archiveDir: string,
+  manifest: ArchiveManifest,
+  config: ReturnType<typeof getConfig>,
+  args: RestoreArgs
+) => {
+  for (const storage of manifest.storage) {
+    const destinationPath = resolveLocalStoragePath(storage.destination, config)
+
+    if (!args.preserveFiles) {
+      await emptyDirectory(destinationPath)
+    } else {
+      await fs.mkdir(destinationPath, { recursive: true })
+    }
+
+    await copyDirectoryContents(
+      path.join(archiveDir, STORAGE_DIR, storage.destination, 'files'),
+      destinationPath
+    )
+
+    console.log(
+      `Storage: restored ${storage.fileCount} ` +
+        `${storage.destination} file(s) to ${destinationPath}`
+    )
+  }
+}
+
+const createDatabase = () => {
+  const config = getConfig()
+  return knex(config.database)
+}
+
+export const downloadProductionArchive = async (
+  cliArgs = process.argv.slice(2)
+) => {
+  if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
+    console.log(DOWNLOAD_USAGE)
+    return 0
+  }
+
+  const args = parseDownloadArgs(cliArgs)
+
+  await loadEnvFile(args.envFile)
+
+  const config = getConfig()
+  const outputDir = path.resolve(process.cwd(), args.outputDir)
+  const stagingDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'activitynext-production-archive-')
+  )
+  const archivePath = path.join(outputDir, createArchiveName())
+  const database = createDatabase()
+
+  try {
+    const databaseManifest = args.skipDatabase
+      ? null
+      : await exportDatabase(database, stagingDir)
+
+    const storagePaths =
+      args.skipStorage || args.storageScope === 'all'
+        ? { fitnessFilePaths: [], mediaFilePaths: [] }
+        : await getReferencedStoragePaths(database)
+
+    const storageManifest = args.skipStorage
+      ? []
+      : await archiveStorage(
+          buildStoragePlan({
+            fitnessFilePaths: storagePaths.fitnessFilePaths,
+            fitnessStorage: config.fitnessStorage,
+            mediaFilePaths: storagePaths.mediaFilePaths,
+            mediaStorage: config.mediaStorage,
+            scope: args.storageScope
+          }),
+          stagingDir,
+          { allowMissingStorage: args.allowMissingStorage }
+        )
+
+    await writeManifest(stagingDir, {
+      createdAt: new Date().toISOString(),
+      database: databaseManifest,
+      source: {
+        host: config.host,
+        nodeEnv: process.env.NODE_ENV
+      },
+      storage: storageManifest,
+      storageScope: args.storageScope,
+      version: ARCHIVE_VERSION
+    })
+
+    await createTarArchive(stagingDir, archivePath)
+    console.log(`Archive written: ${archivePath}`)
+    return 0
+  } finally {
+    await database.destroy()
+    await fs.rm(stagingDir, { force: true, recursive: true })
+  }
+}
+
+export const restoreProductionArchive = async (
+  cliArgs = process.argv.slice(2)
+) => {
+  if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
+    console.log(RESTORE_USAGE)
+    return 0
+  }
+
+  const args = parseRestoreArgs(cliArgs)
+
+  await loadEnvFile(args.envFile)
+  const config = getConfig()
+  ensureRestoreTargetIsLocal(config, args)
+
+  const archiveDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'activitynext-production-restore-')
+  )
+  const database = createDatabase()
+
+  try {
+    await extractTarArchive(path.resolve(args.archive), archiveDir)
+    const manifest = await readManifest(archiveDir)
+
+    if (!args.filesOnly) {
+      await restoreDatabase(database, archiveDir, manifest)
+    }
+
+    if (!args.databaseOnly) {
+      await restoreStorage(archiveDir, manifest, config, args)
+    }
+
+    console.log('Restore complete.')
+    return 0
+  } finally {
+    await database.destroy()
+    await fs.rm(archiveDir, { force: true, recursive: true })
+  }
+}

--- a/scripts/restoreProductionArchive.ts
+++ b/scripts/restoreProductionArchive.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S node -r @swc-node/register
+/**
+ * Restores a production archive into the configured local database and local
+ * filesystem storage.
+ *
+ * Usage:
+ *   scripts/restoreProductionArchive.ts \
+ *     --archive backups/production-archives/activitynext-production-...tar.gz \
+ *     --yes
+ *
+ * This script refuses NODE_ENV=production and remote database hosts unless
+ * --allow-non-local-database is passed.
+ */
+import { restoreProductionArchive } from './productionArchive'
+
+if (require.main === module) {
+  restoreProductionArchive()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Archive restore failed:', error)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary
- Add `scripts/downloadProductionArchive.ts` to create a local tar.gz archive from `.env.production` using read-only database selects and storage downloads.
- Add `scripts/restoreProductionArchive.ts` to restore an archive into a local database plus local media and fitness storage, with explicit `--yes` confirmation and local-target safety checks.
- Add shared archive planning, manifest, database restore ordering, storage restore logic, and focused tests for CLI parsing, restore safety, storage planning, and table ordering.

## Notes
- A strict production download was tested and correctly stopped on inaccessible production storage objects.
- A best-effort production download using `--allow-missing-storage` completed and wrote a local ignored archive at `backups/production-archives/activitynext-production-2026-05-09T174131402Z.tar.gz`.
- The best-effort archive manifest contained 39 DB tables, 1,415,511 rows, 3,562 media files downloaded with 9 failures, and 1,731 fitness files downloaded with 91 failures. The inaccessible objects were HTTP 403s, mostly under the fitness `2026-04-04` prefix.

## Validation
- `yarn run prettier --write .`
- `yarn lint` passed with existing warnings.
- `yarn build`
- `yarn test scripts/productionArchive.test.ts`
- `yarn test --modulePathIgnorePatterns .claude --testPathIgnorePatterns .claude`

## Test Caveat
- Plain `yarn test` currently discovers the ignored `.claude/worktrees/...` nested checkout and fails due duplicate mocks and stale copied tests. The actual working tree suite passes when `.claude` is excluded.