### PR TITLE
fix: unify page header layout

### DIFF
--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -4,6 +4,7 @@ import { RefreshCw } from 'lucide-react'
 import { FC, useCallback, useEffect, useReducer, useRef, useState } from 'react'
 
 import { getTimeline } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
 import { PostBox } from '@/lib/components/post-box/post-box'
 import { Posts } from '@/lib/components/posts/posts'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
@@ -222,23 +223,23 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
       <ScrollToTopButton
         isLoadMoreVisible={hasMoreStatuses && isLoadMoreVisible}
       />
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">Timeline</h1>
-          <p className="text-sm text-muted-foreground">
-            Latest posts from your network.
-          </p>
-        </div>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={refreshTimeline}
-          disabled={isRefreshing}
-          aria-label="Refresh timeline"
-        >
-          <RefreshCw className={cn('size-4', isRefreshing && 'animate-spin')} />
-        </Button>
-      </div>
+      <PageHeader
+        title="Timeline"
+        description="Latest posts from your network."
+        actions={
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={refreshTimeline}
+            disabled={isRefreshing}
+            aria-label="Refresh timeline"
+          >
+            <RefreshCw
+              className={cn('size-4', isRefreshing && 'animate-spin')}
+            />
+          </Button>
+        }
+      />
 
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         <div className="p-4 pb-2">

--- a/app/(timeline)/admin/accounts/[id]/page.tsx
+++ b/app/(timeline)/admin/accounts/[id]/page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMention } from '@/lib/types/domain/actor'
@@ -29,7 +30,7 @@ const Page = async ({ params }: Props) => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3">
         <Link
           href="/admin/accounts"
           aria-label="Back to accounts list"
@@ -37,17 +38,18 @@ const Page = async ({ params }: Props) => {
         >
           <ArrowLeft className="h-5 w-5" />
         </Link>
-        <div>
-          <h1 className="text-2xl font-bold">
-            {account.name || account.email}
-          </h1>
-          <p className="text-sm text-muted-foreground">{account.email}</p>
-        </div>
-        {account.role === 'admin' && (
-          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            Admin
-          </span>
-        )}
+        <PageHeader
+          className="flex-1"
+          title={account.name || account.email}
+          description={account.email}
+          actions={
+            account.role === 'admin' && (
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                Admin
+              </span>
+            )
+          }
+        />
       </div>
 
       <div className="rounded-2xl border bg-background/80 p-6 shadow-sm">

--- a/app/(timeline)/admin/accounts/[id]/page.tsx
+++ b/app/(timeline)/admin/accounts/[id]/page.tsx
@@ -40,15 +40,17 @@ const Page = async ({ params }: Props) => {
         </Link>
         <PageHeader
           className="flex-1"
-          title={account.name || account.email}
-          description={account.email}
-          actions={
-            account.role === 'admin' && (
-              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                Admin
-              </span>
-            )
+          title={
+            <span className="flex flex-wrap items-center gap-3">
+              {account.name || account.email}
+              {account.role === 'admin' ? (
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                  Admin
+                </span>
+              ) : undefined}
+            </span>
           }
+          description={account.name ? account.email : undefined}
         />
       </div>
 

--- a/app/(timeline)/admin/accounts/page.tsx
+++ b/app/(timeline)/admin/accounts/page.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
@@ -35,12 +36,10 @@ const Page = async ({ searchParams }: Props) => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Accounts</h1>
-        <p className="text-sm text-muted-foreground">
-          {total} account{total !== 1 ? 's' : ''} registered
-        </p>
-      </div>
+      <PageHeader
+        title="Accounts"
+        description={`${total} account${total !== 1 ? 's' : ''} registered.`}
+      />
 
       {accounts.length === 0 ? (
         <div className="rounded-xl border border-dashed p-6 text-center text-muted-foreground">

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -16,6 +16,7 @@ import {
   deleteDomainBlockAction,
   importKnownDomainBlocklistAction
 } from '@/app/(timeline)/admin/federation/actions'
+import { PageHeader } from '@/lib/components/page-header'
 import { Button } from '@/lib/components/ui/button'
 import { Checkbox } from '@/lib/components/ui/checkbox'
 import { Input } from '@/lib/components/ui/input'
@@ -186,14 +187,14 @@ const Page = async ({ searchParams }: Props) => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Federation</h1>
-        <p className="text-sm text-muted-foreground">
-          {federationMode === 'allowlist'
-            ? 'Limited federation mode'
-            : 'Open federation mode'}
-        </p>
-      </div>
+      <PageHeader
+        title="Federation"
+        description={
+          federationMode === 'allowlist'
+            ? 'Limited federation mode.'
+            : 'Open federation mode.'
+        }
+      />
 
       {statusMessage && (
         <div

--- a/app/(timeline)/admin/system/page.tsx
+++ b/app/(timeline)/admin/system/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -20,12 +21,7 @@ const Page = async () => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">System</h1>
-        <p className="text-sm text-muted-foreground">
-          Version and configuration
-        </p>
-      </div>
+      <PageHeader title="System" description="Version and configuration." />
 
       <div className="rounded-2xl border bg-background/80 p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold">Version</h2>

--- a/app/(timeline)/admin/tags/[tag]/page.tsx
+++ b/app/(timeline)/admin/tags/[tag]/page.tsx
@@ -56,6 +56,7 @@ const Page = async ({ params, searchParams }: Props) => {
           <ArrowLeft className="h-5 w-5" />
         </Link>
         <PageHeader
+          className="flex-1"
           title={tag.replace(/^#+/, '')}
           description={`${total} public post${total !== 1 ? 's' : ''}.`}
         />

--- a/app/(timeline)/admin/tags/[tag]/page.tsx
+++ b/app/(timeline)/admin/tags/[tag]/page.tsx
@@ -1,7 +1,8 @@
-import { ArrowLeft, ChevronLeft, ChevronRight, Hash } from 'lucide-react'
+import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -46,7 +47,7 @@ const Page = async ({ params, searchParams }: Props) => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3">
         <Link
           href="/admin/tags"
           aria-label="Back to hashtags list"
@@ -54,15 +55,10 @@ const Page = async ({ params, searchParams }: Props) => {
         >
           <ArrowLeft className="h-5 w-5" />
         </Link>
-        <div>
-          <div className="flex items-center gap-2">
-            <Hash className="h-5 w-5 text-muted-foreground" />
-            <h1 className="text-2xl font-bold">{tag.replace(/^#+/, '')}</h1>
-          </div>
-          <p className="text-sm text-muted-foreground">
-            {total} public post{total !== 1 ? 's' : ''}
-          </p>
-        </div>
+        <PageHeader
+          title={tag.replace(/^#+/, '')}
+          description={`${total} public post${total !== 1 ? 's' : ''}.`}
+        />
       </div>
 
       {statuses.length === 0 ? (

--- a/app/(timeline)/admin/tags/page.tsx
+++ b/app/(timeline)/admin/tags/page.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight, Hash } from 'lucide-react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { HashtagSortOrder } from '@/lib/types/database/operations'
@@ -58,12 +59,10 @@ const Page = async ({ searchParams }: Props) => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Hashtags</h1>
-        <p className="text-sm text-muted-foreground">
-          {total} hashtag{total !== 1 ? 's' : ''} in the system
-        </p>
-      </div>
+      <PageHeader
+        title="Hashtags"
+        description={`${total} hashtag${total !== 1 ? 's' : ''} in the system.`}
+      />
 
       <div className="flex gap-2">
         {SORT_OPTIONS.map((option) => (

--- a/app/(timeline)/bookmarks/BookmarksTimeline.tsx
+++ b/app/(timeline)/bookmarks/BookmarksTimeline.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { Bookmark } from 'lucide-react'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
 
 import { getBookmarks } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
 import { Posts } from '@/lib/components/posts/posts'
 import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
 import { Button } from '@/lib/components/ui/button'
@@ -149,15 +149,10 @@ export const BookmarksTimeline: FC<BookmarksTimelineProps> = ({
       <ScrollToTopButton
         isLoadMoreVisible={hasMoreStatuses && isLoadMoreVisible}
       />
-      <div>
-        <div className="flex items-center gap-2">
-          <Bookmark className="size-6 text-muted-foreground" />
-          <h1 className="text-2xl font-semibold">Bookmarks</h1>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Saved posts from your timelines.
-        </p>
-      </div>
+      <PageHeader
+        title="Bookmarks"
+        description="Saved posts from your timelines."
+      />
 
       <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         {currentStatuses.length > 0 ? (

--- a/app/(timeline)/messages/MessagesPage.tsx
+++ b/app/(timeline)/messages/MessagesPage.tsx
@@ -4,7 +4,6 @@ import {
   Archive,
   ArrowLeft,
   Loader2,
-  Mail,
   Plus,
   Search,
   Send,
@@ -30,6 +29,7 @@ import {
   searchAccounts
 } from '@/lib/client'
 import type { DirectConversationView } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
 import { Posts } from '@/lib/components/posts/posts'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
@@ -650,16 +650,16 @@ export const MessagesPage: FC<MessagesPageProps> = ({
       data-layout-width="wide"
       className="flex min-h-0 flex-1 flex-col gap-5 md:gap-6"
     >
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <Mail className="size-6 text-muted-foreground md:size-7" />
-          <h1 className="text-2xl font-semibold md:text-3xl">Messages</h1>
-        </div>
-        <Button variant="outline" size="sm" onClick={startNewConversation}>
-          <Plus className="mr-2 size-4" />
-          New
-        </Button>
-      </div>
+      <PageHeader
+        title="Messages"
+        description="Direct conversations with people you follow."
+        actions={
+          <Button variant="outline" size="sm" onClick={startNewConversation}>
+            <Plus className="mr-2 size-4" />
+            New
+          </Button>
+        }
+      />
 
       <section
         aria-label="Direct messages"

--- a/app/(timeline)/notifications/page.tsx
+++ b/app/(timeline)/notifications/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { Pagination } from '@/lib/components/pagination/Pagination'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
@@ -78,9 +79,10 @@ const Page = async ({ searchParams }: Props) => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Notifications</h1>
-      </div>
+      <PageHeader
+        title="Notifications"
+        description="Recent follows, replies, mentions and activity updates."
+      />
 
       {notificationsWithData.length === 0 ? (
         <div className="rounded-xl border bg-background/80 p-8 text-center text-muted-foreground">

--- a/app/(timeline)/settings/account/page.tsx
+++ b/app/(timeline)/settings/account/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
 import { LogoutButton } from '@/app/(timeline)/settings/LogoutButton'
+import { PageHeader } from '@/lib/components/page-header'
 import { ImageUploadField } from '@/lib/components/settings/ImageUploadField'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
@@ -45,12 +46,10 @@ const Page = async ({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Account Settings</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your account details, email and password.
-        </p>
-      </div>
+      <PageHeader
+        title="Account Settings"
+        description="Manage your account details, email and password."
+      />
 
       <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
         <div>

--- a/app/(timeline)/settings/blocks/page.tsx
+++ b/app/(timeline)/settings/blocks/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { getDatabase } from '@/lib/database'
 import { getFallbackBlockedAccount } from '@/lib/services/accounts/getFallbackBlockedAccount'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -42,12 +43,10 @@ const Page = async () => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Blocked Accounts</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage actors hidden from your timelines and notifications.
-        </p>
-      </div>
+      <PageHeader
+        title="Blocked Accounts"
+        description="Manage actors hidden from your timelines and notifications."
+      />
 
       <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
         <BlocksList

--- a/app/(timeline)/settings/fitness/privacy/page.tsx
+++ b/app/(timeline)/settings/fitness/privacy/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { FitnessPrivacyLocationSettings } from '@/lib/components/settings/FitnessPrivacyLocationSettings'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
@@ -32,6 +33,10 @@ const Page = async () => {
 
   return (
     <div className="space-y-6">
+      <PageHeader
+        title="Fitness Privacy"
+        description="Manage hidden locations for imported fitness routes."
+      />
       <FitnessPrivacyLocationSettings mapboxAccessToken={mapboxAccessToken} />
     </div>
   )

--- a/app/(timeline)/settings/fitness/strava/page.tsx
+++ b/app/(timeline)/settings/fitness/strava/page.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { Card } from '@/lib/components/ui/card'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
@@ -24,23 +25,25 @@ const StravaPage: FC = async () => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Strava Integration</h1>
-        <p className="mt-2 text-muted-foreground">
-          Connect your Strava account to sync fitness activities. You&apos;ll
-          need to create an application in the{' '}
-          <a
-            href="https://www.strava.com/settings/api"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Strava API settings
-          </a>
-          . You can also import historical activities from a Strava export
-          archive.
-        </p>
-      </div>
+      <PageHeader
+        title="Strava Integration"
+        description={
+          <>
+            Connect your Strava account to sync fitness activities. You&apos;ll
+            need to create an application in the{' '}
+            <a
+              href="https://www.strava.com/settings/api"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Strava API settings
+            </a>
+            . You can also import historical activities from a Strava export
+            archive.
+          </>
+        }
+      />
 
       <Card className="p-6">
         <StravaSettingsForm serverActorHandle={actorHandle} />

--- a/app/(timeline)/settings/page.tsx
+++ b/app/(timeline)/settings/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { ActorsSection } from '@/lib/components/settings/ActorsSection'
 import { DeleteActorSection } from '@/lib/components/settings/DeleteActorSection'
 import { ImageUploadField } from '@/lib/components/settings/ImageUploadField'
@@ -50,12 +51,10 @@ const Page = async () => {
   })
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Settings</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your profile and account settings.
-        </p>
-      </div>
+      <PageHeader
+        title="Settings"
+        description="Manage your profile and account settings."
+      />
 
       <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
         <div>

--- a/app/(timeline)/settings/sessions/page.tsx
+++ b/app/(timeline)/settings/sessions/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { SessionsList } from '@/lib/components/settings/SessionsList'
 import { getDatabase } from '@/lib/database'
 import {
@@ -45,16 +46,17 @@ const Page = async () => {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Sessions</h1>
-        <p className="text-sm text-muted-foreground">
-          Review active sessions and revoke access you no longer need.
-        </p>
-        <p className="text-sm text-muted-foreground">
-          {sessions.length} session{sessions.length === 1 ? '' : 's'} linked to
-          your account.
-        </p>
-      </div>
+      <PageHeader
+        title="Sessions"
+        description={
+          <>
+            Review active sessions and revoke access you no longer need.
+            <br />
+            {sessions.length} session{sessions.length === 1 ? '' : 's'} linked
+            to your account.
+          </>
+        }
+      />
 
       <SessionsList
         sessions={sessions}

--- a/app/(timeline)/settings/sessions/page.tsx
+++ b/app/(timeline)/settings/sessions/page.tsx
@@ -50,10 +50,11 @@ const Page = async () => {
         title="Sessions"
         description={
           <>
-            Review active sessions and revoke access you no longer need.
-            <br />
-            {sessions.length} session{sessions.length === 1 ? '' : 's'} linked
-            to your account.
+            <p>Review active sessions and revoke access you no longer need.</p>
+            <p>
+              {sessions.length} session{sessions.length === 1 ? '' : 's'} linked
+              to your account.
+            </p>
           </>
         }
       />

--- a/lib/components/admin/StatsOverview.tsx
+++ b/lib/components/admin/StatsOverview.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react'
 
 import { getAllStatsBuckets } from '@/app/(timeline)/admin/actions'
+import { PageHeader } from '@/lib/components/page-header'
 import {
   ALL_COUNTER_TYPES,
   ServiceStatCounterType,
@@ -211,35 +212,33 @@ export const StatsOverview: FC<Props> = ({ stats, initialBuckets }) => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Overview</h1>
-          <p className="text-sm text-muted-foreground">
-            Service usage statistics
-          </p>
-        </div>
-        <div
-          className="flex items-center gap-1 rounded-lg border bg-background p-1"
-          role="tablist"
-        >
-          {RANGES.map((r) => (
-            <button
-              key={r.value}
-              role="tab"
-              aria-selected={(pendingRange ?? range) === r.value}
-              onClick={() => handleRangeChange(r.value)}
-              disabled={isPending}
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                (pendingRange ?? range) === r.value
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-              } disabled:opacity-50`}
-            >
-              {r.label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <PageHeader
+        title="Overview"
+        description="Service usage statistics."
+        actions={
+          <div
+            className="flex items-center gap-1 rounded-lg border bg-background p-1"
+            role="tablist"
+          >
+            {RANGES.map((r) => (
+              <button
+                key={r.value}
+                role="tab"
+                aria-selected={(pendingRange ?? range) === r.value}
+                onClick={() => handleRangeChange(r.value)}
+                disabled={isPending}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                  (pendingRange ?? range) === r.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                } disabled:opacity-50`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        }
+      />
 
       <div
         className={`transition-opacity ${isPending ? 'opacity-60' : 'opacity-100'}`}

--- a/lib/components/page-header.tsx
+++ b/lib/components/page-header.tsx
@@ -19,9 +19,9 @@ export const PageHeader = ({
     <div className="min-w-0">
       <h1 className="text-2xl font-semibold">{title}</h1>
       {description && (
-        <p className="text-sm text-muted-foreground">{description}</p>
+        <div className="text-sm text-muted-foreground">{description}</div>
       )}
     </div>
-    {actions && <div className="shrink-0">{actions}</div>}
+    {actions && <div className="shrink-0 self-center">{actions}</div>}
   </div>
 )

--- a/lib/components/page-header.tsx
+++ b/lib/components/page-header.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface PageHeaderProps {
+  title: ReactNode
+  description?: ReactNode
+  actions?: ReactNode
+  className?: string
+}
+
+export const PageHeader = ({
+  title,
+  description,
+  actions,
+  className
+}: PageHeaderProps) => (
+  <div className={cn('flex items-start justify-between gap-4', className)}>
+    <div className="min-w-0">
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      {description && (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      )}
+    </div>
+    {actions && <div className="shrink-0">{actions}</div>}
+  </div>
+)

--- a/lib/components/settings/FitnessFileManagement.tsx
+++ b/lib/components/settings/FitnessFileManagement.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
 import { deleteFitnessFile } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
 import { Button } from '@/lib/components/ui/button'
 import {
   Card,
@@ -133,12 +134,10 @@ export function FitnessFileManagement({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Fitness Files</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your uploaded fitness files and storage quota.
-        </p>
-      </div>
+      <PageHeader
+        title="Fitness Files"
+        description="Manage your uploaded fitness files and storage quota."
+      />
 
       <Card>
         <CardHeader>

--- a/lib/components/settings/MediaManagement.tsx
+++ b/lib/components/settings/MediaManagement.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
+import { PageHeader } from '@/lib/components/page-header'
 import { Button } from '@/lib/components/ui/button'
 import {
   Card,
@@ -131,12 +132,10 @@ export function MediaManagement({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Media Storage</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your media uploads and storage quota.
-        </p>
-      </div>
+      <PageHeader
+        title="Media Storage"
+        description="Manage your media uploads and storage quota."
+      />
 
       <Card>
         <CardHeader>

--- a/lib/components/settings/NotificationSettings.tsx
+++ b/lib/components/settings/NotificationSettings.tsx
@@ -10,6 +10,7 @@ import {
   updateEmailNotifications,
   updatePushNotifications
 } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
 import { ActorSelector } from '@/lib/components/settings/ActorSelector'
 import { Label } from '@/lib/components/ui/label'
 import { Switch } from '@/lib/components/ui/switch'
@@ -249,19 +250,21 @@ export const NotificationSettings: FC<Props> = ({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Notification Settings</h1>
-        <p className="text-sm text-muted-foreground">
-          Control which notifications are sent and how. Email notifications go
-          to <span className="font-medium">{accountEmail}</span>.{' '}
-          <Link
-            href="/settings"
-            className="text-blue-600 hover:text-blue-800 underline"
-          >
-            Change email address
-          </Link>
-        </p>
-      </div>
+      <PageHeader
+        title="Notification Settings"
+        description={
+          <>
+            Control which notifications are sent and how. Email notifications go
+            to <span className="font-medium">{accountEmail}</span>.{' '}
+            <Link
+              href="/settings"
+              className="text-blue-600 hover:text-blue-800 underline"
+            >
+              Change email address
+            </Link>
+          </>
+        }
+      />
 
       <ActorSelector actors={actors} selectedActorId={actorId} />
 


### PR DESCRIPTION
## Summary
- Added a shared `PageHeader` component with Timeline-style typography and description layout.
- Updated Timeline, Messages, Bookmarks, Notifications, Admin, and Settings surfaces to use the same no-icon header treatment.
- Removed decorative header icons and normalized admin/settings subpage title weight and descriptions.

## Screenshots
Responsive composites covering Timeline, Messages, Bookmarks, Notifications, Admin, and Settings.

### Mobile (390x844)
![Mobile header comparison](https://files.catbox.moe/mtvlag.png)

### Tablet (768x1024)
![Tablet header comparison](https://files.catbox.moe/uuiik4.png)

### Desktop (1440x1000)
![Desktop header comparison](https://files.catbox.moe/0d15dq.png)

## Validation
- `yarn run prettier --write .`
- `yarn lint` (passes with existing warnings)
- `yarn build`
- `yarn test`

