### PR TITLE
minor: add v2 search contract

### DIFF
--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -8,12 +8,16 @@ const mockSearchHashtags = jest.fn()
 const mockSearchStatusIds = jest.fn()
 const mockGetStatusesByIds = jest.fn()
 const mockGetActorFromId = jest.fn()
+const mockGetActorFromUsername = jest.fn()
+const mockIsCurrentActorFollowing = jest.fn()
 const mockGetStatus = jest.fn()
 const mockGetStatusFromUrl = jest.fn()
 const mockStoredToken = jest.fn()
 const mockGetServerSession = jest.fn()
 const mockGetMastodonStatuses = jest.fn()
 const mockCanActorReadStatus = jest.fn()
+const mockGetWebfingerSelf = jest.fn()
+const mockRecordActorIfNeeded = jest.fn()
 
 const oauthActor = {
   id: 'https://llun.test/users/searcher',
@@ -39,6 +43,8 @@ jest.mock('@/lib/database', () => ({
     searchStatusIds: mockSearchStatusIds,
     getStatusesByIds: mockGetStatusesByIds,
     getActorFromId: mockGetActorFromId,
+    getActorFromUsername: mockGetActorFromUsername,
+    isCurrentActorFollowing: mockIsCurrentActorFollowing,
     getStatus: mockGetStatus,
     getStatusFromUrl: mockGetStatusFromUrl
   }),
@@ -70,6 +76,14 @@ jest.mock('@/lib/services/statusAccess', () => ({
   canActorReadStatus: (...args: unknown[]) => mockCanActorReadStatus(...args)
 }))
 
+jest.mock('@/lib/activities/getWebfingerSelf', () => ({
+  getWebfingerSelf: (...args: unknown[]) => mockGetWebfingerSelf(...args)
+}))
+
+jest.mock('@/lib/actions/utils', () => ({
+  recordActorIfNeeded: (...args: unknown[]) => mockRecordActorIfNeeded(...args)
+}))
+
 const context = { params: Promise.resolve({}) }
 
 describe('GET /api/v2/search', () => {
@@ -84,6 +98,8 @@ describe('GET /api/v2/search', () => {
     mockGetActorFromId.mockImplementation(({ id }) =>
       Promise.resolve(id === oauthActor.id ? oauthActor : null)
     )
+    mockGetActorFromUsername.mockResolvedValue(null)
+    mockIsCurrentActorFollowing.mockResolvedValue(true)
     mockSearchAccountIds.mockResolvedValue(['https://remote.test/users/alice'])
     mockGetMastodonActorsFromIds.mockImplementation(({ ids }) =>
       Promise.resolve(
@@ -124,6 +140,8 @@ describe('GET /api/v2/search', () => {
     mockGetStatus.mockResolvedValue(null)
     mockGetStatusFromUrl.mockResolvedValue(null)
     mockCanActorReadStatus.mockResolvedValue(true)
+    mockGetWebfingerSelf.mockResolvedValue(null)
+    mockRecordActorIfNeeded.mockResolvedValue(null)
   })
 
   it('allows anonymous account and hashtag search but omits statuses', async () => {
@@ -164,7 +182,7 @@ describe('GET /api/v2/search', () => {
     })
   })
 
-  it('delegates authenticated full search with filters and preserves status order', async () => {
+  it('delegates authenticated full search with filters and ignores offset without type', async () => {
     const accountId = encodeURIComponent('https://remote.test/users/alice')
     const response = await GET(
       new NextRequest(
@@ -179,13 +197,13 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 1,
+      offset: 0,
       followingActorId: oauthActor.id
     })
     expect(mockSearchStatusIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 1,
+      offset: 0,
       currentActorId: oauthActor.id,
       accountId: 'https://remote.test/users/alice',
       maxId: 'https://remote.test/users/alice/statuses/9',
@@ -202,6 +220,43 @@ describe('GET /api/v2/search', () => {
         content: 'https://remote.test/users/alice/statuses/1'
       }
     ])
+  })
+
+  it('ignores offset for anonymous multi-type search', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&limit=3&offset=5'
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 0
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 0,
+      excludeUnreviewed: false
+    })
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
+  })
+
+  it('does not require authentication solely for account_id on multi-type search', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&account_id=https%3A%2F%2Fremote.test%2Fusers%2Falice'
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalled()
+    expect(mockSearchHashtags).toHaveBeenCalled()
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 
   it('requires authentication for explicit status search', async () => {
@@ -253,6 +308,49 @@ describe('GET /api/v2/search', () => {
         resolvedStatus,
         {
           id: 'https://remote.test/users/alice/statuses/indexed',
+          actorId: 'https://remote.test/users/alice'
+        }
+      ],
+      oauthActor.id
+    )
+  })
+
+  it('preserves indexed status order after hydrating statuses', async () => {
+    const firstId = 'https://remote.test/users/alice/statuses/1'
+    const secondId = 'https://remote.test/users/alice/statuses/2'
+    mockSearchStatusIds.mockResolvedValue([firstId, secondId])
+    mockGetStatusesByIds.mockResolvedValue([
+      {
+        id: secondId,
+        url: 'https://remote.test/@alice/2',
+        actorId: 'https://remote.test/users/alice'
+      },
+      {
+        id: 'https://remote.test/users/alice/statuses/url-only',
+        url: firstId,
+        actorId: 'https://remote.test/users/alice'
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&type=statuses', {
+        headers: { Authorization: 'Bearer read-search-token' }
+      }),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+      expect.any(Object),
+      [
+        {
+          id: 'https://remote.test/users/alice/statuses/url-only',
+          url: firstId,
+          actorId: 'https://remote.test/users/alice'
+        },
+        {
+          id: secondId,
+          url: 'https://remote.test/@alice/2',
           actorId: 'https://remote.test/users/alice'
         }
       ],
@@ -317,6 +415,70 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
+  it('applies the following filter before including resolved accounts', async () => {
+    const accountUrl = 'http://remote.test/users/resolved'
+    mockGetActorFromId.mockImplementation(({ id }) =>
+      Promise.resolve(
+        id === oauthActor.id
+          ? oauthActor
+          : id === accountUrl
+            ? { id: 'https://remote.test/users/resolved' }
+            : null
+      )
+    )
+    mockIsCurrentActorFollowing.mockResolvedValue(false)
+    mockSearchAccountIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=true&following=true`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockIsCurrentActorFollowing).toHaveBeenCalledWith({
+      currentActorId: oauthActor.id,
+      followingActorId: 'https://remote.test/users/resolved'
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({ ids: [] })
+    expect(data.accounts).toEqual([])
+  })
+
+  it('resolves remote account handles with WebFinger', async () => {
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetWebfingerSelf.mockResolvedValue('https://remote.test/users/charlie')
+    mockRecordActorIfNeeded.mockResolvedValue({
+      id: 'https://remote.test/users/charlie'
+    })
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=%40charlie%40remote.test&type=accounts&resolve=true',
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'charlie',
+      domain: 'remote.test'
+    })
+    expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
+      account: 'charlie@remote.test'
+    })
+    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: 'https://remote.test/users/charlie',
+      database: expect.any(Object)
+    })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: ['https://remote.test/users/charlie']
+    })
+  })
+
   it('does not resolve account URLs after the first page', async () => {
     const accountUrl = 'http://remote.test/users/resolved'
 
@@ -355,6 +517,35 @@ describe('GET /api/v2/search', () => {
       currentActorId: oauthActor.id,
       visibleToActorId: oauthActor.id
     })
+  })
+
+  it('skips malformed hashtag rows', async () => {
+    mockSearchHashtags.mockResolvedValue([
+      {
+        name: 'trailrunning',
+        url: 'https://llun.test/tags/trailrunning',
+        history: []
+      },
+      {
+        name: 'broken',
+        history: []
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&type=hashtags'),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.hashtags).toEqual([
+      {
+        name: 'trailrunning',
+        url: 'https://llun.test/tags/trailrunning',
+        history: []
+      }
+    ])
   })
 
   it('rejects invalid search parameters', async () => {

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -236,26 +236,19 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
-  it('allows anonymous offset paging without including statuses', async () => {
+  it('requires authentication for offset paging', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&limit=3&offset=5'
       ),
       context
     )
+    const data = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(mockSearchAccountIds).toHaveBeenCalledWith({
-      q: 'trail',
-      limit: 3,
-      offset: 5
-    })
-    expect(mockSearchHashtags).toHaveBeenCalledWith({
-      q: 'trail',
-      limit: 3,
-      offset: 5,
-      excludeUnreviewed: false
-    })
+    expect(response.status).toBe(401)
+    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(mockSearchHashtags).not.toHaveBeenCalled()
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 
@@ -299,17 +292,19 @@ describe('GET /api/v2/search', () => {
     })
   })
 
-  it('does not require authentication solely for account_id on multi-type search', async () => {
+  it('requires authentication for account-scoped search', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&account_id=https%3A%2F%2Fremote.test%2Fusers%2Falice'
       ),
       context
     )
+    const data = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(mockSearchAccountIds).toHaveBeenCalled()
-    expect(mockSearchHashtags).toHaveBeenCalled()
+    expect(response.status).toBe(401)
+    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(mockSearchHashtags).not.toHaveBeenCalled()
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 
@@ -389,6 +384,11 @@ describe('GET /api/v2/search', () => {
     expect(response.status).toBe(200)
     expect(mockGetRemoteStatus).toHaveBeenCalledWith({
       statusId: statusUrl,
+      signingActor: oauthActor
+    })
+    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: remoteStatus.actorId,
+      database: expect.any(Object),
       signingActor: oauthActor
     })
     expect(mockGetMastodonStatuses).toHaveBeenCalledWith(

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -188,7 +188,7 @@ describe('GET /api/v2/search', () => {
     })
   })
 
-  it('delegates authenticated full search with filters and ignores offset without type', async () => {
+  it('delegates authenticated full search with filters and honors offset without type', async () => {
     const accountId = encodeURIComponent('https://remote.test/users/alice')
     const response = await GET(
       new NextRequest(
@@ -203,14 +203,22 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 0,
+      offset: 1,
       followingActorId: oauthActor.id
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 2,
+      offset: 1,
+      excludeUnreviewed: false
     })
     expect(mockSearchStatusIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 0,
+      offset: 1,
       currentActorId: oauthActor.id,
+      currentActorUsername: oauthActor.username,
+      currentActorDomain: oauthActor.domain,
       accountId: 'https://remote.test/users/alice',
       maxId: 'https://remote.test/users/alice/statuses/9',
       minId: 'https://remote.test/users/alice/statuses/1'
@@ -228,7 +236,7 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
-  it('requires authentication when offset is passed without type', async () => {
+  it('allows anonymous offset paging without including statuses', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&limit=3&offset=5'
@@ -236,10 +244,18 @@ describe('GET /api/v2/search', () => {
       context
     )
 
-    expect(response.status).toBe(401)
-    expect(await response.json()).toEqual({ status: 'Unauthorized' })
-    expect(mockSearchAccountIds).not.toHaveBeenCalled()
-    expect(mockSearchHashtags).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 5
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 5,
+      excludeUnreviewed: false
+    })
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 
@@ -262,6 +278,24 @@ describe('GET /api/v2/search', () => {
       limit: 20,
       offset: 0,
       excludeUnreviewed: false
+    })
+  })
+
+  it('accepts Mastodon-style truthy boolean query values', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&following=2&resolve=',
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 20,
+      offset: 0,
+      followingActorId: oauthActor.id
     })
   })
 
@@ -346,7 +380,7 @@ describe('GET /api/v2/search', () => {
 
     const response = await GET(
       new NextRequest(
-        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=1`,
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=2`,
         { headers: { Authorization: 'Bearer read-search-token' } }
       ),
       context
@@ -551,11 +585,11 @@ describe('GET /api/v2/search', () => {
 
     expect(response.status).toBe(200)
     expect(mockGetActorFromUsername).toHaveBeenCalledWith({
-      username: 'charlie',
+      username: 'Charlie',
       domain: 'remote.test'
     })
     expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
-      account: 'charlie@remote.test'
+      account: 'Charlie@remote.test'
     })
     expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
       actorId: 'https://remote.test/users/charlie',

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -17,6 +17,7 @@ const mockGetServerSession = jest.fn()
 const mockGetMastodonStatuses = jest.fn()
 const mockCanActorReadStatus = jest.fn()
 const mockGetWebfingerSelf = jest.fn()
+const mockGetActorPerson = jest.fn()
 const mockRecordActorIfNeeded = jest.fn()
 const mockGetRemoteStatus = jest.fn()
 const mockLoggerWarn = jest.fn()
@@ -80,6 +81,10 @@ jest.mock('@/lib/services/statusAccess', () => ({
 
 jest.mock('@/lib/activities/getWebfingerSelf', () => ({
   getWebfingerSelf: (...args: unknown[]) => mockGetWebfingerSelf(...args)
+}))
+
+jest.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: (...args: unknown[]) => mockGetActorPerson(...args)
 }))
 
 jest.mock('@/lib/activities/getRemoteStatus', () => ({
@@ -153,6 +158,7 @@ describe('GET /api/v2/search', () => {
     mockGetStatusFromUrl.mockResolvedValue(null)
     mockCanActorReadStatus.mockResolvedValue(true)
     mockGetWebfingerSelf.mockResolvedValue(null)
+    mockGetActorPerson.mockResolvedValue(null)
     mockRecordActorIfNeeded.mockResolvedValue(null)
     mockGetRemoteStatus.mockResolvedValue(null)
   })
@@ -221,7 +227,7 @@ describe('GET /api/v2/search', () => {
     })
     expect(mockSearchStatusIds).toHaveBeenCalledWith({
       q: 'trail',
-      limit: 2,
+      limit: 4,
       offset: 0,
       currentActorId: oauthActor.id,
       currentActorUsername: oauthActor.username,
@@ -305,6 +311,20 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 
+  it('requires authentication when offset is explicitly zero', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&type=accounts&limit=3&offset=0'
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+  })
+
   it('accepts Mastodon-style false boolean query values', async () => {
     const response = await GET(
       new NextRequest(
@@ -342,6 +362,24 @@ describe('GET /api/v2/search', () => {
       limit: 20,
       offset: 0,
       followingActorId: oauthActor.id
+    })
+  })
+
+  it('does not require authentication for following when accounts are not requested', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&type=hashtags&following=true'
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 20,
+      offset: 0,
+      excludeUnreviewed: false
     })
   })
 
@@ -541,6 +579,57 @@ describe('GET /api/v2/search', () => {
     )
   })
 
+  it('over-fetches indexed statuses before post-hydration filtering', async () => {
+    const firstId = 'https://remote.test/users/alice/statuses/1'
+    const secondId = 'https://remote.test/users/alice/statuses/2'
+    const thirdId = 'https://remote.test/users/alice/statuses/3'
+    mockSearchStatusIds.mockResolvedValue([firstId, secondId, thirdId])
+    mockGetStatusesByIds.mockResolvedValue([
+      {
+        id: secondId,
+        actorId: 'https://remote.test/users/alice'
+      },
+      {
+        id: thirdId,
+        actorId: 'https://remote.test/users/alice'
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&type=statuses&limit=2',
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchStatusIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 4
+      })
+    )
+    expect(mockGetStatusesByIds).toHaveBeenCalledWith({
+      statusIds: [firstId, secondId, thirdId],
+      currentActorId: oauthActor.id,
+      visibleToActorId: oauthActor.id
+    })
+    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+      expect.any(Object),
+      [
+        {
+          id: secondId,
+          actorId: 'https://remote.test/users/alice'
+        },
+        {
+          id: thirdId,
+          actorId: 'https://remote.test/users/alice'
+        }
+      ],
+      oauthActor.id
+    )
+  })
+
   it('resolves account URLs only on the first page and preserves hydration order', async () => {
     const accountUrl = 'http://remote.test/users/resolved'
     mockGetActorFromId.mockImplementation(({ id }) =>
@@ -600,13 +689,17 @@ describe('GET /api/v2/search', () => {
 
   it('resolves uncached account URLs', async () => {
     const accountUrl = 'http://remote.test/users/remote-resolved'
+    const canonicalActorId = 'https://remote.test/users/remote-resolved'
     mockSearchAccountIds.mockResolvedValue([])
+    mockGetActorPerson.mockResolvedValue({
+      id: canonicalActorId
+    })
     mockRecordActorIfNeeded.mockResolvedValue({
-      id: 'https://remote.test/users/remote-resolved'
+      id: canonicalActorId
     })
     mockGetMastodonActorsFromIds.mockResolvedValue([
       {
-        id: 'https://remote.test/users/remote-resolved',
+        id: canonicalActorId,
         url: accountUrl,
         username: 'remote-resolved'
       }
@@ -622,8 +715,12 @@ describe('GET /api/v2/search', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+    expect(mockGetActorPerson).toHaveBeenCalledWith({
       actorId: accountUrl,
+      signingActor: oauthActor
+    })
+    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: canonicalActorId,
       database: expect.any(Object),
       signingActor: oauthActor
     })

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -217,6 +217,7 @@ describe('GET /api/v2/search', () => {
   })
 
   it('prepends a resolved readable status URL before indexed results', async () => {
+    const statusUrl = 'http://remote.test/users/alice/statuses/resolved'
     const resolvedStatus = {
       id: 'https://remote.test/users/alice/statuses/resolved',
       actorId: 'https://remote.test/users/alice'
@@ -229,7 +230,7 @@ describe('GET /api/v2/search', () => {
 
     const response = await GET(
       new NextRequest(
-        `https://llun.test/api/v2/search?q=${encodeURIComponent(resolvedStatus.id)}&type=statuses&resolve=true`,
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=true`,
         { headers: { Authorization: 'Bearer read-search-token' } }
       ),
       context
@@ -242,10 +243,115 @@ describe('GET /api/v2/search', () => {
       currentActor: oauthActor
     })
     expect(mockGetStatusesByIds).toHaveBeenCalledWith({
-      statusIds: [
-        resolvedStatus.id,
-        'https://remote.test/users/alice/statuses/indexed'
+      statusIds: ['https://remote.test/users/alice/statuses/indexed'],
+      currentActorId: oauthActor.id,
+      visibleToActorId: oauthActor.id
+    })
+    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+      expect.any(Object),
+      [
+        resolvedStatus,
+        {
+          id: 'https://remote.test/users/alice/statuses/indexed',
+          actorId: 'https://remote.test/users/alice'
+        }
       ],
+      oauthActor.id
+    )
+  })
+
+  it('resolves account URLs only on the first page and preserves hydration order', async () => {
+    const accountUrl = 'http://remote.test/users/resolved'
+    mockGetActorFromId.mockImplementation(({ id }) =>
+      Promise.resolve(
+        id === oauthActor.id
+          ? oauthActor
+          : id === accountUrl
+            ? { id: 'https://remote.test/users/resolved' }
+            : null
+      )
+    )
+    mockSearchAccountIds.mockResolvedValue([
+      'https://remote.test/users/indexed'
+    ])
+    mockGetMastodonActorsFromIds.mockResolvedValue([
+      {
+        id: 'https://remote.test/users/indexed',
+        url: 'https://remote.test/@indexed',
+        username: 'indexed'
+      },
+      {
+        id: 'https://remote.test/users/resolved',
+        url: accountUrl,
+        username: 'resolved'
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=true`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: [
+        'https://remote.test/users/resolved',
+        'https://remote.test/users/indexed'
+      ]
+    })
+    expect(data.accounts).toEqual([
+      {
+        id: 'https://remote.test/users/resolved',
+        url: accountUrl,
+        username: 'resolved'
+      },
+      {
+        id: 'https://remote.test/users/indexed',
+        url: 'https://remote.test/@indexed',
+        username: 'indexed'
+      }
+    ])
+  })
+
+  it('does not resolve account URLs after the first page', async () => {
+    const accountUrl = 'http://remote.test/users/resolved'
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=true&offset=1`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromId).toHaveBeenCalledTimes(1)
+    expect(mockGetActorFromId).toHaveBeenCalledWith({ id: oauthActor.id })
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: ['https://remote.test/users/alice']
+    })
+  })
+
+  it('does not resolve status URLs after the first page', async () => {
+    const statusUrl = 'http://remote.test/users/alice/statuses/resolved'
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=true&offset=1`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetStatus).not.toHaveBeenCalled()
+    expect(mockGetStatusFromUrl).not.toHaveBeenCalled()
+    expect(mockGetStatusesByIds).toHaveBeenCalledWith({
+      statusIds: ['https://remote.test/users/alice/statuses/1'],
       currentActorId: oauthActor.id,
       visibleToActorId: oauthActor.id
     })

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -18,6 +18,7 @@ const mockGetMastodonStatuses = jest.fn()
 const mockCanActorReadStatus = jest.fn()
 const mockGetWebfingerSelf = jest.fn()
 const mockRecordActorIfNeeded = jest.fn()
+const mockGetRemoteStatus = jest.fn()
 
 const oauthActor = {
   id: 'https://llun.test/users/searcher',
@@ -78,6 +79,10 @@ jest.mock('@/lib/services/statusAccess', () => ({
 
 jest.mock('@/lib/activities/getWebfingerSelf', () => ({
   getWebfingerSelf: (...args: unknown[]) => mockGetWebfingerSelf(...args)
+}))
+
+jest.mock('@/lib/activities/getRemoteStatus', () => ({
+  getRemoteStatus: (...args: unknown[]) => mockGetRemoteStatus(...args)
 }))
 
 jest.mock('@/lib/actions/utils', () => ({
@@ -142,6 +147,7 @@ describe('GET /api/v2/search', () => {
     mockCanActorReadStatus.mockResolvedValue(true)
     mockGetWebfingerSelf.mockResolvedValue(null)
     mockRecordActorIfNeeded.mockResolvedValue(null)
+    mockGetRemoteStatus.mockResolvedValue(null)
   })
 
   it('allows anonymous account and hashtag search but omits statuses', async () => {
@@ -222,7 +228,7 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
-  it('ignores offset for anonymous multi-type search', async () => {
+  it('requires authentication when offset is passed without type', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&limit=3&offset=5'
@@ -230,19 +236,33 @@ describe('GET /api/v2/search', () => {
       context
     )
 
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ status: 'Unauthorized' })
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(mockSearchHashtags).not.toHaveBeenCalled()
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
+  })
+
+  it('accepts Mastodon-style false boolean query values', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&following=0&exclude_unreviewed=off'
+      ),
+      context
+    )
+
     expect(response.status).toBe(200)
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
-      limit: 3,
+      limit: 20,
       offset: 0
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
       q: 'trail',
-      limit: 3,
+      limit: 20,
       offset: 0,
       excludeUnreviewed: false
     })
-    expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 
   it('does not require authentication solely for account_id on multi-type search', async () => {
@@ -311,6 +331,35 @@ describe('GET /api/v2/search', () => {
           actorId: 'https://remote.test/users/alice'
         }
       ],
+      oauthActor.id
+    )
+  })
+
+  it('resolves uncached remote status URLs', async () => {
+    const statusUrl = 'http://remote.test/users/alice/statuses/remote'
+    const remoteStatus = {
+      id: statusUrl,
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockGetRemoteStatus.mockResolvedValue(remoteStatus)
+    mockSearchStatusIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=1`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetRemoteStatus).toHaveBeenCalledWith({
+      statusId: statusUrl,
+      signingActor: oauthActor
+    })
+    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+      expect.any(Object),
+      [remoteStatus],
       oauthActor.id
     )
   })
@@ -415,6 +464,44 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
+  it('resolves uncached account URLs', async () => {
+    const accountUrl = 'http://remote.test/users/remote-resolved'
+    mockSearchAccountIds.mockResolvedValue([])
+    mockRecordActorIfNeeded.mockResolvedValue({
+      id: 'https://remote.test/users/remote-resolved'
+    })
+    mockGetMastodonActorsFromIds.mockResolvedValue([
+      {
+        id: 'https://remote.test/users/remote-resolved',
+        url: accountUrl,
+        username: 'remote-resolved'
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=on`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: accountUrl,
+      database: expect.any(Object),
+      signingActor: oauthActor
+    })
+    expect(data.accounts).toEqual([
+      {
+        id: 'https://remote.test/users/remote-resolved',
+        url: accountUrl,
+        username: 'remote-resolved'
+      }
+    ])
+  })
+
   it('applies the following filter before including resolved accounts', async () => {
     const accountUrl = 'http://remote.test/users/resolved'
     mockGetActorFromId.mockImplementation(({ id }) =>
@@ -456,7 +543,7 @@ describe('GET /api/v2/search', () => {
 
     const response = await GET(
       new NextRequest(
-        'https://llun.test/api/v2/search?q=%40charlie%40remote.test&type=accounts&resolve=true',
+        'https://llun.test/api/v2/search?q=%40Charlie%40Remote.test&type=accounts&resolve=true',
         { headers: { Authorization: 'Bearer read-search-token' } }
       ),
       context
@@ -472,7 +559,8 @@ describe('GET /api/v2/search', () => {
     })
     expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
       actorId: 'https://remote.test/users/charlie',
-      database: expect.any(Object)
+      database: expect.any(Object),
+      signingActor: oauthActor
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: ['https://remote.test/users/charlie']
@@ -512,6 +600,7 @@ describe('GET /api/v2/search', () => {
     expect(response.status).toBe(200)
     expect(mockGetStatus).not.toHaveBeenCalled()
     expect(mockGetStatusFromUrl).not.toHaveBeenCalled()
+    expect(mockGetRemoteStatus).not.toHaveBeenCalled()
     expect(mockGetStatusesByIds).toHaveBeenCalledWith({
       statusIds: ['https://remote.test/users/alice/statuses/1'],
       currentActorId: oauthActor.id,

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -19,6 +19,7 @@ const mockCanActorReadStatus = jest.fn()
 const mockGetWebfingerSelf = jest.fn()
 const mockRecordActorIfNeeded = jest.fn()
 const mockGetRemoteStatus = jest.fn()
+const mockLoggerWarn = jest.fn()
 
 const oauthActor = {
   id: 'https://llun.test/users/searcher',
@@ -87,6 +88,12 @@ jest.mock('@/lib/activities/getRemoteStatus', () => ({
 
 jest.mock('@/lib/actions/utils', () => ({
   recordActorIfNeeded: (...args: unknown[]) => mockRecordActorIfNeeded(...args)
+}))
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args)
+  }
 }))
 
 const context = { params: Promise.resolve({}) }
@@ -371,6 +378,9 @@ describe('GET /api/v2/search', () => {
       actorId: 'https://remote.test/users/alice'
     }
     mockGetRemoteStatus.mockResolvedValue(remoteStatus)
+    mockRecordActorIfNeeded.mockResolvedValue({
+      id: remoteStatus.actorId
+    })
     mockSearchStatusIds.mockResolvedValue([])
 
     const response = await GET(
@@ -395,6 +405,41 @@ describe('GET /api/v2/search', () => {
       expect.any(Object),
       [remoteStatus],
       oauthActor.id
+    )
+  })
+
+  it('omits resolved remote statuses when actor recording fails', async () => {
+    const statusUrl = 'http://remote.test/users/alice/statuses/remote'
+    const remoteStatus = {
+      id: statusUrl,
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockGetRemoteStatus.mockResolvedValue(remoteStatus)
+    mockRecordActorIfNeeded.mockRejectedValue(new Error('blocked'))
+    mockSearchStatusIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=2`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockCanActorReadStatus).not.toHaveBeenCalled()
+    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+      expect.any(Object),
+      [],
+      oauthActor.id
+    )
+    expect(data.statuses).toEqual([])
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Failed to record resolved search actor',
+        actorId: remoteStatus.actorId
+      })
     )
   })
 
@@ -534,6 +579,113 @@ describe('GET /api/v2/search', () => {
         username: 'remote-resolved'
       }
     ])
+  })
+
+  it('canonicalizes Mastodon account profile URLs before recording actors', async () => {
+    const accountUrl = 'https://remote.test/@remote-resolved'
+    const canonicalActorId = 'https://remote.test/users/remote-resolved'
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetWebfingerSelf.mockResolvedValue(canonicalActorId)
+    mockRecordActorIfNeeded.mockResolvedValue({
+      id: canonicalActorId
+    })
+    mockGetMastodonActorsFromIds.mockResolvedValue([
+      {
+        id: canonicalActorId,
+        url: accountUrl,
+        username: 'remote-resolved'
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=on`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockGetWebfingerSelf).toHaveBeenCalledWith({
+      account: 'remote-resolved@remote.test'
+    })
+    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: canonicalActorId,
+      database: expect.any(Object),
+      signingActor: oauthActor
+    })
+    expect(data.accounts).toEqual([
+      {
+        id: canonicalActorId,
+        url: accountUrl,
+        username: 'remote-resolved'
+      }
+    ])
+  })
+
+  it('uses existing canonical actors for Mastodon account profile URLs', async () => {
+    const accountUrl = 'https://remote.test/@remote-resolved'
+    const canonicalActorId = 'https://remote.test/users/remote-resolved'
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetWebfingerSelf.mockResolvedValue(canonicalActorId)
+    mockGetActorFromId.mockImplementation(({ id }) =>
+      Promise.resolve(
+        id === oauthActor.id
+          ? oauthActor
+          : id === canonicalActorId
+            ? { id: canonicalActorId }
+            : null
+      )
+    )
+    mockGetMastodonActorsFromIds.mockResolvedValue([
+      {
+        id: canonicalActorId,
+        url: accountUrl,
+        username: 'remote-resolved'
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=on`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockRecordActorIfNeeded).not.toHaveBeenCalled()
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
+      ids: [canonicalActorId]
+    })
+  })
+
+  it('omits resolved accounts when actor recording fails', async () => {
+    const accountUrl = 'https://remote.test/@blocked'
+    const canonicalActorId = 'https://remote.test/users/blocked'
+    mockSearchAccountIds.mockResolvedValue([])
+    mockGetWebfingerSelf.mockResolvedValue(canonicalActorId)
+    mockRecordActorIfNeeded.mockRejectedValue(new Error('blocked'))
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(accountUrl)}&type=accounts&resolve=on`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({ ids: [] })
+    expect(data.accounts).toEqual([])
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Failed to record resolved search actor',
+        actorId: canonicalActorId
+      })
+    )
   })
 
   it('applies the following filter before including resolved accounts', async () => {

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -195,7 +195,7 @@ describe('GET /api/v2/search', () => {
     })
   })
 
-  it('delegates authenticated full search with filters and honors offset without type', async () => {
+  it('delegates authenticated full search with filters and ignores offset without type', async () => {
     const accountId = encodeURIComponent('https://remote.test/users/alice')
     const response = await GET(
       new NextRequest(
@@ -210,19 +210,19 @@ describe('GET /api/v2/search', () => {
     expect(mockSearchAccountIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 1,
+      offset: 0,
       followingActorId: oauthActor.id
     })
     expect(mockSearchHashtags).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 1,
+      offset: 0,
       excludeUnreviewed: false
     })
     expect(mockSearchStatusIds).toHaveBeenCalledWith({
       q: 'trail',
       limit: 2,
-      offset: 1,
+      offset: 0,
       currentActorId: oauthActor.id,
       currentActorUsername: oauthActor.username,
       currentActorDomain: oauthActor.domain,
@@ -243,10 +243,35 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
-  it('requires authentication for offset paging', async () => {
+  it('ignores offset without an explicit search type', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&limit=3&offset=5'
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 0
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 0,
+      excludeUnreviewed: false
+    })
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
+    expect(data.statuses).toEqual([])
+  })
+
+  it('requires authentication for typed offset paging', async () => {
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&type=hashtags&limit=3&offset=5'
       ),
       context
     )
@@ -299,7 +324,7 @@ describe('GET /api/v2/search', () => {
     })
   })
 
-  it('requires authentication for account-scoped search', async () => {
+  it('does not require authentication for account_id without status search', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&account_id=https%3A%2F%2Fremote.test%2Fusers%2Falice'
@@ -308,11 +333,20 @@ describe('GET /api/v2/search', () => {
     )
     const data = await response.json()
 
-    expect(response.status).toBe(401)
-    expect(data).toEqual({ status: 'Unauthorized' })
-    expect(mockSearchAccountIds).not.toHaveBeenCalled()
-    expect(mockSearchHashtags).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 20,
+      offset: 0
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 20,
+      offset: 0,
+      excludeUnreviewed: false
+    })
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
+    expect(data.statuses).toEqual([])
   })
 
   it('requires authentication for explicit status search', async () => {

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -1,0 +1,263 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockSearchAccountIds = jest.fn()
+const mockGetMastodonActorsFromIds = jest.fn()
+const mockSearchHashtags = jest.fn()
+const mockSearchStatusIds = jest.fn()
+const mockGetStatusesByIds = jest.fn()
+const mockGetActorFromId = jest.fn()
+const mockGetStatus = jest.fn()
+const mockGetStatusFromUrl = jest.fn()
+const mockStoredToken = jest.fn()
+const mockGetServerSession = jest.fn()
+const mockGetMastodonStatuses = jest.fn()
+const mockCanActorReadStatus = jest.fn()
+
+const oauthActor = {
+  id: 'https://llun.test/users/searcher',
+  username: 'searcher',
+  domain: 'llun.test',
+  followersUrl: 'https://llun.test/users/searcher/followers',
+  inboxUrl: 'https://llun.test/users/searcher/inbox',
+  sharedInboxUrl: 'https://llun.test/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1,
+  publicKey: 'public-key',
+  updatedAt: 1
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => ({
+    searchAccountIds: mockSearchAccountIds,
+    getMastodonActorsFromIds: mockGetMastodonActorsFromIds,
+    searchHashtags: mockSearchHashtags,
+    searchStatusIds: mockSearchStatusIds,
+    getStatusesByIds: mockGetStatusesByIds,
+    getActorFromId: mockGetActorFromId,
+    getStatus: mockGetStatus,
+    getStatusFromUrl: mockGetStatusFromUrl
+  }),
+  getKnex: () => () => ({
+    where: () => ({
+      first: () => mockStoredToken()
+    })
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: () => 'https://llun.test',
+  getConfig: () => ({ host: 'llun.test' })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+jest.mock('@/lib/services/mastodon/getMastodonStatus', () => ({
+  getMastodonStatuses: (...args: unknown[]) => mockGetMastodonStatuses(...args)
+}))
+
+jest.mock('@/lib/services/statusAccess', () => ({
+  canActorReadStatus: (...args: unknown[]) => mockCanActorReadStatus(...args)
+}))
+
+const context = { params: Promise.resolve({}) }
+
+describe('GET /api/v2/search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: oauthActor.id,
+      scopes: 'read:search'
+    })
+    mockGetActorFromId.mockImplementation(({ id }) =>
+      Promise.resolve(id === oauthActor.id ? oauthActor : null)
+    )
+    mockSearchAccountIds.mockResolvedValue(['https://remote.test/users/alice'])
+    mockGetMastodonActorsFromIds.mockImplementation(({ ids }) =>
+      Promise.resolve(
+        ids.map((id: string) => ({
+          id,
+          username: id.split('/').at(-1) ?? id
+        }))
+      )
+    )
+    mockSearchHashtags.mockResolvedValue([
+      {
+        name: 'trailrunning',
+        url: 'https://llun.test/tags/trailrunning',
+        history: [],
+        postCount: 2,
+        lastPostAt: 1
+      }
+    ])
+    mockSearchStatusIds.mockResolvedValue([
+      'https://remote.test/users/alice/statuses/1'
+    ])
+    mockGetStatusesByIds.mockImplementation(({ statusIds }) =>
+      Promise.resolve(
+        statusIds.map((id: string) => ({
+          id,
+          actorId: 'https://remote.test/users/alice'
+        }))
+      )
+    )
+    mockGetMastodonStatuses.mockImplementation((_database, statuses) =>
+      Promise.resolve(
+        statuses.map((status: { id: string }) => ({
+          id: status.id,
+          content: status.id
+        }))
+      )
+    )
+    mockGetStatus.mockResolvedValue(null)
+    mockGetStatusFromUrl.mockResolvedValue(null)
+    mockCanActorReadStatus.mockResolvedValue(true)
+  })
+
+  it('allows anonymous account and hashtag search but omits statuses', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&limit=3'),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 0
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 3,
+      offset: 0,
+      excludeUnreviewed: false
+    })
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
+    expect(data).toEqual({
+      accounts: [
+        {
+          id: 'https://remote.test/users/alice',
+          username: 'alice'
+        }
+      ],
+      statuses: [],
+      hashtags: [
+        {
+          name: 'trailrunning',
+          url: 'https://llun.test/tags/trailrunning',
+          history: []
+        }
+      ]
+    })
+  })
+
+  it('delegates authenticated full search with filters and preserves status order', async () => {
+    const accountId = encodeURIComponent('https://remote.test/users/alice')
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=trail&limit=2&offset=1&following=true&account_id=${accountId}&max_id=https%3A%2F%2Fremote.test%2Fusers%2Falice%2Fstatuses%2F9&min_id=https%3A%2F%2Fremote.test%2Fusers%2Falice%2Fstatuses%2F1`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 2,
+      offset: 1,
+      followingActorId: oauthActor.id
+    })
+    expect(mockSearchStatusIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 2,
+      offset: 1,
+      currentActorId: oauthActor.id,
+      accountId: 'https://remote.test/users/alice',
+      maxId: 'https://remote.test/users/alice/statuses/9',
+      minId: 'https://remote.test/users/alice/statuses/1'
+    })
+    expect(mockGetStatusesByIds).toHaveBeenCalledWith({
+      statusIds: ['https://remote.test/users/alice/statuses/1'],
+      currentActorId: oauthActor.id,
+      visibleToActorId: oauthActor.id
+    })
+    expect(data.statuses).toEqual([
+      {
+        id: 'https://remote.test/users/alice/statuses/1',
+        content: 'https://remote.test/users/alice/statuses/1'
+      }
+    ])
+  })
+
+  it('requires authentication for explicit status search', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&type=statuses'),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
+  })
+
+  it('prepends a resolved readable status URL before indexed results', async () => {
+    const resolvedStatus = {
+      id: 'https://remote.test/users/alice/statuses/resolved',
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockGetStatus.mockResolvedValue(resolvedStatus)
+    mockSearchStatusIds.mockResolvedValue([
+      resolvedStatus.id,
+      'https://remote.test/users/alice/statuses/indexed'
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(resolvedStatus.id)}&type=statuses&resolve=true`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockCanActorReadStatus).toHaveBeenCalledWith({
+      database: expect.any(Object),
+      status: resolvedStatus,
+      currentActor: oauthActor
+    })
+    expect(mockGetStatusesByIds).toHaveBeenCalledWith({
+      statusIds: [
+        resolvedStatus.id,
+        'https://remote.test/users/alice/statuses/indexed'
+      ],
+      currentActorId: oauthActor.id,
+      visibleToActorId: oauthActor.id
+    })
+  })
+
+  it('rejects invalid search parameters', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&limit=100'),
+      context
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ status: 'Bad Request' })
+  })
+})

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -273,7 +273,7 @@ describe('GET /api/v2/search', () => {
     )
   })
 
-  it('ignores offset without an explicit search type', async () => {
+  it('requires authentication when offset is provided without an explicit search type', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v2/search?q=trail&limit=3&offset=5'
@@ -282,20 +282,11 @@ describe('GET /api/v2/search', () => {
     )
     const data = await response.json()
 
-    expect(response.status).toBe(200)
-    expect(mockSearchAccountIds).toHaveBeenCalledWith({
-      q: 'trail',
-      limit: 3,
-      offset: 0
-    })
-    expect(mockSearchHashtags).toHaveBeenCalledWith({
-      q: 'trail',
-      limit: 3,
-      offset: 0,
-      excludeUnreviewed: false
-    })
+    expect(response.status).toBe(401)
+    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(mockSearchHashtags).not.toHaveBeenCalled()
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
-    expect(data.statuses).toEqual([])
   })
 
   it('requires authentication for typed offset paging', async () => {

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -243,6 +243,36 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
+  it('normalizes status filter identifiers before database search', async () => {
+    const accountId = encodeURIComponent(
+      'HTTPS://Remote.test/users/alice#owner'
+    )
+    const maxId = encodeURIComponent(
+      'Remote.test:users:alice:statuses:9#section'
+    )
+    const minId = encodeURIComponent(
+      'https://Remote.test/users/alice/statuses/1#section'
+    )
+    mockSearchStatusIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=trail&type=statuses&account_id=${accountId}&max_id=${maxId}&min_id=${minId}`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSearchStatusIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 'https://remote.test/users/alice',
+        maxId: 'https://remote.test/users/alice/statuses/9',
+        minId: 'https://remote.test/users/alice/statuses/1'
+      })
+    )
+  })
+
   it('ignores offset without an explicit search type', async () => {
     const response = await GET(
       new NextRequest(

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -478,8 +478,9 @@ const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) =>
   params.type === 'statuses' ||
   params.resolve === true ||
   params.following === true ||
-  Boolean(params.account_id) ||
-  (params.offset !== undefined && params.offset > 0)
+  (params.type !== undefined &&
+    params.offset !== undefined &&
+    params.offset > 0)
 
 export const GET = traceApiRoute(
   'search',
@@ -500,7 +501,7 @@ export const GET = traceApiRoute(
       const params = parsedParams.data
       const query = params.q.trim()
       const limit = params.limit ?? 20
-      const offset = params.offset ?? 0
+      const offset = params.type ? (params.offset ?? 0) : 0
 
       if (!currentActor && requiresAuthentication({ params })) {
         return apiResponse({

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
 import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getRemoteStatus } from '@/lib/activities/getRemoteStatus'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { getConfig } from '@/lib/config'
@@ -114,9 +115,21 @@ const getProfileUrlAccountHandle = (query: string) => {
   }
 }
 
-const getCanonicalAccountActorId = async (query: string) => {
+const getCanonicalAccountActorId = async ({
+  query,
+  signingActor
+}: {
+  query: string
+  signingActor?: Actor
+}) => {
   const handle = getProfileUrlAccountHandle(query)
-  if (!handle) return query
+  if (!handle) {
+    const person = await getActorPerson({
+      actorId: query,
+      signingActor
+    })
+    return normalizeActorId(person?.id) ?? query
+  }
 
   return (
     (await getWebfingerSelf({
@@ -239,7 +252,10 @@ const resolveAccountId = async ({
     const existingActor = await database.getActorFromId({ id: query })
     const canonicalActorId = existingActor
       ? query
-      : await getCanonicalAccountActorId(query)
+      : await getCanonicalAccountActorId({
+          query,
+          signingActor: currentActor ?? undefined
+        })
     const actor =
       existingActor ??
       (canonicalActorId === query
@@ -428,6 +444,7 @@ const searchStatuses = async ({
   limit: number
   offset: number
 }) => {
+  const indexedLimit = limit * 2
   const [resolvedStatus, indexedIds] = await Promise.all([
     offset === 0
       ? getResolvedStatus({
@@ -439,7 +456,7 @@ const searchStatuses = async ({
       : Promise.resolve(null),
     database.searchStatusIds({
       q: query,
-      limit,
+      limit: indexedLimit,
       offset,
       currentActorId: currentActor.id,
       currentActorUsername: currentActor.username,
@@ -455,7 +472,7 @@ const searchStatuses = async ({
     indexedIds.filter((id): id is string => typeof id === 'string')
   )
     .filter((id) => normalizeLookupId(id) !== resolvedStatusId)
-    .slice(0, resolvedStatus ? limit - 1 : limit)
+    .slice(0, resolvedStatus ? indexedLimit - 1 : indexedLimit)
   const statuses = await database.getStatusesByIds({
     statusIds: ids,
     currentActorId: currentActor.id,
@@ -467,18 +484,23 @@ const searchStatuses = async ({
   })
   return getMastodonStatuses(
     database,
-    [resolvedStatus, ...orderedStatuses].filter((status): status is Status =>
-      Boolean(status)
-    ),
+    [resolvedStatus, ...orderedStatuses]
+      .filter((status): status is Status => Boolean(status))
+      .slice(0, limit),
     currentActor.id
   )
 }
 
-const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) =>
-  params.type === 'statuses' ||
-  params.resolve === true ||
-  params.following === true ||
-  (params.offset !== undefined && params.offset > 0)
+const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) => {
+  const includesAccounts = !params.type || params.type === 'accounts'
+
+  return (
+    params.type === 'statuses' ||
+    params.resolve === true ||
+    (params.following === true && includesAccounts) ||
+    params.offset !== undefined
+  )
+}
 
 export const GET = traceApiRoute(
   'search',

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -1,21 +1,342 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
 
+import { Database } from '@/lib/database/types'
+import {
+  OptionalOAuthGuard,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { canActorReadStatus } from '@/lib/services/statusAccess'
+import { Scope } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status } from '@/lib/types/domain/status'
+import { Tag } from '@/lib/types/mastodon/tag'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_401,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-export const GET = traceApiRoute('search', async (req: NextRequest) => {
-  return apiResponse({
-    req,
-    allowedMethods: CORS_HEADERS,
-    data: {
-      accounts: [],
-      statuses: [],
-      hashtags: []
-    }
+type RouteParams = Record<string, never>
+
+type SearchType = 'accounts' | 'statuses' | 'hashtags'
+
+const SearchTypeParam = z
+  .enum(['account', 'accounts', 'status', 'statuses', 'hashtag', 'hashtags'])
+  .transform((value): SearchType => {
+    if (value === 'account') return 'accounts'
+    if (value === 'status') return 'statuses'
+    if (value === 'hashtag') return 'hashtags'
+    return value
   })
+
+const BooleanParam = z
+  .enum(['true', 'false'])
+  .transform((value) => value === 'true')
+
+const SearchParams = z.object({
+  q: z.string(),
+  type: SearchTypeParam.optional(),
+  resolve: BooleanParam.optional(),
+  following: BooleanParam.optional(),
+  exclude_unreviewed: BooleanParam.optional(),
+  account_id: z.string().optional(),
+  max_id: z.string().optional(),
+  min_id: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(40).optional(),
+  offset: z.coerce.number().int().min(0).optional()
 })
+
+type ParsedSearchParams = z.infer<typeof SearchParams>
+
+const emptySearchResult = {
+  accounts: [],
+  statuses: [],
+  hashtags: []
+}
+
+const getQueryParams = (req: NextRequest) => {
+  const url = new URL(req.url)
+  const queryParams: Record<string, string> = {}
+  url.searchParams.forEach((value, key) => {
+    queryParams[key] = value
+  })
+  return queryParams
+}
+
+const isHttpsUrl = (value: string) => {
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+const normalizeUrlId = (value?: string | null) => {
+  if (!value) return null
+  if (value.startsWith('https://') || value.startsWith('http://')) return value
+  return idToUrl(value)
+}
+
+const dedupeStrings = (values: string[]) => [...new Set(values)]
+
+const resolveAccountId = async ({
+  database,
+  query,
+  resolve
+}: {
+  database: Database
+  query: string
+  resolve: boolean
+}) => {
+  if (!resolve || !isHttpsUrl(query)) return null
+
+  const actor = await database.getActorFromId({ id: query })
+  return actor?.id ?? null
+}
+
+const getResolvedStatus = async ({
+  database,
+  currentActor,
+  query,
+  resolve
+}: {
+  database: Database
+  currentActor: Actor
+  query: string
+  resolve: boolean
+}) => {
+  if (!resolve || !isHttpsUrl(query)) return null
+
+  const status =
+    (await database.getStatus({
+      statusId: query,
+      currentActorId: currentActor.id
+    })) ?? (await database.getStatusFromUrl({ url: query }))
+
+  if (!status) return null
+
+  const canRead = await canActorReadStatus({
+    database,
+    status,
+    currentActor
+  })
+  return canRead ? status : null
+}
+
+const searchAccounts = async ({
+  database,
+  currentActor,
+  params,
+  query,
+  limit,
+  offset
+}: {
+  database: Database
+  currentActor: Actor | null
+  params: ParsedSearchParams
+  query: string
+  limit: number
+  offset: number
+}) => {
+  const resolvedAccountId = await resolveAccountId({
+    database,
+    query,
+    resolve: params.resolve ?? false
+  })
+  const indexedIds = await database.searchAccountIds({
+    q: query,
+    limit,
+    offset,
+    ...(params.following && currentActor
+      ? { followingActorId: currentActor.id }
+      : {})
+  })
+  const ids = dedupeStrings(
+    [resolvedAccountId, ...indexedIds].filter(
+      (id): id is string => typeof id === 'string'
+    )
+  ).slice(0, limit)
+
+  return database.getMastodonActorsFromIds({ ids })
+}
+
+const searchHashtags = async ({
+  database,
+  params,
+  query,
+  limit,
+  offset
+}: {
+  database: Database
+  params: ParsedSearchParams
+  query: string
+  limit: number
+  offset: number
+}) => {
+  const hashtags = await database.searchHashtags({
+    q: query,
+    limit,
+    offset,
+    excludeUnreviewed: params.exclude_unreviewed ?? false
+  })
+
+  return hashtags.map((hashtag) => Tag.parse(hashtag))
+}
+
+const searchStatuses = async ({
+  database,
+  currentActor,
+  params,
+  query,
+  limit,
+  offset
+}: {
+  database: Database
+  currentActor: Actor
+  params: ParsedSearchParams
+  query: string
+  limit: number
+  offset: number
+}) => {
+  const [resolvedStatus, indexedIds] = await Promise.all([
+    getResolvedStatus({
+      database,
+      currentActor,
+      query,
+      resolve: params.resolve ?? false
+    }),
+    database.searchStatusIds({
+      q: query,
+      limit,
+      offset,
+      currentActorId: currentActor.id,
+      accountId: normalizeUrlId(params.account_id),
+      maxId: normalizeUrlId(params.max_id),
+      minId: normalizeUrlId(params.min_id)
+    })
+  ])
+
+  const ids = dedupeStrings(
+    [resolvedStatus?.id, ...indexedIds].filter(
+      (id): id is string => typeof id === 'string'
+    )
+  ).slice(0, limit)
+  const statuses = await database.getStatusesByIds({
+    statusIds: ids,
+    currentActorId: currentActor.id,
+    visibleToActorId: currentActor.id
+  })
+  return getMastodonStatuses(database, statuses as Status[], currentActor.id)
+}
+
+const requiresAuthentication = ({
+  params,
+  offset
+}: {
+  params: ParsedSearchParams
+  offset: number
+}) =>
+  params.type === 'statuses' ||
+  params.resolve === true ||
+  params.following === true ||
+  Boolean(params.account_id) ||
+  offset > 0
+
+export const GET = traceApiRoute(
+  'search',
+  OptionalOAuthGuard<RouteParams>(
+    [Scope.enum['read:search']],
+    async (req, context) => {
+      const parsedParams = SearchParams.safeParse(getQueryParams(req))
+      if (!parsedParams.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+
+      const { database, currentActor } = context
+      const params = parsedParams.data
+      const query = params.q.trim()
+      const limit = params.limit ?? 20
+      const offset = params.offset ?? 0
+
+      if (!currentActor && requiresAuthentication({ params, offset })) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_401,
+          responseStatusCode: 401
+        })
+      }
+
+      if (query.length === 0) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: emptySearchResult
+        })
+      }
+
+      const includeAccounts = !params.type || params.type === 'accounts'
+      const includeHashtags = !params.type || params.type === 'hashtags'
+      const includeStatuses =
+        Boolean(currentActor) && (!params.type || params.type === 'statuses')
+
+      const [accounts, hashtags, statuses] = await Promise.all([
+        includeAccounts
+          ? searchAccounts({
+              database,
+              currentActor,
+              params,
+              query,
+              limit,
+              offset
+            })
+          : [],
+        includeHashtags
+          ? searchHashtags({
+              database,
+              params,
+              query,
+              limit,
+              offset
+            })
+          : [],
+        includeStatuses && currentActor
+          ? searchStatuses({
+              database,
+              currentActor,
+              params,
+              query,
+              limit,
+              offset
+            })
+          : []
+      ])
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {
+          accounts,
+          statuses,
+          hashtags
+        }
+      })
+    },
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
+  )
+)

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -11,6 +11,7 @@ import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { Tag } from '@/lib/types/mastodon/tag'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
@@ -73,9 +74,10 @@ const getQueryParams = (req: NextRequest) => {
   return queryParams
 }
 
-const isHttpsUrl = (value: string) => {
+const isUrl = (value: string) => {
   try {
-    return new URL(value).protocol === 'https:'
+    const protocol = new URL(value).protocol
+    return protocol === 'https:' || protocol === 'http:'
   } catch {
     return false
   }
@@ -89,6 +91,29 @@ const normalizeUrlId = (value?: string | null) => {
 
 const dedupeStrings = (values: string[]) => [...new Set(values)]
 
+const normalizeLookupId = (value?: string | null) => normalizeUrlId(value) ?? ''
+
+const orderAccountsByIds = ({
+  accounts,
+  ids
+}: {
+  accounts: MastodonAccount[]
+  ids: string[]
+}) => {
+  const accountsByLookupId = new Map<string, MastodonAccount>()
+
+  for (const account of accounts) {
+    for (const key of [account.id, account.url]) {
+      const lookupId = normalizeLookupId(key)
+      if (lookupId) accountsByLookupId.set(lookupId, account)
+    }
+  }
+
+  return ids
+    .map((id) => accountsByLookupId.get(normalizeLookupId(id)))
+    .filter((account): account is MastodonAccount => Boolean(account))
+}
+
 const resolveAccountId = async ({
   database,
   query,
@@ -98,7 +123,7 @@ const resolveAccountId = async ({
   query: string
   resolve: boolean
 }) => {
-  if (!resolve || !isHttpsUrl(query)) return null
+  if (!resolve || !isUrl(query)) return null
 
   const actor = await database.getActorFromId({ id: query })
   return actor?.id ?? null
@@ -115,7 +140,7 @@ const getResolvedStatus = async ({
   query: string
   resolve: boolean
 }) => {
-  if (!resolve || !isHttpsUrl(query)) return null
+  if (!resolve || !isUrl(query)) return null
 
   const status =
     (await database.getStatus({
@@ -148,26 +173,31 @@ const searchAccounts = async ({
   limit: number
   offset: number
 }) => {
-  const resolvedAccountId = await resolveAccountId({
-    database,
-    query,
-    resolve: params.resolve ?? false
-  })
-  const indexedIds = await database.searchAccountIds({
-    q: query,
-    limit,
-    offset,
-    ...(params.following && currentActor
-      ? { followingActorId: currentActor.id }
-      : {})
-  })
+  const [resolvedAccountId, indexedIds] = await Promise.all([
+    offset === 0
+      ? resolveAccountId({
+          database,
+          query,
+          resolve: params.resolve ?? false
+        })
+      : Promise.resolve(null),
+    database.searchAccountIds({
+      q: query,
+      limit,
+      offset,
+      ...(params.following && currentActor
+        ? { followingActorId: currentActor.id }
+        : {})
+    })
+  ])
   const ids = dedupeStrings(
     [resolvedAccountId, ...indexedIds].filter(
       (id): id is string => typeof id === 'string'
     )
   ).slice(0, limit)
 
-  return database.getMastodonActorsFromIds({ ids })
+  const accounts = await database.getMastodonActorsFromIds({ ids })
+  return orderAccountsByIds({ accounts, ids })
 }
 
 const searchHashtags = async ({
@@ -209,12 +239,14 @@ const searchStatuses = async ({
   offset: number
 }) => {
   const [resolvedStatus, indexedIds] = await Promise.all([
-    getResolvedStatus({
-      database,
-      currentActor,
-      query,
-      resolve: params.resolve ?? false
-    }),
+    offset === 0
+      ? getResolvedStatus({
+          database,
+          currentActor,
+          query,
+          resolve: params.resolve ?? false
+        })
+      : Promise.resolve(null),
     database.searchStatusIds({
       q: query,
       limit,
@@ -226,17 +258,24 @@ const searchStatuses = async ({
     })
   ])
 
+  const resolvedStatusId = normalizeLookupId(resolvedStatus?.id)
   const ids = dedupeStrings(
-    [resolvedStatus?.id, ...indexedIds].filter(
-      (id): id is string => typeof id === 'string'
-    )
-  ).slice(0, limit)
+    indexedIds.filter((id): id is string => typeof id === 'string')
+  )
+    .filter((id) => normalizeLookupId(id) !== resolvedStatusId)
+    .slice(0, resolvedStatus ? limit - 1 : limit)
   const statuses = await database.getStatusesByIds({
     statusIds: ids,
     currentActorId: currentActor.id,
     visibleToActorId: currentActor.id
   })
-  return getMastodonStatuses(database, statuses as Status[], currentActor.id)
+  return getMastodonStatuses(
+    database,
+    [resolvedStatus, ...(statuses as Status[])].filter(
+      (status): status is Status => Boolean(status)
+    ),
+    currentActor.id
+  )
 }
 
 const requiresAuthentication = ({

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -478,9 +478,7 @@ const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) =>
   params.type === 'statuses' ||
   params.resolve === true ||
   params.following === true ||
-  (params.type !== undefined &&
-    params.offset !== undefined &&
-    params.offset > 0)
+  (params.offset !== undefined && params.offset > 0)
 
 export const GET = traceApiRoute(
   'search',

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -19,6 +19,7 @@ import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { Tag } from '@/lib/types/mastodon/tag'
 import { parseAccountHandle } from '@/lib/utils/accountHandle'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   ERROR_401,
@@ -96,6 +97,60 @@ const normalizeUrlId = (value?: string | null) => {
 const dedupeStrings = (values: string[]) => [...new Set(values)]
 
 const normalizeLookupId = (value?: string | null) => normalizeUrlId(value) ?? ''
+
+const getProfileUrlAccountHandle = (query: string) => {
+  try {
+    const url = new URL(query)
+    const match = /^\/@([^/]+)\/?$/.exec(url.pathname)
+    if (!match) return null
+
+    const profileHandle = decodeURIComponent(match[1])
+    const handle = profileHandle.includes('@')
+      ? `@${profileHandle.replace(/^@/, '')}`
+      : `@${profileHandle}@${url.hostname}`
+    return parseAccountHandle(handle)
+  } catch {
+    return null
+  }
+}
+
+const getCanonicalAccountActorId = async (query: string) => {
+  const handle = getProfileUrlAccountHandle(query)
+  if (!handle) return query
+
+  return (
+    (await getWebfingerSelf({
+      account: `${handle.username}@${handle.domain}`
+    })) ?? query
+  )
+}
+
+const recordResolvedActorIfNeeded = async ({
+  actorId,
+  database,
+  signingActor
+}: {
+  actorId: string
+  database: Database
+  signingActor?: Actor
+}) => {
+  try {
+    return (
+      (await recordActorIfNeeded({
+        actorId,
+        database,
+        signingActor
+      })) ?? null
+    )
+  } catch (err) {
+    logger.warn({
+      message: 'Failed to record resolved search actor',
+      actorId,
+      err
+    })
+    return null
+  }
+}
 
 const orderAccountsByIds = ({
   accounts,
@@ -181,14 +236,20 @@ const resolveAccountId = async ({
   if (!resolve) return null
 
   if (isUrl(query)) {
+    const existingActor = await database.getActorFromId({ id: query })
+    const canonicalActorId = existingActor
+      ? query
+      : await getCanonicalAccountActorId(query)
     const actor =
-      (await database.getActorFromId({ id: query })) ??
-      ((await recordActorIfNeeded({
-        actorId: query,
+      existingActor ??
+      (canonicalActorId === query
+        ? null
+        : await database.getActorFromId({ id: canonicalActorId })) ??
+      (await recordResolvedActorIfNeeded({
+        actorId: canonicalActorId,
         database,
         signingActor: currentActor ?? undefined
-      })) ||
-        null)
+      }))
     if (
       actor &&
       (await canIncludeAccount({
@@ -214,11 +275,11 @@ const resolveAccountId = async ({
       account: `${handle.username}@${handle.domain}`
     })
     actor = actorId
-      ? ((await recordActorIfNeeded({
+      ? await recordResolvedActorIfNeeded({
           actorId,
           database,
           signingActor: currentActor ?? undefined
-        })) ?? null)
+        })
       : null
   }
 
@@ -266,11 +327,12 @@ const getResolvedStatus = async ({
   if (!status) return null
 
   if (!localStatus) {
-    await recordActorIfNeeded({
+    const actor = await recordResolvedActorIfNeeded({
       actorId: status.actorId,
       database,
       signingActor: currentActor
     })
+    if (!actor) return null
   }
 
   const canRead = await canActorReadStatus({

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -250,18 +250,28 @@ const getResolvedStatus = async ({
 }) => {
   if (!resolve || !isUrl(query)) return null
 
-  const status =
+  const localStatus =
     (await database.getStatus({
       statusId: query,
       currentActorId: currentActor.id
-    })) ??
-    (await database.getStatusFromUrl({ url: query })) ??
+    })) ?? (await database.getStatusFromUrl({ url: query }))
+
+  const status =
+    localStatus ??
     (await getRemoteStatus({
       statusId: query,
       signingActor: currentActor
     }))
 
   if (!status) return null
+
+  if (!localStatus) {
+    await recordActorIfNeeded({
+      actorId: status.actorId,
+      database,
+      signingActor: currentActor
+    })
+  }
 
   const canRead = await canActorReadStatus({
     database,
@@ -405,7 +415,9 @@ const searchStatuses = async ({
 const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) =>
   params.type === 'statuses' ||
   params.resolve === true ||
-  params.following === true
+  params.following === true ||
+  Boolean(params.account_id) ||
+  (params.offset !== undefined && params.offset > 0)
 
 export const GET = traceApiRoute(
   'search',

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
 import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { getRemoteStatus } from '@/lib/activities/getRemoteStatus'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
@@ -16,6 +17,7 @@ import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { Tag } from '@/lib/types/mastodon/tag'
+import { parseAccountHandle } from '@/lib/utils/accountHandle'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import {
   ERROR_400,
@@ -43,9 +45,20 @@ const SearchTypeParam = z
     return value
   })
 
-const BooleanParam = z
-  .enum(['true', 'false'])
-  .transform((value) => value === 'true')
+const TRUE_VALUES = new Set(['true', '1', 't', 'yes', 'y', 'on'])
+const FALSE_VALUES = new Set(['false', '0', 'f', 'no', 'n', 'off'])
+
+const BooleanParam = z.string().transform((value, ctx) => {
+  const normalized = value.trim().toLowerCase()
+  if (TRUE_VALUES.has(normalized)) return true
+  if (FALSE_VALUES.has(normalized)) return false
+
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: 'Invalid boolean value'
+  })
+  return z.NEVER
+})
 
 const SearchParams = z.object({
   q: z.string(),
@@ -68,14 +81,8 @@ const emptySearchResult = {
   hashtags: []
 }
 
-const getQueryParams = (req: NextRequest) => {
-  const url = new URL(req.url)
-  const queryParams: Record<string, string> = {}
-  url.searchParams.forEach((value, key) => {
-    queryParams[key] = value
-  })
-  return queryParams
-}
+const getQueryParams = (req: NextRequest) =>
+  Object.fromEntries(new URL(req.url).searchParams)
 
 const isUrl = (value: string) => {
   try {
@@ -95,13 +102,6 @@ const normalizeUrlId = (value?: string | null) => {
 const dedupeStrings = (values: string[]) => [...new Set(values)]
 
 const normalizeLookupId = (value?: string | null) => normalizeUrlId(value) ?? ''
-
-const parseAccountHandle = (value: string) => {
-  const normalized = value.trim().replace(/^@/, '')
-  const [username, domain, ...rest] = normalized.split('@')
-  if (!username || !domain || rest.length > 0) return null
-  return { username, domain }
-}
 
 const orderAccountsByIds = ({
   accounts,
@@ -187,7 +187,14 @@ const resolveAccountId = async ({
   if (!resolve) return null
 
   if (isUrl(query)) {
-    const actor = await database.getActorFromId({ id: query })
+    const actor =
+      (await database.getActorFromId({ id: query })) ??
+      ((await recordActorIfNeeded({
+        actorId: query,
+        database,
+        signingActor: currentActor ?? undefined
+      })) ||
+        null)
     if (
       actor &&
       (await canIncludeAccount({
@@ -213,7 +220,11 @@ const resolveAccountId = async ({
       account: `${handle.username}@${handle.domain}`
     })
     actor = actorId
-      ? ((await recordActorIfNeeded({ actorId, database })) ?? null)
+      ? ((await recordActorIfNeeded({
+          actorId,
+          database,
+          signingActor: currentActor ?? undefined
+        })) ?? null)
       : null
   }
 
@@ -249,7 +260,12 @@ const getResolvedStatus = async ({
     (await database.getStatus({
       statusId: query,
       currentActorId: currentActor.id
-    })) ?? (await database.getStatusFromUrl({ url: query }))
+    })) ??
+    (await database.getStatusFromUrl({ url: query })) ??
+    (await getRemoteStatus({
+      statusId: query,
+      signingActor: currentActor
+    }))
 
   if (!status) return null
 
@@ -378,7 +394,7 @@ const searchStatuses = async ({
     visibleToActorId: currentActor.id
   })
   const orderedStatuses = orderStatusesByIds({
-    statuses: statuses as Status[],
+    statuses,
     ids
   })
   return getMastodonStatuses(
@@ -390,17 +406,11 @@ const searchStatuses = async ({
   )
 }
 
-const requiresAuthentication = ({
-  params,
-  offset
-}: {
-  params: ParsedSearchParams
-  offset: number
-}) =>
+const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) =>
   params.type === 'statuses' ||
   params.resolve === true ||
   params.following === true ||
-  offset > 0
+  params.offset !== undefined
 
 export const GET = traceApiRoute(
   'search',
@@ -423,7 +433,7 @@ export const GET = traceApiRoute(
       const limit = params.limit ?? 20
       const offset = params.type ? (params.offset ?? 0) : 0
 
-      if (!currentActor && requiresAuthentication({ params, offset })) {
+      if (!currentActor && requiresAuthentication({ params })) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -45,19 +45,13 @@ const SearchTypeParam = z
     return value
   })
 
-const TRUE_VALUES = new Set(['true', '1', 't', 'yes', 'y', 'on'])
 const FALSE_VALUES = new Set(['false', '0', 'f', 'no', 'n', 'off'])
 
-const BooleanParam = z.string().transform((value, ctx) => {
+const BooleanParam = z.string().transform((value) => {
   const normalized = value.trim().toLowerCase()
-  if (TRUE_VALUES.has(normalized)) return true
+  if (normalized.length === 0) return undefined
   if (FALSE_VALUES.has(normalized)) return false
-
-  ctx.addIssue({
-    code: z.ZodIssueCode.custom,
-    message: 'Invalid boolean value'
-  })
-  return z.NEVER
+  return true
 })
 
 const SearchParams = z.object({
@@ -376,6 +370,8 @@ const searchStatuses = async ({
       limit,
       offset,
       currentActorId: currentActor.id,
+      currentActorUsername: currentActor.username,
+      currentActorDomain: currentActor.domain,
       accountId: normalizeUrlId(params.account_id),
       maxId: normalizeUrlId(params.max_id),
       minId: normalizeUrlId(params.min_id)
@@ -409,8 +405,7 @@ const searchStatuses = async ({
 const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) =>
   params.type === 'statuses' ||
   params.resolve === true ||
-  params.following === true ||
-  params.offset !== undefined
+  params.following === true
 
 export const GET = traceApiRoute(
   'search',
@@ -431,7 +426,7 @@ export const GET = traceApiRoute(
       const params = parsedParams.data
       const query = params.q.trim()
       const limit = params.limit ?? 20
-      const offset = params.type ? (params.offset ?? 0) : 0
+      const offset = params.offset ?? 0
 
       if (!currentActor && requiresAuthentication({ params })) {
         return apiResponse({

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -498,6 +498,7 @@ const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) => {
     params.type === 'statuses' ||
     params.resolve === true ||
     (params.following === true && includesAccounts) ||
+    // Mastodon requires auth when offset is present, even when the value is 0.
     params.offset !== undefined
   )
 }
@@ -521,6 +522,7 @@ export const GET = traceApiRoute(
       const params = parsedParams.data
       const query = params.q.trim()
       const limit = params.limit ?? 20
+      // Mastodon ignores offset unless an explicit search type is provided.
       const offset = params.type ? (params.offset ?? 0) : 0
 
       if (!currentActor && requiresAuthentication({ params })) {

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -18,6 +18,7 @@ import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { Tag } from '@/lib/types/mastodon/tag'
 import { parseAccountHandle } from '@/lib/utils/accountHandle'
+import { normalizeActorId } from '@/lib/utils/activitypub'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
 import { logger } from '@/lib/utils/logger'
 import {
@@ -90,8 +91,7 @@ const isUrl = (value: string) => {
 
 const normalizeUrlId = (value?: string | null) => {
   if (!value) return null
-  if (value.startsWith('https://') || value.startsWith('http://')) return value
-  return idToUrl(value)
+  return normalizeActorId(isUrl(value) ? value : idToUrl(value))
 }
 
 const dedupeStrings = (values: string[]) => [...new Set(values)]

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
+import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import {
   OptionalOAuthGuard,
@@ -93,6 +96,13 @@ const dedupeStrings = (values: string[]) => [...new Set(values)]
 
 const normalizeLookupId = (value?: string | null) => normalizeUrlId(value) ?? ''
 
+const parseAccountHandle = (value: string) => {
+  const normalized = value.trim().replace(/^@/, '')
+  const [username, domain, ...rest] = normalized.split('@')
+  if (!username || !domain || rest.length > 0) return null
+  return { username, domain }
+}
+
 const orderAccountsByIds = ({
   accounts,
   ids
@@ -114,19 +124,112 @@ const orderAccountsByIds = ({
     .filter((account): account is MastodonAccount => Boolean(account))
 }
 
-const resolveAccountId = async ({
+const getStatusLookupIds = (status: Status) => {
+  const ids = [status.id]
+  if ('url' in status && typeof status.url === 'string') ids.push(status.url)
+  return ids
+}
+
+const orderStatusesByIds = ({
+  statuses,
+  ids
+}: {
+  statuses: Status[]
+  ids: string[]
+}) => {
+  const statusesByLookupId = new Map<string, Status>()
+
+  for (const status of statuses) {
+    for (const key of getStatusLookupIds(status)) {
+      const lookupId = normalizeLookupId(key)
+      if (lookupId) statusesByLookupId.set(lookupId, status)
+    }
+  }
+
+  return ids
+    .map((id) => statusesByLookupId.get(normalizeLookupId(id)))
+    .filter((status): status is Status => Boolean(status))
+}
+
+const canIncludeAccount = async ({
   database,
-  query,
-  resolve
+  actorId,
+  currentActor,
+  following
 }: {
   database: Database
+  actorId: string
+  currentActor: Actor | null
+  following: boolean
+}) => {
+  if (!following) return true
+  if (!currentActor) return false
+
+  return database.isCurrentActorFollowing({
+    currentActorId: currentActor.id,
+    followingActorId: actorId
+  })
+}
+
+const resolveAccountId = async ({
+  database,
+  currentActor,
+  query,
+  resolve,
+  following
+}: {
+  database: Database
+  currentActor: Actor | null
   query: string
   resolve: boolean
+  following: boolean
 }) => {
-  if (!resolve || !isUrl(query)) return null
+  if (!resolve) return null
 
-  const actor = await database.getActorFromId({ id: query })
-  return actor?.id ?? null
+  if (isUrl(query)) {
+    const actor = await database.getActorFromId({ id: query })
+    if (
+      actor &&
+      (await canIncludeAccount({
+        database,
+        actorId: actor.id,
+        currentActor,
+        following
+      }))
+    ) {
+      return actor.id
+    }
+    return null
+  }
+
+  const handle = query.includes('@')
+    ? parseAccountHandle(query)
+    : { username: query, domain: getConfig().host }
+  if (!handle) return null
+
+  let actor = await database.getActorFromUsername(handle)
+  if (!actor && query.includes('@')) {
+    const actorId = await getWebfingerSelf({
+      account: `${handle.username}@${handle.domain}`
+    })
+    actor = actorId
+      ? ((await recordActorIfNeeded({ actorId, database })) ?? null)
+      : null
+  }
+
+  if (
+    actor &&
+    (await canIncludeAccount({
+      database,
+      actorId: actor.id,
+      currentActor,
+      following
+    }))
+  ) {
+    return actor.id
+  }
+
+  return null
 }
 
 const getResolvedStatus = async ({
@@ -177,8 +280,10 @@ const searchAccounts = async ({
     offset === 0
       ? resolveAccountId({
           database,
+          currentActor,
           query,
-          resolve: params.resolve ?? false
+          resolve: params.resolve ?? false,
+          following: params.following ?? false
         })
       : Promise.resolve(null),
     database.searchAccountIds({
@@ -220,7 +325,10 @@ const searchHashtags = async ({
     excludeUnreviewed: params.exclude_unreviewed ?? false
   })
 
-  return hashtags.map((hashtag) => Tag.parse(hashtag))
+  return hashtags.flatMap((hashtag) => {
+    const parsed = Tag.safeParse(hashtag)
+    return parsed.success ? [parsed.data] : []
+  })
 }
 
 const searchStatuses = async ({
@@ -269,10 +377,14 @@ const searchStatuses = async ({
     currentActorId: currentActor.id,
     visibleToActorId: currentActor.id
   })
+  const orderedStatuses = orderStatusesByIds({
+    statuses: statuses as Status[],
+    ids
+  })
   return getMastodonStatuses(
     database,
-    [resolvedStatus, ...(statuses as Status[])].filter(
-      (status): status is Status => Boolean(status)
+    [resolvedStatus, ...orderedStatuses].filter((status): status is Status =>
+      Boolean(status)
     ),
     currentActor.id
   )
@@ -288,7 +400,6 @@ const requiresAuthentication = ({
   params.type === 'statuses' ||
   params.resolve === true ||
   params.following === true ||
-  Boolean(params.account_id) ||
   offset > 0
 
 export const GET = traceApiRoute(
@@ -310,7 +421,7 @@ export const GET = traceApiRoute(
       const params = parsedParams.data
       const query = params.q.trim()
       const limit = params.limit ?? 20
-      const offset = params.offset ?? 0
+      const offset = params.type ? (params.offset ?? 0) : 0
 
       if (!currentActor && requiresAuthentication({ params, offset })) {
         return apiResponse({

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -21,12 +21,12 @@ import {
 } from '@/lib/database/sql/utils/counter'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
-import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import {
   chunkArray,
   deleteRowsByColumnChunks,
   getWhereInBatchSize
 } from '@/lib/database/sql/utils/knex'
+import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import { selectHashtagTagsByStatusIds } from '@/lib/database/sql/utils/status'
 import {
   FEDERATION_SIGNING_ACTOR_TYPE,

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1332,6 +1332,17 @@ describe('StatusDatabase', () => {
           [statuses.primary.post]: 0
         })
       })
+
+      it('returns bulk reblog counts in SQLite-safe batches', async () => {
+        const statusIds = Array.from(
+          { length: 1005 },
+          (_, index) => `${emptyActorId}/statuses/bulk-reblog-count-${index}`
+        )
+        const counts = await database.getStatusReblogsCounts({ statusIds })
+
+        expect(Object.keys(counts)).toHaveLength(statusIds.length)
+        expect(Object.values(counts).every((count) => count === 0)).toBe(true)
+      })
     })
 
     describe('getStatusRepliesCount', () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1319,6 +1319,19 @@ describe('StatusDatabase', () => {
         })
         expect(count).toBe(0)
       })
+
+      it('returns reblog counts for multiple statuses', async () => {
+        const counts = await database.getStatusReblogsCounts({
+          statusIds: [
+            statuses.primary.postWithAttachments,
+            statuses.primary.post
+          ]
+        })
+        expect(counts).toEqual({
+          [statuses.primary.postWithAttachments]: 1,
+          [statuses.primary.post]: 0
+        })
+      })
     })
 
     describe('getStatusRepliesCount', () => {
@@ -1334,6 +1347,16 @@ describe('StatusDatabase', () => {
           statusId: statuses.primary.secondPost
         })
         expect(count).toBe(0)
+      })
+
+      it('returns reply counts for multiple statuses', async () => {
+        const counts = await database.getStatusRepliesCounts({
+          statusIds: [statuses.primary.post, statuses.primary.secondPost]
+        })
+        expect(counts).toEqual({
+          [statuses.primary.post]: 2,
+          [statuses.primary.secondPost]: 0
+        })
       })
 
       it('counts replies that reference parent URL', async () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1996,6 +1996,49 @@ describe('StatusDatabase', () => {
         })
       })
 
+      it('returns actor poll votes for multiple statuses', async () => {
+        const firstPollId = `${emptyActorId}/statuses/poll-votes-bulk-1`
+        const secondPollId = `${emptyActorId}/statuses/poll-votes-bulk-2`
+        const thirdPollId = `${emptyActorId}/statuses/poll-votes-bulk-3`
+        const voterId = `${replyAuthorId}/poll-votes-bulk`
+
+        for (const pollId of [firstPollId, secondPollId, thirdPollId]) {
+          await database.createPoll({
+            id: pollId,
+            url: pollId,
+            actorId: emptyActorId,
+            to: ['https://www.w3.org/ns/activitystreams#Public'],
+            cc: [],
+            text: 'Vote poll',
+            choices: ['Yes', 'No'],
+            pollType: 'anyOf',
+            endAt: Date.now() + 1000
+          })
+        }
+
+        await database.recordPollVotes({
+          statusId: firstPollId,
+          actorId: voterId,
+          choices: [1, 0]
+        })
+        await database.recordPollVotes({
+          statusId: secondPollId,
+          actorId: voterId,
+          choices: [1]
+        })
+
+        await expect(
+          database.getActorPollVotesForStatuses({
+            statusIds: [firstPollId, secondPollId, thirdPollId, firstPollId],
+            actorId: voterId
+          })
+        ).resolves.toEqual({
+          [firstPollId]: [0, 1],
+          [secondPollId]: [1],
+          [thirdPollId]: []
+        })
+      })
+
       it('records a Mastodon poll vote atomically and rejects duplicate voters', async () => {
         const pollId = `${emptyActorId}/statuses/record-poll-votes`
         await database.createPoll({

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -90,7 +90,6 @@ import {
 import type { SQLStatusSearchRow } from './search'
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
 
-const SQLITE_MAX_BINDINGS = 999
 const MAX_ANNOUNCE_RESOLUTION_DEPTH = 10
 // Counts breadth-first reply levels from the deleted root, not total replies.
 // This bounds transaction size while still allowing wide conversation cleanup.
@@ -107,21 +106,6 @@ type StatusDeletionRow = {
 
 const statusReplyDeletionDepthError = (statusId: string) =>
   new Error(`Status reply deletion depth limit exceeded for status ${statusId}`)
-
-const getWhereInBatchSize = (database: Knex) => {
-  const clientName = String(database.client.config.client)
-  if (!clientName.includes('sqlite')) return Number.POSITIVE_INFINITY
-  return SQLITE_MAX_BINDINGS
-}
-
-const chunkArray = <T>(items: T[], size: number) => {
-  const chunkSize = Number.isFinite(size) ? size : Math.max(items.length, 1)
-  const chunks: T[][] = []
-  for (let start = 0; start < items.length; start += chunkSize) {
-    chunks.push(items.slice(start, start + chunkSize))
-  }
-  return chunks
-}
 
 const isReplaceableMediaAttachment = (
   attachment: Attachment

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -6,6 +6,7 @@ import {
   decreaseCounterValue,
   deleteCounterValues,
   getCounterValue,
+  getCounterValues,
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
 import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
@@ -44,6 +45,7 @@ import {
   GetFavouritedByParams,
   GetHashtagStatusesPageParams,
   GetRebloggedByParams,
+  GetStatusCountsParams,
   GetStatusFromUrlHashParams,
   GetStatusFromUrlParams,
   GetStatusParams,
@@ -2259,6 +2261,32 @@ export const StatusSQLDatabaseMixin = (
     return getCounterValue(database, CounterKey.totalReblog(statusId))
   }
 
+  async function getStatusCounterValues(
+    { statusIds }: GetStatusCountsParams,
+    getCounterId: (statusId: string) => string
+  ): Promise<Record<string, number>> {
+    const uniqueStatusIds = [...new Set(statusIds)]
+    const counterIdsByStatusId = new Map(
+      uniqueStatusIds.map((statusId) => [statusId, getCounterId(statusId)])
+    )
+    const counterValues = await getCounterValues(database, [
+      ...counterIdsByStatusId.values()
+    ])
+
+    return Object.fromEntries(
+      uniqueStatusIds.map((statusId) => [
+        statusId,
+        counterValues[counterIdsByStatusId.get(statusId) ?? ''] ?? 0
+      ])
+    )
+  }
+
+  async function getStatusReblogsCounts(
+    params: GetStatusCountsParams
+  ): Promise<Record<string, number>> {
+    return getStatusCounterValues(params, CounterKey.totalReblog)
+  }
+
   async function getStatusRepliesCount({
     statusId,
     url,
@@ -2288,6 +2316,12 @@ export const StatusSQLDatabaseMixin = (
       .first()
 
     return parseInt(String(result?.count ?? '0'), 10)
+  }
+
+  async function getStatusRepliesCounts(
+    params: GetStatusCountsParams
+  ): Promise<Record<string, number>> {
+    return getStatusCounterValues(params, CounterKey.totalReply)
   }
 
   async function recordPollVotes({
@@ -2577,7 +2611,9 @@ export const StatusSQLDatabaseMixin = (
     increaseHashtagCounter,
     decreaseHashtagCounter,
     getStatusReblogsCount,
+    getStatusReblogsCounts,
     getStatusRepliesCount,
+    getStatusRepliesCounts,
     createPollAnswer,
     hasActorVoted,
     getActorPollVotes,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -39,6 +39,7 @@ import {
   CreatePollParams,
   CreateTagParams,
   DeleteStatusParams,
+  GetActorPollVotesForStatusesParams,
   GetActorPollVotesParams,
   GetActorStatusesCountParams,
   GetActorStatusesParams,
@@ -2446,6 +2447,34 @@ export const StatusSQLDatabaseMixin = (
     return results.map((r) => r.choice)
   }
 
+  async function getActorPollVotesForStatuses({
+    statusIds,
+    actorId
+  }: GetActorPollVotesForStatusesParams): Promise<Record<string, number[]>> {
+    const uniqueStatusIds = [...new Set(statusIds)]
+    const votesByStatusId = Object.fromEntries(
+      uniqueStatusIds.map((statusId) => [statusId, []])
+    ) as Record<string, number[]>
+
+    for (const statusIdChunk of chunkArray(
+      uniqueStatusIds,
+      getWhereInBatchSize(database, 1)
+    )) {
+      const results = await database('poll_answers')
+        .where('actorId', actorId)
+        .whereIn('statusId', statusIdChunk)
+        .select<{ statusId: string; choice: number }[]>('statusId', 'choice')
+        .orderBy('statusId', 'asc')
+        .orderBy('choice', 'asc')
+
+      for (const result of results) {
+        votesByStatusId[result.statusId]?.push(Number(result.choice))
+      }
+    }
+
+    return votesByStatusId
+  }
+
   async function incrementPollChoiceVotes({
     statusId,
     choiceIndex
@@ -2624,6 +2653,7 @@ export const StatusSQLDatabaseMixin = (
     createPollAnswer,
     hasActorVoted,
     getActorPollVotes,
+    getActorPollVotesForStatuses,
     incrementPollChoiceVotes,
     recordPollVotes
   }

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -90,6 +90,7 @@ import {
 import type { SQLStatusSearchRow } from './search'
 import { getCompatibleJSON } from './utils/getCompatibleJSON'
 
+const SQLITE_MAX_BINDINGS = 999
 const MAX_ANNOUNCE_RESOLUTION_DEPTH = 10
 // Counts breadth-first reply levels from the deleted root, not total replies.
 // This bounds transaction size while still allowing wide conversation cleanup.
@@ -106,6 +107,21 @@ type StatusDeletionRow = {
 
 const statusReplyDeletionDepthError = (statusId: string) =>
   new Error(`Status reply deletion depth limit exceeded for status ${statusId}`)
+
+const getWhereInBatchSize = (database: Knex) => {
+  const clientName = String(database.client.config.client)
+  if (!clientName.includes('sqlite')) return Number.POSITIVE_INFINITY
+  return SQLITE_MAX_BINDINGS
+}
+
+const chunkArray = <T>(items: T[], size: number) => {
+  const chunkSize = Number.isFinite(size) ? size : Math.max(items.length, 1)
+  const chunks: T[][] = []
+  for (let start = 0; start < items.length; start += chunkSize) {
+    chunks.push(items.slice(start, start + chunkSize))
+  }
+  return chunks
+}
 
 const isReplaceableMediaAttachment = (
   attachment: Attachment
@@ -2269,9 +2285,16 @@ export const StatusSQLDatabaseMixin = (
     const counterIdsByStatusId = new Map(
       uniqueStatusIds.map((statusId) => [statusId, getCounterId(statusId)])
     )
-    const counterValues = await getCounterValues(database, [
-      ...counterIdsByStatusId.values()
-    ])
+    const counterValueRows = await Promise.all(
+      chunkArray(
+        [...counterIdsByStatusId.values()],
+        getWhereInBatchSize(database)
+      ).map((counterIds) => getCounterValues(database, counterIds))
+    )
+    const counterValues = Object.assign({}, ...counterValueRows) as Record<
+      string,
+      number
+    >
 
     return Object.fromEntries(
       uniqueStatusIds.map((statusId) => [

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -124,6 +124,43 @@ describe('#getMastodonStatus', () => {
         getMastodonActorFromId.mockRestore()
       }
     })
+
+    it('hydrates reply parents in bulk while serializing status lists', async () => {
+      const parentId = `${ACTOR1_ID}/statuses/post-1`
+      const replyOne = (await database.getStatus({
+        statusId: `${ACTOR2_ID}/statuses/post-2`
+      })) as Status
+      const replyTwo = (await database.getStatus({
+        statusId: `${ACTOR2_ID}/statuses/reply-1`
+      })) as Status
+      const getStatusesByIds = jest.spyOn(database, 'getStatusesByIds')
+      const getStatus = jest.spyOn(database, 'getStatus')
+
+      try {
+        const mastodonStatuses = await getMastodonStatuses(
+          database,
+          [replyOne, replyTwo],
+          ACTOR1_ID
+        )
+
+        expect(mastodonStatuses).toHaveLength(2)
+        expect(mastodonStatuses.map((status) => status.in_reply_to_id)).toEqual(
+          [urlToId(parentId), urlToId(parentId)]
+        )
+        expect(
+          mastodonStatuses.map((status) => status.in_reply_to_account_id)
+        ).toEqual([urlToId(ACTOR1_ID), urlToId(ACTOR1_ID)])
+        expect(getStatusesByIds).toHaveBeenCalledWith({
+          statusIds: [parentId],
+          currentActorId: ACTOR1_ID,
+          visibleToActorId: ACTOR1_ID
+        })
+        expect(getStatus).not.toHaveBeenCalled()
+      } finally {
+        getStatusesByIds.mockRestore()
+        getStatus.mockRestore()
+      }
+    })
   })
 
   it('returns mastodon status from status model', async () => {

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -48,6 +48,22 @@ describe('#getMastodonStatus', () => {
         database,
         'getMastodonActorsFromIds'
       )
+      const getStatusReblogsCounts = jest.spyOn(
+        database,
+        'getStatusReblogsCounts'
+      )
+      const getStatusRepliesCounts = jest.spyOn(
+        database,
+        'getStatusRepliesCounts'
+      )
+      const getStatusReblogsCount = jest.spyOn(
+        database,
+        'getStatusReblogsCount'
+      )
+      const getStatusRepliesCount = jest.spyOn(
+        database,
+        'getStatusRepliesCount'
+      )
 
       const mastodonStatuses = await getMastodonStatuses(database, [
         firstStatus,
@@ -63,6 +79,14 @@ describe('#getMastodonStatus', () => {
       expect(getMastodonActorsFromIds).toHaveBeenCalledWith({
         ids: [ACTOR1_ID]
       })
+      expect(getStatusReblogsCounts).toHaveBeenCalledWith({
+        statusIds: [firstStatus.id, secondStatus.id]
+      })
+      expect(getStatusRepliesCounts).toHaveBeenCalledWith({
+        statusIds: [firstStatus.id, secondStatus.id]
+      })
+      expect(getStatusReblogsCount).not.toHaveBeenCalled()
+      expect(getStatusRepliesCount).not.toHaveBeenCalled()
     })
 
     it('keys hydrated account cache by actor id when account url is a profile url', async () => {

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -230,13 +230,37 @@ describe('#getMastodonStatus', () => {
         ).toEqual([urlToId(ACTOR1_ID), urlToId(ACTOR1_ID)])
         expect(getStatusesByIds).toHaveBeenCalledWith({
           statusIds: [parentId],
-          currentActorId: ACTOR1_ID,
-          visibleToActorId: ACTOR1_ID
+          currentActorId: ACTOR1_ID
         })
         expect(getStatus).not.toHaveBeenCalled()
       } finally {
         getStatusesByIds.mockRestore()
         getStatus.mockRestore()
+      }
+    })
+
+    it('does not map unmatched bulk accounts by result index', async () => {
+      const status = (await database.getStatus({
+        statusId: `${ACTOR1_ID}/statuses/post-1`
+      })) as Status
+      const getMastodonActorsFromIds = jest
+        .spyOn(database, 'getMastodonActorsFromIds')
+        .mockResolvedValueOnce([
+          {
+            id: 'remote.test:users:unrelated',
+            url: 'https://remote.test/users/unrelated'
+          }
+        ] as Awaited<ReturnType<typeof database.getMastodonActorsFromIds>>)
+
+      try {
+        await expect(getMastodonStatuses(database, [status])).resolves.toEqual(
+          []
+        )
+        expect(getMastodonActorsFromIds).toHaveBeenCalledWith({
+          ids: [ACTOR1_ID]
+        })
+      } finally {
+        getMastodonActorsFromIds.mockRestore()
       }
     })
   })

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -3,6 +3,7 @@ import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
 import { getMentionFromActorID } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import {
@@ -87,6 +88,83 @@ describe('#getMastodonStatus', () => {
       })
       expect(getStatusReblogsCount).not.toHaveBeenCalled()
       expect(getStatusRepliesCount).not.toHaveBeenCalled()
+    })
+
+    it('hydrates poll vote state in bulk while serializing status lists', async () => {
+      const firstPollId = `${ACTOR3_ID}/statuses/mastodon-bulk-poll-1`
+      const secondPollId = `${ACTOR3_ID}/statuses/mastodon-bulk-poll-2`
+
+      await database.createPoll({
+        id: firstPollId,
+        url: firstPollId,
+        actorId: ACTOR3_ID,
+        text: 'First bulk poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Yes', 'No'],
+        endAt: Date.now() + 60_000
+      })
+      await database.createPoll({
+        id: secondPollId,
+        url: secondPollId,
+        actorId: ACTOR3_ID,
+        text: 'Second bulk poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Alpha', 'Beta'],
+        endAt: Date.now() + 60_000
+      })
+      await database.recordPollVotes({
+        statusId: firstPollId,
+        actorId: ACTOR2_ID,
+        choices: [0]
+      })
+      await database.recordPollVotes({
+        statusId: secondPollId,
+        actorId: ACTOR2_ID,
+        choices: [1]
+      })
+
+      const firstPoll = (await database.getStatus({
+        statusId: firstPollId
+      })) as Status
+      const secondPoll = (await database.getStatus({
+        statusId: secondPollId
+      })) as Status
+      const getActorPollVotesForStatuses = jest.spyOn(
+        database,
+        'getActorPollVotesForStatuses'
+      )
+      const hasActorVoted = jest.spyOn(database, 'hasActorVoted')
+      const getActorPollVotes = jest.spyOn(database, 'getActorPollVotes')
+
+      try {
+        const mastodonStatuses = await getMastodonStatuses(
+          database,
+          [firstPoll, secondPoll],
+          ACTOR2_ID
+        )
+
+        expect(mastodonStatuses).toHaveLength(2)
+        expect(getActorPollVotesForStatuses).toHaveBeenCalledTimes(1)
+        expect(getActorPollVotesForStatuses).toHaveBeenCalledWith({
+          statusIds: [firstPollId, secondPollId],
+          actorId: ACTOR2_ID
+        })
+        expect(hasActorVoted).not.toHaveBeenCalled()
+        expect(getActorPollVotes).not.toHaveBeenCalled()
+        expect(mastodonStatuses.map((status) => status.poll?.voted)).toEqual([
+          true,
+          true
+        ])
+        expect(
+          mastodonStatuses.map((status) => status.poll?.own_votes)
+        ).toEqual([[0], [1]])
+      } finally {
+        getActorPollVotesForStatuses.mockRestore()
+        hasActorVoted.mockRestore()
+        getActorPollVotes.mockRestore()
+      }
     })
 
     it('keys hydrated account cache by actor id when account url is a profile url', async () => {

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -34,6 +34,7 @@ interface MastodonTag {
 }
 
 type MastodonAccountCache = Map<string, Promise<Mastodon.Account | null>>
+type ReplyStatusCache = Map<string, Status | null>
 type StatusMetricsCache = {
   reblogs: Map<string, number>
   replies: Map<string, number>
@@ -41,6 +42,7 @@ type StatusMetricsCache = {
 
 interface GetMastodonStatusOptions {
   accountCache?: MastodonAccountCache
+  replyStatusCache?: ReplyStatusCache
   statusMetricsCache?: StatusMetricsCache
 }
 
@@ -132,6 +134,32 @@ const addStatusMetricIds = (status: Status, statusIds: Set<string>) => {
   }
 
   statusIds.add(status.id)
+}
+
+const addStatusReplyIds = (status: Status, statusIds: Set<string>) => {
+  if (status.type === StatusType.enum.Announce) {
+    addStatusReplyIds(status.originalStatus, statusIds)
+    return
+  }
+
+  if (status.reply) statusIds.add(status.reply)
+}
+
+const getReplyStatus = async (
+  database: Database,
+  statusId: string,
+  options?: GetMastodonStatusOptions
+) => {
+  const replyStatusCache = options?.replyStatusCache
+  if (!replyStatusCache) return database.getStatus({ statusId })
+
+  if (replyStatusCache.has(statusId)) {
+    return replyStatusCache.get(statusId) ?? null
+  }
+
+  const replyStatus = await database.getStatus({ statusId })
+  replyStatusCache.set(statusId, replyStatus)
+  return replyStatus
 }
 
 const getStatusReblogsCount = async (
@@ -246,7 +274,7 @@ export const getMastodonStatus = async (
   }
 
   const replyStatus = status.reply
-    ? await database.getStatus({ statusId: status.reply })
+    ? await getReplyStatus(database, status.reply, options)
     : null
   const repliesCount = await getStatusRepliesCount(database, status.id, options)
 
@@ -338,19 +366,30 @@ export const getMastodonStatuses = async (
   statuses.forEach((status) => addStatusActorIds(status, actorIds))
   const metricStatusIds = new Set<string>()
   statuses.forEach((status) => addStatusMetricIds(status, metricStatusIds))
+  const replyStatusIds = new Set<string>()
+  statuses.forEach((status) => addStatusReplyIds(status, replyStatusIds))
   const requestedActorIds = [...actorIds]
   const requestedMetricStatusIds = [...metricStatusIds]
-  const [accounts, reblogCounts, replyCounts] = await Promise.all([
-    database.getMastodonActorsFromIds({
-      ids: requestedActorIds
-    }),
-    database.getStatusReblogsCounts({
-      statusIds: requestedMetricStatusIds
-    }),
-    database.getStatusRepliesCounts({
-      statusIds: requestedMetricStatusIds
-    })
-  ])
+  const requestedReplyStatusIds = [...replyStatusIds]
+  const [accounts, reblogCounts, replyCounts, replyStatuses] =
+    await Promise.all([
+      database.getMastodonActorsFromIds({
+        ids: requestedActorIds
+      }),
+      database.getStatusReblogsCounts({
+        statusIds: requestedMetricStatusIds
+      }),
+      database.getStatusRepliesCounts({
+        statusIds: requestedMetricStatusIds
+      }),
+      requestedReplyStatusIds.length > 0
+        ? database.getStatusesByIds({
+            statusIds: requestedReplyStatusIds,
+            currentActorId,
+            visibleToActorId: currentActorId
+          })
+        : Promise.resolve([])
+    ])
   const requestedActorIdSet = new Set(requestedActorIds)
   const accountCache: MastodonAccountCache = new Map()
   const keyedAccounts = new Set<Mastodon.Account>()
@@ -399,8 +438,15 @@ export const getMastodonStatuses = async (
           replyCounts[statusId] ?? 0
         ])
       )
-    }
+    },
+    replyStatusCache: new Map(
+      requestedReplyStatusIds.map((statusId) => [statusId, null])
+    )
   }
+  for (const replyStatus of replyStatuses) {
+    options.replyStatusCache?.set(replyStatus.id, replyStatus)
+  }
+
   return (
     await Promise.all(
       statuses.map((status) =>

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -421,8 +421,7 @@ export const getMastodonStatuses = async (
       requestedReplyStatusIds.length > 0
         ? database.getStatusesByIds({
             statusIds: requestedReplyStatusIds,
-            currentActorId,
-            visibleToActorId: currentActorId
+            currentActorId
           })
         : Promise.resolve([]),
       requestedPollStatusIds.length > 0 && currentActorId
@@ -434,31 +433,19 @@ export const getMastodonStatuses = async (
     ])
   const requestedActorIdSet = new Set(requestedActorIds)
   const accountCache: MastodonAccountCache = new Map()
-  const keyedAccounts = new Set<Mastodon.Account>()
 
   for (const account of accounts) {
     const decodedActorId =
       typeof account.id === 'string' ? idToUrl(account.id) : ''
     if (requestedActorIdSet.has(decodedActorId)) {
       accountCache.set(decodedActorId, Promise.resolve(account))
-      keyedAccounts.add(account)
       continue
     }
 
     if (requestedActorIdSet.has(account.url)) {
       accountCache.set(account.url, Promise.resolve(account))
-      keyedAccounts.add(account)
     }
   }
-
-  if (accounts.length === requestedActorIds.length) {
-    accounts.forEach((account, index) => {
-      if (!keyedAccounts.has(account)) {
-        accountCache.set(requestedActorIds[index], Promise.resolve(account))
-      }
-    })
-  }
-
   for (const actorId of actorIds) {
     if (!accountCache.has(actorId)) {
       accountCache.set(actorId, Promise.resolve(null))

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -34,9 +34,14 @@ interface MastodonTag {
 }
 
 type MastodonAccountCache = Map<string, Promise<Mastodon.Account | null>>
+type StatusMetricsCache = {
+  reblogs: Map<string, number>
+  replies: Map<string, number>
+}
 
 interface GetMastodonStatusOptions {
   accountCache?: MastodonAccountCache
+  statusMetricsCache?: StatusMetricsCache
 }
 
 const getMastodonAccount = (
@@ -120,6 +125,37 @@ const addStatusActorIds = (status: Status, actorIds: Set<string>) => {
   }
 }
 
+const addStatusMetricIds = (status: Status, statusIds: Set<string>) => {
+  if (status.type === StatusType.enum.Announce) {
+    addStatusMetricIds(status.originalStatus, statusIds)
+    return
+  }
+
+  statusIds.add(status.id)
+}
+
+const getStatusReblogsCount = async (
+  database: Database,
+  statusId: string,
+  options?: GetMastodonStatusOptions
+) => {
+  const reblogsCache = options?.statusMetricsCache?.reblogs
+  if (reblogsCache?.has(statusId)) return reblogsCache.get(statusId) ?? 0
+
+  return database.getStatusReblogsCount({ statusId })
+}
+
+const getStatusRepliesCount = async (
+  database: Database,
+  statusId: string,
+  options?: GetMastodonStatusOptions
+) => {
+  const repliesCache = options?.statusMetricsCache?.replies
+  if (repliesCache?.has(statusId)) return repliesCache.get(statusId) ?? 0
+
+  return database.getStatusRepliesCount({ statusId })
+}
+
 export const getMastodonStatus = async (
   database: Database,
   status: Status,
@@ -140,7 +176,7 @@ export const getMastodonStatus = async (
 
   const reblogsCount =
     status.type !== StatusType.enum.Announce
-      ? await database.getStatusReblogsCount({ statusId: status.id })
+      ? await getStatusReblogsCount(database, status.id, options)
       : 0
 
   const baseData = {
@@ -180,9 +216,11 @@ export const getMastodonStatus = async (
   }
 
   if (status.type === StatusType.enum.Announce) {
-    const originalReblogsCount = await database.getStatusReblogsCount({
-      statusId: status.originalStatus.id
-    })
+    const originalReblogsCount = await getStatusReblogsCount(
+      database,
+      status.originalStatus.id,
+      options
+    )
 
     const originalVisibility = getVisibility(
       status.originalStatus.to,
@@ -210,9 +248,7 @@ export const getMastodonStatus = async (
   const replyStatus = status.reply
     ? await database.getStatus({ statusId: status.reply })
     : null
-  const repliesCount = await database.getStatusRepliesCount({
-    statusId: status.id
-  })
+  const repliesCount = await getStatusRepliesCount(database, status.id, options)
 
   const mentions = getMentionsFromTags(status.tags)
   const emojis = getEmojisFromTags(status.tags)
@@ -300,10 +336,21 @@ export const getMastodonStatuses = async (
 
   const actorIds = new Set<string>()
   statuses.forEach((status) => addStatusActorIds(status, actorIds))
+  const metricStatusIds = new Set<string>()
+  statuses.forEach((status) => addStatusMetricIds(status, metricStatusIds))
   const requestedActorIds = [...actorIds]
-  const accounts = await database.getMastodonActorsFromIds({
-    ids: requestedActorIds
-  })
+  const requestedMetricStatusIds = [...metricStatusIds]
+  const [accounts, reblogCounts, replyCounts] = await Promise.all([
+    database.getMastodonActorsFromIds({
+      ids: requestedActorIds
+    }),
+    database.getStatusReblogsCounts({
+      statusIds: requestedMetricStatusIds
+    }),
+    database.getStatusRepliesCounts({
+      statusIds: requestedMetricStatusIds
+    })
+  ])
   const requestedActorIdSet = new Set(requestedActorIds)
   const accountCache: MastodonAccountCache = new Map()
   const keyedAccounts = new Set<Mastodon.Account>()
@@ -337,7 +384,23 @@ export const getMastodonStatuses = async (
     }
   }
 
-  const options: GetMastodonStatusOptions = { accountCache }
+  const options: GetMastodonStatusOptions = {
+    accountCache,
+    statusMetricsCache: {
+      reblogs: new Map(
+        requestedMetricStatusIds.map((statusId) => [
+          statusId,
+          reblogCounts[statusId] ?? 0
+        ])
+      ),
+      replies: new Map(
+        requestedMetricStatusIds.map((statusId) => [
+          statusId,
+          replyCounts[statusId] ?? 0
+        ])
+      )
+    }
+  }
   return (
     await Promise.all(
       statuses.map((status) =>

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -4,6 +4,7 @@ import { Mastodon } from '@/lib/types/activitypub'
 import { getMastodonAttachment } from '@/lib/types/domain/attachment'
 import {
   Status,
+  StatusPoll,
   StatusType,
   hasStatusBeenEdited
 } from '@/lib/types/domain/status'
@@ -39,11 +40,17 @@ type StatusMetricsCache = {
   reblogs: Map<string, number>
   replies: Map<string, number>
 }
+type PollVoteState = {
+  voted: boolean
+  ownVotes: number[]
+}
+type PollVoteCache = Map<string, PollVoteState>
 
 interface GetMastodonStatusOptions {
   accountCache?: MastodonAccountCache
   replyStatusCache?: ReplyStatusCache
   statusMetricsCache?: StatusMetricsCache
+  pollVoteCache?: PollVoteCache
 }
 
 const getMastodonAccount = (
@@ -145,6 +152,15 @@ const addStatusReplyIds = (status: Status, statusIds: Set<string>) => {
   if (status.reply) statusIds.add(status.reply)
 }
 
+const addStatusPollIds = (status: Status, statusIds: Set<string>) => {
+  if (status.type === StatusType.enum.Announce) {
+    addStatusPollIds(status.originalStatus, statusIds)
+    return
+  }
+
+  if (status.type === StatusType.enum.Poll) statusIds.add(status.id)
+}
+
 const getReplyStatus = async (
   database: Database,
   statusId: string,
@@ -182,6 +198,30 @@ const getStatusRepliesCount = async (
   if (repliesCache?.has(statusId)) return repliesCache.get(statusId) ?? 0
 
   return database.getStatusRepliesCount({ statusId })
+}
+
+const getPollVoteState = async (
+  database: Database,
+  status: StatusPoll,
+  currentActorId?: string,
+  options?: GetMastodonStatusOptions
+): Promise<PollVoteState> => {
+  if (!currentActorId) return { voted: false, ownVotes: [] }
+
+  const cachedVoteState = options?.pollVoteCache?.get(status.id)
+  if (cachedVoteState) return cachedVoteState
+
+  const [voted, ownVotes] = await Promise.all([
+    database.hasActorVoted({
+      statusId: status.id,
+      actorId: currentActorId
+    }),
+    database.getActorPollVotes({
+      statusId: status.id,
+      actorId: currentActorId
+    })
+  ])
+  return { voted, ownVotes }
 }
 
 export const getMastodonStatus = async (
@@ -315,19 +355,12 @@ export const getMastodonStatus = async (
 
   let pollData = null
   if (status.type === StatusType.enum.Poll) {
-    const voted = currentActorId
-      ? await database.hasActorVoted({
-          statusId: status.id,
-          actorId: currentActorId
-        })
-      : false
-
-    const ownVotes = currentActorId
-      ? await database.getActorPollVotes({
-          statusId: status.id,
-          actorId: currentActorId
-        })
-      : []
+    const { voted, ownVotes } = await getPollVoteState(
+      database,
+      status,
+      currentActorId,
+      options
+    )
 
     pollData = Mastodon.Poll.parse({
       id: urlToId(status.id),
@@ -368,10 +401,13 @@ export const getMastodonStatuses = async (
   statuses.forEach((status) => addStatusMetricIds(status, metricStatusIds))
   const replyStatusIds = new Set<string>()
   statuses.forEach((status) => addStatusReplyIds(status, replyStatusIds))
+  const pollStatusIds = new Set<string>()
+  statuses.forEach((status) => addStatusPollIds(status, pollStatusIds))
   const requestedActorIds = [...actorIds]
   const requestedMetricStatusIds = [...metricStatusIds]
   const requestedReplyStatusIds = [...replyStatusIds]
-  const [accounts, reblogCounts, replyCounts, replyStatuses] =
+  const requestedPollStatusIds = currentActorId ? [...pollStatusIds] : []
+  const [accounts, reblogCounts, replyCounts, replyStatuses, pollVotes] =
     await Promise.all([
       database.getMastodonActorsFromIds({
         ids: requestedActorIds
@@ -388,7 +424,13 @@ export const getMastodonStatuses = async (
             currentActorId,
             visibleToActorId: currentActorId
           })
-        : Promise.resolve([])
+        : Promise.resolve([]),
+      requestedPollStatusIds.length > 0 && currentActorId
+        ? database.getActorPollVotesForStatuses({
+            statusIds: requestedPollStatusIds,
+            actorId: currentActorId
+          })
+        : Promise.resolve<Record<string, number[]>>({})
     ])
   const requestedActorIdSet = new Set(requestedActorIds)
   const accountCache: MastodonAccountCache = new Map()
@@ -441,6 +483,18 @@ export const getMastodonStatuses = async (
     },
     replyStatusCache: new Map(
       requestedReplyStatusIds.map((statusId) => [statusId, null])
+    ),
+    pollVoteCache: new Map(
+      requestedPollStatusIds.map((statusId) => {
+        const ownVotes = pollVotes[statusId] ?? []
+        return [
+          statusId,
+          {
+            voted: ownVotes.length > 0,
+            ownVotes
+          }
+        ]
+      })
     )
   }
   for (const replyStatus of replyStatuses) {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -533,6 +533,9 @@ export type DecreaseHashtagCounterParams = {
 export type GetStatusReblogsCountParams = {
   statusId: string
 }
+export type GetStatusCountsParams = {
+  statusIds: string[]
+}
 export type GetStatusRepliesCountParams = {
   statusId: string
   url?: string
@@ -608,7 +611,13 @@ export interface StatusDatabase {
   increaseHashtagCounter(params: IncreaseHashtagCounterParams): Promise<void>
   decreaseHashtagCounter(params: DecreaseHashtagCounterParams): Promise<void>
   getStatusReblogsCount(params: GetStatusReblogsCountParams): Promise<number>
+  getStatusReblogsCounts(
+    params: GetStatusCountsParams
+  ): Promise<Record<string, number>>
   getStatusRepliesCount(params: GetStatusRepliesCountParams): Promise<number>
+  getStatusRepliesCounts(
+    params: GetStatusCountsParams
+  ): Promise<Record<string, number>>
   createPollAnswer(params: CreatePollAnswerParams): Promise<void>
   hasActorVoted(params: HasActorVotedParams): Promise<boolean>
   getActorPollVotes(params: GetActorPollVotesParams): Promise<number[]>

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -555,6 +555,10 @@ export type GetActorPollVotesParams = {
   statusId: string
   actorId: string
 }
+export type GetActorPollVotesForStatusesParams = {
+  statusIds: string[]
+  actorId: string
+}
 export type IncrementPollChoiceVotesParams = {
   statusId: string
   choiceIndex: number
@@ -621,6 +625,9 @@ export interface StatusDatabase {
   createPollAnswer(params: CreatePollAnswerParams): Promise<void>
   hasActorVoted(params: HasActorVotedParams): Promise<boolean>
   getActorPollVotes(params: GetActorPollVotesParams): Promise<number[]>
+  getActorPollVotesForStatuses(
+    params: GetActorPollVotesForStatusesParams
+  ): Promise<Record<string, number[]>>
   incrementPollChoiceVotes(
     params: IncrementPollChoiceVotesParams
   ): Promise<void>


### PR DESCRIPTION
Stacked on #751.

## Summary
- replace the /api/v2/search stub with Mastodon-style account, status, and hashtag search responses
- support q, type, resolve, following, account_id, exclude_unreviewed, max_id, min_id, limit, and offset parsing
- allow anonymous account/hashtag searches while requiring read/read:search authentication for resolve, offset, following, account-filtered, or status searches
- hydrate accounts/statuses through existing Mastodon serializers and include local URL resolution for readable statuses/accounts
- add route tests for auth behavior, parameter validation, CORS-safe errors, result shape, filters, and URL resolution

## Verification
- yarn run prettier --write .
- yarn lint (passes with 11 existing any warnings)
- yarn build
- yarn test