### PR TITLE
Bump version to v1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.10.13",
+  "version": "1.11.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.10.14.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.10.13`
- Base main SHA: `6d2773928f29df4440d0bd44093a6a8355a2ff04`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
