### PR TITLE
Bump version to v1.17.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.17.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.17.6`
- Base main SHA: `e67a45bf58f6766e3bffe32852e0c69075fafb54`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
