### PR TITLE
Bump version to v1.17.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.17.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.17.5`
- Base main SHA: `c2f555fc7cc2b882a86868136b26a67fdec5b44d`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
