### PR TITLE
fix: harden OAuth and app auth boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,9 @@ ACTIVITIES_SECRET_PHASE=
 
 # Trust proxy-managed client IP headers for unauthenticated app registration
 # throttling. Only enable when your instance is reachable exclusively through a
-# proxy that strips client-supplied forwarding headers before setting its own.
+# proxy that overwrites or strips client-supplied forwarding headers before
+# setting its own. Do not enable behind append-only proxies; if the proxy appends
+# to X-Forwarded-For, the first element may still be untrusted.
 # ACTIVITIES_TRUST_PROXY_IP_HEADERS=false
 
 # ============================================================================

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ ACTIVITIES_SECRET_PHASE=
 # Leave unset unless your reverse proxy legitimately serves this instance on multiple hostnames.
 # ACTIVITIES_TRUSTED_HOSTS=["social-alias.example.com"]
 
+# Trust proxy-managed client IP headers for unauthenticated app registration
+# throttling. Only enable when your instance is reachable exclusively through a
+# proxy that strips client-supplied forwarding headers before setting its own.
+# ACTIVITIES_TRUST_PROXY_IP_HEADERS=false
+
 # ============================================================================
 # REQUIRED - Database Configuration
 # ============================================================================

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -150,6 +150,76 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
 
+  test('falls back to the body client_id when Basic credentials omit the delimiter', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${Buffer.from('malformed-client-id').toString('base64')}`
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the body client_id when Basic credentials are not valid base64', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockClients.set('shadow-client', {
+      clientId: 'shadow-client',
+      requirePKCE: false
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${Buffer.from('shadow-client:client-secret').toString('base64')}!`
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
   test('rejects authorization-code exchanges without client credentials before proxying', async () => {
     mockAuthHandler.mockResolvedValue(
       Response.json({ access_token: 'should-not-issue' })

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -81,6 +81,75 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
 
+  test('accepts a case-insensitive Basic auth scheme during PKCE preflight', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `basic ${Buffer.from('pkce-client:client-secret').toString('base64')}`
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('prefers the Basic auth client over a mismatched body client_id for PKCE preflight', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockClients.set('non-pkce-client', {
+      clientId: 'non-pkce-client',
+      requirePKCE: false
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${Buffer.from('pkce-client:client-secret').toString('base64')}`
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'non-pkce-client',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
   test('rejects authorization-code exchanges without client credentials before proxying', async () => {
     mockAuthHandler.mockResolvedValue(
       Response.json({ access_token: 'should-not-issue' })
@@ -165,19 +234,23 @@ describe('OAuth token endpoint', () => {
   })
 
   test('does not look up the client during PKCE preflight when code_verifier is present', async () => {
-    mockAuthHandler.mockResolvedValue(Response.json({ access_token: 'issued' }))
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: 'pkce-client',
+      client_secret: 'client-secret',
+      code: 'authorization-code',
+      code_verifier: 'valid-code-verifier',
+      redirect_uri: 'https://client.llun.dev/callback'
+    })
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      await expect(request.text()).resolves.toBe(body.toString())
+      return Response.json({ access_token: 'issued' })
+    })
 
     const req = new NextRequest('https://llun.test/oauth/token', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        client_id: 'pkce-client',
-        client_secret: 'client-secret',
-        code: 'authorization-code',
-        code_verifier: 'valid-code-verifier',
-        redirect_uri: 'https://client.llun.dev/callback'
-      })
+      body
     })
 
     const response = await POST(req)

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -264,6 +264,44 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).toHaveBeenCalled()
   })
 
+  test('filters destination-conflicting headers before proxying to the auth handler', async () => {
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: 'client-id',
+      client_secret: 'client-secret'
+    })
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      expect(request.headers.get('authorization')).toBe('Bearer original')
+      expect(request.headers.get('content-type')).toBe(
+        'application/x-www-form-urlencoded'
+      )
+      expect(request.headers.has('host')).toBe(false)
+      expect(request.headers.has('content-length')).toBe(false)
+      await expect(request.text()).resolves.toBe(body.toString())
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer original',
+        'content-type': 'application/x-www-form-urlencoded',
+        host: 'llun.test',
+        'content-length': '999'
+      },
+      body
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
   test('returns OAuth server_error when PKCE preflight fails internally', async () => {
     mockClientLookupError = new Error('database unavailable')
 

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -541,4 +541,39 @@ describe('OAuth token endpoint', () => {
     expect(arrayBufferSpy).not.toHaveBeenCalled()
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
+
+  test('rejects token body streams that yield invalid numeric chunks', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: 'client-id',
+        client_secret: 'client-secret'
+      })
+    })
+    Object.defineProperty(req, 'body', {
+      value: {
+        async *[Symbol.asyncIterator]() {
+          yield 256
+        }
+      },
+      configurable: true
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'Unable to read request body'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
 })

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -4,6 +4,7 @@ import { POST } from './route'
 
 const mockAuthHandler = jest.fn()
 const mockClients = new Map<string, Record<string, unknown>>()
+let mockClientLookupCount = 0
 let mockClientLookupError: Error | null = null
 
 jest.mock('@/lib/config', () => ({
@@ -17,6 +18,7 @@ jest.mock('@/lib/database', () => ({
   getKnex: () => (table: string) => ({
     where: (_field: string, value: string) => ({
       first: () => {
+        mockClientLookupCount += 1
         if (mockClientLookupError) return Promise.reject(mockClientLookupError)
         return Promise.resolve(
           table === 'oauthClient' ? mockClients.get(value) : null
@@ -44,6 +46,7 @@ describe('OAuth token endpoint', () => {
   beforeEach(() => {
     mockAuthHandler.mockReset()
     mockClients.clear()
+    mockClientLookupCount = 0
     mockClientLookupError = null
   })
 
@@ -100,6 +103,92 @@ describe('OAuth token endpoint', () => {
     })
     expect(response.status).toBe(401)
     expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('normalizes token request content type before PKCE validation', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'Application/X-WWW-Form-Urlencoded; Charset=UTF-8'
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        client_secret: 'client-secret',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('rejects token requests that are not form encoded before proxying', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        code: 'authorization-code'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description:
+        'Token requests must use application/x-www-form-urlencoded'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('does not look up the client during PKCE preflight when code_verifier is present', async () => {
+    mockAuthHandler.mockResolvedValue(Response.json({ access_token: 'issued' }))
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        client_secret: 'client-secret',
+        code: 'authorization-code',
+        code_verifier: 'valid-code-verifier',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockClientLookupCount).toBe(0)
+    expect(mockAuthHandler).toHaveBeenCalled()
   })
 
   test('returns OAuth server_error when PKCE preflight fails internally', async () => {

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -113,6 +113,47 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
 
+  test('proxies authorization-code exchanges with unpadded Basic credentials and no body client_id when PKCE is not required', async () => {
+    mockClients.set('non-pkce-client', {
+      clientId: 'non-pkce-client',
+      requirePKCE: false
+    })
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: 'authorization-code',
+      redirect_uri: 'https://client.llun.dev/callback'
+    })
+    const credentials = Buffer.from('non-pkce-client:client-secret').toString(
+      'base64'
+    )
+    const unpaddedCredentials = credentials.replace(/=+$/, '')
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      expect(request.headers.get('authorization')).toBe(
+        `Basic ${unpaddedCredentials}`
+      )
+      await expect(request.text()).resolves.toBe(body.toString())
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${unpaddedCredentials}`
+      },
+      body
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
   test('prefers the Basic auth client over a mismatched body client_id for PKCE preflight', async () => {
     mockClients.set('pkce-client', {
       clientId: 'pkce-client',
@@ -218,6 +259,46 @@ describe('OAuth token endpoint', () => {
     })
     expect(response.status).toBe(400)
     expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the body client_id when Basic credentials have partial padding', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockClients.set('non-pkce-client', {
+      clientId: 'non-pkce-client',
+      requirePKCE: false
+    })
+    mockAuthHandler.mockResolvedValue(Response.json({ access_token: 'issued' }))
+
+    const partialPaddingCredentials = `${Buffer.from(
+      'pkce-client:client-secret'
+    )
+      .toString('base64')
+      .replace(/=+$/, '')}=`
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${partialPaddingCredentials}`
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'non-pkce-client',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
   })
 
   test('rejects authorization-code exchanges without client credentials before proxying', async () => {

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -315,4 +315,41 @@ describe('OAuth token endpoint', () => {
     expect(response.status).toBe(413)
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
+
+  test('rejects token bodies that cannot be read with a bounded stream', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        Origin: 'https://client.llun.dev'
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: 'client-id',
+        client_secret: 'client-secret'
+      })
+    })
+    const arrayBufferSpy = jest.spyOn(req, 'arrayBuffer')
+    Object.defineProperty(req, 'body', {
+      value: {},
+      configurable: true
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'Unable to read request body'
+    })
+    expect(response.status).toBe(400)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://client.llun.dev'
+    )
+    expect(arrayBufferSpy).not.toHaveBeenCalled()
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
 })

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockAuthHandler = jest.fn()
+const mockClients = new Map<string, Record<string, unknown>>()
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.test'
+  }),
+  getBaseURL: () => 'https://llun.test'
+}))
+
+jest.mock('@/lib/database', () => ({
+  getKnex: () => (table: string) => ({
+    where: (_field: string, value: string) => ({
+      first: () =>
+        Promise.resolve(table === 'oauthClient' ? mockClients.get(value) : null)
+    })
+  })
+}))
+
+jest.mock('@/lib/services/auth/auth', () => ({
+  getAuth: () => ({
+    handler: mockAuthHandler
+  })
+}))
+
+describe('OAuth token endpoint', () => {
+  beforeEach(() => {
+    mockAuthHandler.mockReset()
+    mockClients.clear()
+  })
+
+  test('rejects authorization-code exchanges for PKCE-required clients when code_verifier is missing', async () => {
+    mockClients.set('pkce-client', {
+      clientId: 'pkce-client',
+      requirePKCE: true
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        client_secret: 'client-secret',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+})

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -4,6 +4,7 @@ import { POST } from './route'
 
 const mockAuthHandler = jest.fn()
 const mockClients = new Map<string, Record<string, unknown>>()
+let mockClientLookupError: Error | null = null
 
 jest.mock('@/lib/config', () => ({
   getConfig: () => ({
@@ -15,8 +16,12 @@ jest.mock('@/lib/config', () => ({
 jest.mock('@/lib/database', () => ({
   getKnex: () => (table: string) => ({
     where: (_field: string, value: string) => ({
-      first: () =>
-        Promise.resolve(table === 'oauthClient' ? mockClients.get(value) : null)
+      first: () => {
+        if (mockClientLookupError) return Promise.reject(mockClientLookupError)
+        return Promise.resolve(
+          table === 'oauthClient' ? mockClients.get(value) : null
+        )
+      }
     })
   })
 }))
@@ -27,10 +32,19 @@ jest.mock('@/lib/services/auth/auth', () => ({
   })
 }))
 
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn()
+  }
+}))
+
 describe('OAuth token endpoint', () => {
   beforeEach(() => {
     mockAuthHandler.mockReset()
     mockClients.clear()
+    mockClientLookupError = null
   })
 
   test('rejects authorization-code exchanges for PKCE-required clients when code_verifier is missing', async () => {
@@ -61,6 +75,82 @@ describe('OAuth token endpoint', () => {
       error_description: 'PKCE is required for this client'
     })
     expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('rejects authorization-code exchanges without client credentials before proxying', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_client'
+    })
+    expect(response.status).toBe(401)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('returns OAuth server_error when PKCE preflight fails internally', async () => {
+    mockClientLookupError = new Error('database unavailable')
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        client_secret: 'client-secret',
+        code: 'authorization-code',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'server_error'
+    })
+    expect(response.status).toBe(500)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('rejects oversized token bodies before buffering them for PKCE checks', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'content-length': '65537'
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'pkce-client',
+        code: 'authorization-code'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'Request body is too large'
+    })
+    expect(response.status).toBe(413)
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
 })

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -15,6 +15,7 @@ import {
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const MAX_TOKEN_REQUEST_BODY_BYTES = 64 * 1024
+const FORM_URLENCODED_MEDIA_TYPE = 'application/x-www-form-urlencoded'
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -86,10 +87,25 @@ const getTokenRequestBody = async (
     }
   }
 
-  const contentType = req.headers.get('content-type') ?? ''
+  const contentType = (req.headers.get('content-type') ?? '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase()
 
-  if (!contentType.includes('application/x-www-form-urlencoded')) {
-    return { params: null, error: null }
+  if (contentType !== FORM_URLENCODED_MEDIA_TYPE) {
+    return {
+      params: null,
+      error: apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {
+          error: 'invalid_request',
+          error_description:
+            'Token requests must use application/x-www-form-urlencoded'
+        },
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
   }
 
   try {
@@ -117,6 +133,7 @@ const validatePkceTokenExchange = async (
   body: URLSearchParams
 ): Promise<Response | null> => {
   if (body.get('grant_type') !== 'authorization_code') return null
+  if (body.get('code_verifier')) return null
 
   const clientId = getClientId(req, body)
   if (!clientId) {
@@ -132,7 +149,7 @@ const validatePkceTokenExchange = async (
     const client = await getKnex()('oauthClient')
       .where('clientId', clientId)
       .first()
-    if (!client?.requirePKCE || body.get('code_verifier')) return null
+    if (!client?.requirePKCE) return null
   } catch (e) {
     logger.error({ message: 'PKCE token preflight failed', error: e })
     return apiResponse({

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -20,10 +20,11 @@ const FORM_URLENCODED_MEDIA_TYPE = 'application/x-www-form-urlencoded'
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const parseBasicClientId = (authorization: string | null): string | null => {
-  if (!authorization?.startsWith('Basic ')) return null
+  const [scheme, credentials] = authorization?.split(/\s+/, 2) ?? []
+  if (scheme?.toLowerCase() !== 'basic' || !credentials) return null
 
   try {
-    const decoded = Buffer.from(authorization.slice('Basic '.length), 'base64')
+    const decoded = Buffer.from(credentials, 'base64')
       .toString('utf8')
       .split(':')[0]
     return decoded || null
@@ -32,19 +33,23 @@ const parseBasicClientId = (authorization: string | null): string | null => {
   }
 }
 
-const getClientId = (req: NextRequest, body: URLSearchParams): string | null =>
-  body.get('client_id') || parseBasicClientId(req.headers.get('authorization'))
+const getClientId = (
+  req: NextRequest,
+  body: URLSearchParams
+): string | null => {
+  const basicClientId = parseBasicClientId(req.headers.get('authorization'))
+  return basicClientId || body.get('client_id')
+}
 
 class TokenRequestBodyTooLargeError extends Error {}
 
 const readTokenRequestBodyWithLimit = async (
   req: NextRequest
 ): Promise<string> => {
-  const clonedReq = req.clone()
-  const body = clonedReq.body
+  const body = req.body
   if (!body) return ''
   if (typeof body.getReader !== 'function') {
-    const bodyBuffer = Buffer.from(await clonedReq.arrayBuffer())
+    const bodyBuffer = Buffer.from(await req.arrayBuffer())
     if (bodyBuffer.byteLength > MAX_TOKEN_REQUEST_BODY_BYTES) {
       throw new TokenRequestBodyTooLargeError()
     }
@@ -70,10 +75,15 @@ const readTokenRequestBodyWithLimit = async (
 
 const getTokenRequestBody = async (
   req: NextRequest
-): Promise<{ params: URLSearchParams | null; error: Response | null }> => {
+): Promise<{
+  bodyText: string | null
+  params: URLSearchParams | null
+  error: Response | null
+}> => {
   const contentLength = Number(req.headers.get('content-length') ?? 0)
   if (contentLength > MAX_TOKEN_REQUEST_BODY_BYTES) {
     return {
+      bodyText: null,
       params: null,
       error: apiResponse({
         req,
@@ -94,6 +104,7 @@ const getTokenRequestBody = async (
 
   if (contentType !== FORM_URLENCODED_MEDIA_TYPE) {
     return {
+      bodyText: null,
       params: null,
       error: apiResponse({
         req,
@@ -110,10 +121,11 @@ const getTokenRequestBody = async (
 
   try {
     const bodyText = await readTokenRequestBodyWithLimit(req)
-    return { params: new URLSearchParams(bodyText), error: null }
+    return { bodyText, params: new URLSearchParams(bodyText), error: null }
   } catch (error) {
     if (!(error instanceof TokenRequestBodyTooLargeError)) throw error
     return {
+      bodyText: null,
       params: null,
       error: apiResponse({
         req,
@@ -173,7 +185,7 @@ const validatePkceTokenExchange = async (
 
 export const POST = async (req: NextRequest) => {
   const auth = getAuth()
-  const { params, error } = await getTokenRequestBody(req)
+  const { bodyText, params, error } = await getTokenRequestBody(req)
   if (error) return error
 
   if (params) {
@@ -186,9 +198,7 @@ export const POST = async (req: NextRequest) => {
   const proxyReq = new Request(url.toString(), {
     method: 'POST',
     headers: req.headers,
-    body: req.body,
-    // @ts-expect-error duplex is needed for streaming body
-    duplex: 'half'
+    body: bodyText ?? ''
   })
 
   let response: Response

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getBaseURL } from '@/lib/config'
+import { getKnex } from '@/lib/database'
 import { getAuth } from '@/lib/services/auth/auth'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { logger } from '@/lib/utils/logger'
@@ -15,17 +16,86 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+const parseBasicClientId = (authorization: string | null): string | null => {
+  if (!authorization?.startsWith('Basic ')) return null
+
+  try {
+    const decoded = Buffer.from(authorization.slice('Basic '.length), 'base64')
+      .toString('utf8')
+      .split(':')[0]
+    return decoded || null
+  } catch {
+    return null
+  }
+}
+
+const getClientId = (req: NextRequest, body: URLSearchParams): string | null =>
+  body.get('client_id') || parseBasicClientId(req.headers.get('authorization'))
+
+const getTokenRequestBody = async (
+  req: NextRequest
+): Promise<{ bodyText: string; params: URLSearchParams | null }> => {
+  const bodyText = await req.text()
+  const contentType = req.headers.get('content-type') ?? ''
+
+  if (!contentType.includes('application/x-www-form-urlencoded')) {
+    return { bodyText, params: null }
+  }
+
+  return { bodyText, params: new URLSearchParams(bodyText) }
+}
+
+const validatePkceTokenExchange = async (
+  req: NextRequest,
+  body: URLSearchParams
+): Promise<Response | null> => {
+  if (body.get('grant_type') !== 'authorization_code') return null
+  if (body.get('code_verifier')) return null
+
+  const clientId = getClientId(req, body)
+  if (!clientId) return null
+
+  try {
+    const client = await getKnex()('oauthClient')
+      .where('clientId', clientId)
+      .first()
+    if (!client?.requirePKCE) return null
+  } catch (e) {
+    logger.error({ message: 'PKCE token preflight failed', error: e })
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: codeMap[500],
+      responseStatusCode: 500
+    })
+  }
+
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: {
+      error: 'invalid_request',
+      error_description: 'PKCE is required for this client'
+    },
+    responseStatusCode: 400
+  })
+}
+
 export const POST = async (req: NextRequest) => {
   const auth = getAuth()
+  const { bodyText, params } = await getTokenRequestBody(req)
+
+  if (params) {
+    const pkceError = await validatePkceTokenExchange(req, params)
+    if (pkceError) return pkceError
+  }
 
   // Rewrite the URL to better-auth's token endpoint
   const url = new URL('/api/auth/oauth2/token', getBaseURL())
   const proxyReq = new Request(url.toString(), {
     method: 'POST',
     headers: req.headers,
-    body: req.body,
-    // @ts-expect-error duplex is needed for streaming body
-    duplex: 'half'
+    body: bodyText
   })
 
   let response: Response

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -16,6 +16,7 @@ import {
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const MAX_TOKEN_REQUEST_BODY_BYTES = 64 * 1024
 const FORM_URLENCODED_MEDIA_TYPE = 'application/x-www-form-urlencoded'
+const TOKEN_PROXY_EXCLUDED_HEADERS = ['content-length', 'host']
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -107,6 +108,14 @@ const readTokenRequestBodyWithLimit = async (
   }
 
   return Buffer.concat(chunks).toString('utf8')
+}
+
+const getTokenProxyHeaders = (headers: Headers): Headers => {
+  const proxyHeaders = new Headers(headers)
+  for (const header of TOKEN_PROXY_EXCLUDED_HEADERS) {
+    proxyHeaders.delete(header)
+  }
+  return proxyHeaders
 }
 
 const getTokenRequestBody = async (
@@ -248,8 +257,8 @@ export const POST = async (req: NextRequest) => {
   // Rewrite the URL to better-auth's token endpoint
   const url = new URL('/api/auth/oauth2/token', getBaseURL())
   const proxyReq = new Request(url.toString(), {
-    method: 'POST',
-    headers: req.headers,
+    method: 'post',
+    headers: getTokenProxyHeaders(req.headers),
     body: bodyText ?? ''
   })
 

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -78,7 +78,12 @@ const appendTokenRequestBodyChunk = (
 const toBodyChunk = (value: unknown): Uint8Array => {
   if (value instanceof Uint8Array) return value
   if (value instanceof ArrayBuffer) return new Uint8Array(value)
-  if (typeof value === 'number') return Uint8Array.of(value)
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0 || value > 255) {
+      throw new TokenRequestBodyUnreadableError()
+    }
+    return Uint8Array.of(value)
+  }
   if (typeof value === 'string') return Buffer.from(value)
   throw new TokenRequestBodyUnreadableError()
 }

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -42,32 +42,68 @@ const getClientId = (
 }
 
 class TokenRequestBodyTooLargeError extends Error {}
+class TokenRequestBodyUnreadableError extends Error {}
+
+const appendTokenRequestBodyChunk = (
+  chunks: Uint8Array[],
+  size: number,
+  value: unknown
+): number => {
+  const chunk = toBodyChunk(value)
+  const nextSize = size + chunk.byteLength
+  if (nextSize > MAX_TOKEN_REQUEST_BODY_BYTES) {
+    throw new TokenRequestBodyTooLargeError()
+  }
+  chunks.push(chunk)
+  return nextSize
+}
+
+const toBodyChunk = (value: unknown): Uint8Array => {
+  if (value instanceof Uint8Array) return value
+  if (value instanceof ArrayBuffer) return new Uint8Array(value)
+  if (typeof value === 'number') return Uint8Array.of(value)
+  if (typeof value === 'string') return Buffer.from(value)
+  throw new TokenRequestBodyUnreadableError()
+}
+
+const getAsyncIterableBody = (
+  body: ReadableStream<Uint8Array>
+): AsyncIterable<Uint8Array> | null => {
+  const asyncIterable = body as ReadableStream<Uint8Array> &
+    AsyncIterable<Uint8Array>
+  if (typeof asyncIterable[Symbol.asyncIterator] === 'function') {
+    return asyncIterable
+  }
+
+  const valuesBody = body as ReadableStream<Uint8Array> & {
+    values?: () => AsyncIterable<Uint8Array>
+  }
+  return typeof valuesBody.values === 'function' ? valuesBody.values() : null
+}
 
 const readTokenRequestBodyWithLimit = async (
   req: NextRequest
 ): Promise<string> => {
   const body = req.body
   if (!body) return ''
-  if (typeof body.getReader !== 'function') {
-    const bodyBuffer = Buffer.from(await req.arrayBuffer())
-    if (bodyBuffer.byteLength > MAX_TOKEN_REQUEST_BODY_BYTES) {
-      throw new TokenRequestBodyTooLargeError()
-    }
-    return bodyBuffer.toString('utf8')
-  }
-
-  const reader = body.getReader()
   const chunks: Uint8Array[] = []
   let size = 0
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    size += value.byteLength
-    if (size > MAX_TOKEN_REQUEST_BODY_BYTES) {
-      throw new TokenRequestBodyTooLargeError()
+  if (typeof body.getReader === 'function') {
+    const reader = body.getReader()
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size = appendTokenRequestBodyChunk(chunks, size, value)
     }
-    chunks.push(value)
+  } else {
+    const asyncIterableBody = getAsyncIterableBody(body)
+    if (!asyncIterableBody) throw new TokenRequestBodyUnreadableError()
+
+    for await (const value of asyncIterableBody) {
+      size = appendTokenRequestBodyChunk(chunks, size, value)
+    }
   }
 
   return Buffer.concat(chunks).toString('utf8')
@@ -123,6 +159,22 @@ const getTokenRequestBody = async (
     const bodyText = await readTokenRequestBodyWithLimit(req)
     return { bodyText, params: new URLSearchParams(bodyText), error: null }
   } catch (error) {
+    if (error instanceof TokenRequestBodyUnreadableError) {
+      return {
+        bodyText: null,
+        params: null,
+        error: apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: {
+            error: 'invalid_request',
+            error_description: 'Unable to read request body'
+          },
+          responseStatusCode: HTTP_STATUS.BAD_REQUEST
+        })
+      }
+    }
+
     if (!(error instanceof TokenRequestBodyTooLargeError)) throw error
     return {
       bodyText: null,

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -6,6 +6,7 @@ import { getAuth } from '@/lib/services/auth/auth'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { logger } from '@/lib/utils/logger'
 import {
+  HTTP_STATUS,
   StatusCode,
   apiResponse,
   codeMap,
@@ -13,6 +14,7 @@ import {
 } from '@/lib/utils/response'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+const MAX_TOKEN_REQUEST_BODY_BYTES = 64 * 1024
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -32,17 +34,82 @@ const parseBasicClientId = (authorization: string | null): string | null => {
 const getClientId = (req: NextRequest, body: URLSearchParams): string | null =>
   body.get('client_id') || parseBasicClientId(req.headers.get('authorization'))
 
+class TokenRequestBodyTooLargeError extends Error {}
+
+const readTokenRequestBodyWithLimit = async (
+  req: NextRequest
+): Promise<string> => {
+  const clonedReq = req.clone()
+  const body = clonedReq.body
+  if (!body) return ''
+  if (typeof body.getReader !== 'function') {
+    const bodyBuffer = Buffer.from(await clonedReq.arrayBuffer())
+    if (bodyBuffer.byteLength > MAX_TOKEN_REQUEST_BODY_BYTES) {
+      throw new TokenRequestBodyTooLargeError()
+    }
+    return bodyBuffer.toString('utf8')
+  }
+
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    size += value.byteLength
+    if (size > MAX_TOKEN_REQUEST_BODY_BYTES) {
+      throw new TokenRequestBodyTooLargeError()
+    }
+    chunks.push(value)
+  }
+
+  return Buffer.concat(chunks).toString('utf8')
+}
+
 const getTokenRequestBody = async (
   req: NextRequest
-): Promise<{ bodyText: string; params: URLSearchParams | null }> => {
-  const bodyText = await req.text()
+): Promise<{ params: URLSearchParams | null; error: Response | null }> => {
+  const contentLength = Number(req.headers.get('content-length') ?? 0)
+  if (contentLength > MAX_TOKEN_REQUEST_BODY_BYTES) {
+    return {
+      params: null,
+      error: apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {
+          error: 'invalid_request',
+          error_description: 'Request body is too large'
+        },
+        responseStatusCode: HTTP_STATUS.PAYLOAD_TOO_LARGE
+      })
+    }
+  }
+
   const contentType = req.headers.get('content-type') ?? ''
 
   if (!contentType.includes('application/x-www-form-urlencoded')) {
-    return { bodyText, params: null }
+    return { params: null, error: null }
   }
 
-  return { bodyText, params: new URLSearchParams(bodyText) }
+  try {
+    const bodyText = await readTokenRequestBodyWithLimit(req)
+    return { params: new URLSearchParams(bodyText), error: null }
+  } catch (error) {
+    if (!(error instanceof TokenRequestBodyTooLargeError)) throw error
+    return {
+      params: null,
+      error: apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {
+          error: 'invalid_request',
+          error_description: 'Request body is too large'
+        },
+        responseStatusCode: HTTP_STATUS.PAYLOAD_TOO_LARGE
+      })
+    }
+  }
 }
 
 const validatePkceTokenExchange = async (
@@ -50,23 +117,29 @@ const validatePkceTokenExchange = async (
   body: URLSearchParams
 ): Promise<Response | null> => {
   if (body.get('grant_type') !== 'authorization_code') return null
-  if (body.get('code_verifier')) return null
 
   const clientId = getClientId(req, body)
-  if (!clientId) return null
+  if (!clientId) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { error: 'invalid_client' },
+      responseStatusCode: HTTP_STATUS.UNAUTHORIZED
+    })
+  }
 
   try {
     const client = await getKnex()('oauthClient')
       .where('clientId', clientId)
       .first()
-    if (!client?.requirePKCE) return null
+    if (!client?.requirePKCE || body.get('code_verifier')) return null
   } catch (e) {
     logger.error({ message: 'PKCE token preflight failed', error: e })
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: codeMap[500],
-      responseStatusCode: 500
+      data: { error: 'server_error' },
+      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
     })
   }
 
@@ -83,7 +156,8 @@ const validatePkceTokenExchange = async (
 
 export const POST = async (req: NextRequest) => {
   const auth = getAuth()
-  const { bodyText, params } = await getTokenRequestBody(req)
+  const { params, error } = await getTokenRequestBody(req)
+  if (error) return error
 
   if (params) {
     const pkceError = await validatePkceTokenExchange(req, params)
@@ -95,7 +169,9 @@ export const POST = async (req: NextRequest) => {
   const proxyReq = new Request(url.toString(), {
     method: 'POST',
     headers: req.headers,
-    body: bodyText
+    body: req.body,
+    // @ts-expect-error duplex is needed for streaming body
+    duplex: 'half'
   })
 
   let response: Response
@@ -106,8 +182,8 @@ export const POST = async (req: NextRequest) => {
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: codeMap[500],
-      responseStatusCode: 500
+      data: { error: 'server_error' },
+      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
     })
   }
 

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -240,7 +240,7 @@ const validatePkceTokenExchange = async (
       error: 'invalid_request',
       error_description: 'PKCE is required for this client'
     },
-    responseStatusCode: 400
+    responseStatusCode: HTTP_STATUS.BAD_REQUEST
   })
 }
 

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -17,18 +17,21 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const MAX_TOKEN_REQUEST_BODY_BYTES = 64 * 1024
 const FORM_URLENCODED_MEDIA_TYPE = 'application/x-www-form-urlencoded'
 const TOKEN_PROXY_EXCLUDED_HEADERS = ['content-length', 'host']
+const BASIC_CREDENTIALS_PATTERN = /^basic\s+([A-Za-z0-9+/]+={0,2})$/i
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const parseBasicClientId = (authorization: string | null): string | null => {
-  const [scheme, credentials] = authorization?.split(/\s+/, 2) ?? []
-  if (scheme?.toLowerCase() !== 'basic' || !credentials) return null
+  const credentials = authorization?.match(BASIC_CREDENTIALS_PATTERN)?.[1]
+  if (!credentials || credentials.length % 4 !== 0) return null
 
   try {
-    const decoded = Buffer.from(credentials, 'base64')
-      .toString('utf8')
-      .split(':')[0]
-    return decoded || null
+    const decoded = Buffer.from(credentials, 'base64').toString('utf8')
+    const delimiterIndex = decoded.indexOf(':')
+    if (delimiterIndex < 0) return null
+
+    const clientId = decoded.slice(0, delimiterIndex)
+    return clientId || null
   } catch {
     return null
   }
@@ -257,7 +260,7 @@ export const POST = async (req: NextRequest) => {
   // Rewrite the URL to better-auth's token endpoint
   const url = new URL('/api/auth/oauth2/token', getBaseURL())
   const proxyReq = new Request(url.toString(), {
-    method: 'post',
+    method: 'POST',
     headers: getTokenProxyHeaders(req.headers),
     body: bodyText ?? ''
   })

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -21,12 +21,25 @@ const BASIC_CREDENTIALS_PATTERN = /^basic\s+([A-Za-z0-9+/]+={0,2})$/i
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+const normalizeBase64Credentials = (credentials: string): string | null => {
+  const paddingLength = credentials.length % 4
+  if (paddingLength === 0) return credentials
+  if (credentials.includes('=') || paddingLength === 1) return null
+
+  return `${credentials}${'='.repeat(4 - paddingLength)}`
+}
+
 const parseBasicClientId = (authorization: string | null): string | null => {
   const credentials = authorization?.match(BASIC_CREDENTIALS_PATTERN)?.[1]
-  if (!credentials || credentials.length % 4 !== 0) return null
+  if (!credentials) return null
+
+  const normalizedCredentials = normalizeBase64Credentials(credentials)
+  if (!normalizedCredentials) return null
 
   try {
-    const decoded = Buffer.from(credentials, 'base64').toString('utf8')
+    const decoded = Buffer.from(normalizedCredentials, 'base64').toString(
+      'utf8'
+    )
     const delimiterIndex = decoded.indexOf(':')
     if (delimiterIndex < 0) return null
 

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -219,12 +219,12 @@ describe('createApplication', () => {
     expect(rows).toHaveLength(5)
   })
 
-  test('it stores anonymous unauthenticated registrations with a cleanup reference', async () => {
+  test('it stores unrated registrations without a shared rate-limit reference', async () => {
     const response = (await createApplication({
-      redirect_uris: 'https://anonymous.llun.dev/callback',
-      client_name: 'anonymousClient',
+      redirect_uris: 'https://unrated.llun.dev/callback',
+      client_name: 'unratedClient',
       scopes: 'read',
-      website: 'https://anonymous.llun.dev'
+      website: 'https://unrated.llun.dev'
     })) as SuccessResponse
 
     expect(response.type).toBe('success')
@@ -232,12 +232,12 @@ describe('createApplication', () => {
       knexDatabase('oauthClient').where({ id: response.id }).first()
     ).resolves.toEqual(
       expect.objectContaining({
-        referenceId: 'app-registration:anonymous'
+        referenceId: ''
       })
     )
   })
 
-  test('it rate limits anonymous app registrations with the global fallback bucket', async () => {
+  test('it does not rate limit registrations when no source key is available', async () => {
     const now = new Date('2030-05-12T12:00:00.000Z')
     const responses: PostResponse[] = []
 
@@ -255,22 +255,18 @@ describe('createApplication', () => {
       )
     }
 
-    expect(
-      responses.slice(0, 5).every((response) => response.type === 'success')
-    ).toBe(true)
-    expect(responses[5]).toEqual({
-      type: 'error',
-      error: 'Too many application registrations'
-    })
+    expect(responses.every((response) => response.type === 'success')).toBe(
+      true
+    )
 
     const rows = await knexDatabase('oauthClient')
-      .where('referenceId', 'app-registration:anonymous')
+      .where('referenceId', '')
       .where('createdAt', '>=', new Date('2030-05-12T11:50:00.000Z'))
       .select()
-    expect(rows).toHaveLength(5)
+    expect(rows).toHaveLength(6)
 
     await knexDatabase('oauthClient')
-      .where('referenceId', 'app-registration:anonymous')
+      .where('referenceId', '')
       .where('createdAt', '>=', new Date('2030-05-12T11:50:00.000Z'))
       .delete()
   })

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -264,11 +264,6 @@ describe('createApplication', () => {
       .where('createdAt', '>=', new Date('2030-05-12T11:50:00.000Z'))
       .select()
     expect(rows).toHaveLength(6)
-
-    await knexDatabase('oauthClient')
-      .where('referenceId', '')
-      .where('createdAt', '>=', new Date('2030-05-12T11:50:00.000Z'))
-      .delete()
   })
 
   test('it checks the rate limit before garbage collecting stale app registrations', async () => {
@@ -333,6 +328,7 @@ describe('createApplication', () => {
 
   test('it garbage-collects stale unused app registrations without deleting token-backed clients', async () => {
     const staleCreatedAt = new Date('2026-05-10T00:00:00.000Z')
+    const recentCreatedAt = new Date('2026-05-12T11:30:00.000Z')
     const now = new Date('2026-05-12T12:00:00.000Z')
 
     await knexDatabase('oauthClient').insert([
@@ -371,6 +367,44 @@ describe('createApplication', () => {
         referenceId: 'app-registration:stale-active',
         createdAt: staleCreatedAt,
         updatedAt: staleCreatedAt
+      },
+      {
+        id: 'stale-anonymous-client-id',
+        clientId: 'stale-anonymous-client',
+        clientSecret: 'hashed-secret',
+        name: 'stale-anonymous',
+        scopes: JSON.stringify(['read']),
+        redirectUris: JSON.stringify([
+          'https://stale-anonymous.llun.dev/callback'
+        ]),
+        requirePKCE: true,
+        disabled: false,
+        grantTypes: JSON.stringify(['authorization_code']),
+        responseTypes: JSON.stringify(['code']),
+        tokenEndpointAuthMethod: 'client_secret_post',
+        referenceId: '',
+        metadata: JSON.stringify({ registeredUnauthenticated: true }),
+        createdAt: staleCreatedAt,
+        updatedAt: staleCreatedAt
+      },
+      {
+        id: 'recent-anonymous-client-id',
+        clientId: 'recent-anonymous-client',
+        clientSecret: 'hashed-secret',
+        name: 'recent-anonymous',
+        scopes: JSON.stringify(['read']),
+        redirectUris: JSON.stringify([
+          'https://recent-anonymous.llun.dev/callback'
+        ]),
+        requirePKCE: true,
+        disabled: false,
+        grantTypes: JSON.stringify(['authorization_code']),
+        responseTypes: JSON.stringify(['code']),
+        tokenEndpointAuthMethod: 'client_secret_post',
+        referenceId: '',
+        metadata: JSON.stringify({ registeredUnauthenticated: true }),
+        createdAt: recentCreatedAt,
+        updatedAt: recentCreatedAt
       }
     ])
     await knexDatabase('oauthAccessToken').insert({
@@ -403,6 +437,18 @@ describe('createApplication', () => {
         .first()
     ).resolves.toEqual(
       expect.objectContaining({ clientId: 'stale-active-client' })
+    )
+    await expect(
+      knexDatabase('oauthClient')
+        .where('clientId', 'stale-anonymous-client')
+        .first()
+    ).resolves.toBeUndefined()
+    await expect(
+      knexDatabase('oauthClient')
+        .where('clientId', 'recent-anonymous-client')
+        .first()
+    ).resolves.toEqual(
+      expect.objectContaining({ clientId: 'recent-anonymous-client' })
     )
   })
 

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -4,7 +4,7 @@ import { getSQLDatabase } from '@/lib/database/sql'
 import { seedDatabase } from '@/lib/stub/database'
 
 import { createApplication } from './createApplication'
-import { SuccessResponse } from './types'
+import { PostResponse, SuccessResponse } from './types'
 
 // Create a knex instance we can use for both the database and for getKnex mock
 const knexDatabase = knex({
@@ -159,5 +159,113 @@ describe('createApplication', () => {
     })) as SuccessResponse
     expect(response.type).toEqual('success')
     expect(response.redirect_uri).toEqual('https://test.llun.dev/callback')
+  })
+
+  test('it rate limits app registration floods from the same unauthenticated source', async () => {
+    const registrationKey = 'flood-source'
+    const now = new Date('2026-05-12T12:00:00.000Z')
+    const responses: PostResponse[] = []
+
+    for (let i = 0; i < 6; i++) {
+      responses.push(
+        await createApplication(
+          {
+            redirect_uris: `https://flood-${i}.llun.dev/callback`,
+            client_name: `floodClient${i}`,
+            scopes: 'read',
+            website: `https://flood-${i}.llun.dev`
+          },
+          { registrationKey, now }
+        )
+      )
+    }
+
+    expect(
+      responses.slice(0, 5).every((response) => response.type === 'success')
+    ).toBe(true)
+    expect(responses[5]).toEqual({
+      type: 'error',
+      error: 'Too many application registrations'
+    })
+
+    const rows = await knexDatabase('oauthClient')
+      .where('referenceId', `app-registration:${registrationKey}`)
+      .select()
+    expect(rows).toHaveLength(5)
+  })
+
+  test('it garbage-collects stale unused app registrations without deleting token-backed clients', async () => {
+    const staleCreatedAt = new Date('2026-05-10T00:00:00.000Z')
+    const now = new Date('2026-05-12T12:00:00.000Z')
+
+    await knexDatabase('oauthClient').insert([
+      {
+        id: 'stale-unused-client-id',
+        clientId: 'stale-unused-client',
+        clientSecret: 'hashed-secret',
+        name: 'stale-unused',
+        scopes: JSON.stringify(['read']),
+        redirectUris: JSON.stringify([
+          'https://stale-unused.llun.dev/callback'
+        ]),
+        requirePKCE: true,
+        disabled: false,
+        grantTypes: JSON.stringify(['authorization_code']),
+        responseTypes: JSON.stringify(['code']),
+        tokenEndpointAuthMethod: 'client_secret_post',
+        referenceId: 'app-registration:stale-unused',
+        createdAt: staleCreatedAt,
+        updatedAt: staleCreatedAt
+      },
+      {
+        id: 'stale-active-client-id',
+        clientId: 'stale-active-client',
+        clientSecret: 'hashed-secret',
+        name: 'stale-active',
+        scopes: JSON.stringify(['read']),
+        redirectUris: JSON.stringify([
+          'https://stale-active.llun.dev/callback'
+        ]),
+        requirePKCE: true,
+        disabled: false,
+        grantTypes: JSON.stringify(['authorization_code']),
+        responseTypes: JSON.stringify(['code']),
+        tokenEndpointAuthMethod: 'client_secret_post',
+        referenceId: 'app-registration:stale-active',
+        createdAt: staleCreatedAt,
+        updatedAt: staleCreatedAt
+      }
+    ])
+    await knexDatabase('oauthAccessToken').insert({
+      id: 'stale-active-token-id',
+      token: 'stale-active-token',
+      clientId: 'stale-active-client',
+      referenceId: null,
+      expiresAt: new Date('2026-05-13T00:00:00.000Z'),
+      scopes: JSON.stringify(['read'])
+    })
+
+    await createApplication(
+      {
+        redirect_uris: 'https://gc.llun.dev/callback',
+        client_name: 'gcClient',
+        scopes: 'read',
+        website: 'https://gc.llun.dev'
+      },
+      { registrationKey: 'gc-source', now }
+    )
+
+    await expect(
+      knexDatabase('oauthClient')
+        .where('clientId', 'stale-unused-client')
+        .first()
+    ).resolves.toBeUndefined()
+    await expect(
+      knexDatabase('oauthClient')
+        .where('clientId', 'stale-active-client')
+        .first()
+    ).resolves.toEqual(
+      expect.objectContaining({ clientId: 'stale-active-client' })
+    )
   })
 })

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -3,7 +3,10 @@ import knex from 'knex'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { seedDatabase } from '@/lib/stub/database'
 
-import { createApplication } from './createApplication'
+import {
+  createApplication,
+  resetAppRegistrationGcStateForTests
+} from './createApplication'
 import { PostResponse, SuccessResponse } from './types'
 
 // Create a knex instance we can use for both the database and for getKnex mock
@@ -24,12 +27,19 @@ describe('createApplication', () => {
   beforeAll(async () => {
     await database.migrate()
     await seedDatabase(database)
-    await createApplication({
-      client_name: 'existsClient',
-      redirect_uris: 'https://exists.llun.dev/apps/redirect',
-      scopes: 'read write',
-      website: 'https://exists.llun.dev'
-    })
+    await createApplication(
+      {
+        client_name: 'existsClient',
+        redirect_uris: 'https://exists.llun.dev/apps/redirect',
+        scopes: 'read write',
+        website: 'https://exists.llun.dev'
+      },
+      { registrationKey: 'setup-source' }
+    )
+  })
+
+  beforeEach(() => {
+    resetAppRegistrationGcStateForTests()
   })
 
   afterAll(async () => {
@@ -37,12 +47,15 @@ describe('createApplication', () => {
   })
 
   test('it generates secret and create application in database and returns application response', async () => {
-    const response = (await createApplication({
-      redirect_uris: 'https://test.llun.dev/apps/redirect',
-      client_name: 'client1',
-      scopes: 'read write',
-      website: 'https://test.llun.dev'
-    })) as SuccessResponse
+    const response = (await createApplication(
+      {
+        redirect_uris: 'https://test.llun.dev/apps/redirect',
+        client_name: 'client1',
+        scopes: 'read write',
+        website: 'https://test.llun.dev'
+      },
+      { registrationKey: 'generated-source' }
+    )) as SuccessResponse
     expect(response).toEqual({
       type: 'success',
       id: expect.toBeString(),
@@ -59,12 +72,15 @@ describe('createApplication', () => {
   })
 
   test('it always creates a new application even when one with the same name exists', async () => {
-    const response = await createApplication({
-      client_name: 'existsClient',
-      redirect_uris: 'https://test.llun.dev/apps/redirect',
-      scopes: 'read write',
-      website: 'https://test.llun.dev'
-    })
+    const response = await createApplication(
+      {
+        client_name: 'existsClient',
+        redirect_uris: 'https://test.llun.dev/apps/redirect',
+        scopes: 'read write',
+        website: 'https://test.llun.dev'
+      },
+      { registrationKey: 'same-name-source' }
+    )
     expect(response).toEqual({
       type: 'success',
       id: expect.toBeString(),
@@ -77,12 +93,15 @@ describe('createApplication', () => {
   })
 
   test('it errors with message validation failed when scope is not valid', async () => {
-    const response = await createApplication({
-      client_name: 'newClient',
-      redirect_uris: 'https://test.llun.dev/apps/redirect',
-      scopes: 'read write something else',
-      website: 'https://test.llun.dev'
-    })
+    const response = await createApplication(
+      {
+        client_name: 'newClient',
+        redirect_uris: 'https://test.llun.dev/apps/redirect',
+        scopes: 'read write something else',
+        website: 'https://test.llun.dev'
+      },
+      { registrationKey: 'invalid-scope-source' }
+    )
     expect(response).toEqual({
       type: 'error',
       error: 'Failed to validate request'
@@ -137,12 +156,15 @@ describe('createApplication', () => {
   })
 
   test('it errors when redirect_uris is empty or whitespace-only', async () => {
-    const response = await createApplication({
-      client_name: 'noRedirectClient',
-      redirect_uris: '   ',
-      scopes: 'read write',
-      website: 'https://test.llun.dev'
-    })
+    const response = await createApplication(
+      {
+        client_name: 'noRedirectClient',
+        redirect_uris: '   ',
+        scopes: 'read write',
+        website: 'https://test.llun.dev'
+      },
+      { registrationKey: 'empty-redirect-source' }
+    )
     expect(response).toEqual({
       type: 'error',
       error: 'Failed to validate request'
@@ -150,13 +172,16 @@ describe('createApplication', () => {
   })
 
   test('it supports newline-separated redirect URIs per Mastodon API spec', async () => {
-    const response = (await createApplication({
-      redirect_uris:
-        'https://test.llun.dev/callback\nhttps://test.llun.dev/alt-callback',
-      client_name: 'multiRedirectClient',
-      scopes: 'read',
-      website: 'https://test.llun.dev'
-    })) as SuccessResponse
+    const response = (await createApplication(
+      {
+        redirect_uris:
+          'https://test.llun.dev/callback\nhttps://test.llun.dev/alt-callback',
+        client_name: 'multiRedirectClient',
+        scopes: 'read',
+        website: 'https://test.llun.dev'
+      },
+      { registrationKey: 'multi-redirect-source' }
+    )) as SuccessResponse
     expect(response.type).toEqual('success')
     expect(response.redirect_uri).toEqual('https://test.llun.dev/callback')
   })
@@ -210,6 +235,44 @@ describe('createApplication', () => {
         referenceId: 'app-registration:anonymous'
       })
     )
+  })
+
+  test('it rate limits anonymous app registrations with the global fallback bucket', async () => {
+    const now = new Date('2030-05-12T12:00:00.000Z')
+    const responses: PostResponse[] = []
+
+    for (let i = 0; i < 6; i++) {
+      responses.push(
+        await createApplication(
+          {
+            redirect_uris: `https://anonymous-flood-${i}.llun.dev/callback`,
+            client_name: `anonymousFloodClient${i}`,
+            scopes: 'read',
+            website: `https://anonymous-flood-${i}.llun.dev`
+          },
+          { now }
+        )
+      )
+    }
+
+    expect(
+      responses.slice(0, 5).every((response) => response.type === 'success')
+    ).toBe(true)
+    expect(responses[5]).toEqual({
+      type: 'error',
+      error: 'Too many application registrations'
+    })
+
+    const rows = await knexDatabase('oauthClient')
+      .where('referenceId', 'app-registration:anonymous')
+      .where('createdAt', '>=', new Date('2030-05-12T11:50:00.000Z'))
+      .select()
+    expect(rows).toHaveLength(5)
+
+    await knexDatabase('oauthClient')
+      .where('referenceId', 'app-registration:anonymous')
+      .where('createdAt', '>=', new Date('2030-05-12T11:50:00.000Z'))
+      .delete()
   })
 
   test('it checks the rate limit before garbage collecting stale app registrations', async () => {

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -194,6 +194,66 @@ describe('createApplication', () => {
     expect(rows).toHaveLength(5)
   })
 
+  test('it checks the rate limit before garbage collecting stale app registrations', async () => {
+    const registrationKey = 'rate-limited-gc-source'
+    const now = new Date('2026-05-12T13:00:00.000Z')
+    const staleCreatedAt = new Date('2026-05-10T00:00:00.000Z')
+
+    for (let i = 0; i < 5; i++) {
+      await createApplication(
+        {
+          redirect_uris: `https://rate-limited-${i}.llun.dev/callback`,
+          client_name: `rateLimitedClient${i}`,
+          scopes: 'read',
+          website: `https://rate-limited-${i}.llun.dev`
+        },
+        { registrationKey, now }
+      )
+    }
+    await knexDatabase('oauthClient').insert({
+      id: 'rate-limited-stale-unused-client-id',
+      clientId: 'rate-limited-stale-unused-client',
+      clientSecret: 'hashed-secret',
+      name: 'rate-limited-stale-unused',
+      scopes: JSON.stringify(['read']),
+      redirectUris: JSON.stringify([
+        'https://rate-limited-stale-unused.llun.dev/callback'
+      ]),
+      requirePKCE: true,
+      disabled: false,
+      grantTypes: JSON.stringify(['authorization_code']),
+      responseTypes: JSON.stringify(['code']),
+      tokenEndpointAuthMethod: 'client_secret_post',
+      referenceId: 'app-registration:rate-limited-stale-unused',
+      createdAt: staleCreatedAt,
+      updatedAt: staleCreatedAt
+    })
+
+    const response = await createApplication(
+      {
+        redirect_uris: 'https://blocked.llun.dev/callback',
+        client_name: 'blockedClient',
+        scopes: 'read',
+        website: 'https://blocked.llun.dev'
+      },
+      { registrationKey, now }
+    )
+
+    expect(response).toEqual({
+      type: 'error',
+      error: 'Too many application registrations'
+    })
+    await expect(
+      knexDatabase('oauthClient')
+        .where('clientId', 'rate-limited-stale-unused-client')
+        .first()
+    ).resolves.toEqual(
+      expect.objectContaining({
+        clientId: 'rate-limited-stale-unused-client'
+      })
+    )
+  })
+
   test('it garbage-collects stale unused app registrations without deleting token-backed clients', async () => {
     const staleCreatedAt = new Date('2026-05-10T00:00:00.000Z')
     const now = new Date('2026-05-12T12:00:00.000Z')

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -405,4 +405,35 @@ describe('createApplication', () => {
       expect.objectContaining({ clientId: 'stale-active-client' })
     )
   })
+
+  test('it orders stale app registration garbage collection before limiting', async () => {
+    const queries: string[] = []
+    const onQuery = (query: { sql: string }) => queries.push(query.sql)
+    knexDatabase.on('query', onQuery)
+
+    try {
+      await createApplication(
+        {
+          redirect_uris: 'https://ordered-gc.llun.dev/callback',
+          client_name: 'orderedGcClient',
+          scopes: 'read',
+          website: 'https://ordered-gc.llun.dev'
+        },
+        {
+          registrationKey: 'ordered-gc-source',
+          now: new Date('2026-05-12T14:00:00.000Z')
+        }
+      )
+    } finally {
+      knexDatabase.off('query', onQuery)
+    }
+
+    const staleClientQuery = queries.find(
+      (sql) =>
+        sql.includes('from `oauthClient`') &&
+        sql.includes('left join `oauthAccessToken`') &&
+        sql.includes('limit ?')
+    )
+    expect(staleClientQuery).toContain('order by `oauthClient`.`createdAt` asc')
+  })
 })

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -194,6 +194,24 @@ describe('createApplication', () => {
     expect(rows).toHaveLength(5)
   })
 
+  test('it stores anonymous unauthenticated registrations with a cleanup reference', async () => {
+    const response = (await createApplication({
+      redirect_uris: 'https://anonymous.llun.dev/callback',
+      client_name: 'anonymousClient',
+      scopes: 'read',
+      website: 'https://anonymous.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+    await expect(
+      knexDatabase('oauthClient').where({ id: response.id }).first()
+    ).resolves.toEqual(
+      expect.objectContaining({
+        referenceId: 'app-registration:anonymous'
+      })
+    )
+  })
+
   test('it checks the rate limit before garbage collecting stale app registrations', async () => {
     const registrationKey = 'rate-limited-gc-source'
     const now = new Date('2026-05-12T13:00:00.000Z')

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -48,7 +48,6 @@ type CreateApplicationOptions = {
 }
 
 const APP_REGISTRATION_REFERENCE_PREFIX = 'app-registration:'
-const ANONYMOUS_APP_REGISTRATION_REFERENCE = `${APP_REGISTRATION_REFERENCE_PREFIX}anonymous`
 const APP_REGISTRATION_LIMIT = 5
 const APP_REGISTRATION_WINDOW_MS = 10 * 60 * 1000
 const APP_REGISTRATION_GC_AFTER_MS = 24 * 60 * 60 * 1000
@@ -164,8 +163,7 @@ export const createApplication = async (
         const rateLimitReference = getRegistrationReference(
           options.registrationKey
         )
-        const registrationReference =
-          rateLimitReference ?? ANONYMOUS_APP_REGISTRATION_REFERENCE
+        const registrationReference = rateLimitReference
 
         if (
           await isAppRegistrationRateLimited({
@@ -244,7 +242,7 @@ export const createApplication = async (
           ]),
           responseTypes: JSON.stringify(['code']),
           tokenEndpointAuthMethod: 'client_secret_post',
-          referenceId: registrationReference,
+          referenceId: registrationReference ?? '',
           metadata: JSON.stringify({ registeredUnauthenticated: true }),
           createdAt: now,
           updatedAt: now

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -57,6 +57,10 @@ const APP_REGISTRATION_GC_BATCH_SIZE = 1000
 
 let lastAppRegistrationGcAt: number | null = null
 
+export const resetAppRegistrationGcStateForTests = () => {
+  lastAppRegistrationGcAt = null
+}
+
 const getRegistrationReference = (registrationKey?: string): string | null => {
   if (!registrationKey) return null
   return `${APP_REGISTRATION_REFERENCE_PREFIX}${registrationKey}`
@@ -167,7 +171,7 @@ export const createApplication = async (
           await isAppRegistrationRateLimited({
             db,
             now,
-            registrationReference: rateLimitReference
+            registrationReference
           })
         ) {
           return ErrorResponse.parse({

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -3,6 +3,7 @@ import type { Knex } from 'knex'
 
 import { getKnex } from '@/lib/database'
 import { Scope } from '@/lib/types/database/operations'
+import { logger } from '@/lib/utils/logger'
 import { getTracer } from '@/lib/utils/trace'
 
 import type {
@@ -50,6 +51,9 @@ const APP_REGISTRATION_REFERENCE_PREFIX = 'app-registration:'
 const APP_REGISTRATION_LIMIT = 5
 const APP_REGISTRATION_WINDOW_MS = 10 * 60 * 1000
 const APP_REGISTRATION_GC_AFTER_MS = 24 * 60 * 60 * 1000
+const APP_REGISTRATION_GC_INTERVAL_MS = 60 * 60 * 1000
+
+let lastAppRegistrationGcAt: number | null = null
 
 const getRegistrationReference = (registrationKey?: string): string | null => {
   if (!registrationKey) return null
@@ -107,6 +111,36 @@ const isAppRegistrationRateLimited = async ({
   return Number(countResult?.count ?? 0) >= APP_REGISTRATION_LIMIT
 }
 
+const shouldRunAppRegistrationGc = (now: Date): boolean => {
+  const nowMs = now.getTime()
+  if (
+    lastAppRegistrationGcAt !== null &&
+    nowMs >= lastAppRegistrationGcAt &&
+    nowMs - lastAppRegistrationGcAt < APP_REGISTRATION_GC_INTERVAL_MS
+  ) {
+    return false
+  }
+
+  lastAppRegistrationGcAt = nowMs
+  return true
+}
+
+const maybeGarbageCollectStaleAppRegistrations = async (
+  db: Knex,
+  now: Date
+) => {
+  if (!shouldRunAppRegistrationGc(now)) return
+
+  try {
+    await garbageCollectStaleAppRegistrations(db, now)
+  } catch (error) {
+    logger.warn({
+      message: 'Stale app registration cleanup failed',
+      error
+    })
+  }
+}
+
 export const createApplication = async (
   request: PostRequest,
   options: CreateApplicationOptions = {}
@@ -124,7 +158,6 @@ export const createApplication = async (
           options.registrationKey
         )
 
-        await garbageCollectStaleAppRegistrations(db, now)
         if (
           await isAppRegistrationRateLimited({
             db,
@@ -137,6 +170,11 @@ export const createApplication = async (
             error: 'Too many application registrations'
           })
         }
+
+        // The registration throttle is a best-effort guard: count + insert is
+        // intentionally not a cross-database atomic hard cap. Cleanup is also
+        // best effort and throttled so rejected floods do not trigger joins.
+        await maybeGarbageCollectStaleAppRegistrations(db, now)
 
         // Always create a new client — per the Mastodon API spec, each POST
         // creates a new application with fresh credentials. Silent secret

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -160,10 +160,9 @@ export const createApplication = async (
 
       try {
         const now = options.now ?? new Date()
-        const rateLimitReference = getRegistrationReference(
+        const registrationReference = getRegistrationReference(
           options.registrationKey
         )
-        const registrationReference = rateLimitReference
 
         if (
           await isAppRegistrationRateLimited({

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -58,6 +58,9 @@ const APP_REGISTRATION_WINDOW_MS = 10 * 60 * 1000
 const APP_REGISTRATION_GC_AFTER_MS = 24 * 60 * 60 * 1000
 const APP_REGISTRATION_GC_INTERVAL_MS = 60 * 60 * 1000
 const APP_REGISTRATION_GC_BATCH_SIZE = 1000
+const REGISTERED_UNAUTHENTICATED_METADATA = JSON.stringify({
+  registeredUnauthenticated: true
+})
 
 let lastAppRegistrationGcAt: number | null = null
 
@@ -68,6 +71,21 @@ export const resetAppRegistrationGcStateForTests = () => {
 const getRegistrationReference = (registrationKey?: string): string | null => {
   if (!registrationKey) return null
   return `${APP_REGISTRATION_REFERENCE_PREFIX}${registrationKey}`
+}
+
+const whereUnauthenticatedAppRegistration = (
+  query: Knex.QueryBuilder
+): void => {
+  query.where(
+    'oauthClient.referenceId',
+    'like',
+    `${APP_REGISTRATION_REFERENCE_PREFIX}%`
+  )
+  query.orWhere((anonymousQuery) => {
+    anonymousQuery
+      .where('oauthClient.referenceId', '')
+      .where('oauthClient.metadata', REGISTERED_UNAUTHENTICATED_METADATA)
+  })
 }
 
 const garbageCollectStaleAppRegistrations = async (db: Knex, now: Date) => {
@@ -84,11 +102,7 @@ const garbageCollectStaleAppRegistrations = async (db: Knex, now: Date) => {
       'oauthClient.clientId'
     )
     .leftJoin('oauthConsent', 'oauthConsent.clientId', 'oauthClient.clientId')
-    .where(
-      'oauthClient.referenceId',
-      'like',
-      `${APP_REGISTRATION_REFERENCE_PREFIX}%`
-    )
+    .where(whereUnauthenticatedAppRegistration)
     .where('oauthClient.createdAt', '<', staleBefore)
     .whereNull('oauthAccessToken.id')
     .whereNull('oauthRefreshToken.id')
@@ -245,7 +259,7 @@ export const createApplication = async (
           responseTypes: JSON.stringify(['code']),
           tokenEndpointAuthMethod: 'client_secret_post',
           referenceId: registrationReference ?? '',
-          metadata: JSON.stringify({ registeredUnauthenticated: true }),
+          metadata: REGISTERED_UNAUTHENTICATED_METADATA,
           createdAt: now,
           updatedAt: now
         })

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -42,6 +42,11 @@ const validationErrorResponse = (): ErrorResponse => ({
   error: 'Failed to validate request'
 })
 
+const rateLimitErrorResponse = (): ErrorResponse => ({
+  type: 'error',
+  error: 'Too many application registrations'
+})
+
 type CreateApplicationOptions = {
   registrationKey?: string
   now?: Date
@@ -172,10 +177,7 @@ export const createApplication = async (
             registrationReference
           })
         ) {
-          return ErrorResponse.parse({
-            type: 'error',
-            error: 'Too many application registrations'
-          })
+          return rateLimitErrorResponse()
         }
 
         // The registration throttle is a best-effort guard: count + insert is

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import type { Knex } from 'knex'
 
 import { getKnex } from '@/lib/database'
 import { Scope } from '@/lib/types/database/operations'
@@ -40,8 +41,75 @@ const validationErrorResponse = (): ErrorResponse => ({
   error: 'Failed to validate request'
 })
 
+type CreateApplicationOptions = {
+  registrationKey?: string
+  now?: Date
+}
+
+const APP_REGISTRATION_REFERENCE_PREFIX = 'app-registration:'
+const APP_REGISTRATION_LIMIT = 5
+const APP_REGISTRATION_WINDOW_MS = 10 * 60 * 1000
+const APP_REGISTRATION_GC_AFTER_MS = 24 * 60 * 60 * 1000
+
+const getRegistrationReference = (registrationKey?: string): string | null => {
+  if (!registrationKey) return null
+  return `${APP_REGISTRATION_REFERENCE_PREFIX}${registrationKey}`
+}
+
+const garbageCollectStaleAppRegistrations = async (db: Knex, now: Date) => {
+  const staleBefore = new Date(now.getTime() - APP_REGISTRATION_GC_AFTER_MS)
+  const staleClientIds = await db('oauthClient')
+    .leftJoin(
+      'oauthAccessToken',
+      'oauthAccessToken.clientId',
+      'oauthClient.clientId'
+    )
+    .leftJoin(
+      'oauthRefreshToken',
+      'oauthRefreshToken.clientId',
+      'oauthClient.clientId'
+    )
+    .leftJoin('oauthConsent', 'oauthConsent.clientId', 'oauthClient.clientId')
+    .where(
+      'oauthClient.referenceId',
+      'like',
+      `${APP_REGISTRATION_REFERENCE_PREFIX}%`
+    )
+    .where('oauthClient.createdAt', '<', staleBefore)
+    .whereNull('oauthAccessToken.id')
+    .whereNull('oauthRefreshToken.id')
+    .whereNull('oauthConsent.id')
+    .pluck('oauthClient.clientId')
+
+  if (staleClientIds.length > 0) {
+    await db('oauthClient').whereIn('clientId', staleClientIds).delete()
+  }
+}
+
+const isAppRegistrationRateLimited = async ({
+  db,
+  now,
+  registrationReference
+}: {
+  db: Knex
+  now: Date
+  registrationReference: string | null
+}): Promise<boolean> => {
+  if (!registrationReference) return false
+
+  const windowStart = new Date(now.getTime() - APP_REGISTRATION_WINDOW_MS)
+  const countResult = await db('oauthClient')
+    .where('referenceId', registrationReference)
+    .where('createdAt', '>=', windowStart)
+    .count<{ count: number | string | bigint }[]>({ count: '*' })
+    .first()
+
+  return Number(countResult?.count ?? 0) >= APP_REGISTRATION_LIMIT
+}
+
 export const createApplication = async (
-  request: PostRequest
+  request: PostRequest,
+  options: CreateApplicationOptions = {}
 ): Promise<PostResponse> => {
   return getTracer().startActiveSpan(
     'createApplication',
@@ -51,14 +119,28 @@ export const createApplication = async (
       const db = getKnex()
 
       try {
+        const now = options.now ?? new Date()
+        const registrationReference = getRegistrationReference(
+          options.registrationKey
+        )
+
+        await garbageCollectStaleAppRegistrations(db, now)
+        if (
+          await isAppRegistrationRateLimited({
+            db,
+            now,
+            registrationReference
+          })
+        ) {
+          return ErrorResponse.parse({
+            type: 'error',
+            error: 'Too many application registrations'
+          })
+        }
+
         // Always create a new client — per the Mastodon API spec, each POST
         // creates a new application with fresh credentials. Silent secret
         // rotation on re-registration would break existing configured clients.
-        //
-        // NOTE: This means popular apps (Ivory, Ice Cubes, etc.) that call
-        // POST /api/v1/apps on every login will accumulate orphaned client
-        // rows. Operators should periodically clean up stale oauthClient rows
-        // that have no associated active tokens or consents.
         const clientId = generateRandomString(32)
         const clientSecret = generateRandomString(32)
         const hashedSecret = hashClientSecret(clientSecret)
@@ -97,8 +179,6 @@ export const createApplication = async (
             return validationErrorResponse()
           }
         }
-        const now = new Date()
-
         const dbId = crypto.randomUUID()
         await db('oauthClient').insert({
           id: dbId,
@@ -108,7 +188,7 @@ export const createApplication = async (
           scopes: JSON.stringify(parsedScopes),
           redirectUris: JSON.stringify(redirectUris),
           uri: request.website || null,
-          requirePKCE: false,
+          requirePKCE: true,
           disabled: false,
           grantTypes: JSON.stringify([
             'authorization_code',
@@ -117,6 +197,8 @@ export const createApplication = async (
           ]),
           responseTypes: JSON.stringify(['code']),
           tokenEndpointAuthMethod: 'client_secret_post',
+          referenceId: registrationReference,
+          metadata: JSON.stringify({ registeredUnauthenticated: true }),
           createdAt: now,
           updatedAt: now
         })

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -88,6 +88,7 @@ const garbageCollectStaleAppRegistrations = async (db: Knex, now: Date) => {
     .whereNull('oauthAccessToken.id')
     .whereNull('oauthRefreshToken.id')
     .whereNull('oauthConsent.id')
+    .orderBy('oauthClient.createdAt', 'asc')
     .limit(APP_REGISTRATION_GC_BATCH_SIZE)
     .pluck('oauthClient.clientId')
 

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -48,10 +48,12 @@ type CreateApplicationOptions = {
 }
 
 const APP_REGISTRATION_REFERENCE_PREFIX = 'app-registration:'
+const ANONYMOUS_APP_REGISTRATION_REFERENCE = `${APP_REGISTRATION_REFERENCE_PREFIX}anonymous`
 const APP_REGISTRATION_LIMIT = 5
 const APP_REGISTRATION_WINDOW_MS = 10 * 60 * 1000
 const APP_REGISTRATION_GC_AFTER_MS = 24 * 60 * 60 * 1000
 const APP_REGISTRATION_GC_INTERVAL_MS = 60 * 60 * 1000
+const APP_REGISTRATION_GC_BATCH_SIZE = 1000
 
 let lastAppRegistrationGcAt: number | null = null
 
@@ -83,6 +85,7 @@ const garbageCollectStaleAppRegistrations = async (db: Knex, now: Date) => {
     .whereNull('oauthAccessToken.id')
     .whereNull('oauthRefreshToken.id')
     .whereNull('oauthConsent.id')
+    .limit(APP_REGISTRATION_GC_BATCH_SIZE)
     .pluck('oauthClient.clientId')
 
   if (staleClientIds.length > 0) {
@@ -154,15 +157,17 @@ export const createApplication = async (
 
       try {
         const now = options.now ?? new Date()
-        const registrationReference = getRegistrationReference(
+        const rateLimitReference = getRegistrationReference(
           options.registrationKey
         )
+        const registrationReference =
+          rateLimitReference ?? ANONYMOUS_APP_REGISTRATION_REFERENCE
 
         if (
           await isAppRegistrationRateLimited({
             db,
             now,
-            registrationReference
+            registrationReference: rateLimitReference
           })
         ) {
           return ErrorResponse.parse({

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -3,9 +3,16 @@ import { NextRequest } from 'next/server'
 import { POST } from './route'
 
 const mockCreateApplication = jest.fn()
+const mockLoggerWarn = jest.fn()
 
 jest.mock('@/lib/database', () => ({
   getDatabase: () => ({})
+}))
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args)
+  }
 }))
 
 jest.mock('./createApplication', () => ({
@@ -15,6 +22,7 @@ jest.mock('./createApplication', () => ({
 describe('apps route', () => {
   beforeEach(() => {
     mockCreateApplication.mockReset()
+    mockLoggerWarn.mockReset()
     mockCreateApplication.mockResolvedValue({
       type: 'success',
       id: 'app-id',
@@ -26,7 +34,7 @@ describe('apps route', () => {
     })
   })
 
-  test('derives registration limits from the connection IP when available', async () => {
+  test('derives registration limits from supported forwarded IP headers', async () => {
     const req = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -40,19 +48,16 @@ describe('apps route', () => {
         redirect_uris: 'https://client.llun.dev/callback'
       })
     })
-    Object.defineProperty(req, 'ip', {
-      value: '203.0.113.5',
-      configurable: true
-    })
 
     await POST(req)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
       registrationKey: expect.stringMatching(/^ip:[A-Za-z0-9_-]{43}$/)
     })
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
   })
 
-  test('ignores raw forwarded IP chains when no trusted source exists', async () => {
+  test('uses the rightmost forwarded IP when stronger platform headers are absent', async () => {
     const forwardedReq = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -64,6 +69,16 @@ describe('apps route', () => {
         redirect_uris: 'https://forwarded.llun.dev/callback'
       })
     })
+
+    await POST(forwardedReq)
+
+    expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
+      registrationKey: expect.stringMatching(/^ip:[A-Za-z0-9_-]{43}$/)
+    })
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
+  })
+
+  test('warns when no supported registration source exists', async () => {
     const directReq = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -75,19 +90,15 @@ describe('apps route', () => {
       })
     })
 
-    await POST(forwardedReq)
     await POST(directReq)
 
-    expect(mockCreateApplication).toHaveBeenNthCalledWith(
-      1,
-      expect.any(Object),
-      { registrationKey: undefined }
-    )
-    expect(mockCreateApplication).toHaveBeenNthCalledWith(
-      2,
-      expect.any(Object),
-      { registrationKey: undefined }
-    )
+    expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
+      registrationKey: undefined
+    })
+    expect(mockLoggerWarn).toHaveBeenCalledWith({
+      message:
+        'App registration source IP is unavailable; rate limiting is disabled'
+    })
   })
 
   test('returns too many requests when app registration is throttled', async () => {

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -52,7 +52,7 @@ describe('apps route', () => {
     })
   })
 
-  test('uses the rightmost forwarded IP and disables rate limiting when no trusted source exists', async () => {
+  test('ignores raw forwarded IP chains and disables rate limiting when no trusted source exists', async () => {
     const forwardedReq = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -81,7 +81,7 @@ describe('apps route', () => {
     expect(mockCreateApplication).toHaveBeenNthCalledWith(
       1,
       expect.any(Object),
-      { registrationKey: hashIpAddress('198.51.100.40') }
+      { registrationKey: undefined }
     )
     expect(mockCreateApplication).toHaveBeenNthCalledWith(
       2,

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -1,0 +1,92 @@
+import crypto from 'crypto'
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockCreateApplication = jest.fn()
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => ({})
+}))
+
+jest.mock('./createApplication', () => ({
+  createApplication: (...args: unknown[]) => mockCreateApplication(...args)
+}))
+
+const hashIpAddress = (ipAddress: string) =>
+  crypto.createHash('sha256').update(ipAddress).digest('base64url')
+
+describe('apps route', () => {
+  beforeEach(() => {
+    mockCreateApplication.mockReset()
+    mockCreateApplication.mockResolvedValue({
+      type: 'success',
+      id: 'app-id',
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      name: 'client',
+      website: null,
+      redirect_uri: 'https://client.llun.dev/callback'
+    })
+  })
+
+  test('keys registration limits with trusted client IP headers before forwarded hops', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'cf-connecting-ip': '203.0.113.10',
+        'x-real-ip': '203.0.113.20',
+        'x-forwarded-for': '198.51.100.30, 198.51.100.40'
+      },
+      body: JSON.stringify({
+        client_name: 'client',
+        redirect_uris: 'https://client.llun.dev/callback'
+      })
+    })
+
+    await POST(req)
+
+    expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
+      registrationKey: hashIpAddress('203.0.113.10')
+    })
+  })
+
+  test('uses the rightmost forwarded IP and disables rate limiting when no trusted source exists', async () => {
+    const forwardedReq = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '198.51.100.30, 198.51.100.40'
+      },
+      body: JSON.stringify({
+        client_name: 'forwarded',
+        redirect_uris: 'https://forwarded.llun.dev/callback'
+      })
+    })
+    const directReq = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_name: 'direct',
+        redirect_uris: 'https://direct.llun.dev/callback'
+      })
+    })
+
+    await POST(forwardedReq)
+    await POST(directReq)
+
+    expect(mockCreateApplication).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Object),
+      { registrationKey: hashIpAddress('198.51.100.40') }
+    )
+    expect(mockCreateApplication).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Object),
+      { registrationKey: undefined }
+    )
+  })
+})

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -3,14 +3,25 @@ import { NextRequest } from 'next/server'
 
 import { POST, resetAppRegistrationWarningStateForTests } from './route'
 
+const mockGetConfig = jest.fn(() => ({
+  secretPhase: 'registration-pepper-secret'
+}))
+
 const hashIpRegistrationKey = (ip: string) =>
-  `ip:${crypto.createHash('sha256').update(ip).digest('base64url')}`
+  `ip:${crypto
+    .createHmac('sha256', mockGetConfig().secretPhase)
+    .update(ip)
+    .digest('base64url')}`
 
 const mockCreateApplication = jest.fn()
 const mockLoggerWarn = jest.fn()
 
 jest.mock('@/lib/database', () => ({
   getDatabase: () => ({})
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => mockGetConfig()
 }))
 
 jest.mock('@/lib/utils/logger', () => ({
@@ -29,6 +40,7 @@ describe('apps route', () => {
   beforeEach(() => {
     process.env = { ...originalEnv }
     resetAppRegistrationWarningStateForTests()
+    mockGetConfig.mockClear()
     mockCreateApplication.mockReset()
     mockLoggerWarn.mockReset()
     mockCreateApplication.mockResolvedValue({
@@ -90,6 +102,12 @@ describe('apps route', () => {
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
       registrationKey: hashIpRegistrationKey('198.51.100.30')
+    })
+    expect(mockCreateApplication).not.toHaveBeenCalledWith(expect.any(Object), {
+      registrationKey: `ip:${crypto
+        .createHash('sha256')
+        .update('198.51.100.30')
+        .digest('base64url')}`
     })
     expect(mockLoggerWarn).not.toHaveBeenCalled()
   })

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
 import { POST } from './route'
@@ -12,9 +11,6 @@ jest.mock('@/lib/database', () => ({
 jest.mock('./createApplication', () => ({
   createApplication: (...args: unknown[]) => mockCreateApplication(...args)
 }))
-
-const hashIpAddress = (ipAddress: string) =>
-  crypto.createHash('sha256').update(ipAddress).digest('base64url')
 
 describe('apps route', () => {
   beforeEach(() => {
@@ -30,7 +26,7 @@ describe('apps route', () => {
     })
   })
 
-  test('keys registration limits with trusted client IP headers before forwarded hops', async () => {
+  test('does not derive registration limits from client-supplied IP headers without trusted proxy config', async () => {
     const req = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -48,11 +44,11 @@ describe('apps route', () => {
     await POST(req)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
-      registrationKey: hashIpAddress('203.0.113.10')
+      registrationKey: undefined
     })
   })
 
-  test('ignores raw forwarded IP chains and disables rate limiting when no trusted source exists', async () => {
+  test('ignores raw forwarded IP chains when no trusted source exists', async () => {
     const forwardedReq = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -26,7 +26,7 @@ describe('apps route', () => {
     })
   })
 
-  test('does not derive registration limits from client-supplied IP headers without trusted proxy config', async () => {
+  test('derives registration limits from the connection IP when available', async () => {
     const req = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -40,11 +40,15 @@ describe('apps route', () => {
         redirect_uris: 'https://client.llun.dev/callback'
       })
     })
+    Object.defineProperty(req, 'ip', {
+      value: '203.0.113.5',
+      configurable: true
+    })
 
     await POST(req)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
-      registrationKey: undefined
+      registrationKey: expect.stringMatching(/^ip:[A-Za-z0-9_-]{43}$/)
     })
   })
 
@@ -84,5 +88,29 @@ describe('apps route', () => {
       expect.any(Object),
       { registrationKey: undefined }
     )
+  })
+
+  test('returns too many requests when app registration is throttled', async () => {
+    mockCreateApplication.mockResolvedValue({
+      type: 'error',
+      error: 'Too many application registrations'
+    })
+    const req = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_name: 'client',
+        redirect_uris: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      status: 'Too Many Requests'
+    })
+    expect(response.status).toBe(429)
   })
 })

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
-import { POST } from './route'
+import { POST, resetAppRegistrationWarningStateForTests } from './route'
 
 const hashIpRegistrationKey = (ip: string) =>
   `ip:${crypto.createHash('sha256').update(ip).digest('base64url')}`
@@ -28,6 +28,7 @@ describe('apps route', () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv }
+    resetAppRegistrationWarningStateForTests()
     mockCreateApplication.mockReset()
     mockLoggerWarn.mockReset()
     mockCreateApplication.mockResolvedValue({
@@ -114,6 +115,26 @@ describe('apps route', () => {
       message:
         'App registration source IP is unavailable; rate limiting is disabled'
     })
+  })
+
+  test('warns only once when app registration source stays unavailable', async () => {
+    const createRequest = (clientName: string) =>
+      new NextRequest('https://llun.test/api/v1/apps', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          client_name: clientName,
+          redirect_uris: `https://${clientName}.llun.dev/callback`
+        })
+      })
+
+    await POST(createRequest('first'))
+    await POST(createRequest('second'))
+
+    expect(mockCreateApplication).toHaveBeenCalledTimes(2)
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
   })
 
   test('returns too many requests when app registration is throttled', async () => {

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -1,6 +1,10 @@
+import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
 import { POST } from './route'
+
+const hashIpRegistrationKey = (ip: string) =>
+  `ip:${crypto.createHash('sha256').update(ip).digest('base64url')}`
 
 const mockCreateApplication = jest.fn()
 const mockLoggerWarn = jest.fn()
@@ -20,7 +24,10 @@ jest.mock('./createApplication', () => ({
 }))
 
 describe('apps route', () => {
+  const originalEnv = process.env
+
   beforeEach(() => {
+    process.env = { ...originalEnv }
     mockCreateApplication.mockReset()
     mockLoggerWarn.mockReset()
     mockCreateApplication.mockResolvedValue({
@@ -34,7 +41,11 @@ describe('apps route', () => {
     })
   })
 
-  test('derives registration limits from supported forwarded IP headers', async () => {
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  test('does not derive registration limits from untrusted forwarded IP headers', async () => {
     const req = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -52,12 +63,16 @@ describe('apps route', () => {
     await POST(req)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
-      registrationKey: expect.stringMatching(/^ip:[A-Za-z0-9_-]{43}$/)
+      registrationKey: undefined
     })
-    expect(mockLoggerWarn).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith({
+      message:
+        'App registration source IP is unavailable; rate limiting is disabled'
+    })
   })
 
-  test('uses the rightmost forwarded IP when stronger platform headers are absent', async () => {
+  test('uses the originating forwarded IP when forwarded IP headers are trusted', async () => {
+    process.env.ACTIVITIES_TRUST_PROXY_IP_HEADERS = 'true'
     const forwardedReq = new NextRequest('https://llun.test/api/v1/apps', {
       method: 'POST',
       headers: {
@@ -73,7 +88,7 @@ describe('apps route', () => {
     await POST(forwardedReq)
 
     expect(mockCreateApplication).toHaveBeenCalledWith(expect.any(Object), {
-      registrationKey: expect.stringMatching(/^ip:[A-Za-z0-9_-]{43}$/)
+      registrationKey: hashIpRegistrationKey('198.51.100.30')
     })
     expect(mockLoggerWarn).not.toHaveBeenCalled()
   })

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
@@ -17,6 +18,17 @@ import { PostRequest } from './types'
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const getAppRegistrationKey = (req: NextRequest): string => {
+  const forwardedFor = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  const ipAddress =
+    forwardedFor ||
+    req.headers.get('cf-connecting-ip') ||
+    req.headers.get('x-real-ip') ||
+    'unknown'
+
+  return crypto.createHash('sha256').update(ipAddress).digest('base64url')
+}
 
 export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
   const database = getDatabase()
@@ -39,7 +51,9 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
       responseStatusCode: 422
     })
   }
-  const response = await createApplication(parseResult.data)
+  const response = await createApplication(parseResult.data, {
+    registrationKey: getAppRegistrationKey(req)
+  })
 
   const { type, ...rest } = response
   if (type === 'error') {

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server'
 import { getDatabase } from '@/lib/database'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_422,
   ERROR_429,
@@ -21,9 +22,32 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+const getTrustedClientIp = (req: NextRequest): string | undefined => {
+  const cfConnectingIp = req.headers.get('cf-connecting-ip')?.trim()
+  if (cfConnectingIp) return cfConnectingIp
+
+  const realIp = req.headers.get('x-real-ip')?.trim()
+  if (realIp) return realIp
+
+  const forwardedFor = req.headers
+    .get('x-forwarded-for')
+    ?.split(',')
+    .at(-1)
+    ?.trim()
+  if (forwardedFor) return forwardedFor
+
+  return undefined
+}
+
 const getAppRegistrationKey = (req: NextRequest): string | undefined => {
-  const connectionIp = (req as NextRequest & { ip?: string }).ip
-  if (!connectionIp) return undefined
+  const connectionIp = getTrustedClientIp(req)
+  if (!connectionIp) {
+    logger.warn({
+      message:
+        'App registration source IP is unavailable; rate limiting is disabled'
+    })
+    return undefined
+  }
 
   const hash = crypto
     .createHash('sha256')

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -22,6 +22,12 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+let hasWarnedMissingAppRegistrationSource = false
+
+export const resetAppRegistrationWarningStateForTests = () => {
+  hasWarnedMissingAppRegistrationSource = false
+}
+
 const shouldTrustProxyIpHeaders = (): boolean =>
   process.env.ACTIVITIES_TRUST_PROXY_IP_HEADERS === 'true'
 
@@ -47,10 +53,13 @@ const getTrustedClientIp = (req: NextRequest): string | undefined => {
 const getAppRegistrationKey = (req: NextRequest): string | undefined => {
   const connectionIp = getTrustedClientIp(req)
   if (!connectionIp) {
-    logger.warn({
-      message:
-        'App registration source IP is unavailable; rate limiting is disabled'
-    })
+    if (!hasWarnedMissingAppRegistrationSource) {
+      hasWarnedMissingAppRegistrationSource = true
+      logger.warn({
+        message:
+          'App registration source IP is unavailable; rate limiting is disabled'
+      })
+    }
     return undefined
   }
 

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -22,7 +22,12 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+const shouldTrustProxyIpHeaders = (): boolean =>
+  process.env.ACTIVITIES_TRUST_PROXY_IP_HEADERS === 'true'
+
 const getTrustedClientIp = (req: NextRequest): string | undefined => {
+  if (!shouldTrustProxyIpHeaders()) return undefined
+
   const cfConnectingIp = req.headers.get('cf-connecting-ip')?.trim()
   if (cfConnectingIp) return cfConnectingIp
 
@@ -32,8 +37,8 @@ const getTrustedClientIp = (req: NextRequest): string | undefined => {
   const forwardedFor = req.headers
     .get('x-forwarded-for')
     ?.split(',')
-    .at(-1)
-    ?.trim()
+    .map((ip) => ip.trim())
+    .find(Boolean)
   if (forwardedFor) return forwardedFor
 
   return undefined

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
@@ -5,7 +6,9 @@ import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import {
   ERROR_422,
+  ERROR_429,
   ERROR_500,
+  HTTP_STATUS,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -18,11 +21,15 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-const getAppRegistrationKey = (_req: NextRequest): undefined => {
-  // This route has no configured trusted-proxy boundary, so forwarded IP
-  // headers are treated as client-supplied. createApplication falls back to
-  // a global anonymous registration bucket when this key is undefined.
-  return undefined
+const getAppRegistrationKey = (req: NextRequest): string | undefined => {
+  const connectionIp = (req as NextRequest & { ip?: string }).ip
+  if (!connectionIp) return undefined
+
+  const hash = crypto
+    .createHash('sha256')
+    .update(connectionIp)
+    .digest('base64url')
+  return `ip:${hash}`
 }
 
 export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
@@ -50,8 +57,16 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
     registrationKey: getAppRegistrationKey(req)
   })
 
-  const { type, ...rest } = response
-  if (type === 'error') {
+  if (response.type === 'error') {
+    if (response.error === 'Too many application registrations') {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_429,
+        responseStatusCode: HTTP_STATUS.TOO_MANY_REQUESTS
+      })
+    }
+
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
@@ -60,5 +75,6 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
     })
   }
 
-  return apiResponse({ req, allowedMethods: CORS_HEADERS, data: rest })
+  const { type: _type, ...data } = response
+  return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
 })

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
@@ -64,7 +65,7 @@ const getAppRegistrationKey = (req: NextRequest): string | undefined => {
   }
 
   const hash = crypto
-    .createHash('sha256')
+    .createHmac('sha256', getConfig().secretPhase)
     .update(connectionIp)
     .digest('base64url')
   return `ip:${hash}`

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
 import { getDatabase } from '@/lib/database'
@@ -19,17 +18,11 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-const getTrustedClientIp = (req: NextRequest): string | undefined =>
-  req.headers.get('cf-connecting-ip')?.trim() ||
-  req.headers.get('x-real-ip')?.trim() ||
-  undefined
-
-const getAppRegistrationKey = (req: NextRequest): string | undefined => {
-  const ipAddress = getTrustedClientIp(req)
-
-  if (!ipAddress) return undefined
-
-  return crypto.createHash('sha256').update(ipAddress).digest('base64url')
+const getAppRegistrationKey = (_req: NextRequest): undefined => {
+  // This route has no configured trusted-proxy boundary, so forwarded IP
+  // headers are treated as client-supplied. createApplication falls back to
+  // a global anonymous registration bucket when this key is undefined.
+  return undefined
 }
 
 export const POST = traceApiRoute('createApp', async (req: NextRequest) => {

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -19,13 +19,18 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-const getAppRegistrationKey = (req: NextRequest): string => {
-  const forwardedFor = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-  const ipAddress =
-    forwardedFor ||
-    req.headers.get('cf-connecting-ip') ||
-    req.headers.get('x-real-ip') ||
-    'unknown'
+const getAppRegistrationKey = (req: NextRequest): string | undefined => {
+  const cloudflareIp = req.headers.get('cf-connecting-ip')?.trim()
+  const realIp = req.headers.get('x-real-ip')?.trim()
+  const forwardedFor = req.headers
+    .get('x-forwarded-for')
+    ?.split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .at(-1)
+  const ipAddress = cloudflareIp || realIp || forwardedFor
+
+  if (!ipAddress) return undefined
 
   return crypto.createHash('sha256').update(ipAddress).digest('base64url')
 }

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -19,16 +19,13 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+const getTrustedClientIp = (req: NextRequest): string | undefined =>
+  req.headers.get('cf-connecting-ip')?.trim() ||
+  req.headers.get('x-real-ip')?.trim() ||
+  undefined
+
 const getAppRegistrationKey = (req: NextRequest): string | undefined => {
-  const cloudflareIp = req.headers.get('cf-connecting-ip')?.trim()
-  const realIp = req.headers.get('x-real-ip')?.trim()
-  const forwardedFor = req.headers
-    .get('x-forwarded-for')
-    ?.split(',')
-    .map((value) => value.trim())
-    .filter(Boolean)
-    .at(-1)
-  const ipAddress = cloudflareIp || realIp || forwardedFor
+  const ipAddress = getTrustedClientIp(req)
 
   if (!ipAddress) return undefined
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -441,7 +441,12 @@ describe('GET /api/v1/statuses/[id]', () => {
         const response = await handler(
           new NextRequest(
             `https://llun.test/api/v1/statuses/${urlToId(statusId)}/${routeName}`,
-            { method }
+            {
+              method,
+              ...(method === 'POST'
+                ? { headers: { Origin: 'https://llun.test' } }
+                : {})
+            }
           ),
           { params: Promise.resolve({ id: urlToId(statusId) }) }
         )
@@ -481,7 +486,10 @@ describe('GET /api/v1/statuses/[id]', () => {
       const response = await unreblogStatus(
         new NextRequest(
           `https://llun.test/api/v1/statuses/${urlToId(originalStatusId)}/unreblog`,
-          { method: 'POST' }
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
         ),
         { params: Promise.resolve({ id: urlToId(originalStatusId) }) }
       )
@@ -516,7 +524,10 @@ describe('GET /api/v1/statuses/[id]', () => {
       const response = await unfavouriteStatus(
         new NextRequest(
           `https://llun.test/api/v1/statuses/${urlToId(statusId)}/unfavourite`,
-          { method: 'POST' }
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
         ),
         { params: Promise.resolve({ id: urlToId(statusId) }) }
       )

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -731,7 +731,8 @@ describe('GET /api/v1/statuses/[id]', () => {
               spoiler_text: ''
             }),
             headers: {
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
             }
           }
         ),
@@ -773,7 +774,8 @@ describe('GET /api/v1/statuses/[id]', () => {
               spoiler_text: null
             }),
             headers: {
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
             }
           }
         ),
@@ -815,7 +817,8 @@ describe('GET /api/v1/statuses/[id]', () => {
               spoiler_text: ''
             }),
             headers: {
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
             }
           }
         ),

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -89,7 +89,8 @@ describe('POST /api/v1/statuses', () => {
           media_ids: [media!.id]
         }),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
         }
       }),
       { params: Promise.resolve({}) }
@@ -160,7 +161,8 @@ describe('POST /api/v1/statuses', () => {
         method: 'POST',
         body,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Origin: 'https://llun.test'
         }
       }),
       { params: Promise.resolve({}) }
@@ -218,7 +220,8 @@ describe('POST /api/v1/statuses', () => {
     const request = new NextRequest('https://llun.test/api/v1/statuses', {
       method: 'POST',
       headers: {
-        'Content-Type': 'multipart/form-data; boundary=test-boundary'
+        'Content-Type': 'multipart/form-data; boundary=test-boundary',
+        Origin: 'https://llun.test'
       }
     })
     Object.defineProperty(request, 'formData', {
@@ -255,7 +258,8 @@ describe('POST /api/v1/statuses', () => {
           status: '   '
         }),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
         }
       }),
       { params: Promise.resolve({}) }
@@ -287,7 +291,8 @@ describe('POST /api/v1/statuses', () => {
           media_ids: [media!.id]
         }),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
         }
       }),
       { params: Promise.resolve({}) }
@@ -321,7 +326,8 @@ describe('POST /api/v1/statuses', () => {
           media_ids: mediaIds
         }),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
         }
       }),
       { params: Promise.resolve({}) }

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -16,9 +16,9 @@ Application configuration can be provided either through environment variables o
 
 ## Proxy Configuration
 
-| Variable                            | Description                                                                                                                                                                                                                                     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ACTIVITIES_TRUST_PROXY_IP_HEADERS` | Set to `true` to use proxy-managed client IP headers for unauthenticated app registration throttling. Only enable when all direct app access is blocked and the trusted proxy strips client-supplied forwarding headers before setting its own. |
+| Variable                            | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACTIVITIES_TRUST_PROXY_IP_HEADERS` | Set to `true` to use proxy-managed client IP headers for unauthenticated app registration throttling. Only enable when all direct app access is blocked and the trusted proxy overwrites or strips client-supplied forwarding headers before setting its own. Do not enable behind append-only proxies; if the proxy appends to `X-Forwarded-For`, the first element may still be untrusted. |
 
 ## Database
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,6 +14,12 @@ Application configuration can be provided either through environment variables o
 | `ACTIVITIES_TRUSTED_HOSTS` | No       | JSON array of additional public hosts accepted from `X-Forwarded-Host` and `X-Activity-Next-Host`.                    |
 | `ACTIVITIES_INSECURE_AUTH` | No       | Set to `true` to allow HTTP (non-HTTPS) authentication. Only for local development.                                   |
 
+## Proxy Configuration
+
+| Variable                            | Description                                                                                                                                                                                                                                     |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACTIVITIES_TRUST_PROXY_IP_HEADERS` | Set to `true` to use proxy-managed client IP headers for unauthenticated app registration throttling. Only enable when all direct app access is blocked and the trusted proxy strips client-supplied forwarding headers before setting its own. |
+
 ## Database
 
 Activity.next supports SQLite and PostgreSQL. The configuration loader also accepts MySQL-compatible Knex clients for deployments that provide the needed driver/runtime support. See [SQLite Setup](sqlite-setup.md) and [PostgreSQL Setup](postgresql-setup.md) for detailed guides.

--- a/lib/database/sql/oauthClientRegistrationMetadataMigration.test.ts
+++ b/lib/database/sql/oauthClientRegistrationMetadataMigration.test.ts
@@ -1,0 +1,36 @@
+import knex from 'knex'
+
+import * as migration from '@/migrations/20260513000000_add_oauth_client_registration_metadata'
+
+describe('OAuth client registration metadata migration', () => {
+  const database = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+
+  beforeAll(async () => {
+    await database.schema.createTable('oauthClient', (table) => {
+      table.string('clientId').primary()
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  test('adds registration metadata columns to existing oauth client tables', async () => {
+    await migration.up(database)
+
+    await expect(
+      database.schema.hasColumn('oauthClient', 'referenceId')
+    ).resolves.toBe(true)
+    await expect(
+      database.schema.hasColumn('oauthClient', 'metadata')
+    ).resolves.toBe(true)
+  })
+
+  test('can run after the columns already exist', async () => {
+    await expect(migration.up(database)).resolves.toBeUndefined()
+  })
+})

--- a/lib/database/sql/oauthClientRegistrationMetadataMigration.test.ts
+++ b/lib/database/sql/oauthClientRegistrationMetadataMigration.test.ts
@@ -3,19 +3,20 @@ import knex from 'knex'
 import * as migration from '@/migrations/20260513000000_add_oauth_client_registration_metadata'
 
 describe('OAuth client registration metadata migration', () => {
-  const database = knex({
-    client: 'better-sqlite3',
-    useNullAsDefault: true,
-    connection: { filename: ':memory:' }
-  })
+  let database: knex.Knex
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
     await database.schema.createTable('oauthClient', (table) => {
       table.string('clientId').primary()
     })
   })
 
-  afterAll(async () => {
+  afterEach(async () => {
     await database.destroy()
   })
 
@@ -32,5 +33,17 @@ describe('OAuth client registration metadata migration', () => {
 
   test('can run after the columns already exist', async () => {
     await expect(migration.up(database)).resolves.toBeUndefined()
+  })
+
+  test('adds an index for app registration rate-limit lookups', async () => {
+    await migration.up(database)
+
+    const indexes = await database.raw("PRAGMA index_list('oauthClient')")
+
+    expect(
+      (indexes as Array<{ name: string }>).some(
+        ({ name }) => name === 'oauth_client_reference_id_idx'
+      )
+    ).toBe(true)
   })
 })

--- a/lib/database/sql/oauthPkceMigration.test.ts
+++ b/lib/database/sql/oauthPkceMigration.test.ts
@@ -1,0 +1,42 @@
+import knex from 'knex'
+
+import * as migration from '@/migrations/20260512230000_require_pkce_for_oauth_clients'
+
+describe('require PKCE for OAuth clients migration', () => {
+  const database = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+
+  beforeAll(async () => {
+    await database.schema.createTable('oauthClient', (table) => {
+      table.string('clientId').primary()
+      table.boolean('requirePKCE').nullable()
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  test('upgrades existing oauth clients to require PKCE', async () => {
+    await database('oauthClient').insert([
+      { clientId: 'pkce-disabled', requirePKCE: false },
+      { clientId: 'pkce-null', requirePKCE: null },
+      { clientId: 'pkce-enabled', requirePKCE: true }
+    ])
+
+    await migration.up(database)
+
+    const clients = await database('oauthClient')
+      .select('clientId', 'requirePKCE')
+      .orderBy('clientId')
+
+    expect(clients).toEqual([
+      { clientId: 'pkce-disabled', requirePKCE: 1 },
+      { clientId: 'pkce-enabled', requirePKCE: 1 },
+      { clientId: 'pkce-null', requirePKCE: 1 }
+    ])
+  })
+})

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -150,6 +150,20 @@ describe('#OAuthGuard', () => {
       expect(mockHandler).toHaveBeenCalled()
     })
 
+    test('ignores non-Bearer authorization when a valid session exists', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = OAuthGuard([Scope.enum.read], mockHandler)
+      const req = createRequest({ Authorization: 'Basic upstream-token' })
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+      expect(mockVerifyAccessToken).not.toHaveBeenCalled()
+    })
+
     test('rejects a cookie-session mutation without same-origin proof', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor1.email }

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -224,7 +224,7 @@ describe('#OAuthGuard', () => {
       const guard = OAuthGuard([Scope.enum.write], mockHandler)
       const req = createRequest(
         {
-          Authorization: 'Bearer read-only-opaque-with-session',
+          Authorization: 'bearer read-only-opaque-with-session',
           Origin: 'https://llun.test'
         },
         'POST'
@@ -549,6 +549,30 @@ describe('#OAuthGuard', () => {
 
       const guard = OAuthGuard([Scope.enum.read], mockHandler)
       const req = createRequest({ Authorization: 'Bearer opaque-token' })
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+      expect(mockVerifyAccessToken).not.toHaveBeenCalled()
+    })
+
+    test('allows request with lowercase bearer opaque token', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const primaryActor = await database.getActorFromEmail({
+        email: seedActor1.email
+      })
+      mockStoredTokens.set(hashToken('lowercase-opaque-token'), {
+        token: hashToken('lowercase-opaque-token'),
+        referenceId: primaryActor?.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        scopes: JSON.stringify(['read'])
+      })
+
+      const guard = OAuthGuard([Scope.enum.read], mockHandler)
+      const req = createRequest({
+        Authorization: 'bearer lowercase-opaque-token'
+      })
       const response = await guard(req, { params: Promise.resolve({}) })
 
       expect(response.status).toBe(200)

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -60,7 +60,8 @@ jest.mock('@/lib/config', () => ({
   getConfig: () => ({
     allowEmails: [],
     host: 'llun.test',
-    secretPhase: 'secret phases'
+    secretPhase: 'secret phases',
+    trustedHosts: ['trusted.llun.test']
   }),
   getBaseURL: () => 'https://llun.test'
 }))
@@ -184,6 +185,19 @@ describe('#OAuthGuard', () => {
 
       const guard = OAuthGuard([Scope.enum.write], mockHandler)
       const req = createRequest({ Origin: 'https://llun.test' }, 'POST')
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+    })
+
+    test('allows a cookie-session mutation with an origin from trusted hosts', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = OAuthGuard([Scope.enum.write], mockHandler)
+      const req = createRequest({ Origin: 'https://trusted.llun.test' }, 'POST')
       const response = await guard(req, { params: Promise.resolve({}) })
 
       expect(response.status).toBe(200)

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -121,9 +121,12 @@ describe('#OAuthGuard', () => {
     mockHandler.mockClear()
   })
 
-  const createRequest = (headers: Record<string, string> = {}) => {
+  const createRequest = (
+    headers: Record<string, string> = {},
+    method = 'GET'
+  ) => {
     return new NextRequest('https://llun.test/api/test', {
-      method: 'GET',
+      method,
       headers
     })
   }
@@ -144,6 +147,60 @@ describe('#OAuthGuard', () => {
 
       expect(response.status).toBe(200)
       expect(mockHandler).toHaveBeenCalled()
+    })
+
+    test('rejects a cookie-session mutation without same-origin proof', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = OAuthGuard([Scope.enum.write], mockHandler)
+      const req = createRequest({}, 'POST')
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(403)
+      expect(mockHandler).not.toHaveBeenCalled()
+    })
+
+    test('allows a cookie-session mutation with a same-origin header', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = OAuthGuard([Scope.enum.write], mockHandler)
+      const req = createRequest({ Origin: 'https://llun.test' }, 'POST')
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+    })
+
+    test('does not fall back to cookie session when a bearer token lacks the required scope', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const primaryActor = await database.getActorFromEmail({
+        email: seedActor1.email
+      })
+      mockStoredTokens.set(hashToken('read-only-opaque-with-session'), {
+        token: hashToken('read-only-opaque-with-session'),
+        referenceId: primaryActor?.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        scopes: JSON.stringify(['read'])
+      })
+
+      const guard = OAuthGuard([Scope.enum.write], mockHandler)
+      const req = createRequest(
+        {
+          Authorization: 'Bearer read-only-opaque-with-session',
+          Origin: 'https://llun.test'
+        },
+        'POST'
+      )
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(401)
+      expect(mockHandler).not.toHaveBeenCalled()
     })
 
     test('returns 401 when session email has no associated actor', async () => {

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -123,9 +123,10 @@ describe('#OAuthGuard', () => {
 
   const createRequest = (
     headers: Record<string, string> = {},
-    method = 'GET'
+    method = 'GET',
+    url = 'https://llun.test/api/test'
   ) => {
-    return new NextRequest('https://llun.test/api/test', {
+    return new NextRequest(url, {
       method,
       headers
     })
@@ -173,6 +174,23 @@ describe('#OAuthGuard', () => {
 
       expect(response.status).toBe(200)
       expect(mockHandler).toHaveBeenCalled()
+    })
+
+    test('rejects a cookie-session mutation when origin only matches the request URL', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const guard = OAuthGuard([Scope.enum.write], mockHandler)
+      const req = createRequest(
+        { Origin: 'https://attacker.test' },
+        'POST',
+        'https://attacker.test/api/test'
+      )
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(403)
+      expect(mockHandler).not.toHaveBeenCalled()
     })
 
     test('does not fall back to cookie session when a bearer token lacks the required scope', async () => {

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -55,16 +55,15 @@ export const getTokenFromHeader = (
   authorizationHeader: string | null
 ): string | null => {
   if (!authorizationHeader) return null
-  const parts = authorizationHeader.split(' ')
-  if (parts.length !== 2 || parts[0] !== 'Bearer') return null
+  const parts = authorizationHeader.trim().split(/\s+/)
+  if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') return null
   return parts[1] || null
 }
 
 const isBearerAuthorizationHeader = (
   authorizationHeader: string | null
 ): boolean =>
-  authorizationHeader === 'Bearer' ||
-  authorizationHeader?.startsWith('Bearer ') === true
+  authorizationHeader?.trim().split(/\s+/, 1)[0]?.toLowerCase() === 'bearer'
 
 const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -18,6 +18,7 @@ import {
   codeMap
 } from '@/lib/utils/response'
 
+import { isTrustedHeaderHost } from './headerHost'
 import {
   AppRouterParams,
   AuthenticatedApiHandle,
@@ -76,16 +77,29 @@ const getOrigin = (value: string | null): string | null => {
   }
 }
 
+const isAllowedOrigin = (value: string | null, baseOrigin: string): boolean => {
+  const origin = getOrigin(value)
+  if (!origin) return false
+  if (origin === baseOrigin) return true
+
+  const originUrl = new URL(origin)
+  const baseUrl = new URL(baseOrigin)
+  return (
+    originUrl.protocol === baseUrl.protocol &&
+    isTrustedHeaderHost(originUrl.host)
+  )
+}
+
 const hasSameOriginProof = (req: NextRequest): boolean => {
   if (!STATE_CHANGING_METHODS.has(req.method)) return true
 
-  const allowedOrigins = new Set([new URL(getBaseURL()).origin])
+  const baseOrigin = new URL(getBaseURL()).origin
 
-  const origin = getOrigin(req.headers.get('Origin'))
-  if (origin) return allowedOrigins.has(origin)
+  const origin = req.headers.get('Origin')
+  if (origin) return isAllowedOrigin(origin, baseOrigin)
 
-  const referer = getOrigin(req.headers.get('Referer'))
-  if (referer) return allowedOrigins.has(referer)
+  const referer = req.headers.get('Referer')
+  if (referer) return isAllowedOrigin(referer, baseOrigin)
 
   return false
 }

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -60,6 +60,32 @@ export const getTokenFromHeader = (
   return parts[1] || null
 }
 
+const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+const getOrigin = (value: string | null): string | null => {
+  if (!value) return null
+  try {
+    return new URL(value).origin
+  } catch {
+    return null
+  }
+}
+
+const hasSameOriginProof = (req: NextRequest): boolean => {
+  if (!STATE_CHANGING_METHODS.has(req.method)) return true
+
+  const allowedOrigins = new Set([new URL(getBaseURL()).origin])
+  if (req.nextUrl?.origin) allowedOrigins.add(req.nextUrl.origin)
+
+  const origin = getOrigin(req.headers.get('Origin'))
+  if (origin) return allowedOrigins.has(origin)
+
+  const referer = getOrigin(req.headers.get('Referer'))
+  if (referer) return allowedOrigins.has(referer)
+
+  return false
+}
+
 type ScopeMatchMode = 'all' | 'any'
 
 type GuardContext<P> = {
@@ -88,139 +114,145 @@ const resolveAuthenticatedContext = async <P>({
     return { authenticated: false, response: apiErrorResponse(500) }
   }
 
-  const session = await getServerAuthSession()
-  if (session?.user?.email) {
-    const currentActor = await getActorFromSession(database, session)
-    if (!currentActor) {
-      return { authenticated: false, response: apiErrorResponse(401) }
-    }
-    return {
-      authenticated: true,
-      context: { currentActor, database, params: context.params }
-    }
-  }
-
   const authorizationToken = req.headers.get('Authorization')
-  const token = getTokenFromHeader(authorizationToken)
-  if (!token) {
-    if (authorizationToken) {
+  if (authorizationToken) {
+    const token = getTokenFromHeader(authorizationToken)
+    if (!token) {
       return { authenticated: false, response: apiErrorResponse(401) }
     }
-    return { authenticated: false }
-  }
 
-  const baseURL = getBaseURL()
-  const jwksUrl = `${baseURL}/api/auth/jwks`
+    const baseURL = getBaseURL()
+    const jwksUrl = `${baseURL}/api/auth/jwks`
 
-  // Distinguish JWT from opaque tokens by format: JWTs have three
-  // dot-separated segments. This prevents tampered/expired JWTs from
-  // falling through to the opaque DB lookup path.
-  let jwtPayload: Record<string, unknown> | null = null
-  let grantedScopes: string[] = []
+    // Distinguish JWT from opaque tokens by format: JWTs have three
+    // dot-separated segments. This prevents tampered/expired JWTs from
+    // falling through to the opaque DB lookup path.
+    let jwtPayload: Record<string, unknown> | null = null
+    let grantedScopes: string[] = []
 
-  if (isJwtFormat(token)) {
     try {
-      jwtPayload = (await verifyAccessToken(token, {
-        jwksUrl,
-        // For 'any' mode, skip scope checking in verifyAccessToken
-        // and do it manually below
-        scopes: matchMode === 'all' ? scopes : [],
-        verifyOptions: {
-          issuer: baseURL,
-          audience: baseURL
-        }
-      })) as Record<string, unknown>
-    } catch {
-      // JWT verification failed (expired, invalid signature, wrong scope,
-      // etc.) — reject immediately, do NOT fall through to opaque lookup
-      return { authenticated: false, response: apiErrorResponse(401) }
-    }
-
-    const jwtScope = jwtPayload.scope as string | undefined
-    const jwtScopes = jwtScope ? jwtScope.split(' ') : []
-    grantedScopes = jwtScopes
-
-    if (matchMode === 'all') {
-      // Defense-in-depth: explicitly verify JWT scope claims in case
-      // verifyAccessToken's scope checking changes in a future version
-      for (const scope of scopes) {
-        if (!jwtScopes.includes(scope)) {
+      if (isJwtFormat(token)) {
+        try {
+          jwtPayload = (await verifyAccessToken(token, {
+            jwksUrl,
+            // For 'any' mode, skip scope checking in verifyAccessToken
+            // and do it manually below
+            scopes: matchMode === 'all' ? scopes : [],
+            verifyOptions: {
+              issuer: baseURL,
+              audience: baseURL
+            }
+          })) as Record<string, unknown>
+        } catch {
+          // JWT verification failed (expired, invalid signature, wrong scope,
+          // etc.) — reject immediately, do NOT fall through to opaque lookup
           return { authenticated: false, response: apiErrorResponse(401) }
         }
-      }
-    } else {
-      // 'any' mode: at least one required scope must be present
-      const hasAny = scopes.some((scope) => jwtScopes.includes(scope))
-      if (!hasAny) {
-        return { authenticated: false, response: apiErrorResponse(401) }
-      }
-    }
-  }
 
-  try {
-    // Verify the token exists in DB (revocation check for JWTs,
-    // primary auth check for opaque tokens).
-    // better-auth's storeToken() hashes ALL token types (JWT and opaque)
-    // via defaultHasher (SHA-256 base64url) before storing in the
-    // oauthAccessToken.token column.
-    // See: @better-auth/oauth-provider/dist/utils-DgozotLg.mjs storeToken()
-    const db = getKnex()
-    const storedToken = await db('oauthAccessToken')
-      .where('token', hashToken(token))
-      .first()
-    if (!storedToken) {
-      return { authenticated: false, response: apiErrorResponse(401) }
-    }
+        const jwtScope = jwtPayload.scope as string | undefined
+        const jwtScopes = jwtScope ? jwtScope.split(' ') : []
+        grantedScopes = jwtScopes
 
-    // For opaque tokens, check expiration and scopes manually
-    // (JWT verification already handles these for JWT tokens)
-    if (!jwtPayload) {
-      if (new Date(storedToken.expiresAt) < new Date()) {
-        return { authenticated: false, response: apiErrorResponse(401) }
-      }
-      const storedScopes = parseStoredScopes(storedToken.scopes as string)
-      grantedScopes = storedScopes
-
-      if (matchMode === 'all') {
-        for (const scope of scopes) {
-          if (!storedScopes.includes(scope)) {
+        if (matchMode === 'all') {
+          // Defense-in-depth: explicitly verify JWT scope claims in case
+          // verifyAccessToken's scope checking changes in a future version
+          for (const scope of scopes) {
+            if (!jwtScopes.includes(scope)) {
+              return { authenticated: false, response: apiErrorResponse(401) }
+            }
+          }
+        } else {
+          // 'any' mode: at least one required scope must be present
+          const hasAny = scopes.some((scope) => jwtScopes.includes(scope))
+          if (!hasAny) {
             return { authenticated: false, response: apiErrorResponse(401) }
           }
         }
-      } else {
-        const hasAny = scopes.some((scope) => storedScopes.includes(scope))
-        if (!hasAny) {
+      }
+
+      // Verify the token exists in DB (revocation check for JWTs,
+      // primary auth check for opaque tokens).
+      // better-auth's storeToken() hashes ALL token types (JWT and opaque)
+      // via defaultHasher (SHA-256 base64url) before storing in the
+      // oauthAccessToken.token column.
+      // See: @better-auth/oauth-provider/dist/utils-DgozotLg.mjs storeToken()
+      const db = getKnex()
+      const storedToken = await db('oauthAccessToken')
+        .where('token', hashToken(token))
+        .first()
+      if (!storedToken) {
+        return { authenticated: false, response: apiErrorResponse(401) }
+      }
+
+      // For opaque tokens, check expiration and scopes manually
+      // (JWT verification already handles these for JWT tokens)
+      if (!jwtPayload) {
+        if (new Date(storedToken.expiresAt) < new Date()) {
           return { authenticated: false, response: apiErrorResponse(401) }
         }
+        const storedScopes = parseStoredScopes(storedToken.scopes as string)
+        grantedScopes = storedScopes
+
+        if (matchMode === 'all') {
+          for (const scope of scopes) {
+            if (!storedScopes.includes(scope)) {
+              return { authenticated: false, response: apiErrorResponse(401) }
+            }
+          }
+        } else {
+          const hasAny = scopes.some((scope) => storedScopes.includes(scope))
+          if (!hasAny) {
+            return { authenticated: false, response: apiErrorResponse(401) }
+          }
+        }
       }
-    }
 
-    // Extract actorId: from JWT claims or from stored referenceId (opaque)
-    const actorId = jwtPayload
-      ? (jwtPayload.actorId as string | null)
-      : (storedToken.referenceId as string | null)
+      // Extract actorId: from JWT claims or from stored referenceId (opaque)
+      const actorId = jwtPayload
+        ? (jwtPayload.actorId as string | null)
+        : (storedToken.referenceId as string | null)
 
-    if (!actorId) {
-      return { authenticated: false, response: apiErrorResponse(401) }
-    }
-
-    const actor = await database.getActorFromId({ id: actorId })
-    if (!actor) {
-      return { authenticated: false, response: apiErrorResponse(401) }
-    }
-
-    return {
-      authenticated: true,
-      context: {
-        currentActor: Actor.parse(actor),
-        database,
-        params: context.params,
-        grantedScopes
+      if (!actorId) {
+        return { authenticated: false, response: apiErrorResponse(401) }
       }
+
+      const actor = await database.getActorFromId({ id: actorId })
+      if (!actor) {
+        return { authenticated: false, response: apiErrorResponse(401) }
+      }
+
+      return {
+        authenticated: true,
+        context: {
+          currentActor: Actor.parse(actor),
+          database,
+          params: context.params,
+          grantedScopes
+        }
+      }
+    } catch (e) {
+      logger.error(e as Error)
+      return { authenticated: false, response: apiErrorResponse(500) }
     }
-  } catch (e) {
-    logger.error(e as Error)
-    return { authenticated: false, response: apiErrorResponse(500) }
+  }
+
+  const session = await getServerAuthSession()
+  if (!session?.user?.email) {
+    return { authenticated: false }
+  }
+
+  if (!hasSameOriginProof(req)) {
+    return { authenticated: false, response: apiErrorResponse(403) }
+  }
+
+  const currentActor = await getActorFromSession(database, session)
+  if (!currentActor) {
+    return { authenticated: false, response: apiErrorResponse(401) }
+  }
+
+  return {
+    authenticated: true,
+    context: { currentActor, database, params: context.params }
   }
 }
 

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -60,6 +60,12 @@ export const getTokenFromHeader = (
   return parts[1] || null
 }
 
+const isBearerAuthorizationHeader = (
+  authorizationHeader: string | null
+): boolean =>
+  authorizationHeader === 'Bearer' ||
+  authorizationHeader?.startsWith('Bearer ') === true
+
 const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 const getOrigin = (value: string | null): string | null => {
@@ -114,7 +120,7 @@ const resolveAuthenticatedContext = async <P>({
   }
 
   const authorizationToken = req.headers.get('Authorization')
-  if (authorizationToken) {
+  if (isBearerAuthorizationHeader(authorizationToken)) {
     const token = getTokenFromHeader(authorizationToken)
     if (!token) {
       return { authenticated: false, response: apiErrorResponse(401) }

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -75,7 +75,6 @@ const hasSameOriginProof = (req: NextRequest): boolean => {
   if (!STATE_CHANGING_METHODS.has(req.method)) return true
 
   const allowedOrigins = new Set([new URL(getBaseURL()).origin])
-  if (req.nextUrl?.origin) allowedOrigins.add(req.nextUrl.origin)
 
   const origin = getOrigin(req.headers.get('Origin'))
   if (origin) return allowedOrigins.has(origin)

--- a/lib/utils/response.ts
+++ b/lib/utils/response.ts
@@ -14,6 +14,7 @@ export const ERROR_403 = { status: 'Forbidden' }
 export const ERROR_404 = { status: 'Not Found' }
 export const ERROR_409 = { status: 'Conflict' }
 export const ERROR_422 = { status: 'Unprocessable entity' }
+export const ERROR_429 = { status: 'Too Many Requests' }
 export const ERROR_413 = { status: 'Payload Too Large' }
 
 export const DEFAULT_200 = { status: 'OK' }
@@ -29,6 +30,7 @@ export const HTTP_STATUS = {
   CONFLICT: 409,
   PAYLOAD_TOO_LARGE: 413,
   UNPROCESSABLE_ENTITY: 422,
+  TOO_MANY_REQUESTS: 429,
   INTERNAL_SERVER_ERROR: 500
 } as const
 
@@ -43,6 +45,7 @@ export const codeMap = {
   [HTTP_STATUS.CONFLICT]: ERROR_409,
   [HTTP_STATUS.PAYLOAD_TOO_LARGE]: ERROR_413,
   [HTTP_STATUS.UNPROCESSABLE_ENTITY]: ERROR_422,
+  [HTTP_STATUS.TOO_MANY_REQUESTS]: ERROR_429,
 
   [HTTP_STATUS.INTERNAL_SERVER_ERROR]: ERROR_500
 }

--- a/migrations/20260512230000_require_pkce_for_oauth_clients.js
+++ b/migrations/20260512230000_require_pkce_for_oauth_clients.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex('oauthClient')
+    .where((builder) => {
+      builder.whereNull('requirePKCE').orWhere('requirePKCE', false)
+    })
+    .update({ requirePKCE: true })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async () => {
+  // Intentionally not reversible: disabling PKCE for existing OAuth clients
+  // would reintroduce the authorization-code hardening gap.
+}

--- a/migrations/20260512230000_require_pkce_for_oauth_clients.js
+++ b/migrations/20260512230000_require_pkce_for_oauth_clients.js
@@ -1,3 +1,8 @@
+// WARNING: This migration unconditionally enables requirePKCE for all
+// existing OAuth clients. Any client that does not support PKCE will stop
+// being able to exchange authorization codes after this migration runs.
+// The change is intentionally irreversible (down() is a no-op).
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }

--- a/migrations/20260513000000_add_oauth_client_registration_metadata.js
+++ b/migrations/20260513000000_add_oauth_client_registration_metadata.js
@@ -1,3 +1,33 @@
+const OAUTH_CLIENT_REFERENCE_ID_INDEX = 'oauth_client_reference_id_idx'
+
+const hasIndex = async (trx, tableName, indexName) => {
+  const client = trx.client.config.client
+
+  if (client === 'better-sqlite3' || client === 'sqlite3') {
+    const indexes = await trx.raw(`PRAGMA index_list('${tableName}')`)
+    return indexes.some(({ name }) => name === indexName)
+  }
+
+  if (client === 'pg' || client === 'postgres' || client === 'postgresql') {
+    const result = await trx
+      .select('indexname')
+      .from('pg_indexes')
+      .where({ tablename: tableName, indexname: indexName })
+      .first()
+    return Boolean(result)
+  }
+
+  if (client === 'mysql' || client === 'mysql2') {
+    const [rows] = await trx.raw('SHOW INDEX FROM ?? WHERE Key_name = ?', [
+      tableName,
+      indexName
+    ])
+    return rows.length > 0
+  }
+
+  return false
+}
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
@@ -12,7 +42,19 @@ exports.up = async (knex) => {
 
     if (!hasReferenceId) {
       await trx.schema.alterTable('oauthClient', (table) => {
-        table.string('referenceId').nullable()
+        table.string('referenceId').notNullable().defaultTo('')
+      })
+    }
+
+    await trx('oauthClient').whereNull('referenceId').update({
+      referenceId: ''
+    })
+
+    if (
+      !(await hasIndex(trx, 'oauthClient', OAUTH_CLIENT_REFERENCE_ID_INDEX))
+    ) {
+      await trx.schema.alterTable('oauthClient', (table) => {
+        table.index(['referenceId'], OAUTH_CLIENT_REFERENCE_ID_INDEX)
       })
     }
 

--- a/migrations/20260513000000_add_oauth_client_registration_metadata.js
+++ b/migrations/20260513000000_add_oauth_client_registration_metadata.js
@@ -1,0 +1,33 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const hasReferenceId = await trx.schema.hasColumn(
+      'oauthClient',
+      'referenceId'
+    )
+    const hasMetadata = await trx.schema.hasColumn('oauthClient', 'metadata')
+
+    if (!hasReferenceId) {
+      await trx.schema.alterTable('oauthClient', (table) => {
+        table.string('referenceId').nullable()
+      })
+    }
+
+    if (!hasMetadata) {
+      await trx.schema.alterTable('oauthClient', (table) => {
+        table.text('metadata').nullable()
+      })
+    }
+  })
+}
+
+/**
+ * @returns { Promise<void> }
+ */
+exports.down = async () => {
+  // Intentionally no-op: fresh databases may already have these columns from
+  // the OAuth provider table migration, and current app code depends on them.
+}


### PR DESCRIPTION
## Summary
- require PKCE for OAuth clients and add a migration for existing clients
- rate-limit and garbage-collect unauthenticated app registrations
- split bearer-token scope enforcement from cookie-session auth and require same-origin proof for cookie-backed mutations

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test

## Notes
- Used Node.js v24.13.0 for all node/yarn commands.
- Nested subagent tooling was not available in this session, so Explore, Plan, spec/code review, and silent-failure review were performed sequentially.