### PR TITLE
Bump version to v1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.17.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.16.1`
- Base main SHA: `517293c1ce2f8aa6153db65c43861baba9960619`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
