### PR TITLE
Bump version to v1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.17.7",
+  "version": "1.18.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.18.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.17.7`
- Base main SHA: `022eb9333612f4d44f4279eb0ab5e464badd0bce`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
