### PR TITLE
fix: timeline hydration mismatch (React #418) from inline Date.now()

### DIFF
--- a/app/(timeline)/MainPageTimeline.test.tsx
+++ b/app/(timeline)/MainPageTimeline.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+import { MainPageTimeline } from './MainPageTimeline'
+
+jest.mock('@/lib/client', () => ({
+  getTimeline: jest.fn()
+}))
+
+jest.mock('@/lib/components/page-header', () => ({
+  PageHeader: () => null
+}))
+
+jest.mock('@/lib/components/post-box/post-box', () => ({
+  PostBox: () => null
+}))
+
+jest.mock('@/lib/components/scroll-to-top-button', () => ({
+  ScrollToTopButton: () => null
+}))
+
+jest.mock('@/lib/components/posts/posts', () => ({
+  Posts: ({
+    statuses,
+    currentTime
+  }: {
+    statuses: Status[]
+    currentTime: number
+  }) => (
+    <div>
+      <div data-testid="posts-current-time">{currentTime}</div>
+      {statuses.map((status) => (
+        <div key={status.id}>{status.id}</div>
+      ))}
+    </div>
+  )
+}))
+
+jest.mock('@/lib/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: ReactNode }) => (
+    <button>{children}</button>
+  )
+}))
+
+jest.mock('@/lib/components/ui/button', () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>
+}))
+
+const FIXED_CURRENT_TIME = new Date('2026-04-30T10:05:00.000Z').getTime()
+
+const profile: ActorProfile = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  domain: 'activities.local',
+  name: 'Llun',
+  followersUrl: 'https://activities.local/users/llun/followers',
+  inboxUrl: 'https://activities.local/users/llun/inbox',
+  sharedInboxUrl: 'https://activities.local/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: FIXED_CURRENT_TIME
+}
+
+const createStatus = (id: string): Status => ({
+  id,
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: FIXED_CURRENT_TIME,
+  updatedAt: FIXED_CURRENT_TIME,
+  type: StatusType.enum.Note,
+  url: id,
+  text: id,
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  attachments: [],
+  tags: []
+})
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('MainPageTimeline', () => {
+  beforeAll(() => {
+    ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      MockIntersectionObserver
+  })
+
+  it('renders posts using the currentTime prop, not a freshly computed Date.now()', () => {
+    // Regression test for React hydration mismatch (error #418): relative
+    // timestamps must derive from the server-provided currentTime prop so SSR
+    // and client-hydration output match. Computing Date.now() inside this
+    // client component yields a different value on the client and breaks
+    // hydration.
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(FIXED_CURRENT_TIME + 5 * 60 * 1000)
+
+    try {
+      render(
+        <MainPageTimeline
+          host="activities.local"
+          currentTime={FIXED_CURRENT_TIME}
+          profile={profile}
+          isMediaUploadEnabled={false}
+          statuses={[createStatus('https://activities.local/users/llun/s/1')]}
+        />
+      )
+
+      const renderedTimes = screen.getAllByTestId('posts-current-time')
+      expect(renderedTimes.length).toBeGreaterThan(0)
+      for (const node of renderedTimes) {
+        expect(node).toHaveTextContent(String(FIXED_CURRENT_TIME))
+      }
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+})

--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -37,6 +37,7 @@ const TIMELINES_TABS: Tab[] = [
 interface MainPageTimelineProps {
   host: string
   profile: ActorProfile
+  currentTime: number
   isMediaUploadEnabled: boolean
   statuses: Status[]
   initialNextMaxStatusId?: string | null
@@ -46,6 +47,7 @@ interface MainPageTimelineProps {
 export const MainPageTimeline: FC<MainPageTimelineProps> = ({
   host,
   profile,
+  currentTime,
   isMediaUploadEnabled,
   statuses,
   initialNextMaxStatusId = null,
@@ -282,7 +284,7 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
           {currentStatuses.length > 0 ? (
             <Posts
               host={host}
-              currentTime={Date.now()}
+              currentTime={currentTime}
               statuses={currentStatuses}
               currentActor={profile}
               showActions

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -15,8 +15,15 @@ jest.mock('@/lib/client', () => ({
 }))
 
 jest.mock('@/lib/components/posts/posts', () => ({
-  Posts: ({ statuses }: { statuses: Status[] }) => (
+  Posts: ({
+    statuses,
+    currentTime
+  }: {
+    statuses: Status[]
+    currentTime: number
+  }) => (
     <div>
+      <div data-testid="posts-current-time">{currentTime}</div>
       {statuses.map((status) => (
         <div key={status.id}>{status.id}</div>
       ))}
@@ -79,6 +86,8 @@ const createStatus = (id: string): Status => {
   }
 }
 
+const FIXED_CURRENT_TIME = new Date('2026-04-30T10:05:00.000Z').getTime()
+
 describe('ActorTimelines', () => {
   const getActorStatusesMock = getActorStatuses as jest.Mock
 
@@ -100,6 +109,7 @@ describe('ActorTimelines', () => {
         actorId="https://remote.example/users/actor"
         statuses={[createStatus('https://remote.example/statuses/newer')]}
         attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
         statusPagination={{
           nextPageUrl:
             'https://remote.example/users/actor/outbox?page=true&max_id=1',
@@ -147,6 +157,7 @@ describe('ActorTimelines', () => {
         actorId="https://remote.example/users/actor"
         statuses={[createStatus('https://remote.example/statuses/newer')]}
         attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
         statusPagination={{
           nextPageUrl:
             'https://remote.example/users/actor/outbox?page=true&max_id=1',
@@ -187,6 +198,7 @@ describe('ActorTimelines', () => {
         actorId="https://remote.example/users/actor"
         statuses={[]}
         attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
         statusPagination={{
           nextPageUrl:
             'https://remote.example/users/actor/outbox?page=true&max_id=1',
@@ -217,6 +229,7 @@ describe('ActorTimelines', () => {
         actorId="https://remote.example/users/actor"
         statuses={[createStatus('https://remote.example/statuses/newer')]}
         attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
         statusPagination={{
           nextPageUrl:
             'https://remote.example/users/actor/outbox?page=true&max_id=1',
@@ -252,6 +265,7 @@ describe('ActorTimelines', () => {
         actorId="https://remote.example/users/actor"
         statuses={[createStatus('https://remote.example/statuses/newer')]}
         attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
         statusPagination={{
           nextPageUrl: repeatedPageUrl,
           prevPageUrl: null
@@ -267,5 +281,40 @@ describe('ActorTimelines', () => {
     expect(
       screen.queryByRole('button', { name: 'Load more' })
     ).not.toBeInTheDocument()
+  })
+
+  it('renders posts using the currentTime prop, not a freshly computed Date.now()', () => {
+    // Regression test for React hydration mismatch (error #418): the relative
+    // timestamps in Posts must derive from the server-provided currentTime prop
+    // so the SSR and client-hydration output match. Computing Date.now() inside
+    // this client component produces a different value on the client and breaks
+    // hydration.
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(FIXED_CURRENT_TIME + 5 * 60 * 1000)
+
+    try {
+      render(
+        <ActorTimelines
+          host="localhost:3000"
+          actorId="https://remote.example/users/actor"
+          statuses={[createStatus('https://remote.example/statuses/newer')]}
+          attachments={[]}
+          currentTime={FIXED_CURRENT_TIME}
+          statusPagination={{
+            nextPageUrl: null,
+            prevPageUrl: null
+          }}
+        />
+      )
+
+      const renderedTimes = screen.getAllByTestId('posts-current-time')
+      expect(renderedTimes.length).toBeGreaterThan(0)
+      for (const node of renderedTimes) {
+        expect(node).toHaveTextContent(String(FIXED_CURRENT_TIME))
+      }
+    } finally {
+      dateNowSpy.mockRestore()
+    }
   })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -20,6 +20,7 @@ import { ActorMediaGallery } from './ActorMediaGallery'
 interface Props {
   host: string
   actorId: string
+  currentTime: number
   statuses: Status[]
   attachments: Attachment[]
   statusPagination?: {
@@ -62,12 +63,12 @@ const appendUniqueStatuses = (
 export const ActorTimelines: FC<Props> = ({
   host,
   actorId,
+  currentTime,
   statuses,
   attachments,
   statusPagination,
   postLineLimit
 }) => {
-  const currentTime = Date.now()
   const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
   const [currentStatusPagination, setCurrentStatusPagination] = useState({
     nextPageUrl: statusPagination?.nextPageUrl ?? null,

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -185,6 +185,7 @@ const Page: FC<Props> = async ({ params }) => {
           key={person.id}
           host={host}
           actorId={person.id}
+          currentTime={Date.now()}
           statuses={statuses}
           attachments={attachments}
           statusPagination={statusPagination}

--- a/app/(timeline)/page.tsx
+++ b/app/(timeline)/page.tsx
@@ -39,6 +39,7 @@ const Page = async () => {
   return (
     <MainPageTimeline
       host={host}
+      currentTime={Date.now()}
       statuses={statuses.map((item) => cleanJson(item))}
       initialNextMaxStatusId={nextMaxStatusId}
       profile={getActorProfile(actor)}


### PR DESCRIPTION
## Problem

Production logs the minified **React error #418** (`args[]=text` → server/client **text content mismatch**) on the timeline page (`https://llun.social/`).

## Root cause

`MainPageTimeline` (home `/`) and `ActorTimelines` (actor profile) are `'use client'` components that computed `Date.now()` **inline during render** and passed it to `<Posts>` as `currentTime`:

```tsx
<Posts currentTime={Date.now()} ... />   // MainPageTimeline
const currentTime = Date.now()           // ActorTimelines
```

Client components are still server-rendered during SSR, so `Date.now()` is evaluated **twice** — once on the server, once again during client hydration (hundreds of ms / seconds later). `Posts` → `Post` renders a relative timestamp via `date-fns` `formatDistance(createdAt, currentTime)`. When the SSR→hydration gap straddles a `formatDistance` rounding bucket (e.g. *“less than a minute”* vs *“1 minute”*), the server HTML and client render disagree → hydration text mismatch → React #418.

This is exactly the anti-pattern called out in `AGENTS.md` (“Never pass `new Date()` / recompute time across the server→client boundary”).

## Fix

Hoist `Date.now()` into the **server page components** and pass `currentTime: number` as a prop, matching the pattern already used by `HashtagTimeline`, `bookmarks`, `search`, and the status detail page. The value is serialized once during SSR and reused at hydration, so the rendered text matches on both sides.

- `app/(timeline)/page.tsx` → passes `currentTime={Date.now()}` to `MainPageTimeline`
- `app/(timeline)/MainPageTimeline.tsx` → takes `currentTime: number`, drops inline `Date.now()`
- `app/(timeline)/[actor]/page.tsx` → passes `currentTime={Date.now()}` to `ActorTimelines`
- `app/(timeline)/[actor]/ActorTimelines.tsx` → takes `currentTime: number`, drops inline `Date.now()`

Both pages render dynamically (`force-dynamic` / cookie reads), so the server `Date.now()` is request-time, not frozen at build.

### Behaviour note
Relative timestamps are now anchored to server-render time and no longer tick on client re-render. This is intentional and matches every sibling timeline — not a regression.

## Tests

Added deterministic regression tests for **both** components: with `Date.now()` mocked to a value far from the passed `currentTime`, the rendered time must equal the **prop**, not `Date.now()`. Each test was confirmed **red before the fix, green after**.

- `app/(timeline)/MainPageTimeline.test.tsx` (new)
- `app/(timeline)/[actor]/ActorTimelines.test.tsx` (extended; existing render sites updated for the now-required prop)

Gate: `prettier` ✅ · `yarn lint` ✅ (0 errors) · `yarn build` ✅ · `yarn test` ✅ (346 suites / 2967 tests).

## Verification note

A live browser repro was **not** run: the bug is timing-dependent (intermittent — a clean load proves nothing), the home timeline requires an authenticated session, and seeding one would mean creating a test user, which the project rules forbid. The fix is instead proven by the deterministic red→green regression tests above, which directly assert the fix mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)