### PR TITLE
Bump version to v1.29.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.29.6",
+  "version": "1.29.7",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.29.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.29.6`
- Base main SHA: `9feee3244a7e0d235232c9da67520798f73174d7`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
