### PR TITLE
minor: add Mastodon-compatible bookmark API

### DIFF
--- a/app/api/v1/bookmarks/route.test.ts
+++ b/app/api/v1/bookmarks/route.test.ts
@@ -1,0 +1,133 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/bookmarks', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('returns bookmarked statuses for the current actor with pagination links', async () => {
+    const firstStatusId = `${ACTOR2_ID}/statuses/api-bookmarks-first`
+    const secondStatusId = `${ACTOR2_ID}/statuses/api-bookmarks-second`
+    await database.createNote({
+      id: firstStatusId,
+      url: firstStatusId,
+      actorId: ACTOR2_ID,
+      text: 'First bookmark',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createNote({
+      id: secondStatusId,
+      url: secondStatusId,
+      actorId: ACTOR2_ID,
+      text: 'Second bookmark',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createBookmark({
+      actorId: ACTOR1_ID,
+      statusId: firstStatusId
+    })
+    await database.createBookmark({
+      actorId: ACTOR1_ID,
+      statusId: secondStatusId
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/bookmarks?limit=1'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Link')).toContain('/api/v1/bookmarks?')
+    const data = await response.json()
+    expect(data).toHaveLength(1)
+    expect(data[0]).toMatchObject({
+      id: expect.stringMatching(
+        new RegExp(`^(${urlToId(firstStatusId)}|${urlToId(secondStatusId)})$`)
+      ),
+      bookmarked: true
+    })
+  })
+
+  it('does not return another actor bookmarks', async () => {
+    const statusId = `${ACTOR2_ID}/statuses/api-bookmarks-other-actor`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR2_ID,
+      text: 'Other actor bookmark',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createBookmark({
+      actorId: ACTOR2_ID,
+      statusId
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/bookmarks?limit=40'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).not.toContainEqual(
+      expect.objectContaining({ id: urlToId(statusId) })
+    )
+  })
+})

--- a/app/api/v1/bookmarks/route.ts
+++ b/app/api/v1/bookmarks/route.ts
@@ -1,0 +1,75 @@
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 40
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const normalizeLimit = (value: string | null) => {
+  const parsed = parseInt(value || `${DEFAULT_LIMIT}`, 10)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return DEFAULT_LIMIT
+  return Math.min(parsed, MAX_LIMIT)
+}
+
+export const GET = traceApiRoute(
+  'getBookmarks',
+  OAuthGuard<{}>([Scope.enum['read:bookmarks']], async (req, context) => {
+    const { database, currentActor } = context
+    const url = new URL(req.url)
+    const limit = normalizeLimit(url.searchParams.get('limit'))
+    const bookmarks = await database.getBookmarks({
+      actorId: currentActor.id,
+      limit,
+      maxId: url.searchParams.get('max_id'),
+      minId: url.searchParams.get('min_id'),
+      sinceId: url.searchParams.get('since_id')
+    })
+
+    const statuses = await database.getStatusesByIds({
+      statusIds: bookmarks.map((bookmark) => bookmark.statusId),
+      currentActorId: currentActor.id,
+      withReplies: false
+    })
+    const mastodonStatuses = (
+      await Promise.all(
+        statuses.map((status) =>
+          getMastodonStatus(database, status, currentActor.id)
+        )
+      )
+    ).filter(Boolean)
+
+    const host = headerHost(req.headers)
+    const buildPaginationUrl = (cursorParam: string, cursorValue: string) => {
+      const params = new URLSearchParams()
+      params.set('limit', limit.toString())
+      params.set(cursorParam, cursorValue)
+
+      return `<https://${host}/api/v1/bookmarks?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
+    }
+    const nextLink =
+      bookmarks.length === limit
+        ? buildPaginationUrl('max_id', bookmarks[bookmarks.length - 1].id)
+        : null
+    const prevLink =
+      bookmarks.length > 0
+        ? buildPaginationUrl('min_id', bookmarks[0].id)
+        : null
+    const links = [nextLink, prevLink].filter(Boolean).join(', ')
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: mastodonStatuses,
+      additionalHeaders: [
+        ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
+      ]
+    })
+  })
+)

--- a/app/api/v1/statuses/[id]/bookmark/route.ts
+++ b/app/api/v1/statuses/[id]/bookmark/route.ts
@@ -22,7 +22,7 @@ interface Params {
 
 export const POST = traceApiRoute(
   'bookmarkStatus',
-  OAuthGuard<Params>([Scope.enum.write], async (req, context) => {
+  OAuthGuard<Params>([Scope.enum['write:bookmarks']], async (req, context) => {
     const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
@@ -48,12 +48,24 @@ export const POST = traceApiRoute(
         responseStatusCode: 404
       })
 
-    // Bookmarking not yet implemented
-    // TODO: Implement bookmarking functionality with database table
+    await database.createBookmark({ actorId: currentActor.id, statusId })
+
+    const updatedStatus = await database.getStatus({
+      statusId,
+      withReplies: false,
+      currentActorId: currentActor.id
+    })
+    if (!updatedStatus)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
 
     const mastodonStatus = await getMastodonStatus(
       database,
-      status,
+      updatedStatus,
       currentActor.id
     )
     if (!mastodonStatus)

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -537,6 +537,119 @@ describe('GET /api/v1/statuses/[id]', () => {
         database.isActorLikedStatus({ actorId: ACTOR3_ID, statusId })
       ).resolves.toBe(false)
     })
+
+    it('bookmarks a readable status and returns bookmarked=true', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-bookmark-public`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public bookmark target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await bookmarkStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/bookmark`,
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data).toMatchObject({
+        id: urlToId(statusId),
+        bookmarked: true
+      })
+      await expect(
+        database.isActorBookmarkedStatus({ actorId: ACTOR2_ID, statusId })
+      ).resolves.toBe(true)
+    })
+
+    it('unbookmarks a readable status and returns bookmarked=false', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-unbookmark-public`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public unbookmark target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createBookmark({ actorId: ACTOR2_ID, statusId })
+
+      const response = await unbookmarkStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/unbookmark`,
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data).toMatchObject({
+        id: urlToId(statusId),
+        bookmarked: false
+      })
+      await expect(
+        database.isActorBookmarkedStatus({ actorId: ACTOR2_ID, statusId })
+      ).resolves.toBe(false)
+    })
+
+    it('allows actors to unbookmark when the original status is no longer readable', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-unbookmark-after-access-change`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Original status that becomes private after a bookmark',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createBookmark({ actorId: ACTOR3_ID, statusId })
+      await database.updateNoteVisibility({
+        statusId,
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+
+      const response = await unbookmarkStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/unbookmark`,
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      await expect(
+        database.isActorBookmarkedStatus({ actorId: ACTOR3_ID, statusId })
+      ).resolves.toBe(false)
+    })
   })
 
   describe('status visibility derivation', () => {

--- a/app/api/v1/statuses/[id]/unbookmark/route.ts
+++ b/app/api/v1/statuses/[id]/unbookmark/route.ts
@@ -22,7 +22,7 @@ interface Params {
 
 export const POST = traceApiRoute(
   'unbookmarkStatus',
-  OAuthGuard<Params>([Scope.enum.write], async (req, context) => {
+  OAuthGuard<Params>([Scope.enum['write:bookmarks']], async (req, context) => {
     const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
@@ -34,26 +34,57 @@ export const POST = traceApiRoute(
       })
 
     const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
+    let status = await getReadableStatus({
       database,
       statusId,
       currentActor,
       withReplies: false
     })
-    if (!status)
+    if (!status) {
+      const isActorBookmarkedStatus = await database.isActorBookmarkedStatus({
+        actorId: currentActor.id,
+        statusId
+      })
+      if (!isActorBookmarkedStatus)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      status = await database.getStatus({
+        statusId,
+        withReplies: false,
+        currentActorId: currentActor.id
+      })
+      if (!status)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+    }
+
+    await database.deleteBookmark({ actorId: currentActor.id, statusId })
+
+    const updatedStatus = await database.getStatus({
+      statusId,
+      withReplies: false,
+      currentActorId: currentActor.id
+    })
+    if (!updatedStatus)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
+        data: ERROR_500,
+        responseStatusCode: 500
       })
-
-    // Unbookmarking not yet implemented
-    // TODO: Implement bookmarking functionality with database table
 
     const mastodonStatus = await getMastodonStatus(
       database,
-      status,
+      updatedStatus,
       currentActor.id
     )
     if (!mastodonStatus)

--- a/lib/database/sql/bookmark.test.ts
+++ b/lib/database/sql/bookmark.test.ts
@@ -1,0 +1,181 @@
+import {
+  databaseBeforeAll,
+  getTestDatabaseTable
+} from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { seedDatabase } from '@/lib/stub/database'
+import { DatabaseSeed } from '@/lib/stub/scenarios/database'
+
+describe('BookmarkDatabase', () => {
+  const { actors, statuses } = DatabaseSeed
+  const primaryActorId = actors.primary.id
+  const replyAuthorId = actors.replyAuthor.id
+  const extraActorId = actors.extra.id
+  const table = getTestDatabaseTable()
+
+  beforeAll(async () => {
+    await databaseBeforeAll(table)
+  })
+
+  afterAll(async () => {
+    await Promise.all(table.map((item) => item[1].destroy()))
+  })
+
+  describe.each(table)('%s', (_, database) => {
+    beforeAll(async () => {
+      await seedDatabase(database as Database)
+    })
+
+    describe('createBookmark', () => {
+      it('creates a private bookmark for a status', async () => {
+        await database.createBookmark({
+          actorId: extraActorId,
+          statusId: statuses.primary.post
+        })
+
+        await expect(
+          database.isActorBookmarkedStatus({
+            actorId: extraActorId,
+            statusId: statuses.primary.post
+          })
+        ).resolves.toBe(true)
+
+        const status = await database.getStatus({
+          statusId: statuses.primary.post,
+          currentActorId: extraActorId
+        })
+        expect(status).toMatchObject({
+          isActorBookmarked: true
+        })
+      })
+
+      it('does not create duplicate bookmarks for the same actor and status', async () => {
+        await database.createBookmark({
+          actorId: replyAuthorId,
+          statusId: statuses.primary.post
+        })
+        await database.createBookmark({
+          actorId: replyAuthorId,
+          statusId: statuses.primary.post
+        })
+
+        const bookmarks = await database.getBookmarks({
+          actorId: replyAuthorId,
+          limit: 10
+        })
+        const matchingBookmarks = bookmarks.filter(
+          (bookmark) => bookmark.statusId === statuses.primary.post
+        )
+        expect(matchingBookmarks).toHaveLength(1)
+      })
+
+      it('does nothing when status does not exist', async () => {
+        const missingStatusId = 'https://nonexistent.status/bookmark'
+
+        await database.createBookmark({
+          actorId: primaryActorId,
+          statusId: missingStatusId
+        })
+
+        await expect(
+          database.isActorBookmarkedStatus({
+            actorId: primaryActorId,
+            statusId: missingStatusId
+          })
+        ).resolves.toBe(false)
+      })
+    })
+
+    describe('deleteBookmark', () => {
+      it('deletes an existing bookmark', async () => {
+        await database.createBookmark({
+          actorId: primaryActorId,
+          statusId: statuses.replyAuthor.replyToPrimary
+        })
+
+        await database.deleteBookmark({
+          actorId: primaryActorId,
+          statusId: statuses.replyAuthor.replyToPrimary
+        })
+
+        await expect(
+          database.isActorBookmarkedStatus({
+            actorId: primaryActorId,
+            statusId: statuses.replyAuthor.replyToPrimary
+          })
+        ).resolves.toBe(false)
+      })
+
+      it('does nothing when bookmark does not exist', async () => {
+        await expect(
+          database.deleteBookmark({
+            actorId: primaryActorId,
+            statusId: statuses.poll.status
+          })
+        ).resolves.toBeUndefined()
+      })
+    })
+
+    describe('getBookmarks', () => {
+      it('returns bookmarks for the current actor only in newest-first order', async () => {
+        await database.createBookmark({
+          actorId: primaryActorId,
+          statusId: statuses.primary.secondPost
+        })
+        await database.createBookmark({
+          actorId: primaryActorId,
+          statusId: statuses.poll.status
+        })
+        await database.createBookmark({
+          actorId: extraActorId,
+          statusId: statuses.replyAuthor.replyToPrimary
+        })
+
+        const bookmarks = await database.getBookmarks({
+          actorId: primaryActorId,
+          limit: 10
+        })
+
+        expect(bookmarks.map((bookmark) => bookmark.actorId)).toEqual(
+          expect.arrayContaining([primaryActorId])
+        )
+        expect(bookmarks).not.toContainEqual(
+          expect.objectContaining({ actorId: extraActorId })
+        )
+        expect(bookmarks.map((bookmark) => bookmark.statusId)).toEqual(
+          expect.arrayContaining([
+            statuses.primary.secondPost,
+            statuses.poll.status
+          ])
+        )
+      })
+
+      it('paginates with internal bookmark ids', async () => {
+        await database.createBookmark({
+          actorId: replyAuthorId,
+          statusId: statuses.primary.secondPost
+        })
+        await database.createBookmark({
+          actorId: replyAuthorId,
+          statusId: statuses.poll.status
+        })
+
+        const firstPage = await database.getBookmarks({
+          actorId: replyAuthorId,
+          limit: 1
+        })
+        expect(firstPage).toHaveLength(1)
+
+        const nextPage = await database.getBookmarks({
+          actorId: replyAuthorId,
+          limit: 10,
+          maxId: firstPage[0].id
+        })
+
+        expect(nextPage).not.toContainEqual(
+          expect.objectContaining({ id: firstPage[0].id })
+        )
+      })
+    })
+  })
+})

--- a/lib/database/sql/bookmark.ts
+++ b/lib/database/sql/bookmark.ts
@@ -1,0 +1,129 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  BookmarkDatabase,
+  CreateBookmarkParams,
+  DeleteBookmarkParams,
+  GetBookmarksParams,
+  IsActorBookmarkedStatusParams
+} from '@/lib/types/database/operations'
+import { Bookmark } from '@/lib/types/domain/bookmark'
+
+const fixBookmarkDataDate = (data: Bookmark): Bookmark => ({
+  ...data,
+  createdAt: getCompatibleTime(data.createdAt),
+  updatedAt: getCompatibleTime(data.updatedAt)
+})
+
+const isUniqueConstraintError = (error: unknown) => {
+  if (typeof error !== 'object' || error === null) return false
+
+  const { code, errno, message } = error as Record<string, unknown>
+  const errorCode = typeof code === 'string' ? code : undefined
+  const errorNumber = typeof errno === 'number' ? errno : undefined
+  const errorMessage = typeof message === 'string' ? message : undefined
+
+  return (
+    errorCode === '23505' ||
+    errorCode === 'ER_DUP_ENTRY' ||
+    errorCode === 'SQLITE_CONSTRAINT_UNIQUE' ||
+    errorNumber === 1062 ||
+    (errorCode === 'SQLITE_CONSTRAINT' &&
+      Boolean(errorMessage?.includes('UNIQUE constraint failed')))
+  )
+}
+
+const applyCursor = (
+  query: Knex.QueryBuilder,
+  cursor: Bookmark,
+  direction: 'newer' | 'older'
+) => {
+  const createdAtOperator = direction === 'older' ? '<' : '>'
+  const idOperator = direction === 'older' ? '<' : '>'
+
+  query.andWhere((builder) => {
+    builder
+      .where('createdAt', createdAtOperator, cursor.createdAt)
+      .orWhere((tieBreaker) => {
+        tieBreaker
+          .where('createdAt', cursor.createdAt)
+          .andWhere('id', idOperator, cursor.id)
+      })
+  })
+}
+
+export const BookmarkSQLDatabaseMixin = (database: Knex): BookmarkDatabase => ({
+  async createBookmark({ actorId, statusId }: CreateBookmarkParams) {
+    const currentTime = new Date()
+
+    try {
+      await database.transaction(async (trx) => {
+        const status = await trx('statuses').where('id', statusId).first('id')
+        if (!status) return
+
+        const existing = await trx('bookmarks')
+          .where({ actorId, statusId })
+          .first('id')
+        if (existing) return
+
+        await trx('bookmarks').insert({
+          id: randomUUID(),
+          actorId,
+          statusId,
+          createdAt: currentTime,
+          updatedAt: currentTime
+        })
+      })
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) throw error
+    }
+  },
+
+  async deleteBookmark({ actorId, statusId }: DeleteBookmarkParams) {
+    await database('bookmarks').where({ actorId, statusId }).delete()
+  },
+
+  async isActorBookmarkedStatus({
+    actorId,
+    statusId
+  }: IsActorBookmarkedStatusParams) {
+    const result = await database('bookmarks')
+      .where({ actorId, statusId })
+      .first('id')
+    return Boolean(result)
+  },
+
+  async getBookmarks({
+    actorId,
+    limit,
+    maxId,
+    minId,
+    sinceId
+  }: GetBookmarksParams) {
+    const query = database<Bookmark>('bookmarks')
+      .where({ actorId })
+      .limit(limit)
+    const cursorId = maxId || minId || sinceId
+
+    if (cursorId) {
+      const cursor = await database<Bookmark>('bookmarks')
+        .where({ actorId, id: cursorId })
+        .first()
+      if (!cursor) return []
+      applyCursor(query, cursor, maxId ? 'older' : 'newer')
+    }
+
+    if (minId || sinceId) {
+      query.orderBy('createdAt', 'asc').orderBy('id', 'asc')
+    } else {
+      query.orderBy('createdAt', 'desc').orderBy('id', 'desc')
+    }
+
+    const bookmarks = await query
+    return (minId || sinceId ? bookmarks.reverse() : bookmarks).map(
+      fixBookmarkDataDate
+    )
+  }
+})

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -4,6 +4,7 @@ import { AccountSQLDatabaseMixin } from '@/lib/database/sql/account'
 import { ActorSQLDatabaseMixin } from '@/lib/database/sql/actor'
 import { AdminSQLDatabaseMixin } from '@/lib/database/sql/admin'
 import { BlockSQLDatabaseMixin } from '@/lib/database/sql/block'
+import { BookmarkSQLDatabaseMixin } from '@/lib/database/sql/bookmark'
 import { FitnessFileSQLDatabaseMixin } from '@/lib/database/sql/fitnessFile'
 import { FitnessRouteHeatmapSQLDatabaseMixin } from '@/lib/database/sql/fitnessRouteHeatmap'
 import { FitnessSettingsSQLDatabaseMixin } from '@/lib/database/sql/fitnessSettings'
@@ -26,6 +27,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const fitnessRouteHeatmapDatabase =
     FitnessRouteHeatmapSQLDatabaseMixin(database)
   const fitnessSettingsDatabase = FitnessSettingsSQLDatabaseMixin(database)
+  const bookmarkDatabase = BookmarkSQLDatabaseMixin(database)
   const blockDatabase = BlockSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const likeDatabase = LikeSQLDatabaseMixin(database)
@@ -38,6 +40,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const statusDatabase = StatusSQLDatabaseMixin(
     database,
     actorDatabase,
+    bookmarkDatabase,
     likeDatabase,
     mediaDatabase
   )
@@ -58,6 +61,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...fitnessFileDatabase,
     ...fitnessRouteHeatmapDatabase,
     ...fitnessSettingsDatabase,
+    ...bookmarkDatabase,
     ...blockDatabase,
     ...followerDatabase,
     ...likeDatabase,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -11,6 +11,7 @@ import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { SQLFitnessFile } from '@/lib/types/database/fitnessFile'
 import { ActorDatabase } from '@/lib/types/database/operations'
+import { BookmarkDatabase } from '@/lib/types/database/operations'
 import { LikeDatabase } from '@/lib/types/database/operations'
 import { MediaDatabase } from '@/lib/types/database/operations'
 import {
@@ -172,6 +173,7 @@ export const buildPubliclyReadableStatusIdsQuery = ({
 export const StatusSQLDatabaseMixin = (
   database: Knex,
   actorDatabase: ActorDatabase,
+  bookmarkDatabase: BookmarkDatabase,
   likeDatabase: LikeDatabase,
   mediaDatabase: MediaDatabase
 ): StatusDatabase => {
@@ -477,6 +479,7 @@ export const StatusSQLDatabaseMixin = (
       replies: [],
       totalLikes: 0,
       isActorLiked: false,
+      isActorBookmarked: false,
       actorAnnounceStatusId: null,
       isLocalActor: Boolean(actor?.account),
       createdAt: getCompatibleTime(statusCreatedAt),
@@ -755,6 +758,7 @@ export const StatusSQLDatabaseMixin = (
       choices: [],
       totalLikes: 0,
       isActorLiked: false,
+      isActorBookmarked: false,
       actorAnnounceStatusId: null,
       endAt,
       pollType,
@@ -1132,6 +1136,7 @@ export const StatusSQLDatabaseMixin = (
       trx('recipients').where('statusId', statusId).delete(),
       trx('tags').where('statusId', statusId).delete(),
       trx('attachments').where('statusId', statusId).delete(),
+      trx('bookmarks').where('statusId', statusId).delete(),
       trx('poll_choices').where('statusId', statusId).delete(),
       trx('timelines').where('statusId', statusId).delete()
     ])
@@ -1369,6 +1374,7 @@ export const StatusSQLDatabaseMixin = (
       totalLikes,
       totalShares,
       isActorLikedStatusResult,
+      isActorBookmarkedStatusResult,
       actorAnnounceStatus,
       edits,
       fitnessFile
@@ -1386,6 +1392,12 @@ export const StatusSQLDatabaseMixin = (
       getCounterValue(database, CounterKey.totalReblog(data.id)),
       currentActorId
         ? likeDatabase.isActorLikedStatus({
+            statusId: data.id,
+            actorId: currentActorId
+          })
+        : false,
+      currentActorId
+        ? bookmarkDatabase.isActorBookmarkedStatus({
             statusId: data.id,
             actorId: currentActorId
           })
@@ -1436,6 +1448,7 @@ export const StatusSQLDatabaseMixin = (
       totalLikes,
       totalShares,
       isActorLiked: isActorLikedStatusResult,
+      isActorBookmarked: isActorBookmarkedStatusResult,
       actorAnnounceStatusId: actorAnnounceStatus?.id ?? null,
       isLocalActor: Boolean(actor?.account),
       attachments: orderedAttachments,

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -8,6 +8,7 @@ import {
   AdminDatabase,
   BaseDatabase,
   BlockDatabase,
+  BookmarkDatabase,
   FollowDatabase,
   LikeDatabase,
   MediaDatabase,
@@ -25,6 +26,7 @@ export type Database = AccountDatabase &
   FitnessRouteHeatmapDatabase &
   FitnessSettingsDatabase &
   StravaArchiveImportDatabase &
+  BookmarkDatabase &
   BlockDatabase &
   FollowDatabase &
   LikeDatabase &

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -544,6 +544,41 @@ describe('#OAuthGuard', () => {
       expect(response.status).toBe(401)
       expect(mockHandler).not.toHaveBeenCalled()
     })
+
+    test('allows broad write JWT scope for write:bookmarks routes', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+      const token = jwtToken('write-bookmarks-compatible')
+
+      const primaryActor = await database.getActorFromEmail({
+        email: seedActor1.email
+      })
+      mockVerifyAccessToken.mockResolvedValue({
+        sub: 'user-id',
+        scope: 'write',
+        actorId: primaryActor?.id
+      })
+      mockStoredTokens.set(hashToken(token), {
+        token: hashToken(token),
+        referenceId: primaryActor?.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        scopes: JSON.stringify(['write'])
+      })
+
+      const guard = OAuthGuard([Scope.enum['write:bookmarks']], mockHandler)
+      const req = createRequest({ Authorization: `Bearer ${token}` })
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
+      expect(mockVerifyAccessToken).toHaveBeenCalledWith(token, {
+        jwksUrl: 'https://llun.test/api/auth/jwks',
+        scopes: [],
+        verifyOptions: {
+          issuer: 'https://llun.test',
+          audience: 'https://llun.test'
+        }
+      })
+    })
   })
 
   describe('opaque token authentication', () => {
@@ -634,6 +669,29 @@ describe('#OAuthGuard', () => {
       const response = await guard(req, { params: Promise.resolve({}) })
 
       expect(response.status).toBe(401)
+    })
+
+    test('allows exact read:bookmarks opaque token for read:bookmarks routes', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const primaryActor = await database.getActorFromEmail({
+        email: seedActor1.email
+      })
+      mockStoredTokens.set(hashToken('read-bookmarks-opaque'), {
+        token: hashToken('read-bookmarks-opaque'),
+        referenceId: primaryActor?.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        scopes: JSON.stringify(['read:bookmarks'])
+      })
+
+      const guard = OAuthGuard([Scope.enum['read:bookmarks']], mockHandler)
+      const req = createRequest({
+        Authorization: 'Bearer read-bookmarks-opaque'
+      })
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(mockHandler).toHaveBeenCalled()
     })
 
     test('returns 401 when opaque token has no referenceId', async () => {

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -106,6 +106,29 @@ const hasSameOriginProof = (req: NextRequest): boolean => {
 
 type ScopeMatchMode = 'all' | 'any'
 
+const grantedScopeSatisfies = (
+  grantedScope: string,
+  requiredScope: Scope
+): boolean => {
+  if (grantedScope === requiredScope) return true
+  if (requiredScope.startsWith('read:')) return grantedScope === Scope.enum.read
+  if (requiredScope.startsWith('write:')) {
+    return grantedScope === Scope.enum.write
+  }
+  return false
+}
+
+const hasGrantedScope = (
+  grantedScopes: string[],
+  requiredScope: Scope
+): boolean =>
+  grantedScopes.some((grantedScope) =>
+    grantedScopeSatisfies(grantedScope, requiredScope)
+  )
+
+const canVerifyScopesDirectly = (scopes: Scope[]): boolean =>
+  scopes.every((scope) => !scope.includes(':'))
+
 type GuardContext<P> = {
   currentActor: Actor
   database: NonNullable<ReturnType<typeof getDatabase>>
@@ -153,9 +176,12 @@ const resolveAuthenticatedContext = async <P>({
         try {
           jwtPayload = (await verifyAccessToken(token, {
             jwksUrl,
-            // For 'any' mode, skip scope checking in verifyAccessToken
-            // and do it manually below
-            scopes: matchMode === 'all' ? scopes : [],
+            // For 'any' mode and hierarchical scopes like write:bookmarks,
+            // skip library scope checking and apply our compatibility rules below.
+            scopes:
+              matchMode === 'all' && canVerifyScopesDirectly(scopes)
+                ? scopes
+                : [],
             verifyOptions: {
               issuer: baseURL,
               audience: baseURL
@@ -175,13 +201,15 @@ const resolveAuthenticatedContext = async <P>({
           // Defense-in-depth: explicitly verify JWT scope claims in case
           // verifyAccessToken's scope checking changes in a future version
           for (const scope of scopes) {
-            if (!jwtScopes.includes(scope)) {
+            if (!hasGrantedScope(jwtScopes, scope)) {
               return { authenticated: false, response: apiErrorResponse(401) }
             }
           }
         } else {
           // 'any' mode: at least one required scope must be present
-          const hasAny = scopes.some((scope) => jwtScopes.includes(scope))
+          const hasAny = scopes.some((scope) =>
+            hasGrantedScope(jwtScopes, scope)
+          )
           if (!hasAny) {
             return { authenticated: false, response: apiErrorResponse(401) }
           }
@@ -213,12 +241,14 @@ const resolveAuthenticatedContext = async <P>({
 
         if (matchMode === 'all') {
           for (const scope of scopes) {
-            if (!storedScopes.includes(scope)) {
+            if (!hasGrantedScope(storedScopes, scope)) {
               return { authenticated: false, response: apiErrorResponse(401) }
             }
           }
         } else {
-          const hasAny = scopes.some((scope) => storedScopes.includes(scope))
+          const hasAny = scopes.some((scope) =>
+            hasGrantedScope(storedScopes, scope)
+          )
           if (!hasAny) {
             return { authenticated: false, response: apiErrorResponse(401) }
           }

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -197,6 +197,35 @@ describe('#getMastodonStatus', () => {
     })
   })
 
+  it('returns bookmarked=true when the current actor has bookmarked the status', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/mastodon-bookmarked-test`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'Bookmarked status',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createBookmark({
+      actorId: ACTOR2_ID,
+      statusId
+    })
+
+    const status = (await database.getStatus({
+      statusId,
+      currentActorId: ACTOR2_ID,
+      withReplies: false
+    })) as Status
+
+    const mastodonStatus = await getMastodonStatus(database, status, ACTOR2_ID)
+
+    expect(mastodonStatus).toMatchObject({
+      id: urlToId(statusId),
+      bookmarked: true
+    })
+  })
+
   it('returns mastodon announce status', async () => {
     const status = (await database.getStatus({
       statusId: `${ACTOR2_ID}/statuses/post-3`

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -212,6 +212,7 @@ export const getMastodonStatus = async (
 
     favourites_count: status.totalLikes || 0,
     favourited: status.isActorLiked ?? false,
+    bookmarked: status.isActorBookmarked ?? false,
 
     edited_at: status.updatedAt ? getISOTimeUTC(status.updatedAt) : null,
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -8,6 +8,7 @@ import { Account } from '@/lib/types/domain/account'
 import { Actor, ActorType } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Block } from '@/lib/types/domain/block'
+import { Bookmark } from '@/lib/types/domain/bookmark'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 import { Session } from '@/lib/types/domain/session'
 import { Status } from '@/lib/types/domain/status'
@@ -740,6 +741,34 @@ export interface LikeDatabase {
 }
 
 // ============================================================================
+// Bookmark Database
+// ============================================================================
+
+interface BaseBookmarkParams {
+  actorId: string
+  statusId: string
+}
+export type CreateBookmarkParams = BaseBookmarkParams
+export type DeleteBookmarkParams = BaseBookmarkParams
+export type IsActorBookmarkedStatusParams = BaseBookmarkParams
+export type GetBookmarksParams = {
+  actorId: string
+  limit: number
+  maxId?: string | null
+  minId?: string | null
+  sinceId?: string | null
+}
+
+export interface BookmarkDatabase {
+  createBookmark(params: CreateBookmarkParams): Promise<void>
+  deleteBookmark(params: DeleteBookmarkParams): Promise<void>
+  isActorBookmarkedStatus(
+    params: IsActorBookmarkedStatusParams
+  ): Promise<boolean>
+  getBookmarks(params: GetBookmarksParams): Promise<Bookmark[]>
+}
+
+// ============================================================================
 // Media Database
 // ============================================================================
 
@@ -996,7 +1025,9 @@ export const Scope = z.enum([
   'profile',
   'email',
   'read',
+  'read:bookmarks',
   'write',
+  'write:bookmarks',
   'follow',
   'push'
 ])
@@ -1007,7 +1038,9 @@ export const UsableScopes = [
   Scope.enum.profile,
   Scope.enum.email,
   Scope.enum.read,
+  Scope.enum['read:bookmarks'],
   Scope.enum.write,
+  Scope.enum['write:bookmarks'],
   Scope.enum.follow
 ]
 

--- a/lib/types/domain/bookmark.ts
+++ b/lib/types/domain/bookmark.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const Bookmark = z.object({
+  id: z.string(),
+  actorId: z.string(),
+  statusId: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number()
+})
+
+export type Bookmark = z.infer<typeof Bookmark>

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -78,6 +78,7 @@ export const StatusNote = StatusBase.extend({
 
   actorAnnounceStatusId: z.string().nullable(),
   isActorLiked: z.boolean(),
+  isActorBookmarked: z.boolean().optional(),
   totalLikes: z.number(),
   totalShares: z.number().default(0),
 
@@ -220,6 +221,7 @@ export const fromNote = (note: Note): StatusNote => {
 
     actorAnnounceStatusId: null,
     isActorLiked: false,
+    isActorBookmarked: false,
     isLocalActor: false,
     totalLikes: 0,
 

--- a/migrations/20260516000000_add_bookmarks_table.js
+++ b/migrations/20260516000000_add_bookmarks_table.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) => {
+  return knex.schema.createTable('bookmarks', function (table) {
+    table.string('id').primary()
+    table.string('actorId').notNullable()
+    table.string('statusId').notNullable()
+
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['actorId', 'statusId'])
+    table.index(['actorId', 'createdAt', 'id'])
+    table.index(['statusId'])
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => {
+  return knex.schema.dropTable('bookmarks')
+}


### PR DESCRIPTION
## Summary
- Add a Mastodon-compatible bookmarks table and database API.
- Implement GET /api/v1/bookmarks plus status bookmark/unbookmark endpoints.
- Serialize bookmarked state in Mastodon status responses and support read/write bookmark OAuth scopes.

## Verification
- yarn test --runTestsByPath lib/database/sql/bookmark.test.ts lib/services/mastodon/getMastodonStatus.test.ts app/api/v1/statuses/[id]/route.test.ts app/api/v1/bookmarks/route.test.ts lib/services/guards/OAuthGuard.test.ts --runInBand
- yarn exec prettier --check app/api/v1/bookmarks/route.ts app/api/v1/bookmarks/route.test.ts app/api/v1/statuses/[id]/bookmark/route.ts app/api/v1/statuses/[id]/unbookmark/route.ts lib/database/sql/bookmark.ts lib/database/sql/bookmark.test.ts lib/services/guards/OAuthGuard.ts lib/services/guards/OAuthGuard.test.ts lib/services/mastodon/getMastodonStatus.ts lib/services/mastodon/getMastodonStatus.test.ts lib/types/database/operations.ts lib/types/domain/bookmark.ts lib/types/domain/status.ts migrations/20260516000000_add_bookmarks_table.js
- yarn lint
- yarn build
- git diff --check
