### PR TITLE
Bump version to v1.29.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.29.5",
+  "version": "1.29.6",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.29.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.29.5`
- Base main SHA: `76cfae06067e62c5833e3adb6bd668cddeef0217`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
