### PR TITLE
fix: Blank notification rows

### DIFF
--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -47,6 +47,12 @@ const account: Mastodon.Account = {
   following_count: 0
 }
 
+const accountWithAvatar: Mastodon.Account = {
+  ...account,
+  avatar: 'https://llun.social/avatar.png',
+  avatar_static: 'https://llun.social/avatar.png'
+}
+
 const status: StatusNote = {
   id: 'https://llun.social/users/ride/statuses/activity-1',
   actorId: 'https://llun.social/users/ride',
@@ -118,7 +124,7 @@ describe('NotificationItem', () => {
       isRead: true,
       createdAt: currentTime,
       updatedAt: currentTime,
-      account,
+      account: accountWithAvatar,
       status
     })
 
@@ -137,6 +143,7 @@ describe('NotificationItem', () => {
     container.querySelectorAll('a').forEach((link) => {
       expect(link.querySelector('a')).toBeNull()
     })
+    expect(container.querySelector('img')).toBeNull()
   })
 
   it('renders grouped activity import notifications as multiple imports', () => {
@@ -215,6 +222,24 @@ describe('NotificationItem', () => {
     }
   )
 
+  it('renders grouped follow notifications without grouped account data', () => {
+    renderNotificationItem({
+      id: 'notification-follow',
+      actorId: 'https://llun.social/users/llun',
+      type: 'follow',
+      sourceActorId: account.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      groupedCount: 3
+    })
+
+    expect(
+      screen.getByText(/and 2 others started following you/)
+    ).toBeInTheDocument()
+  })
+
   it('renders grouped activity import notifications with generic import copy', () => {
     renderNotificationItem({
       id: 'notification-activity-import',
@@ -235,24 +260,31 @@ describe('NotificationItem', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders unavailable copy for stale activity import notifications', () => {
-    renderNotificationItem({
-      id: 'notification-3',
-      actorId: account.id,
-      type: 'activity_import',
-      sourceActorId: account.id,
-      statusId: status.id,
-      isRead: true,
-      createdAt: currentTime,
-      updatedAt: currentTime,
-      account,
-      status: null
-    })
+  it.each([
+    ['activity_import', 'This imported activity is no longer available.'],
+    ['like', 'This post is no longer available.'],
+    ['reply', 'This post is no longer available.'],
+    ['mention', 'This post is no longer available.'],
+    ['reblog', 'This post is no longer available.']
+  ] as const)(
+    'renders unavailable status text for stale %s notifications',
+    (type, expectedText) => {
+      renderNotificationItem({
+        id: `notification-stale-${type}`,
+        actorId: account.id,
+        type,
+        sourceActorId: account.id,
+        statusId: status.id,
+        isRead: true,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+        account,
+        status: null
+      })
 
-    expect(
-      screen.getByText('This imported activity is no longer available.')
-    ).toBeInTheDocument()
-  })
+      expect(screen.getByText(expectedText)).toBeInTheDocument()
+    }
+  )
 
   it('observes unread stale status-backed notifications so they can be marked read', () => {
     const observeElement = jest.fn()
@@ -307,47 +339,6 @@ describe('NotificationItem', () => {
       ).toBeInTheDocument()
     }
   )
-
-  it.each(['like', 'reply'] as const)(
-    'renders unavailable post text for %s notifications with missing statuses',
-    (type) => {
-      renderNotificationItem({
-        id: `notification-${type}`,
-        actorId: account.id,
-        type,
-        sourceActorId: account.id,
-        statusId: status.id,
-        isRead: true,
-        createdAt: currentTime,
-        updatedAt: currentTime,
-        account,
-        status: null
-      })
-
-      expect(
-        screen.getByText('This post is no longer available.')
-      ).toBeInTheDocument()
-    }
-  )
-
-  it('renders unavailable post text for reblog notifications with missing statuses', () => {
-    renderNotificationItem({
-      id: 'notification-reblog',
-      actorId: account.id,
-      type: 'reblog',
-      sourceActorId: account.id,
-      statusId: status.id,
-      isRead: true,
-      createdAt: currentTime,
-      updatedAt: currentTime,
-      account,
-      status: null
-    })
-
-    expect(
-      screen.getByText('This post is no longer available.')
-    ).toBeInTheDocument()
-  })
 
   it('renders unavailable notification text for unknown notification types', () => {
     renderNotificationItem({

--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { Mastodon } from '@/lib/types/activitypub'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
+
+import { NotificationItem } from './NotificationItem'
+
+const currentTime = new Date('2026-05-10T09:19:26.175Z').getTime()
+
+const account: Mastodon.Account = {
+  id: 'https://llun.social/users/ride',
+  username: 'ride',
+  acct: 'ride@llun.social',
+  url: 'https://llun.social/@ride',
+  display_name: 'Ride',
+  note: '',
+  avatar: '',
+  avatar_static: '',
+  header: '',
+  header_static: '',
+  locked: false,
+  source: {
+    note: '',
+    fields: [],
+    privacy: 'public',
+    sensitive: false,
+    language: 'en',
+    follow_requests_count: 0
+  },
+  fields: [],
+  emojis: [],
+  bot: false,
+  group: false,
+  discoverable: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  last_status_at: '2026-05-10',
+  statuses_count: 1,
+  followers_count: 0,
+  following_count: 0
+}
+
+const status: StatusNote = {
+  id: 'https://llun.social/users/ride/statuses/activity-1',
+  actorId: 'https://llun.social/users/ride',
+  actor: {
+    id: 'https://llun.social/users/ride',
+    username: 'ride',
+    domain: 'llun.social',
+    name: 'Ride',
+    followersUrl: 'https://llun.social/users/ride/followers',
+    inboxUrl: 'https://llun.social/users/ride/inbox',
+    sharedInboxUrl: 'https://llun.social/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 1,
+    lastStatusAt: null,
+    createdAt: currentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://llun.social/@ride/activity-1',
+  text: 'Morning Ride\n20.6 km in 53:09 https://www.strava.com/activities/123',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [],
+  tags: []
+}
+
+describe('NotificationItem', () => {
+  it('renders activity import notifications with linked activity content', () => {
+    const { container } = render(
+      <NotificationItem
+        notification={{
+          id: 'notification-1',
+          actorId: account.id,
+          type: 'activity_import',
+          sourceActorId: account.id,
+          statusId: status.id,
+          isRead: true,
+          createdAt: currentTime,
+          updatedAt: currentTime,
+          account,
+          status
+        }}
+        currentActorId={account.id}
+        host="llun.social"
+        isRead={true}
+        observeElement={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText(/Your Strava fitness activity was imported/)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'View activity' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('/@ride@llun.social/')
+    )
+    expect(screen.getByText(/Morning Ride/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /strava.com/ })).toHaveAttribute(
+      'href',
+      'https://www.strava.com/activities/123'
+    )
+    container.querySelectorAll('a').forEach((link) => {
+      expect(link.querySelector('a')).toBeNull()
+    })
+  })
+
+  it('renders grouped activity import notifications as multiple imports', () => {
+    render(
+      <NotificationItem
+        notification={{
+          id: 'notification-1',
+          actorId: account.id,
+          type: 'activity_import',
+          sourceActorId: account.id,
+          statusId: status.id,
+          isRead: true,
+          createdAt: currentTime,
+          updatedAt: currentTime,
+          account,
+          status,
+          groupedCount: 2,
+          groupedIds: ['notification-1', 'notification-2']
+        }}
+        currentActorId={account.id}
+        host="llun.social"
+        isRead={true}
+        observeElement={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText(/Your Strava fitness activities were imported/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'View latest activity' })
+    ).toHaveAttribute('href', expect.stringContaining('/@ride@llun.social/'))
+  })
+
+  it('renders reblog notifications instead of an empty card', () => {
+    render(
+      <NotificationItem
+        notification={{
+          id: 'notification-2',
+          actorId: 'https://llun.social/users/llun',
+          type: 'reblog',
+          sourceActorId: account.id,
+          statusId: status.id,
+          isRead: true,
+          createdAt: currentTime,
+          updatedAt: currentTime,
+          account,
+          status
+        }}
+        currentActorId="https://llun.social/users/llun"
+        host="llun.social"
+        isRead={true}
+        observeElement={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText(/reblogged your/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Ride' })).toHaveAttribute(
+      'href',
+      '/@ride@llun.social'
+    )
+    expect(screen.getByRole('link', { name: 'post' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('/@ride@llun.social/')
+    )
+    expect(screen.getByText(/Morning Ride/)).toBeInTheDocument()
+  })
+
+  it('renders stale status-backed notifications so they can be marked read', () => {
+    render(
+      <NotificationItem
+        notification={{
+          id: 'notification-3',
+          actorId: account.id,
+          type: 'activity_import',
+          sourceActorId: account.id,
+          statusId: status.id,
+          isRead: true,
+          createdAt: currentTime,
+          updatedAt: currentTime,
+          account,
+          status: null
+        }}
+        currentActorId={account.id}
+        host="llun.social"
+        isRead={true}
+        observeElement={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText('This imported activity is no longer available.')
+    ).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -85,13 +85,24 @@ const status: StatusNote = {
 }
 
 const renderNotificationItem = (notification: NotificationItemNotification) => {
+  return renderNotificationItemWithOptions(notification)
+}
+
+const renderNotificationItemWithOptions = (
+  notification: NotificationItemNotification,
+  options: {
+    currentActorId?: string
+    isRead?: boolean
+    observeElement?: (element: HTMLElement | null) => void
+  } = {}
+) => {
   return render(
     <NotificationItem
       notification={notification}
-      currentActorId={notification.actorId}
+      currentActorId={options.currentActorId ?? notification.actorId}
       host="llun.social"
-      isRead={true}
-      observeElement={jest.fn()}
+      isRead={options.isRead ?? true}
+      observeElement={options.observeElement ?? jest.fn()}
     />
   )
 }
@@ -112,7 +123,7 @@ describe('NotificationItem', () => {
     })
 
     expect(
-      screen.getByText(/Your Strava fitness activity was imported/)
+      screen.getByText(/Your fitness activity was imported/)
     ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'View activity' })).toHaveAttribute(
       'href',
@@ -145,7 +156,7 @@ describe('NotificationItem', () => {
     })
 
     expect(
-      screen.getByText(/Your Strava fitness activities were imported/)
+      screen.getByText(/Your fitness activities were imported/)
     ).toBeInTheDocument()
     expect(
       screen.getByRole('link', { name: 'View latest activity' })
@@ -178,11 +189,37 @@ describe('NotificationItem', () => {
     expect(screen.getByText(/Morning Ride/)).toBeInTheDocument()
   })
 
-  it('renders grouped reblog notifications without grouped account data', () => {
+  it.each([
+    ['like', /and 2 others liked your/],
+    ['reply', /and 2 others replied to your/],
+    ['mention', /and 2 others mentioned you in a/],
+    ['reblog', /and 2 others reblogged your/]
+  ] as const)(
+    'renders grouped %s notifications without grouped account data',
+    (type, expectedText) => {
+      renderNotificationItem({
+        id: `notification-${type}`,
+        actorId: 'https://llun.social/users/llun',
+        type,
+        sourceActorId: account.id,
+        statusId: status.id,
+        isRead: true,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+        account,
+        status,
+        groupedCount: 3
+      })
+
+      expect(screen.getByText(expectedText)).toBeInTheDocument()
+    }
+  )
+
+  it('renders grouped activity import notifications with generic import copy', () => {
     renderNotificationItem({
-      id: 'notification-2',
-      actorId: 'https://llun.social/users/llun',
-      type: 'reblog',
+      id: 'notification-activity-import',
+      actorId: account.id,
+      type: 'activity_import',
       sourceActorId: account.id,
       statusId: status.id,
       isRead: true,
@@ -193,10 +230,12 @@ describe('NotificationItem', () => {
       groupedCount: 3
     })
 
-    expect(screen.getByText(/and 2 others reblogged your/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Your fitness activities were imported/)
+    ).toBeInTheDocument()
   })
 
-  it('renders stale status-backed notifications so they can be marked read', () => {
+  it('renders unavailable copy for stale activity import notifications', () => {
     renderNotificationItem({
       id: 'notification-3',
       actorId: account.id,
@@ -213,6 +252,38 @@ describe('NotificationItem', () => {
     expect(
       screen.getByText('This imported activity is no longer available.')
     ).toBeInTheDocument()
+  })
+
+  it('observes unread stale status-backed notifications so they can be marked read', () => {
+    const observeElement = jest.fn()
+
+    renderNotificationItemWithOptions(
+      {
+        id: 'notification-unread-stale',
+        actorId: account.id,
+        type: 'activity_import',
+        sourceActorId: account.id,
+        statusId: status.id,
+        isRead: false,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+        account,
+        status: null
+      },
+      {
+        isRead: false,
+        observeElement
+      }
+    )
+
+    expect(
+      screen.getByText('This imported activity is no longer available.')
+    ).toBeInTheDocument()
+    expect(observeElement).toHaveBeenCalledTimes(1)
+    expect(observeElement.mock.calls[0][0]).toHaveAttribute(
+      'data-notification-id',
+      'notification-unread-stale'
+    )
   })
 
   it.each(['like', 'reply'] as const)(

--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -3,6 +3,7 @@
  */
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
+import { type ComponentProps } from 'react'
 
 import { Mastodon } from '@/lib/types/activitypub'
 import { StatusNote, StatusType } from '@/lib/types/domain/status'
@@ -10,6 +11,9 @@ import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { NotificationItem } from './NotificationItem'
 
 const currentTime = new Date('2026-05-10T09:19:26.175Z').getTime()
+type NotificationItemNotification = ComponentProps<
+  typeof NotificationItem
+>['notification']
 
 const account: Mastodon.Account = {
   id: 'https://llun.social/users/ride',
@@ -80,28 +84,32 @@ const status: StatusNote = {
   tags: []
 }
 
+const renderNotificationItem = (notification: NotificationItemNotification) => {
+  return render(
+    <NotificationItem
+      notification={notification}
+      currentActorId={notification.actorId}
+      host="llun.social"
+      isRead={true}
+      observeElement={jest.fn()}
+    />
+  )
+}
+
 describe('NotificationItem', () => {
   it('renders activity import notifications with linked activity content', () => {
-    const { container } = render(
-      <NotificationItem
-        notification={{
-          id: 'notification-1',
-          actorId: account.id,
-          type: 'activity_import',
-          sourceActorId: account.id,
-          statusId: status.id,
-          isRead: true,
-          createdAt: currentTime,
-          updatedAt: currentTime,
-          account,
-          status
-        }}
-        currentActorId={account.id}
-        host="llun.social"
-        isRead={true}
-        observeElement={jest.fn()}
-      />
-    )
+    const { container } = renderNotificationItem({
+      id: 'notification-1',
+      actorId: account.id,
+      type: 'activity_import',
+      sourceActorId: account.id,
+      statusId: status.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      status
+    })
 
     expect(
       screen.getByText(/Your Strava fitness activity was imported/)
@@ -121,28 +129,20 @@ describe('NotificationItem', () => {
   })
 
   it('renders grouped activity import notifications as multiple imports', () => {
-    render(
-      <NotificationItem
-        notification={{
-          id: 'notification-1',
-          actorId: account.id,
-          type: 'activity_import',
-          sourceActorId: account.id,
-          statusId: status.id,
-          isRead: true,
-          createdAt: currentTime,
-          updatedAt: currentTime,
-          account,
-          status,
-          groupedCount: 2,
-          groupedIds: ['notification-1', 'notification-2']
-        }}
-        currentActorId={account.id}
-        host="llun.social"
-        isRead={true}
-        observeElement={jest.fn()}
-      />
-    )
+    renderNotificationItem({
+      id: 'notification-1',
+      actorId: account.id,
+      type: 'activity_import',
+      sourceActorId: account.id,
+      statusId: status.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      status,
+      groupedCount: 2,
+      groupedIds: ['notification-1', 'notification-2']
+    })
 
     expect(
       screen.getByText(/Your Strava fitness activities were imported/)
@@ -153,26 +153,18 @@ describe('NotificationItem', () => {
   })
 
   it('renders reblog notifications instead of an empty card', () => {
-    render(
-      <NotificationItem
-        notification={{
-          id: 'notification-2',
-          actorId: 'https://llun.social/users/llun',
-          type: 'reblog',
-          sourceActorId: account.id,
-          statusId: status.id,
-          isRead: true,
-          createdAt: currentTime,
-          updatedAt: currentTime,
-          account,
-          status
-        }}
-        currentActorId="https://llun.social/users/llun"
-        host="llun.social"
-        isRead={true}
-        observeElement={jest.fn()}
-      />
-    )
+    renderNotificationItem({
+      id: 'notification-2',
+      actorId: 'https://llun.social/users/llun',
+      type: 'reblog',
+      sourceActorId: account.id,
+      statusId: status.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      status
+    })
 
     expect(screen.getByText(/reblogged your/)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Ride' })).toHaveAttribute(
@@ -186,30 +178,120 @@ describe('NotificationItem', () => {
     expect(screen.getByText(/Morning Ride/)).toBeInTheDocument()
   })
 
+  it('renders grouped reblog notifications without grouped account data', () => {
+    renderNotificationItem({
+      id: 'notification-2',
+      actorId: 'https://llun.social/users/llun',
+      type: 'reblog',
+      sourceActorId: account.id,
+      statusId: status.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      status,
+      groupedCount: 3
+    })
+
+    expect(screen.getByText(/and 2 others reblogged your/)).toBeInTheDocument()
+  })
+
   it('renders stale status-backed notifications so they can be marked read', () => {
-    render(
-      <NotificationItem
-        notification={{
-          id: 'notification-3',
-          actorId: account.id,
-          type: 'activity_import',
-          sourceActorId: account.id,
-          statusId: status.id,
-          isRead: true,
-          createdAt: currentTime,
-          updatedAt: currentTime,
-          account,
-          status: null
-        }}
-        currentActorId={account.id}
-        host="llun.social"
-        isRead={true}
-        observeElement={jest.fn()}
-      />
-    )
+    renderNotificationItem({
+      id: 'notification-3',
+      actorId: account.id,
+      type: 'activity_import',
+      sourceActorId: account.id,
+      statusId: status.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      status: null
+    })
 
     expect(
       screen.getByText('This imported activity is no longer available.')
+    ).toBeInTheDocument()
+  })
+
+  it.each(['like', 'reply'] as const)(
+    'renders unavailable notification text for %s notifications with missing accounts',
+    (type) => {
+      renderNotificationItem({
+        id: `notification-${type}`,
+        actorId: account.id,
+        type,
+        sourceActorId: account.id,
+        statusId: status.id,
+        isRead: true,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+        account: null,
+        status
+      })
+
+      expect(
+        screen.getByText('This notification is no longer available.')
+      ).toBeInTheDocument()
+    }
+  )
+
+  it.each(['like', 'reply'] as const)(
+    'renders unavailable post text for %s notifications with missing statuses',
+    (type) => {
+      renderNotificationItem({
+        id: `notification-${type}`,
+        actorId: account.id,
+        type,
+        sourceActorId: account.id,
+        statusId: status.id,
+        isRead: true,
+        createdAt: currentTime,
+        updatedAt: currentTime,
+        account,
+        status: null
+      })
+
+      expect(
+        screen.getByText('This post is no longer available.')
+      ).toBeInTheDocument()
+    }
+  )
+
+  it('renders unavailable post text for reblog notifications with missing statuses', () => {
+    renderNotificationItem({
+      id: 'notification-reblog',
+      actorId: account.id,
+      type: 'reblog',
+      sourceActorId: account.id,
+      statusId: status.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      status: null
+    })
+
+    expect(
+      screen.getByText('This post is no longer available.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders unavailable notification text for unknown notification types', () => {
+    renderNotificationItem({
+      id: 'notification-unknown',
+      actorId: account.id,
+      type: 'unknown' as never,
+      sourceActorId: account.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account
+    })
+
+    expect(
+      screen.getByText('This notification is no longer available.')
     ).toBeInTheDocument()
   })
 })

--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -143,6 +143,11 @@ describe('NotificationItem', () => {
     container.querySelectorAll('a').forEach((link) => {
       expect(link.querySelector('a')).toBeNull()
     })
+    const activityImportRow = container.querySelector('.flex.items-start.gap-4')
+    expect(activityImportRow).toBeInTheDocument()
+    expect(
+      activityImportRow?.querySelector('[aria-hidden="true"]')
+    ).toHaveClass('size-12', 'shrink-0')
     expect(container.querySelector('img')).toBeNull()
   })
 

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -6,10 +6,12 @@ import { GroupedNotification } from '@/lib/services/notifications/groupNotificat
 import { Mastodon } from '@/lib/types/activitypub'
 import { Status } from '@/lib/types/domain/status'
 
+import { ActivityImportNotification } from './components/ActivityImportNotification'
 import { FollowNotification } from './components/FollowNotification'
 import { FollowRequestNotification } from './components/FollowRequestNotification'
 import { LikeNotification } from './components/LikeNotification'
 import { MentionNotification } from './components/MentionNotification'
+import { ReblogNotification } from './components/ReblogNotification'
 import { ReplyNotification } from './components/ReplyNotification'
 
 interface NotificationWithData extends GroupedNotification {
@@ -45,18 +47,39 @@ export const NotificationItem = ({
     }
   }, [observeElement, isRead])
 
-  if (!notification.account) {
-    return null
-  }
+  const renderUnavailableNotification = (message: string) => (
+    <div className="text-sm text-muted-foreground">{message}</div>
+  )
 
-  // After null check, we know account is non-null
-  const notificationWithAccount: NotificationWithData = {
-    ...notification,
-    account: notification.account,
-    status: notification.status ?? undefined
+  const renderUnavailableStatusNotification = () => {
+    if (notification.type === 'activity_import') {
+      return renderUnavailableNotification(
+        'This imported activity is no longer available.'
+      )
+    }
+
+    return renderUnavailableNotification('This post is no longer available.')
   }
 
   const renderNotification = () => {
+    if (!notification.account) {
+      return renderUnavailableNotification(
+        'This notification is no longer available.'
+      )
+    }
+
+    const notificationWithAccount: NotificationWithData = {
+      ...notification,
+      account: notification.account,
+      status: notification.status ?? undefined
+    }
+
+    const notificationWithStatus = notificationWithAccount.status?.actor
+      ? (notificationWithAccount as NotificationWithData & {
+          status: Status
+        })
+      : null
+
     switch (notificationWithAccount.type) {
       case 'follow_request':
         return (
@@ -68,42 +91,62 @@ export const NotificationItem = ({
       case 'follow':
         return <FollowNotification notification={notificationWithAccount} />
       case 'like':
-        // Status-requiring notifications - type assertion for compatibility
+        if (!notificationWithStatus)
+          return renderUnavailableStatusNotification()
+
         return (
-          <LikeNotification
-            host={host}
-            notification={
-              notificationWithAccount as NotificationWithData & {
-                status: Status
-              }
-            }
-          />
+          <LikeNotification host={host} notification={notificationWithStatus} />
         )
       case 'reply':
+        if (!notificationWithStatus)
+          return renderUnavailableStatusNotification()
+
         return (
           <ReplyNotification
             host={host}
-            notification={
-              notificationWithAccount as NotificationWithData & {
-                status: Status
-              }
-            }
+            notification={notificationWithStatus}
           />
         )
       case 'mention':
+        if (!notificationWithStatus)
+          return renderUnavailableStatusNotification()
+
         return (
           <MentionNotification
             host={host}
-            notification={
-              notificationWithAccount as NotificationWithData & {
-                status: Status
-              }
-            }
+            notification={notificationWithStatus}
+          />
+        )
+      case 'reblog':
+        if (!notificationWithStatus)
+          return renderUnavailableStatusNotification()
+
+        return (
+          <ReblogNotification
+            host={host}
+            notification={notificationWithStatus}
+          />
+        )
+      case 'activity_import':
+        if (!notificationWithStatus)
+          return renderUnavailableStatusNotification()
+
+        return (
+          <ActivityImportNotification
+            host={host}
+            notification={notificationWithStatus}
           />
         )
       default:
-        return null
+        return renderUnavailableNotification(
+          'This notification is no longer available.'
+        )
     }
+  }
+
+  const content = renderNotification()
+  if (!content) {
+    return null
   }
 
   return (
@@ -119,7 +162,7 @@ export const NotificationItem = ({
           aria-label="Unread"
         />
       )}
-      {renderNotification()}
+      {content}
     </div>
   )
 }

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -49,6 +49,8 @@ const renderUnavailableStatusNotification = (notificationType: string) => {
   return renderUnavailableNotification('This post is no longer available.')
 }
 
+const assertNever = (_value: never) => {}
+
 export const NotificationItem = ({
   notification,
   currentActorId,
@@ -114,6 +116,7 @@ export const NotificationItem = ({
       case 'activity_import':
         return renderStatusNotification(ActivityImportNotification)
       default:
+        assertNever(notificationWithAccount.type)
         return renderUnavailableNotification(
           'This notification is no longer available.'
         )

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { type ComponentType, useEffect, useRef } from 'react'
 
 import {
   type NotificationWithAccount,
+  type NotificationWithStatus,
   hasStatusActor
 } from '@/app/(timeline)/notifications/types'
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { Status } from '@/lib/types/domain/status'
+import type { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import type { Mastodon } from '@/lib/types/activitypub'
+import type { Status } from '@/lib/types/domain/status'
 
 import { ActivityImportNotification } from './components/ActivityImportNotification'
 import { FollowNotification } from './components/FollowNotification'
@@ -22,13 +23,17 @@ interface Props {
   notification: GroupedNotification & {
     account: Mastodon.Account | null
     status?: Status | null
-    groupedAccounts?: (Mastodon.Account | null)[] | null
   }
   currentActorId: string
   host: string
   isRead: boolean
   observeElement: (element: HTMLElement | null) => void
 }
+
+type StatusNotificationComponent = ComponentType<{
+  host: string
+  notification: NotificationWithStatus
+}>
 
 const renderUnavailableNotification = (message: string) => (
   <div className="text-sm text-muted-foreground">{message}</div>
@@ -69,13 +74,24 @@ export const NotificationItem = ({
     const notificationWithAccount: NotificationWithAccount = {
       ...notification,
       account: notification.account,
-      status: notification.status ?? null,
-      groupedAccounts: notification.groupedAccounts ?? null
+      status: notification.status ?? null
     }
 
     const notificationWithStatus = hasStatusActor(notificationWithAccount)
       ? notificationWithAccount
       : null
+
+    const renderStatusNotification = (
+      StatusNotification: StatusNotificationComponent
+    ) => {
+      if (!notificationWithStatus) {
+        return renderUnavailableStatusNotification(notificationWithAccount.type)
+      }
+
+      return (
+        <StatusNotification host={host} notification={notificationWithStatus} />
+      )
+    }
 
     switch (notificationWithAccount.type) {
       case 'follow_request':
@@ -88,52 +104,15 @@ export const NotificationItem = ({
       case 'follow':
         return <FollowNotification notification={notificationWithAccount} />
       case 'like':
-        if (!notificationWithStatus)
-          return renderUnavailableStatusNotification(notification.type)
-
-        return (
-          <LikeNotification host={host} notification={notificationWithStatus} />
-        )
+        return renderStatusNotification(LikeNotification)
       case 'reply':
-        if (!notificationWithStatus)
-          return renderUnavailableStatusNotification(notification.type)
-
-        return (
-          <ReplyNotification
-            host={host}
-            notification={notificationWithStatus}
-          />
-        )
+        return renderStatusNotification(ReplyNotification)
       case 'mention':
-        if (!notificationWithStatus)
-          return renderUnavailableStatusNotification(notification.type)
-
-        return (
-          <MentionNotification
-            host={host}
-            notification={notificationWithStatus}
-          />
-        )
+        return renderStatusNotification(MentionNotification)
       case 'reblog':
-        if (!notificationWithStatus)
-          return renderUnavailableStatusNotification(notification.type)
-
-        return (
-          <ReblogNotification
-            host={host}
-            notification={notificationWithStatus}
-          />
-        )
+        return renderStatusNotification(ReblogNotification)
       case 'activity_import':
-        if (!notificationWithStatus)
-          return renderUnavailableStatusNotification(notification.type)
-
-        return (
-          <ActivityImportNotification
-            host={host}
-            notification={notificationWithStatus}
-          />
-        )
+        return renderStatusNotification(ActivityImportNotification)
       default:
         return renderUnavailableNotification(
           'This notification is no longer available.'

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -69,7 +69,8 @@ export const NotificationItem = ({
     const notificationWithAccount: NotificationWithAccount = {
       ...notification,
       account: notification.account,
-      status: notification.status ?? undefined
+      status: notification.status ?? null,
+      groupedAccounts: notification.groupedAccounts ?? null
     }
 
     const notificationWithStatus = hasStatusActor(notificationWithAccount)

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -20,6 +20,12 @@ interface NotificationWithData extends GroupedNotification {
   groupedAccounts?: (Mastodon.Account | null)[] | null
 }
 
+type StatusWithActor = Status & { actor: NonNullable<Status['actor']> }
+
+type NotificationWithStatus = NotificationWithData & {
+  status: StatusWithActor
+}
+
 interface Props {
   notification: GroupedNotification & {
     account: Mastodon.Account | null
@@ -30,6 +36,20 @@ interface Props {
   host: string
   isRead: boolean
   observeElement: (element: HTMLElement | null) => void
+}
+
+const renderUnavailableNotification = (message: string) => (
+  <div className="text-sm text-muted-foreground">{message}</div>
+)
+
+const renderUnavailableStatusNotification = (notificationType: string) => {
+  if (notificationType === 'activity_import') {
+    return renderUnavailableNotification(
+      'This imported activity is no longer available.'
+    )
+  }
+
+  return renderUnavailableNotification('This post is no longer available.')
 }
 
 export const NotificationItem = ({
@@ -47,20 +67,6 @@ export const NotificationItem = ({
     }
   }, [observeElement, isRead])
 
-  const renderUnavailableNotification = (message: string) => (
-    <div className="text-sm text-muted-foreground">{message}</div>
-  )
-
-  const renderUnavailableStatusNotification = () => {
-    if (notification.type === 'activity_import') {
-      return renderUnavailableNotification(
-        'This imported activity is no longer available.'
-      )
-    }
-
-    return renderUnavailableNotification('This post is no longer available.')
-  }
-
   const renderNotification = () => {
     if (!notification.account) {
       return renderUnavailableNotification(
@@ -75,9 +81,7 @@ export const NotificationItem = ({
     }
 
     const notificationWithStatus = notificationWithAccount.status?.actor
-      ? (notificationWithAccount as NotificationWithData & {
-          status: Status
-        })
+      ? (notificationWithAccount as NotificationWithStatus)
       : null
 
     switch (notificationWithAccount.type) {
@@ -92,14 +96,14 @@ export const NotificationItem = ({
         return <FollowNotification notification={notificationWithAccount} />
       case 'like':
         if (!notificationWithStatus)
-          return renderUnavailableStatusNotification()
+          return renderUnavailableStatusNotification(notification.type)
 
         return (
           <LikeNotification host={host} notification={notificationWithStatus} />
         )
       case 'reply':
         if (!notificationWithStatus)
-          return renderUnavailableStatusNotification()
+          return renderUnavailableStatusNotification(notification.type)
 
         return (
           <ReplyNotification
@@ -109,7 +113,7 @@ export const NotificationItem = ({
         )
       case 'mention':
         if (!notificationWithStatus)
-          return renderUnavailableStatusNotification()
+          return renderUnavailableStatusNotification(notification.type)
 
         return (
           <MentionNotification
@@ -119,7 +123,7 @@ export const NotificationItem = ({
         )
       case 'reblog':
         if (!notificationWithStatus)
-          return renderUnavailableStatusNotification()
+          return renderUnavailableStatusNotification(notification.type)
 
         return (
           <ReblogNotification
@@ -129,7 +133,7 @@ export const NotificationItem = ({
         )
       case 'activity_import':
         if (!notificationWithStatus)
-          return renderUnavailableStatusNotification()
+          return renderUnavailableStatusNotification(notification.type)
 
         return (
           <ActivityImportNotification
@@ -145,9 +149,6 @@ export const NotificationItem = ({
   }
 
   const content = renderNotification()
-  if (!content) {
-    return null
-  }
 
   return (
     <div

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useRef } from 'react'
 
+import {
+  type NotificationWithAccount,
+  hasStatusActor
+} from '@/app/(timeline)/notifications/types'
 import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Status } from '@/lib/types/domain/status'
@@ -13,18 +17,6 @@ import { LikeNotification } from './components/LikeNotification'
 import { MentionNotification } from './components/MentionNotification'
 import { ReblogNotification } from './components/ReblogNotification'
 import { ReplyNotification } from './components/ReplyNotification'
-
-interface NotificationWithData extends GroupedNotification {
-  account: Mastodon.Account
-  status?: Status
-  groupedAccounts?: (Mastodon.Account | null)[] | null
-}
-
-type StatusWithActor = Status & { actor: NonNullable<Status['actor']> }
-
-type NotificationWithStatus = NotificationWithData & {
-  status: StatusWithActor
-}
 
 interface Props {
   notification: GroupedNotification & {
@@ -74,14 +66,14 @@ export const NotificationItem = ({
       )
     }
 
-    const notificationWithAccount: NotificationWithData = {
+    const notificationWithAccount: NotificationWithAccount = {
       ...notification,
       account: notification.account,
       status: notification.status ?? undefined
     }
 
-    const notificationWithStatus = notificationWithAccount.status?.actor
-      ? (notificationWithAccount as NotificationWithStatus)
+    const notificationWithStatus = hasStatusActor(notificationWithAccount)
+      ? notificationWithAccount
       : null
 
     switch (notificationWithAccount.type) {

--- a/app/(timeline)/notifications/NotificationsList.tsx
+++ b/app/(timeline)/notifications/NotificationsList.tsx
@@ -3,16 +3,15 @@
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { Status } from '@/lib/types/domain/status'
+import type { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import type { Mastodon } from '@/lib/types/activitypub'
+import type { Status } from '@/lib/types/domain/status'
 
 import { NotificationItem } from './NotificationItem'
 
 interface NotificationWithData extends GroupedNotification {
   account: Mastodon.Account | null
   status?: Status | null
-  groupedAccounts?: (Mastodon.Account | null)[] | null
 }
 
 interface Props {

--- a/app/(timeline)/notifications/components/ActivityImportNotification.tsx
+++ b/app/(timeline)/notifications/components/ActivityImportNotification.tsx
@@ -10,9 +10,11 @@ import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
+type StatusWithActor = Status & { actor: NonNullable<Status['actor']> }
+
 interface NotificationWithData extends GroupedNotification {
   account: Mastodon.Account
-  status: Status
+  status: StatusWithActor
 }
 
 interface Props {
@@ -25,9 +27,10 @@ export const ActivityImportNotification: FC<Props> = ({
   notification
 }) => {
   const { account, status } = notification
-  if (!status.actor) return null
 
   const hasMultiple = notification.groupedCount && notification.groupedCount > 1
+  // activity_import is currently emitted only by the Strava importer.
+  const serviceLabel = 'Strava'
 
   const statusUrl =
     getStatusDetailPath(status) ??
@@ -48,8 +51,8 @@ export const ActivityImportNotification: FC<Props> = ({
       <div className="flex-1 min-w-0">
         <p className="text-sm">
           {hasMultiple
-            ? 'Your Strava fitness activities were imported.'
-            : 'Your Strava fitness activity was imported.'}{' '}
+            ? `Your ${serviceLabel} fitness activities were imported.`
+            : `Your ${serviceLabel} fitness activity was imported.`}{' '}
           <Link href={statusUrl} className="text-primary hover:underline">
             {hasMultiple ? 'View latest activity' : 'View activity'}
           </Link>

--- a/app/(timeline)/notifications/components/ActivityImportNotification.tsx
+++ b/app/(timeline)/notifications/components/ActivityImportNotification.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
@@ -16,36 +15,24 @@ export const ActivityImportNotification: FC<Props> = ({
   host,
   notification
 }) => {
-  const { account, status } = notification
+  const { status } = notification
 
   const hasMultiple = notification.groupedCount && notification.groupedCount > 1
   const statusUrl = getNotificationStatusPath(status)
 
   return (
-    <div className="flex items-start gap-4">
-      <div className="relative size-12 shrink-0">
-        {account.avatar && (
-          <Image
-            src={account.avatar}
-            alt={account.display_name || account.username}
-            fill
-            className="rounded-full object-cover"
-          />
-        )}
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm">
-          {hasMultiple
-            ? 'Your fitness activities were imported.'
-            : 'Your fitness activity was imported.'}{' '}
-          <Link href={statusUrl} className="text-primary hover:underline">
-            {hasMultiple ? 'View latest activity' : 'View activity'}
-          </Link>
-        </p>
-        <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
-          <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
-            {cleanClassName(processStatusText(host, status))}
-          </div>
+    <div className="min-w-0">
+      <p className="text-sm">
+        {hasMultiple
+          ? 'Your fitness activities were imported.'
+          : 'Your fitness activity was imported.'}{' '}
+        <Link href={statusUrl} className="text-primary hover:underline">
+          {hasMultiple ? 'View latest activity' : 'View activity'}
+        </Link>
+      </p>
+      <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
+        <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
+          {cleanClassName(processStatusText(host, status))}
         </div>
       </div>
     </div>

--- a/app/(timeline)/notifications/components/ActivityImportNotification.tsx
+++ b/app/(timeline)/notifications/components/ActivityImportNotification.tsx
@@ -2,24 +2,14 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { getMention } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
-import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+import { getNotificationStatusPath } from '@/app/(timeline)/notifications/getNotificationStatusPath'
+import type { NotificationWithStatus } from '@/app/(timeline)/notifications/types'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
-type StatusWithActor = Status & { actor: NonNullable<Status['actor']> }
-
-interface NotificationWithData extends GroupedNotification {
-  account: Mastodon.Account
-  status: StatusWithActor
-}
-
 interface Props {
   host: string
-  notification: NotificationWithData
+  notification: NotificationWithStatus
 }
 
 export const ActivityImportNotification: FC<Props> = ({
@@ -29,12 +19,7 @@ export const ActivityImportNotification: FC<Props> = ({
   const { account, status } = notification
 
   const hasMultiple = notification.groupedCount && notification.groupedCount > 1
-  // activity_import is currently emitted only by the Strava importer.
-  const serviceLabel = 'Strava'
-
-  const statusUrl =
-    getStatusDetailPath(status) ??
-    `/${getMention(status.actor, true)}/${encodeURIComponent(status.id)}`
+  const statusUrl = getNotificationStatusPath(status)
 
   return (
     <div className="flex items-start gap-4">
@@ -51,8 +36,8 @@ export const ActivityImportNotification: FC<Props> = ({
       <div className="flex-1 min-w-0">
         <p className="text-sm">
           {hasMultiple
-            ? `Your ${serviceLabel} fitness activities were imported.`
-            : `Your ${serviceLabel} fitness activity was imported.`}{' '}
+            ? 'Your fitness activities were imported.'
+            : 'Your fitness activity was imported.'}{' '}
           <Link href={statusUrl} className="text-primary hover:underline">
             {hasMultiple ? 'View latest activity' : 'View activity'}
           </Link>

--- a/app/(timeline)/notifications/components/ActivityImportNotification.tsx
+++ b/app/(timeline)/notifications/components/ActivityImportNotification.tsx
@@ -1,3 +1,4 @@
+import { Activity } from 'lucide-react'
 import Link from 'next/link'
 import { FC } from 'react'
 
@@ -21,18 +22,26 @@ export const ActivityImportNotification: FC<Props> = ({
   const statusUrl = getNotificationStatusPath(status)
 
   return (
-    <div className="min-w-0">
-      <p className="text-sm">
-        {hasMultiple
-          ? 'Your fitness activities were imported.'
-          : 'Your fitness activity was imported.'}{' '}
-        <Link href={statusUrl} className="text-primary hover:underline">
-          {hasMultiple ? 'View latest activity' : 'View activity'}
-        </Link>
-      </p>
-      <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
-        <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
-          {cleanClassName(processStatusText(host, status))}
+    <div className="flex items-start gap-4">
+      <div
+        aria-hidden="true"
+        className="flex size-12 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"
+      >
+        <Activity className="size-5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm">
+          {hasMultiple
+            ? 'Your fitness activities were imported.'
+            : 'Your fitness activity was imported.'}{' '}
+          <Link href={statusUrl} className="text-primary hover:underline">
+            {hasMultiple ? 'View latest activity' : 'View activity'}
+          </Link>
+        </p>
+        <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
+          <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
+            {cleanClassName(processStatusText(host, status))}
+          </div>
         </div>
       </div>
     </div>

--- a/app/(timeline)/notifications/components/ActivityImportNotification.tsx
+++ b/app/(timeline)/notifications/components/ActivityImportNotification.tsx
@@ -13,7 +13,6 @@ import { processStatusText } from '@/lib/utils/text/processStatusText'
 interface NotificationWithData extends GroupedNotification {
   account: Mastodon.Account
   status: Status
-  groupedAccounts?: (Mastodon.Account | null)[] | null
 }
 
 interface Props {
@@ -21,11 +20,14 @@ interface Props {
   notification: NotificationWithData
 }
 
-export const MentionNotification: FC<Props> = ({ host, notification }) => {
-  const { account, status, groupedAccounts, groupedCount } = notification
+export const ActivityImportNotification: FC<Props> = ({
+  host,
+  notification
+}) => {
+  const { account, status } = notification
   if (!status.actor) return null
 
-  const hasMultiple = groupedCount && groupedCount > 1
+  const hasMultiple = notification.groupedCount && notification.groupedCount > 1
 
   const statusUrl =
     getStatusDetailPath(status) ??
@@ -44,34 +46,14 @@ export const MentionNotification: FC<Props> = ({ host, notification }) => {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        {hasMultiple && groupedAccounts ? (
-          <p className="text-sm">
-            <Link
-              href={`/@${account.acct}`}
-              className="font-medium hover:underline"
-            >
-              {account.display_name || account.username}
-            </Link>
-            {groupedCount > 2 && ` and ${groupedCount - 1} others`}
-            {groupedCount === 2 && ' and 1 other'} mentioned you in a{' '}
-            <Link href={statusUrl} className="text-primary hover:underline">
-              post
-            </Link>
-          </p>
-        ) : (
-          <p className="text-sm">
-            <Link
-              href={`/@${account.acct}`}
-              className="font-medium hover:underline"
-            >
-              {account.display_name || account.username}
-            </Link>{' '}
-            mentioned you in a{' '}
-            <Link href={statusUrl} className="text-primary hover:underline">
-              post
-            </Link>
-          </p>
-        )}
+        <p className="text-sm">
+          {hasMultiple
+            ? 'Your Strava fitness activities were imported.'
+            : 'Your Strava fitness activity was imported.'}{' '}
+          <Link href={statusUrl} className="text-primary hover:underline">
+            {hasMultiple ? 'View latest activity' : 'View activity'}
+          </Link>
+        </p>
         <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
           <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
             {cleanClassName(processStatusText(host, status))}

--- a/app/(timeline)/notifications/components/FollowNotification.tsx
+++ b/app/(timeline)/notifications/components/FollowNotification.tsx
@@ -2,12 +2,11 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
+import type { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import type { Mastodon } from '@/lib/types/activitypub'
 
 interface NotificationWithAccount extends GroupedNotification {
   account: Mastodon.Account
-  groupedAccounts?: (Mastodon.Account | null)[] | null
 }
 
 interface Props {
@@ -15,7 +14,7 @@ interface Props {
 }
 
 export const FollowNotification: FC<Props> = ({ notification }) => {
-  const { account, groupedAccounts, groupedCount } = notification
+  const { account, groupedCount } = notification
   const hasMultiple = groupedCount && groupedCount > 1
 
   return (
@@ -31,7 +30,7 @@ export const FollowNotification: FC<Props> = ({ notification }) => {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        {hasMultiple && groupedAccounts ? (
+        {hasMultiple ? (
           <p className="text-sm">
             <Link
               href={`/@${account.acct}`}

--- a/app/(timeline)/notifications/components/LikeNotification.tsx
+++ b/app/(timeline)/notifications/components/LikeNotification.tsx
@@ -72,14 +72,11 @@ export const LikeNotification: FC<Props> = ({ host, notification }) => {
             </Link>
           </p>
         )}
-        <Link
-          href={statusUrl}
-          className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground hover:bg-muted"
-        >
+        <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
           <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
             {cleanClassName(processStatusText(host, status))}
           </div>
-        </Link>
+        </div>
       </div>
     </div>
   )

--- a/app/(timeline)/notifications/components/LikeNotification.tsx
+++ b/app/(timeline)/notifications/components/LikeNotification.tsx
@@ -2,34 +2,21 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { getMention } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
-import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+import { getNotificationStatusPath } from '@/app/(timeline)/notifications/getNotificationStatusPath'
+import type { NotificationWithStatus } from '@/app/(timeline)/notifications/types'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
-interface NotificationWithData extends GroupedNotification {
-  account: Mastodon.Account
-  status: Status
-  groupedAccounts?: (Mastodon.Account | null)[] | null
-}
-
 interface Props {
   host: string
-  notification: NotificationWithData
+  notification: NotificationWithStatus
 }
 
 export const LikeNotification: FC<Props> = ({ host, notification }) => {
-  const { account, status, groupedAccounts, groupedCount } = notification
-  if (!status.actor) return null
+  const { account, status, groupedCount } = notification
 
   const hasMultiple = groupedCount && groupedCount > 1
-
-  const statusUrl =
-    getStatusDetailPath(status) ??
-    `/${getMention(status.actor, true)}/${encodeURIComponent(status.id)}`
+  const statusUrl = getNotificationStatusPath(status)
 
   return (
     <div className="flex items-start gap-4">
@@ -44,7 +31,7 @@ export const LikeNotification: FC<Props> = ({ host, notification }) => {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        {hasMultiple && groupedAccounts ? (
+        {hasMultiple ? (
           <p className="text-sm">
             <Link
               href={`/@${account.acct}`}

--- a/app/(timeline)/notifications/components/MentionNotification.tsx
+++ b/app/(timeline)/notifications/components/MentionNotification.tsx
@@ -2,34 +2,21 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { getMention } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
-import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+import { getNotificationStatusPath } from '@/app/(timeline)/notifications/getNotificationStatusPath'
+import type { NotificationWithStatus } from '@/app/(timeline)/notifications/types'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
-interface NotificationWithData extends GroupedNotification {
-  account: Mastodon.Account
-  status: Status
-  groupedAccounts?: (Mastodon.Account | null)[] | null
-}
-
 interface Props {
   host: string
-  notification: NotificationWithData
+  notification: NotificationWithStatus
 }
 
 export const MentionNotification: FC<Props> = ({ host, notification }) => {
-  const { account, status, groupedAccounts, groupedCount } = notification
-  if (!status.actor) return null
+  const { account, status, groupedCount } = notification
 
   const hasMultiple = groupedCount && groupedCount > 1
-
-  const statusUrl =
-    getStatusDetailPath(status) ??
-    `/${getMention(status.actor, true)}/${encodeURIComponent(status.id)}`
+  const statusUrl = getNotificationStatusPath(status)
 
   return (
     <div className="flex items-start gap-4">
@@ -44,7 +31,7 @@ export const MentionNotification: FC<Props> = ({ host, notification }) => {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        {hasMultiple && groupedAccounts ? (
+        {hasMultiple ? (
           <p className="text-sm">
             <Link
               href={`/@${account.acct}`}

--- a/app/(timeline)/notifications/components/ReblogNotification.tsx
+++ b/app/(timeline)/notifications/components/ReblogNotification.tsx
@@ -10,9 +10,11 @@ import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
+type StatusWithActor = Status & { actor: NonNullable<Status['actor']> }
+
 interface NotificationWithData extends GroupedNotification {
   account: Mastodon.Account
-  status: Status
+  status: StatusWithActor
   groupedAccounts?: (Mastodon.Account | null)[] | null
 }
 
@@ -22,8 +24,7 @@ interface Props {
 }
 
 export const ReblogNotification: FC<Props> = ({ host, notification }) => {
-  const { account, status, groupedAccounts, groupedCount } = notification
-  if (!status.actor) return null
+  const { account, status, groupedCount } = notification
 
   const hasMultiple = groupedCount && groupedCount > 1
 
@@ -44,7 +45,7 @@ export const ReblogNotification: FC<Props> = ({ host, notification }) => {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        {hasMultiple && groupedAccounts ? (
+        {hasMultiple ? (
           <p className="text-sm">
             <Link
               href={`/@${account.acct}`}

--- a/app/(timeline)/notifications/components/ReblogNotification.tsx
+++ b/app/(timeline)/notifications/components/ReblogNotification.tsx
@@ -2,35 +2,21 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { getMention } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
-import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+import { getNotificationStatusPath } from '@/app/(timeline)/notifications/getNotificationStatusPath'
+import type { NotificationWithStatus } from '@/app/(timeline)/notifications/types'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
-type StatusWithActor = Status & { actor: NonNullable<Status['actor']> }
-
-interface NotificationWithData extends GroupedNotification {
-  account: Mastodon.Account
-  status: StatusWithActor
-  groupedAccounts?: (Mastodon.Account | null)[] | null
-}
-
 interface Props {
   host: string
-  notification: NotificationWithData
+  notification: NotificationWithStatus
 }
 
 export const ReblogNotification: FC<Props> = ({ host, notification }) => {
   const { account, status, groupedCount } = notification
 
   const hasMultiple = groupedCount && groupedCount > 1
-
-  const statusUrl =
-    getStatusDetailPath(status) ??
-    `/${getMention(status.actor, true)}/${encodeURIComponent(status.id)}`
+  const statusUrl = getNotificationStatusPath(status)
 
   return (
     <div className="flex items-start gap-4">

--- a/app/(timeline)/notifications/components/ReblogNotification.tsx
+++ b/app/(timeline)/notifications/components/ReblogNotification.tsx
@@ -21,7 +21,7 @@ interface Props {
   notification: NotificationWithData
 }
 
-export const MentionNotification: FC<Props> = ({ host, notification }) => {
+export const ReblogNotification: FC<Props> = ({ host, notification }) => {
   const { account, status, groupedAccounts, groupedCount } = notification
   if (!status.actor) return null
 
@@ -53,7 +53,7 @@ export const MentionNotification: FC<Props> = ({ host, notification }) => {
               {account.display_name || account.username}
             </Link>
             {groupedCount > 2 && ` and ${groupedCount - 1} others`}
-            {groupedCount === 2 && ' and 1 other'} mentioned you in a{' '}
+            {groupedCount === 2 && ' and 1 other'} reblogged your{' '}
             <Link href={statusUrl} className="text-primary hover:underline">
               post
             </Link>
@@ -66,7 +66,7 @@ export const MentionNotification: FC<Props> = ({ host, notification }) => {
             >
               {account.display_name || account.username}
             </Link>{' '}
-            mentioned you in a{' '}
+            reblogged your{' '}
             <Link href={statusUrl} className="text-primary hover:underline">
               post
             </Link>

--- a/app/(timeline)/notifications/components/ReplyNotification.tsx
+++ b/app/(timeline)/notifications/components/ReplyNotification.tsx
@@ -72,14 +72,11 @@ export const ReplyNotification: FC<Props> = ({ host, notification }) => {
             </Link>
           </p>
         )}
-        <Link
-          href={statusUrl}
-          className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground hover:bg-muted"
-        >
+        <div className="mt-2 block rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
           <div className="line-clamp-2 [&_p]:inline [&_br]:hidden">
             {cleanClassName(processStatusText(host, status))}
           </div>
-        </Link>
+        </div>
       </div>
     </div>
   )

--- a/app/(timeline)/notifications/components/ReplyNotification.tsx
+++ b/app/(timeline)/notifications/components/ReplyNotification.tsx
@@ -2,34 +2,21 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { FC } from 'react'
 
-import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
-import { Mastodon } from '@/lib/types/activitypub'
-import { getMention } from '@/lib/types/domain/actor'
-import { Status } from '@/lib/types/domain/status'
-import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+import { getNotificationStatusPath } from '@/app/(timeline)/notifications/getNotificationStatusPath'
+import type { NotificationWithStatus } from '@/app/(timeline)/notifications/types'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
-interface NotificationWithData extends GroupedNotification {
-  account: Mastodon.Account
-  status: Status
-  groupedAccounts?: (Mastodon.Account | null)[] | null
-}
-
 interface Props {
   host: string
-  notification: NotificationWithData
+  notification: NotificationWithStatus
 }
 
 export const ReplyNotification: FC<Props> = ({ host, notification }) => {
-  const { account, status, groupedAccounts, groupedCount } = notification
-  if (!status.actor) return null
+  const { account, status, groupedCount } = notification
 
   const hasMultiple = groupedCount && groupedCount > 1
-
-  const statusUrl =
-    getStatusDetailPath(status) ??
-    `/${getMention(status.actor, true)}/${encodeURIComponent(status.id)}`
+  const statusUrl = getNotificationStatusPath(status)
 
   return (
     <div className="flex items-start gap-4">
@@ -44,7 +31,7 @@ export const ReplyNotification: FC<Props> = ({ host, notification }) => {
         )}
       </div>
       <div className="flex-1 min-w-0">
-        {hasMultiple && groupedAccounts ? (
+        {hasMultiple ? (
           <p className="text-sm">
             <Link
               href={`/@${account.acct}`}

--- a/app/(timeline)/notifications/getNotificationStatusPath.ts
+++ b/app/(timeline)/notifications/getNotificationStatusPath.ts
@@ -1,0 +1,7 @@
+import type { StatusWithActor } from '@/app/(timeline)/notifications/types'
+import { getMention } from '@/lib/types/domain/actor'
+import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+
+export const getNotificationStatusPath = (status: StatusWithActor) =>
+  getStatusDetailPath(status) ??
+  `/${getMention(status.actor, true)}/${encodeURIComponent(status.id)}`

--- a/app/(timeline)/notifications/page.tsx
+++ b/app/(timeline)/notifications/page.tsx
@@ -68,24 +68,10 @@ const Page = async ({ searchParams }: Props) => {
         })
       }
 
-      let groupedAccounts = null
-      if (notification.groupedActors && notification.groupedActors.length > 1) {
-        groupedAccounts = (
-          await Promise.all(
-            notification.groupedActors
-              .slice(0, 3)
-              .map((actorId) =>
-                database.getMastodonActorFromId({ id: actorId })
-              )
-          )
-        ).filter(Boolean)
-      }
-
       return {
         ...notification,
         account,
-        status,
-        groupedAccounts
+        status
       }
     })
   )

--- a/app/(timeline)/notifications/page.tsx
+++ b/app/(timeline)/notifications/page.tsx
@@ -90,31 +90,20 @@ const Page = async ({ searchParams }: Props) => {
     })
   )
 
-  const filteredNotifications = notificationsWithData.filter((notification) => {
-    if (!notification.account) return false
-    if (
-      ['like', 'reply', 'mention'].includes(notification.type) &&
-      (!notification.status || !notification.status.actor)
-    ) {
-      return false
-    }
-    return true
-  })
-
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold">Notifications</h1>
       </div>
 
-      {filteredNotifications.length === 0 ? (
+      {notificationsWithData.length === 0 ? (
         <div className="rounded-xl border bg-background/80 p-8 text-center text-muted-foreground">
           No notifications yet
         </div>
       ) : (
         <>
           <NotificationsList
-            notifications={filteredNotifications}
+            notifications={notificationsWithData}
             currentActorId={actor.id}
             host={host}
           />

--- a/app/(timeline)/notifications/types.ts
+++ b/app/(timeline)/notifications/types.ts
@@ -1,0 +1,21 @@
+import type { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import type { Mastodon } from '@/lib/types/activitypub'
+import type { Status } from '@/lib/types/domain/status'
+
+export interface NotificationWithAccount extends GroupedNotification {
+  account: Mastodon.Account
+  status?: Status
+  groupedAccounts?: (Mastodon.Account | null)[] | null
+}
+
+export type StatusWithActor = Status & {
+  actor: NonNullable<Status['actor']>
+}
+
+export interface NotificationWithStatus extends NotificationWithAccount {
+  status: StatusWithActor
+}
+
+export const hasStatusActor = (
+  notification: NotificationWithAccount
+): notification is NotificationWithStatus => Boolean(notification.status?.actor)

--- a/app/(timeline)/notifications/types.ts
+++ b/app/(timeline)/notifications/types.ts
@@ -4,8 +4,8 @@ import type { Status } from '@/lib/types/domain/status'
 
 export interface NotificationWithAccount extends GroupedNotification {
   account: Mastodon.Account
-  status?: Status
-  groupedAccounts?: (Mastodon.Account | null)[] | null
+  status: Status | null
+  groupedAccounts: (Mastodon.Account | null)[] | null
 }
 
 export type StatusWithActor = Status & {

--- a/app/(timeline)/notifications/types.ts
+++ b/app/(timeline)/notifications/types.ts
@@ -5,7 +5,6 @@ import type { Status } from '@/lib/types/domain/status'
 export interface NotificationWithAccount extends GroupedNotification {
   account: Mastodon.Account
   status: Status | null
-  groupedAccounts: (Mastodon.Account | null)[] | null
 }
 
 export type StatusWithActor = Status & {


### PR DESCRIPTION
## Summary

- Render `activity_import` and `reblog` notifications in the timeline notifications UI instead of falling through to empty cards.
- Render status-backed notifications with missing status data as explicit unavailable rows so they remain visible and can be marked read.
- Avoid nested anchors in notification previews because processed status text can contain links.
- Address review follow-up by using generic fitness import copy, shared notification render types, nullable notification render fields, a notification-local status path helper, and consistent grouped notification fallbacks.

## Root cause

Valid notification types existed in the database and API layer, but the web `NotificationItem` switch did not handle `activity_import` or `reblog`. The component still rendered the outer notification card, so unsupported types produced blank rows. Stale status-backed notifications could also be filtered out or return `null`, leaving unread rows invisible.

## Verification

- `yarn run prettier --write app/(timeline)/notifications/NotificationItem.tsx app/(timeline)/notifications/NotificationItem.test.tsx app/(timeline)/notifications/components/ActivityImportNotification.tsx app/(timeline)/notifications/components/LikeNotification.tsx app/(timeline)/notifications/components/MentionNotification.tsx app/(timeline)/notifications/components/ReblogNotification.tsx app/(timeline)/notifications/components/ReplyNotification.tsx app/(timeline)/notifications/getNotificationStatusPath.ts app/(timeline)/notifications/types.ts`
- `git diff --check origin/codex/fix-blank-notifications..HEAD`
- `yarn test --runTestsByPath 'app/(timeline)/notifications/NotificationItem.test.tsx' --runInBand` - 16 tests passed.
- `yarn lint` - 0 errors, 24 existing `no-explicit-any` warnings in auth/fitness code and duplicated under `.claude/worktrees`.
- `yarn build` - passed.
- `yarn test --runInBand --modulePathIgnorePatterns='<rootDir>/.claude' --testPathIgnorePatterns='<rootDir>/.claude'` - 260 suites / 1,953 tests passed.
- Browser verification at `https://activities.local/notifications` as `@ride@llun.social`: grouped import row renders generic fitness import copy, stale import rows render explicit unavailable text, and the fresh route console has no errors or warnings.

## Notes

Notification preview snippets are intentionally not full-card links. Each notification keeps an explicit `post`, `View activity`, or `View latest activity` link; making the whole preview clickable would reintroduce nested or competing interactive elements because processed status text can render links.

The local stack is running `activitynext-dev` from the Node 24 dev container. `docker compose logs activitynext-dev` showed `/notifications` served from that container; the same tail also included an older timeline hydration warning from `/`, unrelated to this notifications route check.


## Review Follow-up

- Removed unused `groupedAccounts` hydration from the notifications UI path and made follow grouped copy rely on `groupedCount` like the other grouped notification rows.
- Removed the self-avatar from `activity_import` notifications.
- Collapsed repeated status-required fallback guards and made type-only client imports explicit.
- Latest verification: focused notification tests passed with 18 tests, `yarn lint` passed with the same 24 existing warnings, `yarn build` passed, full Jest passed with 260 suites / 1,955 tests, and browser verification at `https://activities.local/notifications` showed the import row with no images and no fresh route console warnings/errors.

## Latest Review Follow-up

- Removed unused `groupedAccounts` hydration from the notifications UI request path, avoiding up to 3 extra actor account lookups per grouped notification while keeping grouped copy based on `groupedCount`.
- Kept `groupedActors` in the grouping service because the Mastodon API notification path still uses it to populate `grouped_accounts`.
- Fixed `activity_import` row alignment in cff9c25cfe5213298147863682cde9b63641ec2f by using the shared notification row shell with a non-account fitness glyph gutter.
- Added an exhaustiveness guard to the notification type switch in cff9c25cfe5213298147863682cde9b63641ec2f while preserving the runtime fallback for unknown or legacy rows.
- Latest verification: focused notification tests passed with 18 tests, `yarn lint` passed with the same 24 existing warnings, `yarn build` passed, full Jest passed with 260 suites / 1,955 tests, and browser verification at `https://activities.local/notifications` showed the import row aligned with visible copy and unavailable fallback rows.