### PR TITLE
Bump version to v1.29.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.29.4",
+  "version": "1.29.5",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.29.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.29.4`
- Base main SHA: `8229d6cd057520dd43b237b085e46cc39c2158f2`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
