### PR TITLE
fix: generate maps when repairing stuck fitness jobs

### DIFF
--- a/scripts/fixStuckFitnessProcessing.test.ts
+++ b/scripts/fixStuckFitnessProcessing.test.ts
@@ -1,0 +1,75 @@
+import { getDatabase } from '@/lib/database'
+import { REGENERATE_FITNESS_MAPS_JOB_NAME } from '@/lib/jobs/names'
+import { regenerateFitnessMapsJob } from '@/lib/jobs/regenerateFitnessMapsJob'
+
+import { fixStuckFitnessProcessing } from './fixStuckFitnessProcessing'
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn()
+}))
+
+jest.mock('@/lib/jobs/regenerateFitnessMapsJob', () => ({
+  regenerateFitnessMapsJob: jest.fn()
+}))
+
+const mockGetDatabase = getDatabase as jest.MockedFunction<typeof getDatabase>
+const mockRegenerateFitnessMapsJob =
+  regenerateFitnessMapsJob as jest.MockedFunction<
+    typeof regenerateFitnessMapsJob
+  >
+
+describe('fixStuckFitnessProcessing', () => {
+  const statusHash = 'a'.repeat(64)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(console, 'log').mockImplementation(() => undefined)
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('regenerates the route map when completing parsed stuck files', async () => {
+    const database = {
+      getStatusFromUrlHash: jest.fn().mockResolvedValue({ id: 'status-1' }),
+      getFitnessFileByStatus: jest.fn().mockResolvedValue({
+        id: 'fitness-file-1',
+        actorId: 'actor-1',
+        statusId: 'status-1',
+        fileName: 'run.fit',
+        fileType: 'fit',
+        mimeType: 'application/vnd.ant.fit',
+        bytes: 1234,
+        processingStatus: 'processing',
+        totalDistanceMeters: 1200
+      }),
+      getFitnessFile: jest.fn().mockResolvedValue({
+        id: 'fitness-file-1',
+        processingStatus: 'completed'
+      }),
+      updateFitnessFileProcessingStatus: jest.fn()
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await fixStuckFitnessProcessing([
+      '--status-hash',
+      statusHash
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(mockRegenerateFitnessMapsJob).toHaveBeenCalledWith(database, {
+      id: expect.stringContaining('fitness-file-1'),
+      name: REGENERATE_FITNESS_MAPS_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        fitnessFileIds: ['fitness-file-1']
+      }
+    })
+    expect(
+      database?.updateFitnessFileProcessingStatus
+    ).not.toHaveBeenCalledWith('fitness-file-1', 'completed')
+  })
+})

--- a/scripts/fixStuckFitnessProcessing.ts
+++ b/scripts/fixStuckFitnessProcessing.ts
@@ -6,7 +6,7 @@
  *
  * Resolution logic per stuck file:
  *   - Activity data already parsed (totalDistanceMeters is set)
- *     → mark 'completed' (data is usable; map can be retried via Settings)
+ *     → regenerate the route map image and mark 'completed'
  *   - Activity data not yet parsed
  *     → mark 'pending' so the job will be re-queued on the next page load
  *
@@ -22,6 +22,8 @@ import { loadEnvConfig } from '@next/env'
 import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
+import { REGENERATE_FITNESS_MAPS_JOB_NAME } from '@/lib/jobs/names'
+import { regenerateFitnessMapsJob } from '@/lib/jobs/regenerateFitnessMapsJob'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
 
 const projectDir = process.cwd()
@@ -75,6 +77,23 @@ const parseArgs = (args: string[]) => {
 const resolveTargetStatus = (file: FitnessFile): 'completed' | 'pending' =>
   typeof file.totalDistanceMeters === 'number' ? 'completed' : 'pending'
 
+const regenerateRouteMap = async (
+  database: NonNullable<ReturnType<typeof getDatabase>>,
+  file: FitnessFile
+) => {
+  await regenerateFitnessMapsJob(database, {
+    id: `fix-stuck-fitness-map:${file.id}`,
+    name: REGENERATE_FITNESS_MAPS_JOB_NAME,
+    data: {
+      actorId: file.actorId,
+      fitnessFileIds: [file.id]
+    }
+  })
+
+  const refreshedFile = await database.getFitnessFile({ id: file.id })
+  return refreshedFile?.processingStatus === 'completed'
+}
+
 async function fixFile(
   database: Awaited<ReturnType<typeof getDatabase>>,
   file: FitnessFile
@@ -91,7 +110,23 @@ async function fixFile(
   const target = resolveTargetStatus(file)
 
   try {
-    await database.updateFitnessFileProcessingStatus(file.id, target)
+    if (target === 'completed') {
+      console.log(
+        `  [${file.id}] ${file.fileName} → regenerating route map` +
+          (file.activityType ? ` (${file.activityType})` : '')
+      )
+
+      const regenerated = await regenerateRouteMap(database, file)
+      if (!regenerated) {
+        console.error(
+          `  [${file.id}] ${file.fileName} — route map regeneration failed`
+        )
+        return 'error'
+      }
+    } else {
+      await database.updateFitnessFileProcessingStatus(file.id, target)
+    }
+
     console.log(
       `  [${file.id}] ${file.fileName} → ${target}` +
         (file.activityType ? ` (${file.activityType})` : '')
@@ -106,7 +141,7 @@ async function fixFile(
   }
 }
 
-async function fixStuckFitnessProcessing(args = process.argv.slice(2)) {
+export async function fixStuckFitnessProcessing(args = process.argv.slice(2)) {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(USAGE)
     return 0
@@ -191,8 +226,7 @@ async function fixStuckFitnessProcessing(args = process.argv.slice(2)) {
 
   if (counts.completed > 0) {
     console.log(
-      '\nFiles marked completed have activity data but no map image.\n' +
-        'Use Settings → Fitness → Regenerate Maps to generate maps (after fixing the OOM issue).'
+      '\nFiles marked completed had route map regeneration attempted.'
     )
   }
 


### PR DESCRIPTION
## Summary

- update `scripts/fixStuckFitnessProcessing.ts` so parsed stuck fitness files run the existing route map regeneration job instead of only flipping `processingStatus`
- re-read the fitness file after regeneration and report an error if map regeneration leaves it non-completed
- add a regression test for the parsed stuck-file repair path

## Root Cause

The repair script recognized parsed fitness files by `totalDistanceMeters`, but it only marked them `completed` and told operators to regenerate maps later from Settings. That left repaired statuses without their route map image.

## Validation

- `yarn run prettier --write .`
- `yarn lint` (0 errors, existing warnings only)
- `yarn build`
- `yarn test`