### PR TITLE
Bump version to v1.25.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.25.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.25.2`
- Base main SHA: `385a5590142071c9ffe890a816b35d732fe3e757`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
