### PR TITLE
Bump version to v1.10.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.10.11.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.10.10`
- Base main SHA: `b5c9a22d64f97eeaf55ca89928a7ad2fa770acd0`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
