### PR TITLE
fix: allow Mastodon clients without PKCE to complete OAuth

### DIFF
--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -249,7 +249,10 @@ export const createApplication = async (
           scopes: JSON.stringify(parsedScopes),
           redirectUris: JSON.stringify(redirectUris),
           uri: request.website || null,
-          requirePKCE: true,
+          // Mastodon /api/v1/apps has no PKCE-capability field; PKCE is opt-in
+          // at authorize-time via code_challenge. better-auth still enforces it
+          // when present, and for public clients regardless of this flag.
+          requirePKCE: false,
           disabled: false,
           grantTypes: JSON.stringify([
             'authorization_code',


### PR DESCRIPTION
## Summary
- `app/api/v1/apps/createApplication.ts` hardcoded `requirePKCE: true` for every new Mastodon-registered app. Mastodon's `/api/v1/apps` spec has no PKCE-capability field, so clients that don't send `code_challenge` (e.g. the official Mastodon iOS app) failed at authorize-time with `pkce+is+required+for+this+client` from better-auth.
- Flip the new-app default to `requirePKCE: false`. PKCE is still enforced by better-auth for public clients (`token_endpoint_auth_method=none`, `type=native`/`user-agent-based`, `public=true`), for `offline_access` scope, and for any client that opts in by sending `code_challenge` — so this restores Mastodon-ecosystem compatibility without disabling PKCE where it actually applies.
- Deliberate partial revert of the hardening intent from `migrations/20260512230000_require_pkce_for_oauth_clients.js`. Existing rows are untouched; affected users can re-add the account in Mastodon iOS to trigger a fresh `/api/v1/apps` registration with the new default.

## Test plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (2902/2902 across 337 suites)
- [ ] On a fresh `yarn dev`, remove the Mastodon iOS account, re-add it pointing at the local domain, and confirm the OAuth round-trip completes without the `pkce is required for this client` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)