### PR TITLE
minor: implement reblogged_by status endpoint

### DIFF
--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -31,11 +31,13 @@ const RebloggedByQueryParams = z.object({
 const getPaginationLinkHeader = ({
   req,
   limit,
-  reblogs
+  reblogs,
+  hasNextPage
 }: {
   req: Request
   limit: number
   reblogs: RebloggedByAccount[]
+  hasNextPage: boolean
 }) => {
   if (reblogs.length === 0) return undefined
 
@@ -55,10 +57,9 @@ const getPaginationLinkHeader = ({
 
   const firstReblog = reblogs[0]
   const lastReblog = reblogs[reblogs.length - 1]
-  const nextLink =
-    reblogs.length >= limit
-      ? `<${buildUrl('max_id', lastReblog.statusId)}>; rel="next"`
-      : null
+  const nextLink = hasNextPage
+    ? `<${buildUrl('max_id', lastReblog.statusId)}>; rel="next"`
+    : null
   const prevLink = `<${buildUrl('since_id', firstReblog.statusId)}>; rel="prev"`
   return [nextLink, prevLink].filter(Boolean).join(', ')
 }
@@ -103,15 +104,22 @@ export const GET = traceApiRoute(
         responseStatusCode: 404
       })
 
-    const reblogs = await database.getRebloggedBy({
+    const reblogsPage = await database.getRebloggedBy({
       statusId,
-      limit,
+      limit: limit + 1,
       maxStatusId: maxId ? idToUrl(maxId) : undefined,
       sinceStatusId: sinceId ? idToUrl(sinceId) : undefined,
       visibleToActorId: currentActor?.id ?? null
     })
+    const hasNextPage = reblogsPage.length > limit
+    const reblogs = reblogsPage.slice(0, limit)
 
-    const paginationLink = getPaginationLinkHeader({ req, limit, reblogs })
+    const paginationLink = getPaginationLinkHeader({
+      req,
+      limit,
+      reblogs,
+      hasNextPage
+    })
 
     const accounts = await database.getMastodonActorsFromIds({
       ids: reblogs.map(({ actorId }) => actorId)

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -111,15 +111,9 @@ export const GET = traceApiRoute(
 
     const paginationLink = getPaginationLinkHeader({ req, limit, reblogs })
 
-    const accounts = (
-      await Promise.all(
-        reblogs.map(({ actorId }) =>
-          database.getMastodonActorFromId({ id: actorId })
-        )
-      )
-    ).filter((account): account is NonNullable<typeof account> =>
-      Boolean(account)
-    )
+    const accounts = await database.getMastodonActorsFromIds({
+      ids: reblogs.map(({ actorId }) => actorId)
+    })
 
     return apiResponse({
       req,

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -1,10 +1,17 @@
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { z } from 'zod'
+
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
-import { Scope } from '@/lib/types/database/operations'
+import { type RebloggedByAccount, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_404,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl } from '@/lib/utils/urlToId'
+import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
@@ -14,9 +21,45 @@ interface Params {
   id: string
 }
 
+const RebloggedByQueryParams = z.object({
+  limit: z.coerce.number().int().min(1).max(80).default(40),
+  max_id: z.string().min(1).optional(),
+  since_id: z.string().min(1).optional()
+})
+
+const getPaginationLinkHeader = ({
+  req,
+  limit,
+  reblogs
+}: {
+  req: Request
+  limit: number
+  reblogs: RebloggedByAccount[]
+}) => {
+  if (reblogs.length === 0) return undefined
+
+  const requestUrl = new URL(req.url)
+  const buildUrl = (cursor: 'max_id' | 'since_id', statusId: string) => {
+    const params = new URLSearchParams()
+    params.set('limit', `${limit}`)
+    params.set(cursor, urlToId(statusId))
+
+    const url = new URL(requestUrl.pathname, requestUrl.origin)
+    url.search = params.toString()
+    return url.toString()
+  }
+
+  const firstReblog = reblogs[0]
+  const lastReblog = reblogs[reblogs.length - 1]
+  return [
+    `<${buildUrl('max_id', lastReblog.statusId)}>; rel="next"`,
+    `<${buildUrl('since_id', firstReblog.statusId)}>; rel="prev"`
+  ].join(', ')
+}
+
 export const GET = traceApiRoute(
   'getStatusRebloggedBy',
-  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
+  OptionalOAuthGuard<Params>([Scope.enum.read], async (req, context) => {
     const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
@@ -27,6 +70,18 @@ export const GET = traceApiRoute(
         responseStatusCode: 404
       })
 
+    const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+    const parsedParams = RebloggedByQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const { limit, max_id: maxId, since_id: sinceId } = parsedParams.data
     const statusId = idToUrl(encodedStatusId)
     const status = await getReadableStatus({
       database,
@@ -42,10 +97,32 @@ export const GET = traceApiRoute(
         responseStatusCode: 404
       })
 
-    // getRebloggedBy not yet implemented - return empty array
-    // TODO: Implement database method to get actors who reblogged this status
+    const reblogs = await database.getRebloggedBy({
+      statusId,
+      limit,
+      maxStatusId: maxId ? idToUrl(maxId) : undefined,
+      sinceStatusId: sinceId ? idToUrl(sinceId) : undefined,
+      visibleToActorId: currentActor?.id ?? null
+    })
 
-    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
+    const paginationLink = getPaginationLinkHeader({ req, limit, reblogs })
+
+    const accounts = (
+      await Promise.all(
+        reblogs.map(({ actor }) =>
+          database.getMastodonActorFromId({ id: actor.id })
+        )
+      )
+    ).filter((account): account is NonNullable<typeof account> =>
+      Boolean(account)
+    )
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: accounts,
+      additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
+    })
   }),
   {
     addAttributes: async (_req, context) => {

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { type RebloggedByAccount, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
@@ -39,22 +40,25 @@ const getPaginationLinkHeader = ({
   if (reblogs.length === 0) return undefined
 
   const requestUrl = new URL(req.url)
+  const host = headerHost(req.headers)
   const buildUrl = (cursor: 'max_id' | 'since_id', statusId: string) => {
     const params = new URLSearchParams()
     params.set('limit', `${limit}`)
     params.set(cursor, urlToId(statusId))
 
-    const url = new URL(requestUrl.pathname, requestUrl.origin)
+    const url = new URL(requestUrl.pathname, `https://${host}`)
     url.search = params.toString()
     return url.toString()
   }
 
   const firstReblog = reblogs[0]
   const lastReblog = reblogs[reblogs.length - 1]
-  return [
-    `<${buildUrl('max_id', lastReblog.statusId)}>; rel="next"`,
-    `<${buildUrl('since_id', firstReblog.statusId)}>; rel="prev"`
-  ].join(', ')
+  const nextLink =
+    reblogs.length >= limit
+      ? `<${buildUrl('max_id', lastReblog.statusId)}>; rel="next"`
+      : null
+  const prevLink = `<${buildUrl('since_id', firstReblog.statusId)}>; rel="prev"`
+  return [nextLink, prevLink].filter(Boolean).join(', ')
 }
 
 export const GET = traceApiRoute(

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -109,8 +109,8 @@ export const GET = traceApiRoute(
 
     const accounts = (
       await Promise.all(
-        reblogs.map(({ actor }) =>
-          database.getMastodonActorFromId({ id: actor.id })
+        reblogs.map(({ actorId }) =>
+          database.getMastodonActorFromId({ id: actorId })
         )
       )
     ).filter((account): account is NonNullable<typeof account> =>

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -41,6 +41,8 @@ const getPaginationLinkHeader = ({
 
   const requestUrl = new URL(req.url)
   const host = headerHost(req.headers)
+  if (!host) return undefined
+
   const buildUrl = (cursor: 'max_id' | 'since_id', statusId: string) => {
     const params = new URLSearchParams()
     params.set('limit', `${limit}`)

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1655,7 +1655,9 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(nextPage.map((account) => account.id)).toEqual([
         urlToId(ACTOR2_ID)
       ])
-      expect(nextResponse.headers.get('Link')).toEqual(
+      const nextLinkHeader = nextResponse.headers.get('Link')
+      expect(nextLinkHeader).not.toEqual(expect.stringContaining('rel="next"'))
+      expect(nextLinkHeader).toEqual(
         expect.stringContaining(
           `since_id=${encodeURIComponent(urlToId(olderAnnounceId))}`
         )

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1,5 +1,7 @@
+import knex from 'knex'
 import { NextRequest } from 'next/server'
 
+import { getSQLDatabase } from '@/lib/database/sql'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getQueue } from '@/lib/services/queue'
@@ -1790,6 +1792,75 @@ describe('GET /api/v1/statuses/[id]', () => {
       ])
     })
 
+    it('includes public legacy boosts stored only in content for anonymous clients', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const knexDatabase = knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: {
+          filename: ':memory:'
+        }
+      })
+      const sqlDatabase = getSQLDatabase(knexDatabase)
+      const previousDatabase = mockDatabase
+
+      try {
+        await sqlDatabase.migrate()
+        await seedDatabase(sqlDatabase)
+        mockDatabase = sqlDatabase
+
+        const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-legacy-boost`
+        await sqlDatabase.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: ACTOR1_ID,
+          text: 'Public status with a legacy boost',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+
+        const legacyAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-legacy-boost`
+        const createdAt = new Date('2024-04-01T00:00:00.000Z')
+        await knexDatabase('statuses').insert({
+          id: legacyAnnounceId,
+          url: null,
+          urlHash: null,
+          actorId: ACTOR2_ID,
+          type: StatusType.enum.Announce,
+          reply: '',
+          content: statusId,
+          originalStatusId: null,
+          createdAt,
+          updatedAt: createdAt
+        })
+        await knexDatabase('recipients').insert({
+          id: crypto.randomUUID(),
+          statusId: legacyAnnounceId,
+          actorId: ACTIVITY_STREAM_PUBLIC,
+          type: 'to',
+          createdAt,
+          updatedAt: createdAt
+        })
+
+        const response = await getStatusRebloggedBy(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+          ),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+
+        expect(response.status).toBe(200)
+        const accounts = (await response.json()) as { id: string }[]
+        expect(accounts.map((account) => account.id)).toEqual([
+          urlToId(ACTOR2_ID)
+        ])
+      } finally {
+        mockDatabase = previousDatabase
+        await knexDatabase.destroy()
+      }
+    })
+
     it('exposes non-public boosts to authenticated actors they are addressed to', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-direct-boost`
       await database.createNote({
@@ -1961,6 +2032,71 @@ describe('GET /api/v1/statuses/[id]', () => {
       const linkHeader = response.headers.get('Link')
       expect(linkHeader).not.toEqual(expect.stringContaining('rel="next"'))
       expect(linkHeader).toEqual(expect.stringContaining('rel="prev"'))
+    })
+
+    it('omits pagination links when no trusted host is configured', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+      const { getConfig } = jest.requireMock('@/lib/config') as {
+        getConfig: jest.Mock
+      }
+      getConfig.mockReturnValue({
+        allowEmails: [],
+        host: '',
+        secretPhase: 'test-secret'
+      })
+
+      try {
+        const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-empty-host`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: ACTOR1_ID,
+          text: 'Public status with pagination and empty configured host',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+
+        const olderAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-empty-host-older`
+        const newerAnnounceId = `${ACTOR3_ID}/statuses/api-reblogged-by-empty-host-newer`
+        await database.createAnnounce({
+          id: olderAnnounceId,
+          actorId: ACTOR2_ID,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId: statusId,
+          createdAt: Date.parse('2024-05-01T00:00:00.000Z')
+        })
+        await database.createAnnounce({
+          id: newerAnnounceId,
+          actorId: ACTOR3_ID,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId: statusId,
+          createdAt: Date.parse('2024-05-02T00:00:00.000Z')
+        })
+
+        const response = await getStatusRebloggedBy(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(
+              statusId
+            )}/reblogged_by?limit=1`
+          ),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+
+        expect(response.status).toBe(200)
+        const accounts = (await response.json()) as { id: string }[]
+        expect(accounts.map((account) => account.id)).toEqual([
+          urlToId(ACTOR3_ID)
+        ])
+        expect(response.headers.get('Link')).toBeNull()
+      } finally {
+        getConfig.mockReturnValue({
+          allowEmails: [],
+          host: 'llun.test',
+          secretPhase: 'test-secret'
+        })
+      }
     })
   })
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1660,6 +1660,94 @@ describe('GET /api/v1/statuses/[id]', () => {
       )
     })
 
+    it('deduplicates boosting accounts before applying cursor pagination', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-duplicate-actors`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with duplicate actor reblogs',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const olderDuplicateAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-duplicate-older`
+      const middleAnnounceId = `${ACTOR3_ID}/statuses/api-reblogged-by-duplicate-middle`
+      const newerDuplicateAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-duplicate-newer`
+
+      await database.createAnnounce({
+        id: olderDuplicateAnnounceId,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-03-01T00:00:00.000Z')
+      })
+      await database.createAnnounce({
+        id: middleAnnounceId,
+        actorId: ACTOR3_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-03-02T00:00:00.000Z')
+      })
+      await database.createAnnounce({
+        id: newerDuplicateAnnounceId,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-03-03T00:00:00.000Z')
+      })
+
+      const fullResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(fullResponse.status).toBe(200)
+      const fullPage = (await fullResponse.json()) as { id: string }[]
+      expect(fullPage.map((account) => account.id)).toEqual([
+        urlToId(ACTOR2_ID),
+        urlToId(ACTOR3_ID)
+      ])
+
+      const firstResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=1`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(firstResponse.status).toBe(200)
+      expect(firstResponse.headers.get('Link')).toEqual(
+        expect.stringContaining(
+          `max_id=${encodeURIComponent(urlToId(newerDuplicateAnnounceId))}`
+        )
+      )
+
+      const nextResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=1&max_id=${urlToId(newerDuplicateAnnounceId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(nextResponse.status).toBe(200)
+      const nextPage = (await nextResponse.json()) as { id: string }[]
+      expect(nextPage.map((account) => account.id)).toEqual([
+        urlToId(ACTOR3_ID)
+      ])
+    })
+
     it('does not expose non-public boosts to anonymous clients', async () => {
       mockGetServerSession.mockResolvedValue(null)
 
@@ -1765,6 +1853,47 @@ describe('GET /api/v1/statuses/[id]', () => {
         )
 
         expect(response.status).toBe(400)
+      }
+    )
+
+    it.each(['max_id', 'since_id'] as const)(
+      'returns an empty page for an invalid %s cursor',
+      async (cursor) => {
+        mockGetServerSession.mockResolvedValue(null)
+
+        const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-invalid-${cursor}`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: ACTOR1_ID,
+          text: 'Public status with invalid cursor reblog',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+        await database.createAnnounce({
+          id: `${ACTOR2_ID}/statuses/api-reblogged-by-invalid-${cursor}`,
+          actorId: ACTOR2_ID,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId: statusId
+        })
+
+        const requestUrl = new URL(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+        )
+        requestUrl.searchParams.set(
+          cursor,
+          urlToId(`${ACTOR2_ID}/statuses/api-reblogged-by-missing-cursor`)
+        )
+
+        const response = await getStatusRebloggedBy(
+          new NextRequest(requestUrl.toString()),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+
+        expect(response.status).toBe(200)
+        await expect(response.json()).resolves.toEqual([])
+        expect(response.headers.get('Link')).toBeNull()
       }
     )
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1586,6 +1586,123 @@ describe('GET /api/v1/statuses/[id]', () => {
     })
   })
 
+  describe('reblogged_by', () => {
+    it('returns boosting accounts with Mastodon pagination for a public status without auth', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-test`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with reblogs',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const olderAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-older`
+      const newerAnnounceId = `${ACTOR3_ID}/statuses/api-reblogged-by-newer`
+      await database.createAnnounce({
+        id: olderAnnounceId,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-01-01T00:00:00.000Z')
+      })
+      await database.createAnnounce({
+        id: newerAnnounceId,
+        actorId: ACTOR3_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-01-02T00:00:00.000Z')
+      })
+
+      const firstResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=1`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(firstResponse.status).toBe(200)
+      const firstPage = (await firstResponse.json()) as { id: string }[]
+      expect(firstPage.map((account) => account.id)).toEqual([
+        urlToId(ACTOR3_ID)
+      ])
+      expect(firstResponse.headers.get('Link')).toEqual(
+        expect.stringContaining(
+          `max_id=${encodeURIComponent(urlToId(newerAnnounceId))}`
+        )
+      )
+
+      const nextResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=1&max_id=${urlToId(newerAnnounceId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(nextResponse.status).toBe(200)
+      const nextPage = (await nextResponse.json()) as { id: string }[]
+      expect(nextPage.map((account) => account.id)).toEqual([
+        urlToId(ACTOR2_ID)
+      ])
+      expect(nextResponse.headers.get('Link')).toEqual(
+        expect.stringContaining(
+          `since_id=${encodeURIComponent(urlToId(olderAnnounceId))}`
+        )
+      )
+    })
+
+    it('does not expose non-public boosts to anonymous clients', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-private-boost`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with a private boost',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      await database.createAnnounce({
+        id: `${ACTOR2_ID}/statuses/api-reblogged-by-public-boost`,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId
+      })
+      await database.createAnnounce({
+        id: `${ACTOR3_ID}/statuses/api-reblogged-by-hidden-boost`,
+        actorId: ACTOR3_ID,
+        to: [`${ACTOR3_ID}/followers`],
+        cc: [],
+        originalStatusId: statusId
+      })
+
+      const response = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const accounts = (await response.json()) as { id: string }[]
+      expect(accounts.map((account) => account.id)).toEqual([
+        urlToId(ACTOR2_ID)
+      ])
+    })
+  })
+
   describe('media attachments', () => {
     it('includes media attachments with correct format', async () => {
       const status = (await database.getStatus({

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1750,6 +1750,126 @@ describe('GET /api/v1/statuses/[id]', () => {
       ])
     })
 
+    it('accepts a visible reblog cursor even after a newer duplicate supersedes it', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-superseded-cursor`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with superseded cursor reblogs',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const cursorAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-superseded-cursor`
+      const olderAnnounceId = `${ACTOR3_ID}/statuses/api-reblogged-by-superseded-older`
+      await database.createAnnounce({
+        id: olderAnnounceId,
+        actorId: ACTOR3_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-06-01T00:00:00.000Z')
+      })
+      await database.createAnnounce({
+        id: cursorAnnounceId,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-06-02T00:00:00.000Z')
+      })
+
+      const firstResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=1`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(firstResponse.status).toBe(200)
+      expect(firstResponse.headers.get('Link')).toEqual(
+        expect.stringContaining(
+          `max_id=${encodeURIComponent(urlToId(cursorAnnounceId))}`
+        )
+      )
+
+      await database.createAnnounce({
+        id: `${ACTOR2_ID}/statuses/api-reblogged-by-superseded-newer`,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-06-03T00:00:00.000Z')
+      })
+
+      const nextResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=1&max_id=${urlToId(cursorAnnounceId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(nextResponse.status).toBe(200)
+      const nextPage = (await nextResponse.json()) as { id: string }[]
+      expect(nextPage.map((account) => account.id)).toEqual([
+        urlToId(ACTOR3_ID)
+      ])
+    })
+
+    it('accepts a since_id cursor even after a newer duplicate supersedes it', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-superseded-since`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with superseded since cursor reblogs',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const cursorAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-superseded-since`
+      await database.createAnnounce({
+        id: cursorAnnounceId,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-07-01T00:00:00.000Z')
+      })
+
+      await database.createAnnounce({
+        id: `${ACTOR2_ID}/statuses/api-reblogged-by-superseded-since-newer`,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-07-02T00:00:00.000Z')
+      })
+
+      const response = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?since_id=${urlToId(cursorAnnounceId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const accounts = (await response.json()) as { id: string }[]
+      expect(accounts.map((account) => account.id)).toEqual([
+        urlToId(ACTOR2_ID)
+      ])
+    })
+
     it('does not expose non-public boosts to anonymous clients', async () => {
       mockGetServerSession.mockResolvedValue(null)
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1701,6 +1701,138 @@ describe('GET /api/v1/statuses/[id]', () => {
         urlToId(ACTOR2_ID)
       ])
     })
+
+    it('exposes non-public boosts to authenticated actors they are addressed to', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-direct-boost`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with a direct boost',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      await database.createAnnounce({
+        id: `${ACTOR3_ID}/statuses/api-reblogged-by-direct-boost`,
+        actorId: ACTOR3_ID,
+        to: [ACTOR2_ID],
+        cc: [],
+        originalStatusId: statusId
+      })
+
+      mockGetServerSession.mockResolvedValue(null)
+      const anonymousResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(anonymousResponse.status).toBe(200)
+      await expect(anonymousResponse.json()).resolves.toEqual([])
+
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+      const authenticatedResponse = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(authenticatedResponse.status).toBe(200)
+      const accounts = (await authenticatedResponse.json()) as { id: string }[]
+      expect(accounts.map((account) => account.id)).toEqual([
+        urlToId(ACTOR3_ID)
+      ])
+    })
+
+    it.each(['0', '81', 'abc'])(
+      'returns bad request for invalid limit=%s',
+      async (limit) => {
+        mockGetServerSession.mockResolvedValue(null)
+
+        const statusId = `${ACTOR1_ID}/statuses/post-1`
+        const response = await getStatusRebloggedBy(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(
+              statusId
+            )}/reblogged_by?limit=${limit}`
+          ),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+
+        expect(response.status).toBe(400)
+      }
+    )
+
+    it('returns not found when the status does not exist', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-missing`
+      const response = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblogged_by`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(404)
+    })
+
+    it('omits next pagination link on the last nonempty page', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblogged-by-last-page`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Public status with last-page reblogs',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const olderAnnounceId = `${ACTOR2_ID}/statuses/api-reblogged-by-last-page-older`
+      const newerAnnounceId = `${ACTOR3_ID}/statuses/api-reblogged-by-last-page-newer`
+      await database.createAnnounce({
+        id: olderAnnounceId,
+        actorId: ACTOR2_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-02-01T00:00:00.000Z')
+      })
+      await database.createAnnounce({
+        id: newerAnnounceId,
+        actorId: ACTOR3_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusId,
+        createdAt: Date.parse('2024-02-02T00:00:00.000Z')
+      })
+
+      const response = await getStatusRebloggedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(
+            statusId
+          )}/reblogged_by?limit=3&max_id=${urlToId(newerAnnounceId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const accounts = (await response.json()) as { id: string }[]
+      expect(accounts.map((account) => account.id)).toEqual([
+        urlToId(ACTOR2_ID)
+      ])
+
+      const linkHeader = response.headers.get('Link')
+      expect(linkHeader).not.toEqual(expect.stringContaining('rel="next"'))
+      expect(linkHeader).toEqual(expect.stringContaining('rel="prev"'))
+    })
   })
 
   describe('media attachments', () => {

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -21,6 +21,7 @@ import {
   TEST_PASSWORD_HASH,
   TEST_USERNAME3
 } from '@/lib/stub/const'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
@@ -338,6 +339,79 @@ describe('ActorDatabase', () => {
           statuses_count: 0,
           followers_count: 0,
           following_count: 0
+        })
+      })
+
+      it('returns mastodon actors from ids in request order', async () => {
+        await withFreshDatabase(async (database) => {
+          const suffix = crypto.randomUUID().slice(0, 8)
+          const username = `bulk-${suffix}`
+          const localActorId = `https://${TEST_DOMAIN}/users/${username}`
+          const remoteActorId = `https://remote-${suffix}.example/users/alice`
+          const statusId = `${localActorId}/statuses/1`
+
+          await database.createAccount({
+            email: `${username}@${TEST_DOMAIN}`,
+            username,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: `privateKey-${suffix}`,
+            publicKey: `publicKey-${suffix}`
+          })
+          await database.createActor({
+            actorId: remoteActorId,
+            username: 'alice',
+            domain: `remote-${suffix}.example`,
+            followersUrl: `${remoteActorId}/followers`,
+            inboxUrl: `${remoteActorId}/inbox`,
+            sharedInboxUrl: `${remoteActorId}/inbox`,
+            publicKey: `remotePublicKey-${suffix}`,
+            createdAt: Date.now()
+          })
+          await database.createNote({
+            id: statusId,
+            url: statusId,
+            actorId: localActorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            text: 'Bulk account lookup test'
+          })
+          await database.createFollow({
+            actorId: remoteActorId,
+            targetActorId: localActorId,
+            inbox: `${remoteActorId}/inbox`,
+            sharedInbox: `${remoteActorId}/inbox`,
+            status: FollowStatus.enum.Accepted
+          })
+          await database.createFollow({
+            actorId: localActorId,
+            targetActorId: remoteActorId,
+            inbox: `${localActorId}/inbox`,
+            sharedInbox: `https://${TEST_DOMAIN}/inbox`,
+            status: FollowStatus.enum.Accepted
+          })
+
+          const actors = await database.getMastodonActorsFromIds({
+            ids: [
+              remoteActorId,
+              'https://missing.example/users/not-found',
+              localActorId,
+              remoteActorId
+            ]
+          })
+
+          expect(actors.map((actor) => actor.url)).toEqual([
+            remoteActorId,
+            localActorId,
+            remoteActorId
+          ])
+          expect(actors[1]).toMatchObject({
+            url: localActorId,
+            last_status_at: expect.toBeString(),
+            statuses_count: 1,
+            followers_count: 1,
+            following_count: 1
+          })
         })
       })
 

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -34,6 +34,7 @@ import {
   GetActorFromIdParams,
   GetActorFromUsernameParams,
   GetActorSettingsParams,
+  GetActorsFromIdsParams,
   GetActorsScheduledForDeletionParams,
   IsCurrentActorFollowingParams,
   IsInternalActorParams,
@@ -59,6 +60,7 @@ export interface SQLActorDatabase extends ActorDatabase {
     sqlAccount?: SQLAccount
   ) => Actor
   getMastodonActor: (actorId: string) => Promise<Mastodon.Account | null>
+  getMastodonActors: (actorIds: string[]) => Promise<Mastodon.Account[]>
 }
 
 const getActorCounterSummary = async (
@@ -493,6 +495,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     return this.getMastodonActor(id)
   },
 
+  async getMastodonActorsFromIds({ ids }: GetActorsFromIdsParams) {
+    return this.getMastodonActors(ids)
+  },
+
   getActor(
     sqlActor: SQLActor,
     followingCount: number,
@@ -568,67 +574,98 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
   },
 
   async getMastodonActor(actorId: string) {
-    const sqlActor = await database<SQLActor>('actors')
-      .where('id', actorId)
-      .first()
-    if (!sqlActor) return null
+    const actors = await this.getMastodonActors([actorId])
+    return actors[0] ?? null
+  },
 
-    const [lastStatus, counters] = await database.transaction(async (trx) =>
+  async getMastodonActors(actorIds: string[]) {
+    const uniqueActorIds = Array.from(new Set(actorIds))
+    if (uniqueActorIds.length === 0) return []
+
+    const sqlActors = await database<SQLActor>('actors').whereIn(
+      'id',
+      uniqueActorIds
+    )
+    if (sqlActors.length === 0) return []
+
+    const existingActorIds = sqlActors.map((actor) => actor.id)
+    const counterIds = existingActorIds.flatMap((id) => [
+      CounterKey.totalFollowers(id),
+      CounterKey.totalFollowing(id),
+      CounterKey.totalStatus(id)
+    ])
+
+    const [lastStatuses, counters] = await database.transaction(async (trx) =>
       Promise.all([
         trx('statuses')
-          .where('actorId', actorId)
-          .orderBy('createdAt', 'desc')
-          .select('createdAt')
-          .first<{ createdAt: number | Date }>(),
-        getActorCounterSummary(trx, actorId)
+          .whereIn('actorId', existingActorIds)
+          .groupBy('actorId')
+          .select('actorId')
+          .max({ createdAt: 'createdAt' }),
+        getCounterValues(trx, counterIds)
       ])
     )
 
-    const settings = getCompatibleJSON(sqlActor.settings)
-    const lastStatusCreatedAt = lastStatus?.createdAt ? lastStatus.createdAt : 0
-    const isLocalHeadlessSigner = isValidFederationSigningSQLActor(
-      sqlActor,
-      getConfiguredActorDomain()
+    const sqlActorById = new Map(sqlActors.map((actor) => [actor.id, actor]))
+    const lastStatusByActorId = new Map(
+      (
+        lastStatuses as {
+          actorId: string
+          createdAt: number | Date | string | null
+        }[]
+      ).map((row) => [row.actorId, row.createdAt])
     )
-    return Mastodon.Account.parse({
-      id: urlToId(sqlActor.id),
-      username: sqlActor.username,
-      acct: `${sqlActor.username}@${sqlActor.domain}`,
-      url: sqlActor.id,
-      display_name: sqlActor.name ?? '',
-      note: sqlActor.summary ?? '',
 
-      avatar: settings.iconUrl ?? '',
-      avatar_static: settings.iconUrl ?? '',
-      header: settings.headerImageUrl ?? '',
-      header_static: settings.headerImageUrl ?? '',
+    return actorIds.flatMap((id) => {
+      const sqlActor = sqlActorById.get(id)
+      if (!sqlActor) return []
 
-      fields: [],
-      emojis: [],
+      const settings = getCompatibleJSON(sqlActor.settings)
+      const lastStatusCreatedAt = lastStatusByActorId.get(id) ?? 0
+      const isLocalHeadlessSigner = isValidFederationSigningSQLActor(
+        sqlActor,
+        getConfiguredActorDomain()
+      )
+      return Mastodon.Account.parse({
+        id: urlToId(sqlActor.id),
+        username: sqlActor.username,
+        acct: `${sqlActor.username}@${sqlActor.domain}`,
+        url: sqlActor.id,
+        display_name: sqlActor.name ?? '',
+        note: sqlActor.summary ?? '',
 
-      locked: settings.manuallyApprovesFollowers ?? true,
-      bot: isMastodonBotActorType(sqlActor.type),
-      group: sqlActor.type === 'Group',
-      discoverable: !isLocalHeadlessSigner,
-      noindex: isLocalHeadlessSigner,
+        avatar: settings.iconUrl ?? '',
+        avatar_static: settings.iconUrl ?? '',
+        header: settings.headerImageUrl ?? '',
+        header_static: settings.headerImageUrl ?? '',
 
-      source: {
-        note: '',
         fields: [],
-        privacy: 'public',
-        sensitive: false,
-        language: 'en',
-        follow_requests_count: 0
-      },
+        emojis: [],
 
-      created_at: getISOTimeUTC(getCompatibleTime(sqlActor.createdAt)),
-      last_status_at: lastStatusCreatedAt
-        ? getISOTimeUTC(getCompatibleTime(lastStatusCreatedAt), true)
-        : null,
+        locked: settings.manuallyApprovesFollowers ?? true,
+        bot: isMastodonBotActorType(sqlActor.type),
+        group: sqlActor.type === 'Group',
+        discoverable: !isLocalHeadlessSigner,
+        noindex: isLocalHeadlessSigner,
 
-      followers_count: counters.followersCount,
-      following_count: counters.followingCount,
-      statuses_count: counters.statusCount
+        source: {
+          note: '',
+          fields: [],
+          privacy: 'public',
+          sensitive: false,
+          language: 'en',
+          follow_requests_count: 0
+        },
+
+        created_at: getISOTimeUTC(getCompatibleTime(sqlActor.createdAt)),
+        last_status_at: lastStatusCreatedAt
+          ? getISOTimeUTC(getCompatibleTime(lastStatusCreatedAt), true)
+          : null,
+
+        followers_count: counters[CounterKey.totalFollowers(sqlActor.id)] ?? 0,
+        following_count: counters[CounterKey.totalFollowing(sqlActor.id)] ?? 0,
+        statuses_count: counters[CounterKey.totalStatus(sqlActor.id)] ?? 0
+      })
     })
   },
 

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1,5 +1,6 @@
 import knex, { Knex } from 'knex'
 
+import { getSQLDatabase } from '@/lib/database/sql'
 import {
   databaseBeforeAll,
   getTestDatabaseTable
@@ -82,6 +83,70 @@ describe('StatusDatabase', () => {
       expect(sql).toContain('actorid')
 
       await mysqlDatabase.destroy()
+    })
+
+    it('includes publicly readable legacy Announces that only store the target in content', async () => {
+      const knexDatabase = knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: {
+          filename: ':memory:'
+        }
+      })
+      const sqlDatabase = getSQLDatabase(knexDatabase)
+
+      try {
+        await sqlDatabase.migrate()
+        await seedDatabase(sqlDatabase)
+
+        const statusId = `${primaryActorId}/statuses/legacy-reblog-target`
+        await sqlDatabase.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: primaryActorId,
+          text: 'Public target for legacy reblog',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+
+        const legacyAnnounceId = `${replyAuthorId}/statuses/legacy-reblog`
+        const createdAt = new Date('2024-04-01T00:00:00.000Z')
+        await knexDatabase('statuses').insert({
+          id: legacyAnnounceId,
+          url: null,
+          urlHash: null,
+          actorId: replyAuthorId,
+          type: StatusType.enum.Announce,
+          reply: '',
+          content: statusId,
+          originalStatusId: null,
+          createdAt,
+          updatedAt: createdAt
+        })
+        await knexDatabase('recipients').insert({
+          id: crypto.randomUUID(),
+          statusId: legacyAnnounceId,
+          actorId: ACTIVITY_STREAM_PUBLIC,
+          type: 'to',
+          createdAt,
+          updatedAt: createdAt
+        })
+
+        await expect(
+          sqlDatabase.getRebloggedBy({
+            statusId,
+            limit: 40,
+            visibleToActorId: null
+          })
+        ).resolves.toEqual([
+          {
+            actorId: replyAuthorId,
+            statusId: legacyAnnounceId
+          }
+        ])
+      } finally {
+        await knexDatabase.destroy()
+      }
     })
   })
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1345,71 +1345,95 @@ export const StatusSQLDatabaseMixin = (
       })
     const reblogTargetStatusIds = reblogBase.clone().select('id')
 
-    let query = reblogBase
+    let visibleReblogsQuery = reblogBase
       .clone()
-      .select<
-        { id: string; actorId: string; createdAt: Date | number | string }[]
-      >('id', 'actorId', 'createdAt')
-      .orderBy('createdAt', 'desc')
-      .orderBy('id', 'desc')
+      .select('statuses.id', 'statuses.actorId', 'statuses.createdAt')
 
-    query = visibleToActorId
-      ? applyPotentiallyReadableStatusFilter({ query, visibleToActorId })
+    visibleReblogsQuery = visibleToActorId
+      ? applyPotentiallyReadableStatusFilter({
+          query: visibleReblogsQuery,
+          visibleToActorId
+        })
       : applyPublicReadableStatusFilter({
-          query,
+          query: visibleReblogsQuery,
           targetStatusIds: reblogTargetStatusIds
         })
 
-    const result = await query
-    const seenActorIds = new Set<string>()
-    const uniqueResult = result.filter((item) => {
-      if (seenActorIds.has(item.actorId)) return false
-      seenActorIds.add(item.actorId)
-      return true
-    })
+    const rankedReblogsQuery = database
+      .select('visible_reblogs.id', 'visible_reblogs.actorId')
+      .select('visible_reblogs.createdAt')
+      .select(
+        database.raw(
+          'ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC, ?? DESC) as ??',
+          [
+            'visible_reblogs.actorId',
+            'visible_reblogs.createdAt',
+            'visible_reblogs.id',
+            'actorReblogRank'
+          ]
+        )
+      )
+      .from(visibleReblogsQuery.as('visible_reblogs'))
 
-    const compareReblogRows = (
-      row: (typeof uniqueResult)[number],
-      cursor: (typeof uniqueResult)[number]
-    ) => {
-      const rowCreatedAt = getCompatibleTime(row.createdAt)
-      const cursorCreatedAt = getCompatibleTime(cursor.createdAt)
-      if (rowCreatedAt !== cursorCreatedAt) {
-        return rowCreatedAt - cursorCreatedAt
-      }
-      if (row.id === cursor.id) return 0
-      return row.id > cursor.id ? 1 : -1
-    }
+    const dedupedReblogsQuery = database
+      .select<
+        { id: string; actorId: string; createdAt: Date }[]
+      >('ranked_reblogs.id', 'ranked_reblogs.actorId', 'ranked_reblogs.createdAt')
+      .from(rankedReblogsQuery.as('ranked_reblogs'))
+      .where('ranked_reblogs.actorReblogRank', 1)
 
-    const maxCursor = maxStatusId
-      ? uniqueResult.find((item) => item.id === maxStatusId)
-      : null
+    const [maxCursor, sinceCursor] = await Promise.all([
+      maxStatusId
+        ? dedupedReblogsQuery
+            .clone()
+            .where('id', maxStatusId)
+            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
+        : null,
+      sinceStatusId
+        ? dedupedReblogsQuery
+            .clone()
+            .where('id', sinceStatusId)
+            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
+        : null
+    ])
     if (maxStatusId && !maxCursor) return []
-
-    const sinceCursor = sinceStatusId
-      ? uniqueResult.find((item) => item.id === sinceStatusId)
-      : null
     if (sinceStatusId && !sinceCursor) return []
 
-    let pageResult = uniqueResult
+    let query = dedupedReblogsQuery
+      .clone()
+      .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
 
     if (maxCursor) {
-      pageResult = pageResult.filter(
-        (item) => compareReblogRows(item, maxCursor) < 0
-      )
+      query = query.where((builder) => {
+        builder
+          .where('createdAt', '<', maxCursor.createdAt)
+          .orWhere((sameTimestampBuilder) => {
+            sameTimestampBuilder
+              .where('createdAt', maxCursor.createdAt)
+              .where('id', '<', maxCursor.id)
+          })
+      })
     }
 
     if (sinceCursor) {
-      pageResult = pageResult.filter(
-        (item) => compareReblogRows(item, sinceCursor) > 0
-      )
+      query = query.where((builder) => {
+        builder
+          .where('createdAt', '>', sinceCursor.createdAt)
+          .orWhere((sameTimestampBuilder) => {
+            sameTimestampBuilder
+              .where('createdAt', sinceCursor.createdAt)
+              .where('id', '>', sinceCursor.id)
+          })
+      })
     }
 
     if (typeof limit === 'number') {
-      pageResult = pageResult.slice(0, limit)
+      query = query.limit(limit)
     }
 
-    return pageResult.map((item) => ({
+    const result = await query
+    return result.map((item) => ({
       actorId: item.actorId,
       statusId: item.id
     }))

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1413,13 +1413,10 @@ export const StatusSQLDatabaseMixin = (
 
     const [maxCursor, sinceCursor] = await Promise.all([
       maxStatusId
-        ? visibleReblogsQuery
-            .clone()
-            .where('statuses.id', maxStatusId)
-            .first<{
-              id: string
-              createdAt: Date
-            }>('statuses.id', 'statuses.createdAt')
+        ? visibleReblogsQuery.clone().where('statuses.id', maxStatusId).first<{
+            id: string
+            createdAt: Date
+          }>('statuses.id', 'statuses.createdAt')
         : null,
       sinceStatusId
         ? visibleReblogsQuery

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -27,6 +27,7 @@ import {
   GetActorStatusesParams,
   GetFavouritedByParams,
   GetHashtagStatusesPageParams,
+  GetRebloggedByParams,
   GetStatusFromUrlHashParams,
   GetStatusFromUrlParams,
   GetStatusParams,
@@ -1328,6 +1329,93 @@ export const StatusSQLDatabaseMixin = (
     return actors.filter((actor): actor is Actor => Boolean(actor))
   }
 
+  async function getRebloggedBy({
+    statusId,
+    limit,
+    maxStatusId,
+    sinceStatusId,
+    visibleToActorId
+  }: GetRebloggedByParams) {
+    const [maxCursor, sinceCursor] = await Promise.all([
+      maxStatusId
+        ? database('statuses')
+            .where('id', maxStatusId)
+            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
+        : null,
+      sinceStatusId
+        ? database('statuses')
+            .where('id', sinceStatusId)
+            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
+        : null
+    ])
+
+    const reblogTargetStatusIds = database('statuses')
+      .select('id')
+      .where('type', StatusType.enum.Announce)
+      .where((builder) => {
+        builder.where('originalStatusId', statusId).orWhere((legacyBuilder) => {
+          legacyBuilder.whereNull('originalStatusId').where('content', statusId)
+        })
+      })
+
+    let query = database('statuses')
+      .select<{ id: string; actorId: string }[]>('id', 'actorId')
+      .where('type', StatusType.enum.Announce)
+      .where((builder) => {
+        builder.where('originalStatusId', statusId).orWhere((legacyBuilder) => {
+          legacyBuilder.whereNull('originalStatusId').where('content', statusId)
+        })
+      })
+      .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
+
+    query = visibleToActorId
+      ? applyPotentiallyReadableStatusFilter({ query, visibleToActorId })
+      : applyPublicReadableStatusFilter({
+          query,
+          targetStatusIds: reblogTargetStatusIds
+        })
+
+    if (maxCursor) {
+      query = query.where((builder) => {
+        builder
+          .where('createdAt', '<', maxCursor.createdAt)
+          .orWhere((sameTimestampBuilder) => {
+            sameTimestampBuilder
+              .where('createdAt', maxCursor.createdAt)
+              .where('id', '<', maxCursor.id)
+          })
+      })
+    }
+
+    if (sinceCursor) {
+      query = query.where((builder) => {
+        builder
+          .where('createdAt', '>', sinceCursor.createdAt)
+          .orWhere((sameTimestampBuilder) => {
+            sameTimestampBuilder
+              .where('createdAt', sinceCursor.createdAt)
+              .where('id', '>', sinceCursor.id)
+          })
+      })
+    }
+
+    if (typeof limit === 'number') {
+      query = query.limit(limit)
+    }
+
+    const result = await query
+    const reblogs = await Promise.all(
+      result.map(async (item) => {
+        const actor = await actorDatabase.getActorFromId({ id: item.actorId })
+        return actor ? { actor, statusId: item.id } : null
+      })
+    )
+    return reblogs.filter((item): item is NonNullable<typeof item> =>
+      Boolean(item)
+    )
+  }
+
   async function createTag({
     statusId,
     name,
@@ -2008,6 +2096,7 @@ export const StatusSQLDatabaseMixin = (
     getPollVotes,
     addStatusTag,
     getFavouritedBy,
+    getRebloggedBy,
     createTag,
     getTags,
     getStatusesByHashtag,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1349,23 +1349,18 @@ export const StatusSQLDatabaseMixin = (
         : null
     ])
 
-    const reblogTargetStatusIds = database('statuses')
-      .select('id')
+    const reblogBase = database('statuses')
       .where('type', StatusType.enum.Announce)
       .where((builder) => {
         builder.where('originalStatusId', statusId).orWhere((legacyBuilder) => {
           legacyBuilder.whereNull('originalStatusId').where('content', statusId)
         })
       })
+    const reblogTargetStatusIds = reblogBase.clone().select('id')
 
-    let query = database('statuses')
+    let query = reblogBase
+      .clone()
       .select<{ id: string; actorId: string }[]>('id', 'actorId')
-      .where('type', StatusType.enum.Announce)
-      .where((builder) => {
-        builder.where('originalStatusId', statusId).orWhere((legacyBuilder) => {
-          legacyBuilder.whereNull('originalStatusId').where('content', statusId)
-        })
-      })
       .orderBy('createdAt', 'desc')
       .orderBy('id', 'desc')
 
@@ -1405,15 +1400,7 @@ export const StatusSQLDatabaseMixin = (
     }
 
     const result = await query
-    const reblogs = await Promise.all(
-      result.map(async (item) => {
-        const actor = await actorDatabase.getActorFromId({ id: item.actorId })
-        return actor ? { actor, statusId: item.id } : null
-      })
-    )
-    return reblogs.filter((item): item is NonNullable<typeof item> =>
-      Boolean(item)
-    )
+    return result.map((item) => ({ actorId: item.actorId, statusId: item.id }))
   }
 
   async function createTag({

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -118,10 +118,21 @@ export const buildPubliclyReadableStatusIdsQuery = ({
         ).orWhereExists(function () {
           this.select(database.raw('1'))
             .from('statuses as original_statuses')
-            .whereRaw('?? = ??', [
-              'original_statuses.id',
-              'target_statuses.originalStatusId'
-            ])
+            .where((originalBuilder) => {
+              originalBuilder
+                .whereRaw('?? = ??', [
+                  'original_statuses.id',
+                  'target_statuses.originalStatusId'
+                ])
+                .orWhere((legacyBuilder) => {
+                  legacyBuilder
+                    .whereNull('target_statuses.originalStatusId')
+                    .whereRaw('?? = ??', [
+                      'original_statuses.id',
+                      'target_statuses.content'
+                    ])
+                })
+            })
             .whereNot('original_statuses.type', StatusType.enum.Announce)
             .whereIn('original_statuses.id', publicRecipientStatusIds(database))
         })
@@ -131,14 +142,15 @@ export const buildPubliclyReadableStatusIdsQuery = ({
   return database
     .withRecursive(
       'publicly_readable_statuses',
-      ['targetId', 'id', 'type', 'originalStatusId'],
+      ['targetId', 'id', 'type', 'originalStatusId', 'content'],
       (cte) => {
         cte
           .select(
             'target_statuses.id as targetId',
             'target_statuses.id',
             'target_statuses.type',
-            'target_statuses.originalStatusId'
+            'target_statuses.originalStatusId',
+            'target_statuses.content'
           )
           .from(targetStatusIdsQuery)
           .innerJoin(
@@ -152,13 +164,19 @@ export const buildPubliclyReadableStatusIdsQuery = ({
               'readable_statuses.targetId',
               'original_statuses.id',
               'original_statuses.type',
-              'original_statuses.originalStatusId'
+              'original_statuses.originalStatusId',
+              'original_statuses.content'
             )
               .from('statuses as original_statuses')
               .innerJoin(
                 'publicly_readable_statuses as readable_statuses',
-                'readable_statuses.originalStatusId',
-                'original_statuses.id'
+                database.raw('(?? = ?? or (?? is null and ?? = ??))', [
+                  'readable_statuses.originalStatusId',
+                  'original_statuses.id',
+                  'readable_statuses.originalStatusId',
+                  'readable_statuses.content',
+                  'original_statuses.id'
+                ])
               )
               .where('readable_statuses.type', StatusType.enum.Announce)
               .whereIn(
@@ -1359,28 +1377,39 @@ export const StatusSQLDatabaseMixin = (
           targetStatusIds: reblogTargetStatusIds
         })
 
-    const rankedReblogsQuery = database
-      .select('visible_reblogs.id', 'visible_reblogs.actorId')
-      .select('visible_reblogs.createdAt')
-      .select(
-        database.raw(
-          'ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC, ?? DESC) as ??',
-          [
-            'visible_reblogs.actorId',
-            'visible_reblogs.createdAt',
-            'visible_reblogs.id',
-            'actorReblogRank'
-          ]
-        )
-      )
-      .from(visibleReblogsQuery.as('visible_reblogs'))
-
     const dedupedReblogsQuery = database
-      .select<
-        { id: string; actorId: string; createdAt: Date }[]
-      >('ranked_reblogs.id', 'ranked_reblogs.actorId', 'ranked_reblogs.createdAt')
-      .from(rankedReblogsQuery.as('ranked_reblogs'))
-      .where('ranked_reblogs.actorReblogRank', 1)
+      .select<{ id: string; actorId: string; createdAt: Date }[]>(
+        'visible_reblogs.id',
+        'visible_reblogs.actorId',
+        'visible_reblogs.createdAt'
+      )
+      .from(visibleReblogsQuery.clone().as('visible_reblogs'))
+      .whereNotExists(function () {
+        this.select(database.raw('1'))
+          .from(visibleReblogsQuery.clone().as('newer_reblogs'))
+          .whereRaw('?? = ??', [
+            'newer_reblogs.actorId',
+            'visible_reblogs.actorId'
+          ])
+          .where((builder) => {
+            builder
+              .whereRaw('?? > ??', [
+                'newer_reblogs.createdAt',
+                'visible_reblogs.createdAt'
+              ])
+              .orWhere((sameTimestampBuilder) => {
+                sameTimestampBuilder
+                  .whereRaw('?? = ??', [
+                    'newer_reblogs.createdAt',
+                    'visible_reblogs.createdAt'
+                  ])
+                  .whereRaw('?? > ??', [
+                    'newer_reblogs.id',
+                    'visible_reblogs.id'
+                  ])
+              })
+          })
+      })
 
     const [maxCursor, sinceCursor] = await Promise.all([
       maxStatusId

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1336,19 +1336,6 @@ export const StatusSQLDatabaseMixin = (
     sinceStatusId,
     visibleToActorId
   }: GetRebloggedByParams) {
-    const [maxCursor, sinceCursor] = await Promise.all([
-      maxStatusId
-        ? database('statuses')
-            .where('id', maxStatusId)
-            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
-        : null,
-      sinceStatusId
-        ? database('statuses')
-            .where('id', sinceStatusId)
-            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
-        : null
-    ])
-
     const reblogBase = database('statuses')
       .where('type', StatusType.enum.Announce)
       .where((builder) => {
@@ -1360,7 +1347,9 @@ export const StatusSQLDatabaseMixin = (
 
     let query = reblogBase
       .clone()
-      .select<{ id: string; actorId: string }[]>('id', 'actorId')
+      .select<
+        { id: string; actorId: string; createdAt: Date | number | string }[]
+      >('id', 'actorId', 'createdAt')
       .orderBy('createdAt', 'desc')
       .orderBy('id', 'desc')
 
@@ -1371,36 +1360,59 @@ export const StatusSQLDatabaseMixin = (
           targetStatusIds: reblogTargetStatusIds
         })
 
+    const result = await query
+    const seenActorIds = new Set<string>()
+    const uniqueResult = result.filter((item) => {
+      if (seenActorIds.has(item.actorId)) return false
+      seenActorIds.add(item.actorId)
+      return true
+    })
+
+    const compareReblogRows = (
+      row: (typeof uniqueResult)[number],
+      cursor: (typeof uniqueResult)[number]
+    ) => {
+      const rowCreatedAt = getCompatibleTime(row.createdAt)
+      const cursorCreatedAt = getCompatibleTime(cursor.createdAt)
+      if (rowCreatedAt !== cursorCreatedAt) {
+        return rowCreatedAt - cursorCreatedAt
+      }
+      if (row.id === cursor.id) return 0
+      return row.id > cursor.id ? 1 : -1
+    }
+
+    const maxCursor = maxStatusId
+      ? uniqueResult.find((item) => item.id === maxStatusId)
+      : null
+    if (maxStatusId && !maxCursor) return []
+
+    const sinceCursor = sinceStatusId
+      ? uniqueResult.find((item) => item.id === sinceStatusId)
+      : null
+    if (sinceStatusId && !sinceCursor) return []
+
+    let pageResult = uniqueResult
+
     if (maxCursor) {
-      query = query.where((builder) => {
-        builder
-          .where('createdAt', '<', maxCursor.createdAt)
-          .orWhere((sameTimestampBuilder) => {
-            sameTimestampBuilder
-              .where('createdAt', maxCursor.createdAt)
-              .where('id', '<', maxCursor.id)
-          })
-      })
+      pageResult = pageResult.filter(
+        (item) => compareReblogRows(item, maxCursor) < 0
+      )
     }
 
     if (sinceCursor) {
-      query = query.where((builder) => {
-        builder
-          .where('createdAt', '>', sinceCursor.createdAt)
-          .orWhere((sameTimestampBuilder) => {
-            sameTimestampBuilder
-              .where('createdAt', sinceCursor.createdAt)
-              .where('id', '>', sinceCursor.id)
-          })
-      })
+      pageResult = pageResult.filter(
+        (item) => compareReblogRows(item, sinceCursor) > 0
+      )
     }
 
     if (typeof limit === 'number') {
-      query = query.limit(limit)
+      pageResult = pageResult.slice(0, limit)
     }
 
-    const result = await query
-    return result.map((item) => ({ actorId: item.actorId, statusId: item.id }))
+    return pageResult.map((item) => ({
+      actorId: item.actorId,
+      statusId: item.id
+    }))
   }
 
   async function createTag({

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1413,16 +1413,22 @@ export const StatusSQLDatabaseMixin = (
 
     const [maxCursor, sinceCursor] = await Promise.all([
       maxStatusId
-        ? dedupedReblogsQuery
+        ? visibleReblogsQuery
             .clone()
-            .where('id', maxStatusId)
-            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
+            .where('statuses.id', maxStatusId)
+            .first<{
+              id: string
+              createdAt: Date
+            }>('statuses.id', 'statuses.createdAt')
         : null,
       sinceStatusId
-        ? dedupedReblogsQuery
+        ? visibleReblogsQuery
             .clone()
-            .where('id', sinceStatusId)
-            .first<{ id: string; createdAt: Date }>('id', 'createdAt')
+            .where('statuses.id', sinceStatusId)
+            .first<{
+              id: string
+              createdAt: Date
+            }>('statuses.id', 'statuses.createdAt')
         : null
     ])
     if (maxStatusId && !maxCursor) return []

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -50,6 +50,7 @@ export type CreateActorParams = {
 export type GetActorFromEmailParams = { email: string }
 export type GetActorFromUsernameParams = { username: string; domain: string }
 export type GetActorFromIdParams = { id: string }
+export type GetActorsFromIdsParams = { ids: string[] }
 export type IsCurrentActorFollowingParams = {
   currentActorId: string
   followingActorId: string
@@ -135,6 +136,9 @@ export interface ActorDatabase {
   getMastodonActorFromId(
     params: GetActorFromIdParams
   ): Promise<Mastodon.Account | null>
+  getMastodonActorsFromIds(
+    params: GetActorsFromIdsParams
+  ): Promise<Mastodon.Account[]>
   updateActor(params: UpdateActorParams): Promise<Actor | null>
   deleteActor(params: DeleteActorParams): Promise<void>
   updateActorFollowersCount(actorId: string): Promise<void>

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -477,7 +477,7 @@ export type GetRebloggedByParams = BaseStatusParams & {
   visibleToActorId?: string | null
 }
 export type RebloggedByAccount = {
-  actor: Actor
+  actorId: string
   statusId: string
 }
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -470,6 +470,16 @@ export type GetFavouritedByParams = BaseStatusParams & {
   limit?: number
   offset?: number
 }
+export type GetRebloggedByParams = BaseStatusParams & {
+  limit?: number
+  maxStatusId?: string
+  sinceStatusId?: string
+  visibleToActorId?: string | null
+}
+export type RebloggedByAccount = {
+  actor: Actor
+  statusId: string
+}
 
 export type CreateTagParams = {
   statusId: string
@@ -570,6 +580,7 @@ export interface StatusDatabase {
   getActorStatuses(params: GetActorStatusesParams): Promise<Status[]>
   getStatusesByIds(params: GetStatusesByIdsParams): Promise<Status[]>
   getFavouritedBy(params: GetFavouritedByParams): Promise<Actor[]>
+  getRebloggedBy(params: GetRebloggedByParams): Promise<RebloggedByAccount[]>
   createTag(params: CreateTagParams): Promise<Tag>
   getTags(params: GetTagsParams): Promise<Tag[]>
   getStatusesByHashtag(params: GetStatusesByHashtagParams): Promise<Status[]>


### PR DESCRIPTION
## Summary
- Implement Mastodon-compatible `GET /api/v1/statuses/:id/reblogged_by`
- Add database lookup for accounts that boosted a status with `limit`, `max_id`, and `since_id` cursor pagination
- Preserve visibility rules so anonymous clients only see public boost activities

## Validation
- `yarn test --runTestsByPath 'app/api/v1/statuses/[id]/route.test.ts'`
- `yarn lint`
- `yarn build`
- `yarn test`