### PR TITLE
Bump version to v1.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.29.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.29.1`
- Base main SHA: `81c65387ca2151467ecc53731c299f13a8269794`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
