### PR TITLE
fix: allow editing post media attachments

### DIFF
--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -255,14 +255,11 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
               dispatchStatusAction(clearAction())
             }}
             onPostUpdated={(updatedStatus: Status) => {
-              const index = currentStatuses.findIndex(
-                (status) => status.id === updatedStatus.id
+              setCurrentStatuses((previousStatuses) =>
+                previousStatuses.map((status) =>
+                  status.id === updatedStatus.id ? updatedStatus : status
+                )
               )
-              // TODO: Update status in Timeline somehow.
-              if (index >= 0) {
-                currentStatuses[index] = updatedStatus
-                setCurrentStatuses(() => currentStatuses)
-              }
               dispatchStatusAction(clearAction())
             }}
           />

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -880,6 +880,139 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
     })
 
+    it('rejects clearing media from a media-only note without partial mutation', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-reject-clear-media-only`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: '',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-reject-clear-media-only.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-reject-clear-media-only.jpg'
+        },
+        description: 'Only media'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-reject-clear-media-only.webp',
+        width: 320,
+        height: 240,
+        name: 'Only media',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_ids: []
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      const updatedStatus = await database.getStatus({ statusId })
+      const attachments = await database.getAttachments({ statusId })
+
+      expect(response.status).toBe(422)
+      expect(updatedStatus?.text).toBe('')
+      expect(attachments).toHaveLength(1)
+      expect(attachments[0]).toMatchObject({
+        url: 'https://llun.test/api/v1/files/medias/api-edit-reject-clear-media-only.webp',
+        name: 'Only media'
+      })
+      expect(getQueue().publish).not.toHaveBeenCalled()
+    })
+
+    it('rejects blank status with empty media ids without partial mutation', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-reject-blank-clear-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Original text before rejected edit',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-reject-blank-clear-media.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-reject-blank-clear-media.jpg'
+        },
+        description: 'Preserved media'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-reject-blank-clear-media.webp',
+        width: 320,
+        height: 240,
+        name: 'Preserved media',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              status: '   ',
+              media_ids: []
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      const updatedStatus = await database.getStatus({ statusId })
+      const attachments = await database.getAttachments({ statusId })
+
+      expect(response.status).toBe(422)
+      expect(updatedStatus?.text).toBe('Original text before rejected edit')
+      expect(attachments).toHaveLength(1)
+      expect(attachments[0]).toMatchObject({
+        url: 'https://llun.test/api/v1/files/medias/api-edit-reject-blank-clear-media.webp',
+        name: 'Preserved media'
+      })
+      expect(getQueue().publish).not.toHaveBeenCalled()
+    })
+
     it('does not partially apply text changes when media ids are forbidden', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-forbidden-media`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -880,6 +880,88 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
     })
 
+    it('allows clearing editable media from a blank note when legacy attachments remain', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-clear-media-keep-legacy`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: '',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-clear-legacy-editable.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-clear-legacy-editable.jpg'
+        },
+        description: 'Editable media'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-clear-legacy-editable.webp',
+        width: 320,
+        height: 240,
+        name: 'Editable media',
+        mediaId: media!.id
+      })
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: 'image/jpeg',
+        url: 'https://remote.example/legacy.jpg',
+        width: 640,
+        height: 480,
+        name: 'Legacy media'
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              status: '   ',
+              media_ids: []
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.media_attachments).toHaveLength(1)
+      expect(data.media_attachments[0]).toMatchObject({
+        type: 'image',
+        url: 'https://remote.example/legacy.jpg',
+        description: 'Legacy media'
+      })
+
+      const attachments = await database.getAttachments({ statusId })
+      expect(attachments).toHaveLength(1)
+      expect(attachments[0]).toMatchObject({
+        mediaId: null,
+        url: 'https://remote.example/legacy.jpg',
+        name: 'Legacy media'
+      })
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
     it('rejects clearing media from a media-only note without partial mutation', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-reject-clear-media-only`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -11,6 +11,7 @@ import { ACTOR3_ID, seedActor3 } from '@/lib/stub/seed/actor3'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
 import { POST as bookmarkStatus } from './bookmark/route'
@@ -720,6 +721,215 @@ describe('GET /api/v1/statuses/[id]', () => {
   })
 
   describe('status update', () => {
+    it('replaces media attachments with a media-only edit and federates the update', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-replace-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Media edit target',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const oldMedia = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-old.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-old.jpg'
+        },
+        description: 'Old media'
+      })
+      const newMedia = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-new.webp',
+          bytes: 2048,
+          mimeType: 'image/png',
+          metaData: { width: 640, height: 480 },
+          fileName: 'api-edit-new.png'
+        },
+        description: 'New media'
+      })
+      expect(oldMedia).not.toBeNull()
+      expect(newMedia).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: oldMedia!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-old.webp',
+        width: 320,
+        height: 240,
+        name: 'Old media',
+        mediaId: oldMedia!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_ids: [newMedia!.id]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.content).toContain('Media edit target')
+      expect(data.media_attachments).toHaveLength(1)
+      expect(data.media_attachments[0]).toMatchObject({
+        type: 'image',
+        url: 'https://llun.test/api/v1/files/medias/api-edit-new.webp',
+        description: 'New media'
+      })
+
+      const attachments = await database.getAttachmentsWithMedia({ statusId })
+      expect(attachments).toHaveLength(1)
+      expect(attachments[0]).toMatchObject({
+        mediaId: String(newMedia!.id),
+        url: 'https://llun.test/api/v1/files/medias/api-edit-new.webp',
+        name: 'New media'
+      })
+
+      const updatedStatus = (await database.getStatus({
+        statusId,
+        withReplies: false
+      })) as Status
+      const activityPubNote = getNoteFromStatus(updatedStatus)
+      expect(activityPubNote?.attachment).toEqual([
+        expect.objectContaining({
+          mediaType: 'image/png',
+          url: 'https://llun.test/api/v1/files/medias/api-edit-new.webp',
+          name: 'New media'
+        })
+      ])
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears media attachments with an empty media id list', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-clear-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Clear media target',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-clear.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-clear.jpg'
+        },
+        description: 'Clear media'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-clear.webp',
+        width: 320,
+        height: 240,
+        name: 'Clear media',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_ids: []
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.media_attachments).toEqual([])
+      await expect(database.getAttachments({ statusId })).resolves.toEqual([])
+      expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not partially apply text changes when media ids are forbidden', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-forbidden-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Original media ownership text',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const foreignMedia = await database.createMedia({
+        actorId: ACTOR2_ID,
+        original: {
+          path: 'medias/api-edit-foreign.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-foreign.jpg'
+        },
+        description: 'Foreign media'
+      })
+      expect(foreignMedia).not.toBeNull()
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              status: 'Should not be applied',
+              media_ids: [foreignMedia!.id]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      const updatedStatus = await database.getStatus({ statusId })
+      expect(response.status).toBe(422)
+      expect(updatedStatus?.text).toBe('Original media ownership text')
+      expect(getQueue().publish).not.toHaveBeenCalled()
+    })
+
     it('applies visibility updates when spoiler_text is also present', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-visibility-with-cw`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -107,6 +107,17 @@ const EditNoteSchema = z.object({
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
 })
 
+const isFitnessStatusAttachment = (attachment: {
+  mediaType: string
+  url: string
+  name?: string | null
+}) =>
+  isFitnessAttachment({
+    mediaType: attachment.mediaType,
+    url: attachment.url,
+    name: attachment.name ?? ''
+  })
+
 export const PUT = traceApiRoute(
   'updateStatus',
   OAuthGuard<Params>([Scope.enum.write], async (req, context) => {
@@ -198,15 +209,18 @@ export const PUT = traceApiRoute(
         const effectiveText =
           changes.status === undefined ? existingStatus.text : changes.status
         const effectiveAttachments = (
-          attachments === undefined ? existingStatus.attachments : attachments
-        ).filter(
-          (attachment) =>
-            !isFitnessAttachment({
-              mediaType: attachment.mediaType,
-              url: attachment.url,
-              name: attachment.name ?? ''
-            })
-        )
+          attachments === undefined
+            ? existingStatus.attachments
+            : [
+                ...attachments,
+                ...existingStatus.attachments.filter(
+                  (attachment) =>
+                    (attachment.mediaId === null ||
+                      attachment.mediaId === undefined) &&
+                    !isFitnessStatusAttachment(attachment)
+                )
+              ]
+        ).filter((attachment) => !isFitnessStatusAttachment(attachment))
 
         if (
           effectiveText.trim().length === 0 &&

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -12,6 +12,7 @@ import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { Scope } from '@/lib/types/database/operations'
+import { isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -190,6 +191,34 @@ export const PUT = traceApiRoute(
           data: ERROR_422,
           responseStatusCode: 422
         })
+      }
+      const changesTextOrMedia =
+        changes.status !== undefined || mediaIds !== undefined
+      if (changesTextOrMedia) {
+        const effectiveText =
+          changes.status === undefined ? existingStatus.text : changes.status
+        const effectiveAttachments = (
+          attachments === undefined ? existingStatus.attachments : attachments
+        ).filter(
+          (attachment) =>
+            !isFitnessAttachment({
+              mediaType: attachment.mediaType,
+              url: attachment.url,
+              name: attachment.name ?? ''
+            })
+        )
+
+        if (
+          effectiveText.trim().length === 0 &&
+          effectiveAttachments.length === 0
+        ) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_422,
+            responseStatusCode: 422
+          })
+        }
       }
 
       if (visibility !== undefined) {

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -7,8 +7,10 @@ import {
   OAuthGuard,
   OptionalOAuthGuard
 } from '@/lib/services/guards/OAuthGuard'
+import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
+import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { Scope } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -100,6 +102,7 @@ export const GET = traceApiRoute(
 const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().nullish(),
+  media_ids: z.array(z.coerce.string()).optional(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
 })
 
@@ -129,11 +132,28 @@ export const PUT = traceApiRoute(
         })
       }
       const changes = parsed.data
+      const mediaIds =
+        changes.media_ids === undefined
+          ? undefined
+          : [...new Set(changes.media_ids)]
+      if (
+        mediaIds !== undefined &&
+        mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS
+      ) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
 
       let updatedNote
 
       const shouldUpdateContent =
-        changes.status !== undefined || changes.spoiler_text !== undefined
+        changes.status !== undefined ||
+        changes.spoiler_text !== undefined ||
+        mediaIds !== undefined
       const visibility = changes.visibility
 
       if (!shouldUpdateContent && visibility === undefined) {
@@ -156,6 +176,19 @@ export const PUT = traceApiRoute(
           allowedMethods: CORS_HEADERS,
           data: ERROR_403,
           responseStatusCode: 403
+        })
+      }
+
+      const attachments =
+        mediaIds === undefined
+          ? undefined
+          : await getAttachmentsFromMediaIds(database, currentActor, mediaIds)
+      if (attachments === null) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
         })
       }
 
@@ -183,6 +216,7 @@ export const PUT = traceApiRoute(
           currentActor,
           text: changes.status,
           summary: changes.spoiler_text,
+          attachments,
           publish: true,
           status:
             updatedNote?.type === StatusType.enum.Note

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -1,14 +1,11 @@
 import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
-import { getBaseURL } from '@/lib/config'
-import { Database } from '@/lib/database/types'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { Scope } from '@/lib/types/database/operations'
-import { Actor } from '@/lib/types/domain/actor'
-import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -97,53 +94,6 @@ const getNoteRequestInput = async (req: Request): Promise<unknown> => {
     media_ids: getFormStringArray(form, 'media_ids', 'media_ids[]'),
     visibility: getFormString(form, 'visibility')
   }
-}
-
-const getMediaUrl = (path: string) => `${getBaseURL()}/api/v1/files/${path}`
-
-const getAttachmentsFromMediaIds = async (
-  database: Database,
-  currentActor: Actor,
-  mediaIds: string[]
-): Promise<PostBoxAttachment[] | null> => {
-  if (mediaIds.length === 0) return []
-
-  const accountId = currentActor.account?.id
-  if (!accountId) return null
-
-  const medias = await Promise.all(
-    mediaIds.map((mediaId) =>
-      database.getMediaByIdForAccount({
-        mediaId,
-        accountId
-      })
-    )
-  )
-
-  const attachments: PostBoxAttachment[] = []
-  for (const media of medias) {
-    if (!media) return null
-    if (media.original.metaData.upload?.state === 'pending') {
-      return null
-    }
-
-    attachments.push({
-      type: 'upload',
-      id: media.id,
-      mediaType: media.original.mimeType,
-      url: getMediaUrl(media.original.path),
-      width: media.original.metaData.width,
-      height: media.original.metaData.height,
-      ...(media.thumbnail
-        ? { posterUrl: getMediaUrl(media.thumbnail.path) }
-        : {}),
-      ...(media.description || media.original.fileName
-        ? { name: media.description || media.original.fileName }
-        : {})
-    })
-  }
-
-  return attachments
 }
 
 export const POST = traceApiRoute(

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -3,6 +3,7 @@ import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Actor } from '@/lib/types/domain/actor'
+import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { StatusNote, StatusType } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getSpan } from '@/lib/utils/trace'
@@ -12,6 +13,7 @@ interface UpdateNoteFromUserInput {
   currentActor: Actor
   text?: string
   summary?: string | null
+  attachments?: PostBoxAttachment[]
   publish?: boolean
   status?: StatusNote
   database: Database
@@ -22,6 +24,7 @@ export const updateNoteFromUserInput = async ({
   currentActor,
   text,
   summary,
+  attachments,
   publish = true,
   status: preloadedStatus,
   database
@@ -41,7 +44,8 @@ export const updateNoteFromUserInput = async ({
   const updatedStatus = await database.updateNote({
     statusId,
     summary: summary === undefined ? status.summary : summary?.trim() || null,
-    text: text ?? status.text
+    text: text ?? status.text,
+    ...(attachments !== undefined ? { attachments } : {})
   })
   if (!updatedStatus) {
     span.end()

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -1,5 +1,7 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
+import { urlToId } from '@/lib/utils/urlToId'
+
 import {
   clearFitnessRouteHeatmaps,
   getActorStatuses,
@@ -44,6 +46,64 @@ describe('client updateNote', () => {
         body: JSON.stringify({
           spoiler_text: 'Updated warning'
         })
+      })
+    )
+  })
+
+  it('sends media ids for media-only edits', async () => {
+    await updateNote({
+      statusId: '123',
+      attachments: [
+        {
+          type: 'upload',
+          id: 'media-1',
+          mediaType: 'image/jpeg',
+          url: 'https://llun.test/api/v1/files/media-1.jpg',
+          width: 640,
+          height: 480,
+          name: 'media-1.jpg'
+        }
+      ]
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/statuses/123',
+      expect.objectContaining({
+        body: JSON.stringify({
+          media_ids: ['media-1']
+        })
+      })
+    )
+  })
+
+  it('sends an empty media id list when all media is removed', async () => {
+    await updateNote({
+      statusId: '123',
+      attachments: []
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/statuses/123',
+      expect.objectContaining({
+        body: JSON.stringify({
+          media_ids: []
+        })
+      })
+    )
+  })
+
+  it('encodes full status URLs before sending updates', async () => {
+    const statusId = 'https://localhost:3001/users/test1/statuses/post-1'
+
+    await updateNote({
+      statusId,
+      attachments: []
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/v1/statuses/${urlToId(statusId)}`,
+      expect.objectContaining({
+        method: 'PUT'
       })
     )
   })

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -107,6 +107,62 @@ describe('client updateNote', () => {
       })
     )
   })
+
+  it('returns server edit metadata for local timeline reconciliation', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        id: 'localhost:users:test1:statuses:post-1',
+        uri: 'https://localhost/users/test1/statuses/post-1',
+        content: '<p>Updated status</p>',
+        text: 'Updated status',
+        spoiler_text: '',
+        created_at: '2026-04-26T10:00:00.000Z',
+        edited_at: '2026-04-26T11:00:00.000Z',
+        in_reply_to_id: null,
+        media_attachments: [
+          {
+            id: 'server-attachment',
+            type: 'image',
+            url: 'https://localhost/api/v1/files/image.jpg',
+            preview_url: null,
+            remote_url: null,
+            description: 'image.jpg',
+            blurhash: null,
+            meta: {
+              original: {
+                width: 640,
+                height: 480,
+                size: '640x480',
+                aspect: 1.3333333333333333
+              }
+            }
+          }
+        ]
+      })
+    )
+
+    await expect(
+      updateNote({
+        statusId: 'https://localhost/users/test1/statuses/post-1',
+        message: 'Updated status'
+      })
+    ).resolves.toMatchObject({
+      content: '<p>Updated status</p>',
+      spoilerText: '',
+      mediaAttachments: [
+        expect.objectContaining({
+          id: 'server-attachment'
+        })
+      ],
+      status: {
+        id: 'https://localhost/users/test1/statuses/post-1',
+        text: 'Updated status',
+        createdAt: new Date('2026-04-26T10:00:00.000Z').getTime(),
+        updatedAt: new Date('2026-04-26T11:00:00.000Z').getTime(),
+        reply: ''
+      }
+    })
+  })
 })
 
 describe('client getActorStatuses', () => {

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -36,7 +36,6 @@ describe('client updateNote', () => {
   it('omits empty status text for content-warning-only edits', async () => {
     await updateNote({
       statusId: '123',
-      message: '',
       contentWarning: 'Updated warning'
     })
 
@@ -45,6 +44,50 @@ describe('client updateNote', () => {
       expect.objectContaining({
         body: JSON.stringify({
           spoiler_text: 'Updated warning'
+        })
+      })
+    )
+  })
+
+  it('sends empty status text when clearing an edit message', async () => {
+    await updateNote({
+      statusId: '123',
+      message: ''
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/statuses/123',
+      expect.objectContaining({
+        body: JSON.stringify({
+          status: ''
+        })
+      })
+    )
+  })
+
+  it('sends empty status text with media ids when clearing text during media edits', async () => {
+    await updateNote({
+      statusId: '123',
+      message: '',
+      attachments: [
+        {
+          type: 'upload',
+          id: 'media-1',
+          mediaType: 'image/jpeg',
+          url: 'https://llun.test/api/v1/files/media-1.jpg',
+          width: 640,
+          height: 480,
+          name: 'media-1.jpg'
+        }
+      ]
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/statuses/123',
+      expect.objectContaining({
+        body: JSON.stringify({
+          status: '',
+          media_ids: ['media-1']
         })
       })
     )

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -206,6 +206,17 @@ describe('client updateNote', () => {
       }
     })
   })
+
+  it('throws an update-specific error when updating a note fails', async () => {
+    fetchMock.mockResponseOnce('', { status: 500 })
+
+    await expect(
+      updateNote({
+        statusId: '123',
+        message: 'Updated status'
+      })
+    ).rejects.toThrow('Fail to update the note')
+  })
 })
 
 describe('client getActorStatuses', () => {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -125,7 +125,7 @@ export const updateNote = async ({
     })
   })
   if (response.status !== 200) {
-    throw new Error('Fail to create a new note')
+    throw new Error('Fail to update the note')
   }
 
   const mastodonStatus = await response.json()

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -97,12 +97,11 @@ export const updateNote = async ({
   contentWarning,
   attachments
 }: UpdateNoteParams): Promise<UpdateNoteResult> => {
-  const normalizedMessage =
-    message !== undefined && message.trim().length > 0 ? message : undefined
+  const hasMessageChange = message !== undefined
   const hasAttachmentChanges = attachments !== undefined
 
   if (
-    normalizedMessage === undefined &&
+    !hasMessageChange &&
     contentWarning === undefined &&
     !hasAttachmentChanges
   ) {
@@ -118,7 +117,7 @@ export const updateNote = async ({
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      ...(normalizedMessage !== undefined ? { status: normalizedMessage } : {}),
+      ...(hasMessageChange ? { status: message } : {}),
       ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {}),
       ...(attachments !== undefined
         ? { media_ids: attachments.map((attachment) => attachment.id) }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -69,27 +69,40 @@ export interface UpdateNoteParams {
   statusId: string
   message?: string
   contentWarning?: string
+  attachments?: PostBoxAttachment[]
 }
 export const updateNote = async ({
   statusId,
   message,
-  contentWarning
+  contentWarning,
+  attachments
 }: UpdateNoteParams) => {
   const normalizedMessage =
     message !== undefined && message.trim().length > 0 ? message : undefined
+  const hasAttachmentChanges = attachments !== undefined
 
-  if (normalizedMessage === undefined && contentWarning === undefined) {
-    throw new Error('Message or content warning must be provided')
+  if (
+    normalizedMessage === undefined &&
+    contentWarning === undefined &&
+    !hasAttachmentChanges
+  ) {
+    throw new Error('Message, content warning, or attachments must be provided')
   }
 
-  const response = await fetch(`/api/v1/statuses/${statusId}`, {
+  const encodedStatusId = statusId.startsWith('http')
+    ? urlToId(statusId)
+    : statusId
+  const response = await fetch(`/api/v1/statuses/${encodedStatusId}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       ...(normalizedMessage !== undefined ? { status: normalizedMessage } : {}),
-      ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {})
+      ...(contentWarning !== undefined ? { spoiler_text: contentWarning } : {}),
+      ...(attachments !== undefined
+        ? { media_ids: attachments.map((attachment) => attachment.id) }
+        : {})
     })
   })
   if (response.status !== 200) {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -10,6 +10,7 @@ import {
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { parseFetchResponseData } from '@/lib/utils/parseFetchResponseData'
@@ -71,12 +72,31 @@ export interface UpdateNoteParams {
   contentWarning?: string
   attachments?: PostBoxAttachment[]
 }
+export interface UpdateNoteResult {
+  content: string
+  spoilerText: string
+  mediaAttachments: MediaAttachment[]
+  status: {
+    id: string
+    text: string | null
+    createdAt: number
+    updatedAt?: number
+    reply: string
+  }
+}
+
+const parseTimestamp = (value: unknown, fallback: number) => {
+  if (typeof value !== 'string') return fallback
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? fallback : timestamp
+}
+
 export const updateNote = async ({
   statusId,
   message,
   contentWarning,
   attachments
-}: UpdateNoteParams) => {
+}: UpdateNoteParams): Promise<UpdateNoteResult> => {
   const normalizedMessage =
     message !== undefined && message.trim().length > 0 ? message : undefined
   const hasAttachmentChanges = attachments !== undefined
@@ -110,14 +130,19 @@ export const updateNote = async ({
   }
 
   const mastodonStatus = await response.json()
+  const createdAt = parseTimestamp(mastodonStatus.created_at, Date.now())
   return {
     content: mastodonStatus.content,
+    spoilerText: mastodonStatus.spoiler_text ?? '',
+    mediaAttachments: Array.isArray(mastodonStatus.media_attachments)
+      ? mastodonStatus.media_attachments
+      : [],
     status: {
-      id: mastodonStatus.id,
-      text: mastodonStatus.content,
-      createdAt: new Date(mastodonStatus.created_at),
+      id: mastodonStatus.uri ?? mastodonStatus.id,
+      text: mastodonStatus.text ?? null,
+      createdAt,
       updatedAt: mastodonStatus.edited_at
-        ? new Date(mastodonStatus.edited_at)
+        ? parseTimestamp(mastodonStatus.edited_at, createdAt)
         : undefined,
       reply: mastodonStatus.in_reply_to_id || ''
     }

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { updateNote, uploadAttachment } from '@/lib/client'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { Attachment } from '@/lib/types/domain/attachment'
+import { EditableStatus, StatusType } from '@/lib/types/domain/status'
+
+import { PostBox } from './post-box'
+
+jest.mock('@/lib/client', () => ({
+  createNote: jest.fn(),
+  createPoll: jest.fn(),
+  deleteFitnessFile: jest.fn(),
+  updateNote: jest.fn(),
+  uploadAttachment: jest.fn(),
+  uploadFitnessFile: jest.fn()
+}))
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <div>{children}</div>
+}))
+
+jest.mock('rehype-sanitize', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('remark-breaks', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('@/lib/utils/resizeImage', () => ({
+  resizeImage: jest.fn((file) => Promise.resolve(file))
+}))
+
+const updateNoteMock = updateNote as jest.MockedFunction<typeof updateNote>
+const uploadAttachmentMock = uploadAttachment as jest.MockedFunction<
+  typeof uploadAttachment
+>
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const profile: ActorProfile = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  domain: 'activities.local',
+  name: 'Llun',
+  followersUrl: 'https://activities.local/users/llun/followers',
+  inboxUrl: 'https://activities.local/users/llun/inbox',
+  sharedInboxUrl: 'https://activities.local/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: currentTime
+}
+
+const existingAttachment: Attachment = {
+  id: 'existing-attachment',
+  actorId: profile.id,
+  statusId: 'https://activities.local/users/llun/statuses/post-1',
+  type: 'Document',
+  mediaType: 'image/jpeg',
+  url: 'https://activities.local/api/v1/files/existing.jpg',
+  width: 320,
+  height: 240,
+  name: 'existing.jpg',
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  mediaId: 'existing-media'
+}
+
+const editStatus: EditableStatus = {
+  id: 'https://activities.local/users/llun/statuses/post-1',
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://activities.local/@llun/post-1',
+  text: 'Original post text',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [existingAttachment],
+  tags: []
+}
+
+describe('PostBox edit media', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.URL.createObjectURL = jest.fn(() => 'blob:new-media')
+    global.URL.revokeObjectURL = jest.fn()
+    global.crypto.randomUUID = jest.fn(() => 'temporary-media-id')
+    uploadAttachmentMock.mockResolvedValue({
+      type: 'upload',
+      id: 'uploaded-media',
+      mediaType: 'image/png',
+      url: 'https://activities.local/api/v1/files/uploaded.png',
+      width: 640,
+      height: 480,
+      name: 'replacement.png'
+    })
+    updateNoteMock.mockResolvedValue({
+      content: '<p>Original post text</p>',
+      status: {
+        id: editStatus.id,
+        text: '<p>Original post text</p>',
+        createdAt: new Date(currentTime),
+        updatedAt: new Date(currentTime),
+        reply: ''
+      }
+    })
+  })
+
+  it('enables update and uploads media when only edit attachments change', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    const updateButton = screen.getByRole('button', { name: 'Update' })
+    expect(updateButton).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Remove media existing.jpg' })
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove media existing.jpg' })
+    )
+    const fileInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+    ).at(-1)!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['replacement'], 'replacement.png', { type: 'image/png' })
+        ]
+      }
+    })
+
+    await waitFor(() => {
+      expect(updateButton).toBeEnabled()
+      expect(
+        screen.getByRole('button', { name: 'Remove media replacement.png' })
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(updateButton)
+
+    await waitFor(() => {
+      expect(uploadAttachmentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'replacement.png' })
+      )
+      expect(updateNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusId: 'activities.local:users:llun:statuses:post-1',
+          attachments: [
+            expect.objectContaining({
+              id: 'uploaded-media',
+              name: 'replacement.png'
+            })
+          ]
+        })
+      )
+    })
+  })
+})

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -546,29 +546,80 @@ describe('PostBox edit media', () => {
     const alertMock = jest.spyOn(window, 'alert').mockImplementation(() => {})
     updateNoteMock.mockRejectedValueOnce(new Error('update failed'))
 
-    render(
-      <PostBox
-        host="activities.local"
-        profile={profile}
-        editStatus={editStatus}
-        isMediaUploadEnabled
-        onDiscardReply={jest.fn()}
-        onPostCreated={jest.fn()}
-        onPostUpdated={jest.fn()}
-        onDiscardEdit={jest.fn()}
-      />
-    )
+    try {
+      render(
+        <PostBox
+          host="activities.local"
+          profile={profile}
+          editStatus={editStatus}
+          isMediaUploadEnabled
+          onDiscardReply={jest.fn()}
+          onPostCreated={jest.fn()}
+          onPostUpdated={jest.fn()}
+          onDiscardEdit={jest.fn()}
+        />
+      )
 
-    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
-      target: { value: 'Updated post text' }
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+      fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+        target: { value: 'Updated post text' }
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }))
 
-    await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith('Fail to update the post')
-    })
+      await waitFor(() => {
+        expect(alertMock).toHaveBeenCalledWith('update failed')
+      })
+    } finally {
+      alertMock.mockRestore()
+    }
+  })
 
-    alertMock.mockRestore()
+  it('shows media upload failure details when edit media upload fails', async () => {
+    const alertMock = jest.spyOn(window, 'alert').mockImplementation(() => {})
+    uploadAttachmentMock.mockRejectedValueOnce(new Error('unsupported file'))
+
+    try {
+      render(
+        <PostBox
+          host="activities.local"
+          profile={profile}
+          editStatus={editStatus}
+          isMediaUploadEnabled
+          onDiscardReply={jest.fn()}
+          onPostCreated={jest.fn()}
+          onPostUpdated={jest.fn()}
+          onDiscardEdit={jest.fn()}
+        />
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Remove media existing.jpg' })
+      )
+      const fileInput = Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      ).at(-1)!
+      fireEvent.change(fileInput, {
+        target: {
+          files: [
+            new File(['replacement'], 'replacement.png', { type: 'image/png' })
+          ]
+        }
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Update' })).toBeEnabled()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+      await waitFor(() => {
+        expect(alertMock).toHaveBeenCalledWith(
+          'Fail to upload replacement.png: unsupported file'
+        )
+      })
+      expect(updateNoteMock).not.toHaveBeenCalled()
+    } finally {
+      alertMock.mockRestore()
+    }
   })
 
   it('does not submit an edit when text, warning, and media are unchanged', async () => {

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -77,6 +77,14 @@ const existingAttachment: Attachment = {
   mediaId: 'existing-media'
 }
 
+const legacyAttachmentWithoutMediaId: Attachment = {
+  ...existingAttachment,
+  id: 'legacy-attachment',
+  url: 'https://activities.local/api/v1/files/legacy.jpg',
+  name: 'legacy.jpg',
+  mediaId: null
+}
+
 const editStatus: EditableStatus = {
   id: 'https://activities.local/users/llun/statuses/post-1',
   actorId: profile.id,
@@ -145,6 +153,188 @@ describe('PostBox edit media', () => {
         updatedAt: updatedTime,
         reply: ''
       }
+    })
+  })
+
+  it('initializes and submits edit text without escaping source text characters', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={{
+          ...editStatus,
+          text: 'a & b < c > d'
+        }}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    expect(screen.getByPlaceholderText("What's on your mind?")).toHaveValue(
+      'a & b < c > d'
+    )
+    expect(screen.getByRole('button', { name: 'Update' })).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: 'a & b < c > d!' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(updateNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'a & b < c > d!'
+        })
+      )
+    })
+  })
+
+  it('does not send legacy attachment ids as media ids', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={{
+          ...editStatus,
+          attachments: [legacyAttachmentWithoutMediaId]
+        }}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Remove media legacy.jpg' })
+    ).not.toBeInTheDocument()
+
+    const fileInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+    ).at(-1)!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['replacement'], 'replacement.png', { type: 'image/png' })
+        ]
+      }
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Update' })).toBeEnabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(updateNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            expect.objectContaining({
+              id: 'uploaded-media'
+            })
+          ]
+        })
+      )
+    })
+    expect(updateNoteMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'legacy-attachment'
+          })
+        ])
+      })
+    )
+  })
+
+  it('uses concrete media types when reconciling unmatched server attachments', async () => {
+    const onPostUpdated = jest.fn()
+    updateNoteMock.mockResolvedValueOnce({
+      content: '<p>Updated post text</p>',
+      spoilerText: '',
+      mediaAttachments: [
+        {
+          id: 'server-video-attachment',
+          type: 'video',
+          url: 'https://activities.local/api/v1/files/video.mp4',
+          preview_url: null,
+          remote_url: null,
+          description: 'video.mp4',
+          blurhash: null,
+          meta: {
+            width: 1280,
+            height: 720,
+            size: '1280x720',
+            aspect: 1.7777777777777777,
+            duration: 12,
+            fps: 30,
+            audio_encode: 'aac',
+            audio_bitrate: '128000',
+            audio_channels: '2',
+            original: {
+              width: 1280,
+              height: 720,
+              size: '1280x720',
+              aspect: 1.7777777777777777,
+              duration: 12,
+              frame_rate: '30/1',
+              bitrate: 1000000
+            },
+            small: {
+              width: 640,
+              height: 360,
+              size: '640x360',
+              aspect: 1.7777777777777777
+            }
+          }
+        }
+      ],
+      status: {
+        id: editStatus.id,
+        text: 'Updated post text',
+        createdAt: currentTime,
+        updatedAt: updatedTime,
+        reply: ''
+      }
+    })
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={{
+          ...editStatus,
+          attachments: []
+        }}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={onPostUpdated}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: 'Updated post text' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(onPostUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            expect.objectContaining({
+              id: 'server-video-attachment',
+              mediaType: 'video/mp4'
+            })
+          ]
+        })
+      )
     })
   })
 

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-import { updateNote, uploadAttachment } from '@/lib/client'
+import { createNote, updateNote, uploadAttachment } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { EditableStatus, StatusType } from '@/lib/types/domain/status'
@@ -40,6 +40,7 @@ jest.mock('@/lib/utils/resizeImage', () => ({
 }))
 
 const updateNoteMock = updateNote as jest.MockedFunction<typeof updateNote>
+const createNoteMock = createNote as jest.MockedFunction<typeof createNote>
 const uploadAttachmentMock = uploadAttachment as jest.MockedFunction<
   typeof uploadAttachment
 >
@@ -154,6 +155,137 @@ describe('PostBox edit media', () => {
         reply: ''
       }
     })
+    createNoteMock.mockResolvedValue({
+      status: editStatus,
+      attachments: []
+    })
+  })
+
+  it('enables and submits a media-only new post', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    const postButton = screen.getByRole('button', { name: 'Post' })
+    expect(postButton).toBeDisabled()
+
+    const fileInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+    ).at(-1)!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['replacement'], 'replacement.png', { type: 'image/png' })
+        ]
+      }
+    })
+
+    await waitFor(() => {
+      expect(postButton).toBeEnabled()
+      expect(
+        screen.getByRole('button', { name: 'Remove media replacement.png' })
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(postButton)
+
+    await waitFor(() => {
+      expect(uploadAttachmentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'replacement.png' })
+      )
+      expect(createNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: '',
+          attachments: [
+            expect.objectContaining({
+              id: 'uploaded-media',
+              name: 'replacement.png'
+            })
+          ]
+        })
+      )
+    })
+  })
+
+  it('keeps a new post with media enabled when text is cleared', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    const postButton = screen.getByRole('button', { name: 'Post' })
+    const textbox = screen.getByPlaceholderText("What's on your mind?")
+    fireEvent.change(textbox, { target: { value: 'caption' } })
+
+    const fileInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+    ).at(-1)!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['replacement'], 'replacement.png', { type: 'image/png' })
+        ]
+      }
+    })
+
+    await waitFor(() => {
+      expect(postButton).toBeEnabled()
+    })
+
+    fireEvent.change(textbox, { target: { value: '' } })
+
+    expect(postButton).toBeEnabled()
+  })
+
+  it('disables a new post when the only media is removed', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    const postButton = screen.getByRole('button', { name: 'Post' })
+    const fileInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+    ).at(-1)!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['replacement'], 'replacement.png', { type: 'image/png' })
+        ]
+      }
+    })
+
+    await waitFor(() => {
+      expect(postButton).toBeEnabled()
+    })
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove media replacement.png' })
+    )
+
+    expect(postButton).toBeDisabled()
   })
 
   it('initializes and submits edit text without escaping source text characters', async () => {
@@ -333,6 +465,70 @@ describe('PostBox edit media', () => {
               mediaType: 'video/mp4'
             })
           ]
+        })
+      )
+    })
+  })
+
+  it('submits an empty message when clearing text from a media edit', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: '' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(updateNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: ''
+        })
+      )
+    })
+  })
+
+  it('does not submit an edit when text, warning, and media are unchanged', async () => {
+    const { container } = render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.submit(container.querySelector('form')!)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: 'Original post text updated' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(updateNoteMock).toHaveBeenCalledTimes(1)
+      expect(updateNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Original post text updated'
         })
       )
     })

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { updateNote, uploadAttachment } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -45,6 +45,7 @@ const uploadAttachmentMock = uploadAttachment as jest.MockedFunction<
 >
 
 const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+const updatedTime = new Date('2026-04-26T11:00:00.000Z').getTime()
 
 const profile: ActorProfile = {
   id: 'https://activities.local/users/llun',
@@ -117,17 +118,39 @@ describe('PostBox edit media', () => {
     })
     updateNoteMock.mockResolvedValue({
       content: '<p>Original post text</p>',
+      spoilerText: '',
+      mediaAttachments: [
+        {
+          id: 'server-attachment',
+          type: 'image',
+          url: 'https://activities.local/api/v1/files/uploaded.png',
+          preview_url: null,
+          remote_url: null,
+          description: 'replacement.png',
+          blurhash: null,
+          meta: {
+            original: {
+              width: 800,
+              height: 600,
+              size: '800x600',
+              aspect: 1.3333333333333333
+            }
+          }
+        }
+      ],
       status: {
         id: editStatus.id,
-        text: '<p>Original post text</p>',
-        createdAt: new Date(currentTime),
-        updatedAt: new Date(currentTime),
+        text: 'Original post text',
+        createdAt: currentTime,
+        updatedAt: updatedTime,
         reply: ''
       }
     })
   })
 
   it('enables update and uploads media when only edit attachments change', async () => {
+    const onPostUpdated = jest.fn()
+
     render(
       <PostBox
         host="activities.local"
@@ -136,7 +159,7 @@ describe('PostBox edit media', () => {
         isMediaUploadEnabled
         onDiscardReply={jest.fn()}
         onPostCreated={jest.fn()}
-        onPostUpdated={jest.fn()}
+        onPostUpdated={onPostUpdated}
         onDiscardEdit={jest.fn()}
       />
     )
@@ -176,7 +199,7 @@ describe('PostBox edit media', () => {
       )
       expect(updateNoteMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          statusId: 'activities.local:users:llun:statuses:post-1',
+          statusId: editStatus.id,
           attachments: [
             expect.objectContaining({
               id: 'uploaded-media',
@@ -185,6 +208,88 @@ describe('PostBox edit media', () => {
           ]
         })
       )
+    })
+
+    expect(onPostUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Original post text',
+        summary: null,
+        updatedAt: updatedTime,
+        attachments: [
+          expect.objectContaining({
+            id: 'server-attachment',
+            mediaId: 'uploaded-media',
+            width: 800,
+            height: 600,
+            createdAt: updatedTime,
+            updatedAt: updatedTime
+          })
+        ]
+      })
+    )
+  })
+
+  it('ignores reentrant submits while edit media upload is in flight', async () => {
+    let resolveUpdate: (value: Awaited<ReturnType<typeof updateNote>>) => void
+    updateNoteMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpdate = resolve
+      })
+    )
+
+    const { container } = render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove media existing.jpg' })
+    )
+    const fileInput = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+    ).at(-1)!
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(['replacement'], 'replacement.png', { type: 'image/png' })
+        ]
+      }
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Update' })).toBeEnabled()
+    })
+
+    const form = container.querySelector('form')!
+    fireEvent.submit(form)
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(uploadAttachmentMock).toHaveBeenCalledTimes(1)
+      expect(updateNoteMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      resolveUpdate!({
+        content: '<p>Original post text</p>',
+        spoilerText: '',
+        mediaAttachments: [],
+        status: {
+          id: editStatus.id,
+          text: 'Original post text',
+          createdAt: currentTime,
+          updatedAt: updatedTime,
+          reply: ''
+        }
+      })
     })
   })
 })

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -86,6 +86,15 @@ const legacyAttachmentWithoutMediaId: Attachment = {
   mediaId: null
 }
 
+const fitnessAttachment: Attachment = {
+  ...existingAttachment,
+  id: 'fitness-attachment',
+  mediaType: 'application/gpx+xml',
+  url: 'https://activities.local/api/v1/fitness-files/fitness-file-1',
+  name: 'activity.gpx',
+  mediaId: 'fitness-media'
+}
+
 const editStatus: EditableStatus = {
   id: 'https://activities.local/users/llun/statuses/post-1',
   actorId: profile.id,
@@ -498,6 +507,70 @@ describe('PostBox edit media', () => {
     })
   })
 
+  it('keeps update disabled when an edit would remove all content', async () => {
+    const { container } = render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    const updateButton = screen.getByRole('button', { name: 'Update' })
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: '' }
+    })
+    expect(updateButton).toBeEnabled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove media existing.jpg' })
+    )
+
+    expect(updateButton).toBeDisabled()
+    fireEvent.submit(container.querySelector('form')!)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(updateNoteMock).not.toHaveBeenCalled()
+  })
+
+  it('shows an edit-specific alert when updating a post fails', async () => {
+    const alertMock = jest.spyOn(window, 'alert').mockImplementation(() => {})
+    updateNoteMock.mockRejectedValueOnce(new Error('update failed'))
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={editStatus}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: 'Updated post text' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(alertMock).toHaveBeenCalledWith('Fail to update the post')
+    })
+
+    alertMock.mockRestore()
+  })
+
   it('does not submit an edit when text, warning, and media are unchanged', async () => {
     const { container } = render(
       <PostBox
@@ -613,6 +686,127 @@ describe('PostBox edit media', () => {
         ]
       })
     )
+  })
+
+  it('preserves fitness attachments in the locally updated status', async () => {
+    const onPostUpdated = jest.fn()
+    updateNoteMock.mockResolvedValueOnce({
+      content: '<p>Updated post text</p>',
+      spoilerText: '',
+      mediaAttachments: [],
+      status: {
+        id: editStatus.id,
+        text: 'Updated post text',
+        createdAt: currentTime,
+        updatedAt: updatedTime,
+        reply: ''
+      }
+    })
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={{
+          ...editStatus,
+          attachments: [fitnessAttachment]
+        }}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={onPostUpdated}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: 'Updated post text' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(onPostUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            expect.objectContaining({
+              id: 'fitness-attachment',
+              mediaType: 'application/gpx+xml',
+              mediaId: 'fitness-media',
+              statusId: editStatus.id,
+              updatedAt: updatedTime
+            })
+          ]
+        })
+      )
+    })
+  })
+
+  it('does not duplicate preserved attachments already returned by the update response', async () => {
+    const onPostUpdated = jest.fn()
+    updateNoteMock.mockResolvedValueOnce({
+      content: '<p>Updated post text</p>',
+      spoilerText: '',
+      mediaAttachments: [
+        {
+          id: 'legacy-attachment',
+          type: 'image',
+          url: 'https://activities.local/api/v1/files/legacy.jpg',
+          preview_url: null,
+          remote_url: null,
+          description: 'legacy.jpg',
+          blurhash: null,
+          meta: {
+            original: {
+              width: 800,
+              height: 600,
+              size: '800x600',
+              aspect: 1.3333333333333333
+            }
+          }
+        }
+      ],
+      status: {
+        id: editStatus.id,
+        text: 'Updated post text',
+        createdAt: currentTime,
+        updatedAt: updatedTime,
+        reply: ''
+      }
+    })
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        editStatus={{
+          ...editStatus,
+          attachments: [legacyAttachmentWithoutMediaId]
+        }}
+        isMediaUploadEnabled
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={onPostUpdated}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText("What's on your mind?"), {
+      target: { value: 'Updated post text' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => {
+      expect(onPostUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            expect.objectContaining({
+              id: 'legacy-attachment'
+            })
+          ]
+        })
+      )
+    })
+    expect(onPostUpdated.mock.calls[0][0].attachments).toHaveLength(1)
   })
 
   it('ignores reentrant submits while edit media upload is in flight', async () => {

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -45,7 +45,6 @@ import {
 import { formatFileSize } from '@/lib/utils/formatFileSize'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { SANITIZED_OPTION } from '@/lib/utils/text/sanitizeText'
-import { urlToId } from '@/lib/utils/urlToId'
 
 import { Duration, PollChoices } from './poll-choices'
 import {
@@ -104,7 +103,7 @@ const getEditableStatusAttachments = (
 const getAttachmentIds = (attachments: Pick<PostBoxAttachment, 'id'>[]) =>
   attachments.map((attachment) => attachment.id)
 
-const areAttachmentIdsEqual = (
+const areAttachmentIdsEqualInOrder = (
   current: Pick<PostBoxAttachment, 'id'>[],
   baseline: Pick<PostBoxAttachment, 'id'>[]
 ) => {
@@ -114,31 +113,115 @@ const areAttachmentIdsEqual = (
   return currentIds.every((id, index) => id === baselineIds[index])
 }
 
-const getStatusAttachmentsFromPostBoxAttachments = ({
+type UpdateNoteResponse = Awaited<ReturnType<typeof updateNote>>
+type UpdateNoteMediaAttachment = UpdateNoteResponse['mediaAttachments'][number]
+
+const getTimestamp = (value: unknown, fallback: number) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const timestamp = Date.parse(value)
+    return Number.isNaN(timestamp) ? fallback : timestamp
+  }
+  if (value instanceof Date) {
+    const timestamp = value.getTime()
+    return Number.isNaN(timestamp) ? fallback : timestamp
+  }
+  return fallback
+}
+
+const getMediaAttachmentDimensions = (
+  mediaAttachment: UpdateNoteMediaAttachment,
+  fallback?: PostBoxAttachment
+) => {
+  const meta = (
+    'meta' in mediaAttachment ? mediaAttachment.meta : undefined
+  ) as
+    | {
+        original?: { width?: number; height?: number }
+        width?: number
+        height?: number
+      }
+    | null
+    | undefined
+
+  return {
+    width: meta?.original?.width ?? meta?.width ?? fallback?.width,
+    height: meta?.original?.height ?? meta?.height ?? fallback?.height
+  }
+}
+
+const getMediaTypeFromMastodonAttachment = (
+  attachment: UpdateNoteMediaAttachment
+) => {
+  switch (attachment.type) {
+    case 'image':
+      return 'image/*'
+    case 'gifv':
+    case 'video':
+      return 'video/*'
+    case 'audio':
+      return 'audio/*'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
+const getStatusAttachmentsFromUpdateResponse = ({
   actorId,
-  attachments,
+  existingAttachments,
+  mediaAttachments,
   statusId,
-  timestamp
+  uploadedAttachments,
+  updatedAt
 }: {
   actorId: string
-  attachments: PostBoxAttachment[]
+  existingAttachments: Attachment[]
+  mediaAttachments: UpdateNoteMediaAttachment[]
   statusId: string
-  timestamp: number
+  uploadedAttachments: PostBoxAttachment[]
+  updatedAt: number
 }): Attachment[] =>
-  attachments.map((attachment, index) => ({
-    id: attachment.id,
-    actorId,
-    statusId,
-    type: 'Document',
-    mediaType: attachment.mediaType,
-    url: attachment.url,
-    width: attachment.width,
-    height: attachment.height,
-    name: attachment.name ?? '',
-    mediaId: attachment.id,
-    createdAt: timestamp + index,
-    updatedAt: timestamp + index
-  }))
+  mediaAttachments.map((mediaAttachment, index) => {
+    // Mastodon returns media attachments in the submitted order; keep this
+    // order-sensitive pairing so Attachment.id comes from the server while
+    // mediaId and fallback metadata come from the uploaded media ids.
+    const uploadedAttachment = uploadedAttachments[index]
+    const existingAttachment = existingAttachments.find(
+      (attachment) =>
+        attachment.id === mediaAttachment.id ||
+        attachment.mediaId === uploadedAttachment?.id ||
+        attachment.url === mediaAttachment.url
+    )
+    const dimensions = getMediaAttachmentDimensions(
+      mediaAttachment,
+      uploadedAttachment
+    )
+    const attachmentCreatedAt = existingAttachment?.createdAt ?? updatedAt
+
+    return {
+      id: mediaAttachment.id,
+      actorId,
+      statusId,
+      type: 'Document',
+      mediaType:
+        existingAttachment?.mediaType ??
+        uploadedAttachment?.mediaType ??
+        getMediaTypeFromMastodonAttachment(mediaAttachment),
+      url: mediaAttachment.url,
+      width: dimensions.width ?? existingAttachment?.width,
+      height: dimensions.height ?? existingAttachment?.height,
+      name:
+        mediaAttachment.description ??
+        existingAttachment?.name ??
+        uploadedAttachment?.name ??
+        '',
+      mediaId: existingAttachment
+        ? (existingAttachment.mediaId ?? null)
+        : (uploadedAttachment?.id ?? null),
+      createdAt: attachmentCreatedAt,
+      updatedAt
+    }
+  })
 
 export const PostBox: FC<Props> = ({
   host,
@@ -159,6 +242,7 @@ export const PostBox: FC<Props> = ({
   const postBoxRef = useRef<HTMLTextAreaElement>(null)
   const formRef = useRef<HTMLFormElement>(null)
   const textRef = useRef(text)
+  const submitInFlightRef = useRef(false)
   const fitnessCleanupInFlightRef = useRef<{
     uploadedId: string
     promise: Promise<boolean>
@@ -190,7 +274,7 @@ export const PostBox: FC<Props> = ({
     return (
       value !== getEditableStatusText(editStatus) ||
       contentWarning !== (editStatus.summary ?? '') ||
-      !areAttachmentIdsEqual(
+      !areAttachmentIdsEqualInOrder(
         extension.attachments,
         getEditableStatusAttachments(editStatus)
       )
@@ -289,6 +373,8 @@ export const PostBox: FC<Props> = ({
 
   const onPost = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault()
+    if (submitInFlightRef.current) return
+    submitInFlightRef.current = true
 
     setAllowPost(false)
     setIsPosting(true)
@@ -331,7 +417,7 @@ export const PostBox: FC<Props> = ({
         const currentContentWarning = postExtension.contentWarningVisible
           ? postExtension.contentWarning
           : ''
-        const attachmentsChanged = !areAttachmentIdsEqual(
+        const attachmentsChanged = !areAttachmentIdsEqualInOrder(
           attachments,
           getEditableStatusAttachments(editStatus)
         )
@@ -341,29 +427,37 @@ export const PostBox: FC<Props> = ({
             ? currentContentWarning
             : undefined
 
-        await updateNote({
-          statusId: urlToId(editStatus.id),
+        const updateResponse = await updateNote({
+          statusId: editStatus.id,
           message: updateMessage,
           contentWarning: updateContentWarning,
           attachments: attachmentsChanged ? attachments : undefined
         })
-        const updateTime = Date.now()
+        const responseStatus = updateResponse.status
+        const responseCreatedAt = getTimestamp(
+          responseStatus.createdAt,
+          editStatus.createdAt
+        )
+        const responseUpdatedAt = getTimestamp(
+          responseStatus.updatedAt,
+          Date.now()
+        )
+        const responseStatusId = responseStatus.id || editStatus.id
         onPostUpdated({
           ...editStatus,
-          text: updateMessage ?? editStatus.text,
-          summary:
-            updateContentWarning === undefined
-              ? editStatus.summary
-              : updateContentWarning.trim() || null,
-          attachments: attachmentsChanged
-            ? getStatusAttachmentsFromPostBoxAttachments({
-                actorId: editStatus.actorId,
-                attachments,
-                statusId: editStatus.id,
-                timestamp: updateTime
-              })
-            : editStatus.attachments,
-          updatedAt: updateTime
+          id: responseStatusId,
+          text: responseStatus.text ?? message,
+          summary: updateResponse.spoilerText.trim() || null,
+          attachments: getStatusAttachmentsFromUpdateResponse({
+            actorId: editStatus.actorId,
+            existingAttachments: editStatus.attachments,
+            mediaAttachments: updateResponse.mediaAttachments,
+            uploadedAttachments: attachments,
+            statusId: responseStatusId,
+            updatedAt: responseUpdatedAt
+          }),
+          createdAt: responseCreatedAt,
+          updatedAt: responseUpdatedAt
         })
         dispatch(resetExtension())
 
@@ -419,6 +513,8 @@ export const PostBox: FC<Props> = ({
       setIsPosting(false)
       setAllowPost(true)
       alert('Fail to create a post')
+    } finally {
+      submitInFlightRef.current = false
     }
   }
 

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -409,7 +409,7 @@ export const PostBox: FC<Props> = ({
             originalId: attachment.id,
             uploadedAttachment: newAttachment
           }
-        } catch {
+        } catch (error) {
           const restoredAttachment = {
             ...attachment,
             isLoading: false
@@ -421,7 +421,11 @@ export const PostBox: FC<Props> = ({
             )
           }
           dispatch(updateAttachment(attachment.id, restoredAttachment))
-          throw new Error(`Fail to upload ${attachment.name}`)
+          const reason =
+            error instanceof Error && error.message ? `: ${error.message}` : ''
+          throw new Error(`Fail to upload ${attachment.name}${reason}`, {
+            cause: error
+          })
         }
       })
     )
@@ -589,10 +593,17 @@ export const PostBox: FC<Props> = ({
 
       setText('')
       setIsPosting(false)
-    } catch {
+    } catch (error) {
       setIsPosting(false)
       setAllowPost(true)
-      alert(editStatus ? 'Fail to update the post' : 'Fail to create a post')
+      const fallbackMessage = editStatus
+        ? 'Fail to update the post'
+        : 'Fail to create a post'
+      alert(
+        error instanceof Error && error.message
+          ? error.message
+          : fallbackMessage
+      )
     } finally {
       submitInFlightRef.current = false
     }

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -89,17 +89,21 @@ interface Props {
 
 const getEditableStatusText = (status: EditableStatus) => status.text
 
+const isEditableStatusMediaAttachment = (
+  attachment: Attachment
+): attachment is Attachment & { mediaId: string } =>
+  Boolean(attachment.mediaId) && !isFitnessAttachment(attachment)
+
 const getEditableStatusAttachments = (
   status: EditableStatus
 ): PostBoxAttachment[] =>
   status.attachments.flatMap((attachment) => {
-    const mediaId = attachment.mediaId
-    if (!mediaId || isFitnessAttachment(attachment)) return []
+    if (!isEditableStatusMediaAttachment(attachment)) return []
 
     return [
       {
         type: 'upload',
-        id: mediaId,
+        id: attachment.mediaId,
         mediaType: attachment.mediaType,
         url: attachment.url,
         width: attachment.width ?? 0,
@@ -108,6 +112,11 @@ const getEditableStatusAttachments = (
       }
     ]
   })
+
+const getPreservedStatusAttachments = (attachments: Attachment[]) =>
+  attachments.filter(
+    (attachment) => !isEditableStatusMediaAttachment(attachment)
+  )
 
 const getAttachmentIds = (attachments: Pick<PostBoxAttachment, 'id'>[]) =>
   attachments.map((attachment) => attachment.id)
@@ -129,6 +138,15 @@ const hasNewPostContent = (
   value.trim().length > 0 ||
   extension.attachments.length > 0 ||
   Boolean(extension.fitnessFile)
+
+const hasEditPostContent = (
+  status: EditableStatus,
+  value: string,
+  extension: { attachments: PostBoxAttachment[] }
+) =>
+  value.trim().length > 0 ||
+  extension.attachments.length > 0 ||
+  getPreservedStatusAttachments(status.attachments).length > 0
 
 type UpdateNoteResponse = Awaited<ReturnType<typeof updateNote>>
 type UpdateNoteMediaAttachment = UpdateNoteResponse['mediaAttachments'][number]
@@ -197,48 +215,70 @@ const getStatusAttachmentsFromUpdateResponse = ({
   statusId: string
   uploadedAttachments: PostBoxAttachment[]
   updatedAt: number
-}): Attachment[] =>
-  mediaAttachments.map((mediaAttachment, index) => {
-    // Mastodon returns media attachments in the submitted order; keep this
-    // order-sensitive pairing so Attachment.id comes from the server while
-    // mediaId and fallback metadata come from the uploaded media ids.
-    const uploadedAttachment = uploadedAttachments[index]
-    const existingAttachment = existingAttachments.find(
-      (attachment) =>
-        attachment.id === mediaAttachment.id ||
-        attachment.mediaId === uploadedAttachment?.id ||
-        attachment.url === mediaAttachment.url
-    )
-    const dimensions = getMediaAttachmentDimensions(
-      mediaAttachment,
-      uploadedAttachment
-    )
-    const attachmentCreatedAt = existingAttachment?.createdAt ?? updatedAt
+}): Attachment[] => {
+  const updatedMediaAttachments: Attachment[] = mediaAttachments.map(
+    (mediaAttachment, index) => {
+      // Mastodon returns media attachments in the submitted order; keep this
+      // order-sensitive pairing so Attachment.id comes from the server while
+      // mediaId and fallback metadata come from the uploaded media ids.
+      const uploadedAttachment = uploadedAttachments[index]
+      const existingAttachment = existingAttachments.find(
+        (attachment) =>
+          attachment.id === mediaAttachment.id ||
+          attachment.mediaId === uploadedAttachment?.id ||
+          attachment.url === mediaAttachment.url
+      )
+      const dimensions = getMediaAttachmentDimensions(
+        mediaAttachment,
+        uploadedAttachment
+      )
+      const attachmentCreatedAt = existingAttachment?.createdAt ?? updatedAt
 
-    return {
-      id: mediaAttachment.id,
-      actorId,
-      statusId,
-      type: 'Document',
-      mediaType:
-        existingAttachment?.mediaType ??
-        uploadedAttachment?.mediaType ??
-        getMediaTypeFromMastodonAttachment(mediaAttachment),
-      url: mediaAttachment.url,
-      width: dimensions.width ?? existingAttachment?.width,
-      height: dimensions.height ?? existingAttachment?.height,
-      name:
-        mediaAttachment.description ??
-        existingAttachment?.name ??
-        uploadedAttachment?.name ??
-        '',
-      mediaId: existingAttachment
-        ? (existingAttachment.mediaId ?? null)
-        : (uploadedAttachment?.id ?? null),
-      createdAt: attachmentCreatedAt,
-      updatedAt
+      return {
+        id: mediaAttachment.id,
+        actorId,
+        statusId,
+        type: 'Document',
+        mediaType:
+          existingAttachment?.mediaType ??
+          uploadedAttachment?.mediaType ??
+          getMediaTypeFromMastodonAttachment(mediaAttachment),
+        url: mediaAttachment.url,
+        width: dimensions.width ?? existingAttachment?.width,
+        height: dimensions.height ?? existingAttachment?.height,
+        name:
+          mediaAttachment.description ??
+          existingAttachment?.name ??
+          uploadedAttachment?.name ??
+          '',
+        mediaId: existingAttachment
+          ? (existingAttachment.mediaId ?? null)
+          : (uploadedAttachment?.id ?? null),
+        createdAt: attachmentCreatedAt,
+        updatedAt
+      }
     }
-  })
+  )
+
+  const preservedAttachments: Attachment[] = getPreservedStatusAttachments(
+    existingAttachments
+  )
+    .filter(
+      (attachment) =>
+        !mediaAttachments.some(
+          (mediaAttachment) =>
+            mediaAttachment.id === attachment.id ||
+            mediaAttachment.url === attachment.url
+        )
+    )
+    .map((attachment) => ({
+      ...attachment,
+      statusId,
+      updatedAt
+    }))
+
+  return [...updatedMediaAttachments, ...preservedAttachments]
+}
 
 export const PostBox: FC<Props> = ({
   host,
@@ -295,6 +335,18 @@ export const PostBox: FC<Props> = ({
         extension.attachments,
         getEditableStatusAttachments(editStatus)
       )
+    )
+  }
+
+  const isEditSubmittable = (
+    value = textRef.current,
+    extension = postExtensionRef.current
+  ) => {
+    if (!editStatus) return false
+
+    return (
+      isEditDirty(value, extension) &&
+      hasEditPostContent(editStatus, value, extension)
     )
   }
 
@@ -390,6 +442,7 @@ export const PostBox: FC<Props> = ({
 
   const onPost = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault()
+    if (!allowPost) return
     if (submitInFlightRef.current) return
     submitInFlightRef.current = true
 
@@ -539,7 +592,7 @@ export const PostBox: FC<Props> = ({
     } catch {
       setIsPosting(false)
       setAllowPost(true)
-      alert('Fail to create a post')
+      alert(editStatus ? 'Fail to update the post' : 'Fail to create a post')
     } finally {
       submitInFlightRef.current = false
     }
@@ -566,7 +619,7 @@ export const PostBox: FC<Props> = ({
     postExtensionRef.current = nextExtension
     dispatch(setAttachments(nextAttachments))
     if (editStatus) {
-      setAllowPost(isEditDirty(textRef.current, nextExtension))
+      setAllowPost(isEditSubmittable(textRef.current, nextExtension))
       return
     }
     setAllowPost(hasNewPostContent(textRef.current, nextExtension))
@@ -642,13 +695,13 @@ export const PostBox: FC<Props> = ({
     if (value.trim().length === 0) {
       setAllowPost(
         editStatus
-          ? isEditDirty(value)
+          ? isEditSubmittable(value)
           : hasNewPostContent(value, postExtensionRef.current)
       )
       return
     }
     if (editStatus) {
-      setAllowPost(isEditDirty(value))
+      setAllowPost(isEditSubmittable(value))
       return
     }
     setAllowPost(true)
@@ -665,7 +718,7 @@ export const PostBox: FC<Props> = ({
         postExtensionRef.current.contentWarningVisible || value.length > 0
     }
     postExtensionRef.current = nextExtension
-    setAllowPost(isEditDirty(textRef.current, nextExtension))
+    setAllowPost(isEditSubmittable(textRef.current, nextExtension))
   }
 
   const onToggleContentWarning = () => {
@@ -678,7 +731,7 @@ export const PostBox: FC<Props> = ({
       contentWarningVisible: nextVisible
     }
     postExtensionRef.current = nextExtension
-    setAllowPost(isEditDirty(textRef.current, nextExtension))
+    setAllowPost(isEditSubmittable(textRef.current, nextExtension))
   }
 
   /**
@@ -949,7 +1002,9 @@ export const PostBox: FC<Props> = ({
                 postExtensionRef.current = nextExtension
                 dispatch(addAttachment(attachment))
                 if (editStatus) {
-                  setAllowPost(isEditDirty(textRef.current, nextExtension))
+                  setAllowPost(
+                    isEditSubmittable(textRef.current, nextExtension)
+                  )
                   return
                 }
                 setAllowPost(hasNewPostContent(textRef.current, nextExtension))

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -35,7 +35,7 @@ import {
   getMention,
   getMentionFromActorID
 } from '@/lib/types/domain/actor'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import {
   EditableStatus,
   Status,
@@ -85,6 +85,61 @@ interface Props {
   onDiscardEdit: () => void
 }
 
+const getEditableStatusText = (status: EditableStatus) =>
+  sanitizeHtml(status.text, { allowedTags: [] })
+
+const getEditableStatusAttachments = (
+  status: EditableStatus
+): PostBoxAttachment[] =>
+  status.attachments.map((attachment) => ({
+    type: 'upload',
+    id: attachment.mediaId ?? attachment.id,
+    mediaType: attachment.mediaType,
+    url: attachment.url,
+    width: attachment.width ?? 0,
+    height: attachment.height ?? 0,
+    name: attachment.name
+  }))
+
+const getAttachmentIds = (attachments: Pick<PostBoxAttachment, 'id'>[]) =>
+  attachments.map((attachment) => attachment.id)
+
+const areAttachmentIdsEqual = (
+  current: Pick<PostBoxAttachment, 'id'>[],
+  baseline: Pick<PostBoxAttachment, 'id'>[]
+) => {
+  const currentIds = getAttachmentIds(current)
+  const baselineIds = getAttachmentIds(baseline)
+  if (currentIds.length !== baselineIds.length) return false
+  return currentIds.every((id, index) => id === baselineIds[index])
+}
+
+const getStatusAttachmentsFromPostBoxAttachments = ({
+  actorId,
+  attachments,
+  statusId,
+  timestamp
+}: {
+  actorId: string
+  attachments: PostBoxAttachment[]
+  statusId: string
+  timestamp: number
+}): Attachment[] =>
+  attachments.map((attachment, index) => ({
+    id: attachment.id,
+    actorId,
+    statusId,
+    type: 'Document',
+    mediaType: attachment.mediaType,
+    url: attachment.url,
+    width: attachment.width,
+    height: attachment.height,
+    name: attachment.name ?? '',
+    mediaId: attachment.id,
+    createdAt: timestamp + index,
+    updatedAt: timestamp + index
+  }))
+
 export const PostBox: FC<Props> = ({
   host,
   profile,
@@ -123,6 +178,25 @@ export const PostBox: FC<Props> = ({
     textRef.current = text
   }, [text])
 
+  const isEditDirty = (
+    value = textRef.current,
+    extension = postExtensionRef.current
+  ) => {
+    if (!editStatus) return false
+
+    const contentWarning = extension.contentWarningVisible
+      ? extension.contentWarning
+      : ''
+    return (
+      value !== getEditableStatusText(editStatus) ||
+      contentWarning !== (editStatus.summary ?? '') ||
+      !areAttachmentIdsEqual(
+        extension.attachments,
+        getEditableStatusAttachments(editStatus)
+      )
+    )
+  }
+
   useEffect(() => {
     return () => {
       postExtensionRef.current.attachments.forEach((attachment) => {
@@ -132,6 +206,86 @@ export const PostBox: FC<Props> = ({
       })
     }
   }, [])
+
+  const uploadMediaAttachments = async () => {
+    const attachmentsToUpload = postExtensionRef.current.attachments
+
+    const uploadResults = await Promise.all(
+      attachmentsToUpload.map(async (attachment) => {
+        if (!attachment.file)
+          return {
+            originalId: attachment.id,
+            uploadedAttachment: attachment
+          }
+
+        const loadingAttachment = {
+          ...attachment,
+          isLoading: true
+        }
+        postExtensionRef.current = {
+          ...postExtensionRef.current,
+          attachments: postExtensionRef.current.attachments.map((item) =>
+            item.id === attachment.id ? loadingAttachment : item
+          )
+        }
+        dispatch(updateAttachment(attachment.id, loadingAttachment))
+
+        try {
+          const uploaded = await uploadAttachment(attachment.file)
+          if (!uploaded) throw new Error()
+
+          // Revoke the blob URL after successful upload
+          if (attachment.url.startsWith('blob:')) {
+            URL.revokeObjectURL(attachment.url)
+          }
+
+          const newAttachment = {
+            ...attachment,
+            ...uploaded,
+            isLoading: false,
+            file: undefined
+          }
+          postExtensionRef.current = {
+            ...postExtensionRef.current,
+            attachments: postExtensionRef.current.attachments.map((item) =>
+              item.id === attachment.id ? newAttachment : item
+            )
+          }
+          dispatch(updateAttachment(attachment.id, newAttachment))
+          return {
+            originalId: attachment.id,
+            uploadedAttachment: newAttachment
+          }
+        } catch {
+          const restoredAttachment = {
+            ...attachment,
+            isLoading: false
+          }
+          postExtensionRef.current = {
+            ...postExtensionRef.current,
+            attachments: postExtensionRef.current.attachments.map((item) =>
+              item.id === attachment.id ? restoredAttachment : item
+            )
+          }
+          dispatch(updateAttachment(attachment.id, restoredAttachment))
+          throw new Error(`Fail to upload ${attachment.name}`)
+        }
+      })
+    )
+
+    // Filter out attachments that were removed during upload
+    const currentAttachmentIds = new Set(
+      postExtensionRef.current.attachments.map((a) => a.id)
+    )
+    return uploadResults
+      .filter((a) => {
+        return (
+          currentAttachmentIds.has(a.originalId) ||
+          currentAttachmentIds.has(a.uploadedAttachment.id)
+        )
+      })
+      .map((a) => a.uploadedAttachment)
+  }
 
   const onPost = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault()
@@ -171,16 +325,45 @@ export const PostBox: FC<Props> = ({
       }
 
       if (editStatus) {
-        const updateMessage = message.trim().length > 0 ? message : undefined
+        const attachments = await uploadMediaAttachments()
+        const baselineText = getEditableStatusText(editStatus)
+        const baselineContentWarning = editStatus.summary ?? ''
+        const currentContentWarning = postExtension.contentWarningVisible
+          ? postExtension.contentWarning
+          : ''
+        const attachmentsChanged = !areAttachmentIdsEqual(
+          attachments,
+          getEditableStatusAttachments(editStatus)
+        )
+        const updateMessage = message !== baselineText ? message : undefined
+        const updateContentWarning =
+          currentContentWarning !== baselineContentWarning
+            ? currentContentWarning
+            : undefined
+
         await updateNote({
           statusId: urlToId(editStatus.id),
           message: updateMessage,
-          contentWarning
+          contentWarning: updateContentWarning,
+          attachments: attachmentsChanged ? attachments : undefined
         })
+        const updateTime = Date.now()
         onPostUpdated({
           ...editStatus,
           text: updateMessage ?? editStatus.text,
-          summary: contentWarning.trim() || null
+          summary:
+            updateContentWarning === undefined
+              ? editStatus.summary
+              : updateContentWarning.trim() || null,
+          attachments: attachmentsChanged
+            ? getStatusAttachmentsFromPostBoxAttachments({
+                actorId: editStatus.actorId,
+                attachments,
+                statusId: editStatus.id,
+                timestamp: updateTime
+              })
+            : editStatus.attachments,
+          updatedAt: updateTime
         })
         dispatch(resetExtension())
 
@@ -215,83 +398,7 @@ export const PostBox: FC<Props> = ({
         }
       }
 
-      const uploadResults = await Promise.all(
-        postExtension.attachments.map(async (attachment) => {
-          if (!attachment.file)
-            return {
-              originalId: attachment.id,
-              uploadedAttachment: attachment
-            }
-
-          dispatch(
-            updateAttachment(attachment.id, {
-              ...attachment,
-              isLoading: true
-            })
-          )
-
-          try {
-            const uploaded = await uploadAttachment(attachment.file)
-            if (!uploaded) throw new Error()
-
-            // Revoke the blob URL after successful upload
-            if (attachment.url.startsWith('blob:')) {
-              URL.revokeObjectURL(attachment.url)
-            }
-
-            const newAttachment = {
-              ...attachment,
-              ...uploaded,
-              isLoading: false,
-              file: undefined
-            }
-            dispatch(updateAttachment(attachment.id, newAttachment))
-            return {
-              originalId: attachment.id,
-              uploadedAttachment: newAttachment
-            }
-          } catch {
-            dispatch(
-              updateAttachment(attachment.id, {
-                ...attachment,
-                isLoading: false
-              })
-            )
-            throw new Error(`Fail to upload ${attachment.name}`)
-          }
-        })
-      )
-
-      // Filter out attachments that were removed during upload
-      const currentAttachmentIds = new Set(
-        postExtensionRef.current.attachments.map((a) => a.id)
-      )
-      const attachments = uploadResults
-        .filter((a) =>
-          // It is possible that the attachment is not in the current list
-          // because it was removed during the upload process.
-          // However, the current list might have the new ID or the old ID.
-          // If the attachment is in the current list, it means it was not removed.
-          // If checking with only original ID, it might be removed by the user
-          // but the current list has the old ID.
-          // If checking with only new ID, it might be removed by the user
-          // but the current list has the new ID.
-          // Wait, the postExtensionRef.current update is async in react
-          // so it might still have the old ID or the new ID?
-          // The dispatch is async, but the ref update is in useEffect which is also async
-          // relative to this function execution?
-          // Actually, dispatch triggers re-render, leading to useEffect update ref.
-          // So inside this async function, the ref update might happen after await.
-          // So we should check if the original ID is in the list (meaning not removed yet / old state)
-          // OR if the new ID is in the list (meaning not removed / new state).
-          {
-            return (
-              currentAttachmentIds.has(a.originalId) ||
-              currentAttachmentIds.has(a.uploadedAttachment.id)
-            )
-          }
-        )
-        .map((a) => a.uploadedAttachment)
+      const attachments = await uploadMediaAttachments()
 
       const response = await createNote({
         message,
@@ -325,12 +432,19 @@ export const PostBox: FC<Props> = ({
     if (attachment.url.startsWith('blob:')) {
       URL.revokeObjectURL(attachment.url)
     }
-    dispatch(
-      setAttachments([
-        ...postExtension.attachments.slice(0, attachmentIndex),
-        ...postExtension.attachments.slice(attachmentIndex + 1)
-      ])
-    )
+    const nextAttachments = [
+      ...postExtension.attachments.slice(0, attachmentIndex),
+      ...postExtension.attachments.slice(attachmentIndex + 1)
+    ]
+    const nextExtension = {
+      ...postExtensionRef.current,
+      attachments: nextAttachments
+    }
+    postExtensionRef.current = nextExtension
+    dispatch(setAttachments(nextAttachments))
+    if (editStatus) {
+      setAllowPost(isEditDirty(textRef.current, nextExtension))
+    }
   }
 
   const onRemoveFitnessFile = useCallback(async () => {
@@ -400,15 +514,15 @@ export const PostBox: FC<Props> = ({
     setText(value)
     textRef.current = value
     if (value.trim().length === 0) {
-      setAllowPost(Boolean(postExtensionRef.current.fitnessFile))
+      setAllowPost(
+        editStatus
+          ? isEditDirty(value)
+          : Boolean(postExtensionRef.current.fitnessFile)
+      )
       return
     }
-    if (
-      editStatus &&
-      value === sanitizeHtml(editStatus.text, { allowedTags: [] }) &&
-      postExtensionRef.current.contentWarning === (editStatus.summary ?? '')
-    ) {
-      setAllowPost(false)
+    if (editStatus) {
+      setAllowPost(isEditDirty(value))
       return
     }
     setAllowPost(true)
@@ -418,10 +532,14 @@ export const PostBox: FC<Props> = ({
     dispatch(setContentWarning(value))
     if (!editStatus) return
 
-    setAllowPost(
-      value !== (editStatus.summary ?? '') ||
-        textRef.current !== sanitizeHtml(editStatus.text, { allowedTags: [] })
-    )
+    const nextExtension = {
+      ...postExtensionRef.current,
+      contentWarning: value,
+      contentWarningVisible:
+        postExtensionRef.current.contentWarningVisible || value.length > 0
+    }
+    postExtensionRef.current = nextExtension
+    setAllowPost(isEditDirty(textRef.current, nextExtension))
   }
 
   const onToggleContentWarning = () => {
@@ -429,11 +547,12 @@ export const PostBox: FC<Props> = ({
     dispatch(setContentWarningVisibility(nextVisible))
     if (!editStatus) return
 
-    const nextContentWarning = nextVisible ? postExtension.contentWarning : ''
-    setAllowPost(
-      nextContentWarning !== (editStatus.summary ?? '') ||
-        textRef.current !== sanitizeHtml(editStatus.text, { allowedTags: [] })
-    )
+    const nextExtension = {
+      ...postExtensionRef.current,
+      contentWarningVisible: nextVisible
+    }
+    postExtensionRef.current = nextExtension
+    setAllowPost(isEditDirty(textRef.current, nextExtension))
   }
 
   /**
@@ -493,18 +612,27 @@ export const PostBox: FC<Props> = ({
 
   useEffect(() => {
     if (editStatus) {
-      setText(editStatus.text)
+      const editText = getEditableStatusText(editStatus)
+      const attachments = getEditableStatusAttachments(editStatus)
+      const nextExtension = {
+        ...DEFAULT_STATE,
+        attachments,
+        contentWarning: editStatus.summary ?? '',
+        contentWarningVisible: Boolean(editStatus.summary)
+      }
+      postExtensionRef.current = nextExtension
+      textRef.current = editText
+      setText(editText)
+      dispatch(setAttachments(attachments))
       dispatch(setContentWarning(editStatus.summary ?? ''))
       dispatch(setContentWarningVisibility(Boolean(editStatus.summary)))
-      setAllowPost(false) // Initial state for edit is disabled until changed? Or should we check?
-      // Original logic in onTextChange checked if text === editStatus.text.
-      // So if we set text to editStatus.text, allowPost should be false.
-      // But we need to update allowPost.
+      setAllowPost(false)
       return
     } else {
       setText('')
-      dispatch(setContentWarning(''))
-      dispatch(setContentWarningVisibility(false))
+      textRef.current = ''
+      postExtensionRef.current = DEFAULT_STATE
+      dispatch(resetExtension())
       setAllowPost(false)
     }
 
@@ -681,7 +809,22 @@ export const PostBox: FC<Props> = ({
               isMediaUploadEnabled={isMediaUploadEnabled}
               attachments={postExtension.attachments}
               onAddAttachment={(attachment) => {
+                const nextExtension = {
+                  ...postExtensionRef.current,
+                  attachments: [
+                    ...postExtensionRef.current.attachments,
+                    attachment
+                  ],
+                  fitnessFile: undefined,
+                  poll: {
+                    ...DEFAULT_STATE.poll
+                  }
+                }
+                postExtensionRef.current = nextExtension
                 dispatch(addAttachment(attachment))
+                if (editStatus) {
+                  setAllowPost(isEditDirty(textRef.current, nextExtension))
+                }
               }}
               onDuplicateError={() =>
                 setWarningMsg('Some files are already selected')
@@ -740,7 +883,9 @@ export const PostBox: FC<Props> = ({
         <div className="grid gap-4 grid-cols-8">
           {postExtension.attachments.map((item, index) => {
             return (
-              <div
+              <button
+                type="button"
+                aria-label={`Remove media ${item.name ?? index + 1}`}
                 className="w-full aspect-square bg-border bg-center bg-cover cursor-pointer relative"
                 key={item.id}
                 style={{
@@ -753,7 +898,7 @@ export const PostBox: FC<Props> = ({
                     <Loader2 className="animate-spin text-primary" />
                   </div>
                 ) : null}
-              </div>
+              </button>
             )
           })}
         </div>

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -12,7 +12,6 @@ import {
 import ReactMarkdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
 import remarkBreaks from 'remark-breaks'
-import sanitizeHtml from 'sanitize-html'
 
 import {
   createNote,
@@ -35,7 +34,11 @@ import {
   getMention,
   getMentionFromActorID
 } from '@/lib/types/domain/actor'
-import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
+import {
+  Attachment,
+  PostBoxAttachment,
+  isFitnessAttachment
+} from '@/lib/types/domain/attachment'
 import {
   EditableStatus,
   Status,
@@ -84,21 +87,27 @@ interface Props {
   onDiscardEdit: () => void
 }
 
-const getEditableStatusText = (status: EditableStatus) =>
-  sanitizeHtml(status.text, { allowedTags: [] })
+const getEditableStatusText = (status: EditableStatus) => status.text
 
 const getEditableStatusAttachments = (
   status: EditableStatus
 ): PostBoxAttachment[] =>
-  status.attachments.map((attachment) => ({
-    type: 'upload',
-    id: attachment.mediaId ?? attachment.id,
-    mediaType: attachment.mediaType,
-    url: attachment.url,
-    width: attachment.width ?? 0,
-    height: attachment.height ?? 0,
-    name: attachment.name
-  }))
+  status.attachments.flatMap((attachment) => {
+    const mediaId = attachment.mediaId
+    if (!mediaId || isFitnessAttachment(attachment)) return []
+
+    return [
+      {
+        type: 'upload',
+        id: mediaId,
+        mediaType: attachment.mediaType,
+        url: attachment.url,
+        width: attachment.width ?? 0,
+        height: attachment.height ?? 0,
+        name: attachment.name
+      }
+    ]
+  })
 
 const getAttachmentIds = (attachments: Pick<PostBoxAttachment, 'id'>[]) =>
   attachments.map((attachment) => attachment.id)
@@ -155,12 +164,12 @@ const getMediaTypeFromMastodonAttachment = (
 ) => {
   switch (attachment.type) {
     case 'image':
-      return 'image/*'
+      return 'image/jpeg'
     case 'gifv':
     case 'video':
-      return 'video/*'
+      return 'video/mp4'
     case 'audio':
-      return 'audio/*'
+      return 'audio/mpeg'
     default:
       return 'application/octet-stream'
   }

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -122,6 +122,14 @@ const areAttachmentIdsEqualInOrder = (
   return currentIds.every((id, index) => id === baselineIds[index])
 }
 
+const hasNewPostContent = (
+  value: string,
+  extension: { attachments: PostBoxAttachment[]; fitnessFile?: unknown }
+) =>
+  value.trim().length > 0 ||
+  extension.attachments.length > 0 ||
+  Boolean(extension.fitnessFile)
+
 type UpdateNoteResponse = Awaited<ReturnType<typeof updateNote>>
 type UpdateNoteMediaAttachment = UpdateNoteResponse['mediaAttachments'][number]
 
@@ -435,12 +443,22 @@ export const PostBox: FC<Props> = ({
           currentContentWarning !== baselineContentWarning
             ? currentContentWarning
             : undefined
+        const updateAttachments = attachmentsChanged ? attachments : undefined
+
+        if (
+          updateMessage === undefined &&
+          updateContentWarning === undefined &&
+          updateAttachments === undefined
+        ) {
+          setIsPosting(false)
+          return
+        }
 
         const updateResponse = await updateNote({
           statusId: editStatus.id,
           message: updateMessage,
           contentWarning: updateContentWarning,
-          attachments: attachmentsChanged ? attachments : undefined
+          attachments: updateAttachments
         })
         const responseStatus = updateResponse.status
         const responseCreatedAt = getTimestamp(
@@ -549,7 +567,9 @@ export const PostBox: FC<Props> = ({
     dispatch(setAttachments(nextAttachments))
     if (editStatus) {
       setAllowPost(isEditDirty(textRef.current, nextExtension))
+      return
     }
+    setAllowPost(hasNewPostContent(textRef.current, nextExtension))
   }
 
   const onRemoveFitnessFile = useCallback(async () => {
@@ -560,11 +580,12 @@ export const PostBox: FC<Props> = ({
 
     const clearFitnessFile = () => {
       dispatch(removeFitnessFile())
-      postExtensionRef.current = {
+      const nextExtension = {
         ...postExtensionRef.current,
         fitnessFile: undefined
       }
-      setAllowPost(textRef.current.trim().length > 0)
+      postExtensionRef.current = nextExtension
+      setAllowPost(hasNewPostContent(textRef.current, nextExtension))
     }
 
     if (!fitnessFile.uploadedId) {
@@ -622,7 +643,7 @@ export const PostBox: FC<Props> = ({
       setAllowPost(
         editStatus
           ? isEditDirty(value)
-          : Boolean(postExtensionRef.current.fitnessFile)
+          : hasNewPostContent(value, postExtensionRef.current)
       )
       return
     }
@@ -929,7 +950,9 @@ export const PostBox: FC<Props> = ({
                 dispatch(addAttachment(attachment))
                 if (editStatus) {
                   setAllowPost(isEditDirty(textRef.current, nextExtension))
+                  return
                 }
+                setAllowPost(hasNewPostContent(textRef.current, nextExtension))
               }}
               onDuplicateError={() =>
                 setWarningMsg('Some files are already selected')

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -286,6 +286,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
           ...item,
           width: item.width ?? undefined,
           height: item.height ?? undefined,
+          mediaId:
+            item.mediaId === null || item.mediaId === undefined
+              ? null
+              : String(item.mediaId),
           createdAt: getCompatibleTime(item.createdAt),
           updatedAt: getCompatibleTime(item.updatedAt)
         })
@@ -323,6 +327,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
           ...item,
           width: item.width ?? undefined,
           height: item.height ?? undefined,
+          mediaId:
+            item.mediaId === null || item.mediaId === undefined
+              ? null
+              : String(item.mediaId),
           createdAt: getCompatibleTime(item.createdAt),
           updatedAt: getCompatibleTime(item.updatedAt)
         })
@@ -362,6 +370,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
           ...item,
           width: item.width ?? undefined,
           height: item.height ?? undefined,
+          mediaId:
+            item.mediaId === null || item.mediaId === undefined
+              ? null
+              : String(item.mediaId),
           createdAt: getCompatibleTime(item.createdAt),
           updatedAt: getCompatibleTime(item.updatedAt)
         })

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -935,6 +935,71 @@ describe('StatusDatabase', () => {
           createdAt: expect.toBeNumber()
         })
       })
+
+      it('replaces note media attachments without changing note text', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-media`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: [],
+          text: 'Original note with media'
+        })
+        await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://example.com/old.jpg',
+          width: 320,
+          height: 240,
+          name: 'old.jpg',
+          mediaId: 'old-media'
+        })
+
+        const updated = await database.updateNote({
+          statusId,
+          text: 'Original note with media',
+          summary: null,
+          attachments: [
+            {
+              type: 'upload',
+              id: 'new-media',
+              mediaType: 'image/png',
+              url: 'https://example.com/new.png',
+              width: 640,
+              height: 480,
+              name: 'new.png'
+            }
+          ]
+        })
+
+        expect(updated).toMatchObject({
+          id: statusId,
+          text: 'Original note with media',
+          attachments: [
+            expect.objectContaining({
+              mediaType: 'image/png',
+              url: 'https://example.com/new.png',
+              name: 'new.png'
+            })
+          ]
+        })
+
+        const attachments = await database.getAttachmentsWithMedia({
+          statusId
+        })
+        expect(attachments).toHaveLength(1)
+        expect(attachments[0]).toMatchObject({
+          mediaId: 'new-media',
+          url: 'https://example.com/new.png'
+        })
+
+        const fetched = (await database.getStatus({
+          statusId
+        })) as StatusNote
+        expect(fetched.edits).toHaveLength(1)
+      })
     })
 
     describe('updateNoteVisibility', () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1000,6 +1000,214 @@ describe('StatusDatabase', () => {
         })) as StatusNote
         expect(fetched.edits).toHaveLength(1)
       })
+
+      it('preserves legacy attachments without media ids when replacing media', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-preserve-legacy`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: [],
+          text: 'Original note with legacy media'
+        })
+        await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://example.com/old.jpg',
+          width: 320,
+          height: 240,
+          name: 'old.jpg',
+          mediaId: 'old-media'
+        })
+        const legacyAttachment = await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://remote.example/legacy.jpg',
+          width: 480,
+          height: 360,
+          name: 'legacy.jpg'
+        })
+
+        const updated = await database.updateNote({
+          statusId,
+          text: 'Original note with legacy media',
+          summary: null,
+          attachments: [
+            {
+              type: 'upload',
+              id: 'new-media',
+              mediaType: 'image/png',
+              url: 'https://example.com/new.png',
+              width: 640,
+              height: 480,
+              name: 'new.png'
+            }
+          ]
+        })
+
+        expect(updated?.attachments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: legacyAttachment.id,
+              mediaId: null,
+              url: 'https://remote.example/legacy.jpg',
+              createdAt: legacyAttachment.createdAt
+            }),
+            expect.objectContaining({
+              mediaId: 'new-media',
+              url: 'https://example.com/new.png'
+            })
+          ])
+        )
+
+        const attachments = await database.getAttachments({ statusId })
+        expect(attachments).toHaveLength(2)
+        expect(attachments).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              mediaId: 'old-media'
+            })
+          ])
+        )
+      })
+
+      it('clears only editable media while preserving legacy and fitness attachments', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-clear-editable-media`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: [],
+          text: 'Original note with mixed attachments'
+        })
+        await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://example.com/old.jpg',
+          width: 320,
+          height: 240,
+          name: 'old.jpg',
+          mediaId: 'old-media'
+        })
+        const legacyAttachment = await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://remote.example/legacy.jpg',
+          width: 480,
+          height: 360,
+          name: 'legacy.jpg'
+        })
+        const fitnessAttachment = await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'application/gpx+xml',
+          url: 'https://example.com/api/v1/fitness-files/activity',
+          name: 'activity.gpx',
+          mediaId: 'fitness-media'
+        })
+
+        const updated = await database.updateNote({
+          statusId,
+          text: 'Original note with mixed attachments',
+          summary: null,
+          attachments: []
+        })
+
+        expect(updated?.attachments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: legacyAttachment.id,
+              mediaId: null
+            }),
+            expect.objectContaining({
+              id: fitnessAttachment.id,
+              mediaId: 'fitness-media'
+            })
+          ])
+        )
+
+        const attachments = await database.getAttachments({ statusId })
+        expect(attachments).toHaveLength(2)
+        expect(attachments).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              mediaId: 'old-media'
+            })
+          ])
+        )
+      })
+
+      it('preserves existing editable attachment rows when their media id remains', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-keep-existing-media`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: [],
+          text: 'Original note with existing media'
+        })
+        const existingAttachment = await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://example.com/existing.jpg',
+          width: 320,
+          height: 240,
+          name: 'existing.jpg',
+          mediaId: 'existing-media',
+          createdAt: new Date('2026-04-26T10:00:00.000Z').getTime()
+        })
+
+        await database.updateNote({
+          statusId,
+          text: 'Original note with existing media',
+          summary: null,
+          attachments: [
+            {
+              type: 'upload',
+              id: 'existing-media',
+              mediaType: 'image/jpeg',
+              url: 'https://example.com/existing.jpg',
+              width: 320,
+              height: 240,
+              name: 'existing.jpg'
+            },
+            {
+              type: 'upload',
+              id: 'new-media',
+              mediaType: 'image/png',
+              url: 'https://example.com/new.png',
+              width: 640,
+              height: 480,
+              name: 'new.png'
+            }
+          ]
+        })
+
+        const attachments = await database.getAttachments({ statusId })
+        expect(attachments).toHaveLength(2)
+        expect(
+          attachments.find(
+            (attachment) => attachment.mediaId === 'existing-media'
+          )
+        ).toMatchObject({
+          id: existingAttachment.id,
+          createdAt: existingAttachment.createdAt,
+          updatedAt: existingAttachment.updatedAt
+        })
+        expect(
+          attachments.find((attachment) => attachment.mediaId === 'new-media')
+        ).toMatchObject({
+          url: 'https://example.com/new.png'
+        })
+      })
     })
 
     describe('updateNoteVisibility', () => {

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -552,7 +552,6 @@ export const StatusSQLDatabaseMixin = (
 
             return trx('attachments').insert({
               ...data,
-              mediaId: attachment.id,
               createdAt: attachmentCreatedAt,
               updatedAt: attachmentCreatedAt
             })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -70,6 +70,13 @@ const PUBLIC_ACTIVITY_RECIPIENTS = [
   ACTIVITY_STREAM_PUBLIC_COMPACT
 ]
 
+const isReplaceableMediaAttachment = (
+  attachment: Attachment
+): attachment is Attachment & { mediaId: string } =>
+  !isFitnessAttachment(attachment) &&
+  attachment.mediaId !== null &&
+  attachment.mediaId !== undefined
+
 const isUniqueConstraintError = (error: unknown) => {
   const { code, errno, message } = error as {
     code?: string
@@ -522,18 +529,36 @@ export const StatusSQLDatabaseMixin = (
         })
 
       if (attachments !== undefined) {
+        const incomingMediaIds = new Set(
+          attachments.map((attachment) => attachment.id)
+        )
+        const existingReplaceableAttachments = status.attachments.filter(
+          isReplaceableMediaAttachment
+        )
         const replaceableAttachmentIds = status.attachments
-          .filter((attachment) => !isFitnessAttachment(attachment))
+          .filter(
+            (attachment) =>
+              isReplaceableMediaAttachment(attachment) &&
+              !incomingMediaIds.has(attachment.mediaId)
+          )
           .map((attachment) => attachment.id)
         if (replaceableAttachmentIds.length > 0) {
           await trx('attachments')
             .where('statusId', status.id)
+            .where('actorId', status.actorId)
             .whereIn('id', replaceableAttachmentIds)
             .delete()
         }
 
+        const existingMediaIds = new Set(
+          existingReplaceableAttachments.map((attachment) => attachment.mediaId)
+        )
+        const newAttachments = attachments.filter(
+          (attachment) => !existingMediaIds.has(attachment.id)
+        )
+
         await Promise.all(
-          attachments.map((attachment, index) => {
+          newAttachments.map((attachment, index) => {
             const attachmentCreatedAt = new Date(currentTime.getTime() + index)
             const data = Attachment.parse({
               id: crypto.randomUUID(),

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -44,6 +44,7 @@ import {
   UpdatePollParams
 } from '@/lib/types/database/operations'
 import { Actor, getActorProfile } from '@/lib/types/domain/actor'
+import { Attachment, isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
 import {
@@ -487,7 +488,8 @@ export const StatusSQLDatabaseMixin = (
   async function updateNote({
     statusId,
     text,
-    summary
+    summary,
+    attachments
   }: UpdateNoteParams): Promise<Status | null> {
     const status = await getStatus({ statusId })
     if (!status) return null
@@ -518,6 +520,45 @@ export const StatusSQLDatabaseMixin = (
           }),
           updatedAt: currentTime
         })
+
+      if (attachments !== undefined) {
+        const replaceableAttachmentIds = status.attachments
+          .filter((attachment) => !isFitnessAttachment(attachment))
+          .map((attachment) => attachment.id)
+        if (replaceableAttachmentIds.length > 0) {
+          await trx('attachments')
+            .where('statusId', status.id)
+            .whereIn('id', replaceableAttachmentIds)
+            .delete()
+        }
+
+        await Promise.all(
+          attachments.map((attachment, index) => {
+            const attachmentCreatedAt = new Date(currentTime.getTime() + index)
+            const data = Attachment.parse({
+              id: crypto.randomUUID(),
+              actorId: status.actorId,
+              statusId: status.id,
+              type: 'Document',
+              mediaType: attachment.mediaType,
+              url: attachment.url,
+              width: attachment.width,
+              height: attachment.height,
+              name: attachment.name ?? '',
+              mediaId: attachment.id,
+              createdAt: attachmentCreatedAt.getTime(),
+              updatedAt: attachmentCreatedAt.getTime()
+            })
+
+            return trx('attachments').insert({
+              ...data,
+              mediaId: attachment.id,
+              createdAt: attachmentCreatedAt,
+              updatedAt: attachmentCreatedAt
+            })
+          })
+        )
+      }
     })
     return getStatus({ statusId })
   }

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -173,6 +173,28 @@ describe('knexAdapter', () => {
       expect(result.expireAt).toBeInstanceOf(Date)
       expect(result.expireAt.getTime()).toBe(expireAt)
     })
+
+    it('leaves invalid date-like fields unchanged while hydrating valid fields', async () => {
+      const expireAt = new Date('2026-05-17T10:00:00.000Z').getTime()
+      await db('sessions').insert({
+        id: 's-invalid-date',
+        user_id: 'u1',
+        token: 'token-invalid-date',
+        createdAt: 'not-a-date',
+        expireAt
+      })
+
+      const result = await adapter.findOne({
+        model: 'sessions',
+        where: [
+          { field: 'id', value: 's-invalid-date', operator: 'eq' as const }
+        ]
+      })
+
+      expect(result.createdAt).toBe('not-a-date')
+      expect(result.expireAt).toBeInstanceOf(Date)
+      expect(result.expireAt.getTime()).toBe(expireAt)
+    })
   })
 
   describe('findMany', () => {

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -52,6 +52,8 @@ describe('knexAdapter', () => {
       table.text('user_id').references('id').inTable('users')
       table.text('token').unique()
       table.timestamp('expires_at')
+      table.timestamp('createdAt')
+      table.timestamp('expireAt')
     })
 
     // The mock createAdapterFactory above uses identity getModelName/getFieldName.
@@ -148,6 +150,28 @@ describe('knexAdapter', () => {
 
       expect(result).toHaveProperty('email', 'alice@test.com')
       expect(result).not.toHaveProperty('display_name')
+    })
+
+    it('hydrates date-like fields from SQLite timestamps', async () => {
+      const createdAt = new Date('2026-05-16T10:00:00.000Z').getTime()
+      const expireAt = new Date('2026-05-17T10:00:00.000Z').getTime()
+      await db('sessions').insert({
+        id: 's1',
+        user_id: 'u1',
+        token: 'token-1',
+        createdAt,
+        expireAt
+      })
+
+      const result = await adapter.findOne({
+        model: 'sessions',
+        where: [{ field: 'id', value: 's1', operator: 'eq' as const }]
+      })
+
+      expect(result.createdAt).toBeInstanceOf(Date)
+      expect(result.createdAt.getTime()).toBe(createdAt)
+      expect(result.expireAt).toBeInstanceOf(Date)
+      expect(result.expireAt.getTime()).toBe(expireAt)
     })
   })
 

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -22,7 +22,10 @@ const hydrateDateFields = <T>(row: T): T => {
       continue
     }
 
-    hydrated[key] = new Date(value as string | number)
+    const date = new Date(value as string | number)
+    if (Number.isNaN(date.getTime())) continue
+
+    hydrated[key] = date
   }
 
   return hydrated as T

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -10,6 +10,24 @@ const supportsNativeBooleans = (db: Knex): boolean => {
   return clientName !== 'better-sqlite3' && clientName !== 'sqlite3'
 }
 
+const hydrateDateFields = <T>(row: T): T => {
+  if (!row || typeof row !== 'object' || row instanceof Date) {
+    return row
+  }
+
+  const hydrated = { ...(row as Record<string, unknown>) }
+  for (const [key, value] of Object.entries(hydrated)) {
+    if (!key.endsWith('At')) continue
+    if (value === null || value === undefined || value instanceof Date) {
+      continue
+    }
+
+    hydrated[key] = new Date(value as string | number)
+  }
+
+  return hydrated as T
+}
+
 const applyWhere = (
   query: Knex.QueryBuilder,
   model: string,
@@ -106,7 +124,7 @@ export const knexAdapter = (db: Knex) =>
           const id = record.id as string
           const row = await db(tableName).where(`${tableName}.id`, id).first()
           if (!row) throw new Error('Failed to create record')
-          return row as any
+          return hydrateDateFields(row) as any
         },
 
         async findOne({ model, where, select }) {
@@ -122,7 +140,7 @@ export const knexAdapter = (db: Knex) =>
             query = applyWhere(query, tableName, where)
           }
           const row = await query
-          return (row ?? null) as any
+          return row ? (hydrateDateFields(row) as any) : null
         },
 
         async findMany({ model, where, limit, sortBy, offset, select }) {
@@ -144,7 +162,7 @@ export const knexAdapter = (db: Knex) =>
           if (limit !== undefined) query = query.limit(limit)
           if (offset !== undefined) query = query.offset(offset)
           const rows = await query
-          return rows as any
+          return rows.map(hydrateDateFields) as any
         },
 
         async count({ model, where }) {
@@ -164,13 +182,13 @@ export const knexAdapter = (db: Knex) =>
             idQuery = applyWhere(idQuery, tableName, where)
           }
           const existing = await idQuery
-          if (!existing) return null as any
+          if (!existing) return null
           const id = existing.id
           await db(tableName)
             .where(`${tableName}.id`, id)
             .update(updateData as Record<string, unknown>)
           const row = await db(tableName).where(`${tableName}.id`, id).first()
-          return (row ?? null) as any
+          return row ? (hydrateDateFields(row) as any) : null
         },
 
         async updateMany({ model, where, update: updateData }) {

--- a/lib/services/statuses/mediaIds.ts
+++ b/lib/services/statuses/mediaIds.ts
@@ -1,0 +1,51 @@
+import { getBaseURL } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { Actor } from '@/lib/types/domain/actor'
+import { PostBoxAttachment } from '@/lib/types/domain/attachment'
+
+const getMediaUrl = (path: string) => `${getBaseURL()}/api/v1/files/${path}`
+
+export const getAttachmentsFromMediaIds = async (
+  database: Database,
+  currentActor: Actor,
+  mediaIds: string[]
+): Promise<PostBoxAttachment[] | null> => {
+  if (mediaIds.length === 0) return []
+
+  const accountId = currentActor.account?.id
+  if (!accountId) return null
+
+  const medias = await Promise.all(
+    mediaIds.map((mediaId) =>
+      database.getMediaByIdForAccount({
+        mediaId,
+        accountId
+      })
+    )
+  )
+
+  const attachments: PostBoxAttachment[] = []
+  for (const media of medias) {
+    if (!media) return null
+    if (media.original.metaData.upload?.state === 'pending') {
+      return null
+    }
+
+    attachments.push({
+      type: 'upload',
+      id: media.id,
+      mediaType: media.original.mimeType,
+      url: getMediaUrl(media.original.path),
+      width: media.original.metaData.width,
+      height: media.original.metaData.height,
+      ...(media.thumbnail
+        ? { posterUrl: getMediaUrl(media.thumbnail.path) }
+        : {}),
+      ...(media.description || media.original.fileName
+        ? { name: media.description || media.original.fileName }
+        : {})
+    })
+  }
+
+  return attachments
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -6,7 +6,7 @@ import { Timeline } from '@/lib/services/timelines/types'
 import { ActorSettings, PostLineLimit } from '@/lib/types/database/rows'
 import { Account } from '@/lib/types/domain/account'
 import { Actor, ActorType } from '@/lib/types/domain/actor'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { Block } from '@/lib/types/domain/block'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 import { Session } from '@/lib/types/domain/session'
@@ -363,7 +363,9 @@ type BaseStatusParams = {
 }
 
 export type UpdateNoteParams = Pick<CreateNoteParams, 'text' | 'summary'> &
-  BaseStatusParams
+  BaseStatusParams & {
+    attachments?: PostBoxAttachment[]
+  }
 
 export type UpdateNoteVisibilityParams = BaseStatusParams & {
   to: string[]

--- a/lib/types/domain/attachment.ts
+++ b/lib/types/domain/attachment.ts
@@ -44,6 +44,7 @@ export const Attachment = z.object({
   width: z.number().optional(),
   height: z.number().optional(),
   name: z.string(),
+  mediaId: z.string().nullable().optional(),
 
   createdAt: z.number(),
   updatedAt: z.number()

--- a/lib/utils/urlToId.test.ts
+++ b/lib/utils/urlToId.test.ts
@@ -44,6 +44,12 @@ describe('#urlToId', () => {
 
     expect(idToUrl(urlToId(actorId))).toEqual(actorId)
   })
+
+  it('round trips URLs with ports', () => {
+    const statusId = 'http://localhost:3001/users/test1/statuses/post-1'
+
+    expect(idToUrl(urlToId(statusId))).toEqual(statusId)
+  })
 })
 
 describe('#idToUrl', () => {

--- a/lib/utils/urlToId.test.ts
+++ b/lib/utils/urlToId.test.ts
@@ -50,6 +50,26 @@ describe('#urlToId', () => {
 
     expect(idToUrl(urlToId(statusId))).toEqual(statusId)
   })
+
+  it('uses Buffer base64url support in Node before browser fallbacks', () => {
+    const originalBtoa = globalThis.btoa
+    const originalAtob = globalThis.atob
+    const actorId = 'https://bsky.brid.gy/ap/did:plc:abc123/statuses/post-1'
+
+    globalThis.btoa = jest.fn(() => {
+      throw new Error('btoa should not be used when Buffer is available')
+    })
+    globalThis.atob = jest.fn(() => {
+      throw new Error('atob should not be used when Buffer is available')
+    })
+
+    try {
+      expect(idToUrl(urlToId(actorId))).toEqual(actorId)
+    } finally {
+      globalThis.btoa = originalBtoa
+      globalThis.atob = originalAtob
+    }
+  })
 })
 
 describe('#idToUrl', () => {

--- a/lib/utils/urlToId.ts
+++ b/lib/utils/urlToId.ts
@@ -10,6 +10,10 @@ const fromBase64Url = (value: string) =>
     .replaceAll('_', '/')
 
 const encodeBase64Url = (value: string) => {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value, 'utf8').toString('base64url')
+  }
+
   if (typeof btoa === 'function' && typeof TextEncoder !== 'undefined') {
     const bytes = new TextEncoder().encode(value)
     const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join(
@@ -18,15 +22,19 @@ const encodeBase64Url = (value: string) => {
     return toBase64Url(btoa(binary))
   }
 
-  return toBase64Url(Buffer.from(value, 'utf8').toString('base64'))
+  throw new Error('Base64url encoding is not available')
 }
 
 const decodeBase64Url = (value: string) => {
-  const base64 = fromBase64Url(value)
-  if (typeof atob !== 'function' || typeof TextDecoder === 'undefined') {
-    return Buffer.from(base64, 'base64').toString('utf8')
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value, 'base64url').toString('utf8')
   }
 
+  if (typeof atob !== 'function' || typeof TextDecoder === 'undefined') {
+    throw new Error('Base64url decoding is not available')
+  }
+
+  const base64 = fromBase64Url(value)
   const binary = atob(base64)
   const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
   return new TextDecoder().decode(bytes)

--- a/lib/utils/urlToId.ts
+++ b/lib/utils/urlToId.ts
@@ -1,28 +1,33 @@
 const OPAQUE_URL_ID_PREFIX = 'apurl_'
 
+const toBase64Url = (value: string) =>
+  value.replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+
+const fromBase64Url = (value: string) =>
+  value
+    .padEnd(value.length + ((4 - (value.length % 4)) % 4), '=')
+    .replaceAll('-', '+')
+    .replaceAll('_', '/')
+
 const encodeBase64Url = (value: string) => {
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(value, 'utf8').toString('base64url')
+  if (typeof btoa === 'function' && typeof TextEncoder !== 'undefined') {
+    const bytes = new TextEncoder().encode(value)
+    const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join(
+      ''
+    )
+    return toBase64Url(btoa(binary))
   }
 
-  const bytes = new TextEncoder().encode(value)
-  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('')
-  return btoa(binary)
-    .replaceAll('+', '-')
-    .replaceAll('/', '_')
-    .replaceAll('=', '')
+  return toBase64Url(Buffer.from(value, 'utf8').toString('base64'))
 }
 
 const decodeBase64Url = (value: string) => {
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(value, 'base64url').toString('utf8')
+  const base64 = fromBase64Url(value)
+  if (typeof atob !== 'function' || typeof TextDecoder === 'undefined') {
+    return Buffer.from(base64, 'base64').toString('utf8')
   }
 
-  const paddedValue = value.padEnd(
-    value.length + ((4 - (value.length % 4)) % 4),
-    '='
-  )
-  const binary = atob(paddedValue.replaceAll('-', '+').replaceAll('_', '/'))
+  const binary = atob(base64)
   const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
   return new TextDecoder().decode(bytes)
 }
@@ -39,7 +44,7 @@ export const urlToId = (idInURLFormat: string) => {
 
     const url = new URL(urlString)
 
-    if (url.pathname.includes(':')) {
+    if (url.host.includes(':') || url.pathname.includes(':')) {
       return `${OPAQUE_URL_ID_PREFIX}${encodeBase64Url(url.toString())}`
     }
 


### PR DESCRIPTION
## Root cause

- Edit mode returned before the media upload path, so newly selected blobs were never uploaded before `updateNote`.
- `updateNote` and `PUT /api/v1/statuses/:id` only sent and accepted text/content warning fields, so media-only edits could not persist or federate.
- The edit dirty state only compared text and content warning, leaving the Update button disabled for attachment-only changes.

## Implementation

- Added optional `media_ids` support to status updates, preserving attachments when omitted and clearing them when `[]` is provided.
- Moved media ID validation/resolution into a shared helper used by both create and edit, preserving ownership checks, pending-upload rejection, dedupe, and max media limits.
- Extended the action and SQL database update path to replace non-fitness media attachments, record edit history, refresh timelines, and queue `SendUpdateNoteJob` for media-only edits.
- Initialized PostBox edit mode with existing media, compared attachment IDs for dirty state, uploaded new blob-backed media before submit, and updated timeline state immutably.
- Fixed local SQLite auth session date hydration and opaque URL IDs with localhost ports found during browser/dev verification.

## Browser/dev verification

- Verified Node/Yarn: `node v24.13.0`, `yarn 4.13.0`.
- Started an isolated dev server on port 3001 with SQLite and local filesystem media storage, migrated the database, and created `test1@example.com`.
- Used the Browser plugin against `http://localhost:3001`, signed in, created a post with image A, edited it without changing text, removed image A, added image B, and submitted successfully.
- Confirmed the Update button enabled for media-only changes, `/api/v2/media` uploaded image B, `PUT /api/v1/statuses/:id` returned `media_attachments` for image B, and refresh/reopen still showed image B with image A gone.

## Test results

- `yarn run prettier --write .`
- `yarn lint` passed with existing warning-only `any` reports.
- `yarn build` passed.
- `yarn test` passed: 298 suites, 2376 tests.

## Config/migrations

- No migrations or runtime configuration changes.
