### PR TITLE
fix: enforce ActivityPub sender and visibility checks

### DIFF
--- a/app/(timeline)/[actor]/[status]/StatusBox.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.tsx
@@ -8,7 +8,12 @@ import { Post } from '@/lib/components/posts/post'
 import { StatusReplyBox } from '@/lib/components/posts/status-reply-box'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
-import { Status, StatusNote, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusNote,
+  StatusType,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 
 import { FitnessStatusDetail } from './FitnessStatusDetail'
@@ -40,7 +45,9 @@ export const StatusBox: FC<Props> = ({
   } | null>(null)
   const [replyTarget, setReplyTarget] = useState<Status | null>(null)
   const actualStatus =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+    status.type === StatusType.enum.Announce
+      ? getOriginalStatus(status)
+      : status
   const shouldRenderFitnessDetail =
     variant === 'detail' &&
     actualStatus.type === StatusType.enum.Note &&

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -10,7 +10,11 @@ import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getQueue } from '@/lib/services/queue'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { FollowStatus } from '@/lib/types/domain/follow'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
@@ -91,7 +95,7 @@ const Page: FC<Props> = async ({ params }) => {
 
   const statusUrl =
     status.type === StatusType.enum.Announce
-      ? status.originalStatus.url
+      ? getOriginalStatus(status).url
       : status.url
 
   let replies: Status[]
@@ -179,7 +183,9 @@ const Page: FC<Props> = async ({ params }) => {
   }
 
   const statusForLayout =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+    status.type === StatusType.enum.Announce
+      ? getOriginalStatus(status)
+      : status
   const isFitnessDashboard =
     statusForLayout.type === StatusType.enum.Note &&
     statusForLayout.fitness?.processingStatus === 'completed'

--- a/app/api/inbox/getJobMessage.test.ts
+++ b/app/api/inbox/getJobMessage.test.ts
@@ -1,8 +1,26 @@
+import { CREATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+
 import { getJobMessage } from './getJobMessage'
 
 const verifiedSenderActorId = 'https://remote.test/users/alice'
 
 describe('getJobMessage', () => {
+  it('rejects Create Note activities when the verified sender actor id is missing', () => {
+    const result = getJobMessage({
+      id: 'https://remote.test/activities/create-unverified',
+      type: 'Create',
+      actor: verifiedSenderActorId,
+      object: {
+        id: 'https://remote.test/users/alice/statuses/1',
+        type: 'Note',
+        attributedTo: verifiedSenderActorId,
+        content: 'Unverified sender'
+      }
+    } as never)
+
+    expect(result).toBeNull()
+  })
+
   it('rejects Create Note activities without object actor attribution when the sender is verified', () => {
     const result = getJobMessage(
       {
@@ -19,6 +37,54 @@ describe('getJobMessage', () => {
     )
 
     expect(result).toBeNull()
+  })
+
+  it('rejects Create Note activities when any nested attribution differs from the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/create-mixed-attribution',
+        type: 'Create',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: 'Note',
+          attributedTo: [
+            { id: `${verifiedSenderActorId}#main-key` },
+            [{ id: 'https://remote.test/users/mallory' }]
+          ],
+          content: 'Mixed attribution'
+        }
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('accepts Create Note activities only when every object actor id matches the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/create-matching-attribution',
+        type: 'Create',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: 'Note',
+          attributedTo: [
+            verifiedSenderActorId,
+            { id: `${verifiedSenderActorId}#main-key` }
+          ],
+          actor: { id: verifiedSenderActorId },
+          content: 'Matching attribution'
+        }
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toMatchObject({
+      name: CREATE_NOTE_JOB_NAME,
+      verifiedSenderActorId
+    })
   })
 
   it.each([

--- a/app/api/inbox/getJobMessage.test.ts
+++ b/app/api/inbox/getJobMessage.test.ts
@@ -115,6 +115,31 @@ describe('getJobMessage', () => {
     })
   })
 
+  it('accepts Create Note activities when the object actor is a link object', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/create-link-actor',
+        type: 'Create',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: 'Note',
+          attributedTo: {
+            type: 'Link',
+            href: verifiedSenderActorId
+          },
+          content: 'Actor link object'
+        }
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toMatchObject({
+      name: CREATE_NOTE_JOB_NAME,
+      verifiedSenderActorId
+    })
+  })
+
   it.each([
     ['Update', 'Update', 'https://remote.test/users/alice#main-key'],
     ['Announce', 'Announce', 'https://remote.test/users/alice#main-key'],
@@ -190,6 +215,39 @@ describe('getJobMessage', () => {
         object: 'https://remote.test/users/alice/statuses/1'
       } as never,
       ''
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('rejects Delete activities when the activity actor differs from the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/delete-spoofed',
+        type: 'Delete',
+        actor: 'https://remote.test/users/mallory',
+        object: 'https://remote.test/users/alice/statuses/1'
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('rejects Undo Announce activities when the activity actor differs from the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/undo-spoofed',
+        type: 'Undo',
+        actor: 'https://remote.test/users/mallory',
+        object: {
+          id: 'https://remote.test/users/alice/statuses/boost-1',
+          type: 'Announce',
+          actor: verifiedSenderActorId,
+          object: 'https://remote.test/users/alice/statuses/1'
+        }
+      } as never,
+      verifiedSenderActorId
     )
 
     expect(result).toBeNull()

--- a/app/api/inbox/getJobMessage.test.ts
+++ b/app/api/inbox/getJobMessage.test.ts
@@ -5,18 +5,21 @@ import { getJobMessage } from './getJobMessage'
 const verifiedSenderActorId = 'https://remote.test/users/alice'
 
 describe('getJobMessage', () => {
-  it('rejects Create Note activities when the verified sender actor id is missing', () => {
-    const result = getJobMessage({
-      id: 'https://remote.test/activities/create-unverified',
-      type: 'Create',
-      actor: verifiedSenderActorId,
-      object: {
-        id: 'https://remote.test/users/alice/statuses/1',
-        type: 'Note',
-        attributedTo: verifiedSenderActorId,
-        content: 'Unverified sender'
-      }
-    } as never)
+  it('rejects Create Note activities when the verified sender actor id is invalid', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/create-unverified',
+        type: 'Create',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: 'Note',
+          attributedTo: verifiedSenderActorId,
+          content: 'Unverified sender'
+        }
+      } as never,
+      ''
+    )
 
     expect(result).toBeNull()
   })
@@ -76,6 +79,31 @@ describe('getJobMessage', () => {
           ],
           actor: { id: verifiedSenderActorId },
           content: 'Matching attribution'
+        }
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toMatchObject({
+      name: CREATE_NOTE_JOB_NAME,
+      verifiedSenderActorId
+    })
+  })
+
+  it('accepts Create Note activities when the inline actor object id matches the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/create-inline-actor',
+        type: 'Create',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: 'Note',
+          attributedTo: {
+            id: verifiedSenderActorId,
+            url: 'https://remote.test/@alice'
+          },
+          content: 'Inline actor object'
         }
       } as never,
       verifiedSenderActorId
@@ -148,6 +176,20 @@ describe('getJobMessage', () => {
         object: 'https://remote.test/users/alice/statuses/1'
       } as never,
       verifiedSenderActorId
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('rejects Announce activities when the verified sender actor id is invalid', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/announce-unverified',
+        type: 'Announce',
+        actor: verifiedSenderActorId,
+        object: 'https://remote.test/users/alice/statuses/1'
+      } as never,
+      ''
     )
 
     expect(result).toBeNull()

--- a/app/api/inbox/getJobMessage.test.ts
+++ b/app/api/inbox/getJobMessage.test.ts
@@ -1,0 +1,89 @@
+import { getJobMessage } from './getJobMessage'
+
+const verifiedSenderActorId = 'https://remote.test/users/alice'
+
+describe('getJobMessage', () => {
+  it('rejects Create Note activities without object actor attribution when the sender is verified', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/create-no-attribution',
+        type: 'Create',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/alice/statuses/1',
+          type: 'Note',
+          content: 'Missing attribution'
+        }
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it.each([
+    ['Update', 'Update', 'https://remote.test/users/alice#main-key'],
+    ['Announce', 'Announce', 'https://remote.test/users/alice#main-key'],
+    ['Delete', 'Delete', 'https://remote.test/users/alice#main-key']
+  ])(
+    'attaches the normalized verified sender actor id to %s job messages',
+    (_label, type, senderActorId) => {
+      const object =
+        type === 'Update'
+          ? {
+              id: 'https://remote.test/users/alice/statuses/1',
+              type: 'Note',
+              attributedTo: verifiedSenderActorId,
+              content: 'Updated content'
+            }
+          : 'https://remote.test/users/alice/statuses/1'
+
+      const result = getJobMessage(
+        {
+          id: `https://remote.test/activities/${type.toLowerCase()}-1`,
+          type,
+          actor: verifiedSenderActorId,
+          object
+        } as never,
+        senderActorId
+      )
+
+      expect(result).toMatchObject({
+        verifiedSenderActorId: verifiedSenderActorId.toLowerCase()
+      })
+    }
+  )
+
+  it('rejects Update Note activities when object attribution differs from the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/update-spoofed',
+        type: 'Update',
+        actor: verifiedSenderActorId,
+        object: {
+          id: 'https://remote.test/users/mallory/statuses/1',
+          type: 'Note',
+          attributedTo: 'https://remote.test/users/mallory',
+          content: 'Spoofed content'
+        }
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('rejects Announce activities when the activity actor differs from the verified sender', () => {
+    const result = getJobMessage(
+      {
+        id: 'https://remote.test/activities/announce-spoofed',
+        type: 'Announce',
+        actor: 'https://remote.test/users/mallory',
+        object: 'https://remote.test/users/alice/statuses/1'
+      } as never,
+      verifiedSenderActorId
+    )
+
+    expect(result).toBeNull()
+  })
+})

--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -79,7 +79,10 @@ const extractActivityPubIds = (value: unknown): string[] => {
   if (Array.isArray(value)) return value.flatMap(extractActivityPubIds)
   if (!isRecord(value)) return []
 
-  return typeof value.id === 'string' ? [value.id] : []
+  if (typeof value.id === 'string') return [value.id]
+  if (typeof value.href === 'string') return [value.href]
+  if (typeof value.url === 'string') return [value.url]
+  return []
 }
 
 const createObjectActorMismatch = (

--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -10,6 +10,7 @@ import {
   UPDATE_NOTE_JOB_NAME,
   UPDATE_POLL_JOB_NAME
 } from '@/lib/jobs/names'
+import type { JobMessage } from '@/lib/services/queue/type'
 import { ENTITY_TYPE_NOTE, ENTITY_TYPE_QUESTION } from '@/lib/types/activitypub'
 import {
   AnnounceAction,
@@ -18,7 +19,9 @@ import {
   UndoAction,
   UpdateAction
 } from '@/lib/types/activitypub/activities'
+import { extractActivityPubId, normalizeActorId } from '@/lib/utils/activitypub'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { isRecord } from '@/lib/utils/typeGuards'
 
 const ENTITY_TYPE_IMAGE = 'Image'
 const ENTITY_TYPE_PAGE = 'Page'
@@ -33,7 +36,43 @@ const NOTE_TYPES = [
   ENTITY_TYPE_VIDEO
 ]
 
-export const getJobMessage = (activity: StatusActivity) => {
+const createJobMessage = ({
+  data,
+  id,
+  name,
+  verifiedSenderActorId
+}: JobMessage) => ({
+  id,
+  name,
+  data,
+  ...(verifiedSenderActorId ? { verifiedSenderActorId } : {})
+})
+
+const createObjectActorMismatch = (
+  object: unknown,
+  verifiedSenderActorId?: string
+) => {
+  if (!verifiedSenderActorId || !isRecord(object)) return false
+
+  const normalizedVerifiedSenderActorId = normalizeActorId(
+    verifiedSenderActorId
+  )
+  if (!normalizedVerifiedSenderActorId) return true
+
+  const objectActorIds = [
+    extractActivityPubId(object.attributedTo),
+    extractActivityPubId(object.actor)
+  ].filter((actorId): actorId is string => Boolean(actorId))
+
+  return objectActorIds.some(
+    (actorId) => normalizeActorId(actorId) !== normalizedVerifiedSenderActorId
+  )
+}
+
+export const getJobMessage = (
+  activity: StatusActivity,
+  verifiedSenderActorId?: string
+) => {
   const deduplicationId = getHashFromString(activity.id)
 
   if (activity.type === CreateAction) {
@@ -42,6 +81,10 @@ export const getJobMessage = (activity: StatusActivity) => {
       activity.object !== null &&
       NOTE_TYPES.includes(activity.object.type)
     ) {
+      if (createObjectActorMismatch(activity.object, verifiedSenderActorId)) {
+        return null
+      }
+
       if (
         activity.object.type === ENTITY_TYPE_NOTE &&
         activity.object.inReplyTo &&
@@ -49,18 +92,20 @@ export const getJobMessage = (activity: StatusActivity) => {
         activity.object.name &&
         !activity.object.content
       ) {
-        return {
+        return createJobMessage({
           id: deduplicationId,
           name: CREATE_POLL_VOTE_JOB_NAME,
-          data: activity.object
-        }
+          data: activity.object,
+          verifiedSenderActorId
+        })
       }
 
-      return {
+      return createJobMessage({
         id: deduplicationId,
         name: CREATE_NOTE_JOB_NAME,
-        data: activity.object
-      }
+        data: activity.object,
+        verifiedSenderActorId
+      })
     }
 
     if (
@@ -68,11 +113,16 @@ export const getJobMessage = (activity: StatusActivity) => {
       activity.object !== null &&
       activity.object.type === ENTITY_TYPE_QUESTION
     ) {
-      return {
+      if (createObjectActorMismatch(activity.object, verifiedSenderActorId)) {
+        return null
+      }
+
+      return createJobMessage({
         id: deduplicationId,
         name: CREATE_POLL_JOB_NAME,
-        data: activity.object
-      }
+        data: activity.object,
+        verifiedSenderActorId
+      })
     }
   }
 

--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -58,10 +58,8 @@ const createJobMessage = ({
 
 const activityActorMismatch = (
   activity: StatusActivity,
-  verifiedSenderActorId?: string
+  verifiedSenderActorId: string
 ) => {
-  if (!verifiedSenderActorId) return false
-
   const normalizedVerifiedSenderActorId = normalizeActorId(
     verifiedSenderActorId
   )
@@ -81,12 +79,12 @@ const extractActivityPubIds = (value: unknown): string[] => {
   if (Array.isArray(value)) return value.flatMap(extractActivityPubIds)
   if (!isRecord(value)) return []
 
-  return [value.id, value.href, value.url].flatMap(extractActivityPubIds)
+  return typeof value.id === 'string' ? [value.id] : []
 }
 
 const createObjectActorMismatch = (
   object: unknown,
-  verifiedSenderActorId?: string
+  verifiedSenderActorId: string
 ) => {
   if (!isRecord(object)) return false
 
@@ -109,7 +107,7 @@ const createObjectActorMismatch = (
 
 export const getJobMessage = (
   activity: StatusActivity,
-  verifiedSenderActorId?: string
+  verifiedSenderActorId: string
 ) => {
   const deduplicationId = getHashFromString(activity.id)
 

--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -76,11 +76,19 @@ const activityActorMismatch = (
   )
 }
 
+const extractActivityPubIds = (value: unknown): string[] => {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) return value.flatMap(extractActivityPubIds)
+  if (!isRecord(value)) return []
+
+  return [value.id, value.href, value.url].flatMap(extractActivityPubIds)
+}
+
 const createObjectActorMismatch = (
   object: unknown,
   verifiedSenderActorId?: string
 ) => {
-  if (!verifiedSenderActorId || !isRecord(object)) return false
+  if (!isRecord(object)) return false
 
   const normalizedVerifiedSenderActorId = normalizeActorId(
     verifiedSenderActorId
@@ -88,14 +96,14 @@ const createObjectActorMismatch = (
   if (!normalizedVerifiedSenderActorId) return true
 
   const objectActorIds = [
-    extractActivityPubId(object.attributedTo),
-    extractActivityPubId(object.actor)
-  ].filter((actorId): actorId is string => Boolean(actorId))
+    ...extractActivityPubIds(object.attributedTo),
+    ...extractActivityPubIds(object.actor)
+  ]
 
   if (objectActorIds.length === 0) return true
 
-  return objectActorIds.some(
-    (actorId) => normalizeActorId(actorId) !== normalizedVerifiedSenderActorId
+  return !objectActorIds.every(
+    (actorId) => normalizeActorId(actorId) === normalizedVerifiedSenderActorId
   )
 }
 

--- a/app/api/inbox/getJobMessage.ts
+++ b/app/api/inbox/getJobMessage.ts
@@ -41,12 +41,40 @@ const createJobMessage = ({
   id,
   name,
   verifiedSenderActorId
-}: JobMessage) => ({
-  id,
-  name,
-  data,
-  ...(verifiedSenderActorId ? { verifiedSenderActorId } : {})
-})
+}: JobMessage) => {
+  const normalizedVerifiedSenderActorId = normalizeActorId(
+    verifiedSenderActorId
+  )
+
+  return {
+    id,
+    name,
+    data,
+    ...(normalizedVerifiedSenderActorId
+      ? { verifiedSenderActorId: normalizedVerifiedSenderActorId }
+      : {})
+  }
+}
+
+const activityActorMismatch = (
+  activity: StatusActivity,
+  verifiedSenderActorId?: string
+) => {
+  if (!verifiedSenderActorId) return false
+
+  const normalizedVerifiedSenderActorId = normalizeActorId(
+    verifiedSenderActorId
+  )
+  const normalizedActivityActorId = normalizeActorId(
+    extractActivityPubId(activity.actor)
+  )
+
+  return (
+    !normalizedVerifiedSenderActorId ||
+    !normalizedActivityActorId ||
+    normalizedActivityActorId !== normalizedVerifiedSenderActorId
+  )
+}
 
 const createObjectActorMismatch = (
   object: unknown,
@@ -63,6 +91,8 @@ const createObjectActorMismatch = (
     extractActivityPubId(object.attributedTo),
     extractActivityPubId(object.actor)
   ].filter((actorId): actorId is string => Boolean(actorId))
+
+  if (objectActorIds.length === 0) return true
 
   return objectActorIds.some(
     (actorId) => normalizeActorId(actorId) !== normalizedVerifiedSenderActorId
@@ -132,11 +162,16 @@ export const getJobMessage = (
       activity.object !== null &&
       activity.object.type === ENTITY_TYPE_QUESTION
     ) {
-      return {
+      if (createObjectActorMismatch(activity.object, verifiedSenderActorId)) {
+        return null
+      }
+
+      return createJobMessage({
         id: deduplicationId,
         name: UPDATE_POLL_JOB_NAME,
-        data: activity.object
-      }
+        data: activity.object,
+        verifiedSenderActorId
+      })
     }
 
     if (
@@ -144,31 +179,46 @@ export const getJobMessage = (
       activity.object !== null &&
       NOTE_TYPES.includes(activity.object.type)
     ) {
-      return {
+      if (createObjectActorMismatch(activity.object, verifiedSenderActorId)) {
+        return null
+      }
+
+      return createJobMessage({
         id: deduplicationId,
         name: UPDATE_NOTE_JOB_NAME,
-        data: activity.object
-      }
+        data: activity.object,
+        verifiedSenderActorId
+      })
     }
   }
 
   if (isMatch(activity, { type: AnnounceAction })) {
-    return {
+    if (activityActorMismatch(activity, verifiedSenderActorId)) {
+      return null
+    }
+
+    return createJobMessage({
       id: deduplicationId,
       name: CREATE_ANNOUNCE_JOB_NAME,
-      data: activity
-    }
+      data: activity,
+      verifiedSenderActorId
+    })
   }
 
   if (
     isMatch(activity, { type: UndoAction, object: { type: AnnounceAction } }) ||
     isMatch(activity, { type: DeleteAction })
   ) {
-    return {
+    if (activityActorMismatch(activity, verifiedSenderActorId)) {
+      return null
+    }
+
+    return createJobMessage({
       id: deduplicationId,
       name: DELETE_OBJECT_JOB_NAME,
-      data: activity.object
-    }
+      data: activity.object,
+      verifiedSenderActorId
+    })
   }
 
   return null

--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -8,6 +8,7 @@ const mockPublish = jest.fn()
 const mockDefaultActivityBody = Symbol('defaultActivityBody')
 let mockActivityBody: unknown = mockDefaultActivityBody
 let mockConsumeRequestBody = false
+let mockVerifiedSenderActorId = 'https://allowed.test/users/a'
 
 jest.mock('@/lib/services/federation/domainPolicy', () => ({
   canFederateWithDomain: (...params: unknown[]) =>
@@ -23,6 +24,7 @@ jest.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
           activityBody: unknown
           database: typeof mockDatabase
           params: Promise<{}>
+          verifiedSenderActorId: string
         }
       ) => Promise<Response> | Response
     ) =>
@@ -42,7 +44,8 @@ jest.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
       return handle(req, {
         activityBody,
         database: mockDatabase,
-        params: context.params
+        params: context.params,
+        verifiedSenderActorId: mockVerifiedSenderActorId
       })
     }
 }))
@@ -86,6 +89,7 @@ describe('POST /api/inbox', () => {
     jest.clearAllMocks()
     mockActivityBody = mockDefaultActivityBody
     mockConsumeRequestBody = false
+    mockVerifiedSenderActorId = 'https://allowed.test/users/a'
   })
 
   it('rejects activities from blocked actor domains', async () => {
@@ -188,5 +192,57 @@ describe('POST /api/inbox', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'CreateNoteJob' })
     )
+  })
+
+  it('carries the verified sender identity into queued jobs', async () => {
+    const actor = 'https://allowed.test/users/a'
+    mockCanFederateWithDomain.mockResolvedValue(true)
+    mockVerifiedSenderActorId = `${actor}#main-key`
+    mockActivityBody = {
+      id: `${actor}/activities/create-1`,
+      type: 'Create',
+      actor,
+      object: {
+        id: `${actor}/statuses/1`,
+        type: 'Note',
+        attributedTo: actor
+      }
+    }
+
+    const response = await POST(createRequest(actor), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(202)
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'CreateNoteJob',
+        verifiedSenderActorId: mockVerifiedSenderActorId
+      })
+    )
+  })
+
+  it('rejects Create Note activities whose inner object actor does not match the verified sender', async () => {
+    const actor = 'https://allowed.test/users/a'
+    mockCanFederateWithDomain.mockResolvedValue(true)
+    mockVerifiedSenderActorId = actor
+    mockActivityBody = {
+      id: `${actor}/activities/create-1`,
+      type: 'Create',
+      actor,
+      object: {
+        id: `${actor}/statuses/1`,
+        type: 'Note',
+        actor: 'https://spoofed.test/users/mallory',
+        attributedTo: actor
+      }
+    }
+
+    const response = await POST(createRequest(actor), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockPublish).not.toHaveBeenCalled()
   })
 })

--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -78,7 +78,8 @@ const createRequest = (actor: unknown) => {
       actor,
       object: {
         id: `${actorId}/statuses/1`,
-        type: 'Note'
+        type: 'Note',
+        attributedTo: actorId
       }
     })
   })
@@ -144,7 +145,8 @@ describe('POST /api/inbox', () => {
       actor,
       object: {
         id: `${actor}/statuses/1`,
-        type: 'Note'
+        type: 'Note',
+        attributedTo: actor
       }
     }
     mockConsumeRequestBody = true
@@ -217,7 +219,7 @@ describe('POST /api/inbox', () => {
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'CreateNoteJob',
-        verifiedSenderActorId: mockVerifiedSenderActorId
+        verifiedSenderActorId: actor
       })
     )
   })

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -23,51 +23,56 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const POST = traceApiRoute(
   'sharedInbox',
-  ActivityPubVerifySenderGuard(async (request, { activityBody, database }) => {
-    const body = activityBody
-    const actor = isRecord(body) ? extractActivityPubId(body.actor) : undefined
+  ActivityPubVerifySenderGuard(
+    async (request, { activityBody, database, verifiedSenderActorId }) => {
+      const body = activityBody
+      const actor = isRecord(body)
+        ? extractActivityPubId(body.actor)
+        : undefined
 
-    // The guard enforces signed POST actors; keep route validation before casting unknown JSON.
-    if (
-      !isRecord(body) ||
-      typeof body.id !== 'string' ||
-      typeof body.type !== 'string' ||
-      !actor ||
-      !normalizeActorId(actor)
-    ) {
+      // The guard enforces signed POST actors; keep route validation before casting unknown JSON.
+      if (
+        !isRecord(body) ||
+        typeof body.id !== 'string' ||
+        typeof body.type !== 'string' ||
+        !actor ||
+        !normalizeActorId(actor)
+      ) {
+        return apiResponse({
+          req: request,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const activity = { ...body, actor } as unknown as StatusActivity
+      if (!(await canFederateWithDomain(database, activity.actor))) {
+        return apiResponse({
+          req: request,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_403,
+          responseStatusCode: 403
+        })
+      }
+
+      const jobMessage = getJobMessage(activity, verifiedSenderActorId)
+      if (!jobMessage) {
+        return apiResponse({
+          req: request,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      await getQueue().publish(jobMessage)
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_400,
-        responseStatusCode: 400
+        data: DEFAULT_202,
+        responseStatusCode: 202
       })
-    }
-    const activity = { ...body, actor } as unknown as StatusActivity
-    if (!(await canFederateWithDomain(database, activity.actor))) {
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_403,
-        responseStatusCode: 403
-      })
-    }
-
-    const jobMessage = getJobMessage(activity)
-    if (!jobMessage) {
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-    }
-
-    await getQueue().publish(jobMessage)
-    return apiResponse({
-      req: request,
-      allowedMethods: CORS_HEADERS,
-      data: DEFAULT_202,
-      responseStatusCode: 202
-    })
-  }, CORS_HEADERS)
+    },
+    CORS_HEADERS
+  )
 )

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -41,6 +41,7 @@ jest.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
           activityBody: unknown
           database: typeof mockDatabase
           params: Promise<{ username: string }>
+          verifiedSenderActorId: string
         }
       ) => Promise<Response> | Response
     ) =>
@@ -67,7 +68,8 @@ jest.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
       return handle(req, {
         activityBody,
         database: mockDatabase,
-        params: context.params
+        params: context.params,
+        verifiedSenderActorId: 'https://remote.test/users/alice'
       })
     }
 }))

--- a/app/api/users/[username]/outbox/route.test.ts
+++ b/app/api/users/[username]/outbox/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import { type Actor } from '@/lib/types/domain/actor'
 import { StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
@@ -49,6 +50,28 @@ const createPublicNoteStatus = (id: string, createdAt = Date.UTC(2026, 0, 1)) =>
     totalShares: 0,
     attachments: [],
     tags: [],
+    createdAt,
+    updatedAt: createdAt
+  }) as const
+
+const createUnreadableAnnounceStatus = (
+  id: string,
+  createdAt = Date.UTC(2026, 0, 1)
+) =>
+  ({
+    id,
+    actorId: mockActor.id,
+    actor: null,
+    type: StatusType.enum.Announce,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    isLocalActor: true,
+    originalStatus: {
+      ...createPublicNoteStatus(`${id}/original`, createdAt - 1),
+      to: [`${mockActor.id}/followers`],
+      cc: []
+    },
     createdAt,
     updatedAt: createdAt
   }) as const
@@ -177,10 +200,61 @@ describe('GET /api/users/[username]/outbox', () => {
 
     expect(mockDatabase.getActorStatuses).toHaveBeenCalledWith({
       actorId: mockActor.id,
-      publicOnly: true
+      publicOnly: true,
+      limit: PER_PAGE_LIMIT
     })
     expect(data.orderedItems).toHaveLength(1)
     expect(data.orderedItems[0].object.id).toBe(publicStatus.id)
+  })
+
+  it('backfills outbox pages after filtering unreadable announces from a full batch', async () => {
+    const createdAt = Date.UTC(2026, 0, 3)
+    const publicStatus = createPublicNoteStatus(
+      'https://example.com/users/test/statuses/public-post-backfill-first',
+      createdAt
+    )
+    const hiddenBatch = Array.from({ length: PER_PAGE_LIMIT - 1 }, (_, index) =>
+      createUnreadableAnnounceStatus(
+        `https://example.com/users/test/statuses/hidden-announce-${index}`,
+        createdAt - index - 1
+      )
+    )
+    const firstBatch = [publicStatus, ...hiddenBatch]
+    const backfilledStatus = createPublicNoteStatus(
+      'https://example.com/users/test/statuses/public-post-backfill-second',
+      createdAt - PER_PAGE_LIMIT - 1
+    )
+    mockDatabase.getActorStatuses
+      .mockResolvedValueOnce(firstBatch)
+      .mockResolvedValueOnce([backfilledStatus])
+
+    const response = await GET(
+      new NextRequest('https://example.com/api/users/test/outbox?page=true', {
+        headers: {
+          accept:
+            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        }
+      }),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    const data = await response.json()
+    const itemIds = data.orderedItems.map(
+      (item: { object: { id: string } }) => item.object.id
+    )
+
+    expect(mockDatabase.getActorStatuses).toHaveBeenNthCalledWith(1, {
+      actorId: mockActor.id,
+      publicOnly: true,
+      limit: PER_PAGE_LIMIT
+    })
+    expect(mockDatabase.getActorStatuses).toHaveBeenNthCalledWith(2, {
+      actorId: mockActor.id,
+      publicOnly: true,
+      limit: PER_PAGE_LIMIT,
+      maxStatusId: firstBatch[firstBatch.length - 1].id
+    })
+    expect(itemIds).toEqual([publicStatus.id, backfilledStatus.id])
   })
 
   it('derives collection totalItems from a SQL count', async () => {

--- a/app/api/users/[username]/outbox/route.test.ts
+++ b/app/api/users/[username]/outbox/route.test.ts
@@ -126,4 +126,62 @@ describe('GET /api/users/[username]/outbox', () => {
     expect(data.orderedItems[0].object).not.toHaveProperty('actorId')
     expect(data.orderedItems[0].object).not.toHaveProperty('text')
   })
+
+  it('omits followers-only statuses from public ActivityPub outbox pages', async () => {
+    const createdAt = Date.UTC(2026, 0, 2)
+    const publicStatus = {
+      id: 'https://example.com/users/test/statuses/public-post',
+      actorId: mockActor.id,
+      actor: null,
+      type: StatusType.enum.Note,
+      url: 'https://example.com/@test/public-post',
+      text: '<p>Public post</p>',
+      summary: null,
+      reply: '',
+      replies: [],
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [`${mockActor.id}/followers`],
+      edits: [],
+      isLocalActor: true,
+      actorAnnounceStatusId: null,
+      isActorLiked: false,
+      totalLikes: 0,
+      totalShares: 0,
+      attachments: [],
+      tags: [],
+      createdAt,
+      updatedAt: createdAt
+    }
+    const privateStatus = {
+      ...publicStatus,
+      id: 'https://example.com/users/test/statuses/private-post',
+      url: 'https://example.com/@test/private-post',
+      text: '<p>Private post</p>',
+      to: [`${mockActor.id}/followers`],
+      cc: []
+    }
+    mockDatabase.getActorStatuses.mockResolvedValue([
+      publicStatus,
+      privateStatus
+    ])
+
+    const response = await GET(
+      new NextRequest('https://example.com/api/users/test/outbox?page=true', {
+        headers: {
+          accept:
+            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        }
+      }),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    const data = await response.json()
+
+    expect(mockDatabase.getActorStatuses).toHaveBeenCalledWith({
+      actorId: mockActor.id,
+      publicOnly: true
+    })
+    expect(data.orderedItems).toHaveLength(1)
+    expect(data.orderedItems[0].object.id).toBe(publicStatus.id)
+  })
 })

--- a/app/api/users/[username]/outbox/route.test.ts
+++ b/app/api/users/[username]/outbox/route.test.ts
@@ -7,6 +7,7 @@ import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { GET } from './route'
 
 const mockDatabase = {
+  getActorStatusesCount: jest.fn(),
   getActorStatuses: jest.fn()
 }
 const mockActor: Actor = {
@@ -69,16 +70,14 @@ jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
 
 describe('GET /api/users/[username]/outbox', () => {
   beforeEach(() => {
+    mockDatabase.getActorStatusesCount.mockClear()
+    mockDatabase.getActorStatusesCount.mockResolvedValue(0)
     mockDatabase.getActorStatuses.mockClear()
     mockDatabase.getActorStatuses.mockResolvedValue([])
   })
 
   it('negotiates collection responses with the shared ActivityPub helper', async () => {
-    mockDatabase.getActorStatuses.mockResolvedValue([
-      createPublicNoteStatus('https://example.com/users/test/statuses/post-1'),
-      createPublicNoteStatus('https://example.com/users/test/statuses/post-2'),
-      createPublicNoteStatus('https://example.com/users/test/statuses/post-3')
-    ])
+    mockDatabase.getActorStatusesCount.mockResolvedValue(3)
 
     const response = await GET(
       new NextRequest('https://example.com/api/users/test/outbox', {
@@ -103,6 +102,11 @@ describe('GET /api/users/[username]/outbox', () => {
       totalItems: 3,
       first: 'https://example.com/users/test/outbox?page=true'
     })
+    expect(mockDatabase.getActorStatusesCount).toHaveBeenCalledWith({
+      actorId: mockActor.id,
+      publicOnly: true
+    })
+    expect(mockDatabase.getActorStatuses).not.toHaveBeenCalled()
   })
 
   it('serializes outbox Create objects as ActivityPub Note objects', async () => {
@@ -179,23 +183,8 @@ describe('GET /api/users/[username]/outbox', () => {
     expect(data.orderedItems[0].object.id).toBe(publicStatus.id)
   })
 
-  it('derives collection totalItems from publicly readable statuses', async () => {
-    const publicStatus = createPublicNoteStatus(
-      'https://example.com/users/test/statuses/public-post',
-      Date.UTC(2026, 0, 3)
-    )
-    const privateStatus = {
-      ...publicStatus,
-      id: 'https://example.com/users/test/statuses/private-post',
-      url: 'https://example.com/@test/private-post',
-      text: '<p>Private post</p>',
-      to: [`${mockActor.id}/followers`],
-      cc: []
-    }
-    mockDatabase.getActorStatuses.mockResolvedValue([
-      publicStatus,
-      privateStatus
-    ])
+  it('derives collection totalItems from a SQL count', async () => {
+    mockDatabase.getActorStatusesCount.mockResolvedValue(1)
 
     const response = await GET(
       new NextRequest('https://example.com/api/users/test/outbox', {
@@ -209,11 +198,11 @@ describe('GET /api/users/[username]/outbox', () => {
 
     const data = await response.json()
 
-    expect(mockDatabase.getActorStatuses).toHaveBeenCalledWith({
+    expect(mockDatabase.getActorStatusesCount).toHaveBeenCalledWith({
       actorId: mockActor.id,
-      limit: mockActor.statusCount,
       publicOnly: true
     })
+    expect(mockDatabase.getActorStatuses).not.toHaveBeenCalled()
     expect(data.totalItems).toBe(1)
   })
 })

--- a/app/api/users/[username]/outbox/route.test.ts
+++ b/app/api/users/[username]/outbox/route.test.ts
@@ -27,6 +27,31 @@ const mockActor: Actor = {
   publicKey: 'public-key'
 }
 
+const createPublicNoteStatus = (id: string, createdAt = Date.UTC(2026, 0, 1)) =>
+  ({
+    id,
+    actorId: mockActor.id,
+    actor: null,
+    type: StatusType.enum.Note,
+    url: id,
+    text: '<p>Hello ActivityPub</p>',
+    summary: null,
+    reply: '',
+    replies: [],
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [`${mockActor.id}/followers`],
+    edits: [],
+    isLocalActor: true,
+    actorAnnounceStatusId: null,
+    isActorLiked: false,
+    totalLikes: 0,
+    totalShares: 0,
+    attachments: [],
+    tags: [],
+    createdAt,
+    updatedAt: createdAt
+  }) as const
+
 jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
   OnlyLocalUserGuard:
     (
@@ -45,9 +70,16 @@ jest.mock('@/lib/services/guards/OnlyLocalUserGuard', () => ({
 describe('GET /api/users/[username]/outbox', () => {
   beforeEach(() => {
     mockDatabase.getActorStatuses.mockClear()
+    mockDatabase.getActorStatuses.mockResolvedValue([])
   })
 
   it('negotiates collection responses with the shared ActivityPub helper', async () => {
+    mockDatabase.getActorStatuses.mockResolvedValue([
+      createPublicNoteStatus('https://example.com/users/test/statuses/post-1'),
+      createPublicNoteStatus('https://example.com/users/test/statuses/post-2'),
+      createPublicNoteStatus('https://example.com/users/test/statuses/post-3')
+    ])
+
     const response = await GET(
       new NextRequest('https://example.com/api/users/test/outbox', {
         headers: {
@@ -75,29 +107,10 @@ describe('GET /api/users/[username]/outbox', () => {
 
   it('serializes outbox Create objects as ActivityPub Note objects', async () => {
     const createdAt = Date.UTC(2026, 0, 1)
-    const status = {
-      id: 'https://example.com/users/test/statuses/post-1',
-      actorId: mockActor.id,
-      actor: null,
-      type: StatusType.enum.Note,
-      url: 'https://example.com/@test/post-1',
-      text: '<p>Hello ActivityPub</p>',
-      summary: null,
-      reply: '',
-      replies: [],
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [`${mockActor.id}/followers`],
-      edits: [],
-      isLocalActor: true,
-      actorAnnounceStatusId: null,
-      isActorLiked: false,
-      totalLikes: 0,
-      totalShares: 0,
-      attachments: [],
-      tags: [],
-      createdAt,
-      updatedAt: createdAt
-    }
+    const status = createPublicNoteStatus(
+      'https://example.com/users/test/statuses/post-1',
+      createdAt
+    )
     mockDatabase.getActorStatuses.mockResolvedValue([status])
 
     const response = await GET(
@@ -129,29 +142,10 @@ describe('GET /api/users/[username]/outbox', () => {
 
   it('omits followers-only statuses from public ActivityPub outbox pages', async () => {
     const createdAt = Date.UTC(2026, 0, 2)
-    const publicStatus = {
-      id: 'https://example.com/users/test/statuses/public-post',
-      actorId: mockActor.id,
-      actor: null,
-      type: StatusType.enum.Note,
-      url: 'https://example.com/@test/public-post',
-      text: '<p>Public post</p>',
-      summary: null,
-      reply: '',
-      replies: [],
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [`${mockActor.id}/followers`],
-      edits: [],
-      isLocalActor: true,
-      actorAnnounceStatusId: null,
-      isActorLiked: false,
-      totalLikes: 0,
-      totalShares: 0,
-      attachments: [],
-      tags: [],
-      createdAt,
-      updatedAt: createdAt
-    }
+    const publicStatus = createPublicNoteStatus(
+      'https://example.com/users/test/statuses/public-post',
+      createdAt
+    )
     const privateStatus = {
       ...publicStatus,
       id: 'https://example.com/users/test/statuses/private-post',
@@ -183,5 +177,43 @@ describe('GET /api/users/[username]/outbox', () => {
     })
     expect(data.orderedItems).toHaveLength(1)
     expect(data.orderedItems[0].object.id).toBe(publicStatus.id)
+  })
+
+  it('derives collection totalItems from publicly readable statuses', async () => {
+    const publicStatus = createPublicNoteStatus(
+      'https://example.com/users/test/statuses/public-post',
+      Date.UTC(2026, 0, 3)
+    )
+    const privateStatus = {
+      ...publicStatus,
+      id: 'https://example.com/users/test/statuses/private-post',
+      url: 'https://example.com/@test/private-post',
+      text: '<p>Private post</p>',
+      to: [`${mockActor.id}/followers`],
+      cc: []
+    }
+    mockDatabase.getActorStatuses.mockResolvedValue([
+      publicStatus,
+      privateStatus
+    ])
+
+    const response = await GET(
+      new NextRequest('https://example.com/api/users/test/outbox', {
+        headers: {
+          accept:
+            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        }
+      }),
+      { params: Promise.resolve({ username: 'test' }) }
+    )
+
+    const data = await response.json()
+
+    expect(mockDatabase.getActorStatuses).toHaveBeenCalledWith({
+      actorId: mockActor.id,
+      limit: mockActor.statusCount,
+      publicOnly: true
+    })
+    expect(data.totalItems).toBe(1)
   })
 })

--- a/app/api/users/[username]/outbox/route.ts
+++ b/app/api/users/[username]/outbox/route.ts
@@ -1,4 +1,5 @@
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
+import { isStatusPubliclyReadable } from '@/lib/services/statusAccess'
 import {
   AnnounceAction,
   CreateAction
@@ -31,7 +32,12 @@ export const GET = traceApiRoute(
         })
       }
 
-      const statuses = await database.getActorStatuses({ actorId: actor.id })
+      const statuses = (
+        await database.getActorStatuses({
+          actorId: actor.id,
+          publicOnly: true
+        })
+      ).filter(isStatusPubliclyReadable)
       const items = statuses.map((status) => {
         if (status.type === StatusType.enum.Announce) {
           return {

--- a/app/api/users/[username]/outbox/route.ts
+++ b/app/api/users/[username]/outbox/route.ts
@@ -33,18 +33,17 @@ export const GET = traceApiRoute(
       const pageParam = url.searchParams.get('page')
       if (!pageParam) {
         const outboxId = getLocalActorOutboxId(actor.id)
-        const statuses = await getPubliclyReadableActorStatuses(
-          database,
-          actor.id,
-          actor.statusCount
-        )
+        const totalItems = await database.getActorStatusesCount({
+          actorId: actor.id,
+          publicOnly: true
+        })
         return activityPubResponse({
           req,
           data: {
             '@context': ACTIVITY_STREAM_URL,
             id: outboxId,
             type: 'OrderedCollection',
-            totalItems: statuses.length,
+            totalItems,
             first: `${outboxId}?page=true`,
             last: `${outboxId}?min_id=0&page=true`
           }

--- a/app/api/users/[username]/outbox/route.ts
+++ b/app/api/users/[username]/outbox/route.ts
@@ -1,3 +1,4 @@
+import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import type { Database } from '@/lib/database/types'
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
 import { isStatusPubliclyReadable } from '@/lib/services/statusAccess'
@@ -5,7 +6,11 @@ import {
   AnnounceAction,
   CreateAction
 } from '@/lib/types/activitypub/activities'
-import { StatusType, toActivityPubObject } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  toActivityPubObject
+} from '@/lib/types/domain/status'
 import { activityPubResponse } from '@/lib/utils/activityPubContentNegotiation'
 import { getLocalActorOutboxId } from '@/lib/utils/activitypubId'
 import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
@@ -15,15 +20,28 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 const getPubliclyReadableActorStatuses = async (
   database: Database,
   actorId: string,
-  limit?: number
-) =>
-  (
-    await database.getActorStatuses({
+  limit = PER_PAGE_LIMIT
+) => {
+  const statuses: Status[] = []
+  let maxStatusId: string | undefined
+
+  while (statuses.length < limit) {
+    const batch = await database.getActorStatuses({
       actorId,
-      ...(limit === undefined ? {} : { limit }),
+      limit,
+      ...(maxStatusId ? { maxStatusId } : {}),
       publicOnly: true
     })
-  ).filter(isStatusPubliclyReadable)
+    if (batch.length === 0) break
+
+    statuses.push(...batch.filter(isStatusPubliclyReadable))
+    if (batch.length < limit) break
+
+    maxStatusId = batch[batch.length - 1].id
+  }
+
+  return statuses.slice(0, limit)
+}
 
 export const GET = traceApiRoute(
   'getActorOutbox',

--- a/app/api/users/[username]/outbox/route.ts
+++ b/app/api/users/[username]/outbox/route.ts
@@ -1,3 +1,4 @@
+import type { Database } from '@/lib/database/types'
 import { OnlyLocalUserGuard } from '@/lib/services/guards/OnlyLocalUserGuard'
 import { isStatusPubliclyReadable } from '@/lib/services/statusAccess'
 import {
@@ -11,6 +12,19 @@ import { ACTIVITY_STREAM_URL } from '@/lib/utils/activitystream'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
+const getPubliclyReadableActorStatuses = async (
+  database: Database,
+  actorId: string,
+  limit?: number
+) =>
+  (
+    await database.getActorStatuses({
+      actorId,
+      ...(limit === undefined ? {} : { limit }),
+      publicOnly: true
+    })
+  ).filter(isStatusPubliclyReadable)
+
 export const GET = traceApiRoute(
   'getActorOutbox',
   OnlyLocalUserGuard(
@@ -19,25 +33,30 @@ export const GET = traceApiRoute(
       const pageParam = url.searchParams.get('page')
       if (!pageParam) {
         const outboxId = getLocalActorOutboxId(actor.id)
+        const statuses = await getPubliclyReadableActorStatuses(
+          database,
+          actor.id,
+          actor.statusCount
+        )
         return activityPubResponse({
           req,
           data: {
             '@context': ACTIVITY_STREAM_URL,
             id: outboxId,
             type: 'OrderedCollection',
-            totalItems: actor.statusCount,
+            totalItems: statuses.length,
             first: `${outboxId}?page=true`,
             last: `${outboxId}?min_id=0&page=true`
           }
         })
       }
 
-      const statuses = (
-        await database.getActorStatuses({
-          actorId: actor.id,
-          publicOnly: true
-        })
-      ).filter(isStatusPubliclyReadable)
+      const statuses = await getPubliclyReadableActorStatuses(
+        database,
+        actor.id
+      )
+      // publicOnly checks the Announce recipients in SQL; this second filter
+      // also confirms the boosted original status is publicly readable.
       const items = statuses.map((status) => {
         if (status.type === StatusType.enum.Announce) {
           return {

--- a/app/api/v1/statuses/[id]/bookmark/route.ts
+++ b/app/api/v1/statuses/[id]/bookmark/route.ts
@@ -1,5 +1,6 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -33,7 +34,12 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/context/route.ts
+++ b/app/api/v1/statuses/[id]/context/route.ts
@@ -1,5 +1,9 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import {
+  filterReadableStatuses,
+  getReadableStatus
+} from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -31,7 +35,11 @@ export const GET = traceApiRoute(
     const { database, currentActor } = context
     const statusId = idToUrl(encodedStatusId)
 
-    const status = await database.getStatus({ statusId })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor
+    })
     if (!status || status.type === StatusType.enum.Announce) {
       return apiResponse({
         req,
@@ -43,16 +51,19 @@ export const GET = traceApiRoute(
 
     const [ancestor, descendants] = await Promise.all([
       status.reply
-        ? database
-            .getStatus({ statusId: status.reply })
-            .then((status) =>
-              status
-                ? getMastodonStatus(database, status, currentActor.id)
-                : null
-            )
+        ? getReadableStatus({
+            database,
+            statusId: status.reply,
+            currentActor
+          }).then((status) =>
+            status ? getMastodonStatus(database, status, currentActor.id) : null
+          )
         : Promise.resolve(null),
       database
         .getStatusReplies({ statusId })
+        .then((statuses) =>
+          filterReadableStatuses({ database, statuses, currentActor })
+        )
         .then((statuses) =>
           Promise.all(
             statuses.map((status) =>

--- a/app/api/v1/statuses/[id]/context/route.ts
+++ b/app/api/v1/statuses/[id]/context/route.ts
@@ -60,7 +60,10 @@ export const GET = traceApiRoute(
           )
         : Promise.resolve(null),
       database
-        .getStatusReplies({ statusId })
+        .getStatusReplies({
+          statusId,
+          visibleToActorId: currentActor.id
+        })
         .then((statuses) =>
           filterReadableStatuses({ database, statuses, currentActor })
         )

--- a/app/api/v1/statuses/[id]/favourite/route.ts
+++ b/app/api/v1/statuses/[id]/favourite/route.ts
@@ -1,6 +1,7 @@
 import { sendLike } from '@/lib/activities'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -34,10 +35,11 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({
+    const status = await getReadableStatus({
+      database,
       statusId,
-      withReplies: false,
-      currentActorId: currentActor.id
+      currentActor,
+      withReplies: false
     })
     if (!status)
       return apiResponse({

--- a/app/api/v1/statuses/[id]/favourited_by/route.ts
+++ b/app/api/v1/statuses/[id]/favourited_by/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -28,7 +29,7 @@ const FavouritedByQueryParams = z.object({
 export const GET = traceApiRoute(
   'getStatusFavouritedBy',
   OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, params } = context
+    const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
       return apiResponse({
@@ -51,6 +52,20 @@ export const GET = traceApiRoute(
 
     const { limit, offset = 0 } = parsedParams.data
     const statusId = idToUrl(encodedStatusId)
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
+    if (!status)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+
     const [actors, totalCount] = await Promise.all([
       database.getFavouritedBy({ statusId, limit, offset }),
       database.getLikeCount({ statusId })

--- a/app/api/v1/statuses/[id]/history/route.ts
+++ b/app/api/v1/statuses/[id]/history/route.ts
@@ -1,4 +1,5 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
@@ -17,7 +18,7 @@ interface Params {
 export const GET = traceApiRoute(
   'getStatusHistory',
   OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, params } = context
+    const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
       return apiResponse({
@@ -28,7 +29,12 @@ export const GET = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/mute/route.ts
+++ b/app/api/v1/statuses/[id]/mute/route.ts
@@ -1,5 +1,6 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -33,7 +34,12 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/pin/route.ts
+++ b/app/api/v1/statuses/[id]/pin/route.ts
@@ -1,5 +1,6 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -34,7 +35,12 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/reblog/route.ts
+++ b/app/api/v1/statuses/[id]/reblog/route.ts
@@ -1,6 +1,7 @@
 import { userAnnounce } from '@/lib/actions/announce'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -35,6 +36,19 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
+    if (!status)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
 
     const announceStatus = await userAnnounce({
       currentActor,

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -1,4 +1,5 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -16,7 +17,7 @@ interface Params {
 export const GET = traceApiRoute(
   'getStatusRebloggedBy',
   OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, params } = context
+    const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
       return apiResponse({
@@ -27,7 +28,12 @@ export const GET = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -15,12 +15,20 @@ import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
 import { POST as bookmarkStatus } from './bookmark/route'
 import { GET as getStatusContext } from './context/route'
+import { POST as favouriteStatus } from './favourite/route'
 import { GET as getStatusFavouritedBy } from './favourited_by/route'
 import { GET as getStatusHistory } from './history/route'
 import { POST as muteStatus } from './mute/route'
+import { POST as pinStatus } from './pin/route'
+import { POST as reblogStatus } from './reblog/route'
 import { GET as getStatusRebloggedBy } from './reblogged_by/route'
 import { GET, PUT } from './route'
 import { GET as getStatusSource } from './source/route'
+import { POST as unbookmarkStatus } from './unbookmark/route'
+import { POST as unfavouriteStatus } from './unfavourite/route'
+import { POST as unmuteStatus } from './unmute/route'
+import { POST as unpinStatus } from './unpin/route'
+import { POST as unreblogStatus } from './unreblog/route'
 
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
@@ -67,7 +75,15 @@ const inaccessibleStatusRouteCases: Array<
 > = [
   ['source', 'GET', getStatusSource],
   ['bookmark', 'POST', bookmarkStatus],
+  ['unbookmark', 'POST', unbookmarkStatus],
   ['mute', 'POST', muteStatus],
+  ['unmute', 'POST', unmuteStatus],
+  ['favourite', 'POST', favouriteStatus],
+  ['unfavourite', 'POST', unfavouriteStatus],
+  ['reblog', 'POST', reblogStatus],
+  ['unreblog', 'POST', unreblogStatus],
+  ['pin', 'POST', pinStatus],
+  ['unpin', 'POST', unpinStatus],
   ['favourited_by', 'GET', getStatusFavouritedBy],
   ['reblogged_by', 'GET', getStatusRebloggedBy]
 ]

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -7,12 +7,20 @@ import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { seedActor3 } from '@/lib/stub/seed/actor3'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
+import { POST as bookmarkStatus } from './bookmark/route'
+import { GET as getStatusContext } from './context/route'
+import { GET as getStatusFavouritedBy } from './favourited_by/route'
+import { GET as getStatusHistory } from './history/route'
+import { POST as muteStatus } from './mute/route'
+import { GET as getStatusRebloggedBy } from './reblogged_by/route'
 import { GET, PUT } from './route'
+import { GET as getStatusSource } from './source/route'
 
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
@@ -48,6 +56,21 @@ jest.mock('@/lib/config', () => ({
     secretPhase: 'test-secret'
   })
 }))
+
+type StatusRouteHandler = (
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) => Promise<Response> | Response
+
+const inaccessibleStatusRouteCases: Array<
+  [string, 'GET' | 'POST', StatusRouteHandler]
+> = [
+  ['source', 'GET', getStatusSource],
+  ['bookmark', 'POST', bookmarkStatus],
+  ['mute', 'POST', muteStatus],
+  ['favourited_by', 'GET', getStatusFavouritedBy],
+  ['reblogged_by', 'GET', getStatusRebloggedBy]
+]
 
 /**
  * Tests for GET /api/v1/statuses/[id]
@@ -182,6 +205,31 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(data.visibility).toBe('private')
     })
 
+    it('returns not found for authenticated non-followers reading followers-only statuses by id', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-private-non-follower-read`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Private non-follower read target',
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(404)
+    })
+
     it('returns not found for authenticated non-recipients of direct statuses', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor2.email }
@@ -299,6 +347,87 @@ describe('GET /api/v1/statuses/[id]', () => {
       const mastodonStatus = await getMastodonStatus(database, fakeStatus)
       expect(mastodonStatus).toBeNull()
     })
+  })
+
+  describe('status-adjacent visibility checks', () => {
+    it('returns not found for context of a followers-only status when requested by a non-follower', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-private-context-non-follower`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Private context target',
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await getStatusContext(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/context`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(404)
+    })
+
+    it('returns not found for history of a followers-only status when requested by a non-follower', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-private-history-non-follower`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Private history target',
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await getStatusHistory(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/history`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(404)
+    })
+
+    it.each(inaccessibleStatusRouteCases)(
+      'returns not found for %s of a followers-only status when requested by a non-follower',
+      async (routeName, method, handler) => {
+        mockGetServerSession.mockResolvedValue({
+          user: { email: seedActor3.email }
+        })
+
+        const statusId = `${ACTOR1_ID}/statuses/api-private-${routeName}-non-follower`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: ACTOR1_ID,
+          text: `Private ${routeName} target`,
+          to: [`${ACTOR1_ID}/followers`],
+          cc: []
+        })
+
+        const response = await handler(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(statusId)}/${routeName}`,
+            { method }
+          ),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+
+        expect(response.status).toBe(404)
+      }
+    )
   })
 
   describe('status visibility derivation', () => {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -7,7 +7,7 @@ import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
-import { seedActor3 } from '@/lib/stub/seed/actor3'
+import { ACTOR3_ID, seedActor3 } from '@/lib/stub/seed/actor3'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
@@ -54,6 +54,11 @@ jest.mock('@/lib/services/queue', () => ({
   getQueue: jest.fn().mockReturnValue({
     publish: jest.fn().mockResolvedValue(undefined)
   })
+}))
+
+jest.mock('@/lib/activities', () => ({
+  sendLike: jest.fn().mockResolvedValue(undefined),
+  sendUndoLike: jest.fn().mockResolvedValue(undefined)
 }))
 
 jest.mock('@/lib/config', () => ({
@@ -444,6 +449,83 @@ describe('GET /api/v1/statuses/[id]', () => {
         expect(response.status).toBe(404)
       }
     )
+
+    it('allows actors to unreblog their announce when the original status is no longer readable', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const originalStatusId = `${ACTOR1_ID}/statuses/api-unreblog-after-access-change`
+      const announceId = `${ACTOR3_ID}/statuses/api-unreblog-after-access-change`
+      await database.createNote({
+        id: originalStatusId,
+        url: originalStatusId,
+        actorId: ACTOR1_ID,
+        text: 'Original status that becomes private after a reblog',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createAnnounce({
+        id: announceId,
+        actorId: ACTOR3_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId
+      })
+      await database.updateNoteVisibility({
+        statusId: originalStatusId,
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await unreblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(originalStatusId)}/unreblog`,
+          { method: 'POST' }
+        ),
+        { params: Promise.resolve({ id: urlToId(originalStatusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      await expect(
+        database.getStatus({ statusId: announceId })
+      ).resolves.toBeNull()
+    })
+
+    it('allows actors to unfavourite their like when the original status is no longer readable', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-unfavourite-after-access-change`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Original status that becomes private after a favourite',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createLike({ actorId: ACTOR3_ID, statusId })
+      await database.updateNoteVisibility({
+        statusId,
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await unfavouriteStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/unfavourite`,
+          { method: 'POST' }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      await expect(
+        database.isActorLikedStatus({ actorId: ACTOR3_ID, statusId })
+      ).resolves.toBe(false)
+    })
   })
 
   describe('status visibility derivation', () => {

--- a/app/api/v1/statuses/[id]/source/route.ts
+++ b/app/api/v1/statuses/[id]/source/route.ts
@@ -1,4 +1,5 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -16,7 +17,7 @@ interface Params {
 export const GET = traceApiRoute(
   'getStatusSource',
   OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, params } = context
+    const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
       return apiResponse({
@@ -27,7 +28,12 @@ export const GET = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/unbookmark/route.ts
+++ b/app/api/v1/statuses/[id]/unbookmark/route.ts
@@ -1,5 +1,6 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -33,7 +34,12 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/unfavourite/route.ts
+++ b/app/api/v1/statuses/[id]/unfavourite/route.ts
@@ -35,19 +35,38 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
+    let status = await getReadableStatus({
       database,
       statusId,
       currentActor,
       withReplies: false
     })
-    if (!status)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
+    if (!status) {
+      const isActorLikedStatus = await database.isActorLikedStatus({
+        actorId: currentActor.id,
+        statusId
       })
+      if (!isActorLikedStatus)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      status = await database.getStatus({
+        statusId,
+        withReplies: false,
+        currentActorId: currentActor.id
+      })
+      if (!status)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+    }
 
     await database.deleteLike({ actorId: currentActor.id, statusId })
     await sendUndoLike({ currentActor, status })

--- a/app/api/v1/statuses/[id]/unfavourite/route.ts
+++ b/app/api/v1/statuses/[id]/unfavourite/route.ts
@@ -1,6 +1,7 @@
 import { sendUndoLike } from '@/lib/activities'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -34,10 +35,11 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({
+    const status = await getReadableStatus({
+      database,
       statusId,
-      withReplies: false,
-      currentActorId: currentActor.id
+      currentActor,
+      withReplies: false
     })
     if (!status)
       return apiResponse({

--- a/app/api/v1/statuses/[id]/unmute/route.ts
+++ b/app/api/v1/statuses/[id]/unmute/route.ts
@@ -1,5 +1,6 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -33,7 +34,12 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/unpin/route.ts
+++ b/app/api/v1/statuses/[id]/unpin/route.ts
@@ -1,5 +1,6 @@
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -34,7 +35,12 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await database.getStatus({ statusId, withReplies: false })
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
     if (!status)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/unreblog/route.ts
+++ b/app/api/v1/statuses/[id]/unreblog/route.ts
@@ -3,6 +3,7 @@ import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
+import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_404,
@@ -36,23 +37,45 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
+    let undoStatusId = statusId
+    const readableStatus = await getReadableStatus({
       database,
       statusId,
       currentActor,
       withReplies: false
     })
-    if (!status)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
+    if (
+      readableStatus?.type !== StatusType.enum.Announce ||
+      readableStatus.actorId !== currentActor.id
+    ) {
+      const ownedAnnounce = await database.getStatus({
+        statusId,
+        withReplies: false,
+        currentActorId: currentActor.id
       })
+      const actorAnnounce =
+        ownedAnnounce?.type === StatusType.enum.Announce &&
+        ownedAnnounce.actorId === currentActor.id
+          ? ownedAnnounce
+          : await database.getActorAnnounceStatus({
+              actorId: currentActor.id,
+              statusId
+            })
+
+      if (!actorAnnounce && !readableStatus)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      undoStatusId = actorAnnounce?.id ?? statusId
+    }
 
     const undoStatus = await userUndoAnnounce({
       currentActor,
-      statusId,
+      statusId: undoStatusId,
       database
     })
 

--- a/app/api/v1/statuses/[id]/unreblog/route.ts
+++ b/app/api/v1/statuses/[id]/unreblog/route.ts
@@ -1,6 +1,7 @@
 import { userUndoAnnounce } from '@/lib/actions/undoAnnounce'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -35,6 +36,19 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
+    const status = await getReadableStatus({
+      database,
+      statusId,
+      currentActor,
+      withReplies: false
+    })
+    if (!status)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
 
     const undoStatus = await userUndoAnnounce({
       currentActor,

--- a/app/api/v1/statuses/[id]/unreblog/route.ts
+++ b/app/api/v1/statuses/[id]/unreblog/route.ts
@@ -48,19 +48,10 @@ export const POST = traceApiRoute(
       readableStatus?.type !== StatusType.enum.Announce ||
       readableStatus.actorId !== currentActor.id
     ) {
-      const ownedAnnounce = await database.getStatus({
-        statusId,
-        withReplies: false,
-        currentActorId: currentActor.id
+      const actorAnnounce = await database.getActorAnnounceStatus({
+        actorId: currentActor.id,
+        statusId
       })
-      const actorAnnounce =
-        ownedAnnounce?.type === StatusType.enum.Announce &&
-        ownedAnnounce.actorId === currentActor.id
-          ? ownedAnnounce
-          : await database.getActorAnnounceStatus({
-              actorId: currentActor.id,
-              statusId
-            })
 
       if (!actorAnnounce && !readableStatus)
         return apiResponse({

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -13,6 +13,7 @@ import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { NotificationType } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
+import { getOriginalStatus } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getTracer } from '@/lib/utils/trace'
@@ -77,10 +78,7 @@ export const userAnnounce = async ({
         .getActorFromId({ id: originalStatus.actorId })
         .catch(() => null)
         .then((targetActor) => {
-          const editableStatus =
-            originalStatus.type === 'Announce'
-              ? originalStatus.originalStatus
-              : originalStatus
+          const editableStatus = getOriginalStatus(originalStatus)
           sendNotificationAlerts({
             database,
             actorId: originalStatus.actorId,

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -8,6 +8,7 @@ import {
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
 import { NotificationType } from '@/lib/types/database/operations'
+import { getOriginalStatus } from '@/lib/types/domain/status'
 
 interface LikeRequestParams {
   activity: LikeStatus
@@ -48,8 +49,7 @@ export const likeRequest = async ({
     ])
       .then(([targetActor, sourceActor]) => {
         if (!sourceActor) return
-        const editableStatus =
-          status.type === 'Announce' ? status.originalStatus : status
+        const editableStatus = getOriginalStatus(status)
         sendNotificationAlerts({
           database,
           actorId: status.actorId,

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -1,7 +1,11 @@
 import { FC } from 'react'
 
 import { PostProps } from '@/lib/components/posts/post'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
 
 import { DeleteButton } from './delete-button'
 import { EditButton } from './edit-button'
@@ -30,7 +34,9 @@ export const Actions: FC<Props> = ({
   if (!currentActor) return null
 
   const actualStatus =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+    status.type === StatusType.enum.Announce
+      ? getOriginalStatus(status)
+      : status
   const canEdit = editable && status.type !== StatusType.enum.Announce
   const isOwner =
     Boolean(actualStatus.isLocalActor) &&

--- a/lib/components/posts/actions/repost-button.tsx
+++ b/lib/components/posts/actions/repost-button.tsx
@@ -3,7 +3,11 @@ import { FC, useEffect, useState } from 'react'
 
 import { repostStatus, undoRepostStatus } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
 interface RepostButtonProps {
@@ -15,7 +19,9 @@ export const RepostButton: FC<RepostButtonProps> = ({
   status
 }) => {
   const mainStatus =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+    status.type === StatusType.enum.Announce
+      ? getOriginalStatus(status)
+      : status
 
   const [repostedStatusId, setRepostedStatusId] = useState<string | null>(
     mainStatus.actorAnnounceStatusId

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -324,6 +324,57 @@ describe('StatusDatabase', () => {
         })
         expect(count).toBe(3)
       })
+
+      it('counts only publicly readable actor statuses when requested', async () => {
+        const suffix = `${Date.now()}-${Math.random()}`
+        const publicStatusId = `${emptyActorId}/statuses/public-${suffix}`
+        const privateStatusId = `${emptyActorId}/statuses/private-${suffix}`
+        const privateAnnounceId = `${emptyActorId}/statuses/announce-private-${suffix}`
+        const beforePublicCount = await database.getActorStatusesCount({
+          actorId: emptyActorId,
+          publicOnly: true
+        })
+
+        await database.createNote({
+          id: publicStatusId,
+          url: publicStatusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Public count status'
+        })
+        await database.createNote({
+          id: privateStatusId,
+          url: privateStatusId,
+          actorId: emptyActorId,
+          to: [`${emptyActorId}/followers`],
+          cc: [],
+          text: 'Private count status'
+        })
+        await database.createAnnounce({
+          id: privateAnnounceId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId: privateStatusId
+        })
+
+        const count = await database.getActorStatusesCount({
+          actorId: emptyActorId,
+          publicOnly: true
+        })
+        const statuses = await database.getActorStatuses({
+          actorId: emptyActorId,
+          publicOnly: true,
+          limit: 50
+        })
+        const publicStatusIds = statuses.map((status) => status.id)
+
+        expect(count).toBe(beforePublicCount + 1)
+        expect(publicStatusIds).toContain(publicStatusId)
+        expect(publicStatusIds).not.toContain(privateStatusId)
+        expect(publicStatusIds).not.toContain(privateAnnounceId)
+      })
     })
 
     describe('getActorStatuses followers audience fallback', () => {
@@ -362,6 +413,65 @@ describe('StatusDatabase', () => {
         expect((replies[1] as StatusNote).text).toBe(
           '<p><span class="h-card"><a href="https://test.llun.dev/@test1@llun.test" target="_blank" class="u-url mention">@<span>test1</span></a></span> This is Actor1 post</p>'
         )
+      })
+
+      it('filters replies to statuses potentially visible to the current actor', async () => {
+        const suffix = `${Date.now()}-${Math.random()}`
+        const parentStatusId = `${primaryActorId}/statuses/context-parent-${suffix}`
+        const publicReplyId = `${replyAuthorId}/statuses/context-public-${suffix}`
+        const directReplyId = `${replyAuthorId}/statuses/context-direct-${suffix}`
+        const hiddenReplyId = `${replyAuthorId}/statuses/context-hidden-${suffix}`
+        const createdAt = Date.now()
+
+        await database.createNote({
+          id: parentStatusId,
+          url: parentStatusId,
+          actorId: primaryActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Context parent',
+          createdAt
+        })
+        await database.createNote({
+          id: publicReplyId,
+          url: publicReplyId,
+          actorId: replyAuthorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Public context reply',
+          reply: parentStatusId,
+          createdAt: createdAt + 1
+        })
+        await database.createNote({
+          id: directReplyId,
+          url: directReplyId,
+          actorId: replyAuthorId,
+          to: [extraActorId],
+          cc: [],
+          text: 'Direct context reply',
+          reply: parentStatusId,
+          createdAt: createdAt + 2
+        })
+        await database.createNote({
+          id: hiddenReplyId,
+          url: hiddenReplyId,
+          actorId: replyAuthorId,
+          to: [primaryActorId],
+          cc: [],
+          text: 'Hidden context reply',
+          reply: parentStatusId,
+          createdAt: createdAt + 3
+        })
+
+        const replies = await database.getStatusReplies({
+          statusId: parentStatusId,
+          visibleToActorId: extraActorId
+        })
+
+        expect(replies.map((status) => status.id)).toEqual([
+          directReplyId,
+          publicReplyId
+        ])
       })
     })
 

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -11,6 +11,7 @@ import { DatabaseSeed } from '@/lib/stub/scenarios/database'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusNote, StatusPoll, StatusType } from '@/lib/types/domain/status'
 import { TagType } from '@/lib/types/domain/tag'
+import { normalizeActorId } from '@/lib/utils/activitypub'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
@@ -375,6 +376,56 @@ describe('StatusDatabase', () => {
         expect(publicStatusIds).not.toContain(privateStatusId)
         expect(publicStatusIds).not.toContain(privateAnnounceId)
       })
+
+      it('excludes nested announces when the boosted original is not publicly readable', async () => {
+        const suffix = `${Date.now()}-${Math.random()}`
+        const privateStatusId = `${emptyActorId}/statuses/nested-private-${suffix}`
+        const firstAnnounceId = `${emptyActorId}/statuses/nested-announce-private-${suffix}`
+        const nestedAnnounceId = `${emptyActorId}/statuses/nested-announce-public-${suffix}`
+        const beforePublicCount = await database.getActorStatusesCount({
+          actorId: emptyActorId,
+          publicOnly: true
+        })
+
+        await database.createNote({
+          id: privateStatusId,
+          url: privateStatusId,
+          actorId: emptyActorId,
+          to: [`${emptyActorId}/followers`],
+          cc: [],
+          text: 'Private nested root status'
+        })
+        await database.createAnnounce({
+          id: firstAnnounceId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId: privateStatusId
+        })
+        await database.createAnnounce({
+          id: nestedAnnounceId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId: firstAnnounceId
+        })
+
+        const count = await database.getActorStatusesCount({
+          actorId: emptyActorId,
+          publicOnly: true
+        })
+        const statuses = await database.getActorStatuses({
+          actorId: emptyActorId,
+          publicOnly: true,
+          limit: 50
+        })
+        const publicStatusIds = statuses.map((status) => status.id)
+
+        expect(count).toBe(beforePublicCount)
+        expect(publicStatusIds).not.toContain(privateStatusId)
+        expect(publicStatusIds).not.toContain(firstAnnounceId)
+        expect(publicStatusIds).not.toContain(nestedAnnounceId)
+      })
     })
 
     describe('getActorStatuses followers audience fallback', () => {
@@ -472,6 +523,56 @@ describe('StatusDatabase', () => {
           directReplyId,
           publicReplyId
         ])
+      })
+
+      it("includes followers-only replies using the reply author's stored followersUrl", async () => {
+        const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+        const customActorId = `https://remote.test/users/context-author-${suffix}`
+        const customFollowersUrl = `https://remote.test/collections/context-author-${suffix}/followers`
+        const parentStatusId = `${primaryActorId}/statuses/context-custom-followers-parent-${suffix}`
+        const replyStatusId = `${customActorId}/statuses/context-custom-followers-reply`
+
+        await database.createActor({
+          actorId: customActorId,
+          username: `context-author-${suffix}`,
+          domain: 'remote.test',
+          followersUrl: customFollowersUrl,
+          inboxUrl: `${customActorId}/inbox`,
+          sharedInboxUrl: 'https://remote.test/inbox',
+          publicKey: `public-key-${suffix}`,
+          createdAt: Date.now()
+        })
+        await database.createFollow({
+          actorId: extraActorId,
+          targetActorId: customActorId,
+          inbox: `${extraActorId}/inbox`,
+          sharedInbox: `${extraActorId}/inbox`,
+          status: FollowStatus.enum.Accepted
+        })
+        await database.createNote({
+          id: parentStatusId,
+          url: parentStatusId,
+          actorId: primaryActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Context parent for custom followers reply'
+        })
+        await database.createNote({
+          id: replyStatusId,
+          url: replyStatusId,
+          actorId: customActorId,
+          to: [customFollowersUrl],
+          cc: [],
+          text: 'Custom followers reply',
+          reply: parentStatusId
+        })
+
+        const replies = await database.getStatusReplies({
+          statusId: parentStatusId,
+          visibleToActorId: extraActorId
+        })
+
+        expect(replies.map((status) => status.id)).toEqual([replyStatusId])
       })
     })
 
@@ -1219,6 +1320,42 @@ describe('StatusDatabase', () => {
           })
         ).toBeArrayOfSize(0)
         expect(afterDeleteCount).toBe(beforeDeleteCount - 1)
+      })
+
+      it('deletes a status when the scoped actor id matches after normalization', async () => {
+        const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+        const rawActorId = `https://Remote.Test/users/delete-author-${suffix}#main-key`
+        const normalizedActorId = normalizeActorId(rawActorId)
+        const statusId = `${rawActorId}/statuses/delete-normalized`
+
+        expect(normalizedActorId).toBeString()
+        expect(normalizedActorId).not.toBe(rawActorId)
+
+        await database.createActor({
+          actorId: rawActorId,
+          username: `delete-author-${suffix}`,
+          domain: 'remote.test',
+          followersUrl: `${rawActorId}/followers`,
+          inboxUrl: `${rawActorId}/inbox`,
+          sharedInboxUrl: 'https://remote.test/inbox',
+          publicKey: `public-key-${suffix}`,
+          createdAt: Date.now()
+        })
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: rawActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Delete with normalized actor id'
+        })
+
+        await database.deleteStatus({
+          statusId,
+          actorId: normalizedActorId ?? undefined
+        })
+
+        expect(await database.getStatus({ statusId })).toBeNull()
       })
 
       it('decreases reply counter when deleting a reply', async () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1,3 +1,5 @@
+import knex, { Knex } from 'knex'
+
 import {
   databaseBeforeAll,
   getTestDatabaseTable
@@ -15,6 +17,8 @@ import { normalizeActorId } from '@/lib/utils/activitypub'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
+import { buildPubliclyReadableStatusIdsQuery } from './status'
+
 describe('StatusDatabase', () => {
   const { actors, statuses } = DatabaseSeed
   const primaryActorId = actors.primary.id
@@ -30,6 +34,50 @@ describe('StatusDatabase', () => {
 
   afterAll(async () => {
     await Promise.all(table.map((item) => item[1].destroy()))
+  })
+
+  describe('public readable status SQL', () => {
+    const createTargetStatusIds = (database: Knex) =>
+      database('statuses')
+        .select('statuses.id')
+        .where('statuses.actorId', primaryActorId)
+
+    it('seeds recursive public readability from the caller target set', async () => {
+      const sqliteDatabase = knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: {
+          filename: ':memory:'
+        }
+      })
+      const sql = buildPubliclyReadableStatusIdsQuery({
+        database: sqliteDatabase,
+        targetStatusIds: createTargetStatusIds(sqliteDatabase)
+      })
+        .toSQL()
+        .sql.toLowerCase()
+
+      expect(sql).toContain('with recursive')
+      expect(sql).toContain('actorid')
+      expect(sql.indexOf('actorid')).toBeLessThan(sql.indexOf('union'))
+
+      await sqliteDatabase.destroy()
+    })
+
+    it('does not use recursive CTEs for MySQL-compatible public readability SQL', async () => {
+      const mysqlDatabase = knex({ client: 'mysql2' })
+      const sql = buildPubliclyReadableStatusIdsQuery({
+        database: mysqlDatabase,
+        targetStatusIds: createTargetStatusIds(mysqlDatabase)
+      })
+        .toSQL()
+        .sql.toLowerCase()
+
+      expect(sql).not.toContain('with recursive')
+      expect(sql).toContain('actorid')
+
+      await mysqlDatabase.destroy()
+    })
   })
 
   describe.each(table)('%s', (_, database) => {
@@ -315,6 +363,58 @@ describe('StatusDatabase', () => {
           'This is Actor1 post 2',
           'This is Actor1 post'
         ])
+      })
+
+      it('paginates statuses that share createdAt using id as a tiebreaker', async () => {
+        const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+        const createdAt = Date.UTC(2035, 0, 1)
+        const firstStatusId = `${emptyActorId}/statuses/tie-z-${suffix}`
+        const secondStatusId = `${emptyActorId}/statuses/tie-y-${suffix}`
+        const thirdStatusId = `${emptyActorId}/statuses/tie-x-${suffix}`
+
+        await database.createNote({
+          id: firstStatusId,
+          url: firstStatusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Tie ordered status z',
+          createdAt
+        })
+        await database.createNote({
+          id: secondStatusId,
+          url: secondStatusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Tie ordered status y',
+          createdAt
+        })
+        await database.createNote({
+          id: thirdStatusId,
+          url: thirdStatusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Tie ordered status x',
+          createdAt
+        })
+
+        const firstPage = await database.getActorStatuses({
+          actorId: emptyActorId,
+          limit: 2
+        })
+        const secondPage = await database.getActorStatuses({
+          actorId: emptyActorId,
+          maxStatusId: secondStatusId,
+          limit: 2
+        })
+
+        expect(firstPage.map((status) => status.id)).toEqual([
+          firstStatusId,
+          secondStatusId
+        ])
+        expect(secondPage.map((status) => status.id)).toContain(thirdStatusId)
       })
     })
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -44,6 +44,7 @@ import {
   UpdatePollParams
 } from '@/lib/types/database/operations'
 import { Actor, getActorProfile } from '@/lib/types/domain/actor'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
 import {
   Status,
@@ -84,6 +85,67 @@ export const StatusSQLDatabaseMixin = (
   likeDatabase: LikeDatabase,
   mediaDatabase: MediaDatabase
 ): StatusDatabase => {
+  const publicActivityRecipients = [
+    ACTIVITY_STREAM_PUBLIC,
+    ACTIVITY_STREAM_PUBLIC_COMPACT
+  ]
+
+  const publicRecipientStatusIds = () =>
+    database('recipients')
+      .select('statusId')
+      .whereIn('recipients.actorId', publicActivityRecipients)
+
+  const applyPublicReadableStatusFilter = (query: Knex.QueryBuilder) =>
+    query.whereIn('statuses.id', publicRecipientStatusIds()).andWhere((qb) => {
+      qb.whereNot('statuses.type', StatusType.enum.Announce).orWhereExists(
+        function () {
+          this.select(database.raw('1'))
+            .from('statuses as original_statuses')
+            .whereRaw('original_statuses.id = statuses.content')
+            .whereIn('original_statuses.id', publicRecipientStatusIds())
+        }
+      )
+    })
+
+  const applyPotentiallyReadableStatusFilter = ({
+    query,
+    visibleToActorId
+  }: {
+    query: Knex.QueryBuilder
+    visibleToActorId: string
+  }) => {
+    const clientName = String(database.client.config.client)
+    const followersAudienceExpression = clientName.includes('mysql')
+      ? "followers_recipients.actorId = CONCAT(statuses.actorId, '/followers')"
+      : "followers_recipients.actorId = statuses.actorId || '/followers'"
+
+    return query.where((qb) => {
+      qb.whereIn(
+        'statuses.id',
+        database('recipients')
+          .select('statusId')
+          .whereIn('recipients.actorId', [
+            ...publicActivityRecipients,
+            visibleToActorId
+          ])
+      )
+        .orWhere('statuses.actorId', visibleToActorId)
+        .orWhereExists(function () {
+          this.select(database.raw('1'))
+            .from('recipients as followers_recipients')
+            .whereRaw('followers_recipients.statusId = statuses.id')
+            .whereRaw(followersAudienceExpression)
+            .whereExists(function () {
+              this.select(database.raw('1'))
+                .from('follows')
+                .where('follows.actorId', visibleToActorId)
+                .whereRaw('follows.targetActorId = statuses.actorId')
+                .where('follows.status', FollowStatus.enum.Accepted)
+            })
+        })
+    })
+  }
+
   const parseStatusContent = (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content: any
@@ -673,7 +735,8 @@ export const StatusSQLDatabaseMixin = (
     statusId,
     url,
     limit,
-    publicOnly = false
+    publicOnly = false,
+    visibleToActorId
   }: GetStatusRepliesParams) {
     let query = database('statuses')
       .where((builder) => {
@@ -685,15 +748,12 @@ export const StatusSQLDatabaseMixin = (
       .orderBy('createdAt', 'desc')
 
     if (publicOnly) {
-      query = query.whereIn(
-        'statuses.id',
-        database('recipients')
-          .select('statusId')
-          .whereIn('recipients.actorId', [
-            ACTIVITY_STREAM_PUBLIC,
-            ACTIVITY_STREAM_PUBLIC_COMPACT
-          ])
-      )
+      query = applyPublicReadableStatusFilter(query)
+    } else if (visibleToActorId) {
+      query = applyPotentiallyReadableStatusFilter({
+        query,
+        visibleToActorId
+      })
     }
 
     if (limit) {
@@ -742,8 +802,21 @@ export const StatusSQLDatabaseMixin = (
   }
 
   async function getActorStatusesCount({
-    actorId
+    actorId,
+    publicOnly = false
   }: GetActorStatusesCountParams) {
+    if (publicOnly) {
+      const result = await applyPublicReadableStatusFilter(
+        database('statuses').where('actorId', actorId)
+      )
+        .countDistinct<{ count: string | number }>({
+          count: 'statuses.id'
+        })
+        .first()
+
+      return parseInt(String(result?.count ?? '0'), 10)
+    }
+
     return getCounterValue(database, CounterKey.totalStatus(actorId))
   }
 
@@ -781,12 +854,16 @@ export const StatusSQLDatabaseMixin = (
         }
       }
 
-      query = query.whereIn(
-        'statuses.id',
-        database('recipients')
-          .select('statusId')
-          .whereIn('recipients.actorId', [...new Set(recipientActorIds)])
-      )
+      if (publicOnly) {
+        query = applyPublicReadableStatusFilter(query)
+      } else {
+        query = query.whereIn(
+          'statuses.id',
+          database('recipients')
+            .select('statusId')
+            .whereIn('recipients.actorId', [...new Set(recipientActorIds)])
+        )
+      }
     }
 
     if (minStatusId) {

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -54,6 +54,7 @@ import {
   StatusType
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
+import { normalizeActorId } from '@/lib/utils/activitypub'
 import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
@@ -95,17 +96,42 @@ export const StatusSQLDatabaseMixin = (
       .select('statusId')
       .whereIn('recipients.actorId', publicActivityRecipients)
 
+  const publiclyReadableStatusIds = () =>
+    database
+      .withRecursive('publicly_readable_statuses', ['id'], (cte) => {
+        cte
+          .select('statuses.id')
+          .from('statuses')
+          .whereNot('statuses.type', StatusType.enum.Announce)
+          .whereIn('statuses.id', publicRecipientStatusIds())
+          .union((qb) => {
+            qb.select('announces.id')
+              .from('statuses as announces')
+              .innerJoin(
+                'publicly_readable_statuses as readable_statuses',
+                'readable_statuses.id',
+                'announces.content'
+              )
+              .where('announces.type', StatusType.enum.Announce)
+              .whereIn('announces.id', publicRecipientStatusIds())
+          })
+      })
+      .select('id')
+      .from('publicly_readable_statuses')
+
   const applyPublicReadableStatusFilter = (query: Knex.QueryBuilder) =>
-    query.whereIn('statuses.id', publicRecipientStatusIds()).andWhere((qb) => {
-      qb.whereNot('statuses.type', StatusType.enum.Announce).orWhereExists(
-        function () {
-          this.select(database.raw('1'))
-            .from('statuses as original_statuses')
-            .whereRaw('original_statuses.id = statuses.content')
-            .whereIn('original_statuses.id', publicRecipientStatusIds())
-        }
-      )
-    })
+    query.whereIn('statuses.id', publiclyReadableStatusIds())
+
+  const actorSettingsTextExpression = (actorAlias: string, key: string) => {
+    const clientName = String(database.client.config.client)
+    if (clientName.includes('pg')) {
+      return `${actorAlias}.settings::jsonb ->> '${key}'`
+    }
+    if (clientName.includes('mysql')) {
+      return `JSON_UNQUOTE(JSON_EXTRACT(${actorAlias}.settings, '$.${key}'))`
+    }
+    return `json_extract(${actorAlias}.settings, '$.${key}')`
+  }
 
   const applyPotentiallyReadableStatusFilter = ({
     query,
@@ -115,9 +141,13 @@ export const StatusSQLDatabaseMixin = (
     visibleToActorId: string
   }) => {
     const clientName = String(database.client.config.client)
-    const followersAudienceExpression = clientName.includes('mysql')
+    const fallbackFollowersAudienceExpression = clientName.includes('mysql')
       ? "followers_recipients.actorId = CONCAT(statuses.actorId, '/followers')"
       : "followers_recipients.actorId = statuses.actorId || '/followers'"
+    const storedFollowersAudienceExpression = `followers_recipients.actorId = ${actorSettingsTextExpression(
+      'status_actors',
+      'followersUrl'
+    )}`
 
     return query.where((qb) => {
       qb.whereIn(
@@ -133,8 +163,17 @@ export const StatusSQLDatabaseMixin = (
         .orWhereExists(function () {
           this.select(database.raw('1'))
             .from('recipients as followers_recipients')
+            .leftJoin(
+              'actors as status_actors',
+              'status_actors.id',
+              'statuses.actorId'
+            )
             .whereRaw('followers_recipients.statusId = statuses.id')
-            .whereRaw(followersAudienceExpression)
+            .where(function () {
+              this.whereRaw(storedFollowersAudienceExpression).orWhereRaw(
+                fallbackFollowersAudienceExpression
+              )
+            })
             .whereExists(function () {
               this.select(database.raw('1'))
                 .from('follows')
@@ -939,12 +978,20 @@ export const StatusSQLDatabaseMixin = (
       return
     }
 
-    const statusQuery = trx('statuses').where('id', statusId)
-    if (actorId) {
-      statusQuery.where('actorId', actorId)
-    }
-    const status = await statusQuery.first()
+    const status = await trx('statuses').where('id', statusId).first()
     if (!status) return
+
+    if (actorId) {
+      const normalizedStoredActorId = normalizeActorId(status.actorId)
+      const normalizedExpectedActorId = normalizeActorId(actorId)
+      if (
+        !normalizedStoredActorId ||
+        !normalizedExpectedActorId ||
+        normalizedStoredActorId !== normalizedExpectedActorId
+      ) {
+        return
+      }
+    }
 
     const replies = await trx('statuses').where('reply', statusId).select('id')
     await Promise.all(

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -64,6 +64,11 @@ import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
 
+const PUBLIC_ACTIVITY_RECIPIENTS = [
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+]
+
 const isUniqueConstraintError = (error: unknown) => {
   const { code, errno, message } = error as {
     code?: string
@@ -80,57 +85,117 @@ const isUniqueConstraintError = (error: unknown) => {
   )
 }
 
+const publicRecipientStatusIds = (database: Knex) =>
+  database('recipients')
+    .select('statusId')
+    .whereIn('recipients.actorId', PUBLIC_ACTIVITY_RECIPIENTS)
+
+export const buildPubliclyReadableStatusIdsQuery = ({
+  database,
+  targetStatusIds
+}: {
+  database: Knex
+  targetStatusIds: Knex.QueryBuilder
+}) => {
+  const clientName = String(database.client.config.client)
+  const targetStatusIdsQuery = targetStatusIds.clone().as('target_status_ids')
+
+  if (clientName.includes('mysql')) {
+    return database
+      .select('target_statuses.id')
+      .from(targetStatusIdsQuery)
+      .innerJoin(
+        'statuses as target_statuses',
+        'target_statuses.id',
+        'target_status_ids.id'
+      )
+      .whereIn('target_statuses.id', publicRecipientStatusIds(database))
+      .where((qb) => {
+        qb.whereNot(
+          'target_statuses.type',
+          StatusType.enum.Announce
+        ).orWhereExists(function () {
+          this.select(database.raw('1'))
+            .from('statuses as original_statuses')
+            .whereRaw('original_statuses.id = target_statuses.content')
+            .whereNot('original_statuses.type', StatusType.enum.Announce)
+            .whereIn('original_statuses.id', publicRecipientStatusIds(database))
+        })
+      })
+  }
+
+  return database
+    .withRecursive(
+      'publicly_readable_statuses',
+      ['targetId', 'id', 'type', 'content'],
+      (cte) => {
+        cte
+          .select(
+            'target_statuses.id as targetId',
+            'target_statuses.id',
+            'target_statuses.type',
+            'target_statuses.content'
+          )
+          .from(targetStatusIdsQuery)
+          .innerJoin(
+            'statuses as target_statuses',
+            'target_statuses.id',
+            'target_status_ids.id'
+          )
+          .whereIn('target_statuses.id', publicRecipientStatusIds(database))
+          .union((qb) => {
+            qb.select(
+              'readable_statuses.targetId',
+              'original_statuses.id',
+              'original_statuses.type',
+              'original_statuses.content'
+            )
+              .from('statuses as original_statuses')
+              .innerJoin(
+                'publicly_readable_statuses as readable_statuses',
+                'readable_statuses.content',
+                'original_statuses.id'
+              )
+              .where('readable_statuses.type', StatusType.enum.Announce)
+              .whereIn(
+                'original_statuses.id',
+                publicRecipientStatusIds(database)
+              )
+          })
+      }
+    )
+    .select('targetId as id')
+    .from('publicly_readable_statuses')
+    .whereNot('type', StatusType.enum.Announce)
+}
+
 export const StatusSQLDatabaseMixin = (
   database: Knex,
   actorDatabase: ActorDatabase,
   likeDatabase: LikeDatabase,
   mediaDatabase: MediaDatabase
 ): StatusDatabase => {
-  const publicActivityRecipients = [
-    ACTIVITY_STREAM_PUBLIC,
-    ACTIVITY_STREAM_PUBLIC_COMPACT
-  ]
+  const applyPublicReadableStatusFilter = ({
+    query,
+    targetStatusIds
+  }: {
+    query: Knex.QueryBuilder
+    targetStatusIds: Knex.QueryBuilder
+  }) =>
+    query.whereIn(
+      'statuses.id',
+      buildPubliclyReadableStatusIdsQuery({ database, targetStatusIds })
+    )
 
-  const publicRecipientStatusIds = () =>
-    database('recipients')
-      .select('statusId')
-      .whereIn('recipients.actorId', publicActivityRecipients)
-
-  const publiclyReadableStatusIds = () =>
-    database
-      .withRecursive('publicly_readable_statuses', ['id'], (cte) => {
-        cte
-          .select('statuses.id')
-          .from('statuses')
-          .whereNot('statuses.type', StatusType.enum.Announce)
-          .whereIn('statuses.id', publicRecipientStatusIds())
-          .union((qb) => {
-            qb.select('announces.id')
-              .from('statuses as announces')
-              .innerJoin(
-                'publicly_readable_statuses as readable_statuses',
-                'readable_statuses.id',
-                'announces.content'
-              )
-              .where('announces.type', StatusType.enum.Announce)
-              .whereIn('announces.id', publicRecipientStatusIds())
-          })
-      })
-      .select('id')
-      .from('publicly_readable_statuses')
-
-  const applyPublicReadableStatusFilter = (query: Knex.QueryBuilder) =>
-    query.whereIn('statuses.id', publiclyReadableStatusIds())
-
-  const actorSettingsTextExpression = (actorAlias: string, key: string) => {
+  const statusActorFollowersUrlExpression = () => {
     const clientName = String(database.client.config.client)
     if (clientName.includes('pg')) {
-      return `${actorAlias}.settings::jsonb ->> '${key}'`
+      return "status_actors.settings::jsonb ->> 'followersUrl'"
     }
     if (clientName.includes('mysql')) {
-      return `JSON_UNQUOTE(JSON_EXTRACT(${actorAlias}.settings, '$.${key}'))`
+      return "JSON_UNQUOTE(JSON_EXTRACT(status_actors.settings, '$.followersUrl'))"
     }
-    return `json_extract(${actorAlias}.settings, '$.${key}')`
+    return "json_extract(status_actors.settings, '$.followersUrl')"
   }
 
   const applyPotentiallyReadableStatusFilter = ({
@@ -144,10 +209,7 @@ export const StatusSQLDatabaseMixin = (
     const fallbackFollowersAudienceExpression = clientName.includes('mysql')
       ? "followers_recipients.actorId = CONCAT(statuses.actorId, '/followers')"
       : "followers_recipients.actorId = statuses.actorId || '/followers'"
-    const storedFollowersAudienceExpression = `followers_recipients.actorId = ${actorSettingsTextExpression(
-      'status_actors',
-      'followersUrl'
-    )}`
+    const storedFollowersAudienceExpression = `followers_recipients.actorId = ${statusActorFollowersUrlExpression()}`
 
     return query.where((qb) => {
       qb.whereIn(
@@ -155,7 +217,7 @@ export const StatusSQLDatabaseMixin = (
         database('recipients')
           .select('statusId')
           .whereIn('recipients.actorId', [
-            ...publicActivityRecipients,
+            ...PUBLIC_ACTIVITY_RECIPIENTS,
             visibleToActorId
           ])
       )
@@ -770,6 +832,25 @@ export const StatusSQLDatabaseMixin = (
     return getStatusWithAttachmentsFromData(status, currentActorId, withReplies)
   }
 
+  const getReplyTargetStatusIds = ({
+    statusId,
+    url
+  }: {
+    statusId: string
+    url?: string
+  }) =>
+    database('statuses')
+      .select('statuses.id')
+      .where((builder) => {
+        builder.where('reply', statusId)
+        if (url) {
+          builder.orWhere('reply', url)
+        }
+      })
+
+  const getActorTargetStatusIds = (actorId: string) =>
+    database('statuses').select('statuses.id').where('actorId', actorId)
+
   async function getStatusReplies({
     statusId,
     url,
@@ -787,7 +868,10 @@ export const StatusSQLDatabaseMixin = (
       .orderBy('createdAt', 'desc')
 
     if (publicOnly) {
-      query = applyPublicReadableStatusFilter(query)
+      query = applyPublicReadableStatusFilter({
+        query,
+        targetStatusIds: getReplyTargetStatusIds({ statusId, url })
+      })
     } else if (visibleToActorId) {
       query = applyPotentiallyReadableStatusFilter({
         query,
@@ -845,9 +929,10 @@ export const StatusSQLDatabaseMixin = (
     publicOnly = false
   }: GetActorStatusesCountParams) {
     if (publicOnly) {
-      const result = await applyPublicReadableStatusFilter(
-        database('statuses').where('actorId', actorId)
-      )
+      const result = await applyPublicReadableStatusFilter({
+        query: database('statuses').where('actorId', actorId),
+        targetStatusIds: getActorTargetStatusIds(actorId)
+      })
         .countDistinct<{ count: string | number }>({
           count: 'statuses.id'
         })
@@ -872,11 +957,12 @@ export const StatusSQLDatabaseMixin = (
     let query = database('statuses')
       .where('actorId', actorId)
       .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
       .limit(limit)
 
     const recipientActorIds =
       publicOnly || visibleToActorId || includeFollowersOnly
-        ? [ACTIVITY_STREAM_PUBLIC, ACTIVITY_STREAM_PUBLIC_COMPACT]
+        ? [...PUBLIC_ACTIVITY_RECIPIENTS]
         : null
 
     if (recipientActorIds) {
@@ -894,7 +980,10 @@ export const StatusSQLDatabaseMixin = (
       }
 
       if (publicOnly) {
-        query = applyPublicReadableStatusFilter(query)
+        query = applyPublicReadableStatusFilter({
+          query,
+          targetStatusIds: getActorTargetStatusIds(actorId)
+        })
       } else {
         query = query.whereIn(
           'statuses.id',
@@ -910,7 +999,15 @@ export const StatusSQLDatabaseMixin = (
         .where('id', minStatusId)
         .first()
       if (minStatus) {
-        query = query.where('createdAt', '>', minStatus.createdAt)
+        query = query.where((wb) => {
+          wb.where('statuses.createdAt', '>', minStatus.createdAt).orWhere(
+            (sameCreatedAt) => {
+              sameCreatedAt
+                .where('statuses.createdAt', '=', minStatus.createdAt)
+                .where('statuses.id', '>', minStatusId)
+            }
+          )
+        })
       }
     }
 
@@ -919,7 +1016,15 @@ export const StatusSQLDatabaseMixin = (
         .where('id', maxStatusId)
         .first()
       if (maxStatus) {
-        query = query.where('createdAt', '<', maxStatus.createdAt)
+        query = query.where((wb) => {
+          wb.where('statuses.createdAt', '<', maxStatus.createdAt).orWhere(
+            (sameCreatedAt) => {
+              sameCreatedAt
+                .where('statuses.createdAt', '=', maxStatus.createdAt)
+                .where('statuses.id', '<', maxStatusId)
+            }
+          )
+        })
       }
     }
 
@@ -1429,15 +1534,10 @@ export const StatusSQLDatabaseMixin = (
     })
 
     if (publicOnly) {
-      query = query.whereIn(
-        'statuses.id',
-        database('recipients')
-          .select('statusId')
-          .whereIn('recipients.actorId', [
-            ACTIVITY_STREAM_PUBLIC,
-            ACTIVITY_STREAM_PUBLIC_COMPACT
-          ])
-      )
+      query = applyPublicReadableStatusFilter({
+        query,
+        targetStatusIds: getReplyTargetStatusIds({ statusId, url })
+      })
     }
 
     const result = await query

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -851,17 +851,22 @@ export const StatusSQLDatabaseMixin = (
   }
 
   async function deleteStatus({
+    actorId,
     statusId,
     trx
   }: DeleteStatusParams & { trx?: Knex.Transaction }) {
     if (!trx) {
       await database.transaction(async (trx) => {
-        await deleteStatus({ statusId, trx })
+        await deleteStatus({ actorId, statusId, trx })
       })
       return
     }
 
-    const status = await trx('statuses').where('id', statusId).first()
+    const statusQuery = trx('statuses').where('id', statusId)
+    if (actorId) {
+      statusQuery.where('actorId', actorId)
+    }
+    const status = await statusQuery.first()
     if (!status) return
 
     const replies = await trx('statuses').where('reply', statusId).select('id')

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -181,6 +181,23 @@ describe('createNoteJob', () => {
     await expect(database.getStatus({ statusId: note.id })).resolves.toBeNull()
   })
 
+  it('ignores inbox notes whose attributedTo does not match the verified sender', async () => {
+    const note = MockMastodonActivityPubNote({
+      id: 'https://somewhere.test/actors/friend/statuses/spoofed-note',
+      from: FRIEND_ACTOR_ID,
+      content: '<p>Spoofed sender</p>'
+    })
+
+    await createNoteJob(database, {
+      id: 'id',
+      name: CREATE_NOTE_JOB_NAME,
+      data: note,
+      verifiedSenderActorId: 'https://somewhere.test/actors/mallory'
+    })
+
+    await expect(database.getStatus({ statusId: note.id })).resolves.toBeNull()
+  })
+
   it('adds note with single content map when contentMap is array', async () => {
     const note = MockMastodonActivityPubNote({
       content: '<p>Hello</p>',

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -81,6 +81,54 @@ describe('createNoteJob', () => {
     expect(status?.actorId).toBe(actorId)
   })
 
+  it('stores attachments under the normalized actor id for notes attributed to sender key fragments', async () => {
+    expect(actor1).toBeDefined()
+    const actorId = actor1?.id as string
+    const rawAttributedTo = `${actorId}#main-key`
+    const note = MockMastodonActivityPubNote({
+      id: `${actorId}/statuses/normalized-attribution-attachment`,
+      from: rawAttributedTo,
+      content: '<p>Hello normalized attachment actor</p>',
+      documents: [
+        MockImageDocument({
+          url: 'https://llun.dev/images/normalized-attachment.jpg'
+        })
+      ]
+    })
+
+    await createNoteJob(database, {
+      id: 'normalized-attribution-attachment',
+      name: CREATE_NOTE_JOB_NAME,
+      data: note,
+      verifiedSenderActorId: actorId
+    })
+
+    const normalizedActorAttachments = await database.getAttachmentsForActor({
+      actorId
+    })
+    const rawActorAttachments = await database.getAttachmentsForActor({
+      actorId: rawAttributedTo
+    })
+
+    expect(normalizedActorAttachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorId,
+          statusId: note.id,
+          url: 'https://llun.dev/images/normalized-attachment.jpg'
+        })
+      ])
+    )
+    expect(rawActorAttachments).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          statusId: note.id,
+          url: 'https://llun.dev/images/normalized-attachment.jpg'
+        })
+      ])
+    )
+  })
+
   it('adds litepub note into database and returns note', async () => {
     const note = MockLitepubNote({ content: '<p>Hello</p>' })
     await createNoteJob(database, {

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -61,6 +61,26 @@ describe('createNoteJob', () => {
     expect(status.createdAt).toEqual(new Date(note.published).getTime())
   })
 
+  it('stores normalized actor ids for notes attributed to sender key fragments', async () => {
+    expect(actor1).toBeDefined()
+    const actorId = actor1?.id as string
+    const note = MockMastodonActivityPubNote({
+      id: `${actorId}/statuses/normalized-attribution`,
+      from: `${actorId}#main-key`,
+      content: '<p>Hello normalized actor</p>'
+    })
+    await createNoteJob(database, {
+      id: 'normalized-attribution',
+      name: CREATE_NOTE_JOB_NAME,
+      data: note,
+      verifiedSenderActorId: actorId
+    })
+
+    const status = await database.getStatus({ statusId: note.id })
+
+    expect(status?.actorId).toBe(actorId)
+  })
+
   it('adds litepub note into database and returns note', async () => {
     const note = MockLitepubNote({ content: '<p>Hello</p>' })
     await createNoteJob(database, {

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -154,7 +154,7 @@ export const createNoteJob = createJobHandle(
       ...attachments.map(async (attachment, index) => {
         if (attachment.type !== 'Document') return
         return database.createAttachment({
-          actorId: note.attributedTo,
+          actorId,
           statusId: note.id,
           mediaType: attachment.mediaType,
           height: attachment.height,

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -21,7 +21,10 @@ import {
   VideoContent
 } from '@/lib/types/activitypub'
 import { StatusType } from '@/lib/types/domain/status'
-import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
+import {
+  normalizeActivityPubContent,
+  normalizeActorId
+} from '@/lib/utils/activitypub'
 
 import { createJobHandle } from './createJobHandle'
 import { CREATE_NOTE_JOB_NAME } from './names'
@@ -66,21 +69,22 @@ export const createNoteJob = createJobHandle(
 
     const text = getContent(note)
     const summary = getSummary(note)
+    const actorId = normalizeActorId(note.attributedTo) ?? note.attributedTo
 
     const publishedAt = new Date(note.published).getTime()
 
     await assertActorCanFederate({
-      actorId: note.attributedTo,
+      actorId,
       database
     })
 
     const [, status] = await Promise.all([
-      recordActorIfNeeded({ actorId: note.attributedTo, database }),
+      recordActorIfNeeded({ actorId, database }),
       database.createNote({
         id: note.id,
         url: typeof note.url === 'string' ? note.url : note.id,
 
-        actorId: note.attributedTo,
+        actorId,
 
         text,
         summary,

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -25,6 +25,7 @@ import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
 
 import { createJobHandle } from './createJobHandle'
 import { CREATE_NOTE_JOB_NAME } from './names'
+import { actorMatchesVerifiedSender } from './verifiedSender'
 
 export const createNoteJob = createJobHandle(
   CREATE_NOTE_JOB_NAME,
@@ -39,6 +40,10 @@ export const createNoteJob = createJobHandle(
     const note = BaseNoteSchema.parse(
       normalizeActivityPubContent(message.data)
     ) as BaseNote
+    if (!actorMatchesVerifiedSender(note.attributedTo, message)) {
+      return
+    }
+
     const attachments = getAttachments(note)
 
     const existingStatus = await database.getStatus({

--- a/lib/jobs/createPollJob.test.ts
+++ b/lib/jobs/createPollJob.test.ts
@@ -160,6 +160,24 @@ describe('createPollJob', () => {
     ).resolves.toBeNull()
   })
 
+  it('ignores inbox questions whose attributedTo does not match the verified sender', async () => {
+    const question = MockActivityPubQuestion({
+      id: 'https://somewhere.test/actors/pollcreator/questions/spoofed',
+      from: REMOTE_ACTOR_ID
+    })
+
+    await createPollJob(database, {
+      id: 'id',
+      name: CREATE_POLL_JOB_NAME,
+      data: question,
+      verifiedSenderActorId: 'https://somewhere.test/actors/mallory'
+    })
+
+    await expect(
+      database.getStatus({ statusId: question.id })
+    ).resolves.toBeNull()
+  })
+
   it('creates poll with oneOf choices', async () => {
     const question = MockActivityPubQuestion({
       oneOf: [createOption('Option A'), createOption('Option B')]

--- a/lib/jobs/createPollJob.ts
+++ b/lib/jobs/createPollJob.ts
@@ -14,6 +14,7 @@ import { normalizeActivityPubContent } from '@/lib/utils/activitypub'
 
 import { createJobHandle } from './createJobHandle'
 import { CREATE_POLL_JOB_NAME } from './names'
+import { actorMatchesVerifiedSender } from './verifiedSender'
 
 export const createPollJob = createJobHandle(
   CREATE_POLL_JOB_NAME,
@@ -25,6 +26,9 @@ export const createPollJob = createJobHandle(
       return
     }
     const question = parseResult.data
+    if (!actorMatchesVerifiedSender(question.attributedTo, message)) {
+      return
+    }
 
     const existingStatus = await database.getStatus({
       statusId: question.id,

--- a/lib/jobs/createPollVoteJob.test.ts
+++ b/lib/jobs/createPollVoteJob.test.ts
@@ -93,6 +93,26 @@ describe('createPollVoteJob', () => {
     expect(updatedPoll.choices[0].totalVotes).toEqual(1)
   })
 
+  it('ignores inbox poll votes whose attributedTo does not match the verified sender', async () => {
+    const voteNote = createVoteNote({
+      from: VOTER_ACTOR_ID,
+      inReplyTo: pollStatus.id,
+      name: 'Option A'
+    })
+
+    await createPollVoteJob(database, {
+      id: 'id',
+      name: CREATE_POLL_VOTE_JOB_NAME,
+      data: voteNote,
+      verifiedSenderActorId: VOTER2_ACTOR_ID
+    })
+
+    const updatedPoll = (await database.getStatus({
+      statusId: pollStatus.id
+    })) as StatusPoll
+    expect(updatedPoll.choices[0].totalVotes).toEqual(0)
+  })
+
   it('ignores vote with content (not a poll vote)', async () => {
     const noteWithContent = createVoteNote({
       from: VOTER_ACTOR_ID,

--- a/lib/jobs/createPollVoteJob.ts
+++ b/lib/jobs/createPollVoteJob.ts
@@ -9,6 +9,7 @@ import { logger } from '@/lib/utils/logger'
 
 import { createJobHandle } from './createJobHandle'
 import { CREATE_POLL_VOTE_JOB_NAME } from './names'
+import { actorMatchesVerifiedSender } from './verifiedSender'
 
 // Poll vote notes have a 'name' field that's not in the standard Note schema
 interface PollVoteData {
@@ -29,6 +30,10 @@ export const createPollVoteJob = createJobHandle(
     const note = parseResult.data
 
     if (note.type !== ENTITY_TYPE_NOTE) {
+      return
+    }
+
+    if (!actorMatchesVerifiedSender(note.attributedTo, message)) {
       return
     }
 

--- a/lib/jobs/deleteObjectJob.test.ts
+++ b/lib/jobs/deleteObjectJob.test.ts
@@ -6,6 +6,7 @@ import { DELETE_OBJECT_JOB_NAME } from '@/lib/jobs/names'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { Actor } from '@/lib/types/domain/actor'
 
 enableFetchMocks()
@@ -89,6 +90,34 @@ describe('deleteObjectJob', () => {
     // Verify status is deleted
     status = await database.getStatus({ statusId, withReplies: false })
     expect(status).toBeNull()
+  })
+
+  it('does not delete a status owned by a different verified sender', async () => {
+    if (!actor1) fail('Actor1 is required')
+
+    const statusId = `${actor1.id}/statuses/not-owned-by-sender-${Date.now()}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: actor1.id,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [],
+      text: 'Status owned by actor1',
+      createdAt: Date.now()
+    })
+
+    await deleteObjectJob(database, {
+      id: 'job-not-owner',
+      name: DELETE_OBJECT_JOB_NAME,
+      data: {
+        type: 'Tombstone',
+        id: statusId
+      },
+      verifiedSenderActorId: ACTOR2_ID
+    })
+
+    const status = await database.getStatus({ statusId, withReplies: false })
+    expect(status).not.toBeNull()
   })
 
   it('processes Announce data for deletion', async () => {

--- a/lib/jobs/deleteObjectJob.ts
+++ b/lib/jobs/deleteObjectJob.ts
@@ -9,6 +9,7 @@ import { createJobHandle } from './createJobHandle'
 import { DELETE_OBJECT_JOB_NAME } from './names'
 import { actorMatchesVerifiedSender } from './verifiedSender'
 
+// Undefined intentionally preserves unscoped deletes for legacy queued messages.
 const getVerifiedSenderActorId = (actorId?: string) =>
   normalizeActorId(actorId) ?? undefined
 

--- a/lib/jobs/deleteObjectJob.ts
+++ b/lib/jobs/deleteObjectJob.ts
@@ -1,9 +1,16 @@
 import { Announce, Tombstone } from '@/lib/types/activitypub'
-import { normalizeActivityPubAnnounce } from '@/lib/utils/activitypub'
+import {
+  normalizeActivityPubAnnounce,
+  normalizeActorId
+} from '@/lib/utils/activitypub'
 import { getTracer } from '@/lib/utils/trace'
 
 import { createJobHandle } from './createJobHandle'
 import { DELETE_OBJECT_JOB_NAME } from './names'
+import { actorMatchesVerifiedSender } from './verifiedSender'
+
+const getVerifiedSenderActorId = (actorId?: string) =>
+  normalizeActorId(actorId) ?? undefined
 
 export const deleteObjectJob = createJobHandle(
   DELETE_OBJECT_JOB_NAME,
@@ -11,6 +18,12 @@ export const deleteObjectJob = createJobHandle(
     await getTracer().startActiveSpan('deleteObject', async (span) => {
       const data = message.data
       if (typeof data === 'string') {
+        if (!actorMatchesVerifiedSender(data, message)) {
+          span.setAttribute('senderMismatch', true)
+          span.end()
+          return
+        }
+
         span.setAttribute('actorId', data)
         await database.deleteActor({
           actorId: data
@@ -24,7 +37,8 @@ export const deleteObjectJob = createJobHandle(
         const tombStone = tombStoneResult.data
         span.setAttribute('statusId', tombStone.id)
         await database.deleteStatus({
-          statusId: tombStone.id
+          statusId: tombStone.id,
+          actorId: getVerifiedSenderActorId(message.verifiedSenderActorId)
         })
         span.end()
         return
@@ -35,9 +49,16 @@ export const deleteObjectJob = createJobHandle(
       )
       if (announceResult.success) {
         const announce = announceResult.data
+        if (!actorMatchesVerifiedSender(announce.actor, message)) {
+          span.setAttribute('senderMismatch', true)
+          span.end()
+          return
+        }
+
         span.setAttribute('statusId', announce.id)
         await database.deleteStatus({
-          statusId: announce.id
+          statusId: announce.id,
+          actorId: getVerifiedSenderActorId(message.verifiedSenderActorId)
         })
         span.end()
         return

--- a/lib/jobs/verifiedSender.ts
+++ b/lib/jobs/verifiedSender.ts
@@ -1,0 +1,19 @@
+import { JobMessage } from '@/lib/services/queue/type'
+import { normalizeActorId } from '@/lib/utils/activitypub'
+
+export const actorMatchesVerifiedSender = (
+  actorId: string,
+  message: JobMessage
+) => {
+  if (!message.verifiedSenderActorId) return true
+
+  const normalizedActorId = normalizeActorId(actorId)
+  const normalizedVerifiedSenderActorId = normalizeActorId(
+    message.verifiedSenderActorId
+  )
+
+  return (
+    Boolean(normalizedActorId) &&
+    normalizedActorId === normalizedVerifiedSenderActorId
+  )
+}

--- a/lib/services/guards/ActivityPubVerifyGuard.test.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.test.ts
@@ -323,6 +323,7 @@ describe('ActivityPubVerifySenderGuard', () => {
     expect(response.status).toBe(200)
     expect(handler).toHaveBeenCalled()
     expect(handler.mock.calls[0]?.[1]).toMatchObject({
+      verifiedSenderActorId: 'https://remote.test/users/alice',
       activityBody: {
         actor: 'https://remote.test/users/alice',
         type: 'Follow'

--- a/lib/services/guards/ActivityPubVerifyGuard.ts
+++ b/lib/services/guards/ActivityPubVerifyGuard.ts
@@ -215,11 +215,15 @@ export const ActivityPubVerifySenderGuard =
       return guardErrorResponse(request, 400, allowedMethods)
     }
 
+    const verifiedSenderActorId = normalizeActorId(senderPublicKey.owner)
+    if (!verifiedSenderActorId) {
+      return guardErrorResponse(request, 400, allowedMethods)
+    }
+
     if (activity.actor) {
-      const normalizedOwner = normalizeActorId(senderPublicKey.owner)
       const normalizedActor = normalizeActorId(activity.actor)
 
-      if (!normalizedOwner || normalizedOwner !== normalizedActor) {
+      if (verifiedSenderActorId !== normalizedActor) {
         return guardErrorResponse(request, 403, allowedMethods)
       }
     }
@@ -227,6 +231,7 @@ export const ActivityPubVerifySenderGuard =
     return handle(request, {
       activityBody: activity.body,
       database,
-      params: context.params
+      params: context.params,
+      verifiedSenderActorId
     })
   }

--- a/lib/services/guards/types.ts
+++ b/lib/services/guards/types.ts
@@ -31,5 +31,6 @@ export type ActivityPubVerifiedSenderHandle<P> = (
     activityBody: unknown
     database: Database
     params: Promise<P>
+    verifiedSenderActorId: string
   }
 ) => Promise<Response> | Response

--- a/lib/services/queue/type.ts
+++ b/lib/services/queue/type.ts
@@ -4,6 +4,7 @@ export interface JobMessage {
   id: string
   name: string
   data: unknown
+  verifiedSenderActorId?: string
 }
 
 export interface Queue {

--- a/lib/services/statusRouteAccess.test.ts
+++ b/lib/services/statusRouteAccess.test.ts
@@ -1,0 +1,70 @@
+import type { Database } from '@/lib/database/types'
+import type { Actor } from '@/lib/types/domain/actor'
+import type { Status } from '@/lib/types/domain/status'
+
+import { canActorReadStatus, isStatusPubliclyReadable } from './statusAccess'
+import { filterReadableStatuses } from './statusRouteAccess'
+
+jest.mock('./statusAccess', () => ({
+  canActorReadStatus: jest.fn(),
+  isStatusPubliclyReadable: jest.fn()
+}))
+
+const createStatus = (id: string) =>
+  ({
+    id,
+    actorId: 'https://example.com/users/alice'
+  }) as Status
+
+describe('filterReadableStatuses', () => {
+  const database = {} as Database
+  const currentActor = {
+    id: 'https://example.com/users/bob'
+  } as Actor
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(isStatusPubliclyReadable as jest.Mock).mockReturnValue(false)
+    ;(canActorReadStatus as jest.Mock).mockResolvedValue(false)
+  })
+
+  it('does not run asynchronous access checks for public statuses', async () => {
+    const publicStatus = createStatus('public')
+    const privateStatus = createStatus('private')
+    ;(isStatusPubliclyReadable as jest.Mock).mockImplementation(
+      (status: Status) => status.id === publicStatus.id
+    )
+    ;(canActorReadStatus as jest.Mock).mockResolvedValue(true)
+
+    const statuses = await filterReadableStatuses({
+      database,
+      statuses: [publicStatus, privateStatus],
+      currentActor
+    })
+
+    expect(statuses).toEqual([publicStatus, privateStatus])
+    expect(canActorReadStatus).toHaveBeenCalledTimes(1)
+    expect(canActorReadStatus).toHaveBeenCalledWith({
+      database,
+      status: privateStatus,
+      currentActor
+    })
+  })
+
+  it('returns only public statuses for anonymous readers', async () => {
+    const publicStatus = createStatus('public')
+    const privateStatus = createStatus('private')
+    ;(isStatusPubliclyReadable as jest.Mock).mockImplementation(
+      (status: Status) => status.id === publicStatus.id
+    )
+
+    const statuses = await filterReadableStatuses({
+      database,
+      statuses: [publicStatus, privateStatus],
+      currentActor: null
+    })
+
+    expect(statuses).toEqual([publicStatus])
+    expect(canActorReadStatus).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/statusRouteAccess.ts
+++ b/lib/services/statusRouteAccess.ts
@@ -1,0 +1,52 @@
+import type { Database } from '@/lib/database/types'
+import type { Actor } from '@/lib/types/domain/actor'
+import type { Status } from '@/lib/types/domain/status'
+
+import { canActorReadStatus } from './statusAccess'
+
+interface GetReadableStatusParams {
+  database: Database
+  statusId: string
+  currentActor: Actor | null
+  withReplies?: boolean
+}
+
+export const getReadableStatus = async ({
+  database,
+  statusId,
+  currentActor,
+  withReplies
+}: GetReadableStatusParams) => {
+  const status = await database.getStatus({
+    statusId,
+    currentActorId: currentActor?.id,
+    ...(withReplies === undefined ? {} : { withReplies })
+  })
+  if (!status) return null
+
+  const hasAccess = await canActorReadStatus({
+    database,
+    status,
+    currentActor
+  })
+  return hasAccess ? status : null
+}
+
+export const filterReadableStatuses = async ({
+  database,
+  statuses,
+  currentActor
+}: {
+  database: Database
+  statuses: Status[]
+  currentActor: Actor | null
+}) =>
+  (
+    await Promise.all(
+      statuses.map(async (status) =>
+        (await canActorReadStatus({ database, status, currentActor }))
+          ? status
+          : null
+      )
+    )
+  ).filter((status): status is Status => status !== null)

--- a/lib/services/statusRouteAccess.ts
+++ b/lib/services/statusRouteAccess.ts
@@ -2,7 +2,7 @@ import type { Database } from '@/lib/database/types'
 import type { Actor } from '@/lib/types/domain/actor'
 import type { Status } from '@/lib/types/domain/status'
 
-import { canActorReadStatus } from './statusAccess'
+import { canActorReadStatus, isStatusPubliclyReadable } from './statusAccess'
 
 interface GetReadableStatusParams {
   database: Database
@@ -40,13 +40,32 @@ export const filterReadableStatuses = async ({
   database: Database
   statuses: Status[]
   currentActor: Actor | null
-}) =>
-  (
+}) => {
+  const readableStatuses: Status[] = []
+  const statusesNeedingAccessCheck: Status[] = []
+
+  for (const status of statuses) {
+    if (isStatusPubliclyReadable(status)) {
+      readableStatuses.push(status)
+    } else if (currentActor) {
+      statusesNeedingAccessCheck.push(status)
+    }
+  }
+
+  const checkedStatuses = (
     await Promise.all(
-      statuses.map(async (status) =>
+      statusesNeedingAccessCheck.map(async (status) =>
         (await canActorReadStatus({ database, status, currentActor }))
           ? status
           : null
       )
     )
   ).filter((status): status is Status => status !== null)
+
+  const readableStatusIds = new Set(readableStatuses.map((status) => status.id))
+  const checkedStatusIds = new Set(checkedStatuses.map((status) => status.id))
+  return statuses.filter(
+    (status) =>
+      readableStatusIds.has(status.id) || checkedStatusIds.has(status.id)
+  )
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -396,7 +396,9 @@ export type GetStatusRepliesParams = BaseStatusParams & {
   limit?: number
   publicOnly?: boolean
 }
-export type DeleteStatusParams = BaseStatusParams
+export type DeleteStatusParams = BaseStatusParams & {
+  actorId?: string
+}
 
 export type GetStatusFromUrlParams = {
   url: string

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -395,6 +395,7 @@ export type GetStatusRepliesParams = BaseStatusParams & {
   url?: string
   limit?: number
   publicOnly?: boolean
+  visibleToActorId?: string | null
 }
 export type DeleteStatusParams = BaseStatusParams & {
   actorId?: string
@@ -440,7 +441,10 @@ export type AddStatusTagParams = {
   value: string
 }
 
-export type GetActorStatusesCountParams = { actorId: string }
+export type GetActorStatusesCountParams = {
+  actorId: string
+  publicOnly?: boolean
+}
 export type GetActorStatusesParams = {
   actorId: string
   minStatusId?: string | null

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -97,14 +97,30 @@ export const StatusPoll = StatusNote.extend({
 })
 export type StatusPoll = z.infer<typeof StatusPoll>
 
-export const StatusAnnounce = StatusBase.extend({
-  type: z.literal(StatusType.enum.Announce),
-  originalStatus: z.union([StatusNote, StatusPoll])
-})
-export type StatusAnnounce = z.infer<typeof StatusAnnounce>
+type StatusBaseData = z.infer<typeof StatusBase>
 
-export const Status = z.union([StatusNote, StatusPoll, StatusAnnounce])
-export type Status = z.infer<typeof Status>
+export type StatusAnnounce = StatusBaseData & {
+  type: 'Announce'
+  originalStatus: Status
+}
+
+export const StatusAnnounce: z.ZodType<StatusAnnounce> = StatusBase.extend({
+  type: z.literal(StatusType.enum.Announce),
+  originalStatus: z.lazy(() => Status)
+})
+
+export type Status = StatusNote | StatusPoll | StatusAnnounce
+export const Status: z.ZodType<Status> = z.lazy(() =>
+  z.union([StatusNote, StatusPoll, StatusAnnounce])
+)
+
+export const getOriginalStatus = (status: Status): StatusNote | StatusPoll => {
+  if (status.type === StatusType.enum.Announce) {
+    return getOriginalStatus(status.originalStatus)
+  }
+
+  return status
+}
 
 export const EditableStatus = z.union([StatusNote, StatusPoll])
 export type EditableStatus = z.infer<typeof EditableStatus>
@@ -307,8 +323,7 @@ export const toActivityPubObject = (status: Status): Note | Question => {
     })
   }
 
-  const originalStatus =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+  const originalStatus = getOriginalStatus(status)
   return Note.parse({
     id: originalStatus.id,
     type: originalStatus.type,

--- a/lib/utils/getNoteFromStatus.ts
+++ b/lib/utils/getNoteFromStatus.ts
@@ -4,16 +4,18 @@ import {
   getDocumentFromAttachment,
   isFitnessAttachment
 } from '@/lib/types/domain/attachment'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
 import { getMentionFromTag } from '@/lib/types/domain/tag'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 
 export const getNoteFromStatus = (status: Status): Note | null => {
-  if (status.type === StatusType.enum.Poll) return null
-
-  const actualStatus =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+  const actualStatus = getOriginalStatus(status)
+  if (actualStatus.type === StatusType.enum.Poll) return null
 
   return Note.parse({
     id: actualStatus.id,

--- a/lib/utils/text/processStatusText.ts
+++ b/lib/utils/text/processStatusText.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, getOriginalStatus } from '@/lib/types/domain/status'
 import { convertEmojisToImages } from '@/lib/utils/text/convertEmojisToImages'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 import { sanitizeText } from '@/lib/utils/text/sanitizeText'
@@ -11,12 +11,7 @@ import { sanitizeText } from '@/lib/utils/text/sanitizeText'
  * @returns The actual status content
  */
 export const getActualStatus = (status: Status) => {
-  switch (status.type) {
-    case StatusType.enum.Announce:
-      return status.originalStatus
-    default:
-      return status
-  }
+  return getOriginalStatus(status)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Carry the ActivityPub inbox guard's verified sender actor IRI into queued jobs and enforce it for Create Note, Create Question, and poll-vote handling.
- Reject spoofed Create payloads whose attributedTo or inner object actor does not match the verified sender.
- Apply timeline-style visibility checks to status-adjacent routes and public ActivityPub outbox pages.

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test

## Notes
- No migrations or config changes.