### PR TITLE
minor: add notification filtered flag and Mastodon compat params

### DIFF
--- a/app/api/v1/notifications/[id]/dismiss/route.ts
+++ b/app/api/v1/notifications/[id]/dismiss/route.ts
@@ -35,11 +35,12 @@ export const POST = traceApiRoute(
 
       const id = (await params).id
 
-      // Verify ownership
+      // Verify ownership (include filtered so filtered notifications can be dismissed)
       const notifications = await database.getNotifications({
         actorId: currentActor.id,
         ids: [id],
-        limit: 1
+        limit: 1,
+        includeFiltered: true
       })
 
       if (notifications.length === 0) {

--- a/app/api/v1/notifications/[id]/route.test.ts
+++ b/app/api/v1/notifications/[id]/route.test.ts
@@ -1,0 +1,150 @@
+import { NextRequest } from 'next/server'
+
+import { GET, POST } from './route'
+
+const mockDatabase = {
+  getNotifications: jest.fn(),
+  deleteNotification: jest.fn(),
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+}
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun'
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/notifications/getMastodonNotification', () => ({
+  getMastodonNotification: jest.fn().mockResolvedValue({
+    id: 'n1',
+    type: 'follow',
+    created_at: '2026-01-01T00:00:00Z',
+    account: {}
+  })
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          database: typeof mockDatabase
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        database: mockDatabase,
+        params: context.params
+      })
+}))
+
+describe('GET /api/v1/notifications/:id', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('fetches with includeFiltered: true so filtered notifications are visible by ID', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'n1',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/alice',
+        filtered: true
+      }
+    ])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/n1',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, {
+      params: Promise.resolve({ id: 'n1' })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        ids: ['n1'],
+        includeFiltered: true
+      })
+    )
+  })
+
+  it('returns 404 when notification does not exist', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/missing',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, {
+      params: Promise.resolve({ id: 'missing' })
+    })
+
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('POST /api/v1/notifications/:id (dismiss)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('dismisses with includeFiltered: true so filtered notifications can be dismissed by ID', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'n1',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/alice',
+        filtered: true
+      }
+    ])
+    mockDatabase.deleteNotification.mockResolvedValueOnce(undefined)
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/n1',
+      { method: 'POST' }
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: 'n1' })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        ids: ['n1'],
+        includeFiltered: true
+      })
+    )
+    expect(mockDatabase.deleteNotification).toHaveBeenCalledWith('n1')
+  })
+
+  it('returns 404 when notification does not exist', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/missing',
+      { method: 'POST' }
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: 'missing' })
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.deleteNotification).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/notifications/[id]/route.ts
+++ b/app/api/v1/notifications/[id]/route.ts
@@ -44,7 +44,8 @@ export const GET = traceApiRoute(
       const notifications = await database.getNotifications({
         actorId: currentActor.id,
         ids: [id],
-        limit: 1
+        limit: 1,
+        includeFiltered: true
       })
 
       if (notifications.length === 0) {
@@ -96,11 +97,12 @@ export const POST = traceApiRoute(
 
       const id = (await params).id
 
-      // Verify ownership
+      // Verify ownership (include filtered so filtered notifications can be dismissed)
       const notifications = await database.getNotifications({
         actorId: currentActor.id,
         ids: [id],
-        limit: 1
+        limit: 1,
+        includeFiltered: true
       })
 
       if (notifications.length === 0) {

--- a/app/api/v1/notifications/[id]/route.ts
+++ b/app/api/v1/notifications/[id]/route.ts
@@ -22,6 +22,9 @@ interface Params {
   id: string
 }
 
+// Mastodon's `supported_types[]` query param is accepted and ignored: every
+// internal notification type maps to a first-class Mastodon type, so there is
+// never an unsupported type that would need a fallback representation.
 export const GET = traceApiRoute(
   'getNotification',
   OAuthGuard<Params>(

--- a/app/api/v1/notifications/clear/route.test.ts
+++ b/app/api/v1/notifications/clear/route.test.ts
@@ -133,9 +133,9 @@ describe('Notification Endpoints', () => {
       })
 
       // Delete them all
-      await Promise.all(
-        notifications.map((n) => database.deleteNotification(n.id))
-      )
+      for (const n of notifications) {
+        await database.deleteNotification(n.id)
+      }
 
       // Verify all are gone
       const remaining = await database.getNotifications({
@@ -144,6 +144,41 @@ describe('Notification Endpoints', () => {
       })
 
       expect(remaining.length).toBe(0)
+    })
+
+    it('clear also deletes filtered notifications', async () => {
+      await database.createNotification({
+        actorId: ACTOR1_ID,
+        type: 'follow',
+        sourceActorId: ACTOR2_ID,
+        statusId: null,
+        filtered: true,
+        createdAt: Date.now()
+      })
+
+      const before = await database.getNotifications({
+        actorId: ACTOR1_ID,
+        limit: 100,
+        includeFiltered: true
+      })
+      expect(before.some((n) => n.filtered)).toBe(true)
+
+      // Clear using includeFiltered: true (as the route does)
+      const all = await database.getNotifications({
+        actorId: ACTOR1_ID,
+        limit: 1000,
+        includeFiltered: true
+      })
+      for (const n of all) {
+        await database.deleteNotification(n.id)
+      }
+
+      const after = await database.getNotifications({
+        actorId: ACTOR1_ID,
+        limit: 100,
+        includeFiltered: true
+      })
+      expect(after.length).toBe(0)
     })
   })
 

--- a/app/api/v1/notifications/clear/route.ts
+++ b/app/api/v1/notifications/clear/route.ts
@@ -28,7 +28,8 @@ export const POST = traceApiRoute(
     while (true) {
       const notifications = await database.getNotifications({
         actorId: currentActor.id,
-        limit: batchSize
+        limit: batchSize,
+        includeFiltered: true
       })
 
       if (notifications.length === 0) {

--- a/app/api/v1/notifications/clear/route.ts
+++ b/app/api/v1/notifications/clear/route.ts
@@ -36,12 +36,10 @@ export const POST = traceApiRoute(
         break
       }
 
-      // Delete batch
-      await Promise.all(
-        notifications.map((notification) =>
-          database.deleteNotification(notification.id)
-        )
-      )
+      // Delete sequentially to avoid concurrent-write contention on SQLite
+      for (const notification of notifications) {
+        await database.deleteNotification(notification.id)
+      }
 
       // If we got fewer than batchSize, we're done
       if (notifications.length < batchSize) {

--- a/app/api/v1/notifications/dismiss/route.ts
+++ b/app/api/v1/notifications/dismiss/route.ts
@@ -45,11 +45,12 @@ export const POST = traceApiRoute(
 
     const { id } = parsed.data
 
-    // Verify ownership
+    // Verify ownership (include filtered so filtered notifications can be dismissed)
     const notifications = await database.getNotifications({
       actorId: currentActor.id,
       ids: [id],
-      limit: 1
+      limit: 1,
+      includeFiltered: true
     })
 
     if (notifications.length === 0) {

--- a/app/api/v1/notifications/read/route.ts
+++ b/app/api/v1/notifications/read/route.ts
@@ -39,12 +39,14 @@ export const POST = traceApiRoute(
       })
     }
 
-    // Verify all notifications belong to the current actor
+    // Verify all notifications belong to the current actor (include filtered so
+    // notifications returned via include_filtered=true can also be marked read)
     const notifications = await database.getNotifications({
       actorId: currentActor.id,
       limit: notificationIds.length,
       offset: 0,
-      ids: notificationIds
+      ids: notificationIds,
+      includeFiltered: true
     })
 
     const validIds = notifications

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 
-import { GET } from './route'
+import { GET, POST } from './route'
 
 const mockDatabase = {
   getNotifications: jest.fn(),
@@ -102,6 +102,30 @@ describe('GET /api/v1/notifications', () => {
 
     await GET(request, { params: Promise.resolve({}) })
 
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        includeFiltered: true
+      })
+    )
+  })
+})
+
+describe('POST /api/v1/notifications (clear-all)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('fetches notifications with includeFiltered: true so filtered notifications are cleared', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest('https://llun.test/api/v1/notifications', {
+      method: 'POST'
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
     expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
       expect.objectContaining({
         actorId: mockCurrentActor.id,

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -109,6 +109,32 @@ describe('GET /api/v1/notifications', () => {
       })
     )
   })
+
+  it.each([
+    ['1', true],
+    ['on', true],
+    ['ON', true],
+    ['True', true],
+    ['false', false],
+    ['0', false],
+    ['off', false]
+  ])(
+    'parses include_filtered=%s as %s (Mastodon boolean compat)',
+    async (value, expected) => {
+      mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+      const request = new NextRequest(
+        `https://llun.test/api/v1/notifications?include_filtered=${value}`,
+        { method: 'GET' }
+      )
+
+      await GET(request, { params: Promise.resolve({}) })
+
+      expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+        expect.objectContaining({ includeFiltered: expected })
+      )
+    }
+  )
 })
 
 describe('POST /api/v1/notifications (clear-all)', () => {

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -74,4 +74,39 @@ describe('GET /api/v1/notifications', () => {
       })
     )
   })
+
+  it('excludes filtered notifications by default', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest('https://llun.test/api/v1/notifications', {
+      method: 'GET'
+    })
+
+    await GET(request, { params: Promise.resolve({}) })
+
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        includeFiltered: false
+      })
+    )
+  })
+
+  it('passes include_filtered=true through to the database', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications?include_filtered=true',
+      { method: 'GET' }
+    )
+
+    await GET(request, { params: Promise.resolve({}) })
+
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        includeFiltered: true
+      })
+    )
+  })
 })

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -44,12 +44,18 @@ const NotificationQueryParams = z.object({
   exclude_types: z.array(z.string()).optional(),
   account_id: z.string().optional(),
   include_filtered: z
-    .enum(['true', 'false'])
-    .transform((val) => val === 'true')
+    .string()
+    .transform((val) => {
+      const n = val.toLowerCase()
+      return n === 'true' || n === '1' || n === 'on'
+    })
     .optional(),
   grouped: z
-    .enum(['true', 'false'])
-    .transform((val) => val === 'true')
+    .string()
+    .transform((val) => {
+      const n = val.toLowerCase()
+      return n === 'true' || n === '1' || n === 'on'
+    })
     .optional()
 })
 
@@ -244,12 +250,10 @@ export const POST = traceApiRoute(
         break
       }
 
-      // Delete batch
-      await Promise.all(
-        notifications.map((notification) =>
-          database.deleteNotification(notification.id)
-        )
-      )
+      // Delete sequentially to avoid concurrent-write contention on SQLite
+      for (const notification of notifications) {
+        await database.deleteNotification(notification.id)
+      }
 
       // If we got fewer than batchSize, we're done
       if (notifications.length < batchSize) {

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -35,6 +35,7 @@ const NotificationQueryParams = z.object({
   min_id: z.string().optional(),
   limit: z.coerce
     .number()
+    .int()
     .min(1)
     .max(MAX_LIMIT)
     .default(DEFAULT_LIMIT)

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -235,7 +235,8 @@ export const POST = traceApiRoute(
     while (true) {
       const notifications = await database.getNotifications({
         actorId: currentActor.id,
-        limit: batchSize
+        limit: batchSize,
+        includeFiltered: true
       })
 
       if (notifications.length === 0) {

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -6,7 +6,8 @@ import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonNotification } from '@/lib/services/notifications/getMastodonNotification'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
-import { NotificationType, Scope } from '@/lib/types/database/operations'
+import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
+import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -41,6 +42,10 @@ const NotificationQueryParams = z.object({
   types: z.array(z.string()).optional(),
   exclude_types: z.array(z.string()).optional(),
   account_id: z.string().optional(),
+  include_filtered: z
+    .enum(['true', 'false'])
+    .transform((val) => val === 'true')
+    .optional(),
   grouped: z
     .enum(['true', 'false'])
     .transform((val) => val === 'true')
@@ -102,27 +107,13 @@ export const GET = traceApiRoute(
       types,
       exclude_types: excludeTypes,
       account_id: accountId,
+      include_filtered: includeFiltered = false,
       grouped = false
     } = parsedParams.data
 
-    // Convert Mastodon types to internal types for filtering
-    const internalTypes = types?.map((type) => {
-      if (type === 'favourite') return 'like'
-      if (type === 'reblog') return 'reblog'
-      // Maps Mastodon 'status' type to internal 'activity_import'.
-      // This codebase has no native follow-post 'status' notifications;
-      // if one is ever added, this mapping must be updated.
-      if (type === 'status') return 'activity_import'
-      return type
-    }) as NotificationType[] | undefined
-
-    const internalExcludeTypes = excludeTypes?.map((type) => {
-      if (type === 'favourite') return 'like'
-      if (type === 'reblog') return 'reblog'
-      // See comment above about 'status' → 'activity_import' mapping
-      if (type === 'status') return 'activity_import'
-      return type
-    }) as NotificationType[] | undefined
+    // Convert Mastodon type names to internal types for filtering
+    const internalTypes = mastodonTypesToInternal(types)
+    const internalExcludeTypes = mastodonTypesToInternal(excludeTypes)
 
     // Fetch notifications
     const notifications = await database.getNotifications({
@@ -131,7 +122,8 @@ export const GET = traceApiRoute(
       maxNotificationId: maxId,
       minNotificationId: minId || sinceId,
       types: internalTypes,
-      excludeTypes: internalExcludeTypes
+      excludeTypes: internalExcludeTypes,
+      includeFiltered
     })
 
     // Group notifications if requested
@@ -182,6 +174,9 @@ export const GET = traceApiRoute(
       }
       if (accountId) {
         params.set('account_id', accountId)
+      }
+      if (includeFiltered) {
+        params.set('include_filtered', 'true')
       }
       if (grouped) {
         params.set('grouped', 'true')

--- a/app/api/v1/notifications/unread_count/route.test.ts
+++ b/app/api/v1/notifications/unread_count/route.test.ts
@@ -117,7 +117,7 @@ describe('GET /api/v1/notifications/unread_count', () => {
       expect.objectContaining({
         actorId: mockCurrentActor.id,
         onlyUnread: true,
-        limit: 100
+        limit: 1000
       })
     )
     expect(mockDatabase.getNotificationsCount).not.toHaveBeenCalled()

--- a/app/api/v1/notifications/unread_count/route.test.ts
+++ b/app/api/v1/notifications/unread_count/route.test.ts
@@ -108,6 +108,39 @@ describe('GET /api/v1/notifications/unread_count', () => {
     )
   })
 
+  it('returns 422 when limit is a float', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/unread_count?limit=1.5',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.getNotificationsCount).not.toHaveBeenCalled()
+  })
+
+  it('caps account_id match count at the requested limit', async () => {
+    const aliceId = 'https://other.test/users/alice'
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      { id: 'n1', sourceActorId: aliceId },
+      { id: 'n2', sourceActorId: aliceId },
+      { id: 'n3', sourceActorId: aliceId }
+    ])
+
+    const accountId = urlToId(aliceId)
+    const request = new NextRequest(
+      `https://llun.test/api/v1/notifications/unread_count?account_id=${encodeURIComponent(accountId)}&limit=2`,
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ count: 2 })
+  })
+
   it('counts via post-fetch account_id filtering on sourceActorId', async () => {
     const aliceId = 'https://other.test/users/alice'
     const bobId = 'https://other.test/users/bob'

--- a/app/api/v1/notifications/unread_count/route.test.ts
+++ b/app/api/v1/notifications/unread_count/route.test.ts
@@ -1,0 +1,125 @@
+import { NextRequest } from 'next/server'
+
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getNotificationsCount: jest.fn(),
+  getNotifications: jest.fn()
+}
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/llun'
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+describe('GET /api/v1/notifications/unread_count', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the unread count capped at the default limit of 100', async () => {
+    mockDatabase.getNotificationsCount.mockResolvedValueOnce(7)
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/unread_count',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ count: 7 })
+    expect(mockDatabase.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        onlyUnread: true,
+        limit: 100
+      })
+    )
+  })
+
+  it('returns 422 when limit exceeds the maximum', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/unread_count?limit=1001',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.getNotificationsCount).not.toHaveBeenCalled()
+  })
+
+  it('maps and forwards type filters to the count query', async () => {
+    mockDatabase.getNotificationsCount.mockResolvedValueOnce(2)
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/unread_count?types[]=favourite&exclude_types[]=follow',
+      { method: 'GET' }
+    )
+
+    await GET(request, { params: Promise.resolve({}) })
+
+    expect(mockDatabase.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        types: ['like'],
+        excludeTypes: ['follow']
+      })
+    )
+  })
+
+  it('counts via post-fetch account_id filtering on sourceActorId', async () => {
+    const aliceId = 'https://other.test/users/alice'
+    const bobId = 'https://other.test/users/bob'
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      { id: 'n1', sourceActorId: aliceId },
+      { id: 'n2', sourceActorId: bobId },
+      { id: 'n3', sourceActorId: aliceId }
+    ])
+
+    const accountId = urlToId(aliceId)
+    const request = new NextRequest(
+      `https://llun.test/api/v1/notifications/unread_count?account_id=${encodeURIComponent(accountId)}`,
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ count: 2 })
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        onlyUnread: true,
+        limit: 100
+      })
+    )
+    expect(mockDatabase.getNotificationsCount).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/notifications/unread_count/route.test.ts
+++ b/app/api/v1/notifications/unread_count/route.test.ts
@@ -93,6 +93,21 @@ describe('GET /api/v1/notifications/unread_count', () => {
     )
   })
 
+  it('merges bare and bracketed forms of the same array param', async () => {
+    mockDatabase.getNotificationsCount.mockResolvedValueOnce(1)
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications/unread_count?types=favourite&types[]=reblog',
+      { method: 'GET' }
+    )
+
+    await GET(request, { params: Promise.resolve({}) })
+
+    expect(mockDatabase.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ types: ['like', 'reblog'] })
+    )
+  })
+
   it('counts via post-fetch account_id filtering on sourceActorId', async () => {
     const aliceId = 'https://other.test/users/alice'
     const bobId = 'https://other.test/users/bob'

--- a/app/api/v1/notifications/unread_count/route.ts
+++ b/app/api/v1/notifications/unread_count/route.ts
@@ -1,13 +1,37 @@
+import { z } from 'zod'
+
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { urlToId } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+const ARRAY_QUERY_PARAMS = new Set(['types', 'exclude_types'])
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const UnreadCountQueryParams = z.object({
+  limit: z.coerce
+    .number()
+    .min(1)
+    .max(MAX_LIMIT)
+    .default(DEFAULT_LIMIT)
+    .optional(),
+  types: z.array(z.string()).optional(),
+  exclude_types: z.array(z.string()).optional(),
+  account_id: z.string().optional()
+})
 
 export const GET = traceApiRoute(
   'getUnreadNotificationsCount',
@@ -22,9 +46,61 @@ export const GET = traceApiRoute(
       })
     }
 
+    const url = new URL(req.url)
+    // Normalize repeated array params (types[], exclude_types[]) to bare keys.
+    const queryParams: Record<string, string | string[]> = {}
+    for (const key of new Set(url.searchParams.keys())) {
+      const normalizedKey = key.replace(/\[\]$/, '')
+      const allValues = url.searchParams.getAll(key)
+      queryParams[normalizedKey] =
+        ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
+          ? allValues
+          : allValues[0]
+    }
+
+    const parsedParams = UnreadCountQueryParams.safeParse(queryParams)
+    if (!parsedParams.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const {
+      limit = DEFAULT_LIMIT,
+      types,
+      exclude_types: excludeTypes,
+      account_id: accountId
+    } = parsedParams.data
+
+    const internalTypes = mastodonTypesToInternal(types)
+    const internalExcludeTypes = mastodonTypesToInternal(excludeTypes)
+
+    // account_id is the Mastodon short id of the source actor; sourceActorId is
+    // stored as a full URL, so (like the list route) it is matched post-fetch
+    // via urlToId rather than in SQL.
+    if (accountId) {
+      const notifications = await database.getNotifications({
+        actorId: currentActor.id,
+        limit,
+        onlyUnread: true,
+        types: internalTypes,
+        excludeTypes: internalExcludeTypes
+      })
+      const count = notifications.filter(
+        (n) => urlToId(n.sourceActorId) === accountId
+      ).length
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
+    }
+
     const count = await database.getNotificationsCount({
       actorId: currentActor.id,
-      onlyUnread: true
+      onlyUnread: true,
+      types: internalTypes,
+      excludeTypes: internalExcludeTypes,
+      limit
     })
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })

--- a/app/api/v1/notifications/unread_count/route.ts
+++ b/app/api/v1/notifications/unread_count/route.ts
@@ -24,6 +24,7 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 const UnreadCountQueryParams = z.object({
   limit: z.coerce
     .number()
+    .int()
     .min(1)
     .max(MAX_LIMIT)
     .default(DEFAULT_LIMIT)

--- a/app/api/v1/notifications/unread_count/route.ts
+++ b/app/api/v1/notifications/unread_count/route.ts
@@ -48,14 +48,26 @@ export const GET = traceApiRoute(
 
     const url = new URL(req.url)
     // Normalize repeated array params (types[], exclude_types[]) to bare keys.
+    // Merge values when both bare and bracketed forms appear (e.g. types + types[]).
     const queryParams: Record<string, string | string[]> = {}
     for (const key of new Set(url.searchParams.keys())) {
       const normalizedKey = key.replace(/\[\]$/, '')
       const allValues = url.searchParams.getAll(key)
-      queryParams[normalizedKey] =
+      const normalizedValue =
         ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
           ? allValues
           : allValues[0]
+      const existing = queryParams[normalizedKey]
+      if (existing === undefined) {
+        queryParams[normalizedKey] = normalizedValue
+      } else {
+        queryParams[normalizedKey] = [
+          ...(Array.isArray(existing) ? existing : [existing]),
+          ...(Array.isArray(normalizedValue)
+            ? normalizedValue
+            : [normalizedValue])
+        ]
+      }
     }
 
     const parsedParams = UnreadCountQueryParams.safeParse(queryParams)
@@ -80,18 +92,22 @@ export const GET = traceApiRoute(
 
     // account_id is the Mastodon short id of the source actor; sourceActorId is
     // stored as a full URL, so (like the list route) it is matched post-fetch
-    // via urlToId rather than in SQL.
+    // via urlToId rather than in SQL. Fetch up to MAX_LIMIT rows so that
+    // matching notifications are not missed if the target account's items fall
+    // beyond the first `limit` unread entries; cap the returned count at `limit`.
     if (accountId) {
       const notifications = await database.getNotifications({
         actorId: currentActor.id,
-        limit,
+        limit: MAX_LIMIT,
         onlyUnread: true,
         types: internalTypes,
         excludeTypes: internalExcludeTypes
       })
-      const count = notifications.filter(
-        (n) => urlToId(n.sourceActorId) === accountId
-      ).length
+      const count = Math.min(
+        notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
+          .length,
+        limit
+      )
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
     }
 

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -286,6 +286,111 @@ describe('Notification Database', () => {
       })
     })
 
+    describe('filtered notifications', () => {
+      beforeEach(async () => {
+        const existing = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 100,
+          includeFiltered: true
+        })
+        for (const notif of existing) {
+          await database.deleteNotification(notif.id)
+        }
+
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.like,
+          sourceActorId: actor2Id,
+          statusId
+        })
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.mention,
+          sourceActorId: actor2Id,
+          statusId,
+          filtered: true
+        })
+      })
+
+      it('hides filtered notifications by default', async () => {
+        const notifications = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 10
+        })
+
+        expect(notifications).toHaveLength(1)
+        expect(notifications[0].type).toBe('like')
+        expect(notifications[0].filtered).toBe(false)
+      })
+
+      it('includes filtered notifications when includeFiltered is true', async () => {
+        const notifications = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 10,
+          includeFiltered: true
+        })
+
+        expect(notifications).toHaveLength(2)
+        expect(notifications.some((n) => n.filtered === true)).toBe(true)
+      })
+
+      it('excludes filtered notifications from the default count', async () => {
+        const count = await database.getNotificationsCount({
+          actorId: actor1Id
+        })
+        expect(count).toBe(1)
+
+        const allCount = await database.getNotificationsCount({
+          actorId: actor1Id,
+          includeFiltered: true
+        })
+        expect(allCount).toBe(2)
+      })
+    })
+
+    describe('getNotificationsCount', () => {
+      beforeEach(async () => {
+        const existing = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 100,
+          includeFiltered: true
+        })
+        for (const notif of existing) {
+          await database.deleteNotification(notif.id)
+        }
+
+        for (let i = 0; i < 5; i++) {
+          await database.createNotification({
+            actorId: actor1Id,
+            type: NotificationType.enum.like,
+            sourceActorId: actor2Id,
+            statusId
+          })
+        }
+      })
+
+      it('caps the count at the provided limit', async () => {
+        const capped = await database.getNotificationsCount({
+          actorId: actor1Id,
+          limit: 3
+        })
+        expect(capped).toBe(3)
+
+        const uncapped = await database.getNotificationsCount({
+          actorId: actor1Id
+        })
+        expect(uncapped).toBe(5)
+      })
+
+      it('filters the count by excludeTypes', async () => {
+        const count = await database.getNotificationsCount({
+          actorId: actor1Id,
+          excludeTypes: [NotificationType.enum.like]
+        })
+        expect(count).toBe(0)
+      })
+    })
+
     describe('deleteNotification', () => {
       it('should delete a notification', async () => {
         const notification = await database.createNotification({

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -13,6 +13,8 @@ import {
 
 const fixNotificationDataDate = (data: Notification): Notification => ({
   ...data,
+  // SQLite stores booleans as 0/1; normalize to a real boolean to honor the type.
+  filtered: Boolean(data.filtered),
   createdAt: getCompatibleTime(data.createdAt),
   updatedAt: getCompatibleTime(data.updatedAt),
   readAt: data.readAt ? getCompatibleTime(data.readAt) : undefined
@@ -27,7 +29,8 @@ export const NotificationSQLDatabaseMixin = (
     sourceActorId,
     statusId,
     followId,
-    groupKey
+    groupKey,
+    filtered = false
   }: CreateNotificationParams) {
     const currentTime = new Date()
     const notification: Notification = {
@@ -39,6 +42,7 @@ export const NotificationSQLDatabaseMixin = (
       followId,
       groupKey,
       isRead: false,
+      filtered,
       createdAt: currentTime.getTime(),
       updatedAt: currentTime.getTime()
     }
@@ -62,13 +66,20 @@ export const NotificationSQLDatabaseMixin = (
     ids,
     maxNotificationId,
     minNotificationId,
-    sinceNotificationId
+    sinceNotificationId,
+    includeFiltered
   }: GetNotificationsParams) {
     let query = database('notifications')
       .where('actorId', actorId)
       .orderBy('createdAt', 'desc')
       .orderBy('id', 'desc') // Secondary sort for deterministic ordering
       .limit(limit)
+
+    // By default hide policy-filtered notifications (they live in the requests
+    // queue). Mastodon's `include_filtered` opts back into seeing them.
+    if (!includeFiltered) {
+      query = query.where('filtered', false)
+    }
 
     // Support cursor-based pagination
     // Scope cursor lookups to actorId to prevent information leaks
@@ -144,9 +155,16 @@ export const NotificationSQLDatabaseMixin = (
   async getNotificationsCount({
     actorId,
     onlyUnread,
-    types
+    types,
+    excludeTypes,
+    limit,
+    includeFiltered
   }: GetNotificationsCountParams) {
     let query = database('notifications').where('actorId', actorId)
+
+    if (!includeFiltered) {
+      query = query.where('filtered', false)
+    }
 
     if (onlyUnread) {
       query = query.where('isRead', false)
@@ -154,6 +172,27 @@ export const NotificationSQLDatabaseMixin = (
 
     if (types && types.length > 0) {
       query = query.whereIn('type', types)
+    }
+
+    if (excludeTypes && excludeTypes.length > 0) {
+      query = query.whereNotIn('type', excludeTypes)
+    }
+
+    // Mastodon caps unread_count at a limit; emulate by counting rows from a
+    // bounded subquery rather than the whole table.
+    if (limit !== undefined) {
+      const subquery = query
+        .clone()
+        .select('id')
+        .orderBy('createdAt', 'desc')
+        .orderBy('id', 'desc')
+        .limit(limit)
+        .as('capped')
+      const result = await database
+        .count<{ count: string }>('* as count')
+        .from(subquery)
+        .first()
+      return parseInt(result?.count ?? '0', 10)
     }
 
     const result = await query.count<{ count: string }>('* as count').first()

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -13,8 +13,9 @@ import {
 
 const fixNotificationDataDate = (data: Notification): Notification => ({
   ...data,
-  // SQLite stores booleans as 0/1; normalize to a real boolean to honor the type.
+  // SQLite stores booleans as 0/1; normalize to real booleans to honor the type.
   filtered: Boolean(data.filtered),
+  isRead: Boolean(data.isRead),
   createdAt: getCompatibleTime(data.createdAt),
   updatedAt: getCompatibleTime(data.updatedAt),
   readAt: data.readAt ? getCompatibleTime(data.readAt) : undefined
@@ -181,13 +182,10 @@ export const NotificationSQLDatabaseMixin = (
     // Mastodon caps unread_count at a limit; emulate by counting rows from a
     // bounded subquery rather than the whole table.
     if (limit !== undefined) {
-      const subquery = query
-        .clone()
-        .select('id')
-        .orderBy('createdAt', 'desc')
-        .orderBy('id', 'desc')
-        .limit(limit)
-        .as('capped')
+      // ORDER BY is intentionally omitted: for a COUNT the sort order does not
+      // affect the result, and skipping it lets the query planner avoid a
+      // potentially expensive sort before the LIMIT.
+      const subquery = query.clone().select('id').limit(limit).as('capped')
       const result = await database
         .count<{ count: string }>('* as count')
         .from(subquery)

--- a/lib/services/notifications/notificationTypeMapping.test.ts
+++ b/lib/services/notifications/notificationTypeMapping.test.ts
@@ -1,0 +1,51 @@
+import {
+  mastodonTypeToInternal,
+  mastodonTypesToInternal
+} from './notificationTypeMapping'
+
+describe('mastodonTypeToInternal', () => {
+  it('maps favourite to like', () => {
+    expect(mastodonTypeToInternal('favourite')).toEqual(['like'])
+  })
+
+  it('maps reblog to reblog', () => {
+    expect(mastodonTypeToInternal('reblog')).toEqual(['reblog'])
+  })
+
+  it('maps status to activity_import', () => {
+    expect(mastodonTypeToInternal('status')).toEqual(['activity_import'])
+  })
+
+  it('maps mention to both mention and reply', () => {
+    expect(mastodonTypeToInternal('mention')).toEqual(['mention', 'reply'])
+  })
+
+  it('passes unknown types through unchanged', () => {
+    expect(mastodonTypeToInternal('follow')).toEqual(['follow'])
+    expect(mastodonTypeToInternal('follow_request')).toEqual(['follow_request'])
+    expect(mastodonTypeToInternal('poll')).toEqual(['poll'])
+  })
+})
+
+describe('mastodonTypesToInternal', () => {
+  it('returns undefined when input is undefined', () => {
+    expect(mastodonTypesToInternal(undefined)).toBeUndefined()
+  })
+
+  it('expands mention to mention and reply', () => {
+    expect(mastodonTypesToInternal(['mention'])).toEqual(['mention', 'reply'])
+  })
+
+  it('deduplicates when mention appears multiple times', () => {
+    expect(mastodonTypesToInternal(['mention', 'mention'])).toEqual([
+      'mention',
+      'reply'
+    ])
+  })
+
+  it('maps multiple types correctly', () => {
+    expect(mastodonTypesToInternal(['favourite', 'mention', 'reblog'])).toEqual(
+      ['like', 'mention', 'reply', 'reblog']
+    )
+  })
+})

--- a/lib/services/notifications/notificationTypeMapping.ts
+++ b/lib/services/notifications/notificationTypeMapping.ts
@@ -1,0 +1,29 @@
+import { NotificationType } from '@/lib/types/database/operations'
+
+/**
+ * Maps a Mastodon notification type name to this codebase's internal
+ * NotificationType. Unknown Mastodon types are passed through unchanged and
+ * cast — callers use these only for SQL `whereIn`/`whereNotIn`, so a value that
+ * matches no row simply filters nothing.
+ *
+ * Note on `status`: Mastodon's `status` type means "a followed account posted".
+ * This codebase has no native follow-post notification, so it is mapped to the
+ * closest internal concept, `activity_import`. If a native follow-post
+ * notification is ever added, update this mapping.
+ */
+export const mastodonTypeToInternal = (type: string): NotificationType => {
+  switch (type) {
+    case 'favourite':
+      return NotificationType.enum.like
+    case 'reblog':
+      return NotificationType.enum.reblog
+    case 'status':
+      return NotificationType.enum.activity_import
+    default:
+      return type as NotificationType
+  }
+}
+
+export const mastodonTypesToInternal = (
+  types: string[] | undefined
+): NotificationType[] | undefined => types?.map(mastodonTypeToInternal)

--- a/lib/services/notifications/notificationTypeMapping.ts
+++ b/lib/services/notifications/notificationTypeMapping.ts
@@ -2,28 +2,36 @@ import { NotificationType } from '@/lib/types/database/operations'
 
 /**
  * Maps a Mastodon notification type name to this codebase's internal
- * NotificationType. Unknown Mastodon types are passed through unchanged and
- * cast — callers use these only for SQL `whereIn`/`whereNotIn`, so a value that
- * matches no row simply filters nothing.
+ * NotificationType values. Returns an array because some Mastodon types cover
+ * multiple internal types: Mastodon `mention` maps to both internal `mention`
+ * and `reply` since both are serialised as `mention` in the Mastodon API.
+ * Unknown Mastodon types are passed through unchanged and cast — callers use
+ * these for SQL `whereIn`/`whereNotIn`, so an unrecognised value matches zero
+ * rows.
  *
  * Note on `status`: Mastodon's `status` type means "a followed account posted".
  * This codebase has no native follow-post notification, so it is mapped to the
  * closest internal concept, `activity_import`. If a native follow-post
  * notification is ever added, update this mapping.
  */
-export const mastodonTypeToInternal = (type: string): NotificationType => {
+export const mastodonTypeToInternal = (type: string): NotificationType[] => {
   switch (type) {
     case 'favourite':
-      return NotificationType.enum.like
+      return [NotificationType.enum.like]
     case 'reblog':
-      return NotificationType.enum.reblog
+      return [NotificationType.enum.reblog]
     case 'status':
-      return NotificationType.enum.activity_import
+      return [NotificationType.enum.activity_import]
+    case 'mention':
+      return [NotificationType.enum.mention, NotificationType.enum.reply]
     default:
-      return type as NotificationType
+      return [type as NotificationType]
   }
 }
 
 export const mastodonTypesToInternal = (
   types: string[] | undefined
-): NotificationType[] | undefined => types?.map(mastodonTypeToInternal)
+): NotificationType[] | undefined => {
+  if (!types) return undefined
+  return [...new Set(types.flatMap(mastodonTypeToInternal))]
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1390,6 +1390,9 @@ export interface Notification {
   isRead: boolean
   readAt?: number
   groupKey?: string
+  // When true, the recipient's notification policy routed this notification to
+  // the per-sender requests queue instead of the main timeline.
+  filtered: boolean
   createdAt: number
   updatedAt: number
 }
@@ -1401,6 +1404,9 @@ export type CreateNotificationParams = {
   statusId?: string
   followId?: string
   groupKey?: string
+  // Set true to route this notification to the per-sender requests queue
+  // (computed by the notification policy). Defaults to false.
+  filtered?: boolean
 }
 
 export type GetNotificationsParams = {
@@ -1414,12 +1420,20 @@ export type GetNotificationsParams = {
   maxNotificationId?: string
   minNotificationId?: string
   sinceNotificationId?: string
+  // When omitted/false, policy-filtered notifications (filtered = true) are
+  // excluded. Pass true to include them (Mastodon `include_filtered`).
+  includeFiltered?: boolean
 }
 
 export type GetNotificationsCountParams = {
   actorId: string
   onlyUnread?: boolean
   types?: NotificationType[]
+  excludeTypes?: NotificationType[]
+  // Cap the count at this many notifications (Mastodon `unread_count` caps at
+  // 100 by default, max 1000). When omitted, counts all matching rows.
+  limit?: number
+  includeFiltered?: boolean
 }
 
 export type MarkNotificationsReadParams = {

--- a/migrations/20260529000000_add_notification_filtered.js
+++ b/migrations/20260529000000_add_notification_filtered.js
@@ -1,0 +1,32 @@
+/**
+ * Adds the `filtered` flag to notifications. A notification is `filtered` when
+ * the recipient's notification policy routed it to the per-sender requests
+ * queue instead of the main timeline. This single column is the spine for the
+ * notification policy, the requests queue, and the `include_filtered` param.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) => {
+  return knex.schema.alterTable('notifications', function (table) {
+    table.boolean('filtered').notNullable().defaultTo(false)
+    table.index(
+      ['actorId', 'filtered', 'createdAt'],
+      'notifications_actor_filtered'
+    )
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => {
+  return knex.schema.alterTable('notifications', function (table) {
+    table.dropIndex(
+      ['actorId', 'filtered', 'createdAt'],
+      'notifications_actor_filtered'
+    )
+    table.dropColumn('filtered')
+  })
+}


### PR DESCRIPTION
## Summary

**Phase 1 of 3** toward full [Mastodon notifications API](https://docs.joinmastodon.org/methods/notifications/) compatibility. This phase adds the missing compatibility parameters on existing endpoints and lays the shared data-model foundation (a `filtered` flag) that Phases 2–3 build on.

### Changes
- **`filtered` column** on `notifications` (migration + `Notification` type + SQL create/read). A notification is `filtered` when the recipient's notification policy (Phase 2) routes it to the per-sender requests queue instead of the main timeline. This single column is the spine for the policy, the requests queue, and `include_filtered`.
- **`GET /api/v1/notifications`** — adds `include_filtered` (default `false`, which hides policy-filtered notifications); preserved across pagination `Link` headers.
- **`GET /api/v1/notifications/unread_count`** — adds `limit` (default 100, max 1000), `types[]`, `exclude_types[]`, `account_id`; count is capped via a bounded subquery. `account_id` is matched post-fetch via `urlToId` to mirror the list route (`sourceActorId` is stored as a full URL).
- **`GET /api/v1/notifications/:id`** — documents that `supported_types[]` is accepted and ignored (every internal type maps to a first-class Mastodon type, so no fallback representation is ever needed).
- Extracts the Mastodon→internal notification type mapping into a shared `notificationTypeMapping.ts` reused by the list and unread_count routes.

### Test results
- `yarn lint` — 0 errors
- `yarn build` — green
- `yarn test` — 347 suites / 2978 tests pass
- Migration applies cleanly on SQLite

New tests cover: `filtered` exclusion (default vs `include_filtered`), the unread-count cap, type-filter forwarding, and `account_id` post-fetch matching.

### Migration note
Adds one column + one index to `notifications`; default `false` so existing rows are unaffected.

### Follow-ups (separate PRs)
- **Phase 2**: notification policy (`v2/notifications/policy`) + enforcement + requests queue (`v1/notifications/requests/*`)
- **Phase 3**: v2 grouped notifications (`v2/notifications`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)