### PR TITLE
Bump version to v1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.19.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.18.0`
- Base main SHA: `e94593018e588723ac56cc4d0fc3466774bbfdf3`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
