### PR TITLE
fix: align post box and controls with design system

### DIFF
--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -199,7 +199,9 @@ describe('PostBox edit media', () => {
     expect(postButton).toBeDisabled()
 
     const fileInput = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="file"][name="file"]'
+      )
     ).at(-1)!
     fireEvent.change(fileInput, {
       target: {
@@ -254,7 +256,9 @@ describe('PostBox edit media', () => {
     fireEvent.change(textbox, { target: { value: 'caption' } })
 
     const fileInput = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="file"][name="file"]'
+      )
     ).at(-1)!
     fireEvent.change(fileInput, {
       target: {
@@ -288,7 +292,9 @@ describe('PostBox edit media', () => {
 
     const postButton = screen.getByRole('button', { name: 'Post' })
     const fileInput = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="file"][name="file"]'
+      )
     ).at(-1)!
     fireEvent.change(fileInput, {
       target: {
@@ -367,7 +373,9 @@ describe('PostBox edit media', () => {
     ).not.toBeInTheDocument()
 
     const fileInput = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="file"][name="file"]'
+      )
     ).at(-1)!
     fireEvent.change(fileInput, {
       target: {
@@ -607,7 +615,9 @@ describe('PostBox edit media', () => {
         screen.getByRole('button', { name: 'Remove media existing.jpg' })
       )
       const fileInput = Array.from(
-        document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+        document.querySelectorAll<HTMLInputElement>(
+          'input[type="file"][name="file"]'
+        )
       ).at(-1)!
       fireEvent.change(fileInput, {
         target: {
@@ -696,7 +706,9 @@ describe('PostBox edit media', () => {
       screen.getByRole('button', { name: 'Remove media existing.jpg' })
     )
     const fileInput = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="file"][name="file"]'
+      )
     ).at(-1)!
     fireEvent.change(fileInput, {
       target: {
@@ -897,7 +909,9 @@ describe('PostBox edit media', () => {
       screen.getByRole('button', { name: 'Remove media existing.jpg' })
     )
     const fileInput = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="file"]')
+      document.querySelectorAll<HTMLInputElement>(
+        'input[type="file"][name="file"]'
+      )
     ).at(-1)!
     fireEvent.change(fileInput, {
       target: {

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -1049,6 +1049,7 @@ export const PostBox: FC<Props> = ({
               onVisibilityChange={(visibility) =>
                 dispatch(setVisibility(visibility))
               }
+              disabled={isPosting}
             />
           </div>
           <div>

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -1006,6 +1006,7 @@ export const PostBox: FC<Props> = ({
                 postExtension.poll.showing ? 'Remove poll' : 'Add poll'
               }
               aria-pressed={postExtension.poll.showing}
+              disabled={isPosting}
               title={postExtension.poll.showing ? 'Remove poll' : 'Add poll'}
               className={cn(
                 postExtension.poll.showing
@@ -1028,6 +1029,7 @@ export const PostBox: FC<Props> = ({
                   : 'Add content warning'
               }
               aria-pressed={postExtension.contentWarningVisible}
+              disabled={isPosting}
               title={
                 postExtension.contentWarningVisible
                   ? 'Remove content warning'

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -46,6 +46,7 @@ import {
   StatusNote,
   StatusType
 } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 import { formatFileSize } from '@/lib/utils/formatFileSize'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { SANITIZED_OPTION } from '@/lib/utils/text/sanitizeText'
@@ -954,48 +955,7 @@ export const PostBox: FC<Props> = ({
           onPollTypeChange={(pollType) => dispatch(setPollType(pollType))}
         />
         <div className="flex justify-between mb-3">
-          <div>
-            <VisibilitySelector
-              visibility={postExtension.visibility}
-              onVisibilityChange={(visibility) =>
-                dispatch(setVisibility(visibility))
-              }
-            />
-            <Button
-              type="button"
-              variant={
-                postExtension.contentWarningVisible ? 'secondary' : 'link'
-              }
-              aria-label={
-                postExtension.contentWarningVisible
-                  ? 'Remove content warning'
-                  : 'Add content warning'
-              }
-              title="Content warning"
-              onClick={onToggleContentWarning}
-            >
-              <AlertTriangle className="size-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="link"
-              onClick={() =>
-                dispatch(setPollVisibility(!postExtension.poll.showing))
-              }
-            >
-              <BarChart3 className="size-4" />
-            </Button>
-            {!replyStatus ? (
-              <UploadFitnessFileButton
-                disabled={isPosting}
-                onFileSelected={(file) => {
-                  setWarningMsg(null)
-                  dispatch(setFitnessFile(file))
-                  setAllowPost(true)
-                }}
-                onError={(message) => setWarningMsg(message)}
-              />
-            ) : null}
+          <div className="flex items-center gap-1">
             <UploadMediaButton
               isMediaUploadEnabled={isMediaUploadEnabled}
               attachments={postExtension.attachments}
@@ -1026,6 +986,59 @@ export const PostBox: FC<Props> = ({
               }
               onUploadStart={() => setWarningMsg(null)}
               onBeforeAddAttachments={onRemoveFitnessFile}
+            />
+            {!replyStatus ? (
+              <UploadFitnessFileButton
+                disabled={isPosting}
+                onFileSelected={(file) => {
+                  setWarningMsg(null)
+                  dispatch(setFitnessFile(file))
+                  setAllowPost(true)
+                }}
+                onError={(message) => setWarningMsg(message)}
+              />
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Add poll"
+              title="Add poll"
+              className={cn(
+                'text-muted-foreground hover:text-foreground',
+                postExtension.poll.showing &&
+                  'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+              )}
+              onClick={() =>
+                dispatch(setPollVisibility(!postExtension.poll.showing))
+              }
+            >
+              <BarChart3 className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={
+                postExtension.contentWarningVisible
+                  ? 'Remove content warning'
+                  : 'Add content warning'
+              }
+              title="Content warning"
+              className={cn(
+                'text-muted-foreground hover:text-foreground',
+                postExtension.contentWarningVisible &&
+                  'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+              )}
+              onClick={onToggleContentWarning}
+            >
+              <AlertTriangle className="size-4" />
+            </Button>
+            <VisibilitySelector
+              visibility={postExtension.visibility}
+              onVisibilityChange={(visibility) =>
+                dispatch(setVisibility(visibility))
+              }
             />
           </div>
           <div>

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -1008,9 +1008,9 @@ export const PostBox: FC<Props> = ({
               aria-pressed={postExtension.poll.showing}
               title={postExtension.poll.showing ? 'Remove poll' : 'Add poll'}
               className={cn(
-                'text-muted-foreground hover:text-foreground',
-                postExtension.poll.showing &&
-                  'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+                postExtension.poll.showing
+                  ? 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
               )}
               onClick={() =>
                 dispatch(setPollVisibility(!postExtension.poll.showing))
@@ -1034,9 +1034,9 @@ export const PostBox: FC<Props> = ({
                   : 'Add content warning'
               }
               className={cn(
-                'text-muted-foreground hover:text-foreground',
-                postExtension.contentWarningVisible &&
-                  'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+                postExtension.contentWarningVisible
+                  ? 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
               )}
               onClick={onToggleContentWarning}
             >

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -954,8 +954,8 @@ export const PostBox: FC<Props> = ({
           }
           onPollTypeChange={(pollType) => dispatch(setPollType(pollType))}
         />
-        <div className="flex justify-between mb-3">
-          <div className="flex items-center gap-1">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+          <div className="flex flex-wrap items-center gap-1">
             <UploadMediaButton
               isMediaUploadEnabled={isMediaUploadEnabled}
               attachments={postExtension.attachments}
@@ -1002,8 +1002,11 @@ export const PostBox: FC<Props> = ({
               type="button"
               variant="ghost"
               size="icon-sm"
-              aria-label="Add poll"
-              title="Add poll"
+              aria-label={
+                postExtension.poll.showing ? 'Remove poll' : 'Add poll'
+              }
+              aria-pressed={postExtension.poll.showing}
+              title={postExtension.poll.showing ? 'Remove poll' : 'Add poll'}
               className={cn(
                 'text-muted-foreground hover:text-foreground',
                 postExtension.poll.showing &&
@@ -1024,7 +1027,12 @@ export const PostBox: FC<Props> = ({
                   ? 'Remove content warning'
                   : 'Add content warning'
               }
-              title="Content warning"
+              aria-pressed={postExtension.contentWarningVisible}
+              title={
+                postExtension.contentWarningVisible
+                  ? 'Remove content warning'
+                  : 'Add content warning'
+              }
               className={cn(
                 'text-muted-foreground hover:text-foreground',
                 postExtension.contentWarningVisible &&

--- a/lib/components/post-box/upload-fitness-file-button.tsx
+++ b/lib/components/post-box/upload-fitness-file-button.tsx
@@ -58,7 +58,9 @@ export const UploadFitnessFileButton: FC<Props> = ({
       />
       <Button
         type="button"
-        variant="link"
+        variant="ghost"
+        size="icon-sm"
+        className="text-muted-foreground hover:text-foreground"
         onClick={onOpenFile}
         disabled={disabled}
         title="Upload fitness activity file (.fit, .gpx, .tcx)"

--- a/lib/components/post-box/visibility-selector.tsx
+++ b/lib/components/post-box/visibility-selector.tsx
@@ -22,6 +22,7 @@ import { MastodonVisibility } from '@/lib/utils/getVisibility'
 interface Props {
   visibility: MastodonVisibility
   onVisibilityChange: (visibility: MastodonVisibility) => void
+  disabled?: boolean
 }
 
 const VISIBILITY_OPTIONS: {
@@ -58,7 +59,8 @@ const VISIBILITY_OPTIONS: {
 
 export const VisibilitySelector: FC<Props> = ({
   visibility,
-  onVisibilityChange
+  onVisibilityChange,
+  disabled
 }) => {
   const currentOption =
     VISIBILITY_OPTIONS.find((opt) => opt.value === visibility) ||
@@ -72,6 +74,7 @@ export const VisibilitySelector: FC<Props> = ({
           type="button"
           variant="ghost"
           size="sm"
+          disabled={disabled}
           title={currentOption.label}
           aria-label={`Set visibility, current: ${currentOption.label}`}
           className="gap-1.5 px-2.5 text-xs font-medium text-muted-foreground hover:text-foreground"
@@ -94,7 +97,7 @@ export const VisibilitySelector: FC<Props> = ({
               className={cn(
                 'flex cursor-pointer items-start gap-2.5',
                 active &&
-                  'bg-primary/10 text-primary focus:bg-primary/10 focus:text-primary'
+                  'bg-primary/10 text-primary focus:bg-primary/15 focus:text-primary'
               )}
             >
               <Icon

--- a/lib/components/post-box/visibility-selector.tsx
+++ b/lib/components/post-box/visibility-selector.tsx
@@ -90,7 +90,7 @@ export const VisibilitySelector: FC<Props> = ({
               key={option.value}
               role="menuitemradio"
               aria-checked={active}
-              onClick={() => onVisibilityChange(option.value)}
+              onSelect={() => onVisibilityChange(option.value)}
               className={cn(
                 'flex cursor-pointer items-start gap-2.5',
                 active &&

--- a/lib/components/post-box/visibility-selector.tsx
+++ b/lib/components/post-box/visibility-selector.tsx
@@ -1,4 +1,12 @@
-import { AtSign, Check, ChevronDown, Globe, Lock, Unlock } from 'lucide-react'
+import {
+  AtSign,
+  Check,
+  ChevronDown,
+  Globe,
+  Lock,
+  type LucideIcon,
+  Unlock
+} from 'lucide-react'
 import { FC } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
@@ -19,7 +27,7 @@ interface Props {
 const VISIBILITY_OPTIONS: {
   value: MastodonVisibility
   label: string
-  Icon: typeof Globe
+  Icon: LucideIcon
   description: string
 }[] = [
   {

--- a/lib/components/post-box/visibility-selector.tsx
+++ b/lib/components/post-box/visibility-selector.tsx
@@ -1,4 +1,4 @@
-import { Globe, Lock, Mail, Unlock } from 'lucide-react'
+import { AtSign, Check, ChevronDown, Globe, Lock, Unlock } from 'lucide-react'
 import { FC } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/lib/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 interface Props {
@@ -25,25 +26,25 @@ const VISIBILITY_OPTIONS: {
     value: 'public',
     label: 'Public',
     icon: <Globe className="size-4" />,
-    description: 'Visible to everyone'
+    description: 'Visible to everyone, shown in public timelines'
   },
   {
     value: 'unlisted',
     label: 'Unlisted',
     icon: <Unlock className="size-4" />,
-    description: 'Not shown in public timelines'
+    description: 'Visible to everyone, hidden from public timelines'
   },
   {
     value: 'private',
     label: 'Followers only',
     icon: <Lock className="size-4" />,
-    description: 'Only visible to your followers'
+    description: 'Visible to your followers only'
   },
   {
     value: 'direct',
     label: 'Direct',
-    icon: <Mail className="size-4" />,
-    description: 'Only mentioned users'
+    icon: <AtSign className="size-4" />,
+    description: 'Visible only to mentioned people'
   }
 ]
 
@@ -60,32 +61,57 @@ export const VisibilitySelector: FC<Props> = ({
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
-          variant="link"
+          variant="ghost"
+          size="sm"
           title={currentOption.label}
-          aria-label={currentOption.label}
+          aria-label={`Set visibility, current: ${currentOption.label}`}
+          className="gap-1.5 px-2.5 text-xs font-medium text-muted-foreground hover:text-foreground"
         >
           {currentOption.icon}
+          <span>{currentOption.label}</span>
+          <ChevronDown className="size-3.5" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {VISIBILITY_OPTIONS.map((option) => (
-          <DropdownMenuItem
-            key={option.value}
-            onClick={() => onVisibilityChange(option.value)}
-            className="flex items-start gap-3 cursor-pointer"
-          >
-            <div className="mt-0.5">{option.icon}</div>
-            <div className="flex-1">
-              <div className="font-medium">{option.label}</div>
-              <div className="text-xs text-muted-foreground">
-                {option.description}
-              </div>
-            </div>
-            {option.value === visibility && (
-              <div className="text-primary">✓</div>
-            )}
-          </DropdownMenuItem>
-        ))}
+      <DropdownMenuContent align="start" className="w-64">
+        {VISIBILITY_OPTIONS.map((option) => {
+          const active = option.value === visibility
+          return (
+            <DropdownMenuItem
+              key={option.value}
+              onClick={() => onVisibilityChange(option.value)}
+              className={cn(
+                'flex cursor-pointer items-start gap-2.5',
+                active &&
+                  'bg-primary/10 text-primary focus:bg-primary/10 focus:text-primary'
+              )}
+            >
+              <span
+                className={cn(
+                  'mt-0.5',
+                  active ? 'text-primary' : 'text-muted-foreground'
+                )}
+              >
+                {option.icon}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span
+                  className={cn(
+                    'block font-medium',
+                    active ? 'text-primary' : 'text-foreground'
+                  )}
+                >
+                  {option.label}
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+              {active ? (
+                <Check className="mt-0.5 ml-auto size-4 text-primary" />
+              ) : null}
+            </DropdownMenuItem>
+          )
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/lib/components/post-box/visibility-selector.tsx
+++ b/lib/components/post-box/visibility-selector.tsx
@@ -105,10 +105,7 @@ export const VisibilitySelector: FC<Props> = ({
               />
               <span className="min-w-0 flex-1">
                 <span
-                  className={cn(
-                    'block font-medium',
-                    active ? 'text-primary' : 'text-foreground'
-                  )}
+                  className={cn('block font-medium', active && 'text-primary')}
                 >
                   {option.label}
                 </span>

--- a/lib/components/post-box/visibility-selector.tsx
+++ b/lib/components/post-box/visibility-selector.tsx
@@ -19,31 +19,31 @@ interface Props {
 const VISIBILITY_OPTIONS: {
   value: MastodonVisibility
   label: string
-  icon: React.ReactNode
+  Icon: typeof Globe
   description: string
 }[] = [
   {
     value: 'public',
     label: 'Public',
-    icon: <Globe className="size-4" />,
+    Icon: Globe,
     description: 'Visible to everyone, shown in public timelines'
   },
   {
     value: 'unlisted',
     label: 'Unlisted',
-    icon: <Unlock className="size-4" />,
+    Icon: Unlock,
     description: 'Visible to everyone, hidden from public timelines'
   },
   {
     value: 'private',
     label: 'Followers only',
-    icon: <Lock className="size-4" />,
+    Icon: Lock,
     description: 'Visible to your followers only'
   },
   {
     value: 'direct',
     label: 'Direct',
-    icon: <AtSign className="size-4" />,
+    Icon: AtSign,
     description: 'Visible only to mentioned people'
   }
 ]
@@ -55,6 +55,7 @@ export const VisibilitySelector: FC<Props> = ({
   const currentOption =
     VISIBILITY_OPTIONS.find((opt) => opt.value === visibility) ||
     VISIBILITY_OPTIONS[0]
+  const CurrentIcon = currentOption.Icon
 
   return (
     <DropdownMenu>
@@ -67,7 +68,7 @@ export const VisibilitySelector: FC<Props> = ({
           aria-label={`Set visibility, current: ${currentOption.label}`}
           className="gap-1.5 px-2.5 text-xs font-medium text-muted-foreground hover:text-foreground"
         >
-          {currentOption.icon}
+          <CurrentIcon className="size-4" />
           <span>{currentOption.label}</span>
           <ChevronDown className="size-3.5" />
         </Button>
@@ -75,9 +76,12 @@ export const VisibilitySelector: FC<Props> = ({
       <DropdownMenuContent align="start" className="w-64">
         {VISIBILITY_OPTIONS.map((option) => {
           const active = option.value === visibility
+          const { Icon } = option
           return (
             <DropdownMenuItem
               key={option.value}
+              role="menuitemradio"
+              aria-checked={active}
               onClick={() => onVisibilityChange(option.value)}
               className={cn(
                 'flex cursor-pointer items-start gap-2.5',
@@ -85,14 +89,12 @@ export const VisibilitySelector: FC<Props> = ({
                   'bg-primary/10 text-primary focus:bg-primary/10 focus:text-primary'
               )}
             >
-              <span
+              <Icon
                 className={cn(
-                  'mt-0.5',
+                  'mt-0.5 size-4',
                   active ? 'text-primary' : 'text-muted-foreground'
                 )}
-              >
-                {option.icon}
-              </span>
+              />
               <span className="min-w-0 flex-1">
                 <span
                   className={cn(


### PR DESCRIPTION
## Summary

Aligns the timeline composer (post box) and its controls with the **Activities.next design system UI Kit** composer.

- **Visibility selector** — trigger now shows **icon + label + chevron** (was icon-only). The dropdown opens below the trigger, with each option rendered as **icon + label + description**, and the active option gets the signature **orange wash** (`bg-primary/10 text-primary`) plus a `Check` icon (previously a plain "✓" glyph). Icon set (`Globe` / `Unlock` / `Lock` / `AtSign`) and descriptions match the design verbatim.
- **Toolbar controls** — poll, content warning, and fitness-upload buttons are now **square ghost icon buttons** (muted-foreground → foreground on hover), reordered to the design sequence: **media → fitness → poll → content warning → visibility**. The poll and content-warning toggles show the orange active wash when enabled.
- **Tests** — `post-box.test` now targets the media file input by its stable `name="file"` attribute instead of positionally, so assertions no longer depend on toolbar button order.

## Screenshots

Validated in-browser against the UI Kit on a local SQLite instance with mock data.

**Composer toolbar**

![Composer toolbar](https://raw.githubusercontent.com/llun/activities.next/claude/postbox-controls-assets/composer-default.png)

**Visibility selector (active option gets orange wash + check, opens below)**

![Visibility selector](https://raw.githubusercontent.com/llun/activities.next/claude/postbox-controls-assets/composer-visibility.png)

## Deliberate deviations from the prototype

- **Preview** stays as the existing Write/Preview tabs (markdown) rather than the prototype's eye-toggle — richer and test-asserted; the "preview" intent is already met.
- **No character counter** — the codebase has no max-length constant, so a counter was omitted rather than inventing a cap (which would change posting behavior).
- **"Add media"** keeps its labeled `Add media 0/N` form (test-asserted, and the count is real UX) instead of the prototype's icon-only image button.

## Testing

- `yarn run prettier --write` ✅
- `yarn lint` ✅ (0 errors)
- `yarn build` ✅
- `yarn test` ✅ (2965 passed / 345 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
