### PR TITLE
Bump version to v1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.16.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.16.0`
- Base main SHA: `d5db151af7a07ef43c3fa8c248b98d723cde89d6`
- Included commits: `7`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
