### PR TITLE
Bump version to v1.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.17.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.17.1`
- Base main SHA: `a7cf04db10abdb9155e4f3d706dd60c0ccd00a45`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
