### PR TITLE
[codex] fix edit post media attachments

### DIFF
--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -17,6 +17,7 @@ import {
 import { Timeline } from '@/lib/services/timelines/types'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
+import { Attachment } from '@/lib/types/domain/attachment'
 import { EditableStatus, Status } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
@@ -75,8 +76,19 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
     window.scrollTo({ top: 0 })
   }
 
-  const onReplyCreated = (status: Status) => {
-    setCurrentStatuses((previousValue) => [status, ...previousValue])
+  const withAttachments = (status: Status, attachments: Attachment[]) => {
+    if (status.type === 'Announce') return status
+    return {
+      ...status,
+      attachments
+    }
+  }
+
+  const onReplyCreated = (status: Status, attachments: Attachment[]) => {
+    setCurrentStatuses((previousValue) => [
+      withAttachments(status, attachments),
+      ...previousValue
+    ])
   }
 
   const onPostDeleted = (status: Status) => {
@@ -250,19 +262,19 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
             isMediaUploadEnabled={isMediaUploadEnabled}
             onDiscardReply={() => dispatchStatusAction(clearAction())}
             onDiscardEdit={() => dispatchStatusAction(clearAction())}
-            onPostCreated={(status: Status) => {
-              setCurrentStatuses((previousValue) => [status, ...previousValue])
+            onPostCreated={(status: Status, attachments: Attachment[]) => {
+              setCurrentStatuses((previousValue) => [
+                withAttachments(status, attachments),
+                ...previousValue
+              ])
               dispatchStatusAction(clearAction())
             }}
             onPostUpdated={(updatedStatus: Status) => {
-              const index = currentStatuses.findIndex(
-                (status) => status.id === updatedStatus.id
+              setCurrentStatuses((previousValue) =>
+                previousValue.map((status) =>
+                  status.id === updatedStatus.id ? updatedStatus : status
+                )
               )
-              // TODO: Update status in Timeline somehow.
-              if (index >= 0) {
-                currentStatuses[index] = updatedStatus
-                setCurrentStatuses(() => currentStatuses)
-              }
               dispatchStatusAction(clearAction())
             }}
           />

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -803,6 +803,89 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(updatedStatus?.summary).toBeNull()
     })
 
+    it('replaces media attachments without changing status text', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-media-only`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Media edit target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+      const oldMedia = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-old.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 100, height: 100 },
+          fileName: 'api-edit-old.jpg'
+        }
+      })
+      const newMedia = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-new.webp',
+          bytes: 2048,
+          mimeType: 'image/png',
+          metaData: { width: 640, height: 480 },
+          fileName: 'api-edit-new.png'
+        },
+        description: 'Replacement image'
+      })
+      expect(oldMedia).not.toBeNull()
+      expect(newMedia).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: oldMedia!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-old.webp',
+        width: 100,
+        height: 100,
+        name: 'api-edit-old.jpg',
+        mediaId: oldMedia!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_ids: [newMedia!.id]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.content).toContain('Media edit target')
+      expect(data.media_attachments).toHaveLength(1)
+      expect(data.media_attachments[0]).toMatchObject({
+        type: 'image',
+        url: 'https://llun.test/api/v1/files/medias/api-edit-new.webp',
+        description: 'Replacement image'
+      })
+
+      const attachments = await database.getAttachmentsWithMedia({ statusId })
+      expect(attachments).toHaveLength(1)
+      expect(attachments[0]).toMatchObject({
+        mediaId: String(newMedia!.id),
+        url: 'https://llun.test/api/v1/files/medias/api-edit-new.webp',
+        name: 'Replacement image'
+      })
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
     it('does not partially apply visibility when content update is forbidden', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor2.email }

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -7,7 +7,9 @@ import {
   OAuthGuard,
   OptionalOAuthGuard
 } from '@/lib/services/guards/OAuthGuard'
+import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getAttachmentsFromMediaIds } from '@/lib/services/mastodon/mediaIds'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
@@ -100,6 +102,7 @@ export const GET = traceApiRoute(
 const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().nullish(),
+  media_ids: z.array(z.coerce.string()).optional(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
 })
 
@@ -134,9 +137,29 @@ export const PUT = traceApiRoute(
 
       const shouldUpdateContent =
         changes.status !== undefined || changes.spoiler_text !== undefined
+      const mediaIds =
+        changes.media_ids !== undefined
+          ? [...new Set(changes.media_ids)]
+          : undefined
+      const shouldUpdateMedia = mediaIds !== undefined
       const visibility = changes.visibility
 
-      if (!shouldUpdateContent && visibility === undefined) {
+      if (
+        !shouldUpdateContent &&
+        !shouldUpdateMedia &&
+        visibility === undefined
+      ) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+      if (
+        mediaIds !== undefined &&
+        mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS
+      ) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -159,12 +182,29 @@ export const PUT = traceApiRoute(
         })
       }
 
+      const attachments =
+        mediaIds !== undefined
+          ? await getAttachmentsFromMediaIds({
+              database,
+              currentActor,
+              mediaIds
+            })
+          : undefined
+      if (attachments === null) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
       if (visibility !== undefined) {
         updatedNote = await updateNoteVisibilityFromUserInput({
           statusId,
           currentActor,
           visibility,
-          publish: !shouldUpdateContent,
+          publish: !shouldUpdateContent && !shouldUpdateMedia,
           status: existingStatus,
           database
         })
@@ -177,12 +217,13 @@ export const PUT = traceApiRoute(
           })
       }
 
-      if (shouldUpdateContent) {
+      if (shouldUpdateContent || shouldUpdateMedia) {
         updatedNote = await updateNoteFromUserInput({
           statusId,
           currentActor,
           text: changes.status,
           summary: changes.spoiler_text,
+          attachments,
           publish: true,
           status:
             updatedNote?.type === StatusType.enum.Note

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -1,14 +1,11 @@
 import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
-import { getBaseURL } from '@/lib/config'
-import { Database } from '@/lib/database/types'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getAttachmentsFromMediaIds } from '@/lib/services/mastodon/mediaIds'
 import { Scope } from '@/lib/types/database/operations'
-import { Actor } from '@/lib/types/domain/actor'
-import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -99,53 +96,6 @@ const getNoteRequestInput = async (req: Request): Promise<unknown> => {
   }
 }
 
-const getMediaUrl = (path: string) => `${getBaseURL()}/api/v1/files/${path}`
-
-const getAttachmentsFromMediaIds = async (
-  database: Database,
-  currentActor: Actor,
-  mediaIds: string[]
-): Promise<PostBoxAttachment[] | null> => {
-  if (mediaIds.length === 0) return []
-
-  const accountId = currentActor.account?.id
-  if (!accountId) return null
-
-  const medias = await Promise.all(
-    mediaIds.map((mediaId) =>
-      database.getMediaByIdForAccount({
-        mediaId,
-        accountId
-      })
-    )
-  )
-
-  const attachments: PostBoxAttachment[] = []
-  for (const media of medias) {
-    if (!media) return null
-    if (media.original.metaData.upload?.state === 'pending') {
-      return null
-    }
-
-    attachments.push({
-      type: 'upload',
-      id: media.id,
-      mediaType: media.original.mimeType,
-      url: getMediaUrl(media.original.path),
-      width: media.original.metaData.width,
-      height: media.original.metaData.height,
-      ...(media.thumbnail
-        ? { posterUrl: getMediaUrl(media.thumbnail.path) }
-        : {}),
-      ...(media.description || media.original.fileName
-        ? { name: media.description || media.original.fileName }
-        : {})
-    })
-  }
-
-  return attachments
-}
-
 export const POST = traceApiRoute(
   'createStatus',
   OAuthGuard([Scope.enum.write], async (req, context) => {
@@ -171,11 +121,11 @@ export const POST = traceApiRoute(
           responseStatusCode: 422
         })
       }
-      const attachments = await getAttachmentsFromMediaIds(
+      const attachments = await getAttachmentsFromMediaIds({
         database,
         currentActor,
         mediaIds
-      )
+      })
       if (!attachments) {
         return apiResponse({
           req,

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -149,5 +149,86 @@ describe('Update note action', () => {
       )
       expect(getQueue().publish).not.toHaveBeenCalled()
     })
+
+    it('replaces attachments without changing note text', async () => {
+      if (!actor1) fail('Actor1 is required')
+      const statusId = `${actor1.id}/statuses/update-note-attachments`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: actor1.id,
+        text: 'Original note with media',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const oldMedia = await database.createMedia({
+        actorId: actor1.id,
+        original: {
+          path: 'medias/action-old.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 100, height: 100 },
+          fileName: 'action-old.jpg'
+        }
+      })
+      const newMedia = await database.createMedia({
+        actorId: actor1.id,
+        original: {
+          path: 'medias/action-new.webp',
+          bytes: 2048,
+          mimeType: 'image/png',
+          metaData: { width: 300, height: 200 },
+          fileName: 'action-new.png'
+        }
+      })
+      expect(oldMedia).not.toBeNull()
+      expect(newMedia).not.toBeNull()
+      await database.createAttachment({
+        actorId: actor1.id,
+        statusId,
+        mediaType: oldMedia!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/action-old.webp',
+        width: 100,
+        height: 100,
+        name: 'action-old.jpg',
+        mediaId: oldMedia!.id
+      })
+
+      const status = await updateNoteFromUserInput({
+        statusId,
+        currentActor: actor1,
+        database,
+        attachments: [
+          {
+            type: 'upload',
+            id: newMedia!.id,
+            mediaType: newMedia!.original.mimeType,
+            url: 'https://llun.test/api/v1/files/medias/action-new.webp',
+            width: 300,
+            height: 200,
+            name: 'action-new.png'
+          }
+        ]
+      })
+
+      if (!status || status.type !== 'Note') fail('Updated note is required')
+      expect(status).toMatchObject({
+        text: 'Original note with media',
+        attachments: [
+          expect.objectContaining({
+            mediaId: String(newMedia!.id),
+            url: 'https://llun.test/api/v1/files/medias/action-new.webp'
+          })
+        ]
+      })
+      expect(status.attachments).toHaveLength(1)
+      expect(
+        await database.getMediaByIdForAccount({
+          mediaId: oldMedia!.id,
+          accountId: actor1.account!.id
+        })
+      ).not.toBeNull()
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -3,6 +3,7 @@ import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Actor } from '@/lib/types/domain/actor'
+import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getSpan } from '@/lib/utils/trace'
@@ -12,6 +13,7 @@ interface UpdateNoteFromUserInput {
   currentActor: Actor
   text?: string
   summary?: string | null
+  attachments?: PostBoxAttachment[]
   publish?: boolean
   status?: StatusNote
   database: Database
@@ -22,6 +24,7 @@ export const updateNoteFromUserInput = async ({
   currentActor,
   text,
   summary,
+  attachments,
   publish = true,
   status: preloadedStatus,
   database
@@ -38,11 +41,32 @@ export const updateNoteFromUserInput = async ({
     return null
   }
 
-  const updatedStatus = await database.updateNote({
+  const contentUpdatedStatus = await database.updateNote({
     statusId,
     summary: summary === undefined ? status.summary : summary?.trim() || null,
     text: text ?? status.text
   })
+  if (!contentUpdatedStatus) {
+    span.end()
+    return null
+  }
+
+  if (attachments !== undefined) {
+    await database.replaceStatusAttachments({
+      actorId: currentActor.id,
+      statusId,
+      attachments: attachments.map((attachment) => ({
+        mediaType: attachment.mediaType,
+        url: attachment.url,
+        width: attachment.width,
+        height: attachment.height,
+        name: attachment.name,
+        mediaId: attachment.id
+      }))
+    })
+  }
+
+  const updatedStatus = await database.getStatus({ statusId })
   if (!updatedStatus) {
     span.end()
     return null

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -47,6 +47,22 @@ describe('client updateNote', () => {
       })
     )
   })
+
+  it('sends media_ids for attachment-only edits', async () => {
+    await updateNote({
+      statusId: '123',
+      mediaIds: ['media-2']
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/statuses/123',
+      expect.objectContaining({
+        body: JSON.stringify({
+          media_ids: ['media-2']
+        })
+      })
+    )
+  })
 })
 
 describe('client getActorStatuses', () => {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -69,17 +69,23 @@ export interface UpdateNoteParams {
   statusId: string
   message?: string
   contentWarning?: string
+  mediaIds?: string[]
 }
 export const updateNote = async ({
   statusId,
   message,
-  contentWarning
+  contentWarning,
+  mediaIds
 }: UpdateNoteParams) => {
   const normalizedMessage =
     message !== undefined && message.trim().length > 0 ? message : undefined
 
-  if (normalizedMessage === undefined && contentWarning === undefined) {
-    throw new Error('Message or content warning must be provided')
+  if (
+    normalizedMessage === undefined &&
+    contentWarning === undefined &&
+    mediaIds === undefined
+  ) {
+    throw new Error('Message, content warning, or media must be provided')
   }
 
   const response = await fetch(`/api/v1/statuses/${statusId}`, {
@@ -89,7 +95,8 @@ export const updateNote = async ({
     },
     body: JSON.stringify({
       ...(normalizedMessage !== undefined ? { status: normalizedMessage } : {}),
-      ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {})
+      ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {}),
+      ...(mediaIds !== undefined ? { media_ids: mediaIds } : {})
     })
   })
   if (response.status !== 200) {

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { updateNote } from '@/lib/client'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { EditableStatus, StatusType } from '@/lib/types/domain/status'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { PostBox } from './post-box'
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: unknown }) => children
+}))
+
+jest.mock('rehype-sanitize', () => jest.fn())
+jest.mock('remark-breaks', () => jest.fn())
+
+jest.mock('@/lib/client', () => ({
+  createNote: jest.fn(),
+  createPoll: jest.fn(),
+  deleteFitnessFile: jest.fn(),
+  updateNote: jest.fn().mockResolvedValue({}),
+  uploadAttachment: jest.fn(),
+  uploadFitnessFile: jest.fn()
+}))
+
+const updateNoteMock = updateNote as jest.MockedFunction<typeof updateNote>
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const profile: ActorProfile = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  domain: 'activities.local',
+  name: 'Llun',
+  followersUrl: 'https://activities.local/users/llun/followers',
+  inboxUrl: 'https://activities.local/users/llun/inbox',
+  sharedInboxUrl: 'https://activities.local/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: currentTime
+}
+
+const editStatus: EditableStatus = {
+  id: 'https://activities.local/users/llun/statuses/post-1',
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://activities.local/@llun/post-1',
+  text: 'Original message',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [
+    {
+      id: 'attachment-old',
+      mediaId: 'media-old',
+      actorId: profile.id,
+      statusId: 'https://activities.local/users/llun/statuses/post-1',
+      type: 'Document',
+      mediaType: 'image/png',
+      url: 'https://activities.local/api/v1/files/medias/old.png',
+      width: 100,
+      height: 100,
+      name: 'old.png',
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
+  ],
+  tags: []
+} as EditableStatus
+
+describe('PostBox edit mode', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('enables update when removing media without changing text', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Update' })).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText('Remove media old.png'))
+    expect(screen.getByRole('button', { name: 'Update' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(updateNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusId: urlToId(editStatus.id),
+          mediaIds: []
+        })
+      )
+    })
+  })
+})

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -35,7 +35,7 @@ import {
   getMention,
   getMentionFromActorID
 } from '@/lib/types/domain/actor'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import {
   EditableStatus,
   Status,
@@ -115,6 +115,57 @@ export const PostBox: FC<Props> = ({
   )
   const postExtensionRef = useRef(postExtension)
 
+  const getEditAttachmentIds = (attachments: PostBoxAttachment[]) =>
+    attachments.map((attachment) => attachment.id)
+
+  const getOriginalEditAttachmentIds = () =>
+    editStatus?.attachments.map(
+      (attachment) => attachment.mediaId ?? attachment.id
+    ) ?? []
+
+  const hasAttachmentListChanged = (attachments: PostBoxAttachment[]) => {
+    const originalIds = getOriginalEditAttachmentIds()
+    const currentIds = getEditAttachmentIds(attachments)
+    return (
+      originalIds.length !== currentIds.length ||
+      originalIds.some((id, index) => id !== currentIds[index])
+    )
+  }
+
+  const getOriginalEditText = () =>
+    editStatus ? sanitizeHtml(editStatus.text, { allowedTags: [] }) : ''
+
+  const isEditDirty = ({
+    nextText = textRef.current,
+    nextContentWarning = postExtensionRef.current.contentWarningVisible
+      ? postExtensionRef.current.contentWarning
+      : '',
+    nextAttachments = postExtensionRef.current.attachments
+  }: {
+    nextText?: string
+    nextContentWarning?: string
+    nextAttachments?: PostBoxAttachment[]
+  } = {}) => {
+    if (!editStatus) return false
+
+    return (
+      nextText !== getOriginalEditText() ||
+      nextContentWarning !== (editStatus.summary ?? '') ||
+      hasAttachmentListChanged(nextAttachments)
+    )
+  }
+
+  const getEditAttachmentsFromStatus = (): PostBoxAttachment[] =>
+    editStatus?.attachments.map((attachment) => ({
+      type: 'upload',
+      id: attachment.mediaId ?? attachment.id,
+      mediaType: attachment.mediaType,
+      url: attachment.url,
+      width: attachment.width ?? 0,
+      height: attachment.height ?? 0,
+      name: attachment.name
+    })) ?? []
+
   useEffect(() => {
     postExtensionRef.current = postExtension
   }, [postExtension])
@@ -132,6 +183,65 @@ export const PostBox: FC<Props> = ({
       })
     }
   }, [])
+
+  const uploadSelectedAttachments = async () => {
+    const uploadResults = await Promise.all(
+      postExtension.attachments.map(async (attachment) => {
+        if (!attachment.file)
+          return {
+            originalId: attachment.id,
+            uploadedAttachment: attachment
+          }
+
+        dispatch(
+          updateAttachment(attachment.id, {
+            ...attachment,
+            isLoading: true
+          })
+        )
+
+        try {
+          const uploaded = await uploadAttachment(attachment.file)
+          if (!uploaded) throw new Error()
+
+          if (attachment.url.startsWith('blob:')) {
+            URL.revokeObjectURL(attachment.url)
+          }
+
+          const newAttachment = {
+            ...attachment,
+            ...uploaded,
+            isLoading: false,
+            file: undefined
+          }
+          dispatch(updateAttachment(attachment.id, newAttachment))
+          return {
+            originalId: attachment.id,
+            uploadedAttachment: newAttachment
+          }
+        } catch {
+          dispatch(
+            updateAttachment(attachment.id, {
+              ...attachment,
+              isLoading: false
+            })
+          )
+          throw new Error(`Fail to upload ${attachment.name}`)
+        }
+      })
+    )
+
+    const currentAttachmentIds = new Set(
+      postExtensionRef.current.attachments.map((a) => a.id)
+    )
+    return uploadResults
+      .filter(
+        (a) =>
+          currentAttachmentIds.has(a.originalId) ||
+          currentAttachmentIds.has(a.uploadedAttachment.id)
+      )
+      .map((a) => a.uploadedAttachment)
+  }
 
   const onPost = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault()
@@ -171,16 +281,51 @@ export const PostBox: FC<Props> = ({
       }
 
       if (editStatus) {
-        const updateMessage = message.trim().length > 0 ? message : undefined
+        const attachments = await uploadSelectedAttachments()
+        const currentContentWarning = postExtension.contentWarningVisible
+          ? postExtension.contentWarning
+          : ''
+        const hasTextChanged = message !== getOriginalEditText()
+        const hasContentWarningChanged =
+          currentContentWarning !== (editStatus.summary ?? '')
+        const hasMediaChanged = hasAttachmentListChanged(attachments)
+        const updateMessage =
+          hasTextChanged && message.trim().length > 0 ? message : undefined
+        const updateContentWarning = hasContentWarningChanged
+          ? currentContentWarning
+          : undefined
+        const mediaIds = hasMediaChanged
+          ? attachments.map((attachment) => attachment.id)
+          : undefined
         await updateNote({
           statusId: urlToId(editStatus.id),
           message: updateMessage,
-          contentWarning
+          contentWarning: updateContentWarning,
+          mediaIds
         })
         onPostUpdated({
           ...editStatus,
           text: updateMessage ?? editStatus.text,
-          summary: contentWarning.trim() || null
+          summary:
+            updateContentWarning !== undefined
+              ? updateContentWarning.trim() || null
+              : editStatus.summary,
+          attachments: hasMediaChanged
+            ? attachments.map((attachment) => ({
+                id: attachment.id,
+                mediaId: attachment.id,
+                actorId: editStatus.actorId,
+                statusId: editStatus.id,
+                type: 'Document' as const,
+                mediaType: attachment.mediaType,
+                url: attachment.url,
+                width: attachment.width,
+                height: attachment.height,
+                name: attachment.name ?? '',
+                createdAt: Date.now(),
+                updatedAt: Date.now()
+              }))
+            : editStatus.attachments
         })
         dispatch(resetExtension())
 
@@ -215,83 +360,7 @@ export const PostBox: FC<Props> = ({
         }
       }
 
-      const uploadResults = await Promise.all(
-        postExtension.attachments.map(async (attachment) => {
-          if (!attachment.file)
-            return {
-              originalId: attachment.id,
-              uploadedAttachment: attachment
-            }
-
-          dispatch(
-            updateAttachment(attachment.id, {
-              ...attachment,
-              isLoading: true
-            })
-          )
-
-          try {
-            const uploaded = await uploadAttachment(attachment.file)
-            if (!uploaded) throw new Error()
-
-            // Revoke the blob URL after successful upload
-            if (attachment.url.startsWith('blob:')) {
-              URL.revokeObjectURL(attachment.url)
-            }
-
-            const newAttachment = {
-              ...attachment,
-              ...uploaded,
-              isLoading: false,
-              file: undefined
-            }
-            dispatch(updateAttachment(attachment.id, newAttachment))
-            return {
-              originalId: attachment.id,
-              uploadedAttachment: newAttachment
-            }
-          } catch {
-            dispatch(
-              updateAttachment(attachment.id, {
-                ...attachment,
-                isLoading: false
-              })
-            )
-            throw new Error(`Fail to upload ${attachment.name}`)
-          }
-        })
-      )
-
-      // Filter out attachments that were removed during upload
-      const currentAttachmentIds = new Set(
-        postExtensionRef.current.attachments.map((a) => a.id)
-      )
-      const attachments = uploadResults
-        .filter((a) =>
-          // It is possible that the attachment is not in the current list
-          // because it was removed during the upload process.
-          // However, the current list might have the new ID or the old ID.
-          // If the attachment is in the current list, it means it was not removed.
-          // If checking with only original ID, it might be removed by the user
-          // but the current list has the old ID.
-          // If checking with only new ID, it might be removed by the user
-          // but the current list has the new ID.
-          // Wait, the postExtensionRef.current update is async in react
-          // so it might still have the old ID or the new ID?
-          // The dispatch is async, but the ref update is in useEffect which is also async
-          // relative to this function execution?
-          // Actually, dispatch triggers re-render, leading to useEffect update ref.
-          // So inside this async function, the ref update might happen after await.
-          // So we should check if the original ID is in the list (meaning not removed yet / old state)
-          // OR if the new ID is in the list (meaning not removed / new state).
-          {
-            return (
-              currentAttachmentIds.has(a.originalId) ||
-              currentAttachmentIds.has(a.uploadedAttachment.id)
-            )
-          }
-        )
-        .map((a) => a.uploadedAttachment)
+      const attachments = await uploadSelectedAttachments()
 
       const response = await createNote({
         message,
@@ -325,12 +394,14 @@ export const PostBox: FC<Props> = ({
     if (attachment.url.startsWith('blob:')) {
       URL.revokeObjectURL(attachment.url)
     }
-    dispatch(
-      setAttachments([
-        ...postExtension.attachments.slice(0, attachmentIndex),
-        ...postExtension.attachments.slice(attachmentIndex + 1)
-      ])
-    )
+    const nextAttachments = [
+      ...postExtension.attachments.slice(0, attachmentIndex),
+      ...postExtension.attachments.slice(attachmentIndex + 1)
+    ]
+    dispatch(setAttachments(nextAttachments))
+    if (editStatus) {
+      setAllowPost(isEditDirty({ nextAttachments }))
+    }
   }
 
   const onRemoveFitnessFile = useCallback(async () => {
@@ -399,16 +470,12 @@ export const PostBox: FC<Props> = ({
   const onTextChange = (value: string) => {
     setText(value)
     textRef.current = value
-    if (value.trim().length === 0) {
-      setAllowPost(Boolean(postExtensionRef.current.fitnessFile))
+    if (editStatus) {
+      setAllowPost(isEditDirty({ nextText: value }))
       return
     }
-    if (
-      editStatus &&
-      value === sanitizeHtml(editStatus.text, { allowedTags: [] }) &&
-      postExtensionRef.current.contentWarning === (editStatus.summary ?? '')
-    ) {
-      setAllowPost(false)
+    if (value.trim().length === 0) {
+      setAllowPost(Boolean(postExtensionRef.current.fitnessFile))
       return
     }
     setAllowPost(true)
@@ -418,10 +485,7 @@ export const PostBox: FC<Props> = ({
     dispatch(setContentWarning(value))
     if (!editStatus) return
 
-    setAllowPost(
-      value !== (editStatus.summary ?? '') ||
-        textRef.current !== sanitizeHtml(editStatus.text, { allowedTags: [] })
-    )
+    setAllowPost(isEditDirty({ nextContentWarning: value }))
   }
 
   const onToggleContentWarning = () => {
@@ -430,10 +494,7 @@ export const PostBox: FC<Props> = ({
     if (!editStatus) return
 
     const nextContentWarning = nextVisible ? postExtension.contentWarning : ''
-    setAllowPost(
-      nextContentWarning !== (editStatus.summary ?? '') ||
-        textRef.current !== sanitizeHtml(editStatus.text, { allowedTags: [] })
-    )
+    setAllowPost(isEditDirty({ nextContentWarning }))
   }
 
   /**
@@ -496,15 +557,14 @@ export const PostBox: FC<Props> = ({
       setText(editStatus.text)
       dispatch(setContentWarning(editStatus.summary ?? ''))
       dispatch(setContentWarningVisibility(Boolean(editStatus.summary)))
-      setAllowPost(false) // Initial state for edit is disabled until changed? Or should we check?
-      // Original logic in onTextChange checked if text === editStatus.text.
-      // So if we set text to editStatus.text, allowPost should be false.
-      // But we need to update allowPost.
+      dispatch(setAttachments(getEditAttachmentsFromStatus()))
+      setAllowPost(false)
       return
     } else {
       setText('')
       dispatch(setContentWarning(''))
       dispatch(setContentWarningVisibility(false))
+      dispatch(setAttachments([]))
       setAllowPost(false)
     }
 
@@ -682,6 +742,16 @@ export const PostBox: FC<Props> = ({
               attachments={postExtension.attachments}
               onAddAttachment={(attachment) => {
                 dispatch(addAttachment(attachment))
+                if (editStatus) {
+                  setAllowPost(
+                    isEditDirty({
+                      nextAttachments: [
+                        ...postExtensionRef.current.attachments,
+                        attachment
+                      ]
+                    })
+                  )
+                }
               }}
               onDuplicateError={() =>
                 setWarningMsg('Some files are already selected')
@@ -743,10 +813,19 @@ export const PostBox: FC<Props> = ({
               <div
                 className="w-full aspect-square bg-border bg-center bg-cover cursor-pointer relative"
                 key={item.id}
+                role="button"
+                aria-label={`Remove media ${item.name ?? item.id}`}
+                tabIndex={0}
                 style={{
                   backgroundImage: `url("${item.posterUrl || item.url}")`
                 }}
                 onClick={() => onRemoveAttachment(index)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault()
+                    onRemoveAttachment(index)
+                  }
+                }}
               >
                 {item.isLoading ? (
                   <div className="absolute inset-0 bg-background/50 flex items-center justify-center">

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -24,7 +24,8 @@ import {
   MarkMediaUploadVerifiedParams,
   Media,
   MediaDatabase,
-  PaginatedMediaWithStatus
+  PaginatedMediaWithStatus,
+  ReplaceStatusAttachmentsParams
 } from '@/lib/types/database/operations'
 import { Attachment } from '@/lib/types/domain/attachment'
 
@@ -254,6 +255,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
       typeof createdAt === 'number' ? new Date(createdAt) : new Date()
     const data = Attachment.parse({
       id: crypto.randomUUID(),
+      mediaId: mediaId === undefined ? null : String(mediaId),
       actorId,
       statusId,
       type: 'Document',
@@ -267,11 +269,55 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     })
     await database('attachments').insert({
       ...data,
-      mediaId,
+      mediaId: data.mediaId,
       createdAt: currentTime,
       updatedAt: currentTime
     })
     return data
+  },
+
+  async replaceStatusAttachments({
+    actorId,
+    statusId,
+    attachments
+  }: ReplaceStatusAttachmentsParams): Promise<Attachment[]> {
+    const baseTime = Date.now()
+    const rows = attachments.map((attachment, index) => {
+      const currentTime = new Date(baseTime + index)
+      const data = Attachment.parse({
+        id: crypto.randomUUID(),
+        mediaId:
+          attachment.mediaId === undefined ? null : String(attachment.mediaId),
+        actorId,
+        statusId,
+        type: 'Document',
+        mediaType: attachment.mediaType,
+        url: attachment.url,
+        width: attachment.width,
+        height: attachment.height,
+        name: attachment.name ?? '',
+        createdAt: currentTime.getTime(),
+        updatedAt: currentTime.getTime()
+      })
+
+      return {
+        data,
+        row: {
+          ...data,
+          createdAt: currentTime,
+          updatedAt: currentTime
+        }
+      }
+    })
+
+    await database.transaction(async (trx) => {
+      await trx('attachments').where('statusId', statusId).delete()
+      if (rows.length > 0) {
+        await trx('attachments').insert(rows.map((item) => item.row))
+      }
+    })
+
+    return rows.map((item) => item.data)
   },
 
   async getAttachments({ statusId }: GetAttachmentsParams) {
@@ -284,6 +330,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         if (!item.actorId) return null
         return Attachment.parse({
           ...item,
+          mediaId:
+            item.mediaId === null || item.mediaId === undefined
+              ? null
+              : String(item.mediaId),
           width: item.width ?? undefined,
           height: item.height ?? undefined,
           createdAt: getCompatibleTime(item.createdAt),
@@ -321,6 +371,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
 
         const attachment = Attachment.parse({
           ...item,
+          mediaId:
+            item.mediaId === null || item.mediaId === undefined
+              ? null
+              : String(item.mediaId),
           width: item.width ?? undefined,
           height: item.height ?? undefined,
           createdAt: getCompatibleTime(item.createdAt),
@@ -360,6 +414,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         if (!item.actorId) return null
         return Attachment.parse({
           ...item,
+          mediaId:
+            item.mediaId === null || item.mediaId === undefined
+              ? null
+              : String(item.mediaId),
           width: item.width ?? undefined,
           height: item.height ?? undefined,
           createdAt: getCompatibleTime(item.createdAt),

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -935,6 +935,88 @@ describe('StatusDatabase', () => {
           createdAt: expect.toBeNumber()
         })
       })
+
+      it('replaces note attachments without deleting underlying media', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-attachments`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Original note attachments'
+        })
+        const actor = await database.getActorFromId({ id: emptyActorId })
+        if (!actor?.account) fail('Actor account is required')
+        const oldMedia = await database.createMedia({
+          actorId: emptyActorId,
+          original: {
+            path: 'medias/sql-old.webp',
+            bytes: 1024,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 },
+            fileName: 'sql-old.jpg'
+          }
+        })
+        const newMedia = await database.createMedia({
+          actorId: emptyActorId,
+          original: {
+            path: 'medias/sql-new.webp',
+            bytes: 2048,
+            mimeType: 'image/png',
+            metaData: { width: 300, height: 200 },
+            fileName: 'sql-new.png'
+          }
+        })
+        expect(oldMedia).not.toBeNull()
+        expect(newMedia).not.toBeNull()
+        await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: oldMedia!.original.mimeType,
+          url: 'https://llun.test/api/v1/files/medias/sql-old.webp',
+          width: 100,
+          height: 100,
+          name: 'sql-old.jpg',
+          mediaId: oldMedia!.id
+        })
+
+        const attachments = await database.replaceStatusAttachments({
+          actorId: emptyActorId,
+          statusId,
+          attachments: [
+            {
+              mediaType: newMedia!.original.mimeType,
+              url: 'https://llun.test/api/v1/files/medias/sql-new.webp',
+              width: 300,
+              height: 200,
+              name: 'sql-new.png',
+              mediaId: newMedia!.id
+            }
+          ]
+        })
+
+        expect(attachments).toHaveLength(1)
+        expect(attachments[0]).toMatchObject({
+          statusId,
+          actorId: emptyActorId,
+          mediaId: String(newMedia!.id),
+          url: 'https://llun.test/api/v1/files/medias/sql-new.webp'
+        })
+        expect(
+          await database.getAttachmentsWithMedia({ statusId })
+        ).toMatchObject([
+          expect.objectContaining({
+            mediaId: String(newMedia!.id)
+          })
+        ])
+        expect(
+          await database.getMediaByIdForAccount({
+            mediaId: oldMedia!.id,
+            accountId: actor.account.id
+          })
+        ).not.toBeNull()
+      })
     })
 
     describe('updateNoteVisibility', () => {

--- a/lib/services/mastodon/mediaIds.ts
+++ b/lib/services/mastodon/mediaIds.ts
@@ -1,0 +1,57 @@
+import { getBaseURL } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+import { PostBoxAttachment } from '@/lib/types/domain/attachment'
+
+const getMediaUrl = (path: string) => `${getBaseURL()}/api/v1/files/${path}`
+
+interface GetAttachmentsFromMediaIdsParams {
+  database: Database
+  currentActor: Actor
+  mediaIds: string[]
+}
+
+export const getAttachmentsFromMediaIds = async ({
+  database,
+  currentActor,
+  mediaIds
+}: GetAttachmentsFromMediaIdsParams): Promise<PostBoxAttachment[] | null> => {
+  if (mediaIds.length === 0) return []
+
+  const accountId = currentActor.account?.id
+  if (!accountId) return null
+
+  const medias = await Promise.all(
+    mediaIds.map((mediaId) =>
+      database.getMediaByIdForAccount({
+        mediaId,
+        accountId
+      })
+    )
+  )
+
+  const attachments: PostBoxAttachment[] = []
+  for (const media of medias) {
+    if (!media) return null
+    if (media.original.metaData.upload?.state === 'pending') {
+      return null
+    }
+
+    attachments.push({
+      type: 'upload',
+      id: media.id,
+      mediaType: media.original.mimeType,
+      url: getMediaUrl(media.original.path),
+      width: media.original.metaData.width,
+      height: media.original.metaData.height,
+      ...(media.thumbnail
+        ? { posterUrl: getMediaUrl(media.thumbnail.path) }
+        : {}),
+      ...(media.description || media.original.fileName
+        ? { name: media.description || media.original.fileName }
+        : {})
+    })
+  }
+
+  return attachments
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -800,6 +800,16 @@ export type CreateAttachmentParams = {
   mediaId?: string
   createdAt?: number
 }
+export type ReplaceStatusAttachmentsParams = {
+  actorId: string
+  statusId: string
+  attachments: Array<
+    Pick<
+      CreateAttachmentParams,
+      'mediaType' | 'url' | 'width' | 'height' | 'name' | 'mediaId'
+    >
+  >
+}
 export type GetAttachmentsParams = {
   statusId: string
 }
@@ -850,6 +860,9 @@ export interface MediaDatabase {
   ): Promise<Media | null>
 
   createAttachment(params: CreateAttachmentParams): Promise<Attachment>
+  replaceStatusAttachments(
+    params: ReplaceStatusAttachmentsParams
+  ): Promise<Attachment[]>
   getAttachments(params: GetAttachmentsParams): Promise<Attachment[]>
   getAttachmentsWithMedia(
     params: GetAttachmentsWithMediaParams

--- a/lib/types/domain/attachment.ts
+++ b/lib/types/domain/attachment.ts
@@ -36,6 +36,7 @@ export type PostBoxAttachment = z.infer<typeof PostBoxAttachment>
 
 export const Attachment = z.object({
   id: z.string(),
+  mediaId: z.string().nullish(),
   actorId: z.string(),
   statusId: z.string(),
   type: z.literal('Document'),


### PR DESCRIPTION
## Summary
- Enable edit-post submissions when media attachments are added, removed, or replaced even if the text is unchanged.
- Upload newly selected media before calling the status update endpoint.
- Accept and validate media_ids on status updates, replace persisted attachments, and federate the refreshed Update activity.

## Verification
- yarn test --runTestsByPath lib/client.test.ts lib/actions/updateNote.test.ts 'app/api/v1/statuses/[id]/route.test.ts' app/api/v1/statuses/route.test.ts lib/components/post-box/post-box.test.tsx lib/database/sql/status.test.ts --runInBand
- git diff --check --cached
- Commit hook lint completed with 0 errors and existing no-explicit-any warnings in auth/fitness and .claude/worktrees files.
- Earlier staging browser smoke verified replacing image-only media on https://activities.local and deleting the smoke post afterward.