### PR TITLE
Bump version to v1.25.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.25.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.25.3`
- Base main SHA: `27369ddf69f64a87218c2cfe1f94ba5befa70eea`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
