### PR TITLE
Bump version to v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.22.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.21.0`
- Base main SHA: `8722a43e351daee078055a10ca0af3c847e228dc`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
