### PR TITLE
Bump version to v1.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.17.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.17.2`
- Base main SHA: `f14d7c1669d63a274bf8ac12dcd19db7eb769e38`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
