### PR TITLE
fix: harden media and fitness ingestion

### DIFF
--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -11,7 +11,9 @@ import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
-import { GET } from './route'
+import * as routeModule from './route'
+
+const { GET } = routeModule
 
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
@@ -62,6 +64,7 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    routeModule.resetFitnessRouteDataSecurityStateForTests?.()
     mockGetFitnessFile.mockResolvedValue({
       type: 'buffer',
       contentType: 'application/vnd.ant.fit',
@@ -89,11 +92,12 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     })
   })
 
-  const createRequest = () =>
+  const createRequest = (headers?: Record<string, string>) =>
     new NextRequest(
       'https://llun.test/api/v1/fitness-files/file-id/route-data',
       {
-        method: 'GET'
+        method: 'GET',
+        headers
       }
     )
 
@@ -174,7 +178,7 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=60')
 
     const payload = (await response.json()) as {
       samples: Array<{ elapsedSeconds: number; isHiddenByPrivacy: boolean }>
@@ -201,6 +205,80 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
       fileType: 'fit',
       buffer: Buffer.from('fit-data')
     })
+  })
+
+  it('caches anonymous public route data parsing responses', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const status = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/public-route-data-cache`,
+      url: `${ACTOR1_ID}/statuses/public-route-data-cache`,
+      actorId: ACTOR1_ID,
+      text: 'Public route data cache',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR1_FOLLOWER_URL]
+    })
+
+    const fitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      statusId: status.id,
+      path: 'fitness/public-route-data-cache.fit',
+      fileName: 'public-route-data-cache.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024
+    })
+
+    const firstResponse = await GET(createRequest(), {
+      params: Promise.resolve({ id: fitnessFile!.id })
+    })
+    const secondResponse = await GET(createRequest(), {
+      params: Promise.resolve({ id: fitnessFile!.id })
+    })
+
+    expect(firstResponse.status).toBe(200)
+    expect(secondResponse.status).toBe(200)
+    expect(secondResponse.headers.get('X-Route-Data-Cache')).toBe('HIT')
+    expect(mockGetFitnessFile).toHaveBeenCalledTimes(1)
+    expect(mockParseFitnessFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('rate-limits anonymous public route data parsing requests', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const status = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/public-route-data-rate-limit`,
+      url: `${ACTOR1_ID}/statuses/public-route-data-rate-limit`,
+      actorId: ACTOR1_ID,
+      text: 'Public route data rate limit',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR1_FOLLOWER_URL]
+    })
+
+    const fitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      statusId: status.id,
+      path: 'fitness/public-route-data-rate-limit.fit',
+      fileName: 'public-route-data-rate-limit.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024
+    })
+
+    let response: Response | null = null
+    for (let index = 0; index < 61; index += 1) {
+      response = await GET(
+        createRequest({
+          'x-forwarded-for': '203.0.113.10'
+        }),
+        {
+          params: Promise.resolve({ id: fitnessFile!.id })
+        }
+      )
+    }
+
+    expect(response?.status).toBe(429)
+    expect(mockGetFitnessFile).toHaveBeenCalledTimes(1)
   })
 
   it('returns not found for private status route data without a session', async () => {

--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -369,6 +369,53 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     })
   })
 
+  it('derives separate no-IP rate limit fallback keys per route file', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const status = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/public-route-data-no-ip-fallback`,
+      url: `${ACTOR1_ID}/statuses/public-route-data-no-ip-fallback`,
+      actorId: ACTOR1_ID,
+      text: 'Public route data no IP fallback',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR1_FOLLOWER_URL]
+    })
+
+    const firstFitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      statusId: status.id,
+      path: 'fitness/public-route-data-no-ip-fallback-1.fit',
+      fileName: 'public-route-data-no-ip-fallback-1.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024
+    })
+    const secondFitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      statusId: status.id,
+      path: 'fitness/public-route-data-no-ip-fallback-2.fit',
+      fileName: 'public-route-data-no-ip-fallback-2.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024
+    })
+
+    const firstResponse = await GET(createRequest(), {
+      params: Promise.resolve({ id: firstFitnessFile!.id })
+    })
+    const secondResponse = await GET(createRequest(), {
+      params: Promise.resolve({ id: secondFitnessFile!.id })
+    })
+
+    expect(firstResponse.status).toBe(200)
+    expect(secondResponse.status).toBe(200)
+    expect(
+      routeModule.getFitnessRouteDataSecurityStateForTests?.()
+    ).toMatchObject({
+      routeDataRateLimitSize: 2
+    })
+  })
+
   it('returns not found for private status route data without a session', async () => {
     mockGetServerSession.mockResolvedValue(null)
 

--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -281,14 +281,14 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     expect(mockGetFitnessFile).toHaveBeenCalledTimes(1)
   })
 
-  it('uses the trusted rightmost forwarded address for anonymous rate limiting', async () => {
+  it('uses the originating forwarded address for anonymous rate limiting', async () => {
     mockGetServerSession.mockResolvedValue(null)
 
     const status = await database.createNote({
-      id: `${ACTOR1_ID}/statuses/public-route-data-rightmost-rate-limit`,
-      url: `${ACTOR1_ID}/statuses/public-route-data-rightmost-rate-limit`,
+      id: `${ACTOR1_ID}/statuses/public-route-data-originating-rate-limit`,
+      url: `${ACTOR1_ID}/statuses/public-route-data-originating-rate-limit`,
       actorId: ACTOR1_ID,
-      text: 'Public route data rightmost rate limit',
+      text: 'Public route data originating rate limit',
       to: [ACTIVITY_STREAM_PUBLIC],
       cc: [ACTOR1_FOLLOWER_URL]
     })
@@ -296,8 +296,8 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     const fitnessFile = await database.createFitnessFile({
       actorId: ACTOR1_ID,
       statusId: status.id,
-      path: 'fitness/public-route-data-rightmost-rate-limit.fit',
-      fileName: 'public-route-data-rightmost-rate-limit.fit',
+      path: 'fitness/public-route-data-originating-rate-limit.fit',
+      fileName: 'public-route-data-originating-rate-limit.fit',
       fileType: 'fit',
       mimeType: 'application/vnd.ant.fit',
       bytes: 1_024
@@ -315,7 +315,7 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
       )
     }
 
-    expect(response?.status).toBe(429)
+    expect(response?.status).toBe(200)
   })
 
   it('keeps route-data security maps bounded', () => {

--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -207,6 +207,39 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     })
   })
 
+  it('keeps authenticated public route data out of shared caches', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+
+    const status = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/authenticated-public-route-data`,
+      url: `${ACTOR1_ID}/statuses/authenticated-public-route-data`,
+      actorId: ACTOR1_ID,
+      text: 'Authenticated public route data',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR1_FOLLOWER_URL]
+    })
+
+    const fitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      statusId: status.id,
+      path: 'fitness/authenticated-public-route-data.fit',
+      fileName: 'authenticated-public-route-data.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024
+    })
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ id: fitnessFile!.id })
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(mockParseFitnessFile).toHaveBeenCalled()
+  })
+
   it('caches anonymous public route data parsing responses', async () => {
     mockGetServerSession.mockResolvedValue(null)
 

--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -281,6 +281,61 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     expect(mockGetFitnessFile).toHaveBeenCalledTimes(1)
   })
 
+  it('uses the trusted rightmost forwarded address for anonymous rate limiting', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const status = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/public-route-data-rightmost-rate-limit`,
+      url: `${ACTOR1_ID}/statuses/public-route-data-rightmost-rate-limit`,
+      actorId: ACTOR1_ID,
+      text: 'Public route data rightmost rate limit',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR1_FOLLOWER_URL]
+    })
+
+    const fitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      statusId: status.id,
+      path: 'fitness/public-route-data-rightmost-rate-limit.fit',
+      fileName: 'public-route-data-rightmost-rate-limit.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024
+    })
+
+    let response: Response | null = null
+    for (let index = 0; index < 61; index += 1) {
+      response = await GET(
+        createRequest({
+          'x-forwarded-for': `198.51.100.${index}, 203.0.113.10`
+        }),
+        {
+          params: Promise.resolve({ id: fitnessFile!.id })
+        }
+      )
+    }
+
+    expect(response?.status).toBe(429)
+  })
+
+  it('keeps route-data security maps bounded', () => {
+    routeModule.resetFitnessRouteDataSecurityStateForTests?.()
+
+    for (let index = 0; index < 1_100; index += 1) {
+      routeModule.seedFitnessRouteDataSecurityStateForTests?.({
+        cacheKey: `cache-${index}`,
+        rateLimitKey: `rate-${index}`
+      })
+    }
+
+    expect(
+      routeModule.getFitnessRouteDataSecurityStateForTests?.()
+    ).toMatchObject({
+      publicRouteDataCacheSize: 500,
+      routeDataRateLimitSize: 500
+    })
+  })
+
   it('returns not found for private status route data without a session', async () => {
     mockGetServerSession.mockResolvedValue(null)
 

--- a/app/api/v1/fitness-files/[id]/route-data/route.test.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.test.ts
@@ -20,11 +20,15 @@ jest.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: () => mockGetServerSession()
 }))
 
+const mockGetConfig = jest.fn().mockReturnValue({
+  host: 'llun.test',
+  allowEmails: [],
+  fitnessStorage: {
+    maxFileSize: 4_096
+  }
+})
 jest.mock('@/lib/config', () => ({
-  getConfig: jest.fn().mockReturnValue({
-    host: 'llun.test',
-    allowEmails: []
-  })
+  getConfig: () => mockGetConfig()
 }))
 
 let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
@@ -41,6 +45,12 @@ const mockParseFitnessFile = jest.fn()
 jest.mock('@/lib/services/fitness-files/parseFitnessFile', () => ({
   parseFitnessFile: (...args: unknown[]) => mockParseFitnessFile(...args),
   isParseableFitnessFileType: jest.fn().mockReturnValue(true)
+}))
+
+const mockReadResponseArrayBufferWithLimit = jest.fn()
+jest.mock('@/lib/utils/streamLimit', () => ({
+  readResponseArrayBufferWithLimit: (...args: unknown[]) =>
+    mockReadResponseArrayBufferWithLimit(...args)
 }))
 
 jest.mock('next/headers', () => ({
@@ -64,7 +74,16 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    routeModule.resetFitnessRouteDataSecurityStateForTests?.()
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [],
+      fitnessStorage: {
+        maxFileSize: 4_096
+      }
+    })
+    mockReadResponseArrayBufferWithLimit.mockResolvedValue(
+      new Uint8Array([1, 2, 3]).buffer
+    )
     mockGetFitnessFile.mockResolvedValue({
       type: 'buffer',
       contentType: 'application/vnd.ant.fit',
@@ -240,7 +259,7 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     expect(mockParseFitnessFile).toHaveBeenCalled()
   })
 
-  it('caches anonymous public route data parsing responses', async () => {
+  it('does not cache anonymous public route data in process memory', async () => {
     mockGetServerSession.mockResolvedValue(null)
 
     const status = await database.createNote({
@@ -271,12 +290,12 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
 
     expect(firstResponse.status).toBe(200)
     expect(secondResponse.status).toBe(200)
-    expect(secondResponse.headers.get('X-Route-Data-Cache')).toBe('HIT')
-    expect(mockGetFitnessFile).toHaveBeenCalledTimes(1)
-    expect(mockParseFitnessFile).toHaveBeenCalledTimes(1)
+    expect(secondResponse.headers.get('X-Route-Data-Cache')).toBeNull()
+    expect(mockGetFitnessFile).toHaveBeenCalledTimes(2)
+    expect(mockParseFitnessFile).toHaveBeenCalledTimes(2)
   })
 
-  it('rate-limits anonymous public route data parsing requests', async () => {
+  it('does not trust spoofable forwarded headers for anonymous route-data state', async () => {
     mockGetServerSession.mockResolvedValue(null)
 
     const status = await database.createNote({
@@ -299,45 +318,7 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     })
 
     let response: Response | null = null
-    for (let index = 0; index < 61; index += 1) {
-      response = await GET(
-        createRequest({
-          'x-forwarded-for': '203.0.113.10'
-        }),
-        {
-          params: Promise.resolve({ id: fitnessFile!.id })
-        }
-      )
-    }
-
-    expect(response?.status).toBe(429)
-    expect(mockGetFitnessFile).toHaveBeenCalledTimes(1)
-  })
-
-  it('uses the originating forwarded address for anonymous rate limiting', async () => {
-    mockGetServerSession.mockResolvedValue(null)
-
-    const status = await database.createNote({
-      id: `${ACTOR1_ID}/statuses/public-route-data-originating-rate-limit`,
-      url: `${ACTOR1_ID}/statuses/public-route-data-originating-rate-limit`,
-      actorId: ACTOR1_ID,
-      text: 'Public route data originating rate limit',
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [ACTOR1_FOLLOWER_URL]
-    })
-
-    const fitnessFile = await database.createFitnessFile({
-      actorId: ACTOR1_ID,
-      statusId: status.id,
-      path: 'fitness/public-route-data-originating-rate-limit.fit',
-      fileName: 'public-route-data-originating-rate-limit.fit',
-      fileType: 'fit',
-      mimeType: 'application/vnd.ant.fit',
-      bytes: 1_024
-    })
-
-    let response: Response | null = null
-    for (let index = 0; index < 61; index += 1) {
+    for (let index = 0; index < 3; index += 1) {
       response = await GET(
         createRequest({
           'x-forwarded-for': `198.51.100.${index}, 203.0.113.10`
@@ -349,71 +330,7 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     }
 
     expect(response?.status).toBe(200)
-  })
-
-  it('keeps route-data security maps bounded', () => {
-    routeModule.resetFitnessRouteDataSecurityStateForTests?.()
-
-    for (let index = 0; index < 1_100; index += 1) {
-      routeModule.seedFitnessRouteDataSecurityStateForTests?.({
-        cacheKey: `cache-${index}`,
-        rateLimitKey: `rate-${index}`
-      })
-    }
-
-    expect(
-      routeModule.getFitnessRouteDataSecurityStateForTests?.()
-    ).toMatchObject({
-      publicRouteDataCacheSize: 500,
-      routeDataRateLimitSize: 500
-    })
-  })
-
-  it('derives separate no-IP rate limit fallback keys per route file', async () => {
-    mockGetServerSession.mockResolvedValue(null)
-
-    const status = await database.createNote({
-      id: `${ACTOR1_ID}/statuses/public-route-data-no-ip-fallback`,
-      url: `${ACTOR1_ID}/statuses/public-route-data-no-ip-fallback`,
-      actorId: ACTOR1_ID,
-      text: 'Public route data no IP fallback',
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [ACTOR1_FOLLOWER_URL]
-    })
-
-    const firstFitnessFile = await database.createFitnessFile({
-      actorId: ACTOR1_ID,
-      statusId: status.id,
-      path: 'fitness/public-route-data-no-ip-fallback-1.fit',
-      fileName: 'public-route-data-no-ip-fallback-1.fit',
-      fileType: 'fit',
-      mimeType: 'application/vnd.ant.fit',
-      bytes: 1_024
-    })
-    const secondFitnessFile = await database.createFitnessFile({
-      actorId: ACTOR1_ID,
-      statusId: status.id,
-      path: 'fitness/public-route-data-no-ip-fallback-2.fit',
-      fileName: 'public-route-data-no-ip-fallback-2.fit',
-      fileType: 'fit',
-      mimeType: 'application/vnd.ant.fit',
-      bytes: 1_024
-    })
-
-    const firstResponse = await GET(createRequest(), {
-      params: Promise.resolve({ id: firstFitnessFile!.id })
-    })
-    const secondResponse = await GET(createRequest(), {
-      params: Promise.resolve({ id: secondFitnessFile!.id })
-    })
-
-    expect(firstResponse.status).toBe(200)
-    expect(secondResponse.status).toBe(200)
-    expect(
-      routeModule.getFitnessRouteDataSecurityStateForTests?.()
-    ).toMatchObject({
-      routeDataRateLimitSize: 2
-    })
+    expect(mockGetFitnessFile).toHaveBeenCalledTimes(3)
   })
 
   it('returns not found for private status route data without a session', async () => {
@@ -762,5 +679,58 @@ describe('GET /api/v1/fitness-files/[id]/route-data', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Cache-Control')).toBe('private, no-store')
     expect(mockParseFitnessFile).toHaveBeenCalled()
+  })
+
+  it('uses configured fitness size limit for redirect downloads', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [],
+      fitnessStorage: {
+        maxFileSize: 123_456
+      }
+    })
+    mockGetFitnessFile.mockResolvedValueOnce({
+      type: 'redirect',
+      redirectUrl: 'https://storage.example/fitness/redirect-route-data.fit'
+    })
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('', {
+        status: 200
+      })
+    )
+
+    const fitnessFile = await database.createFitnessFile({
+      actorId: ACTOR1_ID,
+      path: 'fitness/redirect-route-data.fit',
+      fileName: 'redirect-route-data.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 75_000_000
+    })
+
+    try {
+      const response = await GET(createRequest(), {
+        params: Promise.resolve({ id: fitnessFile!.id })
+      })
+
+      expect(response.status).toBe(200)
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://storage.example/fitness/redirect-route-data.fit'
+      )
+      expect(mockReadResponseArrayBufferWithLimit).toHaveBeenCalledWith(
+        expect.any(Response),
+        123_456,
+        'Fitness redirect body'
+      )
+      expect(mockParseFitnessFile).toHaveBeenCalledWith({
+        fileType: 'fit',
+        buffer: Buffer.from([1, 2, 3])
+      })
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 })

--- a/app/api/v1/fitness-files/[id]/route-data/route.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.ts
@@ -462,6 +462,7 @@ export const GET = traceApiRoute(
             data: cached.payload,
             additionalHeaders: [
               ['Cache-Control', 'public, max-age=60'],
+              ['Vary', 'Authorization, Cookie'],
               ['X-Route-Data-Cache', 'HIT']
             ]
           })
@@ -540,8 +541,11 @@ export const GET = traceApiRoute(
         additionalHeaders: [
           [
             'Cache-Control',
-            isPubliclyAccessible ? 'public, max-age=60' : 'private, no-store'
-          ]
+            isAnonymousPublicRequest
+              ? 'public, max-age=60'
+              : 'private, no-store'
+          ],
+          ['Vary', 'Authorization, Cookie']
         ]
       })
     } catch (error) {

--- a/app/api/v1/fitness-files/[id]/route-data/route.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { DEFAULT_FITNESS_MAX_FILE_SIZE } from '@/lib/config/fitnessStorage'
 import { getDatabase } from '@/lib/database'
 import { Database } from '@/lib/database/types'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -25,10 +26,13 @@ import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   ERROR_404,
+  ERROR_429,
   ERROR_500,
+  HTTP_STATUS,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
+import { readResponseArrayBufferWithLimit } from '@/lib/utils/streamLimit'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 interface Params {
@@ -53,6 +57,81 @@ interface FitnessRouteSegment {
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const MAX_ROUTE_SAMPLE_POINTS = 1_500
+const PUBLIC_ROUTE_DATA_CACHE_TTL_MS = 60_000
+const PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS = 60_000
+const PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS = 60
+
+type RouteDataResponsePayload = {
+  samples: FitnessRouteSample[]
+  segments: FitnessRouteSegment[]
+  totalDurationSeconds: number
+  powerSeries?: unknown
+  heartRateSeries?: unknown
+  altitudeSeries?: unknown
+  speedSeries?: unknown
+}
+
+const publicRouteDataCache = new Map<
+  string,
+  { expiresAt: number; payload: RouteDataResponsePayload }
+>()
+const routeDataRateLimit = new Map<string, { resetAt: number; count: number }>()
+
+export const resetFitnessRouteDataSecurityStateForTests = () => {
+  publicRouteDataCache.clear()
+  routeDataRateLimit.clear()
+}
+
+const getClientRateLimitKey = (req: NextRequest) => {
+  const forwardedFor = req.headers.get('x-forwarded-for')
+  const firstForwarded = forwardedFor?.split(',')[0]?.trim()
+  return (
+    firstForwarded ||
+    req.headers.get('x-real-ip') ||
+    req.headers.get('cf-connecting-ip') ||
+    'anonymous'
+  )
+}
+
+const consumePublicRouteDataRateLimit = (key: string) => {
+  const now = Date.now()
+  const existing = routeDataRateLimit.get(key)
+  if (!existing || existing.resetAt <= now) {
+    routeDataRateLimit.set(key, {
+      resetAt: now + PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS,
+      count: 1
+    })
+    return true
+  }
+
+  existing.count += 1
+  return existing.count <= PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS
+}
+
+const getPublicRouteDataCacheKey = ({
+  fileMetadata,
+  privacySettings
+}: {
+  fileMetadata: FitnessFile
+  privacySettings?: {
+    updatedAt?: number
+    privacyHomeLatitude?: number
+    privacyHomeLongitude?: number
+    privacyHideRadiusMeters?: number
+    privacyLocations?: unknown
+  } | null
+}) =>
+  [
+    fileMetadata.id,
+    fileMetadata.updatedAt,
+    fileMetadata.bytes,
+    fileMetadata.processingStatus ?? '',
+    privacySettings?.updatedAt ?? 0,
+    privacySettings?.privacyHomeLatitude ?? '',
+    privacySettings?.privacyHomeLongitude ?? '',
+    privacySettings?.privacyHideRadiusMeters ?? '',
+    JSON.stringify(privacySettings?.privacyLocations ?? [])
+  ].join(':')
 
 const getFetchResponseErrorDetail = async (
   response: Response
@@ -155,7 +234,13 @@ const getFitnessFileBuffer = async (
     )
   }
 
-  return Buffer.from(await response.arrayBuffer())
+  return Buffer.from(
+    await readResponseArrayBufferWithLimit(
+      response,
+      DEFAULT_FITNESS_MAX_FILE_SIZE,
+      'Fitness redirect body'
+    )
+  )
 }
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
@@ -268,6 +353,54 @@ export const GET = traceApiRoute(
         }
       }
 
+      if (!isParseableFitnessFileType(fileMetadata.fileType)) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+
+      const privacySettings = await database.getFitnessSettings({
+        actorId: fileMetadata.actorId,
+        serviceType: 'general'
+      })
+      const isAnonymousPublicRequest = isPubliclyAccessible && !currentActor
+      if (
+        isAnonymousPublicRequest &&
+        !consumePublicRouteDataRateLimit(getClientRateLimitKey(req))
+      ) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_429,
+          responseStatusCode: HTTP_STATUS.TOO_MANY_REQUESTS,
+          additionalHeaders: [['Retry-After', '60']]
+        })
+      }
+
+      const publicCacheKey = isAnonymousPublicRequest
+        ? getPublicRouteDataCacheKey({
+            fileMetadata,
+            privacySettings
+          })
+        : null
+      if (publicCacheKey) {
+        const cached = publicRouteDataCache.get(publicCacheKey)
+        if (cached && cached.expiresAt > Date.now()) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: cached.payload,
+            additionalHeaders: [
+              ['Cache-Control', 'public, max-age=60'],
+              ['X-Route-Data-Cache', 'HIT']
+            ]
+          })
+        }
+      }
+
       const fitnessFileBuffer = await getFitnessFileBuffer(
         id,
         fileMetadata,
@@ -285,14 +418,6 @@ export const GET = traceApiRoute(
           responseStatusCode: 404
         })
       }
-      if (!isParseableFitnessFileType(fileMetadata.fileType)) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
-        })
-      }
 
       const activityData = await parseFitnessFile({
         fileType: fileMetadata.fileType,
@@ -302,10 +427,6 @@ export const GET = traceApiRoute(
         activityData.trackPoints,
         activityData.totalDurationSeconds
       )
-      const privacySettings = await database.getFitnessSettings({
-        actorId: fileMetadata.actorId,
-        serviceType: 'general'
-      })
       const privacyLocation = getFitnessPrivacyLocations(privacySettings)
 
       const privacyAwareSamples = annotatePointsWithPrivacy(
@@ -325,23 +446,31 @@ export const GET = traceApiRoute(
       )
       const responseSamples = flattenPrivacySegments(sampledSegments)
       const responseSegments = toResponseSegments(sampledSegments)
+      const payload: RouteDataResponsePayload = {
+        samples: responseSamples,
+        segments: responseSegments,
+        totalDurationSeconds: activityData.totalDurationSeconds,
+        powerSeries: activityData.powerSeries,
+        heartRateSeries: activityData.heartRateSeries,
+        altitudeSeries: activityData.altitudeSeries,
+        speedSeries: activityData.speedSeries
+      }
+
+      if (publicCacheKey) {
+        publicRouteDataCache.set(publicCacheKey, {
+          expiresAt: Date.now() + PUBLIC_ROUTE_DATA_CACHE_TTL_MS,
+          payload
+        })
+      }
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: {
-          samples: responseSamples,
-          segments: responseSegments,
-          totalDurationSeconds: activityData.totalDurationSeconds,
-          powerSeries: activityData.powerSeries,
-          heartRateSeries: activityData.heartRateSeries,
-          altitudeSeries: activityData.altitudeSeries,
-          speedSeries: activityData.speedSeries
-        },
+        data: payload,
         additionalHeaders: [
           [
             'Cache-Control',
-            isPubliclyAccessible ? 'no-store' : 'private, no-store'
+            isPubliclyAccessible ? 'public, max-age=60' : 'private, no-store'
           ]
         ]
       })

--- a/app/api/v1/fitness-files/[id]/route-data/route.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.ts
@@ -62,6 +62,12 @@ const PUBLIC_ROUTE_DATA_CACHE_TTL_MS = 60_000
 const PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES = 500
 const PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS = 60_000
 const PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS = 60
+const ROUTE_DATA_RATE_LIMIT_FALLBACK_HEADER_NAMES = [
+  'user-agent',
+  'accept-language',
+  'accept',
+  'sec-fetch-site'
+]
 
 type RouteDataResponsePayload = {
   samples: FitnessRouteSample[]
@@ -142,22 +148,44 @@ export const seedFitnessRouteDataSecurityStateForTests = ({
   })
 }
 
-const getClientRateLimitKey = (req: NextRequest) => {
+const enforceRouteDataSecurityMapBounds = (now: number) => {
+  pruneExpiredRouteDataSecurityEntries(now)
+  pruneOldestMapEntries(
+    publicRouteDataCache,
+    PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES
+  )
+  pruneOldestMapEntries(
+    routeDataRateLimit,
+    PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES
+  )
+}
+
+const getClientRateLimitKey = (req: NextRequest, routeDataId: string) => {
   const requestIp = (req as NextRequest & { ip?: string }).ip
   const forwardedFor = req.headers.get('x-forwarded-for')
   const originatingForwarded = forwardedFor?.split(',')[0]?.trim()
-  return (
+  const clientAddress =
     requestIp ||
     req.headers.get('cf-connecting-ip') ||
     req.headers.get('x-real-ip') ||
-    originatingForwarded ||
-    'anonymous'
+    originatingForwarded
+
+  if (clientAddress) {
+    return `ip:${clientAddress}`
+  }
+
+  const fallbackParts = ROUTE_DATA_RATE_LIMIT_FALLBACK_HEADER_NAMES.map(
+    (headerName) => `${headerName}:${req.headers.get(headerName) ?? ''}`
   )
+  const fallbackKey = getHashFromString(
+    [routeDataId, req.nextUrl.pathname, ...fallbackParts].join('\n')
+  )
+  return `request:${fallbackKey}`
 }
 
 const consumePublicRouteDataRateLimit = (key: string) => {
   const now = Date.now()
-  pruneExpiredRouteDataSecurityEntries(now)
+  enforceRouteDataSecurityMapBounds(now)
   const existing = routeDataRateLimit.get(key)
   if (!existing || existing.resetAt <= now) {
     setBoundedMapEntry(routeDataRateLimit, key, {
@@ -435,7 +463,7 @@ export const GET = traceApiRoute(
       const isAnonymousPublicRequest = isPubliclyAccessible && !currentActor
       if (
         isAnonymousPublicRequest &&
-        !consumePublicRouteDataRateLimit(getClientRateLimitKey(req))
+        !consumePublicRouteDataRateLimit(getClientRateLimitKey(req, id))
       ) {
         return apiResponse({
           req,
@@ -453,6 +481,7 @@ export const GET = traceApiRoute(
           })
         : null
       if (publicCacheKey) {
+        enforceRouteDataSecurityMapBounds(Date.now())
         const cached = publicRouteDataCache.get(publicCacheKey)
         if (cached && cached.expiresAt > Date.now()) {
           setBoundedMapEntry(publicRouteDataCache, publicCacheKey, cached)

--- a/app/api/v1/fitness-files/[id]/route-data/route.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.ts
@@ -145,12 +145,12 @@ export const seedFitnessRouteDataSecurityStateForTests = ({
 const getClientRateLimitKey = (req: NextRequest) => {
   const requestIp = (req as NextRequest & { ip?: string }).ip
   const forwardedFor = req.headers.get('x-forwarded-for')
-  const rightmostForwarded = forwardedFor?.split(',').at(-1)?.trim()
+  const originatingForwarded = forwardedFor?.split(',')[0]?.trim()
   return (
     requestIp ||
     req.headers.get('cf-connecting-ip') ||
     req.headers.get('x-real-ip') ||
-    rightmostForwarded ||
+    originatingForwarded ||
     'anonymous'
   )
 }

--- a/app/api/v1/fitness-files/[id]/route-data/route.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
 import { DEFAULT_FITNESS_MAX_FILE_SIZE } from '@/lib/config/fitnessStorage'
 import { getDatabase } from '@/lib/database'
 import { Database } from '@/lib/database/types'
@@ -21,15 +22,12 @@ import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   ERROR_404,
-  ERROR_429,
   ERROR_500,
-  HTTP_STATUS,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -58,16 +56,6 @@ interface FitnessRouteSegment {
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const MAX_ROUTE_SAMPLE_POINTS = 1_500
-const PUBLIC_ROUTE_DATA_CACHE_TTL_MS = 60_000
-const PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES = 500
-const PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS = 60_000
-const PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS = 60
-const ROUTE_DATA_RATE_LIMIT_FALLBACK_HEADER_NAMES = [
-  'user-agent',
-  'accept-language',
-  'accept',
-  'sec-fetch-site'
-]
 
 type RouteDataResponsePayload = {
   samples: FitnessRouteSample[]
@@ -78,154 +66,6 @@ type RouteDataResponsePayload = {
   altitudeSeries?: unknown
   speedSeries?: unknown
 }
-
-const publicRouteDataCache = new Map<
-  string,
-  { expiresAt: number; payload: RouteDataResponsePayload }
->()
-const routeDataRateLimit = new Map<string, { resetAt: number; count: number }>()
-
-export const resetFitnessRouteDataSecurityStateForTests = () => {
-  publicRouteDataCache.clear()
-  routeDataRateLimit.clear()
-}
-
-export const getFitnessRouteDataSecurityStateForTests = () => ({
-  publicRouteDataCacheSize: publicRouteDataCache.size,
-  routeDataRateLimitSize: routeDataRateLimit.size
-})
-
-const pruneExpiredRouteDataSecurityEntries = (now: number) => {
-  for (const [key, cached] of publicRouteDataCache) {
-    if (cached.expiresAt <= now) {
-      publicRouteDataCache.delete(key)
-    }
-  }
-
-  for (const [key, rateLimit] of routeDataRateLimit) {
-    if (rateLimit.resetAt <= now) {
-      routeDataRateLimit.delete(key)
-    }
-  }
-}
-
-const pruneOldestMapEntries = <T>(map: Map<string, T>, maxEntries: number) => {
-  while (map.size > maxEntries) {
-    const oldestKey = map.keys().next().value
-    if (typeof oldestKey !== 'string') {
-      return
-    }
-    map.delete(oldestKey)
-  }
-}
-
-const setBoundedMapEntry = <T>(map: Map<string, T>, key: string, value: T) => {
-  if (map.has(key)) {
-    map.delete(key)
-  }
-  map.set(key, value)
-  pruneOldestMapEntries(map, PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES)
-}
-
-export const seedFitnessRouteDataSecurityStateForTests = ({
-  cacheKey,
-  rateLimitKey
-}: {
-  cacheKey: string
-  rateLimitKey: string
-}) => {
-  setBoundedMapEntry(publicRouteDataCache, cacheKey, {
-    expiresAt: Date.now() + PUBLIC_ROUTE_DATA_CACHE_TTL_MS,
-    payload: {
-      samples: [],
-      segments: [],
-      totalDurationSeconds: 0
-    }
-  })
-  setBoundedMapEntry(routeDataRateLimit, rateLimitKey, {
-    resetAt: Date.now() + PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS,
-    count: 1
-  })
-}
-
-const enforceRouteDataSecurityMapBounds = (now: number) => {
-  pruneExpiredRouteDataSecurityEntries(now)
-  pruneOldestMapEntries(
-    publicRouteDataCache,
-    PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES
-  )
-  pruneOldestMapEntries(
-    routeDataRateLimit,
-    PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES
-  )
-}
-
-const getClientRateLimitKey = (req: NextRequest, routeDataId: string) => {
-  const requestIp = (req as NextRequest & { ip?: string }).ip
-  const forwardedFor = req.headers.get('x-forwarded-for')
-  const originatingForwarded = forwardedFor?.split(',')[0]?.trim()
-  const clientAddress =
-    requestIp ||
-    req.headers.get('cf-connecting-ip') ||
-    req.headers.get('x-real-ip') ||
-    originatingForwarded
-
-  if (clientAddress) {
-    return `ip:${clientAddress}`
-  }
-
-  const fallbackParts = ROUTE_DATA_RATE_LIMIT_FALLBACK_HEADER_NAMES.map(
-    (headerName) => `${headerName}:${req.headers.get(headerName) ?? ''}`
-  )
-  const fallbackKey = getHashFromString(
-    [routeDataId, req.nextUrl.pathname, ...fallbackParts].join('\n')
-  )
-  return `request:${fallbackKey}`
-}
-
-const consumePublicRouteDataRateLimit = (key: string) => {
-  const now = Date.now()
-  enforceRouteDataSecurityMapBounds(now)
-  const existing = routeDataRateLimit.get(key)
-  if (!existing || existing.resetAt <= now) {
-    setBoundedMapEntry(routeDataRateLimit, key, {
-      resetAt: now + PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS,
-      count: 1
-    })
-    return true
-  }
-
-  existing.count += 1
-  return existing.count <= PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS
-}
-
-const getPrivacyLocationsCacheKeyPart = (privacyLocations: unknown) =>
-  getHashFromString(JSON.stringify(privacyLocations ?? []))
-
-const getPublicRouteDataCacheKey = ({
-  fileMetadata,
-  privacySettings
-}: {
-  fileMetadata: FitnessFile
-  privacySettings?: {
-    updatedAt?: number
-    privacyHomeLatitude?: number
-    privacyHomeLongitude?: number
-    privacyHideRadiusMeters?: number
-    privacyLocations?: unknown
-  } | null
-}) =>
-  [
-    fileMetadata.id,
-    fileMetadata.updatedAt,
-    fileMetadata.bytes,
-    fileMetadata.processingStatus ?? '',
-    privacySettings?.updatedAt ?? 0,
-    privacySettings?.privacyHomeLatitude ?? '',
-    privacySettings?.privacyHomeLongitude ?? '',
-    privacySettings?.privacyHideRadiusMeters ?? '',
-    getPrivacyLocationsCacheKeyPart(privacySettings?.privacyLocations)
-  ].join(':')
 
 const getFetchResponseErrorDetail = async (
   response: Response
@@ -331,7 +171,9 @@ const getFitnessFileBuffer = async (
   return Buffer.from(
     await readResponseArrayBufferWithLimit(
       response,
-      DEFAULT_FITNESS_MAX_FILE_SIZE,
+      getConfig().fitnessStorage?.maxFileSize ??
+        fileMetadata.bytes ??
+        DEFAULT_FITNESS_MAX_FILE_SIZE,
       'Fitness redirect body'
     )
   )
@@ -461,45 +303,6 @@ export const GET = traceApiRoute(
         serviceType: 'general'
       })
       const isAnonymousPublicRequest = isPubliclyAccessible && !currentActor
-      if (
-        isAnonymousPublicRequest &&
-        !consumePublicRouteDataRateLimit(getClientRateLimitKey(req, id))
-      ) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_429,
-          responseStatusCode: HTTP_STATUS.TOO_MANY_REQUESTS,
-          additionalHeaders: [['Retry-After', '60']]
-        })
-      }
-
-      const publicCacheKey = isAnonymousPublicRequest
-        ? getPublicRouteDataCacheKey({
-            fileMetadata,
-            privacySettings
-          })
-        : null
-      if (publicCacheKey) {
-        enforceRouteDataSecurityMapBounds(Date.now())
-        const cached = publicRouteDataCache.get(publicCacheKey)
-        if (cached && cached.expiresAt > Date.now()) {
-          setBoundedMapEntry(publicRouteDataCache, publicCacheKey, cached)
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: cached.payload,
-            additionalHeaders: [
-              ['Cache-Control', 'public, max-age=60'],
-              ['Vary', 'Authorization, Cookie'],
-              ['X-Route-Data-Cache', 'HIT']
-            ]
-          })
-        }
-        if (cached) {
-          publicRouteDataCache.delete(publicCacheKey)
-        }
-      }
 
       const fitnessFileBuffer = await getFitnessFileBuffer(
         id,
@@ -554,13 +357,6 @@ export const GET = traceApiRoute(
         heartRateSeries: activityData.heartRateSeries,
         altitudeSeries: activityData.altitudeSeries,
         speedSeries: activityData.speedSeries
-      }
-
-      if (publicCacheKey) {
-        setBoundedMapEntry(publicRouteDataCache, publicCacheKey, {
-          expiresAt: Date.now() + PUBLIC_ROUTE_DATA_CACHE_TTL_MS,
-          payload
-        })
       }
 
       return apiResponse({

--- a/app/api/v1/fitness-files/[id]/route-data/route.ts
+++ b/app/api/v1/fitness-files/[id]/route-data/route.ts
@@ -21,6 +21,7 @@ import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { logger } from '@/lib/utils/logger'
 import {
@@ -58,6 +59,7 @@ interface FitnessRouteSegment {
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const MAX_ROUTE_SAMPLE_POINTS = 1_500
 const PUBLIC_ROUTE_DATA_CACHE_TTL_MS = 60_000
+const PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES = 500
 const PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS = 60_000
 const PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS = 60
 
@@ -82,22 +84,83 @@ export const resetFitnessRouteDataSecurityStateForTests = () => {
   routeDataRateLimit.clear()
 }
 
+export const getFitnessRouteDataSecurityStateForTests = () => ({
+  publicRouteDataCacheSize: publicRouteDataCache.size,
+  routeDataRateLimitSize: routeDataRateLimit.size
+})
+
+const pruneExpiredRouteDataSecurityEntries = (now: number) => {
+  for (const [key, cached] of publicRouteDataCache) {
+    if (cached.expiresAt <= now) {
+      publicRouteDataCache.delete(key)
+    }
+  }
+
+  for (const [key, rateLimit] of routeDataRateLimit) {
+    if (rateLimit.resetAt <= now) {
+      routeDataRateLimit.delete(key)
+    }
+  }
+}
+
+const pruneOldestMapEntries = <T>(map: Map<string, T>, maxEntries: number) => {
+  while (map.size > maxEntries) {
+    const oldestKey = map.keys().next().value
+    if (typeof oldestKey !== 'string') {
+      return
+    }
+    map.delete(oldestKey)
+  }
+}
+
+const setBoundedMapEntry = <T>(map: Map<string, T>, key: string, value: T) => {
+  if (map.has(key)) {
+    map.delete(key)
+  }
+  map.set(key, value)
+  pruneOldestMapEntries(map, PUBLIC_ROUTE_DATA_SECURITY_MAP_MAX_ENTRIES)
+}
+
+export const seedFitnessRouteDataSecurityStateForTests = ({
+  cacheKey,
+  rateLimitKey
+}: {
+  cacheKey: string
+  rateLimitKey: string
+}) => {
+  setBoundedMapEntry(publicRouteDataCache, cacheKey, {
+    expiresAt: Date.now() + PUBLIC_ROUTE_DATA_CACHE_TTL_MS,
+    payload: {
+      samples: [],
+      segments: [],
+      totalDurationSeconds: 0
+    }
+  })
+  setBoundedMapEntry(routeDataRateLimit, rateLimitKey, {
+    resetAt: Date.now() + PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS,
+    count: 1
+  })
+}
+
 const getClientRateLimitKey = (req: NextRequest) => {
+  const requestIp = (req as NextRequest & { ip?: string }).ip
   const forwardedFor = req.headers.get('x-forwarded-for')
-  const firstForwarded = forwardedFor?.split(',')[0]?.trim()
+  const rightmostForwarded = forwardedFor?.split(',').at(-1)?.trim()
   return (
-    firstForwarded ||
-    req.headers.get('x-real-ip') ||
+    requestIp ||
     req.headers.get('cf-connecting-ip') ||
+    req.headers.get('x-real-ip') ||
+    rightmostForwarded ||
     'anonymous'
   )
 }
 
 const consumePublicRouteDataRateLimit = (key: string) => {
   const now = Date.now()
+  pruneExpiredRouteDataSecurityEntries(now)
   const existing = routeDataRateLimit.get(key)
   if (!existing || existing.resetAt <= now) {
-    routeDataRateLimit.set(key, {
+    setBoundedMapEntry(routeDataRateLimit, key, {
       resetAt: now + PUBLIC_ROUTE_DATA_RATE_LIMIT_WINDOW_MS,
       count: 1
     })
@@ -107,6 +170,9 @@ const consumePublicRouteDataRateLimit = (key: string) => {
   existing.count += 1
   return existing.count <= PUBLIC_ROUTE_DATA_RATE_LIMIT_MAX_REQUESTS
 }
+
+const getPrivacyLocationsCacheKeyPart = (privacyLocations: unknown) =>
+  getHashFromString(JSON.stringify(privacyLocations ?? []))
 
 const getPublicRouteDataCacheKey = ({
   fileMetadata,
@@ -130,7 +196,7 @@ const getPublicRouteDataCacheKey = ({
     privacySettings?.privacyHomeLatitude ?? '',
     privacySettings?.privacyHomeLongitude ?? '',
     privacySettings?.privacyHideRadiusMeters ?? '',
-    JSON.stringify(privacySettings?.privacyLocations ?? [])
+    getPrivacyLocationsCacheKeyPart(privacySettings?.privacyLocations)
   ].join(':')
 
 const getFetchResponseErrorDetail = async (
@@ -389,6 +455,7 @@ export const GET = traceApiRoute(
       if (publicCacheKey) {
         const cached = publicRouteDataCache.get(publicCacheKey)
         if (cached && cached.expiresAt > Date.now()) {
+          setBoundedMapEntry(publicRouteDataCache, publicCacheKey, cached)
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,
@@ -398,6 +465,9 @@ export const GET = traceApiRoute(
               ['X-Route-Data-Cache', 'HIT']
             ]
           })
+        }
+        if (cached) {
+          publicRouteDataCache.delete(publicCacheKey)
         }
       }
 
@@ -457,7 +527,7 @@ export const GET = traceApiRoute(
       }
 
       if (publicCacheKey) {
-        publicRouteDataCache.set(publicCacheKey, {
+        setBoundedMapEntry(publicRouteDataCache, publicCacheKey, {
           expiresAt: Date.now() + PUBLIC_ROUTE_DATA_CACHE_TTL_MS,
           payload
         })

--- a/app/api/v1/medias/presigned/route.test.ts
+++ b/app/api/v1/medias/presigned/route.test.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from 'next/server'
+
+import { PATCH } from './route'
+
+const mockCompletePresignedMediaUpload = jest.fn()
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun',
+  account: { id: 'account-1' }
+}
+const mockDatabase = {}
+
+jest.mock('@/lib/services/medias', () => ({
+  completePresignedMediaUpload: (...params: unknown[]) =>
+    mockCompletePresignedMediaUpload(...params),
+  getPresignedUrl: jest.fn()
+}))
+
+jest.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
+  AuthenticatedGuard:
+    (
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor
+      })
+}))
+
+describe('PATCH /api/v1/medias/presigned', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const createRequest = (body: string) =>
+    new NextRequest('https://llun.test/api/v1/medias/presigned', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body
+    })
+
+  it('returns 422 for invalid completion input', async () => {
+    const response = await PATCH(createRequest(JSON.stringify({})), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(422)
+    expect(mockCompletePresignedMediaUpload).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 for unexpected completion failures', async () => {
+    mockCompletePresignedMediaUpload.mockRejectedValueOnce(
+      new Error('storage unavailable')
+    )
+
+    const response = await PATCH(
+      createRequest(JSON.stringify({ mediaId: 'media-1' })),
+      {
+        params: Promise.resolve({})
+      }
+    )
+
+    expect(response.status).toBe(500)
+    expect(mockCompletePresignedMediaUpload).toHaveBeenCalledWith(
+      mockDatabase,
+      mockCurrentActor,
+      'media-1'
+    )
+  })
+})

--- a/app/api/v1/medias/presigned/route.test.ts
+++ b/app/api/v1/medias/presigned/route.test.ts
@@ -73,4 +73,24 @@ describe('PATCH /api/v1/medias/presigned', () => {
       'media-1'
     )
   })
+
+  it('returns 422 for presigned upload verification failures', async () => {
+    const error = new Error('Uploaded object does not match expected checksum')
+    error.name = 'PresignedUploadValidationError'
+    mockCompletePresignedMediaUpload.mockRejectedValueOnce(error)
+
+    const response = await PATCH(
+      createRequest(JSON.stringify({ mediaId: 'media-1' })),
+      {
+        params: Promise.resolve({})
+      }
+    )
+
+    expect(response.status).toBe(422)
+    expect(mockCompletePresignedMediaUpload).toHaveBeenCalledWith(
+      mockDatabase,
+      mockCurrentActor,
+      'media-1'
+    )
+  })
 })

--- a/app/api/v1/medias/presigned/route.test.ts
+++ b/app/api/v1/medias/presigned/route.test.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 
+import { PresignedUploadValidationError } from '@/lib/services/medias'
+
 import { PATCH } from './route'
 
 const mockCompletePresignedMediaUpload = jest.fn()
@@ -12,7 +14,8 @@ const mockDatabase = {}
 jest.mock('@/lib/services/medias', () => ({
   completePresignedMediaUpload: (...params: unknown[]) =>
     mockCompletePresignedMediaUpload(...params),
-  getPresignedUrl: jest.fn()
+  getPresignedUrl: jest.fn(),
+  PresignedUploadValidationError: class PresignedUploadValidationError extends Error {}
 }))
 
 jest.mock('@/lib/services/guards/AuthenticatedGuard', () => ({
@@ -75,9 +78,11 @@ describe('PATCH /api/v1/medias/presigned', () => {
   })
 
   it('returns 422 for presigned upload verification failures', async () => {
-    const error = new Error('Uploaded object does not match expected checksum')
-    error.name = 'PresignedUploadValidationError'
-    mockCompletePresignedMediaUpload.mockRejectedValueOnce(error)
+    mockCompletePresignedMediaUpload.mockRejectedValueOnce(
+      new PresignedUploadValidationError(
+        'Uploaded object does not match expected checksum'
+      )
+    )
 
     const response = await PATCH(
       createRequest(JSON.stringify({ mediaId: 'media-1' })),

--- a/app/api/v1/medias/presigned/route.ts
+++ b/app/api/v1/medias/presigned/route.ts
@@ -10,6 +10,7 @@ import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_404,
   ERROR_422,
+  ERROR_500,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -113,8 +114,8 @@ export const PATCH = traceApiRoute(
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_422,
-        responseStatusCode: 422
+        data: ERROR_500,
+        responseStatusCode: 500
       })
     }
   })

--- a/app/api/v1/medias/presigned/route.ts
+++ b/app/api/v1/medias/presigned/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import {
+  PresignedUploadValidationError,
   completePresignedMediaUpload,
   getPresignedUrl
 } from '@/lib/services/medias'
@@ -25,9 +26,6 @@ const CORS_HEADERS = [
 const CompletePresignedUploadInput = z.object({
   mediaId: z.string().min(1)
 })
-
-const isPresignedUploadVerificationError = (error: unknown) =>
-  error instanceof Error && error.name === 'PresignedUploadValidationError'
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -114,7 +112,7 @@ export const PATCH = traceApiRoute(
         data: { media }
       })
     } catch (error) {
-      if (isPresignedUploadVerificationError(error)) {
+      if (error instanceof PresignedUploadValidationError) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,

--- a/app/api/v1/medias/presigned/route.ts
+++ b/app/api/v1/medias/presigned/route.ts
@@ -1,5 +1,10 @@
+import { z } from 'zod'
+
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
-import { getPresignedUrl } from '@/lib/services/medias'
+import {
+  completePresignedMediaUpload,
+  getPresignedUrl
+} from '@/lib/services/medias'
 import { PresigedMediaInput } from '@/lib/services/medias/types'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -10,7 +15,15 @@ import {
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
-const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.POST,
+  HttpMethod.enum.PATCH
+]
+
+const CompletePresignedUploadInput = z.object({
+  mediaId: z.string().min(1)
+})
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -20,8 +33,8 @@ export const POST = traceApiRoute(
     const { database, currentActor } = context
     try {
       const content = await req.json()
-      const input = PresigedMediaInput.safeParse(content)
-      if (!input.success) {
+      const parsed = PresigedMediaInput.safeParse(content)
+      if (!parsed.success) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -33,7 +46,7 @@ export const POST = traceApiRoute(
       const presigned = await getPresignedUrl(
         database,
         currentActor,
-        input.data
+        parsed.data
       )
 
       if (!presigned) {
@@ -48,6 +61,53 @@ export const POST = traceApiRoute(
         req,
         allowedMethods: CORS_HEADERS,
         data: { presigned }
+      })
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+  })
+)
+
+export const PATCH = traceApiRoute(
+  'completePresignedMediaUpload',
+  AuthenticatedGuard(async (req, context) => {
+    const { database, currentActor } = context
+    try {
+      const parsed = CompletePresignedUploadInput.safeParse(
+        await req.json().catch(() => null)
+      )
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      const media = await completePresignedMediaUpload(
+        database,
+        currentActor,
+        parsed.data.mediaId
+      )
+      if (!media) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { media }
       })
     } catch {
       return apiResponse({

--- a/app/api/v1/medias/presigned/route.ts
+++ b/app/api/v1/medias/presigned/route.ts
@@ -26,6 +26,9 @@ const CompletePresignedUploadInput = z.object({
   mediaId: z.string().min(1)
 })
 
+const isPresignedUploadVerificationError = (error: unknown) =>
+  error instanceof Error && error.name === 'PresignedUploadValidationError'
+
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const POST = traceApiRoute(
@@ -110,7 +113,16 @@ export const PATCH = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: { media }
       })
-    } catch {
+    } catch (error) {
+      if (isPresignedUploadVerificationError(error)) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/settings/fitness/strava/archive/presigned/route.ts
+++ b/app/api/v1/settings/fitness/strava/archive/presigned/route.ts
@@ -61,8 +61,9 @@ export const POST = traceApiRoute(
         return apiErrorResponse(HTTP_STATUS.CONFLICT)
       }
 
-      const content = await req.json()
-      const parsed = PresignedArchiveInput.safeParse(content)
+      const parsed = PresignedArchiveInput.safeParse(
+        await req.json().catch(() => null)
+      )
       if (!parsed.success) {
         return apiErrorResponse(HTTP_STATUS.UNPROCESSABLE_ENTITY)
       }

--- a/app/api/v1/settings/fitness/strava/archive/route.test.ts
+++ b/app/api/v1/settings/fitness/strava/archive/route.test.ts
@@ -1,7 +1,8 @@
 import { IMPORT_STRAVA_ARCHIVE_JOB_NAME } from '@/lib/jobs/names'
 import {
   deleteFitnessFile,
-  saveFitnessFile
+  saveFitnessFile,
+  verifyPresignedFitnessFileUpload
 } from '@/lib/services/fitness-files'
 import { getQueue } from '@/lib/services/queue'
 
@@ -51,7 +52,8 @@ jest.mock('@/lib/utils/getActorFromSession', () => ({
 
 jest.mock('@/lib/services/fitness-files', () => ({
   saveFitnessFile: jest.fn(),
-  deleteFitnessFile: jest.fn()
+  deleteFitnessFile: jest.fn(),
+  verifyPresignedFitnessFileUpload: jest.fn()
 }))
 
 jest.mock('@/lib/services/queue', () => ({
@@ -72,6 +74,10 @@ const mockSaveFitnessFile = saveFitnessFile as jest.MockedFunction<
 const mockDeleteFitnessFile = deleteFitnessFile as jest.MockedFunction<
   typeof deleteFitnessFile
 >
+const mockVerifyPresignedFitnessFileUpload =
+  verifyPresignedFitnessFileUpload as jest.MockedFunction<
+    typeof verifyPresignedFitnessFileUpload
+  >
 
 describe('Strava archive import route', () => {
   const db: MockDatabase = {
@@ -132,6 +138,7 @@ describe('Strava archive import route', () => {
       size: 1024
     })
     mockDeleteFitnessFile.mockResolvedValue(true)
+    mockVerifyPresignedFitnessFileUpload.mockResolvedValue(true)
   })
 
   it('GET returns current active archive import state', async () => {
@@ -420,10 +427,49 @@ describe('Strava archive import route', () => {
       'strava-archive:550e8400-e29b-41d4-a716-446655440001'
     )
     expect(mockSaveFitnessFile).not.toHaveBeenCalled()
+    expect(mockVerifyPresignedFitnessFileUpload).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ id: 'https://llun.test/users/llun' }),
+      expect.objectContaining({ id: 'pre-created-fitness-file-id' })
+    )
     expect(body.importId).toBeDefined()
 
     const queue = getQueue()
     expect(queue.publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('POST with presigned fitnessFileId rejects an oversized completed upload', async () => {
+    mockVerifyPresignedFitnessFileUpload.mockResolvedValueOnce(false)
+    db.getFitnessFile.mockResolvedValueOnce({
+      id: 'pre-created-fitness-file-id',
+      actorId: 'https://llun.test/users/llun',
+      path: 'fitness/2024-01-01/abc.zip',
+      fileName: 'export.zip',
+      fileType: 'zip',
+      mimeType: 'application/zip',
+      bytes: 2048,
+      importBatchId:
+        'strava-archive-source:550e8400-e29b-41d4-a716-446655440005'
+    })
+
+    const req = new Request(
+      'http://localhost/api/v1/settings/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440005',
+          visibility: 'private'
+        })
+      }
+    )
+
+    const response = await POST(req, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(db.createStravaArchiveImport).not.toHaveBeenCalled()
+    expect(getQueue().publish).not.toHaveBeenCalled()
   })
 
   it('POST with presigned fitnessFileId returns 403 when file belongs to different actor', async () => {

--- a/app/api/v1/settings/fitness/strava/archive/route.test.ts
+++ b/app/api/v1/settings/fitness/strava/archive/route.test.ts
@@ -438,6 +438,45 @@ describe('Strava archive import route', () => {
     expect(queue.publish).toHaveBeenCalledTimes(1)
   })
 
+  it('POST with presigned fitnessFileId rolls back verified upload when queueing fails', async () => {
+    getQueue().publish.mockRejectedValueOnce(new Error('queue unavailable'))
+    db.getFitnessFile.mockResolvedValueOnce({
+      id: 'pre-created-fitness-file-id',
+      actorId: 'https://llun.test/users/llun',
+      path: 'fitness/2024-01-01/abc.zip',
+      fileName: 'export.zip',
+      fileType: 'zip',
+      mimeType: 'application/zip',
+      bytes: 2048,
+      importBatchId:
+        'strava-archive-source:550e8400-e29b-41d4-a716-446655440006'
+    })
+
+    const req = new Request(
+      'http://localhost/api/v1/settings/fitness/strava/archive',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fitnessFileId: 'pre-created-fitness-file-id',
+          archiveId: '550e8400-e29b-41d4-a716-446655440006',
+          visibility: 'private'
+        })
+      }
+    )
+
+    const response = await POST(req, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(500)
+    expect(mockDeleteFitnessFile).toHaveBeenCalledWith(
+      expect.any(Object),
+      'pre-created-fitness-file-id'
+    )
+    expect(db.deleteStravaArchiveImport).toHaveBeenCalledWith({
+      id: 'import-1'
+    })
+  })
+
   it('POST with presigned fitnessFileId rejects an oversized completed upload', async () => {
     mockVerifyPresignedFitnessFileUpload.mockResolvedValueOnce(false)
     db.getFitnessFile.mockResolvedValueOnce({

--- a/app/api/v1/settings/fitness/strava/archive/route.ts
+++ b/app/api/v1/settings/fitness/strava/archive/route.ts
@@ -4,7 +4,8 @@ import { z } from 'zod'
 import { IMPORT_STRAVA_ARCHIVE_JOB_NAME } from '@/lib/jobs/names'
 import {
   deleteFitnessFile,
-  saveFitnessFile
+  saveFitnessFile,
+  verifyPresignedFitnessFileUpload
 } from '@/lib/services/fitness-files'
 import { QuotaExceededError } from '@/lib/services/fitness-files/errors'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
@@ -236,6 +237,20 @@ export const POST = traceApiRoute(
           fitnessFile.fileType !== 'zip' ||
           fitnessFile.importBatchId !== sourceBatchId
         ) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_422,
+            responseStatusCode: 422
+          })
+        }
+
+        const verifiedUpload = await verifyPresignedFitnessFileUpload(
+          database,
+          currentActor,
+          fitnessFile
+        )
+        if (!verifiedUpload) {
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,

--- a/app/api/v1/settings/fitness/strava/archive/route.ts
+++ b/app/api/v1/settings/fitness/strava/archive/route.ts
@@ -263,6 +263,7 @@ export const POST = traceApiRoute(
         const importId = crypto.randomUUID()
 
         archiveFileId = fitnessFile.id
+        archiveFileOwned = true
 
         const importState = await database.createStravaArchiveImport({
           id: importId,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -123,6 +123,9 @@ const getAttachmentsFromMediaIds = async (
   const attachments: PostBoxAttachment[] = []
   for (const media of medias) {
     if (!media) return null
+    if (media.original.metaData.upload?.state === 'pending') {
+      return null
+    }
 
     attachments.push({
       type: 'upload',

--- a/docs/fitness-file-storage.md
+++ b/docs/fitness-file-storage.md
@@ -121,3 +121,4 @@ See [Maintenance Scripts](maintenance.md) for general script guidance.
 - Fitness posts default to private visibility in Strava flows unless the user chooses otherwise.
 - Privacy locations hide configured coordinate radii from route maps, route-data responses, and route heatmaps.
 - File type validation and quota enforcement prevent unsupported uploads and storage abuse.
+- Anonymous public route-data responses rely on HTTP caching plus upstream deployment controls for flood protection. Configure a CDN or reverse-proxy rate limiter for `/api/v1/fitness-files/*/route-data` on self-hosted public instances.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -254,3 +254,7 @@ For database-specific Docker deployment instructions:
 
 - [SQLite Docker Deployment](sqlite-setup.md#docker-deployment-with-sqlite)
 - [PostgreSQL Docker Deployment](postgresql-setup.md#docker-deployment-with-postgresql)
+
+### Public Endpoint Protection
+
+Public fitness route-data responses are cacheable for 60 seconds when the source status is public or unlisted and the request is anonymous. Self-hosted deployments that expose public fitness route data should put Activity.next behind an upstream cache and rate limiter, such as nginx `limit_req`, Cloudflare, or an equivalent reverse proxy rule for `/api/v1/fitness-files/*/route-data`. The application does not keep process-local anonymous rate-limit buckets for this endpoint because client IP headers are deployment-specific, spoofable unless normalized by a trusted proxy, and not shared across serverless instances.

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -256,4 +256,28 @@ describe('client uploadAttachment presigned completion', () => {
       expect.objectContaining({ method: 'DELETE' })
     )
   })
+
+  it('does not retry or clean up permanent presigned upload completion failures', async () => {
+    fetchMock
+      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+      .mockResponseOnce('', { status: 200 })
+      .mockResponseOnce('', { status: 422 })
+
+    await expect(
+      uploadAttachment(
+        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+      )
+    ).resolves.toBeNull()
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/v1/medias/presigned',
+      expect.objectContaining({ method: 'PATCH' })
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/v1/accounts/media/media-1',
+      expect.anything()
+    )
+  })
 })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -170,6 +170,8 @@ describe('fitness route heatmap client calls', () => {
 })
 
 describe('client uploadAttachment presigned completion', () => {
+  let setTimeoutSpy: jest.SpyInstance
+
   const presignedResponse = {
     presigned: {
       url: 'https://storage.example/upload',
@@ -199,6 +201,18 @@ describe('client uploadAttachment presigned completion', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks()
+    setTimeoutSpy = jest
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((handler: Parameters<typeof setTimeout>[0]) => {
+        if (typeof handler === 'function') {
+          handler()
+        }
+        return 0 as unknown as ReturnType<typeof setTimeout>
+      })
+  })
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore()
   })
 
   it('retries presigned upload completion after the file PUT succeeds', async () => {
@@ -234,6 +248,8 @@ describe('client uploadAttachment presigned completion', () => {
       '/api/v1/medias/presigned',
       expect.objectContaining({ method: 'PATCH' })
     )
+    expect(setTimeoutSpy).toHaveBeenNthCalledWith(1, expect.any(Function), 250)
+    expect(setTimeoutSpy).toHaveBeenNthCalledWith(2, expect.any(Function), 500)
   })
 
   it('cleans up pending media when presigned upload completion is exhausted', async () => {
@@ -270,6 +286,7 @@ describe('client uploadAttachment presigned completion', () => {
     ).resolves.toBeNull()
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
     expect(fetchMock).toHaveBeenNthCalledWith(
       3,
       '/api/v1/medias/presigned',

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -6,10 +6,15 @@ import {
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmaps,
   triggerFitnessRouteHeatmap,
-  updateNote
+  updateNote,
+  uploadAttachment
 } from './client'
 
 enableFetchMocks()
+
+jest.mock('@/lib/utils/getMediaWidthAndHeight', () => ({
+  getMediaWidthAndHeight: jest.fn().mockResolvedValue({ width: 10, height: 20 })
+}))
 
 describe('client updateNote', () => {
   beforeEach(() => {
@@ -160,6 +165,95 @@ describe('fitness route heatmap client calls', () => {
           retry: true
         })
       })
+    )
+  })
+})
+
+describe('client uploadAttachment presigned completion', () => {
+  const presignedResponse = {
+    presigned: {
+      url: 'https://storage.example/upload',
+      saveFileOutput: {
+        id: 'media-1',
+        type: 'image',
+        mime_type: 'image/png',
+        url: 'https://llun.test/api/v1/files/media-1.png',
+        preview_url: null,
+        text_url: null,
+        remote_url: null,
+        meta: {
+          original: {
+            width: 10,
+            height: 20,
+            size: '10x20',
+            aspect: 0.5
+          }
+        },
+        description: ''
+      },
+      headers: {
+        'x-amz-meta-checksumsha1': 'checksum'
+      }
+    }
+  }
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('retries presigned upload completion after the file PUT succeeds', async () => {
+    fetchMock
+      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+      .mockResponseOnce('', { status: 200 })
+      .mockResponseOnce('', { status: 503 })
+      .mockResponseOnce('', { status: 503 })
+      .mockResponseOnce(
+        JSON.stringify({
+          media: presignedResponse.presigned.saveFileOutput
+        }),
+        { status: 200 }
+      )
+
+    await expect(
+      uploadAttachment(
+        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+      )
+    ).resolves.toMatchObject({
+      id: 'media-1',
+      name: 'photo.png'
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/v1/medias/presigned',
+      expect.objectContaining({ method: 'PATCH' })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      '/api/v1/medias/presigned',
+      expect.objectContaining({ method: 'PATCH' })
+    )
+  })
+
+  it('cleans up pending media when presigned upload completion is exhausted', async () => {
+    fetchMock
+      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+      .mockResponseOnce('', { status: 200 })
+      .mockResponseOnce('', { status: 503 })
+      .mockResponseOnce('', { status: 503 })
+      .mockResponseOnce('', { status: 503 })
+      .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+
+    await expect(
+      uploadAttachment(
+        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+      )
+    ).resolves.toBeNull()
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/v1/accounts/media/media-1',
+      expect.objectContaining({ method: 'DELETE' })
     )
   })
 })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -348,4 +348,41 @@ describe('client startStravaArchiveImport', () => {
       })
     )
   })
+
+  it('does not fall back to multipart upload when presigned import commit is rejected', async () => {
+    fetchMock
+      .mockResponseOnce(
+        JSON.stringify({
+          presigned: {
+            url: 'https://storage.example/archive.zip',
+            fitnessFileId: 'fitness-file-1',
+            archiveId: 'archive-1'
+          }
+        }),
+        { status: 200 }
+      )
+      .mockResponseOnce('', { status: 200 })
+      .mockResponseOnce(JSON.stringify({ error: 'active import' }), {
+        status: 409
+      })
+
+    await expect(
+      startStravaArchiveImport(
+        new File([Buffer.from('zip-data')], 'export.zip', {
+          type: 'application/zip'
+        }),
+        'private'
+      )
+    ).rejects.toThrow('Failed to start Strava archive import')
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/v1/settings/fitness/strava/archive',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+  })
 })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -5,6 +5,7 @@ import {
   getActorStatuses,
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmaps,
+  startStravaArchiveImport,
   triggerFitnessRouteHeatmap,
   updateNote,
   uploadAttachment
@@ -316,6 +317,35 @@ describe('client uploadAttachment presigned completion', () => {
     expect(fetchMock).toHaveBeenLastCalledWith(
       '/api/v1/accounts/media/media-1',
       expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+})
+
+describe('client startStravaArchiveImport', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it('does not fall back to multipart upload when presigned setup is rejected', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'active import' }), {
+      status: 409
+    })
+
+    await expect(
+      startStravaArchiveImport(
+        new File([Buffer.from('zip-data')], 'export.zip', {
+          type: 'application/zip'
+        }),
+        'private'
+      )
+    ).rejects.toThrow('Failed to get presigned URL for archive')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/settings/fitness/strava/archive/presigned',
+      expect.objectContaining({
+        method: 'POST'
+      })
     )
   })
 })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -297,4 +297,25 @@ describe('client uploadAttachment presigned completion', () => {
       expect.anything()
     )
   })
+
+  it('cleans up pending media when presigned upload completion is unauthorized', async () => {
+    fetchMock
+      .mockResponseOnce(JSON.stringify(presignedResponse), { status: 200 })
+      .mockResponseOnce('', { status: 200 })
+      .mockResponseOnce('', { status: 401 })
+      .mockResponseOnce(JSON.stringify({ success: true }), { status: 200 })
+
+    await expect(
+      uploadAttachment(
+        new File(['file-bytes'], 'photo.png', { type: 'image/png' })
+      )
+    ).resolves.toBeNull()
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/v1/accounts/media/media-1',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
 })

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -862,6 +862,9 @@ const completeUploadPresignedUrlRequest = async ({
 const isPermanentCompletionFailure = (status: number) =>
   status >= 400 && status < 500
 
+const shouldCleanupAfterPermanentCompletionFailure = (status: number) =>
+  status === 401 || status === 403
+
 type CompleteUploadPresignedUrlWithRetryResult =
   | { completed: UploadedAttachment; shouldCleanup: false }
   | { completed: null; shouldCleanup: boolean }
@@ -890,7 +893,12 @@ const completeUploadPresignedUrlWithRetry = async ({
         return { completed: completed.attachment, shouldCleanup: false }
       }
       if (isPermanentCompletionFailure(completed.status)) {
-        return { completed: null, shouldCleanup: false }
+        return {
+          completed: null,
+          shouldCleanup: shouldCleanupAfterPermanentCompletionFailure(
+            completed.status
+          )
+        }
       }
     } catch {
       if (attempt === MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1178,7 +1178,16 @@ export const createStravaArchivePresignedUrl = async (
     }
   )
   if (response.status === 404) return null
-  if (!response.ok) throw new Error('Failed to get presigned URL for archive')
+  if (!response.ok) {
+    const errorDetails = await parseApiError(
+      response,
+      'Failed to get presigned URL for archive'
+    )
+    throw new ApiRequestError(
+      `Failed to get presigned URL for archive: ${response.status} ${errorDetails}`,
+      response.status
+    )
+  }
   return response.json()
 }
 
@@ -1187,9 +1196,18 @@ export const startStravaArchiveImport = async (
   visibility: MastodonVisibility
 ): Promise<StartStravaArchiveImportResult> => {
   // Try presigned upload first (ObjectStorage/S3 backends)
-  const presignedResult = await createStravaArchivePresignedUrl(archive).catch(
-    () => null
-  )
+  let presignedResult: StravaArchivePresignedResult | null = null
+  try {
+    presignedResult = await createStravaArchivePresignedUrl(archive)
+  } catch (error) {
+    if (
+      error instanceof ApiRequestError &&
+      error.status >= 400 &&
+      error.status < 500
+    ) {
+      throw error
+    }
+  }
 
   if (presignedResult) {
     try {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -788,16 +788,18 @@ export const createUploadPresignedUrl = async ({
 interface UploadFileToPresignedUrlParams {
   presignedUrl: string
   media: File
+  headers?: Record<string, string>
 }
 
 export const uploadFileToPresignedUrl = async ({
   presignedUrl,
-  media
+  media,
+  headers = {}
 }: UploadFileToPresignedUrlParams) => {
   const response = await fetch(presignedUrl, {
     method: 'PUT',
     body: media,
-    headers: { 'Content-Type': media.type }
+    headers: { 'Content-Type': media.type, ...headers }
   })
   if (!response.ok) {
     const errorText = await response.text().catch(() => '')
@@ -806,6 +808,36 @@ export const uploadFileToPresignedUrl = async ({
     )
   }
   return response
+}
+
+export const completeUploadPresignedUrl = async ({
+  mediaId
+}: {
+  mediaId: string
+}): Promise<UploadedAttachment | null> => {
+  const response = await fetch('/api/v1/medias/presigned', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ mediaId })
+  })
+  if (response.status !== 200) return null
+
+  const result = (await response.json()) as {
+    media: PresignedUrlOutput['saveFileOutput']
+  }
+
+  return {
+    type: 'upload',
+    id: result.media.id,
+    mediaType: result.media.mime_type,
+    url: result.media.url,
+    posterUrl: result.media.preview_url ?? undefined,
+    width: result.media.meta.original.width,
+    height: result.media.meta.original.height,
+    name: result.media.description
+  }
 }
 
 export const uploadAttachment = async (
@@ -827,17 +859,15 @@ export const uploadAttachment = async (
     }
   }
 
-  const { url: presignedUrl, saveFileOutput } = result.presigned
-  await uploadFileToPresignedUrl({ media: file, presignedUrl })
+  const { url: presignedUrl, saveFileOutput, headers } = result.presigned
+  await uploadFileToPresignedUrl({ media: file, presignedUrl, headers })
+  const completed = await completeUploadPresignedUrl({
+    mediaId: saveFileOutput.id
+  })
+  if (!completed) return null
 
   return {
-    type: 'upload',
-    id: saveFileOutput.id,
-    mediaType: saveFileOutput.mime_type,
-    url: saveFileOutput.url,
-    posterUrl: saveFileOutput.preview_url ?? undefined,
-    width: saveFileOutput.meta.original.width,
-    height: saveFileOutput.meta.original.height,
+    ...completed,
     name: file.name
   }
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -833,7 +833,8 @@ const completeUploadPresignedUrlRequest = async ({
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ mediaId })
+    body: JSON.stringify({ mediaId }),
+    signal: AbortSignal.timeout(30_000)
   })
   if (response.status !== 200) {
     return { ok: false, status: response.status }
@@ -866,6 +867,12 @@ type CompleteUploadPresignedUrlWithRetryResult =
   | { completed: null; shouldCleanup: boolean }
 
 const MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS = 3
+const PRESIGNED_UPLOAD_COMPLETION_RETRY_DELAY_MS = 250
+
+const wait = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
 
 const completeUploadPresignedUrlWithRetry = async ({
   mediaId
@@ -889,6 +896,12 @@ const completeUploadPresignedUrlWithRetry = async ({
       if (attempt === MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
         return { completed: null, shouldCleanup: true }
       }
+    }
+
+    if (attempt < MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
+      await wait(
+        PRESIGNED_UPLOAD_COMPLETION_RETRY_DELAY_MS * 2 ** (attempt - 1)
+      )
     }
   }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -840,6 +840,37 @@ export const completeUploadPresignedUrl = async ({
   }
 }
 
+const MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS = 3
+
+const completeUploadPresignedUrlWithRetry = async ({
+  mediaId
+}: {
+  mediaId: string
+}): Promise<UploadedAttachment | null> => {
+  for (
+    let attempt = 1;
+    attempt <= MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      const completed = await completeUploadPresignedUrl({ mediaId })
+      if (completed) return completed
+    } catch {
+      if (attempt === MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
+        return null
+      }
+    }
+  }
+
+  return null
+}
+
+const cleanupPendingUploadMedia = async (mediaId: string) => {
+  await fetch(`/api/v1/accounts/media/${mediaId}`, {
+    method: 'DELETE'
+  }).catch(() => undefined)
+}
+
 export const uploadAttachment = async (
   file: File
 ): Promise<UploadedAttachment | null> => {
@@ -861,10 +892,13 @@ export const uploadAttachment = async (
 
   const { url: presignedUrl, saveFileOutput, headers } = result.presigned
   await uploadFileToPresignedUrl({ media: file, presignedUrl, headers })
-  const completed = await completeUploadPresignedUrl({
+  const completed = await completeUploadPresignedUrlWithRetry({
     mediaId: saveFileOutput.id
   })
-  if (!completed) return null
+  if (!completed) {
+    await cleanupPendingUploadMedia(saveFileOutput.id)
+    return null
+  }
 
   return {
     ...completed,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1210,10 +1210,18 @@ export const startStravaArchiveImport = async (
   }
 
   if (presignedResult) {
+    const { url, fitnessFileId, archiveId } = presignedResult.presigned
+
     try {
-      const { url, fitnessFileId, archiveId } = presignedResult.presigned
       // Upload archive directly to ObjectStorage via presigned PUT.
       await uploadFileToPresignedUrl({ presignedUrl: url, media: archive })
+    } catch {
+      // Presigned PUT failed (e.g. CORS not configured on the bucket).
+      // Fall through to the server-side upload path below.
+      presignedResult = null
+    }
+
+    if (presignedResult) {
       // Notify server to create import record and queue the job
       const response = await fetch('/api/v1/settings/fitness/strava/archive', {
         method: 'POST',
@@ -1224,9 +1232,6 @@ export const startStravaArchiveImport = async (
         throw new Error('Failed to start Strava archive import')
       }
       return response.json()
-    } catch {
-      // Presigned PUT failed (e.g. CORS not configured on the bucket).
-      // Fall through to the server-side upload path below.
     }
   }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -815,6 +815,19 @@ export const completeUploadPresignedUrl = async ({
 }: {
   mediaId: string
 }): Promise<UploadedAttachment | null> => {
+  const result = await completeUploadPresignedUrlRequest({ mediaId })
+  return result.ok ? result.attachment : null
+}
+
+type CompleteUploadPresignedUrlResult =
+  | { ok: true; attachment: UploadedAttachment }
+  | { ok: false; status: number }
+
+const completeUploadPresignedUrlRequest = async ({
+  mediaId
+}: {
+  mediaId: string
+}): Promise<CompleteUploadPresignedUrlResult> => {
   const response = await fetch('/api/v1/medias/presigned', {
     method: 'PATCH',
     headers: {
@@ -822,23 +835,35 @@ export const completeUploadPresignedUrl = async ({
     },
     body: JSON.stringify({ mediaId })
   })
-  if (response.status !== 200) return null
+  if (response.status !== 200) {
+    return { ok: false, status: response.status }
+  }
 
   const result = (await response.json()) as {
     media: PresignedUrlOutput['saveFileOutput']
   }
 
   return {
-    type: 'upload',
-    id: result.media.id,
-    mediaType: result.media.mime_type,
-    url: result.media.url,
-    posterUrl: result.media.preview_url ?? undefined,
-    width: result.media.meta.original.width,
-    height: result.media.meta.original.height,
-    name: result.media.description
+    ok: true,
+    attachment: {
+      type: 'upload',
+      id: result.media.id,
+      mediaType: result.media.mime_type,
+      url: result.media.url,
+      posterUrl: result.media.preview_url ?? undefined,
+      width: result.media.meta.original.width,
+      height: result.media.meta.original.height,
+      name: result.media.description
+    }
   }
 }
+
+const isPermanentCompletionFailure = (status: number) =>
+  status >= 400 && status < 500
+
+type CompleteUploadPresignedUrlWithRetryResult =
+  | { completed: UploadedAttachment; shouldCleanup: false }
+  | { completed: null; shouldCleanup: boolean }
 
 const MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS = 3
 
@@ -846,23 +871,28 @@ const completeUploadPresignedUrlWithRetry = async ({
   mediaId
 }: {
   mediaId: string
-}): Promise<UploadedAttachment | null> => {
+}): Promise<CompleteUploadPresignedUrlWithRetryResult> => {
   for (
     let attempt = 1;
     attempt <= MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS;
     attempt += 1
   ) {
     try {
-      const completed = await completeUploadPresignedUrl({ mediaId })
-      if (completed) return completed
+      const completed = await completeUploadPresignedUrlRequest({ mediaId })
+      if (completed.ok) {
+        return { completed: completed.attachment, shouldCleanup: false }
+      }
+      if (isPermanentCompletionFailure(completed.status)) {
+        return { completed: null, shouldCleanup: false }
+      }
     } catch {
       if (attempt === MAX_PRESIGNED_UPLOAD_COMPLETION_ATTEMPTS) {
-        return null
+        return { completed: null, shouldCleanup: true }
       }
     }
   }
 
-  return null
+  return { completed: null, shouldCleanup: true }
 }
 
 const cleanupPendingUploadMedia = async (mediaId: string) => {
@@ -892,16 +922,18 @@ export const uploadAttachment = async (
 
   const { url: presignedUrl, saveFileOutput, headers } = result.presigned
   await uploadFileToPresignedUrl({ media: file, presignedUrl, headers })
-  const completed = await completeUploadPresignedUrlWithRetry({
+  const completion = await completeUploadPresignedUrlWithRetry({
     mediaId: saveFileOutput.id
   })
-  if (!completed) {
-    await cleanupPendingUploadMedia(saveFileOutput.id)
+  if (!completion.completed) {
+    if (completion.shouldCleanup) {
+      await cleanupPendingUploadMedia(saveFileOutput.id)
+    }
     return null
   }
 
   return {
-    ...completed,
+    ...completion.completed,
     name: file.name
   }
 }

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -21,6 +21,7 @@ import {
   GetMediaByIdParams,
   GetMediasForAccountParams,
   GetStorageUsageForAccountParams,
+  MarkMediaUploadVerifiedParams,
   Media,
   MediaDatabase,
   PaginatedMediaWithStatus
@@ -78,6 +79,51 @@ const deleteMediaById = async (
   database: Knex,
   mediaId: string
 ): Promise<boolean> => deleteMediaByConditions(database, { id: mediaId })
+
+type MediaRow = {
+  id: string | number
+  actorId: string
+  original: string
+  originalBytes: number | string | bigint
+  originalMimeType: string
+  originalMetaData: string
+  originalFileName?: string | null
+  thumbnail?: string | null
+  thumbnailBytes?: number | string | bigint | null
+  thumbnailMimeType?: string | null
+  thumbnailMetaData?: string | null
+  description?: string | null
+}
+
+type MediaMetaData = Media['original']['metaData']
+
+const parseMediaMetaData = (
+  input?: string | MediaMetaData | null
+): MediaMetaData =>
+  getCompatibleJSON<MediaMetaData>(input ?? ({} as MediaMetaData))
+
+const parseMediaRow = (data: MediaRow): Media => ({
+  id: String(data.id),
+  actorId: data.actorId,
+  original: {
+    path: data.original,
+    bytes: Number(data.originalBytes),
+    mimeType: data.originalMimeType,
+    metaData: parseMediaMetaData(data.originalMetaData),
+    ...(data.originalFileName ? { fileName: data.originalFileName } : {})
+  },
+  ...(data.thumbnail
+    ? {
+        thumbnail: {
+          path: data.thumbnail,
+          bytes: Number(data.thumbnailBytes),
+          mimeType: data.thumbnailMimeType ?? '',
+          metaData: parseMediaMetaData(data.thumbnailMetaData)
+        }
+      }
+    : {}),
+  ...(data.description ? { description: data.description } : {})
+})
 
 export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
   async createMedia({
@@ -143,6 +189,55 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         ...(description ? { description } : null)
       } as Media
     })
+  },
+  async markMediaUploadVerified({
+    mediaId,
+    accountId,
+    verifiedAt
+  }: MarkMediaUploadVerifiedParams): Promise<Media | null> {
+    const data = await database('medias')
+      .join('actors', 'medias.actorId', 'actors.id')
+      .where('medias.id', mediaId)
+      .where('actors.accountId', accountId)
+      .select(
+        'medias.id',
+        'medias.actorId',
+        'medias.original',
+        'medias.originalBytes',
+        'medias.originalMimeType',
+        'medias.originalMetaData',
+        'medias.originalFileName',
+        'medias.thumbnail',
+        'medias.thumbnailBytes',
+        'medias.thumbnailMimeType',
+        'medias.thumbnailMetaData',
+        'medias.description'
+      )
+      .first<MediaRow>()
+
+    if (!data) return null
+
+    const media = parseMediaRow(data)
+    const metaData = {
+      ...media.original.metaData,
+      upload: {
+        ...media.original.metaData.upload,
+        state: 'verified' as const,
+        verifiedAt
+      }
+    }
+
+    await database('medias')
+      .where('id', media.id)
+      .update({ originalMetaData: JSON.stringify(metaData) })
+
+    return {
+      ...media,
+      original: {
+        ...media.original,
+        metaData
+      }
+    }
   },
   async createAttachment({
     actorId,
@@ -330,7 +425,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         path: item.original,
         bytes: Number(item.originalBytes),
         mimeType: item.originalMimeType,
-        metaData: getCompatibleJSON(item.originalMetaData),
+        metaData: parseMediaMetaData(item.originalMetaData),
         ...(item.originalFileName ? { fileName: item.originalFileName } : {})
       },
       ...(item.thumbnail
@@ -339,7 +434,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
               path: item.thumbnail,
               bytes: Number(item.thumbnailBytes),
               mimeType: item.thumbnailMimeType,
-              metaData: getCompatibleJSON(item.thumbnailMetaData)
+              metaData: parseMediaMetaData(item.thumbnailMetaData)
             }
           }
         : {}),
@@ -376,28 +471,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
 
     if (!data) return null
 
-    return {
-      id: String(data.id),
-      actorId: data.actorId,
-      original: {
-        path: data.original,
-        bytes: Number(data.originalBytes),
-        mimeType: data.originalMimeType,
-        metaData: getCompatibleJSON(data.originalMetaData),
-        ...(data.originalFileName ? { fileName: data.originalFileName } : {})
-      },
-      ...(data.thumbnail
-        ? {
-            thumbnail: {
-              path: data.thumbnail,
-              bytes: Number(data.thumbnailBytes),
-              mimeType: data.thumbnailMimeType,
-              metaData: getCompatibleJSON(data.thumbnailMetaData)
-            }
-          }
-        : {}),
-      ...(data.description ? { description: data.description } : {})
-    }
+    return parseMediaRow(data)
   },
 
   async getStorageUsageForAccount({

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -582,7 +582,8 @@ describe('importStravaActivityJob', () => {
       new Response(new Uint8Array([1, 2, 3]), {
         status: 200,
         headers: {
-          'content-type': 'image/jpeg'
+          'content-type': 'image/jpeg',
+          'content-length': '3'
         }
       })
     )

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -637,6 +637,53 @@ describe('importStravaActivityJob', () => {
     }
   })
 
+  it('skips oversized Strava photos without buffering or storing them', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: {
+          'content-type': 'image/jpeg',
+          'content-length': String(10 * 1024 * 1024 + 1)
+        }
+      })
+    )
+
+    mockGetStravaActivity.mockResolvedValueOnce({
+      id: 126,
+      name: 'Morning Run With Large Photo',
+      distance: 5_000,
+      elapsed_time: 1_500,
+      total_elevation_gain: 120,
+      start_date: '2026-01-01T00:00:00.000Z',
+      sport_type: 'Run',
+      visibility: 'everyone'
+    })
+    mockGetStravaActivityStreams.mockResolvedValueOnce(null)
+    mockGetStravaActivityPhotos.mockResolvedValueOnce([
+      {
+        id: 'large-photo',
+        url: 'https://images.example.com/large-photo.jpg'
+      }
+    ])
+
+    try {
+      await importStravaActivityJob(database as unknown as Database, {
+        id: 'job-no-upload-oversized-photo',
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: {
+          actorId: 'actor-1',
+          stravaActivityId: '126'
+        }
+      })
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(mockSaveMedia).not.toHaveBeenCalled()
+      expect(database.createAttachment).not.toHaveBeenCalled()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   it('imports via fitness pipeline using GPX as fallback when TCX is unavailable', async () => {
     mockGetStravaActivity.mockResolvedValueOnce({
       id: 125,

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -40,6 +40,10 @@ import { Visibility } from '@/lib/types/mastodon/visibility'
 import { getManufacturerKeyFromDeviceName } from '@/lib/utils/fitnessDeviceBrands'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
+import {
+  SAFE_DOWNLOAD_MAX_BYTES,
+  readResponseArrayBufferWithLimit
+} from '@/lib/utils/streamLimit'
 
 import { createJobHandle } from './createJobHandle'
 
@@ -329,7 +333,11 @@ const attachStravaPhotosToStatus = async ({
         continue
       }
 
-      const buffer = await photoResponse.arrayBuffer()
+      const buffer = await readResponseArrayBufferWithLimit(
+        photoResponse,
+        SAFE_DOWNLOAD_MAX_BYTES,
+        'Strava photo'
+      )
       if (buffer.byteLength <= 0) {
         continue
       }

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -578,6 +578,81 @@ describe('importStravaArchiveJob', () => {
     )
   })
 
+  it('rolls back staged fitness files sequentially when import enqueue fails', async () => {
+    mockArchiveReaderOpen.mockResolvedValueOnce({
+      close: jest.fn(),
+      hasEntry: jest.fn().mockReturnValue(true),
+      getActivities: jest.fn().mockResolvedValue([
+        {
+          activityId: 'activity-1',
+          activityName: 'Morning Ride',
+          fitnessFilePath: 'activities/activity-1.fit',
+          mediaPaths: []
+        },
+        {
+          activityId: 'activity-2',
+          activityName: 'Evening Ride',
+          fitnessFilePath: 'activities/activity-2.fit',
+          mediaPaths: []
+        }
+      ]),
+      readEntryBuffer: jest.fn().mockResolvedValue(Buffer.from('fitness-file'))
+    } as never)
+    mockSaveFitnessFile
+      .mockResolvedValueOnce({
+        id: 'activity-file-1',
+        type: 'fitness',
+        file_type: 'fit',
+        mime_type: 'application/vnd.ant.fit',
+        url: 'https://llun.test/api/v1/fitness-files/activity-file-1',
+        fileName: 'activity-1.fit',
+        size: 16
+      })
+      .mockResolvedValueOnce({
+        id: 'activity-file-2',
+        type: 'fitness',
+        file_type: 'fit',
+        mime_type: 'application/vnd.ant.fit',
+        url: 'https://llun.test/api/v1/fitness-files/activity-file-2',
+        fileName: 'activity-2.fit',
+        size: 16
+      })
+    mockQueuePublish.mockRejectedValueOnce(new Error('queue unavailable'))
+
+    let activeDeletes = 0
+    let maxActiveDeletes = 0
+    mockDeleteFitnessFile.mockImplementation(async () => {
+      activeDeletes += 1
+      maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes)
+      await Promise.resolve()
+      activeDeletes -= 1
+      return true
+    })
+
+    await importStravaArchiveJob(database as unknown as Database, {
+      id: 'job-queue-fail-sequential-rollback',
+      name: IMPORT_STRAVA_ARCHIVE_JOB_NAME,
+      data: {
+        importId: 'import-1',
+        actorId: 'actor-1',
+        archiveId: 'archive-1',
+        archiveFitnessFileId: 'archive-file-1',
+        batchId: 'strava-archive:archive-1',
+        visibility: 'private'
+      }
+    })
+
+    expect(mockDeleteFitnessFile).toHaveBeenCalledWith(
+      database,
+      'activity-file-1'
+    )
+    expect(mockDeleteFitnessFile).toHaveBeenCalledWith(
+      database,
+      'activity-file-2'
+    )
+    expect(maxActiveDeletes).toBe(1)
+  })
+
   it('cleans up archive source file when actor no longer exists', async () => {
     database.getActorFromId.mockResolvedValueOnce(null as never)
 

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -317,6 +317,15 @@ describe('importStravaArchiveJob', () => {
         }
       }
     )
+    expect(mockToFitnessPayload).toHaveBeenCalledWith(
+      {
+        fitnessFilePath: 'activities/activity-1.fit',
+        buffer: Buffer.from('fitness-file')
+      },
+      {
+        maxGzipOutputBytes: 123_456_789
+      }
+    )
   })
 
   it('splits import into continuation when runtime budget is reached', async () => {

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -285,6 +285,40 @@ describe('importStravaArchiveJob', () => {
     )
   })
 
+  it('opens archive entries with the configured fitness file size limit', async () => {
+    mockGetConfig.mockReturnValue({
+      fitnessStorage: {
+        type: 'fs',
+        path: '/tmp/fitness',
+        maxFileSize: 123_456_789
+      }
+    } as never)
+
+    await importStravaArchiveJob(database as unknown as Database, {
+      id: 'job-configured-reader-limit',
+      name: IMPORT_STRAVA_ARCHIVE_JOB_NAME,
+      data: {
+        importId: 'import-1',
+        actorId: 'actor-1',
+        archiveId: 'archive-1',
+        archiveFitnessFileId: 'archive-file-1',
+        batchId: 'strava-archive:archive-1',
+        visibility: 'private'
+      }
+    })
+
+    expect(mockArchiveReaderOpen).toHaveBeenCalledWith(
+      '/tmp/fitness/archive/path.fit',
+      {
+        limits: {
+          maxEntryCompressedBytes: 123_456_789,
+          maxEntryUncompressedBytes: 123_456_789,
+          maxGzipOutputBytes: 123_456_789
+        }
+      }
+    )
+  })
+
   it('splits import into continuation when runtime budget is reached', async () => {
     let nowCall = 0
     const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => {

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -1,3 +1,7 @@
+import fs from 'fs/promises'
+import { Readable } from 'stream'
+
+import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { importStravaArchiveJob } from '@/lib/jobs/importStravaArchiveJob'
 import {
@@ -16,14 +20,17 @@ import {
 } from '@/lib/services/strava/archiveReader'
 
 const mockQueuePublish = jest.fn()
+const mockS3Send = jest.fn()
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  GetObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: mockS3Send
+  }))
+}))
 
 jest.mock('@/lib/config', () => ({
-  getConfig: jest.fn().mockReturnValue({
-    fitnessStorage: {
-      type: 'fs',
-      path: '/tmp/fitness'
-    }
-  })
+  getConfig: jest.fn()
 }))
 
 jest.mock('@/lib/services/fitness-files', () => ({
@@ -57,6 +64,7 @@ const mockDeleteFitnessFile = deleteFitnessFile as jest.MockedFunction<
   typeof deleteFitnessFile
 >
 const mockSaveMedia = saveMedia as jest.MockedFunction<typeof saveMedia>
+const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
 
 const mockArchiveReaderOpen = StravaArchiveReader.open as jest.MockedFunction<
   typeof StravaArchiveReader.open
@@ -94,6 +102,12 @@ describe('importStravaArchiveJob', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGetConfig.mockReturnValue({
+      fitnessStorage: {
+        type: 'fs',
+        path: '/tmp/fitness'
+      }
+    } as never)
 
     database.getActorFromId.mockResolvedValue({
       id: 'actor-1',
@@ -427,6 +441,53 @@ describe('importStravaArchiveJob', () => {
         id: 'import-1',
         status: 'failed',
         lastError: 'broken zip'
+      })
+    )
+  })
+
+  it('removes temporary object-storage archive copy when streaming fails', async () => {
+    mockGetConfig.mockReturnValue({
+      fitnessStorage: {
+        type: 's3',
+        bucket: 'fitness-bucket',
+        region: 'us-east-1',
+        prefix: '',
+        maxFileSize: 4
+      }
+    } as never)
+    mockS3Send.mockResolvedValueOnce({
+      Body: Readable.from([Buffer.from('partial-data')]),
+      ContentLength: undefined
+    })
+    const unlinkSpy = jest.spyOn(fs, 'unlink')
+
+    try {
+      await importStravaArchiveJob(database as unknown as Database, {
+        id: 'job-object-stream-fail',
+        name: IMPORT_STRAVA_ARCHIVE_JOB_NAME,
+        data: {
+          importId: 'import-1',
+          actorId: 'actor-1',
+          archiveId: 'archive-1',
+          archiveFitnessFileId: 'archive-file-1',
+          batchId: 'strava-archive:archive-1',
+          visibility: 'private'
+        }
+      })
+
+      expect(unlinkSpy).toHaveBeenCalledWith(
+        expect.stringContaining('strava-archive-archive-file-1-')
+      )
+    } finally {
+      unlinkSpy.mockRestore()
+    }
+
+    expect(mockArchiveReaderOpen).not.toHaveBeenCalled()
+    expect(database.updateStravaArchiveImport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'import-1',
+        status: 'failed',
+        lastError: 'Archive object body exceeds byte limit of 4 bytes'
       })
     )
   })

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -15,6 +15,7 @@ import {
 import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
 import { saveMedia } from '@/lib/services/medias/index'
 import {
+  StravaArchiveLimitError,
   StravaArchiveReader,
   toStravaArchiveFitnessFilePayload
 } from '@/lib/services/strava/archiveReader'
@@ -50,6 +51,9 @@ jest.mock('@/lib/services/medias/index', () => ({
 }))
 
 jest.mock('@/lib/services/strava/archiveReader', () => ({
+  StravaArchiveLimitError: jest.requireActual(
+    '@/lib/services/strava/archiveReader'
+  ).StravaArchiveLimitError,
   StravaArchiveReader: {
     open: jest.fn()
   },
@@ -78,6 +82,7 @@ type MockDatabase = Pick<
   Database,
   | 'getActorFromId'
   | 'getFitnessFile'
+  | 'getFitnessFilesByBatchId'
   | 'getFitnessFilesByIds'
   | 'getStravaArchiveImportById'
   | 'updateStravaArchiveImport'
@@ -91,6 +96,7 @@ describe('importStravaArchiveJob', () => {
   const database: jest.Mocked<MockDatabase> = {
     getActorFromId: jest.fn(),
     getFitnessFile: jest.fn(),
+    getFitnessFilesByBatchId: jest.fn(),
     getFitnessFilesByIds: jest.fn(),
     getStravaArchiveImportById: jest.fn(),
     updateStravaArchiveImport: jest.fn(),
@@ -140,6 +146,7 @@ describe('importStravaArchiveJob', () => {
         importStatus: 'completed'
       } as never
     ])
+    database.getFitnessFilesByBatchId.mockResolvedValue([])
     database.getStravaArchiveImportById.mockResolvedValue({
       id: 'import-1',
       actorId: 'actor-1',
@@ -712,6 +719,94 @@ describe('importStravaArchiveJob', () => {
       'activity-file-2'
     )
     expect(maxActiveDeletes).toBe(1)
+  })
+
+  it('rolls back earlier batch fitness files when a continuation hits an archive limit', async () => {
+    mockArchiveReaderOpen.mockResolvedValueOnce({
+      close: jest.fn(),
+      hasEntry: jest.fn().mockReturnValue(true),
+      getActivities: jest.fn().mockResolvedValue([
+        {
+          activityId: 'activity-1',
+          activityName: 'Earlier Ride',
+          fitnessFilePath: 'activities/activity-1.fit',
+          mediaPaths: []
+        },
+        {
+          activityId: 'activity-2',
+          activityName: 'Current Ride',
+          fitnessFilePath: 'activities/activity-2.fit',
+          mediaPaths: []
+        },
+        {
+          activityId: 'activity-3',
+          activityName: 'Oversized Ride',
+          fitnessFilePath: 'activities/activity-3.fit',
+          mediaPaths: []
+        }
+      ]),
+      readEntryBuffer: jest
+        .fn()
+        .mockResolvedValueOnce(Buffer.from('fitness-file'))
+        .mockRejectedValueOnce(
+          new StravaArchiveLimitError(
+            'Archive entry activities/activity-3.fit exceeds compressed size limit'
+          )
+        )
+    } as never)
+    mockSaveFitnessFile.mockResolvedValueOnce({
+      id: 'activity-file-current',
+      type: 'fitness',
+      file_type: 'fit',
+      mime_type: 'application/vnd.ant.fit',
+      url: 'https://llun.test/api/v1/fitness-files/activity-file-current',
+      fileName: 'activity-2.fit',
+      size: 16
+    })
+    database.getFitnessFilesByBatchId.mockResolvedValueOnce([
+      {
+        id: 'activity-file-previous',
+        actorId: 'actor-1',
+        importBatchId: 'strava-archive:archive-1'
+      } as never
+    ])
+
+    await importStravaArchiveJob(database as unknown as Database, {
+      id: 'job-limit-continuation-rollback',
+      name: IMPORT_STRAVA_ARCHIVE_JOB_NAME,
+      data: {
+        importId: 'import-1',
+        actorId: 'actor-1',
+        archiveId: 'archive-1',
+        archiveFitnessFileId: 'archive-file-1',
+        batchId: 'strava-archive:archive-1',
+        visibility: 'private',
+        nextActivityIndex: 1,
+        completedActivitiesCount: 1
+      }
+    })
+
+    expect(mockDeleteFitnessFile).toHaveBeenCalledWith(
+      database,
+      'activity-file-previous'
+    )
+    expect(mockDeleteFitnessFile).toHaveBeenCalledWith(
+      database,
+      'activity-file-current'
+    )
+    expect(mockDeleteFitnessFile).not.toHaveBeenCalledWith(
+      database,
+      'archive-file-1',
+      expect.anything()
+    )
+    expect(database.updateStravaArchiveImport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'import-1',
+        status: 'failed',
+        lastError:
+          'Archive entry activities/activity-3.fit exceeds compressed size limit'
+      })
+    )
   })
 
   it('cleans up archive source file when actor no longer exists', async () => {

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -8,6 +8,7 @@ import { pipeline } from 'stream/promises'
 import type { ReadableStream as NodeReadableStream } from 'stream/web'
 import { z } from 'zod'
 
+import { DEFAULT_FITNESS_MAX_FILE_SIZE } from '@/lib/config/fitnessStorage'
 import { Database } from '@/lib/database/types'
 import { IMPORT_FITNESS_FILES_JOB_NAME } from '@/lib/jobs/names'
 import {
@@ -15,11 +16,13 @@ import {
   getEffectiveFitnessStorageConfig,
   saveFitnessFile
 } from '@/lib/services/fitness-files'
+import { assertFitnessStoragePath } from '@/lib/services/fitness-files/path'
 import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
 import { saveMedia } from '@/lib/services/medias/index'
 import { getQueue } from '@/lib/services/queue'
 import {
   StravaArchiveActivity,
+  StravaArchiveLimitError,
   StravaArchiveReader,
   getArchiveMediaMimeType,
   toStravaArchiveFitnessFilePayload
@@ -27,6 +30,11 @@ import {
 import { Actor } from '@/lib/types/domain/actor'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
+import {
+  assertByteLengthWithinLimit,
+  createByteLimitTransform,
+  readAsyncIterableToBufferWithLimit
+} from '@/lib/utils/streamLimit'
 
 import { createJobHandle } from './createJobHandle'
 import { IMPORT_STRAVA_ARCHIVE_JOB_NAME } from './names'
@@ -101,13 +109,19 @@ const getUniqueAttachmentName = ({
 
 const streamBodyToFile = async ({
   body,
-  outputPath
+  outputPath,
+  maxBytes
 }: {
   body: unknown
   outputPath: string
+  maxBytes: number
 }) => {
   if (body && typeof body === 'object' && 'pipe' in body) {
-    await pipeline(body as NodeJS.ReadableStream, createWriteStream(outputPath))
+    await pipeline(
+      body as NodeJS.ReadableStream,
+      createByteLimitTransform(maxBytes, 'Archive object body'),
+      createWriteStream(outputPath)
+    )
     return
   }
 
@@ -121,7 +135,11 @@ const streamBodyToFile = async ({
     const webStream = (
       body as { transformToWebStream: () => NodeReadableStream }
     ).transformToWebStream()
-    await pipeline(Readable.fromWeb(webStream), createWriteStream(outputPath))
+    await pipeline(
+      Readable.fromWeb(webStream),
+      createByteLimitTransform(maxBytes, 'Archive object body'),
+      createWriteStream(outputPath)
+    )
     return
   }
 
@@ -132,9 +150,26 @@ const streamBodyToFile = async ({
     typeof (body as { transformToByteArray: () => Promise<Uint8Array> })
       .transformToByteArray === 'function'
   ) {
-    const bytes = await (
-      body as { transformToByteArray: () => Promise<Uint8Array> }
-    ).transformToByteArray()
+    const bytes = Buffer.from(
+      await (
+        body as { transformToByteArray: () => Promise<Uint8Array> }
+      ).transformToByteArray()
+    )
+    assertByteLengthWithinLimit({
+      byteLength: bytes.byteLength,
+      maxBytes,
+      label: 'Archive object body'
+    })
+    await fs.writeFile(outputPath, bytes)
+    return
+  }
+
+  if (body && Symbol.asyncIterator in Object(body)) {
+    const bytes = await readAsyncIterableToBufferWithLimit(
+      body as AsyncIterable<unknown>,
+      maxBytes,
+      'Archive object body'
+    )
     await fs.writeFile(outputPath, bytes)
     return
   }
@@ -153,7 +188,10 @@ const resolveArchivePath = async (
 
   if (fitnessStorage.type === 'fs') {
     return {
-      archiveFilePath: path.resolve(fitnessStorage.path, archivePath),
+      archiveFilePath: assertFitnessStoragePath(
+        fitnessStorage.path,
+        archivePath
+      ),
       cleanup: async () => {}
     }
   }
@@ -176,10 +214,16 @@ const resolveArchivePath = async (
   if (!object.Body) {
     throw new Error('Archive object body is empty')
   }
+  assertByteLengthWithinLimit({
+    byteLength: object.ContentLength,
+    maxBytes: fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE,
+    label: 'Archive object body'
+  })
 
   await streamBodyToFile({
     body: object.Body,
-    outputPath: temporaryArchivePath
+    outputPath: temporaryArchivePath,
+    maxBytes: fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE
   })
 
   return {
@@ -229,6 +273,35 @@ const getImportedFitnessFiles = async ({
   }
 
   return importedFiles
+}
+
+const rollbackSavedArchiveFitnessFiles = async ({
+  database,
+  fitnessFileIds
+}: {
+  database: Database
+  fitnessFileIds: string[]
+}) => {
+  const rollbackResults = await Promise.all(
+    fitnessFileIds.map(async (fitnessFileId) => {
+      try {
+        const deleted = await deleteFitnessFile(database, fitnessFileId)
+        return {
+          fitnessFileId,
+          deleted
+        }
+      } catch {
+        return {
+          fitnessFileId,
+          deleted: false
+        }
+      }
+    })
+  )
+
+  return rollbackResults
+    .filter((result) => !result.deleted)
+    .map((result) => result.fitnessFileId)
 }
 
 const attachActivityMediaToStatus = async ({
@@ -661,7 +734,7 @@ export const importStravaArchiveJob = createJobHandle(
             throw new Error('Fitness activity file is missing from archive')
           }
 
-          const fitnessPayload = toStravaArchiveFitnessFilePayload({
+          const fitnessPayload = await toStravaArchiveFitnessFilePayload({
             fitnessFilePath: archiveActivity.fitnessFilePath,
             buffer: fitnessArchiveBuffer
           })
@@ -689,6 +762,26 @@ export const importStravaArchiveJob = createJobHandle(
           })
         } catch (error) {
           const nodeError = error as Error
+          if (nodeError instanceof StravaArchiveLimitError) {
+            const rollbackFailures = await rollbackSavedArchiveFitnessFiles({
+              database,
+              fitnessFileIds: savedArchiveActivities.map(
+                ({ fitnessFileId }) => fitnessFileId
+              )
+            })
+            if (rollbackFailures.length > 0) {
+              logger.error({
+                message:
+                  'Failed to rollback staged Strava archive fitness files after archive limit rejection',
+                actorId,
+                archiveId,
+                importId,
+                rollbackFailures
+              })
+            }
+            throw nodeError
+          }
+
           failedActivities += 1
           if (!importFailureMessage) {
             importFailureMessage = nodeError.message
@@ -723,25 +816,10 @@ export const importStravaArchiveJob = createJobHandle(
             }
           })
         } catch (error) {
-          const rollbackResults = await Promise.all(
-            savedFitnessFileIds.map(async (fitnessFileId) => {
-              try {
-                const deleted = await deleteFitnessFile(database, fitnessFileId)
-                return {
-                  fitnessFileId,
-                  deleted
-                }
-              } catch {
-                return {
-                  fitnessFileId,
-                  deleted: false
-                }
-              }
-            })
-          )
-          const rollbackFailures = rollbackResults
-            .filter((result) => !result.deleted)
-            .map((result) => result.fitnessFileId)
+          const rollbackFailures = await rollbackSavedArchiveFitnessFiles({
+            database,
+            fitnessFileIds: savedFitnessFileIds
+          })
           if (rollbackFailures.length > 0) {
             logger.error({
               message:

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -282,22 +282,22 @@ const rollbackSavedArchiveFitnessFiles = async ({
   database: Database
   fitnessFileIds: string[]
 }) => {
-  const rollbackResults = await Promise.all(
-    fitnessFileIds.map(async (fitnessFileId) => {
-      try {
-        const deleted = await deleteFitnessFile(database, fitnessFileId)
-        return {
-          fitnessFileId,
-          deleted
-        }
-      } catch {
-        return {
-          fitnessFileId,
-          deleted: false
-        }
-      }
-    })
-  )
+  const rollbackResults: { fitnessFileId: string; deleted: boolean }[] = []
+
+  for (const fitnessFileId of fitnessFileIds) {
+    try {
+      const deleted = await deleteFitnessFile(database, fitnessFileId)
+      rollbackResults.push({
+        fitnessFileId,
+        deleted
+      })
+    } catch {
+      rollbackResults.push({
+        fitnessFileId,
+        deleted: false
+      })
+    }
+  }
 
   return rollbackResults
     .filter((result) => !result.deleted)

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -220,11 +220,16 @@ const resolveArchivePath = async (
     label: 'Archive object body'
   })
 
-  await streamBodyToFile({
-    body: object.Body,
-    outputPath: temporaryArchivePath,
-    maxBytes: fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE
-  })
+  try {
+    await streamBodyToFile({
+      body: object.Body,
+      outputPath: temporaryArchivePath,
+      maxBytes: fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE
+    })
+  } catch (error) {
+    await fs.unlink(temporaryArchivePath).catch(() => undefined)
+    throw error
+  }
 
   return {
     archiveFilePath: temporaryArchivePath,

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -768,11 +768,33 @@ export const importStravaArchiveJob = createJobHandle(
         } catch (error) {
           const nodeError = error as Error
           if (nodeError instanceof StravaArchiveLimitError) {
+            const rollbackFitnessFileIds = new Set(
+              savedArchiveActivities.map(({ fitnessFileId }) => fitnessFileId)
+            )
+
+            try {
+              const batchFitnessFiles = await database.getFitnessFilesByBatchId(
+                { batchId }
+              )
+
+              for (const batchFitnessFile of batchFitnessFiles) {
+                rollbackFitnessFileIds.add(batchFitnessFile.id)
+              }
+            } catch (rollbackError) {
+              logger.error({
+                message:
+                  'Failed to load staged Strava archive fitness files for archive limit rollback',
+                actorId,
+                archiveId,
+                importId,
+                batchId,
+                error: (rollbackError as Error).message
+              })
+            }
+
             const rollbackFailures = await rollbackSavedArchiveFitnessFiles({
               database,
-              fitnessFileIds: savedArchiveActivities.map(
-                ({ fitnessFileId }) => fitnessFileId
-              )
+              fitnessFileIds: Array.from(rollbackFitnessFileIds)
             })
             if (rollbackFailures.length > 0) {
               logger.error({

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -751,10 +751,15 @@ export const importStravaArchiveJob = createJobHandle(
             throw new Error('Fitness activity file is missing from archive')
           }
 
-          const fitnessPayload = await toStravaArchiveFitnessFilePayload({
-            fitnessFilePath: archiveActivity.fitnessFilePath,
-            buffer: fitnessArchiveBuffer
-          })
+          const fitnessPayload = await toStravaArchiveFitnessFilePayload(
+            {
+              fitnessFilePath: archiveActivity.fitnessFilePath,
+              buffer: fitnessArchiveBuffer
+            },
+            {
+              maxGzipOutputBytes: maxFitnessFileBytes
+            }
+          )
 
           const fitnessFile = new File(
             [new Uint8Array(fitnessPayload.buffer)],

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -180,11 +180,17 @@ const streamBodyToFile = async ({
 const resolveArchivePath = async (
   archivePath: string,
   archiveFitnessFileId: string
-): Promise<{ archiveFilePath: string; cleanup: () => Promise<void> }> => {
+): Promise<{
+  archiveFilePath: string
+  cleanup: () => Promise<void>
+  maxFitnessFileBytes: number
+}> => {
   const fitnessStorage = getEffectiveFitnessStorageConfig()
   if (!fitnessStorage) {
     throw new Error('Fitness storage is not configured')
   }
+  const maxFitnessFileBytes =
+    fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE
 
   if (fitnessStorage.type === 'fs') {
     return {
@@ -192,7 +198,8 @@ const resolveArchivePath = async (
         fitnessStorage.path,
         archivePath
       ),
-      cleanup: async () => {}
+      cleanup: async () => {},
+      maxFitnessFileBytes
     }
   }
 
@@ -216,7 +223,7 @@ const resolveArchivePath = async (
   }
   assertByteLengthWithinLimit({
     byteLength: object.ContentLength,
-    maxBytes: fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE,
+    maxBytes: maxFitnessFileBytes,
     label: 'Archive object body'
   })
 
@@ -224,7 +231,7 @@ const resolveArchivePath = async (
     await streamBodyToFile({
       body: object.Body,
       outputPath: temporaryArchivePath,
-      maxBytes: fitnessStorage.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE
+      maxBytes: maxFitnessFileBytes
     })
   } catch (error) {
     await fs.unlink(temporaryArchivePath).catch(() => undefined)
@@ -233,6 +240,7 @@ const resolveArchivePath = async (
 
   return {
     archiveFilePath: temporaryArchivePath,
+    maxFitnessFileBytes,
     cleanup: async () => {
       await fs.unlink(temporaryArchivePath).catch(() => undefined)
     }
@@ -683,13 +691,17 @@ export const importStravaArchiveJob = createJobHandle(
     }
 
     try {
-      const { archiveFilePath, cleanup } = await resolveArchivePath(
-        archiveFitnessFile.path,
-        archiveFitnessFile.id
-      )
+      const { archiveFilePath, cleanup, maxFitnessFileBytes } =
+        await resolveArchivePath(archiveFitnessFile.path, archiveFitnessFile.id)
       cleanupArchivePath = cleanup
 
-      archiveReader = await StravaArchiveReader.open(archiveFilePath)
+      archiveReader = await StravaArchiveReader.open(archiveFilePath, {
+        limits: {
+          maxEntryCompressedBytes: maxFitnessFileBytes,
+          maxEntryUncompressedBytes: maxFitnessFileBytes,
+          maxGzipOutputBytes: maxFitnessFileBytes
+        }
+      })
       const archiveActivities = await archiveReader.getActivities()
       const targetTotalActivities =
         checkpoint.totalActivitiesCount ?? archiveActivities.length

--- a/lib/services/fitness-files/S3StorageFile.test.ts
+++ b/lib/services/fitness-files/S3StorageFile.test.ts
@@ -73,4 +73,36 @@ describe('S3FitnessStorage presigned upload verification', () => {
       storage.verifyPresignedUpload(actor, fitnessFile)
     ).resolves.toBe(false)
   })
+
+  it('does not request checksum mode when verifying presigned uploads', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        return {
+          ContentLength: 1024,
+          ContentType: 'application/zip'
+        }
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FitnessStorage(
+      {
+        type: FitnessStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        prefix: ''
+      },
+      'llun.test',
+      database
+    )
+
+    await expect(
+      storage.verifyPresignedUpload(actor, fitnessFile)
+    ).resolves.toBe(true)
+
+    expect(HeadObjectCommand).toHaveBeenCalledWith({
+      Bucket: 'bucket',
+      Key: '2026-01-01/archive.zip'
+    })
+  })
 })

--- a/lib/services/fitness-files/S3StorageFile.test.ts
+++ b/lib/services/fitness-files/S3StorageFile.test.ts
@@ -1,0 +1,76 @@
+import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
+
+import { FitnessStorageType } from '@/lib/config/fitnessStorage'
+import { Database } from '@/lib/database/types'
+import { S3FitnessStorage } from '@/lib/services/fitness-files/S3StorageFile'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+import { Actor } from '@/lib/types/domain/actor'
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const makeCommand = (name: string) =>
+    jest.fn().mockImplementation(function command(input) {
+      this.input = input
+      this.name = name
+    })
+
+  return {
+    S3Client: jest.fn(),
+    HeadObjectCommand: makeCommand('HeadObjectCommand'),
+    DeleteObjectCommand: makeCommand('DeleteObjectCommand'),
+    GetObjectCommand: makeCommand('GetObjectCommand'),
+    PutObjectCommand: makeCommand('PutObjectCommand')
+  }
+})
+
+describe('S3FitnessStorage presigned upload verification', () => {
+  const send = jest.fn()
+  const actor = { id: 'actor-1' } as Actor
+  const fitnessFile = {
+    id: 'fitness-file-1',
+    actorId: 'actor-1',
+    path: '2026-01-01/archive.zip',
+    fileName: 'archive.zip',
+    fileType: 'zip',
+    mimeType: 'application/zip',
+    bytes: 1024
+  } as FitnessFile
+  const database = {
+    deleteFitnessFile: jest.fn()
+  } as unknown as jest.Mocked<Database>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+      () => ({ send }) as unknown as S3Client
+    )
+  })
+
+  it('returns false for missing S3 objects instead of throwing', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        const error = new Error('Not found') as Error & {
+          $metadata?: { httpStatusCode?: number }
+        }
+        error.name = 'NotFound'
+        error.$metadata = { httpStatusCode: 404 }
+        throw error
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FitnessStorage(
+      {
+        type: FitnessStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        prefix: ''
+      },
+      'llun.test',
+      database
+    )
+
+    await expect(
+      storage.verifyPresignedUpload(actor, fitnessFile)
+    ).resolves.toBe(false)
+  })
+})

--- a/lib/services/fitness-files/S3StorageFile.ts
+++ b/lib/services/fitness-files/S3StorageFile.ts
@@ -1,6 +1,7 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   S3Client
 } from '@aws-sdk/client-s3'
@@ -10,11 +11,19 @@ import { format } from 'date-fns'
 import { Readable } from 'stream'
 import type { ReadableStream as WebReadableStream } from 'stream/web'
 
-import { FitnessStorageS3Config } from '@/lib/config/fitnessStorage'
+import {
+  DEFAULT_FITNESS_MAX_FILE_SIZE,
+  FitnessStorageS3Config
+} from '@/lib/config/fitnessStorage'
 import { Database } from '@/lib/database/types'
 import { checkQuotaAvailable } from '@/lib/services/medias/quota'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
+import {
+  assertByteLengthWithinLimit,
+  readUnknownBodyToBufferWithLimit
+} from '@/lib/utils/streamLimit'
 
 import { QuotaExceededError } from './errors'
 import {
@@ -25,6 +34,9 @@ import {
   PresignedFitnessUrlOutput,
   getFitnessFileType
 } from './types'
+
+const normalizeContentType = (contentType?: string) =>
+  contentType?.split(';')[0]?.trim().toLowerCase() ?? ''
 
 export class S3FitnessStorage implements FitnessStorage {
   private static _instance: FitnessStorage
@@ -69,10 +81,20 @@ export class S3FitnessStorage implements FitnessStorage {
       if (!object.Body) return null
 
       const message = object.Body
+      const maxBytes = this._config.maxFileSize ?? DEFAULT_FITNESS_MAX_FILE_SIZE
+      assertByteLengthWithinLimit({
+        byteLength: object.ContentLength,
+        maxBytes,
+        label: 'Fitness object body'
+      })
       return FitnessStorageGetFileOutput.parse({
         type: 'buffer',
         contentType: object.ContentType ?? 'application/octet-stream',
-        buffer: Buffer.from(await message.transformToByteArray())
+        buffer: await readUnknownBodyToBufferWithLimit(
+          message,
+          maxBytes,
+          'Fitness object body'
+        )
       })
     } catch (error) {
       const nodeError = error as {
@@ -257,5 +279,38 @@ export class S3FitnessStorage implements FitnessStorage {
       url,
       fitnessFileId: storedFile.id
     })
+  }
+
+  async verifyPresignedUpload(
+    actor: Actor,
+    fitnessFile: FitnessFile
+  ): Promise<boolean> {
+    if (fitnessFile.actorId !== actor.id) {
+      return false
+    }
+
+    const { bucket, prefix } = this._config
+    const key = prefix ? `${prefix}${fitnessFile.path}` : fitnessFile.path
+    const object = await this._client.send(
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        ChecksumMode: 'ENABLED'
+      })
+    )
+    const contentLength = object.ContentLength
+    const contentType = normalizeContentType(object.ContentType)
+    const expectedContentType = normalizeContentType(fitnessFile.mimeType)
+    const isValid =
+      contentLength === fitnessFile.bytes && contentType === expectedContentType
+
+    if (!isValid) {
+      await this.deleteFile(fitnessFile.path).catch(() => false)
+      await this._database
+        .deleteFitnessFile({ id: fitnessFile.id })
+        .catch(() => false)
+    }
+
+    return isValid
   }
 }

--- a/lib/services/fitness-files/S3StorageFile.ts
+++ b/lib/services/fitness-files/S3StorageFile.ts
@@ -38,6 +38,18 @@ import {
 const normalizeContentType = (contentType?: string) =>
   contentType?.split(';')[0]?.trim().toLowerCase() ?? ''
 
+const isS3NotFoundError = (error: unknown) => {
+  const nodeError = error as {
+    name?: string
+    $metadata?: { httpStatusCode?: number }
+  }
+  return (
+    nodeError.name === 'NoSuchKey' ||
+    nodeError.name === 'NotFound' ||
+    nodeError.$metadata?.httpStatusCode === 404
+  )
+}
+
 export class S3FitnessStorage implements FitnessStorage {
   private static _instance: FitnessStorage
   private _config: FitnessStorageS3Config
@@ -291,13 +303,23 @@ export class S3FitnessStorage implements FitnessStorage {
 
     const { bucket, prefix } = this._config
     const key = prefix ? `${prefix}${fitnessFile.path}` : fitnessFile.path
-    const object = await this._client.send(
-      new HeadObjectCommand({
-        Bucket: bucket,
-        Key: key,
-        ChecksumMode: 'ENABLED'
+    const object = await this._client
+      .send(
+        new HeadObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          ChecksumMode: 'ENABLED'
+        })
+      )
+      .catch((error) => {
+        if (isS3NotFoundError(error)) {
+          return null
+        }
+        throw error
       })
-    )
+    if (!object) {
+      return false
+    }
     const contentLength = object.ContentLength
     const contentType = normalizeContentType(object.ContentType)
     const expectedContentType = normalizeContentType(fitnessFile.mimeType)

--- a/lib/services/fitness-files/S3StorageFile.ts
+++ b/lib/services/fitness-files/S3StorageFile.ts
@@ -307,8 +307,7 @@ export class S3FitnessStorage implements FitnessStorage {
       .send(
         new HeadObjectCommand({
           Bucket: bucket,
-          Key: key,
-          ChecksumMode: 'ENABLED'
+          Key: key
         })
       )
       .catch((error) => {

--- a/lib/services/fitness-files/index.ts
+++ b/lib/services/fitness-files/index.ts
@@ -169,3 +169,25 @@ export const getPresignedFitnessFileUrl = async (
 
   return null
 }
+
+export const verifyPresignedFitnessFileUpload = async (
+  database: Database,
+  actor: Actor,
+  fitnessFile: FitnessFile
+) => {
+  const { host } = getConfig()
+  const fitnessStorage = getEffectiveFitnessStorageConfig()
+
+  if (
+    fitnessStorage?.type === FitnessStorageType.S3Storage ||
+    fitnessStorage?.type === FitnessStorageType.ObjectStorage
+  ) {
+    return S3FitnessStorage.getStorage(
+      fitnessStorage,
+      host,
+      database
+    ).verifyPresignedUpload(actor, fitnessFile)
+  }
+
+  return false
+}

--- a/lib/services/fitness-files/localFile.test.ts
+++ b/lib/services/fitness-files/localFile.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+
+import { FitnessStorageType } from '@/lib/config/fitnessStorage'
+import { Database } from '@/lib/database/types'
+import { LocalFileFitnessStorage } from '@/lib/services/fitness-files/localFile'
+
+describe('LocalFileFitnessStorage path containment', () => {
+  let tempParent: string
+  let storageRoot: string
+  let outsideFile: string
+
+  beforeEach(async () => {
+    tempParent = await fs.mkdtemp(path.join(os.tmpdir(), 'fitness-storage-'))
+    storageRoot = path.join(tempParent, 'root')
+    outsideFile = path.join(tempParent, 'secret.fit')
+    await fs.mkdir(storageRoot)
+    await fs.writeFile(outsideFile, 'secret')
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempParent, { recursive: true, force: true })
+  })
+
+  it('refuses to read or delete files outside the resolved storage root', async () => {
+    const storage = new LocalFileFitnessStorage(
+      {
+        type: FitnessStorageType.LocalFile,
+        path: storageRoot
+      },
+      'localhost:3000',
+      {} as Database
+    )
+
+    await expect(storage.getFile('../secret.fit')).resolves.toBeNull()
+    await expect(storage.deleteFile('../secret.fit')).resolves.toBe(false)
+    await expect(fs.readFile(outsideFile, 'utf8')).resolves.toBe('secret')
+  })
+})

--- a/lib/services/fitness-files/localFile.ts
+++ b/lib/services/fitness-files/localFile.ts
@@ -15,6 +15,7 @@ import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 
 import { QuotaExceededError } from './errors'
+import { assertFitnessStoragePath, resolveFitnessStoragePath } from './path'
 import {
   FitnessFileUploadSchema,
   FitnessStorage,
@@ -63,7 +64,11 @@ export class LocalFileFitnessStorage implements FitnessStorage {
   }
 
   async getFile(filePath: string) {
-    const fullPath = path.resolve(this._config.path, filePath)
+    const fullPath = resolveFitnessStoragePath(this._config.path, filePath)
+    if (!fullPath) {
+      return null
+    }
+
     const ext = path.extname(fullPath).toLowerCase()
     const contentType =
       mime.contentType(ext) ||
@@ -89,7 +94,11 @@ export class LocalFileFitnessStorage implements FitnessStorage {
 
   async deleteFile(filePath: string): Promise<boolean> {
     try {
-      const fullPath = path.resolve(this._config.path, filePath)
+      const fullPath = resolveFitnessStoragePath(this._config.path, filePath)
+      if (!fullPath) {
+        return false
+      }
+
       await fs.unlink(fullPath)
       return true
     } catch (e) {
@@ -130,7 +139,7 @@ export class LocalFileFitnessStorage implements FitnessStorage {
     const randomPrefix = crypto.randomBytes(8).toString('hex')
     const timeDirectory = format(currentTime, 'yyyy-MM-dd')
     const fileName = `${timeDirectory}/${randomPrefix}${ext}`
-    const filePath = path.resolve(this._config.path, fileName)
+    const filePath = assertFitnessStoragePath(this._config.path, fileName)
     await fs.mkdir(path.dirname(filePath), { recursive: true })
 
     // Save file using a stream to avoid buffering large files in memory.
@@ -188,5 +197,9 @@ export class LocalFileFitnessStorage implements FitnessStorage {
     }
   ): Promise<import('./types').PresignedFitnessUrlOutput | null> {
     return null
+  }
+
+  async verifyPresignedUpload(): Promise<boolean> {
+    return false
   }
 }

--- a/lib/services/fitness-files/path.ts
+++ b/lib/services/fitness-files/path.ts
@@ -1,0 +1,29 @@
+import path from 'path'
+
+export const resolveFitnessStoragePath = (
+  storageRootPath: string,
+  filePath: string
+): string | null => {
+  const storageRoot = path.resolve(storageRootPath)
+  const fullPath = path.resolve(storageRoot, filePath)
+  const storageRootPrefix = storageRoot.endsWith(path.sep)
+    ? storageRoot
+    : `${storageRoot}${path.sep}`
+
+  if (fullPath !== storageRoot && !fullPath.startsWith(storageRootPrefix)) {
+    return null
+  }
+
+  return fullPath
+}
+
+export const assertFitnessStoragePath = (
+  storageRootPath: string,
+  filePath: string
+): string => {
+  const fullPath = resolveFitnessStoragePath(storageRootPath, filePath)
+  if (!fullPath) {
+    throw new Error('Fitness storage path escapes storage root')
+  }
+  return fullPath
+}

--- a/lib/services/fitness-files/types.ts
+++ b/lib/services/fitness-files/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { getConfig } from '@/lib/config'
 import { DEFAULT_FITNESS_MAX_FILE_SIZE } from '@/lib/config/fitnessStorage'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { Actor } from '@/lib/types/domain/actor'
 
 import {
@@ -116,6 +117,10 @@ export interface FitnessStorage {
       description?: string
     }
   ): Promise<PresignedFitnessUrlOutput | null>
+  verifyPresignedUpload(
+    actor: Actor,
+    fitnessFile: FitnessFile
+  ): Promise<boolean>
 }
 
 // Helper to determine file type from filename or mime type

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -58,6 +58,7 @@ describe('S3FileStorage presigned upload completion', () => {
           upload: {
             state: 'pending',
             checksumSha1: checksumHex,
+            checksumSha1Base64: checksumBase64,
             contentType: 'image/png',
             size: 1024
           }
@@ -78,6 +79,7 @@ describe('S3FileStorage presigned upload completion', () => {
           upload: {
             state: 'verified',
             checksumSha1: checksumHex,
+            checksumSha1Base64: checksumBase64,
             contentType: 'image/png',
             size: 1024,
             verifiedAt: 1
@@ -120,5 +122,96 @@ describe('S3FileStorage presigned upload completion', () => {
     ).rejects.toThrow('does not match expected size')
     expect(database.markMediaUploadVerified).not.toHaveBeenCalled()
     expect(database.deleteMedia).toHaveBeenCalledWith({ mediaId: 'media-1' })
+  })
+
+  it('uses checksum metadata when S3 checksum fields are unavailable', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        return {
+          ContentLength: 1024,
+          ContentType: 'image/png',
+          Metadata: {
+            checksumsha1: checksumHex
+          }
+        }
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+    await expect(
+      storage.completePresignedUpload(actor, 'media-1')
+    ).resolves.toMatchObject({ id: 'media-1' })
+    expect(database.markMediaUploadVerified).toHaveBeenCalled()
+    expect(database.deleteMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects uploads when no S3 checksum or checksum metadata is available', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        return {
+          ContentLength: 1024,
+          ContentType: 'image/png',
+          Metadata: {}
+        }
+      }
+      if (command instanceof DeleteObjectCommand) {
+        return {}
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+    await expect(
+      storage.completePresignedUpload(actor, 'media-1')
+    ).rejects.toThrow('Uploaded object does not include expected checksum')
+    expect(database.markMediaUploadVerified).not.toHaveBeenCalled()
+    expect(database.deleteMedia).toHaveBeenCalledWith({ mediaId: 'media-1' })
+  })
+
+  it('does not delete media records for transient verification errors', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        throw new Error('S3 timeout')
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+    await expect(
+      storage.completePresignedUpload(actor, 'media-1')
+    ).rejects.toThrow('S3 timeout')
+    expect(database.markMediaUploadVerified).not.toHaveBeenCalled()
+    expect(database.deleteMedia).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -156,6 +156,39 @@ describe('S3FileStorage presigned upload completion', () => {
     expect(database.deleteMedia).not.toHaveBeenCalled()
   })
 
+  it('does not request checksum mode when verifying presigned uploads', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        return {
+          ContentLength: 1024,
+          ContentType: 'image/png',
+          Metadata: {
+            checksumsha1: checksumHex
+          }
+        }
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+    await storage.completePresignedUpload(actor, 'media-1')
+
+    expect(HeadObjectCommand).toHaveBeenCalledWith({
+      Bucket: 'bucket',
+      Key: 'medias/2026-01-01/upload.png'
+    })
+  })
+
   it('rejects uploads when no S3 checksum or checksum metadata is available', async () => {
     send.mockImplementation(async (command) => {
       if (command instanceof HeadObjectCommand) {

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -1,0 +1,124 @@
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  S3Client
+} from '@aws-sdk/client-s3'
+
+import { MediaStorageType } from '@/lib/config/mediaStorage'
+import { Database } from '@/lib/database/types'
+import { S3FileStorage } from '@/lib/services/medias/S3StorageFile'
+import { Actor } from '@/lib/types/domain/actor'
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const makeCommand = (name: string) =>
+    jest.fn().mockImplementation(function command(input) {
+      this.input = input
+      this.name = name
+    })
+
+  return {
+    S3Client: jest.fn(),
+    HeadObjectCommand: makeCommand('HeadObjectCommand'),
+    DeleteObjectCommand: makeCommand('DeleteObjectCommand'),
+    GetObjectCommand: makeCommand('GetObjectCommand'),
+    PutObjectCommand: makeCommand('PutObjectCommand')
+  }
+})
+
+describe('S3FileStorage presigned upload completion', () => {
+  const send = jest.fn()
+  const actor = {
+    id: 'actor-1',
+    account: { id: 'account-1' }
+  } as Actor
+  const checksumHex = 'a9993e364706816aba3e25717850c26c9cd0d89d'
+  const checksumBase64 = Buffer.from(checksumHex, 'hex').toString('base64')
+
+  const database = {
+    getMediaByIdForAccount: jest.fn(),
+    markMediaUploadVerified: jest.fn(),
+    deleteMedia: jest.fn()
+  } as unknown as jest.Mocked<Database>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+      () => ({ send }) as unknown as S3Client
+    )
+    database.getMediaByIdForAccount.mockResolvedValue({
+      id: 'media-1',
+      actorId: 'actor-1',
+      original: {
+        path: 'medias/2026-01-01/upload.png',
+        bytes: 1024,
+        mimeType: 'image/png',
+        metaData: {
+          width: 10,
+          height: 10,
+          upload: {
+            state: 'pending',
+            checksumSha1: checksumHex,
+            contentType: 'image/png',
+            size: 1024
+          }
+        },
+        fileName: 'upload.png'
+      }
+    } as never)
+    database.markMediaUploadVerified.mockResolvedValue({
+      id: 'media-1',
+      actorId: 'actor-1',
+      original: {
+        path: 'medias/2026-01-01/upload.png',
+        bytes: 1024,
+        mimeType: 'image/png',
+        metaData: {
+          width: 10,
+          height: 10,
+          upload: {
+            state: 'verified',
+            checksumSha1: checksumHex,
+            contentType: 'image/png',
+            size: 1024,
+            verifiedAt: 1
+          }
+        },
+        fileName: 'upload.png'
+      }
+    } as never)
+    database.deleteMedia.mockResolvedValue(true)
+  })
+
+  it('rejects oversized presigned uploads before marking media usable', async () => {
+    send.mockImplementation(async (command) => {
+      if (command instanceof HeadObjectCommand) {
+        return {
+          ContentLength: 2048,
+          ContentType: 'image/png',
+          ChecksumSHA1: checksumBase64
+        }
+      }
+      if (command instanceof DeleteObjectCommand) {
+        return {}
+      }
+      throw new Error('Unexpected command')
+    })
+
+    const storage = new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+    await expect(
+      storage.completePresignedUpload(actor, 'media-1')
+    ).rejects.toThrow('does not match expected size')
+    expect(database.markMediaUploadVerified).not.toHaveBeenCalled()
+    expect(database.deleteMedia).toHaveBeenCalledWith({ mediaId: 'media-1' })
+  })
+})

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -50,7 +50,7 @@ const normalizeContentType = (contentType?: string | string[]) => {
 const sha1HexToBase64 = (checksum: string) =>
   Buffer.from(checksum, 'hex').toString('base64')
 
-class PresignedUploadValidationError extends Error {
+export class PresignedUploadValidationError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'PresignedUploadValidationError'

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -50,6 +50,33 @@ const normalizeContentType = (contentType?: string | string[]) => {
 const sha1HexToBase64 = (checksum: string) =>
   Buffer.from(checksum, 'hex').toString('base64')
 
+class PresignedUploadValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PresignedUploadValidationError'
+  }
+}
+
+const isS3NotFoundError = (error: unknown) => {
+  const nodeError = error as {
+    name?: string
+    $metadata?: { httpStatusCode?: number }
+  }
+  return (
+    nodeError.name === 'NoSuchKey' ||
+    nodeError.name === 'NotFound' ||
+    nodeError.$metadata?.httpStatusCode === 404
+  )
+}
+
+const getObjectMetadataChecksumSha1 = (
+  metadata: Record<string, string> | undefined
+) =>
+  metadata?.checksumsha1 ??
+  metadata?.checksumSha1 ??
+  metadata?.['checksum-sha1'] ??
+  null
+
 export class S3FileStorage implements MediaStorage {
   private static _instance: MediaStorage
 
@@ -261,13 +288,22 @@ export class S3FileStorage implements MediaStorage {
     }
 
     try {
-      const object = await this._client.send(
-        new HeadObjectCommand({
-          Bucket: this._config.bucket,
-          Key: media.original.path,
-          ChecksumMode: 'ENABLED'
+      const object = await this._client
+        .send(
+          new HeadObjectCommand({
+            Bucket: this._config.bucket,
+            Key: media.original.path,
+            ChecksumMode: 'ENABLED'
+          })
+        )
+        .catch((error) => {
+          if (isS3NotFoundError(error)) {
+            throw new PresignedUploadValidationError(
+              'Uploaded object is missing'
+            )
+          }
+          throw error
         })
-      )
       const expectedSize = upload.size ?? media.original.bytes
       const expectedContentType = normalizeContentType(
         upload.contentType ?? media.original.mimeType
@@ -275,17 +311,37 @@ export class S3FileStorage implements MediaStorage {
       const actualContentType = normalizeContentType(object.ContentType)
 
       if (object.ContentLength !== expectedSize) {
-        throw new Error('Uploaded object does not match expected size')
+        throw new PresignedUploadValidationError(
+          'Uploaded object does not match expected size'
+        )
       }
       if (actualContentType !== expectedContentType) {
-        throw new Error('Uploaded object does not match expected content type')
+        throw new PresignedUploadValidationError(
+          'Uploaded object does not match expected content type'
+        )
       }
+      const metadataChecksumSha1 = getObjectMetadataChecksumSha1(
+        object.Metadata
+      )
       if (
         object.ChecksumSHA1 &&
         upload.checksumSha1Base64 &&
         object.ChecksumSHA1 !== upload.checksumSha1Base64
       ) {
-        throw new Error('Uploaded object does not match expected checksum')
+        throw new PresignedUploadValidationError(
+          'Uploaded object does not match expected checksum'
+        )
+      }
+      if (
+        !object.ChecksumSHA1 &&
+        upload.checksumSha1 &&
+        metadataChecksumSha1 !== upload.checksumSha1
+      ) {
+        throw new PresignedUploadValidationError(
+          metadataChecksumSha1
+            ? 'Uploaded object does not match expected checksum'
+            : 'Uploaded object does not include expected checksum'
+        )
       }
 
       const verifiedMedia = await this._database.markMediaUploadVerified({
@@ -298,8 +354,10 @@ export class S3FileStorage implements MediaStorage {
       }
       return this._getSaveFileOutput(verifiedMedia)
     } catch (error) {
-      await this.deleteFile(media.original.path).catch(() => false)
-      await this._database.deleteMedia({ mediaId }).catch(() => false)
+      if (error instanceof PresignedUploadValidationError) {
+        await this.deleteFile(media.original.path).catch(() => false)
+        await this._database.deleteMedia({ mediaId }).catch(() => false)
+      }
       throw error
     }
   }

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -1,6 +1,7 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   S3Client
 } from '@aws-sdk/client-s3'
@@ -15,7 +16,11 @@ import sharp from 'sharp'
 
 import { MediaStorageS3Config } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
-import { MAX_HEIGHT, MAX_WIDTH } from '@/lib/services/medias/constants'
+import {
+  MAX_FILE_SIZE,
+  MAX_HEIGHT,
+  MAX_WIDTH
+} from '@/lib/services/medias/constants'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
 import { extractVideoMeta } from '@/lib/services/medias/extractVideoMeta'
 import { checkQuotaAvailable } from '@/lib/services/medias/quota'
@@ -32,6 +37,18 @@ import {
 import { Media } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
+import {
+  assertByteLengthWithinLimit,
+  readUnknownBodyToBufferWithLimit
+} from '@/lib/utils/streamLimit'
+
+const normalizeContentType = (contentType?: string | string[]) => {
+  const value = Array.isArray(contentType) ? contentType[0] : contentType
+  return value?.split(';')[0]?.trim().toLowerCase() ?? ''
+}
+
+const sha1HexToBase64 = (checksum: string) =>
+  Buffer.from(checksum, 'hex').toString('base64')
 
 export class S3FileStorage implements MediaStorage {
   private static _instance: MediaStorage
@@ -78,10 +95,23 @@ export class S3FileStorage implements MediaStorage {
     if (!object.Body) return null
 
     const message = object.Body
+    const maxBytes = this._config.maxFileSize ?? MAX_FILE_SIZE
+    assertByteLengthWithinLimit({
+      byteLength: object.ContentLength,
+      maxBytes,
+      label: 'Media object body'
+    })
     return MediaStorageGetFileOutput.parse({
       type: 'buffer',
-      contentType: (message as IncomingMessage).headers['content-type'],
-      buffer: Buffer.from(await message.transformToByteArray())
+      contentType:
+        object.ContentType ??
+        (message as IncomingMessage).headers?.['content-type'] ??
+        'application/octet-stream',
+      buffer: await readUnknownBodyToBufferWithLimit(
+        message,
+        maxBytes,
+        'Media object body'
+      )
     })
   }
 
@@ -142,13 +172,18 @@ export class S3FileStorage implements MediaStorage {
       presignedMedia.contentType === 'video/quicktime'
         ? 'video/mp4'
         : presignedMedia.contentType
+    const checksumSha1Base64 = sha1HexToBase64(presignedMedia.checksum)
 
     const key = `medias/${timeDirectory}/${randomPrefix}${ext}`
     const command = new PutObjectCommand({
       Bucket: bucket,
       Key: key,
       ContentType: presignedMedia.contentType,
-      ContentLength: presignedMedia.size
+      ContentLength: presignedMedia.size,
+      ChecksumSHA1: checksumSha1Base64,
+      Metadata: {
+        checksumSha1: presignedMedia.checksum
+      }
     })
     const url = await getSignedUrl(this._client, command, { expiresIn: 600 })
     const storedMedia = await this._database.createMedia({
@@ -159,7 +194,14 @@ export class S3FileStorage implements MediaStorage {
         mimeType,
         metaData: {
           width: presignedMedia.width ?? 0,
-          height: presignedMedia.height ?? 0
+          height: presignedMedia.height ?? 0,
+          upload: {
+            state: 'pending',
+            checksumSha1: presignedMedia.checksum,
+            checksumSha1Base64,
+            contentType: presignedMedia.contentType,
+            size: presignedMedia.size
+          }
         },
         fileName
       }
@@ -188,8 +230,78 @@ export class S3FileStorage implements MediaStorage {
           }
         },
         description: ''
+      },
+      headers: {
+        'x-amz-checksum-sha1': checksumSha1Base64,
+        'x-amz-meta-checksumsha1': presignedMedia.checksum
       }
     })
+  }
+
+  async completePresignedUpload(actor: Actor, mediaId: string) {
+    const accountId = actor.account?.id
+    if (!accountId) {
+      throw new Error('Actor account is required to complete media upload')
+    }
+
+    const media = await this._database.getMediaByIdForAccount({
+      mediaId,
+      accountId
+    })
+    if (!media) {
+      return null
+    }
+
+    const upload = media.original.metaData.upload
+    if (upload?.state === 'verified') {
+      return this._getSaveFileOutput(media)
+    }
+    if (!upload || upload.state !== 'pending') {
+      throw new Error('Media upload is not pending verification')
+    }
+
+    try {
+      const object = await this._client.send(
+        new HeadObjectCommand({
+          Bucket: this._config.bucket,
+          Key: media.original.path,
+          ChecksumMode: 'ENABLED'
+        })
+      )
+      const expectedSize = upload.size ?? media.original.bytes
+      const expectedContentType = normalizeContentType(
+        upload.contentType ?? media.original.mimeType
+      )
+      const actualContentType = normalizeContentType(object.ContentType)
+
+      if (object.ContentLength !== expectedSize) {
+        throw new Error('Uploaded object does not match expected size')
+      }
+      if (actualContentType !== expectedContentType) {
+        throw new Error('Uploaded object does not match expected content type')
+      }
+      if (
+        object.ChecksumSHA1 &&
+        upload.checksumSha1Base64 &&
+        object.ChecksumSHA1 !== upload.checksumSha1Base64
+      ) {
+        throw new Error('Uploaded object does not match expected checksum')
+      }
+
+      const verifiedMedia = await this._database.markMediaUploadVerified({
+        mediaId,
+        accountId,
+        verifiedAt: Date.now()
+      })
+      if (!verifiedMedia) {
+        return null
+      }
+      return this._getSaveFileOutput(verifiedMedia)
+    } catch (error) {
+      await this.deleteFile(media.original.path).catch(() => false)
+      await this._database.deleteMedia({ mediaId }).catch(() => false)
+      throw error
+    }
   }
 
   async saveFile(actor: Actor, media: MediaSchema) {

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -292,8 +292,7 @@ export class S3FileStorage implements MediaStorage {
         .send(
           new HeadObjectCommand({
             Bucket: this._config.bucket,
-            Key: media.original.path,
-            ChecksumMode: 'ENABLED'
+            Key: media.original.path
           })
         )
         .catch((error) => {

--- a/lib/services/medias/index.ts
+++ b/lib/services/medias/index.ts
@@ -50,6 +50,26 @@ export const getPresignedUrl = async (
   }
 }
 
+export const completePresignedMediaUpload = async (
+  database: Database,
+  actor: Actor,
+  mediaId: string
+) => {
+  const { mediaStorage, host } = getConfig()
+  switch (mediaStorage?.type) {
+    case MediaStorageType.S3Storage:
+    case MediaStorageType.ObjectStorage: {
+      return S3FileStorage.getStorage(
+        mediaStorage,
+        host,
+        database
+      ).completePresignedUpload(actor, mediaId)
+    }
+    default:
+      return null
+  }
+}
+
 export const getMedia = async (database: Database, path: string) => {
   const { mediaStorage, host } = getConfig()
   switch (mediaStorage?.type) {

--- a/lib/services/medias/index.ts
+++ b/lib/services/medias/index.ts
@@ -1,10 +1,15 @@
 import { getConfig } from '@/lib/config'
 import { MediaStorageType } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
-import { S3FileStorage } from '@/lib/services/medias/S3StorageFile'
+import {
+  PresignedUploadValidationError,
+  S3FileStorage
+} from '@/lib/services/medias/S3StorageFile'
 import { LocalFileStorage } from '@/lib/services/medias/localFile'
 import { MediaSchema, PresigedMediaInput } from '@/lib/services/medias/types'
 import { Actor } from '@/lib/types/domain/actor'
+
+export { PresignedUploadValidationError }
 
 export const saveMedia = async (
   database: Database,

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -107,6 +107,11 @@ export class LocalFileStorage implements MediaStorage {
     return null
   }
 
+  async completePresignedUpload() {
+    // Local storage does not support presigned URLs
+    return null
+  }
+
   async saveFile(actor: Actor, media: MediaSchema) {
     const { file } = media
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {

--- a/lib/services/medias/types.test.ts
+++ b/lib/services/medias/types.test.ts
@@ -1,0 +1,16 @@
+import { PresigedMediaInput } from './types'
+
+describe('PresigedMediaInput', () => {
+  it('normalizes checksum input to lowercase', () => {
+    const parsed = PresigedMediaInput.parse({
+      fileName: 'photo.png',
+      checksum: 'A9993E364706816ABA3E25717850C26C9CD0D89D',
+      width: 10,
+      height: 20,
+      contentType: 'image/png',
+      size: 1024
+    })
+
+    expect(parsed.checksum).toBe('a9993e364706816aba3e25717850c26c9cd0d89d')
+  })
+})

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -75,7 +75,10 @@ export type MediaStorageGetRedirectOutput = z.infer<
 
 export const PresigedMediaInput = z.object({
   fileName: z.string(),
-  checksum: z.string().regex(/^[a-f0-9]{40}$/i),
+  checksum: z
+    .string()
+    .regex(/^[a-f0-9]{40}$/i)
+    .transform((value) => value.toLowerCase()),
   width: z.number(),
   height: z.number(),
   contentType: z

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -75,7 +75,7 @@ export type MediaStorageGetRedirectOutput = z.infer<
 
 export const PresigedMediaInput = z.object({
   fileName: z.string(),
-  checksum: z.string(),
+  checksum: z.string().regex(/^[a-f0-9]{40}$/i),
   width: z.number(),
   height: z.number(),
   contentType: z
@@ -93,7 +93,8 @@ export type PresigedMediaInput = z.infer<typeof PresigedMediaInput>
 
 export const PresignedUrlOutput = z.object({
   url: z.string().url(),
-  saveFileOutput: MediaStorageSaveFileOutput
+  saveFileOutput: MediaStorageSaveFileOutput,
+  headers: z.record(z.string(), z.string()).optional()
 })
 export type PresignedUrlOutput = z.infer<typeof PresignedUrlOutput>
 
@@ -107,6 +108,10 @@ export interface MediaStorage {
     actor: Actor,
     media: PresigedMediaInput
   ): Promise<PresignedUrlOutput | null>
+  completePresignedUpload(
+    actor: Actor,
+    mediaId: string
+  ): Promise<MediaStorageSaveFileOutput | null>
   getFile(
     filePath: string
   ): Promise<MediaStorageGetFileOutput | MediaStorageGetRedirectOutput | null>

--- a/lib/services/strava/archiveReader.open.test.ts
+++ b/lib/services/strava/archiveReader.open.test.ts
@@ -1,7 +1,13 @@
 import { EventEmitter } from 'events'
+import { promisify } from 'util'
 import yauzl from 'yauzl'
+import { gzip as gzipCallback } from 'zlib'
 
-import { StravaArchiveReader } from '@/lib/services/strava/archiveReader'
+import {
+  StravaArchiveLimitError,
+  StravaArchiveReader,
+  toStravaArchiveFitnessFilePayload
+} from '@/lib/services/strava/archiveReader'
 
 jest.mock('yauzl', () => ({
   __esModule: true,
@@ -13,6 +19,7 @@ jest.mock('yauzl', () => ({
 const mockYauzlOpen = yauzl.open as unknown as jest.MockedFunction<
   typeof yauzl.open
 >
+const gzip = promisify(gzipCallback)
 
 describe('StravaArchiveReader.open', () => {
   beforeEach(() => {
@@ -85,6 +92,7 @@ describe('StravaArchiveReader.open', () => {
         limits: { maxEntries: 2 }
       })
     ).rejects.toThrow('exceeds entry limit')
+    expect(zipFile.close).toHaveBeenCalled()
   })
 
   it('rejects 42.zip-style entries with oversized uncompressed data', async () => {
@@ -105,6 +113,7 @@ describe('StravaArchiveReader.open', () => {
         limits: { maxEntryUncompressedBytes: 1024 }
       })
     ).rejects.toThrow('exceeds uncompressed size limit')
+    expect(zipFile.close).toHaveBeenCalled()
   })
 
   it('rejects entries with oversized compressed data', async () => {
@@ -125,6 +134,7 @@ describe('StravaArchiveReader.open', () => {
         limits: { maxEntryCompressedBytes: 1024 }
       })
     ).rejects.toThrow('exceeds compressed size limit')
+    expect(zipFile.close).toHaveBeenCalled()
   })
 
   it('rejects archive entries with parent-directory traversal names', async () => {
@@ -141,5 +151,27 @@ describe('StravaArchiveReader.open', () => {
     await expect(StravaArchiveReader.open('/tmp/export.zip')).rejects.toThrow(
       'Unsafe archive entry path'
     )
+    expect(zipFile.close).toHaveBeenCalled()
+  })
+
+  it('keeps corrupt gzip activity errors distinct from gzip limit errors', async () => {
+    await expect(
+      toStravaArchiveFitnessFilePayload({
+        fitnessFilePath: 'activities/corrupt.fit.gz',
+        buffer: Buffer.from('not gzip data')
+      })
+    ).rejects.not.toBeInstanceOf(StravaArchiveLimitError)
+  })
+
+  it('wraps only gzip byte-limit errors as archive limit errors', async () => {
+    await expect(
+      toStravaArchiveFitnessFilePayload(
+        {
+          fitnessFilePath: 'activities/large.fit.gz',
+          buffer: await gzip(Buffer.alloc(2048))
+        },
+        { maxGzipOutputBytes: 1024 }
+      )
+    ).rejects.toBeInstanceOf(StravaArchiveLimitError)
   })
 })

--- a/lib/services/strava/archiveReader.open.test.ts
+++ b/lib/services/strava/archiveReader.open.test.ts
@@ -19,14 +19,35 @@ describe('StravaArchiveReader.open', () => {
     jest.clearAllMocks()
   })
 
-  it('opens yauzl zip with autoClose disabled', async () => {
+  const mockZipFileWithEntries = (entries: yauzl.Entry[]) => {
     const zipFile = new EventEmitter() as unknown as yauzl.ZipFile
+    let index = 0
     zipFile.readEntry = jest.fn(() => {
       process.nextTick(() => {
+        const entry = entries[index]
+        index += 1
+        if (entry) {
+          zipFile.emit('entry', entry)
+          return
+        }
         zipFile.emit('end')
       })
     })
     zipFile.close = jest.fn()
+    return zipFile
+  }
+
+  const makeEntry = (overrides: Partial<yauzl.Entry>): yauzl.Entry =>
+    ({
+      fileName: 'activities/1.fit',
+      compressionMethod: 8,
+      compressedSize: 12,
+      uncompressedSize: 34,
+      ...overrides
+    }) as yauzl.Entry
+
+  it('opens yauzl zip with autoClose disabled', async () => {
+    const zipFile = mockZipFileWithEntries([])
 
     mockYauzlOpen.mockImplementation((filePath, options, callback) => {
       callback(null, zipFile)
@@ -46,5 +67,79 @@ describe('StravaArchiveReader.open', () => {
 
     reader.close()
     expect(zipFile.close).toHaveBeenCalled()
+  })
+
+  it('rejects archives with too many entries before indexing completes', async () => {
+    const zipFile = mockZipFileWithEntries([
+      makeEntry({ fileName: 'activities/1.fit' }),
+      makeEntry({ fileName: 'activities/2.fit' }),
+      makeEntry({ fileName: 'activities/3.fit' })
+    ])
+    mockYauzlOpen.mockImplementation((filePath, options, callback) => {
+      callback(null, zipFile)
+      return undefined as never
+    })
+
+    await expect(
+      StravaArchiveReader.open('/tmp/export.zip', {
+        limits: { maxEntries: 2 }
+      })
+    ).rejects.toThrow('exceeds entry limit')
+  })
+
+  it('rejects 42.zip-style entries with oversized uncompressed data', async () => {
+    const zipFile = mockZipFileWithEntries([
+      makeEntry({
+        fileName: 'activities/bomb.fit',
+        compressedSize: 1,
+        uncompressedSize: 1_000_000_000
+      })
+    ])
+    mockYauzlOpen.mockImplementation((filePath, options, callback) => {
+      callback(null, zipFile)
+      return undefined as never
+    })
+
+    await expect(
+      StravaArchiveReader.open('/tmp/export.zip', {
+        limits: { maxEntryUncompressedBytes: 1024 }
+      })
+    ).rejects.toThrow('exceeds uncompressed size limit')
+  })
+
+  it('rejects entries with oversized compressed data', async () => {
+    const zipFile = mockZipFileWithEntries([
+      makeEntry({
+        fileName: 'activities/large.fit',
+        compressedSize: 4096,
+        uncompressedSize: 4096
+      })
+    ])
+    mockYauzlOpen.mockImplementation((filePath, options, callback) => {
+      callback(null, zipFile)
+      return undefined as never
+    })
+
+    await expect(
+      StravaArchiveReader.open('/tmp/export.zip', {
+        limits: { maxEntryCompressedBytes: 1024 }
+      })
+    ).rejects.toThrow('exceeds compressed size limit')
+  })
+
+  it('rejects archive entries with parent-directory traversal names', async () => {
+    const zipFile = mockZipFileWithEntries([
+      makeEntry({
+        fileName: '../activities/evil.fit'
+      })
+    ])
+    mockYauzlOpen.mockImplementation((filePath, options, callback) => {
+      callback(null, zipFile)
+      return undefined as never
+    })
+
+    await expect(StravaArchiveReader.open('/tmp/export.zip')).rejects.toThrow(
+      'Unsafe archive entry path'
+    )
   })
 })

--- a/lib/services/strava/archiveReader.open.test.ts
+++ b/lib/services/strava/archiveReader.open.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import fs from 'fs/promises'
 import { promisify } from 'util'
 import yauzl from 'yauzl'
 import { gzip as gzipCallback } from 'zlib'
@@ -152,6 +153,66 @@ describe('StravaArchiveReader.open', () => {
       'Unsafe archive entry path'
     )
     expect(zipFile.close).toHaveBeenCalled()
+  })
+
+  it('continues reading stored entries after partial fs reads', async () => {
+    const localHeaderOffset = 8
+    const entryData = Buffer.from('DATA')
+    const header = Buffer.alloc(30)
+    header.writeUInt16LE(0, 26)
+    header.writeUInt16LE(0, 28)
+    const zipBytes = Buffer.concat([
+      Buffer.alloc(localHeaderOffset),
+      header,
+      entryData
+    ])
+    const zipFile = mockZipFileWithEntries([
+      makeEntry({
+        fileName: 'activities/stored.fit',
+        compressionMethod: 0,
+        compressedSize: entryData.byteLength,
+        uncompressedSize: entryData.byteLength,
+        relativeOffsetOfLocalHeader: localHeaderOffset
+      })
+    ])
+    const readMock = jest.fn(
+      async (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number
+      ) => {
+        const bytesRead = Math.min(length, 2, zipBytes.byteLength - position)
+        if (bytesRead <= 0) {
+          return { bytesRead: 0, buffer }
+        }
+        zipBytes.copy(buffer, offset, position, position + bytesRead)
+        return { bytesRead, buffer }
+      }
+    )
+    const closeMock = jest.fn().mockResolvedValue(undefined)
+    const openSpy = jest.spyOn(fs, 'open').mockResolvedValue({
+      read: readMock,
+      close: closeMock
+    } as never)
+
+    mockYauzlOpen.mockImplementation((filePath, options, callback) => {
+      callback(null, zipFile)
+      return undefined as never
+    })
+
+    try {
+      const reader = await StravaArchiveReader.open('/tmp/export.zip')
+
+      await expect(
+        reader.readEntryBuffer('activities/stored.fit')
+      ).resolves.toEqual(entryData)
+      expect(readMock.mock.calls.length).toBeGreaterThan(2)
+
+      reader.close()
+    } finally {
+      openSpy.mockRestore()
+    }
   })
 
   it('keeps corrupt gzip activity errors distinct from gzip limit errors', async () => {

--- a/lib/services/strava/archiveReader.test.ts
+++ b/lib/services/strava/archiveReader.test.ts
@@ -2,6 +2,7 @@ import { gzipSync } from 'zlib'
 
 import {
   getArchiveMediaMimeType,
+  parseStravaArchiveCsvRows,
   toStravaArchiveFitnessFilePayload
 } from '@/lib/services/strava/archiveReader'
 
@@ -23,8 +24,8 @@ describe('archiveReader helpers', () => {
   })
 
   describe('toStravaArchiveFitnessFilePayload', () => {
-    it('builds payload for uncompressed fitness file', () => {
-      const payload = toStravaArchiveFitnessFilePayload({
+    it('builds payload for uncompressed fitness file', async () => {
+      const payload = await toStravaArchiveFitnessFilePayload({
         fitnessFilePath: 'activities/123.gpx',
         buffer: Buffer.from('<gpx />')
       })
@@ -35,8 +36,8 @@ describe('archiveReader helpers', () => {
       expect(payload.buffer.toString()).toBe('<gpx />')
     })
 
-    it('gunzips compressed fitness file payloads', () => {
-      const payload = toStravaArchiveFitnessFilePayload({
+    it('gunzips compressed fitness file payloads', async () => {
+      const payload = await toStravaArchiveFitnessFilePayload({
         fitnessFilePath: 'activities/123.fit.gz',
         buffer: gzipSync(Buffer.from('fit-binary'))
       })
@@ -47,13 +48,39 @@ describe('archiveReader helpers', () => {
       expect(payload.buffer.toString()).toBe('fit-binary')
     })
 
-    it('throws for unsupported fitness files', () => {
-      expect(() =>
-        toStravaArchiveFitnessFilePayload({
-          fitnessFilePath: 'activities/123.csv',
-          buffer: Buffer.from('bad')
-        })
-      ).toThrow('Unsupported fitness file path')
+    it('throws for unsupported fitness files', async () => {
+      await expect(
+        Promise.resolve().then(() =>
+          toStravaArchiveFitnessFilePayload({
+            fitnessFilePath: 'activities/123.csv',
+            buffer: Buffer.from('bad')
+          })
+        )
+      ).rejects.toThrow('Unsupported fitness file path')
+    })
+
+    it('rejects gzip output that exceeds the configured limit', async () => {
+      await expect(
+        toStravaArchiveFitnessFilePayload(
+          {
+            fitnessFilePath: 'activities/123.fit.gz',
+            buffer: gzipSync(Buffer.from('oversized-gzip-output'))
+          },
+          { maxGzipOutputBytes: 4 }
+        )
+      ).rejects.toThrow('exceeds gzip output limit')
+    })
+  })
+
+  describe('parseStravaArchiveCsvRows', () => {
+    it('rejects CSV row-count overflow without allocating millions of rows', () => {
+      const csv = ['Filename', 'activities/1.fit', 'activities/2.fit'].join(
+        '\n'
+      )
+
+      expect(() => parseStravaArchiveCsvRows(csv, { maxRows: 2 })).toThrow(
+        'exceeds CSV row limit'
+      )
     })
   })
 })

--- a/lib/services/strava/archiveReader.ts
+++ b/lib/services/strava/archiveReader.ts
@@ -5,7 +5,10 @@ import yauzl from 'yauzl'
 import { createGunzip } from 'zlib'
 
 import { DEFAULT_FITNESS_MAX_FILE_SIZE } from '@/lib/config/fitnessStorage'
-import { readAsyncIterableToBufferWithLimit } from '@/lib/utils/streamLimit'
+import {
+  StreamByteLimitError,
+  readAsyncIterableToBufferWithLimit
+} from '@/lib/utils/streamLimit'
 
 type SupportedFitnessFileType = 'fit' | 'gpx' | 'tcx'
 
@@ -141,11 +144,22 @@ const indexZipEntries = async (
   return new Promise((resolve, reject) => {
     const entries = new Map<string, yauzl.Entry>()
     let entryCount = 0
+    let settled = false
 
     const cleanup = () => {
       zipFile.off('entry', onEntry)
       zipFile.off('end', onEnd)
       zipFile.off('error', onError)
+    }
+
+    const rejectAndClose = (error: unknown) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      zipFile.close()
+      reject(error)
     }
 
     const onEntry = (entry: yauzl.Entry) => {
@@ -162,19 +176,21 @@ const indexZipEntries = async (
         entries.set(normalizedPath, entry)
         zipFile.readEntry()
       } catch (error) {
-        cleanup()
-        reject(error)
+        rejectAndClose(error)
       }
     }
 
     const onEnd = () => {
+      if (settled) {
+        return
+      }
+      settled = true
       cleanup()
       resolve(entries)
     }
 
     const onError = (error: Error) => {
-      cleanup()
-      reject(error)
+      rejectAndClose(error)
     }
 
     zipFile.on('entry', onEntry)
@@ -412,7 +428,7 @@ export const toStravaArchiveFitnessFilePayload = async (
         maxGzipOutputBytes,
         'Fitness gzip output'
       ).catch((error) => {
-        if (error instanceof Error) {
+        if (error instanceof StreamByteLimitError) {
           throw new StravaArchiveLimitError(
             `Fitness file ${fitnessFilePath} exceeds gzip output limit`
           )

--- a/lib/services/strava/archiveReader.ts
+++ b/lib/services/strava/archiveReader.ts
@@ -219,6 +219,39 @@ const openZipEntryStream = async (
   })
 }
 
+const readFileRange = async ({
+  fd,
+  buffer,
+  position,
+  label
+}: {
+  fd: Awaited<ReturnType<typeof fs.open>>
+  buffer: Buffer
+  position: number
+  label: string
+}) => {
+  let offset = 0
+
+  while (offset < buffer.byteLength) {
+    const result = await fd.read(
+      buffer,
+      offset,
+      buffer.byteLength - offset,
+      position + offset
+    )
+    if (result.bytesRead === 0) {
+      break
+    }
+    offset += result.bytesRead
+  }
+
+  if (offset < buffer.byteLength) {
+    throw new Error(
+      `Short read on ${label}: expected ${buffer.byteLength}, got ${offset}`
+    )
+  }
+}
+
 // Read a ZIP entry that uses Stored (no compression) directly via fs.read,
 // bypassing yauzl's openReadStream which can hang on Stored entries in large
 // archives due to an fd-slicer read-queue issue.
@@ -244,33 +277,23 @@ const readStoredEntryDirectly = async (
   const fd = await fs.open(zipFilePath, 'r')
   try {
     const headerBuf = Buffer.allocUnsafe(30)
-    const headerResult = await fd.read(
-      headerBuf,
-      0,
-      30,
-      entry.relativeOffsetOfLocalHeader
-    )
-    if (headerResult.bytesRead < 30) {
-      throw new Error(
-        `Short read on local file header for ${entry.fileName}: expected 30, got ${headerResult.bytesRead}`
-      )
-    }
+    await readFileRange({
+      fd,
+      buffer: headerBuf,
+      position: entry.relativeOffsetOfLocalHeader,
+      label: `local file header for ${entry.fileName}`
+    })
     const fileNameLength = headerBuf.readUInt16LE(26)
     const extraFieldLength = headerBuf.readUInt16LE(28)
     const dataOffset =
       entry.relativeOffsetOfLocalHeader + 30 + fileNameLength + extraFieldLength
     const dataBuf = Buffer.allocUnsafe(entry.compressedSize)
-    const dataResult = await fd.read(
-      dataBuf,
-      0,
-      entry.compressedSize,
-      dataOffset
-    )
-    if (dataResult.bytesRead < entry.compressedSize) {
-      throw new Error(
-        `Short read on entry data for ${entry.fileName}: expected ${entry.compressedSize}, got ${dataResult.bytesRead}`
-      )
-    }
+    await readFileRange({
+      fd,
+      buffer: dataBuf,
+      position: dataOffset,
+      label: `entry data for ${entry.fileName}`
+    })
     return dataBuf
   } finally {
     await fd.close()

--- a/lib/services/strava/archiveReader.ts
+++ b/lib/services/strava/archiveReader.ts
@@ -2,7 +2,10 @@ import fs from 'fs/promises'
 import path from 'path'
 import { Readable } from 'stream'
 import yauzl from 'yauzl'
-import { gunzipSync } from 'zlib'
+import { createGunzip } from 'zlib'
+
+import { DEFAULT_FITNESS_MAX_FILE_SIZE } from '@/lib/config/fitnessStorage'
+import { readAsyncIterableToBufferWithLimit } from '@/lib/utils/streamLimit'
 
 type SupportedFitnessFileType = 'fit' | 'gpx' | 'tcx'
 
@@ -21,6 +24,23 @@ const FITNESS_MIME_TYPES: Record<SupportedFitnessFileType, string> = {
   tcx: 'application/vnd.garmin.tcx+xml'
 }
 
+export const STRAVA_ARCHIVE_DEFAULT_LIMITS = {
+  maxEntries: 20_000,
+  maxEntryCompressedBytes: DEFAULT_FITNESS_MAX_FILE_SIZE,
+  maxEntryUncompressedBytes: DEFAULT_FITNESS_MAX_FILE_SIZE,
+  maxGzipOutputBytes: DEFAULT_FITNESS_MAX_FILE_SIZE,
+  maxCsvRows: 100_000
+}
+
+export type StravaArchiveLimits = Partial<typeof STRAVA_ARCHIVE_DEFAULT_LIMITS>
+
+export class StravaArchiveLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'StravaArchiveLimitError'
+  }
+}
+
 export interface StravaArchiveActivity {
   activityId: string
   activityName?: string
@@ -37,6 +57,56 @@ export interface StravaArchiveFitnessFilePayload {
 }
 
 const normalizeArchivePath = (value: string): string => {
+  const normalized = value.replace(/\\/g, '/').trim()
+  if (normalized.startsWith('./')) {
+    return normalized.slice(2)
+  }
+  return normalized
+}
+
+const getArchiveLimits = (limits?: StravaArchiveLimits) => ({
+  ...STRAVA_ARCHIVE_DEFAULT_LIMITS,
+  ...limits
+})
+
+const assertSafeArchivePath = (value: string): string => {
+  const normalized = normalizeArchivePath(value)
+  const parts = normalized.split('/')
+  if (
+    normalized.length === 0 ||
+    normalized.startsWith('/') ||
+    normalized.includes('\0') ||
+    parts.includes('..')
+  ) {
+    throw new StravaArchiveLimitError(
+      `Unsafe archive entry path: ${value || '(empty)'}`
+    )
+  }
+  return normalized
+}
+
+const assertEntryWithinLimits = (
+  entry: yauzl.Entry,
+  limits: ReturnType<typeof getArchiveLimits>
+) => {
+  if (entry.fileName.endsWith('/')) {
+    return
+  }
+
+  if (entry.compressedSize > limits.maxEntryCompressedBytes) {
+    throw new StravaArchiveLimitError(
+      `Archive entry ${entry.fileName} exceeds compressed size limit`
+    )
+  }
+
+  if (entry.uncompressedSize > limits.maxEntryUncompressedBytes) {
+    throw new StravaArchiveLimitError(
+      `Archive entry ${entry.fileName} exceeds uncompressed size limit`
+    )
+  }
+}
+
+const normalizeReferencedArchivePath = (value: string): string => {
   return value
     .replace(/\\/g, '/')
     .replace(/^\.?\//, '')
@@ -65,10 +135,12 @@ const openZipFile = async (filePath: string): Promise<yauzl.ZipFile> => {
 }
 
 const indexZipEntries = async (
-  zipFile: yauzl.ZipFile
+  zipFile: yauzl.ZipFile,
+  limits: ReturnType<typeof getArchiveLimits>
 ): Promise<Map<string, yauzl.Entry>> => {
   return new Promise((resolve, reject) => {
     const entries = new Map<string, yauzl.Entry>()
+    let entryCount = 0
 
     const cleanup = () => {
       zipFile.off('entry', onEntry)
@@ -77,8 +149,22 @@ const indexZipEntries = async (
     }
 
     const onEntry = (entry: yauzl.Entry) => {
-      entries.set(normalizeArchivePath(entry.fileName), entry)
-      zipFile.readEntry()
+      try {
+        entryCount += 1
+        if (entryCount > limits.maxEntries) {
+          throw new StravaArchiveLimitError(
+            `Strava archive exceeds entry limit of ${limits.maxEntries}`
+          )
+        }
+
+        const normalizedPath = assertSafeArchivePath(entry.fileName)
+        assertEntryWithinLimits(entry, limits)
+        entries.set(normalizedPath, entry)
+        zipFile.readEntry()
+      } catch (error) {
+        cleanup()
+        reject(error)
+      }
     }
 
     const onEnd = () => {
@@ -117,21 +203,15 @@ const openZipEntryStream = async (
   })
 }
 
-const readStreamToBuffer = async (stream: Readable): Promise<Buffer> => {
-  const chunks: Buffer[] = []
-  for await (const chunk of stream) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
-  }
-  return Buffer.concat(chunks)
-}
-
 // Read a ZIP entry that uses Stored (no compression) directly via fs.read,
 // bypassing yauzl's openReadStream which can hang on Stored entries in large
 // archives due to an fd-slicer read-queue issue.
 const readStoredEntryDirectly = async (
   zipFilePath: string,
-  entry: yauzl.Entry
+  entry: yauzl.Entry,
+  limits: ReturnType<typeof getArchiveLimits>
 ): Promise<Buffer> => {
+  assertEntryWithinLimits(entry, limits)
   // Local file header layout (PKWARE spec section 4.3.7):
   //   signature         4 bytes
   //   version needed    2 bytes
@@ -181,11 +261,24 @@ const readStoredEntryDirectly = async (
   }
 }
 
-const parseCsvRows = (csvText: string): string[][] => {
+export const parseStravaArchiveCsvRows = (
+  csvText: string,
+  options: { maxRows?: number } = {}
+): string[][] => {
+  const maxRows = options.maxRows ?? STRAVA_ARCHIVE_DEFAULT_LIMITS.maxCsvRows
   const rows: string[][] = []
   let row: string[] = []
   let field = ''
   let inQuotes = false
+
+  const pushRow = () => {
+    rows.push(row)
+    if (rows.length > maxRows) {
+      throw new StravaArchiveLimitError(
+        `activities.csv exceeds CSV row limit of ${maxRows}`
+      )
+    }
+  }
 
   for (let index = 0; index < csvText.length; index += 1) {
     const character = csvText[index]
@@ -218,7 +311,7 @@ const parseCsvRows = (csvText: string): string[][] => {
 
     if (character === '\n') {
       row.push(field)
-      rows.push(row)
+      pushRow()
       row = []
       field = ''
       continue
@@ -231,7 +324,7 @@ const parseCsvRows = (csvText: string): string[][] => {
 
   if (field.length > 0 || row.length > 0) {
     row.push(field)
-    rows.push(row)
+    pushRow()
   }
 
   return rows
@@ -243,7 +336,7 @@ const getMediaPaths = (value: string): string[] => {
   }
   return value
     .split('|')
-    .map((item) => normalizeArchivePath(item))
+    .map((item) => normalizeReferencedArchivePath(item))
     .filter((item) => item.length > 0)
 }
 
@@ -294,20 +387,38 @@ export const getArchiveMediaMimeType = (
   }
 }
 
-export const toStravaArchiveFitnessFilePayload = ({
-  fitnessFilePath,
-  buffer
-}: {
-  fitnessFilePath: string
-  buffer: Buffer
-}): StravaArchiveFitnessFilePayload => {
+export const toStravaArchiveFitnessFilePayload = async (
+  {
+    fitnessFilePath,
+    buffer
+  }: {
+    fitnessFilePath: string
+    buffer: Buffer
+  },
+  options: { maxGzipOutputBytes?: number } = {}
+): Promise<StravaArchiveFitnessFilePayload> => {
   const fileType = getFitnessFileTypeFromPath(fitnessFilePath)
   if (!fileType) {
     throw new Error(`Unsupported fitness file path: ${fitnessFilePath}`)
   }
 
+  const maxGzipOutputBytes =
+    options.maxGzipOutputBytes ??
+    STRAVA_ARCHIVE_DEFAULT_LIMITS.maxGzipOutputBytes
+
   const fitnessBuffer = shouldGunzipFitnessBuffer(fitnessFilePath)
-    ? gunzipSync(buffer)
+    ? await readAsyncIterableToBufferWithLimit(
+        Readable.from(buffer).pipe(createGunzip()),
+        maxGzipOutputBytes,
+        'Fitness gzip output'
+      ).catch((error) => {
+        if (error instanceof Error) {
+          throw new StravaArchiveLimitError(
+            `Fitness file ${fitnessFilePath} exceeds gzip output limit`
+          )
+        }
+        throw error
+      })
     : buffer
 
   const baseName = path.basename(fitnessFilePath)
@@ -327,28 +438,37 @@ export class StravaArchiveReader {
   private _filePath: string
   private _zipFile: yauzl.ZipFile
   private _entriesByPath: Map<string, yauzl.Entry>
+  private _limits: ReturnType<typeof getArchiveLimits>
 
   private constructor({
     filePath,
     zipFile,
-    entriesByPath
+    entriesByPath,
+    limits
   }: {
     filePath: string
     zipFile: yauzl.ZipFile
     entriesByPath: Map<string, yauzl.Entry>
+    limits: ReturnType<typeof getArchiveLimits>
   }) {
     this._filePath = filePath
     this._zipFile = zipFile
     this._entriesByPath = entriesByPath
+    this._limits = limits
   }
 
-  static async open(filePath: string): Promise<StravaArchiveReader> {
+  static async open(
+    filePath: string,
+    options: { limits?: StravaArchiveLimits } = {}
+  ): Promise<StravaArchiveReader> {
+    const limits = getArchiveLimits(options.limits)
     const zipFile = await openZipFile(filePath)
-    const entriesByPath = await indexZipEntries(zipFile)
+    const entriesByPath = await indexZipEntries(zipFile, limits)
     return new StravaArchiveReader({
       filePath,
       zipFile,
-      entriesByPath
+      entriesByPath,
+      limits
     })
   }
 
@@ -357,25 +477,30 @@ export class StravaArchiveReader {
   }
 
   async readEntryBuffer(entryPath: string): Promise<Buffer | null> {
-    const normalizedPath = normalizeArchivePath(entryPath)
+    const normalizedPath = normalizeReferencedArchivePath(entryPath)
     const entry = this._entriesByPath.get(normalizedPath)
     if (!entry || entry.fileName.endsWith('/')) {
       return null
     }
+    assertEntryWithinLimits(entry, this._limits)
 
     // Stored entries (compressionMethod=0) can hang in yauzl's openReadStream
     // due to an fd-slicer read-queue issue in large archives.  Read them
     // directly via fs.read to bypass the problem entirely.
     if (entry.compressionMethod === 0) {
-      return readStoredEntryDirectly(this._filePath, entry)
+      return readStoredEntryDirectly(this._filePath, entry, this._limits)
     }
 
     const entryStream = await openZipEntryStream(this._zipFile, entry)
-    return readStreamToBuffer(entryStream)
+    return readAsyncIterableToBufferWithLimit(
+      entryStream,
+      this._limits.maxEntryUncompressedBytes,
+      `Archive entry ${entry.fileName}`
+    )
   }
 
   hasEntry(entryPath: string): boolean {
-    return this._entriesByPath.has(normalizeArchivePath(entryPath))
+    return this._entriesByPath.has(normalizeReferencedArchivePath(entryPath))
   }
 
   async getActivities(): Promise<StravaArchiveActivity[]> {
@@ -384,7 +509,9 @@ export class StravaArchiveReader {
       throw new Error('Strava archive does not contain activities.csv')
     }
 
-    const rows = parseCsvRows(csvBuffer.toString('utf8'))
+    const rows = parseStravaArchiveCsvRows(csvBuffer.toString('utf8'), {
+      maxRows: this._limits.maxCsvRows
+    })
     if (rows.length === 0) {
       return []
     }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -746,6 +746,14 @@ export interface LikeDatabase {
 interface MetaData {
   width: number
   height: number
+  upload?: {
+    state: 'pending' | 'verified'
+    checksumSha1?: string
+    checksumSha1Base64?: string
+    contentType?: string
+    size?: number
+    verifiedAt?: number
+  }
 }
 
 interface BaseMedia {
@@ -829,9 +837,17 @@ export type GetMediaByIdParams = {
   mediaId: string
   accountId: string
 }
+export type MarkMediaUploadVerifiedParams = {
+  mediaId: string
+  accountId: string
+  verifiedAt: number
+}
 
 export interface MediaDatabase {
   createMedia(params: CreateMediaParams): Promise<Media | null>
+  markMediaUploadVerified(
+    params: MarkMediaUploadVerifiedParams
+  ): Promise<Media | null>
 
   createAttachment(params: CreateAttachmentParams): Promise<Attachment>
   getAttachments(params: GetAttachmentsParams): Promise<Attachment[]>

--- a/lib/utils/streamLimit.test.ts
+++ b/lib/utils/streamLimit.test.ts
@@ -32,4 +32,24 @@ describe('readResponseArrayBufferWithLimit', () => {
       ...new Uint8Array(arrayBuffer)
     ])
   })
+
+  it('cancels streaming responses when the byte limit is exceeded', async () => {
+    const cancel = jest.fn()
+    const response = {
+      headers: new Headers(),
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2]))
+          controller.enqueue(new Uint8Array([3, 4]))
+        },
+        cancel
+      })
+    } as unknown as Response
+
+    await expect(
+      readResponseArrayBufferWithLimit(response, 3, 'Streaming body')
+    ).rejects.toThrow('Streaming body exceeds byte limit of 3 bytes')
+
+    expect(cancel).toHaveBeenCalled()
+  })
 })

--- a/lib/utils/streamLimit.test.ts
+++ b/lib/utils/streamLimit.test.ts
@@ -1,0 +1,35 @@
+import { readResponseArrayBufferWithLimit } from './streamLimit'
+
+describe('readResponseArrayBufferWithLimit', () => {
+  it('rejects non-streaming responses without a safe content length before buffering', async () => {
+    const response = {
+      headers: new Headers(),
+      body: null,
+      arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(2048))
+    } as unknown as Response
+
+    await expect(
+      readResponseArrayBufferWithLimit(response, 1024, 'Fallback body')
+    ).rejects.toThrow('Unable to safely read Fallback body without streaming')
+    expect(response.arrayBuffer).not.toHaveBeenCalled()
+  })
+
+  it('allows non-streaming responses with a content length within the limit', async () => {
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer
+    const response = {
+      headers: new Headers({ 'content-length': '3' }),
+      body: null,
+      arrayBuffer: jest.fn().mockResolvedValue(arrayBuffer)
+    } as unknown as Response
+
+    const result = await readResponseArrayBufferWithLimit(
+      response,
+      1024,
+      'Fallback body'
+    )
+
+    expect([...new Uint8Array(result)]).toEqual([
+      ...new Uint8Array(arrayBuffer)
+    ])
+  })
+})

--- a/lib/utils/streamLimit.ts
+++ b/lib/utils/streamLimit.ts
@@ -45,6 +45,43 @@ export const assertResponseContentLengthWithinLimit = (
   })
 }
 
+const getSafeResponseContentLength = (
+  response: Pick<Response, 'headers'>,
+  maxBytes: number,
+  label: string
+): number | null => {
+  const contentLength = response.headers.get('content-length')
+  if (!contentLength) {
+    return null
+  }
+
+  const parsedLength = Number(contentLength)
+  if (!Number.isFinite(parsedLength) || parsedLength < 0) {
+    return null
+  }
+
+  assertByteLengthWithinLimit({
+    byteLength: parsedLength,
+    maxBytes,
+    label
+  })
+  return parsedLength
+}
+
+const bufferToArrayBuffer = (buffer: Buffer): ArrayBuffer => {
+  if (
+    buffer.byteOffset === 0 &&
+    buffer.byteLength === buffer.buffer.byteLength
+  ) {
+    return buffer.buffer as ArrayBuffer
+  }
+
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength
+  ) as ArrayBuffer
+}
+
 const toBuffer = (chunk: unknown): Buffer => {
   if (Buffer.isBuffer(chunk)) {
     return chunk
@@ -116,19 +153,24 @@ export const readResponseArrayBufferWithLimit = async (
   maxBytes = SAFE_DOWNLOAD_MAX_BYTES,
   label = 'Response body'
 ): Promise<ArrayBuffer> => {
-  assertResponseContentLengthWithinLimit(response, maxBytes, label)
+  const safeContentLength = getSafeResponseContentLength(
+    response,
+    maxBytes,
+    label
+  )
 
   if (!response.body || typeof response.body.getReader !== 'function') {
-    const buffer = Buffer.from(await response.arrayBuffer())
+    if (safeContentLength === null) {
+      throw new Error(`Unable to safely read ${label} without streaming`)
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
     assertByteLengthWithinLimit({
-      byteLength: buffer.byteLength,
+      byteLength: arrayBuffer.byteLength,
       maxBytes,
       label
     })
-    return buffer.buffer.slice(
-      buffer.byteOffset,
-      buffer.byteOffset + buffer.byteLength
-    )
+    return arrayBuffer
   }
 
   const reader = response.body.getReader()
@@ -154,10 +196,7 @@ export const readResponseArrayBufferWithLimit = async (
   }
 
   const buffer = Buffer.concat(chunks, totalBytes)
-  return buffer.buffer.slice(
-    buffer.byteOffset,
-    buffer.byteOffset + buffer.byteLength
-  )
+  return bufferToArrayBuffer(buffer)
 }
 
 export class ByteLimitTransform extends Transform {

--- a/lib/utils/streamLimit.ts
+++ b/lib/utils/streamLimit.ts
@@ -187,6 +187,7 @@ export const readResponseArrayBufferWithLimit = async (
       const buffer = Buffer.from(value)
       totalBytes += buffer.byteLength
       if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => undefined)
         throw new StreamByteLimitError(label, maxBytes)
       }
       chunks.push(buffer)

--- a/lib/utils/streamLimit.ts
+++ b/lib/utils/streamLimit.ts
@@ -1,0 +1,186 @@
+import { Transform, TransformCallback } from 'stream'
+
+export const SAFE_DOWNLOAD_MAX_BYTES = 10 * 1024 * 1024
+
+export class StreamByteLimitError extends Error {
+  constructor(label: string, maxBytes: number) {
+    super(`${label} exceeds byte limit of ${maxBytes} bytes`)
+    this.name = 'StreamByteLimitError'
+  }
+}
+
+export const assertByteLengthWithinLimit = ({
+  byteLength,
+  maxBytes,
+  label
+}: {
+  byteLength: number | undefined
+  maxBytes: number
+  label: string
+}) => {
+  if (
+    typeof byteLength === 'number' &&
+    Number.isFinite(byteLength) &&
+    byteLength > maxBytes
+  ) {
+    throw new StreamByteLimitError(label, maxBytes)
+  }
+}
+
+export const assertResponseContentLengthWithinLimit = (
+  response: Pick<Response, 'headers'>,
+  maxBytes: number,
+  label = 'Response body'
+) => {
+  const contentLength = response.headers.get('content-length')
+  if (!contentLength) {
+    return
+  }
+
+  const parsedLength = Number(contentLength)
+  assertByteLengthWithinLimit({
+    byteLength: parsedLength,
+    maxBytes,
+    label
+  })
+}
+
+const toBuffer = (chunk: unknown): Buffer => {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk)
+  }
+  return Buffer.from(String(chunk))
+}
+
+export const readAsyncIterableToBufferWithLimit = async (
+  stream: AsyncIterable<unknown>,
+  maxBytes: number,
+  label = 'Stream'
+): Promise<Buffer> => {
+  const chunks: Buffer[] = []
+  let totalBytes = 0
+
+  for await (const chunk of stream) {
+    const buffer = toBuffer(chunk)
+    totalBytes += buffer.byteLength
+    if (totalBytes > maxBytes) {
+      throw new StreamByteLimitError(label, maxBytes)
+    }
+    chunks.push(buffer)
+  }
+
+  return Buffer.concat(chunks, totalBytes)
+}
+
+export const readUnknownBodyToBufferWithLimit = async (
+  body: unknown,
+  maxBytes: number,
+  label = 'Stream'
+): Promise<Buffer> => {
+  if (body && Symbol.asyncIterator in Object(body)) {
+    return readAsyncIterableToBufferWithLimit(
+      body as AsyncIterable<unknown>,
+      maxBytes,
+      label
+    )
+  }
+
+  if (
+    body &&
+    typeof body === 'object' &&
+    'transformToByteArray' in body &&
+    typeof (body as { transformToByteArray: () => Promise<Uint8Array> })
+      .transformToByteArray === 'function'
+  ) {
+    const buffer = Buffer.from(
+      await (
+        body as { transformToByteArray: () => Promise<Uint8Array> }
+      ).transformToByteArray()
+    )
+    assertByteLengthWithinLimit({
+      byteLength: buffer.byteLength,
+      maxBytes,
+      label
+    })
+    return buffer
+  }
+
+  throw new Error(`Unable to read ${label}`)
+}
+
+export const readResponseArrayBufferWithLimit = async (
+  response: Response,
+  maxBytes = SAFE_DOWNLOAD_MAX_BYTES,
+  label = 'Response body'
+): Promise<ArrayBuffer> => {
+  assertResponseContentLengthWithinLimit(response, maxBytes, label)
+
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    const buffer = Buffer.from(await response.arrayBuffer())
+    assertByteLengthWithinLimit({
+      byteLength: buffer.byteLength,
+      maxBytes,
+      label
+    })
+    return buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength
+    )
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Buffer[] = []
+  let totalBytes = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+
+      const buffer = Buffer.from(value)
+      totalBytes += buffer.byteLength
+      if (totalBytes > maxBytes) {
+        throw new StreamByteLimitError(label, maxBytes)
+      }
+      chunks.push(buffer)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const buffer = Buffer.concat(chunks, totalBytes)
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength
+  )
+}
+
+export class ByteLimitTransform extends Transform {
+  private _totalBytes = 0
+  private _maxBytes: number
+  private _label: string
+
+  constructor(maxBytes: number, label = 'Stream') {
+    super()
+    this._maxBytes = maxBytes
+    this._label = label
+  }
+
+  _transform(chunk: Buffer, _encoding: string, callback: TransformCallback) {
+    this._totalBytes += chunk.byteLength
+    if (this._totalBytes > this._maxBytes) {
+      callback(new StreamByteLimitError(this._label, this._maxBytes))
+      return
+    }
+
+    callback(null, chunk)
+  }
+}
+
+export const createByteLimitTransform = (maxBytes: number, label = 'Stream') =>
+  new ByteLimitTransform(maxBytes, label)

--- a/scripts/importStravaArchive.ts
+++ b/scripts/importStravaArchive.ts
@@ -197,7 +197,7 @@ async function importStravaArchive(args = process.argv.slice(2)) {
           throw new Error('Fitness activity file is missing from archive')
         }
 
-        const fitnessPayload = toStravaArchiveFitnessFilePayload({
+        const fitnessPayload = await toStravaArchiveFitnessFilePayload({
           fitnessFilePath: activity.fitnessFilePath,
           buffer: fitnessBuffer
         })


### PR DESCRIPTION
## Summary
- Verify S3 presigned media uploads with server-side object metadata before marking uploads usable.
- Add bounded Strava archive parsing and no-partial-commit rejection for archive bombs, oversized entries, gzip output, and CSV row overflow.
- Enforce local fitness storage path containment and stream-limit Strava/S3 downloads.
- Use public cache headers for anonymous fitness route-data responses and document upstream rate-limit requirements for self-hosted deployments.

## Tests
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test
