### PR TITLE
Bump version to v1.17.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.17.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.17.3`
- Base main SHA: `d58e99f6b48e955ffd89f19edbd9f5d837974f13`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
