### PR TITLE
Bump version to v1.10.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.10.13.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.10.12`
- Base main SHA: `0161ac73f54529fbf0783a0e84908b47f8c8f2cf`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
