### PR TITLE
fix: sign redirected ActivityPub key fetches

### DIFF
--- a/lib/services/guards/getSenderPublicKey.test.ts
+++ b/lib/services/guards/getSenderPublicKey.test.ts
@@ -1,4 +1,5 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+import crypto from 'node:crypto'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import {
@@ -10,6 +11,7 @@ import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { logger } from '@/lib/utils/logger'
+import { parse } from '@/lib/utils/signature'
 
 enableFetchMocks()
 
@@ -35,6 +37,7 @@ jest.mock('@/lib/utils/logger', () => ({
 }))
 
 jest.mock('@/lib/utils/trace', () => ({
+  getSpan: () => mockSpan,
   getTracer: () => ({
     startActiveSpan: mockStartActiveSpan
   })
@@ -62,6 +65,31 @@ const createActorDocument = ({
     publicKeyPem
   }
 })
+
+const verifySignedRequestTarget = async ({
+  headers,
+  publicKey,
+  requestTarget
+}: {
+  headers: Record<string, string>
+  publicKey: string
+  requestTarget: string
+}) => {
+  const parsedSignature = await parse(headers.signature)
+  const signedString = (parsedSignature.headers ?? '')
+    .split(' ')
+    .map((header) => {
+      if (header === '(request-target)') {
+        return `(request-target): ${requestTarget}`
+      }
+
+      return `${header}: ${headers[header]}`
+    })
+    .join('\n')
+  const verifier = crypto.createVerify(parsedSignature.algorithm)
+  verifier.update(signedString)
+  return verifier.verify(publicKey, parsedSignature.signature, 'base64')
+}
 
 describe('getSenderPublicKey', () => {
   const database = getTestSQLDatabase()
@@ -611,6 +639,60 @@ describe('getSenderPublicKey', () => {
       host: 'remote.test',
       signature: expect.stringContaining('headers="(request-target) host date"')
     })
+  })
+
+  it('signs redirected remote public key fetches for the redirect target', async () => {
+    const actorId = 'https://remote.test/users/redirected-key'
+    const keyId = `${actorId}#main-key`
+    const redirectTarget = 'https://remote.test/@redirected-key'
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (request) => {
+      const url = new URL(request.url)
+
+      if (url.pathname === '/users/redirected-key') {
+        return {
+          headers: { location: redirectTarget },
+          status: 302
+        }
+      }
+
+      if (url.pathname === '/@redirected-key') {
+        return {
+          body: JSON.stringify(
+            createActorDocument({
+              id: actorId,
+              publicKeyId: keyId,
+              publicKeyPem: 'redirected-public-key'
+            })
+          ),
+          status: 200
+        }
+      }
+
+      return { status: 404 }
+    })
+
+    const publicKey = await getSenderPublicKeyDetails(database, keyId)
+    const signingActor = await database.getFederationSigningActor()
+    if (!signingActor) fail('Federation signing actor is required')
+
+    const redirectedRequest = fetchMock.mock.calls.at(1)?.[1]
+    const redirectedHeaders = redirectedRequest?.headers as Record<
+      string,
+      string
+    >
+
+    expect(publicKey).toEqual({
+      owner: actorId,
+      publicKey: 'redirected-public-key'
+    })
+    expect(
+      await verifySignedRequestTarget({
+        headers: redirectedHeaders,
+        publicKey: signingActor.publicKey,
+        requestTarget: 'get /@redirected-key'
+      })
+    ).toBe(true)
   })
 
   it('returns empty string when remote actor not found', async () => {

--- a/lib/services/guards/getSenderPublicKey.test.ts
+++ b/lib/services/guards/getSenderPublicKey.test.ts
@@ -676,7 +676,11 @@ describe('getSenderPublicKey', () => {
     const signingActor = await database.getFederationSigningActor()
     if (!signingActor) fail('Federation signing actor is required')
 
-    const redirectedRequest = fetchMock.mock.calls.at(1)?.[1]
+    const redirectedCall = fetchMock.mock.calls.find(
+      ([url]) => url === redirectTarget
+    )
+    expect(redirectedCall).toBeDefined()
+    const redirectedRequest = redirectedCall?.[1]
     const redirectedHeaders = redirectedRequest?.headers as Record<
       string,
       string

--- a/lib/services/guards/getSenderPublicKey.test.ts
+++ b/lib/services/guards/getSenderPublicKey.test.ts
@@ -37,7 +37,6 @@ jest.mock('@/lib/utils/logger', () => ({
 }))
 
 jest.mock('@/lib/utils/trace', () => ({
-  getSpan: () => mockSpan,
   getTracer: () => ({
     startActiveSpan: mockStartActiveSpan
   })

--- a/lib/services/guards/getSenderPublicKey.ts
+++ b/lib/services/guards/getSenderPublicKey.ts
@@ -158,10 +158,11 @@ const fetchSenderPublicKey = async (
 ) => {
   const response = await request({
     url: actorId,
-    headers: activityPubRequestHeaders({
-      url: actorId,
-      signingActor
-    })
+    headers: ({ url }) =>
+      activityPubRequestHeaders({
+        url: url.toString(),
+        signingActor
+      })
   })
   if (response.statusCode !== 200) {
     return {

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -1,7 +1,8 @@
 import { getConfig } from '@/lib/config'
 import {
   DEFAULT_SAFE_REMOTE_FETCH_MAX_BODY_BYTES,
-  SafeRemoteFetchHeaders,
+  SafeRemoteFetchHeaderBuilderRequest,
+  SafeRemoteFetchHeaderSource,
   SafeRemoteFetchMethod,
   safeRemoteFetch
 } from '@/lib/utils/safeRemoteFetch'
@@ -46,7 +47,7 @@ const SHARED_HEADERS = {
 export interface RequestOptions {
   url: string
   method?: SafeRemoteFetchMethod
-  headers?: SafeRemoteFetchHeaders
+  headers?: SafeRemoteFetchHeaderSource
   body?: string
   responseTimeout?: number
   numberOfRetry?: number
@@ -89,10 +90,16 @@ const getRequestOptions = ({
   return {
     body,
     connectTimeoutInMilliseconds: defaultResponseTimeout,
-    headers: {
-      ...SHARED_HEADERS,
-      ...headers
-    },
+    headers:
+      typeof headers === 'function'
+        ? (request: SafeRemoteFetchHeaderBuilderRequest) => ({
+            ...SHARED_HEADERS,
+            ...headers(request)
+          })
+        : {
+            ...SHARED_HEADERS,
+            ...headers
+          },
     maxBodyBytes,
     method,
     numberOfRetry:

--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -350,6 +350,77 @@ describe('safeRemoteFetch', () => {
     })
   })
 
+  it('keeps dynamic credentials stripped after cross-host redirect chains', async () => {
+    const seenRequests: Array<{
+      url: string
+      headers: Record<string, string | string[] | undefined>
+    }> = []
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS],
+      transport: async ({ headers, url }) => {
+        seenRequests.push({ headers, url: url.toString() })
+        if (url.hostname === 'safe.example') {
+          return {
+            statusCode: 302,
+            headers: {
+              location: 'https://other.example/redirected'
+            },
+            body: streamFrom([])
+          }
+        }
+
+        if (url.pathname === '/redirected') {
+          return {
+            statusCode: 302,
+            headers: {
+              location: 'https://other.example/final'
+            },
+            body: streamFrom([])
+          }
+        }
+
+        return okResponse()
+      }
+    })
+
+    await safeRemoteFetch({
+      url: 'https://safe.example/actor',
+      headers: ({ url }) => ({
+        authorization: 'Bearer secret',
+        cookie: 'session=secret',
+        signature: `keyId="${url.toString()}",signature="secret"`
+      })
+    })
+
+    expect(seenRequests).toEqual([
+      {
+        url: 'https://safe.example/actor',
+        headers: expect.objectContaining({
+          authorization: 'Bearer secret',
+          cookie: 'session=secret',
+          host: 'safe.example',
+          signature: 'keyId="https://safe.example/actor",signature="secret"'
+        })
+      },
+      {
+        url: 'https://other.example/redirected',
+        headers: expect.not.objectContaining({
+          authorization: expect.any(String),
+          cookie: expect.any(String),
+          signature: expect.any(String)
+        })
+      },
+      {
+        url: 'https://other.example/final',
+        headers: expect.not.objectContaining({
+          authorization: expect.any(String),
+          cookie: expect.any(String),
+          signature: expect.any(String)
+        })
+      }
+    ])
+  })
+
   it('destroys redirect response bodies without buffering them', async () => {
     const redirectBody = streamFrom(['redirect body'])
     const destroy = jest.spyOn(redirectBody, 'destroy')

--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -308,6 +308,48 @@ describe('safeRemoteFetch', () => {
     })
   })
 
+  it('strips dynamic credentials and auth headers on cross-host redirects', async () => {
+    const seenRequests: Array<{
+      url: string
+      headers: Record<string, string | string[] | undefined>
+    }> = []
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS],
+      transport: async ({ headers, url }) => {
+        seenRequests.push({ headers, url: url.toString() })
+        if (url.hostname === 'safe.example') {
+          return {
+            statusCode: 302,
+            headers: {
+              location: 'https://other.example/private-key'
+            },
+            body: streamFrom([])
+          }
+        }
+
+        return okResponse()
+      }
+    })
+
+    await safeRemoteFetch({
+      url: 'https://safe.example/actor',
+      headers: ({ url }) => ({
+        authorization: 'Bearer secret',
+        cookie: 'session=secret',
+        signature: `keyId="${url.toString()}",signature="secret"`
+      })
+    })
+
+    expect(seenRequests[1]).toEqual({
+      url: 'https://other.example/private-key',
+      headers: expect.not.objectContaining({
+        authorization: expect.any(String),
+        cookie: expect.any(String),
+        signature: expect.any(String)
+      })
+    })
+  })
+
   it('destroys redirect response bodies without buffering them', async () => {
     const redirectBody = streamFrom(['redirect body'])
     const destroy = jest.spyOn(redirectBody, 'destroy')

--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -473,6 +473,87 @@ describe('safeRemoteFetch', () => {
     ])
   })
 
+  it('rebuilds dynamic headers without body headers after 303 redirects', async () => {
+    const headerBuilderRequests: Array<{
+      body?: string
+      method: string
+      url: string
+    }> = []
+    const seenRequests: Array<{
+      body?: string
+      headers: Record<string, string | string[] | undefined>
+      method: string
+    }> = []
+    const safeRemoteFetch = createSafeRemoteFetch({
+      resolveHost: async () => [SAFE_ADDRESS],
+      transport: async ({ body, headers, method, url }) => {
+        seenRequests.push({ body, headers, method })
+        if (url.pathname === '/from') {
+          return {
+            statusCode: 303,
+            headers: { location: 'https://safe.example/to' },
+            body: streamFrom([])
+          }
+        }
+
+        return okResponse()
+      }
+    })
+
+    await safeRemoteFetch({
+      body: 'payload',
+      headers: ({ body, method, url }) => {
+        headerBuilderRequests.push({
+          body,
+          method,
+          url: url.toString()
+        })
+
+        return {
+          'content-type': 'text/plain',
+          digest: 'sha-256=payload',
+          signature: `keyId="${url.toString()}",signature="${method}-${body ?? 'none'}"`
+        }
+      },
+      method: 'POST',
+      url: 'https://safe.example/from'
+    })
+
+    expect(headerBuilderRequests).toEqual([
+      {
+        body: 'payload',
+        method: 'POST',
+        url: 'https://safe.example/from'
+      },
+      {
+        body: undefined,
+        method: 'GET',
+        url: 'https://safe.example/to'
+      }
+    ])
+    expect(seenRequests).toEqual([
+      {
+        body: 'payload',
+        headers: expect.objectContaining({
+          'content-type': 'text/plain',
+          digest: 'sha-256=payload',
+          host: 'safe.example',
+          signature:
+            'keyId="https://safe.example/from",signature="POST-payload"'
+        }),
+        method: 'POST'
+      },
+      {
+        body: undefined,
+        headers: {
+          host: 'safe.example',
+          signature: 'keyId="https://safe.example/to",signature="GET-none"'
+        },
+        method: 'GET'
+      }
+    ])
+  })
+
   it('does not leave got stream error listeners after reading the body', async () => {
     const stream = new Readable({
       read() {}

--- a/lib/utils/safeRemoteFetch.test.ts
+++ b/lib/utils/safeRemoteFetch.test.ts
@@ -25,6 +25,14 @@ const okResponse = (body = 'ok') => ({
   body: streamFrom([body])
 })
 
+const expectSensitiveHeadersStripped = (
+  headers: Record<string, string | string[] | undefined>
+) => {
+  expect(headers).not.toHaveProperty('authorization')
+  expect(headers).not.toHaveProperty('cookie')
+  expect(headers).not.toHaveProperty('signature')
+}
+
 describe('safeRemoteFetch', () => {
   afterEach(() => {
     mockGotStream.mockReset()
@@ -298,14 +306,8 @@ describe('safeRemoteFetch', () => {
       }
     })
 
-    expect(seenRequests[1]).toEqual({
-      url: 'https://other.example/private-key',
-      headers: expect.not.objectContaining({
-        authorization: expect.any(String),
-        cookie: expect.any(String),
-        signature: expect.any(String)
-      })
-    })
+    expect(seenRequests[1]?.url).toBe('https://other.example/private-key')
+    expectSensitiveHeadersStripped(seenRequests[1].headers)
   })
 
   it('strips dynamic credentials and auth headers on cross-host redirects', async () => {
@@ -340,14 +342,8 @@ describe('safeRemoteFetch', () => {
       })
     })
 
-    expect(seenRequests[1]).toEqual({
-      url: 'https://other.example/private-key',
-      headers: expect.not.objectContaining({
-        authorization: expect.any(String),
-        cookie: expect.any(String),
-        signature: expect.any(String)
-      })
-    })
+    expect(seenRequests[1]?.url).toBe('https://other.example/private-key')
+    expectSensitiveHeadersStripped(seenRequests[1].headers)
   })
 
   it('keeps dynamic credentials stripped after cross-host redirect chains', async () => {
@@ -392,33 +388,20 @@ describe('safeRemoteFetch', () => {
       })
     })
 
-    expect(seenRequests).toEqual([
-      {
-        url: 'https://safe.example/actor',
-        headers: expect.objectContaining({
-          authorization: 'Bearer secret',
-          cookie: 'session=secret',
-          host: 'safe.example',
-          signature: 'keyId="https://safe.example/actor",signature="secret"'
-        })
-      },
-      {
-        url: 'https://other.example/redirected',
-        headers: expect.not.objectContaining({
-          authorization: expect.any(String),
-          cookie: expect.any(String),
-          signature: expect.any(String)
-        })
-      },
-      {
-        url: 'https://other.example/final',
-        headers: expect.not.objectContaining({
-          authorization: expect.any(String),
-          cookie: expect.any(String),
-          signature: expect.any(String)
-        })
-      }
-    ])
+    expect(seenRequests).toHaveLength(3)
+    expect(seenRequests[0]).toEqual({
+      url: 'https://safe.example/actor',
+      headers: expect.objectContaining({
+        authorization: 'Bearer secret',
+        cookie: 'session=secret',
+        host: 'safe.example',
+        signature: 'keyId="https://safe.example/actor",signature="secret"'
+      })
+    })
+    expect(seenRequests[1]?.url).toBe('https://other.example/redirected')
+    expectSensitiveHeadersStripped(seenRequests[1].headers)
+    expect(seenRequests[2]?.url).toBe('https://other.example/final')
+    expectSensitiveHeadersStripped(seenRequests[2].headers)
   })
 
   it('destroys redirect response bodies without buffering them', async () => {

--- a/lib/utils/safeRemoteFetch.ts
+++ b/lib/utils/safeRemoteFetch.ts
@@ -24,15 +24,9 @@ const BODY_REDIRECT_HEADERS = new Set([
   'digest',
   'signature'
 ])
-const DYNAMIC_BODY_REDIRECT_HEADERS = new Set([
-  'content-digest',
-  'content-encoding',
-  'content-language',
-  'content-length',
-  'content-location',
-  'content-type',
-  'digest'
-])
+const DYNAMIC_BODY_REDIRECT_HEADERS = new Set(
+  [...BODY_REDIRECT_HEADERS].filter((header) => header !== 'signature')
+)
 const RETRY_DISABLED = { limit: 0 }
 
 export type SafeRemoteFetchMethod = Method
@@ -504,6 +498,20 @@ const compactHeaders = (headers: SafeRemoteFetchHeaders = {}) =>
     )
   )
 
+const stripHeaders = (
+  headers: SafeRemoteFetchHeaders,
+  headersToStrip: Set<string>
+) => {
+  const normalizedHeaders = compactHeaders(headers)
+  for (const key of Object.keys(normalizedHeaders)) {
+    if (headersToStrip.has(key.toLowerCase())) {
+      delete normalizedHeaders[key]
+    }
+  }
+
+  return normalizedHeaders
+}
+
 const buildHeaders = ({
   headers,
   previousUrl,
@@ -533,26 +541,27 @@ const buildHeaders = ({
 const getRequestHeaders = ({
   body,
   headers,
+  headersToStrip,
   method,
   previousUrl,
   url
 }: {
   body?: string
   headers: SafeRemoteFetchHeaderSource
+  headersToStrip?: Set<string>
   method: SafeRemoteFetchMethod
   previousUrl?: URL
   url: URL
 }) => {
-  if (typeof headers === 'function') {
-    return buildHeaders({
-      headers: headers({ body, method, url }),
-      previousUrl,
-      url
-    })
+  let effectiveHeaders =
+    typeof headers === 'function' ? headers({ body, method, url }) : headers
+
+  if (headersToStrip && headersToStrip.size > 0) {
+    effectiveHeaders = stripHeaders(effectiveHeaders, headersToStrip)
   }
 
   return buildHeaders({
-    headers,
+    headers: effectiveHeaders,
     previousUrl,
     url
   })
@@ -618,28 +627,20 @@ const getRedirectLocation = (
   return redirectUrl
 }
 
-const stripHeaders = (
-  headers: SafeRemoteFetchHeaders,
-  headersToStrip: Set<string>
-) => {
-  const normalizedHeaders = compactHeaders(headers)
-  for (const key of Object.keys(normalizedHeaders)) {
-    if (headersToStrip.has(key.toLowerCase())) {
-      delete normalizedHeaders[key]
-    }
-  }
-
-  return normalizedHeaders
-}
-
 const stripBodyHeaders = (headers: SafeRemoteFetchHeaders) =>
   stripHeaders(headers, BODY_REDIRECT_HEADERS)
 
-const stripDynamicBodyHeaders = (
-  headerBuilder: SafeRemoteFetchHeaderBuilder
-): SafeRemoteFetchHeaderBuilder => {
-  return (request) =>
-    stripHeaders(headerBuilder(request), DYNAMIC_BODY_REDIRECT_HEADERS)
+const getDynamicHeadersToStrip = ({
+  stripBodyHeaders,
+  stripSensitiveHeaders
+}: {
+  stripBodyHeaders: boolean
+  stripSensitiveHeaders: boolean
+}) => {
+  return new Set([
+    ...(stripBodyHeaders ? DYNAMIC_BODY_REDIRECT_HEADERS : []),
+    ...(stripSensitiveHeaders ? SENSITIVE_REDIRECT_HEADERS : [])
+  ])
 }
 
 export const createSafeRemoteFetch = ({
@@ -668,6 +669,8 @@ export const createSafeRemoteFetch = ({
     let currentHeaders = headers
     let currentMethod = method
     let previousUrl: URL | undefined
+    let shouldStripDynamicBodyHeaders = false
+    let shouldStripDynamicSensitiveHeaders = false
     let redirectCount = 0
     const connectTimeout = connectTimeoutInMilliseconds ?? timeoutInMilliseconds
     const readTimeout = readTimeoutInMilliseconds ?? timeoutInMilliseconds
@@ -681,6 +684,13 @@ export const createSafeRemoteFetch = ({
       const requestHeaders = getRequestHeaders({
         body: currentBody,
         headers: currentHeaders,
+        headersToStrip:
+          typeof currentHeaders === 'function'
+            ? getDynamicHeadersToStrip({
+                stripBodyHeaders: shouldStripDynamicBodyHeaders,
+                stripSensitiveHeaders: shouldStripDynamicSensitiveHeaders
+              })
+            : undefined,
         method: currentMethod,
         previousUrl,
         url: currentUrl
@@ -722,6 +732,7 @@ export const createSafeRemoteFetch = ({
         )
       }
 
+      const isCrossHostRedirect = currentUrl.host !== redirectUrl.host
       previousUrl = currentUrl
       currentUrl = redirectUrl
       redirectCount += 1
@@ -732,7 +743,10 @@ export const createSafeRemoteFetch = ({
 
       if (typeof currentHeaders === 'function') {
         if (response.statusCode === 303) {
-          currentHeaders = stripDynamicBodyHeaders(currentHeaders)
+          shouldStripDynamicBodyHeaders = true
+        }
+        if (isCrossHostRedirect) {
+          shouldStripDynamicSensitiveHeaders = true
         }
       } else {
         currentHeaders =

--- a/lib/utils/safeRemoteFetch.ts
+++ b/lib/utils/safeRemoteFetch.ts
@@ -24,6 +24,15 @@ const BODY_REDIRECT_HEADERS = new Set([
   'digest',
   'signature'
 ])
+const DYNAMIC_BODY_REDIRECT_HEADERS = new Set([
+  'content-digest',
+  'content-encoding',
+  'content-language',
+  'content-length',
+  'content-location',
+  'content-type',
+  'digest'
+])
 const RETRY_DISABLED = { limit: 0 }
 
 export type SafeRemoteFetchMethod = Method
@@ -33,9 +42,12 @@ export type SafeRemoteFetchHeaderBuilderRequest = {
   method: SafeRemoteFetchMethod
   url: URL
 }
+export type SafeRemoteFetchHeaderBuilder = (
+  request: SafeRemoteFetchHeaderBuilderRequest
+) => SafeRemoteFetchHeaders
 export type SafeRemoteFetchHeaderSource =
   | SafeRemoteFetchHeaders
-  | ((request: SafeRemoteFetchHeaderBuilderRequest) => SafeRemoteFetchHeaders)
+  | SafeRemoteFetchHeaderBuilder
 
 export type ResolvedRemoteAddress = {
   address: string
@@ -606,15 +618,28 @@ const getRedirectLocation = (
   return redirectUrl
 }
 
-const stripBodyHeaders = (headers: SafeRemoteFetchHeaders) => {
+const stripHeaders = (
+  headers: SafeRemoteFetchHeaders,
+  headersToStrip: Set<string>
+) => {
   const normalizedHeaders = compactHeaders(headers)
   for (const key of Object.keys(normalizedHeaders)) {
-    if (BODY_REDIRECT_HEADERS.has(key.toLowerCase())) {
+    if (headersToStrip.has(key.toLowerCase())) {
       delete normalizedHeaders[key]
     }
   }
 
   return normalizedHeaders
+}
+
+const stripBodyHeaders = (headers: SafeRemoteFetchHeaders) =>
+  stripHeaders(headers, BODY_REDIRECT_HEADERS)
+
+const stripDynamicBodyHeaders = (
+  headerBuilder: SafeRemoteFetchHeaderBuilder
+): SafeRemoteFetchHeaderBuilder => {
+  return (request) =>
+    stripHeaders(headerBuilder(request), DYNAMIC_BODY_REDIRECT_HEADERS)
 }
 
 export const createSafeRemoteFetch = ({
@@ -703,13 +728,17 @@ export const createSafeRemoteFetch = ({
       if (response.statusCode === 303) {
         currentBody = undefined
         currentMethod = 'GET'
-        currentHeaders =
-          typeof currentHeaders === 'function'
-            ? currentHeaders
-            : stripBodyHeaders(requestHeaders)
+      }
+
+      if (typeof currentHeaders === 'function') {
+        if (response.statusCode === 303) {
+          currentHeaders = stripDynamicBodyHeaders(currentHeaders)
+        }
       } else {
         currentHeaders =
-          typeof currentHeaders === 'function' ? currentHeaders : requestHeaders
+          response.statusCode === 303
+            ? stripBodyHeaders(requestHeaders)
+            : requestHeaders
       }
     }
   }

--- a/lib/utils/safeRemoteFetch.ts
+++ b/lib/utils/safeRemoteFetch.ts
@@ -631,15 +631,15 @@ const stripBodyHeaders = (headers: SafeRemoteFetchHeaders) =>
   stripHeaders(headers, BODY_REDIRECT_HEADERS)
 
 const getDynamicHeadersToStrip = ({
-  stripBodyHeaders,
-  stripSensitiveHeaders
+  shouldStripBodyHeaders,
+  shouldStripSensitiveHeaders
 }: {
-  stripBodyHeaders: boolean
-  stripSensitiveHeaders: boolean
+  shouldStripBodyHeaders: boolean
+  shouldStripSensitiveHeaders: boolean
 }) => {
   return new Set([
-    ...(stripBodyHeaders ? DYNAMIC_BODY_REDIRECT_HEADERS : []),
-    ...(stripSensitiveHeaders ? SENSITIVE_REDIRECT_HEADERS : [])
+    ...(shouldStripBodyHeaders ? DYNAMIC_BODY_REDIRECT_HEADERS : []),
+    ...(shouldStripSensitiveHeaders ? SENSITIVE_REDIRECT_HEADERS : [])
   ])
 }
 
@@ -687,8 +687,8 @@ export const createSafeRemoteFetch = ({
         headersToStrip:
           typeof currentHeaders === 'function'
             ? getDynamicHeadersToStrip({
-                stripBodyHeaders: shouldStripDynamicBodyHeaders,
-                stripSensitiveHeaders: shouldStripDynamicSensitiveHeaders
+                shouldStripBodyHeaders: shouldStripDynamicBodyHeaders,
+                shouldStripSensitiveHeaders: shouldStripDynamicSensitiveHeaders
               })
             : undefined,
         method: currentMethod,

--- a/lib/utils/safeRemoteFetch.ts
+++ b/lib/utils/safeRemoteFetch.ts
@@ -28,6 +28,14 @@ const RETRY_DISABLED = { limit: 0 }
 
 export type SafeRemoteFetchMethod = Method
 export type SafeRemoteFetchHeaders = Headers
+export type SafeRemoteFetchHeaderBuilderRequest = {
+  body?: string
+  method: SafeRemoteFetchMethod
+  url: URL
+}
+export type SafeRemoteFetchHeaderSource =
+  | SafeRemoteFetchHeaders
+  | ((request: SafeRemoteFetchHeaderBuilderRequest) => SafeRemoteFetchHeaders)
 
 export type ResolvedRemoteAddress = {
   address: string
@@ -58,7 +66,7 @@ export type SafeRemoteFetchTransport = (
 export type SafeRemoteFetchOptions = {
   body?: string
   connectTimeoutInMilliseconds?: number
-  headers?: SafeRemoteFetchHeaders
+  headers?: SafeRemoteFetchHeaderSource
   maxBodyBytes?: number
   maxRedirects?: number
   method?: SafeRemoteFetchMethod
@@ -510,6 +518,34 @@ const buildHeaders = ({
   }
 }
 
+const getRequestHeaders = ({
+  body,
+  headers,
+  method,
+  previousUrl,
+  url
+}: {
+  body?: string
+  headers: SafeRemoteFetchHeaderSource
+  method: SafeRemoteFetchMethod
+  previousUrl?: URL
+  url: URL
+}) => {
+  if (typeof headers === 'function') {
+    return buildHeaders({
+      headers: headers({ body, method, url }),
+      previousUrl,
+      url
+    })
+  }
+
+  return buildHeaders({
+    headers,
+    previousUrl,
+    url
+  })
+}
+
 const getHeaderValue = (
   headers: Record<string, string | string[] | undefined>,
   key: string
@@ -617,8 +653,10 @@ export const createSafeRemoteFetch = ({
 
     while (true) {
       assertAllowedProtocol(currentUrl)
-      const requestHeaders = buildHeaders({
+      const requestHeaders = getRequestHeaders({
+        body: currentBody,
         headers: currentHeaders,
+        method: currentMethod,
         previousUrl,
         url: currentUrl
       })
@@ -665,9 +703,13 @@ export const createSafeRemoteFetch = ({
       if (response.statusCode === 303) {
         currentBody = undefined
         currentMethod = 'GET'
-        currentHeaders = stripBodyHeaders(requestHeaders)
+        currentHeaders =
+          typeof currentHeaders === 'function'
+            ? currentHeaders
+            : stripBodyHeaders(requestHeaders)
       } else {
-        currentHeaders = requestHeaders
+        currentHeaders =
+          typeof currentHeaders === 'function' ? currentHeaders : requestHeaders
       }
     }
   }


### PR DESCRIPTION
## Summary

This fixes an inbox verification regression introduced after PR #675 hardened outbound ActivityPub fetches.

Inbound inbox POSTs verify the sender signature by fetching the sender public key. After #675, `safeRemoteFetch` follows redirects internally while reusing the original request headers. For signed ActivityPub key fetches, that meant a redirected fetch could carry a `Signature` header whose `(request-target)` was still the original key URL instead of the redirected URL. Remote servers that validate signed fetches can reject that redirected key lookup, leaving the inbox guard without a usable sender public key and causing 400 responses. If key ownership resolution falls back to or resolves a different owner than the activity actor, the guard can also reject with 403.

## Fix

- Allow `safeRemoteFetch`/`request` callers to provide a header builder function that is evaluated for each effective URL.
- Use that dynamic header builder for `getSenderPublicKey`, so ActivityPub public-key fetches are signed for the actual redirected URL.
- Preserve the existing cross-host redirect protections by still stripping sensitive dynamic headers when the redirect changes hosts.
- Add regression coverage for redirected signed public-key fetches and dynamic-header cross-host stripping.

## Validation

- `yarn test lib/utils/safeRemoteFetch.test.ts lib/utils/request.test.ts lib/services/guards/getSenderPublicKey.test.ts --runInBand`
- `yarn run prettier --write .`
- `yarn lint` (passes with existing warnings in unrelated files)
- `yarn build`
- `yarn test`
