### PR TITLE
Bump version to v1.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.29.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.28.1`
- Base main SHA: `27a595b09c4d0090b867813dea797759050f3c06`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
