### PR TITLE
minor: add search page UI

### DIFF
--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -89,6 +89,13 @@ const renderSearchPage = (params = '') => {
   )
 }
 
+const selectTab = (name: string) => {
+  fireEvent.mouseDown(screen.getByRole('tab', { name }), {
+    button: 0,
+    ctrlKey: false
+  })
+}
+
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void
   let reject!: (reason?: unknown) => void
@@ -142,6 +149,43 @@ describe('SearchPageClient', () => {
     )
   })
 
+  it('renders hashtags without history counts', async () => {
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      hashtags: [
+        {
+          name: 'nocount',
+          url: 'https://local.example/tags/nocount'
+        }
+      ]
+    })
+
+    renderSearchPage('q=nocount&type=hashtags')
+
+    expect(await screen.findByText('#nocount')).toBeInTheDocument()
+    expect(screen.queryByText(/posts$/)).not.toBeInTheDocument()
+  })
+
+  it('renders malformed profile payloads with fallbacks', async () => {
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      accounts: [
+        {
+          ...account('malformed-account', '', ''),
+          username: '',
+          acct: '',
+          note: null
+        }
+      ]
+    })
+
+    renderSearchPage('q=unknown&type=accounts')
+
+    expect(await screen.findByText('Unknown profile')).toBeInTheDocument()
+    expect(screen.getByText('@unknown@local.example')).toBeInTheDocument()
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
   it('submits searches to URL state and clears blank searches', async () => {
     mockSearch.mockResolvedValueOnce(emptySearchResult())
 
@@ -189,7 +233,7 @@ describe('SearchPageClient', () => {
 
     expect(await screen.findByText('Initial Runner')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Profiles' }))
+    selectTab('Profiles')
 
     await waitFor(() => {
       expect(mockSearch).toHaveBeenLastCalledWith(
@@ -215,6 +259,48 @@ describe('SearchPageClient', () => {
       )
     })
     expect(await screen.findByText('Next Runner')).toBeInTheDocument()
+  })
+
+  it('resets load-more state when changing tabs during pagination', async () => {
+    const loadMoreSearch =
+      createDeferred<ReturnType<typeof emptySearchResult>>()
+    mockSearch
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: Array.from({ length: 20 }, (_, index) =>
+          account(`account-${index}`, `Runner ${index}`, `runner${index}`)
+        )
+      })
+      .mockReturnValueOnce(loadMoreSearch.promise)
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        statuses: Array.from({ length: 20 }, (_, index) => ({
+          id: `status-${index}`
+        }))
+      })
+
+    renderSearchPage('q=runner&type=accounts')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load more' }))
+    expect(
+      await screen.findByRole('button', { name: 'Loading...' })
+    ).toBeDisabled()
+
+    selectTab('Posts')
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          q: 'runner',
+          type: 'statuses',
+          limit: 20,
+          offset: 0
+        })
+      )
+    })
+    expect(
+      await screen.findByRole('button', { name: 'Load more' })
+    ).toBeEnabled()
   })
 
   it('shows an error state when the request fails', async () => {

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -316,6 +316,49 @@ describe('SearchPageClient', () => {
     expect(push).not.toHaveBeenCalled()
   })
 
+  it('clears visible results and URL state immediately when the input is cleared', async () => {
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      accounts: [account('trail-account', 'Trail Runner', 'trail')]
+    })
+
+    renderSearchPage('q=trail&type=accounts')
+
+    expect(await screen.findByText('Trail Runner')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: '' }
+    })
+
+    expect(screen.getByText('No search yet')).toBeInTheDocument()
+    expect(screen.queryByText('Trail Runner')).not.toBeInTheDocument()
+    expect(replace).toHaveBeenCalledWith('/search')
+  })
+
+  it('aborts pending searches when the input is cleared', async () => {
+    const pendingSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
+    mockSearch.mockReturnValueOnce(pendingSearch.promise)
+
+    renderSearchPage('q=trail')
+
+    expect(await screen.findByText('Searching...')).toBeInTheDocument()
+    const signal = mockSearch.mock.calls[0][0].signal as AbortSignal
+    expect(signal.aborted).toBe(false)
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: '' }
+    })
+
+    expect(signal.aborted).toBe(true)
+    expect(screen.getByText('No search yet')).toBeInTheDocument()
+    expect(screen.queryByText('Searching...')).not.toBeInTheDocument()
+
+    await act(async () => {
+      pendingSearch.resolve(emptySearchResult())
+      await pendingSearch.promise
+    })
+  })
+
   it('keeps draft input when URL tab state changes without a new query', async () => {
     let params = new URLSearchParams('q=runner&type=accounts')
     ;(useRouter as jest.Mock).mockReturnValue({ replace, push })

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -186,6 +186,25 @@ describe('SearchPageClient', () => {
     expect(screen.getByText('?')).toBeInTheDocument()
   })
 
+  it('renders profile notes with entity decoding and sanitized markup', async () => {
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      accounts: [
+        {
+          ...account('encoded-account', 'Encoded Runner', 'encoded'),
+          note: '<p>Tom &amp; Jerry &lt;run&gt; fast</p><script>alert("x")</script>'
+        }
+      ]
+    })
+
+    renderSearchPage('q=encoded&type=accounts')
+
+    expect(
+      await screen.findByText('Tom & Jerry <run> fast')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/alert/)).not.toBeInTheDocument()
+  })
+
   it('submits searches to URL state and clears blank searches', async () => {
     mockSearch.mockResolvedValueOnce(emptySearchResult())
 
@@ -301,6 +320,37 @@ describe('SearchPageClient', () => {
     expect(
       await screen.findByRole('button', { name: 'Load more' })
     ).toBeEnabled()
+  })
+
+  it('aborts active pagination requests when unmounted', async () => {
+    const loadMoreSearch =
+      createDeferred<ReturnType<typeof emptySearchResult>>()
+    mockSearch
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: Array.from({ length: 20 }, (_, index) =>
+          account(`account-${index}`, `Runner ${index}`, `runner${index}`)
+        )
+      })
+      .mockReturnValueOnce(loadMoreSearch.promise)
+
+    const { unmount } = renderSearchPage('q=runner&type=accounts')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledTimes(2)
+    })
+    const signal = mockSearch.mock.calls[1][0].signal as AbortSignal
+
+    expect(signal.aborted).toBe(false)
+    unmount()
+    expect(signal.aborted).toBe(true)
+
+    await act(async () => {
+      loadMoreSearch.resolve(emptySearchResult())
+      await loadMoreSearch.promise
+    })
   })
 
   it('shows an error state when the request fails', async () => {

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -70,6 +70,11 @@ const account = (id: string, displayName: string, acct: string) => ({
   following_count: 4
 })
 
+const hashtag = (name: string) => ({
+  name,
+  url: `https://local.example/tags/${name}`
+})
+
 const emptySearchResult = () => ({
   accounts: [],
   statuses: [],
@@ -279,6 +284,80 @@ describe('SearchPageClient', () => {
     })
     expect(await screen.findByText('Next Runner')).toBeInTheDocument()
   })
+
+  it.each([
+    {
+      tab: 'accounts',
+      type: 'accounts',
+      duplicateText: 'Runner 19',
+      appendedText: 'Runner 20',
+      initialResults: {
+        ...emptySearchResult(),
+        accounts: Array.from({ length: 20 }, (_, index) =>
+          account(`account-${index}`, `Runner ${index}`, `runner${index}`)
+        )
+      },
+      nextResults: {
+        ...emptySearchResult(),
+        accounts: [
+          account('account-19', 'Runner 19', 'runner19'),
+          account('account-20', 'Runner 20', 'runner20')
+        ]
+      }
+    },
+    {
+      tab: 'statuses',
+      type: 'statuses',
+      duplicateText: 'status-19',
+      appendedText: 'status-20',
+      initialResults: {
+        ...emptySearchResult(),
+        statuses: Array.from({ length: 20 }, (_, index) => ({
+          id: `status-${index}`
+        }))
+      },
+      nextResults: {
+        ...emptySearchResult(),
+        statuses: [{ id: 'status-19' }, { id: 'status-20' }]
+      }
+    },
+    {
+      tab: 'hashtags',
+      type: 'hashtags',
+      duplicateText: '#tag19',
+      appendedText: '#tag20',
+      initialResults: {
+        ...emptySearchResult(),
+        hashtags: Array.from({ length: 20 }, (_, index) =>
+          hashtag(`tag${index}`)
+        )
+      },
+      nextResults: {
+        ...emptySearchResult(),
+        hashtags: [hashtag('tag19'), hashtag('tag20')]
+      }
+    }
+  ])(
+    'deduplicates overlapping $tab load-more results',
+    async ({
+      type,
+      duplicateText,
+      appendedText,
+      initialResults,
+      nextResults
+    }) => {
+      mockSearch
+        .mockResolvedValueOnce(initialResults)
+        .mockResolvedValueOnce(nextResults)
+
+      renderSearchPage(`q=runner&type=${type}`)
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Load more' }))
+
+      expect(await screen.findByText(appendedText)).toBeInTheDocument()
+      expect(screen.getAllByText(duplicateText)).toHaveLength(1)
+    }
+  )
 
   it('resets load-more state when changing tabs during pagination', async () => {
     const loadMoreSearch =

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -171,6 +171,36 @@ describe('SearchPageClient', () => {
     expect(screen.queryByText(/posts$/)).not.toBeInTheDocument()
   })
 
+  it('renders hashtag counts without Array.prototype.at support', async () => {
+    const arrayAt = Array.prototype.at
+    Object.defineProperty(Array.prototype, 'at', {
+      configurable: true,
+      value: undefined
+    })
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      hashtags: [
+        {
+          name: 'legacy',
+          url: 'https://local.example/tags/legacy',
+          history: [{ day: '0', uses: '4', accounts: '1' }]
+        }
+      ]
+    })
+
+    try {
+      renderSearchPage('q=legacy&type=hashtags')
+
+      expect(await screen.findByText('#legacy')).toBeInTheDocument()
+      expect(screen.getByText('4 posts')).toBeInTheDocument()
+    } finally {
+      Object.defineProperty(Array.prototype, 'at', {
+        configurable: true,
+        value: arrayAt
+      })
+    }
+  })
+
   it('renders malformed profile payloads with fallbacks', async () => {
     mockSearch.mockResolvedValueOnce({
       ...emptySearchResult(),
@@ -399,6 +429,40 @@ describe('SearchPageClient', () => {
     expect(
       await screen.findByRole('button', { name: 'Load more' })
     ).toBeEnabled()
+  })
+
+  it('keeps typed results visible and allows retry when loading more fails', async () => {
+    mockSearch
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: Array.from({ length: 20 }, (_, index) =>
+          account(`account-${index}`, `Runner ${index}`, `runner${index}`)
+        )
+      })
+      .mockRejectedValueOnce(new Error('network failed'))
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: [account('account-next', 'Next Runner', 'next')]
+      })
+
+    renderSearchPage('q=runner&type=accounts')
+
+    expect(await screen.findByText('Runner 0')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    expect(
+      await screen.findByText('Failed to load more results. Please try again.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Runner 0')).toBeInTheDocument()
+    expect(screen.queryByText('Search failed')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    expect(await screen.findByText('Next Runner')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Failed to load more results. Please try again.')
+    ).not.toBeInTheDocument()
   })
 
   it('aborts active pagination requests when unmounted', async () => {

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -30,6 +30,7 @@ jest.mock('@/lib/components/posts/posts', () => ({
 
 const mockSearch = search as jest.Mock
 const replace = jest.fn()
+const push = jest.fn()
 
 const currentActor = {
   id: 'https://local.example/users/searcher',
@@ -82,7 +83,7 @@ const emptySearchResult = () => ({
 })
 
 const renderSearchPage = (params = '') => {
-  ;(useRouter as jest.Mock).mockReturnValue({ replace })
+  ;(useRouter as jest.Mock).mockReturnValue({ replace, push })
   ;(useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(params))
 
   return render(
@@ -115,6 +116,7 @@ describe('SearchPageClient', () => {
   beforeEach(() => {
     mockSearch.mockReset()
     replace.mockReset()
+    push.mockReset()
   })
 
   it('initializes from the URL query and renders grouped all results', async () => {
@@ -171,6 +173,25 @@ describe('SearchPageClient', () => {
     expect(screen.queryByText(/posts$/)).not.toBeInTheDocument()
   })
 
+  it('does not coerce empty hashtag history usage into a post count', async () => {
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      hashtags: [
+        {
+          name: 'emptyuses',
+          url: 'https://local.example/tags/emptyuses',
+          history: [{ day: '0', uses: '', accounts: '1' }]
+        }
+      ]
+    })
+
+    renderSearchPage('q=emptyuses&type=hashtags')
+
+    expect(await screen.findByText('#emptyuses')).toBeInTheDocument()
+    expect(screen.queryByText('0 posts')).not.toBeInTheDocument()
+    expect(screen.queryByText(/posts$/)).not.toBeInTheDocument()
+  })
+
   it('renders hashtag counts without Array.prototype.at support', async () => {
     const arrayAt = Array.prototype.at
     Object.defineProperty(Array.prototype, 'at', {
@@ -221,6 +242,18 @@ describe('SearchPageClient', () => {
     expect(screen.getByText('?')).toBeInTheDocument()
   })
 
+  it('renders a full Unicode character for profile avatar initials', async () => {
+    mockSearch.mockResolvedValueOnce({
+      ...emptySearchResult(),
+      accounts: [account('emoji-account', '😀 Runner', 'emoji@remote.example')]
+    })
+
+    renderSearchPage('q=emoji&type=accounts')
+
+    expect(await screen.findByText('😀 Runner')).toBeInTheDocument()
+    expect(screen.getByText('😀')).toBeInTheDocument()
+  })
+
   it('renders profile notes with entity decoding and sanitized markup', async () => {
     mockSearch.mockResolvedValueOnce({
       ...emptySearchResult(),
@@ -251,7 +284,7 @@ describe('SearchPageClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Search' }))
 
     await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith('/search?q=cycling')
+      expect(push).toHaveBeenCalledWith('/search?q=cycling')
     })
     expect(mockSearch).toHaveBeenCalledWith(
       expect.objectContaining({ q: 'cycling' })
@@ -264,6 +297,79 @@ describe('SearchPageClient', () => {
 
     expect(replace).toHaveBeenCalledWith('/search')
     expect(screen.getByText('No search yet')).toBeInTheDocument()
+  })
+
+  it('uses replace when resubmitting the current search query', async () => {
+    mockSearch.mockResolvedValue(emptySearchResult())
+
+    renderSearchPage('q=cycling')
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'cycling' })
+      )
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    expect(replace).toHaveBeenCalledWith('/search?q=cycling')
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('keeps draft input when URL tab state changes without a new query', async () => {
+    let params = new URLSearchParams('q=runner&type=accounts')
+    ;(useRouter as jest.Mock).mockReturnValue({ replace, push })
+    ;(useSearchParams as jest.Mock).mockImplementation(() => params)
+    const initialSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
+    const tabSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
+    mockSearch
+      .mockReturnValueOnce(initialSearch.promise)
+      .mockReturnValueOnce(tabSearch.promise)
+
+    const { rerender } = render(
+      <SearchPageClient
+        host="local.example"
+        currentActor={currentActor}
+        currentTime={1_779_664_800_000}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'runner', type: 'accounts' })
+      )
+    })
+    await act(async () => {
+      initialSearch.resolve(emptySearchResult())
+      await initialSearch.promise
+    })
+
+    const input = screen.getByRole('searchbox', { name: 'Search' })
+    fireEvent.change(input, { target: { value: 'runner draft' } })
+    expect(input).toHaveValue('runner draft')
+
+    params = new URLSearchParams('q=runner&type=statuses')
+    rerender(
+      <SearchPageClient
+        host="local.example"
+        currentActor={currentActor}
+        currentTime={1_779_664_800_000}
+      />
+    )
+
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue(
+      'runner draft'
+    )
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'runner', type: 'statuses' })
+      )
+    })
+    await act(async () => {
+      tabSearch.resolve(emptySearchResult())
+      await tabSearch.promise
+    })
   })
 
   it('loads more results from the selected typed tab offset', async () => {
@@ -501,7 +607,24 @@ describe('SearchPageClient', () => {
 
     renderSearchPage('q=trail')
 
-    expect(await screen.findByText('Search failed')).toBeInTheDocument()
+    const heading = await screen.findByText('Search failed')
+    expect(heading).toBeInTheDocument()
+    expect(heading.closest('div')).toHaveAttribute('aria-live', 'assertive')
+  })
+
+  it('announces searching status politely', async () => {
+    const pendingSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
+    mockSearch.mockReturnValueOnce(pendingSearch.promise)
+
+    renderSearchPage('q=trail')
+
+    const status = await screen.findByText('Searching...')
+    expect(status.closest('div')).toHaveAttribute('aria-live', 'polite')
+
+    await act(async () => {
+      pendingSearch.resolve(emptySearchResult())
+      await pendingSearch.promise
+    })
   })
 
   it('ignores stale responses from earlier searches', async () => {

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -112,6 +112,27 @@ const createDeferred = <T,>() => {
   return { promise, resolve, reject }
 }
 
+const withoutDOMException = async (callback: () => Promise<void>) => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'DOMException')
+  Object.defineProperty(globalThis, 'DOMException', {
+    configurable: true,
+    value: undefined
+  })
+
+  try {
+    await callback()
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, 'DOMException', descriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, 'DOMException')
+    }
+  }
+}
+
+const abortError = () =>
+  Object.assign(new Error('Search aborted'), { name: 'AbortError' })
+
 describe('SearchPageClient', () => {
   beforeEach(() => {
     mockSearch.mockReset()
@@ -655,6 +676,20 @@ describe('SearchPageClient', () => {
     expect(heading.closest('div')).toHaveAttribute('aria-live', 'assertive')
   })
 
+  it('ignores aborted searches when DOMException is unavailable', async () => {
+    await withoutDOMException(async () => {
+      mockSearch.mockRejectedValueOnce(abortError())
+
+      renderSearchPage('q=trail')
+
+      expect(await screen.findByText('Searching...')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByText('Searching...')).not.toBeInTheDocument()
+      })
+      expect(screen.queryByText('Search failed')).not.toBeInTheDocument()
+    })
+  })
+
   it('announces searching status politely', async () => {
     const pendingSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
     mockSearch.mockReturnValueOnce(pendingSearch.promise)
@@ -667,6 +702,32 @@ describe('SearchPageClient', () => {
     await act(async () => {
       pendingSearch.resolve(emptySearchResult())
       await pendingSearch.promise
+    })
+  })
+
+  it('ignores aborted pagination errors when DOMException is unavailable', async () => {
+    await withoutDOMException(async () => {
+      mockSearch
+        .mockResolvedValueOnce({
+          ...emptySearchResult(),
+          accounts: Array.from({ length: 20 }, (_, index) =>
+            account(`account-${index}`, `Runner ${index}`, `runner${index}`)
+          )
+        })
+        .mockRejectedValueOnce(abortError())
+
+      renderSearchPage('q=runner&type=accounts')
+
+      expect(await screen.findByText('Runner 0')).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Load more' })).toBeEnabled()
+      })
+      expect(
+        screen.queryByText('Failed to load more results. Please try again.')
+      ).not.toBeInTheDocument()
+      expect(screen.getByText('Runner 0')).toBeInTheDocument()
     })
   })
 

--- a/app/(timeline)/search/SearchPageClient.test.tsx
+++ b/app/(timeline)/search/SearchPageClient.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+import { search } from '@/lib/client'
+
+import { SearchPageClient } from './SearchPageClient'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn()
+}))
+
+jest.mock('@/lib/client', () => ({
+  search: jest.fn()
+}))
+
+jest.mock('@/lib/components/posts/posts', () => ({
+  Posts: ({ statuses }: { statuses: { id: string }[] }) => (
+    <div data-testid="search-posts">
+      {statuses.map((status) => (
+        <div key={status.id}>{status.id}</div>
+      ))}
+    </div>
+  )
+}))
+
+const mockSearch = search as jest.Mock
+const replace = jest.fn()
+
+const currentActor = {
+  id: 'https://local.example/users/searcher',
+  username: 'searcher',
+  domain: 'local.example',
+  followersUrl: 'https://local.example/users/searcher/followers',
+  inboxUrl: 'https://local.example/users/searcher/inbox',
+  sharedInboxUrl: 'https://local.example/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1
+}
+
+const account = (id: string, displayName: string, acct: string) => ({
+  id,
+  username: acct.split('@')[0],
+  acct,
+  url: `https://remote.example/@${acct}`,
+  display_name: displayName,
+  note: '<p>Trail runner</p>',
+  avatar: '',
+  avatar_static: '',
+  header: '',
+  header_static: '',
+  locked: false,
+  source: {},
+  fields: [],
+  emojis: [],
+  bot: false,
+  group: false,
+  discoverable: true,
+  created_at: '2026-05-25T00:00:00.000Z',
+  last_status_at: null,
+  statuses_count: 12,
+  followers_count: 3,
+  following_count: 4
+})
+
+const emptySearchResult = () => ({
+  accounts: [],
+  statuses: [],
+  hashtags: []
+})
+
+const renderSearchPage = (params = '') => {
+  ;(useRouter as jest.Mock).mockReturnValue({ replace })
+  ;(useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(params))
+
+  return render(
+    <SearchPageClient
+      host="local.example"
+      currentActor={currentActor}
+      currentTime={1_779_664_800_000}
+    />
+  )
+}
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('SearchPageClient', () => {
+  beforeEach(() => {
+    mockSearch.mockReset()
+    replace.mockReset()
+  })
+
+  it('initializes from the URL query and renders grouped all results', async () => {
+    mockSearch.mockResolvedValueOnce({
+      accounts: [
+        account(
+          'https://remote.example/users/alice',
+          'Alice Runner',
+          'alice@remote.example'
+        )
+      ],
+      statuses: [{ id: 'status-1' }],
+      hashtags: [
+        {
+          name: 'trailrunning',
+          url: 'https://local.example/tags/trailrunning',
+          history: [{ day: '0', uses: '7', accounts: '2' }]
+        }
+      ]
+    })
+
+    renderSearchPage('q=trail')
+
+    expect(await screen.findByText('Alice Runner')).toBeInTheDocument()
+    expect(screen.getByText('@alice@remote.example')).toBeInTheDocument()
+    expect(screen.getByText('status-1')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /#trailrunning/i })
+    ).toHaveAttribute('href', '/tags/trailrunning')
+    expect(screen.getByText('7 posts')).toBeInTheDocument()
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: 'trail',
+        limit: 5,
+        resolve: true
+      })
+    )
+  })
+
+  it('submits searches to URL state and clears blank searches', async () => {
+    mockSearch.mockResolvedValueOnce(emptySearchResult())
+
+    renderSearchPage()
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: 'cycling' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/search?q=cycling')
+    })
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'cycling' })
+    )
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: '   ' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    expect(replace).toHaveBeenCalledWith('/search')
+    expect(screen.getByText('No search yet')).toBeInTheDocument()
+  })
+
+  it('loads more results from the selected typed tab offset', async () => {
+    mockSearch
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: [account('account-initial', 'Initial Runner', 'initial')]
+      })
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: Array.from({ length: 20 }, (_, index) =>
+          account(`account-${index}`, `Runner ${index}`, `runner${index}`)
+        )
+      })
+      .mockResolvedValueOnce({
+        ...emptySearchResult(),
+        accounts: [account('account-next', 'Next Runner', 'next')]
+      })
+
+    renderSearchPage('q=runner')
+
+    expect(await screen.findByText('Initial Runner')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Profiles' }))
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          q: 'runner',
+          type: 'accounts',
+          limit: 20,
+          offset: 0
+        })
+      )
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          q: 'runner',
+          type: 'accounts',
+          limit: 20,
+          offset: 20
+        })
+      )
+    })
+    expect(await screen.findByText('Next Runner')).toBeInTheDocument()
+  })
+
+  it('shows an error state when the request fails', async () => {
+    mockSearch.mockRejectedValueOnce(new Error('network failed'))
+
+    renderSearchPage('q=trail')
+
+    expect(await screen.findByText('Search failed')).toBeInTheDocument()
+  })
+
+  it('ignores stale responses from earlier searches', async () => {
+    const firstSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
+    const secondSearch = createDeferred<ReturnType<typeof emptySearchResult>>()
+    mockSearch
+      .mockReturnValueOnce(firstSearch.promise)
+      .mockReturnValueOnce(secondSearch.promise)
+
+    renderSearchPage('q=first')
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1))
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: 'second' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      secondSearch.resolve({
+        ...emptySearchResult(),
+        accounts: [account('second-account', 'Second Result', 'second')]
+      })
+    })
+    expect(await screen.findByText('Second Result')).toBeInTheDocument()
+
+    await act(async () => {
+      firstSearch.resolve({
+        ...emptySearchResult(),
+        accounts: [account('first-account', 'First Result', 'first')]
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('First Result')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -153,6 +153,9 @@ const appendTabResults = (
   return previous
 }
 
+const isAbortError = (err: unknown) =>
+  err instanceof Error && err.name === 'AbortError'
+
 const getAccountUsername = (account: MastodonAccount) =>
   account.username || account.acct?.split('@')[0] || 'unknown'
 
@@ -340,7 +343,7 @@ export const SearchPageClient = ({
       })
       .catch((err) => {
         if (requestIdRef.current !== requestId) return
-        if (err instanceof DOMException && err.name === 'AbortError') return
+        if (isAbortError(err)) return
         setResults(emptySearchResult())
         setError(true)
       })
@@ -428,7 +431,7 @@ export const SearchPageClient = ({
       setHasMore(getTabResults(nextResults, activeTab).length === SEARCH_LIMIT)
     } catch (err) {
       if (requestIdRef.current !== requestId) return
-      if (err instanceof DOMException && err.name === 'AbortError') return
+      if (isAbortError(err)) return
       setError(true)
     } finally {
       if (requestIdRef.current === requestId) {

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -3,7 +3,7 @@
 import { Hash, Search as SearchIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 
 import { SearchResult, SearchType, search as searchClient } from '@/lib/client'
@@ -117,34 +117,49 @@ const appendTabResults = (
   return previous
 }
 
+const getAccountUsername = (account: MastodonAccount) =>
+  account.username || account.acct?.split('@')[0] || 'unknown'
+
+const getAccountLabel = (account: MastodonAccount) =>
+  account.display_name || account.username || account.acct || 'Unknown profile'
+
 const getAccountHandle = (account: MastodonAccount, host: string) => {
-  const acct = account.acct || account.username
-  return acct.includes('@') ? `@${acct}` : `@${account.username}@${host}`
+  const username = getAccountUsername(account)
+  const acct = account.acct || username
+  return acct.includes('@') ? `@${acct}` : `@${username}@${host}`
 }
 
 const getAccountInitial = (account: MastodonAccount) => {
-  const name = account.display_name || account.username
+  const name = account.display_name || account.username || account.acct || ''
   return name.trim()[0]?.toUpperCase() ?? '?'
 }
 
-const getPlainTextFromHtml = (html: string) => {
-  if (!html) return ''
+const stripHtmlTags = (html: string) =>
+  html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const getPlainTextFromHtml = (html: string | null | undefined) => {
+  const safeHtml = html ?? ''
+  if (!safeHtml) return ''
 
   if (typeof document === 'undefined') {
-    return html
-      .replace(/<[^>]+>/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
+    return stripHtmlTags(safeHtml)
   }
 
-  const element = document.createElement('div')
-  element.innerHTML = html
-  return (element.textContent ?? '').replace(/\s+/g, ' ').trim()
+  try {
+    const parser = new DOMParser()
+    const parsed = parser.parseFromString(safeHtml, 'text/html')
+    return (parsed.body.textContent ?? '').replace(/\s+/g, ' ').trim()
+  } catch {
+    return stripHtmlTags(safeHtml)
+  }
 }
 
 const getTagPostCount = (tag: SearchTag) => {
   if (typeof tag.postCount === 'number') return tag.postCount
-  const historyCount = Number(tag.history.at(0)?.uses)
+  const historyCount = Number(tag.history?.at(0)?.uses)
   return Number.isFinite(historyCount) ? historyCount : null
 }
 
@@ -156,7 +171,8 @@ const AccountRow = ({
   host: string
 }) => {
   const handle = getAccountHandle(account, host)
-  const note = getPlainTextFromHtml(account.note)
+  const label = getAccountLabel(account)
+  const note = useMemo(() => getPlainTextFromHtml(account.note), [account.note])
 
   return (
     <Link
@@ -169,9 +185,7 @@ const AccountRow = ({
       </Avatar>
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
-          <p className="truncate text-sm font-medium">
-            {account.display_name || account.username}
-          </p>
+          <p className="truncate text-sm font-medium">{label}</p>
           <p className="truncate text-xs text-muted-foreground">{handle}</p>
         </div>
         {note && (
@@ -255,6 +269,7 @@ export const SearchPageClient = ({
       setResults(emptySearchResult())
       setError(false)
       setIsLoading(false)
+      setIsLoadingMore(false)
       setHasMore(false)
       return
     }
@@ -262,8 +277,10 @@ export const SearchPageClient = ({
     const abortController = new AbortController()
     abortControllerRef.current = abortController
     setIsLoading(true)
+    setIsLoadingMore(false)
     setError(false)
     setHasMore(false)
+    setResults(emptySearchResult())
 
     void searchClient({
       q: query,
@@ -439,11 +456,7 @@ export const SearchPageClient = ({
       <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
         <TabsList className="grid h-auto w-full grid-cols-4 rounded-lg p-1">
           {tabs.map((tab) => (
-            <TabsTrigger
-              key={tab.value}
-              value={tab.value}
-              onClick={() => onTabChange(tab.value)}
-            >
+            <TabsTrigger key={tab.value} value={tab.value}>
               {tab.label}
             </TabsTrigger>
           ))}

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -165,7 +165,7 @@ const getAccountInitial = (account: MastodonAccount) => {
 
 const getTagPostCount = (tag: SearchTag) => {
   if (typeof tag.postCount === 'number') return tag.postCount
-  const historyCount = Number(tag.history?.at(0)?.uses)
+  const historyCount = Number(tag.history?.[0]?.uses)
   return Number.isFinite(historyCount) ? historyCount : null
 }
 
@@ -179,7 +179,7 @@ const AccountRow = ({
   const handle = getAccountHandle(account, host)
   const label = getAccountLabel(account)
   const note = useMemo(
-    () => htmlToPlainText(account.note ?? ''),
+    () => htmlToPlainText(account.note ?? '').trim(),
     [account.note]
   )
 
@@ -481,7 +481,7 @@ export const SearchPageClient = ({
       </Tabs>
 
       <section className="overflow-hidden rounded-lg border bg-background/80 shadow-sm">
-        {error ? (
+        {error && !hasVisibleResults ? (
           <div className="p-8 text-center text-muted-foreground">
             <h2 className="mb-2 text-xl font-semibold">Search failed</h2>
             <p>Try again in a moment.</p>
@@ -504,8 +504,13 @@ export const SearchPageClient = ({
           </div>
         )}
 
-        {activeTab !== 'all' && hasMore && !error && (
+        {activeTab !== 'all' && hasMore && (
           <div className="border-t p-4 text-center">
+            {error && (
+              <p className="mb-2 text-sm text-destructive">
+                Failed to load more results. Please try again.
+              </p>
+            )}
             <Button
               variant="outline"
               disabled={isLoadingMore}

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import {
   ChangeEvent,
   FormEvent,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -277,6 +278,10 @@ export const SearchPageClient = ({
   const submittedQueryRef = useRef(submittedQuery)
   const requestIdRef = useRef(0)
   const abortControllerRef = useRef<AbortController | null>(null)
+  const setSubmittedQueryValue = useCallback((query: string) => {
+    submittedQueryRef.current = query
+    setSubmittedQuery(query)
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -287,19 +292,14 @@ export const SearchPageClient = ({
   }, [])
 
   useEffect(() => {
-    submittedQueryRef.current = submittedQuery
-  }, [submittedQuery])
-
-  useEffect(() => {
     const nextQuery = searchParams.get('q') ?? ''
     const nextTab = getSearchTab(searchParams.get('type'))
     if (submittedQueryRef.current !== nextQuery) {
       setInputValue(nextQuery)
     }
-    setSubmittedQuery(nextQuery)
-    submittedQueryRef.current = nextQuery
+    setSubmittedQueryValue(nextQuery)
     setActiveTab(nextTab)
-  }, [searchParams])
+  }, [searchParams, setSubmittedQueryValue])
 
   useEffect(() => {
     const query = submittedQuery.trim()
@@ -366,8 +366,7 @@ export const SearchPageClient = ({
     const nextTab = query ? activeTab : 'all'
     const previousSubmittedQuery = submittedQueryRef.current
     if (!query) setInputValue('')
-    submittedQueryRef.current = query
-    setSubmittedQuery(query)
+    setSubmittedQueryValue(query)
     setActiveTab(nextTab)
     const nextPath = getSearchPath(query, nextTab)
     if (query && query !== previousSubmittedQuery) {
@@ -385,15 +384,9 @@ export const SearchPageClient = ({
     requestIdRef.current += 1
     abortControllerRef.current?.abort()
     abortControllerRef.current = null
-    submittedQueryRef.current = ''
-    setSubmittedQuery('')
+    setSubmittedQueryValue('')
     setActiveTab('all')
-    setResults(emptySearchResult())
-    setError(false)
-    setIsLoading(false)
-    setIsLoadingMore(false)
-    setHasMore(false)
-    router.replace('/search')
+    if (searchParams.toString()) router.replace('/search')
   }
 
   const onTabChange = (value: string) => {

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -1,0 +1,493 @@
+'use client'
+
+import { Hash, Search as SearchIcon } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+
+import { SearchResult, SearchType, search as searchClient } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
+import { Posts } from '@/lib/components/posts/posts'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import { Tabs, TabsList, TabsTrigger } from '@/lib/components/ui/tabs'
+import { PostLineLimit } from '@/lib/types/database/rows'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import type { Status } from '@/lib/types/domain/status'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+import type { Tag } from '@/lib/types/mastodon/tag'
+import { cn } from '@/lib/utils'
+
+type SearchTab = 'all' | SearchType
+
+interface SearchPageClientProps {
+  host: string
+  currentActor: ActorProfile
+  currentTime: number
+  postLineLimit?: PostLineLimit
+}
+
+type SearchTag = Tag & {
+  postCount?: number
+}
+
+const SEARCH_LIMIT = 20
+const ALL_SEARCH_LIMIT = 5
+
+const tabs: { value: SearchTab; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'accounts', label: 'Profiles' },
+  { value: 'statuses', label: 'Posts' },
+  { value: 'hashtags', label: 'Hashtags' }
+]
+
+const emptySearchResult = (): SearchResult => ({
+  accounts: [],
+  statuses: [],
+  hashtags: []
+})
+
+const getSearchTab = (type: string | null): SearchTab => {
+  if (type === 'accounts' || type === 'statuses' || type === 'hashtags') {
+    return type
+  }
+  return 'all'
+}
+
+const getSearchType = (tab: SearchTab): SearchType | undefined =>
+  tab === 'all' ? undefined : tab
+
+const getSearchLimit = (tab: SearchTab) =>
+  tab === 'all' ? ALL_SEARCH_LIMIT : SEARCH_LIMIT
+
+const getSearchPath = (query: string, tab: SearchTab) => {
+  const trimmedQuery = query.trim()
+  if (!trimmedQuery) return '/search'
+
+  const params = new URLSearchParams({ q: trimmedQuery })
+  const type = getSearchType(tab)
+  if (type) params.set('type', type)
+  return `/search?${params.toString()}`
+}
+
+const hasResults = (results: SearchResult) =>
+  results.accounts.length > 0 ||
+  results.statuses.length > 0 ||
+  results.hashtags.length > 0
+
+const getTabResultCount = (results: SearchResult, tab: SearchTab) => {
+  if (tab === 'accounts') return results.accounts.length
+  if (tab === 'statuses') return results.statuses.length
+  if (tab === 'hashtags') return results.hashtags.length
+  return 0
+}
+
+const getTabResults = (results: SearchResult, tab: SearchTab) => {
+  if (tab === 'accounts') return results.accounts
+  if (tab === 'statuses') return results.statuses
+  if (tab === 'hashtags') return results.hashtags
+  return []
+}
+
+const appendTabResults = (
+  previous: SearchResult,
+  next: SearchResult,
+  tab: SearchTab
+): SearchResult => {
+  if (tab === 'accounts') {
+    return {
+      ...previous,
+      accounts: [...previous.accounts, ...next.accounts]
+    }
+  }
+  if (tab === 'statuses') {
+    return {
+      ...previous,
+      statuses: [...previous.statuses, ...next.statuses]
+    }
+  }
+  if (tab === 'hashtags') {
+    return {
+      ...previous,
+      hashtags: [...previous.hashtags, ...next.hashtags]
+    }
+  }
+  return previous
+}
+
+const getAccountHandle = (account: MastodonAccount, host: string) => {
+  const acct = account.acct || account.username
+  return acct.includes('@') ? `@${acct}` : `@${account.username}@${host}`
+}
+
+const getAccountInitial = (account: MastodonAccount) => {
+  const name = account.display_name || account.username
+  return name.trim()[0]?.toUpperCase() ?? '?'
+}
+
+const getPlainTextFromHtml = (html: string) => {
+  if (!html) return ''
+
+  if (typeof document === 'undefined') {
+    return html
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+
+  const element = document.createElement('div')
+  element.innerHTML = html
+  return (element.textContent ?? '').replace(/\s+/g, ' ').trim()
+}
+
+const getTagPostCount = (tag: SearchTag) => {
+  if (typeof tag.postCount === 'number') return tag.postCount
+  const historyCount = Number(tag.history.at(0)?.uses)
+  return Number.isFinite(historyCount) ? historyCount : null
+}
+
+const AccountRow = ({
+  account,
+  host
+}: {
+  account: MastodonAccount
+  host: string
+}) => {
+  const handle = getAccountHandle(account, host)
+  const note = getPlainTextFromHtml(account.note)
+
+  return (
+    <Link
+      href={`/${handle}`}
+      className="flex min-w-0 items-start gap-3 border-b border-border/60 p-4 transition-colors last:border-b-0 hover:bg-muted/40"
+    >
+      <Avatar className="size-11 shrink-0">
+        {account.avatar && <AvatarImage src={account.avatar} />}
+        <AvatarFallback>{getAccountInitial(account)}</AvatarFallback>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
+          <p className="truncate text-sm font-medium">
+            {account.display_name || account.username}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">{handle}</p>
+        </div>
+        {note && (
+          <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+            {note}
+          </p>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+const HashtagRow = ({ tag }: { tag: SearchTag }) => {
+  const postCount = getTagPostCount(tag)
+
+  return (
+    <Link
+      href={`/tags/${encodeURIComponent(tag.name)}`}
+      className="flex items-center gap-3 border-b border-border/60 p-4 transition-colors last:border-b-0 hover:bg-muted/40"
+    >
+      <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Hash className="size-5" />
+      </span>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium">#{tag.name}</p>
+        {postCount !== null && (
+          <p className="text-xs text-muted-foreground">
+            {postCount} {postCount === 1 ? 'post' : 'posts'}
+          </p>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+const Group = ({ title, children }: { title: string; children: ReactNode }) => (
+  <section className="border-b border-border/60 last:border-b-0">
+    <h2 className="border-b border-border/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      {title}
+    </h2>
+    {children}
+  </section>
+)
+
+export const SearchPageClient = ({
+  host,
+  currentActor,
+  currentTime,
+  postLineLimit
+}: SearchPageClientProps) => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const initialQuery = searchParams.get('q') ?? ''
+  const initialTab = getSearchTab(searchParams.get('type'))
+  const [inputValue, setInputValue] = useState(initialQuery)
+  const [submittedQuery, setSubmittedQuery] = useState(initialQuery)
+  const [activeTab, setActiveTab] = useState<SearchTab>(initialTab)
+  const [results, setResults] = useState<SearchResult>(emptySearchResult)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const requestIdRef = useRef(0)
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    const nextQuery = searchParams.get('q') ?? ''
+    const nextTab = getSearchTab(searchParams.get('type'))
+    setInputValue(nextQuery)
+    setSubmittedQuery(nextQuery)
+    setActiveTab(nextTab)
+  }, [searchParams])
+
+  useEffect(() => {
+    const query = submittedQuery.trim()
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+    abortControllerRef.current?.abort()
+
+    if (!query) {
+      setResults(emptySearchResult())
+      setError(false)
+      setIsLoading(false)
+      setHasMore(false)
+      return
+    }
+
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
+    setIsLoading(true)
+    setError(false)
+    setHasMore(false)
+
+    void searchClient({
+      q: query,
+      type: getSearchType(activeTab),
+      limit: getSearchLimit(activeTab),
+      offset: activeTab === 'all' ? undefined : 0,
+      resolve: true,
+      signal: abortController.signal
+    })
+      .then((nextResults) => {
+        if (requestIdRef.current !== requestId) return
+        setResults(nextResults)
+        setHasMore(
+          activeTab !== 'all' &&
+            getTabResults(nextResults, activeTab).length ===
+              getSearchLimit(activeTab)
+        )
+      })
+      .catch((err) => {
+        if (requestIdRef.current !== requestId) return
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setResults(emptySearchResult())
+        setError(true)
+      })
+      .finally(() => {
+        if (requestIdRef.current !== requestId) return
+        setIsLoading(false)
+        if (abortControllerRef.current === abortController) {
+          abortControllerRef.current = null
+        }
+      })
+
+    return () => {
+      abortController.abort()
+    }
+  }, [activeTab, submittedQuery])
+
+  const submitSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const query = inputValue.trim()
+    const nextTab = query ? activeTab : 'all'
+    setSubmittedQuery(query)
+    setActiveTab(nextTab)
+    router.replace(getSearchPath(query, nextTab))
+  }
+
+  const onTabChange = (value: string) => {
+    const nextTab = getSearchTab(value)
+    setActiveTab(nextTab)
+    router.replace(getSearchPath(submittedQuery, nextTab))
+  }
+
+  const loadMore = async () => {
+    const query = submittedQuery.trim()
+    const type = getSearchType(activeTab)
+    if (!query || !type || isLoadingMore) return
+
+    const requestId = requestIdRef.current + 1
+    requestIdRef.current = requestId
+    abortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
+    setIsLoadingMore(true)
+    setError(false)
+
+    try {
+      const nextResults = await searchClient({
+        q: query,
+        type,
+        limit: SEARCH_LIMIT,
+        offset: getTabResultCount(results, activeTab),
+        resolve: true,
+        signal: abortController.signal
+      })
+      if (requestIdRef.current !== requestId) return
+      setResults((previous) =>
+        appendTabResults(previous, nextResults, activeTab)
+      )
+      setHasMore(getTabResults(nextResults, activeTab).length === SEARCH_LIMIT)
+    } catch (err) {
+      if (requestIdRef.current !== requestId) return
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      setError(true)
+    } finally {
+      if (requestIdRef.current === requestId) {
+        setIsLoadingMore(false)
+        if (abortControllerRef.current === abortController) {
+          abortControllerRef.current = null
+        }
+      }
+    }
+  }
+
+  const renderAccounts = (accounts: MastodonAccount[]) =>
+    accounts.map((account) => (
+      <AccountRow key={account.id} account={account} host={host} />
+    ))
+
+  const renderHashtags = (hashtags: Tag[]) =>
+    hashtags.map((tag) => <HashtagRow key={tag.name} tag={tag} />)
+
+  const renderPosts = (statuses: Status[]) => (
+    <Posts
+      host={host}
+      className="mt-0"
+      currentTime={currentTime}
+      statuses={statuses}
+      currentActor={currentActor}
+      showActions
+      postLineLimit={postLineLimit}
+    />
+  )
+
+  const renderAllResults = () => {
+    if (!hasResults(results)) return null
+
+    return (
+      <>
+        {results.accounts.length > 0 && (
+          <Group title="Profiles">{renderAccounts(results.accounts)}</Group>
+        )}
+        {results.statuses.length > 0 && (
+          <Group title="Posts">{renderPosts(results.statuses)}</Group>
+        )}
+        {results.hashtags.length > 0 && (
+          <Group title="Hashtags">{renderHashtags(results.hashtags)}</Group>
+        )}
+      </>
+    )
+  }
+
+  const renderTypedResults = () => {
+    if (activeTab === 'accounts') return renderAccounts(results.accounts)
+    if (activeTab === 'statuses') return renderPosts(results.statuses)
+    if (activeTab === 'hashtags') return renderHashtags(results.hashtags)
+    return renderAllResults()
+  }
+
+  const hasVisibleResults =
+    activeTab === 'all'
+      ? hasResults(results)
+      : getTabResultCount(results, activeTab) > 0
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Search"
+        description="Find profiles, posts, and tags."
+      />
+
+      <form
+        role="search"
+        aria-label="Search"
+        className="flex gap-2"
+        onSubmit={submitSearch}
+      >
+        <div className="relative min-w-0 flex-1">
+          <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            aria-label="Search"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="Search"
+            className="h-11 pl-9"
+          />
+        </div>
+        <Button type="submit" className="h-11 shrink-0">
+          Search
+        </Button>
+      </form>
+
+      <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
+        <TabsList className="grid h-auto w-full grid-cols-4 rounded-lg p-1">
+          {tabs.map((tab) => (
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              onClick={() => onTabChange(tab.value)}
+            >
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <section className="overflow-hidden rounded-lg border bg-background/80 shadow-sm">
+        {error ? (
+          <div className="p-8 text-center text-muted-foreground">
+            <h2 className="mb-2 text-xl font-semibold">Search failed</h2>
+            <p>Try again in a moment.</p>
+          </div>
+        ) : isLoading ? (
+          <div className="p-8 text-center text-muted-foreground">
+            <p className="text-sm font-medium">Searching...</p>
+          </div>
+        ) : !submittedQuery.trim() ? (
+          <div className="p-8 text-center text-muted-foreground">
+            <h2 className="mb-2 text-xl font-semibold">No search yet</h2>
+            <p>Enter a query to start.</p>
+          </div>
+        ) : hasVisibleResults ? (
+          renderTypedResults()
+        ) : (
+          <div className="p-8 text-center text-muted-foreground">
+            <h2 className="mb-2 text-xl font-semibold">No results found</h2>
+            <p>No matches for "{submittedQuery}".</p>
+          </div>
+        )}
+
+        {activeTab !== 'all' && hasMore && !error && (
+          <div
+            className={cn('border-t p-4 text-center', isLoading && 'hidden')}
+          >
+            <Button
+              variant="outline"
+              disabled={isLoadingMore}
+              onClick={loadMore}
+            >
+              {isLoadingMore ? 'Loading...' : 'Load more'}
+            </Button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -18,7 +18,6 @@ import { ActorProfile } from '@/lib/types/domain/actor'
 import type { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Tag } from '@/lib/types/mastodon/tag'
-import { cn } from '@/lib/utils'
 import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
 type SearchTab = 'all' | SearchType
@@ -92,6 +91,23 @@ const getTabResults = (results: SearchResult, tab: SearchTab) => {
   return []
 }
 
+const appendUniqueBy = <T,>(
+  previous: T[],
+  next: T[],
+  getKey: (item: T) => string
+) => {
+  const seen = new Set(previous.map(getKey))
+  return [
+    ...previous,
+    ...next.filter((item) => {
+      const key = getKey(item)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  ]
+}
+
 const appendTabResults = (
   previous: SearchResult,
   next: SearchResult,
@@ -100,19 +116,31 @@ const appendTabResults = (
   if (tab === 'accounts') {
     return {
       ...previous,
-      accounts: [...previous.accounts, ...next.accounts]
+      accounts: appendUniqueBy(
+        previous.accounts,
+        next.accounts,
+        (account) => account.id
+      )
     }
   }
   if (tab === 'statuses') {
     return {
       ...previous,
-      statuses: [...previous.statuses, ...next.statuses]
+      statuses: appendUniqueBy(
+        previous.statuses,
+        next.statuses,
+        (status) => status.id
+      )
     }
   }
   if (tab === 'hashtags') {
     return {
       ...previous,
-      hashtags: [...previous.hashtags, ...next.hashtags]
+      hashtags: appendUniqueBy(
+        previous.hashtags,
+        next.hashtags,
+        (tag) => tag.name
+      )
     }
   }
   return previous
@@ -477,9 +505,7 @@ export const SearchPageClient = ({
         )}
 
         {activeTab !== 'all' && hasMore && !error && (
-          <div
-            className={cn('border-t p-4 text-center', isLoading && 'hidden')}
-          >
+          <div className="border-t p-4 text-center">
             <Button
               variant="outline"
               disabled={isLoadingMore}

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -19,6 +19,7 @@ import type { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { cn } from '@/lib/utils'
+import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
 type SearchTab = 'all' | SearchType
 
@@ -134,29 +135,6 @@ const getAccountInitial = (account: MastodonAccount) => {
   return name.trim()[0]?.toUpperCase() ?? '?'
 }
 
-const stripHtmlTags = (html: string) =>
-  html
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-
-const getPlainTextFromHtml = (html: string | null | undefined) => {
-  const safeHtml = html ?? ''
-  if (!safeHtml) return ''
-
-  if (typeof document === 'undefined') {
-    return stripHtmlTags(safeHtml)
-  }
-
-  try {
-    const parser = new DOMParser()
-    const parsed = parser.parseFromString(safeHtml, 'text/html')
-    return (parsed.body.textContent ?? '').replace(/\s+/g, ' ').trim()
-  } catch {
-    return stripHtmlTags(safeHtml)
-  }
-}
-
 const getTagPostCount = (tag: SearchTag) => {
   if (typeof tag.postCount === 'number') return tag.postCount
   const historyCount = Number(tag.history?.at(0)?.uses)
@@ -172,7 +150,7 @@ const AccountRow = ({
 }) => {
   const handle = getAccountHandle(account, host)
   const label = getAccountLabel(account)
-  const note = useMemo(() => getPlainTextFromHtml(account.note), [account.note])
+  const note = useMemo(() => htmlToPlainText(account.note), [account.note])
 
   return (
     <Link
@@ -250,6 +228,14 @@ export const SearchPageClient = ({
   const [hasMore, setHasMore] = useState(false)
   const requestIdRef = useRef(0)
   const abortControllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    return () => {
+      requestIdRef.current += 1
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     const nextQuery = searchParams.get('q') ?? ''

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -150,7 +150,10 @@ const AccountRow = ({
 }) => {
   const handle = getAccountHandle(account, host)
   const label = getAccountLabel(account)
-  const note = useMemo(() => htmlToPlainText(account.note), [account.note])
+  const note = useMemo(
+    () => htmlToPlainText(account.note ?? ''),
+    [account.note]
+  )
 
   return (
     <Link

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -160,12 +160,15 @@ const getAccountHandle = (account: MastodonAccount, host: string) => {
 
 const getAccountInitial = (account: MastodonAccount) => {
   const name = account.display_name || account.username || account.acct || ''
-  return name.trim()[0]?.toUpperCase() ?? '?'
+  const trimmed = name.trim()
+  return Array.from(trimmed)[0]?.toUpperCase() ?? '?'
 }
 
 const getTagPostCount = (tag: SearchTag) => {
   if (typeof tag.postCount === 'number') return tag.postCount
-  const historyCount = Number(tag.history?.[0]?.uses)
+  const uses = tag.history?.[0]?.uses
+  if (uses === undefined || uses === null || uses === '') return null
+  const historyCount = Number(uses)
   return Number.isFinite(historyCount) ? historyCount : null
 }
 
@@ -247,16 +250,21 @@ export const SearchPageClient = ({
 }: SearchPageClientProps) => {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const initialQuery = searchParams.get('q') ?? ''
-  const initialTab = getSearchTab(searchParams.get('type'))
-  const [inputValue, setInputValue] = useState(initialQuery)
-  const [submittedQuery, setSubmittedQuery] = useState(initialQuery)
-  const [activeTab, setActiveTab] = useState<SearchTab>(initialTab)
+  const [inputValue, setInputValue] = useState(
+    () => searchParams.get('q') ?? ''
+  )
+  const [submittedQuery, setSubmittedQuery] = useState(
+    () => searchParams.get('q') ?? ''
+  )
+  const [activeTab, setActiveTab] = useState<SearchTab>(() =>
+    getSearchTab(searchParams.get('type'))
+  )
   const [results, setResults] = useState<SearchResult>(emptySearchResult)
   const [isLoading, setIsLoading] = useState(false)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [error, setError] = useState(false)
   const [hasMore, setHasMore] = useState(false)
+  const submittedQueryRef = useRef(submittedQuery)
   const requestIdRef = useRef(0)
   const abortControllerRef = useRef<AbortController | null>(null)
 
@@ -269,10 +277,17 @@ export const SearchPageClient = ({
   }, [])
 
   useEffect(() => {
+    submittedQueryRef.current = submittedQuery
+  }, [submittedQuery])
+
+  useEffect(() => {
     const nextQuery = searchParams.get('q') ?? ''
     const nextTab = getSearchTab(searchParams.get('type'))
-    setInputValue(nextQuery)
+    if (submittedQueryRef.current !== nextQuery) {
+      setInputValue(nextQuery)
+    }
     setSubmittedQuery(nextQuery)
+    submittedQueryRef.current = nextQuery
     setActiveTab(nextTab)
   }, [searchParams])
 
@@ -339,9 +354,17 @@ export const SearchPageClient = ({
     event.preventDefault()
     const query = inputValue.trim()
     const nextTab = query ? activeTab : 'all'
+    const previousSubmittedQuery = submittedQueryRef.current
+    if (!query) setInputValue('')
+    submittedQueryRef.current = query
     setSubmittedQuery(query)
     setActiveTab(nextTab)
-    router.replace(getSearchPath(query, nextTab))
+    const nextPath = getSearchPath(query, nextTab)
+    if (query && query !== previousSubmittedQuery) {
+      router.push(nextPath)
+    } else {
+      router.replace(nextPath)
+    }
   }
 
   const onTabChange = (value: string) => {
@@ -482,12 +505,18 @@ export const SearchPageClient = ({
 
       <section className="overflow-hidden rounded-lg border bg-background/80 shadow-sm">
         {error && !hasVisibleResults ? (
-          <div className="p-8 text-center text-muted-foreground">
+          <div
+            className="p-8 text-center text-muted-foreground"
+            aria-live="assertive"
+          >
             <h2 className="mb-2 text-xl font-semibold">Search failed</h2>
             <p>Try again in a moment.</p>
           </div>
         ) : isLoading ? (
-          <div className="p-8 text-center text-muted-foreground">
+          <div
+            className="p-8 text-center text-muted-foreground"
+            aria-live="polite"
+          >
             <p className="text-sm font-medium">Searching...</p>
           </div>
         ) : !submittedQuery.trim() ? (

--- a/app/(timeline)/search/SearchPageClient.tsx
+++ b/app/(timeline)/search/SearchPageClient.tsx
@@ -3,7 +3,14 @@
 import { Hash, Search as SearchIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { FormEvent, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ChangeEvent,
+  FormEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import type { ReactNode } from 'react'
 
 import { SearchResult, SearchType, search as searchClient } from '@/lib/client'
@@ -367,6 +374,25 @@ export const SearchPageClient = ({
     }
   }
 
+  const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value
+    setInputValue(value)
+    if (value.trim()) return
+
+    requestIdRef.current += 1
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = null
+    submittedQueryRef.current = ''
+    setSubmittedQuery('')
+    setActiveTab('all')
+    setResults(emptySearchResult())
+    setError(false)
+    setIsLoading(false)
+    setIsLoadingMore(false)
+    setHasMore(false)
+    router.replace('/search')
+  }
+
   const onTabChange = (value: string) => {
     const nextTab = getSearchTab(value)
     setActiveTab(nextTab)
@@ -483,7 +509,7 @@ export const SearchPageClient = ({
             type="search"
             aria-label="Search"
             value={inputValue}
-            onChange={(event) => setInputValue(event.target.value)}
+            onChange={onInputChange}
             placeholder="Search"
             className="h-11 pl-9"
           />

--- a/app/(timeline)/search/page.tsx
+++ b/app/(timeline)/search/page.tsx
@@ -1,0 +1,51 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+
+import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorProfile } from '@/lib/types/domain/actor'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { SearchPageClient } from './SearchPageClient'
+
+export const dynamic = 'force-dynamic'
+export const metadata: Metadata = {
+  title: 'Activities.next: Search'
+}
+
+const Page = async () => {
+  const { host } = getConfig()
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor) {
+    return redirect('/auth/signin')
+  }
+
+  const settings = await database.getActorSettings({ actorId: actor.id })
+
+  return (
+    <Suspense
+      fallback={
+        <div className="p-8 text-center text-muted-foreground">
+          <p className="text-sm font-medium">Loading search...</p>
+        </div>
+      }
+    >
+      <SearchPageClient
+        host={host}
+        currentActor={getActorProfile(actor)}
+        currentTime={Date.now()}
+        postLineLimit={settings?.postLineLimit}
+      />
+    </Suspense>
+  )
+}
+
+export default Page

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -522,11 +522,7 @@ describe('GET /api/v2/search', () => {
 
     expect(response.status).toBe(200)
     expect(mockCanActorReadStatus).not.toHaveBeenCalled()
-    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
-      expect.any(Object),
-      [],
-      oauthActor.id
-    )
+    expect(mockGetMastodonStatuses).not.toHaveBeenCalled()
     expect(data.statuses).toEqual([])
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -628,6 +624,23 @@ describe('GET /api/v2/search', () => {
       ],
       oauthActor.id
     )
+  })
+
+  it('skips Mastodon status hydration when no domain statuses are found', async () => {
+    mockSearchStatusIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&type=statuses', {
+        headers: { Authorization: 'Bearer read-search-token' }
+      }),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.statuses).toEqual([])
+    expect(mockGetStatusesByIds).not.toHaveBeenCalled()
+    expect(mockGetMastodonStatuses).not.toHaveBeenCalled()
   })
 
   it('resolves account URLs only on the first page and preserves hydration order', async () => {

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -975,6 +975,28 @@ describe('GET /api/v2/search', () => {
     ])
   })
 
+  it('returns domain statuses when activities_next format is requested', async () => {
+    const domainStatus = {
+      id: 'https://remote.test/users/alice/statuses/domain',
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockSearchStatusIds.mockResolvedValue([domainStatus.id])
+    mockGetStatusesByIds.mockResolvedValue([domainStatus])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&type=statuses&format=activities_next',
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.statuses).toEqual([domainStatus])
+    expect(mockGetMastodonStatuses).not.toHaveBeenCalled()
+  })
+
   it('rejects invalid search parameters', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v2/search?q=trail&limit=100'),

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -1010,6 +1010,37 @@ describe('GET /api/v2/search', () => {
     expect(mockGetMastodonStatuses).not.toHaveBeenCalled()
   })
 
+  it('ignores unknown format values and returns default Mastodon statuses', async () => {
+    const domainStatus = {
+      id: 'https://remote.test/users/alice/statuses/mastodon',
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockSearchStatusIds.mockResolvedValue([domainStatus.id])
+    mockGetStatusesByIds.mockResolvedValue([domainStatus])
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v2/search?q=trail&type=statuses&format=mastodon',
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.statuses).toEqual([
+      {
+        id: domainStatus.id,
+        content: domainStatus.id
+      }
+    ])
+    expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+      expect.any(Object),
+      [domainStatus],
+      oauthActor.id
+    )
+  })
+
   it('rejects invalid search parameters', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v2/search?q=trail&limit=100'),

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -60,6 +60,8 @@ const BooleanParam = z.string().transform((value) => {
 const SearchParams = z.object({
   q: z.string(),
   type: SearchTypeParam.optional(),
+  // The app search UI still consumes Mastodon-shaped accounts and hashtags;
+  // this format flag only keeps statuses in the app's domain shape.
   format: z.enum(['activities_next']).optional(),
   resolve: BooleanParam.optional(),
   following: BooleanParam.optional(),

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -474,6 +474,11 @@ const searchStatuses = async ({
   )
     .filter((id) => normalizeLookupId(id) !== resolvedStatusId)
     .slice(0, resolvedStatus ? indexedLimit - 1 : indexedLimit)
+
+  if (ids.length === 0) {
+    return resolvedStatus ? [resolvedStatus] : []
+  }
+
   const statuses = await database.getStatusesByIds({
     statusIds: ids,
     currentActorId: currentActor.id,
@@ -578,11 +583,13 @@ export const GET = traceApiRoute(
       const statuses =
         params.format === 'activities_next'
           ? domainStatuses
-          : await getMastodonStatuses(
-              database,
-              domainStatuses,
-              currentActor?.id
-            )
+          : domainStatuses.length === 0
+            ? []
+            : await getMastodonStatuses(
+                database,
+                domainStatuses,
+                currentActor?.id
+              )
 
       return apiResponse({
         req,

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -60,6 +60,7 @@ const BooleanParam = z.string().transform((value) => {
 const SearchParams = z.object({
   q: z.string(),
   type: SearchTypeParam.optional(),
+  format: z.enum(['activities_next']).optional(),
   resolve: BooleanParam.optional(),
   following: BooleanParam.optional(),
   exclude_unreviewed: BooleanParam.optional(),
@@ -482,13 +483,9 @@ const searchStatuses = async ({
     statuses,
     ids
   })
-  return getMastodonStatuses(
-    database,
-    [resolvedStatus, ...orderedStatuses]
-      .filter((status): status is Status => Boolean(status))
-      .slice(0, limit),
-    currentActor.id
-  )
+  return [resolvedStatus, ...orderedStatuses]
+    .filter((status): status is Status => Boolean(status))
+    .slice(0, limit)
 }
 
 const requiresAuthentication = ({ params }: { params: ParsedSearchParams }) => {
@@ -547,7 +544,7 @@ export const GET = traceApiRoute(
       const includeStatuses =
         Boolean(currentActor) && (!params.type || params.type === 'statuses')
 
-      const [accounts, hashtags, statuses] = await Promise.all([
+      const [accounts, hashtags, domainStatuses] = await Promise.all([
         includeAccounts
           ? searchAccounts({
               database,
@@ -578,6 +575,14 @@ export const GET = traceApiRoute(
             })
           : []
       ])
+      const statuses =
+        params.format === 'activities_next'
+          ? domainStatuses
+          : await getMastodonStatuses(
+              database,
+              domainStatuses,
+              currentActor?.id
+            )
 
       return apiResponse({
         req,

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -57,12 +57,18 @@ const BooleanParam = z.string().transform((value) => {
   return true
 })
 
+const SearchFormatParam = z
+  .string()
+  .transform((value): 'activities_next' | undefined =>
+    value === 'activities_next' ? value : undefined
+  )
+
 const SearchParams = z.object({
   q: z.string(),
   type: SearchTypeParam.optional(),
   // The app search UI still consumes Mastodon-shaped accounts and hashtags;
   // this format flag only keeps statuses in the app's domain shape.
-  format: z.enum(['activities_next']).optional(),
+  format: SearchFormatParam.optional(),
   resolve: BooleanParam.optional(),
   following: BooleanParam.optional(),
   exclude_unreviewed: BooleanParam.optional(),

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -471,6 +471,15 @@ describe('client search', () => {
       'Search request failed (502): Bad gateway'
     )
   })
+
+  it('truncates long raw response text from failed search requests', async () => {
+    const longResponseText = 'x'.repeat(250)
+    fetchMock.mockResponseOnce(longResponseText, { status: 502 })
+
+    await expect(search({ q: 'trail' })).rejects.toThrow(
+      `Search request failed (502): ${'x'.repeat(200)}...`
+    )
+  })
 })
 
 describe('fitness route heatmap client calls', () => {

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -480,6 +480,16 @@ describe('client search', () => {
       `Search request failed (502): ${'x'.repeat(200)}...`
     )
   })
+
+  it('truncates long JSON messages from failed search requests', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ message: 'x'.repeat(250) }), {
+      status: 502
+    })
+
+    await expect(search({ q: 'trail' })).rejects.toThrow(
+      `Search request failed (502): ${'x'.repeat(200)}...`
+    )
+  })
 })
 
 describe('fitness route heatmap client calls', () => {

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -454,16 +454,22 @@ describe('client search', () => {
     })
   })
 
-  it('returns an empty result when the search request is rejected', async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ status: 'Unauthorized' }), {
+  it('throws a detailed error when the search request is rejected', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ message: 'Unauthorized' }), {
       status: 401
     })
 
-    await expect(search({ q: 'trail' })).resolves.toEqual({
-      accounts: [],
-      statuses: [],
-      hashtags: []
-    })
+    await expect(search({ q: 'trail' })).rejects.toThrow(
+      'Search request failed (401): Unauthorized'
+    )
+  })
+
+  it('throws raw response text when the search error response is not JSON', async () => {
+    fetchMock.mockResponseOnce('Bad gateway', { status: 502 })
+
+    await expect(search({ q: 'trail' })).rejects.toThrow(
+      'Search request failed (502): Bad gateway'
+    )
   })
 })
 

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -397,15 +397,6 @@ describe('client bookmark helpers', () => {
 describe('client search', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
-    Object.defineProperty(globalThis, 'window', {
-      configurable: true,
-      value: {
-        origin: 'https://local.example'
-      }
-    })
-  })
-
-  afterEach(() => {
     Reflect.deleteProperty(globalThis, 'window')
   })
 
@@ -436,10 +427,14 @@ describe('client search', () => {
     })
 
     const [url, init] = fetchMock.mock.calls[0]
-    const parsedUrl = new URL(url as string)
-    expect(parsedUrl.toString()).toBe(
-      'https://local.example/api/v2/search?q=trail+run&type=statuses&limit=10&offset=20&resolve=true&format=activities_next'
-    )
+    const parsedUrl = new URL(url as string, 'https://local.example')
+    expect(parsedUrl.pathname).toBe('/api/v2/search')
+    expect(parsedUrl.searchParams.get('q')).toBe('trail run')
+    expect(parsedUrl.searchParams.get('type')).toBe('statuses')
+    expect(parsedUrl.searchParams.get('limit')).toBe('10')
+    expect(parsedUrl.searchParams.get('offset')).toBe('20')
+    expect(parsedUrl.searchParams.get('resolve')).toBe('true')
+    expect(parsedUrl.searchParams.get('format')).toBe('activities_next')
     expect(init).toEqual(
       expect.objectContaining({
         method: 'GET',
@@ -447,6 +442,16 @@ describe('client search', () => {
         signal: abortController.signal
       })
     )
+  })
+
+  it('returns an empty result when the search response is not JSON', async () => {
+    fetchMock.mockResponseOnce('<html>bad gateway</html>', { status: 200 })
+
+    await expect(search({ q: 'trail' })).resolves.toEqual({
+      accounts: [],
+      statuses: [],
+      hashtags: []
+    })
   })
 
   it('returns an empty result when the search request is rejected', async () => {

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -13,6 +13,7 @@ import {
   getBookmarks,
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmaps,
+  search,
   startStravaArchiveImport,
   triggerFitnessRouteHeatmap,
   undoBookmarkStatus,
@@ -390,6 +391,74 @@ describe('client bookmark helpers', () => {
         headers: { Accept: 'application/json' }
       })
     )
+  })
+})
+
+describe('client search', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        origin: 'https://local.example'
+      }
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window')
+  })
+
+  it('builds the v2 search URL with typed filters and forwards abort signals', async () => {
+    const abortController = new AbortController()
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        accounts: [],
+        statuses: [{ id: 'status-1' }],
+        hashtags: []
+      }),
+      { status: 200 }
+    )
+
+    await expect(
+      search({
+        q: 'trail run',
+        type: 'statuses',
+        limit: 10,
+        offset: 20,
+        resolve: true,
+        signal: abortController.signal
+      })
+    ).resolves.toEqual({
+      accounts: [],
+      statuses: [{ id: 'status-1' }],
+      hashtags: []
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    const parsedUrl = new URL(url as string)
+    expect(parsedUrl.toString()).toBe(
+      'https://local.example/api/v2/search?q=trail+run&type=statuses&limit=10&offset=20&resolve=true&format=activities_next'
+    )
+    expect(init).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: abortController.signal
+      })
+    )
+  })
+
+  it('returns an empty result when the search request is rejected', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ status: 'Unauthorized' }), {
+      status: 401
+    })
+
+    await expect(search({ q: 'trail' })).resolves.toEqual({
+      accounts: [],
+      statuses: [],
+      hashtags: []
+    })
   })
 })
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1987,21 +1987,27 @@ export const search = async ({
   resolve = true,
   signal
 }: SearchParams): Promise<SearchResult> => {
-  const url = new URL(`${window.origin}/api/v2/search`)
-  url.searchParams.set('q', q)
-  if (type) url.searchParams.set('type', type)
-  if (limit !== undefined) url.searchParams.set('limit', `${limit}`)
-  if (offset !== undefined) url.searchParams.set('offset', `${offset}`)
-  url.searchParams.set('resolve', resolve ? 'true' : 'false')
-  url.searchParams.set('format', 'activities_next')
+  const params = new URLSearchParams({
+    q,
+    resolve: resolve ? 'true' : 'false',
+    format: 'activities_next'
+  })
+  if (type) params.set('type', type)
+  if (limit !== undefined) params.set('limit', `${limit}`)
+  if (offset !== undefined) params.set('offset', `${offset}`)
 
-  const response = await fetch(url.toString(), {
+  const response = await fetch(`/api/v2/search?${params.toString()}`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
     signal
   })
   if (!response.ok) return emptySearchResult()
-  return (await response.json()) as SearchResult
+  const text = await response.text()
+  try {
+    return JSON.parse(text) as SearchResult
+  } catch {
+    return emptySearchResult()
+  }
 }
 
 export const searchAccounts = async ({

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1979,6 +1979,13 @@ const emptySearchResult = (): SearchResult => ({
   hashtags: []
 })
 
+const MAX_SEARCH_ERROR_DETAIL_LENGTH = 200
+
+const truncateSearchErrorDetail = (detail: string) =>
+  detail.length > MAX_SEARCH_ERROR_DETAIL_LENGTH
+    ? `${detail.slice(0, MAX_SEARCH_ERROR_DETAIL_LENGTH)}...`
+    : detail
+
 const getSearchResponseErrorMessage = (response: Response, text: string) => {
   let detail = text || response.statusText
 
@@ -1993,7 +2000,7 @@ const getSearchResponseErrorMessage = (response: Response, text: string) => {
             ? data.status
             : detail
   } catch {
-    // Keep the raw response text for non-JSON failures.
+    detail = truncateSearchErrorDetail(detail)
   }
 
   return `Search request failed (${response.status})${detail ? `: ${detail}` : ''}`

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -12,6 +12,7 @@ import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
+import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getMediaWidthAndHeight } from '@/lib/utils/getMediaWidthAndHeight'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
@@ -1953,6 +1954,54 @@ export const hideConversation = async ({
     headers: { Accept: 'application/json' }
   })
   return response.ok
+}
+
+export type SearchType = 'accounts' | 'statuses' | 'hashtags'
+
+export interface SearchResult<TStatus = Status> {
+  accounts: MastodonAccount[]
+  statuses: TStatus[]
+  hashtags: Tag[]
+}
+
+export interface SearchParams {
+  q: string
+  type?: SearchType
+  limit?: number
+  offset?: number
+  resolve?: boolean
+  signal?: AbortSignal
+}
+
+const emptySearchResult = (): SearchResult => ({
+  accounts: [],
+  statuses: [],
+  hashtags: []
+})
+
+export const search = async ({
+  q,
+  type,
+  limit,
+  offset,
+  resolve = true,
+  signal
+}: SearchParams): Promise<SearchResult> => {
+  const url = new URL(`${window.origin}/api/v2/search`)
+  url.searchParams.set('q', q)
+  if (type) url.searchParams.set('type', type)
+  if (limit !== undefined) url.searchParams.set('limit', `${limit}`)
+  if (offset !== undefined) url.searchParams.set('offset', `${offset}`)
+  url.searchParams.set('resolve', resolve ? 'true' : 'false')
+  url.searchParams.set('format', 'activities_next')
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal
+  })
+  if (!response.ok) return emptySearchResult()
+  return (await response.json()) as SearchResult
 }
 
 export const searchAccounts = async ({

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2000,9 +2000,10 @@ const getSearchResponseErrorMessage = (response: Response, text: string) => {
             ? data.status
             : detail
   } catch {
-    detail = truncateSearchErrorDetail(detail)
+    // Keep the raw response text for non-JSON failures.
   }
 
+  detail = truncateSearchErrorDetail(detail)
   return `Search request failed (${response.status})${detail ? `: ${detail}` : ''}`
 }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1979,6 +1979,26 @@ const emptySearchResult = (): SearchResult => ({
   hashtags: []
 })
 
+const getSearchResponseErrorMessage = (response: Response, text: string) => {
+  let detail = text || response.statusText
+
+  try {
+    const data = JSON.parse(text) as Record<string, unknown>
+    detail =
+      typeof data.message === 'string'
+        ? data.message
+        : typeof data.error === 'string'
+          ? data.error
+          : typeof data.status === 'string'
+            ? data.status
+            : detail
+  } catch {
+    // Keep the raw response text for non-JSON failures.
+  }
+
+  return `Search request failed (${response.status})${detail ? `: ${detail}` : ''}`
+}
+
 export const search = async ({
   q,
   type,
@@ -2001,8 +2021,10 @@ export const search = async ({
     headers: { Accept: 'application/json' },
     signal
   })
-  if (!response.ok) return emptySearchResult()
   const text = await response.text()
+  if (!response.ok) {
+    throw new Error(getSearchResponseErrorMessage(response, text))
+  }
   try {
     return JSON.parse(text) as SearchResult
   } catch {

--- a/lib/components/layout/mobile-nav.test.tsx
+++ b/lib/components/layout/mobile-nav.test.tsx
@@ -23,18 +23,21 @@ describe('MobileNav', () => {
     expect(
       within(nav).getByRole('link', { name: /timeline/i })
     ).toHaveAttribute('href', '/')
+    expect(within(nav).getByRole('link', { name: /search/i })).toHaveAttribute(
+      'href',
+      '/search'
+    )
     expect(
       within(nav).getByRole('link', { name: /messages/i })
     ).toHaveAttribute('href', '/messages')
     expect(
-      within(nav).getByRole('link', { name: /bookmarks/i })
-    ).toHaveAttribute('href', '/bookmarks')
-    expect(within(nav).getByRole('link', { name: /fitness/i })).toHaveAttribute(
-      'href',
-      '/@llun@llun.test/fitness'
-    )
+      within(nav).getByRole('link', { name: /notifications/i })
+    ).toHaveAttribute('href', '/notifications')
     expect(
-      within(nav).queryByRole('link', { name: /notifications/i })
+      within(nav).queryByRole('link', { name: /bookmarks/i })
+    ).not.toBeInTheDocument()
+    expect(
+      within(nav).queryByRole('link', { name: /fitness/i })
     ).not.toBeInTheDocument()
     expect(
       within(nav).queryByRole('link', { name: /admin/i })
@@ -49,8 +52,12 @@ describe('MobileNav', () => {
     )
 
     expect(
-      await screen.findByRole('menuitem', { name: /notifications/i })
-    ).toHaveAttribute('href', '/notifications')
+      await screen.findByRole('menuitem', { name: /bookmarks/i })
+    ).toHaveAttribute('href', '/bookmarks')
+    expect(screen.getByRole('menuitem', { name: /fitness/i })).toHaveAttribute(
+      'href',
+      '/@llun@llun.test/fitness'
+    )
     expect(screen.getByRole('menuitem', { name: /admin/i })).toHaveAttribute(
       'href',
       '/admin'

--- a/lib/components/layout/mobile-nav.tsx
+++ b/lib/components/layout/mobile-nav.tsx
@@ -20,6 +20,8 @@ interface MobileNavProps {
   isAdmin?: boolean
 }
 
+const mobileDirectHrefs = ['/', '/search', '/messages', '/notifications']
+
 export function MobileNav({
   unreadCount = 0,
   fitnessUrl,
@@ -28,8 +30,15 @@ export function MobileNav({
   const pathname = usePathname()
   const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
   const hasOverflow = allNavItems.length > 5
-  const directNavItems = hasOverflow ? allNavItems.slice(0, 4) : allNavItems
-  const overflowNavItems = hasOverflow ? allNavItems.slice(4) : []
+  const directNavItems = hasOverflow
+    ? mobileDirectHrefs.flatMap((href) => {
+        const item = allNavItems.find((navItem) => navItem.href === href)
+        return item ? [item] : []
+      })
+    : allNavItems
+  const overflowNavItems = hasOverflow
+    ? allNavItems.filter((item) => !directNavItems.includes(item))
+    : []
   const isItemActive = (href: string) =>
     pathname === href || pathname.startsWith(href + '/')
   const isOverflowActive = overflowNavItems.some((item) =>

--- a/lib/components/layout/nav-items.test.ts
+++ b/lib/components/layout/nav-items.test.ts
@@ -7,6 +7,7 @@ describe('buildNavItems', () => {
   it('places bookmarks before notifications in the base navigation', () => {
     expect(itemHrefs({})).toEqual([
       '/',
+      '/search',
       '/messages',
       '/bookmarks',
       '/notifications',
@@ -17,6 +18,7 @@ describe('buildNavItems', () => {
   it('anchors fitness before notifications', () => {
     expect(itemHrefs({ fitnessUrl: '/@llun@llun.test/fitness' })).toEqual([
       '/',
+      '/search',
       '/messages',
       '/bookmarks',
       '/@llun@llun.test/fitness',
@@ -28,6 +30,7 @@ describe('buildNavItems', () => {
   it('anchors admin before settings', () => {
     expect(itemHrefs({ isAdmin: true })).toEqual([
       '/',
+      '/search',
       '/messages',
       '/bookmarks',
       '/notifications',
@@ -41,6 +44,7 @@ describe('buildNavItems', () => {
       itemHrefs({ fitnessUrl: '/@llun@llun.test/fitness', isAdmin: true })
     ).toEqual([
       '/',
+      '/search',
       '/messages',
       '/bookmarks',
       '/@llun@llun.test/fitness',

--- a/lib/components/layout/nav-items.ts
+++ b/lib/components/layout/nav-items.ts
@@ -4,6 +4,7 @@ import {
   Bookmark,
   Home,
   Mail,
+  Search,
   Settings,
   Shield
 } from 'lucide-react'
@@ -17,6 +18,7 @@ export interface NavItem {
 
 const baseNavItems: NavItem[] = [
   { href: '/', label: 'Timeline', icon: Home },
+  { href: '/search', label: 'Search', icon: Search },
   { href: '/messages', label: 'Messages', icon: Mail },
   { href: '/bookmarks', label: 'Bookmarks', icon: Bookmark },
   { href: '/notifications', label: 'Notifications', icon: Bell },

--- a/lib/components/layout/sidebar.test.tsx
+++ b/lib/components/layout/sidebar.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { usePathname, useRouter } from 'next/navigation'
+
+import { Sidebar } from '@/lib/components/layout/sidebar'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useRouter: jest.fn()
+}))
+
+describe('Sidebar', () => {
+  const push = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(usePathname as jest.Mock).mockReturnValue('/')
+    ;(useRouter as jest.Mock).mockReturnValue({ push })
+  })
+
+  it('routes desktop search submissions to the search page', () => {
+    render(
+      <Sidebar
+        user={{
+          name: 'Llun',
+          username: 'llun',
+          handle: '@llun@activities.local'
+        }}
+      />
+    )
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search' }), {
+      target: { value: 'trail running' }
+    })
+    fireEvent.submit(screen.getByRole('search', { name: 'Search' }))
+
+    expect(push).toHaveBeenCalledWith('/search?q=trail+running')
+  })
+})

--- a/lib/components/layout/sidebar.test.tsx
+++ b/lib/components/layout/sidebar.test.tsx
@@ -3,13 +3,14 @@
  */
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 import { Sidebar } from '@/lib/components/layout/sidebar'
 
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
-  useRouter: jest.fn()
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn()
 }))
 
 describe('Sidebar', () => {
@@ -19,6 +20,7 @@ describe('Sidebar', () => {
     jest.clearAllMocks()
     ;(usePathname as jest.Mock).mockReturnValue('/')
     ;(useRouter as jest.Mock).mockReturnValue({ push })
+    ;(useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams())
   })
 
   it('routes desktop search submissions to the search page', () => {
@@ -38,5 +40,61 @@ describe('Sidebar', () => {
     fireEvent.submit(screen.getByRole('search', { name: 'Search' }))
 
     expect(push).toHaveBeenCalledWith('/search?q=trail+running')
+  })
+
+  it('hydrates the desktop search input from the current search URL', () => {
+    ;(usePathname as jest.Mock).mockReturnValue('/search')
+    ;(useSearchParams as jest.Mock).mockReturnValue(
+      new URLSearchParams('q=trail')
+    )
+
+    render(
+      <Sidebar
+        user={{
+          name: 'Llun',
+          username: 'llun',
+          handle: '@llun@activities.local'
+        }}
+      />
+    )
+
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue(
+      'trail'
+    )
+  })
+
+  it('clears the desktop search input when the URL is not a search page', () => {
+    let pathname = '/search'
+    let params = new URLSearchParams('q=trail')
+    ;(usePathname as jest.Mock).mockImplementation(() => pathname)
+    ;(useSearchParams as jest.Mock).mockImplementation(() => params)
+
+    const { rerender } = render(
+      <Sidebar
+        user={{
+          name: 'Llun',
+          username: 'llun',
+          handle: '@llun@activities.local'
+        }}
+      />
+    )
+
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue(
+      'trail'
+    )
+
+    pathname = '/notifications'
+    params = new URLSearchParams()
+    rerender(
+      <Sidebar
+        user={{
+          name: 'Llun',
+          username: 'llun',
+          handle: '@llun@activities.local'
+        }}
+      />
+    )
+
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('')
   })
 })

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -2,8 +2,8 @@
 
 import { Search as SearchIcon } from 'lucide-react'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
-import { FormEvent, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { FormEvent, useEffect, useState } from 'react'
 
 import {
   ActorInfo,
@@ -48,8 +48,15 @@ export function Sidebar({
 }: SidebarProps) {
   const pathname = usePathname()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
-  const [searchQuery, setSearchQuery] = useState('')
+  const currentSearchQuery =
+    pathname === '/search' ? (searchParams.get('q') ?? '') : ''
+  const [searchQuery, setSearchQuery] = useState(() => currentSearchQuery)
+
+  useEffect(() => {
+    setSearchQuery(currentSearchQuery)
+  }, [currentSearchQuery])
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { Search as SearchIcon } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { FormEvent, useEffect, useState } from 'react'
+import { FormEvent, Suspense, useEffect, useState } from 'react'
 
 import {
   ActorInfo,
@@ -38,18 +38,27 @@ interface SidebarProps {
   isAdmin?: boolean
 }
 
-export function Sidebar({
-  user,
-  currentActor,
-  actors = [],
-  unreadCount = 0,
-  fitnessUrl,
-  isAdmin = false
-}: SidebarProps) {
+function SidebarSearchFallback() {
+  return (
+    <form role="search" aria-label="Search" className="px-3 pb-3">
+      <div className="relative">
+        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          aria-label="Search"
+          placeholder="Search"
+          className="h-10 rounded-lg pl-9"
+          disabled
+        />
+      </div>
+    </form>
+  )
+}
+
+function SidebarSearch() {
   const pathname = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
   const currentSearchQuery =
     pathname === '/search' ? (searchParams.get('q') ?? '') : ''
   const [searchQuery, setSearchQuery] = useState(() => currentSearchQuery)
@@ -57,11 +66,6 @@ export function Sidebar({
   useEffect(() => {
     setSearchQuery(currentSearchQuery)
   }, [currentSearchQuery])
-
-  const getAvatarInitial = (username: string) => {
-    if (!username) return '?'
-    return username[0].toUpperCase()
-  }
 
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -76,6 +80,44 @@ export function Sidebar({
   }
 
   return (
+    <form
+      role="search"
+      aria-label="Search"
+      className="px-3 pb-3"
+      onSubmit={submitSearch}
+    >
+      <div className="relative">
+        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          aria-label="Search"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="Search"
+          className="h-10 rounded-lg pl-9"
+        />
+      </div>
+    </form>
+  )
+}
+
+export function Sidebar({
+  user,
+  currentActor,
+  actors = [],
+  unreadCount = 0,
+  fitnessUrl,
+  isAdmin = false
+}: SidebarProps) {
+  const pathname = usePathname()
+  const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
+
+  const getAvatarInitial = (username: string) => {
+    if (!username) return '?'
+    return username[0].toUpperCase()
+  }
+
+  return (
     <TooltipProvider delayDuration={0}>
       {/* Full sidebar - Desktop */}
       <aside className="fixed left-0 top-0 z-40 h-screen w-[280px] border-r bg-background/90 backdrop-blur hidden xl:flex flex-col">
@@ -83,24 +125,9 @@ export function Sidebar({
           <Logo size="md" />
         </div>
 
-        <form
-          role="search"
-          aria-label="Search"
-          className="px-3 pb-3"
-          onSubmit={submitSearch}
-        >
-          <div className="relative">
-            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              type="search"
-              aria-label="Search"
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search"
-              className="h-10 rounded-lg pl-9"
-            />
-          </div>
-        </form>
+        <Suspense fallback={<SidebarSearchFallback />}>
+          <SidebarSearch />
+        </Suspense>
 
         <nav className="flex-1 px-3">
           <ul className="space-y-1">

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { Search as SearchIcon } from 'lucide-react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
+import { FormEvent, useState } from 'react'
 
 import {
   ActorInfo,
@@ -11,6 +13,8 @@ import { Logo } from '@/lib/components/layout/logo'
 import { buildNavItems } from '@/lib/components/layout/nav-items'
 import { NotificationBadge } from '@/lib/components/notification-badge/NotificationBadge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
 import {
   Tooltip,
   TooltipContent,
@@ -44,11 +48,25 @@ export function Sidebar({
   isAdmin = false
 }: SidebarProps) {
   const pathname = usePathname()
+  const router = useRouter()
   const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
+  const [searchQuery, setSearchQuery] = useState('')
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'
     return username[0].toUpperCase()
+  }
+
+  const submitSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const query = searchQuery.trim()
+    if (!query) {
+      router.push('/search')
+      return
+    }
+
+    const params = new URLSearchParams({ q: query })
+    router.push(`/search?${params.toString()}`)
   }
 
   return (
@@ -58,6 +76,34 @@ export function Sidebar({
         <div className="p-6">
           <Logo size="md" />
         </div>
+
+        <form
+          role="search"
+          aria-label="Search"
+          className="px-3 pb-3"
+          onSubmit={submitSearch}
+        >
+          <div className="relative">
+            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              aria-label="Search"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search"
+              className="h-10 rounded-lg pl-9 pr-10"
+            />
+            <Button
+              type="submit"
+              variant="ghost"
+              size="icon"
+              aria-label="Search"
+              className="absolute right-1 top-1/2 size-8 -translate-y-1/2"
+            >
+              <SearchIcon className="size-4" />
+            </Button>
+          </div>
+        </form>
 
         <nav className="flex-1 px-3">
           <ul className="space-y-1">

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -13,7 +13,6 @@ import { Logo } from '@/lib/components/layout/logo'
 import { buildNavItems } from '@/lib/components/layout/nav-items'
 import { NotificationBadge } from '@/lib/components/notification-badge/NotificationBadge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
-import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import {
   Tooltip,
@@ -91,17 +90,8 @@ export function Sidebar({
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Search"
-              className="h-10 rounded-lg pl-9 pr-10"
+              className="h-10 rounded-lg pl-9"
             />
-            <Button
-              type="submit"
-              variant="ghost"
-              size="icon"
-              aria-label="Search"
-              className="absolute right-1 top-1/2 size-8 -translate-y-1/2"
-            >
-              <SearchIcon className="size-4" />
-            </Button>
           </div>
         </form>
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,8 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: process.env.BUILD_STANDALONE ? 'standalone' : undefined,
   assetPrefix: '/activities',
+  allowedDevOrigins:
+    process.env.NODE_ENV === 'development' ? ['activities.local'] : undefined,
   serverExternalPackages: [
     '@aws-sdk/client-lambda',
     '@aws-sdk/client-s3',


### PR DESCRIPTION
## Summary

Adds a Mastodon-style authenticated `/search` experience backed by `/api/v2/search`.

- Adds `format=activities_next` support so app UI can reuse domain `Status` objects while preserving Mastodon-shaped default API responses.
- Adds `search(...)` to the client, a URL-backed `/search` page with All/Profiles/Posts/Hashtags tabs, typed pagination, loading/empty/error states, and stale request handling.
- Adds global search entry points in desktop sidebar and mobile/nav, keeping Search and Notifications directly accessible on mobile.
- Allows `activities.local` as a Next dev origin only in development so the local Traefik/dev setup hydrates correctly without changing production/test config.

## Screenshots

Screenshots from `https://activities.local` with the existing local account.

### Desktop: All Results

![Desktop search all results](https://gist.githubusercontent.com/llun/28548a0de07c831fb0610d655a15f31a/raw/search-all-desktop.png)

### Desktop: Posts Tab

![Desktop search posts tab](https://gist.githubusercontent.com/llun/28548a0de07c831fb0610d655a15f31a/raw/search-posts-desktop.png)

### Mobile: Search Navigation

![Mobile search UI](https://gist.githubusercontent.com/llun/28548a0de07c831fb0610d655a15f31a/raw/search-mobile.png)

## Validation

- `yarn run prettier --write .`
- `yarn lint` (passes with 11 pre-existing `no-explicit-any` warnings in auth/fitness files)
- `yarn build`
- `yarn test` (329 suites, 2795 tests)
- Rebuilt local search index with `yarn search:reindex` against the local Postgres dev DB.
- Browser-verified `https://activities.local/search` with the existing `llun@activities.local` account:
  - All tab renders grouped profiles and posts.
  - Profiles tab updates URL/type and renders account rows.
  - Posts tab renders statuses and Load more appends the next page.
  - Hashtags tab handles the local empty hashtag index.
  - Desktop sidebar search routes to `/search?q=...`.
  - Mobile nav keeps Timeline/Search/Messages/Notifications direct and moves overflow into More.
  - Authenticated browser fetches to `/api/v2/search?format=activities_next` returned expected accounts/statuses/hashtags shapes.
  - Review-fix browser check confirmed new-query Back navigation, tab-change draft preservation, sidebar URL hydration, and sidebar clearing off `/search`.
  - Compatibility browser fetch confirmed `format=mastodon` falls back to Mastodon-shaped status results instead of 400.
  - Clear-input browser check confirmed clearing the field immediately resets to `/search`, removes stale posts, and stops the searching state.
  - Abort-error regression tests cover environments without global `DOMException` for initial search and pagination.
  - Review follow-up tests cover long JSON error message truncation and sidebar/search-page regressions.







