### PR TITLE
Bump version to v1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.20.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.19.0`
- Base main SHA: `bc2cc2cd33b11c630122af694b6dd63d786e9503`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
