### PR TITLE
Bump version to v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.13.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.12.0`
- Base main SHA: `c87ab45f600ad3841035d70e17e23678f9571ba2`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
