### PR TITLE
fix: enable GFM in PostBox markdown preview

### DIFF
--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -35,6 +35,11 @@ jest.mock('remark-breaks', () => ({
   default: jest.fn()
 }))
 
+jest.mock('remark-gfm', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
 jest.mock('@/lib/utils/resizeImage', () => ({
   resizeImage: jest.fn((file) => Promise.resolve(file))
 }))

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -20,9 +20,20 @@ jest.mock('@/lib/client', () => ({
   uploadFitnessFile: jest.fn()
 }))
 
+let lastRemarkPlugins: unknown[] = []
+
 jest.mock('react-markdown', () => ({
   __esModule: true,
-  default: ({ children }: { children: string }) => <div>{children}</div>
+  default: ({
+    children,
+    remarkPlugins
+  }: {
+    children: string
+    remarkPlugins?: unknown[]
+  }) => {
+    if (remarkPlugins) lastRemarkPlugins = remarkPlugins
+    return <div>{children}</div>
+  }
 }))
 
 jest.mock('rehype-sanitize', () => ({
@@ -927,5 +938,43 @@ describe('PostBox edit media', () => {
         }
       })
     })
+  })
+})
+
+describe('PostBox markdown preview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    lastRemarkPlugins = []
+  })
+
+  it('passes remarkGfm and remarkBreaks plugins to the preview renderer', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    const textarea = screen.getByPlaceholderText("What's on your mind?")
+    fireEvent.change(textarea, { target: { value: '~~strikethrough~~' } })
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole('tab', { name: 'Preview' }))
+    })
+
+    const mockRemarkGfm = jest.requireMock('remark-gfm').default
+    const mockRemarkBreaks = jest.requireMock('remark-breaks').default
+
+    await waitFor(() => {
+      expect(lastRemarkPlugins).toContain(mockRemarkGfm)
+    })
+    expect(lastRemarkPlugins).toContain(mockRemarkBreaks)
+    expect(lastRemarkPlugins.indexOf(mockRemarkGfm)).toBeLessThan(
+      lastRemarkPlugins.indexOf(mockRemarkBreaks)
+    )
   })
 })

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -31,7 +31,7 @@ jest.mock('react-markdown', () => ({
     children: string
     remarkPlugins?: unknown[]
   }) => {
-    if (remarkPlugins) lastRemarkPlugins = remarkPlugins
+    lastRemarkPlugins = remarkPlugins ?? []
     return <div>{children}</div>
   }
 }))

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -977,4 +977,24 @@ describe('PostBox markdown preview', () => {
       lastRemarkPlugins.indexOf(mockRemarkBreaks)
     )
   })
+
+  it('shows nothing to preview message when textarea is empty', async () => {
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        onDiscardReply={jest.fn()}
+        onPostCreated={jest.fn()}
+        onPostUpdated={jest.fn()}
+        onDiscardEdit={jest.fn()}
+      />
+    )
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole('tab', { name: 'Preview' }))
+    })
+
+    expect(screen.getByText('Nothing to preview')).toBeInTheDocument()
+    expect(lastRemarkPlugins).toHaveLength(0)
+  })
 })

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -20,20 +20,14 @@ jest.mock('@/lib/client', () => ({
   uploadFitnessFile: jest.fn()
 }))
 
-let lastRemarkPlugins: unknown[] = []
+const mockReactMarkdown = jest.fn(({ children }: { children: string }) => (
+  <div>{children}</div>
+))
 
 jest.mock('react-markdown', () => ({
   __esModule: true,
-  default: ({
-    children,
-    remarkPlugins
-  }: {
-    children: string
-    remarkPlugins?: unknown[]
-  }) => {
-    lastRemarkPlugins = remarkPlugins ?? []
-    return <div>{children}</div>
-  }
+  default: (props: { children: string; remarkPlugins?: unknown[] }) =>
+    mockReactMarkdown(props)
 }))
 
 jest.mock('rehype-sanitize', () => ({
@@ -944,7 +938,6 @@ describe('PostBox edit media', () => {
 describe('PostBox markdown preview', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    lastRemarkPlugins = []
   })
 
   it('passes remarkGfm and remarkBreaks plugins to the preview renderer', async () => {
@@ -962,19 +955,22 @@ describe('PostBox markdown preview', () => {
     const textarea = screen.getByPlaceholderText("What's on your mind?")
     fireEvent.change(textarea, { target: { value: '~~strikethrough~~' } })
 
-    await act(async () => {
-      fireEvent.mouseDown(screen.getByRole('tab', { name: 'Preview' }))
-    })
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Preview' }))
 
     const mockRemarkGfm = jest.requireMock('remark-gfm').default
     const mockRemarkBreaks = jest.requireMock('remark-breaks').default
 
     await waitFor(() => {
-      expect(lastRemarkPlugins).toContain(mockRemarkGfm)
+      expect(mockReactMarkdown).toHaveBeenCalled()
     })
-    expect(lastRemarkPlugins).toContain(mockRemarkBreaks)
-    expect(lastRemarkPlugins.indexOf(mockRemarkGfm)).toBeLessThan(
-      lastRemarkPlugins.indexOf(mockRemarkBreaks)
+
+    const plugins =
+      mockReactMarkdown.mock.calls[mockReactMarkdown.mock.calls.length - 1][0]
+        .remarkPlugins ?? []
+    expect(plugins).toContain(mockRemarkGfm)
+    expect(plugins).toContain(mockRemarkBreaks)
+    expect(plugins.indexOf(mockRemarkGfm)).toBeLessThan(
+      plugins.indexOf(mockRemarkBreaks)
     )
   })
 
@@ -990,11 +986,9 @@ describe('PostBox markdown preview', () => {
       />
     )
 
-    await act(async () => {
-      fireEvent.mouseDown(screen.getByRole('tab', { name: 'Preview' }))
-    })
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Preview' }))
 
     expect(screen.getByText('Nothing to preview')).toBeInTheDocument()
-    expect(lastRemarkPlugins).toHaveLength(0)
+    expect(mockReactMarkdown).not.toHaveBeenCalled()
   })
 })

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -20,9 +20,11 @@ jest.mock('@/lib/client', () => ({
   uploadFitnessFile: jest.fn()
 }))
 
-const mockReactMarkdown = jest.fn(({ children }: { children: string }) => (
-  <div>{children}</div>
-))
+const mockReactMarkdown = jest.fn(
+  ({ children }: { children: string; remarkPlugins?: unknown[] }) => (
+    <div>{children}</div>
+  )
+)
 
 jest.mock('react-markdown', () => ({
   __esModule: true,

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -12,6 +12,7 @@ import {
 import ReactMarkdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
 import remarkBreaks from 'remark-breaks'
+import remarkGfm from 'remark-gfm'
 
 import {
   createNote,
@@ -917,7 +918,7 @@ export const PostBox: FC<Props> = ({
                   {text ? (
                     <div className="markdown-content max-w-none">
                       <ReactMarkdown
-                        remarkPlugins={[remarkBreaks]}
+                        remarkPlugins={[remarkGfm, remarkBreaks]}
                         rehypePlugins={[
                           [
                             rehypeSanitize,

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-modal": "^3.16.3",
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "resend": "^6.12.2",
     "sanitize-html": "^2.17.4",
     "sharp": "^0.34.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,7 @@ __metadata:
     react-modal: "npm:^3.16.3"
     rehype-sanitize: "npm:^6.0.0"
     remark-breaks: "npm:^4.0.0"
+    remark-gfm: "npm:^4.0.1"
     resend: "npm:^6.12.2"
     sanitize-html: "npm:^2.17.4"
     sharp: "npm:^0.34.5"
@@ -10025,6 +10026,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-table@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "markdown-table@npm:3.0.4"
+  checksum: 10c0/1257b31827629a54c24a5030a3dac952256c559174c95ce3ef89bebd6bff0cb1444b1fd667b1a1bb53307f83278111505b3e26f0c4e7b731e0060d435d2d930b
+  languageName: node
+  linkType: hard
+
 "marked@npm:^18.0.3":
   version: 18.0.3
   resolution: "marked@npm:18.0.3"
@@ -10070,6 +10078,83 @@ __metadata:
     micromark-util-types: "npm:^2.0.0"
     unist-util-stringify-position: "npm:^4.0.0"
   checksum: 10c0/76eb2bd2c6f7a0318087c73376b8af6d7561c1e16654e7667e640f391341096c56142618fd0ff62f6d39e5ab4895898b9789c84cd7cec2874359a437a0e1ff15
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-autolink-literal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-gfm-autolink-literal@npm:2.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    ccount: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-find-and-replace: "npm:^3.0.0"
+    micromark-util-character: "npm:^2.0.0"
+  checksum: 10c0/963cd22bd42aebdec7bdd0a527c9494d024d1ad0739c43dc040fee35bdfb5e29c22564330a7418a72b5eab51d47a6eff32bc0255ef3ccb5cebfe8970e91b81b6
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-footnote@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "mdast-util-gfm-footnote@npm:2.1.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.1.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+  checksum: 10c0/8ab965ee6be3670d76ec0e95b2ba3101fc7444eec47564943ab483d96ac17d29da2a4e6146a2a288be30c21b48c4f3938a1e54b9a46fbdd321d49a5bc0077ed0
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-strikethrough@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-strikethrough@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/b053e93d62c7545019bd914271ea9e5667ad3b3b57d16dbf68e56fea39a7e19b4a345e781312714eb3d43fdd069ff7ee22a3ca7f6149dfa774554f19ce3ac056
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-table@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    markdown-table: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/128af47c503a53bd1c79f20642561e54a510ad5e2db1e418d28fefaf1294ab839e6c838e341aef5d7e404f9170b9ca3d1d89605f234efafde93ee51174a6e31e
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-task-list-item@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-task-list-item@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/258d725288482b636c0a376c296431390c14b4f29588675297cb6580a8598ed311fc73ebc312acfca12cc8546f07a3a285a53a3b082712e2cbf5c190d677d834
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "mdast-util-gfm@npm:3.1.0"
+  dependencies:
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-gfm-autolink-literal: "npm:^2.0.0"
+    mdast-util-gfm-footnote: "npm:^2.0.0"
+    mdast-util-gfm-strikethrough: "npm:^2.0.0"
+    mdast-util-gfm-table: "npm:^2.0.0"
+    mdast-util-gfm-task-list-item: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/4bedcfb6a20e39901c8772f0d2bb2d7a64ae87a54c13cbd92eec062cf470fbb68c2ad754e149af5b30794e2de61c978ab1de1ace03c0c40f443ca9b9b8044f81
   languageName: node
   linkType: hard
 
@@ -10219,6 +10304,99 @@ __metadata:
     micromark-util-symbol: "npm:^2.0.0"
     micromark-util-types: "npm:^2.0.0"
   checksum: 10c0/bd4a794fdc9e88dbdf59eaf1c507ddf26e5f7ddf4e52566c72239c0f1b66adbcd219ba2cd42350debbe24471434d5f5e50099d2b3f4e5762ca222ba8e5b549ee
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-autolink-literal@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-autolink-literal@npm:2.1.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/84e6fbb84ea7c161dfa179665dc90d51116de4c28f3e958260c0423e5a745372b7dcbc87d3cde98213b532e6812f847eef5ae561c9397d7f7da1e59872ef3efe
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-footnote@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-footnote@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/d172e4218968b7371b9321af5cde8c77423f73b233b2b0fcf3ff6fd6f61d2e0d52c49123a9b7910612478bf1f0d5e88c75a3990dd68f70f3933fe812b9f77edc
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-strikethrough@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-strikethrough@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/ef4f248b865bdda71303b494671b7487808a340b25552b11ca6814dff3fcfaab9be8d294643060bbdb50f79313e4a686ab18b99cbe4d3ee8a4170fcd134234fb
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-table@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "micromark-extension-gfm-table@npm:2.1.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/04bc00e19b435fa0add62cd029d8b7eb6137522f77832186b1d5ef34544a9bd030c9cf85e92ddfcc5c31f6f0a58a43d4b96dba4fc21316037c734630ee12c912
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-tagfilter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-tagfilter@npm:2.0.0"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/995558843fff137ae4e46aecb878d8a4691cdf23527dcf1e2f0157d66786be9f7bea0109c52a8ef70e68e3f930af811828ba912239438e31a9cfb9981f44d34d
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-task-list-item@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-task-list-item@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/78aa537d929e9309f076ba41e5edc99f78d6decd754b6734519ccbbfca8abd52e1c62df68d41a6ae64d2a3fc1646cea955893c79680b0b4385ced4c52296181f
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "micromark-extension-gfm@npm:3.0.0"
+  dependencies:
+    micromark-extension-gfm-autolink-literal: "npm:^2.0.0"
+    micromark-extension-gfm-footnote: "npm:^2.0.0"
+    micromark-extension-gfm-strikethrough: "npm:^2.0.0"
+    micromark-extension-gfm-table: "npm:^2.0.0"
+    micromark-extension-gfm-tagfilter: "npm:^2.0.0"
+    micromark-extension-gfm-task-list-item: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/970e28df6ebdd7c7249f52a0dda56e0566fbfa9ae56c8eeeb2445d77b6b89d44096880cd57a1c01e7821b1f4e31009109fbaca4e89731bff7b83b8519690e5d9
   languageName: node
   linkType: hard
 
@@ -12009,6 +12187,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-gfm@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "remark-gfm@npm:4.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-gfm: "npm:^3.0.0"
+    micromark-extension-gfm: "npm:^3.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-stringify: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/427ecc6af3e76222662061a5f670a3e4e33ec5fffe2cabf04034da6a3f9a1bda1fc023e838a636385ba314e66e2bebbf017ca61ebea357eb0f5200fe0625a4b7
+  languageName: node
+  linkType: hard
+
 "remark-parse@npm:^11.0.0":
   version: 11.0.0
   resolution: "remark-parse@npm:11.0.0"
@@ -12031,6 +12223,17 @@ __metadata:
     unified: "npm:^11.0.0"
     vfile: "npm:^6.0.0"
   checksum: 10c0/f9eccacfb596d9605581dc05bfad28635d6ded5dd0a18e88af5fd4df0d3fcf9612e1501d4513bc2164d833cfe9636dab20400080b09e53f155c6e1442a1231fb
+  languageName: node
+  linkType: hard
+
+"remark-stringify@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "remark-stringify@npm:11.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/0cdb37ce1217578f6f847c7ec9f50cbab35df5b9e3903d543e74b405404e67c07defcb23cd260a567b41b769400f6de03c2c3d9cd6ae7a6707d5c8d89ead489f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add `remark-gfm` to the PostBox preview so the `Preview` tab matches
  what the server actually renders.
- Server-side posts go through `marked` with `gfm: true`
  (`lib/utils/text/convertMarkdownText.ts`), which already supports
  `~~strikethrough~~`, autolinks, etc. The preview used `react-markdown`
  without `remark-gfm`, so users typing GFM syntax saw raw `~~`
  characters in the preview while the published post correctly rendered
  the strikethrough.
- `del` is already in `SANITIZED_OPTION.allowedTags`, so the sanitizer
  keeps the strikethrough; non-allowed GFM additions (tables, task
  lists) continue to be stripped to text, matching existing post-render
  behavior.

## Before vs after (verified locally)

Input typed in the Write tab:

```markdown
Markdown preview test:

- **bold**
- *italic*
- ~~strikethrough~~ (GFM)
- `inline code`
- [link](https://example.com)

And a paragraph with auto link: https://activities.local
```

- **Before**: the `~~strikethrough~~` list item rendered as literal
  `~~strikethrough~~ (GFM)` and the trailing URL stayed as plain text.
- **After**: the strikethrough list item renders as a struck-through
  `strikethrough` (with `(GFM)` next to it) and the trailing URL is now
  an actual `<a>` link. Bold, italic, inline code, lists, and explicit
  links continue to render as before.

## Test plan

- [x] `yarn run prettier --write .`
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (345 suites / 2963 tests pass)
- [x] Manually verified in browser at `https://activities.local/` by
      typing the markdown above and switching to the Preview tab.
      Strikethrough now renders as `<del>` and the URL becomes an
      autolink, matching the rendered status after posting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)