### PR TITLE
Bump version to v1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.11.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.11.1`
- Base main SHA: `54c2c951fe3bb5be71c9611d9b52fa2170b95e5f`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
