### PR TITLE
Bump version to v1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.21.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.20.0`
- Base main SHA: `af4f870038105426e9526af36bef3384d8a7b5ac`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
