### PR TITLE
Bump version to v1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.25.4",
+  "version": "1.26.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.26.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.25.4`
- Base main SHA: `179e42ee508773c97196d74fe253fa2e6f898c8e`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
