### PR TITLE
fix: prevent mobile post actions overflow

### DIFF
--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -6,7 +6,6 @@ import {
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
-import { cn } from '@/lib/utils'
 
 import { DeleteButton } from './delete-button'
 import { EditButton } from './edit-button'
@@ -20,12 +19,8 @@ interface Props extends PostProps {
   onShowEdits?: (status: Status) => void
 }
 
-const statusActionGridColumnsByCount: Record<number, string> = {
-  1: 'grid-cols-1',
-  2: 'grid-cols-2',
-  3: 'grid-cols-3',
-  4: 'grid-cols-4'
-}
+const actionRowClassName =
+  'grid w-full grid-cols-4 items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6'
 
 export const Actions: FC<Props> = ({
   host,
@@ -50,10 +45,19 @@ export const Actions: FC<Props> = ({
     Boolean(actualStatus.isLocalActor) &&
     currentActor.id === actualStatus.actorId
   const hasEditHistory = actualStatus.edits.length > 0
-  const statusActions: ReactNode[] = []
+  const primaryActions: ReactNode[] = [
+    <ReplyButton key="reply" status={actualStatus} onReply={onReply} />,
+    <RepostButton
+      key="repost"
+      currentActor={currentActor}
+      status={actualStatus}
+    />,
+    <LikeButton key="like" currentActor={currentActor} status={actualStatus} />
+  ]
+  const secondaryActions: ReactNode[] = []
 
   if (hasEditHistory) {
-    statusActions.push(
+    primaryActions.push(
       <EditHistoryButton
         key="edit-history"
         status={actualStatus}
@@ -64,13 +68,13 @@ export const Actions: FC<Props> = ({
   }
 
   if (isOwner) {
-    statusActions.push(
+    secondaryActions.push(
       <VisibilityButton key="visibility" status={actualStatus} />
     )
   }
 
   if (canEdit) {
-    statusActions.push(
+    secondaryActions.push(
       <EditButton key="edit" status={actualStatus} onEdit={onEdit} />,
       <DeleteButton
         key="delete"
@@ -80,32 +84,25 @@ export const Actions: FC<Props> = ({
     )
   }
 
-  const hasStatusActions = statusActions.length > 0
-  const statusActionGridColumns =
-    statusActionGridColumnsByCount[statusActions.length] ?? 'grid-cols-1'
+  const hasSecondaryActions = secondaryActions.length > 0
 
   return (
     <div className="mt-3 flex flex-col gap-2 text-muted-foreground sm:flex-row sm:items-center sm:gap-6">
       <div
         role="group"
-        aria-label="Post social actions"
-        className="grid w-full grid-cols-3 items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6"
+        aria-label="Post primary actions"
+        className={actionRowClassName}
       >
-        <ReplyButton status={actualStatus} onReply={onReply} />
-        <RepostButton currentActor={currentActor} status={actualStatus} />
-        <LikeButton currentActor={currentActor} status={actualStatus} />
+        {primaryActions}
       </div>
 
-      {hasStatusActions && (
+      {hasSecondaryActions && (
         <div
           role="group"
-          aria-label="Post status actions"
-          className={cn(
-            'grid w-full items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6',
-            statusActionGridColumns
-          )}
+          aria-label="Post secondary actions"
+          className={actionRowClassName}
         >
-          {statusActions}
+          {secondaryActions}
         </div>
       )}
     </div>

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -86,16 +86,14 @@ export const Actions: FC<Props> = ({
   }
 
   const hasSecondaryActions = secondaryActions.length > 0
+  const actionColumnClassName = hasEditHistory ? 'grid-cols-4' : 'grid-cols-3'
 
   return (
     <div className="mt-3 flex flex-col gap-2 text-muted-foreground sm:flex-row sm:items-center sm:gap-6">
       <div
         role="group"
         aria-label="Post primary actions"
-        className={cn(
-          actionRowClassName,
-          hasEditHistory ? 'grid-cols-4' : 'grid-cols-3'
-        )}
+        className={cn(actionRowClassName, actionColumnClassName)}
       >
         {primaryActions}
       </div>
@@ -104,7 +102,7 @@ export const Actions: FC<Props> = ({
         <div
           role="group"
           aria-label="Post secondary actions"
-          className={cn(actionRowClassName, 'grid-cols-4')}
+          className={cn(actionRowClassName, actionColumnClassName)}
         >
           {secondaryActions}
         </div>

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -6,6 +6,7 @@ import {
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 
 import { DeleteButton } from './delete-button'
 import { EditButton } from './edit-button'
@@ -20,7 +21,7 @@ interface Props extends PostProps {
 }
 
 const actionRowClassName =
-  'grid w-full grid-cols-4 items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6'
+  'grid w-full items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6'
 
 export const Actions: FC<Props> = ({
   host,
@@ -91,7 +92,10 @@ export const Actions: FC<Props> = ({
       <div
         role="group"
         aria-label="Post primary actions"
-        className={actionRowClassName}
+        className={cn(
+          actionRowClassName,
+          hasEditHistory ? 'grid-cols-4' : 'grid-cols-3'
+        )}
       >
         {primaryActions}
       </div>
@@ -100,7 +104,7 @@ export const Actions: FC<Props> = ({
         <div
           role="group"
           aria-label="Post secondary actions"
-          className={actionRowClassName}
+          className={cn(actionRowClassName, 'grid-cols-4')}
         >
           {secondaryActions}
         </div>

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -88,6 +88,7 @@ export const Actions: FC<Props> = ({
   }
 
   const hasSecondaryActions = secondaryActions.length > 0
+  // Use the same mobile grid for both rows so secondary controls align under primary controls.
   const actionColumnClassName = hasEditHistory ? 'grid-cols-4' : 'grid-cols-3'
 
   return (

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 
 import { PostProps } from '@/lib/components/posts/post'
 import {
@@ -43,15 +43,43 @@ export const Actions: FC<Props> = ({
     Boolean(actualStatus.isLocalActor) &&
     currentActor.id === actualStatus.actorId
   const hasEditHistory = actualStatus.edits.length > 0
-  const hasStatusActions = hasEditHistory || isOwner || canEdit
-  const statusActionCount =
-    (hasEditHistory ? 1 : 0) + (isOwner ? 1 : 0) + (canEdit ? 2 : 0)
+  const statusActions: ReactNode[] = []
+
+  if (hasEditHistory) {
+    statusActions.push(
+      <EditHistoryButton
+        key="edit-history"
+        status={actualStatus}
+        host={host}
+        onShowEdits={onShowEdits}
+      />
+    )
+  }
+
+  if (isOwner) {
+    statusActions.push(
+      <VisibilityButton key="visibility" status={actualStatus} />
+    )
+  }
+
+  if (canEdit) {
+    statusActions.push(
+      <EditButton key="edit" status={actualStatus} onEdit={onEdit} />,
+      <DeleteButton
+        key="delete"
+        status={actualStatus}
+        onPostDeleted={onPostDeleted}
+      />
+    )
+  }
+
+  const hasStatusActions = statusActions.length > 0
   const statusActionGridColumns =
-    statusActionCount === 4
+    statusActions.length === 4
       ? 'grid-cols-4'
-      : statusActionCount === 3
+      : statusActions.length === 3
         ? 'grid-cols-3'
-        : statusActionCount === 2
+        : statusActions.length === 2
           ? 'grid-cols-2'
           : 'grid-cols-1'
 
@@ -76,23 +104,7 @@ export const Actions: FC<Props> = ({
             statusActionGridColumns
           )}
         >
-          {hasEditHistory && (
-            <EditHistoryButton
-              status={actualStatus}
-              host={host}
-              onShowEdits={onShowEdits}
-            />
-          )}
-          {isOwner && <VisibilityButton status={actualStatus} />}
-          {canEdit && (
-            <>
-              <EditButton status={actualStatus} onEdit={onEdit} />
-              <DeleteButton
-                status={actualStatus}
-                onPostDeleted={onPostDeleted}
-              />
-            </>
-          )}
+          {statusActions}
         </div>
       )}
     </div>

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -6,6 +6,7 @@ import {
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 
 import { DeleteButton } from './delete-button'
 import { EditButton } from './edit-button'
@@ -43,13 +44,23 @@ export const Actions: FC<Props> = ({
     currentActor.id === actualStatus.actorId
   const hasEditHistory = actualStatus.edits.length > 0
   const hasStatusActions = hasEditHistory || isOwner || canEdit
+  const statusActionCount =
+    (hasEditHistory ? 1 : 0) + (isOwner ? 1 : 0) + (canEdit ? 2 : 0)
+  const statusActionGridColumns =
+    statusActionCount === 4
+      ? 'grid-cols-4'
+      : statusActionCount === 3
+        ? 'grid-cols-3'
+        : statusActionCount === 2
+          ? 'grid-cols-2'
+          : 'grid-cols-1'
 
   return (
     <div className="mt-3 flex flex-col gap-2 text-muted-foreground sm:flex-row sm:items-center sm:gap-6">
       <div
         role="group"
         aria-label="Post social actions"
-        className="flex w-full items-center justify-between gap-2 sm:w-auto sm:justify-start sm:gap-6"
+        className="grid w-full grid-cols-3 items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6"
       >
         <ReplyButton status={actualStatus} onReply={onReply} />
         <RepostButton currentActor={currentActor} status={actualStatus} />
@@ -60,7 +71,10 @@ export const Actions: FC<Props> = ({
         <div
           role="group"
           aria-label="Post status actions"
-          className="flex w-full items-center justify-end gap-2 sm:w-auto sm:justify-start sm:gap-6"
+          className={cn(
+            'grid w-full items-center justify-items-center gap-2 sm:flex sm:w-auto sm:justify-start sm:gap-6',
+            statusActionGridColumns
+          )}
         >
           <EditHistoryButton
             status={actualStatus}

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -20,6 +20,13 @@ interface Props extends PostProps {
   onShowEdits?: (status: Status) => void
 }
 
+const statusActionGridColumnsByCount: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4'
+}
+
 export const Actions: FC<Props> = ({
   host,
   currentActor,
@@ -75,13 +82,7 @@ export const Actions: FC<Props> = ({
 
   const hasStatusActions = statusActions.length > 0
   const statusActionGridColumns =
-    statusActions.length === 4
-      ? 'grid-cols-4'
-      : statusActions.length === 3
-        ? 'grid-cols-3'
-        : statusActions.length === 2
-          ? 'grid-cols-2'
-          : 'grid-cols-1'
+    statusActionGridColumnsByCount[statusActions.length] ?? 'grid-cols-1'
 
   return (
     <div className="mt-3 flex flex-col gap-2 text-muted-foreground sm:flex-row sm:items-center sm:gap-6">

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -26,6 +26,7 @@ const actionRowClassName =
 export const Actions: FC<Props> = ({
   host,
   currentActor,
+  currentTime,
   status,
   editable = false,
   showActions = false,
@@ -63,6 +64,7 @@ export const Actions: FC<Props> = ({
         key="edit-history"
         status={actualStatus}
         host={host}
+        currentTime={currentTime}
         onShowEdits={onShowEdits}
       />
     )

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -41,27 +41,44 @@ export const Actions: FC<Props> = ({
   const isOwner =
     Boolean(actualStatus.isLocalActor) &&
     currentActor.id === actualStatus.actorId
+  const hasEditHistory = actualStatus.edits.length > 0
+  const hasStatusActions = hasEditHistory || isOwner || canEdit
 
   return (
-    <div className="mt-3 flex items-center gap-6 text-muted-foreground">
-      <ReplyButton status={actualStatus} onReply={onReply} />
-      <RepostButton currentActor={currentActor} status={actualStatus} />
-      <LikeButton currentActor={currentActor} status={actualStatus} />
-
-      <div className="flex items-center gap-6">
-        <EditHistoryButton
-          status={actualStatus}
-          host={host}
-          onShowEdits={onShowEdits}
-        />
-        {isOwner && <VisibilityButton status={actualStatus} />}
-        {canEdit && (
-          <>
-            <EditButton status={actualStatus} onEdit={onEdit} />
-            <DeleteButton status={actualStatus} onPostDeleted={onPostDeleted} />
-          </>
-        )}
+    <div className="mt-3 flex flex-col gap-2 text-muted-foreground sm:flex-row sm:items-center sm:gap-6">
+      <div
+        role="group"
+        aria-label="Post social actions"
+        className="flex w-full items-center justify-between gap-2 sm:w-auto sm:justify-start sm:gap-6"
+      >
+        <ReplyButton status={actualStatus} onReply={onReply} />
+        <RepostButton currentActor={currentActor} status={actualStatus} />
+        <LikeButton currentActor={currentActor} status={actualStatus} />
       </div>
+
+      {hasStatusActions && (
+        <div
+          role="group"
+          aria-label="Post status actions"
+          className="flex w-full items-center justify-end gap-2 sm:w-auto sm:justify-start sm:gap-6"
+        >
+          <EditHistoryButton
+            status={actualStatus}
+            host={host}
+            onShowEdits={onShowEdits}
+          />
+          {isOwner && <VisibilityButton status={actualStatus} />}
+          {canEdit && (
+            <>
+              <EditButton status={actualStatus} onEdit={onEdit} />
+              <DeleteButton
+                status={actualStatus}
+                onPostDeleted={onPostDeleted}
+              />
+            </>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -76,11 +76,13 @@ export const Actions: FC<Props> = ({
             statusActionGridColumns
           )}
         >
-          <EditHistoryButton
-            status={actualStatus}
-            host={host}
-            onShowEdits={onShowEdits}
-          />
+          {hasEditHistory && (
+            <EditHistoryButton
+              status={actualStatus}
+              host={host}
+              onShowEdits={onShowEdits}
+            />
+          )}
           {isOwner && <VisibilityButton status={actualStatus} />}
           {canEdit && (
             <>

--- a/lib/components/posts/actions/delete-button.tsx
+++ b/lib/components/posts/actions/delete-button.tsx
@@ -14,6 +14,7 @@ export const DeleteButton: FC<Props> = ({ status, onPostDeleted }) => {
     <button
       className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted hover:text-red-500 transition-colors"
       title="Delete post"
+      aria-label="Delete post"
       onClick={async (e) => {
         e.stopPropagation()
         const deleteConfirmation = window.confirm(

--- a/lib/components/posts/actions/edit-button.tsx
+++ b/lib/components/posts/actions/edit-button.tsx
@@ -14,6 +14,7 @@ export const EditButton: FC<Props> = ({ status, onEdit }) => {
     <button
       className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
       title="Edit"
+      aria-label="Edit post"
       onClick={(e) => {
         e.stopPropagation()
         onEdit?.(status)

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -80,7 +80,7 @@ export const EditHistoryButton: FC<Props> = ({
             {edits.map((edit, index) => {
               return (
                 <li
-                  key={edit.createdAt + index}
+                  key={`${edit.createdAt}-${index}`}
                   className="flex flex-col items-start p-3"
                 >
                   <div className="self-end bg-primary text-primary-foreground px-3 py-1 rounded-full text-xs">

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -23,19 +23,24 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
   }`
 
   return (
-    <button
-      className="relative flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
-      onClick={(e) => {
-        e.stopPropagation()
-        onShowEdits?.(status)
-        setShowHistory((value) => !value)
-      }}
-      title={editCountLabel}
-      aria-label={`Show edit history, ${editCountLabel}`}
-    >
-      <History className="h-4 w-4" />
+    <div className="relative inline-flex">
+      <button
+        className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
+        onClick={(e) => {
+          e.stopPropagation()
+          onShowEdits?.(status)
+          setShowHistory((value) => !value)
+        }}
+        title={editCountLabel}
+        aria-label={`Show edit history, ${editCountLabel}`}
+      >
+        <History className="h-4 w-4" />
+      </button>
       {showHistory && (
-        <div className="absolute bottom-full left-0 mb-2 w-[25rem] z-20 max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:w-auto">
+        <div
+          className="absolute bottom-full left-0 mb-2 w-[25rem] z-20 max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:w-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
           <ul className="divide-y divide-border rounded-lg border bg-background shadow-lg">
             {status.edits.reverse().map((edit, index) => {
               return (
@@ -59,6 +64,6 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
           </ul>
         </div>
       )}
-    </button>
+    </div>
   )
 }

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -23,6 +23,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
   const editCountLabel = `${status.edits.length} ${
     status.edits.length === 1 ? 'edit' : 'edits'
   }`
+  const edits = [...status.edits].reverse()
   const closeHistory = () => {
     setShowHistory(false)
     triggerRef.current?.focus()
@@ -70,7 +71,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
             </button>
           </div>
           <ul className="max-h-80 divide-y divide-border overflow-auto max-md:max-h-[calc(100vh-10rem)]">
-            {status.edits.reverse().map((edit, index) => {
+            {edits.map((edit, index) => {
               return (
                 <li
                   key={edit.createdAt + index}

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -1,6 +1,6 @@
 import { formatDistance } from 'date-fns'
-import { History } from 'lucide-react'
-import { FC, useState } from 'react'
+import { History, X } from 'lucide-react'
+import { FC, useId, useState } from 'react'
 
 import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
@@ -15,6 +15,7 @@ interface Props {
 
 export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
   const [showHistory, setShowHistory] = useState<boolean>(false)
+  const editHistoryId = useId()
 
   if (status.edits.length === 0) return null
 
@@ -33,15 +34,36 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
         }}
         title={editCountLabel}
         aria-label={`Show edit history, ${editCountLabel}`}
+        aria-expanded={showHistory}
+        aria-controls={showHistory ? editHistoryId : undefined}
       >
         <History className="h-4 w-4" />
       </button>
       {showHistory && (
         <div
-          className="absolute bottom-full left-0 mb-2 w-[25rem] z-20 max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:w-auto"
+          id={editHistoryId}
+          role="dialog"
+          aria-label="Edit history"
+          className="absolute bottom-full left-0 z-20 mb-2 w-[25rem] rounded-lg border bg-background shadow-lg max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:max-h-[calc(100vh-7rem)] max-md:w-auto"
           onClick={(e) => e.stopPropagation()}
         >
-          <ul className="divide-y divide-border rounded-lg border bg-background shadow-lg">
+          <div className="flex items-center justify-between border-b px-3 py-2">
+            <span className="text-sm font-medium text-foreground">
+              Edit history
+            </span>
+            <button
+              type="button"
+              className="rounded-full p-1 transition-colors hover:bg-muted"
+              aria-label="Close edit history"
+              onClick={(e) => {
+                e.stopPropagation()
+                setShowHistory(false)
+              }}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <ul className="max-h-80 divide-y divide-border overflow-auto max-md:max-h-[calc(100vh-10rem)]">
             {status.edits.reverse().map((edit, index) => {
               return (
                 <li

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -9,11 +9,17 @@ import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 
 interface Props {
   host: string
+  currentTime: number
   status: StatusNote | StatusPoll
   onShowEdits?: (status: Status) => void
 }
 
-export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
+export const EditHistoryButton: FC<Props> = ({
+  host,
+  currentTime,
+  status,
+  onShowEdits
+}) => {
   const [showHistory, setShowHistory] = useState<boolean>(false)
   const editHistoryId = useId()
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -78,7 +84,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
                   className="flex flex-col items-start p-3"
                 >
                   <div className="self-end bg-primary text-primary-foreground px-3 py-1 rounded-full text-xs">
-                    {formatDistance(edit.createdAt, Date.now())}
+                    {formatDistance(edit.createdAt, currentTime)}
                   </div>
                   <div className="mr-auto text-left mt-2 whitespace-normal overflow-auto max-h-40">
                     {cleanClassName(

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -35,7 +35,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
     >
       <History className="h-4 w-4" />
       {showHistory && (
-        <div className="absolute bottom-full left-0 mb-2 w-[25rem] max-md:left-[-8rem] max-md:w-[18rem] z-20">
+        <div className="absolute bottom-full left-0 mb-2 w-[25rem] max-md:left-0 max-md:w-[18rem] z-20">
           <ul className="divide-y divide-border rounded-lg border bg-background shadow-lg">
             {status.edits.reverse().map((edit, index) => {
               return (

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -1,6 +1,6 @@
 import { formatDistance } from 'date-fns'
 import { History, X } from 'lucide-react'
-import { FC, useId, useState } from 'react'
+import { FC, useId, useRef, useState } from 'react'
 
 import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
@@ -16,16 +16,22 @@ interface Props {
 export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
   const [showHistory, setShowHistory] = useState<boolean>(false)
   const editHistoryId = useId()
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   if (status.edits.length === 0) return null
 
   const editCountLabel = `${status.edits.length} ${
     status.edits.length === 1 ? 'edit' : 'edits'
   }`
+  const closeHistory = () => {
+    setShowHistory(false)
+    triggerRef.current?.focus()
+  }
 
   return (
     <div className="relative inline-flex">
       <button
+        ref={triggerRef}
         className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
         onClick={(e) => {
           e.stopPropagation()
@@ -42,7 +48,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
       {showHistory && (
         <div
           id={editHistoryId}
-          role="dialog"
+          role="region"
           aria-label="Edit history"
           className="absolute bottom-full left-0 z-20 mb-2 w-[25rem] rounded-lg border bg-background shadow-lg max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:max-h-[calc(100vh-7rem)] max-md:w-auto"
           onClick={(e) => e.stopPropagation()}
@@ -57,7 +63,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
               aria-label="Close edit history"
               onClick={(e) => {
                 e.stopPropagation()
-                setShowHistory(false)
+                closeHistory()
               }}
             >
               <X className="h-4 w-4" />

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -18,6 +18,10 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
 
   if (status.edits.length === 0) return null
 
+  const editCountLabel = `${status.edits.length} ${
+    status.edits.length === 1 ? 'edit' : 'edits'
+  }`
+
   return (
     <button
       className="relative flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
@@ -26,8 +30,8 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
         onShowEdits?.(status)
         setShowHistory((value) => !value)
       }}
-      title={`${status.edits.length} edits`}
-      aria-label="Show edit history"
+      title={editCountLabel}
+      aria-label={`Show edit history, ${editCountLabel}`}
     >
       <History className="h-4 w-4" />
       {showHistory && (

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -27,6 +27,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
         setShowHistory((value) => !value)
       }}
       title={`${status.edits.length} edits`}
+      aria-label="Show edit history"
     >
       <History className="h-4 w-4" />
       {showHistory && (

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -35,7 +35,7 @@ export const EditHistoryButton: FC<Props> = ({ host, status, onShowEdits }) => {
     >
       <History className="h-4 w-4" />
       {showHistory && (
-        <div className="absolute bottom-full left-0 mb-2 w-[25rem] max-md:left-0 max-md:w-[18rem] z-20">
+        <div className="absolute bottom-full left-0 mb-2 w-[25rem] z-20 max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:w-auto">
           <ul className="divide-y divide-border rounded-lg border bg-background shadow-lg">
             {status.edits.reverse().map((edit, index) => {
               return (

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -13,11 +13,19 @@ interface LikeButtonProps {
 export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
   const [isActorLiked, setIsActorLiked] = useState<boolean>(status.isActorLiked)
   const [totalLikes, setTotalLikes] = useState<number>(status.totalLikes)
+  const likeLabel =
+    totalLikes > 0
+      ? `${isActorLiked ? 'Unlike' : 'Like'}, ${totalLikes} ${
+          totalLikes === 1 ? 'like' : 'likes'
+        }`
+      : isActorLiked
+        ? 'Unlike'
+        : 'Like'
 
   return (
     <button
       title={isActorLiked ? 'Unlike' : 'Like'}
-      aria-label={isActorLiked ? 'Unlike' : 'Like'}
+      aria-label={likeLabel}
       disabled={status.actorId === currentActor?.id}
       className={cn(
         'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -17,6 +17,7 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
   return (
     <button
       title={isActorLiked ? 'Unlike' : 'Like'}
+      aria-label={isActorLiked ? 'Unlike' : 'Like'}
       disabled={status.actorId === currentActor?.id}
       className={cn(
         'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -24,7 +24,7 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
 
   return (
     <button
-      title={isActorLiked ? 'Unlike' : 'Like'}
+      title={likeLabel}
       aria-label={likeLabel}
       disabled={status.actorId === currentActor?.id}
       className={cn(

--- a/lib/components/posts/actions/reply-button.tsx
+++ b/lib/components/posts/actions/reply-button.tsx
@@ -10,11 +10,18 @@ interface Props {
 }
 
 export const ReplyButton: FC<Props> = ({ status, onReply }) => {
+  const replyLabel =
+    status.replies.length > 0
+      ? `Reply to post, ${status.replies.length} ${
+          status.replies.length === 1 ? 'reply' : 'replies'
+        }`
+      : 'Reply to post'
+
   return (
     <button
       className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-blue-500"
       title="Reply"
-      aria-label="Reply to post"
+      aria-label={replyLabel}
       onClick={() => onReply?.(status)}
     >
       <MessageCircle className="h-4 w-4" />

--- a/lib/components/posts/actions/reply-button.tsx
+++ b/lib/components/posts/actions/reply-button.tsx
@@ -14,6 +14,7 @@ export const ReplyButton: FC<Props> = ({ status, onReply }) => {
     <button
       className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-blue-500"
       title="Reply"
+      aria-label="Reply to post"
       onClick={() => onReply?.(status)}
     >
       <MessageCircle className="h-4 w-4" />

--- a/lib/components/posts/actions/reply-button.tsx
+++ b/lib/components/posts/actions/reply-button.tsx
@@ -20,7 +20,7 @@ export const ReplyButton: FC<Props> = ({ status, onReply }) => {
   return (
     <button
       className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-blue-500"
-      title="Reply"
+      title={replyLabel}
       aria-label={replyLabel}
       onClick={() => onReply?.(status)}
     >

--- a/lib/components/posts/actions/repost-button.tsx
+++ b/lib/components/posts/actions/repost-button.tsx
@@ -33,11 +33,13 @@ export const RepostButton: FC<RepostButtonProps> = ({
   }, [mainStatus.actorAnnounceStatusId])
 
   if (!currentActor) return null
+  const repostLabel = repostedStatusId ? 'Undo repost' : 'Repost'
+
   return (
     <button
       disabled={isLoading}
-      title="Repost"
-      aria-label="Repost"
+      title={repostLabel}
+      aria-label={repostLabel}
       className={cn(
         'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',
         repostedStatusId !== null ? 'text-green-500' : 'hover:text-green-500'

--- a/lib/components/posts/actions/repost-button.tsx
+++ b/lib/components/posts/actions/repost-button.tsx
@@ -37,6 +37,7 @@ export const RepostButton: FC<RepostButtonProps> = ({
     <button
       disabled={isLoading}
       title="Repost"
+      aria-label="Repost"
       className={cn(
         'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',
         repostedStatusId !== null ? 'text-green-500' : 'hover:text-green-500'

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -363,4 +363,76 @@ describe('Post', () => {
       screen.queryByRole('link', { name: '@hackers.pub' })
     ).not.toBeInTheDocument()
   })
+
+  it('splits owner actions into mobile-safe social and status action groups', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        editable
+        showActions
+        status={{
+          ...status,
+          edits: [{ text: 'Previous content', createdAt: currentTime - 1000 }]
+        }}
+        onEdit={jest.fn()}
+        onPostDeleted={jest.fn()}
+        onReply={jest.fn()}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    const socialActions = screen.getByRole('group', {
+      name: 'Post social actions'
+    })
+    const statusActions = screen.getByRole('group', {
+      name: 'Post status actions'
+    })
+
+    expect(socialActions).toHaveClass('w-full', 'justify-between')
+    expect(statusActions).toHaveClass('w-full', 'justify-end')
+
+    expect(
+      screen.getByRole('button', { name: 'Reply to post' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Repost' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Like' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show edit history' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Visibility: Direct' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Edit post' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Delete post' })
+    ).toBeInTheDocument()
+  })
+
+  it('does not render an empty status action group', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={{
+          ...status.actor!,
+          id: 'https://activities.local/users/other',
+          username: 'other'
+        }}
+        currentTime={currentTime}
+        showActions
+        status={status}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('group', { name: 'Post social actions' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('group', { name: 'Post status actions' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -471,6 +471,44 @@ describe('Post', () => {
     expect(editHistoryButton).toHaveFocus()
   })
 
+  it('renders edit history newest first without mutating status edits', () => {
+    const edits = [
+      { text: 'First draft', createdAt: currentTime - 2000 },
+      { text: 'Second draft', createdAt: currentTime - 1000 }
+    ]
+
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          edits
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Show edit history, 2 edits'
+      })
+    )
+
+    const historyItems = screen.getAllByRole('listitem')
+
+    expect(
+      within(historyItems[0]).getByText('Second draft')
+    ).toBeInTheDocument()
+    expect(within(historyItems[1]).getByText('First draft')).toBeInTheDocument()
+    expect(edits.map((edit) => edit.text)).toEqual([
+      'First draft',
+      'Second draft'
+    ])
+  })
+
   it('does not render an empty status action group', () => {
     render(
       <Post
@@ -524,7 +562,8 @@ describe('Post', () => {
         .getAllByRole('button')
         .map((button) => button.getAttribute('aria-label'))
     ).toEqual(['Reply to post', 'Repost', 'Like'])
-    expect(secondaryActions).toHaveClass('grid-cols-4')
+    expect(secondaryActions).toHaveClass('grid-cols-3')
+    expect(secondaryActions).not.toHaveClass('grid-cols-4')
     expect(
       within(secondaryActions)
         .getAllByRole('button')

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -409,7 +409,7 @@ describe('Post', () => {
     expect(screen.getByRole('button', { name: 'Repost' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Like' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show edit history' })
+      screen.getByRole('button', { name: 'Show edit history, 1 edit' })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Visibility: Direct' })
@@ -465,7 +465,38 @@ describe('Post', () => {
       screen.getByRole('group', { name: 'Post status actions' })
     ).toHaveClass('grid-cols-3')
     expect(
-      screen.queryByRole('button', { name: 'Show edit history' })
+      screen.queryByRole('button', { name: /Show edit history/ })
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps visible social action counts in accessible labels', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={{
+          ...status.actor!,
+          id: 'https://activities.local/users/other',
+          username: 'other'
+        }}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          replies: [
+            { ...status, id: 'https://activities.local/replies/1' },
+            { ...status, id: 'https://activities.local/replies/2' }
+          ],
+          totalLikes: 3
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Reply to post, 2 replies' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Like, 3 likes' })
+    ).toBeInTheDocument()
   })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -499,4 +499,28 @@ describe('Post', () => {
       screen.getByRole('button', { name: 'Like, 3 likes' })
     ).toBeInTheDocument()
   })
+
+  it('labels repost action as undo when post is already reposted', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={{
+          ...status.actor!,
+          id: 'https://activities.local/users/other',
+          username: 'other'
+        }}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          actorAnnounceStatusId: 'https://activities.local/announces/1'
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Undo repost' })
+    ).toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -509,6 +509,40 @@ describe('Post', () => {
     ])
   })
 
+  it('uses currentTime for edit history relative timestamps', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(currentTime + 7 * 24 * 60 * 60 * 1000)
+
+    try {
+      render(
+        <Post
+          host="activities.local"
+          currentActor={status.actor ?? undefined}
+          currentTime={currentTime}
+          showActions
+          status={{
+            ...status,
+            edits: [
+              { text: 'Previous content', createdAt: currentTime - 60000 }
+            ]
+          }}
+          onShowAttachment={jest.fn()}
+        />
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'Show edit history, 1 edit'
+        })
+      )
+
+      expect(screen.getByText('1 minute')).toBeInTheDocument()
+      expect(screen.queryByText('7 days')).not.toBeInTheDocument()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('does not render an empty status action group', () => {
     render(
       <Post

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import {
@@ -383,33 +383,35 @@ describe('Post', () => {
       />
     )
 
-    expect(
-      screen.getByRole('group', {
-        name: 'Post social actions'
-      })
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('group', {
-        name: 'Post status actions'
-      })
-    ).toBeInTheDocument()
+    const socialActions = screen.getByRole('group', {
+      name: 'Post social actions'
+    })
+    const statusActions = screen.getByRole('group', {
+      name: 'Post status actions'
+    })
 
     expect(
-      screen.getByRole('button', { name: 'Reply to post' })
-    ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Repost' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Like' })).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'Show edit history, 1 edit' })
+      within(socialActions).getByRole('button', { name: 'Reply to post' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Visibility: Direct' })
+      within(socialActions).getByRole('button', { name: 'Repost' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Edit post' })
+      within(socialActions).getByRole('button', { name: 'Like' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Delete post' })
+      within(statusActions).getByRole('button', {
+        name: 'Show edit history, 1 edit'
+      })
+    ).toBeInTheDocument()
+    expect(
+      within(statusActions).getByRole('button', { name: 'Visibility: Direct' })
+    ).toBeInTheDocument()
+    expect(
+      within(statusActions).getByRole('button', { name: 'Edit post' })
+    ).toBeInTheDocument()
+    expect(
+      within(statusActions).getByRole('button', { name: 'Delete post' })
     ).toBeInTheDocument()
   })
 

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -415,6 +415,39 @@ describe('Post', () => {
     ).toBeInTheDocument()
   })
 
+  it('keeps edit history panel open when interacting with panel content', () => {
+    const onShowEdits = jest.fn()
+
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          edits: [{ text: 'Previous content', createdAt: currentTime - 1000 }]
+        }}
+        onShowAttachment={jest.fn()}
+        onShowEdits={onShowEdits}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show edit history, 1 edit' })
+    )
+
+    const editHistoryContent = screen.getByText('Previous content')
+
+    expect(editHistoryContent).toBeInTheDocument()
+    expect(onShowEdits).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(editHistoryContent)
+
+    expect(screen.getByText('Previous content')).toBeInTheDocument()
+    expect(onShowEdits).toHaveBeenCalledTimes(1)
+  })
+
   it('does not render an empty status action group', () => {
     render(
       <Post

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -445,4 +445,27 @@ describe('Post', () => {
       screen.queryByRole('group', { name: 'Post status actions' })
     ).not.toBeInTheDocument()
   })
+
+  it('does not render edit history action when status has no edits', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        editable
+        showActions
+        status={status}
+        onEdit={jest.fn()}
+        onPostDeleted={jest.fn()}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('group', { name: 'Post status actions' })
+    ).toHaveClass('grid-cols-3')
+    expect(
+      screen.queryByRole('button', { name: 'Show edit history' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -383,25 +383,16 @@ describe('Post', () => {
       />
     )
 
-    const socialActions = screen.getByRole('group', {
-      name: 'Post social actions'
-    })
-    const statusActions = screen.getByRole('group', {
-      name: 'Post status actions'
-    })
-
-    expect(socialActions).toHaveClass(
-      'grid',
-      'w-full',
-      'grid-cols-3',
-      'justify-items-center'
-    )
-    expect(statusActions).toHaveClass(
-      'grid',
-      'w-full',
-      'grid-cols-4',
-      'justify-items-center'
-    )
+    expect(
+      screen.getByRole('group', {
+        name: 'Post social actions'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('group', {
+        name: 'Post status actions'
+      })
+    ).toBeInTheDocument()
 
     expect(
       screen.getByRole('button', { name: 'Reply to post' })
@@ -463,7 +454,7 @@ describe('Post', () => {
 
     expect(
       screen.getByRole('group', { name: 'Post status actions' })
-    ).toHaveClass('grid-cols-3')
+    ).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /Show edit history/ })
     ).not.toBeInTheDocument()
@@ -494,10 +485,38 @@ describe('Post', () => {
 
     expect(
       screen.getByRole('button', { name: 'Reply to post, 2 replies' })
-    ).toBeInTheDocument()
+    ).toHaveAttribute('title', 'Reply to post, 2 replies')
     expect(
       screen.getByRole('button', { name: 'Like, 3 likes' })
-    ).toBeInTheDocument()
+    ).toHaveAttribute('title', 'Like, 3 likes')
+  })
+
+  it('keeps singular social action counts in accessible labels', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={{
+          ...status.actor!,
+          id: 'https://activities.local/users/other',
+          username: 'other'
+        }}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          replies: [{ ...status, id: 'https://activities.local/replies/1' }],
+          totalLikes: 1
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Reply to post, 1 reply' })
+    ).toHaveAttribute('title', 'Reply to post, 1 reply')
+    expect(
+      screen.getByRole('button', { name: 'Like, 1 like' })
+    ).toHaveAttribute('title', 'Like, 1 like')
   })
 
   it('labels repost action as undo when post is already reposted', () => {

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -390,8 +390,18 @@ describe('Post', () => {
       name: 'Post status actions'
     })
 
-    expect(socialActions).toHaveClass('w-full', 'justify-between')
-    expect(statusActions).toHaveClass('w-full', 'justify-end')
+    expect(socialActions).toHaveClass(
+      'grid',
+      'w-full',
+      'grid-cols-3',
+      'justify-items-center'
+    )
+    expect(statusActions).toHaveClass(
+      'grid',
+      'w-full',
+      'grid-cols-4',
+      'justify-items-center'
+    )
 
     expect(
       screen.getByRole('button', { name: 'Reply to post' })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -447,17 +447,17 @@ describe('Post', () => {
     fireEvent.click(editHistoryButton)
 
     const editHistoryContent = screen.getByText('Previous content')
-    const editHistoryDialog = screen.getByRole('dialog', {
+    const editHistoryRegion = screen.getByRole('region', {
       name: 'Edit history'
     })
 
     expect(editHistoryContent).toBeInTheDocument()
     expect(onShowEdits).toHaveBeenCalledTimes(1)
-    expect(editHistoryDialog).toBeInTheDocument()
+    expect(editHistoryRegion).toBeInTheDocument()
     expect(editHistoryButton).toHaveAttribute('aria-expanded', 'true')
     expect(editHistoryButton).toHaveAttribute(
       'aria-controls',
-      editHistoryDialog.id
+      editHistoryRegion.id
     )
 
     fireEvent.click(editHistoryContent)
@@ -468,6 +468,7 @@ describe('Post', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close edit history' }))
 
     expect(screen.queryByText('Previous content')).not.toBeInTheDocument()
+    expect(editHistoryButton).toHaveFocus()
   })
 
   it('does not render an empty status action group', () => {
@@ -509,9 +510,26 @@ describe('Post', () => {
       />
     )
 
+    const primaryActions = screen.getByRole('group', {
+      name: 'Post primary actions'
+    })
+    const secondaryActions = screen.getByRole('group', {
+      name: 'Post secondary actions'
+    })
+
+    expect(primaryActions).toHaveClass('grid-cols-3')
+    expect(primaryActions).not.toHaveClass('grid-cols-4')
     expect(
-      screen.getByRole('group', { name: 'Post secondary actions' })
-    ).toBeInTheDocument()
+      within(primaryActions)
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Reply to post', 'Repost', 'Like'])
+    expect(secondaryActions).toHaveClass('grid-cols-4')
+    expect(
+      within(secondaryActions)
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Visibility: Direct', 'Edit post', 'Delete post'])
     expect(
       screen.queryByRole('button', { name: /Show edit history/ })
     ).not.toBeInTheDocument()

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -364,7 +364,7 @@ describe('Post', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('splits owner actions into mobile-safe social and status action groups', () => {
+  it('splits owner actions into a four-item primary row and left-aligned secondary row', () => {
     render(
       <Post
         host="activities.local"
@@ -383,36 +383,41 @@ describe('Post', () => {
       />
     )
 
-    const socialActions = screen.getByRole('group', {
-      name: 'Post social actions'
+    const primaryActions = screen.getByRole('group', {
+      name: 'Post primary actions'
     })
-    const statusActions = screen.getByRole('group', {
-      name: 'Post status actions'
+    const secondaryActions = screen.getByRole('group', {
+      name: 'Post secondary actions'
     })
 
+    expect(primaryActions).toHaveClass(
+      'grid',
+      'w-full',
+      'grid-cols-4',
+      'justify-items-center',
+      'sm:flex',
+      'sm:w-auto',
+      'sm:justify-start'
+    )
+    expect(secondaryActions).toHaveClass(
+      'grid',
+      'w-full',
+      'grid-cols-4',
+      'justify-items-center',
+      'sm:flex',
+      'sm:w-auto',
+      'sm:justify-start'
+    )
     expect(
-      within(socialActions).getByRole('button', { name: 'Reply to post' })
-    ).toBeInTheDocument()
+      within(primaryActions)
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Reply to post', 'Repost', 'Like', 'Show edit history, 1 edit'])
     expect(
-      within(socialActions).getByRole('button', { name: 'Repost' })
-    ).toBeInTheDocument()
-    expect(
-      within(socialActions).getByRole('button', { name: 'Like' })
-    ).toBeInTheDocument()
-    expect(
-      within(statusActions).getByRole('button', {
-        name: 'Show edit history, 1 edit'
-      })
-    ).toBeInTheDocument()
-    expect(
-      within(statusActions).getByRole('button', { name: 'Visibility: Direct' })
-    ).toBeInTheDocument()
-    expect(
-      within(statusActions).getByRole('button', { name: 'Edit post' })
-    ).toBeInTheDocument()
-    expect(
-      within(statusActions).getByRole('button', { name: 'Delete post' })
-    ).toBeInTheDocument()
+      within(secondaryActions)
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Visibility: Direct', 'Edit post', 'Delete post'])
   })
 
   it('keeps edit history panel open when interacting with panel content', () => {
@@ -433,19 +438,36 @@ describe('Post', () => {
       />
     )
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Show edit history, 1 edit' })
-    )
+    const editHistoryButton = screen.getByRole('button', {
+      name: 'Show edit history, 1 edit'
+    })
+
+    expect(editHistoryButton).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(editHistoryButton)
 
     const editHistoryContent = screen.getByText('Previous content')
+    const editHistoryDialog = screen.getByRole('dialog', {
+      name: 'Edit history'
+    })
 
     expect(editHistoryContent).toBeInTheDocument()
     expect(onShowEdits).toHaveBeenCalledTimes(1)
+    expect(editHistoryDialog).toBeInTheDocument()
+    expect(editHistoryButton).toHaveAttribute('aria-expanded', 'true')
+    expect(editHistoryButton).toHaveAttribute(
+      'aria-controls',
+      editHistoryDialog.id
+    )
 
     fireEvent.click(editHistoryContent)
 
     expect(screen.getByText('Previous content')).toBeInTheDocument()
     expect(onShowEdits).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close edit history' }))
+
+    expect(screen.queryByText('Previous content')).not.toBeInTheDocument()
   })
 
   it('does not render an empty status action group', () => {
@@ -465,10 +487,10 @@ describe('Post', () => {
     )
 
     expect(
-      screen.getByRole('group', { name: 'Post social actions' })
+      screen.getByRole('group', { name: 'Post primary actions' })
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('group', { name: 'Post status actions' })
+      screen.queryByRole('group', { name: 'Post secondary actions' })
     ).not.toBeInTheDocument()
   })
 
@@ -488,7 +510,7 @@ describe('Post', () => {
     )
 
     expect(
-      screen.getByRole('group', { name: 'Post status actions' })
+      screen.getByRole('group', { name: 'Post secondary actions' })
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /Show edit history/ })


### PR DESCRIPTION
## Summary
- Rebalanced mobile post actions into two equal-spaced grid rows: reply, repost, like, and edit history on the first row; visibility, edit, and delete on a left-aligned second row.
- Kept desktop behavior as a single-line flex layout at `sm` and above.
- Added accessible group labels and explicit icon-button labels, including expanded/controls state for edit history.
- Added an explicit close control for the mobile edit-history dialog.

## Root cause
The previous mobile layout kept every post action in one horizontal flex row. Owner-only controls pushed the row wider than the post content, so the rightmost delete action could overflow and become hidden or unreachable.

## Mobile screenshot
![Mobile post actions at 390x844](https://gist.githubusercontent.com/llun/3d956b250a6bd131e07217e70e1e2f68/raw/mobile-post-actions-fix-4-3.svg)

## Browser verification
- Started `yarn dev` with Node 24 and disposable local SQLite runtime env.
- Opened `http://localhost:3000` in Browser at `390x844`.
- Seeded and signed in as a local owner account.
- Verified owner post shows all seven actions: reply, repost, like, edit history, visibility, edit, and delete.
- Verified first action row contains 4 controls and second action row contains 3 left-aligned controls.
- Verified no horizontal overflow: viewport width `390`, document scroll width `375`.
- Verified both action rows stay within post content width: row width `257` <= post content width `257`.
- Verified the edit-history dialog opens, exposes a close button, and returns focus to the trigger after close.

## Tests
- `yarn run prettier --write .` - pass
- `yarn test lib/components/posts/post.test.tsx` - pass (19 tests)
- `yarn lint` - pass (existing warnings only in auth/fitness files)
- `yarn build` - pass
- `yarn test` - pass (297 suites, 2375 tests)

## Config and migrations
No config, API, database, or migration changes.
