### PR TITLE
minor: add indexed account search

### DIFF
--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -197,4 +197,17 @@ describe('GET /api/v1/accounts/search', () => {
       ids: ['https://remote.test/users/alice']
     })
   })
+
+  it('rejects deep search offsets', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=runner&offset=10001',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -81,6 +81,7 @@ describe('GET /api/v1/accounts/search', () => {
       'https://remote.test/users/alice',
       'https://remote.test/users/bob'
     ])
+    mockIsCurrentActorFollowing.mockResolvedValue(false)
     mockGetMastodonActorsFromIds.mockImplementation(({ ids }) =>
       Promise.resolve(ids.map((id: string) => ({ id, username: id })))
     )
@@ -127,6 +128,50 @@ describe('GET /api/v1/accounts/search', () => {
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: [resolvedActor.id, 'https://remote.test/users/alice']
+    })
+  })
+
+  it('includes followed local exact matches when following is true', async () => {
+    const localActor = { id: 'https://llun.test/users/local-runner' }
+    mockGetActorFromUsername.mockResolvedValue(localActor)
+    mockIsCurrentActorFollowing.mockResolvedValue(true)
+    mockSearchAccountIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=local-runner&following=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockIsCurrentActorFollowing).toHaveBeenCalledWith({
+      currentActorId: oauthActor.id,
+      followingActorId: localActor.id
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: [localActor.id]
+    })
+  })
+
+  it('does not prepend exact matches after the first page', async () => {
+    const resolvedActor = { id: 'https://remote.test/users/charlie' }
+    mockGetWebfingerSelf.mockResolvedValue(resolvedActor.id)
+    mockRecordActorIfNeeded.mockResolvedValue(resolvedActor)
+    mockSearchAccountIds.mockResolvedValue(['https://remote.test/users/alice'])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=@charlie@remote.test&resolve=true&offset=1',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: ['https://remote.test/users/alice']
     })
   })
 })

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -127,8 +127,12 @@ describe('GET /api/v1/accounts/search', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'Charlie',
+      domain: 'remote.test'
+    })
     expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
-      account: 'charlie@remote.test'
+      account: 'Charlie@remote.test'
     })
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: '@Charlie@Remote.test',

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -101,6 +101,7 @@ describe('GET /api/v1/accounts/search', () => {
       q: 'runner',
       limit: 2,
       offset: 1,
+      localDomain: 'llun.test',
       exactActorIds: [],
       followingActorId: oauthActor.id
     })
@@ -109,14 +110,16 @@ describe('GET /api/v1/accounts/search', () => {
     })
   })
 
-  it('prepends a resolved exact remote handle before indexed broad results', async () => {
+  it('resolves a remote handle only after indexed search misses', async () => {
     const resolvedActor = { id: 'https://remote.test/users/charlie' }
     mockGetWebfingerSelf.mockResolvedValue(resolvedActor.id)
     mockRecordActorIfNeeded.mockResolvedValue(resolvedActor)
-    mockSearchAccountIds.mockResolvedValue([
-      resolvedActor.id,
-      'https://remote.test/users/alice'
-    ])
+    mockSearchAccountIds
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        resolvedActor.id,
+        'https://remote.test/users/alice'
+      ])
 
     const response = await GET(
       new NextRequest(
@@ -127,17 +130,22 @@ describe('GET /api/v1/accounts/search', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
-      username: 'Charlie',
-      domain: 'remote.test'
+    expect(mockGetActorFromUsername).not.toHaveBeenCalled()
+    expect(mockSearchAccountIds).toHaveBeenNthCalledWith(1, {
+      q: '@Charlie@Remote.test',
+      limit: 40,
+      offset: 0,
+      localDomain: 'llun.test',
+      exactActorIds: []
     })
     expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
       account: 'Charlie@remote.test'
     })
-    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+    expect(mockSearchAccountIds).toHaveBeenNthCalledWith(2, {
       q: '@Charlie@Remote.test',
       limit: 40,
       offset: 0,
+      localDomain: 'llun.test',
       exactActorIds: [resolvedActor.id]
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
@@ -145,9 +153,8 @@ describe('GET /api/v1/accounts/search', () => {
     })
   })
 
-  it('passes exact matches through indexed following filters', async () => {
+  it('delegates local exact username resolution to indexed search', async () => {
     const localActor = { id: 'https://llun.test/users/local-runner' }
-    mockGetActorFromUsername.mockResolvedValue(localActor)
     mockSearchAccountIds.mockResolvedValue([localActor.id])
 
     const response = await GET(
@@ -159,12 +166,14 @@ describe('GET /api/v1/accounts/search', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).not.toHaveBeenCalled()
     expect(mockIsCurrentActorFollowing).not.toHaveBeenCalled()
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'local-runner',
       limit: 40,
       offset: 0,
-      exactActorIds: [localActor.id],
+      localDomain: 'llun.test',
+      exactActorIds: [],
       followingActorId: oauthActor.id
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
@@ -172,10 +181,7 @@ describe('GET /api/v1/accounts/search', () => {
     })
   })
 
-  it('does not prepend exact matches after the first page', async () => {
-    const resolvedActor = { id: 'https://remote.test/users/charlie' }
-    mockGetWebfingerSelf.mockResolvedValue(resolvedActor.id)
-    mockRecordActorIfNeeded.mockResolvedValue(resolvedActor)
+  it('does not resolve remote handles after the first page', async () => {
     mockSearchAccountIds.mockResolvedValue(['https://remote.test/users/alice'])
 
     const response = await GET(
@@ -187,11 +193,13 @@ describe('GET /api/v1/accounts/search', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: '@charlie@remote.test',
       limit: 40,
       offset: 1,
-      exactActorIds: [resolvedActor.id]
+      localDomain: 'llun.test',
+      exactActorIds: []
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: ['https://remote.test/users/alice']
@@ -209,5 +217,34 @@ describe('GET /api/v1/accounts/search', () => {
 
     expect(response.status).toBe(400)
     expect(mockSearchAccountIds).not.toHaveBeenCalled()
+  })
+
+  it('does not webfinger when indexed search finds a mixed-case handle locally', async () => {
+    mockSearchAccountIds.mockResolvedValue([
+      'https://remote.test/users/Charlie'
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=@Charlie@Remote.test&resolve=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).not.toHaveBeenCalled()
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
+    expect(mockRecordActorIfNeeded).not.toHaveBeenCalled()
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: '@Charlie@Remote.test',
+      limit: 40,
+      offset: 0,
+      localDomain: 'llun.test',
+      exactActorIds: []
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: ['https://remote.test/users/Charlie']
+    })
   })
 })

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -223,6 +223,13 @@ describe('GET /api/v1/accounts/search', () => {
     mockSearchAccountIds.mockResolvedValue([
       'https://remote.test/users/Charlie'
     ])
+    mockGetMastodonActorsFromIds.mockResolvedValue([
+      {
+        id: 'https://remote.test/users/Charlie',
+        username: 'Charlie',
+        acct: 'Charlie@remote.test'
+      }
+    ])
 
     const response = await GET(
       new NextRequest(
@@ -245,6 +252,61 @@ describe('GET /api/v1/accounts/search', () => {
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: ['https://remote.test/users/Charlie']
+    })
+  })
+
+  it('webfingers remote handles when indexed search only finds unrelated accounts', async () => {
+    const resolvedActor = { id: 'https://remote.test/users/charlie' }
+    mockGetWebfingerSelf.mockResolvedValue(resolvedActor.id)
+    mockRecordActorIfNeeded.mockResolvedValue(resolvedActor)
+    mockSearchAccountIds
+      .mockResolvedValueOnce(['https://llun.test/users/charlie-brown'])
+      .mockResolvedValueOnce([
+        resolvedActor.id,
+        'https://llun.test/users/charlie-brown'
+      ])
+    mockGetMastodonActorsFromIds
+      .mockResolvedValueOnce([
+        {
+          id: 'https://llun.test/users/charlie-brown',
+          username: 'charlie-brown',
+          acct: 'charlie-brown@llun.test'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: resolvedActor.id,
+          username: 'charlie',
+          acct: 'charlie@remote.test'
+        },
+        {
+          id: 'https://llun.test/users/charlie-brown',
+          username: 'charlie-brown',
+          acct: 'charlie-brown@llun.test'
+        }
+      ])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=@charlie@remote.test&resolve=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
+      account: 'charlie@remote.test'
+    })
+    expect(mockSearchAccountIds).toHaveBeenNthCalledWith(2, {
+      q: '@charlie@remote.test',
+      limit: 40,
+      offset: 0,
+      localDomain: 'llun.test',
+      exactActorIds: [resolvedActor.id]
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenLastCalledWith({
+      ids: [resolvedActor.id, 'https://llun.test/users/charlie-brown']
     })
   })
 })

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -120,7 +120,7 @@ describe('GET /api/v1/accounts/search', () => {
 
     const response = await GET(
       new NextRequest(
-        'https://llun.test/api/v1/accounts/search?q=@charlie@remote.test&resolve=true',
+        'https://llun.test/api/v1/accounts/search?q=@Charlie@Remote.test&resolve=true',
         { headers: { Authorization: 'Bearer read-accounts-token' } }
       ),
       context
@@ -131,7 +131,7 @@ describe('GET /api/v1/accounts/search', () => {
       account: 'charlie@remote.test'
     })
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
-      q: '@charlie@remote.test',
+      q: '@Charlie@Remote.test',
       limit: 40,
       offset: 0,
       exactActorIds: [resolvedActor.id]

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -145,10 +145,9 @@ describe('GET /api/v1/accounts/search', () => {
     })
   })
 
-  it('includes followed local exact matches when following is true', async () => {
+  it('passes exact matches through indexed following filters', async () => {
     const localActor = { id: 'https://llun.test/users/local-runner' }
     mockGetActorFromUsername.mockResolvedValue(localActor)
-    mockIsCurrentActorFollowing.mockResolvedValue(true)
     mockSearchAccountIds.mockResolvedValue([localActor.id])
 
     const response = await GET(
@@ -160,10 +159,7 @@ describe('GET /api/v1/accounts/search', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(mockIsCurrentActorFollowing).toHaveBeenCalledWith({
-      currentActorId: oauthActor.id,
-      followingActorId: localActor.id
-    })
+    expect(mockIsCurrentActorFollowing).not.toHaveBeenCalled()
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'local-runner',
       limit: 40,

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -1,0 +1,132 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockSearchAccountIds = jest.fn()
+const mockGetMastodonActorsFromIds = jest.fn()
+const mockGetActorFromId = jest.fn()
+const mockGetActorFromUsername = jest.fn()
+const mockGetWebfingerSelf = jest.fn()
+const mockRecordActorIfNeeded = jest.fn()
+const mockIsCurrentActorFollowing = jest.fn()
+const mockGetServerSession = jest.fn()
+const mockStoredToken = jest.fn()
+
+const oauthActor = {
+  id: 'https://llun.test/users/oauth-user',
+  username: 'oauth-user',
+  domain: 'llun.test',
+  followersUrl: 'https://llun.test/users/oauth-user/followers',
+  inboxUrl: 'https://llun.test/users/oauth-user/inbox',
+  sharedInboxUrl: 'https://llun.test/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  publicKey: 'public-key',
+  updatedAt: 1
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => ({
+    searchAccountIds: mockSearchAccountIds,
+    getMastodonActorsFromIds: mockGetMastodonActorsFromIds,
+    getActorFromId: mockGetActorFromId,
+    getActorFromUsername: mockGetActorFromUsername,
+    isCurrentActorFollowing: mockIsCurrentActorFollowing
+  }),
+  getKnex: () => () => ({
+    where: () => ({
+      first: () => mockStoredToken()
+    })
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: () => 'https://llun.test',
+  getConfig: () => ({ host: 'llun.test' })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/activities/getWebfingerSelf', () => ({
+  getWebfingerSelf: (...args: unknown[]) => mockGetWebfingerSelf(...args)
+}))
+
+jest.mock('@/lib/actions/utils', () => ({
+  recordActorIfNeeded: (...args: unknown[]) => mockRecordActorIfNeeded(...args)
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+const context = { params: Promise.resolve({}) }
+
+describe('GET /api/v1/accounts/search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: oauthActor.id,
+      scopes: 'read:accounts'
+    })
+    mockGetActorFromId.mockResolvedValue(oauthActor)
+    mockGetActorFromUsername.mockResolvedValue(null)
+    mockSearchAccountIds.mockResolvedValue([
+      'https://remote.test/users/alice',
+      'https://remote.test/users/bob'
+    ])
+    mockGetMastodonActorsFromIds.mockImplementation(({ ids }) =>
+      Promise.resolve(ids.map((id: string) => ({ id, username: id })))
+    )
+  })
+
+  it('delegates indexed account search with offset and following filters', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=runner&limit=2&offset=1&following=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'runner',
+      limit: 2,
+      offset: 1,
+      followingActorId: oauthActor.id
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: ['https://remote.test/users/alice', 'https://remote.test/users/bob']
+    })
+  })
+
+  it('prepends a resolved exact remote handle before indexed broad results', async () => {
+    const resolvedActor = { id: 'https://remote.test/users/charlie' }
+    mockGetWebfingerSelf.mockResolvedValue(resolvedActor.id)
+    mockRecordActorIfNeeded.mockResolvedValue(resolvedActor)
+    mockSearchAccountIds.mockResolvedValue(['https://remote.test/users/alice'])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/search?q=@charlie@remote.test&resolve=true',
+        { headers: { Authorization: 'Bearer read-accounts-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
+      account: 'charlie@remote.test'
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: [resolvedActor.id, 'https://remote.test/users/alice']
+    })
+  })
+})

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -101,6 +101,7 @@ describe('GET /api/v1/accounts/search', () => {
       q: 'runner',
       limit: 2,
       offset: 1,
+      exactActorIds: [],
       followingActorId: oauthActor.id
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
@@ -112,7 +113,10 @@ describe('GET /api/v1/accounts/search', () => {
     const resolvedActor = { id: 'https://remote.test/users/charlie' }
     mockGetWebfingerSelf.mockResolvedValue(resolvedActor.id)
     mockRecordActorIfNeeded.mockResolvedValue(resolvedActor)
-    mockSearchAccountIds.mockResolvedValue(['https://remote.test/users/alice'])
+    mockSearchAccountIds.mockResolvedValue([
+      resolvedActor.id,
+      'https://remote.test/users/alice'
+    ])
 
     const response = await GET(
       new NextRequest(
@@ -126,6 +130,12 @@ describe('GET /api/v1/accounts/search', () => {
     expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
       account: 'charlie@remote.test'
     })
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: '@charlie@remote.test',
+      limit: 40,
+      offset: 0,
+      exactActorIds: [resolvedActor.id]
+    })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: [resolvedActor.id, 'https://remote.test/users/alice']
     })
@@ -135,7 +145,7 @@ describe('GET /api/v1/accounts/search', () => {
     const localActor = { id: 'https://llun.test/users/local-runner' }
     mockGetActorFromUsername.mockResolvedValue(localActor)
     mockIsCurrentActorFollowing.mockResolvedValue(true)
-    mockSearchAccountIds.mockResolvedValue([])
+    mockSearchAccountIds.mockResolvedValue([localActor.id])
 
     const response = await GET(
       new NextRequest(
@@ -149,6 +159,13 @@ describe('GET /api/v1/accounts/search', () => {
     expect(mockIsCurrentActorFollowing).toHaveBeenCalledWith({
       currentActorId: oauthActor.id,
       followingActorId: localActor.id
+    })
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'local-runner',
+      limit: 40,
+      offset: 0,
+      exactActorIds: [localActor.id],
+      followingActorId: oauthActor.id
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: [localActor.id]
@@ -170,6 +187,12 @@ describe('GET /api/v1/accounts/search', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: '@charlie@remote.test',
+      limit: 40,
+      offset: 1,
+      exactActorIds: [resolvedActor.id]
+    })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: ['https://remote.test/users/alice']
     })

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -16,8 +16,8 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const SearchParams = z.object({
   q: z.string(),
-  limit: z.coerce.number().min(1).max(80).default(40).optional(),
-  offset: z.coerce.number().min(0).default(0).optional(),
+  limit: z.coerce.number().int().min(1).max(80).default(40).optional(),
+  offset: z.coerce.number().int().min(0).max(10000).default(0).optional(),
   resolve: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -102,8 +102,16 @@ export const GET = traceApiRoute(
           username: query,
           domain: getConfig().host
         })
-        if (actor && !following) {
-          resultIds.push(actor.id)
+        if (actor) {
+          const canIncludeExact =
+            !following ||
+            (await database.isCurrentActorFollowing({
+              currentActorId: context.currentActor.id,
+              followingActorId: actor.id
+            }))
+          if (canIncludeExact) {
+            resultIds.push(actor.id)
+          }
         }
       }
 
@@ -113,7 +121,9 @@ export const GET = traceApiRoute(
         offset,
         ...(following ? { followingActorId: context.currentActor.id } : {})
       })
-      const ids = [...new Set([...resultIds, ...indexedIds])].slice(0, limit)
+      const ids = [
+        ...new Set([...(offset === 0 ? resultIds : []), ...indexedIds])
+      ].slice(0, limit)
       const results = await database.getMastodonActorsFromIds({ ids })
 
       return apiResponse({

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -64,42 +64,36 @@ export const GET = traceApiRoute(
       }
 
       const query = q.trim()
-      const exactActorIds: string[] = []
-      const addExactActorId = (actor: { id: string } | null | undefined) => {
-        if (!actor) return
-        exactActorIds.push(actor.id)
+      const localDomain = getConfig().host
+      const getSearchParams = (exactActorIds: string[] = []) => {
+        return {
+          q: query,
+          limit,
+          offset,
+          localDomain,
+          exactActorIds,
+          ...(following ? { followingActorId: context.currentActor.id } : {})
+        }
       }
 
-      if (query.includes('@')) {
+      let indexedIds = await database.searchAccountIds(getSearchParams())
+      if (resolve && offset === 0 && indexedIds.length === 0) {
         const handle = parseAccountHandle(query)
         if (handle) {
-          let actor = await database.getActorFromUsername(handle)
-          if (!actor && resolve) {
-            const actorId = await getWebfingerSelf({
-              account: `${handle.username}@${handle.domain}`
-            })
-            actor = actorId
-              ? ((await recordActorIfNeeded({ actorId, database })) ?? null)
-              : null
+          const actorId = await getWebfingerSelf({
+            account: `${handle.username}@${handle.domain}`
+          })
+          const actor = actorId
+            ? ((await recordActorIfNeeded({ actorId, database })) ?? null)
+            : null
+          if (actor) {
+            indexedIds = await database.searchAccountIds(
+              getSearchParams([actor.id])
+            )
           }
-
-          addExactActorId(actor)
         }
-      } else {
-        const actor = await database.getActorFromUsername({
-          username: query,
-          domain: getConfig().host
-        })
-        addExactActorId(actor)
       }
 
-      const indexedIds = await database.searchAccountIds({
-        q: query,
-        limit,
-        offset,
-        exactActorIds,
-        ...(following ? { followingActorId: context.currentActor.id } : {})
-      })
       const results = await database.getMastodonActorsFromIds({
         ids: indexedIds
       })

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -70,7 +70,7 @@ export const GET = traceApiRoute(
       }
 
       const query = q.trim()
-      const resultIds: string[] = []
+      const exactActorIds: string[] = []
 
       if (query.includes('@')) {
         const handle = parseAccountHandle(query)
@@ -93,7 +93,7 @@ export const GET = traceApiRoute(
                 followingActorId: actor.id
               }))
             if (canIncludeExact) {
-              resultIds.push(actor.id)
+              exactActorIds.push(actor.id)
             }
           }
         }
@@ -110,7 +110,7 @@ export const GET = traceApiRoute(
               followingActorId: actor.id
             }))
           if (canIncludeExact) {
-            resultIds.push(actor.id)
+            exactActorIds.push(actor.id)
           }
         }
       }
@@ -119,12 +119,12 @@ export const GET = traceApiRoute(
         q: query,
         limit,
         offset,
+        exactActorIds,
         ...(following ? { followingActorId: context.currentActor.id } : {})
       })
-      const ids = [
-        ...new Set([...(offset === 0 ? resultIds : []), ...indexedIds])
-      ].slice(0, limit)
-      const results = await database.getMastodonActorsFromIds({ ids })
+      const results = await database.getMastodonActorsFromIds({
+        ids: indexedIds
+      })
 
       return apiResponse({
         req,

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -5,7 +5,6 @@ import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { getConfig } from '@/lib/config'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
-import { Actor } from '@/lib/types/domain/actor'
 import { parseAccountHandle } from '@/lib/utils/accountHandle'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -66,17 +65,9 @@ export const GET = traceApiRoute(
 
       const query = q.trim()
       const exactActorIds: string[] = []
-      const addExactActorId = async (actor: Actor | null | undefined) => {
+      const addExactActorId = (actor: { id: string } | null | undefined) => {
         if (!actor) return
-        const canIncludeExact =
-          !following ||
-          (await database.isCurrentActorFollowing({
-            currentActorId: context.currentActor.id,
-            followingActorId: actor.id
-          }))
-        if (canIncludeExact) {
-          exactActorIds.push(actor.id)
-        }
+        exactActorIds.push(actor.id)
       }
 
       if (query.includes('@')) {
@@ -92,14 +83,14 @@ export const GET = traceApiRoute(
               : null
           }
 
-          await addExactActorId(actor)
+          addExactActorId(actor)
         }
       } else {
         const actor = await database.getActorFromUsername({
           username: query,
           domain: getConfig().host
         })
-        await addExactActorId(actor)
+        addExactActorId(actor)
       }
 
       const indexedIds = await database.searchAccountIds({

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -57,16 +57,21 @@ export const GET = traceApiRoute(
         })
       }
 
-      const { q, limit = 40, resolve = false } = parsedParams.data
+      const {
+        q,
+        limit = 40,
+        offset = 0,
+        resolve = false,
+        following = false
+      } = parsedParams.data
 
       if (!q || q.trim().length === 0) {
         return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
       }
 
       const query = q.trim()
-      const results = []
+      const resultIds: string[] = []
 
-      // Try exact match first (username@domain or just username)
       if (query.includes('@')) {
         const handle = parseAccountHandle(query)
         if (handle) {
@@ -80,31 +85,41 @@ export const GET = traceApiRoute(
               : null
           }
 
-          const mastodonActor = actor
-            ? await database.getMastodonActorFromId({ id: actor.id })
-            : null
-          if (mastodonActor) {
-            results.push(mastodonActor)
+          if (actor) {
+            const canIncludeExact =
+              !following ||
+              (await database.isCurrentActorFollowing({
+                currentActorId: context.currentActor.id,
+                followingActorId: actor.id
+              }))
+            if (canIncludeExact) {
+              resultIds.push(actor.id)
+            }
           }
         }
       } else {
-        // Try as local username
         const actor = await database.getActorFromUsername({
           username: query,
           domain: getConfig().host
         })
-        if (actor) {
-          const mastodonActor = await database.getMastodonActorFromId({
-            id: actor.id
-          })
-          if (mastodonActor) results.push(mastodonActor)
+        if (actor && !following) {
+          resultIds.push(actor.id)
         }
       }
+
+      const indexedIds = await database.searchAccountIds({
+        q: query,
+        limit,
+        offset,
+        ...(following ? { followingActorId: context.currentActor.id } : {})
+      })
+      const ids = [...new Set([...resultIds, ...indexedIds])].slice(0, limit)
+      const results = await database.getMastodonActorsFromIds({ ids })
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: results.slice(0, limit)
+        data: results
       })
     }
   )

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -5,6 +5,8 @@ import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { getConfig } from '@/lib/config'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { parseAccountHandle } from '@/lib/utils/accountHandle'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -12,13 +14,6 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
-
-const parseAccountHandle = (value: string) => {
-  const normalized = value.trim().replace(/^@/, '')
-  const [username, domain, ...rest] = normalized.split('@')
-  if (!username || !domain || rest.length > 0) return null
-  return { username, domain }
-}
 
 const SearchParams = z.object({
   q: z.string(),
@@ -71,6 +66,18 @@ export const GET = traceApiRoute(
 
       const query = q.trim()
       const exactActorIds: string[] = []
+      const addExactActorId = async (actor: Actor | null | undefined) => {
+        if (!actor) return
+        const canIncludeExact =
+          !following ||
+          (await database.isCurrentActorFollowing({
+            currentActorId: context.currentActor.id,
+            followingActorId: actor.id
+          }))
+        if (canIncludeExact) {
+          exactActorIds.push(actor.id)
+        }
+      }
 
       if (query.includes('@')) {
         const handle = parseAccountHandle(query)
@@ -85,34 +92,14 @@ export const GET = traceApiRoute(
               : null
           }
 
-          if (actor) {
-            const canIncludeExact =
-              !following ||
-              (await database.isCurrentActorFollowing({
-                currentActorId: context.currentActor.id,
-                followingActorId: actor.id
-              }))
-            if (canIncludeExact) {
-              exactActorIds.push(actor.id)
-            }
-          }
+          await addExactActorId(actor)
         }
       } else {
         const actor = await database.getActorFromUsername({
           username: query,
           domain: getConfig().host
         })
-        if (actor) {
-          const canIncludeExact =
-            !following ||
-            (await database.isCurrentActorFollowing({
-              currentActorId: context.currentActor.id,
-              followingActorId: actor.id
-            }))
-          if (canIncludeExact) {
-            exactActorIds.push(actor.id)
-          }
-        }
+        await addExactActorId(actor)
       }
 
       const indexedIds = await database.searchAccountIds({

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -77,26 +77,34 @@ export const GET = traceApiRoute(
       }
 
       let indexedIds = await database.searchAccountIds(getSearchParams())
-      if (resolve && offset === 0 && indexedIds.length === 0) {
-        const handle = parseAccountHandle(query)
-        if (handle) {
-          const actorId = await getWebfingerSelf({
-            account: `${handle.username}@${handle.domain}`
-          })
-          const actor = actorId
-            ? ((await recordActorIfNeeded({ actorId, database })) ?? null)
-            : null
-          if (actor) {
-            indexedIds = await database.searchAccountIds(
-              getSearchParams([actor.id])
-            )
-          }
-        }
-      }
-
-      const results = await database.getMastodonActorsFromIds({
+      let results = await database.getMastodonActorsFromIds({
         ids: indexedIds
       })
+
+      const handle = resolve && offset === 0 ? parseAccountHandle(query) : null
+      const exactAcct = handle
+        ? `${handle.username}@${handle.domain}`.toLowerCase()
+        : null
+      const hasExactHandle = exactAcct
+        ? results.some((actor) => actor.acct.toLowerCase() === exactAcct)
+        : false
+
+      if (handle && !hasExactHandle) {
+        const actorId = await getWebfingerSelf({
+          account: `${handle.username}@${handle.domain}`
+        })
+        const actor = actorId
+          ? ((await recordActorIfNeeded({ actorId, database })) ?? null)
+          : null
+        if (actor) {
+          indexedIds = await database.searchAccountIds(
+            getSearchParams([actor.id])
+          )
+          results = await database.getMastodonActorsFromIds({
+            ids: indexedIds
+          })
+        }
+      }
 
       return apiResponse({
         req,

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -384,20 +384,21 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       inboxUrl: getLocalActorInboxId(actorId),
       sharedInboxUrl: getLocalActorSharedInboxId(domain)
     }
+    const actor = {
+      id: actorId,
+      type: 'Person' as const,
+      accountId,
+      username,
+      domain,
+      settings: JSON.stringify(actorSettings),
+      publicKey,
+      privateKey,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
 
     await database.transaction(async (trx) => {
-      await trx('actors').insert({
-        id: actorId,
-        type: 'Person',
-        accountId,
-        username,
-        domain,
-        settings: JSON.stringify(actorSettings),
-        publicKey,
-        privateKey,
-        createdAt: currentTime,
-        updatedAt: currentTime
-      })
+      await trx('actors').insert(actor)
       await increaseCounterValue(
         trx,
         CounterKey.serviceTotalActors(),
@@ -405,7 +406,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         currentTime
       )
       await incrementBucket(trx, 'actors', 1, currentTime)
-      await indexActorSearchDocument(trx, { id: actorId })
+      await indexActorSearchDocument(trx, { id: actorId, actor })
     })
 
     return actorId

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -143,9 +143,8 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       )
       await incrementBucket(trx, 'accounts', 1, currentTime)
       await incrementBucket(trx, 'actors', 1, currentTime)
+      await indexActorSearchDocument(trx, { id: actorId })
     })
-
-    await indexActorSearchDocument(database, { id: actorId })
 
     return accountId
   },
@@ -385,27 +384,28 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       sharedInboxUrl: getLocalActorSharedInboxId(domain)
     }
 
-    await database('actors').insert({
-      id: actorId,
-      type: 'Person',
-      accountId,
-      username,
-      domain,
-      settings: JSON.stringify(actorSettings),
-      publicKey,
-      privateKey,
-      createdAt: currentTime,
-      updatedAt: currentTime
+    await database.transaction(async (trx) => {
+      await trx('actors').insert({
+        id: actorId,
+        type: 'Person',
+        accountId,
+        username,
+        domain,
+        settings: JSON.stringify(actorSettings),
+        publicKey,
+        privateKey,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      await increaseCounterValue(
+        trx,
+        CounterKey.serviceTotalActors(),
+        1,
+        currentTime
+      )
+      await incrementBucket(trx, 'actors', 1, currentTime)
+      await indexActorSearchDocument(trx, { id: actorId })
     })
-    await increaseCounterValue(
-      database,
-      CounterKey.serviceTotalActors(),
-      1,
-      currentTime
-    )
-    await incrementBucket(database, 'actors', 1, currentTime)
-
-    await indexActorSearchDocument(database, { id: actorId })
 
     return actorId
   },

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -89,6 +89,18 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       inboxUrl: getLocalActorInboxId(actorId),
       sharedInboxUrl: getLocalActorSharedInboxId(domain)
     }
+    const actor = {
+      id: actorId,
+      type: 'Person' as const,
+      accountId,
+      username,
+      domain,
+      settings: JSON.stringify(actorSettings),
+      publicKey,
+      privateKey,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
 
     await database.transaction(async (trx) => {
       await trx('accounts').insert({
@@ -102,18 +114,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         createdAt: currentTime,
         updatedAt: currentTime
       })
-      await trx('actors').insert({
-        id: actorId,
-        type: 'Person',
-        accountId,
-        username,
-        domain,
-        settings: JSON.stringify(actorSettings),
-        publicKey,
-        privateKey,
-        createdAt: currentTime,
-        updatedAt: currentTime
-      })
+      await trx('actors').insert(actor)
       await trx('account_providers').insert({
         id: `credential_${accountId}`,
         accountId,
@@ -143,7 +144,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       )
       await incrementBucket(trx, 'accounts', 1, currentTime)
       await incrementBucket(trx, 'actors', 1, currentTime)
-      await indexActorSearchDocument(trx, { id: actorId })
+      await indexActorSearchDocument(trx, { id: actorId, actor })
     })
 
     return accountId

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex'
 
+import { indexActorSearchDocument } from '@/lib/database/sql/search'
 import {
   CounterKey,
   getCounterValues,
@@ -143,6 +144,8 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       await incrementBucket(trx, 'accounts', 1, currentTime)
       await incrementBucket(trx, 'actors', 1, currentTime)
     })
+
+    await indexActorSearchDocument(database, { id: actorId })
 
     return accountId
   },
@@ -401,6 +404,8 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       currentTime
     )
     await incrementBucket(database, 'actors', 1, currentTime)
+
+    await indexActorSearchDocument(database, { id: actorId })
 
     return actorId
   },

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -274,20 +274,24 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       inboxUrl,
       sharedInboxUrl
     }
-    await database('actors').insert({
+    const actor = {
       id: actorId,
       type,
       username,
       domain,
       name,
       summary,
+      accountId: null,
       settings: JSON.stringify(settings),
       publicKey,
       privateKey,
+      deletionStatus: null,
+      deletionScheduledAt: null,
       createdAt: new Date(createdAt),
       updatedAt: currentTime
-    })
-    await indexActorSearchDocument(database, { id: actorId })
+    }
+    await database('actors').insert(actor)
+    await indexActorSearchDocument(database, { id: actorId, actor })
     return this.getActorFromId({ id: actorId })
   },
 
@@ -319,20 +323,24 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       inboxUrl,
       sharedInboxUrl
     }
-    await database('actors').insert({
+    const actor = {
       id: actorId,
       type,
       username,
       domain,
       name,
       summary,
+      accountId: null,
       settings: JSON.stringify(settings),
       publicKey,
       privateKey,
+      deletionStatus: null,
+      deletionScheduledAt: null,
       createdAt: new Date(createdAt),
       updatedAt: currentTime
-    })
-    await indexActorSearchDocument(database, { id: actorId })
+    }
+    await database('actors').insert(actor)
+    await indexActorSearchDocument(database, { id: actorId, actor })
     return this.getMastodonActor(actorId)
   },
 
@@ -813,6 +821,17 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(sharedInboxUrl ? { sharedInboxUrl } : null)
     }
 
+    const currentTime = new Date()
+    const updatedActor: SQLActor = {
+      ...persistedActor,
+      ...(type ? { type } : null),
+      ...(name ? { name } : null),
+      ...(summary ? { summary } : null),
+      ...(publicKey ? { publicKey } : null),
+      settings: JSON.stringify(settings),
+      updatedAt: currentTime
+    }
+
     await database<SQLActor>('actors')
       .where('id', actorId)
       .update({
@@ -823,9 +842,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         ...(publicKey ? { publicKey } : null),
 
         settings: JSON.stringify(settings),
-        updatedAt: new Date()
+        updatedAt: currentTime
       })
-    await indexActorSearchDocument(database, { id: actorId })
+    await indexActorSearchDocument(database, {
+      id: actorId,
+      actor: updatedActor
+    })
     return this.getActorFromId({ id: actorId })
   },
 
@@ -920,6 +942,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       deletionScheduledAt: scheduledAt,
       updatedAt: currentTime
     })
+    await indexActorSearchDocument(database, { id: actorId })
   },
 
   async cancelActorDeletion({ actorId }: CancelActorDeletionParams) {
@@ -929,6 +952,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       deletionScheduledAt: null,
       updatedAt: currentTime
     })
+    await indexActorSearchDocument(database, { id: actorId })
   },
 
   async startActorDeletion({ actorId }: StartActorDeletionParams) {
@@ -937,6 +961,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       deletionStatus: 'deleting',
       updatedAt: currentTime
     })
+    await indexActorSearchDocument(database, { id: actorId })
   },
 
   async getActorsScheduledForDeletion({

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -290,8 +290,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       createdAt: new Date(createdAt),
       updatedAt: currentTime
     }
-    await database('actors').insert(actor)
-    await indexActorSearchDocument(database, { id: actorId, actor })
+    await database.transaction(async (trx) => {
+      await trx('actors').insert(actor)
+      await indexActorSearchDocument(trx, { id: actorId, actor })
+    })
     return this.getActorFromId({ id: actorId })
   },
 
@@ -339,8 +341,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       createdAt: new Date(createdAt),
       updatedAt: currentTime
     }
-    await database('actors').insert(actor)
-    await indexActorSearchDocument(database, { id: actorId, actor })
+    await database.transaction(async (trx) => {
+      await trx('actors').insert(actor)
+      await indexActorSearchDocument(trx, { id: actorId, actor })
+    })
     return this.getMastodonActor(actorId)
   },
 
@@ -852,8 +856,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
   },
 
   async deleteActor({ actorId }: DeleteActorParams) {
-    await database('actors').where('id', actorId).delete()
-    await deleteActorSearchDocument(database, { id: actorId })
+    await database.transaction(async (trx) => {
+      await trx('actors').where('id', actorId).delete()
+      await deleteActorSearchDocument(trx, { id: actorId })
+    })
   },
 
   async updateActorFollowersCount(actorId: string) {
@@ -1416,7 +1422,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
       // Finally delete the actor
       await trx('actors').where('id', actorId).delete()
+      await deleteActorSearchDocument(trx, { id: actorId })
     })
-    await deleteActorSearchDocument(database, { id: actorId })
   }
 })

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -88,6 +88,56 @@ const getActorCounterSummary = async (
   }
 }
 
+const insertActorWithSearchIndex = async (
+  database: Knex,
+  {
+    actorId,
+    type = 'Person',
+    username,
+    domain,
+    name,
+    summary,
+    iconUrl,
+    headerImageUrl,
+    followersUrl,
+    inboxUrl,
+    sharedInboxUrl,
+    publicKey,
+    privateKey,
+    createdAt
+  }: CreateActorParams
+) => {
+  const currentTime = new Date()
+  const settings: ActorSettings = {
+    iconUrl,
+    headerImageUrl,
+    followersUrl,
+    inboxUrl,
+    sharedInboxUrl
+  }
+  const actor = {
+    id: actorId,
+    type,
+    username,
+    domain,
+    name,
+    summary,
+    accountId: null,
+    settings: JSON.stringify(settings),
+    publicKey,
+    privateKey,
+    deletionStatus: null,
+    deletionScheduledAt: null,
+    createdAt: new Date(createdAt),
+    updatedAt: currentTime
+  }
+
+  await database.transaction(async (trx) => {
+    await trx('actors').insert(actor)
+    await indexActorSearchDocument(trx, { id: actorId, actor })
+  })
+}
+
 const parseStatusContent = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   content: any
@@ -246,105 +296,17 @@ const getMastodonAccountFromSQLActor = ({
 }
 
 export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
-  async createActor({
-    actorId,
-    type = 'Person',
-
-    username,
-    domain,
-    name,
-    summary,
-    iconUrl,
-    headerImageUrl,
-    followersUrl,
-    inboxUrl,
-    sharedInboxUrl,
-
-    publicKey,
-    privateKey,
-
-    createdAt
-  }: CreateActorParams) {
-    const currentTime = new Date()
-
-    const settings: ActorSettings = {
-      iconUrl,
-      headerImageUrl,
-      followersUrl,
-      inboxUrl,
-      sharedInboxUrl
-    }
-    const actor = {
-      id: actorId,
-      type,
-      username,
-      domain,
-      name,
-      summary,
-      accountId: null,
-      settings: JSON.stringify(settings),
-      publicKey,
-      privateKey,
-      deletionStatus: null,
-      deletionScheduledAt: null,
-      createdAt: new Date(createdAt),
-      updatedAt: currentTime
-    }
-    await database.transaction(async (trx) => {
-      await trx('actors').insert(actor)
-      await indexActorSearchDocument(trx, { id: actorId, actor })
-    })
+  async createActor(params: CreateActorParams) {
+    await insertActorWithSearchIndex(database, params)
+    const { actorId } = params
     return this.getActorFromId({ id: actorId })
   },
 
-  async createMastodonActor({
-    actorId,
-    type = 'Person',
-
-    username,
-    domain,
-    name,
-    summary,
-    iconUrl,
-    headerImageUrl,
-    followersUrl,
-    inboxUrl,
-    sharedInboxUrl,
-
-    publicKey,
-    privateKey,
-
-    createdAt
-  }: CreateActorParams): Promise<Mastodon.Account | null> {
-    const currentTime = new Date()
-
-    const settings: ActorSettings = {
-      iconUrl,
-      headerImageUrl,
-      followersUrl,
-      inboxUrl,
-      sharedInboxUrl
-    }
-    const actor = {
-      id: actorId,
-      type,
-      username,
-      domain,
-      name,
-      summary,
-      accountId: null,
-      settings: JSON.stringify(settings),
-      publicKey,
-      privateKey,
-      deletionStatus: null,
-      deletionScheduledAt: null,
-      createdAt: new Date(createdAt),
-      updatedAt: currentTime
-    }
-    await database.transaction(async (trx) => {
-      await trx('actors').insert(actor)
-      await indexActorSearchDocument(trx, { id: actorId, actor })
-    })
+  async createMastodonActor(
+    params: CreateActorParams
+  ): Promise<Mastodon.Account | null> {
+    await insertActorWithSearchIndex(database, params)
+    const { actorId } = params
     return this.getMastodonActor(actorId)
   },
 

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -836,21 +836,23 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       updatedAt: currentTime
     }
 
-    await database<SQLActor>('actors')
-      .where('id', actorId)
-      .update({
-        ...(type ? { type } : null),
-        ...(name ? { name } : null),
-        ...(summary ? { summary } : null),
+    await database.transaction(async (trx) => {
+      await trx<SQLActor>('actors')
+        .where('id', actorId)
+        .update({
+          ...(type ? { type } : null),
+          ...(name ? { name } : null),
+          ...(summary ? { summary } : null),
 
-        ...(publicKey ? { publicKey } : null),
+          ...(publicKey ? { publicKey } : null),
 
-        settings: JSON.stringify(settings),
-        updatedAt: currentTime
+          settings: JSON.stringify(settings),
+          updatedAt: currentTime
+        })
+      await indexActorSearchDocument(trx, {
+        id: actorId,
+        actor: updatedActor
       })
-    await indexActorSearchDocument(database, {
-      id: actorId,
-      actor: updatedActor
     })
     return this.getActorFromId({ id: actorId })
   },
@@ -943,31 +945,37 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     scheduledAt
   }: ScheduleActorDeletionParams) {
     const currentTime = new Date()
-    await database<SQLActor>('actors').where('id', actorId).update({
-      deletionStatus: 'scheduled',
-      deletionScheduledAt: scheduledAt,
-      updatedAt: currentTime
+    await database.transaction(async (trx) => {
+      await trx<SQLActor>('actors').where('id', actorId).update({
+        deletionStatus: 'scheduled',
+        deletionScheduledAt: scheduledAt,
+        updatedAt: currentTime
+      })
+      await indexActorSearchDocument(trx, { id: actorId })
     })
-    await indexActorSearchDocument(database, { id: actorId })
   },
 
   async cancelActorDeletion({ actorId }: CancelActorDeletionParams) {
     const currentTime = new Date()
-    await database<SQLActor>('actors').where('id', actorId).update({
-      deletionStatus: null,
-      deletionScheduledAt: null,
-      updatedAt: currentTime
+    await database.transaction(async (trx) => {
+      await trx<SQLActor>('actors').where('id', actorId).update({
+        deletionStatus: null,
+        deletionScheduledAt: null,
+        updatedAt: currentTime
+      })
+      await indexActorSearchDocument(trx, { id: actorId })
     })
-    await indexActorSearchDocument(database, { id: actorId })
   },
 
   async startActorDeletion({ actorId }: StartActorDeletionParams) {
     const currentTime = new Date()
-    await database<SQLActor>('actors').where('id', actorId).update({
-      deletionStatus: 'deleting',
-      updatedAt: currentTime
+    await database.transaction(async (trx) => {
+      await trx<SQLActor>('actors').where('id', actorId).update({
+        deletionStatus: 'deleting',
+        updatedAt: currentTime
+      })
+      await indexActorSearchDocument(trx, { id: actorId })
     })
-    await indexActorSearchDocument(database, { id: actorId })
   },
 
   async getActorsScheduledForDeletion({

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -2,6 +2,10 @@ import { Knex } from 'knex'
 
 import { getConfig } from '@/lib/config'
 import {
+  deleteActorSearchDocument,
+  indexActorSearchDocument
+} from '@/lib/database/sql/search'
+import {
   CounterKey,
   decreaseCounterValue,
   deleteCounterValue,
@@ -283,6 +287,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       createdAt: new Date(createdAt),
       updatedAt: currentTime
     })
+    await indexActorSearchDocument(database, { id: actorId })
     return this.getActorFromId({ id: actorId })
   },
 
@@ -327,6 +332,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       createdAt: new Date(createdAt),
       updatedAt: currentTime
     })
+    await indexActorSearchDocument(database, { id: actorId })
     return this.getMastodonActor(actorId)
   },
 
@@ -819,11 +825,13 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         settings: JSON.stringify(settings),
         updatedAt: new Date()
       })
+    await indexActorSearchDocument(database, { id: actorId })
     return this.getActorFromId({ id: actorId })
   },
 
   async deleteActor({ actorId }: DeleteActorParams) {
     await database('actors').where('id', actorId).delete()
+    await deleteActorSearchDocument(database, { id: actorId })
   },
 
   async updateActorFollowersCount(actorId: string) {
@@ -1384,5 +1392,6 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       // Finally delete the actor
       await trx('actors').where('id', actorId).delete()
     })
+    await deleteActorSearchDocument(database, { id: actorId })
   }
 })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -932,6 +932,12 @@ describe('SearchDatabase foundation', () => {
       ).resolves.toEqual([actorId])
       await expect(
         database.searchAccountIds({
+          q: 'secret',
+          limit: 10
+        })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchAccountIds({
           q: '@secret@remote.test',
           limit: 10
         })
@@ -940,6 +946,13 @@ describe('SearchDatabase foundation', () => {
         .where('id', actorId)
         .update({ username: 'Secret' })
       await database.indexActorSearchDocument({ id: actorId })
+      await expect(
+        database.searchAccountIds({
+          q: 'secret',
+          limit: 10,
+          localDomain: 'remote.test'
+        })
+      ).resolves.toEqual([actorId])
       await expect(
         database.searchAccountIds({
           q: '@secret@remote.test',

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -929,6 +929,16 @@ describe('SearchDatabase foundation', () => {
           limit: 10
         })
       ).resolves.toEqual([actorId])
+      await knexDatabase('actors')
+        .where('id', actorId)
+        .update({ username: 'Secret' })
+      await database.indexActorSearchDocument({ id: actorId })
+      await expect(
+        database.searchAccountIds({
+          q: '@secret@remote.test',
+          limit: 10
+        })
+      ).resolves.toEqual([actorId])
       await database.deleteActorSearchDocument({ id: actorId })
       await expect(
         database.searchAccountIds({
@@ -936,6 +946,42 @@ describe('SearchDatabase foundation', () => {
           limit: 10
         })
       ).resolves.toEqual([actorId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('escapes account ordering prefix wildcards', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const alphaId = 'https://remote.test/users/alpha'
+    const xunnerId = 'https://remote.test/users/xunner'
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: xunnerId,
+        username: 'xunner',
+        summary: '_unner literal token'
+      })
+      await createSearchActor(database, {
+        id: alphaId,
+        username: 'alpha',
+        summary: '_unner literal token'
+      })
+
+      await expect(
+        database.searchAccountIds({
+          q: '_unner',
+          limit: 10
+        })
+      ).resolves.toEqual([alphaId, xunnerId])
     } finally {
       await database.destroy()
     }
@@ -979,6 +1025,56 @@ describe('SearchDatabase foundation', () => {
       ).resolves.toEqual([
         getLocalActorId({ domain: 'remote.test', username: 'local-runner' })
       ])
+    } finally {
+      knexDatabase.off('query', handleQuery)
+      await database.destroy()
+    }
+  })
+
+  it('indexes account actors without reloading the inserted actor', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorSelectQueries: string[] = []
+    const handleQuery = ({ sql }: { sql: string }) => {
+      if (
+        sql.toLowerCase().startsWith('select') &&
+        (sql.includes('from `actors`') || sql.includes('from "actors"'))
+      ) {
+        actorSelectQueries.push(sql)
+      }
+    }
+
+    try {
+      await database.migrate()
+      const accountId = await database.createAccount({
+        email: 'local-runner@remote.test',
+        username: 'local-runner',
+        passwordHash: 'password-hash',
+        domain: 'remote.test',
+        privateKey: 'private-key',
+        publicKey: 'public-key'
+      })
+
+      knexDatabase.on('query', handleQuery)
+      const actorId = await database.createActorForAccount({
+        accountId,
+        username: 'secondary-runner',
+        domain: 'remote.test',
+        privateKey: 'secondary-private-key',
+        publicKey: 'secondary-public-key'
+      })
+      knexDatabase.off('query', handleQuery)
+
+      expect(actorSelectQueries).toHaveLength(0)
+      await expect(
+        database.searchAccountIds({ q: 'secondary-runner', limit: 10 })
+      ).resolves.toEqual([actorId])
     } finally {
       knexDatabase.off('query', handleQuery)
       await database.destroy()
@@ -1116,6 +1212,17 @@ describe('SearchDatabase foundation', () => {
         summary: 'Runner'
       })
 
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([actorId])
+      await database.scheduleActorDeletion({
+        actorId,
+        scheduledAt: new Date()
+      })
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([])
+      await database.cancelActorDeletion({ actorId })
       await expect(
         database.searchAccountIds({ q: 'runner', limit: 10 })
       ).resolves.toEqual([actorId])

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -1082,12 +1082,19 @@ describe('SearchDatabase foundation', () => {
     })
     const database = getSQLDatabase(knexDatabase)
     const insertQueries: string[] = []
+    const actorSelectQueries: string[] = []
     const handleQuery = ({ sql }: { sql: string }) => {
       if (
         sql.includes('insert into `search_documents`') ||
         sql.includes('insert into "search_documents"')
       ) {
         insertQueries.push(sql)
+      }
+      if (
+        sql.toLowerCase().startsWith('select') &&
+        (sql.includes('from `actors`') || sql.includes('from "actors"'))
+      ) {
+        actorSelectQueries.push(sql)
       }
     }
 
@@ -1109,6 +1116,8 @@ describe('SearchDatabase foundation', () => {
       knexDatabase.off('query', handleQuery)
 
       expect(insertQueries).toHaveLength(1)
+      expect(actorSelectQueries).toHaveLength(1)
+      expect(actorSelectQueries[0]).not.toContain('select *')
       await expect(
         database.searchAccountIds({ q: 'runner', limit: 10 })
       ).resolves.toEqual([

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -1072,6 +1072,55 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('reindexes account search documents with a batched upsert', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const insertQueries: string[] = []
+    const handleQuery = ({ sql }: { sql: string }) => {
+      if (
+        sql.includes('insert into `search_documents`') ||
+        sql.includes('insert into "search_documents"')
+      ) {
+        insertQueries.push(sql)
+      }
+    }
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/alice',
+        username: 'alice',
+        summary: 'Runner'
+      })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/bob',
+        username: 'bob',
+        summary: 'Runner'
+      })
+
+      knexDatabase.on('query', handleQuery)
+      await database.reindexSearchAccounts({ limit: 10 })
+      knexDatabase.off('query', handleQuery)
+
+      expect(insertQueries).toHaveLength(1)
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([
+        'https://remote.test/users/alice',
+        'https://remote.test/users/bob'
+      ])
+    } finally {
+      knexDatabase.off('query', handleQuery)
+      await database.destroy()
+    }
+  })
+
   it('excludes internal federation signing actors from account search', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -924,4 +924,143 @@ describe('SearchDatabase foundation', () => {
       await database.destroy()
     }
   })
+
+  it('paginates exact account matches with indexed results without skipping', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const exactActorId = 'https://remote.test/users/runner'
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: exactActorId,
+        username: 'runner',
+        summary: 'Hidden runner'
+      })
+      await knexDatabase('actors')
+        .where('id', exactActorId)
+        .update({
+          settings: JSON.stringify({
+            followersUrl: `${exactActorId}/followers`,
+            inboxUrl: `${exactActorId}/inbox`,
+            sharedInboxUrl: 'https://remote.test/inbox',
+            noindex: true
+          })
+        })
+      await database.indexActorSearchDocument({ id: exactActorId })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/alice',
+        username: 'alice',
+        summary: 'Runner'
+      })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/bob',
+        username: 'bob',
+        summary: 'Runner'
+      })
+
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
+          limit: 2,
+          offset: 0,
+          exactActorIds: [exactActorId]
+        })
+      ).resolves.toEqual([exactActorId, 'https://remote.test/users/alice'])
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
+          limit: 2,
+          offset: 2,
+          exactActorIds: [exactActorId]
+        })
+      ).resolves.toEqual(['https://remote.test/users/bob'])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('updates account search discoverability during deletion transitions', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/deleting-runner'
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'deleting-runner',
+        summary: 'Runner'
+      })
+
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([actorId])
+      await database.startActorDeletion({ actorId })
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([])
+      await database.cancelActorDeletion({ actorId })
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([actorId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('excludes internal federation signing actors from account search', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/__instance__'
+
+    try {
+      await database.migrate()
+      await database.createActor({
+        actorId,
+        type: 'Service',
+        username: '__instance__',
+        domain: 'remote.test',
+        name: 'Instance actor',
+        summary: 'Service actor used for ActivityPub federation signing.',
+        inboxUrl: `${actorId}/inbox`,
+        sharedInboxUrl: 'https://remote.test/inbox',
+        followersUrl: `${actorId}/followers`,
+        publicKey: 'public-key',
+        privateKey: 'private-key',
+        createdAt: 1
+      })
+
+      await expect(
+        database.searchAccountIds({ q: 'instance', limit: 10 })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchAccountIds({
+          q: '@__instance__@remote.test',
+          limit: 10,
+          exactActorIds: [actorId]
+        })
+      ).resolves.toEqual([])
+    } finally {
+      await database.destroy()
+    }
+  })
 })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -925,6 +925,13 @@ describe('SearchDatabase foundation', () => {
       ).resolves.toEqual([])
       await expect(
         database.searchAccountIds({
+          q: 'secret',
+          limit: 10,
+          localDomain: 'remote.test'
+        })
+      ).resolves.toEqual([actorId])
+      await expect(
+        database.searchAccountIds({
           q: '@secret@remote.test',
           limit: 10
         })
@@ -1203,17 +1210,36 @@ describe('SearchDatabase foundation', () => {
     })
     const database = getSQLDatabase(knexDatabase)
     const actorId = 'https://remote.test/users/deleting-runner'
+    const viewerId = 'https://remote.test/users/deletion-viewer'
 
     try {
       await database.migrate()
+      await createSearchActor(database, {
+        id: viewerId,
+        username: 'deletion-viewer'
+      })
       await createSearchActor(database, {
         id: actorId,
         username: 'deleting-runner',
         summary: 'Runner'
       })
+      await database.createFollow({
+        actorId: viewerId,
+        targetActorId: actorId,
+        status: FollowStatus.enum.Accepted,
+        inbox: `${actorId}/inbox`,
+        sharedInbox: 'https://remote.test/inbox'
+      })
 
       await expect(
         database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([actorId])
+      await expect(
+        database.searchAccountIds({
+          q: '@deleting-runner@remote.test',
+          limit: 10,
+          followingActorId: viewerId
+        })
       ).resolves.toEqual([actorId])
       await database.scheduleActorDeletion({
         actorId,
@@ -1221,6 +1247,19 @@ describe('SearchDatabase foundation', () => {
       })
       await expect(
         database.searchAccountIds({ q: 'runner', limit: 10 })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchAccountIds({
+          q: '@deleting-runner@remote.test',
+          limit: 10
+        })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchAccountIds({
+          q: '@deleting-runner@remote.test',
+          limit: 10,
+          followingActorId: viewerId
+        })
       ).resolves.toEqual([])
       await database.cancelActorDeletion({ actorId })
       await expect(
@@ -1291,6 +1330,65 @@ describe('SearchDatabase foundation', () => {
         'https://remote.test/users/alice',
         'https://remote.test/users/bob'
       ])
+    } finally {
+      knexDatabase.off('query', handleQuery)
+      await database.destroy()
+    }
+  })
+
+  it('sizes SQLite account reindex batches from the search document column count', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const insertQueries: string[] = []
+    const handleQuery = ({ sql }: { sql: string }) => {
+      if (
+        sql.includes('insert into `search_documents`') ||
+        sql.includes('insert into "search_documents"')
+      ) {
+        insertQueries.push(sql)
+      }
+    }
+
+    try {
+      await database.migrate()
+      for (let index = 0; index < 83; index += 1) {
+        const actorId = `https://remote.test/users/batch-runner-${index}`
+        await knexDatabase('actors').insert({
+          id: actorId,
+          type: 'Person',
+          username: `batch-runner-${index}`,
+          domain: 'remote.test',
+          name: null,
+          summary: 'Runner',
+          accountId: null,
+          settings: JSON.stringify({
+            followersUrl: `${actorId}/followers`,
+            inboxUrl: `${actorId}/inbox`,
+            sharedInboxUrl: 'https://remote.test/inbox'
+          }),
+          publicKey: 'public-key',
+          privateKey: null,
+          deletionStatus: null,
+          deletionScheduledAt: null,
+          createdAt: new Date(1),
+          updatedAt: new Date(1)
+        })
+      }
+
+      knexDatabase.on('query', handleQuery)
+      await database.reindexSearchAccounts({ limit: 83 })
+      knexDatabase.off('query', handleQuery)
+
+      expect(insertQueries).toHaveLength(1)
+      await expect(
+        database.searchAccountIds({ q: 'runner', limit: 100 })
+      ).resolves.toHaveLength(83)
     } finally {
       knexDatabase.off('query', handleQuery)
       await database.destroy()

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -7,6 +7,7 @@ import {
   applySearchDocumentOrdering
 } from '@/lib/database/sql/search/documents'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { getLocalActorId } from '@/lib/utils/activitypubId'
 
 const createSearchActor = async (
   database: ReturnType<typeof getSQLDatabase>,
@@ -79,17 +80,6 @@ describe('SearchDatabase foundation', () => {
     const database = getSQLDatabase(knexDatabase)
 
     try {
-      await expect(
-        database.searchAccountIds({ q: 'runner', limit: 10 })
-      ).rejects.toThrow('not implemented: searchAccountIds')
-      await expect(
-        database.indexActorSearchDocument({
-          id: 'https://remote.test/users/alice'
-        })
-      ).rejects.toThrow('not implemented: indexActorSearchDocument')
-      await expect(database.reindexSearchAccounts()).rejects.toThrow(
-        'not implemented: reindexSearchAccounts'
-      )
       await expect(
         database.searchHashtags({ q: 'runner', limit: 10 })
       ).rejects.toThrow('not implemented: searchHashtags')
@@ -841,6 +831,8 @@ describe('SearchDatabase foundation', () => {
       }
     })
     const database = getSQLDatabase(knexDatabase)
+    const aliceId = 'https://remote.test/users/alice'
+    const bobId = 'https://remote.test/users/bob'
 
     try {
       await database.migrate()
@@ -849,18 +841,29 @@ describe('SearchDatabase foundation', () => {
         username: 'viewer'
       })
       await createSearchActor(database, {
-        id: 'https://remote.test/users/alice',
+        id: aliceId,
         username: 'alice',
         summary: 'Runner'
       })
       await createSearchActor(database, {
-        id: 'https://remote.test/users/bob',
+        id: bobId,
         username: 'bob',
         summary: 'Runner'
       })
+      await knexDatabase('actors')
+        .where('id', bobId)
+        .update({
+          settings: JSON.stringify({
+            followersUrl: `${bobId}/followers`,
+            inboxUrl: `${bobId}/inbox`,
+            sharedInboxUrl: 'https://remote.test/inbox',
+            noindex: true
+          })
+        })
+      await database.indexActorSearchDocument({ id: bobId })
       await database.createFollow({
         actorId: 'https://remote.test/users/viewer',
-        targetActorId: 'https://remote.test/users/bob',
+        targetActorId: bobId,
         status: FollowStatus.enum.Accepted,
         inbox: 'https://remote.test/users/bob/inbox',
         sharedInbox: 'https://remote.test/inbox'
@@ -869,10 +872,16 @@ describe('SearchDatabase foundation', () => {
       await expect(
         database.searchAccountIds({
           q: 'runner',
+          limit: 10
+        })
+      ).resolves.toEqual([aliceId])
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
           limit: 10,
           followingActorId: 'https://remote.test/users/viewer'
         })
-      ).resolves.toEqual(['https://remote.test/users/bob'])
+      ).resolves.toEqual([bobId])
     } finally {
       await database.destroy()
     }
@@ -920,7 +929,58 @@ describe('SearchDatabase foundation', () => {
           limit: 10
         })
       ).resolves.toEqual([actorId])
+      await database.deleteActorSearchDocument({ id: actorId })
+      await expect(
+        database.searchAccountIds({
+          q: '@secret@remote.test',
+          limit: 10
+        })
+      ).resolves.toEqual([actorId])
     } finally {
+      await database.destroy()
+    }
+  })
+
+  it('indexes local account creation without reloading the inserted actor', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorSelectQueries: string[] = []
+    const handleQuery = ({ sql }: { sql: string }) => {
+      if (
+        sql.toLowerCase().startsWith('select') &&
+        (sql.includes('from `actors`') || sql.includes('from "actors"'))
+      ) {
+        actorSelectQueries.push(sql)
+      }
+    }
+
+    try {
+      await database.migrate()
+      knexDatabase.on('query', handleQuery)
+      await database.createAccount({
+        email: 'local-runner@remote.test',
+        username: 'local-runner',
+        passwordHash: 'password-hash',
+        domain: 'remote.test',
+        privateKey: 'private-key',
+        publicKey: 'public-key'
+      })
+      knexDatabase.off('query', handleQuery)
+
+      expect(actorSelectQueries).toHaveLength(0)
+      await expect(
+        database.searchAccountIds({ q: 'local-runner', limit: 10 })
+      ).resolves.toEqual([
+        getLocalActorId({ domain: 'remote.test', username: 'local-runner' })
+      ])
+    } finally {
+      knexDatabase.off('query', handleQuery)
       await database.destroy()
     }
   })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -8,6 +8,37 @@ import {
 } from '@/lib/database/sql/search/documents'
 import { FollowStatus } from '@/lib/types/domain/follow'
 
+const createSearchActor = async (
+  database: ReturnType<typeof getSQLDatabase>,
+  {
+    id,
+    username,
+    domain = 'remote.test',
+    name,
+    summary
+  }: {
+    id: string
+    username: string
+    domain?: string
+    name?: string
+    summary?: string
+  }
+) => {
+  await database.createActor({
+    actorId: id,
+    username,
+    domain,
+    name,
+    summary,
+    inboxUrl: `${id}/inbox`,
+    sharedInboxUrl: `https://${domain}/inbox`,
+    followersUrl: `${id}/followers`,
+    publicKey: 'public-key',
+    privateKey: 'private-key',
+    createdAt: 1
+  })
+}
+
 describe('SearchDatabase foundation', () => {
   const createTableMock = () => {
     const column = {
@@ -763,5 +794,134 @@ describe('SearchDatabase foundation', () => {
       fn: { now: jest.fn() }
     })
     expect(raw).not.toHaveBeenCalled()
+  })
+
+  it('indexes actors and searches accounts by profile text', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/alice',
+        username: 'alice',
+        name: 'Alice Runner',
+        summary: 'Trail running logs'
+      })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/bob',
+        username: 'bob',
+        name: 'Bob Builder'
+      })
+
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
+          limit: 10,
+          offset: 0
+        })
+      ).resolves.toEqual(['https://remote.test/users/alice'])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('filters account search to followed actors when requested', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/viewer',
+        username: 'viewer'
+      })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/alice',
+        username: 'alice',
+        summary: 'Runner'
+      })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/bob',
+        username: 'bob',
+        summary: 'Runner'
+      })
+      await database.createFollow({
+        actorId: 'https://remote.test/users/viewer',
+        targetActorId: 'https://remote.test/users/bob',
+        status: FollowStatus.enum.Accepted,
+        inbox: 'https://remote.test/users/bob/inbox',
+        sharedInbox: 'https://remote.test/inbox'
+      })
+
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
+          limit: 10,
+          followingActorId: 'https://remote.test/users/viewer'
+        })
+      ).resolves.toEqual(['https://remote.test/users/bob'])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('only returns non-discoverable accounts for exact handle matches', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/secret'
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'secret',
+        summary: 'Hidden account'
+      })
+      await knexDatabase('actors')
+        .where('id', actorId)
+        .update({
+          settings: JSON.stringify({
+            followersUrl: `${actorId}/followers`,
+            inboxUrl: `${actorId}/inbox`,
+            sharedInboxUrl: 'https://remote.test/inbox',
+            noindex: true
+          })
+        })
+      await database.indexActorSearchDocument({ id: actorId })
+
+      await expect(
+        database.searchAccountIds({
+          q: 'hidden',
+          limit: 10
+        })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchAccountIds({
+          q: '@secret@remote.test',
+          limit: 10
+        })
+      ).resolves.toEqual([actorId])
+    } finally {
+      await database.destroy()
+    }
   })
 })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -986,6 +986,57 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('returns exact account matches without existing search documents', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const exactActorId = 'https://remote.test/users/legacy-runner'
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: exactActorId,
+        username: 'legacy-runner',
+        summary: 'Legacy runner'
+      })
+      await database.deleteActorSearchDocument({ id: exactActorId })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/alice',
+        username: 'alice',
+        summary: 'Runner'
+      })
+      await createSearchActor(database, {
+        id: 'https://remote.test/users/bob',
+        username: 'bob',
+        summary: 'Runner'
+      })
+
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
+          limit: 2,
+          offset: 0,
+          exactActorIds: [exactActorId]
+        })
+      ).resolves.toEqual([exactActorId, 'https://remote.test/users/alice'])
+      await expect(
+        database.searchAccountIds({
+          q: 'runner',
+          limit: 2,
+          offset: 2,
+          exactActorIds: [exactActorId]
+        })
+      ).resolves.toEqual(['https://remote.test/users/bob'])
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('updates account search discoverability during deletion transitions', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -203,36 +203,40 @@ const applyFollowingFilter = ({
 const getExactAccountIds = async ({
   database,
   q,
-  handle,
   localDomain,
   exactActorIds,
   followingActorId
 }: {
   database: Knex
   q: string
-  handle: ReturnType<typeof parseAccountHandle>
   localDomain?: string | null
   exactActorIds: string[]
   followingActorId?: string | null
 }) => {
+  const trimmedQuery = q.trim()
+  const handle = parseAccountHandle(trimmedQuery)
+  const normalizedLocalDomain = localDomain?.toLowerCase() ?? null
   const localUsername =
-    !handle && localDomain && !q.includes('@')
-      ? q.trim().replace(/^@/, '')
+    !handle && normalizedLocalDomain && !trimmedQuery.includes('@')
+      ? trimmedQuery
       : null
-  const exactHandle = handle ?? {
-    username: localUsername ?? '',
-    domain: localDomain?.toLowerCase() ?? ''
-  }
-  const handleActorRows =
-    handle || localUsername
-      ? await database('actors')
-          .select<{ id: string }[]>('actors.id')
-          .whereRaw('LOWER(??) = ?', [
-            'actors.username',
-            exactHandle.username.toLowerCase()
-          ])
-          .whereRaw('LOWER(??) = ?', ['actors.domain', exactHandle.domain])
-      : []
+  const exactHandle =
+    handle ??
+    (localUsername && normalizedLocalDomain
+      ? {
+          username: localUsername,
+          domain: normalizedLocalDomain
+        }
+      : null)
+  const handleActorRows = exactHandle
+    ? await database('actors')
+        .select<{ id: string }[]>('actors.id')
+        .whereRaw('LOWER(??) = ?', [
+          'actors.username',
+          exactHandle.username.toLowerCase()
+        ])
+        .whereRaw('LOWER(??) = ?', ['actors.domain', exactHandle.domain])
+    : []
   const normalizedExactActorIds = [
     ...new Set([...exactActorIds, ...handleActorRows.map((row) => row.id)])
   ]
@@ -320,7 +324,6 @@ export const searchAccountIds = async (
     exactActorIds = []
   }: SearchAccountsParams
 ): Promise<string[]> => {
-  const handle = parseAccountHandle(q)
   const normalizedQuery = q.trim().replace(/^@/, '').toLowerCase()
   const normalizedExactActorIds = [...new Set(exactActorIds)]
   // Only visible exact matches participate in pagination; filtered exact IDs
@@ -328,7 +331,6 @@ export const searchAccountIds = async (
   const exactResultIds = await getExactAccountIds({
     database,
     q,
-    handle,
     localDomain,
     exactActorIds: normalizedExactActorIds,
     followingActorId

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -20,6 +20,7 @@ import {
   SEARCH_DOCUMENTS_TABLE,
   applySearchDocumentFilter,
   deleteSearchDocument,
+  escapeLikePattern,
   getSearchDocumentId,
   normalizeSearchText
 } from './documents'
@@ -68,7 +69,7 @@ const isDiscoverableAccount = (actor: AccountSearchActor) => {
     !actor.accountId
   return (
     settings.noindex !== true &&
-    actor.deletionStatus !== 'deleting' &&
+    actor.deletionStatus == null &&
     !isInternalFederationActor
   )
 }
@@ -91,14 +92,15 @@ const applyAccountOrdering = ({
   normalizedQuery: string
 }) => {
   const lowerHandleSQL = getLowerAccountHandleSQL(database)
+  const normalizedQueryLikePattern = `${escapeLikePattern(normalizedQuery)}%`
 
   query
     .orderByRaw(
       `case
         when ${lowerHandleSQL} = ? then 0
         when lower(??) = ? then 1
-        when ${lowerHandleSQL} like ? then 2
-        when lower(??) like ? then 3
+        when ${lowerHandleSQL} like ? ESCAPE '\\' then 2
+        when lower(??) like ? ESCAPE '\\' then 3
         else 4
       end`,
       [
@@ -109,9 +111,9 @@ const applyAccountOrdering = ({
         normalizedQuery,
         'actors.username',
         'actors.domain',
-        `${normalizedQuery}%`,
+        normalizedQueryLikePattern,
         'actors.username',
-        `${normalizedQuery}%`
+        normalizedQueryLikePattern
       ]
     )
     .orderByRaw('LOWER(??)', ['actors.username'])
@@ -127,21 +129,15 @@ const chunkArray = <T>(items: T[], size: number) => {
 }
 
 const applySearchableAccountFilters = (query: Knex.QueryBuilder) => {
-  query
-    .where((builder) => {
-      builder
-        .whereNull('actors.deletionStatus')
-        .orWhereNot('actors.deletionStatus', 'deleting')
-    })
-    .whereNot((builder) => {
-      builder
-        .where('actors.type', FEDERATION_SIGNING_ACTOR_TYPE)
-        .whereRaw("?? LIKE ? ESCAPE '\\'", [
-          'actors.username',
-          FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
-        ])
-        .whereNull('actors.accountId')
-    })
+  query.whereNull('actors.deletionStatus').whereNot((builder) => {
+    builder
+      .where('actors.type', FEDERATION_SIGNING_ACTOR_TYPE)
+      .whereRaw("?? LIKE ? ESCAPE '\\'", [
+        'actors.username',
+        FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
+      ])
+      .whereNull('actors.accountId')
+  })
 }
 
 const applyFollowingFilter = ({
@@ -178,8 +174,11 @@ const getExactAccountIds = async ({
   const handleActorRows = handle
     ? await database('actors')
         .select<{ id: string }[]>('actors.id')
-        .where('actors.username', handle.username)
-        .where('actors.domain', handle.domain)
+        .whereRaw('LOWER(??) = ?', [
+          'actors.username',
+          handle.username.toLowerCase()
+        ])
+        .whereRaw('LOWER(??) = ?', ['actors.domain', handle.domain])
     : []
   const normalizedExactActorIds = [
     ...new Set([...exactActorIds, ...handleActorRows.map((row) => row.id)])
@@ -267,6 +266,8 @@ export const searchAccountIds = async (
   const handle = parseAccountHandle(q)
   const normalizedQuery = q.trim().replace(/^@/, '').toLowerCase()
   const normalizedExactActorIds = [...new Set(exactActorIds)]
+  // Only visible exact matches participate in pagination; filtered exact IDs
+  // fall back to the indexed result window instead of reserving page slots.
   const exactResultIds = await getExactAccountIds({
     database,
     handle,

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -321,7 +321,20 @@ export const reindexSearchAccounts = async (
   database: Knex,
   { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
 ): Promise<ReindexSearchDocumentsResult> => {
-  const query = database<SQLActor>('actors').select('*').orderBy('id', 'asc')
+  const query = database<SQLActor>('actors')
+    .select(
+      'id',
+      'username',
+      'domain',
+      'settings',
+      'createdAt',
+      'type',
+      'accountId',
+      'name',
+      'summary',
+      'deletionStatus'
+    )
+    .orderBy('id', 'asc')
   if (afterId) query.where('id', '>', afterId)
 
   const rows = await query.limit(limit)

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -166,14 +166,24 @@ const applyFollowingFilter = ({
 
 const getExactAccountIds = async ({
   database,
+  handle,
   exactActorIds,
   followingActorId
 }: {
   database: Knex
+  handle: ReturnType<typeof parseAccountHandle>
   exactActorIds: string[]
   followingActorId?: string | null
 }) => {
-  const normalizedExactActorIds = [...new Set(exactActorIds)]
+  const handleActorRows = handle
+    ? await database('actors')
+        .select<{ id: string }[]>('actors.id')
+        .where('actors.username', handle.username)
+        .where('actors.domain', handle.domain)
+    : []
+  const normalizedExactActorIds = [
+    ...new Set([...exactActorIds, ...handleActorRows.map((row) => row.id)])
+  ]
   if (normalizedExactActorIds.length === 0) return []
 
   const query = database('actors')
@@ -224,7 +234,7 @@ const upsertActorSearchDocuments = async (
   for (const chunk of chunkArray(rows, ACCOUNT_SEARCH_DOCUMENT_BATCH_SIZE)) {
     await database(SEARCH_DOCUMENTS_TABLE)
       .insert(chunk)
-      .onConflict(['entityType', 'entityId'])
+      .onConflict('id')
       .merge(SEARCH_DOCUMENT_MERGE_COLUMNS)
   }
 }
@@ -259,6 +269,7 @@ export const searchAccountIds = async (
   const normalizedExactActorIds = [...new Set(exactActorIds)]
   const exactResultIds = await getExactAccountIds({
     database,
+    handle,
     exactActorIds: normalizedExactActorIds,
     followingActorId
   })
@@ -281,22 +292,9 @@ export const searchAccountIds = async (
     query.whereNotIn('search_documents.entityId', exactResultIds)
   }
 
-  query.where((builder) => {
-    builder.where('search_documents.discoverable', true)
-    if (handle) {
-      builder.orWhere((exactBuilder) => {
-        exactBuilder
-          .whereRaw('LOWER(??) = ?', [
-            'actors.username',
-            handle.username.toLowerCase()
-          ])
-          .whereRaw('LOWER(??) = ?', ['actors.domain', handle.domain])
-      })
-    }
-    if (normalizedExactActorIds.length > 0) {
-      builder.orWhereIn('search_documents.entityId', normalizedExactActorIds)
-    }
-  })
+  if (!followingActorId) {
+    query.where('search_documents.discoverable', true)
+  }
 
   applyFollowingFilter({ database, query, followingActorId })
 

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -248,7 +248,10 @@ export const searchAccountIds = async (
     if (handle) {
       builder.orWhere((exactBuilder) => {
         exactBuilder
-          .whereRaw('LOWER(??) = ?', ['actors.username', handle.username])
+          .whereRaw('LOWER(??) = ?', [
+            'actors.username',
+            handle.username.toLowerCase()
+          ])
           .whereRaw('LOWER(??) = ?', ['actors.domain', handle.domain])
       })
     }

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -3,6 +3,11 @@ import { Knex } from 'knex'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
+  FEDERATION_SIGNING_ACTOR_TYPE,
+  FEDERATION_SIGNING_ACTOR_USERNAME,
+  isFederationSigningActorUsername
+} from '@/lib/services/federation/instanceActor'
+import {
   ReindexSearchDocumentsParams,
   ReindexSearchDocumentsResult,
   SearchAccountsParams
@@ -18,6 +23,16 @@ import {
   upsertSearchDocument
 } from './documents'
 
+const FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN = `${FEDERATION_SIGNING_ACTOR_USERNAME.replace(/[\\%_]/g, '\\$&')}%`
+
+type AccountSearchActor = Pick<
+  SQLActor,
+  'id' | 'username' | 'domain' | 'settings' | 'createdAt'
+> &
+  Partial<
+    Pick<SQLActor, 'type' | 'accountId' | 'name' | 'summary' | 'deletionStatus'>
+  >
+
 const parseAccountHandle = (value: string) => {
   const normalized = value.trim().replace(/^@/, '').toLowerCase()
   const [username, domain, ...rest] = normalized.split('@')
@@ -25,7 +40,7 @@ const parseAccountHandle = (value: string) => {
   return { username, domain }
 }
 
-const getAccountDocumentText = (actor: SQLActor) => {
+const getAccountDocumentText = (actor: AccountSearchActor) => {
   const acct = `${actor.username}@${actor.domain}`
   return normalizeSearchText(
     [
@@ -38,11 +53,19 @@ const getAccountDocumentText = (actor: SQLActor) => {
   )
 }
 
-const isDiscoverableAccount = (actor: SQLActor) => {
+const isDiscoverableAccount = (actor: AccountSearchActor) => {
   const settings = getCompatibleJSON<Record<string, unknown>>(
     actor.settings as string | Record<string, unknown>
   )
-  return settings.noindex !== true && actor.deletionStatus !== 'deleting'
+  const isInternalFederationActor =
+    actor.type === FEDERATION_SIGNING_ACTOR_TYPE &&
+    isFederationSigningActorUsername(actor.username) &&
+    !actor.accountId
+  return (
+    settings.noindex !== true &&
+    actor.deletionStatus !== 'deleting' &&
+    !isInternalFederationActor
+  )
 }
 
 const getLowerAccountHandleSQL = (database: Knex) => {
@@ -56,13 +79,22 @@ const getLowerAccountHandleSQL = (database: Knex) => {
 const applyAccountOrdering = ({
   database,
   query,
-  normalizedQuery
+  normalizedQuery,
+  exactActorIds
 }: {
   database: Knex
   query: Knex.QueryBuilder
   normalizedQuery: string
+  exactActorIds: string[]
 }) => {
   const lowerHandleSQL = getLowerAccountHandleSQL(database)
+
+  if (exactActorIds.length > 0) {
+    query.orderByRaw(
+      `case when ?? in (${exactActorIds.map(() => '?').join(', ')}) then 0 else 1 end`,
+      ['search_documents.entityId', ...exactActorIds]
+    )
+  }
 
   query
     .orderByRaw(
@@ -90,7 +122,10 @@ const applyAccountOrdering = ({
     .orderBy('search_documents.entityId', 'asc')
 }
 
-const upsertActorSearchDocument = async (database: Knex, actor: SQLActor) => {
+const upsertActorSearchDocument = async (
+  database: Knex,
+  actor: AccountSearchActor
+) => {
   await upsertSearchDocument(database, {
     entityType: 'account',
     entityId: actor.id,
@@ -103,9 +138,11 @@ const upsertActorSearchDocument = async (database: Knex, actor: SQLActor) => {
 
 export const indexActorSearchDocument = async (
   database: Knex,
-  { id }: { id: string }
+  { id, actor: providedActor }: { id: string; actor?: AccountSearchActor }
 ): Promise<void> => {
-  const actor = await database<SQLActor>('actors').where('id', id).first()
+  const actor =
+    providedActor ??
+    (await database<SQLActor>('actors').where('id', id).first())
   if (!actor) {
     await deleteActorSearchDocument(database, { id })
     return
@@ -116,14 +153,35 @@ export const indexActorSearchDocument = async (
 
 export const searchAccountIds = async (
   database: Knex,
-  { q, limit, offset = 0, followingActorId }: SearchAccountsParams
+  {
+    q,
+    limit,
+    offset = 0,
+    followingActorId,
+    exactActorIds = []
+  }: SearchAccountsParams
 ): Promise<string[]> => {
   const handle = parseAccountHandle(q)
   const normalizedQuery = q.trim().replace(/^@/, '').toLowerCase()
+  const normalizedExactActorIds = [...new Set(exactActorIds)]
   const query = database(SEARCH_DOCUMENTS_TABLE)
     .innerJoin('actors', 'actors.id', 'search_documents.entityId')
     .select<{ entityId: string }[]>('search_documents.entityId')
     .where('search_documents.entityType', 'account')
+    .where((builder) => {
+      builder
+        .whereNull('actors.deletionStatus')
+        .orWhereNot('actors.deletionStatus', 'deleting')
+    })
+    .whereNot((builder) => {
+      builder
+        .where('actors.type', FEDERATION_SIGNING_ACTOR_TYPE)
+        .whereRaw("?? LIKE ? ESCAPE '\\'", [
+          'actors.username',
+          FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
+        ])
+        .whereNull('actors.accountId')
+    })
 
   await applySearchDocumentFilter({ database, query, q })
 
@@ -135,6 +193,9 @@ export const searchAccountIds = async (
           .whereRaw('LOWER(??) = ?', ['actors.username', handle.username])
           .whereRaw('LOWER(??) = ?', ['actors.domain', handle.domain])
       })
+    }
+    if (normalizedExactActorIds.length > 0) {
+      builder.orWhereIn('search_documents.entityId', normalizedExactActorIds)
     }
   })
 
@@ -148,7 +209,12 @@ export const searchAccountIds = async (
     })
   }
 
-  applyAccountOrdering({ database, query, normalizedQuery })
+  applyAccountOrdering({
+    database,
+    query,
+    normalizedQuery,
+    exactActorIds: normalizedExactActorIds
+  })
 
   const rows = await query.limit(limit).offset(offset)
   return rows.map((row) => row.entityId)

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/types/database/operations'
 import { SQLActor } from '@/lib/types/database/rows'
 import { FollowStatus } from '@/lib/types/domain/follow'
+import { parseAccountHandle } from '@/lib/utils/accountHandle'
 
 import {
   SEARCH_DOCUMENTS_TABLE,
@@ -32,13 +33,6 @@ type AccountSearchActor = Pick<
   Partial<
     Pick<SQLActor, 'type' | 'accountId' | 'name' | 'summary' | 'deletionStatus'>
   >
-
-const parseAccountHandle = (value: string) => {
-  const normalized = value.trim().replace(/^@/, '').toLowerCase()
-  const [username, domain, ...rest] = normalized.split('@')
-  if (!username || !domain || rest.length > 0) return null
-  return { username, domain }
-}
 
 const getAccountDocumentText = (actor: AccountSearchActor) => {
   const acct = `${actor.username}@${actor.domain}`
@@ -122,6 +116,67 @@ const applyAccountOrdering = ({
     .orderBy('search_documents.entityId', 'asc')
 }
 
+const applySearchableAccountFilters = (query: Knex.QueryBuilder) => {
+  query
+    .where((builder) => {
+      builder
+        .whereNull('actors.deletionStatus')
+        .orWhereNot('actors.deletionStatus', 'deleting')
+    })
+    .whereNot((builder) => {
+      builder
+        .where('actors.type', FEDERATION_SIGNING_ACTOR_TYPE)
+        .whereRaw("?? LIKE ? ESCAPE '\\'", [
+          'actors.username',
+          FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
+        ])
+        .whereNull('actors.accountId')
+    })
+}
+
+const applyFollowingFilter = ({
+  database,
+  query,
+  followingActorId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  followingActorId?: string | null
+}) => {
+  if (!followingActorId) return
+
+  query.whereExists(function () {
+    this.select(database.raw('1'))
+      .from('follows')
+      .where('follows.actorId', followingActorId)
+      .whereRaw('?? = ??', ['follows.targetActorId', 'actors.id'])
+      .where('follows.status', FollowStatus.enum.Accepted)
+  })
+}
+
+const getExactAccountIds = async ({
+  database,
+  exactActorIds,
+  followingActorId
+}: {
+  database: Knex
+  exactActorIds: string[]
+  followingActorId?: string | null
+}) => {
+  const normalizedExactActorIds = [...new Set(exactActorIds)]
+  if (normalizedExactActorIds.length === 0) return []
+
+  const query = database('actors')
+    .select<{ id: string }[]>('actors.id')
+    .whereIn('actors.id', normalizedExactActorIds)
+  applySearchableAccountFilters(query)
+  applyFollowingFilter({ database, query, followingActorId })
+
+  const rows = await query
+  const visibleActorIds = new Set(rows.map((row) => row.id))
+  return normalizedExactActorIds.filter((id) => visibleActorIds.has(id))
+}
+
 const upsertActorSearchDocument = async (
   database: Knex,
   actor: AccountSearchActor
@@ -164,26 +219,29 @@ export const searchAccountIds = async (
   const handle = parseAccountHandle(q)
   const normalizedQuery = q.trim().replace(/^@/, '').toLowerCase()
   const normalizedExactActorIds = [...new Set(exactActorIds)]
+  const exactResultIds = await getExactAccountIds({
+    database,
+    exactActorIds: normalizedExactActorIds,
+    followingActorId
+  })
+  const exactPageIds =
+    offset < exactResultIds.length
+      ? exactResultIds.slice(offset, offset + limit)
+      : []
+  const indexedLimit = limit - exactPageIds.length
+  if (indexedLimit <= 0) return exactPageIds
+  const indexedOffset = Math.max(offset - exactResultIds.length, 0)
+
   const query = database(SEARCH_DOCUMENTS_TABLE)
     .innerJoin('actors', 'actors.id', 'search_documents.entityId')
     .select<{ entityId: string }[]>('search_documents.entityId')
     .where('search_documents.entityType', 'account')
-    .where((builder) => {
-      builder
-        .whereNull('actors.deletionStatus')
-        .orWhereNot('actors.deletionStatus', 'deleting')
-    })
-    .whereNot((builder) => {
-      builder
-        .where('actors.type', FEDERATION_SIGNING_ACTOR_TYPE)
-        .whereRaw("?? LIKE ? ESCAPE '\\'", [
-          'actors.username',
-          FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN
-        ])
-        .whereNull('actors.accountId')
-    })
+  applySearchableAccountFilters(query)
 
   await applySearchDocumentFilter({ database, query, q })
+  if (exactResultIds.length > 0) {
+    query.whereNotIn('search_documents.entityId', exactResultIds)
+  }
 
   query.where((builder) => {
     builder.where('search_documents.discoverable', true)
@@ -199,15 +257,7 @@ export const searchAccountIds = async (
     }
   })
 
-  if (followingActorId) {
-    query.whereExists(function () {
-      this.select(database.raw('1'))
-        .from('follows')
-        .where('follows.actorId', followingActorId)
-        .whereRaw('?? = ??', ['follows.targetActorId', 'actors.id'])
-        .where('follows.status', FollowStatus.enum.Accepted)
-    })
-  }
+  applyFollowingFilter({ database, query, followingActorId })
 
   applyAccountOrdering({
     database,
@@ -216,8 +266,8 @@ export const searchAccountIds = async (
     exactActorIds: normalizedExactActorIds
   })
 
-  const rows = await query.limit(limit).offset(offset)
-  return rows.map((row) => row.entityId)
+  const rows = await query.limit(indexedLimit).offset(indexedOffset)
+  return [...exactPageIds, ...rows.map((row) => row.entityId)]
 }
 
 export const deleteActorSearchDocument = async (
@@ -235,7 +285,9 @@ export const reindexSearchAccounts = async (
   if (afterId) query.where('id', '>', afterId)
 
   const rows = await query.limit(limit)
-  await Promise.all(rows.map((row) => upsertActorSearchDocument(database, row)))
+  for (const row of rows) {
+    await upsertActorSearchDocument(database, row)
+  }
 
   return {
     indexed: rows.length,

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -90,6 +90,17 @@ const applyAccountOrdering = ({
     .orderBy('search_documents.entityId', 'asc')
 }
 
+const upsertActorSearchDocument = async (database: Knex, actor: SQLActor) => {
+  await upsertSearchDocument(database, {
+    entityType: 'account',
+    entityId: actor.id,
+    documentText: getAccountDocumentText(actor),
+    actorId: actor.id,
+    entityCreatedAt: getCompatibleTime(actor.createdAt),
+    discoverable: isDiscoverableAccount(actor)
+  })
+}
+
 export const indexActorSearchDocument = async (
   database: Knex,
   { id }: { id: string }
@@ -100,14 +111,7 @@ export const indexActorSearchDocument = async (
     return
   }
 
-  await upsertSearchDocument(database, {
-    entityType: 'account',
-    entityId: actor.id,
-    documentText: getAccountDocumentText(actor),
-    actorId: actor.id,
-    entityCreatedAt: getCompatibleTime(actor.createdAt),
-    discoverable: isDiscoverableAccount(actor)
-  })
+  await upsertActorSearchDocument(database, actor)
 }
 
 export const searchAccountIds = async (
@@ -161,13 +165,11 @@ export const reindexSearchAccounts = async (
   database: Knex,
   { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
 ): Promise<ReindexSearchDocumentsResult> => {
-  const query = database<SQLActor>('actors').select('id').orderBy('id', 'asc')
+  const query = database<SQLActor>('actors').select('*').orderBy('id', 'asc')
   if (afterId) query.where('id', '>', afterId)
 
   const rows = await query.limit(limit)
-  for (const row of rows) {
-    await indexActorSearchDocument(database, { id: row.id })
-  }
+  await Promise.all(rows.map((row) => upsertActorSearchDocument(database, row)))
 
   return {
     indexed: rows.length,

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -26,7 +26,13 @@ import {
 } from './documents'
 
 const FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN = `${FEDERATION_SIGNING_ACTOR_USERNAME.replace(/[\\%_]/g, '\\$&')}%`
-const ACCOUNT_SEARCH_DOCUMENT_BATCH_SIZE = 80
+const SQLITE_INSERT_PARAMETER_LIMIT = 999
+const ACCOUNT_SEARCH_DOCUMENT_DEFAULT_BATCH_SIZE = 500
+const SQLITE_CLIENTS = new Set(['sqlite3', 'better-sqlite3'])
+const ACCOUNT_ORDER_COLUMNS = {
+  username: 'actors.username',
+  domain: 'actors.domain'
+} as const
 const SEARCH_DOCUMENT_MERGE_COLUMNS = [
   'documentText',
   'actorId',
@@ -82,6 +88,20 @@ const getLowerAccountHandleSQL = (database: Knex) => {
   return "LOWER(?? || '@' || ??)"
 }
 
+const getClientName = (database: Knex) =>
+  String(database.client.config.client).toLowerCase()
+
+const getAccountSearchDocumentBatchSize = (
+  database: Knex,
+  row: Record<string, unknown>
+) => {
+  const columnCount = Math.max(Object.keys(row).length, 1)
+  if (SQLITE_CLIENTS.has(getClientName(database))) {
+    return Math.max(1, Math.floor(SQLITE_INSERT_PARAMETER_LIMIT / columnCount))
+  }
+  return ACCOUNT_SEARCH_DOCUMENT_DEFAULT_BATCH_SIZE
+}
+
 const applyAccountOrdering = ({
   database,
   query,
@@ -93,30 +113,50 @@ const applyAccountOrdering = ({
 }) => {
   const lowerHandleSQL = getLowerAccountHandleSQL(database)
   const normalizedQueryLikePattern = `${escapeLikePattern(normalizedQuery)}%`
+  const orderCases = [
+    {
+      condition: `${lowerHandleSQL} = ?`,
+      bindings: [
+        ACCOUNT_ORDER_COLUMNS.username,
+        ACCOUNT_ORDER_COLUMNS.domain,
+        normalizedQuery
+      ],
+      rank: 0
+    },
+    {
+      condition: 'lower(??) = ?',
+      bindings: [ACCOUNT_ORDER_COLUMNS.username, normalizedQuery],
+      rank: 1
+    },
+    {
+      condition: `${lowerHandleSQL} like ? ESCAPE '\\'`,
+      bindings: [
+        ACCOUNT_ORDER_COLUMNS.username,
+        ACCOUNT_ORDER_COLUMNS.domain,
+        normalizedQueryLikePattern
+      ],
+      rank: 2
+    },
+    {
+      condition: "lower(??) like ? ESCAPE '\\'",
+      bindings: [ACCOUNT_ORDER_COLUMNS.username, normalizedQueryLikePattern],
+      rank: 3
+    }
+  ]
 
   query
     .orderByRaw(
-      `case
-        when ${lowerHandleSQL} = ? then 0
-        when lower(??) = ? then 1
-        when ${lowerHandleSQL} like ? ESCAPE '\\' then 2
-        when lower(??) like ? ESCAPE '\\' then 3
-        else 4
-      end`,
       [
-        'actors.username',
-        'actors.domain',
-        normalizedQuery,
-        'actors.username',
-        normalizedQuery,
-        'actors.username',
-        'actors.domain',
-        normalizedQueryLikePattern,
-        'actors.username',
-        normalizedQueryLikePattern
-      ]
+        'case',
+        ...orderCases.map(
+          ({ condition, rank }) => `when ${condition} then ${rank}`
+        ),
+        `else ${orderCases.length}`,
+        'end'
+      ].join('\n'),
+      orderCases.flatMap(({ bindings }) => bindings)
     )
-    .orderByRaw('LOWER(??)', ['actors.username'])
+    .orderByRaw('LOWER(??)', [ACCOUNT_ORDER_COLUMNS.username])
     .orderBy('search_documents.entityId', 'asc')
 }
 
@@ -162,24 +202,37 @@ const applyFollowingFilter = ({
 
 const getExactAccountIds = async ({
   database,
+  q,
   handle,
+  localDomain,
   exactActorIds,
   followingActorId
 }: {
   database: Knex
+  q: string
   handle: ReturnType<typeof parseAccountHandle>
+  localDomain?: string | null
   exactActorIds: string[]
   followingActorId?: string | null
 }) => {
-  const handleActorRows = handle
-    ? await database('actors')
-        .select<{ id: string }[]>('actors.id')
-        .whereRaw('LOWER(??) = ?', [
-          'actors.username',
-          handle.username.toLowerCase()
-        ])
-        .whereRaw('LOWER(??) = ?', ['actors.domain', handle.domain])
-    : []
+  const localUsername =
+    !handle && localDomain && !q.includes('@')
+      ? q.trim().replace(/^@/, '')
+      : null
+  const exactHandle = handle ?? {
+    username: localUsername ?? '',
+    domain: localDomain?.toLowerCase() ?? ''
+  }
+  const handleActorRows =
+    handle || localUsername
+      ? await database('actors')
+          .select<{ id: string }[]>('actors.id')
+          .whereRaw('LOWER(??) = ?', [
+            'actors.username',
+            exactHandle.username.toLowerCase()
+          ])
+          .whereRaw('LOWER(??) = ?', ['actors.domain', exactHandle.domain])
+      : []
   const normalizedExactActorIds = [
     ...new Set([...exactActorIds, ...handleActorRows.map((row) => row.id)])
   ]
@@ -230,7 +283,8 @@ const upsertActorSearchDocuments = async (
     getActorSearchDocumentRow(actor, currentTime)
   )
 
-  for (const chunk of chunkArray(rows, ACCOUNT_SEARCH_DOCUMENT_BATCH_SIZE)) {
+  const batchSize = getAccountSearchDocumentBatchSize(database, rows[0])
+  for (const chunk of chunkArray(rows, batchSize)) {
     await database(SEARCH_DOCUMENTS_TABLE)
       .insert(chunk)
       .onConflict('id')
@@ -238,6 +292,8 @@ const upsertActorSearchDocuments = async (
   }
 }
 
+// Passing a fresh actor row indexes that exact shape; passing only an id
+// re-reads actors and deletes the search document if the actor row is gone.
 export const indexActorSearchDocument = async (
   database: Knex,
   { id, actor: providedActor }: { id: string; actor?: AccountSearchActor }
@@ -259,6 +315,7 @@ export const searchAccountIds = async (
     q,
     limit,
     offset = 0,
+    localDomain,
     followingActorId,
     exactActorIds = []
   }: SearchAccountsParams
@@ -270,7 +327,9 @@ export const searchAccountIds = async (
   // fall back to the indexed result window instead of reserving page slots.
   const exactResultIds = await getExactAccountIds({
     database,
+    q,
     handle,
+    localDomain,
     exactActorIds: normalizedExactActorIds,
     followingActorId
   })
@@ -320,6 +379,8 @@ export const reindexSearchAccounts = async (
   database: Knex,
   { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
 ): Promise<ReindexSearchDocumentsResult> => {
+  // Reindexing walks a snapshot best-effort; normal write paths refresh their
+  // own search documents and may temporarily race this batch on live systems.
   const query = database<SQLActor>('actors')
     .select(
       'id',

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -20,11 +20,22 @@ import {
   SEARCH_DOCUMENTS_TABLE,
   applySearchDocumentFilter,
   deleteSearchDocument,
-  normalizeSearchText,
-  upsertSearchDocument
+  getSearchDocumentId,
+  normalizeSearchText
 } from './documents'
 
 const FEDERATION_SIGNING_ACTOR_USERNAME_LIKE_PATTERN = `${FEDERATION_SIGNING_ACTOR_USERNAME.replace(/[\\%_]/g, '\\$&')}%`
+const ACCOUNT_SEARCH_DOCUMENT_BATCH_SIZE = 80
+const SEARCH_DOCUMENT_MERGE_COLUMNS = [
+  'documentText',
+  'actorId',
+  'visibility',
+  'entityCreatedAt',
+  'discoverable',
+  'postCount',
+  'lastPostAt',
+  'updatedAt'
+]
 
 type AccountSearchActor = Pick<
   SQLActor,
@@ -73,22 +84,13 @@ const getLowerAccountHandleSQL = (database: Knex) => {
 const applyAccountOrdering = ({
   database,
   query,
-  normalizedQuery,
-  exactActorIds
+  normalizedQuery
 }: {
   database: Knex
   query: Knex.QueryBuilder
   normalizedQuery: string
-  exactActorIds: string[]
 }) => {
   const lowerHandleSQL = getLowerAccountHandleSQL(database)
-
-  if (exactActorIds.length > 0) {
-    query.orderByRaw(
-      `case when ?? in (${exactActorIds.map(() => '?').join(', ')}) then 0 else 1 end`,
-      ['search_documents.entityId', ...exactActorIds]
-    )
-  }
 
   query
     .orderByRaw(
@@ -114,6 +116,14 @@ const applyAccountOrdering = ({
     )
     .orderByRaw('LOWER(??)', ['actors.username'])
     .orderBy('search_documents.entityId', 'asc')
+}
+
+const chunkArray = <T>(items: T[], size: number) => {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
 }
 
 const applySearchableAccountFilters = (query: Knex.QueryBuilder) => {
@@ -177,18 +187,46 @@ const getExactAccountIds = async ({
   return normalizedExactActorIds.filter((id) => visibleActorIds.has(id))
 }
 
-const upsertActorSearchDocument = async (
-  database: Knex,
-  actor: AccountSearchActor
-) => {
-  await upsertSearchDocument(database, {
+const getActorSearchDocumentRow = (
+  actor: AccountSearchActor,
+  currentTime: Date
+) => ({
+  id: getSearchDocumentId({
     entityType: 'account',
-    entityId: actor.id,
-    documentText: getAccountDocumentText(actor),
-    actorId: actor.id,
-    entityCreatedAt: getCompatibleTime(actor.createdAt),
-    discoverable: isDiscoverableAccount(actor)
-  })
+    entityId: actor.id
+  }),
+  entityType: 'account',
+  entityId: actor.id,
+  documentText: getAccountDocumentText(actor),
+  actorId: actor.id,
+  visibility: null,
+  entityCreatedAt: actor.createdAt
+    ? new Date(getCompatibleTime(actor.createdAt))
+    : null,
+  discoverable: isDiscoverableAccount(actor),
+  postCount: null,
+  lastPostAt: null,
+  createdAt: currentTime,
+  updatedAt: currentTime
+})
+
+const upsertActorSearchDocuments = async (
+  database: Knex,
+  actors: AccountSearchActor[]
+) => {
+  if (actors.length === 0) return
+
+  const currentTime = new Date()
+  const rows = actors.map((actor) =>
+    getActorSearchDocumentRow(actor, currentTime)
+  )
+
+  for (const chunk of chunkArray(rows, ACCOUNT_SEARCH_DOCUMENT_BATCH_SIZE)) {
+    await database(SEARCH_DOCUMENTS_TABLE)
+      .insert(chunk)
+      .onConflict(['entityType', 'entityId'])
+      .merge(SEARCH_DOCUMENT_MERGE_COLUMNS)
+  }
 }
 
 export const indexActorSearchDocument = async (
@@ -203,7 +241,7 @@ export const indexActorSearchDocument = async (
     return
   }
 
-  await upsertActorSearchDocument(database, actor)
+  await upsertActorSearchDocuments(database, [actor])
 }
 
 export const searchAccountIds = async (
@@ -265,8 +303,7 @@ export const searchAccountIds = async (
   applyAccountOrdering({
     database,
     query,
-    normalizedQuery,
-    exactActorIds: normalizedExactActorIds
+    normalizedQuery
   })
 
   const rows = await query.limit(indexedLimit).offset(indexedOffset)
@@ -288,9 +325,7 @@ export const reindexSearchAccounts = async (
   if (afterId) query.where('id', '>', afterId)
 
   const rows = await query.limit(limit)
-  for (const row of rows) {
-    await upsertActorSearchDocument(database, row)
-  }
+  await upsertActorSearchDocuments(database, rows)
 
   return {
     indexed: rows.length,

--- a/lib/database/sql/search/account.ts
+++ b/lib/database/sql/search/account.ts
@@ -1,22 +1,154 @@
 import { Knex } from 'knex'
 
+import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
+  ReindexSearchDocumentsParams,
   ReindexSearchDocumentsResult,
   SearchAccountsParams
 } from '@/lib/types/database/operations'
+import { SQLActor } from '@/lib/types/database/rows'
+import { FollowStatus } from '@/lib/types/domain/follow'
 
-import { deleteSearchDocument } from './documents'
-import { throwUnimplementedSearchMethod } from './notImplemented'
+import {
+  SEARCH_DOCUMENTS_TABLE,
+  applySearchDocumentFilter,
+  deleteSearchDocument,
+  normalizeSearchText,
+  upsertSearchDocument
+} from './documents'
 
-export const searchAccountIds = async (
-  _database: Knex,
-  _params: SearchAccountsParams
-): Promise<string[]> => throwUnimplementedSearchMethod('searchAccountIds')
+const parseAccountHandle = (value: string) => {
+  const normalized = value.trim().replace(/^@/, '').toLowerCase()
+  const [username, domain, ...rest] = normalized.split('@')
+  if (!username || !domain || rest.length > 0) return null
+  return { username, domain }
+}
+
+const getAccountDocumentText = (actor: SQLActor) => {
+  const acct = `${actor.username}@${actor.domain}`
+  return normalizeSearchText(
+    [
+      actor.username,
+      acct,
+      `@${acct}`,
+      actor.name ?? '',
+      actor.summary ?? ''
+    ].join(' ')
+  )
+}
+
+const isDiscoverableAccount = (actor: SQLActor) => {
+  const settings = getCompatibleJSON<Record<string, unknown>>(
+    actor.settings as string | Record<string, unknown>
+  )
+  return settings.noindex !== true && actor.deletionStatus !== 'deleting'
+}
+
+const getLowerAccountHandleSQL = (database: Knex) => {
+  const clientName = String(database.client.config.client)
+  if (clientName.includes('mysql')) {
+    return "LOWER(CONCAT(??, '@', ??))"
+  }
+  return "LOWER(?? || '@' || ??)"
+}
+
+const applyAccountOrdering = ({
+  database,
+  query,
+  normalizedQuery
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  normalizedQuery: string
+}) => {
+  const lowerHandleSQL = getLowerAccountHandleSQL(database)
+
+  query
+    .orderByRaw(
+      `case
+        when ${lowerHandleSQL} = ? then 0
+        when lower(??) = ? then 1
+        when ${lowerHandleSQL} like ? then 2
+        when lower(??) like ? then 3
+        else 4
+      end`,
+      [
+        'actors.username',
+        'actors.domain',
+        normalizedQuery,
+        'actors.username',
+        normalizedQuery,
+        'actors.username',
+        'actors.domain',
+        `${normalizedQuery}%`,
+        'actors.username',
+        `${normalizedQuery}%`
+      ]
+    )
+    .orderByRaw('LOWER(??)', ['actors.username'])
+    .orderBy('search_documents.entityId', 'asc')
+}
 
 export const indexActorSearchDocument = async (
-  _database: Knex,
-  _params: { id: string }
-): Promise<void> => throwUnimplementedSearchMethod('indexActorSearchDocument')
+  database: Knex,
+  { id }: { id: string }
+): Promise<void> => {
+  const actor = await database<SQLActor>('actors').where('id', id).first()
+  if (!actor) {
+    await deleteActorSearchDocument(database, { id })
+    return
+  }
+
+  await upsertSearchDocument(database, {
+    entityType: 'account',
+    entityId: actor.id,
+    documentText: getAccountDocumentText(actor),
+    actorId: actor.id,
+    entityCreatedAt: getCompatibleTime(actor.createdAt),
+    discoverable: isDiscoverableAccount(actor)
+  })
+}
+
+export const searchAccountIds = async (
+  database: Knex,
+  { q, limit, offset = 0, followingActorId }: SearchAccountsParams
+): Promise<string[]> => {
+  const handle = parseAccountHandle(q)
+  const normalizedQuery = q.trim().replace(/^@/, '').toLowerCase()
+  const query = database(SEARCH_DOCUMENTS_TABLE)
+    .innerJoin('actors', 'actors.id', 'search_documents.entityId')
+    .select<{ entityId: string }[]>('search_documents.entityId')
+    .where('search_documents.entityType', 'account')
+
+  await applySearchDocumentFilter({ database, query, q })
+
+  query.where((builder) => {
+    builder.where('search_documents.discoverable', true)
+    if (handle) {
+      builder.orWhere((exactBuilder) => {
+        exactBuilder
+          .whereRaw('LOWER(??) = ?', ['actors.username', handle.username])
+          .whereRaw('LOWER(??) = ?', ['actors.domain', handle.domain])
+      })
+    }
+  })
+
+  if (followingActorId) {
+    query.whereExists(function () {
+      this.select(database.raw('1'))
+        .from('follows')
+        .where('follows.actorId', followingActorId)
+        .whereRaw('?? = ??', ['follows.targetActorId', 'actors.id'])
+        .where('follows.status', FollowStatus.enum.Accepted)
+    })
+  }
+
+  applyAccountOrdering({ database, query, normalizedQuery })
+
+  const rows = await query.limit(limit).offset(offset)
+  return rows.map((row) => row.entityId)
+}
 
 export const deleteActorSearchDocument = async (
   database: Knex,
@@ -26,7 +158,19 @@ export const deleteActorSearchDocument = async (
 }
 
 export const reindexSearchAccounts = async (
-  _database?: Knex,
-  _params?: unknown
-): Promise<ReindexSearchDocumentsResult> =>
-  throwUnimplementedSearchMethod('reindexSearchAccounts')
+  database: Knex,
+  { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
+): Promise<ReindexSearchDocumentsResult> => {
+  const query = database<SQLActor>('actors').select('id').orderBy('id', 'asc')
+  if (afterId) query.where('id', '>', afterId)
+
+  const rows = await query.limit(limit)
+  for (const row of rows) {
+    await indexActorSearchDocument(database, { id: row.id })
+  }
+
+  return {
+    indexed: rows.length,
+    nextCursor: rows.length === limit ? rows[rows.length - 1].id : null
+  }
+}

--- a/lib/database/sql/search/documents.ts
+++ b/lib/database/sql/search/documents.ts
@@ -59,7 +59,8 @@ const isPostgres = (database: Knex) =>
 
 const isMySQL = (database: Knex) => MYSQL_CLIENTS.has(getClientName(database))
 
-const escapeLikePattern = (value: string) => value.replace(/[\\%_]/g, '\\$&')
+export const escapeLikePattern = (value: string) =>
+  value.replace(/[\\%_]/g, '\\$&')
 
 const DEFAULT_MYSQL_FULL_TEXT_MIN_TOKEN_SIZE = 4
 const MIN_MYSQL_LIKE_FALLBACK_TOKEN_LENGTH = 2

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -659,6 +659,7 @@ export type SearchAccountsParams = {
   limit: number
   offset?: number
   followingActorId?: string | null
+  exactActorIds?: string[]
 }
 
 export type SearchHashtagsParams = {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -658,6 +658,7 @@ export type SearchAccountsParams = {
   q: string
   limit: number
   offset?: number
+  localDomain?: string | null
   followingActorId?: string | null
   exactActorIds?: string[]
 }

--- a/lib/utils/accountHandle.ts
+++ b/lib/utils/accountHandle.ts
@@ -1,0 +1,6 @@
+export const parseAccountHandle = (value: string) => {
+  const normalized = value.trim().replace(/^@/, '').toLowerCase()
+  const [username, domain, ...rest] = normalized.split('@')
+  if (!username || !domain || rest.length > 0) return null
+  return { username, domain }
+}

--- a/lib/utils/accountHandle.ts
+++ b/lib/utils/accountHandle.ts
@@ -1,6 +1,6 @@
 export const parseAccountHandle = (value: string) => {
-  const normalized = value.trim().replace(/^@/, '').toLowerCase()
+  const normalized = value.trim().replace(/^@/, '')
   const [username, domain, ...rest] = normalized.split('@')
   if (!username || !domain || rest.length > 0) return null
-  return { username, domain }
+  return { username, domain: domain.toLowerCase() }
 }


### PR DESCRIPTION
## Summary
- index actors into search_documents when account and actor write paths create, update, or delete actors
- replace v1 account search with indexed broad search plus exact/remote handle resolution
- add account search database and route coverage, including following-only and non-discoverable exact matches

## Stack
- Depends on #748

## Test Results
- yarn run prettier --write .
- yarn lint
- yarn build
- yarn test