### PR TITLE
fix: reject absolute media file paths in public files route

### DIFF
--- a/app/api/v1/files/[...pathname]/route.test.ts
+++ b/app/api/v1/files/[...pathname]/route.test.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from 'next/server'
+
+import { getMedia } from '@/lib/services/medias'
+
+import { GET } from './route'
+
+const mockDatabase = { id: 'test-database' }
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn(() => mockDatabase)
+}))
+
+jest.mock('@/lib/services/medias', () => ({
+  getMedia: jest.fn()
+}))
+
+describe('GET /api/v1/files/[...pathname]', () => {
+  const mockGetMedia = getMedia as jest.MockedFunction<typeof getMedia>
+
+  beforeEach(() => {
+    mockGetMedia.mockReset()
+  })
+
+  const getFile = (pathname: string[]) =>
+    GET(new NextRequest('https://llun.test/api/v1/files/test.png'), {
+      params: Promise.resolve({ pathname })
+    })
+
+  it('rejects absolute POSIX paths before media lookup', async () => {
+    const response = await getFile(['/etc/passwd'])
+
+    expect(response.status).toBe(404)
+    expect(mockGetMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects Windows drive-prefixed paths before media lookup', async () => {
+    const response = await getFile([
+      'C:\\Windows\\System32\\drivers\\etc\\hosts'
+    ])
+
+    expect(response.status).toBe(404)
+    expect(mockGetMedia).not.toHaveBeenCalled()
+  })
+
+  it('normalizes mixed-slash traversal before media lookup', async () => {
+    mockGetMedia.mockResolvedValue({
+      type: 'buffer',
+      buffer: Buffer.from('image-data'),
+      contentType: 'image/png'
+    })
+
+    const response = await getFile(['safe', '..', '..\\secret.png'])
+
+    expect(response.status).toBe(200)
+    expect(mockGetMedia).toHaveBeenCalledWith(mockDatabase, 'secret.png')
+  })
+})

--- a/app/api/v1/files/[...pathname]/route.ts
+++ b/app/api/v1/files/[...pathname]/route.ts
@@ -15,9 +15,15 @@ export const GET = traceApiRoute(
   'getFile',
   async (req: NextRequest, context: { params: Promise<Params> }) => {
     const { pathname } = await context.params
-    const userPath = path
-      .normalize(Array.isArray(pathname) ? pathname.join('/') : pathname)
-      .replace(/^(\.\.(\/|\\|$))+/, '')
+    const normalizedPath = path.normalize(
+      Array.isArray(pathname) ? pathname.join('/') : pathname
+    )
+
+    if (path.isAbsolute(normalizedPath) || /^[a-zA-Z]:/.test(normalizedPath)) {
+      return apiErrorResponse(404)
+    }
+
+    const userPath = normalizedPath.replace(/^(\.\.(\/|\\|$))+/, '')
     const database = getDatabase()
     if (!database) {
       return apiErrorResponse(500)

--- a/app/api/v1/files/[...pathname]/route.ts
+++ b/app/api/v1/files/[...pathname]/route.ts
@@ -19,6 +19,7 @@ export const GET = traceApiRoute(
       Array.isArray(pathname) ? pathname.join('/') : pathname
     )
 
+    // POSIX hosts do not treat Windows drive paths as absolute.
     if (path.isAbsolute(normalizedPath) || /^[a-zA-Z]:/.test(normalizedPath)) {
       return apiErrorResponse(404)
     }

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -1,0 +1,74 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+
+import { MediaStorageType } from '@/lib/config/mediaStorage'
+import { Database } from '@/lib/database/types'
+
+import { LocalFileStorage } from './localFile'
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn()
+  }
+}))
+
+describe('LocalFileStorage.getFile', () => {
+  let tempDir: string
+  let mediaRoot: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'activities-media-'))
+    mediaRoot = path.join(tempDir, 'media')
+    await fs.mkdir(mediaRoot)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  const createStorage = () =>
+    new LocalFileStorage(
+      {
+        type: MediaStorageType.LocalFile,
+        path: mediaRoot
+      },
+      'llun.test',
+      {} as Database
+    )
+
+  it('reads files inside the media root', async () => {
+    await fs.writeFile(path.join(mediaRoot, 'avatar.png'), 'image-data')
+
+    const result = await createStorage().getFile('avatar.png')
+
+    expect(result).toMatchObject({
+      type: 'buffer',
+      contentType: 'image/png'
+    })
+    expect(result?.type === 'buffer' ? result.buffer.toString() : null).toBe(
+      'image-data'
+    )
+  })
+
+  it('returns null when a relative path escapes the media root', async () => {
+    await fs.mkdir(path.join(mediaRoot, 'nested'))
+    await fs.writeFile(path.join(tempDir, 'secret.png'), 'secret-data')
+
+    const result = await createStorage().getFile('nested/../../secret.png')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when an absolute path escapes the media root', async () => {
+    const outsidePath = path.join(tempDir, 'absolute-secret.png')
+    await fs.writeFile(outsidePath, 'secret-data')
+
+    const result = await createStorage().getFile(outsidePath)
+
+    expect(result).toBeNull()
+  })
+})

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -51,7 +51,17 @@ export class LocalFileStorage implements MediaStorage {
   }
 
   async getFile(filePath: string) {
-    const fullPath = path.resolve(this._config.path, filePath)
+    const storageRoot = path.resolve(this._config.path)
+    const fullPath = path.resolve(storageRoot, filePath)
+    const relativePath = path.relative(storageRoot, fullPath)
+    if (
+      relativePath === '..' ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath)
+    ) {
+      return null
+    }
+
     const contentType = mime.contentType(path.extname(fullPath))
     if (!contentType) return null
 


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated local-file disclosure through public media reads by rejecting absolute route input and enforcing media-root containment in local file storage.

### Description

- Reject absolute POSIX and Windows drive-prefixed paths in `app/api/v1/files/[...pathname]/route.ts` before media lookup.
- Add storage-layer containment in `LocalFileStorage.getFile` so any caller of `getMedia()` cannot read outside the configured media root via absolute or traversal paths.
- Add regression coverage for POSIX absolute paths, Windows drive-prefixed paths, mixed-slash route traversal normalization, and local storage escape attempts.

### Testing

- `yarn run prettier --write .`
- `yarn lint` (passes with existing no-explicit-any warnings in auth and fitness files)
- `yarn build`
- `yarn test --runInBand --runTestsByPath app/api/v1/files/[...pathname]/route.test.ts lib/services/medias/localFile.test.ts`
- `yarn test`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fcd5285483289163984d55763529)