### PR TITLE
Bump version to v1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.15.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.14.1`
- Base main SHA: `d735857273381c5e98f470fe861d1228285720e8`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
