### PR TITLE
minor: add counter-backed instance activity API

### DIFF
--- a/app/api/v1/instance/activity/route.test.ts
+++ b/app/api/v1/instance/activity/route.test.ts
@@ -37,6 +37,7 @@ describe('GET /api/v1/instance/activity', () => {
       }
     ])
     expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('public, max-age=3600')
     expect(getInstanceActivity).toHaveBeenCalledTimes(1)
   })
 

--- a/app/api/v1/instance/activity/route.test.ts
+++ b/app/api/v1/instance/activity/route.test.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockGetDatabase = jest.fn()
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockGetDatabase()
+}))
+
+describe('GET /api/v1/instance/activity', () => {
+  beforeEach(() => {
+    mockGetDatabase.mockReset()
+  })
+
+  it('returns Mastodon-shaped weekly activity from the database service', async () => {
+    const getInstanceActivity = jest.fn().mockResolvedValue([
+      {
+        week: '1765756800',
+        statuses: '12',
+        logins: '4',
+        registrations: '2'
+      }
+    ])
+    mockGetDatabase.mockReturnValue({ getInstanceActivity })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/activity'),
+      { params: Promise.resolve({}) }
+    )
+
+    await expect(response.json()).resolves.toEqual([
+      {
+        week: '1765756800',
+        statuses: '12',
+        logins: '4',
+        registrations: '2'
+      }
+    ])
+    expect(response.status).toBe(200)
+    expect(getInstanceActivity).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a JSON 500 when the database is unavailable', async () => {
+    mockGetDatabase.mockReturnValue(null)
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/activity'),
+      { params: Promise.resolve({}) }
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      status: 'Internal Server Error'
+    })
+    expect(response.status).toBe(500)
+  })
+})

--- a/app/api/v1/instance/activity/route.test.ts
+++ b/app/api/v1/instance/activity/route.test.ts
@@ -54,4 +54,22 @@ describe('GET /api/v1/instance/activity', () => {
     })
     expect(response.status).toBe(500)
   })
+
+  it('returns a JSON 500 when the activity query fails', async () => {
+    const getInstanceActivity = jest
+      .fn()
+      .mockRejectedValue(new Error('query failed'))
+    mockGetDatabase.mockReturnValue({ getInstanceActivity })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/activity'),
+      { params: Promise.resolve({}) }
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      status: 'Internal Server Error'
+    })
+    expect(response.status).toBe(500)
+    expect(getInstanceActivity).toHaveBeenCalledTimes(1)
+  })
 })

--- a/app/api/v1/instance/activity/route.ts
+++ b/app/api/v1/instance/activity/route.ts
@@ -28,6 +28,7 @@ export const GET = traceApiRoute('getInstanceActivity', async (req) => {
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
-    data
+    data,
+    additionalHeaders: [['Cache-Control', 'public, max-age=3600']]
   })
 })

--- a/app/api/v1/instance/activity/route.ts
+++ b/app/api/v1/instance/activity/route.ts
@@ -1,5 +1,11 @@
+import { getDatabase } from '@/lib/database'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_500,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
@@ -7,9 +13,21 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute('getInstanceActivity', async (req) => {
+  const database = getDatabase()
+  if (!database) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_500,
+      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+    })
+  }
+
+  const data = await database.getInstanceActivity()
+
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
-    data: []
+    data
   })
 })

--- a/app/api/v1/instance/activity/route.ts
+++ b/app/api/v1/instance/activity/route.ts
@@ -23,7 +23,17 @@ export const GET = traceApiRoute('getInstanceActivity', async (req) => {
     })
   }
 
-  const data = await database.getInstanceActivity()
+  let data
+  try {
+    data = await database.getInstanceActivity()
+  } catch {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_500,
+      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+    })
+  }
 
   return apiResponse({
     req,

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -471,25 +471,66 @@ describe('AccountDatabase', () => {
           })
 
           const markerRows = await knexDatabase('counters')
-            .where('id', 'like', `unique-login:%:${accountId}`)
+            .where('id', `unique-login:${accountId}`)
             .orderBy('id', 'asc')
-            .select('id')
+            .select('id', 'value')
 
           expect(await getLoginTotal()).toBe(2)
           expect(markerRows).toEqual([
             {
-              id: `unique-login:${Math.floor(
-                Date.UTC(2026, 0, 5) / 1000
-              )}:${accountId}`
-            },
-            {
-              id: `unique-login:${Math.floor(
-                Date.UTC(2026, 0, 12) / 1000
-              )}:${accountId}`
+              id: `unique-login:${accountId}`,
+              value: Math.floor(Date.UTC(2026, 0, 12) / 1000)
             }
           ])
         } finally {
           jest.useRealTimers()
+          await knexDatabase.destroy()
+        }
+      })
+
+      it('creates account sessions when login counter recording fails', async () => {
+        const knexDatabase = knex({
+          client: 'better-sqlite3',
+          useNullAsDefault: true,
+          connection: {
+            filename: ':memory:'
+          }
+        })
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+        const errorSpy = jest
+          .spyOn(console, 'error')
+          .mockImplementation(() => undefined)
+
+        try {
+          await sqlDatabase.migrate()
+
+          const accountId = await sqlDatabase.createAccount({
+            email: `login-failure-${crypto.randomUUID()}@${TEST_DOMAIN}`,
+            username: `login-failure-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-login-failure-key',
+            publicKey: 'public-login-failure-key'
+          })
+
+          await knexDatabase.schema.dropTable('counters')
+
+          await expect(
+            sqlDatabase.createAccountSession({
+              accountId,
+              token: 'login-counter-failure',
+              expireAt: Date.now() + 60_000
+            })
+          ).resolves.toBeUndefined()
+
+          const session = await knexDatabase('sessions')
+            .where('token', 'login-counter-failure')
+            .first()
+
+          expect(session).toMatchObject({ accountId })
+        } finally {
+          await new Promise((resolve) => setImmediate(resolve))
+          errorSpy.mockRestore()
           await knexDatabase.destroy()
         }
       })

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { DatabaseSeed } from '@/lib/stub/scenarios/database'
+import { logger } from '@/lib/utils/logger'
 import { urlToId } from '@/lib/utils/urlToId'
 
 describe('AccountDatabase', () => {
@@ -498,7 +499,7 @@ describe('AccountDatabase', () => {
         })
         const sqlDatabase = getSQLDatabase(knexDatabase)
         const errorSpy = jest
-          .spyOn(console, 'error')
+          .spyOn(logger, 'error')
           .mockImplementation(() => undefined)
 
         try {

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -1,5 +1,7 @@
 import crypto from 'crypto'
+import knex from 'knex'
 
+import { getSQLDatabase } from '@/lib/database/sql'
 import {
   TestDatabaseTable,
   databaseBeforeAll,
@@ -415,6 +417,81 @@ describe('AccountDatabase', () => {
         await database.deleteAccountSession({ token })
         const deleted = await database.getAccountSession({ token })
         expect(deleted).toBeNull()
+      })
+
+      it('records login counters once per account per UTC week', async () => {
+        const knexDatabase = knex({
+          client: 'better-sqlite3',
+          useNullAsDefault: true,
+          connection: {
+            filename: ':memory:'
+          }
+        })
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        const getLoginTotal = async () => {
+          const row = await knexDatabase('counters')
+            .where('id', 'like', 'bucket:logins:%')
+            .sum<{ total: number | string | null }>('value as total')
+            .first()
+          return Number(row?.total ?? 0)
+        }
+
+        try {
+          await sqlDatabase.migrate()
+
+          jest.useFakeTimers()
+          jest.setSystemTime(new Date('2026-01-08T10:00:00.000Z'))
+
+          const accountId = await sqlDatabase.createAccount({
+            email: `login-${crypto.randomUUID()}@${TEST_DOMAIN}`,
+            username: `login-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-login-key',
+            publicKey: 'public-login-key'
+          })
+
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token: 'login-week-one-a',
+            expireAt: Date.now() + 60_000
+          })
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token: 'login-week-one-b',
+            expireAt: Date.now() + 120_000
+          })
+
+          jest.setSystemTime(new Date('2026-01-13T10:00:00.000Z'))
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token: 'login-week-two',
+            expireAt: Date.now() + 60_000
+          })
+
+          const markerRows = await knexDatabase('counters')
+            .where('id', 'like', `unique-login:%:${accountId}`)
+            .orderBy('id', 'asc')
+            .select('id')
+
+          expect(await getLoginTotal()).toBe(2)
+          expect(markerRows).toEqual([
+            {
+              id: `unique-login:${Math.floor(
+                Date.UTC(2026, 0, 5) / 1000
+              )}:${accountId}`
+            },
+            {
+              id: `unique-login:${Math.floor(
+                Date.UTC(2026, 0, 12) / 1000
+              )}:${accountId}`
+            }
+          ])
+        } finally {
+          jest.useRealTimers()
+          await knexDatabase.destroy()
+        }
       })
     })
   })

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex'
 
-import { recordWeeklyLogin } from '@/lib/database/sql/instanceActivity'
+import { recordWeeklyLoginSafely } from '@/lib/database/sql/instanceActivity'
 import { indexActorSearchDocument } from '@/lib/database/sql/search'
 import {
   CounterKey,
@@ -267,8 +267,8 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         createdAt: currentTime,
         updatedAt: currentTime
       })
-      await recordWeeklyLogin(trx, accountId, currentTime)
     })
+    await recordWeeklyLoginSafely(database, accountId, currentTime)
   },
 
   async getAccountSession({ token }: GetAccountSessionParams): Promise<{

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -255,18 +255,16 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
   }: CreateAccountSessionParams): Promise<void> {
     const currentTime = new Date()
 
-    await database.transaction(async (trx) => {
-      await trx('sessions').insert({
-        id: crypto.randomUUID(),
-        accountId,
-        token,
-        actorId: actorId ?? null,
+    await database('sessions').insert({
+      id: crypto.randomUUID(),
+      accountId,
+      token,
+      actorId: actorId ?? null,
 
-        expireAt: new Date(expireAt),
+      expireAt: new Date(expireAt),
 
-        createdAt: currentTime,
-        updatedAt: currentTime
-      })
+      createdAt: currentTime,
+      updatedAt: currentTime
     })
     await recordWeeklyLoginSafely(database, accountId, currentTime)
   },

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex'
 
+import { recordWeeklyLogin } from '@/lib/database/sql/instanceActivity'
 import { indexActorSearchDocument } from '@/lib/database/sql/search'
 import {
   CounterKey,
@@ -254,16 +255,19 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
   }: CreateAccountSessionParams): Promise<void> {
     const currentTime = new Date()
 
-    await database('sessions').insert({
-      id: crypto.randomUUID(),
-      accountId,
-      token,
-      actorId: actorId ?? null,
+    await database.transaction(async (trx) => {
+      await trx('sessions').insert({
+        id: crypto.randomUUID(),
+        accountId,
+        token,
+        actorId: actorId ?? null,
 
-      expireAt: new Date(expireAt),
+        expireAt: new Date(expireAt),
 
-      createdAt: currentTime,
-      updatedAt: currentTime
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      await recordWeeklyLogin(trx, accountId, currentTime)
     })
   },
 

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -10,6 +10,7 @@ import { FitnessFileSQLDatabaseMixin } from '@/lib/database/sql/fitnessFile'
 import { FitnessRouteHeatmapSQLDatabaseMixin } from '@/lib/database/sql/fitnessRouteHeatmap'
 import { FitnessSettingsSQLDatabaseMixin } from '@/lib/database/sql/fitnessSettings'
 import { FollowerSQLDatabaseMixin } from '@/lib/database/sql/follow'
+import { InstanceActivitySQLDatabaseMixin } from '@/lib/database/sql/instanceActivity'
 import { LikeSQLDatabaseMixin } from '@/lib/database/sql/like'
 import { MediaSQLDatabaseMixin } from '@/lib/database/sql/media'
 import { NotificationSQLDatabaseMixin } from '@/lib/database/sql/notification'
@@ -32,6 +33,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const bookmarkDatabase = BookmarkSQLDatabaseMixin(database)
   const blockDatabase = BlockSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
+  const instanceActivityDatabase = InstanceActivitySQLDatabaseMixin(database)
   const likeDatabase = LikeSQLDatabaseMixin(database)
   const mediaDatabase = MediaSQLDatabaseMixin(database)
   const notificationDatabase = NotificationSQLDatabaseMixin(database)
@@ -68,6 +70,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...fitnessFileDatabase,
     ...fitnessRouteHeatmapDatabase,
     ...fitnessSettingsDatabase,
+    ...instanceActivityDatabase,
     ...bookmarkDatabase,
     ...blockDatabase,
     ...followerDatabase,

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -2,8 +2,10 @@ import knex, { Knex } from 'knex'
 
 import {
   getInstanceActivityFromCounters,
-  recordWeeklyLogin
+  recordWeeklyLogin,
+  recordWeeklyLoginSafely
 } from '@/lib/database/sql/instanceActivity'
+import { logger } from '@/lib/utils/logger'
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -204,5 +206,67 @@ describe('instance activity counters', () => {
     expect(loginRows.reduce((total, row) => total + Number(row.value), 0)).toBe(
       2
     )
+  })
+
+  it('leaves weekly login markers retryable when bucket increments fail', async () => {
+    const currentTime = new Date('2026-02-04T10:00:00.000Z')
+
+    await database.raw(`
+      CREATE TRIGGER fail_login_bucket_update
+      BEFORE UPDATE OF value ON counters
+      WHEN NEW.id LIKE 'bucket:logins:%'
+      BEGIN
+        SELECT RAISE(ABORT, 'bucket failure');
+      END;
+    `)
+
+    try {
+      await recordWeeklyLogin(database, 'account-retry', currentTime)
+    } catch (error) {
+      expect(String(error)).toContain('bucket failure')
+    }
+
+    await database.raw('DROP TRIGGER fail_login_bucket_update')
+    await recordWeeklyLogin(database, 'account-retry', currentTime)
+
+    const marker = await database('counters')
+      .where('id', 'unique-login:account-retry')
+      .first('id', 'value')
+    const loginRows = await database('counters')
+      .where('id', 'like', 'bucket:logins:%')
+      .select('value')
+
+    expect(marker).toEqual({
+      id: 'unique-login:account-retry',
+      value: Math.floor(Date.UTC(2026, 1, 2) / 1000)
+    })
+    expect(loginRows.reduce((total, row) => total + Number(row.value), 0)).toBe(
+      1
+    )
+  })
+
+  it('logs weekly login recording failures with structured logger metadata', async () => {
+    const loggerErrorSpy = jest
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      await database.schema.dropTable('counters')
+      await recordWeeklyLoginSafely(
+        database,
+        'account-log-error',
+        new Date('2026-02-04T10:00:00.000Z')
+      )
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({ code: 'SQLITE_ERROR' }),
+          accountId: 'account-log-error'
+        }),
+        'Failed to record weekly login'
+      )
+    } finally {
+      loggerErrorSpy.mockRestore()
+    }
   })
 })

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -152,9 +152,10 @@ describe('instance activity counters', () => {
     }
   })
 
-  it('filters bucket rows by date range in the database query', async () => {
-    const queries: string[] = []
-    const onQuery = (query: { sql: string }) => queries.push(query.sql)
+  it('filters bucket rows by sortable counter id range in the database query', async () => {
+    const queries: { sql: string; bindings?: unknown[] }[] = []
+    const onQuery = (query: { sql: string; bindings?: unknown[] }) =>
+      queries.push(query)
     database.on('query', onQuery)
 
     try {
@@ -166,11 +167,23 @@ describe('instance activity counters', () => {
     }
 
     const countersQuery = queries.find((query) =>
-      query.includes('from `counters`')
+      query.sql.includes('from `counters`')
     )
 
-    expect(countersQuery).toContain('`bucketHour` >= ?')
-    expect(countersQuery).toContain('`bucketHour` < ?')
+    expect(countersQuery?.sql).toContain('`id` >= ?')
+    expect(countersQuery?.sql).toContain('`id` < ?')
+    expect(countersQuery?.sql).not.toContain('`bucketHour` >= ?')
+    expect(countersQuery?.sql).not.toContain('`bucketHour` < ?')
+    expect(countersQuery?.bindings).toEqual(
+      expect.arrayContaining([
+        'bucket:local-statuses:2026030900',
+        'bucket:local-statuses:2026060100',
+        'bucket:logins:2026030900',
+        'bucket:logins:2026060100',
+        'bucket:accounts:2026030900',
+        'bucket:accounts:2026060100'
+      ])
+    )
   })
 
   it('stores one weekly login marker per account', async () => {

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -146,4 +146,25 @@ describe('instance activity counters', () => {
       }
     }
   })
+
+  it('filters bucket rows by date range in the database query', async () => {
+    const queries: string[] = []
+    const onQuery = (query: { sql: string }) => queries.push(query.sql)
+    database.on('query', onQuery)
+
+    try {
+      await getInstanceActivityFromCounters(database, {
+        now: new Date('2026-05-26T12:00:00.000Z')
+      })
+    } finally {
+      database.off('query', onQuery)
+    }
+
+    const countersQuery = queries.find((query) =>
+      query.includes('from `counters`')
+    )
+
+    expect(countersQuery).toContain('`bucketHour` >= ?')
+    expect(countersQuery).toContain('`bucketHour` < ?')
+  })
 })

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -1,0 +1,115 @@
+import knex, { Knex } from 'knex'
+
+import { getInstanceActivityFromCounters } from '@/lib/database/sql/instanceActivity'
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+const toUnixSeconds = (date: Date) => Math.floor(date.getTime() / 1000)
+
+describe('instance activity counters', () => {
+  let database: Knex
+
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+
+    await database.schema.createTable('counters', (table) => {
+      table.string('id').primary()
+      table.integer('value').defaultTo(0)
+      table.timestamp('bucketHour', { useTz: true }).nullable()
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+  })
+
+  afterEach(async () => {
+    await database.destroy()
+  })
+
+  const insertBucket = async ({
+    type,
+    hour,
+    value
+  }: {
+    type: string
+    hour: Date
+    value: number
+  }) => {
+    const y = hour.getUTCFullYear()
+    const mo = String(hour.getUTCMonth() + 1).padStart(2, '0')
+    const d = String(hour.getUTCDate()).padStart(2, '0')
+    const h = String(hour.getUTCHours()).padStart(2, '0')
+    const hourKey = `${y}${mo}${d}${h}`
+
+    await database('counters').insert({
+      id: `bucket:${type}:${hourKey}`,
+      value,
+      bucketHour: hour,
+      createdAt: hour,
+      updatedAt: hour
+    })
+  }
+
+  it('returns 12 newest-first UTC weeks using only counter buckets', async () => {
+    const now = new Date('2026-05-26T12:00:00.000Z')
+    const newestWeekStart = new Date('2026-05-25T00:00:00.000Z')
+    const previousWeekStart = new Date(newestWeekStart.getTime() - WEEK_MS)
+    const twoWeeksAgoStart = new Date(newestWeekStart.getTime() - 2 * WEEK_MS)
+
+    await insertBucket({
+      type: 'local-statuses',
+      hour: new Date('2026-05-25T01:00:00.000Z'),
+      value: 3
+    })
+    await insertBucket({
+      type: 'accounts',
+      hour: new Date('2026-05-19T08:00:00.000Z'),
+      value: 2
+    })
+    await insertBucket({
+      type: 'logins',
+      hour: new Date('2026-05-11T12:00:00.000Z'),
+      value: 4
+    })
+    await insertBucket({
+      type: 'statuses',
+      hour: new Date('2026-05-25T02:00:00.000Z'),
+      value: 999
+    })
+
+    const activity = await getInstanceActivityFromCounters(database, { now })
+
+    expect(activity).toHaveLength(12)
+    expect(activity.slice(0, 3)).toEqual([
+      {
+        week: String(toUnixSeconds(newestWeekStart)),
+        statuses: '3',
+        logins: '0',
+        registrations: '0'
+      },
+      {
+        week: String(toUnixSeconds(previousWeekStart)),
+        statuses: '0',
+        logins: '0',
+        registrations: '2'
+      },
+      {
+        week: String(toUnixSeconds(twoWeeksAgoStart)),
+        statuses: '0',
+        logins: '4',
+        registrations: '0'
+      }
+    ])
+    expect(activity[11]).toEqual({
+      week: String(
+        toUnixSeconds(new Date(newestWeekStart.getTime() - 11 * WEEK_MS))
+      ),
+      statuses: '0',
+      logins: '0',
+      registrations: '0'
+    })
+  })
+})

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -112,4 +112,38 @@ describe('instance activity counters', () => {
       registrations: '0'
     })
   })
+
+  it('groups SQLite timestamp strings without timezone as UTC', async () => {
+    const originalTimeZone = process.env.TZ
+    process.env.TZ = 'Europe/Amsterdam'
+
+    try {
+      await database('counters').insert({
+        id: 'bucket:local-statuses:2026052500',
+        value: 1,
+        bucketHour: '2026-05-25 00:30:00.000',
+        createdAt: '2026-05-25 00:30:00.000',
+        updatedAt: '2026-05-25 00:30:00.000'
+      })
+
+      const activity = await getInstanceActivityFromCounters(database, {
+        now: new Date('2026-05-26T12:00:00.000Z')
+      })
+
+      expect(activity[0]).toMatchObject({
+        week: String(toUnixSeconds(new Date('2026-05-25T00:00:00.000Z'))),
+        statuses: '1'
+      })
+      expect(activity[1]).toMatchObject({
+        week: String(toUnixSeconds(new Date('2026-05-18T00:00:00.000Z'))),
+        statuses: '0'
+      })
+    } finally {
+      if (originalTimeZone === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTimeZone
+      }
+    }
+  })
 })

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -1,6 +1,9 @@
 import knex, { Knex } from 'knex'
 
-import { getInstanceActivityFromCounters } from '@/lib/database/sql/instanceActivity'
+import {
+  getInstanceActivityFromCounters,
+  recordWeeklyLogin
+} from '@/lib/database/sql/instanceActivity'
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -166,5 +169,40 @@ describe('instance activity counters', () => {
 
     expect(countersQuery).toContain('`bucketHour` >= ?')
     expect(countersQuery).toContain('`bucketHour` < ?')
+  })
+
+  it('stores one weekly login marker per account', async () => {
+    await recordWeeklyLogin(
+      database,
+      'account-login',
+      new Date('2026-01-08T10:00:00.000Z')
+    )
+    await recordWeeklyLogin(
+      database,
+      'account-login',
+      new Date('2026-01-09T10:00:00.000Z')
+    )
+    await recordWeeklyLogin(
+      database,
+      'account-login',
+      new Date('2026-01-13T10:00:00.000Z')
+    )
+
+    const markerRows = await database('counters')
+      .where('id', 'like', 'unique-login:%')
+      .select('id', 'value')
+    const loginRows = await database('counters')
+      .where('id', 'like', 'bucket:logins:%')
+      .select('value')
+
+    expect(markerRows).toEqual([
+      {
+        id: 'unique-login:account-login',
+        value: Math.floor(Date.UTC(2026, 0, 12) / 1000)
+      }
+    ])
+    expect(loginRows.reduce((total, row) => total + Number(row.value), 0)).toBe(
+      2
+    )
   })
 })

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -169,10 +169,8 @@ export const getInstanceActivityFromCounters = async (
   }))
 }
 
-export const getWeeklyLoginMarkerId = (
-  accountId: string,
-  currentTime = new Date()
-): string => `unique-login:${getWeekKey(currentTime)}:${accountId}`
+export const getWeeklyLoginMarkerId = (accountId: string): string =>
+  `unique-login:${accountId}`
 
 export const recordWeeklyLogin = async (
   database: SQLDatabase,
@@ -181,7 +179,8 @@ export const recordWeeklyLogin = async (
 ): Promise<void> => {
   if (!accountId) return
 
-  const markerId = getWeeklyLoginMarkerId(accountId, currentTime)
+  const markerId = getWeeklyLoginMarkerId(accountId)
+  const weekKey = Number(getWeekKey(currentTime))
 
   await database('counters')
     .insert({
@@ -196,14 +195,28 @@ export const recordWeeklyLogin = async (
 
   const marked = await database('counters')
     .where('id', markerId)
-    .andWhere('value', 0)
+    .andWhere((builder) => {
+      builder.whereNull('value').orWhere('value', '<', weekKey)
+    })
     .update({
-      value: 1,
+      value: weekKey,
       updatedAt: currentTime
     })
 
   if (marked > 0) {
     await incrementBucket(database, 'logins', 1, currentTime)
+  }
+}
+
+export const recordWeeklyLoginSafely = async (
+  database: SQLDatabase,
+  accountId: string | null | undefined,
+  currentTime = new Date()
+): Promise<void> => {
+  try {
+    await recordWeeklyLogin(database, accountId, currentTime)
+  } catch (error) {
+    console.error('Failed to record weekly login', error)
   }
 }
 

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -8,6 +8,7 @@ import {
   InstanceActivityDatabase,
   InstanceActivityWeek
 } from '@/lib/types/database/operations'
+import { logger } from '@/lib/utils/logger'
 
 type SQLDatabase = Knex | Knex.Transaction
 
@@ -30,6 +31,9 @@ const COUNTER_TYPES: Record<string, ActivityCounterKey> = {
 const COUNTER_TYPE_ENTRIES = Object.entries(COUNTER_TYPES)
 
 const SQLITE_CLIENTS = new Set(['better-sqlite3', 'sqlite3'])
+
+const isTransaction = (database: SQLDatabase): database is Knex.Transaction =>
+  Boolean((database as { isTransaction?: boolean }).isTransaction)
 
 export const getUTCWeekStart = (date: Date): Date => {
   const day = date.getUTCDay()
@@ -173,13 +177,11 @@ export const getInstanceActivityFromCounters = async (
 export const getWeeklyLoginMarkerId = (accountId: string): string =>
   `unique-login:${accountId}`
 
-export const recordWeeklyLogin = async (
+const recordWeeklyLoginWithinTransaction = async (
   database: SQLDatabase,
-  accountId: string | null | undefined,
-  currentTime = new Date()
+  accountId: string,
+  currentTime: Date
 ): Promise<void> => {
-  if (!accountId) return
-
   const markerId = getWeeklyLoginMarkerId(accountId)
   const weekKey = Number(getWeekKey(currentTime))
 
@@ -209,6 +211,23 @@ export const recordWeeklyLogin = async (
   }
 }
 
+export const recordWeeklyLogin = async (
+  database: SQLDatabase,
+  accountId: string | null | undefined,
+  currentTime = new Date()
+): Promise<void> => {
+  if (!accountId) return
+
+  if (isTransaction(database)) {
+    await recordWeeklyLoginWithinTransaction(database, accountId, currentTime)
+    return
+  }
+
+  await database.transaction(async (trx) => {
+    await recordWeeklyLoginWithinTransaction(trx, accountId, currentTime)
+  })
+}
+
 export const recordWeeklyLoginSafely = async (
   database: SQLDatabase,
   accountId: string | null | undefined,
@@ -217,7 +236,14 @@ export const recordWeeklyLoginSafely = async (
   try {
     await recordWeeklyLogin(database, accountId, currentTime)
   } catch (error) {
-    console.error('Failed to record weekly login', error)
+    logger.error(
+      {
+        err: error,
+        accountId,
+        currentTime: currentTime.toISOString()
+      },
+      'Failed to record weekly login'
+    )
   }
 }
 

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -28,6 +28,8 @@ const COUNTER_TYPES: Record<string, ActivityCounterKey> = {
   'bucket:accounts:': 'registrations'
 }
 
+const SQLITE_CLIENTS = new Set(['better-sqlite3', 'sqlite3'])
+
 export const getUTCWeekStart = (date: Date): Date => {
   const day = date.getUTCDay()
   const daysSinceMonday = (day + 6) % 7
@@ -52,6 +54,58 @@ const getBucketCounterType = (id: string): ActivityCounterKey | null => {
   return null
 }
 
+const isSQLiteClient = (database: Knex): boolean =>
+  SQLITE_CLIENTS.has(String(database.client.config.client))
+
+const formatUTCTimestamp = (date: Date, separator: ' ' | 'T'): string => {
+  const y = date.getUTCFullYear()
+  const mo = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  const h = String(date.getUTCHours()).padStart(2, '0')
+  const mi = String(date.getUTCMinutes()).padStart(2, '0')
+  const s = String(date.getUTCSeconds()).padStart(2, '0')
+  const ms = String(date.getUTCMilliseconds()).padStart(3, '0')
+
+  return `${y}-${mo}-${d}${separator}${h}:${mi}:${s}.${ms}`
+}
+
+const addBucketHourRangeFilter = (
+  query: Knex.QueryBuilder<CounterRow, CounterRow[]>,
+  database: Knex,
+  start: Date,
+  end: Date
+): Knex.QueryBuilder<CounterRow, CounterRow[]> => {
+  if (!isSQLiteClient(database)) {
+    return query
+      .andWhere('bucketHour', '>=', start)
+      .andWhere('bucketHour', '<', end)
+  }
+
+  return query.andWhere((builder) => {
+    builder
+      .where((range) => {
+        range
+          .where('bucketHour', '>=', start.getTime())
+          .andWhere('bucketHour', '<', end.getTime())
+      })
+      .orWhere((range) => {
+        range
+          .where('bucketHour', '>=', formatUTCTimestamp(start, ' '))
+          .andWhere('bucketHour', '<', formatUTCTimestamp(end, ' '))
+      })
+      .orWhere((range) => {
+        range
+          .where('bucketHour', '>=', formatUTCTimestamp(start, 'T'))
+          .andWhere('bucketHour', '<', formatUTCTimestamp(end, 'T'))
+      })
+      .orWhere((range) => {
+        range
+          .where('bucketHour', '>=', start.toISOString())
+          .andWhere('bucketHour', '<', end.toISOString())
+      })
+  })
+}
+
 export const getInstanceActivityFromCounters = async (
   database: Knex,
   { now = new Date() }: GetInstanceActivityParams = {}
@@ -74,8 +128,13 @@ export const getInstanceActivityFromCounters = async (
   })
   const weekByKey = new Map(weeks.map((week) => [week.weekKey, week]))
 
-  const rows = await database<CounterRow>('counters')
-    .whereNotNull('bucketHour')
+  const query = database<CounterRow>('counters').whereNotNull('bucketHour')
+  const rows = await addBucketHourRangeFilter(
+    query,
+    database,
+    oldestWeekStart,
+    newestWeekEnd
+  )
     .andWhere((builder) => {
       builder
         .where('id', 'like', 'bucket:local-statuses:%')

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -27,6 +27,7 @@ const COUNTER_TYPES: Record<string, ActivityCounterKey> = {
   'bucket:logins:': 'logins',
   'bucket:accounts:': 'registrations'
 }
+const COUNTER_TYPE_ENTRIES = Object.entries(COUNTER_TYPES)
 
 const SQLITE_CLIENTS = new Set(['better-sqlite3', 'sqlite3'])
 
@@ -47,7 +48,7 @@ const getWeekKey = (date: Date): string =>
   String(Math.floor(getUTCWeekStart(date).getTime() / 1000))
 
 const getBucketCounterType = (id: string): ActivityCounterKey | null => {
-  for (const [prefix, counterType] of Object.entries(COUNTER_TYPES)) {
+  for (const [prefix, counterType] of COUNTER_TYPE_ENTRIES) {
     if (id.startsWith(prefix)) return counterType
   }
 

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -29,8 +29,7 @@ const COUNTER_TYPES: Record<string, ActivityCounterKey> = {
   'bucket:accounts:': 'registrations'
 }
 const COUNTER_TYPE_ENTRIES = Object.entries(COUNTER_TYPES)
-
-const SQLITE_CLIENTS = new Set(['better-sqlite3', 'sqlite3'])
+const COUNTER_TYPE_PREFIXES = Object.keys(COUNTER_TYPES)
 
 const isTransaction = (database: SQLDatabase): database is Knex.Transaction =>
   Boolean((database as { isTransaction?: boolean }).isTransaction)
@@ -51,67 +50,20 @@ export const getUTCWeekStart = (date: Date): Date => {
 const getWeekKey = (date: Date): string =>
   String(Math.floor(getUTCWeekStart(date).getTime() / 1000))
 
+const formatBucketHour = (date: Date): string => {
+  const y = date.getUTCFullYear()
+  const mo = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  const h = String(date.getUTCHours()).padStart(2, '0')
+  return `${y}${mo}${d}${h}`
+}
+
 const getBucketCounterType = (id: string): ActivityCounterKey | null => {
   for (const [prefix, counterType] of COUNTER_TYPE_ENTRIES) {
     if (id.startsWith(prefix)) return counterType
   }
 
   return null
-}
-
-const isSQLiteClient = (database: Knex): boolean =>
-  SQLITE_CLIENTS.has(String(database.client.config.client))
-
-const formatUTCTimestamp = (date: Date, separator: ' ' | 'T'): string => {
-  const y = date.getUTCFullYear()
-  const mo = String(date.getUTCMonth() + 1).padStart(2, '0')
-  const d = String(date.getUTCDate()).padStart(2, '0')
-  const h = String(date.getUTCHours()).padStart(2, '0')
-  const mi = String(date.getUTCMinutes()).padStart(2, '0')
-  const s = String(date.getUTCSeconds()).padStart(2, '0')
-  const ms = String(date.getUTCMilliseconds()).padStart(3, '0')
-
-  return `${y}-${mo}-${d}${separator}${h}:${mi}:${s}.${ms}`
-}
-
-const addBucketHourRangeFilter = (
-  query: Knex.QueryBuilder<CounterRow, CounterRow[]>,
-  database: Knex,
-  start: Date,
-  end: Date
-): Knex.QueryBuilder<CounterRow, CounterRow[]> => {
-  if (!isSQLiteClient(database)) {
-    return query
-      .andWhere('bucketHour', '>=', start)
-      .andWhere('bucketHour', '<', end)
-  }
-
-  // Existing SQLite fixtures/local DBs can store Knex timestamps as epoch
-  // numbers or as UTC strings depending on the writer. Keep all known formats
-  // queryable, then re-check the parsed Date in memory below.
-  return query.andWhere((builder) => {
-    builder
-      .where((range) => {
-        range
-          .where('bucketHour', '>=', start.getTime())
-          .andWhere('bucketHour', '<', end.getTime())
-      })
-      .orWhere((range) => {
-        range
-          .where('bucketHour', '>=', formatUTCTimestamp(start, ' '))
-          .andWhere('bucketHour', '<', formatUTCTimestamp(end, ' '))
-      })
-      .orWhere((range) => {
-        range
-          .where('bucketHour', '>=', formatUTCTimestamp(start, 'T'))
-          .andWhere('bucketHour', '<', formatUTCTimestamp(end, 'T'))
-      })
-      .orWhere((range) => {
-        range
-          .where('bucketHour', '>=', start.toISOString())
-          .andWhere('bucketHour', '<', end.toISOString())
-      })
-  })
 }
 
 export const getInstanceActivityFromCounters = async (
@@ -135,19 +87,19 @@ export const getInstanceActivityFromCounters = async (
     }
   })
   const weekByKey = new Map(weeks.map((week) => [week.weekKey, week]))
+  const oldestHourKey = formatBucketHour(oldestWeekStart)
+  const newestHourKey = formatBucketHour(newestWeekEnd)
 
-  const query = database<CounterRow>('counters').whereNotNull('bucketHour')
-  const rows = await addBucketHourRangeFilter(
-    query,
-    database,
-    oldestWeekStart,
-    newestWeekEnd
-  )
+  const rows = await database<CounterRow>('counters')
+    .whereNotNull('bucketHour')
     .andWhere((builder) => {
-      builder
-        .where('id', 'like', 'bucket:local-statuses:%')
-        .orWhere('id', 'like', 'bucket:logins:%')
-        .orWhere('id', 'like', 'bucket:accounts:%')
+      for (const prefix of COUNTER_TYPE_PREFIXES) {
+        builder.orWhere((range) => {
+          range
+            .where('id', '>=', `${prefix}${oldestHourKey}`)
+            .andWhere('id', '<', `${prefix}${newestHourKey}`)
+        })
+      }
     })
     .select('id', 'value', 'bucketHour')
 

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -86,6 +86,9 @@ const addBucketHourRangeFilter = (
       .andWhere('bucketHour', '<', end)
   }
 
+  // Existing SQLite fixtures/local DBs can store Knex timestamps as epoch
+  // numbers or as UTC strings depending on the writer. Keep all known formats
+  // queryable, then re-check the parsed Date in memory below.
   return query.andWhere((builder) => {
     builder
       .where((range) => {

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex'
 
 import { parseCounterValue } from '@/lib/database/sql/utils/counter'
 import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   GetInstanceActivityParams,
   InstanceActivityDatabase,
@@ -75,8 +76,6 @@ export const getInstanceActivityFromCounters = async (
 
   const rows = await database<CounterRow>('counters')
     .whereNotNull('bucketHour')
-    .andWhere('bucketHour', '>=', oldestWeekStart)
-    .andWhere('bucketHour', '<', newestWeekEnd)
     .andWhere((builder) => {
       builder
         .where('id', 'like', 'bucket:local-statuses:%')
@@ -90,8 +89,12 @@ export const getInstanceActivityFromCounters = async (
     if (!counterType || row.bucketHour === null) continue
 
     const bucketHour =
-      row.bucketHour instanceof Date ? row.bucketHour : new Date(row.bucketHour)
+      row.bucketHour instanceof Date
+        ? row.bucketHour
+        : new Date(getCompatibleTime(row.bucketHour))
     if (Number.isNaN(bucketHour.getTime())) continue
+
+    if (bucketHour < oldestWeekStart || bucketHour >= newestWeekEnd) continue
 
     const week = weekByKey.get(getWeekKey(bucketHour))
     if (!week) continue

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -1,0 +1,161 @@
+import { Knex } from 'knex'
+
+import { parseCounterValue } from '@/lib/database/sql/utils/counter'
+import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
+import {
+  GetInstanceActivityParams,
+  InstanceActivityDatabase,
+  InstanceActivityWeek
+} from '@/lib/types/database/operations'
+
+type SQLDatabase = Knex | Knex.Transaction
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+const INSTANCE_ACTIVITY_WEEKS = 12
+
+type ActivityCounterKey = 'statuses' | 'logins' | 'registrations'
+
+type CounterRow = {
+  id: string
+  value: number | string | bigint | null
+  bucketHour: Date | string | number | null
+}
+
+const COUNTER_TYPES: Record<string, ActivityCounterKey> = {
+  'bucket:local-statuses:': 'statuses',
+  'bucket:logins:': 'logins',
+  'bucket:accounts:': 'registrations'
+}
+
+export const getUTCWeekStart = (date: Date): Date => {
+  const day = date.getUTCDay()
+  const daysSinceMonday = (day + 6) % 7
+
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate() - daysSinceMonday
+    )
+  )
+}
+
+const getWeekKey = (date: Date): string =>
+  String(Math.floor(getUTCWeekStart(date).getTime() / 1000))
+
+const getBucketCounterType = (id: string): ActivityCounterKey | null => {
+  for (const [prefix, counterType] of Object.entries(COUNTER_TYPES)) {
+    if (id.startsWith(prefix)) return counterType
+  }
+
+  return null
+}
+
+export const getInstanceActivityFromCounters = async (
+  database: Knex,
+  { now = new Date() }: GetInstanceActivityParams = {}
+): Promise<InstanceActivityWeek[]> => {
+  const newestWeekStart = getUTCWeekStart(now)
+  const oldestWeekStart = new Date(
+    newestWeekStart.getTime() - (INSTANCE_ACTIVITY_WEEKS - 1) * WEEK_MS
+  )
+  const newestWeekEnd = new Date(newestWeekStart.getTime() + WEEK_MS)
+
+  const weeks = Array.from({ length: INSTANCE_ACTIVITY_WEEKS }, (_, index) => {
+    const weekStart = new Date(newestWeekStart.getTime() - index * WEEK_MS)
+    return {
+      weekStart,
+      weekKey: String(Math.floor(weekStart.getTime() / 1000)),
+      statuses: 0,
+      logins: 0,
+      registrations: 0
+    }
+  })
+  const weekByKey = new Map(weeks.map((week) => [week.weekKey, week]))
+
+  const rows = await database<CounterRow>('counters')
+    .whereNotNull('bucketHour')
+    .andWhere('bucketHour', '>=', oldestWeekStart)
+    .andWhere('bucketHour', '<', newestWeekEnd)
+    .andWhere((builder) => {
+      builder
+        .where('id', 'like', 'bucket:local-statuses:%')
+        .orWhere('id', 'like', 'bucket:logins:%')
+        .orWhere('id', 'like', 'bucket:accounts:%')
+    })
+    .select('id', 'value', 'bucketHour')
+
+  for (const row of rows) {
+    const counterType = getBucketCounterType(row.id)
+    if (!counterType || row.bucketHour === null) continue
+
+    const bucketHour =
+      row.bucketHour instanceof Date ? row.bucketHour : new Date(row.bucketHour)
+    if (Number.isNaN(bucketHour.getTime())) continue
+
+    const week = weekByKey.get(getWeekKey(bucketHour))
+    if (!week) continue
+
+    week[counterType] += parseCounterValue(row.value)
+  }
+
+  return weeks.map(({ weekKey, statuses, logins, registrations }) => ({
+    week: weekKey,
+    statuses: String(statuses),
+    logins: String(logins),
+    registrations: String(registrations)
+  }))
+}
+
+export const getWeeklyLoginMarkerId = (
+  accountId: string,
+  currentTime = new Date()
+): string => `unique-login:${getWeekKey(currentTime)}:${accountId}`
+
+export const recordWeeklyLogin = async (
+  database: SQLDatabase,
+  accountId: string | null | undefined,
+  currentTime = new Date()
+): Promise<void> => {
+  if (!accountId) return
+
+  const markerId = getWeeklyLoginMarkerId(accountId, currentTime)
+
+  await database('counters')
+    .insert({
+      id: markerId,
+      value: 0,
+      bucketHour: null,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+    .onConflict('id')
+    .ignore()
+
+  const marked = await database('counters')
+    .where('id', markerId)
+    .andWhere('value', 0)
+    .update({
+      value: 1,
+      updatedAt: currentTime
+    })
+
+  if (marked > 0) {
+    await incrementBucket(database, 'logins', 1, currentTime)
+  }
+}
+
+export const incrementLocalStatusBucket = async (
+  database: SQLDatabase,
+  currentTime = new Date()
+): Promise<void> => {
+  await incrementBucket(database, 'local-statuses', 1, currentTime)
+}
+
+export const InstanceActivitySQLDatabaseMixin = (
+  database: Knex
+): InstanceActivityDatabase => ({
+  getInstanceActivity(params?: GetInstanceActivityParams) {
+    return getInstanceActivityFromCounters(database, params)
+  }
+})

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -237,6 +237,30 @@ describe('instance activity counter migration', () => {
     })
   })
 
+  it('does not double-count bucket counters when the migration is rerun', async () => {
+    await migration.up(database)
+
+    const getBucketTotals = async () => {
+      const localStatusRows = await database('counters')
+        .where('id', 'like', 'bucket:local-statuses:%')
+        .select('value')
+      const loginRows = await database('counters')
+        .where('id', 'like', 'bucket:logins:%')
+        .select('value')
+
+      return {
+        localStatuses: sumCounterRows(localStatusRows),
+        logins: sumCounterRows(loginRows)
+      }
+    }
+
+    const firstRunTotals = await getBucketTotals()
+
+    await migration.up(database)
+
+    expect(await getBucketTotals()).toEqual(firstRunTotals)
+  })
+
   it('removes instance activity counters on rollback', async () => {
     await migration.up(database)
     await migration.down(database)
@@ -245,6 +269,7 @@ describe('instance activity counter migration', () => {
       .where('id', 'like', 'bucket:local-statuses:%')
       .orWhere('id', 'like', 'bucket:logins:%')
       .orWhere('id', 'like', 'unique-login:%')
+      .orWhere('id', 'like', 'backfill:instance-activity:%')
 
     expect(remainingRows).toHaveLength(0)
   })

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -188,4 +188,62 @@ describe('instance activity counter migration', () => {
 
     expect(remainingRows).toHaveLength(0)
   })
+
+  it('backfills SQLite timestamp strings without timezone as UTC', async () => {
+    const originalTimeZone = process.env.TZ
+    process.env.TZ = 'Europe/Amsterdam'
+
+    try {
+      await database('accounts').insert({
+        id: 'account-sqlite-time',
+        createdAt: '2026-05-25 00:30:00.000',
+        updatedAt: '2026-05-25 00:30:00.000'
+      })
+      await database('actors').insert({
+        id: 'https://local.test/users/sqlite-time',
+        accountId: 'account-sqlite-time',
+        createdAt: '2026-05-25 00:30:00.000',
+        updatedAt: '2026-05-25 00:30:00.000'
+      })
+      await database('statuses').insert({
+        id: 'sqlite-time-status',
+        actorId: 'https://local.test/users/sqlite-time',
+        createdAt: '2026-05-25 00:30:00.000',
+        updatedAt: '2026-05-25 00:30:00.000'
+      })
+      await database('sessions').insert({
+        id: 'sqlite-time-session',
+        accountId: 'account-sqlite-time',
+        token: 'sqlite-time-token',
+        expireAt: '2026-06-25 00:30:00.000',
+        createdAt: '2026-05-25 00:30:00.000',
+        updatedAt: '2026-05-25 00:30:00.000'
+      })
+
+      await migration.up(database)
+
+      const statusBucket = await database('counters')
+        .where('id', 'bucket:local-statuses:2026052500')
+        .first()
+      const loginBucket = await database('counters')
+        .where('id', 'bucket:logins:2026052500')
+        .first()
+      const marker = await database('counters')
+        .where(
+          'id',
+          `unique-login:${Math.floor(Date.UTC(2026, 4, 25) / 1000)}:account-sqlite-time`
+        )
+        .first()
+
+      expect(statusBucket?.value).toBe(1)
+      expect(loginBucket?.value).toBe(1)
+      expect(marker?.value).toBe(1)
+    } finally {
+      if (originalTimeZone === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTimeZone
+      }
+    }
+  })
 })

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -1,0 +1,191 @@
+import knex, { Knex } from 'knex'
+
+import * as migration from '@/migrations/20260526112702_backfill_instance_activity_counters'
+
+const sumCounterRows = (rows: { value: number | string | null }[]) =>
+  rows.reduce((total, row) => total + Number(row.value ?? 0), 0)
+
+describe('instance activity counter migration', () => {
+  let database: Knex
+
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+
+    await database.schema.createTable('accounts', (table) => {
+      table.string('id').primary()
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+    await database.schema.createTable('actors', (table) => {
+      table.string('id').primary()
+      table.string('accountId').nullable()
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+    await database.schema.createTable('statuses', (table) => {
+      table.string('id').primary()
+      table.string('actorId').notNullable()
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+    await database.schema.createTable('sessions', (table) => {
+      table.string('id').primary()
+      table.string('accountId').notNullable()
+      table.string('token').notNullable()
+      table.timestamp('expireAt', { useTz: true })
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+    await database.schema.createTable('counters', (table) => {
+      table.string('id').primary()
+      table.integer('value').defaultTo(0)
+      table.timestamp('bucketHour', { useTz: true }).nullable()
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+
+    await database('accounts').insert([
+      {
+        id: 'account-a',
+        createdAt: new Date('2026-05-19T08:00:00.000Z'),
+        updatedAt: new Date('2026-05-19T08:00:00.000Z')
+      },
+      {
+        id: 'account-b',
+        createdAt: new Date('2026-05-21T08:00:00.000Z'),
+        updatedAt: new Date('2026-05-21T08:00:00.000Z')
+      }
+    ])
+    await database('actors').insert([
+      {
+        id: 'https://local.test/users/a',
+        accountId: 'account-a',
+        createdAt: new Date('2026-05-19T08:00:00.000Z'),
+        updatedAt: new Date('2026-05-19T08:00:00.000Z')
+      },
+      {
+        id: 'https://remote.test/users/r',
+        accountId: null,
+        createdAt: new Date('2026-05-19T08:00:00.000Z'),
+        updatedAt: new Date('2026-05-19T08:00:00.000Z')
+      }
+    ])
+    await database('statuses').insert([
+      {
+        id: 'local-status-a',
+        actorId: 'https://local.test/users/a',
+        createdAt: new Date('2026-05-19T10:00:00.000Z'),
+        updatedAt: new Date('2026-05-19T10:00:00.000Z')
+      },
+      {
+        id: 'local-status-b',
+        actorId: 'https://local.test/users/a',
+        createdAt: new Date('2026-05-20T11:00:00.000Z'),
+        updatedAt: new Date('2026-05-20T11:00:00.000Z')
+      },
+      {
+        id: 'remote-status',
+        actorId: 'https://remote.test/users/r',
+        createdAt: new Date('2026-05-20T12:00:00.000Z'),
+        updatedAt: new Date('2026-05-20T12:00:00.000Z')
+      }
+    ])
+    await database('sessions').insert([
+      {
+        id: 'session-a-week-one-first',
+        accountId: 'account-a',
+        token: 'token-a-1',
+        expireAt: new Date('2026-06-19T09:00:00.000Z'),
+        createdAt: new Date('2026-05-19T09:00:00.000Z'),
+        updatedAt: new Date('2026-05-19T09:00:00.000Z')
+      },
+      {
+        id: 'session-a-week-one-second',
+        accountId: 'account-a',
+        token: 'token-a-2',
+        expireAt: new Date('2026-06-20T09:00:00.000Z'),
+        createdAt: new Date('2026-05-20T09:00:00.000Z'),
+        updatedAt: new Date('2026-05-20T09:00:00.000Z')
+      },
+      {
+        id: 'session-b-week-one',
+        accountId: 'account-b',
+        token: 'token-b-1',
+        expireAt: new Date('2026-06-21T09:00:00.000Z'),
+        createdAt: new Date('2026-05-21T09:00:00.000Z'),
+        updatedAt: new Date('2026-05-21T09:00:00.000Z')
+      },
+      {
+        id: 'session-a-week-two',
+        accountId: 'account-a',
+        token: 'token-a-3',
+        expireAt: new Date('2026-06-26T09:00:00.000Z'),
+        createdAt: new Date('2026-05-26T09:00:00.000Z'),
+        updatedAt: new Date('2026-05-26T09:00:00.000Z')
+      }
+    ])
+  })
+
+  afterEach(async () => {
+    await database.destroy()
+  })
+
+  it('backfills local status buckets, weekly login buckets, and login markers', async () => {
+    await migration.up(database)
+
+    const localStatusRows = await database('counters')
+      .where('id', 'like', 'bucket:local-statuses:%')
+      .orderBy('id', 'asc')
+      .select('id', 'value')
+    const loginRows = await database('counters')
+      .where('id', 'like', 'bucket:logins:%')
+      .orderBy('id', 'asc')
+      .select('id', 'value')
+    const markerRows = await database('counters')
+      .where('id', 'like', 'unique-login:%')
+      .orderBy('id', 'asc')
+      .select('id', 'value', 'bucketHour')
+
+    expect(sumCounterRows(localStatusRows)).toBe(2)
+    expect(sumCounterRows(loginRows)).toBe(3)
+    expect(markerRows).toEqual([
+      {
+        id: `unique-login:${Math.floor(
+          Date.UTC(2026, 4, 18) / 1000
+        )}:account-a`,
+        value: 1,
+        bucketHour: null
+      },
+      {
+        id: `unique-login:${Math.floor(
+          Date.UTC(2026, 4, 18) / 1000
+        )}:account-b`,
+        value: 1,
+        bucketHour: null
+      },
+      {
+        id: `unique-login:${Math.floor(
+          Date.UTC(2026, 4, 25) / 1000
+        )}:account-a`,
+        value: 1,
+        bucketHour: null
+      }
+    ])
+  })
+
+  it('removes instance activity counters on rollback', async () => {
+    await migration.up(database)
+    await migration.down(database)
+
+    const remainingRows = await database('counters')
+      .where('id', 'like', 'bucket:local-statuses:%')
+      .orWhere('id', 'like', 'bucket:logins:%')
+      .orWhere('id', 'like', 'unique-login:%')
+
+    expect(remainingRows).toHaveLength(0)
+  })
+})

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -261,6 +261,42 @@ describe('instance activity counter migration', () => {
     expect(await getBucketTotals()).toEqual(firstRunTotals)
   })
 
+  it('writes up to 180 counter rows per chunk to reduce migration round trips', async () => {
+    await database('statuses').delete()
+    await database('sessions').delete()
+
+    const statusRows = Array.from({ length: 180 }, (_, index) => {
+      const createdAt = new Date(
+        Date.UTC(2026, 0, 1, 0, 0, 0) + index * 60 * 60 * 1000
+      )
+
+      return {
+        id: `chunk-status-${String(index).padStart(3, '0')}`,
+        actorId: 'https://local.test/users/a',
+        createdAt,
+        updatedAt: createdAt
+      }
+    })
+
+    await database('statuses').insert(statusRows)
+
+    const queries: string[] = []
+    const onQuery = (query: { sql: string }) => queries.push(query.sql)
+    database.on('query', onQuery)
+
+    try {
+      await migration.up(database)
+    } finally {
+      database.off('query', onQuery)
+    }
+
+    const counterInsertQueries = queries.filter((query) =>
+      query.startsWith('insert into `counters`')
+    )
+
+    expect(counterInsertQueries).toHaveLength(2)
+  })
+
   it('removes instance activity counters on rollback', async () => {
     await migration.up(database)
     await migration.down(database)

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -307,4 +307,43 @@ describe('instance activity counter migration', () => {
   it('does not run in the default Knex migration transaction', () => {
     expect(migration.config).toEqual({ transaction: false })
   })
+
+  it('builds MySQL activity-counter upserts without deprecated VALUES()', async () => {
+    const mysqlDatabase = knex({ client: 'mysql2' })
+    const currentTime = new Date('2026-05-26T12:00:00.000Z')
+    const row = {
+      id: 'bucket:logins:2026052612',
+      value: 1,
+      bucketHour: currentTime,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
+
+    try {
+      const bucketSql = migration
+        .buildMySQLBucketCounterUpsertQuery(mysqlDatabase, [row])
+        .toSQL().sql
+      const markerSql = migration
+        .buildMySQLLoginMarkerUpsertQuery(mysqlDatabase, [
+          {
+            ...row,
+            id: 'unique-login:account-a',
+            bucketHour: null
+          }
+        ])
+        .toSQL().sql
+
+      expect(bucketSql).toContain(' as `new_values` on duplicate key update ')
+      expect(bucketSql).toContain(
+        '`value` = `counters`.`value` + `new_values`.`value`'
+      )
+      expect(markerSql).toContain(
+        'case when `new_values`.`value` > `counters`.`value`'
+      )
+      expect(bucketSql).not.toContain('VALUES(')
+      expect(markerSql).not.toContain('VALUES(')
+    } finally {
+      await mysqlDatabase.destroy()
+    }
+  })
 })

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -365,6 +365,45 @@ describe('instance activity counter migration', () => {
     }
   })
 
+  it.each(['userId', 'user_id'])(
+    'backfills weekly logins from a singular session table using %s',
+    async (sessionAccountColumn) => {
+      await database.schema.dropTable('sessions')
+      await database.schema.createTable('session', (table) => {
+        table.string('id').primary()
+        table.string(sessionAccountColumn).notNullable()
+        table.string('token').notNullable()
+        table.timestamp('expireAt', { useTz: true })
+        table.timestamp('createdAt', { useTz: true })
+        table.timestamp('updatedAt', { useTz: true })
+      })
+
+      await database('session').insert({
+        id: `singular-session-${sessionAccountColumn}`,
+        [sessionAccountColumn]: 'account-a',
+        token: `singular-token-${sessionAccountColumn}`,
+        expireAt: new Date('2026-06-19T09:00:00.000Z'),
+        createdAt: new Date('2026-05-19T09:00:00.000Z'),
+        updatedAt: new Date('2026-05-19T09:00:00.000Z')
+      })
+
+      await migration.up(database)
+
+      const loginRows = await database('counters')
+        .where('id', 'like', 'bucket:logins:%')
+        .select('value')
+      const marker = await database('counters')
+        .where('id', 'unique-login:account-a')
+        .first('id', 'value')
+
+      expect(sumCounterRows(loginRows)).toBe(1)
+      expect(marker).toEqual({
+        id: 'unique-login:account-a',
+        value: Math.floor(Date.UTC(2026, 4, 18) / 1000)
+      })
+    }
+  )
+
   it('does not run in the default Knex migration transaction', () => {
     expect(migration.config).toEqual({ transaction: false })
   })

--- a/lib/database/sql/instanceActivityMigration.test.ts
+++ b/lib/database/sql/instanceActivityMigration.test.ts
@@ -154,27 +154,87 @@ describe('instance activity counter migration', () => {
     expect(sumCounterRows(loginRows)).toBe(3)
     expect(markerRows).toEqual([
       {
-        id: `unique-login:${Math.floor(
-          Date.UTC(2026, 4, 18) / 1000
-        )}:account-a`,
-        value: 1,
+        id: 'unique-login:account-a',
+        value: Math.floor(Date.UTC(2026, 4, 25) / 1000),
         bucketHour: null
       },
       {
-        id: `unique-login:${Math.floor(
-          Date.UTC(2026, 4, 18) / 1000
-        )}:account-b`,
-        value: 1,
-        bucketHour: null
-      },
-      {
-        id: `unique-login:${Math.floor(
-          Date.UTC(2026, 4, 25) / 1000
-        )}:account-a`,
-        value: 1,
+        id: 'unique-login:account-b',
+        value: Math.floor(Date.UTC(2026, 4, 18) / 1000),
         bucketHour: null
       }
     ])
+  })
+
+  it('adds historical buckets to live counters without double-counting live login markers', async () => {
+    const liveCounterCreatedAt = new Date('2026-05-19T10:30:00.000Z')
+    const liveWeek = Math.floor(Date.UTC(2026, 4, 18) / 1000)
+
+    await database('counters').insert([
+      {
+        id: 'bucket:local-statuses:2026051910',
+        value: 5,
+        bucketHour: new Date('2026-05-19T10:00:00.000Z'),
+        createdAt: liveCounterCreatedAt,
+        updatedAt: liveCounterCreatedAt
+      },
+      {
+        id: 'bucket:logins:2026051909',
+        value: 3,
+        bucketHour: new Date('2026-05-19T09:00:00.000Z'),
+        createdAt: liveCounterCreatedAt,
+        updatedAt: liveCounterCreatedAt
+      },
+      {
+        id: 'unique-login:account-a',
+        value: liveWeek,
+        bucketHour: null,
+        createdAt: liveCounterCreatedAt,
+        updatedAt: liveCounterCreatedAt
+      }
+    ])
+    await database('statuses').insert({
+      id: 'live-status-after-counter',
+      actorId: 'https://local.test/users/a',
+      createdAt: new Date('2026-05-19T10:45:00.000Z'),
+      updatedAt: new Date('2026-05-19T10:45:00.000Z')
+    })
+    await database('sessions').insert({
+      id: 'historical-session-before-counter',
+      accountId: 'account-b',
+      token: 'token-before-counter',
+      expireAt: new Date('2026-06-19T09:30:00.000Z'),
+      createdAt: new Date('2026-05-19T09:30:00.000Z'),
+      updatedAt: new Date('2026-05-19T09:30:00.000Z')
+    })
+    await database('sessions').insert({
+      id: 'live-session-after-counter',
+      accountId: 'account-a',
+      token: 'token-live-after-counter',
+      expireAt: new Date('2026-06-19T10:45:00.000Z'),
+      createdAt: new Date('2026-05-19T10:45:00.000Z'),
+      updatedAt: new Date('2026-05-19T10:45:00.000Z')
+    })
+
+    await migration.up(database)
+
+    const statusBucket = await database('counters')
+      .where('id', 'bucket:local-statuses:2026051910')
+      .first()
+    const loginBucket = await database('counters')
+      .where('id', 'bucket:logins:2026051909')
+      .first()
+    const markerRows = await database('counters')
+      .where('id', 'like', 'unique-login:%')
+      .orderBy('id', 'asc')
+      .select('id', 'value')
+
+    expect(statusBucket?.value).toBe(6)
+    expect(loginBucket?.value).toBe(4)
+    expect(markerRows).toContainEqual({
+      id: 'unique-login:account-a',
+      value: liveWeek
+    })
   })
 
   it('removes instance activity counters on rollback', async () => {
@@ -229,15 +289,12 @@ describe('instance activity counter migration', () => {
         .where('id', 'bucket:logins:2026052500')
         .first()
       const marker = await database('counters')
-        .where(
-          'id',
-          `unique-login:${Math.floor(Date.UTC(2026, 4, 25) / 1000)}:account-sqlite-time`
-        )
+        .where('id', 'unique-login:account-sqlite-time')
         .first()
 
       expect(statusBucket?.value).toBe(1)
       expect(loginBucket?.value).toBe(1)
-      expect(marker?.value).toBe(1)
+      expect(marker?.value).toBe(Math.floor(Date.UTC(2026, 4, 25) / 1000))
     } finally {
       if (originalTimeZone === undefined) {
         delete process.env.TZ
@@ -245,5 +302,9 @@ describe('instance activity counter migration', () => {
         process.env.TZ = originalTimeZone
       }
     }
+  })
+
+  it('does not run in the default Knex migration transaction', () => {
+    expect(migration.config).toEqual({ transaction: false })
   })
 })

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -3794,5 +3794,76 @@ describe('StatusDatabase', () => {
         expect(total).toBe(0)
       })
     })
+
+    describe('instance activity local status buckets', () => {
+      it('increments local status buckets only for statuses from local actors', async () => {
+        const knexDatabase = knex({
+          client: 'better-sqlite3',
+          useNullAsDefault: true,
+          connection: {
+            filename: ':memory:'
+          }
+        })
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        const getCounterTotal = async (counterType: string) => {
+          const row = await knexDatabase('counters')
+            .where('id', 'like', `bucket:${counterType}:%`)
+            .sum<{ total: number | string | null }>('value as total')
+            .first()
+          return Number(row?.total ?? 0)
+        }
+
+        try {
+          await sqlDatabase.migrate()
+
+          const suffix = crypto.randomUUID().slice(0, 8)
+          const localUsername = `local-status-${suffix}`
+          const localActorId = `https://${TEST_DOMAIN}/users/${localUsername}`
+          const remoteActorId = `https://remote-${suffix}.test/users/alice`
+
+          await sqlDatabase.createAccount({
+            email: `${localUsername}@${TEST_DOMAIN}`,
+            username: localUsername,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: `private-${suffix}`,
+            publicKey: `public-${suffix}`
+          })
+          await sqlDatabase.createActor({
+            actorId: remoteActorId,
+            username: `alice-${suffix}`,
+            domain: `remote-${suffix}.test`,
+            followersUrl: `${remoteActorId}/followers`,
+            inboxUrl: `${remoteActorId}/inbox`,
+            sharedInboxUrl: `https://remote-${suffix}.test/inbox`,
+            publicKey: `remote-public-${suffix}`,
+            createdAt: Date.now()
+          })
+
+          await sqlDatabase.createNote({
+            id: `${localActorId}/statuses/local-bucket`,
+            url: `${localActorId}/statuses/local-bucket`,
+            actorId: localActorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            text: 'Local status'
+          })
+          await sqlDatabase.createNote({
+            id: `${remoteActorId}/statuses/remote-bucket`,
+            url: `${remoteActorId}/statuses/remote-bucket`,
+            actorId: remoteActorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            text: 'Remote status'
+          })
+
+          expect(await getCounterTotal('statuses')).toBe(2)
+          expect(await getCounterTotal('local-statuses')).toBe(1)
+        } finally {
+          await knexDatabase.destroy()
+        }
+      })
+    })
   })
 })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex'
 
 import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { incrementLocalStatusBucket } from '@/lib/database/sql/instanceActivity'
 import {
   CounterKey,
   decreaseCounterValue,
@@ -368,6 +369,9 @@ export const StatusSQLDatabaseMixin = (
       .first<{ accountId: string | null }>('accountId')
     if (actor?.accountId) {
       await adjust(trx, CounterKey.nodeinfoLocalPosts(), 1, currentTime)
+      if (step === 'increment') {
+        await incrementLocalStatusBucket(trx, currentTime)
+      }
     }
 
     if (type === StatusType.enum.Announce) {

--- a/lib/database/sql/utils/getCompatibleTime.test.ts
+++ b/lib/database/sql/utils/getCompatibleTime.test.ts
@@ -16,6 +16,23 @@ describe('getCompatibleTime', () => {
     )
   })
 
+  it('parses SQLite timestamp strings without timezone as UTC', () => {
+    const originalTimeZone = process.env.TZ
+    process.env.TZ = 'Europe/Amsterdam'
+
+    try {
+      expect(getCompatibleTime('2026-05-25 00:30:00.000')).toBe(
+        Date.UTC(2026, 4, 25, 0, 30)
+      )
+    } finally {
+      if (originalTimeZone === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTimeZone
+      }
+    }
+  })
+
   it('returns NaN for an invalid date string', () => {
     expect(getCompatibleTime('not-a-date')).toBeNaN()
   })

--- a/lib/database/sql/utils/getCompatibleTime.ts
+++ b/lib/database/sql/utils/getCompatibleTime.ts
@@ -1,5 +1,14 @@
+const SQLITE_UTC_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$/
+
 export const getCompatibleTime = (time: number | Date | string): number => {
   if (typeof time === 'number') return time
-  if (typeof time === 'string') return new Date(time).getTime()
+  if (typeof time === 'string') {
+    const trimmed = time.trim()
+    const normalized = SQLITE_UTC_TIMESTAMP_PATTERN.test(trimmed)
+      ? `${trimmed.replace(' ', 'T')}Z`
+      : trimmed
+    return new Date(normalized).getTime()
+  }
   return time.getTime()
 }

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -11,6 +11,7 @@ import {
   BookmarkDatabase,
   DirectConversationDatabase,
   FollowDatabase,
+  InstanceActivityDatabase,
   LikeDatabase,
   MediaDatabase,
   NotificationDatabase,
@@ -24,6 +25,7 @@ import {
 export type Database = AccountDatabase &
   ActorDatabase &
   AdminDatabase &
+  InstanceActivityDatabase &
   FitnessFileDatabase &
   FitnessRouteHeatmapDatabase &
   FitnessSettingsDatabase &

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -56,6 +56,14 @@ describe('knexAdapter', () => {
       table.timestamp('expireAt')
     })
 
+    await db.schema.createTable('counters', (table) => {
+      table.string('id').primary()
+      table.integer('value').defaultTo(0)
+      table.timestamp('bucketHour', { useTz: true }).nullable()
+      table.timestamp('createdAt', { useTz: true })
+      table.timestamp('updatedAt', { useTz: true })
+    })
+
     // The mock createAdapterFactory above uses identity getModelName/getFieldName.
     // This means table names = model names and field names are used as-is,
     // which lets us test the raw adapter CRUD logic and where-clause operators.
@@ -68,6 +76,7 @@ describe('knexAdapter', () => {
   })
 
   beforeEach(async () => {
+    await db('counters').delete()
     await db('sessions').delete()
     await db('accounts').delete()
     await db('users').delete()
@@ -104,6 +113,58 @@ describe('knexAdapter', () => {
 
       const count = await adapter.count({ model: 'users' })
       expect(count).toBe(2)
+    })
+
+    it('records weekly login counters when creating sessions', async () => {
+      const getLoginTotal = async () => {
+        const row = await db('counters')
+          .where('id', 'like', 'bucket:logins:%')
+          .sum<{ total: number | string | null }>('value as total')
+          .first()
+        return Number(row?.total ?? 0)
+      }
+
+      await db('users').insert({
+        id: 'u-login',
+        email: 'login@test.com'
+      })
+
+      try {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2026-02-04T10:00:00.000Z'))
+
+        await adapter.create({
+          model: 'sessions',
+          data: {
+            id: 's-login-1',
+            user_id: 'u-login',
+            token: 'login-token-1',
+            expireAt: Date.now() + 60_000
+          }
+        })
+        await adapter.create({
+          model: 'sessions',
+          data: {
+            id: 's-login-2',
+            user_id: 'u-login',
+            token: 'login-token-2',
+            expireAt: Date.now() + 120_000
+          }
+        })
+
+        const markerRows = await db('counters')
+          .where('id', 'like', 'unique-login:%:u-login')
+          .select('id')
+
+        expect(await getLoginTotal()).toBe(1)
+        expect(markerRows).toEqual([
+          {
+            id: `unique-login:${Math.floor(Date.UTC(2026, 1, 2) / 1000)}:u-login`
+          }
+        ])
+      } finally {
+        jest.useRealTimers()
+      }
     })
   })
 

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -56,6 +56,15 @@ describe('knexAdapter', () => {
       table.timestamp('expireAt')
     })
 
+    await db.schema.createTable('session', (table) => {
+      table.text('id').primary()
+      table.text('user_id').references('id').inTable('users')
+      table.text('token').unique()
+      table.timestamp('expires_at')
+      table.timestamp('createdAt')
+      table.timestamp('expireAt')
+    })
+
     await db.schema.createTable('counters', (table) => {
       table.string('id').primary()
       table.integer('value').defaultTo(0)
@@ -77,6 +86,7 @@ describe('knexAdapter', () => {
 
   beforeEach(async () => {
     await db('counters').delete()
+    await db('session').delete()
     await db('sessions').delete()
     await db('accounts').delete()
     await db('users').delete()
@@ -162,6 +172,40 @@ describe('knexAdapter', () => {
             id: `unique-login:${Math.floor(Date.UTC(2026, 1, 2) / 1000)}:u-login`
           }
         ])
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it('records weekly login counters when creating a singular session model', async () => {
+      const getLoginTotal = async () => {
+        const row = await db('counters')
+          .where('id', 'like', 'bucket:logins:%')
+          .sum<{ total: number | string | null }>('value as total')
+          .first()
+        return Number(row?.total ?? 0)
+      }
+
+      await db('users').insert({
+        id: 'u-singular-login',
+        email: 'singular-login@test.com'
+      })
+
+      try {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2026-02-04T10:00:00.000Z'))
+
+        await adapter.create({
+          model: 'session',
+          data: {
+            id: 's-singular-login',
+            user_id: 'u-singular-login',
+            token: 'singular-login-token',
+            expireAt: Date.now() + 60_000
+          }
+        })
+
+        expect(await getLoginTotal()).toBe(1)
       } finally {
         jest.useRealTimers()
       }

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -50,6 +50,7 @@ describe('knexAdapter', () => {
     await db.schema.createTable('sessions', (table) => {
       table.text('id').primary()
       table.text('user_id').references('id').inTable('users')
+      table.text('accountId')
       table.text('token').unique()
       table.timestamp('expires_at')
       table.timestamp('createdAt')
@@ -59,6 +60,7 @@ describe('knexAdapter', () => {
     await db.schema.createTable('session', (table) => {
       table.text('id').primary()
       table.text('user_id').references('id').inTable('users')
+      table.text('accountId')
       table.text('token').unique()
       table.timestamp('expires_at')
       table.timestamp('createdAt')
@@ -163,13 +165,14 @@ describe('knexAdapter', () => {
         })
 
         const markerRows = await db('counters')
-          .where('id', 'like', 'unique-login:%:u-login')
-          .select('id')
+          .where('id', 'unique-login:u-login')
+          .select('id', 'value')
 
         expect(await getLoginTotal()).toBe(1)
         expect(markerRows).toEqual([
           {
-            id: `unique-login:${Math.floor(Date.UTC(2026, 1, 2) / 1000)}:u-login`
+            id: 'unique-login:u-login',
+            value: Math.floor(Date.UTC(2026, 1, 2) / 1000)
           }
         ])
       } finally {
@@ -211,6 +214,97 @@ describe('knexAdapter', () => {
       }
     })
 
+    it('uses the Better Auth user id before stray accountId session fields', async () => {
+      await db('users').insert([
+        {
+          id: 'u-ba-canonical',
+          email: 'ba-canonical@test.com'
+        },
+        {
+          id: 'u-ba-stray',
+          email: 'ba-stray@test.com'
+        }
+      ])
+
+      try {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2026-02-04T10:00:00.000Z'))
+
+        await adapter.create({
+          model: 'session',
+          data: {
+            id: 's-ba-precedence',
+            user_id: 'u-ba-canonical',
+            accountId: 'u-ba-stray',
+            token: 'ba-precedence-token',
+            expireAt: Date.now() + 60_000
+          }
+        })
+
+        const markerRows = await db('counters')
+          .where('id', 'like', 'unique-login:%')
+          .select('id', 'value')
+
+        expect(markerRows).toEqual([
+          {
+            id: 'unique-login:u-ba-canonical',
+            value: Math.floor(Date.UTC(2026, 1, 2) / 1000)
+          }
+        ])
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it('creates sessions when login counter recording fails', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined)
+
+      try {
+        await db('users').insert({
+          id: 'u-login-failure',
+          email: 'login-failure@test.com'
+        })
+        await db.schema.dropTable('counters')
+
+        await expect(
+          adapter.create({
+            model: 'session',
+            data: {
+              id: 's-login-failure',
+              user_id: 'u-login-failure',
+              token: 'login-failure-token',
+              expireAt: Date.now() + 60_000
+            }
+          })
+        ).resolves.toMatchObject({
+          id: 's-login-failure',
+          user_id: 'u-login-failure'
+        })
+
+        await expect(
+          db('session').where('id', 's-login-failure').first()
+        ).resolves.toMatchObject({
+          id: 's-login-failure',
+          user_id: 'u-login-failure'
+        })
+      } finally {
+        await new Promise((resolve) => setImmediate(resolve))
+        errorSpy.mockRestore()
+        const hasCounters = await db.schema.hasTable('counters')
+        if (!hasCounters) {
+          await db.schema.createTable('counters', (table) => {
+            table.string('id').primary()
+            table.integer('value').defaultTo(0)
+            table.timestamp('bucketHour', { useTz: true }).nullable()
+            table.timestamp('createdAt', { useTz: true })
+            table.timestamp('updatedAt', { useTz: true })
+          })
+        }
+      }
+    })
+
     it('records session timestamp strings without timezone as UTC', async () => {
       const originalTimeZone = process.env.TZ
       process.env.TZ = 'Europe/Amsterdam'
@@ -233,14 +327,13 @@ describe('knexAdapter', () => {
         })
 
         const markerRows = await db('counters')
-          .where('id', 'like', 'unique-login:%:u-sqlite-time')
-          .select('id')
+          .where('id', 'unique-login:u-sqlite-time')
+          .select('id', 'value')
 
         expect(markerRows).toEqual([
           {
-            id: `unique-login:${Math.floor(
-              Date.UTC(2026, 4, 25) / 1000
-            )}:u-sqlite-time`
+            id: 'unique-login:u-sqlite-time',
+            value: Math.floor(Date.UTC(2026, 4, 25) / 1000)
           }
         ])
       } finally {

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -210,6 +210,47 @@ describe('knexAdapter', () => {
         jest.useRealTimers()
       }
     })
+
+    it('records session timestamp strings without timezone as UTC', async () => {
+      const originalTimeZone = process.env.TZ
+      process.env.TZ = 'Europe/Amsterdam'
+
+      try {
+        await db('users').insert({
+          id: 'u-sqlite-time',
+          email: 'sqlite-time@test.com'
+        })
+
+        await adapter.create({
+          model: 'sessions',
+          data: {
+            id: 's-sqlite-time',
+            user_id: 'u-sqlite-time',
+            token: 'sqlite-time-token',
+            createdAt: '2026-05-25 00:30:00.000',
+            expireAt: '2026-06-25 00:30:00.000'
+          }
+        })
+
+        const markerRows = await db('counters')
+          .where('id', 'like', 'unique-login:%:u-sqlite-time')
+          .select('id')
+
+        expect(markerRows).toEqual([
+          {
+            id: `unique-login:${Math.floor(
+              Date.UTC(2026, 4, 25) / 1000
+            )}:u-sqlite-time`
+          }
+        ])
+      } finally {
+        if (originalTimeZone === undefined) {
+          delete process.env.TZ
+        } else {
+          process.env.TZ = originalTimeZone
+        }
+      }
+    })
   })
 
   describe('findOne', () => {

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -1,5 +1,7 @@
 import knex, { Knex } from 'knex'
 
+import { logger } from '@/lib/utils/logger'
+
 import { knexAdapter } from './knexAdapter'
 
 jest.mock('better-auth/adapters', () => ({
@@ -262,7 +264,7 @@ describe('knexAdapter', () => {
 
     it('creates sessions when login counter recording fails', async () => {
       const errorSpy = jest
-        .spyOn(console, 'error')
+        .spyOn(logger, 'error')
         .mockImplementation(() => undefined)
 
       try {

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -244,6 +244,9 @@ describe('knexAdapter', () => {
         const markerRows = await db('counters')
           .where('id', 'like', 'unique-login:%')
           .select('id', 'value')
+        const sessionRow = await db('session')
+          .where('id', 's-ba-precedence')
+          .first()
 
         expect(markerRows).toEqual([
           {
@@ -251,6 +254,7 @@ describe('knexAdapter', () => {
             value: Math.floor(Date.UTC(2026, 1, 2) / 1000)
           }
         ])
+        expect(sessionRow?.accountId).toBe('u-ba-canonical')
       } finally {
         jest.useRealTimers()
       }

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -256,9 +256,69 @@ describe('knexAdapter', () => {
             value: Math.floor(Date.UTC(2026, 1, 2) / 1000)
           }
         ])
-        expect(sessionRow?.accountId).toBe('u-ba-canonical')
+        expect(sessionRow?.accountId).toBeNull()
       } finally {
         jest.useRealTimers()
+      }
+    })
+
+    it('does not require accountId columns on singular session tables', async () => {
+      const singularDb = knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: { filename: ':memory:' }
+      })
+      const singularAdapter = knexAdapter(singularDb)({} as never)
+
+      try {
+        await singularDb.schema.createTable('users', (table) => {
+          table.text('id').primary()
+          table.text('email')
+        })
+        await singularDb.schema.createTable('session', (table) => {
+          table.text('id').primary()
+          table.text('user_id').references('id').inTable('users')
+          table.text('token').unique()
+          table.timestamp('expireAt')
+          table.timestamp('createdAt')
+        })
+        await singularDb.schema.createTable('counters', (table) => {
+          table.string('id').primary()
+          table.integer('value').defaultTo(0)
+          table.timestamp('bucketHour', { useTz: true }).nullable()
+          table.timestamp('createdAt', { useTz: true })
+          table.timestamp('updatedAt', { useTz: true })
+        })
+        await singularDb('users').insert({
+          id: 'u-singular-no-account-column',
+          email: 'singular-no-account-column@test.com'
+        })
+
+        await expect(
+          singularAdapter.create({
+            model: 'session',
+            data: {
+              id: 's-singular-no-account-column',
+              user_id: 'u-singular-no-account-column',
+              accountId: 'u-should-not-be-inserted',
+              token: 'singular-no-account-column-token',
+              expireAt: Date.now() + 60_000
+            }
+          })
+        ).resolves.toMatchObject({
+          id: 's-singular-no-account-column',
+          user_id: 'u-singular-no-account-column'
+        })
+
+        await expect(
+          singularDb('counters')
+            .where('id', 'unique-login:u-singular-no-account-column')
+            .first()
+        ).resolves.toMatchObject({
+          id: 'unique-login:u-singular-no-account-column'
+        })
+      } finally {
+        await singularDb.destroy()
       }
     })
 

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -162,7 +162,11 @@ export const knexAdapter = (db: Knex) =>
           if (model === 'session' || tableName === 'sessions') {
             const accountId = getSessionAccountId(record, model)
             const createdAt = getSessionCreatedAt(record)
-            if (accountId) record.accountId = accountId
+            if (accountId && tableName === 'sessions') {
+              record.accountId = accountId
+            } else if (tableName !== 'sessions') {
+              delete record.accountId
+            }
             await db(tableName).insert(record)
             const row = await db(tableName).where(`${tableName}.id`, id).first()
             if (!row) throw new Error('Failed to create record')

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -161,13 +161,10 @@ export const knexAdapter = (db: Knex) =>
           const id = record.id as string
 
           if (model === 'session' || tableName === 'sessions') {
-            let row: unknown
             const accountId = getSessionAccountId(record, model)
             const createdAt = getSessionCreatedAt(record)
-            await db.transaction(async (trx) => {
-              await trx(tableName).insert(record)
-              row = await trx(tableName).where(`${tableName}.id`, id).first()
-            })
+            await db(tableName).insert(record)
+            const row = await db(tableName).where(`${tableName}.id`, id).first()
             if (!row) throw new Error('Failed to create record')
             await recordWeeklyLoginSafely(db, accountId, createdAt)
             return hydrateDateFields(row) as any

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -1,6 +1,8 @@
 import { CleanedWhere, createAdapterFactory } from 'better-auth/adapters'
 import { Knex } from 'knex'
 
+import { recordWeeklyLogin } from '@/lib/database/sql/instanceActivity'
+
 const escapeLikeValue = (value: unknown): string => {
   return String(value).replace(/[%_\\]/g, '\\$&')
 }
@@ -29,6 +31,29 @@ const hydrateDateFields = <T>(row: T): T => {
   }
 
   return hydrated as T
+}
+
+const getSessionAccountId = (
+  record: Record<string, unknown>
+): string | null => {
+  const accountId = record.accountId ?? record.userId ?? record.user_id
+  return typeof accountId === 'string' && accountId.length > 0
+    ? accountId
+    : null
+}
+
+const getSessionCreatedAt = (record: Record<string, unknown>): Date => {
+  const createdAt = record.createdAt
+  if (createdAt instanceof Date && !Number.isNaN(createdAt.getTime())) {
+    return createdAt
+  }
+
+  if (typeof createdAt === 'string' || typeof createdAt === 'number') {
+    const parsed = new Date(createdAt)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+
+  return new Date()
 }
 
 const applyWhere = (
@@ -123,8 +148,24 @@ export const knexAdapter = (db: Knex) =>
         async create({ data, model }) {
           const tableName = getModelName(model)
           const record = data as Record<string, unknown>
-          await db(tableName).insert(record)
           const id = record.id as string
+
+          if (tableName === 'sessions') {
+            let row: unknown
+            await db.transaction(async (trx) => {
+              await trx(tableName).insert(record)
+              await recordWeeklyLogin(
+                trx,
+                getSessionAccountId(record),
+                getSessionCreatedAt(record)
+              )
+              row = await trx(tableName).where(`${tableName}.id`, id).first()
+            })
+            if (!row) throw new Error('Failed to create record')
+            return hydrateDateFields(row) as any
+          }
+
+          await db(tableName).insert(record)
           const row = await db(tableName).where(`${tableName}.id`, id).first()
           if (!row) throw new Error('Failed to create record')
           return hydrateDateFields(row) as any

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -2,6 +2,7 @@ import { CleanedWhere, createAdapterFactory } from 'better-auth/adapters'
 import { Knex } from 'knex'
 
 import { recordWeeklyLogin } from '@/lib/database/sql/instanceActivity'
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 
 const escapeLikeValue = (value: unknown): string => {
   return String(value).replace(/[%_\\]/g, '\\$&')
@@ -24,7 +25,7 @@ const hydrateDateFields = <T>(row: T): T => {
       continue
     }
 
-    const date = new Date(value as string | number)
+    const date = new Date(getCompatibleTime(value as string | number))
     if (Number.isNaN(date.getTime())) continue
 
     hydrated[key] = date
@@ -49,7 +50,7 @@ const getSessionCreatedAt = (record: Record<string, unknown>): Date => {
   }
 
   if (typeof createdAt === 'string' || typeof createdAt === 'number') {
-    const parsed = new Date(createdAt)
+    const parsed = new Date(getCompatibleTime(createdAt))
     if (!Number.isNaN(parsed.getTime())) return parsed
   }
 

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -41,15 +41,14 @@ const getSessionAccountId = (
   record: Record<string, unknown>,
   model: string
 ): string | null => {
+  const userId = getStringValue(record.userId) ?? getStringValue(record.user_id)
+  const accountId = getStringValue(record.accountId)
+
   if (model === 'session') {
-    return getStringValue(record.userId) ?? getStringValue(record.user_id)
+    return userId ?? accountId
   }
 
-  return (
-    getStringValue(record.accountId) ??
-    getStringValue(record.userId) ??
-    getStringValue(record.user_id)
-  )
+  return accountId ?? userId
 }
 
 const getSessionCreatedAt = (record: Record<string, unknown>): Date => {
@@ -163,6 +162,7 @@ export const knexAdapter = (db: Knex) =>
           if (model === 'session' || tableName === 'sessions') {
             const accountId = getSessionAccountId(record, model)
             const createdAt = getSessionCreatedAt(record)
+            if (accountId) record.accountId = accountId
             await db(tableName).insert(record)
             const row = await db(tableName).where(`${tableName}.id`, id).first()
             if (!row) throw new Error('Failed to create record')

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -150,7 +150,7 @@ export const knexAdapter = (db: Knex) =>
           const record = data as Record<string, unknown>
           const id = record.id as string
 
-          if (tableName === 'sessions') {
+          if (model === 'session' || tableName === 'sessions') {
             let row: unknown
             await db.transaction(async (trx) => {
               await trx(tableName).insert(record)

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -1,7 +1,7 @@
 import { CleanedWhere, createAdapterFactory } from 'better-auth/adapters'
 import { Knex } from 'knex'
 
-import { recordWeeklyLogin } from '@/lib/database/sql/instanceActivity'
+import { recordWeeklyLoginSafely } from '@/lib/database/sql/instanceActivity'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 
 const escapeLikeValue = (value: unknown): string => {
@@ -34,13 +34,22 @@ const hydrateDateFields = <T>(row: T): T => {
   return hydrated as T
 }
 
+const getStringValue = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null
+
 const getSessionAccountId = (
-  record: Record<string, unknown>
+  record: Record<string, unknown>,
+  model: string
 ): string | null => {
-  const accountId = record.accountId ?? record.userId ?? record.user_id
-  return typeof accountId === 'string' && accountId.length > 0
-    ? accountId
-    : null
+  if (model === 'session') {
+    return getStringValue(record.userId) ?? getStringValue(record.user_id)
+  }
+
+  return (
+    getStringValue(record.accountId) ??
+    getStringValue(record.userId) ??
+    getStringValue(record.user_id)
+  )
 }
 
 const getSessionCreatedAt = (record: Record<string, unknown>): Date => {
@@ -153,16 +162,14 @@ export const knexAdapter = (db: Knex) =>
 
           if (model === 'session' || tableName === 'sessions') {
             let row: unknown
+            const accountId = getSessionAccountId(record, model)
+            const createdAt = getSessionCreatedAt(record)
             await db.transaction(async (trx) => {
               await trx(tableName).insert(record)
-              await recordWeeklyLogin(
-                trx,
-                getSessionAccountId(record),
-                getSessionCreatedAt(record)
-              )
               row = await trx(tableName).where(`${tableName}.id`, id).first()
             })
             if (!row) throw new Error('Failed to create record')
+            await recordWeeklyLoginSafely(db, accountId, createdAt)
             return hydrateDateFields(row) as any
           }
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1406,6 +1406,17 @@ export interface ServiceStatsBucket {
   value: number
 }
 
+export interface InstanceActivityWeek {
+  week: string
+  statuses: string
+  logins: string
+  registrations: string
+}
+
+export interface GetInstanceActivityParams {
+  now?: Date
+}
+
 export type ServiceStatCounterType =
   | 'accounts'
   | 'actors'
@@ -1564,4 +1575,10 @@ export interface AdminDatabase {
   importDomainBlocks(params: {
     blocks: ImportDomainBlockParams[]
   }): Promise<{ created: number; updated: number; skipped: number }>
+}
+
+export interface InstanceActivityDatabase {
+  getInstanceActivity(
+    params?: GetInstanceActivityParams
+  ): Promise<InstanceActivityWeek[]>
 }

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -1,5 +1,8 @@
-const CHUNK_SIZE = 100
+const COUNTER_WRITE_CHUNK_SIZE = 180
+const MARKER_LOOKUP_CHUNK_SIZE = 900
 const READ_CHUNK_SIZE = 1000
+// SQLite defaults to 999 bound parameters. Counter writes bind five values per
+// row, so 180 rows keeps each insert/upsert comfortably under that limit.
 const ACTIVITY_COUNTER_PREFIXES = [
   'bucket:local-statuses:%',
   'bucket:logins:%',
@@ -323,16 +326,19 @@ const upsertCounters = async (knex, counters, currentTime) => {
   const bucketRows = rows.filter((row) => row.id.startsWith('bucket:'))
   const markerRows = rows.filter((row) => row.id.startsWith('unique-login:'))
 
-  for (let i = 0; i < bucketRows.length; i += CHUNK_SIZE) {
+  for (let i = 0; i < bucketRows.length; i += COUNTER_WRITE_CHUNK_SIZE) {
     await upsertBucketBackfillChunk(
       knex,
-      bucketRows.slice(i, i + CHUNK_SIZE),
+      bucketRows.slice(i, i + COUNTER_WRITE_CHUNK_SIZE),
       currentTime
     )
   }
 
-  for (let i = 0; i < markerRows.length; i += CHUNK_SIZE) {
-    await upsertLoginMarkerRows(knex, markerRows.slice(i, i + CHUNK_SIZE))
+  for (let i = 0; i < markerRows.length; i += COUNTER_WRITE_CHUNK_SIZE) {
+    await upsertLoginMarkerRows(
+      knex,
+      markerRows.slice(i, i + COUNTER_WRITE_CHUNK_SIZE)
+    )
   }
 }
 
@@ -402,9 +408,9 @@ const getExistingLoginMarkerWeeks = async (knex, markerIds) => {
   const existing = new Map()
   if (markerIds.length === 0) return existing
 
-  for (let i = 0; i < markerIds.length; i += CHUNK_SIZE) {
+  for (let i = 0; i < markerIds.length; i += MARKER_LOOKUP_CHUNK_SIZE) {
     const rows = await knex('counters')
-      .whereIn('id', markerIds.slice(i, i + CHUNK_SIZE))
+      .whereIn('id', markerIds.slice(i, i + MARKER_LOOKUP_CHUNK_SIZE))
       .select('id', 'value')
 
     for (const row of rows) {

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -1,8 +1,17 @@
 const CHUNK_SIZE = 100
 const READ_CHUNK_SIZE = 1000
+const SQLITE_UTC_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$/
 
 const toDate = (value) => {
   if (value instanceof Date) return value
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    const normalized = SQLITE_UTC_TIMESTAMP_PATTERN.test(trimmed)
+      ? `${trimmed.replace(' ', 'T')}Z`
+      : trimmed
+    return new Date(normalized)
+  }
   return new Date(value)
 }
 

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -8,6 +8,9 @@ const ACTIVITY_COUNTER_PREFIXES = [
   'bucket:logins:%',
   'unique-login:%'
 ]
+const SESSION_TABLE_NAMES = ['sessions', 'session']
+const SESSION_ACCOUNT_ID_COLUMNS = ['accountId', 'userId', 'user_id']
+const SESSION_CREATED_AT_COLUMNS = ['createdAt', 'created_at']
 const BACKFILL_COUNTER_PREFIX = 'backfill:instance-activity:'
 const SQLITE_UTC_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$/
@@ -61,6 +64,37 @@ const getWeekKey = (date) =>
 const getLoginMarkerId = (accountId) => `unique-login:${accountId}`
 const getBackfillCounterId = (counterId) =>
   `${BACKFILL_COUNTER_PREFIX}${counterId}`
+
+const getFirstExistingColumn = async (knex, tableName, columnNames) => {
+  for (const columnName of columnNames) {
+    if (await knex.schema.hasColumn(tableName, columnName)) return columnName
+  }
+
+  return null
+}
+
+const getSessionBackfillSource = async (knex) => {
+  for (const tableName of SESSION_TABLE_NAMES) {
+    if (!(await knex.schema.hasTable(tableName))) continue
+
+    const accountIdColumn = await getFirstExistingColumn(
+      knex,
+      tableName,
+      SESSION_ACCOUNT_ID_COLUMNS
+    )
+    const createdAtColumn = await getFirstExistingColumn(
+      knex,
+      tableName,
+      SESSION_CREATED_AT_COLUMNS
+    )
+
+    if (accountIdColumn && createdAtColumn) {
+      return { tableName, accountIdColumn, createdAtColumn }
+    }
+  }
+
+  return null
+}
 
 const isMySQLClient = (knex) => {
   const client = String(knex.client.config.client).toLowerCase()
@@ -368,13 +402,20 @@ const backfillLocalStatusCounters = async (knex, counters, backfillEnd) => {
 
 const collectFirstWeeklyLogins = async (knex, backfillEnd) => {
   const firstLoginByWeek = new Map()
+  const sessionSource = await getSessionBackfillSource(knex)
+  if (!sessionSource) return firstLoginByWeek
+
   let lastSessionId = ''
 
   while (true) {
-    const sessions = await knex('sessions')
-      .whereNotNull('accountId')
+    const sessions = await knex(sessionSource.tableName)
+      .whereNotNull(sessionSource.accountIdColumn)
       .where('id', '>', lastSessionId)
-      .select('id', 'accountId', 'createdAt')
+      .select(
+        'id',
+        { accountId: sessionSource.accountIdColumn },
+        { createdAt: sessionSource.createdAtColumn }
+      )
       .orderBy('id', 'asc')
       .limit(READ_CHUNK_SIZE)
 

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -1,5 +1,10 @@
 const CHUNK_SIZE = 100
 const READ_CHUNK_SIZE = 1000
+const ACTIVITY_COUNTER_PREFIXES = [
+  'bucket:local-statuses:%',
+  'bucket:logins:%',
+  'unique-login:%'
+]
 const SQLITE_UTC_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$/
 
@@ -49,6 +54,8 @@ const getUTCWeekStart = (date) => {
 const getWeekKey = (date) =>
   String(Math.floor(getUTCWeekStart(date).getTime() / 1000))
 
+const getLoginMarkerId = (accountId) => `unique-login:${accountId}`
+
 const addBucketCounter = (counters, counterType, date, value = 1) => {
   const bucketHour = truncateToHour(date)
   const id = `bucket:${counterType}:${formatBucketHour(bucketHour)}`
@@ -61,6 +68,22 @@ const addBucketCounter = (counters, counterType, date, value = 1) => {
   })
 }
 
+const getExistingActivityCounterCutoff = async (knex, currentTime) => {
+  const row = await knex('counters')
+    .where((builder) => {
+      for (const prefix of ACTIVITY_COUNTER_PREFIXES) {
+        builder.orWhere('id', 'like', prefix)
+      }
+    })
+    .min('createdAt as createdAt')
+    .first()
+
+  if (!row?.createdAt) return currentTime
+
+  const createdAt = toDate(row.createdAt)
+  return Number.isNaN(createdAt.getTime()) ? currentTime : createdAt
+}
+
 const upsertCounters = async (knex, counters, currentTime) => {
   const rows = [...counters.values()].map((counter) => ({
     id: counter.id,
@@ -69,17 +92,36 @@ const upsertCounters = async (knex, counters, currentTime) => {
     createdAt: currentTime,
     updatedAt: currentTime
   }))
+  const bucketRows = rows.filter((row) => row.id.startsWith('bucket:'))
+  const markerRows = rows.filter((row) => row.id.startsWith('unique-login:'))
 
-  for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
-    const chunk = rows.slice(i, i + CHUNK_SIZE)
+  for (let i = 0; i < bucketRows.length; i += CHUNK_SIZE) {
+    const chunk = bucketRows.slice(i, i + CHUNK_SIZE)
     await knex('counters')
       .insert(chunk)
       .onConflict('id')
-      .merge(['value', 'bucketHour', 'updatedAt'])
+      .merge({
+        value: knex.raw('"counters"."value" + excluded."value"'),
+        bucketHour: knex.raw('excluded."bucketHour"'),
+        updatedAt: knex.raw('excluded."updatedAt"')
+      })
+  }
+
+  for (let i = 0; i < markerRows.length; i += CHUNK_SIZE) {
+    const chunk = markerRows.slice(i, i + CHUNK_SIZE)
+    await knex('counters')
+      .insert(chunk)
+      .onConflict('id')
+      .merge({
+        value: knex.raw(
+          'CASE WHEN excluded."value" > "counters"."value" THEN excluded."value" ELSE "counters"."value" END'
+        ),
+        updatedAt: knex.raw('excluded."updatedAt"')
+      })
   }
 }
 
-const backfillLocalStatusCounters = async (knex, counters) => {
+const backfillLocalStatusCounters = async (knex, counters, backfillEnd) => {
   let lastStatusId = ''
 
   while (true) {
@@ -97,13 +139,14 @@ const backfillLocalStatusCounters = async (knex, counters) => {
       lastStatusId = status.id
       const createdAt = toDate(status.createdAt)
       if (Number.isNaN(createdAt.getTime())) continue
+      if (createdAt >= backfillEnd) continue
       addBucketCounter(counters, 'local-statuses', createdAt)
     }
   }
 }
 
-const collectFirstWeeklyLogins = async (knex) => {
-  const firstLoginByMarker = new Map()
+const collectFirstWeeklyLogins = async (knex, backfillEnd) => {
+  const firstLoginByWeek = new Map()
   let lastSessionId = ''
 
   while (true) {
@@ -122,19 +165,52 @@ const collectFirstWeeklyLogins = async (knex) => {
 
       const createdAt = toDate(session.createdAt)
       if (Number.isNaN(createdAt.getTime())) continue
+      if (createdAt >= backfillEnd) continue
 
-      const markerId = `unique-login:${getWeekKey(createdAt)}:${session.accountId}`
-      const existing = firstLoginByMarker.get(markerId)
+      const weekKey = getWeekKey(createdAt)
+      const weeklyLoginId = `${session.accountId}:${weekKey}`
+      const existing = firstLoginByWeek.get(weeklyLoginId)
       if (!existing || createdAt.getTime() < existing.createdAt.getTime()) {
-        firstLoginByMarker.set(markerId, {
+        firstLoginByWeek.set(weeklyLoginId, {
           accountId: session.accountId,
+          weekKey,
           createdAt
         })
       }
     }
   }
 
-  return firstLoginByMarker
+  return firstLoginByWeek
+}
+
+const getExistingLoginMarkerWeeks = async (knex, markerIds) => {
+  const existing = new Map()
+  if (markerIds.length === 0) return existing
+
+  for (let i = 0; i < markerIds.length; i += CHUNK_SIZE) {
+    const rows = await knex('counters')
+      .whereIn('id', markerIds.slice(i, i + CHUNK_SIZE))
+      .select('id', 'value')
+
+    for (const row of rows) {
+      const value = Number(row.value)
+      if (Number.isFinite(value)) {
+        existing.set(row.id, value)
+      }
+    }
+  }
+
+  return existing
+}
+
+const setLoginMarker = (counters, accountId, weekKey, existingWeek) => {
+  const markerId = getLoginMarkerId(accountId)
+  const currentValue = counters.get(markerId)?.value ?? existingWeek ?? 0
+  counters.set(markerId, {
+    id: markerId,
+    value: Math.max(Number(currentValue), Number(weekKey)),
+    bucketHour: null
+  })
 }
 
 /**
@@ -143,18 +219,27 @@ const collectFirstWeeklyLogins = async (knex) => {
  */
 exports.up = async function (knex) {
   const currentTime = new Date()
+  const backfillEnd = await getExistingActivityCounterCutoff(knex, currentTime)
   const counters = new Map()
 
-  await backfillLocalStatusCounters(knex, counters)
+  await backfillLocalStatusCounters(knex, counters, backfillEnd)
 
-  const firstLoginByMarker = await collectFirstWeeklyLogins(knex)
-  for (const [markerId, login] of firstLoginByMarker.entries()) {
-    counters.set(markerId, {
-      id: markerId,
-      value: 1,
-      bucketHour: null
-    })
-    addBucketCounter(counters, 'logins', login.createdAt)
+  const firstLoginByWeek = await collectFirstWeeklyLogins(knex, backfillEnd)
+  const markerIds = [
+    ...new Set(
+      [...firstLoginByWeek.values()].map((login) =>
+        getLoginMarkerId(login.accountId)
+      )
+    )
+  ]
+  const existingMarkerWeeks = await getExistingLoginMarkerWeeks(knex, markerIds)
+  for (const login of firstLoginByWeek.values()) {
+    const markerId = getLoginMarkerId(login.accountId)
+    const existingWeek = existingMarkerWeeks.get(markerId)
+    if (existingWeek !== Number(login.weekKey)) {
+      addBucketCounter(counters, 'logins', login.createdAt)
+    }
+    setLoginMarker(counters, login.accountId, login.weekKey, existingWeek)
   }
 
   await upsertCounters(knex, counters, currentTime)
@@ -171,3 +256,5 @@ exports.down = async function (knex) {
     .orWhere('id', 'like', 'unique-login:%')
     .delete()
 }
+
+exports.config = { transaction: false }

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -58,7 +58,12 @@ const getLoginMarkerId = (accountId) => `unique-login:${accountId}`
 
 const isMySQLClient = (knex) => {
   const client = String(knex.client.config.client).toLowerCase()
-  return client.includes('mysql') || client.includes('maria')
+  return client.includes('mysql')
+}
+
+const isMariaDBClient = (knex) => {
+  const client = String(knex.client.config.client).toLowerCase()
+  return client.includes('maria')
 }
 
 const addBucketCounter = (counters, counterType, date, value = 1) => {
@@ -89,8 +94,76 @@ const getExistingActivityCounterCutoff = async (knex, currentTime) => {
   return Number.isNaN(createdAt.getTime()) ? currentTime : createdAt
 }
 
+const MYSQL_COUNTER_ALIAS = 'new_values'
+const COUNTER_COLUMNS = ['id', 'value', 'bucketHour', 'createdAt', 'updatedAt']
+
+const buildMySQLCounterInsertQuery = (
+  knex,
+  rows,
+  updateSql,
+  updateBindings
+) => {
+  const rowPlaceholders = rows.map(() => '(?, ?, ?, ?, ?)').join(', ')
+  const rowBindings = rows.flatMap((row) =>
+    COUNTER_COLUMNS.map((column) => row[column])
+  )
+
+  return knex.raw(
+    `insert into ?? (??, ??, ??, ??, ??) values ${rowPlaceholders} as ?? on duplicate key update ${updateSql}`,
+    [
+      'counters',
+      ...COUNTER_COLUMNS,
+      ...rowBindings,
+      MYSQL_COUNTER_ALIAS,
+      ...updateBindings
+    ]
+  )
+}
+
+const buildMySQLBucketCounterUpsertQuery = (knex, rows) =>
+  buildMySQLCounterInsertQuery(
+    knex,
+    rows,
+    '?? = ??.?? + ??.??, ?? = ??.??, ?? = ??.??',
+    [
+      'value',
+      'counters',
+      'value',
+      MYSQL_COUNTER_ALIAS,
+      'value',
+      'bucketHour',
+      MYSQL_COUNTER_ALIAS,
+      'bucketHour',
+      'updatedAt',
+      MYSQL_COUNTER_ALIAS,
+      'updatedAt'
+    ]
+  )
+
+const buildMySQLLoginMarkerUpsertQuery = (knex, rows) =>
+  buildMySQLCounterInsertQuery(
+    knex,
+    rows,
+    '?? = case when ??.?? > ??.?? then ??.?? else ??.?? end, ?? = ??.??',
+    [
+      'value',
+      MYSQL_COUNTER_ALIAS,
+      'value',
+      'counters',
+      'value',
+      MYSQL_COUNTER_ALIAS,
+      'value',
+      'counters',
+      'value',
+      'updatedAt',
+      MYSQL_COUNTER_ALIAS,
+      'updatedAt'
+    ]
+  )
+
 const upsertCounters = async (knex, counters, currentTime) => {
   const isMySQL = isMySQLClient(knex)
+  const isMariaDB = isMariaDBClient(knex)
   const rows = [...counters.values()].map((counter) => ({
     id: counter.id,
     value: counter.value,
@@ -103,17 +176,22 @@ const upsertCounters = async (knex, counters, currentTime) => {
 
   for (let i = 0; i < bucketRows.length; i += CHUNK_SIZE) {
     const chunk = bucketRows.slice(i, i + CHUNK_SIZE)
+    if (isMySQL) {
+      await buildMySQLBucketCounterUpsertQuery(knex, chunk)
+      continue
+    }
+
     await knex('counters')
       .insert(chunk)
       .onConflict('id')
       .merge({
-        value: isMySQL
+        value: isMariaDB
           ? knex.raw('?? + VALUES(??)', ['counters.value', 'value'])
           : knex.raw('?? + excluded.??', ['counters.value', 'value']),
-        bucketHour: isMySQL
+        bucketHour: isMariaDB
           ? knex.raw('VALUES(??)', ['bucketHour'])
           : knex.raw('excluded.??', ['bucketHour']),
-        updatedAt: isMySQL
+        updatedAt: isMariaDB
           ? knex.raw('VALUES(??)', ['updatedAt'])
           : knex.raw('excluded.??', ['updatedAt'])
       })
@@ -121,11 +199,16 @@ const upsertCounters = async (knex, counters, currentTime) => {
 
   for (let i = 0; i < markerRows.length; i += CHUNK_SIZE) {
     const chunk = markerRows.slice(i, i + CHUNK_SIZE)
+    if (isMySQL) {
+      await buildMySQLLoginMarkerUpsertQuery(knex, chunk)
+      continue
+    }
+
     await knex('counters')
       .insert(chunk)
       .onConflict('id')
       .merge({
-        value: isMySQL
+        value: isMariaDB
           ? knex.raw('CASE WHEN VALUES(??) > ?? THEN VALUES(??) ELSE ?? END', [
               'value',
               'counters.value',
@@ -136,7 +219,7 @@ const upsertCounters = async (knex, counters, currentTime) => {
               'CASE WHEN excluded.?? > ?? THEN excluded.?? ELSE ?? END',
               ['value', 'counters.value', 'value', 'counters.value']
             ),
-        updatedAt: isMySQL
+        updatedAt: isMariaDB
           ? knex.raw('VALUES(??)', ['updatedAt'])
           : knex.raw('excluded.??', ['updatedAt'])
       })
@@ -279,4 +362,6 @@ exports.down = async function (knex) {
     .delete()
 }
 
+exports.buildMySQLBucketCounterUpsertQuery = buildMySQLBucketCounterUpsertQuery
+exports.buildMySQLLoginMarkerUpsertQuery = buildMySQLLoginMarkerUpsertQuery
 exports.config = { transaction: false }

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -1,4 +1,5 @@
 const CHUNK_SIZE = 100
+const READ_CHUNK_SIZE = 1000
 
 const toDate = (value) => {
   if (value instanceof Date) return value
@@ -69,6 +70,64 @@ const upsertCounters = async (knex, counters, currentTime) => {
   }
 }
 
+const backfillLocalStatusCounters = async (knex, counters) => {
+  let lastStatusId = ''
+
+  while (true) {
+    const statuses = await knex('statuses')
+      .join('actors', 'statuses.actorId', 'actors.id')
+      .whereNotNull('actors.accountId')
+      .where('statuses.id', '>', lastStatusId)
+      .select('statuses.id', 'statuses.createdAt')
+      .orderBy('statuses.id', 'asc')
+      .limit(READ_CHUNK_SIZE)
+
+    if (statuses.length === 0) break
+
+    for (const status of statuses) {
+      lastStatusId = status.id
+      const createdAt = toDate(status.createdAt)
+      if (Number.isNaN(createdAt.getTime())) continue
+      addBucketCounter(counters, 'local-statuses', createdAt)
+    }
+  }
+}
+
+const collectFirstWeeklyLogins = async (knex) => {
+  const firstLoginByMarker = new Map()
+  let lastSessionId = ''
+
+  while (true) {
+    const sessions = await knex('sessions')
+      .whereNotNull('accountId')
+      .where('id', '>', lastSessionId)
+      .select('id', 'accountId', 'createdAt')
+      .orderBy('id', 'asc')
+      .limit(READ_CHUNK_SIZE)
+
+    if (sessions.length === 0) break
+
+    for (const session of sessions) {
+      lastSessionId = session.id
+      if (!session.accountId) continue
+
+      const createdAt = toDate(session.createdAt)
+      if (Number.isNaN(createdAt.getTime())) continue
+
+      const markerId = `unique-login:${getWeekKey(createdAt)}:${session.accountId}`
+      const existing = firstLoginByMarker.get(markerId)
+      if (!existing || createdAt.getTime() < existing.createdAt.getTime()) {
+        firstLoginByMarker.set(markerId, {
+          accountId: session.accountId,
+          createdAt
+        })
+      }
+    }
+  }
+
+  return firstLoginByMarker
+}
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
@@ -77,38 +136,9 @@ exports.up = async function (knex) {
   const currentTime = new Date()
   const counters = new Map()
 
-  const localStatuses = await knex('statuses')
-    .join('actors', 'statuses.actorId', 'actors.id')
-    .whereNotNull('actors.accountId')
-    .select('statuses.createdAt')
+  await backfillLocalStatusCounters(knex, counters)
 
-  for (const status of localStatuses) {
-    const createdAt = toDate(status.createdAt)
-    if (Number.isNaN(createdAt.getTime())) continue
-    addBucketCounter(counters, 'local-statuses', createdAt)
-  }
-
-  const sessions = await knex('sessions')
-    .whereNotNull('accountId')
-    .select('accountId', 'createdAt')
-
-  const firstLoginByMarker = new Map()
-  for (const session of sessions) {
-    if (!session.accountId) continue
-
-    const createdAt = toDate(session.createdAt)
-    if (Number.isNaN(createdAt.getTime())) continue
-
-    const markerId = `unique-login:${getWeekKey(createdAt)}:${session.accountId}`
-    const existing = firstLoginByMarker.get(markerId)
-    if (!existing || createdAt.getTime() < existing.createdAt.getTime()) {
-      firstLoginByMarker.set(markerId, {
-        accountId: session.accountId,
-        createdAt
-      })
-    }
-  }
-
+  const firstLoginByMarker = await collectFirstWeeklyLogins(knex)
   for (const [markerId, login] of firstLoginByMarker.entries()) {
     counters.set(markerId, {
       id: markerId,

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -5,6 +5,7 @@ const ACTIVITY_COUNTER_PREFIXES = [
   'bucket:logins:%',
   'unique-login:%'
 ]
+const BACKFILL_COUNTER_PREFIX = 'backfill:instance-activity:'
 const SQLITE_UTC_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$/
 
@@ -55,6 +56,8 @@ const getWeekKey = (date) =>
   String(Math.floor(getUTCWeekStart(date).getTime() / 1000))
 
 const getLoginMarkerId = (accountId) => `unique-login:${accountId}`
+const getBackfillCounterId = (counterId) =>
+  `${BACKFILL_COUNTER_PREFIX}${counterId}`
 
 const isMySQLClient = (knex) => {
   const client = String(knex.client.config.client).toLowerCase()
@@ -161,9 +164,155 @@ const buildMySQLLoginMarkerUpsertQuery = (knex, rows) =>
     ]
   )
 
-const upsertCounters = async (knex, counters, currentTime) => {
+const buildMySQLBackfillMarkerUpsertQuery = (knex, rows) =>
+  buildMySQLCounterInsertQuery(knex, rows, '?? = ??.??, ?? = ??.??', [
+    'value',
+    MYSQL_COUNTER_ALIAS,
+    'value',
+    'updatedAt',
+    MYSQL_COUNTER_ALIAS,
+    'updatedAt'
+  ])
+
+const upsertBucketRows = async (knex, rows) => {
+  if (rows.length === 0) return
+
   const isMySQL = isMySQLClient(knex)
   const isMariaDB = isMariaDBClient(knex)
+
+  if (isMySQL) {
+    await buildMySQLBucketCounterUpsertQuery(knex, rows)
+    return
+  }
+
+  await knex('counters')
+    .insert(rows)
+    .onConflict('id')
+    .merge({
+      value: isMariaDB
+        ? knex.raw('?? + VALUES(??)', ['counters.value', 'value'])
+        : knex.raw('?? + excluded.??', ['counters.value', 'value']),
+      bucketHour: isMariaDB
+        ? knex.raw('VALUES(??)', ['bucketHour'])
+        : knex.raw('excluded.??', ['bucketHour']),
+      updatedAt: isMariaDB
+        ? knex.raw('VALUES(??)', ['updatedAt'])
+        : knex.raw('excluded.??', ['updatedAt'])
+    })
+}
+
+const getExistingBackfillValues = async (knex, bucketRows) => {
+  if (bucketRows.length === 0) return new Map()
+
+  const markerIds = bucketRows.map((row) => getBackfillCounterId(row.id))
+  const rows = await knex('counters')
+    .whereIn('id', markerIds)
+    .select('id', 'value')
+
+  return new Map(
+    rows.map((row) => [
+      String(row.id).slice(BACKFILL_COUNTER_PREFIX.length),
+      Number(row.value ?? 0)
+    ])
+  )
+}
+
+const upsertBackfillMarkerRows = async (knex, rows) => {
+  if (rows.length === 0) return
+
+  const isMySQL = isMySQLClient(knex)
+  const isMariaDB = isMariaDBClient(knex)
+
+  if (isMySQL) {
+    await buildMySQLBackfillMarkerUpsertQuery(knex, rows)
+    return
+  }
+
+  await knex('counters')
+    .insert(rows)
+    .onConflict('id')
+    .merge({
+      value: isMariaDB
+        ? knex.raw('VALUES(??)', ['value'])
+        : knex.raw('excluded.??', ['value']),
+      updatedAt: isMariaDB
+        ? knex.raw('VALUES(??)', ['updatedAt'])
+        : knex.raw('excluded.??', ['updatedAt'])
+    })
+}
+
+const upsertBucketBackfillChunk = async (knex, bucketRows, currentTime) => {
+  if (bucketRows.length === 0) return
+
+  const existingBackfillValues = await getExistingBackfillValues(
+    knex,
+    bucketRows
+  )
+  const deltaRows = []
+  const markerRows = []
+
+  for (const row of bucketRows) {
+    const currentValue = Number(row.value)
+    const appliedValue = existingBackfillValues.get(row.id) ?? 0
+    const delta = currentValue - appliedValue
+
+    if (delta !== 0) {
+      deltaRows.push({
+        ...row,
+        value: delta
+      })
+    }
+
+    markerRows.push({
+      id: getBackfillCounterId(row.id),
+      value: currentValue,
+      bucketHour: null,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+  }
+
+  await knex.transaction(async (trx) => {
+    await upsertBucketRows(trx, deltaRows)
+    await upsertBackfillMarkerRows(trx, markerRows)
+  })
+}
+
+const upsertLoginMarkerRows = async (knex, rows) => {
+  if (rows.length === 0) return
+
+  const isMySQL = isMySQLClient(knex)
+  const isMariaDB = isMariaDBClient(knex)
+
+  if (isMySQL) {
+    await buildMySQLLoginMarkerUpsertQuery(knex, rows)
+    return
+  }
+
+  await knex('counters')
+    .insert(rows)
+    .onConflict('id')
+    .merge({
+      value: isMariaDB
+        ? knex.raw('CASE WHEN VALUES(??) > ?? THEN VALUES(??) ELSE ?? END', [
+            'value',
+            'counters.value',
+            'value',
+            'counters.value'
+          ])
+        : knex.raw('CASE WHEN excluded.?? > ?? THEN excluded.?? ELSE ?? END', [
+            'value',
+            'counters.value',
+            'value',
+            'counters.value'
+          ]),
+      updatedAt: isMariaDB
+        ? knex.raw('VALUES(??)', ['updatedAt'])
+        : knex.raw('excluded.??', ['updatedAt'])
+    })
+}
+
+const upsertCounters = async (knex, counters, currentTime) => {
   const rows = [...counters.values()].map((counter) => ({
     id: counter.id,
     value: counter.value,
@@ -175,54 +324,15 @@ const upsertCounters = async (knex, counters, currentTime) => {
   const markerRows = rows.filter((row) => row.id.startsWith('unique-login:'))
 
   for (let i = 0; i < bucketRows.length; i += CHUNK_SIZE) {
-    const chunk = bucketRows.slice(i, i + CHUNK_SIZE)
-    if (isMySQL) {
-      await buildMySQLBucketCounterUpsertQuery(knex, chunk)
-      continue
-    }
-
-    await knex('counters')
-      .insert(chunk)
-      .onConflict('id')
-      .merge({
-        value: isMariaDB
-          ? knex.raw('?? + VALUES(??)', ['counters.value', 'value'])
-          : knex.raw('?? + excluded.??', ['counters.value', 'value']),
-        bucketHour: isMariaDB
-          ? knex.raw('VALUES(??)', ['bucketHour'])
-          : knex.raw('excluded.??', ['bucketHour']),
-        updatedAt: isMariaDB
-          ? knex.raw('VALUES(??)', ['updatedAt'])
-          : knex.raw('excluded.??', ['updatedAt'])
-      })
+    await upsertBucketBackfillChunk(
+      knex,
+      bucketRows.slice(i, i + CHUNK_SIZE),
+      currentTime
+    )
   }
 
   for (let i = 0; i < markerRows.length; i += CHUNK_SIZE) {
-    const chunk = markerRows.slice(i, i + CHUNK_SIZE)
-    if (isMySQL) {
-      await buildMySQLLoginMarkerUpsertQuery(knex, chunk)
-      continue
-    }
-
-    await knex('counters')
-      .insert(chunk)
-      .onConflict('id')
-      .merge({
-        value: isMariaDB
-          ? knex.raw('CASE WHEN VALUES(??) > ?? THEN VALUES(??) ELSE ?? END', [
-              'value',
-              'counters.value',
-              'value',
-              'counters.value'
-            ])
-          : knex.raw(
-              'CASE WHEN excluded.?? > ?? THEN excluded.?? ELSE ?? END',
-              ['value', 'counters.value', 'value', 'counters.value']
-            ),
-        updatedAt: isMariaDB
-          ? knex.raw('VALUES(??)', ['updatedAt'])
-          : knex.raw('excluded.??', ['updatedAt'])
-      })
+    await upsertLoginMarkerRows(knex, markerRows.slice(i, i + CHUNK_SIZE))
   }
 }
 
@@ -359,6 +469,7 @@ exports.down = async function (knex) {
     .where('id', 'like', 'bucket:local-statuses:%')
     .orWhere('id', 'like', 'bucket:logins:%')
     .orWhere('id', 'like', 'unique-login:%')
+    .orWhere('id', 'like', `${BACKFILL_COUNTER_PREFIX}%`)
     .delete()
 }
 

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -101,9 +101,9 @@ const upsertCounters = async (knex, counters, currentTime) => {
       .insert(chunk)
       .onConflict('id')
       .merge({
-        value: knex.raw('"counters"."value" + excluded."value"'),
-        bucketHour: knex.raw('excluded."bucketHour"'),
-        updatedAt: knex.raw('excluded."updatedAt"')
+        value: knex.raw('?? + excluded.??', ['counters.value', 'value']),
+        bucketHour: knex.raw('excluded.??', ['bucketHour']),
+        updatedAt: knex.raw('excluded.??', ['updatedAt'])
       })
   }
 
@@ -114,9 +114,10 @@ const upsertCounters = async (knex, counters, currentTime) => {
       .onConflict('id')
       .merge({
         value: knex.raw(
-          'CASE WHEN excluded."value" > "counters"."value" THEN excluded."value" ELSE "counters"."value" END'
+          'CASE WHEN excluded.?? > ?? THEN excluded.?? ELSE ?? END',
+          ['value', 'counters.value', 'value', 'counters.value']
         ),
-        updatedAt: knex.raw('excluded."updatedAt"')
+        updatedAt: knex.raw('excluded.??', ['updatedAt'])
       })
   }
 }

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -56,6 +56,11 @@ const getWeekKey = (date) =>
 
 const getLoginMarkerId = (accountId) => `unique-login:${accountId}`
 
+const isMySQLClient = (knex) => {
+  const client = String(knex.client.config.client).toLowerCase()
+  return client.includes('mysql') || client.includes('maria')
+}
+
 const addBucketCounter = (counters, counterType, date, value = 1) => {
   const bucketHour = truncateToHour(date)
   const id = `bucket:${counterType}:${formatBucketHour(bucketHour)}`
@@ -85,6 +90,7 @@ const getExistingActivityCounterCutoff = async (knex, currentTime) => {
 }
 
 const upsertCounters = async (knex, counters, currentTime) => {
+  const isMySQL = isMySQLClient(knex)
   const rows = [...counters.values()].map((counter) => ({
     id: counter.id,
     value: counter.value,
@@ -101,9 +107,15 @@ const upsertCounters = async (knex, counters, currentTime) => {
       .insert(chunk)
       .onConflict('id')
       .merge({
-        value: knex.raw('?? + excluded.??', ['counters.value', 'value']),
-        bucketHour: knex.raw('excluded.??', ['bucketHour']),
-        updatedAt: knex.raw('excluded.??', ['updatedAt'])
+        value: isMySQL
+          ? knex.raw('?? + VALUES(??)', ['counters.value', 'value'])
+          : knex.raw('?? + excluded.??', ['counters.value', 'value']),
+        bucketHour: isMySQL
+          ? knex.raw('VALUES(??)', ['bucketHour'])
+          : knex.raw('excluded.??', ['bucketHour']),
+        updatedAt: isMySQL
+          ? knex.raw('VALUES(??)', ['updatedAt'])
+          : knex.raw('excluded.??', ['updatedAt'])
       })
   }
 
@@ -113,11 +125,20 @@ const upsertCounters = async (knex, counters, currentTime) => {
       .insert(chunk)
       .onConflict('id')
       .merge({
-        value: knex.raw(
-          'CASE WHEN excluded.?? > ?? THEN excluded.?? ELSE ?? END',
-          ['value', 'counters.value', 'value', 'counters.value']
-        ),
-        updatedAt: knex.raw('excluded.??', ['updatedAt'])
+        value: isMySQL
+          ? knex.raw('CASE WHEN VALUES(??) > ?? THEN VALUES(??) ELSE ?? END', [
+              'value',
+              'counters.value',
+              'value',
+              'counters.value'
+            ])
+          : knex.raw(
+              'CASE WHEN excluded.?? > ?? THEN excluded.?? ELSE ?? END',
+              ['value', 'counters.value', 'value', 'counters.value']
+            ),
+        updatedAt: isMySQL
+          ? knex.raw('VALUES(??)', ['updatedAt'])
+          : knex.raw('excluded.??', ['updatedAt'])
       })
   }
 }

--- a/migrations/20260526112702_backfill_instance_activity_counters.js
+++ b/migrations/20260526112702_backfill_instance_activity_counters.js
@@ -1,0 +1,134 @@
+const CHUNK_SIZE = 100
+
+const toDate = (value) => {
+  if (value instanceof Date) return value
+  return new Date(value)
+}
+
+const truncateToHour = (date) =>
+  new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours()
+    )
+  )
+
+const formatBucketHour = (date) => {
+  const y = date.getUTCFullYear()
+  const mo = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  const h = String(date.getUTCHours()).padStart(2, '0')
+  return `${y}${mo}${d}${h}`
+}
+
+const getUTCWeekStart = (date) => {
+  const day = date.getUTCDay()
+  const daysSinceMonday = (day + 6) % 7
+
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate() - daysSinceMonday
+    )
+  )
+}
+
+const getWeekKey = (date) =>
+  String(Math.floor(getUTCWeekStart(date).getTime() / 1000))
+
+const addBucketCounter = (counters, counterType, date, value = 1) => {
+  const bucketHour = truncateToHour(date)
+  const id = `bucket:${counterType}:${formatBucketHour(bucketHour)}`
+  const existing = counters.get(id)
+
+  counters.set(id, {
+    id,
+    value: (existing?.value ?? 0) + value,
+    bucketHour
+  })
+}
+
+const upsertCounters = async (knex, counters, currentTime) => {
+  const rows = [...counters.values()].map((counter) => ({
+    id: counter.id,
+    value: counter.value,
+    bucketHour: counter.bucketHour ?? null,
+    createdAt: currentTime,
+    updatedAt: currentTime
+  }))
+
+  for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + CHUNK_SIZE)
+    await knex('counters')
+      .insert(chunk)
+      .onConflict('id')
+      .merge(['value', 'bucketHour', 'updatedAt'])
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const currentTime = new Date()
+  const counters = new Map()
+
+  const localStatuses = await knex('statuses')
+    .join('actors', 'statuses.actorId', 'actors.id')
+    .whereNotNull('actors.accountId')
+    .select('statuses.createdAt')
+
+  for (const status of localStatuses) {
+    const createdAt = toDate(status.createdAt)
+    if (Number.isNaN(createdAt.getTime())) continue
+    addBucketCounter(counters, 'local-statuses', createdAt)
+  }
+
+  const sessions = await knex('sessions')
+    .whereNotNull('accountId')
+    .select('accountId', 'createdAt')
+
+  const firstLoginByMarker = new Map()
+  for (const session of sessions) {
+    if (!session.accountId) continue
+
+    const createdAt = toDate(session.createdAt)
+    if (Number.isNaN(createdAt.getTime())) continue
+
+    const markerId = `unique-login:${getWeekKey(createdAt)}:${session.accountId}`
+    const existing = firstLoginByMarker.get(markerId)
+    if (!existing || createdAt.getTime() < existing.createdAt.getTime()) {
+      firstLoginByMarker.set(markerId, {
+        accountId: session.accountId,
+        createdAt
+      })
+    }
+  }
+
+  for (const [markerId, login] of firstLoginByMarker.entries()) {
+    counters.set(markerId, {
+      id: markerId,
+      value: 1,
+      bucketHour: null
+    })
+    addBucketCounter(counters, 'logins', login.createdAt)
+  }
+
+  await upsertCounters(knex, counters, currentTime)
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex('counters')
+    .where('id', 'like', 'bucket:local-statuses:%')
+    .orWhere('id', 'like', 'bucket:logins:%')
+    .orWhere('id', 'like', 'unique-login:%')
+    .delete()
+}


### PR DESCRIPTION
## Summary
- implement `/api/v1/instance/activity` with 12 newest-first Mastodon-shaped weekly records backed by `counters`
- add local status and unique weekly login counter writes, including Better Auth session creation
- add a migration to backfill `bucket:local-statuses:*`, `bucket:logins:*`, and `unique-login:*` marker rows

## Validation
- `yarn run prettier --write .`
- `yarn lint` (warnings only: existing `no-explicit-any` warnings in auth adapter tests/adapter and fitness parser)
- `yarn build`
- `yarn test --runInBand`
- `ACTIVITIES_DATABASE_TYPE=sql ACTIVITIES_DATABASE_CLIENT=pg ACTIVITIES_DATABASE_PG_HOST=localhost ACTIVITIES_DATABASE_PG_PORT=5432 ACTIVITIES_DATABASE_PG_USER=postgres ACTIVITIES_DATABASE_PG_PASSWORD=postgres ACTIVITIES_DATABASE_PG_DATABASE=activities ACTIVITIES_DATABASE_PG_SSL_MODE=disable yarn migrate`
- `curl -ksS https://activities.local/api/v1/instance/activity` returned HTTP 200, 12 records, string values, newest-first weeks

## Notes
- The runtime API read path only reads counter buckets; historical domain-table aggregation is limited to the migration backfill.
