### PR TITLE
minor: add mute account UI (profile action + settings tab)

### DIFF
--- a/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.test.tsx
@@ -23,6 +23,12 @@ jest.mock('@/lib/components/block-action/block-action', () => ({
   )
 }))
 
+jest.mock('@/lib/components/mute-action/mute-action', () => ({
+  MuteAction: ({ targetActorId }: { targetActorId: string }) => (
+    <div data-testid="mute-action">{targetActorId}</div>
+  )
+}))
+
 const relationship = (
   overrides: Partial<MastodonRelationship> = {}
 ): MastodonRelationship => ({
@@ -55,12 +61,13 @@ describe('ProfileRelationshipActions', () => {
     )
 
     expect(screen.queryByTestId('follow-action')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mute-action')).not.toBeInTheDocument()
     expect(screen.getByTestId('block-action')).toHaveTextContent(
       'https://remote.test/users/blocked'
     )
   })
 
-  it('shows the follow action when the relationship is not blocked', () => {
+  it('shows the follow and mute actions when the relationship is not blocked', () => {
     render(
       <ProfileRelationshipActions
         targetActorId="https://remote.test/users/open"
@@ -70,6 +77,9 @@ describe('ProfileRelationshipActions', () => {
     )
 
     expect(screen.getByTestId('follow-action')).toHaveTextContent(
+      'https://remote.test/users/open'
+    )
+    expect(screen.getByTestId('mute-action')).toHaveTextContent(
       'https://remote.test/users/open'
     )
     expect(screen.getByTestId('block-action')).toHaveTextContent(

--- a/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
@@ -21,8 +21,13 @@ export const ProfileRelationshipActions: FC<
   <div className="flex flex-wrap gap-2">
     {!isBlockedRelationship(relationship) ? (
       <>
-        <FollowAction targetActorId={targetActorId} isLoggedIn={isLoggedIn} />
+        <FollowAction
+          key={`follow-${targetActorId}`}
+          targetActorId={targetActorId}
+          isLoggedIn={isLoggedIn}
+        />
         <MuteAction
+          key={`mute-${targetActorId}`}
           targetActorId={targetActorId}
           isLoggedIn={isLoggedIn}
           initialRelationship={relationship}
@@ -30,6 +35,7 @@ export const ProfileRelationshipActions: FC<
       </>
     ) : null}
     <BlockAction
+      key={`block-${targetActorId}`}
       targetActorId={targetActorId}
       isLoggedIn={isLoggedIn}
       initialRelationship={relationship}

--- a/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
+++ b/app/(timeline)/[actor]/ProfileRelationshipActions.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 
 import { BlockAction } from '@/lib/components/block-action/block-action'
 import { FollowAction } from '@/lib/components/follow-action/follow-action'
+import { MuteAction } from '@/lib/components/mute-action/mute-action'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 
 interface ProfileRelationshipActionsProps {
@@ -19,7 +20,14 @@ export const ProfileRelationshipActions: FC<
 > = ({ targetActorId, isLoggedIn, relationship }) => (
   <div className="flex flex-wrap gap-2">
     {!isBlockedRelationship(relationship) ? (
-      <FollowAction targetActorId={targetActorId} isLoggedIn={isLoggedIn} />
+      <>
+        <FollowAction targetActorId={targetActorId} isLoggedIn={isLoggedIn} />
+        <MuteAction
+          targetActorId={targetActorId}
+          isLoggedIn={isLoggedIn}
+          initialRelationship={relationship}
+        />
+      </>
     ) : null}
     <BlockAction
       targetActorId={targetActorId}

--- a/app/(timeline)/settings/layout.tsx
+++ b/app/(timeline)/settings/layout.tsx
@@ -27,6 +27,7 @@ const Layout: FC<Props> = ({ children }) => {
     { name: 'Media', url: '/settings/media' },
     { name: 'Notifications', url: '/settings/notifications' },
     { name: 'Blocked Accounts', url: '/settings/blocks' },
+    { name: 'Muted Accounts', url: '/settings/mutes' },
     { name: 'Fitness', url: '/settings/fitness' },
     { name: 'Sessions', url: '/settings/sessions' }
   ]

--- a/app/(timeline)/settings/mutes/MutesList.test.tsx
+++ b/app/(timeline)/settings/mutes/MutesList.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react'
+
+import { getMutes, unmute } from '@/lib/client'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+
+import { MutesList } from './MutesList'
+
+jest.mock('@/lib/client', () => ({
+  getMutes: jest.fn(),
+  unmute: jest.fn()
+}))
+
+const createAccount = (
+  id: string,
+  username: string,
+  displayName: string
+): MastodonAccount => ({
+  id,
+  username,
+  acct: username,
+  url: `https://example.test/users/${username}`,
+  display_name: displayName,
+  note: '',
+  avatar: '',
+  avatar_static: '',
+  header: '',
+  header_static: '',
+  locked: false,
+  source: {
+    note: '',
+    fields: [],
+    privacy: 'public',
+    sensitive: false,
+    language: null
+  },
+  fields: [],
+  emojis: [],
+  bot: false,
+  group: false,
+  discoverable: true,
+  noindex: false,
+  created_at: '2026-01-01T00:00:00.000Z',
+  last_status_at: null,
+  statuses_count: 0,
+  followers_count: 0,
+  following_count: 0
+})
+
+describe('MutesList', () => {
+  const unmuteMock = unmute as jest.Mock
+  const getMutesMock = getMutes as jest.Mock
+  const firstAccount = createAccount('actor-1', 'alpha', 'Alpha')
+  const secondAccount = createAccount('actor-2', 'beta', 'Beta')
+
+  beforeEach(() => {
+    unmuteMock.mockReset()
+    getMutesMock.mockReset()
+  })
+
+  it('shows the empty state when there are no muted accounts', () => {
+    render(<MutesList accounts={[]} nextMaxId={null} />)
+    expect(screen.getByText('No muted accounts.')).toBeInTheDocument()
+  })
+
+  it('removes only the successfully unmuted account', async () => {
+    unmuteMock.mockResolvedValueOnce({ muting: false })
+
+    render(
+      <MutesList accounts={[firstAccount, secondAccount]} nextMaxId={null} />
+    )
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Unmute' })[1])
+    await screen.findByText('Unmute account')
+    const dialogButtons = screen.getAllByRole('button', { name: 'Unmute' })
+    fireEvent.click(dialogButtons[dialogButtons.length - 1])
+
+    await waitFor(() => {
+      expect(unmuteMock).toHaveBeenCalledWith({
+        targetActorId: secondAccount.url
+      })
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('dialog', { name: 'Unmute account' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+  })
+
+  it('clears load-more loading state when fetching more mutes fails', async () => {
+    let rejectGetMutes: (error: Error) => void = () => undefined
+    getMutesMock.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectGetMutes = reject
+      })
+    )
+
+    render(<MutesList accounts={[firstAccount]} nextMaxId="next-cursor" />)
+
+    const loadMoreButton = screen.getByRole('button', { name: 'Load more' })
+    fireEvent.click(loadMoreButton)
+
+    await waitFor(() => {
+      expect(loadMoreButton).toBeDisabled()
+    })
+
+    await act(async () => {
+      rejectGetMutes(new Error('network failed'))
+    })
+
+    await waitFor(() => {
+      expect(loadMoreButton).toBeEnabled()
+    })
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+  })
+
+  it('appends fetched accounts on Load more', async () => {
+    const thirdAccount = createAccount('actor-3', 'gamma', 'Gamma')
+    getMutesMock.mockResolvedValueOnce({
+      accounts: [thirdAccount],
+      nextMaxId: null,
+      prevMinId: null
+    })
+
+    render(<MutesList accounts={[firstAccount]} nextMaxId="next-cursor" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => {
+      expect(getMutesMock).toHaveBeenCalledWith({
+        limit: 80,
+        maxId: 'next-cursor'
+      })
+    })
+    expect(await screen.findByText('Gamma')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Load more' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the error message when unmute returns a still-muting relationship', async () => {
+    unmuteMock.mockResolvedValueOnce({ muting: true })
+
+    render(<MutesList accounts={[firstAccount]} nextMaxId={null} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unmute' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Unmute account' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Unmute' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to unmute account. Please try again.'
+    )
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/settings/mutes/MutesList.tsx
+++ b/app/(timeline)/settings/mutes/MutesList.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { Loader2, VolumeX } from 'lucide-react'
+import Link from 'next/link'
+import { FC, useState } from 'react'
+
+import { getMutes, unmute } from '@/lib/client'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Button } from '@/lib/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/lib/components/ui/dialog'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+
+interface MutesListProps {
+  accounts: MastodonAccount[]
+  nextMaxId: string | null
+}
+
+const getInitials = (account: MastodonAccount) =>
+  (account.display_name || account.username)
+    .trim()
+    .split(/\s+/)
+    .map((part) => Array.from(part)[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
+export const MutesList: FC<MutesListProps> = ({ accounts, nextMaxId }) => {
+  const [mutedAccounts, setMutedAccounts] = useState(accounts)
+  const [unmutingIds, setUnmutingIds] = useState<Set<string>>(() => new Set())
+  const [confirmAccount, setConfirmAccount] = useState<MastodonAccount | null>(
+    null
+  )
+  const [nextCursor, setNextCursor] = useState(nextMaxId)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState('')
+
+  const onUnmute = async (account: MastodonAccount) => {
+    setError('')
+    setUnmutingIds((current) => new Set(current).add(account.id))
+
+    try {
+      const relationship = await unmute({ targetActorId: account.url })
+      if (!relationship || relationship.muting) {
+        setError('Failed to unmute account. Please try again.')
+        return
+      }
+
+      setMutedAccounts((current) =>
+        current.filter((item) => item.id !== account.id)
+      )
+      setConfirmAccount(null)
+    } catch (_err) {
+      setError('Failed to unmute account. Please try again.')
+    } finally {
+      setUnmutingIds((current) => {
+        const next = new Set(current)
+        next.delete(account.id)
+        return next
+      })
+    }
+  }
+
+  const onOpenConfirm = (account: MastodonAccount) => {
+    setError('')
+    setConfirmAccount(account)
+  }
+
+  const onCloseConfirm = () => {
+    setError('')
+    setConfirmAccount(null)
+  }
+
+  const onLoadMore = async () => {
+    if (!nextCursor) return
+
+    setIsLoadingMore(true)
+    try {
+      const result = await getMutes({ limit: 80, maxId: nextCursor })
+      setMutedAccounts((current) => [...current, ...result.accounts])
+      setNextCursor(result.nextMaxId)
+    } catch (_err) {
+      return
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }
+
+  const isConfirmAccountUnmuting = confirmAccount
+    ? unmutingIds.has(confirmAccount.id)
+    : false
+
+  if (mutedAccounts.length === 0 && !nextCursor) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+        No muted accounts.
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {mutedAccounts.length > 0 ? (
+        <div className="divide-y rounded-lg border">
+          {mutedAccounts.map((account) => (
+            <div
+              key={account.id}
+              className="flex items-center justify-between gap-4 p-4"
+            >
+              <Link
+                href={account.url}
+                className="flex min-w-0 items-center gap-3 hover:underline"
+              >
+                <Avatar className="h-10 w-10">
+                  <AvatarImage src={account.avatar || undefined} />
+                  <AvatarFallback>{getInitials(account)}</AvatarFallback>
+                </Avatar>
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">
+                    {account.display_name || account.username}
+                  </span>
+                  <span className="block truncate text-sm text-muted-foreground">
+                    @{account.acct}
+                  </span>
+                </span>
+              </Link>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenConfirm(account)}
+                disabled={unmutingIds.has(account.id)}
+              >
+                {unmutingIds.has(account.id) ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <VolumeX />
+                )}
+                Unmute
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No muted accounts on this page.
+        </div>
+      )}
+
+      {nextCursor ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onLoadMore}
+            disabled={isLoadingMore}
+          >
+            {isLoadingMore ? <Loader2 className="animate-spin" /> : null}
+            Load more
+          </Button>
+        </div>
+      ) : null}
+
+      <Dialog
+        open={confirmAccount !== null}
+        onOpenChange={(open) => {
+          if (isConfirmAccountUnmuting) return
+          if (!open) onCloseConfirm()
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unmute account</DialogTitle>
+            <DialogDescription>
+              This actor&apos;s posts and notifications will appear in your
+              timelines and notifications again.
+            </DialogDescription>
+          </DialogHeader>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCloseConfirm}
+              disabled={isConfirmAccountUnmuting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => confirmAccount && onUnmute(confirmAccount)}
+              disabled={!confirmAccount || isConfirmAccountUnmuting}
+            >
+              {isConfirmAccountUnmuting ? (
+                <Loader2 className="animate-spin" />
+              ) : null}
+              Unmute
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/app/(timeline)/settings/mutes/page.tsx
+++ b/app/(timeline)/settings/mutes/page.tsx
@@ -32,13 +32,17 @@ const Page = async () => {
     actorId: actor.id,
     limit: MUTES_PAGE_LIMIT
   })
-  const accounts = await Promise.all(
-    mutes.map(async (mute) => {
-      const account = await database.getMastodonActorFromId({
-        id: mute.targetActorId
-      })
-      return account ?? getFallbackMutedAccount(mute)
-    })
+  const targetActorIds = mutes.map((mute) => mute.targetActorId)
+  const hydratedAccounts =
+    targetActorIds.length > 0
+      ? await database.getMastodonActorsFromIds({ ids: targetActorIds })
+      : []
+  const accountsByUrl = new Map(
+    hydratedAccounts.map((account) => [account.url, account])
+  )
+  const accounts = mutes.map(
+    (mute) =>
+      accountsByUrl.get(mute.targetActorId) ?? getFallbackMutedAccount(mute)
   )
 
   return (

--- a/app/(timeline)/settings/mutes/page.tsx
+++ b/app/(timeline)/settings/mutes/page.tsx
@@ -1,0 +1,65 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { PageHeader } from '@/lib/components/page-header'
+import { getDatabase } from '@/lib/database'
+import { getFallbackMutedAccount } from '@/lib/services/accounts/getFallbackMutedAccount'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { MutesList } from './MutesList'
+
+export const dynamic = 'force-dynamic'
+const MUTES_PAGE_LIMIT = 80
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Muted Accounts'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor || !actor.account) {
+    return redirect('/auth/signin')
+  }
+
+  const mutes = await database.getMutes({
+    actorId: actor.id,
+    limit: MUTES_PAGE_LIMIT
+  })
+  const accounts = await Promise.all(
+    mutes.map(async (mute) => {
+      const account = await database.getMastodonActorFromId({
+        id: mute.targetActorId
+      })
+      return account ?? getFallbackMutedAccount(mute)
+    })
+  )
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Muted Accounts"
+        description="Manage actors hidden from your timelines and notifications."
+      />
+
+      <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+        <MutesList
+          accounts={accounts}
+          nextMaxId={
+            mutes.length === MUTES_PAGE_LIMIT
+              ? (mutes[mutes.length - 1]?.id ?? null)
+              : null
+          }
+        />
+      </section>
+    </div>
+  )
+}
+
+export default Page

--- a/app/api/v1/mutes/route.test.ts
+++ b/app/api/v1/mutes/route.test.ts
@@ -1,0 +1,151 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/mutes', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  const createdTargets: string[] = []
+  const createMute = async (targetActorId: string) => {
+    createdTargets.push(targetActorId)
+    await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId,
+      notifications: true,
+      endsAt: null
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  afterEach(async () => {
+    while (createdTargets.length > 0) {
+      const targetActorId = createdTargets.pop()
+      if (targetActorId) {
+        await database.deleteMute({ actorId: ACTOR1_ID, targetActorId })
+      }
+    }
+  })
+
+  const createRequest = (query = '') =>
+    new NextRequest(`https://llun.test/api/v1/mutes${query}`)
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns an empty array when the actor has no mutes', async () => {
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([])
+    expect(response.headers.get('Link')).toBeNull()
+  })
+
+  it('returns Mastodon accounts for muted actors newest first', async () => {
+    await createMute(ACTOR2_ID)
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toHaveLength(1)
+    expect(data[0]).toEqual(expect.objectContaining({ url: ACTOR2_ID }))
+  })
+
+  it('emits a Link header with max_id when the page is full', async () => {
+    const remoteA = 'https://remote.test/users/list-mute-link-a'
+    const remoteB = 'https://remote.test/users/list-mute-link-b'
+    for (const target of [remoteA, remoteB]) {
+      await createMute(target)
+    }
+
+    const response = await GET(createRequest('?limit=1'), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const linkHeader = response.headers.get('Link')
+    expect(linkHeader).toContain('rel="next"')
+    expect(linkHeader).toContain('rel="prev"')
+    expect(linkHeader).toContain('max_id=')
+  })
+
+  it('substitutes a fallback account when the muted actor cannot be hydrated', async () => {
+    const orphanedTarget = 'https://remote.test/users/ghost-mute-target'
+    await createMute(orphanedTarget)
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toHaveLength(1)
+    expect(data[0]).toEqual(
+      expect.objectContaining({
+        url: orphanedTarget,
+        display_name: 'Account unavailable'
+      })
+    )
+  })
+})

--- a/app/api/v1/mutes/route.ts
+++ b/app/api/v1/mutes/route.ts
@@ -1,0 +1,70 @@
+import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { getFallbackMutedAccount } from '@/lib/services/accounts/getFallbackMutedAccount'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const MAX_LIMIT = 80
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'getMutes',
+  OAuthGuard([Scope.enum.read], async (req, { database, currentActor }) => {
+    const url = new URL(req.url)
+    const parsedLimit = parseInt(
+      url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
+      10
+    )
+    const limit =
+      Number.isSafeInteger(parsedLimit) && parsedLimit > 0
+        ? Math.min(parsedLimit, MAX_LIMIT)
+        : PER_PAGE_LIMIT
+
+    const mutes = await database.getMutes({
+      actorId: currentActor.id,
+      limit,
+      maxId: url.searchParams.get('max_id'),
+      minId: url.searchParams.get('min_id'),
+      sinceId: url.searchParams.get('since_id')
+    })
+
+    const accounts = await Promise.all(
+      mutes.map(async (mute) => {
+        const account = await database.getMastodonActorFromId({
+          id: mute.targetActorId
+        })
+        return account ?? getFallbackMutedAccount(mute)
+      })
+    )
+
+    const host = headerHost(req.headers)
+    const buildPaginationUrl = (cursorParam: string, cursorValue: string) => {
+      const params = new URLSearchParams()
+      params.set('limit', limit.toString())
+      params.set(cursorParam, cursorValue)
+
+      return `<https://${host}/api/v1/mutes?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
+    }
+    const nextLink =
+      mutes.length === limit
+        ? buildPaginationUrl('max_id', mutes[mutes.length - 1].id)
+        : null
+    const prevLink =
+      mutes.length > 0 ? buildPaginationUrl('min_id', mutes[0].id) : null
+    const links = [nextLink, prevLink].filter(Boolean).join(', ')
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: accounts,
+      additionalHeaders: [
+        ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
+      ]
+    })
+  })
+)

--- a/app/api/v1/mutes/route.ts
+++ b/app/api/v1/mutes/route.ts
@@ -33,13 +33,17 @@ export const GET = traceApiRoute(
       sinceId: url.searchParams.get('since_id')
     })
 
-    const accounts = await Promise.all(
-      mutes.map(async (mute) => {
-        const account = await database.getMastodonActorFromId({
-          id: mute.targetActorId
-        })
-        return account ?? getFallbackMutedAccount(mute)
-      })
+    const targetActorIds = mutes.map((mute) => mute.targetActorId)
+    const hydratedAccounts =
+      targetActorIds.length > 0
+        ? await database.getMastodonActorsFromIds({ ids: targetActorIds })
+        : []
+    const accountsByUrl = new Map(
+      hydratedAccounts.map((account) => [account.url, account])
+    )
+    const accounts = mutes.map(
+      (mute) =>
+        accountsByUrl.get(mute.targetActorId) ?? getFallbackMutedAccount(mute)
     )
 
     const host = headerHost(req.headers)

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -626,9 +626,7 @@ export const mute = async ({
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(
-      notifications === undefined ? {} : { notifications }
-    )
+    body: JSON.stringify(notifications === undefined ? {} : { notifications })
   })
   if (response.status !== 200) return null
   return (await response.json()) as MastodonRelationship

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -611,6 +611,83 @@ export const getBlocks = async ({
   }
 }
 
+interface MuteParams {
+  targetActorId: string
+  notifications?: boolean
+}
+
+export const mute = async ({
+  targetActorId,
+  notifications
+}: MuteParams): Promise<MastodonRelationship | null> => {
+  const encodedId = urlToId(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/mute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(
+      notifications === undefined ? {} : { notifications }
+    )
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonRelationship
+}
+
+export const unmute = async ({
+  targetActorId
+}: FollowParams): Promise<MastodonRelationship | null> => {
+  const encodedId = urlToId(targetActorId)
+  const response = await fetch(`/api/v1/accounts/${encodedId}/unmute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonRelationship
+}
+
+interface GetMutesParams {
+  limit?: number
+  maxId?: string
+  minId?: string
+}
+
+interface GetMutesResult {
+  accounts: MastodonAccount[]
+  nextMaxId: string | null
+  prevMinId: string | null
+}
+
+export const getMutes = async ({
+  limit,
+  maxId,
+  minId
+}: GetMutesParams = {}): Promise<GetMutesResult> => {
+  const url = new URL(`${window.origin}/api/v1/mutes`)
+  if (limit) url.searchParams.set('limit', `${limit}`)
+  if (maxId) url.searchParams.set('max_id', maxId)
+  if (minId) url.searchParams.set('min_id', minId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (response.status !== 200) {
+    return { accounts: [], nextMaxId: null, prevMinId: null }
+  }
+
+  const linkHeader = response.headers.get('Link')
+  return {
+    accounts: (await response.json()) as MastodonAccount[],
+    nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
+    prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
+  }
+}
+
 export interface GetBookmarksParams {
   limit?: number
   maxBookmarkId?: string

--- a/lib/components/mute-action/mute-action.test.tsx
+++ b/lib/components/mute-action/mute-action.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react'
+
+import { mute, unmute } from '@/lib/client'
+import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+
+import { MuteAction } from './mute-action'
+
+const refresh = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh
+  })
+}))
+
+jest.mock('@/lib/client', () => ({
+  mute: jest.fn(),
+  unmute: jest.fn()
+}))
+
+const relationship = (
+  overrides: Partial<MastodonRelationship> = {}
+): MastodonRelationship => ({
+  id: 'target',
+  following: false,
+  showing_reblogs: false,
+  notifying: false,
+  followed_by: false,
+  blocking: false,
+  blocked_by: false,
+  muting: false,
+  muting_notifications: false,
+  requested: false,
+  requested_by: false,
+  domain_blocking: false,
+  endorsed: false,
+  languages: ['en'],
+  note: '',
+  ...overrides
+})
+
+describe('MuteAction', () => {
+  const muteMock = mute as jest.Mock
+  const unmuteMock = unmute as jest.Mock
+
+  beforeEach(() => {
+    muteMock.mockReset()
+    unmuteMock.mockReset()
+    refresh.mockReset()
+  })
+
+  it('renders nothing when not logged in', () => {
+    const { container } = render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn={false}
+        initialRelationship={relationship()}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there is no relationship yet', () => {
+    const { container } = render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={null}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('opens the confirm dialog when clicking Mute', async () => {
+    render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute' }))
+    await screen.findByRole('dialog', { name: 'Mute account' })
+  })
+
+  it('mutes with notifications=true by default and switches to Unmute', async () => {
+    muteMock.mockResolvedValue(relationship({ muting: true }))
+
+    render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Mute account' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Mute' }))
+
+    await waitFor(() => {
+      expect(muteMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target',
+        notifications: true
+      })
+    })
+    expect(refresh).toHaveBeenCalled()
+    await screen.findByRole('button', { name: 'Unmute' })
+  })
+
+  it('sends notifications=false when the checkbox is cleared', async () => {
+    muteMock.mockResolvedValue(relationship({ muting: true }))
+
+    render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Mute account' })
+    fireEvent.click(
+      within(dialog).getByLabelText('Also hide notifications from this actor')
+    )
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Mute' }))
+
+    await waitFor(() => {
+      expect(muteMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target',
+        notifications: false
+      })
+    })
+  })
+
+  it('unmutes directly without showing a dialog', async () => {
+    unmuteMock.mockResolvedValue(relationship({ muting: false }))
+
+    render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship({ muting: true })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unmute' }))
+
+    await waitFor(() => {
+      expect(unmuteMock).toHaveBeenCalledWith({
+        targetActorId: 'https://example.test/users/target'
+      })
+    })
+    expect(
+      screen.queryByRole('dialog', { name: 'Mute account' })
+    ).not.toBeInTheDocument()
+    await screen.findByRole('button', { name: 'Mute' })
+  })
+
+  it('shows an error message when the mute call returns null', async () => {
+    muteMock.mockResolvedValue(null)
+
+    render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Mute account' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Mute' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to mute account. Please try again.'
+    )
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})

--- a/lib/components/mute-action/mute-action.test.tsx
+++ b/lib/components/mute-action/mute-action.test.tsx
@@ -3,6 +3,7 @@
  */
 import '@testing-library/jest-dom'
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -167,6 +168,47 @@ describe('MuteAction', () => {
       screen.queryByRole('dialog', { name: 'Mute account' })
     ).not.toBeInTheDocument()
     await screen.findByRole('button', { name: 'Mute' })
+  })
+
+  it('keeps the dialog open and disables Cancel while a mute is in flight', async () => {
+    let resolveMute: (value: MastodonRelationship | null) => void = () =>
+      undefined
+    muteMock.mockReturnValueOnce(
+      new Promise<MastodonRelationship | null>((resolve) => {
+        resolveMute = resolve
+      })
+    )
+
+    render(
+      <MuteAction
+        targetActorId="https://example.test/users/target"
+        isLoggedIn
+        initialRelationship={relationship()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Mute account' })
+    const dialogMuteButton = within(dialog).getByRole('button', {
+      name: 'Mute'
+    })
+    fireEvent.click(dialogMuteButton)
+
+    const cancelButton = within(dialog).getByRole('button', { name: 'Cancel' })
+    await waitFor(() => {
+      expect(cancelButton).toBeDisabled()
+    })
+
+    fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' })
+    expect(
+      screen.getByRole('dialog', { name: 'Mute account' })
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      resolveMute(relationship({ muting: true }))
+    })
+
+    await screen.findByRole('button', { name: 'Unmute' })
   })
 
   it('shows an error message when the mute call returns null', async () => {

--- a/lib/components/mute-action/mute-action.tsx
+++ b/lib/components/mute-action/mute-action.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { Loader2, VolumeX } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { FC, useState } from 'react'
+
+import { mute as muteAccount, unmute as unmuteAccount } from '@/lib/client'
+import { Button } from '@/lib/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/lib/components/ui/dialog'
+import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+
+interface MuteActionProps {
+  targetActorId: string
+  isLoggedIn: boolean
+  initialRelationship: MastodonRelationship | null
+}
+
+export const MuteAction: FC<MuteActionProps> = ({
+  targetActorId,
+  isLoggedIn,
+  initialRelationship
+}) => {
+  const router = useRouter()
+  const [relationship, setRelationship] = useState<MastodonRelationship | null>(
+    initialRelationship
+  )
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isMuteDialogOpen, setIsMuteDialogOpen] = useState(false)
+  const [muteNotifications, setMuteNotifications] = useState(true)
+  const [error, setError] = useState('')
+
+  if (!isLoggedIn || relationship === null) return null
+
+  const onMute = async () => {
+    setError('')
+    setIsSubmitting(true)
+    try {
+      const next = await muteAccount({
+        targetActorId,
+        notifications: muteNotifications
+      })
+      if (!next || !next.muting) {
+        setError('Failed to mute account. Please try again.')
+        return
+      }
+      setRelationship(next)
+      setIsMuteDialogOpen(false)
+      router.refresh()
+    } catch (_err) {
+      setError('Failed to mute account. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const onUnmute = async () => {
+    setError('')
+    setIsSubmitting(true)
+    try {
+      const next = await unmuteAccount({ targetActorId })
+      if (!next || next.muting) {
+        setError('Failed to unmute account. Please try again.')
+        return
+      }
+      setRelationship(next)
+      router.refresh()
+    } catch (_err) {
+      setError('Failed to unmute account. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (relationship.muting) {
+    return (
+      <div className="flex flex-col items-start gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onUnmute}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? <Loader2 className="animate-spin" /> : <VolumeX />}
+          Unmute
+        </Button>
+        {error ? (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <Dialog
+      open={isMuteDialogOpen}
+      onOpenChange={(open) => {
+        setError('')
+        setIsMuteDialogOpen(open)
+        if (open) setMuteNotifications(true)
+      }}
+    >
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => {
+          setError('')
+          setMuteNotifications(true)
+          setIsMuteDialogOpen(true)
+        }}
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? <Loader2 className="animate-spin" /> : <VolumeX />}
+        Mute
+      </Button>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Mute account</DialogTitle>
+          <DialogDescription>
+            Posts from this actor will be hidden from your timelines. They can
+            still see and reply to your posts.
+          </DialogDescription>
+        </DialogHeader>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={muteNotifications}
+            onChange={(event) => setMuteNotifications(event.target.checked)}
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          Also hide notifications from this actor
+        </label>
+        {error ? (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setIsMuteDialogOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={onMute} disabled={isSubmitting}>
+            {isSubmitting ? <Loader2 className="animate-spin" /> : null}
+            Mute
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/components/mute-action/mute-action.tsx
+++ b/lib/components/mute-action/mute-action.tsx
@@ -117,6 +117,7 @@ export const MuteAction: FC<MuteActionProps> = ({
       <Dialog
         open={isMuteDialogOpen}
         onOpenChange={(open) => {
+          if (isSubmitting) return
           setError('')
           setIsMuteDialogOpen(open)
           if (open) setMuteNotifications(true)
@@ -149,6 +150,7 @@ export const MuteAction: FC<MuteActionProps> = ({
               type="button"
               variant="outline"
               onClick={() => setIsMuteDialogOpen(false)}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>

--- a/lib/components/mute-action/mute-action.tsx
+++ b/lib/components/mute-action/mute-action.tsx
@@ -100,14 +100,7 @@ export const MuteAction: FC<MuteActionProps> = ({
   }
 
   return (
-    <Dialog
-      open={isMuteDialogOpen}
-      onOpenChange={(open) => {
-        setError('')
-        setIsMuteDialogOpen(open)
-        if (open) setMuteNotifications(true)
-      }}
-    >
+    <>
       <Button
         type="button"
         variant="outline"
@@ -121,42 +114,51 @@ export const MuteAction: FC<MuteActionProps> = ({
         {isSubmitting ? <Loader2 className="animate-spin" /> : <VolumeX />}
         Mute
       </Button>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Mute account</DialogTitle>
-          <DialogDescription>
-            Posts from this actor will be hidden from your timelines. They can
-            still see and reply to your posts.
-          </DialogDescription>
-        </DialogHeader>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={muteNotifications}
-            onChange={(event) => setMuteNotifications(event.target.checked)}
-            className="h-4 w-4 rounded border-gray-300"
-          />
-          Also hide notifications from this actor
-        </label>
-        {error ? (
-          <p role="alert" className="text-sm text-destructive">
-            {error}
-          </p>
-        ) : null}
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setIsMuteDialogOpen(false)}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={onMute} disabled={isSubmitting}>
-            {isSubmitting ? <Loader2 className="animate-spin" /> : null}
-            Mute
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <Dialog
+        open={isMuteDialogOpen}
+        onOpenChange={(open) => {
+          setError('')
+          setIsMuteDialogOpen(open)
+          if (open) setMuteNotifications(true)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Mute account</DialogTitle>
+            <DialogDescription>
+              Posts from this actor will be hidden from your timelines. They can
+              still see and reply to your posts.
+            </DialogDescription>
+          </DialogHeader>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={muteNotifications}
+              onChange={(event) => setMuteNotifications(event.target.checked)}
+              className="h-4 w-4 rounded border-gray-300"
+            />
+            Also hide notifications from this actor
+          </label>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsMuteDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={onMute} disabled={isSubmitting}>
+              {isSubmitting ? <Loader2 className="animate-spin" /> : null}
+              Mute
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/lib/database/sql/mute.test.ts
+++ b/lib/database/sql/mute.test.ts
@@ -367,6 +367,53 @@ describe('MuteDatabase', () => {
       ])
     })
 
+    it('floats a re-muted expired row back to the top', async () => {
+      const actorId = muteActorId()
+      const oldTarget = targetActorId()
+      const newerTarget = targetActorId()
+      const pastEndsAt = Date.now() - 1000
+
+      // Seed an expired mute with old timestamps.
+      const oldDate = new Date(Date.now() - 60_000)
+      await knexDatabase('mutes').insert({
+        id: crypto.randomUUID(),
+        actorId,
+        actorHost: new URL(actorId).host,
+        targetActorId: oldTarget,
+        targetActorHost: new URL(oldTarget).host,
+        notifications: true,
+        endsAt: pastEndsAt,
+        createdAt: oldDate,
+        updatedAt: oldDate
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+
+      // Mute a second target fresh.
+      await database.createMute({
+        actorId,
+        targetActorId: newerTarget,
+        notifications: true,
+        endsAt: null
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+
+      // Re-mute the originally-expired target. createMute keeps the
+      // original createdAt but bumps updatedAt — getMutes must rank by
+      // updatedAt so this surfaces above newerTarget.
+      await database.createMute({
+        actorId,
+        targetActorId: oldTarget,
+        notifications: true,
+        endsAt: null
+      })
+
+      const mutes = await database.getMutes({ actorId })
+      expect(mutes.map((mute) => mute.targetActorId)).toEqual([
+        oldTarget,
+        newerTarget
+      ])
+    })
+
     it('filters out other actors mutes', async () => {
       const actorA = muteActorId()
       const actorB = muteActorId()

--- a/lib/database/sql/mute.test.ts
+++ b/lib/database/sql/mute.test.ts
@@ -259,6 +259,136 @@ describe('MuteDatabase', () => {
     ).resolves.toBe(false)
   })
 
+  describe('getMutes', () => {
+    const muteActorId = () =>
+      `https://remote.test/users/list-muter-${crypto.randomUUID()}`
+
+    it('returns mutes for the actor ordered by newest first', async () => {
+      const actorId = muteActorId()
+      const bob = targetActorId()
+      const carol = targetActorId()
+
+      await database.createMute({
+        actorId,
+        targetActorId: bob,
+        notifications: true,
+        endsAt: null
+      })
+      // Ensure deterministic createdAt ordering even on fast clocks.
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      await database.createMute({
+        actorId,
+        targetActorId: carol,
+        notifications: false,
+        endsAt: null
+      })
+
+      const mutes = await database.getMutes({ actorId })
+      expect(mutes).toHaveLength(2)
+      expect(mutes[0].targetActorId).toBe(carol)
+      expect(mutes[1].targetActorId).toBe(bob)
+    })
+
+    it('omits expired mutes', async () => {
+      const actorId = muteActorId()
+      const target = targetActorId()
+      await knexDatabase('mutes').insert({
+        id: crypto.randomUUID(),
+        actorId,
+        actorHost: new URL(actorId).host,
+        targetActorId: target,
+        targetActorHost: new URL(target).host,
+        notifications: true,
+        endsAt: Date.now() - 1000,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })
+
+      const mutes = await database.getMutes({ actorId })
+      expect(mutes).toHaveLength(0)
+    })
+
+    it('honors limit and max_id pagination', async () => {
+      const actorId = muteActorId()
+      const targets: string[] = []
+      for (let index = 0; index < 3; index += 1) {
+        const target = targetActorId()
+        targets.push(target)
+        await database.createMute({
+          actorId,
+          targetActorId: target,
+          notifications: true,
+          endsAt: null
+        })
+        await new Promise((resolve) => setTimeout(resolve, 5))
+      }
+
+      const firstPage = await database.getMutes({ actorId, limit: 2 })
+      expect(firstPage).toHaveLength(2)
+
+      const secondPage = await database.getMutes({
+        actorId,
+        limit: 2,
+        maxId: firstPage[firstPage.length - 1].id
+      })
+      expect(secondPage).toHaveLength(1)
+      expect(secondPage[0].id).not.toBe(firstPage[1].id)
+      // Newest first means oldest mute is on the second page.
+      expect(secondPage[0].targetActorId).toBe(targets[0])
+    })
+
+    it('returns earlier rows ascending when min_id is set', async () => {
+      const actorId = muteActorId()
+      const targets: string[] = []
+      for (let index = 0; index < 3; index += 1) {
+        const target = targetActorId()
+        targets.push(target)
+        await database.createMute({
+          actorId,
+          targetActorId: target,
+          notifications: true,
+          endsAt: null
+        })
+        await new Promise((resolve) => setTimeout(resolve, 5))
+      }
+
+      const allDescending = await database.getMutes({ actorId })
+      // allDescending order: [targets[2], targets[1], targets[0]]
+      const oldest = allDescending[allDescending.length - 1]
+      const newerPage = await database.getMutes({
+        actorId,
+        minId: oldest.id
+      })
+      expect(newerPage).toHaveLength(2)
+      // min_id returns rows newer than cursor, newest first to match other pages.
+      expect(newerPage.map((mute) => mute.targetActorId)).toEqual([
+        targets[2],
+        targets[1]
+      ])
+    })
+
+    it('filters out other actors mutes', async () => {
+      const actorA = muteActorId()
+      const actorB = muteActorId()
+      await database.createMute({
+        actorId: actorA,
+        targetActorId: targetActorId(),
+        notifications: true,
+        endsAt: null
+      })
+      await database.createMute({
+        actorId: actorB,
+        targetActorId: targetActorId(),
+        notifications: true,
+        endsAt: null
+      })
+
+      const mutes = await database.getMutes({ actorId: actorA })
+      expect(mutes).toHaveLength(1)
+      expect(mutes[0].actorId).toBe(actorA)
+    })
+  })
+
   it('getMuteRelations excludes expired mutes', async () => {
     const actorId = `https://remote.test/users/expiry-${crypto.randomUUID()}`
     const expiredTarget = targetActorId()

--- a/lib/database/sql/mute.ts
+++ b/lib/database/sql/mute.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex'
 import { randomUUID } from 'node:crypto'
 
+import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import {
@@ -8,6 +9,7 @@ import {
   DeleteMuteParams,
   GetMuteParams,
   GetMuteRelationsParams,
+  GetMutesParams,
   IsMutingParams,
   MuteDatabase,
   MuteRelation
@@ -143,6 +145,52 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
         : null
     if (endsAt !== null && endsAt < Date.now()) return false
     return true
+  },
+
+  async getMutes({
+    actorId,
+    limit = PER_PAGE_LIMIT,
+    maxId,
+    minId,
+    sinceId
+  }: GetMutesParams) {
+    const now = Date.now()
+    const query = database<Mute>('mutes')
+      .where('actorId', actorId)
+      .andWhere((builder) =>
+        builder.whereNull('endsAt').orWhere('endsAt', '>', now)
+      )
+      .limit(limit)
+
+    const cursorId = maxId || minId || sinceId
+    if (cursorId) {
+      const cursor = await database<Mute>('mutes')
+        .where({ actorId, id: cursorId })
+        .first()
+      if (!cursor) return []
+
+      const direction = maxId ? 'older' : 'newer'
+      const createdAtOperator = direction === 'older' ? '<' : '>'
+      const idOperator = direction === 'older' ? '<' : '>'
+      query.andWhere((builder) => {
+        builder
+          .where('createdAt', createdAtOperator, cursor.createdAt)
+          .orWhere((tieBreaker) => {
+            tieBreaker
+              .where('createdAt', cursor.createdAt)
+              .andWhere('id', idOperator, cursor.id)
+          })
+      })
+    }
+
+    if (minId) {
+      query.orderBy('createdAt', 'asc').orderBy('id', 'asc')
+    } else {
+      query.orderBy('createdAt', 'desc').orderBy('id', 'desc')
+    }
+
+    const mutes = await query
+    return (minId ? mutes.reverse() : mutes).map(fixMuteDataDate)
   },
 
   async getMuteRelations({ actorIds, targetActorIds }: GetMuteRelationsParams) {

--- a/lib/database/sql/mute.ts
+++ b/lib/database/sql/mute.ts
@@ -154,6 +154,10 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
     minId,
     sinceId
   }: GetMutesParams) {
+    // Ordering by updatedAt rather than createdAt so that re-muting an
+    // expired row (which only bumps updatedAt) surfaces the freshly
+    // reactivated mute at the top of the list, instead of leaving it
+    // buried at its original creation position.
     const now = Date.now()
     const query = database<Mute>('mutes')
       .where('actorId', actorId)
@@ -170,23 +174,23 @@ export const MuteSQLDatabaseMixin = (database: Knex): MuteDatabase => ({
       if (!cursor) return []
 
       const direction = maxId ? 'older' : 'newer'
-      const createdAtOperator = direction === 'older' ? '<' : '>'
+      const updatedAtOperator = direction === 'older' ? '<' : '>'
       const idOperator = direction === 'older' ? '<' : '>'
       query.andWhere((builder) => {
         builder
-          .where('createdAt', createdAtOperator, cursor.createdAt)
+          .where('updatedAt', updatedAtOperator, cursor.updatedAt)
           .orWhere((tieBreaker) => {
             tieBreaker
-              .where('createdAt', cursor.createdAt)
+              .where('updatedAt', cursor.updatedAt)
               .andWhere('id', idOperator, cursor.id)
           })
       })
     }
 
     if (minId) {
-      query.orderBy('createdAt', 'asc').orderBy('id', 'asc')
+      query.orderBy('updatedAt', 'asc').orderBy('id', 'asc')
     } else {
-      query.orderBy('createdAt', 'desc').orderBy('id', 'desc')
+      query.orderBy('updatedAt', 'desc').orderBy('id', 'desc')
     }
 
     const mutes = await query

--- a/lib/services/accounts/getFallbackMutedAccount.ts
+++ b/lib/services/accounts/getFallbackMutedAccount.ts
@@ -1,0 +1,70 @@
+import { Mute } from '@/lib/types/domain/mute'
+import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { urlToId } from '@/lib/utils/urlToId'
+
+const UUID_LIKE_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const USERNAME_PATTERN = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,63}$/
+
+const getFallbackUsername = (mute: Mute) => {
+  const segment = mute.targetActorId.split('/').filter(Boolean).pop()
+  if (!segment) return mute.targetActorHost
+
+  let decodedSegment: string
+  try {
+    decodedSegment = decodeURIComponent(segment)
+  } catch {
+    return mute.targetActorHost
+  }
+
+  if (
+    !USERNAME_PATTERN.test(decodedSegment) ||
+    UUID_LIKE_PATTERN.test(decodedSegment)
+  ) {
+    return mute.targetActorHost
+  }
+
+  return decodedSegment
+}
+
+export const getFallbackMutedAccount = (mute: Mute): MastodonAccount => {
+  const username = getFallbackUsername(mute)
+  const acct =
+    username === mute.targetActorHost
+      ? mute.targetActorHost
+      : `${username}@${mute.targetActorHost}`
+
+  return {
+    id: urlToId(mute.targetActorId),
+    username,
+    acct,
+    url: mute.targetActorId,
+    display_name: 'Account unavailable',
+    note: '',
+    avatar: '',
+    avatar_static: '',
+    header: '',
+    header_static: '',
+    locked: false,
+    source: {
+      note: '',
+      fields: [],
+      privacy: 'public',
+      sensitive: false,
+      language: 'en',
+      follow_requests_count: 0
+    },
+    fields: [],
+    emojis: [],
+    bot: false,
+    group: false,
+    discoverable: false,
+    noindex: true,
+    created_at: getISOTimeUTC(0),
+    last_status_at: null,
+    statuses_count: 0,
+    followers_count: 0,
+    following_count: 0
+  }
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1022,6 +1022,13 @@ export type MuteRelation = Pick<
   Mute,
   'actorId' | 'targetActorId' | 'notifications'
 >
+export type GetMutesParams = {
+  actorId: string
+  limit?: number
+  maxId?: string | null
+  minId?: string | null
+  sinceId?: string | null
+}
 
 export interface MuteDatabase {
   createMute(params: CreateMuteParams): Promise<Mute>
@@ -1029,6 +1036,7 @@ export interface MuteDatabase {
   getMute(params: GetMuteParams): Promise<Mute | null>
   isMuting(params: IsMutingParams): Promise<boolean>
   getMuteRelations(params: GetMuteRelationsParams): Promise<MuteRelation[]>
+  getMutes(params: GetMutesParams): Promise<Mute[]>
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Surfaces the existing mute backend in the UI: profile **Mute / Unmute** button with a confirmation dialog (and an *Also hide notifications* checkbox) plus a new **Settings → Muted Accounts** tab that lists muted actors with inline unmute controls.
- Adds the missing pieces of the wire: `MuteDatabase.getMutes` (paginated, expiry-filtered, cursor-based like `getBlocks`), `GET /api/v1/mutes` returning `MastodonAccount[]` with Mastodon `Link` headers, `mute` / `unmute` / `getMutes` helpers in `lib/client.ts`, and a `getFallbackMutedAccount` shell for orphaned remote targets.
- Mirrors the Block feature visually and structurally so the two surfaces stay consistent — no shared abstractions, since the design doc anticipates mute may diverge (duration picker) later.

## Test plan
- [x] `yarn run prettier --write .`
- [x] `yarn lint` (0 errors)
- [x] `yarn build`
- [x] `yarn test` (342 suites / 2941 tests pass)
- [ ] Manual smoke: profile Mute → Unmute round-trip, `/settings/mutes` list + unmute, *Also hide notifications* unchecked path, Mute button hidden when a block relationship exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)