### PR TITLE
Bump version to v1.25.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.25.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.25.1`
- Base main SHA: `666ef968484d99073c07b95400d8c30a309bb987`
- Included commits: `7`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
