### PR TITLE
Bump version to v1.29.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.29.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.29.2`
- Base main SHA: `c36b5a38f6fb2809345675d4e700375b2cff8b56`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
