### PR TITLE
docs: make CLAUDE.md explicitly read AGENTS.md and override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code – activities.next
 
-Follow `AGENTS.md` for all project rules. If an `AGENTS.override.md` file is present in a checkout, it takes precedence where it conflicts.
+**Always read `AGENTS.md` at the start of any task** and follow it for all project rules. If `AGENTS.override.md` is also present in the checkout, read it as well — it takes precedence over `AGENTS.md` wherever the two conflict. Treat `AGENTS.override.md` as a layer applied on top of `AGENTS.md`, not a full replacement.
 
 ## Key reminders for this machine
 


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md` so it explicitly instructs Claude to read `AGENTS.md` at the start of any task and to also read `AGENTS.override.md` when present.
- Clarify that the override file is layered on top of `AGENTS.md` (precedence on conflict), not a full replacement.

## Test plan
- [x] No code changes; docs-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)