### PR TITLE
minor: add indexed status search

### DIFF
--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex'
 import { getConfig } from '@/lib/config'
 import {
   deleteActorSearchDocument,
+  deleteStatusSearchDocumentsByStatusIds,
   indexActorSearchDocument,
   indexHashtagSearchDocuments,
   normalizeHashtagSearchName
@@ -76,18 +77,6 @@ export interface SQLActorDatabase extends ActorDatabase {
   ) => Actor
   getMastodonActor: (actorId: string) => Promise<Mastodon.Account | null>
   getMastodonActors: (actorIds: string[]) => Promise<Mastodon.Account[]>
-}
-
-const deleteStatusSearchDocumentsByStatusIds = async (
-  trx: Knex.Transaction,
-  statusIds: string[]
-) => {
-  for (const statusIdChunk of chunkArray(statusIds, getWhereInBatchSize(trx))) {
-    await trx('search_documents')
-      .where('entityType', 'status')
-      .whereIn('entityId', statusIdChunk)
-      .delete()
-  }
 }
 
 const getActorCounterSummary = async (

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -3,7 +3,6 @@ import { Knex } from 'knex'
 import { getConfig } from '@/lib/config'
 import {
   deleteActorSearchDocument,
-  deleteStatusSearchDocument,
   indexActorSearchDocument,
   indexHashtagSearchDocuments,
   normalizeHashtagSearchName
@@ -1365,11 +1364,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
       // Delete statuses
       await trx('statuses').where('actorId', actorId).delete()
-      await Promise.all(
-        statusIds.map((statusId) =>
-          deleteStatusSearchDocument(trx, { statusId })
-        )
-      )
+      if (statusIds.length > 0) {
+        await trx('search_documents')
+          .where('entityType', 'status')
+          .whereIn('entityId', statusIds)
+          .delete()
+      }
 
       // Delete follows (both directions)
       await trx('follows').where('actorId', actorId).delete()

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex'
 import { getConfig } from '@/lib/config'
 import {
   deleteActorSearchDocument,
+  deleteStatusSearchDocument,
   indexActorSearchDocument,
   indexHashtagSearchDocuments,
   normalizeHashtagSearchName
@@ -1364,6 +1365,11 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
       // Delete statuses
       await trx('statuses').where('actorId', actorId).delete()
+      await Promise.all(
+        statusIds.map((statusId) =>
+          deleteStatusSearchDocument(trx, { statusId })
+        )
+      )
 
       // Delete follows (both directions)
       await trx('follows').where('actorId', actorId).delete()

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -20,6 +20,7 @@ import {
 } from '@/lib/database/sql/utils/counter'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import {
   chunkArray,
   deleteRowsByColumnChunks,
@@ -146,21 +147,6 @@ const insertActorWithSearchIndex = async (
     await trx('actors').insert(actor)
     await indexActorSearchDocument(trx, { id: actorId, actor })
   })
-}
-
-const parseStatusContent = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: any
-): string | Record<string, unknown> | null => {
-  if (!content) return null
-  if (typeof content === 'string') {
-    try {
-      return getCompatibleJSON(content)
-    } catch {
-      return content
-    }
-  }
-  return content
 }
 
 const getStatusUrlHash = (url: string): string => getHashFromString(url)

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -78,6 +78,18 @@ export interface SQLActorDatabase extends ActorDatabase {
   getMastodonActors: (actorIds: string[]) => Promise<Mastodon.Account[]>
 }
 
+const deleteStatusSearchDocumentsByStatusIds = async (
+  trx: Knex.Transaction,
+  statusIds: string[]
+) => {
+  for (const statusIdChunk of chunkArray(statusIds, getWhereInBatchSize(trx))) {
+    await trx('search_documents')
+      .where('entityType', 'status')
+      .whereIn('entityId', statusIdChunk)
+      .delete()
+  }
+}
+
 const getActorCounterSummary = async (
   trx: Knex.Transaction,
   actorId: string
@@ -1351,10 +1363,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       // Delete statuses
       await trx('statuses').where('actorId', actorId).delete()
       if (statusIds.length > 0) {
-        await trx('search_documents')
-          .where('entityType', 'status')
-          .whereIn('entityId', statusIds)
-          .delete()
+        await deleteStatusSearchDocumentsByStatusIds(trx, statusIds)
       }
 
       // Delete follows (both directions)

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -1947,6 +1947,46 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('preserves word boundaries when indexing status HTML', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const statusId = `${actorId}/statuses/status-search-html-spacing`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: '<p>alpineword</p><p>ridgeword</p>',
+        createdAt: 1
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'ridgeword',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([statusId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('rebuilds status search documents in batches', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',
@@ -1986,6 +2026,67 @@ describe('SearchDatabase foundation', () => {
           currentActorId: actorId
         })
       ).resolves.toEqual([statusId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('uses status creation time for stable reindex pagination', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const firstStatusId = `${actorId}/statuses/m-cursor`
+    const secondStatusId = `${actorId}/statuses/a-newer-status`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await database.createNote({
+        id: firstStatusId,
+        url: firstStatusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'firstcursorword',
+        createdAt: 1
+      })
+
+      const firstPage = await database.reindexSearchStatuses({ limit: 1 })
+      expect(firstPage).toEqual({ indexed: 1, nextCursor: firstStatusId })
+
+      await database.createNote({
+        id: secondStatusId,
+        url: secondStatusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'secondcursorword',
+        createdAt: 2
+      })
+      await database.deleteStatusSearchDocument({ statusId: secondStatusId })
+
+      await expect(
+        database.reindexSearchStatuses({
+          afterId: firstPage.nextCursor,
+          limit: 10
+        })
+      ).resolves.toEqual({ indexed: 1, nextCursor: null })
+      await expect(
+        database.searchStatusIds({
+          q: 'secondcursorword',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([secondStatusId])
     } finally {
       await database.destroy()
     }

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -2148,6 +2148,30 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('treats malformed status reindex cursors as invalid cursors', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+
+    try {
+      await database.migrate()
+
+      await expect(
+        database.reindexSearchStatuses({
+          afterId: 'status-created-at:1:%E0%A4%A',
+          limit: 10
+        })
+      ).resolves.toEqual({ indexed: 0, nextCursor: null })
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('bounds status search pagination when cursor search documents are missing', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',
@@ -2345,6 +2369,13 @@ describe('SearchDatabase foundation', () => {
           currentActorId: viewerId
         })
       ).resolves.toEqual([statusId])
+      await expect(
+        database.searchStatusIds({
+          q: 'keyworddelta',
+          limit: 10,
+          currentActorId: `${viewerId}#main-key`
+        })
+      ).resolves.toEqual([statusId])
     } finally {
       await database.destroy()
     }
@@ -2362,6 +2393,7 @@ describe('SearchDatabase foundation', () => {
     const viewerId = 'https://remote.test/users/viewer'
     const authorId = 'https://remote.test/users/author'
     const statusId = `${authorId}/statuses/mention-search`
+    const missingHrefStatusId = `${authorId}/statuses/mention-search-empty-value`
 
     try {
       await database.migrate()
@@ -2405,6 +2437,32 @@ describe('SearchDatabase foundation', () => {
         })
       ).resolves.toEqual([statusId])
 
+      await database.createNote({
+        id: missingHrefStatusId,
+        url: missingHrefStatusId,
+        actorId: authorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'Mention without href fallbackword',
+        createdAt: 2
+      })
+      await database.createTag({
+        statusId: missingHrefStatusId,
+        type: 'mention',
+        name: '@viewer',
+        value: ''
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'fallbackword',
+          limit: 10,
+          currentActorId: viewerId,
+          currentActorUsername: 'viewer',
+          currentActorDomain: 'remote.test'
+        })
+      ).resolves.toEqual([missingHrefStatusId])
+
       await database.createBlock({
         actorId: viewerId,
         targetActorId: authorId,
@@ -2416,6 +2474,15 @@ describe('SearchDatabase foundation', () => {
           q: 'searchword',
           limit: 10,
           currentActorId: viewerId,
+          currentActorUsername: 'viewer',
+          currentActorDomain: 'remote.test'
+        })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchStatusIds({
+          q: 'searchword',
+          limit: 10,
+          currentActorId: `${viewerId}#main-key`,
           currentActorUsername: 'viewer',
           currentActorDomain: 'remote.test'
         })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -3,6 +3,7 @@ import knex, { Knex } from 'knex'
 import { getSQLDatabase } from '@/lib/database/sql'
 import {
   getSearchTokens,
+  indexStatusSearchDocument,
   normalizeHashtagSearchName
 } from '@/lib/database/sql/search'
 import {
@@ -173,6 +174,50 @@ describe('SearchDatabase foundation', () => {
           lastPostAt: 0
         })
       ])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('indexes a preloaded status row without reading the statuses table', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const statusId = 'https://remote.test/users/alice/statuses/preloaded'
+
+    try {
+      await database.migrate()
+
+      await indexStatusSearchDocument(knexDatabase, {
+        status: {
+          id: statusId,
+          actorId: 'https://remote.test/users/alice',
+          type: StatusType.enum.Note,
+          content: JSON.stringify({
+            text: 'Preloaded trail run',
+            summary: 'Morning effort'
+          }),
+          createdAt: new Date('2026-05-25T07:00:00.000Z')
+        }
+      })
+
+      await expect(
+        knexDatabase('search_documents')
+          .where({
+            entityType: 'status',
+            entityId: statusId
+          })
+          .first()
+      ).resolves.toMatchObject({
+        documentText: 'Preloaded trail run Morning effort',
+        actorId: 'https://remote.test/users/alice',
+        visibility: 'direct'
+      })
     } finally {
       await database.destroy()
     }

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -2053,10 +2053,6 @@ describe('SearchDatabase foundation', () => {
     try {
       await database.migrate()
       await createSearchActor(database, {
-        id: viewerId,
-        username: 'viewer'
-      })
-      await createSearchActor(database, {
         id: authorId,
         username: 'author'
       })
@@ -2080,7 +2076,9 @@ describe('SearchDatabase foundation', () => {
         database.searchStatusIds({
           q: 'searchword',
           limit: 10,
-          currentActorId: viewerId
+          currentActorId: viewerId,
+          currentActorUsername: 'viewer',
+          currentActorDomain: 'remote.test'
         })
       ).resolves.toEqual([statusId])
 
@@ -2094,7 +2092,9 @@ describe('SearchDatabase foundation', () => {
         database.searchStatusIds({
           q: 'searchword',
           limit: 10,
-          currentActorId: viewerId
+          currentActorId: viewerId,
+          currentActorUsername: 'viewer',
+          currentActorDomain: 'remote.test'
         })
       ).resolves.toEqual([])
     } finally {

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -1864,6 +1864,200 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('indexes status text, strips HTML, and updates status search documents on edits', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const statusId = `${actorId}/statuses/status-search-update`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: '<p>Original <strong>trailblazer</strong></p>',
+        createdAt: 1
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'trailblazer',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([statusId])
+
+      await database.updateNote({
+        statusId,
+        text: '<p>Edited summitmarker</p>',
+        summary: ''
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'trailblazer',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([])
+      await expect(
+        database.searchStatusIds({
+          q: 'summitmarker',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([statusId])
+
+      await database.deleteStatus({ statusId })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'summitmarker',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('requires status search matches to be interacted-with or owned', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const viewerId = 'https://remote.test/users/viewer'
+    const authorId = 'https://remote.test/users/author'
+    const statusId = `${authorId}/statuses/public-search`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: viewerId,
+        username: 'viewer'
+      })
+      await createSearchActor(database, {
+        id: authorId,
+        username: 'author'
+      })
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: authorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'Public but not broadly searchable keyworddelta',
+        createdAt: 1
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'keyworddelta',
+          limit: 10,
+          currentActorId: viewerId
+        })
+      ).resolves.toEqual([])
+
+      await database.createLike({
+        actorId: viewerId,
+        statusId
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'keyworddelta',
+          limit: 10,
+          currentActorId: viewerId
+        })
+      ).resolves.toEqual([statusId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('returns mentioned statuses and filters blocked authors', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const viewerId = 'https://remote.test/users/viewer'
+    const authorId = 'https://remote.test/users/author'
+    const statusId = `${authorId}/statuses/mention-search`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: viewerId,
+        username: 'viewer'
+      })
+      await createSearchActor(database, {
+        id: authorId,
+        username: 'author'
+      })
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: authorId,
+        to: [viewerId],
+        cc: [],
+        text: 'Direct mention searchword',
+        createdAt: 1
+      })
+      await database.createTag({
+        statusId,
+        type: 'mention',
+        name: '@viewer',
+        value: 'https://remote.test/@viewer'
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'searchword',
+          limit: 10,
+          currentActorId: viewerId
+        })
+      ).resolves.toEqual([statusId])
+
+      await database.createBlock({
+        actorId: viewerId,
+        targetActorId: authorId,
+        uri: `${viewerId}#blocks/${encodeURIComponent(authorId)}`
+      })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'searchword',
+          limit: 10,
+          currentActorId: viewerId
+        })
+      ).resolves.toEqual([])
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('rebuilds hashtag search aggregates from legacy bare normalized tag names', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -1,4 +1,4 @@
-import knex from 'knex'
+import knex, { Knex } from 'knex'
 
 import { getSQLDatabase } from '@/lib/database/sql'
 import {
@@ -7,7 +7,8 @@ import {
 } from '@/lib/database/sql/search'
 import {
   applySearchDocumentFilter,
-  applySearchDocumentOrdering
+  applySearchDocumentOrdering,
+  getSearchDocumentId
 } from '@/lib/database/sql/search/documents'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
@@ -46,6 +47,17 @@ const createSearchActor = async (
     privateKey: 'private-key',
     createdAt: 1
   })
+}
+
+const insertRowsInChunks = async (
+  knexDatabase: Knex,
+  tableName: string,
+  rows: Record<string, unknown>[],
+  chunkSize: number
+) => {
+  for (let start = 0; start < rows.length; start += chunkSize) {
+    await knexDatabase(tableName).insert(rows.slice(start, start + chunkSize))
+  }
 }
 
 describe('SearchDatabase foundation', () => {
@@ -1979,6 +1991,80 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('deletes stale status search documents in SQLite-safe batches', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const statusCount = 1005
+    const currentTime = new Date()
+    const statuses = Array.from({ length: statusCount }, (_, index) => {
+      const statusId = `${actorId}/statuses/stale-empty-${index}`
+      return {
+        id: statusId,
+        url: statusId,
+        actorId,
+        type: StatusType.enum.Note,
+        content: JSON.stringify({
+          url: statusId,
+          text: '',
+          summary: ''
+        }),
+        reply: '',
+        createdAt: currentTime,
+        updatedAt: currentTime
+      }
+    })
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await insertRowsInChunks(knexDatabase, 'statuses', statuses, 100)
+      await insertRowsInChunks(
+        knexDatabase,
+        'search_documents',
+        statuses.map((status) => ({
+          id: getSearchDocumentId({
+            entityType: 'status',
+            entityId: status.id
+          }),
+          entityType: 'status',
+          entityId: status.id,
+          documentText: 'stale text',
+          actorId,
+          visibility: 'public',
+          entityCreatedAt: currentTime,
+          discoverable: null,
+          postCount: null,
+          lastPostAt: null,
+          createdAt: currentTime,
+          updatedAt: currentTime
+        })),
+        80
+      )
+
+      await expect(
+        database.reindexSearchStatuses({ limit: statusCount + 1 })
+      ).resolves.toEqual({ indexed: statusCount, nextCursor: null })
+
+      const countRow = await knexDatabase('search_documents')
+        .where('entityType', 'status')
+        .count<{ count: number | string }>({ count: 'id' })
+        .first()
+      expect(Number(countRow?.count ?? 0)).toBe(0)
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('requires status search matches to be interacted-with or owned', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',
@@ -2666,6 +2752,88 @@ describe('SearchDatabase foundation', () => {
       expect(hashtagSearchWriteIndex).toBeGreaterThan(actorCommitIndex)
     } finally {
       knexDatabase.off('query', handleQuery)
+      await database.destroy()
+    }
+  })
+
+  it('deletes actor status search documents in SQLite-safe batches', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const statusCount = 1005
+    const currentTime = new Date()
+    const statuses = Array.from({ length: statusCount }, (_, index) => {
+      const statusId = `${actorId}/statuses/delete-search-${index}`
+      return {
+        id: statusId,
+        url: statusId,
+        actorId,
+        type: StatusType.enum.Note,
+        content: JSON.stringify({
+          url: statusId,
+          text: `Delete searchable status ${index}`,
+          summary: ''
+        }),
+        reply: '',
+        createdAt: currentTime,
+        updatedAt: currentTime
+      }
+    })
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await insertRowsInChunks(knexDatabase, 'statuses', statuses, 100)
+      await insertRowsInChunks(
+        knexDatabase,
+        'search_documents',
+        statuses.map((status) => ({
+          id: getSearchDocumentId({
+            entityType: 'status',
+            entityId: status.id
+          }),
+          entityType: 'status',
+          entityId: status.id,
+          documentText: 'delete searchable status',
+          actorId,
+          visibility: 'public',
+          entityCreatedAt: currentTime,
+          discoverable: null,
+          postCount: null,
+          lastPostAt: null,
+          createdAt: currentTime,
+          updatedAt: currentTime
+        })),
+        80
+      )
+
+      await expect(database.deleteActorData({ actorId })).resolves.toBe(
+        undefined
+      )
+
+      const [statusCountRow, searchDocumentCountRow] = await Promise.all([
+        knexDatabase('statuses')
+          .where('actorId', actorId)
+          .count<{ count: number | string }>({ count: 'id' })
+          .first(),
+        knexDatabase('search_documents')
+          .where('entityType', 'status')
+          .where('actorId', actorId)
+          .count<{ count: number | string }>({ count: 'id' })
+          .first()
+      ])
+      expect(Number(statusCountRow?.count ?? 0)).toBe(0)
+      expect(Number(searchDocumentCountRow?.count ?? 0)).toBe(0)
+    } finally {
       await database.destroy()
     }
   })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -2373,7 +2373,7 @@ describe('SearchDatabase foundation', () => {
         id: statusId,
         url: statusId,
         actorId: authorId,
-        to: [viewerId],
+        to: [ACTIVITY_STREAM_PUBLIC],
         cc: [],
         text: 'Direct mention searchword',
         createdAt: 1
@@ -2382,7 +2382,7 @@ describe('SearchDatabase foundation', () => {
         statusId,
         type: 'mention',
         name: '@viewer',
-        value: 'https://remote.test/@viewer'
+        value: viewerId
       })
 
       await expect(
@@ -2390,6 +2390,16 @@ describe('SearchDatabase foundation', () => {
           q: 'searchword',
           limit: 10,
           currentActorId: viewerId,
+          currentActorUsername: 'viewer',
+          currentActorDomain: 'remote.test'
+        })
+      ).resolves.toEqual([statusId])
+
+      await expect(
+        database.searchStatusIds({
+          q: 'searchword',
+          limit: 10,
+          currentActorId: `${viewerId}#main-key`,
           currentActorUsername: 'viewer',
           currentActorDomain: 'remote.test'
         })

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -2031,6 +2031,59 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('indexes legacy raw-string status content', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const statusId = `${actorId}/statuses/raw-string-search`
+    const currentTime = new Date()
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await knexDatabase('statuses').insert({
+        id: statusId,
+        url: statusId,
+        actorId,
+        type: StatusType.enum.Note,
+        content: '<p>Legacy raw string summitlegacy</p>',
+        reply: '',
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      await knexDatabase('recipients').insert({
+        id: crypto.randomUUID(),
+        statusId,
+        actorId: ACTIVITY_STREAM_PUBLIC,
+        type: 'to',
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+
+      await expect(
+        database.reindexSearchStatuses({ limit: 10 })
+      ).resolves.toEqual({ indexed: 1, nextCursor: null })
+      await expect(
+        database.searchStatusIds({
+          q: 'summitlegacy',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([statusId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('uses status creation time for stable reindex pagination', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',
@@ -2061,7 +2114,9 @@ describe('SearchDatabase foundation', () => {
       })
 
       const firstPage = await database.reindexSearchStatuses({ limit: 1 })
-      expect(firstPage).toEqual({ indexed: 1, nextCursor: firstStatusId })
+      expect(firstPage.indexed).toBe(1)
+      expect(firstPage.nextCursor).toContain('status-created-at:')
+      expect(firstPage.nextCursor).not.toBe(firstStatusId)
 
       await database.createNote({
         id: secondStatusId,
@@ -2072,6 +2127,7 @@ describe('SearchDatabase foundation', () => {
         text: 'secondcursorword',
         createdAt: 2
       })
+      await database.deleteStatus({ statusId: firstStatusId })
       await database.deleteStatusSearchDocument({ statusId: secondStatusId })
 
       await expect(
@@ -2087,6 +2143,76 @@ describe('SearchDatabase foundation', () => {
           currentActorId: actorId
         })
       ).resolves.toEqual([secondStatusId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('bounds status search pagination when cursor search documents are missing', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const newestStatusId = `${actorId}/statuses/pagination-newest`
+    const cursorStatusId = `${actorId}/statuses/pagination-cursor`
+    const oldestStatusId = `${actorId}/statuses/pagination-oldest`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await database.createNote({
+        id: oldestStatusId,
+        url: oldestStatusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'paginationboundword oldest',
+        createdAt: 1
+      })
+      await database.createNote({
+        id: cursorStatusId,
+        url: cursorStatusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'paginationboundword cursor',
+        createdAt: 2
+      })
+      await database.createNote({
+        id: newestStatusId,
+        url: newestStatusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'paginationboundword newest',
+        createdAt: 3
+      })
+      await database.deleteStatusSearchDocument({ statusId: cursorStatusId })
+
+      await expect(
+        database.searchStatusIds({
+          q: 'paginationboundword',
+          limit: 10,
+          currentActorId: actorId,
+          maxId: cursorStatusId
+        })
+      ).resolves.toEqual([oldestStatusId])
+      await expect(
+        database.searchStatusIds({
+          q: 'paginationboundword',
+          limit: 10,
+          currentActorId: actorId,
+          maxId: `${actorId}/statuses/missing-cursor`
+        })
+      ).resolves.toEqual([])
     } finally {
       await database.destroy()
     }

--- a/lib/database/sql/search.test.ts
+++ b/lib/database/sql/search.test.ts
@@ -1935,6 +1935,50 @@ describe('SearchDatabase foundation', () => {
     }
   })
 
+  it('rebuilds status search documents in batches', async () => {
+    const knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(knexDatabase)
+    const actorId = 'https://remote.test/users/alice'
+    const statusId = `${actorId}/statuses/status-search-reindex`
+
+    try {
+      await database.migrate()
+      await createSearchActor(database, {
+        id: actorId,
+        username: 'alice'
+      })
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: '<p>Batch reindexable summitword</p>',
+        createdAt: 1
+      })
+      await database.deleteStatusSearchDocument({ statusId })
+
+      await expect(
+        database.reindexSearchStatuses({ limit: 10 })
+      ).resolves.toEqual({ indexed: 1, nextCursor: null })
+      await expect(
+        database.searchStatusIds({
+          q: 'summitword',
+          limit: 10,
+          currentActorId: actorId
+        })
+      ).resolves.toEqual([statusId])
+    } finally {
+      await database.destroy()
+    }
+  })
+
   it('requires status search matches to be interacted-with or owned', async () => {
     const knexDatabase = knex({
       client: 'better-sqlite3',

--- a/lib/database/sql/search/index.ts
+++ b/lib/database/sql/search/index.ts
@@ -77,3 +77,5 @@ export {
   searchStatusIds,
   upsertSearchDocument
 }
+
+export type { SQLStatusSearchRow } from './status'

--- a/lib/database/sql/search/index.ts
+++ b/lib/database/sql/search/index.ts
@@ -24,6 +24,7 @@ import {
 } from './hashtag'
 import {
   deleteStatusSearchDocument,
+  deleteStatusSearchDocumentsByStatusIds,
   indexStatusSearchDocument,
   reindexSearchStatuses,
   searchStatusIds
@@ -60,6 +61,7 @@ export {
   deleteHashtagSearchDocument,
   deleteSearchDocument,
   deleteStatusSearchDocument,
+  deleteStatusSearchDocumentsByStatusIds,
   getSearchTokens,
   indexActorSearchDocument,
   indexHashtagSearchDocument,

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -118,6 +118,21 @@ const getSearchDocumentInsertBatchSize = (
   return Math.max(1, Math.floor(SQLITE_MAX_BINDINGS / columnCount))
 }
 
+const deleteStatusSearchDocumentsByStatusIds = async (
+  database: Knex,
+  statusIds: string[]
+) => {
+  for (const statusIdChunk of chunkArray(
+    statusIds,
+    getWhereInBatchSize(database)
+  )) {
+    await database(SEARCH_DOCUMENTS_TABLE)
+      .where('entityType', 'status')
+      .whereIn('entityId', statusIdChunk)
+      .delete()
+  }
+}
+
 const reindexStatusSearchDocuments = async (
   database: Knex,
   statuses: SQLStatusRow[]
@@ -171,10 +186,7 @@ const reindexStatusSearchDocuments = async (
   }))
 
   if (statusIdsToDelete.length > 0) {
-    await database(SEARCH_DOCUMENTS_TABLE)
-      .where('entityType', 'status')
-      .whereIn('entityId', statusIdsToDelete)
-      .delete()
+    await deleteStatusSearchDocumentsByStatusIds(database, statusIdsToDelete)
   }
 
   if (rows.length === 0) return
@@ -409,7 +421,7 @@ export const searchStatusIds = async (
     .where('search_documents.entityType', 'status')
     .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
 
-  applySearchDocumentFilter({ database, query, q })
+  await applySearchDocumentFilter({ database, query, q })
   if (accountId) query.where('statuses.actorId', accountId)
 
   applyPotentiallyReadableStatusFilter({

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -1,5 +1,4 @@
 import { Knex } from 'knex'
-import sanitizeHtml from 'sanitize-html'
 
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
@@ -13,6 +12,7 @@ import {
   SearchStatusesParams
 } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
+import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
 import {
   SEARCH_DOCUMENTS_TABLE,
@@ -49,19 +49,15 @@ const chunkArray = <T>(items: T[], size: number) => {
   return chunks
 }
 
-const stripHTML = (value: string) =>
-  sanitizeHtml(value, {
-    allowedTags: [],
-    allowedAttributes: {}
-  })
-
 const getStatusDocumentText = (status: SQLStatusRow) => {
   const content = parseStatusContent(status.content)
   if (!content || typeof content === 'string') return ''
 
   const text = typeof content.text === 'string' ? content.text : ''
   const summary = typeof content.summary === 'string' ? content.summary : ''
-  return normalizeSearchText([stripHTML(text), stripHTML(summary)].join(' '))
+  return normalizeSearchText(
+    [htmlToPlainText(text), htmlToPlainText(summary)].join(' ')
+  )
 }
 
 const getStatusVisibilityFromRecipientIds = (recipientIds: string[]) => {
@@ -396,6 +392,37 @@ const applyBlockedAccountFilter = ({
   })
 }
 
+const applyStatusReindexCursor = async ({
+  database,
+  query,
+  afterId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  afterId: string | null
+}) => {
+  if (!afterId) return
+
+  const cursor = await database<SQLStatusRow>('statuses')
+    .where('id', afterId)
+    .first('id', 'createdAt')
+
+  if (!cursor) {
+    query.where('id', '>', afterId)
+    return
+  }
+
+  query.where((builder) => {
+    builder
+      .where('createdAt', '>', cursor.createdAt)
+      .orWhere((sameTimeBuilder) => {
+        sameTimeBuilder
+          .where('createdAt', cursor.createdAt)
+          .where('id', '>', cursor.id)
+      })
+  })
+}
+
 export const searchStatusIds = async (
   database: Knex,
   {
@@ -454,9 +481,10 @@ export const reindexSearchStatuses = async (
   const query = database<SQLStatusRow>('statuses')
     .select('id', 'actorId', 'type', 'content', 'createdAt')
     .whereIn('type', [StatusType.enum.Note, StatusType.enum.Poll])
+    .orderBy('createdAt', 'asc')
     .orderBy('id', 'asc')
 
-  if (afterId) query.where('id', '>', afterId)
+  await applyStatusReindexCursor({ database, query, afterId })
 
   const rows = await query.limit(limit)
   await reindexStatusSearchDocuments(database, rows)

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -1,22 +1,110 @@
 import { Knex } from 'knex'
+import sanitizeHtml from 'sanitize-html'
 
+import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { applyPotentiallyReadableStatusFilter } from '@/lib/database/sql/utils/statusVisibility'
 import {
+  ReindexSearchDocumentsParams,
   ReindexSearchDocumentsResult,
   SearchStatusesParams
 } from '@/lib/types/database/operations'
+import { StatusType } from '@/lib/types/domain/status'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
 
-import { deleteSearchDocument } from './documents'
-import { throwUnimplementedSearchMethod } from './notImplemented'
+import {
+  SEARCH_DOCUMENTS_TABLE,
+  applySearchDocumentFilter,
+  deleteSearchDocument,
+  normalizeSearchText,
+  upsertSearchDocument
+} from './documents'
 
-export const searchStatusIds = async (
-  _database: Knex,
-  _params: SearchStatusesParams
-): Promise<string[]> => throwUnimplementedSearchMethod('searchStatusIds')
+type SQLStatusRow = {
+  id: string
+  actorId: string
+  type: string
+  content: string | Record<string, unknown> | null
+  createdAt: number | Date
+}
+
+const parseStatusContent = (
+  content: SQLStatusRow['content']
+): Record<string, unknown> | string | null => {
+  if (!content) return null
+  if (typeof content === 'string') {
+    try {
+      return getCompatibleJSON(content)
+    } catch {
+      return content
+    }
+  }
+  return content
+}
+
+const stripHTML = (value: string) =>
+  sanitizeHtml(value, {
+    allowedTags: [],
+    allowedAttributes: {}
+  })
+
+const getStatusDocumentText = (status: SQLStatusRow) => {
+  const content = parseStatusContent(status.content)
+  if (!content || typeof content === 'string') return ''
+
+  const text = typeof content.text === 'string' ? content.text : ''
+  const summary = typeof content.summary === 'string' ? content.summary : ''
+  return normalizeSearchText([stripHTML(text), stripHTML(summary)].join(' '))
+}
+
+const getStatusVisibility = async (database: Knex, statusId: string) => {
+  const recipients = await database('recipients').where('statusId', statusId)
+  const recipientIds = recipients.map((recipient) => String(recipient.actorId))
+  if (
+    recipientIds.some((actorId) =>
+      [ACTIVITY_STREAM_PUBLIC, ACTIVITY_STREAM_PUBLIC_COMPACT].includes(actorId)
+    )
+  ) {
+    return 'public'
+  }
+  if (recipientIds.length === 0) return 'direct'
+  return 'private'
+}
 
 export const indexStatusSearchDocument = async (
-  _database: Knex,
-  _params: { statusId: string }
-): Promise<void> => throwUnimplementedSearchMethod('indexStatusSearchDocument')
+  database: Knex,
+  { statusId }: { statusId: string }
+): Promise<void> => {
+  const status = await database<SQLStatusRow>('statuses')
+    .where('id', statusId)
+    .first()
+  if (
+    !status ||
+    (status.type !== StatusType.enum.Note &&
+      status.type !== StatusType.enum.Poll)
+  ) {
+    await deleteStatusSearchDocument(database, { statusId })
+    return
+  }
+
+  const documentText = getStatusDocumentText(status)
+  if (!documentText) {
+    await deleteStatusSearchDocument(database, { statusId })
+    return
+  }
+
+  await upsertSearchDocument(database, {
+    entityType: 'status',
+    entityId: status.id,
+    documentText,
+    actorId: status.actorId,
+    visibility: await getStatusVisibility(database, status.id),
+    entityCreatedAt: getCompatibleTime(status.createdAt)
+  })
+}
 
 export const deleteStatusSearchDocument = async (
   database: Knex,
@@ -28,8 +116,203 @@ export const deleteStatusSearchDocument = async (
   })
 }
 
+const applyCursorFilter = async ({
+  database,
+  query,
+  maxId,
+  minId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  maxId?: string | null
+  minId?: string | null
+}) => {
+  if (maxId) {
+    const cursor = await database(SEARCH_DOCUMENTS_TABLE)
+      .where({ entityType: 'status', entityId: maxId })
+      .first<{ entityCreatedAt: number | Date; entityId: string }>()
+    if (cursor) {
+      query.where((builder) => {
+        builder
+          .where(
+            'search_documents.entityCreatedAt',
+            '<',
+            cursor.entityCreatedAt
+          )
+          .orWhere((sameTimeBuilder) => {
+            sameTimeBuilder
+              .where('search_documents.entityCreatedAt', cursor.entityCreatedAt)
+              .where('search_documents.entityId', '<', cursor.entityId)
+          })
+      })
+    }
+  }
+
+  if (minId) {
+    const cursor = await database(SEARCH_DOCUMENTS_TABLE)
+      .where({ entityType: 'status', entityId: minId })
+      .first<{ entityCreatedAt: number | Date; entityId: string }>()
+    if (cursor) {
+      query.where((builder) => {
+        builder
+          .where(
+            'search_documents.entityCreatedAt',
+            '>',
+            cursor.entityCreatedAt
+          )
+          .orWhere((sameTimeBuilder) => {
+            sameTimeBuilder
+              .where('search_documents.entityCreatedAt', cursor.entityCreatedAt)
+              .where('search_documents.entityId', '>', cursor.entityId)
+          })
+      })
+    }
+  }
+}
+
+const getMentionSearchValues = async (
+  database: Knex,
+  currentActorId: string
+) => {
+  const actor = await database('actors')
+    .where('id', currentActorId)
+    .first<{ username: string; domain: string }>('username', 'domain')
+  if (!actor) return [currentActorId]
+
+  return [
+    currentActorId,
+    `https://${actor.domain}/@${actor.username}`,
+    `https://${actor.domain}/@${actor.username}@${actor.domain}`
+  ]
+}
+
+const applyRestrictiveStatusSearchPolicy = ({
+  database,
+  query,
+  currentActorId,
+  mentionValues
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  currentActorId: string
+  mentionValues: string[]
+}) => {
+  query.where((builder) => {
+    builder
+      .where('statuses.actorId', currentActorId)
+      .orWhereExists(function () {
+        this.select(database.raw('1'))
+          .from('likes')
+          .where('likes.actorId', currentActorId)
+          .whereRaw('?? = ??', ['likes.statusId', 'statuses.id'])
+      })
+      .orWhereExists(function () {
+        this.select(database.raw('1'))
+          .from('bookmarks')
+          .where('bookmarks.actorId', currentActorId)
+          .whereRaw('?? = ??', ['bookmarks.statusId', 'statuses.id'])
+      })
+      .orWhereExists(function () {
+        this.select(database.raw('1'))
+          .from('tags')
+          .where('tags.type', 'mention')
+          .whereRaw('?? = ??', ['tags.statusId', 'statuses.id'])
+          .whereIn('tags.value', mentionValues)
+      })
+  })
+}
+
+const applyBlockedAccountFilter = ({
+  database,
+  query,
+  currentActorId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  currentActorId: string
+}) => {
+  query.whereNotExists(function () {
+    this.select(database.raw('1'))
+      .from('blocks')
+      .where((builder) => {
+        builder
+          .where((outgoing) => {
+            outgoing
+              .where('blocks.actorId', currentActorId)
+              .whereRaw('?? = ??', ['blocks.targetActorId', 'statuses.actorId'])
+          })
+          .orWhere((incoming) => {
+            incoming
+              .where('blocks.targetActorId', currentActorId)
+              .whereRaw('?? = ??', ['blocks.actorId', 'statuses.actorId'])
+          })
+      })
+  })
+}
+
+export const searchStatusIds = async (
+  database: Knex,
+  {
+    q,
+    limit,
+    offset = 0,
+    currentActorId,
+    accountId,
+    minId,
+    maxId
+  }: SearchStatusesParams
+): Promise<string[]> => {
+  const mentionValues = await getMentionSearchValues(database, currentActorId)
+  const query = database(SEARCH_DOCUMENTS_TABLE)
+    .innerJoin('statuses', 'statuses.id', 'search_documents.entityId')
+    .select<{ entityId: string }[]>('search_documents.entityId')
+    .where('search_documents.entityType', 'status')
+    .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
+
+  applySearchDocumentFilter({ database, query, q })
+  if (accountId) query.where('statuses.actorId', accountId)
+
+  applyPotentiallyReadableStatusFilter({
+    database,
+    query,
+    visibleToActorId: currentActorId
+  })
+  applyRestrictiveStatusSearchPolicy({
+    database,
+    query,
+    currentActorId,
+    mentionValues
+  })
+  applyBlockedAccountFilter({ database, query, currentActorId })
+  await applyCursorFilter({ database, query, maxId, minId })
+
+  const rows = await query
+    .orderBy('search_documents.entityCreatedAt', 'desc')
+    .orderBy('search_documents.entityId', 'desc')
+    .limit(limit)
+    .offset(offset)
+
+  return rows.map((row) => row.entityId)
+}
+
 export const reindexSearchStatuses = async (
-  _database?: Knex,
-  _params?: unknown
-): Promise<ReindexSearchDocumentsResult> =>
-  throwUnimplementedSearchMethod('reindexSearchStatuses')
+  database: Knex,
+  { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
+): Promise<ReindexSearchDocumentsResult> => {
+  const query = database<SQLStatusRow>('statuses')
+    .select('id')
+    .whereIn('type', [StatusType.enum.Note, StatusType.enum.Poll])
+    .orderBy('id', 'asc')
+
+  if (afterId) query.where('id', '>', afterId)
+
+  const rows = await query.limit(limit)
+  for (const row of rows) {
+    await indexStatusSearchDocument(database, { statusId: row.id })
+  }
+
+  return {
+    indexed: rows.length,
+    nextCursor: rows.length === limit ? rows[rows.length - 1].id : null
+  }
+}

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -1,5 +1,11 @@
 import { Knex } from 'knex'
 
+import {
+  SQLITE_MAX_BINDINGS,
+  chunkArray,
+  getClientName,
+  getWhereInBatchSize
+} from '@/lib/database/sql/utils/knex'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import {
@@ -12,6 +18,7 @@ import {
   SearchStatusesParams
 } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
+import { normalizeActorId } from '@/lib/utils/activitypub'
 import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
 import {
@@ -35,25 +42,7 @@ type StatusCursor = {
   entityCreatedAt: number | Date
 }
 
-const SQLITE_MAX_BINDINGS = 999
 const STATUS_REINDEX_CURSOR_PREFIX = 'status-created-at:'
-
-const getClientName = (database: Knex) => String(database.client.config.client)
-
-const getWhereInBatchSize = (database: Knex) => {
-  if (!getClientName(database).includes('sqlite'))
-    return Number.POSITIVE_INFINITY
-  return SQLITE_MAX_BINDINGS
-}
-
-const chunkArray = <T>(items: T[], size: number) => {
-  const chunkSize = Number.isFinite(size) ? size : Math.max(items.length, 1)
-  const chunks: T[][] = []
-  for (let start = 0; start < items.length; start += chunkSize) {
-    chunks.push(items.slice(start, start + chunkSize))
-  }
-  return chunks
-}
 
 const getStatusDocumentText = (status: SQLStatusRow) => {
   const content = parseStatusContent(status.content)
@@ -125,13 +114,13 @@ const getSearchDocumentInsertBatchSize = (
   return Math.max(1, Math.floor(SQLITE_MAX_BINDINGS / columnCount))
 }
 
-const deleteStatusSearchDocumentsByStatusIds = async (
-  database: Knex,
+export const deleteStatusSearchDocumentsByStatusIds = async (
+  database: Knex | Knex.Transaction,
   statusIds: string[]
 ) => {
   for (const statusIdChunk of chunkArray(
     statusIds,
-    getWhereInBatchSize(database)
+    getWhereInBatchSize(database, 1)
   )) {
     await database(SEARCH_DOCUMENTS_TABLE)
       .where('entityType', 'status')
@@ -333,24 +322,33 @@ const getMentionSearchValues = async (
     'currentActorId' | 'currentActorUsername' | 'currentActorDomain'
   >
 ) => {
+  const normalizeMentionValues = (values: string[]) => [
+    ...new Set(
+      values.flatMap((value) => {
+        const normalizedValue = normalizeActorId(value)
+        return normalizedValue ? [value, normalizedValue] : [value]
+      })
+    )
+  ]
+
   if (currentActorUsername && currentActorDomain) {
-    return [
+    return normalizeMentionValues([
       currentActorId,
       `https://${currentActorDomain}/@${currentActorUsername}`,
       `https://${currentActorDomain}/@${currentActorUsername}@${currentActorDomain}`
-    ]
+    ])
   }
 
   const actor = await database('actors')
     .where('id', currentActorId)
     .first<{ username: string; domain: string }>('username', 'domain')
-  if (!actor) return [currentActorId]
+  if (!actor) return normalizeMentionValues([currentActorId])
 
-  return [
+  return normalizeMentionValues([
     currentActorId,
     `https://${actor.domain}/@${actor.username}`,
     `https://${actor.domain}/@${actor.username}@${actor.domain}`
-  ]
+  ])
 }
 
 const applyRestrictiveStatusSearchPolicy = ({

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -307,9 +307,9 @@ export const reindexSearchStatuses = async (
   if (afterId) query.where('id', '>', afterId)
 
   const rows = await query.limit(limit)
-  for (const row of rows) {
-    await indexStatusSearchDocument(database, { statusId: row.id })
-  }
+  await Promise.all(
+    rows.map((row) => indexStatusSearchDocument(database, { statusId: row.id }))
+  )
 
   return {
     indexed: rows.length,

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -1,19 +1,18 @@
 import { Knex } from 'knex'
 import sanitizeHtml from 'sanitize-html'
 
-import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
-import { applyPotentiallyReadableStatusFilter } from '@/lib/database/sql/utils/statusVisibility'
+import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
+import {
+  PUBLIC_ACTIVITY_RECIPIENTS,
+  applyPotentiallyReadableStatusFilter
+} from '@/lib/database/sql/utils/statusVisibility'
 import {
   ReindexSearchDocumentsParams,
   ReindexSearchDocumentsResult,
   SearchStatusesParams
 } from '@/lib/types/database/operations'
 import { StatusType } from '@/lib/types/domain/status'
-import {
-  ACTIVITY_STREAM_PUBLIC,
-  ACTIVITY_STREAM_PUBLIC_COMPACT
-} from '@/lib/utils/activitystream'
 
 import {
   SEARCH_DOCUMENTS_TABLE,
@@ -31,19 +30,7 @@ type SQLStatusRow = {
   createdAt: number | Date
 }
 
-const parseStatusContent = (
-  content: SQLStatusRow['content']
-): Record<string, unknown> | string | null => {
-  if (!content) return null
-  if (typeof content === 'string') {
-    try {
-      return getCompatibleJSON(content)
-    } catch {
-      return content
-    }
-  }
-  return content
-}
+const SQLITE_MAX_BINDINGS = 999
 
 const stripHTML = (value: string) =>
   sanitizeHtml(value, {
@@ -62,9 +49,7 @@ const getStatusDocumentText = (status: SQLStatusRow) => {
 
 const getStatusVisibilityFromRecipientIds = (recipientIds: string[]) => {
   if (
-    recipientIds.some((actorId) =>
-      [ACTIVITY_STREAM_PUBLIC, ACTIVITY_STREAM_PUBLIC_COMPACT].includes(actorId)
-    )
+    recipientIds.some((actorId) => PUBLIC_ACTIVITY_RECIPIENTS.includes(actorId))
   ) {
     return 'public'
   }
@@ -92,56 +77,68 @@ const getStatusRecipientIdsByStatusId = async (
   return recipientIdsByStatusId
 }
 
+const getSearchDocumentInsertBatchSize = (
+  database: Knex,
+  row: Record<string, unknown>
+) => {
+  const clientName = String(database.client.config.client)
+  if (!clientName.includes('sqlite')) return Number.POSITIVE_INFINITY
+
+  const columnCount = Math.max(1, Object.keys(row).length)
+  return Math.max(1, Math.floor(SQLITE_MAX_BINDINGS / columnCount))
+}
+
 const reindexStatusSearchDocuments = async (
   database: Knex,
   statuses: SQLStatusRow[]
 ) => {
-  const statusIds = statuses.map((status) => status.id)
-  if (statusIds.length === 0) return
+  if (statuses.length === 0) return
 
-  const recipientIdsByStatusId = await getStatusRecipientIdsByStatusId(
-    database,
-    statusIds
-  )
   const currentTime = new Date()
   const statusIdsToDelete: string[] = []
-  const rows = statuses.flatMap((status) => {
+  const candidates: { status: SQLStatusRow; documentText: string }[] = []
+
+  for (const status of statuses) {
     if (
       status.type !== StatusType.enum.Note &&
       status.type !== StatusType.enum.Poll
     ) {
       statusIdsToDelete.push(status.id)
-      return []
+      continue
     }
 
     const documentText = getStatusDocumentText(status)
     if (!documentText) {
       statusIdsToDelete.push(status.id)
-      return []
+      continue
     }
 
-    return [
-      {
-        id: getSearchDocumentId({
-          entityType: 'status',
-          entityId: status.id
-        }),
-        entityType: 'status',
-        entityId: status.id,
-        documentText,
-        actorId: status.actorId,
-        visibility: getStatusVisibilityFromRecipientIds(
-          recipientIdsByStatusId.get(status.id) ?? []
-        ),
-        entityCreatedAt: new Date(getCompatibleTime(status.createdAt)),
-        discoverable: null,
-        postCount: null,
-        lastPostAt: null,
-        createdAt: currentTime,
-        updatedAt: currentTime
-      }
-    ]
-  })
+    candidates.push({ status, documentText })
+  }
+
+  const recipientIdsByStatusId = await getStatusRecipientIdsByStatusId(
+    database,
+    candidates.map(({ status }) => status.id)
+  )
+  const rows = candidates.map(({ status, documentText }) => ({
+    id: getSearchDocumentId({
+      entityType: 'status',
+      entityId: status.id
+    }),
+    entityType: 'status',
+    entityId: status.id,
+    documentText,
+    actorId: status.actorId,
+    visibility: getStatusVisibilityFromRecipientIds(
+      recipientIdsByStatusId.get(status.id) ?? []
+    ),
+    entityCreatedAt: new Date(getCompatibleTime(status.createdAt)),
+    discoverable: null,
+    postCount: null,
+    lastPostAt: null,
+    createdAt: currentTime,
+    updatedAt: currentTime
+  }))
 
   if (statusIdsToDelete.length > 0) {
     await database(SEARCH_DOCUMENTS_TABLE)
@@ -152,16 +149,19 @@ const reindexStatusSearchDocuments = async (
 
   if (rows.length === 0) return
 
-  await database(SEARCH_DOCUMENTS_TABLE)
-    .insert(rows)
-    .onConflict(['entityType', 'entityId'])
-    .merge([
-      'documentText',
-      'actorId',
-      'visibility',
-      'entityCreatedAt',
-      'updatedAt'
-    ])
+  const batchSize = getSearchDocumentInsertBatchSize(database, rows[0])
+  for (let start = 0; start < rows.length; start += batchSize) {
+    await database(SEARCH_DOCUMENTS_TABLE)
+      .insert(rows.slice(start, start + batchSize))
+      .onConflict(['entityType', 'entityId'])
+      .merge([
+        'documentText',
+        'actorId',
+        'visibility',
+        'entityCreatedAt',
+        'updatedAt'
+      ])
+  }
 }
 
 export const indexStatusSearchDocument = async (

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex'
 
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   SQLITE_MAX_BINDINGS,
   chunkArray,
   getClientName,
   getWhereInBatchSize
 } from '@/lib/database/sql/utils/knex'
-import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import {
   PUBLIC_ACTIVITY_RECIPIENTS,
@@ -324,28 +324,34 @@ const getMentionSearchValues = async (
 ) => {
   const normalizeMentionValues = (values: string[]) => [
     ...new Set(
-      values.flatMap((value) => {
+      values.filter(Boolean).flatMap((value) => {
         const normalizedValue = normalizeActorId(value)
         return normalizedValue ? [value, normalizedValue] : [value]
       })
     )
   ]
+  const normalizedCurrentActorId =
+    normalizeActorId(currentActorId) ?? currentActorId
 
   if (currentActorUsername && currentActorDomain) {
     return normalizeMentionValues([
       currentActorId,
+      `@${currentActorUsername}`,
+      `@${currentActorUsername}@${currentActorDomain}`,
       `https://${currentActorDomain}/@${currentActorUsername}`,
       `https://${currentActorDomain}/@${currentActorUsername}@${currentActorDomain}`
     ])
   }
 
   const actor = await database('actors')
-    .where('id', currentActorId)
+    .where('id', normalizedCurrentActorId)
     .first<{ username: string; domain: string }>('username', 'domain')
   if (!actor) return normalizeMentionValues([currentActorId])
 
   return normalizeMentionValues([
     currentActorId,
+    `@${actor.username}`,
+    `@${actor.username}@${actor.domain}`,
     `https://${actor.domain}/@${actor.username}`,
     `https://${actor.domain}/@${actor.username}@${actor.domain}`
   ])
@@ -382,7 +388,11 @@ const applyRestrictiveStatusSearchPolicy = ({
           .from('tags')
           .where('tags.type', 'mention')
           .whereRaw('?? = ??', ['tags.statusId', 'statuses.id'])
-          .whereIn('tags.value', mentionValues)
+          .where((mentionBuilder) => {
+            mentionBuilder
+              .whereIn('tags.value', mentionValues)
+              .orWhereIn('tags.name', mentionValues)
+          })
       })
   })
 }
@@ -479,9 +489,13 @@ const parseStatusReindexCursor = (
   const createdAt = Number(payload.slice(0, separatorIndex))
   if (!Number.isFinite(createdAt)) return null
 
-  return {
-    createdAt,
-    id: decodeURIComponent(payload.slice(separatorIndex + 1))
+  try {
+    return {
+      createdAt,
+      id: decodeURIComponent(payload.slice(separatorIndex + 1))
+    }
+  } catch {
+    return null
   }
 }
 
@@ -504,6 +518,8 @@ export const searchStatusIds = async (
     maxId
   }: SearchStatusesParams
 ): Promise<string[]> => {
+  const normalizedCurrentActorId =
+    normalizeActorId(currentActorId) ?? currentActorId
   const mentionValues = await getMentionSearchValues(database, {
     currentActorId,
     currentActorUsername,
@@ -521,15 +537,19 @@ export const searchStatusIds = async (
   applyPotentiallyReadableStatusFilter({
     database,
     query,
-    visibleToActorId: currentActorId
+    visibleToActorId: normalizedCurrentActorId
   })
   applyRestrictiveStatusSearchPolicy({
     database,
     query,
-    currentActorId,
+    currentActorId: normalizedCurrentActorId,
     mentionValues
   })
-  applyBlockedAccountFilter({ database, query, currentActorId })
+  applyBlockedAccountFilter({
+    database,
+    query,
+    currentActorId: normalizedCurrentActorId
+  })
   await applyCursorFilter({ database, query, maxId, minId })
 
   const rows = await query

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -191,7 +191,7 @@ const reindexStatusSearchDocuments = async (
   for (let start = 0; start < rows.length; start += batchSize) {
     await database(SEARCH_DOCUMENTS_TABLE)
       .insert(rows.slice(start, start + batchSize))
-      .onConflict(['entityType', 'entityId'])
+      .onConflict('id')
       .merge([
         'documentText',
         'actorId',

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -29,13 +29,17 @@ import {
   normalizeSearchText
 } from './documents'
 
-type SQLStatusRow = {
+export type SQLStatusSearchRow = {
   id: string
   actorId: string
   type: string
   content: string | Record<string, unknown> | null
   createdAt: number | Date
 }
+
+type IndexStatusSearchDocumentParams =
+  | { statusId: string }
+  | { status: SQLStatusSearchRow }
 
 type StatusCursor = {
   entityId: string
@@ -44,7 +48,7 @@ type StatusCursor = {
 
 const STATUS_REINDEX_CURSOR_PREFIX = 'status-created-at:'
 
-const getStatusDocumentText = (status: SQLStatusRow) => {
+const getStatusDocumentText = (status: SQLStatusSearchRow) => {
   const content = parseStatusContent(status.content)
   if (!content) return ''
   if (typeof content === 'string')
@@ -131,13 +135,13 @@ export const deleteStatusSearchDocumentsByStatusIds = async (
 
 const reindexStatusSearchDocuments = async (
   database: Knex,
-  statuses: SQLStatusRow[]
+  statuses: SQLStatusSearchRow[]
 ) => {
   if (statuses.length === 0) return
 
   const currentTime = new Date()
   const statusIdsToDelete: string[] = []
-  const candidates: { status: SQLStatusRow; documentText: string }[] = []
+  const candidates: { status: SQLStatusSearchRow; documentText: string }[] = []
 
   for (const status of statuses) {
     if (
@@ -204,13 +208,18 @@ const reindexStatusSearchDocuments = async (
 
 export const indexStatusSearchDocument = async (
   database: Knex,
-  { statusId }: { statusId: string }
+  params: IndexStatusSearchDocumentParams
 ): Promise<void> => {
-  const status = await database<SQLStatusRow>('statuses')
-    .where('id', statusId)
+  if ('status' in params) {
+    await reindexStatusSearchDocuments(database, [params.status])
+    return
+  }
+
+  const status = await database<SQLStatusSearchRow>('statuses')
+    .where('id', params.statusId)
     .first()
   if (!status) {
-    await deleteStatusSearchDocument(database, { statusId })
+    await deleteStatusSearchDocument(database, { statusId: params.statusId })
     return
   }
 
@@ -440,7 +449,7 @@ const applyStatusReindexCursor = async ({
 
   if (!cursor) {
     cursor =
-      (await database<SQLStatusRow>('statuses')
+      (await database<SQLStatusSearchRow>('statuses')
         .where('id', afterId)
         .first('id', 'createdAt')) ?? null
   }
@@ -499,7 +508,7 @@ const parseStatusReindexCursor = (
   }
 }
 
-const getStatusReindexCursor = (status: SQLStatusRow) =>
+const getStatusReindexCursor = (status: SQLStatusSearchRow) =>
   `${STATUS_REINDEX_CURSOR_PREFIX}${getCompatibleTime(
     status.createdAt
   )}:${encodeURIComponent(status.id)}`
@@ -565,7 +574,7 @@ export const reindexSearchStatuses = async (
   database: Knex,
   { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
 ): Promise<ReindexSearchDocumentsResult> => {
-  const query = database<SQLStatusRow>('statuses')
+  const query = database<SQLStatusSearchRow>('statuses')
     .select('id', 'actorId', 'type', 'content', 'createdAt')
     .whereIn('type', [StatusType.enum.Note, StatusType.enum.Poll])
     .orderBy('createdAt', 'asc')

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -19,8 +19,8 @@ import {
   SEARCH_DOCUMENTS_TABLE,
   applySearchDocumentFilter,
   deleteSearchDocument,
-  normalizeSearchText,
-  upsertSearchDocument
+  getSearchDocumentId,
+  normalizeSearchText
 } from './documents'
 
 type SQLStatusRow = {
@@ -60,9 +60,7 @@ const getStatusDocumentText = (status: SQLStatusRow) => {
   return normalizeSearchText([stripHTML(text), stripHTML(summary)].join(' '))
 }
 
-const getStatusVisibility = async (database: Knex, statusId: string) => {
-  const recipients = await database('recipients').where('statusId', statusId)
-  const recipientIds = recipients.map((recipient) => String(recipient.actorId))
+const getStatusVisibilityFromRecipientIds = (recipientIds: string[]) => {
   if (
     recipientIds.some((actorId) =>
       [ACTIVITY_STREAM_PUBLIC, ACTIVITY_STREAM_PUBLIC_COMPACT].includes(actorId)
@@ -74,6 +72,98 @@ const getStatusVisibility = async (database: Knex, statusId: string) => {
   return 'private'
 }
 
+const getStatusRecipientIdsByStatusId = async (
+  database: Knex,
+  statusIds: string[]
+) => {
+  const recipientIdsByStatusId = new Map<string, string[]>()
+  if (statusIds.length === 0) return recipientIdsByStatusId
+
+  const rows = await database('recipients')
+    .whereIn('statusId', statusIds)
+    .select<{ statusId: string; actorId: string }[]>('statusId', 'actorId')
+
+  for (const row of rows) {
+    const recipientIds = recipientIdsByStatusId.get(row.statusId) ?? []
+    recipientIds.push(String(row.actorId))
+    recipientIdsByStatusId.set(row.statusId, recipientIds)
+  }
+
+  return recipientIdsByStatusId
+}
+
+const reindexStatusSearchDocuments = async (
+  database: Knex,
+  statuses: SQLStatusRow[]
+) => {
+  const statusIds = statuses.map((status) => status.id)
+  if (statusIds.length === 0) return
+
+  const recipientIdsByStatusId = await getStatusRecipientIdsByStatusId(
+    database,
+    statusIds
+  )
+  const currentTime = new Date()
+  const statusIdsToDelete: string[] = []
+  const rows = statuses.flatMap((status) => {
+    if (
+      status.type !== StatusType.enum.Note &&
+      status.type !== StatusType.enum.Poll
+    ) {
+      statusIdsToDelete.push(status.id)
+      return []
+    }
+
+    const documentText = getStatusDocumentText(status)
+    if (!documentText) {
+      statusIdsToDelete.push(status.id)
+      return []
+    }
+
+    return [
+      {
+        id: getSearchDocumentId({
+          entityType: 'status',
+          entityId: status.id
+        }),
+        entityType: 'status',
+        entityId: status.id,
+        documentText,
+        actorId: status.actorId,
+        visibility: getStatusVisibilityFromRecipientIds(
+          recipientIdsByStatusId.get(status.id) ?? []
+        ),
+        entityCreatedAt: new Date(getCompatibleTime(status.createdAt)),
+        discoverable: null,
+        postCount: null,
+        lastPostAt: null,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      }
+    ]
+  })
+
+  if (statusIdsToDelete.length > 0) {
+    await database(SEARCH_DOCUMENTS_TABLE)
+      .where('entityType', 'status')
+      .whereIn('entityId', statusIdsToDelete)
+      .delete()
+  }
+
+  if (rows.length === 0) return
+
+  await database(SEARCH_DOCUMENTS_TABLE)
+    .insert(rows)
+    .onConflict(['entityType', 'entityId'])
+    .merge([
+      'documentText',
+      'actorId',
+      'visibility',
+      'entityCreatedAt',
+      'updatedAt'
+    ])
+}
+
 export const indexStatusSearchDocument = async (
   database: Knex,
   { statusId }: { statusId: string }
@@ -81,29 +171,12 @@ export const indexStatusSearchDocument = async (
   const status = await database<SQLStatusRow>('statuses')
     .where('id', statusId)
     .first()
-  if (
-    !status ||
-    (status.type !== StatusType.enum.Note &&
-      status.type !== StatusType.enum.Poll)
-  ) {
+  if (!status) {
     await deleteStatusSearchDocument(database, { statusId })
     return
   }
 
-  const documentText = getStatusDocumentText(status)
-  if (!documentText) {
-    await deleteStatusSearchDocument(database, { statusId })
-    return
-  }
-
-  await upsertSearchDocument(database, {
-    entityType: 'status',
-    entityId: status.id,
-    documentText,
-    actorId: status.actorId,
-    visibility: await getStatusVisibility(database, status.id),
-    entityCreatedAt: getCompatibleTime(status.createdAt)
-  })
+  await reindexStatusSearchDocuments(database, [status])
 }
 
 export const deleteStatusSearchDocument = async (
@@ -300,16 +373,14 @@ export const reindexSearchStatuses = async (
   { afterId = null, limit = 500 }: ReindexSearchDocumentsParams = {}
 ): Promise<ReindexSearchDocumentsResult> => {
   const query = database<SQLStatusRow>('statuses')
-    .select('id')
+    .select('id', 'actorId', 'type', 'content', 'createdAt')
     .whereIn('type', [StatusType.enum.Note, StatusType.enum.Poll])
     .orderBy('id', 'asc')
 
   if (afterId) query.where('id', '>', afterId)
 
   const rows = await query.limit(limit)
-  await Promise.all(
-    rows.map((row) => indexStatusSearchDocument(database, { statusId: row.id }))
-  )
+  await reindexStatusSearchDocuments(database, rows)
 
   return {
     indexed: rows.length,

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -32,6 +32,23 @@ type SQLStatusRow = {
 
 const SQLITE_MAX_BINDINGS = 999
 
+const getClientName = (database: Knex) => String(database.client.config.client)
+
+const getWhereInBatchSize = (database: Knex) => {
+  if (!getClientName(database).includes('sqlite'))
+    return Number.POSITIVE_INFINITY
+  return SQLITE_MAX_BINDINGS
+}
+
+const chunkArray = <T>(items: T[], size: number) => {
+  const chunkSize = Number.isFinite(size) ? size : Math.max(items.length, 1)
+  const chunks: T[][] = []
+  for (let start = 0; start < items.length; start += chunkSize) {
+    chunks.push(items.slice(start, start + chunkSize))
+  }
+  return chunks
+}
+
 const stripHTML = (value: string) =>
   sanitizeHtml(value, {
     allowedTags: [],
@@ -64,9 +81,22 @@ const getStatusRecipientIdsByStatusId = async (
   const recipientIdsByStatusId = new Map<string, string[]>()
   if (statusIds.length === 0) return recipientIdsByStatusId
 
-  const rows = await database('recipients')
-    .whereIn('statusId', statusIds)
-    .select<{ statusId: string; actorId: string }[]>('statusId', 'actorId')
+  const statusIdChunks = chunkArray(
+    [...new Set(statusIds)],
+    getWhereInBatchSize(database)
+  )
+
+  const rows = (
+    await Promise.all(
+      statusIdChunks.map((statusIdChunk) =>
+        database('recipients')
+          .whereIn('statusId', statusIdChunk)
+          .select<
+            { statusId: string; actorId: string }[]
+          >('statusId', 'actorId')
+      )
+    )
+  ).flat()
 
   for (const row of rows) {
     const recipientIds = recipientIdsByStatusId.get(row.statusId) ?? []
@@ -81,7 +111,7 @@ const getSearchDocumentInsertBatchSize = (
   database: Knex,
   row: Record<string, unknown>
 ) => {
-  const clientName = String(database.client.config.client)
+  const clientName = getClientName(database)
   if (!clientName.includes('sqlite')) return Number.POSITIVE_INFINITY
 
   const columnCount = Math.max(1, Object.keys(row).length)
@@ -200,10 +230,28 @@ const applyCursorFilter = async ({
   maxId?: string | null
   minId?: string | null
 }) => {
+  const cursorIds = [
+    ...new Set([maxId, minId].filter((id): id is string => Boolean(id)))
+  ]
+  const cursors = new Map<
+    string,
+    { entityCreatedAt: number | Date; entityId: string }
+  >()
+
+  if (cursorIds.length > 0) {
+    const rows = await database(SEARCH_DOCUMENTS_TABLE)
+      .where('entityType', 'status')
+      .whereIn('entityId', cursorIds)
+      .select<
+        { entityCreatedAt: number | Date; entityId: string }[]
+      >('entityCreatedAt', 'entityId')
+    for (const row of rows) {
+      cursors.set(row.entityId, row)
+    }
+  }
+
   if (maxId) {
-    const cursor = await database(SEARCH_DOCUMENTS_TABLE)
-      .where({ entityType: 'status', entityId: maxId })
-      .first<{ entityCreatedAt: number | Date; entityId: string }>()
+    const cursor = cursors.get(maxId)
     if (cursor) {
       query.where((builder) => {
         builder
@@ -222,9 +270,7 @@ const applyCursorFilter = async ({
   }
 
   if (minId) {
-    const cursor = await database(SEARCH_DOCUMENTS_TABLE)
-      .where({ entityType: 'status', entityId: minId })
-      .first<{ entityCreatedAt: number | Date; entityId: string }>()
+    const cursor = cursors.get(minId)
     if (cursor) {
       query.where((builder) => {
         builder
@@ -245,8 +291,23 @@ const applyCursorFilter = async ({
 
 const getMentionSearchValues = async (
   database: Knex,
-  currentActorId: string
+  {
+    currentActorId,
+    currentActorUsername,
+    currentActorDomain
+  }: Pick<
+    SearchStatusesParams,
+    'currentActorId' | 'currentActorUsername' | 'currentActorDomain'
+  >
 ) => {
+  if (currentActorUsername && currentActorDomain) {
+    return [
+      currentActorId,
+      `https://${currentActorDomain}/@${currentActorUsername}`,
+      `https://${currentActorDomain}/@${currentActorUsername}@${currentActorDomain}`
+    ]
+  }
+
   const actor = await database('actors')
     .where('id', currentActorId)
     .first<{ username: string; domain: string }>('username', 'domain')
@@ -330,12 +391,18 @@ export const searchStatusIds = async (
     limit,
     offset = 0,
     currentActorId,
+    currentActorUsername,
+    currentActorDomain,
     accountId,
     minId,
     maxId
   }: SearchStatusesParams
 ): Promise<string[]> => {
-  const mentionValues = await getMentionSearchValues(database, currentActorId)
+  const mentionValues = await getMentionSearchValues(database, {
+    currentActorId,
+    currentActorUsername,
+    currentActorDomain
+  })
   const query = database(SEARCH_DOCUMENTS_TABLE)
     .innerJoin('statuses', 'statuses.id', 'search_documents.entityId')
     .select<{ entityId: string }[]>('search_documents.entityId')

--- a/lib/database/sql/search/status.ts
+++ b/lib/database/sql/search/status.ts
@@ -30,7 +30,13 @@ type SQLStatusRow = {
   createdAt: number | Date
 }
 
+type StatusCursor = {
+  entityId: string
+  entityCreatedAt: number | Date
+}
+
 const SQLITE_MAX_BINDINGS = 999
+const STATUS_REINDEX_CURSOR_PREFIX = 'status-created-at:'
 
 const getClientName = (database: Knex) => String(database.client.config.client)
 
@@ -51,7 +57,9 @@ const chunkArray = <T>(items: T[], size: number) => {
 
 const getStatusDocumentText = (status: SQLStatusRow) => {
   const content = parseStatusContent(status.content)
-  if (!content || typeof content === 'string') return ''
+  if (!content) return ''
+  if (typeof content === 'string')
+    return normalizeSearchText(htmlToPlainText(content))
 
   const text = typeof content.text === 'string' ? content.text : ''
   const summary = typeof content.summary === 'string' ? content.summary : ''
@@ -59,6 +67,9 @@ const getStatusDocumentText = (status: SQLStatusRow) => {
     [htmlToPlainText(text), htmlToPlainText(summary)].join(' ')
   )
 }
+
+const toDatabaseTimestamp = (value: number | Date) =>
+  new Date(getCompatibleTime(value))
 
 const getStatusVisibilityFromRecipientIds = (recipientIds: string[]) => {
   if (
@@ -241,10 +252,7 @@ const applyCursorFilter = async ({
   const cursorIds = [
     ...new Set([maxId, minId].filter((id): id is string => Boolean(id)))
   ]
-  const cursors = new Map<
-    string,
-    { entityCreatedAt: number | Date; entityId: string }
-  >()
+  const cursors = new Map<string, StatusCursor>()
 
   if (cursorIds.length > 0) {
     const rows = await database(SEARCH_DOCUMENTS_TABLE)
@@ -256,11 +264,26 @@ const applyCursorFilter = async ({
     for (const row of rows) {
       cursors.set(row.entityId, row)
     }
+
+    const missingCursorIds = cursorIds.filter((id) => !cursors.has(id))
+    if (missingCursorIds.length > 0) {
+      const statusRows = await database('statuses')
+        .whereIn('id', missingCursorIds)
+        .select<{ id: string; createdAt: number | Date }[]>('id', 'createdAt')
+      for (const row of statusRows) {
+        cursors.set(row.id, {
+          entityId: row.id,
+          entityCreatedAt: toDatabaseTimestamp(row.createdAt)
+        })
+      }
+    }
   }
 
   if (maxId) {
     const cursor = cursors.get(maxId)
-    if (cursor) {
+    if (!cursor) {
+      query.whereRaw('1 = 0')
+    } else {
       query.where((builder) => {
         builder
           .where(
@@ -279,7 +302,9 @@ const applyCursorFilter = async ({
 
   if (minId) {
     const cursor = cursors.get(minId)
-    if (cursor) {
+    if (!cursor) {
+      query.whereRaw('1 = 0')
+    } else {
       query.where((builder) => {
         builder
           .where(
@@ -403,25 +428,69 @@ const applyStatusReindexCursor = async ({
 }) => {
   if (!afterId) return
 
-  const cursor = await database<SQLStatusRow>('statuses')
-    .where('id', afterId)
-    .first('id', 'createdAt')
+  let cursor = parseStatusReindexCursor(afterId)
 
   if (!cursor) {
-    query.where('id', '>', afterId)
+    cursor =
+      (await database<SQLStatusRow>('statuses')
+        .where('id', afterId)
+        .first('id', 'createdAt')) ?? null
+  }
+
+  if (!cursor) {
+    const searchDocumentCursor = await database(SEARCH_DOCUMENTS_TABLE)
+      .where('entityType', 'status')
+      .where('entityId', afterId)
+      .first<{
+        entityId: string
+        entityCreatedAt: number | Date
+      }>('entityId', 'entityCreatedAt')
+    if (searchDocumentCursor) {
+      cursor = {
+        id: searchDocumentCursor.entityId,
+        createdAt: searchDocumentCursor.entityCreatedAt
+      }
+    }
+  }
+
+  if (!cursor) {
+    query.whereRaw('1 = 0')
     return
   }
 
   query.where((builder) => {
     builder
-      .where('createdAt', '>', cursor.createdAt)
+      .where('createdAt', '>', toDatabaseTimestamp(cursor.createdAt))
       .orWhere((sameTimeBuilder) => {
         sameTimeBuilder
-          .where('createdAt', cursor.createdAt)
+          .where('createdAt', toDatabaseTimestamp(cursor.createdAt))
           .where('id', '>', cursor.id)
       })
   })
 }
+
+const parseStatusReindexCursor = (
+  cursor: string
+): { id: string; createdAt: number | Date } | null => {
+  if (!cursor.startsWith(STATUS_REINDEX_CURSOR_PREFIX)) return null
+
+  const payload = cursor.slice(STATUS_REINDEX_CURSOR_PREFIX.length)
+  const separatorIndex = payload.indexOf(':')
+  if (separatorIndex < 1) return null
+
+  const createdAt = Number(payload.slice(0, separatorIndex))
+  if (!Number.isFinite(createdAt)) return null
+
+  return {
+    createdAt,
+    id: decodeURIComponent(payload.slice(separatorIndex + 1))
+  }
+}
+
+const getStatusReindexCursor = (status: SQLStatusRow) =>
+  `${STATUS_REINDEX_CURSOR_PREFIX}${getCompatibleTime(
+    status.createdAt
+  )}:${encodeURIComponent(status.id)}`
 
 export const searchStatusIds = async (
   database: Knex,
@@ -491,6 +560,9 @@ export const reindexSearchStatuses = async (
 
   return {
     indexed: rows.length,
-    nextCursor: rows.length === limit ? rows[rows.length - 1].id : null
+    nextCursor:
+      rows.length === limit
+        ? getStatusReindexCursor(rows[rows.length - 1])
+        : null
   }
 }

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2739,9 +2739,15 @@ describe('StatusDatabase', () => {
         const parentStatusId = `${actorId}/statuses/bulk-parent`
         const firstReplyStatusId = `${actorId}/statuses/bulk-reply-1`
         const secondReplyStatusId = `${actorId}/statuses/bulk-reply-2`
-        const queries: string[] = []
-        const handleQuery = ({ sql }: { sql: string }) => {
-          queries.push(sql.toLowerCase())
+        const queries: { bindings: unknown[]; sql: string }[] = []
+        const handleQuery = ({
+          bindings,
+          sql
+        }: {
+          bindings?: unknown[]
+          sql: string
+        }) => {
+          queries.push({ bindings: bindings ?? [], sql: sql.toLowerCase() })
         }
 
         try {
@@ -2795,24 +2801,32 @@ describe('StatusDatabase', () => {
 
           expect(
             queries.some(
-              (sql) =>
+              ({ sql }) =>
                 sql.includes('from `statuses`') && sql.includes('`id` in')
             )
           ).toBe(true)
           expect(
             queries.some(
-              (sql) =>
+              ({ sql }) =>
                 sql.includes('from `tags`') && sql.includes('`statusid` in')
             )
           ).toBe(true)
           expect(
             queries.some(
-              (sql) =>
+              ({ sql }) =>
                 sql.startsWith('delete') &&
                 sql.includes('`recipients`') &&
                 sql.includes('`statusid` in')
             )
           ).toBe(true)
+          const searchDocumentDeletes = queries.filter(
+            ({ bindings, sql }) =>
+              sql.startsWith('delete') &&
+              sql.includes('`search_documents`') &&
+              bindings.includes('status')
+          )
+          expect(searchDocumentDeletes).toHaveLength(1)
+          expect(searchDocumentDeletes[0].sql).toContain('`entityid` in')
         } finally {
           knexDatabase.off('query', handleQuery)
           await knexDatabase.destroy()

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -85,6 +85,7 @@ import {
   indexStatusSearchDocument,
   normalizeHashtagSearchName
 } from './search'
+import type { SQLStatusSearchRow } from './search'
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
 
 const MAX_ANNOUNCE_RESOLUTION_DEPTH = 10
@@ -399,6 +400,19 @@ export const StatusSQLDatabaseMixin = (
     const currentTime = new Date()
     const statusCreatedAt = createdAt ? new Date(createdAt) : currentTime
     const statusUpdatedAt = currentTime
+    const content = {
+      url,
+      text,
+      summary
+    }
+    const statusContent = JSON.stringify(content)
+    const searchStatus: SQLStatusSearchRow = {
+      id,
+      actorId,
+      type: StatusType.enum.Note,
+      content: statusContent,
+      createdAt: statusCreatedAt
+    }
 
     await database.transaction(async (trx) => {
       await trx('statuses').insert({
@@ -407,11 +421,7 @@ export const StatusSQLDatabaseMixin = (
         urlHash: getStatusUrlHash(url),
         actorId,
         type: StatusType.enum.Note,
-        content: JSON.stringify({
-          url,
-          text,
-          summary
-        }),
+        content: statusContent,
         reply,
         replyHash: getStatusReplyHash(reply),
         createdAt: statusCreatedAt,
@@ -421,11 +431,7 @@ export const StatusSQLDatabaseMixin = (
         actorId,
         type: StatusType.enum.Note,
         reply,
-        content: {
-          url,
-          text,
-          summary
-        },
+        content,
         step: 'increment',
         trx,
         currentTime
@@ -459,7 +465,7 @@ export const StatusSQLDatabaseMixin = (
       )
     })
 
-    await indexStatusSearchDocument(database, { statusId: id })
+    await indexStatusSearchDocument(database, { status: searchStatus })
 
     const actor = await actorDatabase.getActorFromId({ id: actorId })
     return StatusNote.parse({
@@ -503,6 +509,19 @@ export const StatusSQLDatabaseMixin = (
       summary: status.summary
     }
     const currentTime = new Date()
+    const content = {
+      url: status.url,
+      text,
+      summary
+    }
+    const statusContent = JSON.stringify(content)
+    const searchStatus: SQLStatusSearchRow = {
+      id: status.id,
+      actorId: status.actorId,
+      type: status.type,
+      content: statusContent,
+      createdAt: status.createdAt
+    }
     await database.transaction(async (trx) => {
       await trx('status_history').insert({
         statusId: status.id,
@@ -515,11 +534,7 @@ export const StatusSQLDatabaseMixin = (
         .update({
           url: status.url || null,
           urlHash: status.url ? getStatusUrlHash(status.url) : null,
-          content: JSON.stringify({
-            url: status.url,
-            text,
-            summary
-          }),
+          content: statusContent,
           updatedAt: currentTime
         })
 
@@ -579,7 +594,7 @@ export const StatusSQLDatabaseMixin = (
         )
       }
     })
-    await indexStatusSearchDocument(database, { statusId })
+    await indexStatusSearchDocument(database, { status: searchStatus })
     return getStatus({ statusId })
   }
 
@@ -594,6 +609,17 @@ export const StatusSQLDatabaseMixin = (
 
     let affectedHashtags: string[] = []
     const currentTime = new Date()
+    const searchStatus: SQLStatusSearchRow = {
+      id: status.id,
+      actorId: status.actorId,
+      type: status.type,
+      content: JSON.stringify({
+        url: status.url,
+        text: status.text,
+        summary: status.summary
+      }),
+      createdAt: status.createdAt
+    }
     await database.transaction(async (trx) => {
       await trx('recipients').where('statusId', status.id).delete()
       await trx('timelines').where('statusId', status.id).delete()
@@ -629,7 +655,7 @@ export const StatusSQLDatabaseMixin = (
         hashtags: affectedHashtags
       })
     }
-    await indexStatusSearchDocument(database, { statusId })
+    await indexStatusSearchDocument(database, { status: searchStatus })
     return getStatus({ statusId })
   }
 
@@ -734,6 +760,21 @@ export const StatusSQLDatabaseMixin = (
     const currentTime = new Date()
     const statusCreatedAt = createdAt ? new Date(createdAt) : currentTime
     const statusUpdatedAt = currentTime
+    const content = {
+      url,
+      text,
+      summary,
+      endAt,
+      pollType
+    }
+    const statusContent = JSON.stringify(content)
+    const searchStatus: SQLStatusSearchRow = {
+      id,
+      actorId,
+      type: StatusType.enum.Poll,
+      content: statusContent,
+      createdAt: statusCreatedAt
+    }
 
     await database.transaction(async (trx) => {
       await trx('statuses').insert({
@@ -742,13 +783,7 @@ export const StatusSQLDatabaseMixin = (
         urlHash: getStatusUrlHash(url),
         actorId,
         type: StatusType.enum.Poll,
-        content: JSON.stringify({
-          url,
-          text,
-          summary,
-          endAt,
-          pollType
-        }),
+        content: statusContent,
         reply,
         replyHash: getStatusReplyHash(reply),
         createdAt: statusCreatedAt,
@@ -758,13 +793,7 @@ export const StatusSQLDatabaseMixin = (
         actorId,
         type: StatusType.enum.Poll,
         reply,
-        content: {
-          url,
-          text,
-          summary,
-          endAt,
-          pollType
-        },
+        content,
         step: 'increment',
         trx,
         currentTime
@@ -809,7 +838,7 @@ export const StatusSQLDatabaseMixin = (
       )
     })
 
-    await indexStatusSearchDocument(database, { statusId: id })
+    await indexStatusSearchDocument(database, { status: searchStatus })
 
     const actor = await actorDatabase.getActorFromId({ id: actorId })
     return StatusPoll.parse({
@@ -854,6 +883,21 @@ export const StatusSQLDatabaseMixin = (
     const data = getCompatibleJSON(existingStatus.content)
     const nextText = text ?? data.text
     const nextSummary = summary ?? data.summary
+    const content = {
+      url: data.url,
+      text: nextText,
+      summary: nextSummary,
+      endAt: data.endAt,
+      pollType: data.pollType
+    }
+    const statusContent = JSON.stringify(content)
+    const searchStatus: SQLStatusSearchRow = {
+      id: existingStatus.id,
+      actorId: existingStatus.actorId,
+      type: existingStatus.type,
+      content: statusContent,
+      createdAt: existingStatus.createdAt
+    }
 
     await database.transaction(async (trx) => {
       if (nextText !== data.text || nextSummary !== data.summary) {
@@ -872,13 +916,7 @@ export const StatusSQLDatabaseMixin = (
           .update({
             url: data.url || null,
             urlHash: data.url ? getStatusUrlHash(data.url) : null,
-            content: JSON.stringify({
-              url: data.url,
-              text: nextText,
-              summary: nextSummary,
-              endAt: data.endAt,
-              pollType: data.pollType
-            }),
+            content: statusContent,
             updatedAt: currentTime
           })
       }
@@ -894,7 +932,7 @@ export const StatusSQLDatabaseMixin = (
           })
       }
     })
-    await indexStatusSearchDocument(database, { statusId })
+    await indexStatusSearchDocument(database, { status: searchStatus })
     return getStatus({ statusId })
   }
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -79,8 +79,10 @@ import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
 import {
+  deleteStatusSearchDocument,
   indexHashtagSearchDocument,
   indexHashtagSearchDocuments,
+  indexStatusSearchDocument,
   normalizeHashtagSearchName
 } from './search'
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
@@ -644,6 +646,8 @@ export const StatusSQLDatabaseMixin = (
       )
     })
 
+    await indexStatusSearchDocument(database, { statusId: id })
+
     const actor = await actorDatabase.getActorFromId({ id: actorId })
     return StatusNote.parse({
       id,
@@ -762,6 +766,7 @@ export const StatusSQLDatabaseMixin = (
         )
       }
     })
+    await indexStatusSearchDocument(database, { statusId })
     return getStatus({ statusId })
   }
 
@@ -811,6 +816,7 @@ export const StatusSQLDatabaseMixin = (
         hashtags: affectedHashtags
       })
     }
+    await indexStatusSearchDocument(database, { statusId })
     return getStatus({ statusId })
   }
 
@@ -990,6 +996,8 @@ export const StatusSQLDatabaseMixin = (
       )
     })
 
+    await indexStatusSearchDocument(database, { statusId: id })
+
     const actor = await actorDatabase.getActorFromId({ id: actorId })
     return StatusPoll.parse({
       id,
@@ -1073,6 +1081,7 @@ export const StatusSQLDatabaseMixin = (
           })
       }
     })
+    await indexStatusSearchDocument(database, { statusId })
     return getStatus({ statusId })
   }
 
@@ -1861,6 +1870,16 @@ export const StatusSQLDatabaseMixin = (
       statuses: statusesToDelete,
       trx
     })
+    for (const statusIdChunk of chunkArray(
+      statusIdsToDelete,
+      getWhereInBatchSize(trx)
+    )) {
+      await Promise.all(
+        statusIdChunk.map((statusId) =>
+          deleteStatusSearchDocument(trx, { statusId })
+        )
+      )
+    }
     await deleteCounterValues(
       trx,
       statusIdsToDelete.flatMap((statusId) => [

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -16,10 +16,15 @@ import {
   deleteRowsByColumnChunks,
   getWhereInBatchSize
 } from '@/lib/database/sql/utils/knex'
+import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import {
   StatusHashtagTagRow,
   selectHashtagTagsByStatusIds
 } from '@/lib/database/sql/utils/status'
+import {
+  PUBLIC_ACTIVITY_RECIPIENTS,
+  applyPotentiallyReadableStatusFilter as applyPotentiallyReadableStatusVisibilityFilter
+} from '@/lib/database/sql/utils/statusVisibility'
 import { SQLFitnessFile } from '@/lib/types/database/fitnessFile'
 import { ActorDatabase } from '@/lib/types/database/operations'
 import { BookmarkDatabase } from '@/lib/types/database/operations'
@@ -59,7 +64,6 @@ import {
 } from '@/lib/types/database/operations'
 import { Actor, getActorProfile } from '@/lib/types/domain/actor'
 import { Attachment, isFitnessAttachment } from '@/lib/types/domain/attachment'
-import { FollowStatus } from '@/lib/types/domain/follow'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
 import {
   Status,
@@ -70,10 +74,7 @@ import {
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
-import {
-  ACTIVITY_STREAM_PUBLIC,
-  ACTIVITY_STREAM_PUBLIC_COMPACT
-} from '@/lib/utils/activitystream'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getAttachmentMediaPath } from '@/lib/utils/getAttachmentMediaPath'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
@@ -87,10 +88,6 @@ import {
 } from './search'
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
 
-const PUBLIC_ACTIVITY_RECIPIENTS = [
-  ACTIVITY_STREAM_PUBLIC,
-  ACTIVITY_STREAM_PUBLIC_COMPACT
-]
 const MAX_ANNOUNCE_RESOLUTION_DEPTH = 10
 // Counts breadth-first reply levels from the deleted root, not total replies.
 // This bounds transaction size while still allowing wide conversation cleanup.
@@ -244,200 +241,18 @@ export const StatusSQLDatabaseMixin = (
       buildPubliclyReadableStatusIdsQuery({ database, targetStatusIds })
     )
 
-  const statusActorFollowersUrlExpression = () => {
-    const clientName = String(database.client.config.client)
-    if (clientName.includes('pg')) {
-      return "status_actors.settings::jsonb ->> 'followersUrl'"
-    }
-    if (clientName.includes('mysql')) {
-      return "JSON_UNQUOTE(JSON_EXTRACT(status_actors.settings, '$.followersUrl'))"
-    }
-    return "json_extract(status_actors.settings, '$.followersUrl')"
-  }
-
   const applyPotentiallyReadableStatusFilter = ({
     query,
     visibleToActorId
   }: {
     query: Knex.QueryBuilder
     visibleToActorId: string
-  }) => {
-    const clientName = String(database.client.config.client)
-    const fallbackFollowersAudienceExpression = {
-      sql: clientName.includes('mysql')
-        ? "?? = CONCAT(??, '/followers')"
-        : "?? = ?? || '/followers'",
-      bindings: ['followers_recipients.actorId', 'statuses.actorId']
-    }
-    const storedFollowersAudienceExpression = {
-      sql: `?? = ${statusActorFollowersUrlExpression()}`,
-      bindings: ['followers_recipients.actorId']
-    }
-    const applyRecipientlessReplyBaseFilter = (builder: Knex.QueryBuilder) => {
-      builder
-        .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
-        .whereNotExists(function () {
-          this.select(database.raw('1'))
-            .from('recipients as reply_recipients')
-            .whereRaw('?? = ??', ['reply_recipients.statusId', 'statuses.id'])
-        })
-    }
-    const applyRecipientlessReplyParentReferenceFilter = ({
-      builder,
-      parentReferenceColumn,
-      parentReferenceHashColumn
-    }: {
-      builder: Knex.QueryBuilder
-      parentReferenceColumn: string
-      parentReferenceHashColumn?: string
-    }) => {
-      if (parentReferenceHashColumn) {
-        builder.whereRaw('?? = ??', [
-          'statuses.replyHash',
-          parentReferenceHashColumn
-        ])
-      }
-      builder.whereRaw('?? = ??', ['statuses.reply', parentReferenceColumn])
-    }
-    const applyRecipientlessReplyParentAuthorFilter = (
-      builder: Knex.QueryBuilder,
-      parentReferenceColumn: string,
-      parentReferenceHashColumn?: string
-    ) => {
-      builder
-        .select(database.raw('1'))
-        .from('statuses as reply_parent_statuses')
-        .where('reply_parent_statuses.actorId', visibleToActorId)
-      applyRecipientlessReplyParentReferenceFilter({
-        builder,
-        parentReferenceColumn,
-        parentReferenceHashColumn
-      })
-    }
-    const applyRecipientlessReplyParentConversationParticipantFilter = (
-      builder: Knex.QueryBuilder,
-      parentReferenceColumn: string,
-      parentReferenceHashColumn?: string
-    ) => {
-      builder
-        .select(database.raw('1'))
-        .from('statuses as reply_parent_statuses')
-        .innerJoin(
-          'direct_conversation_statuses as reply_parent_direct_statuses',
-          'reply_parent_direct_statuses.statusId',
-          'reply_parent_statuses.id'
-        )
-        .innerJoin(
-          'direct_conversation_participants as reply_parent_direct_participants',
-          'reply_parent_direct_participants.conversationId',
-          'reply_parent_direct_statuses.conversationId'
-        )
-        .where('reply_parent_direct_participants.actorId', visibleToActorId)
-      applyRecipientlessReplyParentReferenceFilter({
-        builder,
-        parentReferenceColumn,
-        parentReferenceHashColumn
-      })
-    }
-
-    return query.where((qb) => {
-      qb.whereIn(
-        'statuses.id',
-        database('recipients')
-          .select('statusId')
-          .whereIn('recipients.actorId', [
-            ...PUBLIC_ACTIVITY_RECIPIENTS,
-            visibleToActorId
-          ])
-      )
-        .orWhere('statuses.actorId', visibleToActorId)
-        .orWhere((recipientlessReplyQb) => {
-          applyRecipientlessReplyBaseFilter(recipientlessReplyQb)
-          recipientlessReplyQb.andWhere((parentVisibilityQb) => {
-            parentVisibilityQb
-              .whereExists(function () {
-                applyRecipientlessReplyParentAuthorFilter(
-                  this,
-                  'reply_parent_statuses.id'
-                )
-              })
-              .orWhereExists(function () {
-                applyRecipientlessReplyParentAuthorFilter(
-                  this,
-                  'reply_parent_statuses.url',
-                  'reply_parent_statuses.urlHash'
-                )
-              })
-              .orWhereExists(function () {
-                applyRecipientlessReplyParentConversationParticipantFilter(
-                  this,
-                  'reply_parent_statuses.id'
-                )
-              })
-              .orWhereExists(function () {
-                applyRecipientlessReplyParentConversationParticipantFilter(
-                  this,
-                  'reply_parent_statuses.url',
-                  'reply_parent_statuses.urlHash'
-                )
-              })
-          })
-        })
-        .orWhereExists(function () {
-          this.select(database.raw('1'))
-            .from('recipients as followers_recipients')
-            .leftJoin(
-              'actors as status_actors',
-              'status_actors.id',
-              'statuses.actorId'
-            )
-            .whereRaw('?? = ??', [
-              'followers_recipients.statusId',
-              'statuses.id'
-            ])
-            .where(function () {
-              this.whereRaw(
-                storedFollowersAudienceExpression.sql,
-                storedFollowersAudienceExpression.bindings
-              ).orWhereRaw(
-                fallbackFollowersAudienceExpression.sql,
-                fallbackFollowersAudienceExpression.bindings
-              )
-            })
-            .whereExists(function () {
-              this.select(database.raw('1'))
-                .from('follows')
-                .where('follows.actorId', visibleToActorId)
-                .whereRaw('?? = ??', [
-                  'follows.targetActorId',
-                  'statuses.actorId'
-                ])
-                .where('follows.status', FollowStatus.enum.Accepted)
-            })
-        })
+  }) =>
+    applyPotentiallyReadableStatusVisibilityFilter({
+      database,
+      query,
+      visibleToActorId
     })
-  }
-
-  const parseStatusContent = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    content: any
-  ):
-    | string
-    | {
-        id?: string
-        url?: string
-      }
-    | null => {
-    if (!content) return null
-    if (typeof content === 'string') {
-      try {
-        return getCompatibleJSON(content)
-      } catch {
-        return content
-      }
-    }
-    return content
-  }
 
   const sortAttachmentsForFitnessMap = <T extends { id: string; url: string }>(
     attachments: T[],
@@ -467,8 +282,7 @@ export const StatusSQLDatabaseMixin = (
   }
 
   const getOriginalStatusIdFromAnnounceContent = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    content: any
+    content: unknown
   ): string | null => {
     const parsed = parseStatusContent(content)
     if (!parsed) return null

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -79,7 +79,7 @@ import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
 import {
-  deleteStatusSearchDocument,
+  deleteStatusSearchDocumentsByStatusIds,
   indexHashtagSearchDocument,
   indexHashtagSearchDocuments,
   indexStatusSearchDocument,
@@ -1683,16 +1683,7 @@ export const StatusSQLDatabaseMixin = (
       statuses: statusesToDelete,
       trx
     })
-    for (const statusIdChunk of chunkArray(
-      statusIdsToDelete,
-      getWhereInBatchSize(trx)
-    )) {
-      await Promise.all(
-        statusIdChunk.map((statusId) =>
-          deleteStatusSearchDocument(trx, { statusId })
-        )
-      )
-    }
+    await deleteStatusSearchDocumentsByStatusIds(trx, statusIdsToDelete)
     await deleteCounterValues(
       trx,
       statusIdsToDelete.flatMap((statusId) => [

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -74,7 +74,6 @@ import {
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
-import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getAttachmentMediaPath } from '@/lib/utils/getAttachmentMediaPath'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'

--- a/lib/database/sql/utils/parseStatusContent.ts
+++ b/lib/database/sql/utils/parseStatusContent.ts
@@ -1,0 +1,21 @@
+import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
+
+export type ParsedStatusContent = string | Record<string, unknown> | null
+
+const isParsedStatusContent = (
+  value: unknown
+): value is Exclude<ParsedStatusContent, null> =>
+  typeof value === 'string' || (value !== null && typeof value === 'object')
+
+export const parseStatusContent = (content: unknown): ParsedStatusContent => {
+  if (!content) return null
+  if (typeof content === 'string') {
+    try {
+      const parsed = getCompatibleJSON<unknown>(content)
+      return isParsedStatusContent(parsed) ? parsed : null
+    } catch {
+      return content
+    }
+  }
+  return isParsedStatusContent(content) ? content : null
+}

--- a/lib/database/sql/utils/statusVisibility.ts
+++ b/lib/database/sql/utils/statusVisibility.ts
@@ -1,0 +1,186 @@
+import { Knex } from 'knex'
+
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { StatusType } from '@/lib/types/domain/status'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
+
+export const PUBLIC_ACTIVITY_RECIPIENTS = [
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+]
+
+const statusActorFollowersUrlExpression = (database: Knex) => {
+  const clientName = String(database.client.config.client)
+  if (clientName.includes('pg')) {
+    return "status_actors.settings::jsonb ->> 'followersUrl'"
+  }
+  if (clientName.includes('mysql')) {
+    return "JSON_UNQUOTE(JSON_EXTRACT(status_actors.settings, '$.followersUrl'))"
+  }
+  return "json_extract(status_actors.settings, '$.followersUrl')"
+}
+
+export const applyPotentiallyReadableStatusFilter = ({
+  database,
+  query,
+  visibleToActorId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  visibleToActorId: string
+}) => {
+  const clientName = String(database.client.config.client)
+  const fallbackFollowersAudienceExpression = {
+    sql: clientName.includes('mysql')
+      ? "?? = CONCAT(??, '/followers')"
+      : "?? = ?? || '/followers'",
+    bindings: ['followers_recipients.actorId', 'statuses.actorId']
+  }
+  const storedFollowersAudienceExpression = {
+    sql: `?? = ${statusActorFollowersUrlExpression(database)}`,
+    bindings: ['followers_recipients.actorId']
+  }
+  const applyRecipientlessReplyBaseFilter = (builder: Knex.QueryBuilder) => {
+    builder
+      .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
+      .whereNotExists(function () {
+        this.select(database.raw('1'))
+          .from('recipients as reply_recipients')
+          .whereRaw('?? = ??', ['reply_recipients.statusId', 'statuses.id'])
+      })
+  }
+  const applyRecipientlessReplyParentReferenceFilter = ({
+    builder,
+    parentReferenceColumn,
+    parentReferenceHashColumn
+  }: {
+    builder: Knex.QueryBuilder
+    parentReferenceColumn: string
+    parentReferenceHashColumn?: string
+  }) => {
+    if (parentReferenceHashColumn) {
+      builder.whereRaw('?? = ??', [
+        'statuses.replyHash',
+        parentReferenceHashColumn
+      ])
+    }
+    builder.whereRaw('?? = ??', ['statuses.reply', parentReferenceColumn])
+  }
+  const applyRecipientlessReplyParentAuthorFilter = (
+    builder: Knex.QueryBuilder,
+    parentReferenceColumn: string,
+    parentReferenceHashColumn?: string
+  ) => {
+    builder
+      .select(database.raw('1'))
+      .from('statuses as reply_parent_statuses')
+      .where('reply_parent_statuses.actorId', visibleToActorId)
+    applyRecipientlessReplyParentReferenceFilter({
+      builder,
+      parentReferenceColumn,
+      parentReferenceHashColumn
+    })
+  }
+  const applyRecipientlessReplyParentConversationParticipantFilter = (
+    builder: Knex.QueryBuilder,
+    parentReferenceColumn: string,
+    parentReferenceHashColumn?: string
+  ) => {
+    builder
+      .select(database.raw('1'))
+      .from('statuses as reply_parent_statuses')
+      .innerJoin(
+        'direct_conversation_statuses as reply_parent_direct_statuses',
+        'reply_parent_direct_statuses.statusId',
+        'reply_parent_statuses.id'
+      )
+      .innerJoin(
+        'direct_conversation_participants as reply_parent_direct_participants',
+        'reply_parent_direct_participants.conversationId',
+        'reply_parent_direct_statuses.conversationId'
+      )
+      .where('reply_parent_direct_participants.actorId', visibleToActorId)
+    applyRecipientlessReplyParentReferenceFilter({
+      builder,
+      parentReferenceColumn,
+      parentReferenceHashColumn
+    })
+  }
+
+  return query.where((qb) => {
+    qb.whereIn(
+      'statuses.id',
+      database('recipients')
+        .select('statusId')
+        .whereIn('recipients.actorId', [
+          ...PUBLIC_ACTIVITY_RECIPIENTS,
+          visibleToActorId
+        ])
+    )
+      .orWhere('statuses.actorId', visibleToActorId)
+      .orWhere((recipientlessReplyQb) => {
+        applyRecipientlessReplyBaseFilter(recipientlessReplyQb)
+        recipientlessReplyQb.andWhere((parentVisibilityQb) => {
+          parentVisibilityQb
+            .whereExists(function () {
+              applyRecipientlessReplyParentAuthorFilter(
+                this,
+                'reply_parent_statuses.id'
+              )
+            })
+            .orWhereExists(function () {
+              applyRecipientlessReplyParentAuthorFilter(
+                this,
+                'reply_parent_statuses.url',
+                'reply_parent_statuses.urlHash'
+              )
+            })
+            .orWhereExists(function () {
+              applyRecipientlessReplyParentConversationParticipantFilter(
+                this,
+                'reply_parent_statuses.id'
+              )
+            })
+            .orWhereExists(function () {
+              applyRecipientlessReplyParentConversationParticipantFilter(
+                this,
+                'reply_parent_statuses.url',
+                'reply_parent_statuses.urlHash'
+              )
+            })
+        })
+      })
+      .orWhereExists(function () {
+        this.select(database.raw('1'))
+          .from('recipients as followers_recipients')
+          .leftJoin(
+            'actors as status_actors',
+            'status_actors.id',
+            'statuses.actorId'
+          )
+          .whereRaw('?? = ??', ['followers_recipients.statusId', 'statuses.id'])
+          .where(function () {
+            this.whereRaw(
+              storedFollowersAudienceExpression.sql,
+              storedFollowersAudienceExpression.bindings
+            ).orWhereRaw(
+              fallbackFollowersAudienceExpression.sql,
+              fallbackFollowersAudienceExpression.bindings
+            )
+          })
+          .whereExists(function () {
+            this.select(database.raw('1'))
+              .from('follows')
+              .where('follows.actorId', visibleToActorId)
+              .whereRaw('?? = ??', [
+                'follows.targetActorId',
+                'statuses.actorId'
+              ])
+              .where('follows.status', FollowStatus.enum.Accepted)
+          })
+      })
+  })
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -696,6 +696,8 @@ export type SearchStatusesParams = {
   limit: number
   offset?: number
   currentActorId: string
+  currentActorUsername?: string | null
+  currentActorDomain?: string | null
   accountId?: string | null
   minId?: string | null
   maxId?: string | null

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "test": "jest",
     "prettier": "prettier --write app migrations lib",
+    "search:reindex": "node -r @swc-node/register scripts/rebuildSearchIndex.ts",
     "migrate": "knex migrate:latest",
     "migrate:make": "knex migrate:make",
     "prepare": "husky"

--- a/scripts/rebuildSearchIndex.ts
+++ b/scripts/rebuildSearchIndex.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S node -r @swc-node/register
+import { loadEnvConfig } from '@next/env'
+
+import { getDatabase } from '@/lib/database'
+
+const DEFAULT_BATCH_SIZE = 500
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
+
+const parseBatchSize = () => {
+  const value = Number(process.env.SEARCH_REINDEX_BATCH_SIZE)
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_BATCH_SIZE
+}
+
+async function reindexEntity(
+  name: string,
+  reindex: (params: {
+    afterId?: string | null
+    limit: number
+  }) => Promise<{ indexed: number; nextCursor: string | null }>
+) {
+  const limit = parseBatchSize()
+  let afterId: string | null = null
+  let total = 0
+
+  do {
+    const result = await reindex({ afterId, limit })
+    total += result.indexed
+    afterId = result.nextCursor
+    console.log(`${name}: indexed ${total}`)
+  } while (afterId)
+}
+
+async function rebuildSearchIndex() {
+  const database = getDatabase()
+  if (!database) {
+    console.error('Database is not available')
+    return 1
+  }
+
+  try {
+    await reindexEntity('accounts', (params) =>
+      database.reindexSearchAccounts(params)
+    )
+    await reindexEntity('hashtags', (params) =>
+      database.reindexSearchHashtags(params)
+    )
+    await reindexEntity('statuses', (params) =>
+      database.reindexSearchStatuses(params)
+    )
+    console.log('Search index rebuild complete')
+    return 0
+  } finally {
+    await database.destroy()
+  }
+}
+
+rebuildSearchIndex()
+  .then((code) => process.exit(code))
+  .catch((error) => {
+    const nodeError = error as Error
+    console.error(nodeError.message)
+    process.exit(1)
+  })


### PR DESCRIPTION
Stacked on #750.

## Summary
- index Note/Poll status bodies into the shared search document table, with HTML stripping and status visibility metadata
- keep status search documents current on create, edit, visibility update, delete, and actor deletion
- add readable-status, interaction, mention, and block filters for status search results
- cover status indexing, update/delete behavior, interaction requirements, mentions, and block filtering

## Verification
- yarn run prettier --write .
- yarn lint (passes with 11 existing any warnings)
- yarn build
- yarn test