### PR TITLE
Bump version to v1.10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.10.12.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.10.11`
- Base main SHA: `459689c004cb54fe928f2664feeb3544038ba3cc`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
