### PR TITLE
fix: delegate OAuth authorize through Better Auth

### DIFF
--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -139,7 +139,14 @@ describe('AuthorizeCard', () => {
         redirect: true,
         url: '//phanpy.local/?code=oauth-code'
       })
-    ).toBe('http://phanpy.local/?code=oauth-code')
+    ).toBeUndefined()
+
+    expect(
+      getConsentRedirectUrl({
+        redirect: true,
+        url: '/oauth/callback?code=oauth-code'
+      })
+    ).toBeUndefined()
   })
 
   it('submits denial with the signed Better Auth query and follows url redirects', async () => {

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -11,6 +11,7 @@ import { AuthorizeCard, getConsentRedirectUrl } from './AuthorizeCard'
 import { SearchParams } from './types'
 
 const mockPush = jest.fn()
+const mockNavigate = jest.fn()
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush })
@@ -55,6 +56,7 @@ const signedSearchParams: SearchParams = {
 describe('AuthorizeCard', () => {
   beforeEach(() => {
     mockPush.mockReset()
+    mockNavigate.mockReset()
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({})
@@ -72,6 +74,7 @@ describe('AuthorizeCard', () => {
         searchParams={signedSearchParams}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
+        navigate={mockNavigate}
       />
     )
 
@@ -119,8 +122,91 @@ describe('AuthorizeCard', () => {
     expect(
       getConsentRedirectUrl({
         redirect: true,
+        url: 'https://phanpy.local/?code=oauth-code',
+        redirect_uri: 'https://legacy.example/?code=legacy-code'
+      })
+    ).toBe('https://phanpy.local/?code=oauth-code')
+
+    expect(
+      getConsentRedirectUrl({
+        redirect: true,
         url: 'javascript:alert(1)'
       })
     ).toBeUndefined()
+  })
+
+  it('submits denial with the signed Better Auth query and follows url redirects', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        url: 'https://phanpy.local/?error=access_denied&state=return-state'
+      })
+    })
+
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={signedSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        navigate={mockNavigate}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/oauth2/consent',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(requestInit.body)
+
+    expect(body.accept).toBe(false)
+    expect(body.oauth_query).toBe(
+      'response_type=code' +
+        '&client_id=phanpy-client' +
+        '&redirect_uri=not-a-url' +
+        '&scope=read+write+follow+push' +
+        '&state=return-state' +
+        '&code_challenge=challenge' +
+        '&code_challenge_method=S256' +
+        '&exp=1779800000' +
+        '&sig=signed-query'
+    )
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'https://phanpy.local/?error=access_denied&state=return-state'
+      )
+    })
+  })
+
+  it('falls back to access_denied redirect when denial has no redirect URL', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={{
+          ...signedSearchParams,
+          redirect_uri: 'https://phanpy.local/'
+        }}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        navigate={mockNavigate}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'https://phanpy.local/?error=access_denied&state=return-state'
+      )
+    })
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -115,5 +115,12 @@ describe('AuthorizeCard', () => {
         url: 'https://phanpy.local/?code=oauth-code'
       })
     ).toBe('https://phanpy.local/?code=oauth-code')
+
+    expect(
+      getConsentRedirectUrl({
+        redirect: true,
+        url: 'javascript:alert(1)'
+      })
+    ).toBeUndefined()
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -41,6 +41,17 @@ const actors = [
   }
 ] as unknown as Actor[]
 
+const alternateActors = [
+  actors[0],
+  {
+    id: 'https://activities.local/users/testactor2',
+    username: 'testactor2',
+    domain: 'activities.local',
+    name: 'testactor2',
+    iconUrl: null
+  }
+] as unknown as Actor[]
+
 const signedSearchParams: SearchParams = {
   client_id: 'phanpy-client',
   redirect_uri: 'not-a-url',
@@ -95,7 +106,10 @@ describe('AuthorizeCard', () => {
       )
     })
 
-    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0]
+    const consentCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === '/api/auth/oauth2/consent'
+    )
+    const [, requestInit] = consentCall
     const body = JSON.parse(requestInit.body)
 
     expect(body.accept).toBe(true)
@@ -109,6 +123,39 @@ describe('AuthorizeCard', () => {
     expect(oauthQuery.get('code_challenge_method')).toBe('S256')
     expect(oauthQuery.get('sig')).toBe('signed-query')
     expect(oauthQuery.get('exp')).toBe('1779800000')
+  })
+
+  it('persists the selected actor before approving consent', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={signedSearchParams}
+        actors={alternateActors}
+        currentActorId="https://activities.local/users/testactor2"
+        navigate={mockNavigate}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2))
+
+    const [switchUrl, switchRequestInit] = (global.fetch as jest.Mock).mock
+      .calls[0]
+    expect(switchUrl).toBe('/api/v1/actors/switch')
+    expect(switchRequestInit).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          actorId: 'https://activities.local/users/testactor2'
+        })
+      })
+    )
+
+    expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe(
+      '/api/auth/oauth2/consent'
+    )
   })
 
   it('reads Better Auth consent redirect URLs from url responses', () => {

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { Actor } from '@/lib/types/domain/actor'
+import { Client } from '@/lib/types/oauth2/client'
+
+import { AuthorizeCard, getConsentRedirectUrl } from './AuthorizeCard'
+import { SearchParams } from './types'
+
+const mockPush = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush })
+}))
+
+const client: Client = {
+  id: 'db-client-id',
+  clientId: 'phanpy-client',
+  clientSecret: null,
+  name: 'Phanpy',
+  redirectUris: ['https://phanpy.local/'],
+  scopes: ['read', 'write', 'follow', 'push'],
+  website: 'https://phanpy.local',
+  requirePKCE: true,
+  disabled: false,
+  createdAt: 0,
+  updatedAt: 0
+}
+
+const actors = [
+  {
+    id: 'https://activities.local/users/llun',
+    username: 'llun',
+    domain: 'activities.local',
+    name: 'llun',
+    iconUrl: null
+  }
+] as unknown as Actor[]
+
+const signedSearchParams: SearchParams = {
+  client_id: 'phanpy-client',
+  redirect_uri: 'not-a-url',
+  response_type: 'code',
+  scope: 'read write follow push',
+  state: 'return-state',
+  code_challenge: 'challenge',
+  code_challenge_method: 'S256',
+  sig: 'signed-query',
+  exp: '1779800000'
+}
+
+describe('AuthorizeCard', () => {
+  beforeEach(() => {
+    mockPush.mockReset()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    }) as jest.Mock
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('submits selected Phanpy scopes with the signed Better Auth query', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={signedSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+      />
+    )
+
+    expect(screen.getByLabelText('read')).toBeChecked()
+    expect(screen.getByLabelText('write')).toBeChecked()
+    expect(screen.getByLabelText('follow')).toBeChecked()
+    expect(screen.getByLabelText('push')).toBeChecked()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/oauth2/consent',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+    })
+
+    const [, requestInit] = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(requestInit.body)
+
+    expect(body.accept).toBe(true)
+    expect(body.scope).toBe('read write follow push')
+
+    const oauthQuery = new URLSearchParams(body.oauth_query)
+    expect(oauthQuery.get('client_id')).toBe('phanpy-client')
+    expect(oauthQuery.get('scope')).toBe('read write follow push')
+    expect(oauthQuery.get('state')).toBe('return-state')
+    expect(oauthQuery.get('code_challenge')).toBe('challenge')
+    expect(oauthQuery.get('code_challenge_method')).toBe('S256')
+    expect(oauthQuery.get('sig')).toBe('signed-query')
+    expect(oauthQuery.get('exp')).toBe('1779800000')
+  })
+
+  it('reads Better Auth consent redirect URLs from url responses', () => {
+    expect(
+      getConsentRedirectUrl({
+        redirect: true,
+        url: 'https://phanpy.local/?code=oauth-code'
+      })
+    ).toBe('https://phanpy.local/?code=oauth-code')
+  })
+})

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -139,7 +139,7 @@ describe('AuthorizeCard', () => {
         redirect: true,
         url: '//phanpy.local/?code=oauth-code'
       })
-    ).toBe('https://phanpy.local/?code=oauth-code')
+    ).toBe('http://phanpy.local/?code=oauth-code')
   })
 
   it('submits denial with the signed Better Auth query and follows url redirects', async () => {

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -133,6 +133,13 @@ describe('AuthorizeCard', () => {
         url: 'javascript:alert(1)'
       })
     ).toBeUndefined()
+
+    expect(
+      getConsentRedirectUrl({
+        redirect: true,
+        url: '//phanpy.local/?code=oauth-code'
+      })
+    ).toBe('https://phanpy.local/?code=oauth-code')
   })
 
   it('submits denial with the signed Better Auth query and follows url redirects', async () => {

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -33,16 +33,18 @@ interface Props {
   searchParams: SearchParams
   actors: Actor[]
   currentActorId: string
+  navigate?: (url: string) => void
 }
 
 interface ConsentResponse {
   redirect?: boolean
-  redirect_uri?: string
   url?: string
+  // Legacy shape from the original custom consent handler.
+  redirect_uri?: string
 }
 
 export const getConsentRedirectUrl = (data: ConsentResponse) => {
-  const redirectUrl = data.redirect_uri ?? data.url
+  const redirectUrl = data.url ?? data.redirect_uri
   if (!redirectUrl) return undefined
 
   try {
@@ -57,11 +59,16 @@ export const getConsentRedirectUrl = (data: ConsentResponse) => {
   return undefined
 }
 
+const navigateTo = (url: string) => {
+  window.location.href = url
+}
+
 export const AuthorizeCard: FC<Props> = ({
   searchParams,
   client,
   actors,
-  currentActorId
+  currentActorId,
+  navigate = navigateTo
 }) => {
   const requestedScopes = searchParams.scope.split(' ')
   const router = useRouter()
@@ -109,7 +116,7 @@ export const AuthorizeCard: FC<Props> = ({
         if (searchParams.state) {
           errorUrl.searchParams.set('state', searchParams.state)
         }
-        window.location.href = errorUrl.toString()
+        navigate(errorUrl.toString())
         return
       } catch {
         // Malformed redirect_uri — fall through to router push
@@ -140,7 +147,7 @@ export const AuthorizeCard: FC<Props> = ({
         const data = (await response.json()) as ConsentResponse
         const redirectUrl = getConsentRedirectUrl(data)
         if (redirectUrl) {
-          window.location.href = redirectUrl
+          navigate(redirectUrl)
           return
         }
       }
@@ -168,7 +175,7 @@ export const AuthorizeCard: FC<Props> = ({
         const data = (await response.json()) as ConsentResponse
         const redirectUrl = getConsentRedirectUrl(data)
         if (redirectUrl) {
-          window.location.href = redirectUrl
+          navigate(redirectUrl)
           return
         }
         // Denial processed but no redirect — use access_denied

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -43,12 +43,19 @@ interface ConsentResponse {
   redirect_uri?: string
 }
 
+const getConsentRedirectBaseUrl = () => {
+  if (typeof window === 'undefined') return 'https://activities.local'
+  return window.location.origin === 'http://localhost'
+    ? 'https://activities.local'
+    : window.location.origin
+}
+
 export const getConsentRedirectUrl = (data: ConsentResponse) => {
   const redirectUrl = data.url ?? data.redirect_uri
   if (!redirectUrl) return undefined
 
   try {
-    const parsed = new URL(redirectUrl, 'https://activities.local')
+    const parsed = new URL(redirectUrl, getConsentRedirectBaseUrl())
     if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
       return parsed.toString()
     }

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -108,6 +108,15 @@ export const AuthorizeCard: FC<Props> = ({
     }
   }
 
+  const persistSelectedActor = async () => {
+    const response = await fetch('/api/v1/actors/switch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ actorId: selectedActorId })
+    })
+    return response.ok
+  }
+
   const redirectWithError = (error: string) => {
     const redirectUri = searchParams.redirect_uri
     if (redirectUri) {
@@ -133,6 +142,10 @@ export const AuthorizeCard: FC<Props> = ({
     try {
       const formData = new FormData(e.currentTarget)
       const selectedScopes = formData.getAll('scope') as string[]
+      if (!(await persistSelectedActor())) {
+        redirectWithError('server_error')
+        return
+      }
 
       const response = await fetch('/api/auth/oauth2/consent', {
         method: 'POST',

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -50,7 +50,7 @@ export const getConsentRedirectUrl = (data: ConsentResponse) => {
   try {
     const parsed = new URL(redirectUrl, 'https://activities.local')
     if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return redirectUrl
+      return parsed.toString()
     }
   } catch {
     // Invalid redirect response; fall through to the existing error handling.

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -45,9 +45,7 @@ interface ConsentResponse {
 
 const getConsentRedirectBaseUrl = () => {
   if (typeof window === 'undefined') return 'https://activities.local'
-  return window.location.origin === 'http://localhost'
-    ? 'https://activities.local'
-    : window.location.origin
+  return window.location.origin
 }
 
 export const getConsentRedirectUrl = (data: ConsentResponse) => {

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -25,6 +25,7 @@ import { UsableScopes } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { Client } from '@/lib/types/oauth2/client'
 
+import { buildOAuthQuery } from './authorizeQuery'
 import { SearchParams } from './types'
 
 interface Props {
@@ -33,6 +34,15 @@ interface Props {
   actors: Actor[]
   currentActorId: string
 }
+
+interface ConsentResponse {
+  redirect?: boolean
+  redirect_uri?: string
+  url?: string
+}
+
+export const getConsentRedirectUrl = (data: ConsentResponse) =>
+  data.redirect_uri ?? data.url
 
 export const AuthorizeCard: FC<Props> = ({
   searchParams,
@@ -77,14 +87,6 @@ export const AuthorizeCard: FC<Props> = ({
     }
   }
 
-  const buildOAuthQuery = () => {
-    const oauthQuery = new URLSearchParams()
-    for (const [key, value] of Object.entries(searchParams)) {
-      if (value !== undefined) oauthQuery.set(key, String(value))
-    }
-    return oauthQuery.toString()
-  }
-
   const redirectWithError = (error: string) => {
     const redirectUri = searchParams.redirect_uri
     if (redirectUri) {
@@ -117,14 +119,15 @@ export const AuthorizeCard: FC<Props> = ({
         body: JSON.stringify({
           accept: true,
           scope: selectedScopes.join(' '),
-          oauth_query: buildOAuthQuery()
+          oauth_query: buildOAuthQuery(searchParams)
         })
       })
 
       if (response.ok) {
-        const data = (await response.json()) as { redirect_uri?: string }
-        if (data.redirect_uri) {
-          window.location.href = data.redirect_uri
+        const data = (await response.json()) as ConsentResponse
+        const redirectUrl = getConsentRedirectUrl(data)
+        if (redirectUrl) {
+          window.location.href = redirectUrl
           return
         }
       }
@@ -145,13 +148,14 @@ export const AuthorizeCard: FC<Props> = ({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           accept: false,
-          oauth_query: buildOAuthQuery()
+          oauth_query: buildOAuthQuery(searchParams)
         })
       })
       if (response.ok) {
-        const data = (await response.json()) as { redirect_uri?: string }
-        if (data.redirect_uri) {
-          window.location.href = data.redirect_uri
+        const data = (await response.json()) as ConsentResponse
+        const redirectUrl = getConsentRedirectUrl(data)
+        if (redirectUrl) {
+          window.location.href = redirectUrl
           return
         }
         // Denial processed but no redirect — use access_denied

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -43,17 +43,13 @@ interface ConsentResponse {
   redirect_uri?: string
 }
 
-const getConsentRedirectBaseUrl = () => {
-  if (typeof window === 'undefined') return 'https://activities.local'
-  return window.location.origin
-}
-
 export const getConsentRedirectUrl = (data: ConsentResponse) => {
   const redirectUrl = data.url ?? data.redirect_uri
   if (!redirectUrl) return undefined
+  if (!/^https?:\/\//i.test(redirectUrl)) return undefined
 
   try {
-    const parsed = new URL(redirectUrl, getConsentRedirectBaseUrl())
+    const parsed = new URL(redirectUrl)
     if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
       return parsed.toString()
     }

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -41,8 +41,21 @@ interface ConsentResponse {
   url?: string
 }
 
-export const getConsentRedirectUrl = (data: ConsentResponse) =>
-  data.redirect_uri ?? data.url
+export const getConsentRedirectUrl = (data: ConsentResponse) => {
+  const redirectUrl = data.redirect_uri ?? data.url
+  if (!redirectUrl) return undefined
+
+  try {
+    const parsed = new URL(redirectUrl, 'https://activities.local')
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return redirectUrl
+    }
+  } catch {
+    // Invalid redirect response; fall through to the existing error handling.
+  }
+
+  return undefined
+}
 
 export const AuthorizeCard: FC<Props> = ({
   searchParams,

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -101,6 +101,21 @@ describe('OAuth authorize query helpers', () => {
     )
   })
 
+  it('skips nullish values when serializing query params', () => {
+    const paramsWithNullValue = {
+      ...unsignedParams,
+      state: null,
+      exp: '1779800000',
+      sig: 'signed-query'
+    } as unknown as SearchParams
+
+    const oauthQuery = new URLSearchParams(buildOAuthQuery(paramsWithNullValue))
+
+    expect(oauthQuery.has('state')).toBe(false)
+    expect(oauthQuery.get('sig')).toBe('signed-query')
+    expect(oauthQuery.get('exp')).toBe('1779800000')
+  })
+
   it('delegates when only one Better Auth signature param is present', () => {
     expect(
       shouldDelegateToBetterAuth({

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -116,6 +116,41 @@ describe('OAuth authorize query helpers', () => {
     expect(oauthQuery.get('exp')).toBe('1779800000')
   })
 
+  it('preserves request_uri params for Better Auth authorization queries', () => {
+    const paramsWithRequestUri: SearchParams = {
+      ...unsignedParams,
+      request_uri: 'urn:ietf:params:oauth:request_uri:request-id'
+    }
+
+    const oauthQuery = new URLSearchParams(
+      buildOAuthQuery(paramsWithRequestUri)
+    )
+
+    expect(oauthQuery.get('request_uri')).toBe(
+      'urn:ietf:params:oauth:request_uri:request-id'
+    )
+  })
+
+  it('skips blank Better Auth signature params when delegating', () => {
+    const partialSignatureParams: SearchParams = {
+      ...unsignedParams,
+      sig: '',
+      exp: '1779800000'
+    }
+
+    expect(shouldDelegateToBetterAuth(partialSignatureParams)).toBe(true)
+
+    const authorizeUrl = new URL(
+      buildBetterAuthAuthorizeUrl(
+        partialSignatureParams,
+        'https://activities.local'
+      )
+    )
+
+    expect(authorizeUrl.searchParams.has('sig')).toBe(false)
+    expect(authorizeUrl.searchParams.get('exp')).toBe('1779800000')
+  })
+
   it('delegates when only one Better Auth signature param is present', () => {
     expect(
       shouldDelegateToBetterAuth({

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -87,6 +87,17 @@ describe('OAuth authorize query helpers', () => {
     expect(oauthQuery.get('exp')).toBe('1779800000')
   })
 
+  it('treats Better Auth signed exp values as epoch seconds', () => {
+    const signedParams: SearchParams = {
+      ...unsignedParams,
+      sig: 'signed-query',
+      // Representative 10-digit value emitted by Better Auth signParams.
+      exp: '1779815588'
+    }
+
+    expect(shouldDelegateToBetterAuth(signedParams)).toBe(false)
+  })
+
   it('serializes signed consent queries in Better Auth signature order', () => {
     const signedParams: SearchParams = {
       ...unsignedParams,

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -1,0 +1,118 @@
+import {
+  buildBetterAuthAuthorizeUrl,
+  buildOAuthAuthorizePath,
+  buildOAuthQuery,
+  shouldDelegateToBetterAuth
+} from './authorizeQuery'
+import { SearchParams } from './types'
+
+const unsignedParams: SearchParams = {
+  client_id: 'phanpy-client',
+  redirect_uri: 'https://phanpy.local/?from=login',
+  response_type: 'code',
+  scope: 'read write follow push',
+  state: 'state with spaces',
+  code_challenge: 'challenge/with+symbols=',
+  code_challenge_method: 'S256'
+}
+
+describe('OAuth authorize query helpers', () => {
+  it('delegates unsigned Mastodon-compatible authorize requests to Better Auth', () => {
+    expect(shouldDelegateToBetterAuth(unsignedParams)).toBe(true)
+
+    const authorizeUrl = new URL(
+      buildBetterAuthAuthorizeUrl(unsignedParams, 'https://activities.local')
+    )
+
+    expect(authorizeUrl.origin).toBe('https://activities.local')
+    expect(authorizeUrl.pathname).toBe('/api/auth/oauth2/authorize')
+    expect(authorizeUrl.searchParams.get('client_id')).toBe('phanpy-client')
+    expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(
+      'https://phanpy.local/?from=login'
+    )
+    expect(authorizeUrl.searchParams.get('response_type')).toBe('code')
+    expect(authorizeUrl.searchParams.get('scope')).toBe(
+      'read write follow push'
+    )
+    expect(authorizeUrl.searchParams.get('state')).toBe('state with spaces')
+    expect(authorizeUrl.searchParams.get('code_challenge')).toBe(
+      'challenge/with+symbols='
+    )
+    expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(authorizeUrl.searchParams.has('sig')).toBe(false)
+    expect(authorizeUrl.searchParams.has('exp')).toBe(false)
+  })
+
+  it('preserves the raw authorize path for sign-in redirectBack', () => {
+    const redirectBack = new URL(
+      buildOAuthAuthorizePath(unsignedParams),
+      'https://activities.local'
+    )
+
+    expect(redirectBack.pathname).toBe('/oauth/authorize')
+    expect(redirectBack.searchParams.get('client_id')).toBe('phanpy-client')
+    expect(redirectBack.searchParams.get('redirect_uri')).toBe(
+      'https://phanpy.local/?from=login'
+    )
+    expect(redirectBack.searchParams.get('scope')).toBe(
+      'read write follow push'
+    )
+    expect(redirectBack.searchParams.get('code_challenge')).toBe(
+      'challenge/with+symbols='
+    )
+  })
+
+  it('treats signed Better Auth params as consent-page params', () => {
+    const signedParams: SearchParams = {
+      ...unsignedParams,
+      sig: 'signed-query',
+      exp: '1779800000'
+    }
+
+    expect(shouldDelegateToBetterAuth(signedParams)).toBe(false)
+
+    const oauthQuery = new URLSearchParams(buildOAuthQuery(signedParams))
+
+    expect(oauthQuery.get('client_id')).toBe('phanpy-client')
+    expect(oauthQuery.get('scope')).toBe('read write follow push')
+    expect(oauthQuery.get('sig')).toBe('signed-query')
+    expect(oauthQuery.get('exp')).toBe('1779800000')
+  })
+
+  it('serializes signed consent queries in Better Auth signature order', () => {
+    const signedParams: SearchParams = {
+      ...unsignedParams,
+      prompt: 'consent',
+      exp: '1779800000',
+      sig: 'signature/with+symbols='
+    }
+
+    expect(buildOAuthQuery(signedParams)).toBe(
+      'response_type=code' +
+        '&client_id=phanpy-client' +
+        '&redirect_uri=https%3A%2F%2Fphanpy.local%2F%3Ffrom%3Dlogin' +
+        '&scope=read+write+follow+push' +
+        '&state=state+with+spaces' +
+        '&code_challenge=challenge%2Fwith%2Bsymbols%3D' +
+        '&code_challenge_method=S256' +
+        '&prompt=consent' +
+        '&exp=1779800000' +
+        '&sig=signature%2Fwith%2Bsymbols%3D'
+    )
+  })
+
+  it('delegates when only one Better Auth signature param is present', () => {
+    expect(
+      shouldDelegateToBetterAuth({
+        ...unsignedParams,
+        sig: 'partial-signature'
+      })
+    ).toBe(true)
+    expect(
+      shouldDelegateToBetterAuth({
+        ...unsignedParams,
+        exp: '1779800000'
+      })
+    ).toBe(true)
+  })
+})

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -148,7 +148,7 @@ describe('OAuth authorize query helpers', () => {
     )
 
     expect(authorizeUrl.searchParams.has('sig')).toBe(false)
-    expect(authorizeUrl.searchParams.get('exp')).toBe('1779800000')
+    expect(authorizeUrl.searchParams.has('exp')).toBe(false)
   })
 
   it('delegates when only one Better Auth signature param is present', () => {

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts
@@ -17,6 +17,14 @@ const unsignedParams: SearchParams = {
 }
 
 describe('OAuth authorize query helpers', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 1700000000000)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('delegates unsigned Mastodon-compatible authorize requests to Better Auth', () => {
     expect(shouldDelegateToBetterAuth(unsignedParams)).toBe(true)
 
@@ -164,5 +172,32 @@ describe('OAuth authorize query helpers', () => {
         exp: '1779800000'
       })
     ).toBe(true)
+  })
+
+  it('delegates expired or malformed Better Auth signature params', () => {
+    const expiredSignatureParams: SearchParams = {
+      ...unsignedParams,
+      sig: 'expired-signature',
+      exp: '1699999999'
+    }
+
+    expect(shouldDelegateToBetterAuth(expiredSignatureParams)).toBe(true)
+    expect(
+      shouldDelegateToBetterAuth({
+        ...unsignedParams,
+        sig: 'malformed-signature',
+        exp: 'not-a-number'
+      })
+    ).toBe(true)
+
+    const authorizeUrl = new URL(
+      buildBetterAuthAuthorizeUrl(
+        expiredSignatureParams,
+        'https://activities.local'
+      )
+    )
+
+    expect(authorizeUrl.searchParams.has('sig')).toBe(false)
+    expect(authorizeUrl.searchParams.has('exp')).toBe(false)
   })
 })

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -15,15 +15,28 @@ const BetterAuthAuthorizationParamOrder = [
   'sig'
 ]
 
+const BetterAuthAuthorizationParamSet = new Set(
+  BetterAuthAuthorizationParamOrder
+)
+
+const shouldIncludeOAuthParam = (
+  key: string,
+  value: string | null | undefined
+): value is string =>
+  value != null && (value !== '' || (key !== 'sig' && key !== 'exp'))
+
 export const buildOAuthQuery = (params: SearchParams): string => {
   const oauthQuery = new URLSearchParams()
   const values = params as Record<string, string | null | undefined>
   for (const key of BetterAuthAuthorizationParamOrder) {
     const value = values[key]
-    if (value != null) oauthQuery.set(key, value)
+    if (shouldIncludeOAuthParam(key, value)) oauthQuery.set(key, value)
   }
   for (const [key, value] of Object.entries(values)) {
-    if (value != null && !BetterAuthAuthorizationParamOrder.includes(key)) {
+    if (
+      shouldIncludeOAuthParam(key, value) &&
+      !BetterAuthAuthorizationParamSet.has(key)
+    ) {
       oauthQuery.set(key, value)
     }
   }

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -1,0 +1,49 @@
+import { SearchParams } from './types'
+
+const BetterAuthAuthorizationParamOrder = [
+  'response_type',
+  'client_id',
+  'redirect_uri',
+  'scope',
+  'state',
+  'request_uri',
+  'code_challenge',
+  'code_challenge_method',
+  'nonce',
+  'prompt',
+  'exp',
+  'sig'
+]
+
+export const buildOAuthQuery = (params: SearchParams): string => {
+  const oauthQuery = new URLSearchParams()
+  const values = params as Record<string, string | undefined>
+  for (const key of BetterAuthAuthorizationParamOrder) {
+    const value = values[key]
+    if (value !== undefined) oauthQuery.set(key, value)
+  }
+  for (const [key, value] of Object.entries(values)) {
+    if (
+      value !== undefined &&
+      !BetterAuthAuthorizationParamOrder.includes(key)
+    ) {
+      oauthQuery.set(key, value)
+    }
+  }
+  return oauthQuery.toString()
+}
+
+export const buildOAuthAuthorizePath = (params: SearchParams): string =>
+  `/oauth/authorize?${buildOAuthQuery(params)}`
+
+export const buildBetterAuthAuthorizeUrl = (
+  params: SearchParams,
+  baseUrl: string
+): string => {
+  const url = new URL('/api/auth/oauth2/authorize', baseUrl)
+  url.search = buildOAuthQuery(params)
+  return url.toString()
+}
+
+export const shouldDelegateToBetterAuth = (params: SearchParams): boolean =>
+  !params.sig || !params.exp

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -65,9 +65,16 @@ export const buildBetterAuthAuthorizeUrl = (
   return url.toString()
 }
 
+const hasExpiredBetterAuthSignature = (exp: string): boolean => {
+  const expiresAt = Number(exp)
+  return !Number.isFinite(expiresAt) || Date.now() / 1000 > expiresAt
+}
+
 // Better Auth consent signatures require sig and exp as an inseparable pair. If
-// either field is absent or blank, treat the request as unsigned and send it
-// through Better Auth so it can validate the client request and sign a fresh
-// consent query.
-export const shouldDelegateToBetterAuth = (params: SearchParams): boolean =>
-  !params.sig || !params.exp
+// either field is absent, blank, or expired, treat the request as unsigned and
+// send it through Better Auth so it can validate the client request and sign a
+// fresh consent query.
+export const shouldDelegateToBetterAuth = (params: SearchParams): boolean => {
+  if (!params.sig || !params.exp) return true
+  return hasExpiredBetterAuthSignature(params.exp)
+}

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -17,16 +17,13 @@ const BetterAuthAuthorizationParamOrder = [
 
 export const buildOAuthQuery = (params: SearchParams): string => {
   const oauthQuery = new URLSearchParams()
-  const values = params as Record<string, string | undefined>
+  const values = params as Record<string, string | null | undefined>
   for (const key of BetterAuthAuthorizationParamOrder) {
     const value = values[key]
-    if (value !== undefined) oauthQuery.set(key, value)
+    if (value != null) oauthQuery.set(key, value)
   }
   for (const [key, value] of Object.entries(values)) {
-    if (
-      value !== undefined &&
-      !BetterAuthAuthorizationParamOrder.includes(key)
-    ) {
+    if (value != null && !BetterAuthAuthorizationParamOrder.includes(key)) {
       oauthQuery.set(key, value)
     }
   }

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -1,5 +1,9 @@
 import { SearchParams } from './types'
 
+// Better Auth 1.6.9 signs serializeAuthorizationQuery(ctx.query).toString()
+// before appending sig in @better-auth/oauth-provider/dist/index.mjs. Keep this
+// order in sync when upgrading Better Auth or consent signature verification can
+// fail even when the query values are unchanged.
 const BetterAuthAuthorizationParamOrder = [
   'response_type',
   'client_id',
@@ -32,6 +36,9 @@ export const buildOAuthQuery = (params: SearchParams): string => {
     const value = values[key]
     if (shouldIncludeOAuthParam(key, value)) oauthQuery.set(key, value)
   }
+  // Preserve future/raw caller params after the signature-sensitive keys. The
+  // page currently passes parsed SearchParams, but keeping extras here makes
+  // the helper safe if a route later forwards raw URLSearchParams-shaped data.
   for (const [key, value] of Object.entries(values)) {
     if (
       shouldIncludeOAuthParam(key, value) &&
@@ -50,10 +57,17 @@ export const buildBetterAuthAuthorizeUrl = (
   params: SearchParams,
   baseUrl: string
 ): string => {
+  const authorizeParams = shouldDelegateToBetterAuth(params)
+    ? { ...params, sig: undefined, exp: undefined }
+    : params
   const url = new URL('/api/auth/oauth2/authorize', baseUrl)
-  url.search = buildOAuthQuery(params)
+  url.search = buildOAuthQuery(authorizeParams)
   return url.toString()
 }
 
+// Better Auth consent signatures require sig and exp as an inseparable pair. If
+// either field is absent or blank, treat the request as unsigned and send it
+// through Better Auth so it can validate the client request and sign a fresh
+// consent query.
 export const shouldDelegateToBetterAuth = (params: SearchParams): boolean =>
   !params.sig || !params.exp

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -1,9 +1,11 @@
 import { SearchParams } from './types'
 
 // Better Auth 1.6.9 signs serializeAuthorizationQuery(ctx.query).toString()
-// before appending sig in @better-auth/oauth-provider/dist/index.mjs. Keep this
-// order in sync when upgrading Better Auth or consent signature verification can
-// fail even when the query values are unchanged.
+// before appending sig in @better-auth/oauth-provider/dist/index.mjs. Its
+// signParams helper sets exp with Math.floor(Date.now() / 1e3) + codeExpiresIn
+// in the same file. Keep both the order and seconds-based exp units in sync
+// when upgrading Better Auth or consent signature verification can fail even
+// when the query values are unchanged.
 const BetterAuthAuthorizationParamOrder = [
   'response_type',
   'client_id',

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -35,11 +35,19 @@ const Page: FC<Props> = async ({ searchParams }) => {
   }
   const params = parsedResult.data
 
-  const [actor, client] = await Promise.all([
-    getActorFromSession(database, session),
-    database.getClientFromId({ clientId: params.client_id })
-  ])
+  const actor = await getActorFromSession(database, session)
 
+  if (!actor || !actor.account) {
+    const url = new URL('/auth/signin', getBaseURL())
+    url.searchParams.append('redirectBack', buildOAuthAuthorizePath(params))
+    return redirect(url.toString())
+  }
+
+  if (shouldDelegateToBetterAuth(params)) {
+    return redirect(buildBetterAuthAuthorizeUrl(params, getBaseURL()))
+  }
+
+  const client = await database.getClientFromId({ clientId: params.client_id })
   if (!client) {
     return notFound()
   }
@@ -50,16 +58,6 @@ const Page: FC<Props> = async ({ searchParams }) => {
     !client.redirectUris.includes(params.redirect_uri)
   ) {
     return notFound()
-  }
-
-  if (!actor || !actor.account) {
-    const url = new URL('/auth/signin', getBaseURL())
-    url.searchParams.append('redirectBack', buildOAuthAuthorizePath(params))
-    return redirect(url.toString())
-  }
-
-  if (shouldDelegateToBetterAuth(params)) {
-    return redirect(buildBetterAuthAuthorizeUrl(params, getBaseURL()))
   }
 
   // Fetch all actors for this account

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -8,6 +8,11 @@ import { Actor } from '@/lib/types/domain/actor'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { AuthorizeCard } from './AuthorizeCard'
+import {
+  buildBetterAuthAuthorizeUrl,
+  buildOAuthAuthorizePath,
+  shouldDelegateToBetterAuth
+} from './authorizeQuery'
 import { SearchParams } from './types'
 
 export const dynamic = 'force-dynamic'
@@ -23,11 +28,12 @@ const Page: FC<Props> = async ({ searchParams }) => {
   }
 
   const session = await getServerAuthSession()
-  const params = await searchParams
-  const parsedResult = SearchParams.safeParse(params)
+  const rawParams = await searchParams
+  const parsedResult = SearchParams.safeParse(rawParams)
   if (!parsedResult.success) {
     return notFound()
   }
+  const params = parsedResult.data
 
   const [actor, client] = await Promise.all([
     getActorFromSession(database, session),
@@ -48,11 +54,12 @@ const Page: FC<Props> = async ({ searchParams }) => {
 
   if (!actor || !actor.account) {
     const url = new URL('/auth/signin', getBaseURL())
-    url.searchParams.append(
-      'redirectBack',
-      `/oauth/authorize?${new URLSearchParams(Object.entries(params).filter(([, v]) => v !== undefined) as [string, string][])}`
-    )
+    url.searchParams.append('redirectBack', buildOAuthAuthorizePath(params))
     return redirect(url.toString())
+  }
+
+  if (shouldDelegateToBetterAuth(params)) {
+    return redirect(buildBetterAuthAuthorizeUrl(params, getBaseURL()))
   }
 
   // Fetch all actors for this account

--- a/app/(nosidebar)/oauth/authorize/types.ts
+++ b/app/(nosidebar)/oauth/authorize/types.ts
@@ -10,6 +10,7 @@ export const SearchParams = z.object({
   exp: z.string().optional(),
   // Optional PKCE and state params
   state: z.string().optional(),
+  request_uri: z.string().optional(),
   code_challenge: z.string().optional(),
   code_challenge_method: z.string().optional(),
   nonce: z.string().optional(),

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -159,6 +159,27 @@ describe('createApplication', () => {
     expect(JSON.parse(dbClient.scopes)).toEqual(['write:accounts'])
   })
 
+  test('it accepts Mastodon push scopes', async () => {
+    const response = (await createApplication({
+      client_name: 'pushScopesClient',
+      redirect_uris: 'https://test.llun.dev/apps/redirect',
+      scopes: 'read write follow push',
+      website: 'https://test.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(JSON.parse(dbClient.scopes)).toEqual([
+      'read',
+      'write',
+      'follow',
+      'push'
+    ])
+  })
+
   test('it defaults omitted scopes to read', async () => {
     const response = (await createApplication({
       client_name: 'defaultScopesClient',

--- a/app/api/v1/push/subscribe/route.test.ts
+++ b/app/api/v1/push/subscribe/route.test.ts
@@ -2,10 +2,13 @@ import { NextRequest } from 'next/server'
 
 import { Database } from '@/lib/database/types'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { Scope } from '@/lib/types/database/operations'
 
 import { DELETE, POST } from './route'
 
 const mockGetServerSession = jest.fn()
+const mockOAuthGuard = jest.fn()
+const mockCurrentActor = { ...seedActor1, id: ACTOR1_ID }
 jest.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: () => mockGetServerSession()
 }))
@@ -32,6 +35,29 @@ jest.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
 }))
 
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      scopes: Scope[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          database: MockDatabase
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) => {
+      mockOAuthGuard(scopes, handle)
+      return handle(req, {
+        currentActor: mockCurrentActor,
+        database: mockDatabase!,
+        params: context.params
+      })
+    }
+}))
+
 jest.mock('next/headers', () => ({
   cookies: jest.fn().mockResolvedValue({
     get: () => undefined
@@ -44,6 +70,7 @@ const auth = 'test-auth-key'
 
 describe('POST /api/v1/push/subscribe', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     mockDatabase = {
       getAccountFromEmail: jest.fn().mockResolvedValue({
         id: 'account1',
@@ -76,10 +103,17 @@ describe('POST /api/v1/push/subscribe', () => {
     const req = new NextRequest('http://localhost/api/v1/push/subscribe', {
       method: 'POST',
       body: JSON.stringify({ invalid: true }),
-      headers: { 'Content-Type': 'application/json' }
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://localhost'
+      }
     })
     const res = await POST(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(400)
+    expect(mockOAuthGuard).toHaveBeenCalledWith(
+      [Scope.enum.push],
+      expect.any(Function)
+    )
   })
 
   it('creates subscription and returns id', async () => {
@@ -89,7 +123,10 @@ describe('POST /api/v1/push/subscribe', () => {
         endpoint,
         keys: { p256dh, auth }
       }),
-      headers: { 'Content-Type': 'application/json' }
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://localhost'
+      }
     })
     const res = await POST(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(200)
@@ -100,6 +137,7 @@ describe('POST /api/v1/push/subscribe', () => {
 
 describe('DELETE /api/v1/push/subscribe', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     mockDatabase = {
       getAccountFromEmail: jest.fn().mockResolvedValue({
         id: 'account1',
@@ -124,17 +162,27 @@ describe('DELETE /api/v1/push/subscribe', () => {
     const req = new NextRequest('http://localhost/api/v1/push/subscribe', {
       method: 'DELETE',
       body: JSON.stringify({ bad: 'data' }),
-      headers: { 'Content-Type': 'application/json' }
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://localhost'
+      }
     })
     const res = await DELETE(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(400)
+    expect(mockOAuthGuard).toHaveBeenCalledWith(
+      [Scope.enum.push],
+      expect.any(Function)
+    )
   })
 
   it('deletes subscription and returns OK', async () => {
     const req = new NextRequest('http://localhost/api/v1/push/subscribe', {
       method: 'DELETE',
       body: JSON.stringify({ endpoint }),
-      headers: { 'Content-Type': 'application/json' }
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://localhost'
+      }
     })
     const res = await DELETE(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(200)

--- a/app/api/v1/push/subscribe/route.ts
+++ b/app/api/v1/push/subscribe/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
-import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
 import { apiErrorResponse, apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
@@ -18,7 +19,7 @@ const UnsubscribeRequest = z.object({
 
 export const POST = traceApiRoute(
   'pushSubscribe',
-  AuthenticatedGuard(async (req, { currentActor, database }) => {
+  OAuthGuard([Scope.enum.push], async (req, { currentActor, database }) => {
     let body
     try {
       body = await req.json()
@@ -48,7 +49,7 @@ export const POST = traceApiRoute(
 
 export const DELETE = traceApiRoute(
   'pushUnsubscribe',
-  AuthenticatedGuard(async (req, { currentActor, database }) => {
+  OAuthGuard([Scope.enum.push], async (req, { currentActor, database }) => {
     let body
     try {
       body = await req.json()

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -574,6 +574,40 @@ describe('#OAuthGuard', () => {
       expect(mockVerifyAccessToken).not.toHaveBeenCalled()
     })
 
+    test('allows Better Auth opaque token with account userId and no actor referenceId', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const primaryActor = await database.getActorFromEmail({
+        email: seedActor1.email
+      })
+      if (!primaryActor?.account) throw new Error('Primary actor not found')
+
+      mockStoredTokens.set(hashToken('better-auth-opaque-token'), {
+        token: hashToken('better-auth-opaque-token'),
+        referenceId: '',
+        userId: primaryActor.account.id,
+        expiresAt: new Date(Date.now() + 3600000),
+        scopes: JSON.stringify(['read'])
+      })
+
+      let capturedActor: Actor | undefined
+      const handler = jest.fn().mockImplementation((_req, context) => {
+        capturedActor = context.currentActor
+        return NextResponse.json({ success: true }, { status: 200 })
+      })
+
+      const guard = OAuthGuard([Scope.enum.read], handler)
+      const req = createRequest({
+        Authorization: 'Bearer better-auth-opaque-token'
+      })
+      const response = await guard(req, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      expect(handler).toHaveBeenCalled()
+      expect(capturedActor?.account?.id).toBe(primaryActor.account.id)
+      expect(mockVerifyAccessToken).not.toHaveBeenCalled()
+    })
+
     test('allows request with lowercase bearer opaque token', async () => {
       mockGetServerSession.mockResolvedValue(null)
 

--- a/lib/services/guards/OAuthGuard.test.ts
+++ b/lib/services/guards/OAuthGuard.test.ts
@@ -574,7 +574,7 @@ describe('#OAuthGuard', () => {
       expect(mockVerifyAccessToken).not.toHaveBeenCalled()
     })
 
-    test('allows Better Auth opaque token with account userId and no actor referenceId', async () => {
+    test('returns 401 when Better Auth opaque token has account userId but no actor referenceId', async () => {
       mockGetServerSession.mockResolvedValue(null)
 
       const primaryActor = await database.getActorFromEmail({
@@ -590,21 +590,14 @@ describe('#OAuthGuard', () => {
         scopes: JSON.stringify(['read'])
       })
 
-      let capturedActor: Actor | undefined
-      const handler = jest.fn().mockImplementation((_req, context) => {
-        capturedActor = context.currentActor
-        return NextResponse.json({ success: true }, { status: 200 })
-      })
-
-      const guard = OAuthGuard([Scope.enum.read], handler)
+      const guard = OAuthGuard([Scope.enum.read], mockHandler)
       const req = createRequest({
         Authorization: 'Bearer better-auth-opaque-token'
       })
       const response = await guard(req, { params: Promise.resolve({}) })
 
-      expect(response.status).toBe(200)
-      expect(handler).toHaveBeenCalled()
-      expect(capturedActor?.account?.id).toBe(primaryActor.account.id)
+      expect(response.status).toBe(401)
+      expect(mockHandler).not.toHaveBeenCalled()
       expect(mockVerifyAccessToken).not.toHaveBeenCalled()
     })
 

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -240,21 +240,11 @@ const resolveAuthenticatedContext = async <P>({
         ? (jwtPayload.actorId as string | null)
         : ((storedToken.referenceId as string | null) || null)
 
-      let actor = actorId
-        ? await database.getActorFromId({ id: actorId })
-        : null
-
-      if (!actor && !jwtPayload) {
-        const accountId = (storedToken.userId as string | null) || null
-        if (accountId) {
-          // Better Auth opaque tokens store the authenticated account in userId
-          // and leave referenceId blank. Resolve that account to its local
-          // actor so Mastodon API bearer tokens work without a browser session.
-          const actors = await database.getActorsForAccount({ accountId })
-          actor = actors[0] ?? null
-        }
+      if (!actorId) {
+        return { authenticated: false, response: apiErrorResponse(401) }
       }
 
+      const actor = await database.getActorFromId({ id: actorId })
       if (!actor) {
         return { authenticated: false, response: apiErrorResponse(401) }
       }

--- a/lib/services/guards/OAuthGuard.ts
+++ b/lib/services/guards/OAuthGuard.ts
@@ -238,13 +238,23 @@ const resolveAuthenticatedContext = async <P>({
       // Extract actorId: from JWT claims or from stored referenceId (opaque)
       const actorId = jwtPayload
         ? (jwtPayload.actorId as string | null)
-        : (storedToken.referenceId as string | null)
+        : ((storedToken.referenceId as string | null) || null)
 
-      if (!actorId) {
-        return { authenticated: false, response: apiErrorResponse(401) }
+      let actor = actorId
+        ? await database.getActorFromId({ id: actorId })
+        : null
+
+      if (!actor && !jwtPayload) {
+        const accountId = (storedToken.userId as string | null) || null
+        if (accountId) {
+          // Better Auth opaque tokens store the authenticated account in userId
+          // and leave referenceId blank. Resolve that account to its local
+          // actor so Mastodon API bearer tokens work without a browser session.
+          const actors = await database.getActorsForAccount({ accountId })
+          actor = actors[0] ?? null
+        }
       }
 
-      const actor = await database.getActorFromId({ id: actorId })
       if (!actor) {
         return { authenticated: false, response: apiErrorResponse(401) }
       }

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -55,6 +55,7 @@ describe('wellknown services', () => {
       expect(metadata.scopes_supported).toContain('write:accounts')
       expect(metadata.scopes_supported).toContain('write:bookmarks')
       expect(metadata.scopes_supported).toContain('follow')
+      expect(metadata.scopes_supported).toContain('push')
     })
   })
 
@@ -90,6 +91,7 @@ describe('wellknown services', () => {
       expect(config.scopes_supported).toContain('read:bookmarks')
       expect(config.scopes_supported).toContain('write:accounts')
       expect(config.scopes_supported).toContain('write:bookmarks')
+      expect(config.scopes_supported).toContain('push')
       expect(config.claims_supported).toContain('sub')
       expect(config.claims_supported).toContain('name')
       expect(config.claims_supported).toContain('email')

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1322,7 +1322,8 @@ export const UsableScopes = [
   Scope.enum['write:bookmarks'],
   Scope.enum['write:statuses'],
   Scope.enum['write:conversations'],
-  Scope.enum.follow
+  Scope.enum.follow,
+  Scope.enum.push
 ]
 
 export const GetClientFromNameParams = z.object({


### PR DESCRIPTION
## Summary
- Delegate authenticated unsigned `/oauth/authorize` requests through Better Auth so OAuth queries are validated and signed before consent.
- Serialize signed consent `oauth_query` params in Better Auth signature order and follow normalized consent endpoint `url` responses.
- Persist the selected consent actor before approval so Better Auth stores that actor id in OAuth token `referenceId`; bearer-token auth now fails closed when an opaque token has no actor reference.
- Add `push` to usable OAuth scopes, advertise it in app registration/well-known metadata, and guard `POST`/`DELETE /api/v1/push/subscribe` with `OAuthGuard([Scope.enum.push])`.

## Verification
- `PATH=/Users/llun/.nvm/versions/node/v24.15.0/bin:$PATH yarn test --runTestsByPath lib/services/guards/OAuthGuard.test.ts 'app/(nosidebar)/oauth/authorize/authorizeQuery.test.ts' 'app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx' app/api/v1/push/subscribe/route.test.ts lib/services/wellknown/index.test.ts app/api/v1/apps/createApplication.test.ts --runInBand`
- `PATH=/Users/llun/.nvm/versions/node/v24.15.0/bin:$PATH yarn lint` (passes with existing `any` warnings in unrelated files)
- `PATH=/Users/llun/.nvm/versions/node/v24.15.0/bin:$PATH yarn build`
- `PATH=/Users/llun/.nvm/versions/node/v24.15.0/bin:$PATH yarn test --runInBand --silent` (334 suites / 2870 tests passed earlier after the unrelated heatmap flake passed on rerun)
- `activities.local` API smoke with existing local account plus a local OAuth app: unsigned authorize delegates to Better Auth, `prompt=consent` returns a signed consent URL with `sig` and `exp`, signed consent POST returns 200 with a Phanpy redirect code, token exchange returns 200 with `read write follow push`, the issued token stores `referenceId=https://activities.local/users/testactor2` after switching to that actor, unauthenticated push subscribe returns 401, OAuth bearer-token push subscribe/delete return 200, and browser-session push subscribe/delete with same-origin `Origin` return 200.

## Compatibility Note
- Existing OAuth bearer tokens without the `push` scope will not be authorized for `POST`/`DELETE /api/v1/push/subscribe`; clients need to request a fresh token including `push`. Browser-session calls are still supported through `OAuthGuard`'s session fallback when the request includes same-origin proof.

## Notes
- The full local dev stack rebuild hit Docker VM disk pressure while building Pixelfed, so validation used the existing Activity.next/Traefik/Postgres services.
