### PR TITLE
fix: show pointer cursor on status actions

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -285,12 +285,16 @@ export const undoRepostStatus = async ({ statusId }: DefaultStatusParams) => {
  * @see https://docs.joinmastodon.org/methods/statuses/#favourite
  */
 export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
-  await fetch(`/api/v1/statuses/${urlToId(statusId)}/favourite`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
+  const response = await fetch(
+    `/api/v1/statuses/${urlToId(statusId)}/favourite`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
     }
-  })
+  )
+  return response.status === 200
 }
 
 export const bookmarkStatus = async ({ statusId }: DefaultStatusParams) => {
@@ -381,12 +385,16 @@ export const getStatusFavouritedBy = async ({
  * @see https://docs.joinmastodon.org/methods/statuses/#unfavourite
  */
 export const undoLikeStatus = async ({ statusId }: DefaultStatusParams) => {
-  await fetch(`/api/v1/statuses/${urlToId(statusId)}/unfavourite`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
+  const response = await fetch(
+    `/api/v1/statuses/${urlToId(statusId)}/unfavourite`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
     }
-  })
+  )
+  return response.status === 200
 }
 
 export const undoBookmarkStatus = async ({ statusId }: DefaultStatusParams) => {

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -56,7 +56,11 @@ export const Actions: FC<Props> = ({
       currentActor={currentActor}
       status={actualStatus}
     />,
-    <LikeButton key="like" currentActor={currentActor} status={actualStatus} />,
+    <LikeButton
+      key={`like-${actualStatus.id}-${actualStatus.isActorLiked}-${actualStatus.totalLikes}`}
+      currentActor={currentActor}
+      status={actualStatus}
+    />,
     <BookmarkButton
       key="bookmark"
       status={actualStatus}

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -57,7 +57,7 @@ export const Actions: FC<Props> = ({
       status={actualStatus}
     />,
     <LikeButton
-      key={`like-${actualStatus.id}-${actualStatus.isActorLiked}-${actualStatus.totalLikes}`}
+      key={`${actualStatus.id}-like`}
       currentActor={currentActor}
       status={actualStatus}
     />,

--- a/lib/components/posts/actions/bookmark-button.tsx
+++ b/lib/components/posts/actions/bookmark-button.tsx
@@ -52,7 +52,7 @@ export const BookmarkButton: FC<BookmarkButtonProps> = ({
         aria-label={bookmarkLabel}
         disabled={isLoading}
         className={cn(
-          'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed',
+          'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
           isBookmarked ? 'text-amber-500' : 'hover:text-amber-500'
         )}
         onClick={async (e) => {

--- a/lib/components/posts/actions/bookmark-button.tsx
+++ b/lib/components/posts/actions/bookmark-button.tsx
@@ -52,7 +52,7 @@ export const BookmarkButton: FC<BookmarkButtonProps> = ({
         aria-label={bookmarkLabel}
         disabled={isLoading}
         className={cn(
-          'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',
+          'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed',
           isBookmarked ? 'text-amber-500' : 'hover:text-amber-500'
         )}
         onClick={async (e) => {

--- a/lib/components/posts/actions/delete-button.test.tsx
+++ b/lib/components/posts/actions/delete-button.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+import { deleteStatus } from '@/lib/client'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
+
+import { DeleteButton } from './delete-button'
+
+jest.mock('@/lib/client', () => ({
+  deleteStatus: jest.fn()
+}))
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const status: StatusNote = {
+  id: 'https://activities.local/users/llun/statuses/post-1',
+  actorId: 'https://activities.local/users/llun',
+  actor: {
+    id: 'https://activities.local/users/llun',
+    username: 'llun',
+    domain: 'activities.local',
+    name: 'Llun',
+    followersUrl: 'https://activities.local/users/llun/followers',
+    inboxUrl: 'https://activities.local/users/llun/inbox',
+    sharedInboxUrl: 'https://activities.local/inbox',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: currentTime
+  },
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://activities.local/@llun/post-1',
+  text: 'Post content',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  isActorBookmarked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [],
+  tags: []
+}
+
+describe('DeleteButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('disables while deleting to avoid duplicate requests', async () => {
+    let resolveDelete: (value: boolean) => void = () => {}
+    const deletePromise = new Promise<boolean>((resolve) => {
+      resolveDelete = resolve
+    })
+    ;(deleteStatus as jest.Mock).mockReturnValue(deletePromise)
+    const confirm = jest.spyOn(window, 'confirm').mockReturnValue(true)
+    const onPostDeleted = jest.fn()
+
+    render(<DeleteButton status={status} onPostDeleted={onPostDeleted} />)
+
+    const button = screen.getByRole('button', { name: 'Delete post' })
+    fireEvent.click(button)
+
+    expect(button).toBeDisabled()
+    fireEvent.click(button)
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(deleteStatus).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveDelete(true)
+      await deletePromise
+    })
+
+    expect(button).toBeEnabled()
+    expect(onPostDeleted).toHaveBeenCalledWith(status)
+  })
+
+  it('shows an error and keeps the post when delete fails', async () => {
+    ;(deleteStatus as jest.Mock).mockResolvedValue(false)
+    jest.spyOn(window, 'confirm').mockReturnValue(true)
+    const onPostDeleted = jest.fn()
+
+    render(<DeleteButton status={status} onPostDeleted={onPostDeleted} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete post' }))
+
+    expect(
+      await screen.findByText('Failed to delete post. Please try again.')
+    ).toHaveAttribute('role', 'alert')
+    expect(screen.getByRole('button', { name: 'Delete post' })).toBeEnabled()
+    expect(onPostDeleted).not.toHaveBeenCalled()
+  })
+})

--- a/lib/components/posts/actions/delete-button.tsx
+++ b/lib/components/posts/actions/delete-button.tsx
@@ -1,33 +1,81 @@
 import { Trash2 } from 'lucide-react'
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 
 import { deleteStatus } from '@/lib/client'
 import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 
 interface Props {
   status: StatusNote | StatusPoll
   onPostDeleted?: (status: Status) => void
 }
 
+const DELETE_ERROR_DISMISS_MS = 4000
+
 export const DeleteButton: FC<Props> = ({ status, onPostDeleted }) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const failureMessage = 'Failed to delete post. Please try again.'
+
+  useEffect(() => {
+    if (!error) return
+
+    const timeoutId = setTimeout(() => {
+      setError(null)
+    }, DELETE_ERROR_DISMISS_MS)
+
+    return () => clearTimeout(timeoutId)
+  }, [error])
+
   return (
-    <button
-      className="flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-red-500"
-      title="Delete post"
-      aria-label="Delete post"
-      onClick={async (e) => {
-        e.stopPropagation()
-        const deleteConfirmation = window.confirm(
-          `Confirm delete status! ${
-            status.text.length ? `${status.text.slice(0, 20)}...` : status.id
-          }`
-        )
-        if (!deleteConfirmation) return
-        await deleteStatus({ statusId: status.id })
-        onPostDeleted?.(status)
-      }}
-    >
-      <Trash2 className="h-4 w-4" />
-    </button>
+    <span className="relative inline-flex items-center justify-center">
+      <button
+        className={cn(
+          'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
+          'hover:text-red-500'
+        )}
+        title="Delete post"
+        aria-label="Delete post"
+        disabled={isLoading}
+        onClick={async (e) => {
+          e.stopPropagation()
+          if (isLoading) return
+
+          const deleteConfirmation = window.confirm(
+            `Confirm delete status! ${
+              status.text.length ? `${status.text.slice(0, 20)}...` : status.id
+            }`
+          )
+          if (!deleteConfirmation) return
+
+          setIsLoading(true)
+          setError(null)
+          try {
+            const success = await deleteStatus({ statusId: status.id })
+            if (!success) {
+              setError(failureMessage)
+              return
+            }
+
+            onPostDeleted?.(status)
+          } catch {
+            setError(failureMessage)
+          } finally {
+            setIsLoading(false)
+          }
+        }}
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+      {error ? (
+        <span
+          className="pointer-events-none absolute right-0 top-full z-10 mt-1 w-max max-w-[min(12rem,calc(100vw-2rem))] break-words rounded-md border bg-background px-2 py-1 text-left text-xs text-destructive shadow-sm"
+          data-testid="delete-error"
+          role="alert"
+        >
+          {error}
+        </span>
+      ) : null}
+    </span>
   )
 }

--- a/lib/components/posts/actions/delete-button.tsx
+++ b/lib/components/posts/actions/delete-button.tsx
@@ -12,7 +12,7 @@ interface Props {
 export const DeleteButton: FC<Props> = ({ status, onPostDeleted }) => {
   return (
     <button
-      className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted hover:text-red-500 transition-colors"
+      className="flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-red-500"
       title="Delete post"
       aria-label="Delete post"
       onClick={async (e) => {

--- a/lib/components/posts/actions/edit-button.tsx
+++ b/lib/components/posts/actions/edit-button.tsx
@@ -12,7 +12,7 @@ export const EditButton: FC<Props> = ({ status, onEdit }) => {
   if (status.type === StatusType.enum.Announce) return null
   return (
     <button
-      className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
+      className="flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted"
       title="Edit"
       aria-label="Edit post"
       onClick={(e) => {

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -39,7 +39,7 @@ export const EditHistoryButton: FC<Props> = ({
     <div className="relative inline-flex">
       <button
         ref={triggerRef}
-        className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors"
+        className="flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted"
         onClick={(e) => {
           e.stopPropagation()
           onShowEdits?.(status)

--- a/lib/components/posts/actions/like-button.test.tsx
+++ b/lib/components/posts/actions/like-button.test.tsx
@@ -123,4 +123,46 @@ describe('LikeButton', () => {
     ).toHaveAttribute('role', 'alert')
     expect(screen.getByRole('button', { name: 'Unlike, 1 like' })).toBeEnabled()
   })
+
+  it('syncs visible like state when status props update', () => {
+    const { rerender } = render(
+      <LikeButton currentActor={currentActor} status={status} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Like' })).toBeEnabled()
+
+    rerender(
+      <LikeButton
+        currentActor={currentActor}
+        status={{ ...status, isActorLiked: true, totalLikes: 3 }}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Unlike, 3 likes' })
+    ).toBeEnabled()
+  })
+
+  it('clears like errors when status props update', async () => {
+    ;(likeStatus as jest.Mock).mockResolvedValue(false)
+    const { rerender } = render(
+      <LikeButton currentActor={currentActor} status={status} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Like' }))
+
+    expect(
+      await screen.findByText('Failed to like post. Please try again.')
+    ).toHaveAttribute('role', 'alert')
+
+    rerender(
+      <LikeButton
+        currentActor={currentActor}
+        status={{ ...status, totalLikes: 1 }}
+      />
+    )
+
+    expect(screen.queryByTestId('like-error')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Like, 1 like' })).toBeEnabled()
+  })
 })

--- a/lib/components/posts/actions/like-button.test.tsx
+++ b/lib/components/posts/actions/like-button.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+import { likeStatus, undoLikeStatus } from '@/lib/client'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
+
+import { LikeButton } from './like-button'
+
+jest.mock('@/lib/client', () => ({
+  likeStatus: jest.fn(),
+  undoLikeStatus: jest.fn()
+}))
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const actor: ActorProfile = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  domain: 'activities.local',
+  name: 'Llun',
+  followersUrl: 'https://activities.local/users/llun/followers',
+  inboxUrl: 'https://activities.local/users/llun/inbox',
+  sharedInboxUrl: 'https://activities.local/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: currentTime
+}
+
+const currentActor: ActorProfile = {
+  ...actor,
+  id: 'https://activities.local/users/other',
+  username: 'other'
+}
+
+const status: StatusNote = {
+  id: 'https://activities.local/users/llun/statuses/post-1',
+  actorId: actor.id,
+  actor,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Note,
+  url: 'https://activities.local/@llun/post-1',
+  text: 'Post content',
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  isActorBookmarked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [],
+  tags: []
+}
+
+describe('LikeButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('disables while liking to avoid duplicate requests', async () => {
+    let resolveLike: (value: boolean) => void = () => {}
+    const likePromise = new Promise<boolean>((resolve) => {
+      resolveLike = resolve
+    })
+    ;(likeStatus as jest.Mock).mockReturnValue(likePromise)
+
+    render(<LikeButton currentActor={currentActor} status={status} />)
+
+    const button = screen.getByRole('button', { name: 'Like' })
+    fireEvent.click(button)
+
+    expect(button).toBeDisabled()
+    fireEvent.click(button)
+    expect(likeStatus).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveLike(true)
+      await likePromise
+    })
+
+    expect(screen.getByRole('button', { name: 'Unlike, 1 like' })).toBeEnabled()
+  })
+
+  it('shows an error and keeps state when liking fails', async () => {
+    ;(likeStatus as jest.Mock).mockResolvedValue(false)
+
+    render(<LikeButton currentActor={currentActor} status={status} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Like' }))
+
+    expect(
+      await screen.findByText('Failed to like post. Please try again.')
+    ).toHaveAttribute('role', 'alert')
+    expect(screen.getByRole('button', { name: 'Like' })).toBeEnabled()
+    expect(screen.queryByText('1')).not.toBeInTheDocument()
+  })
+
+  it('shows an error and keeps state when unliking rejects', async () => {
+    ;(undoLikeStatus as jest.Mock).mockRejectedValue(new Error('network down'))
+
+    render(
+      <LikeButton
+        currentActor={currentActor}
+        status={{ ...status, isActorLiked: true, totalLikes: 1 }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unlike, 1 like' }))
+
+    expect(
+      await screen.findByText('Failed to unlike post. Please try again.')
+    ).toHaveAttribute('role', 'alert')
+    expect(screen.getByRole('button', { name: 'Unlike, 1 like' })).toBeEnabled()
+  })
+})

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -14,10 +14,20 @@ interface LikeButtonProps {
 const LIKE_ERROR_DISMISS_MS = 4000
 
 export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
-  const [isActorLiked, setIsActorLiked] = useState<boolean>(status.isActorLiked)
-  const [totalLikes, setTotalLikes] = useState<number>(status.totalLikes)
+  const [{ isActorLiked, totalLikes }, setLikeState] = useState({
+    isActorLiked: status.isActorLiked,
+    totalLikes: status.totalLikes
+  })
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setLikeState({
+      isActorLiked: status.isActorLiked,
+      totalLikes: status.totalLikes
+    })
+    setError(null)
+  }, [status.id, status.isActorLiked, status.totalLikes])
 
   useEffect(() => {
     if (!error) return
@@ -69,10 +79,16 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
               return
             }
 
-            setIsActorLiked(nextIsActorLiked)
-            setTotalLikes((prev) =>
-              nextIsActorLiked ? prev + 1 : Math.max(0, prev - 1)
-            )
+            setLikeState((prev) => {
+              if (prev.isActorLiked === nextIsActorLiked) return prev
+
+              return {
+                isActorLiked: nextIsActorLiked,
+                totalLikes: nextIsActorLiked
+                  ? prev.totalLikes + 1
+                  : Math.max(0, prev.totalLikes - 1)
+              }
+            })
           } catch {
             setError(failureMessage)
           } finally {

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -1,5 +1,5 @@
 import { Heart } from 'lucide-react'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 
 import { likeStatus, undoLikeStatus } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
@@ -10,9 +10,32 @@ interface LikeButtonProps {
   currentActor?: ActorProfile
   status: StatusNote | StatusPoll
 }
+
+const LIKE_ERROR_DISMISS_MS = 4000
+
 export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
   const [isActorLiked, setIsActorLiked] = useState<boolean>(status.isActorLiked)
   const [totalLikes, setTotalLikes] = useState<number>(status.totalLikes)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setIsActorLiked(status.isActorLiked)
+    setTotalLikes(status.totalLikes)
+    setError(null)
+  }, [status.isActorLiked, status.totalLikes])
+
+  useEffect(() => {
+    if (!error) return
+
+    const timeoutId = setTimeout(() => {
+      setError(null)
+    }, LIKE_ERROR_DISMISS_MS)
+
+    return () => clearTimeout(timeoutId)
+  }, [error])
+
+  const isOwnPost = status.actorId === currentActor?.id
   const likeLabel =
     totalLikes > 0
       ? `${isActorLiked ? 'Unlike' : 'Like'}, ${totalLikes} ${
@@ -21,31 +44,60 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
       : isActorLiked
         ? 'Unlike'
         : 'Like'
+  const failureMessage = isActorLiked
+    ? 'Failed to unlike post. Please try again.'
+    : 'Failed to like post. Please try again.'
 
   return (
-    <button
-      title={likeLabel}
-      aria-label={likeLabel}
-      disabled={status.actorId === currentActor?.id}
-      className={cn(
-        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
-        isActorLiked ? 'text-red-500' : 'hover:text-red-500'
-      )}
-      onClick={async (e) => {
-        e.stopPropagation()
-        if (isActorLiked) {
-          await undoLikeStatus({ statusId: status.id })
-          setIsActorLiked(false)
-          setTotalLikes((prev) => prev - 1)
-          return
-        }
-        await likeStatus({ statusId: status.id })
-        setIsActorLiked(true)
-        setTotalLikes((prev) => prev + 1)
-      }}
-    >
-      <Heart className={cn('h-4 w-4', { 'fill-current': isActorLiked })} />
-      {totalLikes > 0 && <span>{totalLikes}</span>}
-    </button>
+    <span className="relative inline-flex items-center justify-center">
+      <button
+        title={likeLabel}
+        aria-label={likeLabel}
+        disabled={isOwnPost || isLoading}
+        className={cn(
+          'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
+          isActorLiked ? 'text-red-500' : 'hover:text-red-500'
+        )}
+        onClick={async (e) => {
+          e.stopPropagation()
+          if (isOwnPost || isLoading) return
+
+          setIsLoading(true)
+          setError(null)
+          try {
+            const nextIsActorLiked = !isActorLiked
+            const success = isActorLiked
+              ? await undoLikeStatus({ statusId: status.id })
+              : await likeStatus({ statusId: status.id })
+
+            if (success === false) {
+              setError(failureMessage)
+              return
+            }
+
+            setIsActorLiked(nextIsActorLiked)
+            setTotalLikes((prev) =>
+              nextIsActorLiked ? prev + 1 : Math.max(0, prev - 1)
+            )
+          } catch {
+            setError(failureMessage)
+          } finally {
+            setIsLoading(false)
+          }
+        }}
+      >
+        <Heart className={cn('h-4 w-4', { 'fill-current': isActorLiked })} />
+        {totalLikes > 0 && <span>{totalLikes}</span>}
+      </button>
+      {error ? (
+        <span
+          className="pointer-events-none absolute right-0 top-full z-10 mt-1 w-max max-w-[min(12rem,calc(100vw-2rem))] break-words rounded-md border bg-background px-2 py-1 text-left text-xs text-destructive shadow-sm"
+          data-testid="like-error"
+          role="alert"
+        >
+          {error}
+        </span>
+      ) : null}
+    </span>
   )
 }

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -28,7 +28,7 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
       aria-label={likeLabel}
       disabled={status.actorId === currentActor?.id}
       className={cn(
-        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed',
+        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
         isActorLiked ? 'text-red-500' : 'hover:text-red-500'
       )}
       onClick={async (e) => {

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -20,12 +20,6 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    setIsActorLiked(status.isActorLiked)
-    setTotalLikes(status.totalLikes)
-    setError(null)
-  }, [status.isActorLiked, status.totalLikes])
-
-  useEffect(() => {
     if (!error) return
 
     const timeoutId = setTimeout(() => {

--- a/lib/components/posts/actions/like-button.tsx
+++ b/lib/components/posts/actions/like-button.tsx
@@ -28,7 +28,7 @@ export const LikeButton: FC<LikeButtonProps> = ({ currentActor, status }) => {
       aria-label={likeLabel}
       disabled={status.actorId === currentActor?.id}
       className={cn(
-        'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',
+        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed',
         isActorLiked ? 'text-red-500' : 'hover:text-red-500'
       )}
       onClick={async (e) => {

--- a/lib/components/posts/actions/reply-button.tsx
+++ b/lib/components/posts/actions/reply-button.tsx
@@ -19,7 +19,7 @@ export const ReplyButton: FC<Props> = ({ status, onReply }) => {
 
   return (
     <button
-      className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-blue-500"
+      className="flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted hover:text-blue-500"
       title={replyLabel}
       aria-label={replyLabel}
       onClick={() => onReply?.(status)}

--- a/lib/components/posts/actions/repost-button.tsx
+++ b/lib/components/posts/actions/repost-button.tsx
@@ -41,7 +41,7 @@ export const RepostButton: FC<RepostButtonProps> = ({
       title={repostLabel}
       aria-label={repostLabel}
       className={cn(
-        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed',
+        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
         repostedStatusId !== null ? 'text-green-500' : 'hover:text-green-500'
       )}
       onClick={async (e) => {

--- a/lib/components/posts/actions/repost-button.tsx
+++ b/lib/components/posts/actions/repost-button.tsx
@@ -41,7 +41,7 @@ export const RepostButton: FC<RepostButtonProps> = ({
       title={repostLabel}
       aria-label={repostLabel}
       className={cn(
-        'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted',
+        'flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed',
         repostedStatusId !== null ? 'text-green-500' : 'hover:text-green-500'
       )}
       onClick={async (e) => {

--- a/lib/components/posts/actions/visibility-button.tsx
+++ b/lib/components/posts/actions/visibility-button.tsx
@@ -84,7 +84,7 @@ export const VisibilityButton: FC<Props> = ({ status }) => {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className="flex items-center gap-1.5 rounded-full px-2 py-1 text-sm hover:bg-muted transition-colors disabled:opacity-50"
+          className="flex cursor-pointer items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           title={currentOption.label}
           aria-label={`Visibility: ${currentOption.label}`}
           disabled={saving}

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -783,13 +783,19 @@ describe('Post', () => {
       />
     )
 
-    expect(screen.getByRole('button', { name: 'Like' })).toBeDisabled()
+    expect(
+      await screen.findByRole('button', { name: 'Like, 4 likes' })
+    ).toBeDisabled()
     expect(likeStatus).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       resolveLike(true)
       await likePromise
     })
+
+    expect(
+      screen.getByRole('button', { name: 'Unlike, 5 likes' })
+    ).toBeEnabled()
   })
 
   it('keeps visible social action counts in accessible labels', () => {

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -655,6 +655,7 @@ describe('Post', () => {
         host="activities.local"
         currentActor={status.actor ?? undefined}
         currentTime={currentTime}
+        editable
         showActions
         status={status}
         onShowAttachment={jest.fn()}
@@ -673,6 +674,15 @@ describe('Post', () => {
     ).toHaveClass('disabled:opacity-50')
     expect(
       within(primaryActions).getByRole('button', { name: 'Bookmark' })
+    ).toHaveClass('disabled:opacity-50')
+
+    const secondaryActions = screen.getByRole('group', {
+      name: 'Post secondary actions'
+    })
+    expect(
+      within(secondaryActions).getByRole('button', {
+        name: 'Visibility: Direct'
+      })
     ).toHaveClass('disabled:opacity-50')
   })
 

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -2,9 +2,10 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { ReactNode } from 'react'
 
+import { likeStatus } from '@/lib/client'
 import {
   StatusAnnounce,
   StatusNote,
@@ -25,6 +26,17 @@ jest.mock('./poll', () => ({
 
 jest.mock('./attachments', () => ({
   Attachments: () => null
+}))
+
+jest.mock('@/lib/client', () => ({
+  bookmarkStatus: jest.fn(),
+  undoBookmarkStatus: jest.fn(),
+  deleteStatus: jest.fn(),
+  likeStatus: jest.fn(),
+  undoLikeStatus: jest.fn(),
+  repostStatus: jest.fn(),
+  undoRepostStatus: jest.fn(),
+  updateStatusVisibility: jest.fn()
 }))
 
 const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
@@ -117,6 +129,10 @@ const boostedStatus: StatusAnnounce = {
 }
 
 describe('Post', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('does not nest long-post collapse inside expanded content warnings', () => {
     render(
       <Post
@@ -686,7 +702,7 @@ describe('Post', () => {
     ).toHaveClass('disabled:opacity-50')
   })
 
-  it('resets like action state when rendering updated status data', () => {
+  it('resets like action state when rendering a different status', () => {
     const otherActor = {
       ...status.actor!,
       id: 'https://activities.local/users/other',
@@ -713,6 +729,8 @@ describe('Post', () => {
         showActions
         status={{
           ...status,
+          id: 'https://activities.local/users/llun/statuses/post-2',
+          url: 'https://activities.local/@llun/post-2',
           isActorLiked: true,
           totalLikes: 2
         }}
@@ -723,6 +741,55 @@ describe('Post', () => {
     expect(
       screen.getByRole('button', { name: 'Unlike, 2 likes' })
     ).toBeInTheDocument()
+  })
+
+  it('keeps pending like action state when the same status receives updated counts', async () => {
+    let resolveLike: (value: boolean) => void = () => {}
+    const likePromise = new Promise<boolean>((resolve) => {
+      resolveLike = resolve
+    })
+    ;(likeStatus as jest.Mock).mockReturnValue(likePromise)
+    const otherActor = {
+      ...status.actor!,
+      id: 'https://activities.local/users/other',
+      username: 'other'
+    }
+    const { rerender } = render(
+      <Post
+        host="activities.local"
+        currentActor={otherActor}
+        currentTime={currentTime}
+        showActions
+        status={status}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Like' }))
+
+    expect(screen.getByRole('button', { name: 'Like' })).toBeDisabled()
+
+    rerender(
+      <Post
+        host="activities.local"
+        currentActor={otherActor}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          totalLikes: 4
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Like' })).toBeDisabled()
+    expect(likeStatus).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveLike(true)
+      await likePromise
+    })
   })
 
   it('keeps visible social action counts in accessible labels', () => {

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -686,6 +686,45 @@ describe('Post', () => {
     ).toHaveClass('disabled:opacity-50')
   })
 
+  it('resets like action state when rendering updated status data', () => {
+    const otherActor = {
+      ...status.actor!,
+      id: 'https://activities.local/users/other',
+      username: 'other'
+    }
+    const { rerender } = render(
+      <Post
+        host="activities.local"
+        currentActor={otherActor}
+        currentTime={currentTime}
+        showActions
+        status={status}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Like' })).toBeInTheDocument()
+
+    rerender(
+      <Post
+        host="activities.local"
+        currentActor={otherActor}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          isActorLiked: true,
+          totalLikes: 2
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Unlike, 2 likes' })
+    ).toBeInTheDocument()
+  })
+
   it('keeps visible social action counts in accessible labels', () => {
     render(
       <Post

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -649,6 +649,33 @@ describe('Post', () => {
     })
   })
 
+  it('uses disabled opacity styling for async-capable status action buttons', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        showActions
+        status={status}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    const primaryActions = screen.getByRole('group', {
+      name: 'Post primary actions'
+    })
+
+    expect(
+      within(primaryActions).getByRole('button', { name: 'Repost' })
+    ).toHaveClass('disabled:opacity-50')
+    expect(
+      within(primaryActions).getByRole('button', { name: 'Like' })
+    ).toHaveClass('disabled:opacity-50')
+    expect(
+      within(primaryActions).getByRole('button', { name: 'Bookmark' })
+    ).toHaveClass('disabled:opacity-50')
+  })
+
   it('keeps visible social action counts in accessible labels', () => {
     render(
       <Post

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -615,6 +615,40 @@ describe('Post', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('uses a pointer cursor for status action buttons', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        editable
+        showActions
+        status={{
+          ...status,
+          edits: [{ text: 'Previous content', createdAt: currentTime - 1000 }]
+        }}
+        onEdit={jest.fn()}
+        onPostDeleted={jest.fn()}
+        onReply={jest.fn()}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    const actionButtons = [
+      ...within(
+        screen.getByRole('group', { name: 'Post primary actions' })
+      ).getAllByRole('button'),
+      ...within(
+        screen.getByRole('group', { name: 'Post secondary actions' })
+      ).getAllByRole('button')
+    ]
+
+    expect(actionButtons).toHaveLength(8)
+    actionButtons.forEach((button) => {
+      expect(button).toHaveClass('cursor-pointer')
+    })
+  })
+
   it('keeps visible social action counts in accessible labels', () => {
     render(
       <Post


### PR DESCRIPTION
## Summary

Status action controls were implemented as custom raw buttons with hover styling, but they did not set a pointer cursor. On desktop, hovering actions such as reply, repost, bookmark, visibility, edit, and delete could keep the default cursor even though the controls were clickable.

This change adds explicit `cursor-pointer` styling to the status action buttons and keeps loading or disabled actions using `disabled:cursor-not-allowed` where those states already exist.

## Root Cause

The shared `Button` component already includes pointer cursor styling, but the status action row uses bespoke button components under `lib/components/posts/actions/`. Those components had hover color/background classes without cursor styling, so desktop mouse hover did not consistently communicate that enabled controls were interactive.

## Verification

- Added a regression test in `lib/components/posts/post.test.tsx` that renders the full status action set and verifies each action button carries `cursor-pointer`.
- Confirmed the test failed before the fix and passed after the fix.
- `yarn run prettier --write .`
- `yarn lint` passed with existing `no-explicit-any` warnings outside this change.
- `yarn build` passed.
- `yarn test` passed: 318 suites, 2600 tests.
- Verified in browser at `https://activities.local` using the local `activities.local` dev stack: hovered enabled status action buttons reported computed `cursor: pointer`.

## Notes

The local worktree contains unrelated unstaged changes outside this PR. They were not staged or committed.
