### PR TITLE
minor: render large fitness heatmaps reliably (+ clear route cache)

### DIFF
--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -102,6 +102,50 @@ const pendingSummary: FitnessRouteHeatmapSummaryData = {
 }
 
 const TEST_NOW = 1_700_000_060_000
+const IN_FLIGHT_HISTORY_POLL_WINDOW_MS = 15 * 60_000
+
+const pendingSummaryAtAge = (
+  ageMs: number
+): FitnessRouteHeatmapSummaryData => ({
+  ...pendingSummary,
+  updatedAt: TEST_NOW - ageMs
+})
+
+const buildLargeHeatmap = (): FitnessRouteHeatmapData => {
+  const segmentCount = 80
+  const pointsPerSegment = 1000
+  const segments: FitnessRouteHeatmapData['segments'] = Array.from(
+    { length: segmentCount },
+    (_, segmentIndex) => ({
+      points: Array.from({ length: pointsPerSegment }, (_point, pointIndex) => {
+        const progress =
+          (segmentIndex * pointsPerSegment + pointIndex) /
+          (segmentCount * pointsPerSegment - 1)
+        const branchOffset = (segmentIndex % 8) * 0.0008
+
+        return {
+          lat: 52.36 + progress * 0.03 + Math.sin(pointIndex / 30) * 0.0002,
+          lng: 4.88 + branchOffset + progress * 0.03
+        }
+      })
+    })
+  )
+
+  return {
+    ...completedHeatmap,
+    id: 'route-heatmap-large',
+    bounds: {
+      minLat: 52.36,
+      maxLat: 52.39,
+      minLng: 4.88,
+      maxLng: 4.916
+    },
+    segments,
+    activityCount: segmentCount,
+    pointCount: segmentCount * pointsPerSegment,
+    updatedAt: 3
+  }
+}
 
 describe('FitnessHeatmapView', () => {
   beforeEach(() => {
@@ -121,10 +165,7 @@ describe('FitnessHeatmapView', () => {
     jest.useFakeTimers()
     jest.setSystemTime(TEST_NOW)
     mockGetFitnessRouteHeatmaps.mockResolvedValue([
-      {
-        ...pendingSummary,
-        updatedAt: TEST_NOW
-      }
+      pendingSummaryAtAge(IN_FLIGHT_HISTORY_POLL_WINDOW_MS)
     ])
 
     render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
@@ -159,10 +200,7 @@ describe('FitnessHeatmapView', () => {
     jest.useFakeTimers()
     jest.setSystemTime(TEST_NOW)
     mockGetFitnessRouteHeatmaps.mockResolvedValue([
-      {
-        ...pendingSummary,
-        updatedAt: TEST_NOW - 10 * 60_000
-      }
+      pendingSummaryAtAge(IN_FLIGHT_HISTORY_POLL_WINDOW_MS + 1)
     ])
 
     render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
@@ -291,11 +329,57 @@ describe('RouteHeatmapMap', () => {
     )
   })
 
+  it('falls back with a diagnostic reason when Mapbox setup fails', async () => {
+    const mapConstructor = jest.fn().mockImplementation(() => ({
+      on: (_event: string, callback: () => void) => callback(),
+      remove: jest.fn(),
+      resize: jest.fn(),
+      addSource: jest.fn(() => {
+        throw new Error('source unavailable')
+      }),
+      addLayer: jest.fn(),
+      getSource: jest.fn(),
+      fitBounds: jest.fn()
+    }))
+    mockLoadMapboxModule.mockResolvedValue({
+      Map: mapConstructor
+    })
+
+    const { container } = render(
+      <RouteHeatmapMap
+        heatmap={completedHeatmap}
+        mapboxAccessToken="mapbox-token"
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText('Routes')).toBeInTheDocument())
+    expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
+    expect(
+      container.querySelector('[data-mapbox-fallback-reason="render-failed"]')
+    ).toBeInTheDocument()
+  })
+
+  it('falls back with a diagnostic reason when Mapbox fails to load', async () => {
+    mockLoadMapboxModule.mockRejectedValue(new Error('module unavailable'))
+
+    const { container } = render(
+      <RouteHeatmapMap
+        heatmap={completedHeatmap}
+        mapboxAccessToken="mapbox-token"
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText('Routes')).toBeInTheDocument())
+    expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[data-mapbox-fallback-reason="module-load-failed"]'
+      )
+    ).toBeInTheDocument()
+  })
+
   it('uses the SVG route fallback for large route caches', () => {
-    const largeHeatmap = {
-      ...completedHeatmap,
-      pointCount: 80_000
-    }
+    const largeHeatmap = buildLargeHeatmap()
 
     const { container } = render(
       <RouteHeatmapMap
@@ -306,7 +390,9 @@ describe('RouteHeatmapMap', () => {
 
     expect(screen.getByText('Routes')).toBeInTheDocument()
     expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
-    expect(container.querySelector('polyline')).toBeInTheDocument()
+    expect(container.querySelectorAll('polyline')).toHaveLength(
+      largeHeatmap.segments.length
+    )
     expect(mockLoadMapboxModule).not.toHaveBeenCalled()
   })
 })

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -107,6 +107,13 @@ const pendingSummary: FitnessRouteHeatmapSummaryData = {
   updatedAt: 2
 }
 
+const completedSummary: FitnessRouteHeatmapSummaryData = {
+  ...pendingSummary,
+  id: 'route-heatmap-completed',
+  status: 'completed',
+  cursorOffset: 0
+}
+
 const TEST_NOW = 1_700_000_060_000
 const IN_FLIGHT_HISTORY_POLL_WINDOW_MS = 15 * 60_000
 
@@ -270,6 +277,32 @@ describe('FitnessHeatmapView', () => {
           periodType: 'yearly',
           periodKey: '2026',
           retry: false
+        })
+      )
+    })
+  })
+
+  it('allows manual generation retry for a missing selection when other route caches exist', async () => {
+    mockGetFitnessRouteHeatmap.mockResolvedValue(null)
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([completedSummary])
+    mockTriggerFitnessRouteHeatmap
+      .mockRejectedValueOnce(new Error('queue unavailable'))
+      .mockResolvedValueOnce(true)
+
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    expect(await screen.findByText('queue unavailable')).toBeInTheDocument()
+
+    const generateButton = screen.getByRole('button', { name: /Generate/i })
+    fireEvent.click(generateButton)
+
+    await waitFor(() => {
+      expect(mockTriggerFitnessRouteHeatmap).toHaveBeenCalledTimes(2)
+      expect(mockTriggerFitnessRouteHeatmap).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          actorId: 'https://llun.test/users/llun',
+          periodType: 'all_time',
+          periodKey: 'all'
         })
       )
     })

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -101,6 +101,8 @@ const pendingSummary: FitnessRouteHeatmapSummaryData = {
   updatedAt: 2
 }
 
+const TEST_NOW = 1_700_000_060_000
+
 describe('FitnessHeatmapView', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -115,8 +117,53 @@ describe('FitnessHeatmapView', () => {
     jest.useRealTimers()
   })
 
-  it('keeps polling history entries without stalling a completed selection', async () => {
+  it('keeps polling fresh history entries without stalling a completed selection', async () => {
     jest.useFakeTimers()
+    jest.setSystemTime(TEST_NOW)
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([
+      {
+        ...pendingSummary,
+        updatedAt: TEST_NOW
+      }
+    ])
+
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    await waitFor(() => {
+      expect(mockGetFitnessRouteHeatmap).toHaveBeenCalledTimes(1)
+      expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('Generating…')).toBeInTheDocument()
+    })
+
+    mockGetFitnessRouteHeatmap.mockClear()
+
+    const callsAfterInitialLoad = mockGetFitnessRouteHeatmaps.mock.calls.length
+
+    for (let i = 0; i < 2; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(5000)
+        await Promise.resolve()
+      })
+    }
+
+    expect(mockGetFitnessRouteHeatmaps.mock.calls.length).toBeGreaterThan(
+      callsAfterInitialLoad
+    )
+    expect(mockGetFitnessRouteHeatmap).not.toHaveBeenCalled()
+    expect(
+      screen.queryByText('Route cache is taking longer than expected')
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not keep polling stale in-progress history entries', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(TEST_NOW)
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([
+      {
+        ...pendingSummary,
+        updatedAt: TEST_NOW - 10 * 60_000
+      }
+    ])
 
     render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
 
@@ -125,31 +172,16 @@ describe('FitnessHeatmapView', () => {
       expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(1)
     })
 
-    mockGetFitnessRouteHeatmap.mockClear()
-
     const callsAfterInitialLoad = mockGetFitnessRouteHeatmaps.mock.calls.length
 
-    for (let i = 0; i < 35; i++) {
-      await act(async () => {
-        jest.advanceTimersByTime(5000)
-        await Promise.resolve()
-      })
-    }
-    const callsAfterStallWindow = mockGetFitnessRouteHeatmaps.mock.calls.length
-
     await act(async () => {
-      jest.advanceTimersByTime(5000)
+      jest.advanceTimersByTime(15_000)
       await Promise.resolve()
     })
 
-    expect(callsAfterStallWindow).toBeGreaterThan(callsAfterInitialLoad)
-    expect(mockGetFitnessRouteHeatmaps.mock.calls.length).toBeGreaterThan(
-      callsAfterStallWindow
+    expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(
+      callsAfterInitialLoad
     )
-    expect(mockGetFitnessRouteHeatmap).not.toHaveBeenCalled()
-    expect(
-      screen.queryByText('Route cache is taking longer than expected')
-    ).not.toBeInTheDocument()
   })
 
   it('ignores stale selection responses before mutating state or enqueueing', async () => {
@@ -257,5 +289,24 @@ describe('RouteHeatmapMap', () => {
         attributionControl: true
       })
     )
+  })
+
+  it('uses the SVG route fallback for large route caches', () => {
+    const largeHeatmap = {
+      ...completedHeatmap,
+      pointCount: 80_000
+    }
+
+    const { container } = render(
+      <RouteHeatmapMap
+        heatmap={largeHeatmap}
+        mapboxAccessToken="mapbox-token"
+      />
+    )
+
+    expect(screen.getByText('Routes')).toBeInTheDocument()
+    expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
+    expect(container.querySelector('polyline')).toBeInTheDocument()
+    expect(mockLoadMapboxModule).not.toHaveBeenCalled()
   })
 })

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -375,6 +375,33 @@ describe('FitnessHeatmapView', () => {
     expect(mockClearFitnessRouteHeatmaps).not.toHaveBeenCalled()
   })
 
+  it('keeps page errors when the clear route cache dialog is opened and cancelled', async () => {
+    mockTriggerFitnessRouteHeatmap.mockRejectedValueOnce(
+      new Error('refresh broken')
+    )
+
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Clear cache/i })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }))
+
+    expect(await screen.findByText('refresh broken')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
+    const dialog = screen.getByRole('dialog')
+
+    expect(screen.getByText('refresh broken')).toBeInTheDocument()
+    expect(within(dialog).queryByRole('alert')).not.toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /Cancel/i }))
+
+    expect(screen.getByText('refresh broken')).toBeInTheDocument()
+    expect(mockClearFitnessRouteHeatmaps).not.toHaveBeenCalled()
+  })
+
   it('surfaces an error when clearing route caches fails', async () => {
     mockClearFitnessRouteHeatmaps.mockRejectedValue(new Error('boom'))
 

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -419,6 +419,11 @@ describe('RouteHeatmapMap', () => {
     expect(
       container.querySelector('[data-mapbox-fallback-reason="render-failed"]')
     ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[data-mapbox-fallback-error="source unavailable"]'
+      )
+    ).toBeInTheDocument()
   })
 
   it('falls back with a diagnostic reason when Mapbox fails to load', async () => {
@@ -438,6 +443,70 @@ describe('RouteHeatmapMap', () => {
         '[data-mapbox-fallback-reason="module-load-failed"]'
       )
     ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        '[data-mapbox-fallback-error="module unavailable"]'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('retries Mapbox when the same route cache is regenerated', async () => {
+    const failingMapConstructor = jest.fn().mockImplementation(() => ({
+      on: (_event: string, callback: () => void) => callback(),
+      remove: jest.fn(),
+      resize: jest.fn(),
+      addSource: jest.fn(() => {
+        throw new Error('source unavailable')
+      }),
+      addLayer: jest.fn(),
+      getSource: jest.fn(),
+      fitBounds: jest.fn()
+    }))
+    mockLoadMapboxModule.mockResolvedValue({
+      Map: failingMapConstructor
+    })
+
+    const { container, rerender } = render(
+      <RouteHeatmapMap
+        heatmap={completedHeatmap}
+        mapboxAccessToken="mapbox-token"
+      />
+    )
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-mapbox-fallback-reason="render-failed"]')
+      ).toBeInTheDocument()
+    )
+
+    const workingMapConstructor = jest.fn().mockImplementation(() => ({
+      on: (_event: string, callback: () => void) => callback(),
+      remove: jest.fn(),
+      resize: jest.fn(),
+      addSource: jest.fn(),
+      addLayer: jest.fn(),
+      getSource: jest.fn(),
+      fitBounds: jest.fn()
+    }))
+    mockLoadMapboxModule.mockResolvedValue({
+      Map: workingMapConstructor
+    })
+
+    rerender(
+      <RouteHeatmapMap
+        heatmap={{
+          ...completedHeatmap,
+          updatedAt: completedHeatmap.updatedAt + 1
+        }}
+        mapboxAccessToken="mapbox-token"
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText('Mapbox')).toBeInTheDocument())
+    await waitFor(() => expect(workingMapConstructor).toHaveBeenCalled())
+    expect(
+      container.querySelector('[data-mapbox-fallback-reason]')
+    ).not.toBeInTheDocument()
   })
 
   it('uses the SVG route fallback for large route caches', () => {
@@ -451,10 +520,27 @@ describe('RouteHeatmapMap', () => {
     )
 
     expect(screen.getByText('Routes')).toBeInTheDocument()
+    expect(
+      screen.getByText('Interactive map unavailable. Showing routes.')
+    ).toBeInTheDocument()
     expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
-    expect(container.querySelectorAll('polyline')).toHaveLength(
-      largeHeatmap.segments.length
-    )
+    const polylines = Array.from(container.querySelectorAll('polyline'))
+    expect(polylines).toHaveLength(largeHeatmap.segments.length)
+    expect(
+      polylines.map(
+        (polyline) =>
+          polyline.getAttribute('points')?.trim().split(/\s+/).filter(Boolean)
+            .length ?? 0
+      )
+    ).toEqual(largeHeatmap.segments.map((segment) => segment.points.length))
+    expect(
+      container.querySelector(
+        '[data-mapbox-fallback-reason="route-cache-too-large"]'
+      )
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-mapbox-fallback-error]')
+    ).not.toBeInTheDocument()
     expect(mockLoadMapboxModule).not.toHaveBeenCalled()
   })
 })

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -275,10 +275,7 @@ describe('FitnessHeatmapView', () => {
     })
   })
 
-  it('clears all route caches and reloads the current selection', async () => {
-    const confirmSpy = jest
-      .spyOn(window, 'confirm')
-      .mockImplementation(() => true)
+  it('clears all route caches without immediately requeueing the current selection', async () => {
     mockClearFitnessRouteHeatmaps.mockResolvedValue(2)
     mockGetFitnessRouteHeatmap
       .mockResolvedValueOnce(completedHeatmap)
@@ -294,6 +291,8 @@ describe('FitnessHeatmapView', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Clear route caches/i }))
 
     await waitFor(() => {
       expect(mockClearFitnessRouteHeatmaps).toHaveBeenCalledWith({
@@ -301,6 +300,15 @@ describe('FitnessHeatmapView', () => {
       })
       expect(mockGetFitnessRouteHeatmap).toHaveBeenCalledTimes(2)
       expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(2)
+      expect(mockTriggerFitnessRouteHeatmap).not.toHaveBeenCalled()
+    })
+
+    const generateButton = await screen.findByRole('button', {
+      name: /Generate/i
+    })
+    fireEvent.click(generateButton)
+
+    await waitFor(() => {
       expect(mockTriggerFitnessRouteHeatmap).toHaveBeenCalledWith(
         expect.objectContaining({
           actorId: 'https://llun.test/users/llun',
@@ -309,14 +317,23 @@ describe('FitnessHeatmapView', () => {
         })
       )
     })
-
-    confirmSpy.mockRestore()
   })
 
   it('does not clear route caches when confirmation is cancelled', async () => {
-    const confirmSpy = jest
-      .spyOn(window, 'confirm')
-      .mockImplementation(() => false)
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Clear cache/i })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }))
+
+    expect(mockClearFitnessRouteHeatmaps).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error when clearing route caches fails', async () => {
+    mockClearFitnessRouteHeatmaps.mockRejectedValue(new Error('boom'))
 
     render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
 
@@ -325,9 +342,13 @@ describe('FitnessHeatmapView', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Clear route caches/i }))
 
-    expect(mockClearFitnessRouteHeatmaps).not.toHaveBeenCalled()
-    confirmSpy.mockRestore()
+    expect(await screen.findByText('boom')).toBeInTheDocument()
+    expect(mockClearFitnessRouteHeatmaps).toHaveBeenCalledWith({
+      actorId: 'https://llun.test/users/llun'
+    })
+    expect(mockTriggerFitnessRouteHeatmap).not.toHaveBeenCalled()
   })
 })
 

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -2,7 +2,14 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react'
 
 import {
   clearFitnessRouteHeatmaps,
@@ -306,6 +313,9 @@ describe('FitnessHeatmapView', () => {
         })
       )
     })
+    await waitFor(() => {
+      expect(screen.queryByText('queue unavailable')).not.toBeInTheDocument()
+    })
   })
 
   it('clears all route caches without immediately requeueing the current selection', async () => {
@@ -375,13 +385,19 @@ describe('FitnessHeatmapView', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
-    fireEvent.click(screen.getByRole('button', { name: /Clear route caches/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: /Clear route caches/i })
+    )
 
-    expect(await screen.findByText('boom')).toBeInTheDocument()
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('boom')
     expect(mockClearFitnessRouteHeatmaps).toHaveBeenCalledWith({
       actorId: 'https://llun.test/users/llun'
     })
     expect(mockTriggerFitnessRouteHeatmap).not.toHaveBeenCalled()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /Cancel/i }))
+    expect(screen.queryByText('boom')).not.toBeInTheDocument()
   })
 })
 

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import {
+  clearFitnessRouteHeatmaps,
   getDistinctFitnessActivityTypes,
   getFitnessCalendarData,
   getFitnessRouteHeatmap,
@@ -24,6 +25,7 @@ jest.mock('@/lib/utils/mapbox', () => ({
 }))
 
 jest.mock('@/lib/client', () => ({
+  clearFitnessRouteHeatmaps: jest.fn(),
   getDistinctFitnessActivityTypes: jest.fn(),
   getFitnessCalendarData: jest.fn(),
   getFitnessRouteHeatmap: jest.fn(),
@@ -34,6 +36,10 @@ jest.mock('@/lib/client', () => ({
 const mockLoadMapboxModule = loadMapboxModule as jest.MockedFunction<
   typeof loadMapboxModule
 >
+const mockClearFitnessRouteHeatmaps =
+  clearFitnessRouteHeatmaps as jest.MockedFunction<
+    typeof clearFitnessRouteHeatmaps
+  >
 const mockGetDistinctFitnessActivityTypes =
   getDistinctFitnessActivityTypes as jest.MockedFunction<
     typeof getDistinctFitnessActivityTypes
@@ -154,6 +160,7 @@ describe('FitnessHeatmapView', () => {
     mockGetFitnessCalendarData.mockResolvedValue([])
     mockGetFitnessRouteHeatmap.mockResolvedValue(completedHeatmap)
     mockGetFitnessRouteHeatmaps.mockResolvedValue([pendingSummary])
+    mockClearFitnessRouteHeatmaps.mockResolvedValue(0)
     mockTriggerFitnessRouteHeatmap.mockResolvedValue(true)
   })
 
@@ -266,6 +273,61 @@ describe('FitnessHeatmapView', () => {
         })
       )
     })
+  })
+
+  it('clears all route caches and reloads the current selection', async () => {
+    const confirmSpy = jest
+      .spyOn(window, 'confirm')
+      .mockImplementation(() => true)
+    mockClearFitnessRouteHeatmaps.mockResolvedValue(2)
+    mockGetFitnessRouteHeatmap
+      .mockResolvedValueOnce(completedHeatmap)
+      .mockResolvedValueOnce(null)
+    mockGetFitnessRouteHeatmaps
+      .mockResolvedValueOnce([pendingSummary])
+      .mockResolvedValueOnce([])
+
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Clear cache/i })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
+
+    await waitFor(() => {
+      expect(mockClearFitnessRouteHeatmaps).toHaveBeenCalledWith({
+        actorId: 'https://llun.test/users/llun'
+      })
+      expect(mockGetFitnessRouteHeatmap).toHaveBeenCalledTimes(2)
+      expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(2)
+      expect(mockTriggerFitnessRouteHeatmap).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 'https://llun.test/users/llun',
+          periodType: 'all_time',
+          periodKey: 'all'
+        })
+      )
+    })
+
+    confirmSpy.mockRestore()
+  })
+
+  it('does not clear route caches when confirmation is cancelled', async () => {
+    const confirmSpy = jest
+      .spyOn(window, 'confirm')
+      .mockImplementation(() => false)
+
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Clear cache/i })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear cache/i }))
+
+    expect(mockClearFitnessRouteHeatmaps).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
   })
 })
 

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -29,6 +29,15 @@ import {
 } from '@/lib/components/fitness/FitnessCalendarHeatmap'
 import { FitnessHeatmapList } from '@/lib/components/fitness/FitnessHeatmapList'
 import { RegionSelector } from '@/lib/components/fitness/RegionSelector'
+import { Button } from '@/lib/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/lib/components/ui/dialog'
 import { deserializeRegions, serializeRegions } from '@/lib/fitness/regions'
 import { cn } from '@/lib/utils'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
@@ -524,8 +533,10 @@ export const FitnessHeatmapView: FC<Props> = ({
   const [generationPending, setGenerationPending] = useState(false)
   const [isRetrying, setIsRetrying] = useState(false)
   const [isClearingCache, setIsClearingCache] = useState(false)
+  const [isClearCacheDialogOpen, setIsClearCacheDialogOpen] = useState(false)
   const [currentTime, setCurrentTime] = useState<number>(() => Date.now())
   const [pollingStalled, setPollingStalled] = useState(false)
+  const isClearingCacheRef = useRef(false)
   const generationKeyRef = useRef<string | null>(null)
   const selectionKeyRef = useRef<string>('')
   const fetchRequestIdRef = useRef(0)
@@ -611,81 +622,85 @@ export const FitnessHeatmapView: FC<Props> = ({
     selectionKey
   ])
 
-  const fetchData = useCallback(async () => {
-    const requestId = fetchRequestIdRef.current + 1
-    fetchRequestIdRef.current = requestId
-    const isCurrentRequest = () =>
-      fetchRequestIdRef.current === requestId &&
-      selectionKeyRef.current === selectionKey
+  const fetchData = useCallback(
+    async (options?: { queueMissing?: boolean }) => {
+      const requestId = fetchRequestIdRef.current + 1
+      fetchRequestIdRef.current = requestId
+      const queueMissing = options?.queueMissing ?? true
+      const isCurrentRequest = () =>
+        fetchRequestIdRef.current === requestId &&
+        selectionKeyRef.current === selectionKey
 
-    setIsLoading(true)
-    setError(null)
+      setIsLoading(true)
+      setError(null)
 
-    try {
-      const { startDate, endDate } = getCalendarDateRange(
-        periodType,
-        effectivePeriodKey
-      )
-      const [heatmap, calendar, allHeatmaps] = await Promise.all([
-        getFitnessRouteHeatmap({
-          actorId,
-          activityType: selectedActivityType,
+      try {
+        const { startDate, endDate } = getCalendarDateRange(
           periodType,
-          periodKey: effectivePeriodKey,
-          region: serializedRegion
-        }),
-        getFitnessCalendarData({
-          actorId,
-          startDate,
-          endDate,
-          activityType: selectedActivityType
-        }),
-        getFitnessRouteHeatmaps({ actorId })
-      ])
+          effectivePeriodKey
+        )
+        const [heatmap, calendar, allHeatmaps] = await Promise.all([
+          getFitnessRouteHeatmap({
+            actorId,
+            activityType: selectedActivityType,
+            periodType,
+            periodKey: effectivePeriodKey,
+            region: serializedRegion
+          }),
+          getFitnessCalendarData({
+            actorId,
+            startDate,
+            endDate,
+            activityType: selectedActivityType
+          }),
+          getFitnessRouteHeatmaps({ actorId })
+        ])
 
-      if (!isCurrentRequest()) return
+        if (!isCurrentRequest()) return
 
-      setHeatmapData(heatmap)
-      setCalendarDays(calendar)
-      setHeatmaps(allHeatmaps)
+        setHeatmapData(heatmap)
+        setCalendarDays(calendar)
+        setHeatmaps(allHeatmaps)
 
-      if (heatmap === null) {
-        if (generationKeyRef.current !== selectionKey) {
-          if (!isCurrentRequest()) return
-          generationKeyRef.current = selectionKey
-          try {
-            const queued = await queueCurrentRouteHeatmap()
-            if (!queued && generationKeyRef.current === selectionKey) {
-              generationKeyRef.current = null
-            }
-          } catch (err) {
+        if (heatmap === null && queueMissing) {
+          if (generationKeyRef.current !== selectionKey) {
             if (!isCurrentRequest()) return
-            generationKeyRef.current = null
-            throw err
+            generationKeyRef.current = selectionKey
+            try {
+              const queued = await queueCurrentRouteHeatmap()
+              if (!queued && generationKeyRef.current === selectionKey) {
+                generationKeyRef.current = null
+              }
+            } catch (err) {
+              if (!isCurrentRequest()) return
+              generationKeyRef.current = null
+              throw err
+            }
           }
         }
+      } catch (err) {
+        if (!isCurrentRequest()) return
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to load route heatmap data.'
+        )
+      } finally {
+        if (isCurrentRequest()) {
+          setIsLoading(false)
+        }
       }
-    } catch (err) {
-      if (!isCurrentRequest()) return
-      setError(
-        err instanceof Error
-          ? err.message
-          : 'Failed to load route heatmap data.'
-      )
-    } finally {
-      if (isCurrentRequest()) {
-        setIsLoading(false)
-      }
-    }
-  }, [
-    actorId,
-    selectedActivityType,
-    periodType,
-    effectivePeriodKey,
-    serializedRegion,
-    selectionKey,
-    queueCurrentRouteHeatmap
-  ])
+    },
+    [
+      actorId,
+      selectedActivityType,
+      periodType,
+      effectivePeriodKey,
+      serializedRegion,
+      selectionKey,
+      queueCurrentRouteHeatmap
+    ]
+  )
 
   useEffect(() => {
     fetchData()
@@ -893,15 +908,9 @@ export const FitnessHeatmapView: FC<Props> = ({
   }
 
   const clearRouteCache = useCallback(async () => {
-    if (isClearingCache) return
-    if (
-      !window.confirm(
-        'Clear all route heatmap cache for this account? This includes queued, generating, and failed route caches.'
-      )
-    ) {
-      return
-    }
+    if (isClearingCacheRef.current) return
 
+    isClearingCacheRef.current = true
     setIsClearingCache(true)
     setError(null)
     try {
@@ -912,7 +921,8 @@ export const FitnessHeatmapView: FC<Props> = ({
       setHeatmaps([])
       setGenerationPending(false)
       setPollingStalled(false)
-      await fetchData()
+      await fetchData({ queueMissing: false })
+      setIsClearCacheDialogOpen(false)
     } catch (err) {
       setError(
         err instanceof Error
@@ -920,15 +930,18 @@ export const FitnessHeatmapView: FC<Props> = ({
           : 'Failed to clear route heatmap cache.'
       )
     } finally {
+      isClearingCacheRef.current = false
       setIsClearingCache(false)
     }
-  }, [actorId, fetchData, isClearingCache])
+  }, [actorId, fetchData])
 
   const routeCount = heatmapData?.segments.length ?? 0
   const hasCompletedRoutes =
     heatmapData?.status === 'completed' && heatmapData.pointCount > 0
   const hasRouteCache =
     Boolean(heatmapData) || heatmaps.length > 0 || generationPending
+  const canRefreshRouteCache =
+    !isLoading && (Boolean(heatmapData) || !hasRouteCache)
 
   return (
     <div className="flex min-h-[720px] flex-col bg-background">
@@ -1152,7 +1165,7 @@ export const FitnessHeatmapView: FC<Props> = ({
                 <div className="flex items-center gap-1.5">
                   {hasRouteCache && (
                     <button
-                      onClick={clearRouteCache}
+                      onClick={() => setIsClearCacheDialogOpen(true)}
                       disabled={isClearingCache || isRetrying}
                       className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
                     >
@@ -1165,7 +1178,7 @@ export const FitnessHeatmapView: FC<Props> = ({
                       Clear cache
                     </button>
                   )}
-                  {heatmapData && (
+                  {canRefreshRouteCache && (
                     <button
                       onClick={retryCurrent}
                       disabled={isRetrying || isClearingCache}
@@ -1174,7 +1187,7 @@ export const FitnessHeatmapView: FC<Props> = ({
                       <RefreshCw
                         className={cn('size-3', isRetrying && 'animate-spin')}
                       />
-                      Refresh
+                      {heatmapData ? 'Refresh' : 'Generate'}
                     </button>
                   )}
                 </div>
@@ -1189,6 +1202,47 @@ export const FitnessHeatmapView: FC<Props> = ({
           </div>
         </aside>
       </div>
+      <Dialog
+        open={isClearCacheDialogOpen}
+        onOpenChange={(open) => {
+          if (isClearingCache) return
+          setIsClearCacheDialogOpen(open)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Clear route cache</DialogTitle>
+            <DialogDescription>
+              Clear all route heatmap cache for this account, including queued,
+              generating, and failed route caches. This does not immediately
+              start a new route cache job.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsClearCacheDialogOpen(false)}
+              disabled={isClearingCache}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={clearRouteCache}
+              disabled={isClearingCache}
+            >
+              {isClearingCache ? (
+                <Trash2 className="animate-pulse" />
+              ) : (
+                <Trash2 />
+              )}
+              Clear route caches
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -534,6 +534,7 @@ export const FitnessHeatmapView: FC<Props> = ({
   const [isRetrying, setIsRetrying] = useState(false)
   const [isClearingCache, setIsClearingCache] = useState(false)
   const [isClearCacheDialogOpen, setIsClearCacheDialogOpen] = useState(false)
+  const [clearCacheError, setClearCacheError] = useState<string | null>(null)
   const [currentTime, setCurrentTime] = useState<number>(() => Date.now())
   const [pollingStalled, setPollingStalled] = useState(false)
   const isClearingCacheRef = useRef(false)
@@ -907,12 +908,19 @@ export const FitnessHeatmapView: FC<Props> = ({
     }
   }
 
+  const setClearCacheDialogOpen = useCallback((open: boolean) => {
+    if (isClearingCacheRef.current) return
+
+    setClearCacheError(null)
+    setIsClearCacheDialogOpen(open)
+  }, [])
+
   const clearRouteCache = useCallback(async () => {
     if (isClearingCacheRef.current) return
 
     isClearingCacheRef.current = true
     setIsClearingCache(true)
-    setError(null)
+    setClearCacheError(null)
     try {
       await clearFitnessRouteHeatmaps({ actorId })
       generationKeyRef.current = null
@@ -922,9 +930,10 @@ export const FitnessHeatmapView: FC<Props> = ({
       setGenerationPending(false)
       setPollingStalled(false)
       await fetchData({ queueMissing: false })
+      setClearCacheError(null)
       setIsClearCacheDialogOpen(false)
     } catch (err) {
-      setError(
+      setClearCacheError(
         err instanceof Error
           ? err.message
           : 'Failed to clear route heatmap cache.'
@@ -1165,10 +1174,7 @@ export const FitnessHeatmapView: FC<Props> = ({
                 <div className="flex items-center gap-1.5">
                   {hasRouteCache && (
                     <button
-                      onClick={() => {
-                        setError(null)
-                        setIsClearCacheDialogOpen(true)
-                      }}
+                      onClick={() => setClearCacheDialogOpen(true)}
                       disabled={isClearingCache || isRetrying}
                       className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
                     >
@@ -1207,11 +1213,7 @@ export const FitnessHeatmapView: FC<Props> = ({
       </div>
       <Dialog
         open={isClearCacheDialogOpen}
-        onOpenChange={(open) => {
-          if (isClearingCache) return
-          setError(null)
-          setIsClearCacheDialogOpen(open)
-        }}
+        onOpenChange={setClearCacheDialogOpen}
       >
         <DialogContent>
           <DialogHeader>
@@ -1222,22 +1224,19 @@ export const FitnessHeatmapView: FC<Props> = ({
               start a new route cache job.
             </DialogDescription>
           </DialogHeader>
-          {error ? (
+          {clearCacheError ? (
             <p
               role="alert"
               className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
             >
-              {error}
+              {clearCacheError}
             </p>
           ) : null}
           <DialogFooter>
             <Button
               type="button"
               variant="outline"
-              onClick={() => {
-                setError(null)
-                setIsClearCacheDialogOpen(false)
-              }}
+              onClick={() => setClearCacheDialogOpen(false)}
               disabled={isClearingCache}
             >
               Cancel

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -61,7 +61,15 @@ type MapboxGL = {
   Map: new (options: Record<string, unknown>) => MapboxMap
 }
 
-type MapboxFallbackReason = 'module-load-failed' | 'render-failed'
+type MapboxFallbackReason =
+  | 'module-load-failed'
+  | 'render-failed'
+  | 'route-cache-too-large'
+
+interface MapboxFallbackError {
+  message: string
+  stack?: string
+}
 
 const MAP_WIDTH = 960
 const MAP_HEIGHT = 560
@@ -71,7 +79,8 @@ const ROUTE_HEATMAP_POLLING_INTERVAL_MS = 5000
 const STALLED_POLLING_LIMIT = 30
 // Keep recent background jobs live while ignoring restored/stuck rows that are days old.
 const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
-// Mapbox GL can render smaller route sets interactively; large caches use SVG to avoid blank canvases.
+// Conservative cap: staging reproduced blank Mapbox canvases around 80k route points.
+// Keep a 4x safety margin until this path has browser/device benchmarks.
 const MAPBOX_MAX_ROUTE_POINTS = 20_000
 const ROUTE_HEATMAP_MAP_HEIGHT_CLASS = 'h-[420px]'
 
@@ -121,6 +130,19 @@ const MAPBOX_ROUTE_LINE_PAINT = {
 
 const getRouteLineStyle = (isHiddenByPrivacy: boolean) =>
   isHiddenByPrivacy ? ROUTE_LINE_STYLES.hidden : ROUTE_LINE_STYLES.visible
+
+const getMapboxFallbackError = (error: unknown): MapboxFallbackError => {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack
+    }
+  }
+
+  return {
+    message: String(error)
+  }
+}
 
 const formatActivityType = (type?: string): string =>
   type
@@ -267,8 +289,12 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const mapRef = useRef<MapboxMap | null>(null)
   const routeGeoJsonRef = useRef(buildRouteGeoJson([]))
-  const [mapboxFallbackReason, setMapboxFallbackReason] =
-    useState<MapboxFallbackReason | null>(null)
+  const [runtimeMapboxFallbackReason, setRuntimeMapboxFallbackReason] =
+    useState<Exclude<MapboxFallbackReason, 'route-cache-too-large'> | null>(
+      null
+    )
+  const [mapboxFallbackError, setMapboxFallbackError] =
+    useState<MapboxFallbackError | null>(null)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
 
   const hasRoutes =
@@ -277,13 +303,22 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   const bounds = heatmap?.bounds
   const isWithinMapboxBudget =
     heatmap !== null && heatmap.pointCount <= MAPBOX_MAX_ROUTE_POINTS
-  const shouldUseMapbox = Boolean(
-    mapboxAccessToken &&
+  const budgetMapboxFallbackReason: MapboxFallbackReason | null =
+    mapboxAccessToken && hasRoutes && !isWithinMapboxBudget
+      ? 'route-cache-too-large'
+      : null
+  const mapboxFallbackReason =
+    runtimeMapboxFallbackReason ?? budgetMapboxFallbackReason
+  const mapboxFallbackErrorMessage =
+    process.env.NODE_ENV !== 'production'
+      ? mapboxFallbackError?.message
+      : undefined
+  const shouldUseMapbox =
+    Boolean(mapboxAccessToken) &&
     hasRoutes &&
-    bounds &&
+    Boolean(bounds) &&
     isWithinMapboxBudget &&
-    !mapboxFallbackReason
-  )
+    !runtimeMapboxFallbackReason
   const routeGeoJson = useMemo(
     () => buildRouteGeoJson(hasRoutes && heatmap ? heatmap.segments : []),
     [hasRoutes, heatmap?.id, heatmap?.updatedAt]
@@ -294,8 +329,9 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   }, [routeGeoJson])
 
   useEffect(() => {
-    setMapboxFallbackReason(null)
-  }, [heatmap?.id, mapboxAccessToken])
+    setRuntimeMapboxFallbackReason(null)
+    setMapboxFallbackError(null)
+  }, [heatmap?.id, heatmap?.updatedAt, mapboxAccessToken])
 
   useEffect(() => {
     if (!shouldUseMapbox || !containerRef.current || !bounds) {
@@ -343,16 +379,18 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
             })
             map.fitBounds(mapBounds, { padding: 56, duration: 0 })
             setIsMapLoaded(true)
-          } catch {
+          } catch (error) {
             if (!cancelled) {
-              setMapboxFallbackReason('render-failed')
+              setMapboxFallbackError(getMapboxFallbackError(error))
+              setRuntimeMapboxFallbackReason('render-failed')
             }
           }
         })
       })
-      .catch(() => {
+      .catch((error) => {
         if (!cancelled) {
-          setMapboxFallbackReason('module-load-failed')
+          setMapboxFallbackError(getMapboxFallbackError(error))
+          setRuntimeMapboxFallbackReason('module-load-failed')
         }
       })
 
@@ -430,6 +468,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
         ROUTE_HEATMAP_MAP_HEIGHT_CLASS
       )}
       data-mapbox-fallback-reason={mapboxFallbackReason ?? undefined}
+      data-mapbox-fallback-error={mapboxFallbackErrorMessage}
     >
       <svg
         viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -56,9 +56,10 @@ type MapboxMap = {
 }
 
 type MapboxGL = {
-  accessToken?: string
   Map: new (options: Record<string, unknown>) => MapboxMap
 }
+
+type MapboxFallbackReason = 'module-load-failed' | 'render-failed'
 
 const MAP_WIDTH = 960
 const MAP_HEIGHT = 560
@@ -66,8 +67,9 @@ const MAP_PADDING = 52
 const currentYear = new Date().getUTCFullYear()
 const ROUTE_HEATMAP_POLLING_INTERVAL_MS = 5000
 const STALLED_POLLING_LIMIT = 30
-const STALE_IN_FLIGHT_HEATMAP_MS =
-  STALLED_POLLING_LIMIT * ROUTE_HEATMAP_POLLING_INTERVAL_MS
+// Keep recent background jobs live while ignoring restored/stuck rows that are days old.
+const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
+// Mapbox GL can render smaller route sets interactively; large caches use SVG to avoid blank canvases.
 const MAPBOX_MAX_ROUTE_POINTS = 20_000
 
 const METRIC_LABELS: Record<CalendarMetric, string> = {
@@ -262,7 +264,8 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const mapRef = useRef<MapboxMap | null>(null)
   const routeGeoJsonRef = useRef(buildRouteGeoJson([]))
-  const [mapboxFailed, setMapboxFailed] = useState(false)
+  const [mapboxFallbackReason, setMapboxFallbackReason] =
+    useState<MapboxFallbackReason | null>(null)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
 
   const hasRoutes =
@@ -270,13 +273,13 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     heatmap.segments.some((segment) => segment.points.length >= 2)
   const bounds = heatmap?.bounds
   const isWithinMapboxBudget =
-    heatmap === null || heatmap.pointCount <= MAPBOX_MAX_ROUTE_POINTS
+    heatmap !== null && heatmap.pointCount <= MAPBOX_MAX_ROUTE_POINTS
   const shouldUseMapbox = Boolean(
     mapboxAccessToken &&
     hasRoutes &&
     bounds &&
     isWithinMapboxBudget &&
-    !mapboxFailed
+    !mapboxFallbackReason
   )
   const routeGeoJson = useMemo(
     () => buildRouteGeoJson(hasRoutes && heatmap ? heatmap.segments : []),
@@ -288,7 +291,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   }, [routeGeoJson])
 
   useEffect(() => {
-    setMapboxFailed(false)
+    setMapboxFallbackReason(null)
   }, [heatmap?.id, mapboxAccessToken])
 
   useEffect(() => {
@@ -307,7 +310,6 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
       .then((mapboxgl) => {
         if (cancelled || !containerRef.current) return
 
-        mapboxgl.accessToken = mapboxAccessToken
         const map = new mapboxgl.Map({
           container: containerRef.current,
           style: 'mapbox://styles/mapbox/outdoors-v12',
@@ -317,7 +319,6 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
           fitBoundsOptions: { padding: 56 }
         })
         mapRef.current = map
-        map.resize()
 
         map.on('load', () => {
           if (!map || cancelled) return
@@ -341,14 +342,14 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
             setIsMapLoaded(true)
           } catch {
             if (!cancelled) {
-              setMapboxFailed(true)
+              setMapboxFallbackReason('render-failed')
             }
           }
         })
       })
       .catch(() => {
         if (!cancelled) {
-          setMapboxFailed(true)
+          setMapboxFallbackReason('module-load-failed')
         }
       })
 
@@ -405,10 +406,13 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   }
 
   return (
-    <div className="relative min-h-[420px] overflow-hidden bg-slate-100 dark:bg-slate-950">
+    <div
+      className="relative h-[420px] overflow-hidden bg-slate-100 dark:bg-slate-950"
+      data-mapbox-fallback-reason={mapboxFallbackReason ?? undefined}
+    >
       <svg
         viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
-        className="h-full min-h-[420px] w-full"
+        className="h-full w-full"
         role="img"
         aria-label="Fitness route heatmap"
         preserveAspectRatio="xMidYMid slice"
@@ -432,6 +436,9 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
       <div className="absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
         Routes
       </div>
+      {mapboxFallbackReason ? (
+        <p className="sr-only">Interactive map unavailable. Showing routes.</p>
+      ) : null}
     </div>
   )
 }

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -56,6 +56,7 @@ type MapboxMap = {
 }
 
 type MapboxGL = {
+  accessToken?: string
   Map: new (options: Record<string, unknown>) => MapboxMap
 }
 
@@ -63,7 +64,11 @@ const MAP_WIDTH = 960
 const MAP_HEIGHT = 560
 const MAP_PADDING = 52
 const currentYear = new Date().getUTCFullYear()
+const ROUTE_HEATMAP_POLLING_INTERVAL_MS = 5000
 const STALLED_POLLING_LIMIT = 30
+const STALE_IN_FLIGHT_HEATMAP_MS =
+  STALLED_POLLING_LIMIT * ROUTE_HEATMAP_POLLING_INTERVAL_MS
+const MAPBOX_MAX_ROUTE_POINTS = 20_000
 
 const METRIC_LABELS: Record<CalendarMetric, string> = {
   count: 'Count',
@@ -124,6 +129,13 @@ const isRouteHeatmapInFlight = (
     | null
     | undefined
 ): boolean => heatmap?.status === 'generating' || heatmap?.status === 'pending'
+
+const shouldPollRouteHeatmapSummary = (
+  heatmap: Pick<FitnessRouteHeatmapSummaryData, 'status' | 'updatedAt'>,
+  currentTime: number
+): boolean =>
+  isRouteHeatmapInFlight(heatmap) &&
+  currentTime - heatmap.updatedAt <= STALE_IN_FLIGHT_HEATMAP_MS
 
 const getCalendarDateRange = (
   periodType: PeriodType,
@@ -257,8 +269,14 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     heatmap?.status === 'completed' &&
     heatmap.segments.some((segment) => segment.points.length >= 2)
   const bounds = heatmap?.bounds
+  const isWithinMapboxBudget =
+    heatmap === null || heatmap.pointCount <= MAPBOX_MAX_ROUTE_POINTS
   const shouldUseMapbox = Boolean(
-    mapboxAccessToken && hasRoutes && bounds && !mapboxFailed
+    mapboxAccessToken &&
+    hasRoutes &&
+    bounds &&
+    isWithinMapboxBudget &&
+    !mapboxFailed
   )
   const routeGeoJson = useMemo(
     () => buildRouteGeoJson(hasRoutes && heatmap ? heatmap.segments : []),
@@ -289,6 +307,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
       .then((mapboxgl) => {
         if (cancelled || !containerRef.current) return
 
+        mapboxgl.accessToken = mapboxAccessToken
         const map = new mapboxgl.Map({
           container: containerRef.current,
           style: 'mapbox://styles/mapbox/outdoors-v12',
@@ -298,25 +317,33 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
           fitBoundsOptions: { padding: 56 }
         })
         mapRef.current = map
+        map.resize()
 
         map.on('load', () => {
           if (!map || cancelled) return
-          map.addSource('route-heatmap', {
-            type: 'geojson',
-            data: routeGeoJsonRef.current
-          })
-          map.addLayer({
-            id: 'route-heatmap-lines',
-            type: 'line',
-            source: 'route-heatmap',
-            layout: {
-              'line-cap': 'round',
-              'line-join': 'round'
-            },
-            paint: MAPBOX_ROUTE_LINE_PAINT
-          })
-          map.fitBounds(mapBounds, { padding: 56, duration: 0 })
-          setIsMapLoaded(true)
+          try {
+            map.resize()
+            map.addSource('route-heatmap', {
+              type: 'geojson',
+              data: routeGeoJsonRef.current
+            })
+            map.addLayer({
+              id: 'route-heatmap-lines',
+              type: 'line',
+              source: 'route-heatmap',
+              layout: {
+                'line-cap': 'round',
+                'line-join': 'round'
+              },
+              paint: MAPBOX_ROUTE_LINE_PAINT
+            })
+            map.fitBounds(mapBounds, { padding: 56, duration: 0 })
+            setIsMapLoaded(true)
+          } catch {
+            if (!cancelled) {
+              setMapboxFailed(true)
+            }
+          }
         })
       })
       .catch(() => {
@@ -360,7 +387,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
   if (shouldUseMapbox) {
     return (
-      <div className="relative min-h-[420px] overflow-hidden bg-muted">
+      <div className="relative h-[420px] overflow-hidden bg-muted">
         <div ref={containerRef} className="absolute inset-0" />
         <div className="absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
           Mapbox
@@ -597,8 +624,11 @@ export const FitnessHeatmapView: FC<Props> = ({
   }, [fetchData])
 
   const hasAnyListInFlight = useMemo(
-    () => heatmaps.some(isRouteHeatmapInFlight),
-    [heatmaps]
+    () =>
+      heatmaps.some((heatmap) =>
+        shouldPollRouteHeatmapSummary(heatmap, currentTime)
+      ),
+    [currentTime, heatmaps]
   )
   const isFocusedHeatmapInFlight =
     generationPending || isRouteHeatmapInFlight(heatmapData)
@@ -679,7 +709,7 @@ export const FitnessHeatmapView: FC<Props> = ({
           }
         })
         .catch(() => {})
-    }, 5000)
+    }, ROUTE_HEATMAP_POLLING_INTERVAL_MS)
 
     return () => clearInterval(id)
   }, [

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -941,7 +941,7 @@ export const FitnessHeatmapView: FC<Props> = ({
   const hasRouteCache =
     Boolean(heatmapData) || heatmaps.length > 0 || generationPending
   const canRefreshRouteCache =
-    !isLoading && (Boolean(heatmapData) || !hasRouteCache)
+    !isLoading && !generationPending && !isRouteHeatmapInFlight(heatmapData)
 
   return (
     <div className="flex min-h-[720px] flex-col bg-background">

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -1165,7 +1165,10 @@ export const FitnessHeatmapView: FC<Props> = ({
                 <div className="flex items-center gap-1.5">
                   {hasRouteCache && (
                     <button
-                      onClick={() => setIsClearCacheDialogOpen(true)}
+                      onClick={() => {
+                        setError(null)
+                        setIsClearCacheDialogOpen(true)
+                      }}
                       disabled={isClearingCache || isRetrying}
                       className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
                     >
@@ -1206,6 +1209,7 @@ export const FitnessHeatmapView: FC<Props> = ({
         open={isClearCacheDialogOpen}
         onOpenChange={(open) => {
           if (isClearingCache) return
+          setError(null)
           setIsClearCacheDialogOpen(open)
         }}
       >
@@ -1218,11 +1222,22 @@ export const FitnessHeatmapView: FC<Props> = ({
               start a new route cache job.
             </DialogDescription>
           </DialogHeader>
+          {error ? (
+            <p
+              role="alert"
+              className="rounded border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {error}
+            </p>
+          ) : null}
           <DialogFooter>
             <Button
               type="button"
               variant="outline"
-              onClick={() => setIsClearCacheDialogOpen(false)}
+              onClick={() => {
+                setError(null)
+                setIsClearCacheDialogOpen(false)
+              }}
               disabled={isClearingCache}
             >
               Cancel
@@ -1232,13 +1247,12 @@ export const FitnessHeatmapView: FC<Props> = ({
               variant="destructive"
               onClick={clearRouteCache}
               disabled={isClearingCache}
+              aria-busy={isClearingCache}
             >
-              {isClearingCache ? (
-                <Trash2 className="animate-pulse" />
-              ) : (
-                <Trash2 />
-              )}
-              Clear route caches
+              <Trash2
+                className={isClearingCache ? 'animate-pulse' : undefined}
+              />
+              {isClearingCache ? 'Clearing...' : 'Clear route caches'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -6,7 +6,8 @@ import {
   Loader2,
   Map,
   RefreshCw,
-  Route
+  Route,
+  Trash2
 } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -15,6 +16,7 @@ import {
   FitnessRouteHeatmapData,
   FitnessRouteHeatmapSegment,
   FitnessRouteHeatmapSummaryData,
+  clearFitnessRouteHeatmaps,
   getDistinctFitnessActivityTypes,
   getFitnessCalendarData,
   getFitnessRouteHeatmap,
@@ -482,6 +484,7 @@ export const FitnessHeatmapView: FC<Props> = ({
   const [error, setError] = useState<string | null>(null)
   const [generationPending, setGenerationPending] = useState(false)
   const [isRetrying, setIsRetrying] = useState(false)
+  const [isClearingCache, setIsClearingCache] = useState(false)
   const [currentTime, setCurrentTime] = useState<number>(() => Date.now())
   const [pollingStalled, setPollingStalled] = useState(false)
   const generationKeyRef = useRef<string | null>(null)
@@ -850,9 +853,43 @@ export const FitnessHeatmapView: FC<Props> = ({
     }
   }
 
+  const clearRouteCache = useCallback(async () => {
+    if (isClearingCache) return
+    if (
+      !window.confirm(
+        'Clear all route heatmap cache for this account? This includes queued, generating, and failed route caches.'
+      )
+    ) {
+      return
+    }
+
+    setIsClearingCache(true)
+    setError(null)
+    try {
+      await clearFitnessRouteHeatmaps({ actorId })
+      generationKeyRef.current = null
+      pollingProgressRef.current = null
+      setHeatmapData(null)
+      setHeatmaps([])
+      setGenerationPending(false)
+      setPollingStalled(false)
+      await fetchData()
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to clear route heatmap cache.'
+      )
+    } finally {
+      setIsClearingCache(false)
+    }
+  }, [actorId, fetchData, isClearingCache])
+
   const routeCount = heatmapData?.segments.length ?? 0
   const hasCompletedRoutes =
     heatmapData?.status === 'completed' && heatmapData.pointCount > 0
+  const hasRouteCache =
+    Boolean(heatmapData) || heatmaps.length > 0 || generationPending
 
   return (
     <div className="flex min-h-[720px] flex-col bg-background">
@@ -1073,18 +1110,35 @@ export const FitnessHeatmapView: FC<Props> = ({
                   <Route className="size-4" />
                   Route Cache
                 </h2>
-                {heatmapData && (
-                  <button
-                    onClick={retryCurrent}
-                    disabled={isRetrying}
-                    className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-                  >
-                    <RefreshCw
-                      className={cn('size-3', isRetrying && 'animate-spin')}
-                    />
-                    Refresh
-                  </button>
-                )}
+                <div className="flex items-center gap-1.5">
+                  {hasRouteCache && (
+                    <button
+                      onClick={clearRouteCache}
+                      disabled={isClearingCache || isRetrying}
+                      className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      <Trash2
+                        className={cn(
+                          'size-3',
+                          isClearingCache && 'animate-pulse'
+                        )}
+                      />
+                      Clear cache
+                    </button>
+                  )}
+                  {heatmapData && (
+                    <button
+                      onClick={retryCurrent}
+                      disabled={isRetrying || isClearingCache}
+                      className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      <RefreshCw
+                        className={cn('size-3', isRetrying && 'animate-spin')}
+                      />
+                      Refresh
+                    </button>
+                  )}
+                </div>
               </div>
               <FitnessHeatmapList
                 heatmaps={heatmaps}

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -71,6 +71,7 @@ const STALLED_POLLING_LIMIT = 30
 const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
 // Mapbox GL can render smaller route sets interactively; large caches use SVG to avoid blank canvases.
 const MAPBOX_MAX_ROUTE_POINTS = 20_000
+const ROUTE_HEATMAP_MAP_HEIGHT_CLASS = 'h-[420px]'
 
 const METRIC_LABELS: Record<CalendarMetric, string> = {
   count: 'Count',
@@ -380,7 +381,12 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
   if (!hasRoutes || !heatmap) {
     return (
-      <div className="flex min-h-[420px] items-center justify-center bg-muted/40 text-sm text-muted-foreground">
+      <div
+        className={cn(
+          'flex items-center justify-center bg-muted/40 text-sm text-muted-foreground',
+          ROUTE_HEATMAP_MAP_HEIGHT_CLASS
+        )}
+      >
         No route data for this selection
       </div>
     )
@@ -388,7 +394,12 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
   if (shouldUseMapbox) {
     return (
-      <div className="relative h-[420px] overflow-hidden bg-muted">
+      <div
+        className={cn(
+          'relative overflow-hidden bg-muted',
+          ROUTE_HEATMAP_MAP_HEIGHT_CLASS
+        )}
+      >
         <div ref={containerRef} className="absolute inset-0" />
         <div className="absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
           Mapbox
@@ -399,7 +410,12 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
   if (!svgMap) {
     return (
-      <div className="flex min-h-[420px] items-center justify-center bg-muted/40 text-sm text-muted-foreground">
+      <div
+        className={cn(
+          'flex items-center justify-center bg-muted/40 text-sm text-muted-foreground',
+          ROUTE_HEATMAP_MAP_HEIGHT_CLASS
+        )}
+      >
         No route data for this selection
       </div>
     )
@@ -407,7 +423,10 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
   return (
     <div
-      className="relative h-[420px] overflow-hidden bg-slate-100 dark:bg-slate-950"
+      className={cn(
+        'relative overflow-hidden bg-slate-100 dark:bg-slate-950',
+        ROUTE_HEATMAP_MAP_HEIGHT_CLASS
+      )}
       data-mapbox-fallback-reason={mapboxFallbackReason ?? undefined}
     >
       <svg

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap/route.test.ts
@@ -229,6 +229,66 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
     )
   })
 
+  it('versions the job id when restoring a cleared route heatmap cache', async () => {
+    const deletedAt = Date.now() - 1000
+    mockDb.getFitnessRouteHeatmapByKey.mockResolvedValue({
+      id: 'route-heatmap-deleted',
+      actorId: ACTOR1_ID,
+      activityType: 'running',
+      periodType: 'monthly',
+      periodKey: '2026-04',
+      region: 'netherlands',
+      status: 'completed',
+      segments: [],
+      activityCount: 8,
+      pointCount: 200,
+      cursorOffset: 0,
+      isPartial: false,
+      createdAt: deletedAt - 1000,
+      updatedAt: deletedAt,
+      deletedAt
+    })
+
+    const request = new NextRequest(baseUrl, {
+      method: 'POST',
+      body: JSON.stringify({
+        activity_type: 'running',
+        period_type: 'monthly',
+        period_key: '2026-04',
+        region: 'netherlands'
+      })
+    })
+    const response = await POST(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockDb.getFitnessRouteHeatmapByKey).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID,
+      activityType: 'running',
+      periodType: 'monthly',
+      periodKey: '2026-04',
+      region: 'netherlands',
+      includeDeleted: true
+    })
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: getHashFromString(
+          `${ACTOR1_ID}:route-heatmap:running:monthly:2026-04:netherlands:restore:route-heatmap-deleted:${deletedAt}`
+        ),
+        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+        data: expect.objectContaining({
+          actorId: ACTOR1_ID,
+          activityType: 'running',
+          periodType: 'monthly',
+          periodKey: '2026-04',
+          region: 'netherlands',
+          requestedAt: expect.any(Number)
+        })
+      })
+    )
+  })
+
   it('uses a unique retry job id for existing non-resumable caches', async () => {
     const retryNonce = '00000000-0000-4000-8000-000000000000'
     const randomUUIDSpy = jest

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap/route.test.ts
@@ -217,13 +217,14 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: ACTOR1_ID,
           activityType: 'running',
           periodType: 'monthly',
           periodKey: '2026-04',
-          region: 'netherlands,singapore'
-        }
+          region: 'netherlands,singapore',
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })
@@ -274,13 +275,14 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
             `${ACTOR1_ID}:route-heatmap:running:monthly:2026-04:netherlands:retry:route-heatmap-failed-zero:${retryNonce}`
           ),
           name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-          data: {
+          data: expect.objectContaining({
             actorId: ACTOR1_ID,
             activityType: 'running',
             periodType: 'monthly',
             periodKey: '2026-04',
-            region: 'netherlands'
-          }
+            region: 'netherlands',
+            requestedAt: expect.any(Number)
+          })
         })
       )
     } finally {
@@ -330,13 +332,14 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
             `${ACTOR1_ID}:route-heatmap:running:monthly:2026-04:netherlands`
           ),
           name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-          data: {
+          data: expect.objectContaining({
             actorId: ACTOR1_ID,
             activityType: 'running',
             periodType: 'monthly',
             periodKey: '2026-04',
-            region: 'netherlands'
-          }
+            region: 'netherlands',
+            requestedAt: expect.any(Number)
+          })
         })
       )
     } finally {
@@ -384,15 +387,16 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
           `${ACTOR1_ID}:route-heatmap:running:monthly:2026-04:netherlands:resume:route-heatmap-failed:500`
         ),
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: ACTOR1_ID,
           activityType: 'running',
           periodType: 'monthly',
           periodKey: '2026-04',
           region: 'netherlands',
           resume: true,
-          cursorOffset: 500
-        }
+          cursorOffset: 500,
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })
@@ -436,15 +440,16 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
           `${ACTOR1_ID}:route-heatmap:running:monthly:2026-04:netherlands:resume:route-heatmap-partial:1000000`
         ),
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: ACTOR1_ID,
           activityType: 'running',
           periodType: 'monthly',
           periodKey: '2026-04',
           region: 'netherlands',
           resume: true,
-          cursorOffset: 1_000_000
-        }
+          cursorOffset: 1_000_000,
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })
@@ -466,13 +471,14 @@ describe('/api/v1/accounts/[id]/fitness-route-heatmap', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: ACTOR1_ID,
           activityType: null,
           periodType: 'monthly',
           periodKey: '2026-04',
-          region: ''
-        }
+          region: '',
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap/route.ts
@@ -278,6 +278,7 @@ export const POST = traceApiRoute(
       existing !== null &&
       !shouldResume &&
       (existing.status === 'failed' || existing.status === 'generating')
+    const requestedAt = Date.now()
     const baseJobId =
       id +
       ':route-heatmap:' +
@@ -306,6 +307,7 @@ export const POST = traceApiRoute(
           periodType,
           periodKey,
           region,
+          requestedAt,
           ...(shouldResume
             ? { resume: true, cursorOffset: existing.cursorOffset }
             : {})

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap/route.ts
@@ -181,6 +181,7 @@ export const GET = traceApiRoute(
 export const POST = traceApiRoute(
   'triggerFitnessRouteHeatmap',
   async (req: NextRequest, params: AppRouterParams<Params>) => {
+    const requestedAt = Date.now()
     const database = getDatabase()
     if (!database) {
       return apiResponse({
@@ -278,7 +279,6 @@ export const POST = traceApiRoute(
       existing !== null &&
       !shouldResume &&
       (existing.status === 'failed' || existing.status === 'generating')
-    const requestedAt = Date.now()
     const baseJobId =
       id +
       ':route-heatmap:' +

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap/route.ts
@@ -267,16 +267,19 @@ export const POST = traceApiRoute(
       activityType: activityType ?? null,
       periodType,
       periodKey,
-      region
+      region,
+      includeDeleted: true
     })
     const shouldResume =
       existing !== null &&
+      !existing.deletedAt &&
       existing.cursorOffset > 0 &&
       (existing.status === 'failed' ||
         (existing.status === 'completed' && existing.isPartial))
     const shouldUseRetryId =
       retry === true &&
       existing !== null &&
+      !existing.deletedAt &&
       !shouldResume &&
       (existing.status === 'failed' || existing.status === 'generating')
     const baseJobId =
@@ -294,7 +297,9 @@ export const POST = traceApiRoute(
         ? `${baseJobId}:resume:${existing.id}:${existing.cursorOffset}`
         : shouldUseRetryId
           ? `${baseJobId}:retry:${existing.id}:${crypto.randomUUID()}`
-          : baseJobId
+          : existing?.deletedAt
+            ? `${baseJobId}:restore:${existing.id}:${existing.deletedAt}`
+            : baseJobId
     )
 
     try {

--- a/app/api/v1/accounts/[id]/fitness-route-heatmaps/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmaps/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server'
 import { Database } from '@/lib/database/types'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 
-import { GET } from './route'
+import { DELETE, GET } from './route'
 
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
@@ -15,7 +15,11 @@ jest.mock('@/lib/utils/getActorFromSession', () => ({
   getActorFromSession: (...args: unknown[]) => mockGetActorFromSession(...args)
 }))
 
-type MockDatabase = Pick<Database, 'getFitnessRouteHeatmapSummariesForActor'>
+type MockDatabase = Pick<
+  Database,
+  | 'deleteFitnessRouteHeatmapsForActor'
+  | 'getFitnessRouteHeatmapSummariesForActor'
+>
 
 let mockDatabase: MockDatabase | null = null
 jest.mock('@/lib/database', () => ({
@@ -24,6 +28,7 @@ jest.mock('@/lib/database', () => ({
 
 describe('GET /api/v1/accounts/[id]/fitness-route-heatmaps', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
+    deleteFitnessRouteHeatmapsForActor: jest.fn(),
     getFitnessRouteHeatmapSummariesForActor: jest.fn()
   }
 
@@ -44,6 +49,7 @@ describe('GET /api/v1/accounts/[id]/fitness-route-heatmaps', () => {
       id: ACTOR1_ID
     })
     mockDb.getFitnessRouteHeatmapSummariesForActor.mockResolvedValue([])
+    mockDb.deleteFitnessRouteHeatmapsForActor.mockResolvedValue(0)
   })
 
   it('returns owner route heatmap history', async () => {
@@ -136,5 +142,35 @@ describe('GET /api/v1/accounts/[id]/fitness-route-heatmaps', () => {
     })
 
     expect(response.status).toBe(403)
+  })
+
+  it('clears owner route heatmap history', async () => {
+    mockDb.deleteFitnessRouteHeatmapsForActor.mockResolvedValue(3)
+
+    const request = new NextRequest(baseUrl, { method: 'DELETE' })
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDb.deleteFitnessRouteHeatmapsForActor).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID
+    })
+    await expect(response.json()).resolves.toEqual({ deleted: 3 })
+  })
+
+  it('does not clear route heatmap history for another actor', async () => {
+    mockGetActorFromSession.mockResolvedValue({
+      ...seedActor1,
+      id: 'https://llun.test/users/other'
+    })
+
+    const request = new NextRequest(baseUrl, { method: 'DELETE' })
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockDb.deleteFitnessRouteHeatmapsForActor).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/accounts/[id]/fitness-route-heatmaps/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmaps/route.ts
@@ -14,7 +14,11 @@ import {
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
-const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.DELETE
+]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -93,6 +97,69 @@ export const GET = traceApiRoute(
       data: {
         heatmaps: heatmaps.map(serializeRouteHeatmapSummary)
       }
+    })
+  },
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { accountId: params?.id || 'unknown' }
+    }
+  }
+)
+
+export const DELETE = traceApiRoute(
+  'deleteAccountFitnessRouteHeatmaps',
+  async (req, params: AppRouterParams<Params>) => {
+    const session = await getServerAuthSession()
+    if (!session?.user?.email) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const currentActor = await getActorFromSession(database, session)
+    if (!currentActor) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const { id: encodedAccountId } = await params.params
+    const id = idToUrl(encodedAccountId)
+
+    if (currentActor.id !== id) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: 403
+      })
+    }
+
+    const deleted = await database.deleteFitnessRouteHeatmapsForActor({
+      actorId: id
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { deleted }
     })
   },
   {

--- a/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.test.ts
+++ b/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.test.ts
@@ -99,12 +99,13 @@ describe('DELETE /api/v1/accounts/fitness-files/[fitnessFileId]', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: 'actor-1',
           activityType: 'running',
           periodType: 'monthly',
-          periodKey: '2026-04'
-        }
+          periodKey: '2026-04',
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })

--- a/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.test.ts
+++ b/app/api/v1/accounts/fitness-files/[fitnessFileId]/route.test.ts
@@ -27,7 +27,10 @@ jest.mock('@/lib/services/fitness-files', () => ({
 
 type MockDatabase = Pick<
   Database,
-  'getFitnessFile' | 'getActorFromId' | 'getDistinctRouteHeatmapRegionsForActor'
+  | 'getFitnessFile'
+  | 'getActorFromId'
+  | 'getDistinctRouteHeatmapRegionsForActor'
+  | 'getFitnessRouteHeatmapByKey'
 >
 
 let mockDatabase: MockDatabase | null = null
@@ -44,7 +47,8 @@ describe('DELETE /api/v1/accounts/fitness-files/[fitnessFileId]', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
     getFitnessFile: jest.fn(),
     getActorFromId: jest.fn(),
-    getDistinctRouteHeatmapRegionsForActor: jest.fn()
+    getDistinctRouteHeatmapRegionsForActor: jest.fn(),
+    getFitnessRouteHeatmapByKey: jest.fn()
   }
 
   beforeAll(() => {
@@ -79,6 +83,7 @@ describe('DELETE /api/v1/accounts/fitness-files/[fitnessFileId]', () => {
       account: { id: 'account-1' }
     } as Awaited<ReturnType<Database['getActorFromId']>>)
     mockDb.getDistinctRouteHeatmapRegionsForActor.mockResolvedValue([])
+    mockDb.getFitnessRouteHeatmapByKey.mockResolvedValue(null)
     mockDeleteFitnessFileFromStorage.mockResolvedValue(true)
     mockPublish.mockResolvedValue(undefined)
   })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -1,6 +1,7 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import {
+  clearFitnessRouteHeatmaps,
   getActorStatuses,
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmaps,
@@ -110,6 +111,24 @@ describe('fitness route heatmap client calls', () => {
       })
     ).rejects.toThrow(
       'Failed to load route heatmaps (503): upstream unavailable'
+    )
+  })
+
+  it('clears all route heatmaps for an actor', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ deleted: 3 }), { status: 200 })
+
+    await expect(
+      clearFitnessRouteHeatmaps({
+        actorId: 'https://llun.test/users/test1'
+      })
+    ).resolves.toBe(3)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://llun.test/api/v1/accounts/llun.test:users:test1/fitness-route-heatmaps',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: { Accept: 'application/json' }
+      })
     )
   })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1532,6 +1532,28 @@ export const getFitnessRouteHeatmaps = async ({
   return json.heatmaps as FitnessRouteHeatmapSummaryData[]
 }
 
+export const clearFitnessRouteHeatmaps = async ({
+  actorId
+}: {
+  actorId: string
+}): Promise<number> => {
+  const encodedId = urlToId(actorId)
+  const response = await fetch(
+    `${window.origin}/api/v1/accounts/${encodedId}/fitness-route-heatmaps`,
+    {
+      method: 'DELETE',
+      headers: { Accept: 'application/json' }
+    }
+  )
+  if (!response.ok) {
+    throw new Error(
+      await getRouteHeatmapResponseErrorMessage(response, 'route heatmaps')
+    )
+  }
+  const json = await response.json()
+  return typeof json.deleted === 'number' ? json.deleted : 0
+}
+
 export const getFitnessCalendarData = async ({
   actorId,
   startDate,

--- a/lib/database/sql/fitnessRouteHeatmap.test.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.test.ts
@@ -143,6 +143,32 @@ describe('FitnessRouteHeatmapDatabase', () => {
 
         expect(result).toBe(false)
       })
+
+      it('does not revive a route cache deleted after the restore cutoff', async () => {
+        const cutoff = Date.now() - 10_000
+        const created = await database.createFitnessRouteHeatmap({
+          actorId: actors.replyAuthor.id,
+          activityType: 'delete-race-sql',
+          periodType: 'monthly',
+          periodKey: '2099-03'
+        })
+
+        await database.deleteFitnessRouteHeatmapsForActor({
+          actorId: actors.replyAuthor.id
+        })
+
+        const result = await database.updateFitnessRouteHeatmapStatus({
+          id: created.id,
+          status: 'generating',
+          clearDeleted: true,
+          clearDeletedBefore: cutoff
+        })
+
+        expect(result).toBe(false)
+        await expect(
+          database.getFitnessRouteHeatmap({ id: created.id })
+        ).resolves.toBeNull()
+      })
     })
 
     describe('getFitnessRouteHeatmapsForActor', () => {

--- a/lib/database/sql/fitnessRouteHeatmap.test.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.test.ts
@@ -169,6 +169,30 @@ describe('FitnessRouteHeatmapDatabase', () => {
           database.getFitnessRouteHeatmap({ id: created.id })
         ).resolves.toBeNull()
       })
+
+      it('does not revive a deleted route cache without an explicit restore cutoff', async () => {
+        const created = await database.createFitnessRouteHeatmap({
+          actorId: actors.replyAuthor.id,
+          activityType: 'delete-default-cutoff-sql',
+          periodType: 'monthly',
+          periodKey: '2099-04'
+        })
+
+        await database.deleteFitnessRouteHeatmapsForActor({
+          actorId: actors.replyAuthor.id
+        })
+
+        const result = await database.updateFitnessRouteHeatmapStatus({
+          id: created.id,
+          status: 'generating',
+          clearDeleted: true
+        })
+
+        expect(result).toBe(false)
+        await expect(
+          database.getFitnessRouteHeatmap({ id: created.id })
+        ).resolves.toBeNull()
+      })
     })
 
     describe('getFitnessRouteHeatmapsForActor', () => {

--- a/lib/database/sql/fitnessRouteHeatmap.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.ts
@@ -53,6 +53,7 @@ export interface UpdateFitnessRouteHeatmapStatusParams {
   cursorOffset?: number
   isPartial?: boolean
   clearDeleted?: boolean
+  clearDeletedBefore?: number
 }
 
 export interface GetDistinctActivityTypesParams {
@@ -330,7 +331,8 @@ export const FitnessRouteHeatmapSQLDatabaseMixin = (
     pointCount,
     cursorOffset,
     isPartial,
-    clearDeleted
+    clearDeleted,
+    clearDeletedBefore
   }: UpdateFitnessRouteHeatmapStatusParams) {
     const updateData: Record<string, unknown> = {
       status,
@@ -365,6 +367,12 @@ export const FitnessRouteHeatmapSQLDatabaseMixin = (
     const query = database('fitness_route_heatmaps').where('id', id)
     if (!clearDeleted) {
       query.whereNull('deletedAt')
+    } else if (clearDeletedBefore !== undefined) {
+      query.where((builder) => {
+        builder
+          .whereNull('deletedAt')
+          .orWhere('deletedAt', '<=', new Date(clearDeletedBefore))
+      })
     }
     const result = await query.update(updateData)
 

--- a/lib/database/sql/fitnessRouteHeatmap.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.ts
@@ -367,11 +367,12 @@ export const FitnessRouteHeatmapSQLDatabaseMixin = (
     const query = database('fitness_route_heatmaps').where('id', id)
     if (!clearDeleted) {
       query.whereNull('deletedAt')
-    } else if (clearDeletedBefore !== undefined) {
+    } else {
+      const clearDeletedCutoff = clearDeletedBefore ?? 0
       query.where((builder) => {
         builder
           .whereNull('deletedAt')
-          .orWhere('deletedAt', '<=', new Date(clearDeletedBefore))
+          .orWhere('deletedAt', '<=', new Date(clearDeletedCutoff))
       })
     }
     const result = await query.update(updateData)

--- a/lib/jobs/enqueueFitnessRouteHeatmapJobs.test.ts
+++ b/lib/jobs/enqueueFitnessRouteHeatmapJobs.test.ts
@@ -36,12 +36,13 @@ describe('enqueueFitnessRouteHeatmapJobs', () => {
     expect(getQueue().publish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: 'actor-1',
           activityType: 'running',
           periodType: 'monthly',
-          periodKey: '2026-04'
-        }
+          periodKey: '2026-04',
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })
@@ -63,25 +64,27 @@ describe('enqueueFitnessRouteHeatmapJobs', () => {
     expect(getQueue().publish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: 'actor-1',
           activityType: null,
           periodType: 'yearly',
           periodKey: '2026',
-          region: 'netherlands'
-        }
+          region: 'netherlands',
+          requestedAt: expect.any(Number)
+        })
       })
     )
     expect(getQueue().publish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: 'actor-1',
           activityType: null,
           periodType: 'monthly',
           periodKey: '2026-04',
-          region: 'singapore'
-        }
+          region: 'singapore',
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })

--- a/lib/jobs/enqueueFitnessRouteHeatmapJobs.test.ts
+++ b/lib/jobs/enqueueFitnessRouteHeatmapJobs.test.ts
@@ -2,6 +2,7 @@ import { Database } from '@/lib/database/types'
 import { enqueueFitnessRouteHeatmapJobs } from '@/lib/jobs/enqueueFitnessRouteHeatmapJobs'
 import { GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 jest.mock('@/lib/services/queue', () => ({
   getQueue: jest.fn().mockReturnValue({
@@ -9,16 +10,21 @@ jest.mock('@/lib/services/queue', () => ({
   })
 }))
 
-type MockDatabase = Pick<Database, 'getDistinctRouteHeatmapRegionsForActor'>
+type MockDatabase = Pick<
+  Database,
+  'getDistinctRouteHeatmapRegionsForActor' | 'getFitnessRouteHeatmapByKey'
+>
 
 describe('enqueueFitnessRouteHeatmapJobs', () => {
   const mockDatabase: jest.Mocked<MockDatabase> = {
-    getDistinctRouteHeatmapRegionsForActor: jest.fn()
+    getDistinctRouteHeatmapRegionsForActor: jest.fn(),
+    getFitnessRouteHeatmapByKey: jest.fn()
   }
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockDatabase.getDistinctRouteHeatmapRegionsForActor.mockResolvedValue([])
+    mockDatabase.getFitnessRouteHeatmapByKey.mockResolvedValue(null)
   })
 
   it('publishes standard route heatmap variants for all activity and activity type scopes', async () => {
@@ -35,6 +41,52 @@ describe('enqueueFitnessRouteHeatmapJobs', () => {
     expect(getQueue().publish).toHaveBeenCalledTimes(6)
     expect(getQueue().publish).toHaveBeenCalledWith(
       expect.objectContaining({
+        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+        data: expect.objectContaining({
+          actorId: 'actor-1',
+          activityType: 'running',
+          periodType: 'monthly',
+          periodKey: '2026-04',
+          requestedAt: expect.any(Number)
+        })
+      })
+    )
+  })
+
+  it('versions job ids for route caches cleared before enqueue', async () => {
+    const deletedAt = Date.now() - 1000
+    mockDatabase.getFitnessRouteHeatmapByKey.mockImplementation(
+      async ({ activityType, periodType, periodKey }) =>
+        activityType === 'running' &&
+        periodType === 'monthly' &&
+        periodKey === '2026-04'
+          ? ({
+              id: 'deleted-route-cache',
+              deletedAt
+            } as Awaited<ReturnType<Database['getFitnessRouteHeatmapByKey']>>)
+          : null
+    )
+
+    await enqueueFitnessRouteHeatmapJobs({
+      database: mockDatabase as Database,
+      actorId: 'actor-1',
+      activityType: 'running',
+      activityStartTime: new Date('2026-04-15T07:00:00.000Z')
+    })
+
+    expect(mockDatabase.getFitnessRouteHeatmapByKey).toHaveBeenCalledWith({
+      actorId: 'actor-1',
+      activityType: 'running',
+      periodType: 'monthly',
+      periodKey: '2026-04',
+      region: '',
+      includeDeleted: true
+    })
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: getHashFromString(
+          `actor-1:route-heatmap:running:monthly:2026-04::restore:deleted-route-cache:${deletedAt}`
+        ),
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
         data: expect.objectContaining({
           actorId: 'actor-1',

--- a/lib/jobs/enqueueFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/enqueueFitnessRouteHeatmapJobs.ts
@@ -103,17 +103,29 @@ export const enqueueFitnessRouteHeatmapJobs = async ({
 
   const queue = getQueue()
   const results = await Promise.allSettled(
-    allVariants.map((variant) => {
-      const jobId = getHashFromString(
+    allVariants.map(async (variant) => {
+      const baseJobId =
         actorId +
-          ':route-heatmap:' +
-          (variant.activityType ?? 'all') +
-          ':' +
-          variant.periodType +
-          ':' +
-          variant.periodKey +
-          ':' +
-          (variant.region ?? '')
+        ':route-heatmap:' +
+        (variant.activityType ?? 'all') +
+        ':' +
+        variant.periodType +
+        ':' +
+        variant.periodKey +
+        ':' +
+        (variant.region ?? '')
+      const existing = await database.getFitnessRouteHeatmapByKey({
+        actorId,
+        activityType: variant.activityType,
+        periodType: variant.periodType,
+        periodKey: variant.periodKey,
+        region: variant.region ?? '',
+        includeDeleted: true
+      })
+      const jobId = getHashFromString(
+        existing?.deletedAt
+          ? `${baseJobId}:restore:${existing.id}:${existing.deletedAt}`
+          : baseJobId
       )
 
       return queue.publish({

--- a/lib/jobs/enqueueFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/enqueueFitnessRouteHeatmapJobs.ts
@@ -99,6 +99,7 @@ export const enqueueFitnessRouteHeatmapJobs = async ({
     baseVariants.map((variant) => ({ ...variant, region }))
   )
   const allVariants = [...baseVariants, ...regionVariants]
+  const requestedAt = Date.now()
 
   const queue = getQueue()
   const results = await Promise.allSettled(
@@ -123,6 +124,7 @@ export const enqueueFitnessRouteHeatmapJobs = async ({
           activityType: variant.activityType,
           periodType: variant.periodType,
           periodKey: variant.periodKey,
+          requestedAt,
           ...(variant.region ? { region: variant.region } : {})
         }
       })

--- a/lib/jobs/enqueueFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/enqueueFitnessRouteHeatmapJobs.ts
@@ -84,6 +84,7 @@ export const enqueueFitnessRouteHeatmapJobs = async ({
   activityType = null,
   activityStartTime
 }: EnqueueFitnessRouteHeatmapJobsParams) => {
+  const requestedAt = Date.now()
   const activityDate = toActivityDate(activityStartTime)
   const baseVariants = buildBaseVariants(activityType, activityDate)
 
@@ -99,7 +100,6 @@ export const enqueueFitnessRouteHeatmapJobs = async ({
     baseVariants.map((variant) => ({ ...variant, region }))
   )
   const allVariants = [...baseVariants, ...regionVariants]
-  const requestedAt = Date.now()
 
   const queue = getQueue()
   const results = await Promise.allSettled(

--- a/lib/jobs/generateFitnessRouteHeatmapJob.test.ts
+++ b/lib/jobs/generateFitnessRouteHeatmapJob.test.ts
@@ -247,6 +247,60 @@ describe('generateFitnessRouteHeatmapJob', () => {
     expect(mockGetFitnessFile).not.toHaveBeenCalled()
   })
 
+  it('does not restore a route cache deleted after the job read it', async () => {
+    await database.createFitnessRouteHeatmap({
+      actorId: actor.id,
+      activityType: 'delete-race-test',
+      periodType: 'monthly',
+      periodKey: '2099-03'
+    })
+
+    const requestedAt = Date.now() - 10_000
+    const getByKey = database.getFitnessRouteHeatmapByKey.bind(database)
+    const deleteAfterRead = jest
+      .spyOn(database, 'getFitnessRouteHeatmapByKey')
+      .mockImplementation(async (params) => {
+        const heatmap = await getByKey(params)
+        if (
+          params.actorId === actor.id &&
+          params.activityType === 'delete-race-test' &&
+          params.periodType === 'monthly' &&
+          params.periodKey === '2099-03'
+        ) {
+          await database.deleteFitnessRouteHeatmapsForActor({
+            actorId: actor.id
+          })
+        }
+        return heatmap
+      })
+
+    try {
+      await generateFitnessRouteHeatmapJob(database, {
+        id: 'job-route-heatmap-clear-race',
+        name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+        data: {
+          actorId: actor.id,
+          activityType: 'delete-race-test',
+          periodType: 'monthly',
+          periodKey: '2099-03',
+          requestedAt
+        }
+      })
+    } finally {
+      deleteAfterRead.mockRestore()
+    }
+
+    await expect(
+      database.getFitnessRouteHeatmapByKey({
+        actorId: actor.id,
+        activityType: 'delete-race-test',
+        periodType: 'monthly',
+        periodKey: '2099-03'
+      })
+    ).resolves.toBeNull()
+    expect(mockGetFitnessFile).not.toHaveBeenCalled()
+  })
+
   it('skips failed file parses and completes from remaining route data', async () => {
     const firstId = await createCompletedFitnessFile(
       'running',

--- a/lib/jobs/generateFitnessRouteHeatmapJob.test.ts
+++ b/lib/jobs/generateFitnessRouteHeatmapJob.test.ts
@@ -208,6 +208,45 @@ describe('generateFitnessRouteHeatmapJob', () => {
     await database.deleteFitnessRouteHeatmapsForActor({ actorId: actor.id })
   })
 
+  it('does not restore deleted route caches from stale queued jobs', async () => {
+    await database.createFitnessRouteHeatmap({
+      actorId: actor.id,
+      activityType: 'stale-clear-test',
+      periodType: 'monthly',
+      periodKey: '2099-02'
+    })
+    await database.deleteFitnessRouteHeatmapsForActor({ actorId: actor.id })
+    const deletedHeatmap = await database.getFitnessRouteHeatmapByKey({
+      actorId: actor.id,
+      activityType: 'stale-clear-test',
+      periodType: 'monthly',
+      periodKey: '2099-02',
+      includeDeleted: true
+    })
+
+    await generateFitnessRouteHeatmapJob(database, {
+      id: 'job-route-heatmap-stale-after-clear',
+      name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
+      data: {
+        actorId: actor.id,
+        activityType: 'stale-clear-test',
+        periodType: 'monthly',
+        periodKey: '2099-02',
+        requestedAt: (deletedHeatmap?.deletedAt ?? Date.now()) - 1
+      }
+    })
+
+    await expect(
+      database.getFitnessRouteHeatmapByKey({
+        actorId: actor.id,
+        activityType: 'stale-clear-test',
+        periodType: 'monthly',
+        periodKey: '2099-02'
+      })
+    ).resolves.toBeNull()
+    expect(mockGetFitnessFile).not.toHaveBeenCalled()
+  })
+
   it('skips failed file parses and completes from remaining route data', async () => {
     const firstId = await createCompletedFitnessFile(
       'running',
@@ -359,10 +398,21 @@ describe('generateFitnessRouteHeatmapJob', () => {
     expect(first?.status).toBe('completed')
 
     await database.deleteFitnessRouteHeatmapsForActor({ actorId: actor.id })
+    const deleted = await database.getFitnessRouteHeatmapByKey({
+      actorId: actor.id,
+      activityType: 'running',
+      periodType: 'monthly',
+      periodKey: '2026-05',
+      includeDeleted: true
+    })
 
     await generateFitnessRouteHeatmapJob(database, {
       ...job,
-      id: 'job-route-heatmap-revive-again'
+      id: 'job-route-heatmap-revive-again',
+      data: {
+        ...job.data,
+        requestedAt: (deleted?.deletedAt ?? Date.now()) + 1
+      }
     })
 
     const revived = await database.getFitnessRouteHeatmapByKey({

--- a/lib/jobs/generateFitnessRouteHeatmapJob.ts
+++ b/lib/jobs/generateFitnessRouteHeatmapJob.ts
@@ -317,22 +317,37 @@ export const generateFitnessRouteHeatmapJob = createJobHandle(
           allSegmentPointCount = countSegmentPoints(allSegments)
           activityCount = existing.activityCount
         }
-        await database.updateFitnessRouteHeatmapStatus({
-          id: existing.id,
-          status: 'generating',
-          error: null,
-          clearDeleted: true,
-          ...(isResume
-            ? {}
-            : {
-                bounds: null,
-                segments: null,
-                activityCount: 0,
-                pointCount: 0,
-                cursorOffset: 0,
-                isPartial: false
-              })
-        })
+        const markedGenerating = await database.updateFitnessRouteHeatmapStatus(
+          {
+            id: existing.id,
+            status: 'generating',
+            error: null,
+            clearDeleted: true,
+            clearDeletedBefore: requestedAt ?? 0,
+            ...(isResume
+              ? {}
+              : {
+                  bounds: null,
+                  segments: null,
+                  activityCount: 0,
+                  pointCount: 0,
+                  cursorOffset: 0,
+                  isPartial: false
+                })
+          }
+        )
+        if (!markedGenerating) {
+          logger.info({
+            message:
+              'Skipping stale route heatmap generation after cache clear',
+            actorId,
+            periodType,
+            periodKey,
+            requestedAt,
+            status: existing.status
+          })
+          return
+        }
       } else {
         const created = await database.createFitnessRouteHeatmap({
           actorId,

--- a/lib/jobs/generateFitnessRouteHeatmapJob.ts
+++ b/lib/jobs/generateFitnessRouteHeatmapJob.ts
@@ -74,7 +74,8 @@ const JobData = z.object({
   region: z.string().nullable().optional(),
   resume: z.boolean().optional(),
   cursorOffset: z.number().int().nonnegative().optional(),
-  maxCursorOffset: z.number().int().positive().optional()
+  maxCursorOffset: z.number().int().positive().optional(),
+  requestedAt: z.number().int().nonnegative().optional()
 })
 
 const getPeriodRange = (
@@ -225,7 +226,8 @@ export const generateFitnessRouteHeatmapJob = createJobHandle(
       region,
       resume,
       cursorOffset: requestedCursorOffset,
-      maxCursorOffset: requestedMaxCursorOffset
+      maxCursorOffset: requestedMaxCursorOffset,
+      requestedAt
     } = JobData.parse(message.data)
 
     const startedAt = Date.now()
@@ -254,6 +256,25 @@ export const generateFitnessRouteHeatmapJob = createJobHandle(
       })
 
       const isResume = resume === true
+      if (existing?.deletedAt) {
+        const canRestoreDeleted =
+          !isResume &&
+          requestedAt !== undefined &&
+          requestedAt >= existing.deletedAt
+        if (!canRestoreDeleted) {
+          logger.info({
+            message: 'Skipping stale route heatmap generation',
+            actorId,
+            periodType,
+            periodKey,
+            requestedAt,
+            deletedAt: existing.deletedAt,
+            status: existing.status
+          })
+          return
+        }
+      }
+
       const canResumeExisting =
         existing &&
         (['generating', 'failed'].includes(existing.status) ||
@@ -391,7 +412,8 @@ export const generateFitnessRouteHeatmapJob = createJobHandle(
             ...(normalizedRegion ? { region: normalizedRegion } : {}),
             resume: true,
             cursorOffset: nextCursorOffset,
-            maxCursorOffset: maxCursorOffsetForRun
+            maxCursorOffset: maxCursorOffsetForRun,
+            ...(requestedAt !== undefined ? { requestedAt } : {})
           }
         })
 

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -229,42 +229,54 @@ describe('processFitnessFileJob', () => {
     const heatmapPayloads = heatmapCalls.map(
       ([msg]: [{ data: object }]) => msg.data
     )
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: 'running',
-      periodType: 'all_time',
-      periodKey: 'all'
-    })
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: 'running',
-      periodType: 'yearly',
-      periodKey: '2026'
-    })
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: 'running',
-      periodType: 'monthly',
-      periodKey: '2026-01'
-    })
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: null,
-      periodType: 'all_time',
-      periodKey: 'all'
-    })
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: null,
-      periodType: 'yearly',
-      periodKey: '2026'
-    })
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: null,
-      periodType: 'monthly',
-      periodKey: '2026-01'
-    })
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: 'running',
+        periodType: 'all_time',
+        periodKey: 'all'
+      })
+    )
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: 'running',
+        periodType: 'yearly',
+        periodKey: '2026'
+      })
+    )
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: 'running',
+        periodType: 'monthly',
+        periodKey: '2026-01'
+      })
+    )
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: null,
+        periodType: 'all_time',
+        periodKey: 'all'
+      })
+    )
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: null,
+        periodType: 'yearly',
+        periodKey: '2026'
+      })
+    )
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: null,
+        periodType: 'monthly',
+        periodKey: '2026-01'
+      })
+    )
   })
 
   it('completes without map generation when there are no GPS coordinates', async () => {
@@ -477,18 +489,22 @@ describe('processFitnessFileJob', () => {
       })
     }
 
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: null,
-      periodType: 'yearly',
-      periodKey: '2025'
-    })
-    expect(heatmapPayloads).toContainEqual({
-      actorId: actor.id,
-      activityType: null,
-      periodType: 'monthly',
-      periodKey: '2025-03'
-    })
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: null,
+        periodType: 'yearly',
+        periodKey: '2025'
+      })
+    )
+    expect(heatmapPayloads).toContainEqual(
+      expect.objectContaining({
+        actorId: actor.id,
+        activityType: null,
+        periodType: 'monthly',
+        periodKey: '2025-03'
+      })
+    )
   })
 
   it('does not queue heatmap jobs when processing fails', async () => {

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.test.ts
@@ -129,24 +129,26 @@ describe('recreateFitnessRouteHeatmapJobs', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: 'actor-1',
           activityType: 'run',
           periodType: 'monthly',
-          periodKey: '2026-01'
-        }
+          periodKey: '2026-01',
+          requestedAt: expect.any(Number)
+        })
       })
     )
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME,
-        data: {
+        data: expect.objectContaining({
           actorId: 'actor-1',
           activityType: 'cycle',
           periodType: 'monthly',
           periodKey: '2026-02',
-          region: 'encoded-region'
-        }
+          region: 'encoded-region',
+          requestedAt: expect.any(Number)
+        })
       })
     )
   })

--- a/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
+++ b/lib/jobs/recreateFitnessRouteHeatmapJobs.ts
@@ -235,12 +235,14 @@ const publishRouteHeatmapVariant = ({
   queue,
   runId,
   actorId,
-  variant
+  variant,
+  requestedAt
 }: {
   queue: Queue
   runId: string
   actorId: string
   variant: RecreateFitnessRouteHeatmapVariant
+  requestedAt: number
 }) =>
   queue.publish({
     id: buildJobId({ runId, actorId, variant }),
@@ -250,6 +252,7 @@ const publishRouteHeatmapVariant = ({
       activityType: variant.activityType,
       periodType: variant.periodType,
       periodKey: variant.periodKey,
+      requestedAt,
       ...(variant.region ? { region: variant.region } : {})
     }
   })
@@ -258,12 +261,14 @@ const publishRouteHeatmapVariants = async ({
   queue,
   runId,
   actorId,
-  variants
+  variants,
+  requestedAt
 }: {
   queue: Queue
   runId: string
   actorId: string
   variants: RecreateFitnessRouteHeatmapVariant[]
+  requestedAt: number
 }): Promise<PromiseSettledResult<void>[]> => {
   const results: PromiseSettledResult<void>[] = []
   let nextIndex = 0
@@ -282,7 +287,8 @@ const publishRouteHeatmapVariants = async ({
           queue,
           runId,
           actorId,
-          variant: variants[index]
+          variant: variants[index],
+          requestedAt
         })
         results[index] = { status: 'fulfilled', value: undefined }
       } catch (error) {
@@ -327,6 +333,7 @@ export const recreateFitnessRouteHeatmapJobs = async ({
     actorId
   })
   const queue = getQueue()
+  const requestedAt = Date.now()
   const errors: RecreateFitnessRouteHeatmapJobError[] = []
   let queuedCount = 0
 
@@ -334,7 +341,8 @@ export const recreateFitnessRouteHeatmapJobs = async ({
     queue,
     runId,
     actorId,
-    variants
+    variants,
+    requestedAt
   })
 
   publishResults.forEach((result, index) => {


### PR DESCRIPTION
## Summary

- Render large route heatmap caches with the SVG route fallback instead of sending oversized geometry through Mapbox GL.
- Set Mapbox access token/resize defensively for smaller interactive route maps.
- Stop polling stale in-progress route heatmap summaries so old staging rows do not hammer the history endpoint.

## Root Cause

The staging `@ride@llun.social` all-time heatmap has 80,000 cached route points. With a Mapbox token configured, the view chose the Mapbox branch and produced a blank map area for that large payload. The route cache list also treated six-day-old `generating` summaries as live work and kept polling `/fitness-route-heatmaps`.

## Verification

- `yarn run prettier --write .`
- `yarn test --runTestsByPath 'app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx' --runInBand --modulePathIgnorePatterns='.claude/worktrees'`
- `yarn lint` (passes with existing warnings)
- `yarn build`
- `yarn test` fails only because local `.claude/worktrees` tests/mocks are discovered
- `yarn test --modulePathIgnorePatterns='.claude/worktrees'`
- Browser-verified `https://activities.local/@ride@llun.social/fitness/heatmap` renders route geometry and no longer repeats heatmap summary polling after reload.