### PR TITLE
fix: quote Postgres bookmark visibility columns

### DIFF
--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -155,19 +155,15 @@ describe('StatusDatabase', () => {
       const postgresDatabase = knex({ client: 'pg' })
       const sqlDatabase = getSQLDatabase(postgresDatabase)
       const queries: string[] = []
+      const onQuery = (query: { sql: string }) => queries.push(query.sql)
 
-      postgresDatabase.client.acquireConnection = jest
-        .fn()
-        .mockResolvedValue({})
-      postgresDatabase.client.releaseConnection = jest.fn()
-      postgresDatabase.client._query = jest
-        .fn()
-        .mockImplementation(async (_connection, query) => {
-          queries.push(query.sql)
-          query.response = { rows: [] }
-          return query
+      postgresDatabase.on('query', onQuery)
+      postgresDatabase.client.acquireConnection = jest.fn().mockResolvedValue({
+        query: jest.fn((_queryConfig, callback) => {
+          callback(null, { command: 'SELECT', rows: [] })
         })
-      postgresDatabase.client.processResponse = (query) => query.response.rows
+      })
+      postgresDatabase.client.releaseConnection = jest.fn()
 
       try {
         await sqlDatabase.getStatusesByIds({
@@ -188,6 +184,7 @@ describe('StatusDatabase', () => {
           '"follows"."targetActorId" = "statuses"."actorId"'
         )
       } finally {
+        postgresDatabase.off('query', onQuery)
         await postgresDatabase.destroy()
       }
     })

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -150,6 +150,49 @@ describe('StatusDatabase', () => {
     })
   })
 
+  describe('potentially readable status SQL', () => {
+    it('quotes camelCase identifiers in PostgreSQL follower audience checks', async () => {
+      const postgresDatabase = knex({ client: 'pg' })
+      const sqlDatabase = getSQLDatabase(postgresDatabase)
+      const queries: string[] = []
+
+      postgresDatabase.client.acquireConnection = jest
+        .fn()
+        .mockResolvedValue({})
+      postgresDatabase.client.releaseConnection = jest.fn()
+      postgresDatabase.client._query = jest
+        .fn()
+        .mockImplementation(async (_connection, query) => {
+          queries.push(query.sql)
+          query.response = { rows: [] }
+          return query
+        })
+      postgresDatabase.client.processResponse = (query) => query.response.rows
+
+      try {
+        await sqlDatabase.getStatusesByIds({
+          statusIds: [`${primaryActorId}/statuses/postgres-readable`],
+          visibleToActorId: replyAuthorId
+        })
+
+        expect(queries[0]).toContain(
+          '"followers_recipients"."statusId" = "statuses"."id"'
+        )
+        expect(queries[0]).toContain(
+          '"followers_recipients"."actorId" = status_actors.settings::jsonb ->> \'followersUrl\''
+        )
+        expect(queries[0]).toContain(
+          '"followers_recipients"."actorId" = "statuses"."actorId" || \'/followers\''
+        )
+        expect(queries[0]).toContain(
+          '"follows"."targetActorId" = "statuses"."actorId"'
+        )
+      } finally {
+        await postgresDatabase.destroy()
+      }
+    })
+  })
+
   describe.each(table)('%s', (_, database) => {
     beforeAll(async () => {
       await seedDatabase(database as Database)

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -230,9 +230,18 @@ export const StatusSQLDatabaseMixin = (
   }) => {
     const clientName = String(database.client.config.client)
     const fallbackFollowersAudienceExpression = clientName.includes('mysql')
-      ? "followers_recipients.actorId = CONCAT(statuses.actorId, '/followers')"
-      : "followers_recipients.actorId = statuses.actorId || '/followers'"
-    const storedFollowersAudienceExpression = `followers_recipients.actorId = ${statusActorFollowersUrlExpression()}`
+      ? {
+          sql: "?? = CONCAT(??, '/followers')",
+          bindings: ['followers_recipients.actorId', 'statuses.actorId']
+        }
+      : {
+          sql: "?? = ?? || '/followers'",
+          bindings: ['followers_recipients.actorId', 'statuses.actorId']
+        }
+    const storedFollowersAudienceExpression = {
+      sql: `?? = ${statusActorFollowersUrlExpression()}`,
+      bindings: ['followers_recipients.actorId']
+    }
 
     return query.where((qb) => {
       qb.whereIn(
@@ -253,17 +262,27 @@ export const StatusSQLDatabaseMixin = (
               'status_actors.id',
               'statuses.actorId'
             )
-            .whereRaw('followers_recipients.statusId = statuses.id')
+            .whereRaw('?? = ??', [
+              'followers_recipients.statusId',
+              'statuses.id'
+            ])
             .where(function () {
-              this.whereRaw(storedFollowersAudienceExpression).orWhereRaw(
-                fallbackFollowersAudienceExpression
+              this.whereRaw(
+                storedFollowersAudienceExpression.sql,
+                storedFollowersAudienceExpression.bindings
+              ).orWhereRaw(
+                fallbackFollowersAudienceExpression.sql,
+                fallbackFollowersAudienceExpression.bindings
               )
             })
             .whereExists(function () {
               this.select(database.raw('1'))
                 .from('follows')
                 .where('follows.actorId', visibleToActorId)
-                .whereRaw('follows.targetActorId = statuses.actorId')
+                .whereRaw('?? = ??', [
+                  'follows.targetActorId',
+                  'statuses.actorId'
+                ])
                 .where('follows.status', FollowStatus.enum.Accepted)
             })
         })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -229,15 +229,12 @@ export const StatusSQLDatabaseMixin = (
     visibleToActorId: string
   }) => {
     const clientName = String(database.client.config.client)
-    const fallbackFollowersAudienceExpression = clientName.includes('mysql')
-      ? {
-          sql: "?? = CONCAT(??, '/followers')",
-          bindings: ['followers_recipients.actorId', 'statuses.actorId']
-        }
-      : {
-          sql: "?? = ?? || '/followers'",
-          bindings: ['followers_recipients.actorId', 'statuses.actorId']
-        }
+    const fallbackFollowersAudienceExpression = {
+      sql: clientName.includes('mysql')
+        ? "?? = CONCAT(??, '/followers')"
+        : "?? = ?? || '/followers'",
+      bindings: ['followers_recipients.actorId', 'statuses.actorId']
+    }
     const storedFollowersAudienceExpression = {
       sql: `?? = ${statusActorFollowersUrlExpression()}`,
       bindings: ['followers_recipients.actorId']


### PR DESCRIPTION
## Summary

- Fix the follower-audience visibility query used when loading bookmarked statuses so PostgreSQL preserves camelCase column names.
- Add a PostgreSQL SQL-generation regression test for the bookmark/readability path.

## Root Cause

The readable-status filter used raw SQL comparisons like `followers_recipients.statusId = statuses.id`. PostgreSQL folds unquoted identifiers to lowercase, so `statusId` became `statusid` and bookmarks could return 500 when this path was evaluated.

## Validation

- `yarn run prettier --write .`
- `yarn lint` (passes with existing unrelated warnings)
- `yarn build`
- `yarn test`