### PR TITLE
fix: normalize API validation and response handling

### DIFF
--- a/app/api/v1/accounts/[id]/media/route.test.ts
+++ b/app/api/v1/accounts/[id]/media/route.test.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getActorFromId: jest.fn(),
+  getAttachmentsForActor: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('GET /api/v1/accounts/:id/media', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: 'https://llun.test/users/llun'
+    })
+  })
+
+  it('returns 422 when media query parameters fail schema validation', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v1/accounts/llun.test:users:llun/media?limit=0',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, {
+      params: Promise.resolve({ id: 'llun.test:users:llun' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(data.status).toBe('Unprocessable entity')
+    expect(mockDatabase.getAttachmentsForActor).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/[id]/media/route.ts
+++ b/app/api/v1/accounts/[id]/media/route.ts
@@ -8,6 +8,7 @@ import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
   ERROR_404,
+  ERROR_422,
   ERROR_500,
   apiResponse,
   defaultOptions
@@ -64,9 +65,17 @@ export const GET = traceApiRoute(
 
     const url = new URL(req.url)
     const queryParams = Object.fromEntries(url.searchParams.entries())
-    const parsedParams = MediaQueryParams.parse(queryParams)
+    const parsedParams = MediaQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
 
-    const { limit = 25, max_created_at: maxCreatedAt } = parsedParams
+    const { limit = 25, max_created_at: maxCreatedAt } = parsedParams.data
 
     const attachments = await database.getAttachmentsForActor({
       actorId: id,

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -103,7 +103,7 @@ describe('POST /api/v1/accounts/email', () => {
     expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
   })
 
-  it('returns a bad request error when email change processing fails', async () => {
+  it('returns an internal server error when email change processing fails', async () => {
     mockDb.requestEmailChange.mockRejectedValue(new Error('database failed'))
 
     const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
@@ -114,8 +114,10 @@ describe('POST /api/v1/accounts/email', () => {
 
     const response = await POST(request, { params: Promise.resolve({}) })
 
-    expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      status: 'Internal Server Error'
+    })
     expect(mockDb.requestEmailChange).toHaveBeenCalled()
   })
 

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -103,6 +103,22 @@ describe('POST /api/v1/accounts/email', () => {
     expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
   })
 
+  it('returns a bad request error when email change processing fails', async () => {
+    mockDb.requestEmailChange.mockRejectedValue(new Error('database failed'))
+
+    const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
+      method: 'POST',
+      body: JSON.stringify({ newEmail: 'new-email@llun.test' }),
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+    expect(mockDb.requestEmailChange).toHaveBeenCalled()
+  })
+
   it('returns 400 for body failing schema validation', async () => {
     const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
       method: 'POST',

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -121,7 +121,7 @@ describe('POST /api/v1/accounts/email', () => {
     expect(mockDb.requestEmailChange).toHaveBeenCalled()
   })
 
-  it('returns 400 for body failing schema validation', async () => {
+  it('returns 422 for body failing schema validation', async () => {
     const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
       method: 'POST',
       body: JSON.stringify({ newEmail: 'not-an-email' }),
@@ -130,7 +130,7 @@ describe('POST /api/v1/accounts/email', () => {
 
     const response = await POST(request, { params: Promise.resolve({}) })
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(422)
     expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -1,0 +1,118 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+const mockSendMail = jest.fn()
+jest.mock('@/lib/services/email', () => ({
+  sendMail: (...args: unknown[]) => mockSendMail(...args)
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    allowEmails: [],
+    allowActorDomains: [],
+    email: {
+      serviceFromAddress: 'noreply@llun.test'
+    }
+  })
+}))
+
+type MockDatabase = Pick<
+  Database,
+  | 'getAccountFromEmail'
+  | 'getActorsForAccount'
+  | 'getActorFromId'
+  | 'requestEmailChange'
+>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: () => undefined
+  })
+}))
+
+const account = {
+  id: 'account-1',
+  email: seedActor1.email,
+  defaultActorId: ACTOR1_ID,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
+
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  account,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
+
+describe('POST /api/v1/accounts/email', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getAccountFromEmail: jest.fn(),
+    getActorsForAccount: jest.fn(),
+    getActorFromId: jest.fn(),
+    requestEmailChange: jest.fn()
+  }
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockSendMail.mockResolvedValue(undefined)
+    mockDb.getAccountFromEmail.mockResolvedValue(account)
+    mockDb.getActorsForAccount.mockResolvedValue([actor])
+    mockDb.getActorFromId.mockResolvedValue(actor)
+    mockDb.requestEmailChange.mockResolvedValue(undefined)
+  })
+
+  it('returns 400 for invalid JSON body', async () => {
+    const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
+      method: 'POST',
+      body: 'not-json',
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for body failing schema validation', async () => {
+    const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
+      method: 'POST',
+      body: JSON.stringify({ newEmail: 'not-an-email' }),
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/email/route.ts
+++ b/app/api/v1/accounts/email/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { getConfig } from '@/lib/config'
 import { sendMail } from '@/lib/services/email'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { logger } from '@/lib/utils/logger'
 import {
   HTTP_STATUS,
   apiErrorResponse,
@@ -38,7 +39,7 @@ export const POST = traceApiRoute(
 
     const parsed = EmailChangeRequest.safeParse(body)
     if (!parsed.success) {
-      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
     }
     const { newEmail } = parsed.data
 
@@ -85,7 +86,13 @@ export const POST = traceApiRoute(
               `
             }
           })
-        } catch (_error) {
+        } catch (error) {
+          logger.error({
+            message: 'Failed to send email change verification email',
+            accountId: currentActor.account.id,
+            newEmail,
+            error
+          })
           return apiResponse({
             req,
             allowedMethods: [],
@@ -119,7 +126,13 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (_error) {
+    } catch (error) {
+      logger.error({
+        message: 'Failed to request email change',
+        accountId: currentActor.account.id,
+        newEmail,
+        error
+      })
       return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })

--- a/app/api/v1/accounts/email/route.ts
+++ b/app/api/v1/accounts/email/route.ts
@@ -120,12 +120,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: { error: 'Failed to request email change' },
-        responseStatusCode: 500
-      })
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
     }
   })
 )

--- a/app/api/v1/accounts/email/route.ts
+++ b/app/api/v1/accounts/email/route.ts
@@ -4,7 +4,11 @@ import { z } from 'zod'
 import { getConfig } from '@/lib/config'
 import { sendMail } from '@/lib/services/email'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
-import { apiResponse } from '@/lib/utils/response'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const EmailChangeRequest = z.object({
@@ -27,7 +31,11 @@ export const POST = traceApiRoute(
 
     try {
       const body = await req.json()
-      const { newEmail } = EmailChangeRequest.parse(body)
+      const parsed = EmailChangeRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
+      const { newEmail } = parsed.data
 
       // Check if email is already in use
       const existingAccount = await database.getAccountFromEmail({
@@ -105,15 +113,7 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return apiResponse({
-          req,
-          allowedMethods: [],
-          data: { error: 'Invalid email address' },
-          responseStatusCode: 400
-        })
-      }
+    } catch (_error) {
       return apiResponse({
         req,
         allowedMethods: [],

--- a/app/api/v1/accounts/email/route.ts
+++ b/app/api/v1/accounts/email/route.ts
@@ -29,20 +29,20 @@ export const POST = traceApiRoute(
       })
     }
 
+    let body: unknown
     try {
-      let body: unknown
-      try {
-        body = await req.json()
-      } catch (_error) {
-        return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
-      }
+      body = await req.json()
+    } catch (_error) {
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+    }
 
-      const parsed = EmailChangeRequest.safeParse(body)
-      if (!parsed.success) {
-        return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
-      }
-      const { newEmail } = parsed.data
+    const parsed = EmailChangeRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+    }
+    const { newEmail } = parsed.data
 
+    try {
       // Check if email is already in use
       const existingAccount = await database.getAccountFromEmail({
         email: newEmail
@@ -120,7 +120,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })
 )

--- a/app/api/v1/accounts/email/route.ts
+++ b/app/api/v1/accounts/email/route.ts
@@ -30,10 +30,16 @@ export const POST = traceApiRoute(
     }
 
     try {
-      const body = await req.json()
+      let body: unknown
+      try {
+        body = await req.json()
+      } catch (_error) {
+        return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      }
+
       const parsed = EmailChangeRequest.safeParse(body)
       if (!parsed.success) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+        return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
       }
       const { newEmail } = parsed.data
 

--- a/app/api/v1/accounts/email/verify/route.test.ts
+++ b/app/api/v1/accounts/email/verify/route.test.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    allowEmails: [],
+    allowActorDomains: []
+  })
+}))
+
+type MockDatabase = Pick<
+  Database,
+  'getAccountFromEmail' | 'getActorsForAccount' | 'verifyEmailChange'
+>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: () => undefined
+  })
+}))
+
+const account = {
+  id: 'account-1',
+  email: seedActor1.email,
+  defaultActorId: ACTOR1_ID,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
+
+const actor = {
+  ...seedActor1,
+  id: ACTOR1_ID,
+  account,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+}
+
+describe('POST /api/v1/accounts/email/verify', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getAccountFromEmail: jest.fn(),
+    getActorsForAccount: jest.fn(),
+    verifyEmailChange: jest.fn()
+  }
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockDb.getAccountFromEmail.mockResolvedValue(account)
+    mockDb.getActorsForAccount.mockResolvedValue([actor])
+    mockDb.verifyEmailChange.mockResolvedValue(account)
+  })
+
+  it.each([
+    ['invalid JSON', 'not-json'],
+    ['empty JSON body', '']
+  ])('returns 400 for %s', async (_name, body) => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/email/verify',
+      {
+        method: 'POST',
+        body,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.verifyEmailChange).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/email/verify/route.test.ts
+++ b/app/api/v1/accounts/email/verify/route.test.ts
@@ -95,7 +95,7 @@ describe('POST /api/v1/accounts/email/verify', () => {
     expect(mockDb.verifyEmailChange).not.toHaveBeenCalled()
   })
 
-  it('returns a bad request error when email verification processing fails', async () => {
+  it('returns an internal server error when email verification processing fails', async () => {
     mockDb.verifyEmailChange.mockRejectedValue(new Error('database failed'))
 
     const request = new NextRequest(
@@ -109,7 +109,9 @@ describe('POST /api/v1/accounts/email/verify', () => {
 
     const response = await POST(request, { params: Promise.resolve({}) })
 
-    expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      status: 'Internal Server Error'
+    })
   })
 })

--- a/app/api/v1/accounts/email/verify/route.ts
+++ b/app/api/v1/accounts/email/verify/route.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod'
 
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
-import { apiResponse } from '@/lib/utils/response'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const EmailVerifyRequest = z.object({
@@ -24,7 +28,11 @@ export const POST = traceApiRoute(
 
     try {
       const body = await req.json()
-      const { emailChangeCode } = EmailVerifyRequest.parse(body)
+      const parsed = EmailVerifyRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
+      const { emailChangeCode } = parsed.data
 
       const updatedAccount = await database.verifyEmailChange({
         accountId: currentActor.account.id,
@@ -50,15 +58,7 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return apiResponse({
-          req,
-          allowedMethods: [],
-          data: { error: 'Invalid verification code' },
-          responseStatusCode: 400
-        })
-      }
+    } catch (_error) {
       return apiResponse({
         req,
         allowedMethods: [],

--- a/app/api/v1/accounts/email/verify/route.ts
+++ b/app/api/v1/accounts/email/verify/route.ts
@@ -27,7 +27,13 @@ export const POST = traceApiRoute(
     }
 
     try {
-      const body = await req.json()
+      let body: unknown
+      try {
+        body = await req.json()
+      } catch (_error) {
+        return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      }
+
       const parsed = EmailVerifyRequest.safeParse(body)
       if (!parsed.success) {
         return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)

--- a/app/api/v1/accounts/email/verify/route.ts
+++ b/app/api/v1/accounts/email/verify/route.ts
@@ -65,12 +65,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: { error: 'Failed to verify email change' },
-        responseStatusCode: 500
-      })
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
     }
   })
 )

--- a/app/api/v1/accounts/email/verify/route.ts
+++ b/app/api/v1/accounts/email/verify/route.ts
@@ -26,20 +26,20 @@ export const POST = traceApiRoute(
       })
     }
 
+    let body: unknown
     try {
-      let body: unknown
-      try {
-        body = await req.json()
-      } catch (_error) {
-        return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
-      }
+      body = await req.json()
+    } catch (_error) {
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+    }
 
-      const parsed = EmailVerifyRequest.safeParse(body)
-      if (!parsed.success) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
-      }
-      const { emailChangeCode } = parsed.data
+    const parsed = EmailVerifyRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+    }
+    const { emailChangeCode } = parsed.data
 
+    try {
       const updatedAccount = await database.verifyEmailChange({
         accountId: currentActor.account.id,
         emailChangeCode
@@ -65,7 +65,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })
 )

--- a/app/api/v1/accounts/email/verify/route.ts
+++ b/app/api/v1/accounts/email/verify/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { logger } from '@/lib/utils/logger'
 import {
   HTTP_STATUS,
   apiErrorResponse,
@@ -64,7 +65,12 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (_error) {
+    } catch (error) {
+      logger.error({
+        message: 'Failed to verify email change',
+        accountId: currentActor.account.id,
+        error
+      })
       return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })

--- a/app/api/v1/accounts/like/route.test.ts
+++ b/app/api/v1/accounts/like/route.test.ts
@@ -1,0 +1,85 @@
+import { NextRequest } from 'next/server'
+
+import { DELETE, POST } from './route'
+
+const mockDatabase = {
+  getStatus: jest.fn(),
+  createLike: jest.fn(),
+  deleteLike: jest.fn()
+}
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun'
+}
+
+const mockSendLike = jest.fn()
+const mockSendUndoLike = jest.fn()
+
+jest.mock('@/lib/activities', () => ({
+  sendLike: (...args: unknown[]) => mockSendLike(...args),
+  sendUndoLike: (...args: unknown[]) => mockSendUndoLike(...args)
+}))
+
+jest.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+describe('POST /api/v1/accounts/like', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 422 when the request payload fails schema validation', async () => {
+    const request = new NextRequest('https://llun.test/api/v1/accounts/like', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({})
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(data.status).toBe('Unprocessable entity')
+    expect(mockDatabase.getStatus).not.toHaveBeenCalled()
+    expect(mockSendLike).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/v1/accounts/like', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 422 when the request payload fails schema validation', async () => {
+    const request = new NextRequest('https://llun.test/api/v1/accounts/like', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({})
+    })
+
+    const response = await DELETE(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(data.status).toBe('Unprocessable entity')
+    expect(mockDatabase.getStatus).not.toHaveBeenCalled()
+    expect(mockSendUndoLike).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/like/route.test.ts
+++ b/app/api/v1/accounts/like/route.test.ts
@@ -60,6 +60,22 @@ describe('POST /api/v1/accounts/like', () => {
     expect(mockDatabase.getStatus).not.toHaveBeenCalled()
     expect(mockSendLike).not.toHaveBeenCalled()
   })
+
+  it('returns 400 when the request payload is malformed JSON', async () => {
+    const request = new NextRequest('https://llun.test/api/v1/accounts/like', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{'
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.status).toBe('Bad Request')
+    expect(mockDatabase.getStatus).not.toHaveBeenCalled()
+    expect(mockSendLike).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /api/v1/accounts/like', () => {
@@ -79,6 +95,22 @@ describe('DELETE /api/v1/accounts/like', () => {
 
     expect(response.status).toBe(422)
     expect(data.status).toBe('Unprocessable entity')
+    expect(mockDatabase.getStatus).not.toHaveBeenCalled()
+    expect(mockSendUndoLike).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the request payload is malformed JSON', async () => {
+    const request = new NextRequest('https://llun.test/api/v1/accounts/like', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: '{'
+    })
+
+    const response = await DELETE(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.status).toBe('Bad Request')
     expect(mockDatabase.getStatus).not.toHaveBeenCalled()
     expect(mockSendUndoLike).not.toHaveBeenCalled()
   })

--- a/app/api/v1/accounts/like/route.ts
+++ b/app/api/v1/accounts/like/route.ts
@@ -8,6 +8,7 @@ import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   DEFAULT_202,
+  ERROR_400,
   ERROR_404,
   ERROR_422,
   apiResponse,
@@ -29,7 +30,18 @@ export const POST = traceApiRoute(
   'likeToAccount',
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
-    const body = await req.json()
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
     const parsed = LikeStatusRequest.safeParse(body)
     if (!parsed.success) {
       return apiResponse({
@@ -60,7 +72,18 @@ export const DELETE = traceApiRoute(
   'unlikeToAccount',
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
-    const body = await req.json()
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
     const parsed = LikeStatusRequest.safeParse(body)
     if (!parsed.success) {
       return apiResponse({

--- a/app/api/v1/accounts/like/route.ts
+++ b/app/api/v1/accounts/like/route.ts
@@ -9,6 +9,7 @@ import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   DEFAULT_202,
   ERROR_404,
+  ERROR_422,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -29,7 +30,17 @@ export const POST = traceApiRoute(
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
     const body = await req.json()
-    const { statusId } = LikeStatusRequest.parse(body)
+    const parsed = LikeStatusRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const { statusId } = parsed.data
     const status = await database.getStatus({ statusId, withReplies: false })
     if (!status)
       return apiResponse({
@@ -50,7 +61,17 @@ export const DELETE = traceApiRoute(
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
     const body = await req.json()
-    const { statusId } = LikeStatusRequest.parse(body)
+    const parsed = LikeStatusRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const { statusId } = parsed.data
     const status = await database.getStatus({ statusId, withReplies: false })
     if (!status)
       return apiResponse({

--- a/app/api/v1/accounts/password/reset/request/route.test.ts
+++ b/app/api/v1/accounts/password/reset/request/route.test.ts
@@ -1,0 +1,101 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+
+import { POST } from './route'
+
+const mockSendMail = jest.fn()
+jest.mock('@/lib/services/email', () => ({
+  sendMail: (...args: unknown[]) => mockSendMail(...args)
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    email: {
+      serviceFromAddress: 'noreply@llun.test'
+    }
+  })
+}))
+
+type MockDatabase = Pick<
+  Database,
+  'getAccountFromEmail' | 'requestPasswordReset'
+>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('POST /api/v1/accounts/password/reset/request', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getAccountFromEmail: jest.fn(),
+    requestPasswordReset: jest.fn()
+  }
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSendMail.mockResolvedValue(undefined)
+    mockDb.getAccountFromEmail.mockResolvedValue({
+      id: 'account-1',
+      email: 'test@llun.test',
+      passwordResetCode: 'existing-reset-code',
+      passwordResetCodeExpiresAt: Date.now() + 60_000,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    })
+    mockDb.requestPasswordReset.mockResolvedValue(true)
+  })
+
+  it('returns uniform success and does not rotate reset code when email sending fails', async () => {
+    mockSendMail.mockRejectedValue(new Error('mail failed'))
+
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset/request',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email: 'test@llun.test' }),
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      success: true,
+      message:
+        'If an account exists for that email, a password reset link has been sent.'
+    })
+    expect(mockDb.requestPasswordReset).not.toHaveBeenCalled()
+  })
+
+  it('returns uniform success for invalid request bodies', async () => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset/request',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email: 'not-an-email' }),
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      success: true,
+      message:
+        'If an account exists for that email, a password reset link has been sent.'
+    })
+    expect(mockDb.getAccountFromEmail).not.toHaveBeenCalled()
+    expect(mockDb.requestPasswordReset).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/password/reset/request/route.test.ts
+++ b/app/api/v1/accounts/password/reset/request/route.test.ts
@@ -52,8 +52,17 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     mockDb.requestPasswordReset.mockResolvedValue(true)
   })
 
-  it('returns uniform success and does not rotate reset code when email sending fails', async () => {
+  it('returns uniform success and restores the reset code when email sending fails', async () => {
     mockSendMail.mockRejectedValue(new Error('mail failed'))
+    const previousExpiresAt = Date.now() + 60_000
+    mockDb.getAccountFromEmail.mockResolvedValue({
+      id: 'account-1',
+      email: 'test@llun.test',
+      passwordResetCode: 'existing-reset-code',
+      passwordResetCodeExpiresAt: previousExpiresAt,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    })
 
     const request = new NextRequest(
       'http://llun.test/api/v1/accounts/password/reset/request',
@@ -73,7 +82,19 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
       message:
         'If an account exists for that email, a password reset link has been sent.'
     })
-    expect(mockDb.requestPasswordReset).not.toHaveBeenCalled()
+    expect(mockDb.requestPasswordReset).toHaveBeenCalledTimes(2)
+    expect(mockDb.requestPasswordReset).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        email: 'test@llun.test',
+        passwordResetCode: expect.not.stringMatching('existing-reset-code')
+      })
+    )
+    expect(mockDb.requestPasswordReset).toHaveBeenNthCalledWith(2, {
+      email: 'test@llun.test',
+      passwordResetCode: 'existing-reset-code',
+      expiresAt: previousExpiresAt
+    })
   })
 
   it('returns uniform success for invalid request bodies', async () => {

--- a/app/api/v1/accounts/password/reset/request/route.test.ts
+++ b/app/api/v1/accounts/password/reset/request/route.test.ts
@@ -33,6 +33,12 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     getAccountFromEmail: jest.fn(),
     requestPasswordReset: jest.fn()
   }
+  const buildRequest = (body: unknown) =>
+    new NextRequest('http://llun.test/api/v1/accounts/password/reset/request', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' }
+    })
 
   beforeAll(() => {
     mockDatabase = mockDb
@@ -64,14 +70,7 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
       updatedAt: Date.now()
     })
 
-    const request = new NextRequest(
-      'http://llun.test/api/v1/accounts/password/reset/request',
-      {
-        method: 'POST',
-        body: JSON.stringify({ email: 'test@llun.test' }),
-        headers: { 'Content-Type': 'application/json' }
-      }
-    )
+    const request = buildRequest({ email: 'test@llun.test' })
 
     const response = await POST(request, { params: Promise.resolve({}) })
     const data = await response.json()
@@ -97,15 +96,40 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     })
   })
 
-  it('returns uniform success for invalid request bodies', async () => {
-    const request = new NextRequest(
-      'http://llun.test/api/v1/accounts/password/reset/request',
-      {
-        method: 'POST',
-        body: JSON.stringify({ email: 'not-an-email' }),
-        headers: { 'Content-Type': 'application/json' }
-      }
+  it('returns an error when email sending fails and reset code restoration returns false', async () => {
+    mockSendMail.mockRejectedValue(new Error('mail failed'))
+    mockDb.requestPasswordReset.mockResolvedValueOnce(true)
+    mockDb.requestPasswordReset.mockResolvedValueOnce(false)
+
+    const request = buildRequest({ email: 'test@llun.test' })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ status: 'Internal Server Error' })
+    expect(mockDb.requestPasswordReset).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns an error when email sending fails and reset code restoration rejects', async () => {
+    mockSendMail.mockRejectedValue(new Error('mail failed'))
+    mockDb.requestPasswordReset.mockResolvedValueOnce(true)
+    mockDb.requestPasswordReset.mockRejectedValueOnce(
+      new Error('restore failed')
     )
+
+    const request = buildRequest({ email: 'test@llun.test' })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ status: 'Internal Server Error' })
+    expect(mockDb.requestPasswordReset).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns uniform success for invalid request bodies', async () => {
+    const request = buildRequest({ email: 'not-an-email' })
 
     const response = await POST(request, { params: Promise.resolve({}) })
     const data = await response.json()

--- a/app/api/v1/accounts/password/reset/request/route.test.ts
+++ b/app/api/v1/accounts/password/reset/request/route.test.ts
@@ -9,6 +9,15 @@ jest.mock('@/lib/services/email', () => ({
   sendMail: (...args: unknown[]) => mockSendMail(...args)
 }))
 
+const mockLoggerError = jest.fn()
+const mockLoggerWarn = jest.fn()
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args)
+  }
+}))
+
 jest.mock('@/lib/config', () => ({
   getConfig: jest.fn().mockReturnValue({
     host: 'llun.test',
@@ -37,7 +46,20 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     new NextRequest('http://llun.test/api/v1/accounts/password/reset/request', {
       method: 'POST',
       body: JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json' }
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://client.llun.test'
+      }
+    })
+
+  const buildRawRequest = (body: string) =>
+    new NextRequest('http://llun.test/api/v1/accounts/password/reset/request', {
+      method: 'POST',
+      body,
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://client.llun.test'
+      }
     })
 
   beforeAll(() => {
@@ -128,19 +150,56 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     expect(mockDb.requestPasswordReset).toHaveBeenCalledTimes(2)
   })
 
-  it('returns uniform success for invalid request bodies', async () => {
+  it('returns a CORS-aware bad request response for schema-invalid request bodies', async () => {
     const request = buildRequest({ email: 'not-an-email' })
 
     const response = await POST(request, { params: Promise.resolve({}) })
     const data = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(data).toEqual({
-      success: true,
-      message:
-        'If an account exists for that email, a password reset link has been sent.'
-    })
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ status: 'Bad Request' })
+    expect(response.headers.get('access-control-allow-origin')).toBe(
+      'https://client.llun.test'
+    )
+    expect(mockLoggerError).not.toHaveBeenCalled()
     expect(mockDb.getAccountFromEmail).not.toHaveBeenCalled()
     expect(mockDb.requestPasswordReset).not.toHaveBeenCalled()
+  })
+
+  it('returns a CORS-aware bad request response for malformed JSON bodies', async () => {
+    const request = buildRawRequest('{')
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ status: 'Bad Request' })
+    expect(response.headers.get('access-control-allow-origin')).toBe(
+      'https://client.llun.test'
+    )
+    expect(mockLoggerError).not.toHaveBeenCalled()
+    expect(mockDb.getAccountFromEmail).not.toHaveBeenCalled()
+    expect(mockDb.requestPasswordReset).not.toHaveBeenCalled()
+  })
+
+  it('returns a CORS-aware internal error response for account lookup failures', async () => {
+    mockDb.getAccountFromEmail.mockRejectedValue(new Error('database failed'))
+
+    const request = buildRequest({ email: 'test@llun.test' })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ status: 'Internal Server Error' })
+    expect(response.headers.get('access-control-allow-origin')).toBe(
+      'https://client.llun.test'
+    )
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      { error: expect.any(Error) },
+      'Failed to request password reset'
+    )
+    expect(mockDb.requestPasswordReset).not.toHaveBeenCalled()
+    expect(mockSendMail).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/accounts/password/reset/request/route.ts
+++ b/app/api/v1/accounts/password/reset/request/route.ts
@@ -8,12 +8,7 @@ import { hashPasswordResetCode } from '@/lib/services/auth/passwordResetCode'
 import { sendMail } from '@/lib/services/email'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { logger } from '@/lib/utils/logger'
-import {
-  ERROR_422,
-  ERROR_500,
-  apiResponse,
-  defaultOptions
-} from '@/lib/utils/response'
+import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const PasswordResetRequest = z.object({ email: z.string().email() })
@@ -23,6 +18,14 @@ const SUCCESS_MESSAGE =
   'If an account exists for that email, a password reset link has been sent.'
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const passwordResetSuccessResponse = (req: NextRequest) =>
+  apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: { success: true, message: SUCCESS_MESSAGE },
+    responseStatusCode: 200
+  })
 
 export const POST = traceApiRoute(
   'requestPasswordReset',
@@ -41,12 +44,7 @@ export const POST = traceApiRoute(
       const body = await request.json()
       const parsed = PasswordResetRequest.safeParse(body)
       if (!parsed.success) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
-        })
+        return passwordResetSuccessResponse(request)
       }
       const { email } = parsed.data
       const config = getConfig()
@@ -58,36 +56,11 @@ export const POST = traceApiRoute(
             { email },
             'Password reset requested but email service is not configured'
           )
-          return apiResponse({
-            req: request,
-            allowedMethods: CORS_HEADERS,
-            data: { success: true, message: SUCCESS_MESSAGE },
-            responseStatusCode: 200
-          })
+          return passwordResetSuccessResponse(request)
         }
 
         const passwordResetCode = crypto.randomBytes(32).toString('base64url')
         const passwordResetCodeHash = hashPasswordResetCode(passwordResetCode)
-        const previousPasswordResetCode = account.passwordResetCode ?? null
-        const previousPasswordResetCodeExpiresAt =
-          account.passwordResetCodeExpiresAt ?? null
-
-        const saved = await database.requestPasswordReset({
-          email,
-          passwordResetCode: passwordResetCodeHash
-        })
-        if (!saved) {
-          logger.error(
-            { email },
-            'Password reset code persistence failed for existing account'
-          )
-          return apiResponse({
-            req: request,
-            allowedMethods: CORS_HEADERS,
-            data: { success: true, message: SUCCESS_MESSAGE },
-            responseStatusCode: 200
-          })
-        }
 
         try {
           await sendMail({
@@ -107,35 +80,26 @@ export const POST = traceApiRoute(
           })
         } catch (_error) {
           logger.error({ email }, 'Failed to send password reset email')
-          await database.requestPasswordReset({
-            email,
-            passwordResetCode: previousPasswordResetCode,
-            ...(previousPasswordResetCodeExpiresAt !== null
-              ? { expiresAt: previousPasswordResetCodeExpiresAt }
-              : null)
-          })
-          return apiResponse({
-            req: request,
-            allowedMethods: CORS_HEADERS,
-            data: { success: true, message: SUCCESS_MESSAGE },
-            responseStatusCode: 200
-          })
+          return passwordResetSuccessResponse(request)
+        }
+
+        const saved = await database.requestPasswordReset({
+          email,
+          passwordResetCode: passwordResetCodeHash
+        })
+        if (!saved) {
+          logger.error(
+            { email },
+            'Password reset code persistence failed for existing account'
+          )
+          return passwordResetSuccessResponse(request)
         }
       }
 
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: { success: true, message: SUCCESS_MESSAGE },
-        responseStatusCode: 200
-      })
-    } catch (_error) {
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: { error: 'Failed to request password reset' },
-        responseStatusCode: 500
-      })
+      return passwordResetSuccessResponse(request)
+    } catch (error) {
+      logger.error({ error }, 'Failed to request password reset')
+      return passwordResetSuccessResponse(request)
     }
   }
 )

--- a/app/api/v1/accounts/password/reset/request/route.ts
+++ b/app/api/v1/accounts/password/reset/request/route.ts
@@ -8,7 +8,12 @@ import { hashPasswordResetCode } from '@/lib/services/auth/passwordResetCode'
 import { sendMail } from '@/lib/services/email'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { logger } from '@/lib/utils/logger'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const PasswordResetRequest = z.object({ email: z.string().email() })
@@ -27,25 +32,43 @@ const passwordResetSuccessResponse = (req: NextRequest) =>
     responseStatusCode: 200
   })
 
+const badRequestResponse = (req: NextRequest) =>
+  apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: ERROR_400,
+    responseStatusCode: 400
+  })
+
+const internalServerErrorResponse = (req: NextRequest) =>
+  apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: ERROR_500,
+    responseStatusCode: 500
+  })
+
 export const POST = traceApiRoute(
   'requestPasswordReset',
   async (request: NextRequest) => {
     const database = getDatabase()
     if (!database) {
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_500,
-        responseStatusCode: 500
-      })
+      return internalServerErrorResponse(request)
+    }
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return badRequestResponse(request)
+    }
+
+    const parsed = PasswordResetRequest.safeParse(body)
+    if (!parsed.success) {
+      return badRequestResponse(request)
     }
 
     try {
-      const body = await request.json()
-      const parsed = PasswordResetRequest.safeParse(body)
-      if (!parsed.success) {
-        return passwordResetSuccessResponse(request)
-      }
       const { email } = parsed.data
       const config = getConfig()
       const account = await database.getAccountFromEmail({ email })
@@ -108,24 +131,14 @@ export const POST = traceApiRoute(
                 { email },
                 'Failed to restore previous password reset code'
               )
-              return apiResponse({
-                req: request,
-                allowedMethods: CORS_HEADERS,
-                data: ERROR_500,
-                responseStatusCode: 500
-              })
+              return internalServerErrorResponse(request)
             }
           } catch (error) {
             logger.error(
               { email, error },
               'Failed to restore previous password reset code'
             )
-            return apiResponse({
-              req: request,
-              allowedMethods: CORS_HEADERS,
-              data: ERROR_500,
-              responseStatusCode: 500
-            })
+            return internalServerErrorResponse(request)
           }
           return passwordResetSuccessResponse(request)
         }
@@ -134,7 +147,7 @@ export const POST = traceApiRoute(
       return passwordResetSuccessResponse(request)
     } catch (error) {
       logger.error({ error }, 'Failed to request password reset')
-      return passwordResetSuccessResponse(request)
+      return internalServerErrorResponse(request)
     }
   }
 )

--- a/app/api/v1/accounts/password/reset/request/route.ts
+++ b/app/api/v1/accounts/password/reset/request/route.ts
@@ -96,18 +96,36 @@ export const POST = traceApiRoute(
         } catch (_error) {
           logger.error({ email }, 'Failed to send password reset email')
           try {
-            await database.requestPasswordReset({
+            const restored = await database.requestPasswordReset({
               email,
               passwordResetCode: previousPasswordResetCode,
               ...(previousPasswordResetCodeExpiresAt !== null
                 ? { expiresAt: previousPasswordResetCodeExpiresAt }
                 : null)
             })
+            if (!restored) {
+              logger.error(
+                { email },
+                'Failed to restore previous password reset code'
+              )
+              return apiResponse({
+                req: request,
+                allowedMethods: CORS_HEADERS,
+                data: ERROR_500,
+                responseStatusCode: 500
+              })
+            }
           } catch (error) {
             logger.error(
               { email, error },
               'Failed to restore previous password reset code'
             )
+            return apiResponse({
+              req: request,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_500,
+              responseStatusCode: 500
+            })
           }
           return passwordResetSuccessResponse(request)
         }

--- a/app/api/v1/accounts/password/reset/request/route.ts
+++ b/app/api/v1/accounts/password/reset/request/route.ts
@@ -61,6 +61,21 @@ export const POST = traceApiRoute(
 
         const passwordResetCode = crypto.randomBytes(32).toString('base64url')
         const passwordResetCodeHash = hashPasswordResetCode(passwordResetCode)
+        const previousPasswordResetCode = account.passwordResetCode ?? null
+        const previousPasswordResetCodeExpiresAt =
+          account.passwordResetCodeExpiresAt ?? null
+
+        const saved = await database.requestPasswordReset({
+          email,
+          passwordResetCode: passwordResetCodeHash
+        })
+        if (!saved) {
+          logger.error(
+            { email },
+            'Password reset code persistence failed for existing account'
+          )
+          return passwordResetSuccessResponse(request)
+        }
 
         try {
           await sendMail({
@@ -80,18 +95,20 @@ export const POST = traceApiRoute(
           })
         } catch (_error) {
           logger.error({ email }, 'Failed to send password reset email')
-          return passwordResetSuccessResponse(request)
-        }
-
-        const saved = await database.requestPasswordReset({
-          email,
-          passwordResetCode: passwordResetCodeHash
-        })
-        if (!saved) {
-          logger.error(
-            { email },
-            'Password reset code persistence failed for existing account'
-          )
+          try {
+            await database.requestPasswordReset({
+              email,
+              passwordResetCode: previousPasswordResetCode,
+              ...(previousPasswordResetCodeExpiresAt !== null
+                ? { expiresAt: previousPasswordResetCodeExpiresAt }
+                : null)
+            })
+          } catch (error) {
+            logger.error(
+              { email, error },
+              'Failed to restore previous password reset code'
+            )
+          }
           return passwordResetSuccessResponse(request)
         }
       }

--- a/app/api/v1/accounts/password/reset/request/route.ts
+++ b/app/api/v1/accounts/password/reset/request/route.ts
@@ -8,7 +8,12 @@ import { hashPasswordResetCode } from '@/lib/services/auth/passwordResetCode'
 import { sendMail } from '@/lib/services/email'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { logger } from '@/lib/utils/logger'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const PasswordResetRequest = z.object({ email: z.string().email() })
@@ -34,7 +39,16 @@ export const POST = traceApiRoute(
 
     try {
       const body = await request.json()
-      const { email } = PasswordResetRequest.parse(body)
+      const parsed = PasswordResetRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiResponse({
+          req: request,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+      const { email } = parsed.data
       const config = getConfig()
       const account = await database.getAccountFromEmail({ email })
 
@@ -115,16 +129,7 @@ export const POST = traceApiRoute(
         data: { success: true, message: SUCCESS_MESSAGE },
         responseStatusCode: 200
       })
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: { error: 'Invalid email address' },
-          responseStatusCode: 400
-        })
-      }
-
+    } catch (_error) {
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/accounts/password/reset/route.test.ts
+++ b/app/api/v1/accounts/password/reset/route.test.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+
+import { POST } from './route'
+
+const mockBcryptHash = jest.fn()
+jest.mock('bcrypt', () => ({
+  __esModule: true,
+  default: {
+    hash: (...args: unknown[]) => mockBcryptHash(...args)
+  }
+}))
+
+type MockDatabase = Pick<
+  Database,
+  'validatePasswordResetCode' | 'resetPasswordWithCode'
+>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('POST /api/v1/accounts/password/reset', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    validatePasswordResetCode: jest.fn(),
+    resetPasswordWithCode: jest.fn()
+  }
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockBcryptHash.mockResolvedValue('new-password-hash')
+    mockDb.validatePasswordResetCode.mockResolvedValue('account-1')
+    mockDb.resetPasswordWithCode.mockResolvedValue({
+      id: 'account-1'
+    })
+  })
+
+  it('returns a CORS-aware bad request response for malformed JSON bodies', async () => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password/reset',
+      {
+        method: 'POST',
+        body: '{',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://client.llun.test'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ status: 'Bad Request' })
+    expect(response.headers.get('access-control-allow-origin')).toBe(
+      'https://client.llun.test'
+    )
+    expect(mockDb.validatePasswordResetCode).not.toHaveBeenCalled()
+    expect(mockDb.resetPasswordWithCode).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/password/reset/route.ts
+++ b/app/api/v1/accounts/password/reset/route.ts
@@ -5,7 +5,12 @@ import { z } from 'zod'
 import { getDatabase } from '@/lib/database'
 import { hashPasswordResetCode } from '@/lib/services/auth/passwordResetCode'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const ResetPasswordRequest = z.object({
@@ -32,7 +37,16 @@ export const POST = traceApiRoute(
 
     try {
       const body = await request.json()
-      const { code, newPassword } = ResetPasswordRequest.parse(body)
+      const parsed = ResetPasswordRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiResponse({
+          req: request,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+      const { code, newPassword } = parsed.data
       const passwordResetCode = hashPasswordResetCode(code)
       const accountId = await database.validatePasswordResetCode({
         passwordResetCode
@@ -70,16 +84,7 @@ export const POST = traceApiRoute(
         data: { success: true, message: 'Password reset successfully' },
         responseStatusCode: 200
       })
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: { error: 'Invalid password format' },
-          responseStatusCode: 400
-        })
-      }
-
+    } catch (_error) {
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/accounts/password/reset/route.ts
+++ b/app/api/v1/accounts/password/reset/route.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { getDatabase } from '@/lib/database'
 import { hashPasswordResetCode } from '@/lib/services/auth/passwordResetCode'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   ERROR_422,
@@ -97,7 +98,8 @@ export const POST = traceApiRoute(
         data: { success: true, message: 'Password reset successfully' },
         responseStatusCode: 200
       })
-    } catch (_error) {
+    } catch (error) {
+      logger.error({ message: 'Failed to reset password', error })
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/accounts/password/reset/route.ts
+++ b/app/api/v1/accounts/password/reset/route.ts
@@ -6,6 +6,7 @@ import { getDatabase } from '@/lib/database'
 import { hashPasswordResetCode } from '@/lib/services/auth/passwordResetCode'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
+  ERROR_400,
   ERROR_422,
   ERROR_500,
   apiResponse,
@@ -35,17 +36,29 @@ export const POST = traceApiRoute(
       })
     }
 
+    let body: unknown
     try {
-      const body = await request.json()
-      const parsed = ResetPasswordRequest.safeParse(body)
-      if (!parsed.success) {
-        return apiResponse({
-          req: request,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
-        })
-      }
+      body = await request.json()
+    } catch {
+      return apiResponse({
+        req: request,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const parsed = ResetPasswordRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req: request,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    try {
       const { code, newPassword } = parsed.data
       const passwordResetCode = hashPasswordResetCode(code)
       const accountId = await database.validatePasswordResetCode({

--- a/app/api/v1/accounts/password/route.test.ts
+++ b/app/api/v1/accounts/password/route.test.ts
@@ -5,6 +5,16 @@ import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 
 import { POST } from './route'
 
+const mockBcryptCompare = jest.fn()
+const mockBcryptHash = jest.fn()
+jest.mock('bcrypt', () => ({
+  __esModule: true,
+  default: {
+    compare: (...args: unknown[]) => mockBcryptCompare(...args),
+    hash: (...args: unknown[]) => mockBcryptHash(...args)
+  }
+}))
+
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: () => mockGetServerSession()
@@ -20,7 +30,7 @@ jest.mock('@/lib/config', () => ({
 
 type MockDatabase = Pick<
   Database,
-  'getAccountFromEmail' | 'getActorsForAccount'
+  'changePassword' | 'getAccountFromEmail' | 'getActorsForAccount'
 >
 
 let mockDatabase: MockDatabase | null = null
@@ -58,6 +68,7 @@ const actor = {
 
 describe('POST /api/v1/accounts/password', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
+    changePassword: jest.fn(),
     getAccountFromEmail: jest.fn(),
     getActorsForAccount: jest.fn()
   }
@@ -71,6 +82,9 @@ describe('POST /api/v1/accounts/password', () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
+    mockBcryptCompare.mockResolvedValue(true)
+    mockBcryptHash.mockResolvedValue('new-password-hash')
+    mockDb.changePassword.mockResolvedValue(undefined)
     mockDb.getAccountFromEmail.mockResolvedValue(account)
     mockDb.getActorsForAccount.mockResolvedValue([actor])
   })
@@ -89,5 +103,51 @@ describe('POST /api/v1/accounts/password', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+  })
+
+  it('returns 422 for body failing schema validation', async () => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          currentPassword: 'current-password',
+          newPassword: 'short'
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockDb.changePassword).not.toHaveBeenCalled()
+  })
+
+  it('returns an internal server error when password change processing fails', async () => {
+    mockDb.changePassword.mockRejectedValue(new Error('database failed'))
+
+    const request = new NextRequest(
+      'http://llun.test/api/v1/accounts/password',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          currentPassword: 'current-password',
+          newPassword: 'new-password'
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      status: 'Internal Server Error'
+    })
+    expect(mockDb.changePassword).toHaveBeenCalledWith({
+      accountId: account.id,
+      newPasswordHash: 'new-password-hash'
+    })
   })
 })

--- a/app/api/v1/accounts/password/route.test.ts
+++ b/app/api/v1/accounts/password/route.test.ts
@@ -20,7 +20,7 @@ jest.mock('@/lib/config', () => ({
 
 type MockDatabase = Pick<
   Database,
-  'getAccountFromEmail' | 'getActorsForAccount' | 'verifyEmailChange'
+  'getAccountFromEmail' | 'getActorsForAccount'
 >
 
 let mockDatabase: MockDatabase | null = null
@@ -38,6 +38,7 @@ const account = {
   id: 'account-1',
   email: seedActor1.email,
   defaultActorId: ACTOR1_ID,
+  passwordHash: 'password-hash',
   createdAt: Date.now(),
   updatedAt: Date.now()
 }
@@ -55,11 +56,10 @@ const actor = {
   updatedAt: Date.now()
 }
 
-describe('POST /api/v1/accounts/email/verify', () => {
+describe('POST /api/v1/accounts/password', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
     getAccountFromEmail: jest.fn(),
-    getActorsForAccount: jest.fn(),
-    verifyEmailChange: jest.fn()
+    getActorsForAccount: jest.fn()
   }
 
   beforeAll(() => {
@@ -73,36 +73,14 @@ describe('POST /api/v1/accounts/email/verify', () => {
     })
     mockDb.getAccountFromEmail.mockResolvedValue(account)
     mockDb.getActorsForAccount.mockResolvedValue([actor])
-    mockDb.verifyEmailChange.mockResolvedValue(account)
   })
 
-  it.each([
-    ['invalid JSON', 'not-json'],
-    ['empty JSON body', '']
-  ])('returns 400 for %s', async (_name, body) => {
+  it('returns a bad request error for invalid JSON body', async () => {
     const request = new NextRequest(
-      'http://llun.test/api/v1/accounts/email/verify',
+      'http://llun.test/api/v1/accounts/password',
       {
         method: 'POST',
-        body,
-        headers: { 'Content-Type': 'application/json' }
-      }
-    )
-
-    const response = await POST(request, { params: Promise.resolve({}) })
-
-    expect(response.status).toBe(400)
-    expect(mockDb.verifyEmailChange).not.toHaveBeenCalled()
-  })
-
-  it('returns a bad request error when email verification processing fails', async () => {
-    mockDb.verifyEmailChange.mockRejectedValue(new Error('database failed'))
-
-    const request = new NextRequest(
-      'http://llun.test/api/v1/accounts/email/verify',
-      {
-        method: 'POST',
-        body: JSON.stringify({ emailChangeCode: 'verification-code' }),
+        body: 'not-json',
         headers: { 'Content-Type': 'application/json' }
       }
     )

--- a/app/api/v1/accounts/password/route.ts
+++ b/app/api/v1/accounts/password/route.ts
@@ -37,14 +37,20 @@ export const POST = traceApiRoute(
       })
     }
 
+    let body: unknown
     try {
-      const body = await req.json()
-      const parsed = PasswordChangeRequest.safeParse(body)
-      if (!parsed.success) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
-      }
-      const { currentPassword, newPassword } = parsed.data
+      body = await req.json()
+    } catch (_error) {
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+    }
 
+    const parsed = PasswordChangeRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+    }
+    const { currentPassword, newPassword } = parsed.data
+
+    try {
       // Verify current password
       const isPasswordCorrect = await bcrypt.compare(
         currentPassword,
@@ -79,7 +85,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })
 )

--- a/app/api/v1/accounts/password/route.ts
+++ b/app/api/v1/accounts/password/route.ts
@@ -79,12 +79,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: { error: 'Failed to change password' },
-        responseStatusCode: 500
-      })
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
     }
   })
 )

--- a/app/api/v1/accounts/password/route.ts
+++ b/app/api/v1/accounts/password/route.ts
@@ -2,6 +2,7 @@ import bcrypt from 'bcrypt'
 import { z } from 'zod'
 
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { logger } from '@/lib/utils/logger'
 import {
   HTTP_STATUS,
   apiErrorResponse,
@@ -84,7 +85,12 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (_error) {
+    } catch (error) {
+      logger.error({
+        message: 'Failed to change password',
+        accountId: currentActor.account.id,
+        error
+      })
       return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })

--- a/app/api/v1/accounts/password/route.ts
+++ b/app/api/v1/accounts/password/route.ts
@@ -2,7 +2,11 @@ import bcrypt from 'bcrypt'
 import { z } from 'zod'
 
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
-import { apiResponse } from '@/lib/utils/response'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const PasswordChangeRequest = z.object({
@@ -35,7 +39,11 @@ export const POST = traceApiRoute(
 
     try {
       const body = await req.json()
-      const { currentPassword, newPassword } = PasswordChangeRequest.parse(body)
+      const parsed = PasswordChangeRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
+      const { currentPassword, newPassword } = parsed.data
 
       // Verify current password
       const isPasswordCorrect = await bcrypt.compare(
@@ -70,15 +78,7 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return apiResponse({
-          req,
-          allowedMethods: [],
-          data: { error: 'Invalid password format' },
-          responseStatusCode: 400
-        })
-      }
+    } catch (_error) {
       return apiResponse({
         req,
         allowedMethods: [],

--- a/app/api/v1/accounts/profile/route.ts
+++ b/app/api/v1/accounts/profile/route.ts
@@ -6,6 +6,7 @@ import {
   POST_LINE_LIMIT_VALUES,
   PostLineLimit
 } from '@/lib/types/database/rows'
+import { HTTP_STATUS, apiErrorResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const ProfileRequest = z.object({
@@ -30,7 +31,10 @@ export const POST = traceApiRoute(
     const body = await req.formData()
     const json = Object.fromEntries(body.entries())
 
-    const parsed = ProfileRequest.parse(json)
+    const parsed = ProfileRequest.safeParse(json)
+    if (!parsed.success) {
+      return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+    }
     // Handle checkbox behavior:
     // 1. If 'on', it's checked -> true
     // 2. If missing but marker is present, it's unchecked -> false
@@ -41,7 +45,7 @@ export const POST = traceApiRoute(
       manuallyApprovesFollowers: rawValue,
       postLineLimit: rawPostLineLimit,
       ...safeParsed
-    } = parsed
+    } = parsed.data
 
     let manuallyApprovesFollowers: boolean | undefined
     if (rawValue === 'on') {

--- a/app/api/v1/accounts/repost/route.test.ts
+++ b/app/api/v1/accounts/repost/route.test.ts
@@ -1,0 +1,88 @@
+import { NextRequest } from 'next/server'
+
+import { DELETE, POST } from './route'
+
+const mockDatabase = {}
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun'
+}
+
+const mockUserAnnounce = jest.fn()
+const mockUserUndoAnnounce = jest.fn()
+
+jest.mock('@/lib/actions/announce', () => ({
+  userAnnounce: (...args: unknown[]) => mockUserAnnounce(...args)
+}))
+
+jest.mock('@/lib/actions/undoAnnounce', () => ({
+  userUndoAnnounce: (...args: unknown[]) => mockUserUndoAnnounce(...args)
+}))
+
+jest.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+describe('POST /api/v1/accounts/repost', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 400 when the request payload is malformed JSON', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v1/accounts/repost',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{'
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.status).toBe('Bad Request')
+    expect(mockUserAnnounce).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/v1/accounts/repost', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 400 when the request payload is malformed JSON', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v1/accounts/repost',
+      {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: '{'
+      }
+    )
+
+    const response = await DELETE(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.status).toBe('Bad Request')
+    expect(mockUserUndoAnnounce).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/repost/route.ts
+++ b/app/api/v1/accounts/repost/route.ts
@@ -27,7 +27,17 @@ export const POST = traceApiRoute(
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
     const body = await req.json()
-    const { statusId } = RepostRequest.parse(body)
+    const parsed = RepostRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const { statusId } = parsed.data
     const announceStatus = await userAnnounce({
       currentActor,
       statusId,
@@ -54,7 +64,17 @@ export const DELETE = traceApiRoute(
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
     const body = await req.json()
-    const { statusId } = RepostRequest.parse(body)
+    const parsed = RepostRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const { statusId } = parsed.data
     const undoStatus = await userUndoAnnounce({
       currentActor,
       statusId,

--- a/app/api/v1/accounts/repost/route.ts
+++ b/app/api/v1/accounts/repost/route.ts
@@ -9,7 +9,12 @@ import { userAnnounce } from '@/lib/actions/announce'
 import { userUndoAnnounce } from '@/lib/actions/undoAnnounce'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { ERROR_422, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_422,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const RepostRequest = z.object({ statusId: z.string() })
@@ -26,7 +31,18 @@ export const POST = traceApiRoute(
   'repostToAccount',
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
-    const body = await req.json()
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
     const parsed = RepostRequest.safeParse(body)
     if (!parsed.success) {
       return apiResponse({
@@ -63,7 +79,18 @@ export const DELETE = traceApiRoute(
   'unrepostToAccount',
   AuthenticatedGuard(async (req, context) => {
     const { database, currentActor } = context
-    const body = await req.json()
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
     const parsed = RepostRequest.safeParse(body)
     if (!parsed.success) {
       return apiResponse({

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -120,18 +120,20 @@ describe('createApplication', () => {
     expect(JSON.parse(dbClient.scopes)).toEqual(['read'])
   })
 
-  test('it errors when scopes are whitespace-only', async () => {
-    const response = await createApplication({
+  test('it defaults whitespace-only scopes to read', async () => {
+    const response = (await createApplication({
       client_name: 'blankScopesClient',
       redirect_uris: 'https://test.llun.dev/apps/redirect',
       scopes: '   \n\t  ',
       website: 'https://test.llun.dev'
-    })
+    })) as SuccessResponse
 
-    expect(response).toEqual({
-      type: 'error',
-      error: 'Failed to validate request'
-    })
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(JSON.parse(dbClient.scopes)).toEqual(['read'])
   })
 
   test('it errors when redirect_uris is empty or whitespace-only', async () => {

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -89,6 +89,22 @@ describe('createApplication', () => {
     })
   })
 
+  test('it ignores extra whitespace between scopes', async () => {
+    const response = (await createApplication({
+      client_name: 'whitespaceScopesClient',
+      redirect_uris: 'https://test.llun.dev/apps/redirect',
+      scopes: '  read   write\nfollow\t',
+      website: 'https://test.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(JSON.parse(dbClient.scopes)).toEqual(['read', 'write', 'follow'])
+  })
+
   test('it errors when redirect_uris is empty or whitespace-only', async () => {
     const response = await createApplication({
       client_name: 'noRedirectClient',

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -105,6 +105,35 @@ describe('createApplication', () => {
     expect(JSON.parse(dbClient.scopes)).toEqual(['read', 'write', 'follow'])
   })
 
+  test('it defaults omitted scopes to read', async () => {
+    const response = (await createApplication({
+      client_name: 'defaultScopesClient',
+      redirect_uris: 'https://test.llun.dev/apps/redirect',
+      website: 'https://test.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(JSON.parse(dbClient.scopes)).toEqual(['read'])
+  })
+
+  test('it errors when scopes are whitespace-only', async () => {
+    const response = await createApplication({
+      client_name: 'blankScopesClient',
+      redirect_uris: 'https://test.llun.dev/apps/redirect',
+      scopes: '   \n\t  ',
+      website: 'https://test.llun.dev'
+    })
+
+    expect(response).toEqual({
+      type: 'error',
+      error: 'Failed to validate request'
+    })
+  })
+
   test('it errors when redirect_uris is empty or whitespace-only', async () => {
     const response = await createApplication({
       client_name: 'noRedirectClient',

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -62,7 +62,9 @@ export const createApplication = async (
         const clientId = generateRandomString(32)
         const clientSecret = generateRandomString(32)
         const hashedSecret = hashClientSecret(clientSecret)
-        const scopeValues = (scopes || '').trim().split(/\s+/).filter(Boolean)
+        const scopeValues = (scopes.trim() || Scope.enum.read)
+          .split(/\s+/)
+          .filter(Boolean)
         if (scopeValues.length === 0) {
           return validationErrorResponse()
         }

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -62,7 +62,7 @@ export const createApplication = async (
         const clientId = generateRandomString(32)
         const clientSecret = generateRandomString(32)
         const hashedSecret = hashClientSecret(clientSecret)
-        const scopeValues = scopes.trim().split(/\s+/).filter(Boolean)
+        const scopeValues = (scopes || '').trim().split(/\s+/).filter(Boolean)
         if (scopeValues.length === 0) {
           return validationErrorResponse()
         }

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -62,8 +62,12 @@ export const createApplication = async (
         const clientId = generateRandomString(32)
         const clientSecret = generateRandomString(32)
         const hashedSecret = hashClientSecret(clientSecret)
+        const scopeValues = scopes.trim().split(/\s+/).filter(Boolean)
+        if (scopeValues.length === 0) {
+          return validationErrorResponse()
+        }
         const parsedScopes: Scope[] = []
-        for (const scope of scopes.split(' ')) {
+        for (const scope of scopeValues) {
           const parsed = Scope.safeParse(scope)
           if (!parsed.success) {
             return validationErrorResponse()

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -4,7 +4,7 @@ import { getKnex } from '@/lib/database'
 import { Scope } from '@/lib/types/database/operations'
 import { getTracer } from '@/lib/utils/trace'
 
-import {
+import type {
   ErrorResponse,
   PostRequest,
   PostResponse,
@@ -35,6 +35,11 @@ const generateRandomString = (length: number): string => {
   return result
 }
 
+const validationErrorResponse = (): ErrorResponse => ({
+  type: 'error',
+  error: 'Failed to validate request'
+})
+
 export const createApplication = async (
   request: PostRequest
 ): Promise<PostResponse> => {
@@ -57,19 +62,21 @@ export const createApplication = async (
         const clientId = generateRandomString(32)
         const clientSecret = generateRandomString(32)
         const hashedSecret = hashClientSecret(clientSecret)
-        const parsedScopes = scopes
-          .split(' ')
-          .map((scope) => Scope.parse(scope))
+        const parsedScopes: Scope[] = []
+        for (const scope of scopes.split(' ')) {
+          const parsed = Scope.safeParse(scope)
+          if (!parsed.success) {
+            return validationErrorResponse()
+          }
+          parsedScopes.push(parsed.data)
+        }
         // Mastodon API: multiple redirect URIs are newline-separated
         const redirectUris = request.redirect_uris
           .split('\n')
           .map((uri) => uri.trim())
           .filter(Boolean)
         if (redirectUris.length === 0) {
-          return ErrorResponse.parse({
-            type: 'error',
-            error: 'Failed to validate request'
-          })
+          return validationErrorResponse()
         }
         // RFC 8252 §7.1: native apps may use custom URI schemes (e.g. myapp://callback)
         // or http://localhost for loopback redirect.
@@ -78,16 +85,10 @@ export const createApplication = async (
           try {
             const parsed = new URL(uri)
             if (unsafeSchemes.has(parsed.protocol)) {
-              return ErrorResponse.parse({
-                type: 'error',
-                error: 'Failed to validate request'
-              })
+              return validationErrorResponse()
             }
           } catch {
-            return ErrorResponse.parse({
-              type: 'error',
-              error: 'Failed to validate request'
-            })
+            return validationErrorResponse()
           }
         }
         const now = new Date()
@@ -114,7 +115,7 @@ export const createApplication = async (
           updatedAt: now
         })
 
-        return SuccessResponse.parse({
+        const response: SuccessResponse = {
           type: 'success',
           id: dbId,
           client_id: clientId,
@@ -122,14 +123,12 @@ export const createApplication = async (
           name: request.client_name,
           website: request.website,
           redirect_uri: redirectUris[0]
-        })
+        }
+        return response
       } catch (error) {
         const nodeError = error as NodeJS.ErrnoException
         span.recordException(nodeError)
-        return ErrorResponse.parse({
-          type: 'error',
-          error: 'Failed to validate request'
-        })
+        return validationErrorResponse()
       } finally {
         span.end()
       }

--- a/app/api/v1/medias/presigned/route.ts
+++ b/app/api/v1/medias/presigned/route.ts
@@ -20,10 +20,20 @@ export const POST = traceApiRoute(
     const { database, currentActor } = context
     try {
       const content = await req.json()
+      const input = PresigedMediaInput.safeParse(content)
+      if (!input.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
       const presigned = await getPresignedUrl(
         database,
         currentActor,
-        PresigedMediaInput.parse(content)
+        input.data
       )
 
       if (!presigned) {

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getNotifications: jest.fn(),
+  deleteNotification: jest.fn()
+}
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun'
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+describe('GET /api/v1/notifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 422 when notification query parameters fail schema validation', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications?limit=0',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(data.status).toBe('Unprocessable entity')
+    expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -52,4 +52,25 @@ describe('GET /api/v1/notifications', () => {
     expect(data.status).toBe('Unprocessable entity')
     expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
   })
+
+  it('normalizes a single types[] query parameter to an array', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications?types[]=favourite',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual([])
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        types: ['like']
+      })
+    )
+  })
 })

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -23,6 +23,7 @@ const CORS_HEADERS = [
 ]
 const DEFAULT_LIMIT = 40
 const MAX_LIMIT = 80
+const ARRAY_QUERY_PARAMS = new Set(['types', 'exclude_types'])
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -62,20 +63,26 @@ export const GET = traceApiRoute(
     // Handle repeated query params (types[], exclude_types[])
     // Normalize keys by removing [] suffix to match Zod schema
     const queryParams: Record<string, string | string[]> = {}
-    url.searchParams.forEach((value, key) => {
+    for (const key of new Set(url.searchParams.keys())) {
       // Normalize key: types[] -> types, exclude_types[] -> exclude_types
       const normalizedKey = key.replace(/\[\]$/, '')
+      const allValues = url.searchParams.getAll(key)
+      const normalizedValue =
+        ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
+          ? allValues
+          : allValues[0]
       const existing = queryParams[normalizedKey]
-      if (existing) {
-        queryParams[normalizedKey] = Array.isArray(existing)
-          ? [...existing, value]
-          : [existing, value]
+      if (existing === undefined) {
+        queryParams[normalizedKey] = normalizedValue
       } else {
-        // Check if this key appears multiple times
-        const allValues = url.searchParams.getAll(key)
-        queryParams[normalizedKey] = allValues.length > 1 ? allValues : value
+        queryParams[normalizedKey] = [
+          ...(Array.isArray(existing) ? existing : [existing]),
+          ...(Array.isArray(normalizedValue)
+            ? normalizedValue
+            : [normalizedValue])
+        ]
       }
-    })
+    }
     const parsedParams = NotificationQueryParams.safeParse(queryParams)
     if (!parsedParams.success) {
       return apiResponse({

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -7,7 +7,12 @@ import { getMastodonNotification } from '@/lib/services/notifications/getMastodo
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
 import { NotificationType, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -71,7 +76,15 @@ export const GET = traceApiRoute(
         queryParams[normalizedKey] = allValues.length > 1 ? allValues : value
       }
     })
-    const parsedParams = NotificationQueryParams.parse(queryParams)
+    const parsedParams = NotificationQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
 
     const {
       limit = DEFAULT_LIMIT,
@@ -82,7 +95,7 @@ export const GET = traceApiRoute(
       exclude_types: excludeTypes,
       account_id: accountId,
       grouped = false
-    } = parsedParams
+    } = parsedParams.data
 
     // Convert Mastodon types to internal types for filtering
     const internalTypes = types?.map((type) => {

--- a/app/api/v1/settings/fitness/general/route.test.ts
+++ b/app/api/v1/settings/fitness/general/route.test.ts
@@ -408,6 +408,49 @@ describe('Fitness General Settings API', () => {
       )
     })
 
+    it('falls back to legacy settings when no privacyLocations payload is sent', async () => {
+      mockDb.createFitnessSettings.mockResolvedValue({
+        id: 'general-settings-id',
+        actorId: ACTOR1_ID,
+        serviceType: 'general',
+        privacyHomeLatitude: 13.7563,
+        privacyHomeLongitude: 100.5018,
+        privacyHideRadiusMeters: 10,
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      })
+
+      const request = new NextRequest(
+        'http://llun.test/api/v1/settings/fitness/general',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            privacyHomeLatitude: 13.7563,
+            privacyHomeLongitude: 100.5018,
+            privacyHideRadiusMeters: 10
+          })
+        }
+      )
+
+      const response = await POST(request, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockDb.createFitnessSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          privacyLocations: [
+            {
+              latitude: 13.7563,
+              longitude: 100.5018,
+              hideRadiusMeters: 10
+            }
+          ],
+          privacyHomeLatitude: 13.7563,
+          privacyHomeLongitude: 100.5018,
+          privacyHideRadiusMeters: 10
+        })
+      )
+    })
+
     it('rejects request when only one coordinate is provided', async () => {
       const request = new NextRequest(
         'http://llun.test/api/v1/settings/fitness/general',

--- a/app/api/v1/settings/fitness/general/route.test.ts
+++ b/app/api/v1/settings/fitness/general/route.test.ts
@@ -532,5 +532,23 @@ describe('Fitness General Settings API', () => {
       expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
       expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
     })
+
+    it('returns a bad request error for invalid JSON body', async () => {
+      const request = new NextRequest(
+        'http://llun.test/api/v1/settings/fitness/general',
+        {
+          method: 'POST',
+          body: 'not-json',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+
+      const response = await POST(request, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+      expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
+      expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
+    })
   })
 })

--- a/app/api/v1/settings/fitness/general/route.test.ts
+++ b/app/api/v1/settings/fitness/general/route.test.ts
@@ -451,6 +451,26 @@ describe('Fitness General Settings API', () => {
       )
     })
 
+    it('rejects invalid privacyLocations instead of falling back to legacy fields', async () => {
+      const request = new NextRequest(
+        'http://llun.test/api/v1/settings/fitness/general',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            privacyLocations: [{ latitude: 13.7563 }],
+            privacyHomeLatitude: 13.7563,
+            privacyHomeLongitude: 100.5018,
+            privacyHideRadiusMeters: 10
+          })
+        }
+      )
+
+      const response = await POST(request, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(422)
+      expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
+    })
+
     it('rejects request when only one coordinate is provided', async () => {
       const request = new NextRequest(
         'http://llun.test/api/v1/settings/fitness/general',

--- a/app/api/v1/settings/fitness/general/route.test.ts
+++ b/app/api/v1/settings/fitness/general/route.test.ts
@@ -447,5 +447,27 @@ describe('Fitness General Settings API', () => {
       expect(response.status).toBe(400)
       expect(data.error).toContain('home location')
     })
+
+    it('returns 422 when the settings payload fails schema validation', async () => {
+      const request = new NextRequest(
+        'http://llun.test/api/v1/settings/fitness/general',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            privacyHomeLatitude: '13.7563',
+            privacyHomeLongitude: 100.5018,
+            privacyHideRadiusMeters: 10
+          })
+        }
+      )
+
+      const response = await POST(request, { params: Promise.resolve({}) })
+      const data = await response.json()
+
+      expect(response.status).toBe(422)
+      expect(data.status).toBe('Unprocessable entity')
+      expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
+      expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
+    })
   })
 })

--- a/app/api/v1/settings/fitness/general/route.test.ts
+++ b/app/api/v1/settings/fitness/general/route.test.ts
@@ -550,5 +550,31 @@ describe('Fitness General Settings API', () => {
       expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
       expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
     })
+
+    it('returns an internal server error when saving settings fails', async () => {
+      mockDb.createFitnessSettings.mockRejectedValue(
+        new Error('database failed')
+      )
+
+      const request = new NextRequest(
+        'http://llun.test/api/v1/settings/fitness/general',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            privacyHomeLatitude: 13.7563,
+            privacyHomeLongitude: 100.5018,
+            privacyHideRadiusMeters: 10
+          })
+        }
+      )
+
+      const response = await POST(request, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        status: 'Internal Server Error'
+      })
+      expect(mockDb.createFitnessSettings).toHaveBeenCalled()
+    })
   })
 })

--- a/app/api/v1/settings/fitness/general/route.ts
+++ b/app/api/v1/settings/fitness/general/route.ts
@@ -266,12 +266,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: { error: 'Failed to save fitness general settings' },
-        responseStatusCode: 500
-      })
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
     }
   })
 )

--- a/app/api/v1/settings/fitness/general/route.ts
+++ b/app/api/v1/settings/fitness/general/route.ts
@@ -7,6 +7,7 @@ import {
   sanitizePrivacyRadiusMeters
 } from '@/lib/services/fitness-files/privacy'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { logger } from '@/lib/utils/logger'
 import {
   HTTP_STATUS,
   apiErrorResponse,
@@ -271,7 +272,12 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (_error) {
+    } catch (error) {
+      logger.error({
+        message: 'Failed to save fitness general settings',
+        actorId: currentActor.id,
+        error
+      })
       return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })

--- a/app/api/v1/settings/fitness/general/route.ts
+++ b/app/api/v1/settings/fitness/general/route.ts
@@ -66,20 +66,12 @@ const safeParseFitnessGeneralSettingsRequest = (
 ):
   | { success: true; data: FitnessGeneralSettingsRequest }
   | { success: false } => {
-  if (
-    body &&
-    typeof body === 'object' &&
-    Object.prototype.hasOwnProperty.call(body, 'privacyLocations')
-  ) {
-    const parsed = FitnessGeneralSettingsListRequest.safeParse(body)
-    return parsed.success
-      ? { success: true, data: parsed.data }
-      : { success: false }
-  }
+  const listResult = FitnessGeneralSettingsListRequest.safeParse(body)
+  if (listResult.success) return { success: true, data: listResult.data }
 
-  const parsed = FitnessGeneralSettingsLegacyRequest.safeParse(body)
-  return parsed.success
-    ? { success: true, data: parsed.data }
+  const legacyResult = FitnessGeneralSettingsLegacyRequest.safeParse(body)
+  return legacyResult.success
+    ? { success: true, data: legacyResult.data }
     : { success: false }
 }
 

--- a/app/api/v1/settings/fitness/general/route.ts
+++ b/app/api/v1/settings/fitness/general/route.ts
@@ -7,7 +7,11 @@ import {
   sanitizePrivacyRadiusMeters
 } from '@/lib/services/fitness-files/privacy'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
-import { apiResponse } from '@/lib/utils/response'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const PrivacyRadiusSchema = z
@@ -57,18 +61,26 @@ type FitnessGeneralSettingsRequest =
   | z.infer<typeof FitnessGeneralSettingsLegacyRequest>
   | z.infer<typeof FitnessGeneralSettingsListRequest>
 
-const parseFitnessGeneralSettingsRequest = (
+const safeParseFitnessGeneralSettingsRequest = (
   body: unknown
-): FitnessGeneralSettingsRequest => {
+):
+  | { success: true; data: FitnessGeneralSettingsRequest }
+  | { success: false } => {
   if (
     body &&
     typeof body === 'object' &&
     Object.prototype.hasOwnProperty.call(body, 'privacyLocations')
   ) {
-    return FitnessGeneralSettingsListRequest.parse(body)
+    const parsed = FitnessGeneralSettingsListRequest.safeParse(body)
+    return parsed.success
+      ? { success: true, data: parsed.data }
+      : { success: false }
   }
 
-  return FitnessGeneralSettingsLegacyRequest.parse(body)
+  const parsed = FitnessGeneralSettingsLegacyRequest.safeParse(body)
+  return parsed.success
+    ? { success: true, data: parsed.data }
+    : { success: false }
 }
 
 interface FitnessGeneralSettingsResponse {
@@ -209,8 +221,12 @@ export const POST = traceApiRoute(
 
     try {
       const body = await req.json()
-      const parsed = parseFitnessGeneralSettingsRequest(body)
-      const normalized = toSettingsPayload(parsed)
+      const parsed = safeParseFitnessGeneralSettingsRequest(body)
+      if (!parsed.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
+
+      const normalized = toSettingsPayload(parsed.data)
       if ('error' in normalized) {
         return apiResponse({
           req,
@@ -251,18 +267,7 @@ export const POST = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        const errorMessage =
-          error.issues.length > 0 ? error.issues[0].message : 'Invalid input'
-        return apiResponse({
-          req,
-          allowedMethods: [],
-          data: { error: errorMessage },
-          responseStatusCode: 400
-        })
-      }
-
+    } catch (_error) {
       return apiResponse({
         req,
         allowedMethods: [],

--- a/app/api/v1/settings/fitness/general/route.ts
+++ b/app/api/v1/settings/fitness/general/route.ts
@@ -217,23 +217,29 @@ export const POST = traceApiRoute(
   AuthenticatedGuard(async (req, context) => {
     const { currentActor, database } = context
 
+    let body: unknown
     try {
-      const body = await req.json()
-      const parsed = safeParseFitnessGeneralSettingsRequest(body)
-      if (!parsed.success) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
-      }
+      body = await req.json()
+    } catch (_error) {
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+    }
 
-      const normalized = toSettingsPayload(parsed.data)
-      if ('error' in normalized) {
-        return apiResponse({
-          req,
-          allowedMethods: [],
-          data: { error: normalized.error },
-          responseStatusCode: 400
-        })
-      }
+    const parsed = safeParseFitnessGeneralSettingsRequest(body)
+    if (!parsed.success) {
+      return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+    }
 
+    const normalized = toSettingsPayload(parsed.data)
+    if ('error' in normalized) {
+      return apiResponse({
+        req,
+        allowedMethods: [],
+        data: { error: normalized.error },
+        responseStatusCode: 400
+      })
+    }
+
+    try {
       const existing = await database.getFitnessSettings({
         actorId: currentActor.id,
         serviceType: 'general'
@@ -266,7 +272,7 @@ export const POST = traceApiRoute(
         responseStatusCode: 200
       })
     } catch (_error) {
-      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
+      return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
   })
 )

--- a/app/api/v1/settings/fitness/general/route.ts
+++ b/app/api/v1/settings/fitness/general/route.ts
@@ -61,6 +61,11 @@ type FitnessGeneralSettingsRequest =
   | z.infer<typeof FitnessGeneralSettingsLegacyRequest>
   | z.infer<typeof FitnessGeneralSettingsListRequest>
 
+const hasPrivacyLocationsPayload = (body: unknown) =>
+  body !== null &&
+  typeof body === 'object' &&
+  Object.prototype.hasOwnProperty.call(body, 'privacyLocations')
+
 const safeParseFitnessGeneralSettingsRequest = (
   body: unknown
 ):
@@ -68,6 +73,7 @@ const safeParseFitnessGeneralSettingsRequest = (
   | { success: false } => {
   const listResult = FitnessGeneralSettingsListRequest.safeParse(body)
   if (listResult.success) return { success: true, data: listResult.data }
+  if (hasPrivacyLocationsPayload(body)) return { success: false }
 
   const legacyResult = FitnessGeneralSettingsLegacyRequest.safeParse(body)
   return legacyResult.success

--- a/app/api/v1/settings/fitness/strava/archive/presigned/route.ts
+++ b/app/api/v1/settings/fitness/strava/archive/presigned/route.ts
@@ -62,7 +62,11 @@ export const POST = traceApiRoute(
       }
 
       const content = await req.json()
-      const input = PresignedArchiveInput.parse(content)
+      const parsed = PresignedArchiveInput.safeParse(content)
+      if (!parsed.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
+      const input = parsed.data
 
       const archiveId = crypto.randomUUID()
       const sourceBatchId = getStravaArchiveSourceBatchId(archiveId)
@@ -110,9 +114,6 @@ export const POST = traceApiRoute(
 
       if (error instanceof QuotaExceededError) {
         return apiErrorResponse(HTTP_STATUS.PAYLOAD_TOO_LARGE)
-      }
-      if (error instanceof z.ZodError) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
       }
       return apiErrorResponse(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }

--- a/app/api/v1/settings/fitness/strava/route.test.ts
+++ b/app/api/v1/settings/fitness/strava/route.test.ts
@@ -254,8 +254,8 @@ describe('Strava Settings API', () => {
       const response = await POST(request, { params: Promise.resolve({}) })
       const data = await response.json()
 
-      expect(response.status).toBe(400)
-      expect(data.error).toContain('numeric')
+      expect(response.status).toBe(422)
+      expect(data.status).toBe('Unprocessable entity')
     })
 
     it('rejects empty client secret when creating a connection', async () => {
@@ -273,8 +273,8 @@ describe('Strava Settings API', () => {
       const response = await POST(request, { params: Promise.resolve({}) })
       const data = await response.json()
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBeDefined()
+      expect(response.status).toBe(422)
+      expect(data.status).toBe('Unprocessable entity')
     })
 
     it('rejects invalid visibility values', async () => {
@@ -293,8 +293,8 @@ describe('Strava Settings API', () => {
       const response = await POST(request, { params: Promise.resolve({}) })
       const data = await response.json()
 
-      expect(response.status).toBe(400)
-      expect(data.error).toBeDefined()
+      expect(response.status).toBe(422)
+      expect(data.status).toBe('Unprocessable entity')
     })
   })
 

--- a/app/api/v1/settings/fitness/strava/route.test.ts
+++ b/app/api/v1/settings/fitness/strava/route.test.ts
@@ -296,6 +296,26 @@ describe('Strava Settings API', () => {
       expect(response.status).toBe(422)
       expect(data.status).toBe('Unprocessable entity')
     })
+
+    it('returns a bad request response for malformed JSON bodies', async () => {
+      const request = new NextRequest(
+        'http://llun.test/api/v1/settings/fitness/strava',
+        {
+          method: 'POST',
+          body: '{',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      )
+
+      const response = await POST(request, { params: Promise.resolve({}) })
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.status).toBe('Bad Request')
+      expect(mockDb.getFitnessSettings).not.toHaveBeenCalled()
+      expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
+      expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
+    })
   })
 
   describe('DELETE /api/v1/settings/fitness/strava', () => {

--- a/app/api/v1/settings/fitness/strava/route.ts
+++ b/app/api/v1/settings/fitness/strava/route.ts
@@ -164,7 +164,12 @@ export const POST = traceApiRoute(
       }
 
       return getStravaSettingsSavedResponse(req)
-    } catch (_error) {
+    } catch (error) {
+      logger.error({
+        message: 'Failed to save Strava settings',
+        actorId: currentActor.id,
+        error
+      })
       return apiResponse({
         req,
         allowedMethods: [],
@@ -238,7 +243,12 @@ export const DELETE = traceApiRoute(
         },
         responseStatusCode: 200
       })
-    } catch (_error) {
+    } catch (error) {
+      logger.error({
+        message: 'Failed to delete Strava settings',
+        actorId: currentActor.id,
+        error
+      })
       return apiResponse({
         req,
         allowedMethods: [],

--- a/app/api/v1/settings/fitness/strava/route.ts
+++ b/app/api/v1/settings/fitness/strava/route.ts
@@ -11,6 +11,7 @@ import { Visibility } from '@/lib/types/mastodon/visibility'
 import { generateAlphanumeric } from '@/lib/utils/crypto'
 import { logger } from '@/lib/utils/logger'
 import {
+  ERROR_400,
   HTTP_STATUS,
   apiErrorResponse,
   apiResponse
@@ -106,12 +107,24 @@ export const POST = traceApiRoute(
   AuthenticatedGuard(async (req, context) => {
     const { currentActor, database } = context
 
+    let body: unknown
     try {
-      const body = await req.json()
-      const parsed = StravaSettingsRequest.safeParse(body)
-      if (!parsed.success) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
-      }
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: [],
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const parsed = StravaSettingsRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+    }
+
+    try {
       const { clientId, clientSecret, defaultVisibility } = parsed.data
 
       const existing = await database.getFitnessSettings({

--- a/app/api/v1/settings/fitness/strava/route.ts
+++ b/app/api/v1/settings/fitness/strava/route.ts
@@ -11,7 +11,6 @@ import { Visibility } from '@/lib/types/mastodon/visibility'
 import { generateAlphanumeric } from '@/lib/utils/crypto'
 import { logger } from '@/lib/utils/logger'
 import {
-  ERROR_400,
   HTTP_STATUS,
   apiErrorResponse,
   apiResponse
@@ -111,12 +110,7 @@ export const POST = traceApiRoute(
     try {
       body = await req.json()
     } catch {
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: ERROR_400,
-        responseStatusCode: 400
-      })
+      return apiErrorResponse(HTTP_STATUS.BAD_REQUEST)
     }
 
     const parsed = StravaSettingsRequest.safeParse(body)

--- a/app/api/v1/settings/fitness/strava/route.ts
+++ b/app/api/v1/settings/fitness/strava/route.ts
@@ -10,7 +10,11 @@ import {
 import { Visibility } from '@/lib/types/mastodon/visibility'
 import { generateAlphanumeric } from '@/lib/utils/crypto'
 import { logger } from '@/lib/utils/logger'
-import { apiResponse } from '@/lib/utils/response'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const StravaSettingsRequest = z.object({
@@ -104,8 +108,11 @@ export const POST = traceApiRoute(
 
     try {
       const body = await req.json()
-      const { clientId, clientSecret, defaultVisibility } =
-        StravaSettingsRequest.parse(body)
+      const parsed = StravaSettingsRequest.safeParse(body)
+      if (!parsed.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
+      const { clientId, clientSecret, defaultVisibility } = parsed.data
 
       const existing = await database.getFitnessSettings({
         actorId: currentActor.id,
@@ -150,12 +157,7 @@ export const POST = traceApiRoute(
       }
 
       return getStravaSettingsSavedResponse(req)
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        const errorMessage =
-          error.issues.length > 0 ? error.issues[0].message : 'Invalid input'
-        return getValidationErrorResponse(req, errorMessage)
-      }
+    } catch (_error) {
       return apiResponse({
         req,
         allowedMethods: [],

--- a/app/api/v1/webhooks/strava/[webhookToken]/route.test.ts
+++ b/app/api/v1/webhooks/strava/[webhookToken]/route.test.ts
@@ -19,6 +19,15 @@ jest.mock('@/lib/services/queue', () => ({
   })
 }))
 
+const mockLoggerWarn = jest.fn()
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args)
+  }
+}))
+
 describe('Strava Webhook API', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
     getFitnessSettingsByWebhookToken: jest.fn()
@@ -134,6 +143,56 @@ describe('Strava Webhook API', () => {
         data: {
           actorId: 'actor-1',
           stravaActivityId: '13579',
+          visibility: 'private'
+        }
+      })
+    )
+  })
+
+  it('falls back to private when persisted webhook visibility is invalid', async () => {
+    mockDb.getFitnessSettingsByWebhookToken.mockResolvedValueOnce({
+      id: 'fitness-settings-1',
+      actorId: 'actor-1',
+      serviceType: 'strava',
+      webhookToken: 'token-123',
+      accessToken: 'access-token',
+      defaultVisibility: 'followers_only' as never,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    })
+
+    const request = new NextRequest(
+      'http://llun.test/api/v1/webhooks/strava/token-123',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          object_type: 'activity',
+          object_id: 24680,
+          aspect_type: 'create',
+          owner_id: 1,
+          event_time: 1_735_689_600
+        })
+      }
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ webhookToken: 'token-123' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Invalid Strava default visibility; falling back to private',
+        actorId: 'actor-1'
+      })
+    )
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '24680',
           visibility: 'private'
         }
       })

--- a/app/api/v1/webhooks/strava/[webhookToken]/route.ts
+++ b/app/api/v1/webhooks/strava/[webhookToken]/route.ts
@@ -7,7 +7,11 @@ import { getQueue } from '@/lib/services/queue'
 import { Visibility } from '@/lib/types/mastodon/visibility'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
-import { apiResponse } from '@/lib/utils/response'
+import {
+  HTTP_STATUS,
+  apiErrorResponse,
+  apiResponse
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 type Params = { webhookToken: string }
@@ -161,6 +165,12 @@ export const POST = traceApiRoute(
       }
 
       const stravaActivityId = String(body.object_id)
+      const visibility = Visibility.safeParse(
+        fitnessSettings.defaultVisibility ?? 'private'
+      )
+      if (!visibility.success) {
+        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      }
 
       await getQueue().publish({
         id: getHashFromString(
@@ -170,9 +180,7 @@ export const POST = traceApiRoute(
         data: {
           actorId: fitnessSettings.actorId,
           stravaActivityId,
-          visibility: Visibility.parse(
-            fitnessSettings.defaultVisibility ?? 'private'
-          )
+          visibility: visibility.data
         }
       })
 

--- a/app/api/v1/webhooks/strava/[webhookToken]/route.ts
+++ b/app/api/v1/webhooks/strava/[webhookToken]/route.ts
@@ -7,11 +7,7 @@ import { getQueue } from '@/lib/services/queue'
 import { Visibility } from '@/lib/types/mastodon/visibility'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
-import {
-  HTTP_STATUS,
-  apiErrorResponse,
-  apiResponse
-} from '@/lib/utils/response'
+import { apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 type Params = { webhookToken: string }
@@ -165,11 +161,18 @@ export const POST = traceApiRoute(
       }
 
       const stravaActivityId = String(body.object_id)
-      const visibility = Visibility.safeParse(
+      const parsedVisibility = Visibility.safeParse(
         fitnessSettings.defaultVisibility ?? 'private'
       )
-      if (!visibility.success) {
-        return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
+      const visibility = parsedVisibility.success
+        ? parsedVisibility.data
+        : 'private'
+      if (!parsedVisibility.success) {
+        logger.warn({
+          message: 'Invalid Strava default visibility; falling back to private',
+          actorId: fitnessSettings.actorId,
+          defaultVisibility: fitnessSettings.defaultVisibility
+        })
       }
 
       await getQueue().publish({
@@ -180,7 +183,7 @@ export const POST = traceApiRoute(
         data: {
           actorId: fitnessSettings.actorId,
           stravaActivityId,
-          visibility: visibility.data
+          visibility
         }
       })
 

--- a/app/api/v2/media/route.ts
+++ b/app/api/v2/media/route.ts
@@ -16,8 +16,17 @@ export const POST = traceApiRoute(
     try {
       const { database, currentActor } = context
       const form = await req.formData()
-      const media = MediaSchema.parse(Object.fromEntries(form.entries()))
-      const response = await saveMedia(database, currentActor, media)
+      const media = MediaSchema.safeParse(Object.fromEntries(form.entries()))
+      if (!media.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      const response = await saveMedia(database, currentActor, media.data)
       if (!response) {
         return apiResponse({
           req,


### PR DESCRIPTION
## Summary
- Replace route-handler Zod parse calls in app/api with safeParse validation branches
- Return structured 422 responses for invalid route input while preserving CORS headers on OPTIONS routes
- Add invalid-input regression coverage for settings, account, media, and notification endpoints

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test