### PR TITLE
fix: Fitness heatmap staging map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,15 @@ WORKDIR /opt/activities.next
 USER app
 
 FROM base AS build
+# Public Mapbox value (starts with pk.) used by next.config.ts to include
+# Mapbox CSP sources in standalone build response headers.
+ARG MAPBOX_PUBLIC_VALUE=""
 ADD --chown=app:app . /opt/activities.next/
 RUN yarn config set -H enableGlobalCache true
 RUN yarn install --immutable
 RUN yarn dedupe
 RUN ACTIVITIES_SECRET_PHASE=build-placeholder yarn knex migrate:latest --disable-transactions
-RUN ACTIVITIES_SECRET_PHASE=build-placeholder BUILD_STANDALONE=true yarn build
+RUN ACTIVITIES_FITNESS_MAPBOX_ACCESS_TOKEN="${MAPBOX_PUBLIC_VALUE}" ACTIVITIES_SECRET_PHASE=build-placeholder BUILD_STANDALONE=true yarn build
 
 FROM base AS output
 ENV NODE_ENV="production"

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -318,6 +318,25 @@ describe('FitnessHeatmapView', () => {
     })
   })
 
+  it('keeps the route map in a full-width region outside the route cache panel', async () => {
+    render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
+
+    const routeMapRegion = await screen.findByRole('region', {
+      name: 'Route heatmap map'
+    })
+    const routeCacheHeading = screen.getByRole('heading', {
+      name: 'Route Cache'
+    })
+
+    expect(routeMapRegion).not.toContainElement(routeCacheHeading)
+    // The cache panel should follow the full-width map region instead of
+    // being nested beside it in the same grid row.
+    expect(
+      routeMapRegion.compareDocumentPosition(routeCacheHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it('clears all route caches without immediately requeueing the current selection', async () => {
     mockClearFitnessRouteHeatmaps.mockResolvedValue(2)
     mockGetFitnessRouteHeatmap

--- a/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.tsx
@@ -449,7 +449,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
           ROUTE_HEATMAP_MAP_HEIGHT_CLASS
         )}
       >
-        <div ref={containerRef} className="absolute inset-0" />
+        <div ref={containerRef} className="h-full w-full" />
         <div className="absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
           Mapbox
         </div>
@@ -951,6 +951,14 @@ export const FitnessHeatmapView: FC<Props> = ({
     Boolean(heatmapData) || heatmaps.length > 0 || generationPending
   const canRefreshRouteCache =
     !isLoading && !generationPending && !isRouteHeatmapInFlight(heatmapData)
+  const routeStatusOverlay =
+    heatmapData?.status === 'failed'
+      ? 'failed'
+      : pollingStalled && !hasCompletedRoutes
+        ? 'polling-stalled'
+        : !isLoading && generationPending && !hasCompletedRoutes
+          ? 'generation-pending'
+          : null
 
   return (
     <div className="flex min-h-[720px] flex-col bg-background">
@@ -1034,82 +1042,108 @@ export const FitnessHeatmapView: FC<Props> = ({
         </div>
       )}
 
+      <section aria-label="Route heatmap map" className="min-w-0 border-b">
+        <div className="border-b px-3 py-2">
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <span className="inline-flex items-center gap-1.5 font-medium">
+              <Map className="size-4" />
+              {formatActivityType(selectedActivityType)}
+            </span>
+            <span className="text-muted-foreground">
+              {periodType === 'all_time' ? 'All time' : effectivePeriodKey}
+            </span>
+            <span className="text-muted-foreground">
+              {selectedRegionIds.length > 0
+                ? `${selectedRegionIds.length} regions`
+                : 'World'}
+            </span>
+            {isLoading && (
+              <span
+                role="status"
+                className="inline-flex items-center gap-1.5 text-muted-foreground"
+              >
+                <Loader2 className="size-3 animate-spin" />
+                Loading…
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="relative overflow-hidden">
+          <RouteHeatmapMap
+            heatmap={heatmapData}
+            mapboxAccessToken={mapboxAccessToken}
+          />
+          {routeStatusOverlay === 'generation-pending' && (
+            <div
+              className="absolute inset-x-3 bottom-3 rounded border bg-background/95 px-3 py-2 text-sm text-muted-foreground shadow-sm"
+              aria-live="polite"
+            >
+              Route cache queued
+            </div>
+          )}
+          {routeStatusOverlay === 'polling-stalled' && (
+            <div
+              className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-3 rounded border bg-background/95 px-3 py-2 text-sm shadow-sm"
+              aria-live="polite"
+            >
+              <span className="inline-flex items-center gap-2 text-muted-foreground">
+                <AlertCircle className="size-4" />
+                Route cache is taking longer than expected
+              </span>
+              <Button
+                type="button"
+                onClick={retryCurrent}
+                disabled={isRetrying}
+                variant="outline"
+                size="sm"
+                className="h-7 px-2 text-xs"
+              >
+                <RefreshCw
+                  className={cn('size-3', isRetrying && 'animate-spin')}
+                />
+                Retry
+              </Button>
+            </div>
+          )}
+          {routeStatusOverlay === 'failed' && (
+            <div
+              className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-3 rounded border bg-background/95 px-3 py-2 text-sm shadow-sm"
+              aria-live="assertive"
+            >
+              <span className="inline-flex items-center gap-2 text-destructive">
+                <AlertCircle className="size-4" />
+                Route cache failed
+              </span>
+              <Button
+                type="button"
+                onClick={retryCurrent}
+                disabled={isRetrying}
+                variant="outline"
+                size="sm"
+                className="h-7 px-2 text-xs"
+              >
+                <RefreshCw
+                  className={cn('size-3', isRetrying && 'animate-spin')}
+                />
+                Retry
+              </Button>
+            </div>
+          )}
+        </div>
+      </section>
+
       <div className="grid flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_320px]">
         <main className="min-w-0">
-          <div className="border-b px-3 py-2">
-            <div className="flex flex-wrap items-center gap-4 text-sm">
-              <span className="inline-flex items-center gap-1.5 font-medium">
-                <Map className="size-4" />
-                {formatActivityType(selectedActivityType)}
-              </span>
-              <span className="text-muted-foreground">
-                {periodType === 'all_time' ? 'All time' : effectivePeriodKey}
-              </span>
-              <span className="text-muted-foreground">
-                {selectedRegionIds.length > 0
-                  ? `${selectedRegionIds.length} regions`
-                  : 'World'}
-              </span>
-              {isLoading && (
-                <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                  <Loader2 className="size-3 animate-spin" />
-                  Loading
-                </span>
-              )}
-            </div>
-          </div>
-
-          <div className="relative overflow-hidden border-b">
-            <RouteHeatmapMap
-              heatmap={heatmapData}
-              mapboxAccessToken={mapboxAccessToken}
-            />
-            {!isLoading && generationPending && !hasCompletedRoutes && (
-              <div className="absolute inset-x-3 bottom-3 rounded border bg-background/95 px-3 py-2 text-sm text-muted-foreground shadow-sm">
-                Route cache queued
-              </div>
-            )}
-            {pollingStalled && !hasCompletedRoutes && (
-              <div className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-3 rounded border bg-background/95 px-3 py-2 text-sm shadow-sm">
-                <span className="inline-flex items-center gap-2 text-muted-foreground">
-                  <AlertCircle className="size-4" />
-                  Route cache is taking longer than expected
-                </span>
-                <button
-                  onClick={retryCurrent}
-                  disabled={isRetrying}
-                  className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-                >
-                  <RefreshCw
-                    className={cn('size-3', isRetrying && 'animate-spin')}
-                  />
-                  Retry
-                </button>
-              </div>
-            )}
-            {heatmapData?.status === 'failed' && (
-              <div className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-3 rounded border bg-background/95 px-3 py-2 text-sm shadow-sm">
-                <span className="inline-flex items-center gap-2 text-destructive">
-                  <AlertCircle className="size-4" />
-                  Route cache failed
-                </span>
-                <button
-                  onClick={retryCurrent}
-                  disabled={isRetrying}
-                  className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-                >
-                  <RefreshCw
-                    className={cn('size-3', isRetrying && 'animate-spin')}
-                  />
-                  Retry
-                </button>
-              </div>
-            )}
-          </div>
-
-          <section className="space-y-3 px-3 py-4">
+          <section
+            aria-labelledby="activity-calendar-heading"
+            className="space-y-3 px-3 py-4"
+          >
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <h2 className="inline-flex items-center gap-2 text-base font-medium">
+              <h2
+                id="activity-calendar-heading"
+                className="inline-flex items-center gap-2 text-base font-medium"
+              >
                 <CalendarDays className="size-4" />
                 Activity Calendar
               </h2>
@@ -1117,9 +1151,11 @@ export const FitnessHeatmapView: FC<Props> = ({
                 {METRIC_OPTIONS.map(([key, label]) => (
                   <button
                     key={key}
+                    type="button"
+                    aria-pressed={calendarMetric === key}
                     onClick={() => setCalendarMetric(key)}
                     className={cn(
-                      'rounded px-2 py-1 text-xs transition-colors',
+                      'rounded px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                       calendarMetric === key
                         ? 'bg-foreground text-background'
                         : 'text-muted-foreground hover:text-foreground'
@@ -1174,9 +1210,11 @@ export const FitnessHeatmapView: FC<Props> = ({
                 <div className="flex items-center gap-1.5">
                   {hasRouteCache && (
                     <button
+                      type="button"
                       onClick={() => setClearCacheDialogOpen(true)}
                       disabled={isClearingCache || isRetrying}
-                      className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+                      aria-haspopup="dialog"
+                      className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
                     >
                       <Trash2
                         className={cn(
@@ -1189,9 +1227,10 @@ export const FitnessHeatmapView: FC<Props> = ({
                   )}
                   {canRefreshRouteCache && (
                     <button
+                      type="button"
                       onClick={retryCurrent}
                       disabled={isRetrying || isClearingCache}
-                      className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+                      className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
                     >
                       <RefreshCw
                         className={cn('size-3', isRetrying && 'animate-spin')}
@@ -1251,7 +1290,7 @@ export const FitnessHeatmapView: FC<Props> = ({
               <Trash2
                 className={isClearingCache ? 'animate-pulse' : undefined}
               />
-              {isClearingCache ? 'Clearing...' : 'Clear route caches'}
+              {isClearingCache ? 'Clearing…' : 'Clear route caches'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/(timeline)/[actor]/fitness/heatmap/page.tsx
+++ b/app/(timeline)/[actor]/fitness/heatmap/page.tsx
@@ -72,6 +72,7 @@ const Page: FC<Props> = async ({ params }) => {
         <Button variant="ghost" size="icon" asChild>
           <Link href={`/@${currentActor.username}@${actorDomain}/fitness`}>
             <ArrowLeft className="h-5 w-5" />
+            <span className="sr-only">Back to fitness</span>
           </Link>
         </Button>
         <div>

--- a/lib/components/fitness/FitnessHeatmapList.tsx
+++ b/lib/components/fitness/FitnessHeatmapList.tsx
@@ -56,9 +56,10 @@ const RetryButton: FC<RetryButtonProps> = ({
   return (
     <span className="inline-flex flex-col gap-0.5">
       <button
+        type="button"
         className={cn(
           'inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium',
-          'text-muted-foreground hover:bg-muted hover:text-foreground transition-colors',
+          'text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           isRetrying && 'pointer-events-none opacity-50'
         )}
         disabled={isRetrying}
@@ -79,7 +80,11 @@ const RetryButton: FC<RetryButtonProps> = ({
         <RefreshCw className={cn('size-3', isRetrying && 'animate-spin')} />
         {label}
       </button>
-      {error && <span className="text-destructive text-xs">{error}</span>}
+      {error && (
+        <span aria-live="polite" className="text-destructive text-xs">
+          {error}
+        </span>
+      )}
     </span>
   )
 }
@@ -146,7 +151,8 @@ const HeatmapRow: FC<HeatmapRowProps> = ({
   return (
     <div className="flex items-start gap-2 rounded p-2 hover:bg-muted">
       <button
-        className="flex flex-1 flex-col gap-1 text-left"
+        type="button"
+        className="flex min-w-0 flex-1 flex-col gap-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         onClick={() => onSelect(heatmap)}
       >
         <span className="flex items-center gap-1.5 text-xs">
@@ -156,12 +162,12 @@ const HeatmapRow: FC<HeatmapRowProps> = ({
             {formatRelativeTime(currentTime - heatmap.updatedAt)}
           </span>
         </span>
-        <span className="text-sm">
+        <span className="break-words text-sm">
           {formatActivityType(heatmap.activityType)} ·{' '}
           {formatPeriod(heatmap.periodType, heatmap.periodKey)}
         </span>
         {regionLabel && (
-          <span className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+          <span className="inline-block max-w-full break-words rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
             {regionLabel}
           </span>
         )}
@@ -229,7 +235,9 @@ export const FitnessHeatmapList: FC<FitnessHeatmapListProps> = ({
       {completed.length > 0 && (
         <div className="flex flex-col gap-1">
           <button
-            className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            type="button"
+            aria-expanded={isCompletedOpen}
+            className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={() => setIsCompletedOpen((prev) => !prev)}
           >
             {isCompletedOpen ? (


### PR DESCRIPTION
## Summary

- Move the fitness route map into its own full-width section above the calendar/cache grid.
- Fix the Mapbox container sizing so the canvas fills the full route-map area on desktop and mobile.
- Allow Docker builds to receive the public Mapbox token at build time so standalone staging output includes the Mapbox CSP entries.
- Tighten small accessibility details around icon/back controls, button types, pressed state, live retry errors, and focus rings.

## Why

The staging standalone build was reading the Mapbox token only at runtime, so generated headers did not include Mapbox CSP sources. After passing the public token during build, Mapbox scripts/styles/API calls are allowed. The Mapbox GL stylesheet also overrides the container positioning class, which collapsed the map container height; using explicit full height/width keeps the canvas sized to the intended map area.

## Validation

- `yarn run prettier --write .`
- `yarn test --runTestsByPath 'app/(timeline)/[actor]/fitness/heatmap/FitnessHeatmapView.test.tsx' 'lib/components/fitness/FitnessHeatmapList.test.tsx' 'next.config.test.ts' --runInBand --modulePathIgnorePatterns='<rootDir>/.claude'` - 48 passed
- `yarn lint` - 0 errors, 24 existing warnings
- `yarn node ./node_modules/next/dist/bin/next build`
- `git diff --check`
- Staging rebuild: `../activities.local/scripts/staging_run.sh --rebuild`
- Browser verification at `https://activities.local/@ride@llun.social/fitness/heatmap` with monthly `2016-09`: desktop and mobile Mapbox canvas filled the map area, with no CSP console errors, no Mapbox request failures, and no horizontal overflow.

## Notes

The sibling `activities.local` checkout has a local compose change to pass `MAPBOX_PUBLIC_VALUE` into the Activity.next Docker build. That checkout has no GitHub remote configured here, so this PR only contains the Activity.next app changes.