### PR TITLE
feat: implement account mute/unmute API with persistent storage

### DIFF
--- a/app/api/v1/accounts/[id]/mute/route.test.ts
+++ b/app/api/v1/accounts/[id]/mute/route.test.ts
@@ -1,0 +1,165 @@
+import { NextRequest } from 'next/server'
+
+import { applyMute } from '@/lib/actions/applyMute'
+import { getRelationship } from '@/lib/services/accounts/relationship'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockDatabase = {}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me',
+  domain: 'local.test'
+}
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+jest.mock('@/lib/actions/applyMute', () => ({
+  applyMute: jest.fn()
+}))
+
+jest.mock('@/lib/services/accounts/relationship', () => ({
+  getRelationship: jest.fn()
+}))
+
+const createRequest = (
+  targetActorId: string,
+  body?: Record<string, unknown>
+) => {
+  const req = new NextRequest(
+    `https://local.test/api/v1/accounts/${urlToId(targetActorId)}/mute`,
+    {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+      headers: body ? { 'content-type': 'application/json' } : {}
+    }
+  )
+  return req
+}
+
+describe('POST /api/v1/accounts/:id/mute', () => {
+  const applyMuteMock = applyMute as jest.Mock
+  const getRelationshipMock = getRelationship as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getRelationshipMock.mockResolvedValue({
+      id: 'target-id',
+      muting: true,
+      muting_notifications: true
+    })
+  })
+
+  it('calls applyMute with notifications=true by default', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    await POST(createRequest(targetActorId), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(applyMuteMock).toHaveBeenCalledWith({
+      database: mockDatabase,
+      actorId: mockCurrentActor.id,
+      targetActorId,
+      notifications: true,
+      endsAt: null
+    })
+  })
+
+  it('calls applyMute with notifications=false when specified', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    await POST(createRequest(targetActorId, { notifications: false }), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ notifications: false })
+    )
+  })
+
+  it('computes endsAt from positive duration', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+    const before = Date.now()
+
+    await POST(createRequest(targetActorId, { duration: 3600 }), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    const call = applyMuteMock.mock.calls[0][0]
+    expect(call.endsAt).toBeGreaterThanOrEqual(before + 3600 * 1000)
+  })
+
+  it('treats negative duration as no expiry', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    await POST(createRequest(targetActorId, { duration: -60 }), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ endsAt: null })
+    )
+  })
+
+  it('floors fractional duration to integer seconds', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+    const before = Date.now()
+
+    await POST(createRequest(targetActorId, { duration: 3600.9 }), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    const call = applyMuteMock.mock.calls[0][0]
+    expect(call.endsAt).toBeGreaterThanOrEqual(before + 3600 * 1000)
+    expect(call.endsAt).toBeLessThan(before + 3601 * 1000)
+  })
+
+  it('skips applyMute when muting self', async () => {
+    await POST(
+      createRequest(mockCurrentActor.id),
+      { params: Promise.resolve({ id: urlToId(mockCurrentActor.id) }) }
+    )
+
+    expect(applyMuteMock).not.toHaveBeenCalled()
+    expect(getRelationshipMock).toHaveBeenCalled()
+  })
+
+  it('handles empty body gracefully', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    const response = await POST(createRequest(targetActorId), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(response.status).not.toBe(500)
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ notifications: true, endsAt: null })
+    )
+  })
+})

--- a/app/api/v1/accounts/[id]/mute/route.test.ts
+++ b/app/api/v1/accounts/[id]/mute/route.test.ts
@@ -184,15 +184,29 @@ describe('POST /api/v1/accounts/:id/mute', () => {
     const targetActorId = 'https://remote.test/users/alice'
     applyMuteMock.mockResolvedValue({})
 
+    await POST(createRequest(targetActorId, { duration: Infinity }), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ endsAt: null })
+    )
+  })
+
+  it('preserves valid notifications:false when duration is invalid', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
     await POST(
-      createRequest(targetActorId, { duration: Infinity }),
+      createRequest(targetActorId, { notifications: false, duration: -1 }),
       {
         params: Promise.resolve({ id: urlToId(targetActorId) })
       }
     )
 
+    // notifications:false must be preserved even though duration is invalid
     expect(applyMuteMock).toHaveBeenCalledWith(
-      expect.objectContaining({ endsAt: null })
+      expect.objectContaining({ notifications: false, endsAt: null })
     )
   })
 })

--- a/app/api/v1/accounts/[id]/mute/route.test.ts
+++ b/app/api/v1/accounts/[id]/mute/route.test.ts
@@ -6,7 +6,9 @@ import { urlToId } from '@/lib/utils/urlToId'
 
 import { POST } from './route'
 
-const mockDatabase = {}
+const mockDatabase = {
+  getActorFromId: jest.fn()
+}
 const mockCurrentActor = {
   id: 'https://local.test/users/me',
   domain: 'local.test'
@@ -62,6 +64,9 @@ describe('POST /api/v1/accounts/:id/mute', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: 'https://remote.test/users/alice'
+    })
     getRelationshipMock.mockResolvedValue({
       id: 'target-id',
       muting: true,
@@ -141,10 +146,9 @@ describe('POST /api/v1/accounts/:id/mute', () => {
   })
 
   it('skips applyMute when muting self', async () => {
-    await POST(
-      createRequest(mockCurrentActor.id),
-      { params: Promise.resolve({ id: urlToId(mockCurrentActor.id) }) }
-    )
+    await POST(createRequest(mockCurrentActor.id), {
+      params: Promise.resolve({ id: urlToId(mockCurrentActor.id) })
+    })
 
     expect(applyMuteMock).not.toHaveBeenCalled()
     expect(getRelationshipMock).toHaveBeenCalled()
@@ -161,6 +165,34 @@ describe('POST /api/v1/accounts/:id/mute', () => {
     expect(response.status).not.toBe(500)
     expect(applyMuteMock).toHaveBeenCalledWith(
       expect.objectContaining({ notifications: true, endsAt: null })
+    )
+  })
+
+  it('returns 404 when target actor does not exist', async () => {
+    const targetActorId = 'https://remote.test/users/unknown'
+    mockDatabase.getActorFromId.mockResolvedValue(null)
+
+    const response = await POST(createRequest(targetActorId), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(response.status).toBe(404)
+    expect(applyMuteMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores invalid duration values (non-finite or non-integer body)', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    await POST(
+      createRequest(targetActorId, { duration: Infinity }),
+      {
+        params: Promise.resolve({ id: urlToId(targetActorId) })
+      }
+    )
+
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ endsAt: null })
     )
   })
 })

--- a/app/api/v1/accounts/[id]/mute/route.test.ts
+++ b/app/api/v1/accounts/[id]/mute/route.test.ts
@@ -110,6 +110,7 @@ describe('POST /api/v1/accounts/:id/mute', () => {
 
     const call = applyMuteMock.mock.calls[0][0]
     expect(call.endsAt).toBeGreaterThanOrEqual(before + 3600 * 1000)
+    expect(call.endsAt).toBeLessThan(before + 3601 * 1000)
   })
 
   it('treats negative duration as no expiry', async () => {

--- a/app/api/v1/accounts/[id]/mute/route.ts
+++ b/app/api/v1/accounts/[id]/mute/route.ts
@@ -19,13 +19,14 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const MuteBodySchema = z.object({
-  notifications: z.boolean().optional(),
+  notifications: z.boolean().catch(true).optional(),
   duration: z
     .number()
     .finite()
     .min(0)
     .max(3_153_600_000)
     .transform(Math.floor)
+    .catch(0)
     .optional()
 })
 

--- a/app/api/v1/accounts/[id]/mute/route.ts
+++ b/app/api/v1/accounts/[id]/mute/route.ts
@@ -33,8 +33,9 @@ export const POST = traceApiRoute(
     if (targetActorId !== currentActor.id) {
       const body = await req.json().catch(() => ({}))
       const notifications: boolean = body.notifications !== false
-      const durationSeconds =
-        typeof body.duration === 'number' ? body.duration : 0
+      const rawDuration =
+        typeof body.duration === 'number' ? Math.floor(body.duration) : 0
+      const durationSeconds = rawDuration > 0 ? rawDuration : 0
       const endsAt =
         durationSeconds > 0 ? Date.now() + durationSeconds * 1000 : null
       await applyMute({

--- a/app/api/v1/accounts/[id]/mute/route.ts
+++ b/app/api/v1/accounts/[id]/mute/route.ts
@@ -1,15 +1,33 @@
+import { z } from 'zod'
+
 import { applyMute } from '@/lib/actions/applyMute'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_404,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const MuteBodySchema = z.object({
+  notifications: z.boolean().optional(),
+  duration: z
+    .number()
+    .finite()
+    .min(0)
+    .max(3_153_600_000)
+    .transform(Math.floor)
+    .optional()
+})
 
 interface Params {
   id: string
@@ -31,13 +49,19 @@ export const POST = traceApiRoute(
     const targetActorId = idToUrl(encodedAccountId)
 
     if (targetActorId !== currentActor.id) {
-      const body = (await req.json().catch(() => ({}))) ?? {}
+      const targetActor = await database.getActorFromId({ id: targetActorId })
+      if (!targetActor)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const rawBody = await req.json().catch(() => ({}))
+      const body = MuteBodySchema.safeParse(rawBody).data ?? {}
       const notifications: boolean = body.notifications !== false
-      const rawDuration =
-        typeof body.duration === 'number' && Number.isFinite(body.duration)
-          ? Math.floor(body.duration)
-          : 0
-      const durationSeconds = rawDuration > 0 ? rawDuration : 0
+      const durationSeconds = body.duration ?? 0
       const endsAt =
         durationSeconds > 0 ? Date.now() + durationSeconds * 1000 : null
       await applyMute({

--- a/app/api/v1/accounts/[id]/mute/route.ts
+++ b/app/api/v1/accounts/[id]/mute/route.ts
@@ -31,10 +31,12 @@ export const POST = traceApiRoute(
     const targetActorId = idToUrl(encodedAccountId)
 
     if (targetActorId !== currentActor.id) {
-      const body = await req.json().catch(() => ({}))
+      const body = (await req.json().catch(() => ({}))) ?? {}
       const notifications: boolean = body.notifications !== false
       const rawDuration =
-        typeof body.duration === 'number' ? Math.floor(body.duration) : 0
+        typeof body.duration === 'number' && Number.isFinite(body.duration)
+          ? Math.floor(body.duration)
+          : 0
       const durationSeconds = rawDuration > 0 ? rawDuration : 0
       const endsAt =
         durationSeconds > 0 ? Date.now() + durationSeconds * 1000 : null

--- a/app/api/v1/accounts/[id]/mute/route.ts
+++ b/app/api/v1/accounts/[id]/mute/route.ts
@@ -1,3 +1,4 @@
+import { applyMute } from '@/lib/actions/applyMute'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
@@ -29,8 +30,21 @@ export const POST = traceApiRoute(
 
     const targetActorId = idToUrl(encodedAccountId)
 
-    // Muting not yet implemented - return relationship with muting: false
-    // TODO: Implement muting functionality
+    if (targetActorId !== currentActor.id) {
+      const body = await req.json().catch(() => ({}))
+      const notifications: boolean = body.notifications !== false
+      const durationSeconds =
+        typeof body.duration === 'number' ? body.duration : 0
+      const endsAt =
+        durationSeconds > 0 ? Date.now() + durationSeconds * 1000 : null
+      await applyMute({
+        database,
+        actorId: currentActor.id,
+        targetActorId,
+        notifications,
+        endsAt
+      })
+    }
 
     const relationship = await getRelationship({
       database,

--- a/app/api/v1/accounts/[id]/unmute/route.test.ts
+++ b/app/api/v1/accounts/[id]/unmute/route.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server'
+
+import { applyUnmute } from '@/lib/actions/applyUnmute'
+import { getRelationship } from '@/lib/services/accounts/relationship'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockDatabase = {}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me',
+  domain: 'local.test'
+}
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+jest.mock('@/lib/actions/applyUnmute', () => ({
+  applyUnmute: jest.fn()
+}))
+
+jest.mock('@/lib/services/accounts/relationship', () => ({
+  getRelationship: jest.fn()
+}))
+
+const createRequest = (targetActorId: string) =>
+  new NextRequest(
+    `https://local.test/api/v1/accounts/${urlToId(targetActorId)}/unmute`,
+    { method: 'POST' }
+  )
+
+describe('POST /api/v1/accounts/:id/unmute', () => {
+  const applyUnmuteMock = applyUnmute as jest.Mock
+  const getRelationshipMock = getRelationship as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getRelationshipMock.mockResolvedValue({
+      id: 'target-id',
+      muting: false,
+      muting_notifications: false
+    })
+  })
+
+  it('calls applyUnmute with the correct params', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyUnmuteMock.mockResolvedValue(null)
+
+    await POST(createRequest(targetActorId), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(applyUnmuteMock).toHaveBeenCalledWith({
+      database: mockDatabase,
+      actorId: mockCurrentActor.id,
+      targetActorId
+    })
+    expect(getRelationshipMock).toHaveBeenCalled()
+  })
+
+  it('is a no-op (does not call applyUnmute) when unmuting self', async () => {
+    await POST(
+      createRequest(mockCurrentActor.id),
+      { params: Promise.resolve({ id: urlToId(mockCurrentActor.id) }) }
+    )
+
+    expect(applyUnmuteMock).not.toHaveBeenCalled()
+    expect(getRelationshipMock).toHaveBeenCalled()
+  })
+
+  it('succeeds even if target was not muted (no-op unmute)', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyUnmuteMock.mockResolvedValue(null)
+
+    const response = await POST(createRequest(targetActorId), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(response.status).not.toBe(404)
+    expect(response.status).not.toBe(500)
+  })
+})

--- a/app/api/v1/accounts/[id]/unmute/route.test.ts
+++ b/app/api/v1/accounts/[id]/unmute/route.test.ts
@@ -6,16 +6,7 @@ import { urlToId } from '@/lib/utils/urlToId'
 
 import { POST } from './route'
 
-const mockMuteRecord = {
-  id: 'mute-1',
-  actorId: 'https://local.test/users/me',
-  targetActorId: 'https://remote.test/users/alice',
-  notifications: true,
-  endsAt: null
-}
-
 const mockDatabase = {
-  getMute: jest.fn(),
   getActorFromId: jest.fn()
 }
 const mockCurrentActor = {
@@ -64,7 +55,14 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockDatabase.getMute.mockResolvedValue(mockMuteRecord)
+    // Default: applyUnmute deleted a record
+    applyUnmuteMock.mockResolvedValue({
+      id: 'mute-1',
+      actorId: mockCurrentActor.id,
+      targetActorId: 'https://remote.test/users/alice',
+      notifications: true,
+      endsAt: null
+    })
     mockDatabase.getActorFromId.mockResolvedValue({
       id: 'https://remote.test/users/alice'
     })
@@ -75,9 +73,8 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
     })
   })
 
-  it('calls applyUnmute with the correct params when mute exists', async () => {
+  it('calls applyUnmute with the correct params', async () => {
     const targetActorId = 'https://remote.test/users/alice'
-    applyUnmuteMock.mockResolvedValue(null)
 
     await POST(createRequest(targetActorId), {
       params: Promise.resolve({ id: urlToId(targetActorId) })
@@ -100,13 +97,11 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
     expect(getRelationshipMock).toHaveBeenCalled()
   })
 
-  it('succeeds even if target was not muted (no-op unmute)', async () => {
+  it('succeeds when target was not muted (no-op unmute) and actor exists', async () => {
     const targetActorId = 'https://remote.test/users/alice'
-    mockDatabase.getMute.mockResolvedValue(null)
-    mockDatabase.getActorFromId.mockResolvedValue({
-      id: targetActorId
-    })
+    // applyUnmute returns null → no existing mute deleted
     applyUnmuteMock.mockResolvedValue(null)
+    mockDatabase.getActorFromId.mockResolvedValue({ id: targetActorId })
 
     const response = await POST(createRequest(targetActorId), {
       params: Promise.resolve({ id: urlToId(targetActorId) })
@@ -114,12 +109,11 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
 
     expect(response.status).not.toBe(404)
     expect(response.status).not.toBe(500)
-    expect(applyUnmuteMock).not.toHaveBeenCalled()
   })
 
   it('returns 404 when target actor does not exist and no mute record', async () => {
     const targetActorId = 'https://remote.test/users/unknown'
-    mockDatabase.getMute.mockResolvedValue(null)
+    applyUnmuteMock.mockResolvedValue(null)
     mockDatabase.getActorFromId.mockResolvedValue(null)
 
     const response = await POST(createRequest(targetActorId), {
@@ -127,6 +121,5 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
     })
 
     expect(response.status).toBe(404)
-    expect(applyUnmuteMock).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/accounts/[id]/unmute/route.test.ts
+++ b/app/api/v1/accounts/[id]/unmute/route.test.ts
@@ -6,7 +6,18 @@ import { urlToId } from '@/lib/utils/urlToId'
 
 import { POST } from './route'
 
-const mockDatabase = {}
+const mockMuteRecord = {
+  id: 'mute-1',
+  actorId: 'https://local.test/users/me',
+  targetActorId: 'https://remote.test/users/alice',
+  notifications: true,
+  endsAt: null
+}
+
+const mockDatabase = {
+  getMute: jest.fn(),
+  getActorFromId: jest.fn()
+}
 const mockCurrentActor = {
   id: 'https://local.test/users/me',
   domain: 'local.test'
@@ -53,6 +64,10 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDatabase.getMute.mockResolvedValue(mockMuteRecord)
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: 'https://remote.test/users/alice'
+    })
     getRelationshipMock.mockResolvedValue({
       id: 'target-id',
       muting: false,
@@ -60,7 +75,7 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
     })
   })
 
-  it('calls applyUnmute with the correct params', async () => {
+  it('calls applyUnmute with the correct params when mute exists', async () => {
     const targetActorId = 'https://remote.test/users/alice'
     applyUnmuteMock.mockResolvedValue(null)
 
@@ -77,10 +92,9 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
   })
 
   it('is a no-op (does not call applyUnmute) when unmuting self', async () => {
-    await POST(
-      createRequest(mockCurrentActor.id),
-      { params: Promise.resolve({ id: urlToId(mockCurrentActor.id) }) }
-    )
+    await POST(createRequest(mockCurrentActor.id), {
+      params: Promise.resolve({ id: urlToId(mockCurrentActor.id) })
+    })
 
     expect(applyUnmuteMock).not.toHaveBeenCalled()
     expect(getRelationshipMock).toHaveBeenCalled()
@@ -88,6 +102,10 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
 
   it('succeeds even if target was not muted (no-op unmute)', async () => {
     const targetActorId = 'https://remote.test/users/alice'
+    mockDatabase.getMute.mockResolvedValue(null)
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: targetActorId
+    })
     applyUnmuteMock.mockResolvedValue(null)
 
     const response = await POST(createRequest(targetActorId), {
@@ -96,5 +114,19 @@ describe('POST /api/v1/accounts/:id/unmute', () => {
 
     expect(response.status).not.toBe(404)
     expect(response.status).not.toBe(500)
+    expect(applyUnmuteMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when target actor does not exist and no mute record', async () => {
+    const targetActorId = 'https://remote.test/users/unknown'
+    mockDatabase.getMute.mockResolvedValue(null)
+    mockDatabase.getActorFromId.mockResolvedValue(null)
+
+    const response = await POST(createRequest(targetActorId), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(response.status).toBe(404)
+    expect(applyUnmuteMock).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/accounts/[id]/unmute/route.ts
+++ b/app/api/v1/accounts/[id]/unmute/route.ts
@@ -36,12 +36,15 @@ export const POST = traceApiRoute(
     const targetActorId = idToUrl(encodedAccountId)
 
     if (targetActorId !== currentActor.id) {
-      const existingMute = await database.getMute({
+      // deleteMute uses a raw lookup (no expiry filter) so expired rows are
+      // cleaned up too. If nothing was deleted, validate the actor exists.
+      const deleted = await applyUnmute({
+        database,
         actorId: currentActor.id,
         targetActorId
       })
 
-      if (!existingMute) {
+      if (!deleted) {
         const targetActor = await database.getActorFromId({ id: targetActorId })
         if (!targetActor)
           return apiResponse({
@@ -50,10 +53,6 @@ export const POST = traceApiRoute(
             data: ERROR_404,
             responseStatusCode: 404
           })
-      }
-
-      if (existingMute) {
-        await applyUnmute({ database, actorId: currentActor.id, targetActorId })
       }
     }
 

--- a/app/api/v1/accounts/[id]/unmute/route.ts
+++ b/app/api/v1/accounts/[id]/unmute/route.ts
@@ -3,7 +3,12 @@ import { getRelationship } from '@/lib/services/accounts/relationship'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/getCORSHeaders'
-import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_404,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
@@ -31,7 +36,25 @@ export const POST = traceApiRoute(
     const targetActorId = idToUrl(encodedAccountId)
 
     if (targetActorId !== currentActor.id) {
-      await applyUnmute({ database, actorId: currentActor.id, targetActorId })
+      const existingMute = await database.getMute({
+        actorId: currentActor.id,
+        targetActorId
+      })
+
+      if (!existingMute) {
+        const targetActor = await database.getActorFromId({ id: targetActorId })
+        if (!targetActor)
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_404,
+            responseStatusCode: 404
+          })
+      }
+
+      if (existingMute) {
+        await applyUnmute({ database, actorId: currentActor.id, targetActorId })
+      }
     }
 
     const relationship = await getRelationship({

--- a/app/api/v1/accounts/[id]/unmute/route.ts
+++ b/app/api/v1/accounts/[id]/unmute/route.ts
@@ -1,3 +1,4 @@
+import { applyUnmute } from '@/lib/actions/applyUnmute'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
@@ -29,8 +30,9 @@ export const POST = traceApiRoute(
 
     const targetActorId = idToUrl(encodedAccountId)
 
-    // Unmuting not yet implemented - return relationship with muting: false
-    // TODO: Implement muting functionality
+    if (targetActorId !== currentActor.id) {
+      await applyUnmute({ database, actorId: currentActor.id, targetActorId })
+    }
 
     const relationship = await getRelationship({
       database,

--- a/lib/actions/applyMute.ts
+++ b/lib/actions/applyMute.ts
@@ -1,0 +1,23 @@
+import { Database } from '@/lib/database/types'
+
+interface ApplyMuteParams {
+  database: Database
+  actorId: string
+  targetActorId: string
+  notifications: boolean
+  endsAt: number | null
+}
+
+export const applyMute = ({
+  database,
+  actorId,
+  targetActorId,
+  notifications,
+  endsAt
+}: ApplyMuteParams) =>
+  database.createMute({
+    actorId,
+    targetActorId,
+    notifications,
+    endsAt
+  })

--- a/lib/actions/applyUnmute.ts
+++ b/lib/actions/applyUnmute.ts
@@ -1,0 +1,17 @@
+import { Database } from '@/lib/database/types'
+
+interface ApplyUnmuteParams {
+  database: Database
+  actorId: string
+  targetActorId: string
+}
+
+export const applyUnmute = ({
+  database,
+  actorId,
+  targetActorId
+}: ApplyUnmuteParams) =>
+  database.deleteMute({
+    actorId,
+    targetActorId
+  })

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -1399,6 +1399,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         })
         .delete()
 
+      await trx('mutes')
+        .where((builder) => {
+          builder.where('actorId', actorId).orWhere('targetActorId', actorId)
+        })
+        .delete()
+
       // Delete likes made by this actor
       await trx('likes').where('actorId', actorId).delete()
 

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -4,6 +4,7 @@ import { AccountSQLDatabaseMixin } from '@/lib/database/sql/account'
 import { ActorSQLDatabaseMixin } from '@/lib/database/sql/actor'
 import { AdminSQLDatabaseMixin } from '@/lib/database/sql/admin'
 import { BlockSQLDatabaseMixin } from '@/lib/database/sql/block'
+import { MuteSQLDatabaseMixin } from '@/lib/database/sql/mute'
 import { BookmarkSQLDatabaseMixin } from '@/lib/database/sql/bookmark'
 import { DirectConversationSQLDatabaseMixin } from '@/lib/database/sql/conversation'
 import { FitnessFileSQLDatabaseMixin } from '@/lib/database/sql/fitnessFile'
@@ -32,6 +33,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const fitnessSettingsDatabase = FitnessSettingsSQLDatabaseMixin(database)
   const bookmarkDatabase = BookmarkSQLDatabaseMixin(database)
   const blockDatabase = BlockSQLDatabaseMixin(database)
+  const muteDatabase = MuteSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const instanceActivityDatabase = InstanceActivitySQLDatabaseMixin(database)
   const likeDatabase = LikeSQLDatabaseMixin(database)
@@ -73,6 +75,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...instanceActivityDatabase,
     ...bookmarkDatabase,
     ...blockDatabase,
+    ...muteDatabase,
     ...followerDatabase,
     ...likeDatabase,
     ...mediaDatabase,

--- a/lib/database/sql/mute.test.ts
+++ b/lib/database/sql/mute.test.ts
@@ -1,0 +1,173 @@
+import crypto from 'crypto'
+import knex, { Knex } from 'knex'
+
+import { getSQLDatabase } from '@/lib/database/sql'
+import { Database } from '@/lib/database/types'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+
+describe('MuteDatabase', () => {
+  let knexDatabase: Knex
+  let database: Database
+
+  beforeAll(async () => {
+    knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    database = getSQLDatabase(knexDatabase)
+    await database.migrate()
+    await seedDatabase(database)
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  const targetActorId = () =>
+    `https://remote.test/users/muted-${crypto.randomUUID()}`
+
+  it('creates a mute and returns it', async () => {
+    const target = targetActorId()
+
+    const mute = await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId: target,
+      notifications: true,
+      endsAt: null
+    })
+
+    expect(mute.actorId).toBe(ACTOR1_ID)
+    expect(mute.targetActorId).toBe(target)
+    expect(mute.notifications).toBe(true)
+    expect(mute.endsAt).toBeNull()
+    expect(await database.isMuting({ actorId: ACTOR1_ID, targetActorId: target })).toBe(true)
+  })
+
+  it('updates notifications and endsAt when re-muting the same target', async () => {
+    const target = targetActorId()
+    const endsAt = Date.now() + 60_000
+
+    await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId: target,
+      notifications: true,
+      endsAt: null
+    })
+
+    const updated = await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId: target,
+      notifications: false,
+      endsAt
+    })
+
+    expect(updated.notifications).toBe(false)
+    expect(updated.endsAt).toBe(endsAt)
+
+    const fetched = await database.getMute({ actorId: ACTOR1_ID, targetActorId: target })
+    expect(fetched?.notifications).toBe(false)
+    expect(fetched?.endsAt).toBe(endsAt)
+  })
+
+  it('deletes a mute and returns the old record', async () => {
+    const target = targetActorId()
+
+    const created = await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId: target,
+      notifications: true,
+      endsAt: null
+    })
+
+    const deleted = await database.deleteMute({
+      actorId: ACTOR1_ID,
+      targetActorId: target
+    })
+
+    expect(deleted?.id).toBe(created.id)
+    expect(await database.isMuting({ actorId: ACTOR1_ID, targetActorId: target })).toBe(false)
+  })
+
+  it('returns null when deleting a non-existent mute', async () => {
+    const result = await database.deleteMute({
+      actorId: ACTOR1_ID,
+      targetActorId: targetActorId()
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('returns false from isMuting when no mute exists', async () => {
+    const result = await database.isMuting({
+      actorId: ACTOR1_ID,
+      targetActorId: targetActorId()
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it('getMute returns null when no mute exists', async () => {
+    const result = await database.getMute({
+      actorId: ACTOR1_ID,
+      targetActorId: targetActorId()
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('getMuteRelations returns only forward directional relations', async () => {
+    const actorId = `https://remote.test/users/muter-${crypto.randomUUID()}`
+    const mutedTarget = targetActorId()
+    const unrelatedTarget = targetActorId()
+    const reverseMuter = targetActorId()
+
+    await database.createMute({
+      actorId,
+      targetActorId: mutedTarget,
+      notifications: true,
+      endsAt: null
+    })
+    await database.createMute({
+      actorId: reverseMuter,
+      targetActorId: actorId,
+      notifications: false,
+      endsAt: null
+    })
+
+    const relations = await database.getMuteRelations({
+      actorIds: [actorId],
+      targetActorIds: [mutedTarget, unrelatedTarget]
+    })
+
+    expect(relations).toHaveLength(1)
+    expect(relations[0]).toMatchObject({
+      actorId,
+      targetActorId: mutedTarget,
+      notifications: true
+    })
+  })
+
+  it('getMuteRelations returns empty array for empty inputs', async () => {
+    await expect(
+      database.getMuteRelations({ actorIds: [], targetActorIds: [] })
+    ).resolves.toEqual([])
+
+    await expect(
+      database.getMuteRelations({
+        actorIds: [ACTOR1_ID],
+        targetActorIds: []
+      })
+    ).resolves.toEqual([])
+
+    await expect(
+      database.getMuteRelations({
+        actorIds: [],
+        targetActorIds: [targetActorId()]
+      })
+    ).resolves.toEqual([])
+  })
+})

--- a/lib/database/sql/mute.test.ts
+++ b/lib/database/sql/mute.test.ts
@@ -171,6 +171,42 @@ describe('MuteDatabase', () => {
     ).resolves.toEqual([])
   })
 
+  it('re-muting an expired mute updates the row instead of throwing (unique constraint)', async () => {
+    const target = targetActorId()
+    const pastEndsAt = Date.now() - 1000
+
+    // Insert an expired mute directly (bypassing createMute so endsAt is in the past)
+    await knexDatabase('mutes').insert({
+      id: crypto.randomUUID(),
+      actorId: ACTOR1_ID,
+      actorHost: new URL(ACTOR1_ID).host,
+      targetActorId: target,
+      targetActorHost: new URL(target).host,
+      notifications: true,
+      endsAt: pastEndsAt,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+
+    // Re-muting should succeed (UPDATE, not INSERT) and return fresh params
+    const remute = await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId: target,
+      notifications: false,
+      endsAt: null
+    })
+
+    expect(remute.notifications).toBe(false)
+    expect(remute.endsAt).toBeNull()
+    // Only one row should exist
+    const count = await knexDatabase('mutes').where({ actorId: ACTOR1_ID, targetActorId: target }).count('id as n').first()
+    expect(Number(count?.n)).toBe(1)
+    // And getMute now sees it as active
+    await expect(
+      database.getMute({ actorId: ACTOR1_ID, targetActorId: target })
+    ).resolves.not.toBeNull()
+  })
+
   it('getMute returns null for an expired mute', async () => {
     const target = targetActorId()
     const pastEndsAt = Date.now() - 1000

--- a/lib/database/sql/mute.test.ts
+++ b/lib/database/sql/mute.test.ts
@@ -170,4 +170,91 @@ describe('MuteDatabase', () => {
       })
     ).resolves.toEqual([])
   })
+
+  it('getMute returns null for an expired mute', async () => {
+    const target = targetActorId()
+    const pastEndsAt = Date.now() - 1000
+
+    await knexDatabase('mutes').insert({
+      id: crypto.randomUUID(),
+      actorId: ACTOR1_ID,
+      actorHost: new URL(ACTOR1_ID).host,
+      targetActorId: target,
+      targetActorHost: new URL(target).host,
+      notifications: true,
+      endsAt: pastEndsAt,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+
+    await expect(
+      database.getMute({ actorId: ACTOR1_ID, targetActorId: target })
+    ).resolves.toBeNull()
+  })
+
+  it('isMuting returns false for an expired mute', async () => {
+    const target = targetActorId()
+    const pastEndsAt = Date.now() - 1000
+
+    await knexDatabase('mutes').insert({
+      id: crypto.randomUUID(),
+      actorId: ACTOR1_ID,
+      actorHost: new URL(ACTOR1_ID).host,
+      targetActorId: target,
+      targetActorHost: new URL(target).host,
+      notifications: true,
+      endsAt: pastEndsAt,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+
+    await expect(
+      database.isMuting({ actorId: ACTOR1_ID, targetActorId: target })
+    ).resolves.toBe(false)
+  })
+
+  it('getMuteRelations excludes expired mutes', async () => {
+    const actorId = `https://remote.test/users/expiry-${crypto.randomUUID()}`
+    const expiredTarget = targetActorId()
+    const activeTarget = targetActorId()
+    const pastEndsAt = Date.now() - 1000
+    const futureEndsAt = Date.now() + 60_000
+
+    await knexDatabase('mutes').insert([
+      {
+        id: crypto.randomUUID(),
+        actorId,
+        actorHost: new URL(actorId).host,
+        targetActorId: expiredTarget,
+        targetActorHost: new URL(expiredTarget).host,
+        notifications: true,
+        endsAt: pastEndsAt,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        id: crypto.randomUUID(),
+        actorId,
+        actorHost: new URL(actorId).host,
+        targetActorId: activeTarget,
+        targetActorHost: new URL(activeTarget).host,
+        notifications: false,
+        endsAt: futureEndsAt,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ])
+
+    const relations = await database.getMuteRelations({
+      actorIds: [actorId],
+      targetActorIds: [expiredTarget, activeTarget]
+    })
+
+    expect(relations).toHaveLength(1)
+    expect(relations[0]).toMatchObject({
+      actorId,
+      targetActorId: activeTarget,
+      notifications: false
+    })
+  })
 })

--- a/lib/database/sql/mute.ts
+++ b/lib/database/sql/mute.ts
@@ -49,15 +49,20 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
   }: CreateMuteParams) {
     const currentTime = new Date()
 
-    const existingMute = await this.getMute({ actorId, targetActorId })
-    if (existingMute) {
+    // Use a raw DB lookup (no expiry filter) so that expired rows are updated
+    // rather than triggering a unique-constraint violation on INSERT.
+    const existingRow = await database<Mute>('mutes')
+      .where({ actorId, targetActorId })
+      .first()
+
+    if (existingRow) {
       await database('mutes').where({ actorId, targetActorId }).update({
         notifications,
         endsAt,
         updatedAt: currentTime
       })
       return {
-        ...existingMute,
+        ...fixMuteDataDate(existingRow),
         notifications,
         endsAt,
         updatedAt: currentTime.getTime()
@@ -86,7 +91,10 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
     } catch (error) {
       if (!isUniqueConstraintError(error)) throw error
 
-      const duplicated = await this.getMute({ actorId, targetActorId })
+      // Race: another request inserted between our SELECT and INSERT — update it.
+      const duplicated = await database<Mute>('mutes')
+        .where({ actorId, targetActorId })
+        .first()
       if (duplicated) {
         await database('mutes').where({ actorId, targetActorId }).update({
           notifications,
@@ -94,7 +102,7 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
           updatedAt: currentTime
         })
         return {
-          ...duplicated,
+          ...fixMuteDataDate(duplicated),
           notifications,
           endsAt,
           updatedAt: currentTime.getTime()

--- a/lib/database/sql/mute.ts
+++ b/lib/database/sql/mute.ts
@@ -17,7 +17,10 @@ import { Mute } from '@/lib/types/domain/mute'
 const fixMuteDataDate = (data: Mute): Mute => ({
   ...data,
   notifications: Boolean(data.notifications),
-  endsAt: data.endsAt ? Number(data.endsAt) : null,
+  endsAt:
+    data.endsAt !== null && data.endsAt !== undefined
+      ? Number(data.endsAt)
+      : null,
   createdAt: getCompatibleTime(data.createdAt),
   updatedAt: getCompatibleTime(data.updatedAt)
 })

--- a/lib/database/sql/mute.ts
+++ b/lib/database/sql/mute.ts
@@ -1,0 +1,164 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
+import {
+  CreateMuteParams,
+  DeleteMuteParams,
+  GetMuteParams,
+  GetMuteRelationsParams,
+  IsMutingParams,
+  MuteDatabase,
+  MuteRelation
+} from '@/lib/types/database/operations'
+import { Mute } from '@/lib/types/domain/mute'
+
+const fixMuteDataDate = (data: Mute): Mute => ({
+  ...data,
+  notifications: Boolean(data.notifications),
+  endsAt: data.endsAt ? Number(data.endsAt) : null,
+  createdAt: getCompatibleTime(data.createdAt),
+  updatedAt: getCompatibleTime(data.updatedAt)
+})
+
+const MUTE_RELATION_LOOKUP_CHUNK_SIZE = 1000
+
+const chunkArray = <T>(items: T[], chunkSize: number) => {
+  const chunks: T[][] = []
+
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize))
+  }
+
+  return chunks
+}
+
+export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
+  async createMute({
+    actorId,
+    targetActorId,
+    notifications,
+    endsAt
+  }: CreateMuteParams) {
+    const currentTime = new Date()
+
+    const existingMute = await this.getMute({ actorId, targetActorId })
+    if (existingMute) {
+      await database('mutes').where({ actorId, targetActorId }).update({
+        notifications,
+        endsAt,
+        updatedAt: currentTime
+      })
+      return {
+        ...existingMute,
+        notifications,
+        endsAt,
+        updatedAt: currentTime.getTime()
+      }
+    }
+
+    const mute: Mute = {
+      id: randomUUID(),
+      actorId,
+      actorHost: new URL(actorId).host,
+      targetActorId,
+      targetActorHost: new URL(targetActorId).host,
+      notifications,
+      endsAt,
+      createdAt: currentTime.getTime(),
+      updatedAt: currentTime.getTime()
+    }
+
+    try {
+      await database('mutes').insert({
+        ...mute,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      return mute
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) throw error
+
+      const duplicated = await this.getMute({ actorId, targetActorId })
+      if (duplicated) {
+        await database('mutes').where({ actorId, targetActorId }).update({
+          notifications,
+          endsAt,
+          updatedAt: currentTime
+        })
+        return { ...duplicated, notifications, endsAt, updatedAt: currentTime.getTime() }
+      }
+      throw error
+    }
+  },
+
+  async deleteMute({ actorId, targetActorId }: DeleteMuteParams) {
+    const existingMute = await database<Mute>('mutes')
+      .where({ actorId, targetActorId })
+      .first()
+    if (!existingMute) return null
+
+    await database('mutes').where('id', existingMute.id).delete()
+    return fixMuteDataDate(existingMute)
+  },
+
+  async getMute({ actorId, targetActorId }: GetMuteParams) {
+    const mute = await database<Mute>('mutes')
+      .where({ actorId, targetActorId })
+      .first()
+    if (!mute) return null
+    return fixMuteDataDate(mute)
+  },
+
+  async isMuting({ actorId, targetActorId }: IsMutingParams) {
+    const mute = await database('mutes')
+      .where({ actorId, targetActorId })
+      .first('id')
+    return Boolean(mute)
+  },
+
+  async getMuteRelations({
+    actorIds,
+    targetActorIds
+  }: GetMuteRelationsParams) {
+    const uniqueActorIds = [...new Set(actorIds)]
+    const uniqueTargetActorIds = [...new Set(targetActorIds)]
+
+    if (uniqueActorIds.length === 0 || uniqueTargetActorIds.length === 0) {
+      return []
+    }
+
+    const relationsByKey = new Map<string, MuteRelation>()
+    const actorIdChunks = chunkArray(
+      uniqueActorIds,
+      MUTE_RELATION_LOOKUP_CHUNK_SIZE
+    )
+    const targetActorIdChunks = chunkArray(
+      uniqueTargetActorIds,
+      MUTE_RELATION_LOOKUP_CHUNK_SIZE
+    )
+
+    const relationGroups = await Promise.all(
+      actorIdChunks.flatMap((actorIdChunk) =>
+        targetActorIdChunks.map((targetActorIdChunk) =>
+          database<MuteRelation>('mutes')
+            .select('actorId', 'targetActorId', 'notifications')
+            .whereIn('actorId', actorIdChunk)
+            .whereIn('targetActorId', targetActorIdChunk)
+        )
+      )
+    )
+
+    for (const relations of relationGroups) {
+      for (const relation of relations) {
+        relationsByKey.set(
+          JSON.stringify([relation.actorId, relation.targetActorId]),
+          { ...relation, notifications: Boolean(relation.notifications) }
+        )
+      }
+    }
+
+    return [...relationsByKey.values()]
+  }
+})

--- a/lib/database/sql/mute.ts
+++ b/lib/database/sql/mute.ts
@@ -25,7 +25,10 @@ const fixMuteDataDate = (data: Mute): Mute => ({
   updatedAt: getCompatibleTime(data.updatedAt)
 })
 
-const MUTE_RELATION_LOOKUP_CHUNK_SIZE = 1000
+// Each query uses two WHERE IN clauses (actorId + targetActorId).
+// Keep chunk size at 400 so the combined parameter count (400 * 2 = 800)
+// stays safely below SQLite's default limit of 999 bound parameters.
+const MUTE_RELATION_LOOKUP_CHUNK_SIZE = 400
 
 const chunkArray = <T>(items: T[], chunkSize: number) => {
   const chunks: T[][] = []
@@ -90,7 +93,12 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
           endsAt,
           updatedAt: currentTime
         })
-        return { ...duplicated, notifications, endsAt, updatedAt: currentTime.getTime() }
+        return {
+          ...duplicated,
+          notifications,
+          endsAt,
+          updatedAt: currentTime.getTime()
+        }
       }
       throw error
     }
@@ -111,14 +119,22 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
       .where({ actorId, targetActorId })
       .first()
     if (!mute) return null
-    return fixMuteDataDate(mute)
+    const fixed = fixMuteDataDate(mute)
+    if (fixed.endsAt !== null && fixed.endsAt < Date.now()) return null
+    return fixed
   },
 
   async isMuting({ actorId, targetActorId }: IsMutingParams) {
-    const mute = await database('mutes')
+    const mute = await database<Pick<Mute, 'id' | 'endsAt'>>('mutes')
       .where({ actorId, targetActorId })
-      .first('id')
-    return Boolean(mute)
+      .first('id', 'endsAt')
+    if (!mute) return false
+    const endsAt =
+      mute.endsAt !== null && mute.endsAt !== undefined
+        ? Number(mute.endsAt)
+        : null
+    if (endsAt !== null && endsAt < Date.now()) return false
+    return true
   },
 
   async getMuteRelations({
@@ -141,24 +157,32 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
       uniqueTargetActorIds,
       MUTE_RELATION_LOOKUP_CHUNK_SIZE
     )
+    const now = Date.now()
 
-    const relationGroups = await Promise.all(
-      actorIdChunks.flatMap((actorIdChunk) =>
-        targetActorIdChunks.map((targetActorIdChunk) =>
-          database<MuteRelation>('mutes')
-            .select('actorId', 'targetActorId', 'notifications')
-            .whereIn('actorId', actorIdChunk)
-            .whereIn('targetActorId', targetActorIdChunk)
-        )
-      )
-    )
+    for (const actorIdChunk of actorIdChunks) {
+      for (const targetActorIdChunk of targetActorIdChunks) {
+        const relations = await database<
+          MuteRelation & { endsAt: number | null }
+        >('mutes')
+          .select('actorId', 'targetActorId', 'notifications', 'endsAt')
+          .whereIn('actorId', actorIdChunk)
+          .whereIn('targetActorId', targetActorIdChunk)
 
-    for (const relations of relationGroups) {
-      for (const relation of relations) {
-        relationsByKey.set(
-          JSON.stringify([relation.actorId, relation.targetActorId]),
-          { ...relation, notifications: Boolean(relation.notifications) }
-        )
+        for (const relation of relations) {
+          const endsAt =
+            relation.endsAt !== null && relation.endsAt !== undefined
+              ? Number(relation.endsAt)
+              : null
+          if (endsAt !== null && endsAt < now) continue
+          relationsByKey.set(
+            JSON.stringify([relation.actorId, relation.targetActorId]),
+            {
+              actorId: relation.actorId,
+              targetActorId: relation.targetActorId,
+              notifications: Boolean(relation.notifications)
+            }
+          )
+        }
       }
     }
 

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -14,6 +14,7 @@ import {
   InstanceActivityDatabase,
   LikeDatabase,
   MediaDatabase,
+  MuteDatabase,
   NotificationDatabase,
   OAuthDatabase,
   PushSubscriptionDatabase,
@@ -31,6 +32,7 @@ export type Database = AccountDatabase &
   FitnessSettingsDatabase &
   StravaArchiveImportDatabase &
   BlockDatabase &
+  MuteDatabase &
   BookmarkDatabase &
   DirectConversationDatabase &
   FollowDatabase &

--- a/lib/services/accounts/relationship.test.ts
+++ b/lib/services/accounts/relationship.test.ts
@@ -9,7 +9,8 @@ describe('#getRelationship', () => {
     getActorFromId: jest.fn(),
     isCurrentActorFollowing: jest.fn(),
     getAcceptedOrRequestedFollow: jest.fn(),
-    isBlocking: jest.fn()
+    isBlocking: jest.fn(),
+    getMute: jest.fn()
   }
 
   const mockCurrentActor = {
@@ -25,6 +26,7 @@ describe('#getRelationship', () => {
       summary: 'Target user bio'
     })
     mockDatabase.isBlocking.mockResolvedValue(false)
+    mockDatabase.getMute.mockResolvedValue(null)
   })
 
   it('returns relationship with following=true when following', async () => {
@@ -169,5 +171,62 @@ describe('#getRelationship', () => {
     })
 
     expect(relationship.note).toBe('')
+  })
+
+  it('returns muting=true and muting_notifications=true when muted with notifications', async () => {
+    mockDatabase.isCurrentActorFollowing.mockResolvedValue(false)
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    mockDatabase.getMute.mockResolvedValue({
+      id: 'mute-1',
+      actorId: mockCurrentActor.id,
+      targetActorId: 'https://example.com/users/target',
+      notifications: true,
+      endsAt: null
+    })
+
+    const relationship = await getRelationship({
+      database: mockDatabase as unknown as Database,
+      currentActor: mockCurrentActor as unknown as Actor,
+      targetActorId: 'https://example.com/users/target'
+    })
+
+    expect(relationship.muting).toBe(true)
+    expect(relationship.muting_notifications).toBe(true)
+  })
+
+  it('returns muting=true and muting_notifications=false when muted without notifications', async () => {
+    mockDatabase.isCurrentActorFollowing.mockResolvedValue(false)
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    mockDatabase.getMute.mockResolvedValue({
+      id: 'mute-2',
+      actorId: mockCurrentActor.id,
+      targetActorId: 'https://example.com/users/target',
+      notifications: false,
+      endsAt: null
+    })
+
+    const relationship = await getRelationship({
+      database: mockDatabase as unknown as Database,
+      currentActor: mockCurrentActor as unknown as Actor,
+      targetActorId: 'https://example.com/users/target'
+    })
+
+    expect(relationship.muting).toBe(true)
+    expect(relationship.muting_notifications).toBe(false)
+  })
+
+  it('returns muting=false and muting_notifications=false when not muted', async () => {
+    mockDatabase.isCurrentActorFollowing.mockResolvedValue(false)
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    mockDatabase.getMute.mockResolvedValue(null)
+
+    const relationship = await getRelationship({
+      database: mockDatabase as unknown as Database,
+      currentActor: mockCurrentActor as unknown as Actor,
+      targetActorId: 'https://example.com/users/target'
+    })
+
+    expect(relationship.muting).toBe(false)
+    expect(relationship.muting_notifications).toBe(false)
   })
 })

--- a/lib/services/accounts/relationship.ts
+++ b/lib/services/accounts/relationship.ts
@@ -17,7 +17,7 @@ export const getRelationship = async ({
 }: GetRelationshipParams): Promise<Mastodon.Relationship> => {
   const actor = await database.getActorFromId({ id: targetActorId })
 
-  const [isFollowing, isFollowedBy, follow, isBlocking, isBlockedBy] =
+  const [isFollowing, isFollowedBy, follow, isBlocking, isBlockedBy, muteRecord] =
     await Promise.all([
       database.isCurrentActorFollowing({
         currentActorId: currentActor.id,
@@ -38,6 +38,10 @@ export const getRelationship = async ({
       database.isBlocking({
         actorId: targetActorId,
         targetActorId: currentActor.id
+      }),
+      database.getMute({
+        actorId: currentActor.id,
+        targetActorId
       })
     ])
 
@@ -53,8 +57,8 @@ export const getRelationship = async ({
     followed_by: isFollowedBy,
     blocking: isBlocking,
     blocked_by: isBlockedBy,
-    muting: false,
-    muting_notifications: false,
+    muting: muteRecord !== null,
+    muting_notifications: muteRecord?.notifications ?? false,
     requested: isRequested,
     requested_by: false,
     domain_blocking: false,

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -7,6 +7,7 @@ import { Actor, ActorType } from '@/lib/types/domain/actor'
 import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { Block } from '@/lib/types/domain/block'
 import { Bookmark } from '@/lib/types/domain/bookmark'
+import { Mute } from '@/lib/types/domain/mute'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 import { Session } from '@/lib/types/domain/session'
 import { Status, StatusType } from '@/lib/types/domain/status'
@@ -982,6 +983,42 @@ export interface BlockDatabase {
   isEitherBlocking(params: IsEitherBlockingParams): Promise<boolean>
   getBlocks(params: GetBlocksParams): Promise<Block[]>
   getBlockRelations(params: GetBlockRelationsParams): Promise<BlockRelation[]>
+}
+
+// ============================================================================
+// Mute Database
+// ============================================================================
+
+export type CreateMuteParams = {
+  actorId: string
+  targetActorId: string
+  notifications: boolean
+  endsAt: number | null
+}
+export type DeleteMuteParams = {
+  actorId: string
+  targetActorId: string
+}
+export type GetMuteParams = {
+  actorId: string
+  targetActorId: string
+}
+export type IsMutingParams = {
+  actorId: string
+  targetActorId: string
+}
+export type GetMuteRelationsParams = {
+  actorIds: string[]
+  targetActorIds: string[]
+}
+export type MuteRelation = Pick<Mute, 'actorId' | 'targetActorId' | 'notifications'>
+
+export interface MuteDatabase {
+  createMute(params: CreateMuteParams): Promise<Mute>
+  deleteMute(params: DeleteMuteParams): Promise<Mute | null>
+  getMute(params: GetMuteParams): Promise<Mute | null>
+  isMuting(params: IsMutingParams): Promise<boolean>
+  getMuteRelations(params: GetMuteRelationsParams): Promise<MuteRelation[]>
 }
 
 // ============================================================================

--- a/lib/types/domain/mute.ts
+++ b/lib/types/domain/mute.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const Mute = z.object({
+  id: z.string(),
+  actorId: z.string(),
+  actorHost: z.string(),
+
+  targetActorId: z.string(),
+  targetActorHost: z.string(),
+
+  notifications: z.boolean(),
+  endsAt: z.number().nullable(),
+
+  createdAt: z.number(),
+  updatedAt: z.number()
+})
+
+export type Mute = z.infer<typeof Mute>

--- a/migrations/20260527000000_add_mutes_table.js
+++ b/migrations/20260527000000_add_mutes_table.js
@@ -1,0 +1,28 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) =>
+  knex.schema.createTable('mutes', (table) => {
+    table.string('id').primary()
+    table.string('actorId').notNullable()
+    table.string('actorHost').notNullable()
+    table.string('targetActorId').notNullable()
+    table.string('targetActorHost').notNullable()
+    table.boolean('notifications').notNullable().defaultTo(true)
+    table.bigInteger('endsAt').nullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['actorId', 'targetActorId'], {
+      indexName: 'mutes_actor_target_unique'
+    })
+    table.index(['actorId', 'createdAt'], 'mutes_actor_created')
+    table.index(['targetActorId'], 'mutes_target')
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => knex.schema.dropTable('mutes')


### PR DESCRIPTION
## Summary

- Add `mutes` table migration with `notifications` (bool) and `endsAt` (Unix ms bigint) columns; no AP federation, local-only
- Add `MuteDatabase` interface + `MuteSQLDatabaseMixin` (idempotent create/update, delete, isMuting, getMuteRelations); wire into `Database` type and SQL index
- Replace hardcoded `muting: false` in relationship service with real `getMute` lookup; implement `POST /api/v1/accounts/:id/mute` (body: `notifications`, `duration`) and `/unmute` route handlers

## Test Plan

- [x] `yarn build` passes (no TypeScript errors)
- [x] `yarn lint` passes (0 errors)
- [x] All 2884 tests pass (`yarn test`)
- [x] New `lib/database/sql/mute.test.ts` covers create, re-mute update, delete, isMuting, getMuteRelations directional filtering, empty-input edge cases
- [x] `lib/services/accounts/relationship.test.ts` extended with muting=true/false and muting_notifications=true/false test cases
- [ ] Manual: `POST /api/v1/accounts/:id/mute` → `muting: true, muting_notifications: true`
- [ ] Manual: `POST /api/v1/accounts/:id/mute` with `{"notifications": false}` → `muting_notifications: false`
- [ ] Manual: `GET /api/v1/accounts/relationships?id[]=:id` reflects mute state
- [ ] Manual: `POST /api/v1/accounts/:id/unmute` → `muting: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)