### PR TITLE
Bump version to v1.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.24.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.23.0`
- Base main SHA: `bf3f53792154a0ff4cc579cb89b8c773c391d2ab`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
