### PR TITLE
fix: avoid marking new replies as edited

### DIFF
--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -140,6 +140,21 @@ describe('Create note action', () => {
       })
     })
 
+    it('omits ActivityPub updated timestamp for newly created replies', async () => {
+      const status = (await createNoteFromUserInput({
+        text: '@test2@llun.test Hello from a new reply',
+        currentActor: actor1,
+        replyNoteId: `${actor2?.id}/statuses/post-2`,
+        database
+      })) as StatusNote
+
+      const note = getNoteFromStatus(status) as Note
+
+      expect(note.inReplyTo).toBe(`${actor2?.id}/statuses/post-2`)
+      expect(note.content).toContain('class="u-url mention"')
+      expect(note).not.toHaveProperty('updated')
+    })
+
     it('does not create reply notification or alert when reply target blocks source', async () => {
       await clearSettledNotificationAlerts()
       const originalStatus = (await createNoteFromUserInput({

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -155,6 +155,26 @@ describe('Create note action', () => {
       expect(note).not.toHaveProperty('updated')
     })
 
+    it('allows ActivityPub updated timestamp to be explicitly omitted', async () => {
+      const status = (await createNoteFromUserInput({
+        text: 'Original note for explicit updated option',
+        currentActor: actor1,
+        database
+      })) as StatusNote
+      const updatedStatus = (await database.updateNote({
+        statusId: status.id,
+        text: 'Edited note for explicit updated option',
+        summary: null
+      })) as StatusNote
+
+      const note = getNoteFromStatus(updatedStatus, {
+        includeUpdated: false
+      }) as Note
+
+      expect(updatedStatus.edits).toHaveLength(1)
+      expect(note).not.toHaveProperty('updated')
+    })
+
     it('does not create reply notification or alert when reply target blocks source', async () => {
       await clearSettledNotificationAlerts()
       const originalStatus = (await createNoteFromUserInput({

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -152,7 +152,7 @@ export const sendUpdateNote = async ({
       }
     },
     async (span) => {
-      const note = getNoteFromStatus(status)
+      const note = getNoteFromStatus(status, { includeUpdated: true })
       if (!note) {
         span.end()
         return

--- a/lib/jobs/sendUpdateNoteJob.test.ts
+++ b/lib/jobs/sendUpdateNoteJob.test.ts
@@ -8,6 +8,7 @@ import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 
 enableFetchMocks()
@@ -42,6 +43,8 @@ describe('Send update note job', () => {
       statusId: `${actor1.id}/statuses/post-1`,
       withReplies: false
     })) as Status
+    const note = getNoteFromStatus(status)
+    if (!note) fail('Note is required')
 
     await sendUpdateNoteJob(database, {
       id: 'job-id',
@@ -58,7 +61,10 @@ describe('Send update note job', () => {
       actor: actor1.id,
       to: [ACTIVITY_STREAM_PUBLIC],
       cc: [],
-      object: getNoteFromStatus(status)
+      object: {
+        ...note,
+        updated: getISOTimeUTC(status.updatedAt)
+      }
     })
   })
 

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -9,6 +9,7 @@ import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { getMastodonStatus, getMastodonStatuses } from './getMastodonStatus'
@@ -125,8 +126,31 @@ describe('#getMastodonStatus', () => {
       sensitive: false,
       url: `${ACTOR1_ID}/statuses/post-1`,
       created_at: expect.toBeString(),
-      edited_at: expect.toBeString()
+      edited_at: null
     })
+  })
+
+  it('marks an edited status with edited_at', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/mastodon-edited-note`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'Original content',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const editedStatus = (await database.updateNote({
+      statusId,
+      text: 'Edited content',
+      summary: null
+    })) as Status
+
+    const mastodonStatus = await getMastodonStatus(database, editedStatus)
+
+    expect(mastodonStatus?.edited_at).toBe(
+      getISOTimeUTC(editedStatus.updatedAt)
+    )
   })
 
   it('processes and returns properly formatted content', async () => {
@@ -290,7 +314,7 @@ describe('#getMastodonStatus', () => {
         visibility: 'public',
         url: `${ACTOR2_ID}/statuses/post-2`,
         created_at: expect.toBeString(),
-        edited_at: expect.toBeString()
+        edited_at: null
       }
     })
   })
@@ -316,6 +340,35 @@ describe('#getMastodonStatus', () => {
       in_reply_to_id: urlToId(`${ACTOR1_ID}/statuses/post-1`),
       in_reply_to_account_id: urlToId(ACTOR1_ID)
     })
+  })
+
+  it('does not mark a newly created reply as edited', async () => {
+    const parentStatus = await database.createNote({
+      id: `${ACTOR2_ID}/statuses/mastodon-unedited-parent`,
+      url: `${ACTOR2_ID}/statuses/mastodon-unedited-parent`,
+      actorId: ACTOR2_ID,
+      text: 'Parent for unedited reply',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const replyStatus = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/mastodon-unedited-reply`,
+      url: `${ACTOR1_ID}/statuses/mastodon-unedited-reply`,
+      actorId: ACTOR1_ID,
+      text: '@test2@llun.test Reply with a linked actor mention',
+      reply: parentStatus.id,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR2_ID]
+    })
+
+    const mastodonStatus = await getMastodonStatus(database, replyStatus)
+
+    expect(mastodonStatus).toMatchObject({
+      in_reply_to_id: urlToId(parentStatus.id),
+      in_reply_to_account_id: urlToId(ACTOR2_ID),
+      edited_at: null
+    })
+    expect(mastodonStatus?.content).toContain('class="u-url mention"')
   })
 
   it('returns null when account is not found', async () => {

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -2,7 +2,11 @@ import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { Mastodon } from '@/lib/types/activitypub'
 import { getMastodonAttachment } from '@/lib/types/domain/attachment'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusType,
+  hasStatusBeenEdited
+} from '@/lib/types/domain/status'
 import { Tag, TagType } from '@/lib/types/domain/tag'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getVisibility } from '@/lib/utils/getVisibility'
@@ -142,7 +146,10 @@ export const getMastodonStatus = async (
   const baseData = {
     id: urlToId(status.id),
     created_at: getISOTimeUTC(status.createdAt),
-    edited_at: status.updatedAt ? getISOTimeUTC(status.updatedAt) : null,
+    edited_at:
+      status.type !== StatusType.enum.Announce && hasStatusBeenEdited(status)
+        ? getISOTimeUTC(status.updatedAt)
+        : null,
 
     sensitive: false,
     spoiler_text: '',
@@ -226,7 +233,9 @@ export const getMastodonStatus = async (
     favourites_count: status.totalLikes || 0,
     favourited: status.isActorLiked ?? false,
 
-    edited_at: status.updatedAt ? getISOTimeUTC(status.updatedAt) : null,
+    edited_at: hasStatusBeenEdited(status)
+      ? getISOTimeUTC(status.updatedAt)
+      : null,
 
     reblogged: status.actorAnnounceStatusId !== null,
     content: processStatusText(host, status),

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -233,10 +233,6 @@ export const getMastodonStatus = async (
     favourites_count: status.totalLikes || 0,
     favourited: status.isActorLiked ?? false,
 
-    edited_at: hasStatusBeenEdited(status)
-      ? getISOTimeUTC(status.updatedAt)
-      : null,
-
     reblogged: status.actorAnnounceStatusId !== null,
     content: processStatusText(host, status),
 

--- a/lib/types/domain/status.test.ts
+++ b/lib/types/domain/status.test.ts
@@ -175,7 +175,6 @@ describe('Status', () => {
           summary: null,
           inReplyTo: null,
           published: getISOTimeUTC(status?.createdAt ?? 0),
-          updated: getISOTimeUTC(status?.updatedAt ?? 0),
           url: status.url,
           attributedTo: status.actorId,
           to: status.to,
@@ -210,6 +209,32 @@ describe('Status', () => {
             type: 'Collection',
             totalItems: 0
           }
+        })
+        expect(note).not.toHaveProperty('updated')
+      })
+
+      it('includes updated in Note objects after an edit', async () => {
+        const statusId = `${actor1?.id}/statuses/edited-activitypub-object`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: actor1?.id ?? ACTOR1_ID,
+          text: 'Original ActivityPub object content',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+        const status = (await database.updateNote({
+          statusId,
+          text: 'Edited ActivityPub object content',
+          summary: null
+        })) as StatusNote
+
+        const note = toActivityPubObject(status)
+
+        expect(note).toMatchObject({
+          id: statusId,
+          content: 'Edited ActivityPub object content',
+          updated: getISOTimeUTC(status.updatedAt)
         })
       })
 

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -123,6 +123,11 @@ export const getOriginalStatus = (status: Status): StatusNote | StatusPoll => {
   return status
 }
 
+export const hasStatusBeenEdited = (status: Status): boolean => {
+  const originalStatus = getOriginalStatus(status)
+  return originalStatus.edits.length > 0
+}
+
 export const EditableStatus = z.union([StatusNote, StatusPoll])
 export type EditableStatus = z.infer<typeof EditableStatus>
 
@@ -321,7 +326,9 @@ export const toActivityPubObject = (status: Status): Note | Question => {
       ...(status.endAt <= Date.now()
         ? { closed: getISOTimeUTC(status.endAt) }
         : {}),
-      ...(status.updatedAt ? { updated: getISOTimeUTC(status.updatedAt) } : {})
+      ...(hasStatusBeenEdited(status)
+        ? { updated: getISOTimeUTC(status.updatedAt) }
+        : {})
     })
   }
 
@@ -362,7 +369,7 @@ export const toActivityPubObject = (status: Status): Note | Question => {
     },
 
     published: getISOTimeUTC(originalStatus.createdAt),
-    ...(originalStatus.updatedAt
+    ...(hasStatusBeenEdited(originalStatus)
       ? { updated: getISOTimeUTC(originalStatus.updatedAt) }
       : null)
   })

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -328,7 +328,7 @@ export const toActivityPubObject = (status: Status): Note | Question => {
         : {}),
       ...(hasStatusBeenEdited(status)
         ? { updated: getISOTimeUTC(status.updatedAt) }
-        : {})
+        : null)
     })
   }
 

--- a/lib/utils/getNoteFromStatus.ts
+++ b/lib/utils/getNoteFromStatus.ts
@@ -7,15 +7,24 @@ import {
 import {
   Status,
   StatusType,
-  getOriginalStatus
+  getOriginalStatus,
+  hasStatusBeenEdited
 } from '@/lib/types/domain/status'
 import { getMentionFromTag } from '@/lib/types/domain/tag'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 
-export const getNoteFromStatus = (status: Status): Note | null => {
+interface GetNoteFromStatusOptions {
+  includeUpdated?: boolean
+}
+
+export const getNoteFromStatus = (
+  status: Status,
+  options: GetNoteFromStatusOptions = {}
+): Note | null => {
   const actualStatus = getOriginalStatus(status)
   if (actualStatus.type === StatusType.enum.Poll) return null
+  const includeUpdated = options.includeUpdated || hasStatusBeenEdited(status)
 
   return Note.parse({
     id: actualStatus.id,
@@ -43,7 +52,7 @@ export const getNoteFromStatus = (status: Status): Note | null => {
         getNoteFromStatus(Status.parse(reply))
       )
     },
-    ...(actualStatus.updatedAt
+    ...(includeUpdated
       ? { updated: getISOTimeUTC(actualStatus.updatedAt) }
       : null)
   })

--- a/lib/utils/getNoteFromStatus.ts
+++ b/lib/utils/getNoteFromStatus.ts
@@ -24,7 +24,7 @@ export const getNoteFromStatus = (
 ): Note | null => {
   const actualStatus = getOriginalStatus(status)
   if (actualStatus.type === StatusType.enum.Poll) return null
-  const includeUpdated = options.includeUpdated || hasStatusBeenEdited(status)
+  const includeUpdated = options.includeUpdated ?? hasStatusBeenEdited(status)
 
   return Note.parse({
     id: actualStatus.id,


### PR DESCRIPTION
## Summary
- only expose Mastodon `edited_at` and ActivityPub `updated` when a status has edit history
- keep explicit outbound ActivityPub `Update` deliveries carrying an `updated` timestamp
- add regressions for newly-created replies preserving mention links without being marked edited

## Root Cause
`updatedAt` is an internal row timestamp, but the serializers exposed it as edit metadata for every newly-created status. Mastodon clients can interpret that as an update/edit event, and reply content can be refreshed through the edit path.

## Validation
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" yarn test lib/actions/createNote.test.ts lib/actions/updateNote.test.ts lib/services/mastodon/getMastodonStatus.test.ts lib/types/domain/status.test.ts lib/jobs/sendUpdateNoteJob.test.ts lib/jobs/sendNoteJob.test.ts --runInBand`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" yarn eslint lib/actions/createNote.test.ts lib/activities/index.ts lib/jobs/sendUpdateNoteJob.test.ts lib/services/mastodon/getMastodonStatus.ts lib/services/mastodon/getMastodonStatus.test.ts lib/types/domain/status.ts lib/types/domain/status.test.ts lib/utils/getNoteFromStatus.ts`
- `git diff --check`