### PR TITLE
minor: add notification policy and requests queue (Mastodon)

### DIFF
--- a/app/api/v1/notifications/requests/[id]/accept/route.test.ts
+++ b/app/api/v1/notifications/requests/[id]/accept/route.test.ts
@@ -6,7 +6,9 @@ import { POST } from './route'
 
 const mockDatabase = {
   getNotificationRequest: jest.fn(),
-  acceptNotificationRequests: jest.fn()
+  acceptNotificationRequests: jest.fn(),
+  getActorSettings: jest.fn().mockResolvedValue(undefined),
+  updateActor: jest.fn().mockResolvedValue(null)
 }
 
 const mockCurrentActor = { id: 'https://llun.test/users/llun' }

--- a/app/api/v1/notifications/requests/[id]/accept/route.test.ts
+++ b/app/api/v1/notifications/requests/[id]/accept/route.test.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from 'next/server'
+
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  getNotificationRequest: jest.fn(),
+  acceptNotificationRequests: jest.fn()
+}
+
+const mockCurrentActor = { id: 'https://llun.test/users/llun' }
+const SOURCE_ACTOR_ID = 'https://other.test/users/stranger'
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, { currentActor: mockCurrentActor, params: context.params })
+}))
+
+describe('POST /api/v1/notifications/requests/[id]/accept', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('accepts the request and clears the filtered flag', async () => {
+    mockDatabase.getNotificationRequest.mockResolvedValueOnce({
+      sourceActorId: SOURCE_ACTOR_ID,
+      notificationsCount: 2
+    })
+
+    const id = urlToId(SOURCE_ACTOR_ID)
+    const request = new NextRequest(
+      `https://llun.test/api/v1/notifications/requests/${id}/accept`,
+      { method: 'POST' }
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({})
+    expect(mockDatabase.acceptNotificationRequests).toHaveBeenCalledWith({
+      actorId: mockCurrentActor.id,
+      sourceActorIds: [SOURCE_ACTOR_ID]
+    })
+  })
+
+  it('returns 404 when the request does not exist', async () => {
+    mockDatabase.getNotificationRequest.mockResolvedValueOnce(null)
+
+    const id = urlToId(SOURCE_ACTOR_ID)
+    const request = new NextRequest(
+      `https://llun.test/api/v1/notifications/requests/${id}/accept`,
+      { method: 'POST' }
+    )
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.acceptNotificationRequests).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/notifications/requests/[id]/accept/route.ts
+++ b/app/api/v1/notifications/requests/[id]/accept/route.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { addAcceptedSender } from '@/lib/services/notifications/evaluateNotificationPolicy'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -48,10 +49,13 @@ export const POST = traceApiRoute(
         })
       }
 
-      await database.acceptNotificationRequests({
-        actorId: currentActor.id,
-        sourceActorIds: [sourceActorId]
-      })
+      await Promise.all([
+        database.acceptNotificationRequests({
+          actorId: currentActor.id,
+          sourceActorIds: [sourceActorId]
+        }),
+        addAcceptedSender(database, currentActor.id, sourceActorId)
+      ])
 
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
     }

--- a/app/api/v1/notifications/requests/[id]/accept/route.ts
+++ b/app/api/v1/notifications/requests/[id]/accept/route.ts
@@ -35,7 +35,7 @@ export const POST = traceApiRoute(
         })
       }
 
-      const sourceActorId = idToUrl(decodeURIComponent((await params).id))
+      const sourceActorId = idToUrl((await params).id)
       const request = await database.getNotificationRequest({
         actorId: currentActor.id,
         sourceActorId

--- a/app/api/v1/notifications/requests/[id]/accept/route.ts
+++ b/app/api/v1/notifications/requests/[id]/accept/route.ts
@@ -1,0 +1,59 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_404,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const POST = traceApiRoute(
+  'acceptNotificationRequest',
+  OAuthGuard<Params>(
+    [Scope.enum.write],
+    async (req, { currentActor, params }) => {
+      const database = getDatabase()
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const sourceActorId = idToUrl(decodeURIComponent((await params).id))
+      const request = await database.getNotificationRequest({
+        actorId: currentActor.id,
+        sourceActorId
+      })
+      if (!request) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      await database.acceptNotificationRequests({
+        actorId: currentActor.id,
+        sourceActorIds: [sourceActorId]
+      })
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+    }
+  )
+)

--- a/app/api/v1/notifications/requests/[id]/dismiss/route.ts
+++ b/app/api/v1/notifications/requests/[id]/dismiss/route.ts
@@ -34,7 +34,7 @@ export const POST = traceApiRoute(
         })
       }
 
-      const sourceActorId = idToUrl(decodeURIComponent((await params).id))
+      const sourceActorId = idToUrl((await params).id)
       const request = await database.getNotificationRequest({
         actorId: currentActor.id,
         sourceActorId

--- a/app/api/v1/notifications/requests/[id]/dismiss/route.ts
+++ b/app/api/v1/notifications/requests/[id]/dismiss/route.ts
@@ -1,0 +1,59 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_404,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const POST = traceApiRoute(
+  'dismissNotificationRequest',
+  OAuthGuard<Params>(
+    [Scope.enum.write],
+    async (req, { currentActor, params }) => {
+      const database = getDatabase()
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const sourceActorId = idToUrl(decodeURIComponent((await params).id))
+      const request = await database.getNotificationRequest({
+        actorId: currentActor.id,
+        sourceActorId
+      })
+      if (!request) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      await database.dismissNotificationRequests({
+        actorId: currentActor.id,
+        sourceActorIds: [sourceActorId]
+      })
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+    }
+  )
+)

--- a/app/api/v1/notifications/requests/[id]/route.ts
+++ b/app/api/v1/notifications/requests/[id]/route.ts
@@ -35,7 +35,7 @@ export const GET = traceApiRoute(
         })
       }
 
-      const sourceActorId = idToUrl(decodeURIComponent((await params).id))
+      const sourceActorId = idToUrl((await params).id)
       const request = await database.getNotificationRequest({
         actorId: currentActor.id,
         sourceActorId

--- a/app/api/v1/notifications/requests/[id]/route.ts
+++ b/app/api/v1/notifications/requests/[id]/route.ts
@@ -1,0 +1,69 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonNotificationRequest } from '@/lib/services/notifications/getMastodonNotificationRequest'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_404,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const GET = traceApiRoute(
+  'getNotificationRequest',
+  OAuthGuard<Params>(
+    [Scope.enum.read],
+    async (req, { currentActor, params }) => {
+      const database = getDatabase()
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const sourceActorId = idToUrl(decodeURIComponent((await params).id))
+      const request = await database.getNotificationRequest({
+        actorId: currentActor.id,
+        sourceActorId
+      })
+      if (!request) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      const data = await getMastodonNotificationRequest(
+        database,
+        request,
+        currentActor.id
+      )
+      if (!data) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+    }
+  )
+)

--- a/app/api/v1/notifications/requests/accept/route.ts
+++ b/app/api/v1/notifications/requests/accept/route.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+// Mastodon sends the account ids under `id[]`; accept either `id` or `id[]`.
+const BulkBody = z
+  .object({
+    id: z.array(z.string()).optional(),
+    'id[]': z.array(z.string()).optional()
+  })
+  .transform((value) => value.id ?? value['id[]'] ?? [])
+
+export const POST = traceApiRoute(
+  'acceptNotificationRequests',
+  OAuthGuard([Scope.enum.write], async (req, { currentActor }) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const body = await req.json().catch(() => null)
+    const parsed = BulkBody.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    await database.acceptNotificationRequests({
+      actorId: currentActor.id,
+      sourceActorIds: parsed.data.map((id) => idToUrl(id))
+    })
+
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+  })
+)

--- a/app/api/v1/notifications/requests/accept/route.ts
+++ b/app/api/v1/notifications/requests/accept/route.ts
@@ -42,10 +42,12 @@ export const POST = traceApiRoute(
       })
     }
 
+    const contentType = req.headers.get('content-type') ?? ''
     let rawBody: unknown
-    try {
-      rawBody = await req.json()
-    } catch {
+    if (
+      contentType.includes('application/x-www-form-urlencoded') ||
+      contentType.includes('multipart/form-data')
+    ) {
       const formData = await req.formData().catch(() => null)
       if (formData) {
         const ids = formData.getAll('id[]')
@@ -55,6 +57,8 @@ export const POST = traceApiRoute(
       } else {
         rawBody = {}
       }
+    } else {
+      rawBody = await req.json().catch(() => ({}))
     }
     const parsed = BulkBody.safeParse(rawBody)
     if (!parsed.success) {
@@ -66,7 +70,20 @@ export const POST = traceApiRoute(
       })
     }
 
-    const sourceActorIds = parsed.data.map((id) => idToUrl(id))
+    const allSourceActorIds = parsed.data.map((id) => idToUrl(id))
+    // Only add senders that have an actual pending request to prevent arbitrary
+    // allowlisting of accounts the user never intentionally accepted.
+    const pendingRequests = await Promise.all(
+      allSourceActorIds.map((sourceActorId) =>
+        database.getNotificationRequest({
+          actorId: currentActor.id,
+          sourceActorId
+        })
+      )
+    )
+    const sourceActorIds = allSourceActorIds.filter(
+      (_, i) => pendingRequests[i] !== null
+    )
     await Promise.all([
       database.acceptNotificationRequests({
         actorId: currentActor.id,

--- a/app/api/v1/notifications/requests/accept/route.ts
+++ b/app/api/v1/notifications/requests/accept/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { addAcceptedSender } from '@/lib/services/notifications/evaluateNotificationPolicy'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -17,13 +18,16 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-// Mastodon sends the account ids under `id[]`; accept either `id` or `id[]`.
+// Mastodon sends ids under `id[]` (array) or `id` (single string or array).
+const normalizeIds = (v: string | string[] | undefined) =>
+  v === undefined ? [] : Array.isArray(v) ? v : [v]
+
 const BulkBody = z
   .object({
-    id: z.array(z.string()).optional(),
-    'id[]': z.array(z.string()).optional()
+    id: z.union([z.string(), z.array(z.string())]).optional(),
+    'id[]': z.union([z.string(), z.array(z.string())]).optional()
   })
-  .transform((value) => value.id ?? value['id[]'] ?? [])
+  .transform((value) => normalizeIds(value.id ?? value['id[]']))
 
 export const POST = traceApiRoute(
   'acceptNotificationRequests',
@@ -38,8 +42,21 @@ export const POST = traceApiRoute(
       })
     }
 
-    const body = await req.json().catch(() => null)
-    const parsed = BulkBody.safeParse(body)
+    let rawBody: unknown
+    try {
+      rawBody = await req.json()
+    } catch {
+      const formData = await req.formData().catch(() => null)
+      if (formData) {
+        const ids = formData.getAll('id[]')
+        const idSingle = formData.get('id')
+        rawBody =
+          ids.length > 0 ? { 'id[]': ids } : idSingle ? { id: idSingle } : {}
+      } else {
+        rawBody = {}
+      }
+    }
+    const parsed = BulkBody.safeParse(rawBody)
     if (!parsed.success) {
       return apiResponse({
         req,
@@ -49,10 +66,16 @@ export const POST = traceApiRoute(
       })
     }
 
-    await database.acceptNotificationRequests({
-      actorId: currentActor.id,
-      sourceActorIds: parsed.data.map((id) => idToUrl(id))
-    })
+    const sourceActorIds = parsed.data.map((id) => idToUrl(id))
+    await Promise.all([
+      database.acceptNotificationRequests({
+        actorId: currentActor.id,
+        sourceActorIds
+      }),
+      ...sourceActorIds.map((sourceActorId) =>
+        addAcceptedSender(database, currentActor.id, sourceActorId)
+      )
+    ])
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
   })

--- a/app/api/v1/notifications/requests/accept/route.ts
+++ b/app/api/v1/notifications/requests/accept/route.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
-import { addAcceptedSender } from '@/lib/services/notifications/evaluateNotificationPolicy'
+import { addAcceptedSenders } from '@/lib/services/notifications/evaluateNotificationPolicy'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -72,9 +72,7 @@ export const POST = traceApiRoute(
         actorId: currentActor.id,
         sourceActorIds
       }),
-      ...sourceActorIds.map((sourceActorId) =>
-        addAcceptedSender(database, currentActor.id, sourceActorId)
-      )
+      addAcceptedSenders(database, currentActor.id, sourceActorIds)
     ])
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })

--- a/app/api/v1/notifications/requests/dismiss/route.ts
+++ b/app/api/v1/notifications/requests/dismiss/route.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+// Mastodon sends the account ids under `id[]`; accept either `id` or `id[]`.
+const BulkBody = z
+  .object({
+    id: z.array(z.string()).optional(),
+    'id[]': z.array(z.string()).optional()
+  })
+  .transform((value) => value.id ?? value['id[]'] ?? [])
+
+export const POST = traceApiRoute(
+  'dismissNotificationRequests',
+  OAuthGuard([Scope.enum.write], async (req, { currentActor }) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const body = await req.json().catch(() => null)
+    const parsed = BulkBody.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    await database.dismissNotificationRequests({
+      actorId: currentActor.id,
+      sourceActorIds: parsed.data.map((id) => idToUrl(id))
+    })
+
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+  })
+)

--- a/app/api/v1/notifications/requests/dismiss/route.ts
+++ b/app/api/v1/notifications/requests/dismiss/route.ts
@@ -41,10 +41,12 @@ export const POST = traceApiRoute(
       })
     }
 
+    const contentType = req.headers.get('content-type') ?? ''
     let rawBody: unknown
-    try {
-      rawBody = await req.json()
-    } catch {
+    if (
+      contentType.includes('application/x-www-form-urlencoded') ||
+      contentType.includes('multipart/form-data')
+    ) {
       const formData = await req.formData().catch(() => null)
       if (formData) {
         const ids = formData.getAll('id[]')
@@ -54,6 +56,8 @@ export const POST = traceApiRoute(
       } else {
         rawBody = {}
       }
+    } else {
+      rawBody = await req.json().catch(() => ({}))
     }
     const parsed = BulkBody.safeParse(rawBody)
     if (!parsed.success) {

--- a/app/api/v1/notifications/requests/dismiss/route.ts
+++ b/app/api/v1/notifications/requests/dismiss/route.ts
@@ -17,13 +17,16 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-// Mastodon sends the account ids under `id[]`; accept either `id` or `id[]`.
+// Mastodon sends ids under `id[]` (array) or `id` (single string or array).
+const normalizeIds = (v: string | string[] | undefined) =>
+  v === undefined ? [] : Array.isArray(v) ? v : [v]
+
 const BulkBody = z
   .object({
-    id: z.array(z.string()).optional(),
-    'id[]': z.array(z.string()).optional()
+    id: z.union([z.string(), z.array(z.string())]).optional(),
+    'id[]': z.union([z.string(), z.array(z.string())]).optional()
   })
-  .transform((value) => value.id ?? value['id[]'] ?? [])
+  .transform((value) => normalizeIds(value.id ?? value['id[]']))
 
 export const POST = traceApiRoute(
   'dismissNotificationRequests',
@@ -38,8 +41,21 @@ export const POST = traceApiRoute(
       })
     }
 
-    const body = await req.json().catch(() => null)
-    const parsed = BulkBody.safeParse(body)
+    let rawBody: unknown
+    try {
+      rawBody = await req.json()
+    } catch {
+      const formData = await req.formData().catch(() => null)
+      if (formData) {
+        const ids = formData.getAll('id[]')
+        const idSingle = formData.get('id')
+        rawBody =
+          ids.length > 0 ? { 'id[]': ids } : idSingle ? { id: idSingle } : {}
+      } else {
+        rawBody = {}
+      }
+    }
+    const parsed = BulkBody.safeParse(rawBody)
     if (!parsed.success) {
       return apiResponse({
         req,

--- a/app/api/v1/notifications/requests/merged/route.ts
+++ b/app/api/v1/notifications/requests/merged/route.ts
@@ -1,0 +1,22 @@
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+// Accepting a notification request resolves synchronously here (it just clears
+// the filtered flag), so merges are always complete by the time this is polled.
+export const GET = traceApiRoute(
+  'getNotificationRequestsMerged',
+  OAuthGuard([Scope.enum.read], async (req) =>
+    apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { merged: true }
+    })
+  )
+)

--- a/app/api/v1/notifications/requests/route.ts
+++ b/app/api/v1/notifications/requests/route.ts
@@ -1,0 +1,52 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonNotificationRequest } from '@/lib/services/notifications/getMastodonNotificationRequest'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 40
+const MAX_LIMIT = 80
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'getNotificationRequests',
+  OAuthGuard([Scope.enum.read], async (req, { currentActor }) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const url = new URL(req.url)
+    const limit = Math.min(
+      parseInt(url.searchParams.get('limit') || `${DEFAULT_LIMIT}`, 10),
+      MAX_LIMIT
+    )
+    const page = parseInt(url.searchParams.get('page') || '1', 10)
+    const offset = (page - 1) * limit
+
+    const requests = await database.getNotificationRequests({
+      actorId: currentActor.id,
+      limit,
+      offset
+    })
+
+    const data = (
+      await Promise.all(
+        requests.map((request) =>
+          getMastodonNotificationRequest(database, request, currentActor.id)
+        )
+      )
+    ).filter(Boolean)
+
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+  })
+)

--- a/app/api/v1/notifications/requests/route.ts
+++ b/app/api/v1/notifications/requests/route.ts
@@ -30,7 +30,7 @@ export const GET = traceApiRoute(
     const url = new URL(req.url)
     const parsedLimit = parseInt(url.searchParams.get('limit') ?? '', 10)
     const limit = Math.min(
-      Number.isNaN(parsedLimit) ? DEFAULT_LIMIT : parsedLimit,
+      Math.max(1, Number.isNaN(parsedLimit) ? DEFAULT_LIMIT : parsedLimit),
       MAX_LIMIT
     )
     const parsedPage = parseInt(url.searchParams.get('page') ?? '', 10)
@@ -40,40 +40,42 @@ export const GET = traceApiRoute(
     const sinceIdParam =
       url.searchParams.get('since_id') ?? url.searchParams.get('min_id')
 
-    let maxUpdatedAt: number | undefined
-    let sinceUpdatedAt: number | undefined
+    let maxCursor: { updatedAt: number; sourceActorId: string } | undefined
+    let sinceCursor: { updatedAt: number; sourceActorId: string } | undefined
 
     if (maxIdParam) {
+      const sourceActorId = idToUrl(maxIdParam)
       const cursor = await database.getNotificationRequest({
         actorId: currentActor.id,
-        sourceActorId: idToUrl(maxIdParam)
+        sourceActorId
       })
       // Cursor not found (request was accepted/dismissed): return empty list
       // rather than falling back to page 1, which would cause clients to loop.
       if (!cursor) {
         return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
       }
-      maxUpdatedAt = cursor.updatedAt
+      maxCursor = { updatedAt: cursor.updatedAt, sourceActorId }
     } else if (sinceIdParam) {
+      const sourceActorId = idToUrl(sinceIdParam)
       const cursor = await database.getNotificationRequest({
         actorId: currentActor.id,
-        sourceActorId: idToUrl(sinceIdParam)
+        sourceActorId
       })
       if (!cursor) {
         return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
       }
-      sinceUpdatedAt = cursor.updatedAt
+      sinceCursor = { updatedAt: cursor.updatedAt, sourceActorId }
     }
 
-    const useCursor = maxUpdatedAt !== undefined || sinceUpdatedAt !== undefined
+    const useCursor = maxCursor !== undefined || sinceCursor !== undefined
     const offset = useCursor ? 0 : (page - 1) * limit
 
     const requests = await database.getNotificationRequests({
       actorId: currentActor.id,
       limit,
       offset,
-      maxUpdatedAt,
-      sinceUpdatedAt
+      maxCursor,
+      sinceCursor
     })
 
     const data = (

--- a/app/api/v1/notifications/requests/route.ts
+++ b/app/api/v1/notifications/requests/route.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonNotificationRequest } from '@/lib/services/notifications/getMastodonNotificationRequest'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -83,6 +84,24 @@ export const GET = traceApiRoute(
       )
     ).filter(Boolean)
 
-    return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+    // Build Link headers so Mastodon clients can paginate with max_id/min_id.
+    const host = headerHost(req.headers)
+    const pathBase = '/api/v1/notifications/requests'
+    const buildLink = (cursorParam: string, cursorValue: string) =>
+      `<https://${host}${pathBase}?limit=${limit}&${cursorParam}=${cursorValue}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
+
+    const nextLink =
+      data.length > 0 ? buildLink('max_id', data[data.length - 1]!.id) : null
+    const prevLink = data.length > 0 ? buildLink('min_id', data[0]!.id) : null
+    const links = [nextLink, prevLink].filter(Boolean).join(', ')
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data,
+      additionalHeaders: [
+        ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
+      ]
+    })
   })
 )

--- a/app/api/v1/notifications/requests/route.ts
+++ b/app/api/v1/notifications/requests/route.ts
@@ -5,6 +5,7 @@ import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const DEFAULT_LIMIT = 40
@@ -26,17 +27,44 @@ export const GET = traceApiRoute(
     }
 
     const url = new URL(req.url)
+    const parsedLimit = parseInt(url.searchParams.get('limit') ?? '', 10)
     const limit = Math.min(
-      parseInt(url.searchParams.get('limit') || `${DEFAULT_LIMIT}`, 10),
+      Number.isNaN(parsedLimit) ? DEFAULT_LIMIT : parsedLimit,
       MAX_LIMIT
     )
-    const page = parseInt(url.searchParams.get('page') || '1', 10)
-    const offset = (page - 1) * limit
+    const parsedPage = parseInt(url.searchParams.get('page') ?? '', 10)
+    const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage
+
+    const maxIdParam = url.searchParams.get('max_id')
+    const sinceIdParam =
+      url.searchParams.get('since_id') ?? url.searchParams.get('min_id')
+
+    let maxUpdatedAt: number | undefined
+    let sinceUpdatedAt: number | undefined
+
+    if (maxIdParam) {
+      const cursor = await database.getNotificationRequest({
+        actorId: currentActor.id,
+        sourceActorId: idToUrl(maxIdParam)
+      })
+      if (cursor) maxUpdatedAt = cursor.updatedAt
+    } else if (sinceIdParam) {
+      const cursor = await database.getNotificationRequest({
+        actorId: currentActor.id,
+        sourceActorId: idToUrl(sinceIdParam)
+      })
+      if (cursor) sinceUpdatedAt = cursor.updatedAt
+    }
+
+    const useCursor = maxUpdatedAt !== undefined || sinceUpdatedAt !== undefined
+    const offset = useCursor ? 0 : (page - 1) * limit
 
     const requests = await database.getNotificationRequests({
       actorId: currentActor.id,
       limit,
-      offset
+      offset,
+      maxUpdatedAt,
+      sinceUpdatedAt
     })
 
     const data = (

--- a/app/api/v1/notifications/requests/route.ts
+++ b/app/api/v1/notifications/requests/route.ts
@@ -47,13 +47,21 @@ export const GET = traceApiRoute(
         actorId: currentActor.id,
         sourceActorId: idToUrl(maxIdParam)
       })
-      if (cursor) maxUpdatedAt = cursor.updatedAt
+      // Cursor not found (request was accepted/dismissed): return empty list
+      // rather than falling back to page 1, which would cause clients to loop.
+      if (!cursor) {
+        return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
+      }
+      maxUpdatedAt = cursor.updatedAt
     } else if (sinceIdParam) {
       const cursor = await database.getNotificationRequest({
         actorId: currentActor.id,
         sourceActorId: idToUrl(sinceIdParam)
       })
-      if (cursor) sinceUpdatedAt = cursor.updatedAt
+      if (!cursor) {
+        return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
+      }
+      sinceUpdatedAt = cursor.updatedAt
     }
 
     const useCursor = maxUpdatedAt !== undefined || sinceUpdatedAt !== undefined

--- a/app/api/v2/notifications/policy/route.test.ts
+++ b/app/api/v2/notifications/policy/route.test.ts
@@ -1,0 +1,109 @@
+import { NextRequest } from 'next/server'
+
+import { DEFAULT_NOTIFICATION_POLICY } from '@/lib/types/database/operations'
+
+import { GET, PATCH } from './route'
+
+const mockDatabase = {
+  getNotificationPolicy: jest.fn(),
+  updateNotificationPolicy: jest.fn(),
+  getNotificationsCount: jest.fn(),
+  getNotificationRequestsCount: jest.fn()
+}
+
+const mockCurrentActor = { id: 'https://llun.test/users/llun' }
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          database: typeof mockDatabase
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        database: mockDatabase,
+        params: context.params
+      })
+}))
+
+describe('/api/v2/notifications/policy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getNotificationPolicy.mockResolvedValue({
+      ...DEFAULT_NOTIFICATION_POLICY
+    })
+    mockDatabase.getNotificationsCount.mockResolvedValue(3)
+    mockDatabase.getNotificationRequestsCount.mockResolvedValue(1)
+  })
+
+  it('returns the policy with a pending-counts summary', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/policy',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toMatchObject({
+      for_not_following: 'accept',
+      summary: { pending_requests_count: 1, pending_notifications_count: 3 }
+    })
+    expect(mockDatabase.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ filteredOnly: true })
+    )
+  })
+
+  it('updates the policy on PATCH and echoes the result', async () => {
+    mockDatabase.updateNotificationPolicy.mockResolvedValue({
+      ...DEFAULT_NOTIFICATION_POLICY,
+      for_not_following: 'filter'
+    })
+    mockDatabase.getNotificationPolicy.mockResolvedValue({
+      ...DEFAULT_NOTIFICATION_POLICY,
+      for_not_following: 'filter'
+    })
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/policy',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ for_not_following: 'filter' })
+      }
+    )
+
+    const response = await PATCH(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.for_not_following).toBe('filter')
+    expect(mockDatabase.updateNotificationPolicy).toHaveBeenCalledWith({
+      actorId: mockCurrentActor.id,
+      for_not_following: 'filter'
+    })
+  })
+
+  it('returns 422 for an invalid policy value', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/policy',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ for_not_following: 'nonsense' })
+      }
+    )
+
+    const response = await PATCH(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.updateNotificationPolicy).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v2/notifications/policy/route.ts
+++ b/app/api/v2/notifications/policy/route.ts
@@ -77,7 +77,21 @@ export const PATCH = traceApiRoute(
         })
       }
 
-      const body = await req.json().catch(() => null)
+      let body: unknown
+      try {
+        body = await req.json()
+      } catch {
+        const formData = await req.formData().catch(() => null)
+        if (formData) {
+          const obj: Record<string, string> = {}
+          formData.forEach((value, key) => {
+            obj[key] = String(value)
+          })
+          body = obj
+        } else {
+          body = {}
+        }
+      }
       const parsed = UpdatePolicyBody.safeParse(body)
       if (!parsed.success) {
         return apiResponse({

--- a/app/api/v2/notifications/policy/route.ts
+++ b/app/api/v2/notifications/policy/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { Database } from '@/lib/database/types'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { NotificationPolicyValue, Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PATCH
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const UpdatePolicyBody = z.object({
+  for_not_following: NotificationPolicyValue.optional(),
+  for_not_followers: NotificationPolicyValue.optional(),
+  for_new_accounts: NotificationPolicyValue.optional(),
+  for_private_mentions: NotificationPolicyValue.optional(),
+  for_limited_accounts: NotificationPolicyValue.optional()
+})
+
+const buildPolicyResponse = async (database: Database, actorId: string) => {
+  const [policy, pendingNotificationsCount, pendingRequestsCount] =
+    await Promise.all([
+      database.getNotificationPolicy({ actorId }),
+      database.getNotificationsCount({ actorId, filteredOnly: true }),
+      database.getNotificationRequestsCount({ actorId })
+    ])
+
+  return {
+    ...policy,
+    summary: {
+      pending_requests_count: pendingRequestsCount,
+      pending_notifications_count: pendingNotificationsCount
+    }
+  }
+}
+
+export const GET = traceApiRoute(
+  'getNotificationPolicy',
+  OAuthGuard([Scope.enum.read], async (req, { currentActor, database }) => {
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const data = await buildPolicyResponse(database, currentActor.id)
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+  })
+)
+
+export const PATCH = traceApiRoute(
+  'updateNotificationPolicy',
+  OAuthGuard(
+    [Scope.enum.write],
+    async (req: NextRequest, { currentActor, database }) => {
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const body = await req.json().catch(() => null)
+      const parsed = UpdatePolicyBody.safeParse(body)
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      await database.updateNotificationPolicy({
+        actorId: currentActor.id,
+        ...parsed.data
+      })
+
+      const data = await buildPolicyResponse(database, currentActor.id)
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+    }
+  )
+)

--- a/app/api/v2/notifications/policy/route.ts
+++ b/app/api/v2/notifications/policy/route.ts
@@ -77,10 +77,12 @@ export const PATCH = traceApiRoute(
         })
       }
 
+      const contentType = req.headers.get('content-type') ?? ''
       let body: unknown
-      try {
-        body = await req.json()
-      } catch {
+      if (
+        contentType.includes('application/x-www-form-urlencoded') ||
+        contentType.includes('multipart/form-data')
+      ) {
         const formData = await req.formData().catch(() => null)
         if (formData) {
           const obj: Record<string, string> = {}
@@ -91,6 +93,8 @@ export const PATCH = traceApiRoute(
         } else {
           body = {}
         }
+      } else {
+        body = await req.json().catch(() => ({}))
       }
       const parsed = UpdatePolicyBody.safeParse(body)
       if (!parsed.success) {

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -66,7 +66,7 @@ export const userAnnounce = async ({
         currentActor.id
       )
     ) {
-      await createNotificationWithPolicy(database, {
+      const reblogNotification = await createNotificationWithPolicy(database, {
         actorId: originalStatus.actorId,
         type: NotificationType.enum.reblog,
         sourceActorId: currentActor.id,
@@ -74,33 +74,35 @@ export const userAnnounce = async ({
         groupKey: `reblog:${originalStatus.id}`
       })
 
-      // Fire-and-forget: notification delivery must not fail the announce action
-      database
-        .getActorFromId({ id: originalStatus.actorId })
-        .catch(() => null)
-        .then((targetActor) => {
-          const editableStatus = getOriginalStatus(originalStatus)
-          sendNotificationAlerts({
-            database,
-            actorId: originalStatus.actorId,
-            sourceActorId: currentActor.id,
-            sourceActor: currentActor,
-            statusId: originalStatus.id,
-            events: [
-              {
-                type: NotificationType.enum.reblog,
-                emailContent: targetActor?.account
-                  ? {
-                      recipientEmail: targetActor.account.email,
-                      subject: getSubject(currentActor),
-                      text: getTextContent(currentActor, editableStatus),
-                      html: getHTMLContent(currentActor, editableStatus)
-                    }
-                  : undefined
-              }
-            ]
+      if (reblogNotification && !reblogNotification.filtered) {
+        // Fire-and-forget: notification delivery must not fail the announce action
+        database
+          .getActorFromId({ id: originalStatus.actorId })
+          .catch(() => null)
+          .then((targetActor) => {
+            const editableStatus = getOriginalStatus(originalStatus)
+            sendNotificationAlerts({
+              database,
+              actorId: originalStatus.actorId,
+              sourceActorId: currentActor.id,
+              sourceActor: currentActor,
+              statusId: originalStatus.id,
+              events: [
+                {
+                  type: NotificationType.enum.reblog,
+                  emailContent: targetActor?.account
+                    ? {
+                        recipientEmail: targetActor.account.email,
+                        subject: getSubject(currentActor),
+                        text: getTextContent(currentActor, editableStatus),
+                        html: getHTMLContent(currentActor, editableStatus)
+                      }
+                    : undefined
+                }
+              ]
+            })
           })
-        })
+      }
     }
 
     await getQueue().publish({

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -78,7 +78,6 @@ export const userAnnounce = async ({
         // Fire-and-forget: notification delivery must not fail the announce action
         database
           .getActorFromId({ id: originalStatus.actorId })
-          .catch(() => null)
           .then((targetActor) => {
             const editableStatus = getOriginalStatus(originalStatus)
             sendNotificationAlerts({
@@ -102,6 +101,7 @@ export const userAnnounce = async ({
               ]
             })
           })
+          .catch(() => undefined)
       }
     }
 

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -7,6 +7,7 @@ import {
   getSubject,
   getTextContent
 } from '@/lib/services/email/templates/reblog'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
 import { getQueue } from '@/lib/services/queue'
@@ -65,7 +66,7 @@ export const userAnnounce = async ({
         currentActor.id
       )
     ) {
-      await database.createNotification({
+      await createNotificationWithPolicy(database, {
         actorId: originalStatus.actorId,
         type: NotificationType.enum.reblog,
         sourceActorId: currentActor.id,

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -64,33 +64,38 @@ export const createFollower = async ({
       sharedInbox: followerActor.sharedInboxUrl
     })
 
-    // Create follow_request notification
-    await createNotificationWithPolicy(database, {
-      actorId: targetActor.id,
-      type: NotificationType.enum.follow_request,
-      sourceActorId: followerActor.id,
-      followId: follow.id
-    })
-
-    sendNotificationAlerts({
+    // Create follow_request notification; only send alerts if accepted.
+    const followRequestNotification = await createNotificationWithPolicy(
       database,
-      actorId: targetActor.id,
-      sourceActorId: followerActor.id,
-      sourceActor: followerActor,
-      events: [
-        {
-          type: NotificationType.enum.follow_request,
-          emailContent: targetActor.account
-            ? {
-                recipientEmail: targetActor.account.email,
-                subject: getFollowRequestSubject(followerActor),
-                text: getFollowRequestTextContent(followerActor),
-                html: getFollowRequestHTMLContent(followerActor)
-              }
-            : undefined
-        }
-      ]
-    })
+      {
+        actorId: targetActor.id,
+        type: NotificationType.enum.follow_request,
+        sourceActorId: followerActor.id,
+        followId: follow.id
+      }
+    )
+
+    if (followRequestNotification && !followRequestNotification.filtered) {
+      sendNotificationAlerts({
+        database,
+        actorId: targetActor.id,
+        sourceActorId: followerActor.id,
+        sourceActor: followerActor,
+        events: [
+          {
+            type: NotificationType.enum.follow_request,
+            emailContent: targetActor.account
+              ? {
+                  recipientEmail: targetActor.account.email,
+                  subject: getFollowRequestSubject(followerActor),
+                  text: getFollowRequestTextContent(followerActor),
+                  html: getFollowRequestHTMLContent(followerActor)
+                }
+              : undefined
+          }
+        ]
+      })
+    }
   } else {
     // Auto-accept: create follow with Accepted status and send Accept activity
     const follow = await database.createFollow({
@@ -101,7 +106,7 @@ export const createFollower = async ({
       sharedInbox: followerActor.sharedInboxUrl
     })
 
-    await Promise.all([
+    const [, followNotification] = await Promise.all([
       acceptFollow(targetActor, followerActor.inboxUrl, followRequest),
       // Create follow notification (auto-accepted)
       createNotificationWithPolicy(database, {
@@ -112,25 +117,27 @@ export const createFollower = async ({
       })
     ])
 
-    sendNotificationAlerts({
-      database,
-      actorId: targetActor.id,
-      sourceActorId: followerActor.id,
-      sourceActor: followerActor,
-      events: [
-        {
-          type: NotificationType.enum.follow,
-          emailContent: targetActor.account
-            ? {
-                recipientEmail: targetActor.account.email,
-                subject: getFollowSubject(followerActor),
-                text: getFollowTextContent(followerActor),
-                html: getFollowHTMLContent(followerActor)
-              }
-            : undefined
-        }
-      ]
-    })
+    if (followNotification && !followNotification.filtered) {
+      sendNotificationAlerts({
+        database,
+        actorId: targetActor.id,
+        sourceActorId: followerActor.id,
+        sourceActor: followerActor,
+        events: [
+          {
+            type: NotificationType.enum.follow,
+            emailContent: targetActor.account
+              ? {
+                  recipientEmail: targetActor.account.email,
+                  subject: getFollowSubject(followerActor),
+                  text: getFollowTextContent(followerActor),
+                  html: getFollowHTMLContent(followerActor)
+                }
+              : undefined
+          }
+        ]
+      })
+    }
   }
 
   return followRequest

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -12,6 +12,7 @@ import {
   getSubject as getFollowRequestSubject,
   getTextContent as getFollowRequestTextContent
 } from '@/lib/services/email/templates/followRequest'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { NotificationType } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -64,7 +65,7 @@ export const createFollower = async ({
     })
 
     // Create follow_request notification
-    await database.createNotification({
+    await createNotificationWithPolicy(database, {
       actorId: targetActor.id,
       type: NotificationType.enum.follow_request,
       sourceActorId: followerActor.id,
@@ -103,7 +104,7 @@ export const createFollower = async ({
     await Promise.all([
       acceptFollow(targetActor, followerActor.inboxUrl, followRequest),
       // Create follow notification (auto-accepted)
-      database.createNotification({
+      createNotificationWithPolicy(database, {
         actorId: targetActor.id,
         type: NotificationType.enum.follow,
         sourceActorId: followerActor.id,

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -15,6 +15,7 @@ import {
   getSubject as getReplySubject,
   getTextContent as getReplyTextContent
 } from '@/lib/services/email/templates/reply'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
@@ -460,7 +461,7 @@ export const createNoteFromUserInput = async ({
     eligibleNotificationActorIds.has(replyStatus.actorId)
   ) {
     notificationPromises.push(
-      database.createNotification({
+      createNotificationWithPolicy(database, {
         actorId: replyStatus.actorId,
         type: NotificationType.enum.reply,
         sourceActorId: currentActor.id,
@@ -476,7 +477,7 @@ export const createNoteFromUserInput = async ({
     // Don't create notification for self-mentions
     if (eligibleNotificationActorIds.has(mentionedActorId)) {
       notificationPromises.push(
-        database.createNotification({
+        createNotificationWithPolicy(database, {
           actorId: mentionedActorId,
           type: NotificationType.enum.mention,
           sourceActorId: currentActor.id,

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -444,7 +444,6 @@ export const createNoteFromUserInput = async ({
     replyVisibility === 'direct'
       ? mentionTags
       : recipientMentions
-  const notificationPromises = []
   const eligibleNotificationActorIds = await getNotificationEligibleActorIds(
     database,
     [
@@ -454,13 +453,19 @@ export const createNoteFromUserInput = async ({
     currentActor.id
   )
 
+  // Map actorId → notification promise so we can gate alert dispatch on the verdict.
+  const notificationEntries: Array<
+    [string, ReturnType<typeof createNotificationWithPolicy>]
+  > = []
+
   // Create reply notification if this is a reply
   if (
     shouldNotifyReply &&
     replyStatus &&
     eligibleNotificationActorIds.has(replyStatus.actorId)
   ) {
-    notificationPromises.push(
+    notificationEntries.push([
+      replyStatus.actorId,
       createNotificationWithPolicy(database, {
         actorId: replyStatus.actorId,
         type: NotificationType.enum.reply,
@@ -468,7 +473,7 @@ export const createNoteFromUserInput = async ({
         statusId,
         groupKey: `reply:${replyStatus.id}`
       })
-    )
+    ])
   }
 
   // Create mention notifications
@@ -476,7 +481,8 @@ export const createNoteFromUserInput = async ({
     const mentionedActorId = mention.href
     // Don't create notification for self-mentions
     if (eligibleNotificationActorIds.has(mentionedActorId)) {
-      notificationPromises.push(
+      notificationEntries.push([
+        mentionedActorId,
         createNotificationWithPolicy(database, {
           actorId: mentionedActorId,
           type: NotificationType.enum.mention,
@@ -484,13 +490,22 @@ export const createNoteFromUserInput = async ({
           statusId,
           groupKey: `mention:${statusId}`
         })
-      )
+      ])
     }
   }
 
-  if (notificationPromises.length > 0) {
-    await Promise.all(notificationPromises)
-  }
+  // Only send push/email alerts for notifications that were accepted (non-null, filtered=false).
+  const notificationResults = await Promise.all(
+    notificationEntries.map(([, p]) => p)
+  )
+  const alertActorIds = new Set(
+    notificationEntries
+      .filter((_, i) => {
+        const n = notificationResults[i]
+        return n !== null && !n.filtered
+      })
+      .map(([actorId]) => actorId)
+  )
 
   const status = (await database.getStatus({
     statusId,
@@ -508,7 +523,7 @@ export const createNoteFromUserInput = async ({
   if (
     shouldNotifyReply &&
     replyStatus &&
-    eligibleNotificationActorIds.has(replyStatus.actorId)
+    alertActorIds.has(replyStatus.actorId)
   ) {
     seenActorIds.add(replyStatus.actorId)
     database
@@ -542,7 +557,7 @@ export const createNoteFromUserInput = async ({
     const mentionedActorId = mention.href
     if (
       !seenActorIds.has(mentionedActorId) &&
-      eligibleNotificationActorIds.has(mentionedActorId)
+      alertActorIds.has(mentionedActorId)
     ) {
       seenActorIds.add(mentionedActorId)
       database

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -5,6 +5,7 @@ import {
   getSubject,
   getTextContent
 } from '@/lib/services/email/templates/like'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
 import { NotificationType } from '@/lib/types/database/operations'
@@ -34,7 +35,7 @@ export const likeRequest = async ({
     status &&
     (await shouldCreateNotification(database, status.actorId, request.actor))
   ) {
-    await database.createNotification({
+    await createNotificationWithPolicy(database, {
       actorId: status.actorId,
       type: NotificationType.enum.like,
       sourceActorId: request.actor,

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -35,7 +35,7 @@ export const likeRequest = async ({
     status &&
     (await shouldCreateNotification(database, status.actorId, request.actor))
   ) {
-    await createNotificationWithPolicy(database, {
+    const likeNotification = await createNotificationWithPolicy(database, {
       actorId: status.actorId,
       type: NotificationType.enum.like,
       sourceActorId: request.actor,
@@ -43,35 +43,37 @@ export const likeRequest = async ({
       groupKey: `like:${status.id}`
     })
 
-    // Fire-and-forget: notification delivery must not fail the like action
-    Promise.all([
-      database.getActorFromId({ id: status.actorId }),
-      database.getActorFromId({ id: request.actor })
-    ])
-      .then(([targetActor, sourceActor]) => {
-        if (!sourceActor) return
-        const editableStatus = getOriginalStatus(status)
-        sendNotificationAlerts({
-          database,
-          actorId: status.actorId,
-          sourceActorId: request.actor,
-          sourceActor,
-          statusId: status.id,
-          events: [
-            {
-              type: NotificationType.enum.like,
-              emailContent: targetActor?.account
-                ? {
-                    recipientEmail: targetActor.account.email,
-                    subject: getSubject(sourceActor),
-                    text: getTextContent(sourceActor, editableStatus),
-                    html: getHTMLContent(sourceActor, editableStatus)
-                  }
-                : undefined
-            }
-          ]
+    if (likeNotification && !likeNotification.filtered) {
+      // Fire-and-forget: notification delivery must not fail the like action
+      Promise.all([
+        database.getActorFromId({ id: status.actorId }),
+        database.getActorFromId({ id: request.actor })
+      ])
+        .then(([targetActor, sourceActor]) => {
+          if (!sourceActor) return
+          const editableStatus = getOriginalStatus(status)
+          sendNotificationAlerts({
+            database,
+            actorId: status.actorId,
+            sourceActorId: request.actor,
+            sourceActor,
+            statusId: status.id,
+            events: [
+              {
+                type: NotificationType.enum.like,
+                emailContent: targetActor?.account
+                  ? {
+                      recipientEmail: targetActor.account.email,
+                      subject: getSubject(sourceActor),
+                      text: getTextContent(sourceActor, editableStatus),
+                      html: getHTMLContent(sourceActor, editableStatus)
+                    }
+                  : undefined
+              }
+            ]
+          })
         })
-      })
-      .catch(() => undefined)
+        .catch(() => undefined)
+    }
   }
 }

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -661,6 +661,45 @@ describe('ActorDatabase', () => {
       })
     })
 
+    describe('notification policy', () => {
+      const policyActorId = `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`
+
+      it('returns the all-accept default when unset', async () => {
+        const policy = await database.getNotificationPolicy({
+          actorId: policyActorId
+        })
+        expect(policy).toEqual({
+          for_not_following: 'accept',
+          for_not_followers: 'accept',
+          for_new_accounts: 'accept',
+          for_private_mentions: 'accept',
+          for_limited_accounts: 'accept'
+        })
+      })
+
+      it('merges partial updates over the existing policy', async () => {
+        await database.updateNotificationPolicy({
+          actorId: policyActorId,
+          for_not_following: 'filter'
+        })
+        await database.updateNotificationPolicy({
+          actorId: policyActorId,
+          for_new_accounts: 'drop'
+        })
+
+        const policy = await database.getNotificationPolicy({
+          actorId: policyActorId
+        })
+        expect(policy).toEqual({
+          for_not_following: 'filter',
+          for_not_followers: 'accept',
+          for_new_accounts: 'drop',
+          for_private_mentions: 'accept',
+          for_limited_accounts: 'accept'
+        })
+      })
+    })
+
     describe('#updateActor', () => {
       it('updates actor information and returns it in mastodon actor', async () => {
         await database.updateActor({

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -827,11 +827,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
           const toAdd = appendNotificationAcceptedSenders.filter(
             (id) => !existing.has(id)
           )
-          // Always use the fresh value so a concurrent write to
-          // notificationAcceptedSenders is never clobbered, even when toAdd
-          // is empty (all IDs were already present in the fresh row).
+          // Base the merge on freshSettings so all settings fields (policy,
+          // email/push notifications, etc.) come from the locked row, not the
+          // stale pre-transaction snapshot. This prevents concurrent settings
+          // changes from being clobbered by this write.
           finalSettings = {
-            ...finalSettings,
+            ...freshSettings,
             notificationAcceptedSenders: [...existing, ...toAdd]
           }
         }

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -758,6 +758,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     pushNotifications,
     notificationPolicy,
     notificationAcceptedSenders,
+    appendNotificationAcceptedSenders,
     fitness,
 
     publicKey,
@@ -785,6 +786,16 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(notificationPolicy !== undefined ? { notificationPolicy } : null),
       ...(notificationAcceptedSenders !== undefined
         ? { notificationAcceptedSenders }
+        : null),
+      ...(appendNotificationAcceptedSenders !== undefined
+        ? {
+            notificationAcceptedSenders: [
+              ...new Set([
+                ...(persistedSettings?.notificationAcceptedSenders ?? []),
+                ...appendNotificationAcceptedSenders
+              ])
+            ]
+          }
         : null),
       ...(fitness !== undefined ? { fitness } : null),
 

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -827,11 +827,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
           const toAdd = appendNotificationAcceptedSenders.filter(
             (id) => !existing.has(id)
           )
-          if (toAdd.length > 0) {
-            finalSettings = {
-              ...finalSettings,
-              notificationAcceptedSenders: [...existing, ...toAdd]
-            }
+          // Always use the fresh value so a concurrent write to
+          // notificationAcceptedSenders is never clobbered, even when toAdd
+          // is empty (all IDs were already present in the fresh row).
+          finalSettings = {
+            ...finalSettings,
+            notificationAcceptedSenders: [...existing, ...toAdd]
           }
         }
       }

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -41,6 +41,7 @@ import {
   ActorDatabase,
   CancelActorDeletionParams,
   CreateActorParams,
+  DEFAULT_NOTIFICATION_POLICY,
   DeleteActorDataParams,
   DeleteActorParams,
   GetActorFollowersCountParams,
@@ -53,9 +54,11 @@ import {
   GetActorsScheduledForDeletionParams,
   IsCurrentActorFollowingParams,
   IsInternalActorParams,
+  NotificationPolicy,
   ScheduleActorDeletionParams,
   StartActorDeletionParams,
-  UpdateActorParams
+  UpdateActorParams,
+  UpdateNotificationPolicyParams
 } from '@/lib/types/database/operations'
 import { ActorSettings, SQLAccount, SQLActor } from '@/lib/types/database/rows'
 import { Account } from '@/lib/types/domain/account'
@@ -753,6 +756,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     postLineLimit,
     emailNotifications,
     pushNotifications,
+    notificationPolicy,
     fitness,
 
     publicKey,
@@ -777,6 +781,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(postLineLimit !== undefined ? { postLineLimit } : null),
       ...(emailNotifications !== undefined ? { emailNotifications } : null),
       ...(pushNotifications !== undefined ? { pushNotifications } : null),
+      ...(notificationPolicy !== undefined ? { notificationPolicy } : null),
       ...(fitness !== undefined ? { fitness } : null),
 
       ...(followersUrl ? { followersUrl } : null),
@@ -897,6 +902,24 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       .first()
     if (!persistedActor) return undefined
     return getCompatibleJSON(persistedActor.settings) as ActorSettings
+  },
+
+  async getNotificationPolicy({ actorId }: GetActorSettingsParams) {
+    const settings = await this.getActorSettings({ actorId })
+    return {
+      ...DEFAULT_NOTIFICATION_POLICY,
+      ...(settings?.notificationPolicy ?? {})
+    }
+  },
+
+  async updateNotificationPolicy({
+    actorId,
+    ...partial
+  }: UpdateNotificationPolicyParams) {
+    const current = await this.getNotificationPolicy({ actorId })
+    const notificationPolicy: NotificationPolicy = { ...current, ...partial }
+    await this.updateActor({ actorId, notificationPolicy })
+    return notificationPolicy
   },
 
   async scheduleActorDeletion({

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -757,6 +757,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     emailNotifications,
     pushNotifications,
     notificationPolicy,
+    notificationAcceptedSenders,
     fitness,
 
     publicKey,
@@ -782,6 +783,9 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(emailNotifications !== undefined ? { emailNotifications } : null),
       ...(pushNotifications !== undefined ? { pushNotifications } : null),
       ...(notificationPolicy !== undefined ? { notificationPolicy } : null),
+      ...(notificationAcceptedSenders !== undefined
+        ? { notificationAcceptedSenders }
+        : null),
       ...(fitness !== undefined ? { fitness } : null),
 
       ...(followersUrl ? { followersUrl } : null),

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -24,7 +24,8 @@ import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   chunkArray,
   deleteRowsByColumnChunks,
-  getWhereInBatchSize
+  getWhereInBatchSize,
+  isPostgresClient
 } from '@/lib/database/sql/utils/knex'
 import { parseStatusContent } from '@/lib/database/sql/utils/parseStatusContent'
 import { selectHashtagTagsByStatusIds } from '@/lib/database/sql/utils/status'
@@ -787,16 +788,8 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(notificationAcceptedSenders !== undefined
         ? { notificationAcceptedSenders }
         : null),
-      ...(appendNotificationAcceptedSenders !== undefined
-        ? {
-            notificationAcceptedSenders: [
-              ...new Set([
-                ...(persistedSettings?.notificationAcceptedSenders ?? []),
-                ...appendNotificationAcceptedSenders
-              ])
-            ]
-          }
-        : null),
+      // appendNotificationAcceptedSenders is handled inside the transaction
+      // with a fresh read to prevent lost-update races.
       ...(fitness !== undefined ? { fitness } : null),
 
       ...(followersUrl ? { followersUrl } : null),
@@ -816,6 +809,33 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     }
 
     await database.transaction(async (trx) => {
+      let finalSettings = settings
+
+      if (appendNotificationAcceptedSenders !== undefined) {
+        // Re-read inside the transaction (with row lock on PostgreSQL) to merge
+        // accepted senders atomically and avoid lost-update races.
+        const freshActorQuery = trx<SQLActor>('actors').where('id', actorId)
+        if (isPostgresClient(database)) freshActorQuery.forUpdate()
+        const freshActor = await freshActorQuery.first()
+        if (freshActor) {
+          const freshSettings = getCompatibleJSON<ActorSettings>(
+            freshActor.settings
+          )
+          const existing = new Set(
+            freshSettings?.notificationAcceptedSenders ?? []
+          )
+          const toAdd = appendNotificationAcceptedSenders.filter(
+            (id) => !existing.has(id)
+          )
+          if (toAdd.length > 0) {
+            finalSettings = {
+              ...finalSettings,
+              notificationAcceptedSenders: [...existing, ...toAdd]
+            }
+          }
+        }
+      }
+
       await trx<SQLActor>('actors')
         .where('id', actorId)
         .update({
@@ -825,12 +845,12 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
           ...(publicKey ? { publicKey } : null),
 
-          settings: JSON.stringify(settings),
+          settings: JSON.stringify(finalSettings),
           updatedAt: currentTime
         })
       await indexActorSearchDocument(trx, {
         id: actorId,
-        actor: updatedActor
+        actor: { ...updatedActor, settings: JSON.stringify(finalSettings) }
       })
     })
     return this.getActorFromId({ id: actorId })

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -391,6 +391,124 @@ describe('Notification Database', () => {
       })
     })
 
+    describe('notification requests', () => {
+      const actor3Id = 'https://example.com/users/actor3'
+
+      beforeEach(async () => {
+        const existing = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 100,
+          includeFiltered: true
+        })
+        for (const notif of existing) {
+          await database.deleteNotification(notif.id)
+        }
+
+        // Two filtered notifications from actor2, one from actor3, plus one
+        // accepted (unfiltered) notification that must never appear as a request.
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.mention,
+          sourceActorId: actor2Id,
+          statusId,
+          filtered: true
+        })
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.like,
+          sourceActorId: actor2Id,
+          statusId,
+          filtered: true
+        })
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: actor3Id,
+          filtered: true
+        })
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.like,
+          sourceActorId: actor2Id,
+          statusId
+        })
+      })
+
+      it('groups filtered notifications by source actor', async () => {
+        const requests = await database.getNotificationRequests({
+          actorId: actor1Id,
+          limit: 40
+        })
+
+        expect(requests).toHaveLength(2)
+        const actor2Request = requests.find((r) => r.sourceActorId === actor2Id)
+        expect(actor2Request?.notificationsCount).toBe(2)
+        expect(actor2Request?.lastNotification.filtered).toBe(true)
+      })
+
+      it('counts distinct source actors with filtered notifications', async () => {
+        const count = await database.getNotificationRequestsCount({
+          actorId: actor1Id
+        })
+        expect(count).toBe(2)
+      })
+
+      it('fetches a single request by source actor', async () => {
+        const request = await database.getNotificationRequest({
+          actorId: actor1Id,
+          sourceActorId: actor2Id
+        })
+        expect(request?.notificationsCount).toBe(2)
+
+        const missing = await database.getNotificationRequest({
+          actorId: actor1Id,
+          sourceActorId: 'https://example.com/users/nobody'
+        })
+        expect(missing).toBeNull()
+      })
+
+      it('accept clears the filtered flag and surfaces notifications', async () => {
+        await database.acceptNotificationRequests({
+          actorId: actor1Id,
+          sourceActorIds: [actor2Id]
+        })
+
+        const remaining = await database.getNotificationRequests({
+          actorId: actor1Id,
+          limit: 40
+        })
+        expect(remaining.map((r) => r.sourceActorId)).toEqual([actor3Id])
+
+        // The two accepted notifications now show in the default (unfiltered) list.
+        const visible = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 40
+        })
+        const fromActor2 = visible.filter((n) => n.sourceActorId === actor2Id)
+        expect(fromActor2).toHaveLength(3)
+        expect(fromActor2.every((n) => n.filtered === false)).toBe(true)
+      })
+
+      it('dismiss deletes the filtered notifications', async () => {
+        await database.dismissNotificationRequests({
+          actorId: actor1Id,
+          sourceActorIds: [actor2Id]
+        })
+
+        const all = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 40,
+          includeFiltered: true
+        })
+        const filteredFromActor2 = all.filter(
+          (n) => n.sourceActorId === actor2Id && n.filtered
+        )
+        expect(filteredFromActor2).toHaveLength(0)
+        // The previously-accepted actor2 notification is untouched.
+        expect(all.filter((n) => n.sourceActorId === actor2Id)).toHaveLength(1)
+      })
+    })
+
     describe('deleteNotification', () => {
       it('should delete a notification', async () => {
         const notification = await database.createNotification({

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -268,9 +268,9 @@ export const NotificationSQLDatabaseMixin = (
       .limit(limit)
 
     if (maxUpdatedAt !== undefined) {
-      query = query.havingRaw('MAX(createdAt) < ?', [maxUpdatedAt])
+      query = query.havingRaw('MAX(createdAt) < ?', [new Date(maxUpdatedAt)])
     } else if (sinceUpdatedAt !== undefined) {
-      query = query.havingRaw('MAX(createdAt) > ?', [sinceUpdatedAt])
+      query = query.havingRaw('MAX(createdAt) > ?', [new Date(sinceUpdatedAt)])
     } else {
       query = query.offset(offset)
     }

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex'
 
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { chunkArray, getWhereInBatchSize } from '@/lib/database/sql/utils/knex'
 import {
   CreateNotificationParams,
   GetNotificationRequestParams,
@@ -244,9 +245,11 @@ export const NotificationSQLDatabaseMixin = (
   async getNotificationRequests({
     actorId,
     limit,
-    offset = 0
+    offset = 0,
+    maxUpdatedAt,
+    sinceUpdatedAt
   }: GetNotificationRequestsParams) {
-    const groups = await database('notifications')
+    let query = database('notifications')
       .where('actorId', actorId)
       .andWhere('filtered', true)
       .groupBy('sourceActorId')
@@ -263,20 +266,31 @@ export const NotificationSQLDatabaseMixin = (
       .max('createdAt as lastCreatedAt')
       .orderBy('lastCreatedAt', 'desc')
       .limit(limit)
-      .offset(offset)
 
-    const requests: NotificationRequest[] = []
-    for (const group of groups) {
-      const request = await buildNotificationRequest(
-        database,
-        actorId,
-        group.sourceActorId,
-        Number(group.count),
-        group.firstCreatedAt,
-        group.lastCreatedAt
-      )
-      if (request) requests.push(request)
+    if (maxUpdatedAt !== undefined) {
+      query = query.havingRaw('MAX(createdAt) < ?', [maxUpdatedAt])
+    } else if (sinceUpdatedAt !== undefined) {
+      query = query.havingRaw('MAX(createdAt) > ?', [sinceUpdatedAt])
+    } else {
+      query = query.offset(offset)
     }
+
+    const groups = await query
+
+    const requests = (
+      await Promise.all(
+        groups.map((group) =>
+          buildNotificationRequest(
+            database,
+            actorId,
+            group.sourceActorId,
+            Number(group.count),
+            group.firstCreatedAt,
+            group.lastCreatedAt
+          )
+        )
+      )
+    ).filter((r): r is NotificationRequest => r !== null)
     return requests
   },
 
@@ -326,11 +340,16 @@ export const NotificationSQLDatabaseMixin = (
     sourceActorIds
   }: ResolveNotificationRequestsParams) {
     if (sourceActorIds.length === 0) return
-    await database('notifications')
-      .where('actorId', actorId)
-      .andWhere('filtered', true)
-      .whereIn('sourceActorId', sourceActorIds)
-      .update({ filtered: false, updatedAt: new Date() })
+    const batchSize = getWhereInBatchSize(database)
+    await Promise.all(
+      chunkArray(sourceActorIds, batchSize).map((chunk) =>
+        database('notifications')
+          .where('actorId', actorId)
+          .andWhere('filtered', true)
+          .whereIn('sourceActorId', chunk)
+          .update({ filtered: false, updatedAt: new Date() })
+      )
+    )
   },
 
   async dismissNotificationRequests({
@@ -338,11 +357,16 @@ export const NotificationSQLDatabaseMixin = (
     sourceActorIds
   }: ResolveNotificationRequestsParams) {
     if (sourceActorIds.length === 0) return
-    await database('notifications')
-      .where('actorId', actorId)
-      .andWhere('filtered', true)
-      .whereIn('sourceActorId', sourceActorIds)
-      .delete()
+    const batchSize = getWhereInBatchSize(database)
+    await Promise.all(
+      chunkArray(sourceActorIds, batchSize).map((chunk) =>
+        database('notifications')
+          .where('actorId', actorId)
+          .andWhere('filtered', true)
+          .whereIn('sourceActorId', chunk)
+          .delete()
+      )
+    )
   },
 
   async deleteNotification(notificationId: string) {

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -246,8 +246,8 @@ export const NotificationSQLDatabaseMixin = (
     actorId,
     limit,
     offset = 0,
-    maxUpdatedAt,
-    sinceUpdatedAt
+    maxCursor,
+    sinceCursor
   }: GetNotificationRequestsParams) {
     let query = database('notifications')
       .where('actorId', actorId)
@@ -265,12 +265,31 @@ export const NotificationSQLDatabaseMixin = (
       .min('createdAt as firstCreatedAt')
       .max('createdAt as lastCreatedAt')
       .orderBy('lastCreatedAt', 'desc')
+      .orderBy('sourceActorId', 'asc')
       .limit(limit)
 
-    if (maxUpdatedAt !== undefined) {
-      query = query.havingRaw('MAX(createdAt) < ?', [new Date(maxUpdatedAt)])
-    } else if (sinceUpdatedAt !== undefined) {
-      query = query.havingRaw('MAX(createdAt) > ?', [new Date(sinceUpdatedAt)])
+    if (maxCursor !== undefined) {
+      // Groups older than cursor: (MAX(createdAt) < cursor) OR
+      // (MAX(createdAt) = cursor AND sourceActorId > cursor.sourceActorId)
+      query = query.havingRaw(
+        'MAX(createdAt) < ? OR (MAX(createdAt) = ? AND sourceActorId > ?)',
+        [
+          new Date(maxCursor.updatedAt),
+          new Date(maxCursor.updatedAt),
+          maxCursor.sourceActorId
+        ]
+      )
+    } else if (sinceCursor !== undefined) {
+      // Groups newer than cursor: (MAX(createdAt) > cursor) OR
+      // (MAX(createdAt) = cursor AND sourceActorId < cursor.sourceActorId)
+      query = query.havingRaw(
+        'MAX(createdAt) > ? OR (MAX(createdAt) = ? AND sourceActorId < ?)',
+        [
+          new Date(sinceCursor.updatedAt),
+          new Date(sinceCursor.updatedAt),
+          sinceCursor.sourceActorId
+        ]
+      )
     } else {
       query = query.offset(offset)
     }
@@ -327,12 +346,14 @@ export const NotificationSQLDatabaseMixin = (
   },
 
   async getNotificationRequestsCount({ actorId }: { actorId: string }) {
+    // Mastodon caps pending_requests_count at 100 in the policy summary.
+    const MAX_REQUESTS_COUNT = 100
     const result = await database('notifications')
       .where('actorId', actorId)
       .andWhere('filtered', true)
       .countDistinct<{ count: string }>('sourceActorId as count')
       .first()
-    return parseInt(result?.count ?? '0', 10)
+    return Math.min(parseInt(result?.count ?? '0', 10), MAX_REQUESTS_COUNT)
   },
 
   async acceptNotificationRequests({

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -3,11 +3,15 @@ import { Knex } from 'knex'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   CreateNotificationParams,
+  GetNotificationRequestParams,
+  GetNotificationRequestsParams,
   GetNotificationsCountParams,
   GetNotificationsParams,
   MarkNotificationsReadParams,
   Notification,
   NotificationDatabase,
+  NotificationRequest,
+  ResolveNotificationRequestsParams,
   UpdateNotificationParams
 } from '@/lib/types/database/operations'
 
@@ -159,11 +163,14 @@ export const NotificationSQLDatabaseMixin = (
     types,
     excludeTypes,
     limit,
-    includeFiltered
+    includeFiltered,
+    filteredOnly
   }: GetNotificationsCountParams) {
     let query = database('notifications').where('actorId', actorId)
 
-    if (!includeFiltered) {
+    if (filteredOnly) {
+      query = query.where('filtered', true)
+    } else if (!includeFiltered) {
       query = query.where('filtered', false)
     }
 
@@ -234,7 +241,139 @@ export const NotificationSQLDatabaseMixin = (
     await database('notifications').where('id', notificationId).update(updates)
   },
 
+  async getNotificationRequests({
+    actorId,
+    limit,
+    offset = 0
+  }: GetNotificationRequestsParams) {
+    const groups = await database('notifications')
+      .where('actorId', actorId)
+      .andWhere('filtered', true)
+      .groupBy('sourceActorId')
+      .select('sourceActorId')
+      .count<
+        {
+          sourceActorId: string
+          count: string | number
+          firstCreatedAt: number | Date | string
+          lastCreatedAt: number | Date | string
+        }[]
+      >('* as count')
+      .min('createdAt as firstCreatedAt')
+      .max('createdAt as lastCreatedAt')
+      .orderBy('lastCreatedAt', 'desc')
+      .limit(limit)
+      .offset(offset)
+
+    const requests: NotificationRequest[] = []
+    for (const group of groups) {
+      const request = await buildNotificationRequest(
+        database,
+        actorId,
+        group.sourceActorId,
+        Number(group.count),
+        group.firstCreatedAt,
+        group.lastCreatedAt
+      )
+      if (request) requests.push(request)
+    }
+    return requests
+  },
+
+  async getNotificationRequest({
+    actorId,
+    sourceActorId
+  }: GetNotificationRequestParams) {
+    const group = await database('notifications')
+      .where('actorId', actorId)
+      .andWhere('filtered', true)
+      .andWhere('sourceActorId', sourceActorId)
+      .groupBy('sourceActorId')
+      .select('sourceActorId')
+      .count<
+        {
+          count: string | number
+          firstCreatedAt: number | Date | string
+          lastCreatedAt: number | Date | string
+        }[]
+      >('* as count')
+      .min('createdAt as firstCreatedAt')
+      .max('createdAt as lastCreatedAt')
+      .first()
+    if (!group) return null
+
+    return buildNotificationRequest(
+      database,
+      actorId,
+      sourceActorId,
+      Number(group.count),
+      group.firstCreatedAt,
+      group.lastCreatedAt
+    )
+  },
+
+  async getNotificationRequestsCount({ actorId }: { actorId: string }) {
+    const result = await database('notifications')
+      .where('actorId', actorId)
+      .andWhere('filtered', true)
+      .countDistinct<{ count: string }>('sourceActorId as count')
+      .first()
+    return parseInt(result?.count ?? '0', 10)
+  },
+
+  async acceptNotificationRequests({
+    actorId,
+    sourceActorIds
+  }: ResolveNotificationRequestsParams) {
+    if (sourceActorIds.length === 0) return
+    await database('notifications')
+      .where('actorId', actorId)
+      .andWhere('filtered', true)
+      .whereIn('sourceActorId', sourceActorIds)
+      .update({ filtered: false, updatedAt: new Date() })
+  },
+
+  async dismissNotificationRequests({
+    actorId,
+    sourceActorIds
+  }: ResolveNotificationRequestsParams) {
+    if (sourceActorIds.length === 0) return
+    await database('notifications')
+      .where('actorId', actorId)
+      .andWhere('filtered', true)
+      .whereIn('sourceActorId', sourceActorIds)
+      .delete()
+  },
+
   async deleteNotification(notificationId: string) {
     await database('notifications').where('id', notificationId).delete()
   }
 })
+
+// Resolves the most recent filtered notification from a source actor and packs
+// it with the group counts into a NotificationRequest.
+const buildNotificationRequest = async (
+  database: Knex,
+  actorId: string,
+  sourceActorId: string,
+  notificationsCount: number,
+  firstCreatedAt: number | Date | string,
+  lastCreatedAt: number | Date | string
+): Promise<NotificationRequest | null> => {
+  const last = await database<Notification>('notifications')
+    .where('actorId', actorId)
+    .andWhere('filtered', true)
+    .andWhere('sourceActorId', sourceActorId)
+    .orderBy('createdAt', 'desc')
+    .orderBy('id', 'desc')
+    .first()
+  if (!last) return null
+
+  return {
+    sourceActorId,
+    notificationsCount,
+    lastNotification: fixNotificationDataDate(last),
+    createdAt: getCompatibleTime(firstCreatedAt),
+    updatedAt: getCompatibleTime(lastCreatedAt)
+  }
+}

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -17,6 +17,7 @@ import {
 import { saveFitnessFile } from '@/lib/services/fitness-files'
 import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
 import { saveMedia } from '@/lib/services/medias/index'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { getQueue } from '@/lib/services/queue'
 import {
   StravaActivity,
@@ -553,7 +554,7 @@ export const importStravaActivityJob = createJobHandle(
         })
 
         if (isNewFallback) {
-          await database.createNotification({
+          await createNotificationWithPolicy(database, {
             actorId,
             type: 'activity_import',
             sourceActorId: actorId,
@@ -689,7 +690,7 @@ export const importStravaActivityJob = createJobHandle(
     })
 
     if (isNewImport) {
-      await database.createNotification({
+      await createNotificationWithPolicy(database, {
         actorId,
         type: 'activity_import',
         sourceActorId: actorId,

--- a/lib/services/notifications/createNotificationWithPolicy.ts
+++ b/lib/services/notifications/createNotificationWithPolicy.ts
@@ -1,0 +1,34 @@
+import { Database } from '@/lib/database/types'
+import { evaluateNotificationPolicy } from '@/lib/services/notifications/evaluateNotificationPolicy'
+import {
+  CreateNotificationParams,
+  Notification
+} from '@/lib/types/database/operations'
+
+/**
+ * Creates a notification, applying the recipient's notification policy:
+ * - drop   → nothing is persisted, returns null
+ * - filter → persisted with filtered = true (lands in the requests queue)
+ * - accept → persisted with filtered = false (shows in the main timeline)
+ *
+ * This is the single enforcement seam for all notification creation. Call this
+ * instead of database.createNotification from application code.
+ */
+export const createNotificationWithPolicy = async (
+  database: Database,
+  params: CreateNotificationParams
+): Promise<Notification | null> => {
+  const verdict = await evaluateNotificationPolicy(database, {
+    actorId: params.actorId,
+    type: params.type,
+    sourceActorId: params.sourceActorId,
+    statusId: params.statusId
+  })
+
+  if (verdict === 'drop') return null
+
+  return database.createNotification({
+    ...params,
+    filtered: verdict === 'filter'
+  })
+}

--- a/lib/services/notifications/evaluateNotificationPolicy.test.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.test.ts
@@ -11,6 +11,7 @@ const NOW = 1_700_000_000_000
 
 type MockDb = {
   getNotificationPolicy: jest.Mock
+  getActorSettings: jest.Mock
   isCurrentActorFollowing: jest.Mock
   getActorFromId: jest.Mock
   getStatus: jest.Mock
@@ -24,6 +25,8 @@ const createDatabase = (
     getNotificationPolicy: jest
       .fn()
       .mockResolvedValue({ ...DEFAULT_NOTIFICATION_POLICY, ...policy }),
+    // Default: no accepted senders list.
+    getActorSettings: jest.fn().mockResolvedValue(undefined),
     // Default: neither side follows the other.
     isCurrentActorFollowing: jest.fn().mockResolvedValue(false),
     getActorFromId: jest.fn().mockResolvedValue({ createdAt: 0 }),

--- a/lib/services/notifications/evaluateNotificationPolicy.test.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.test.ts
@@ -1,0 +1,183 @@
+import { Database } from '@/lib/database/types'
+import { evaluateNotificationPolicy } from '@/lib/services/notifications/evaluateNotificationPolicy'
+import {
+  DEFAULT_NOTIFICATION_POLICY,
+  NotificationPolicy
+} from '@/lib/types/database/operations'
+
+const RECIPIENT = 'https://llun.test/users/me'
+const SOURCE = 'https://other.test/users/stranger'
+const NOW = 1_700_000_000_000
+
+type MockDb = {
+  getNotificationPolicy: jest.Mock
+  isCurrentActorFollowing: jest.Mock
+  getActorFromId: jest.Mock
+  getStatus: jest.Mock
+}
+
+const createDatabase = (
+  policy: Partial<NotificationPolicy>,
+  overrides: Partial<MockDb> = {}
+): { database: Database; mock: MockDb } => {
+  const mock: MockDb = {
+    getNotificationPolicy: jest
+      .fn()
+      .mockResolvedValue({ ...DEFAULT_NOTIFICATION_POLICY, ...policy }),
+    // Default: neither side follows the other.
+    isCurrentActorFollowing: jest.fn().mockResolvedValue(false),
+    getActorFromId: jest.fn().mockResolvedValue({ createdAt: 0 }),
+    getStatus: jest.fn().mockResolvedValue(null),
+    ...overrides
+  }
+  return { database: mock as unknown as Database, mock }
+}
+
+describe('#evaluateNotificationPolicy', () => {
+  it('accepts notifications from yourself without consulting the policy', async () => {
+    const { database, mock } = createDatabase({ for_not_following: 'drop' })
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'like',
+      sourceActorId: RECIPIENT,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('accept')
+    expect(mock.getNotificationPolicy).not.toHaveBeenCalled()
+  })
+
+  it('short-circuits to accept when every dimension is accept', async () => {
+    const { database, mock } = createDatabase({})
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'like',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('accept')
+    expect(mock.isCurrentActorFollowing).not.toHaveBeenCalled()
+  })
+
+  it('filters when recipient does not follow a for_not_following=filter source', async () => {
+    const { database } = createDatabase({ for_not_following: 'filter' })
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'like',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('filter')
+  })
+
+  it('accepts when recipient already follows the source', async () => {
+    const { database } = createDatabase(
+      { for_not_following: 'drop' },
+      {
+        isCurrentActorFollowing: jest
+          .fn()
+          .mockImplementation(({ currentActorId }) =>
+            Promise.resolve(currentActorId === RECIPIENT)
+          )
+      }
+    )
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'like',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('accept')
+  })
+
+  it('returns the most restrictive verdict across matching dimensions', async () => {
+    const { database } = createDatabase({
+      for_not_following: 'filter',
+      for_not_followers: 'drop'
+    })
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'like',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('drop')
+  })
+
+  it('filters new accounts younger than 30 days', async () => {
+    const tenDaysAgo = NOW - 10 * 24 * 60 * 60 * 1000
+    const { database } = createDatabase(
+      { for_new_accounts: 'filter' },
+      { getActorFromId: jest.fn().mockResolvedValue({ createdAt: tenDaysAgo }) }
+    )
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'follow',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('filter')
+  })
+
+  it('accepts accounts older than 30 days under for_new_accounts', async () => {
+    const longAgo = NOW - 90 * 24 * 60 * 60 * 1000
+    const { database } = createDatabase(
+      { for_new_accounts: 'filter' },
+      { getActorFromId: jest.fn().mockResolvedValue({ createdAt: longAgo }) }
+    )
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'follow',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('accept')
+  })
+
+  it('filters direct mentions under for_private_mentions', async () => {
+    const { database } = createDatabase(
+      { for_private_mentions: 'filter' },
+      {
+        getStatus: jest.fn().mockResolvedValue({ to: [RECIPIENT], cc: [] })
+      }
+    )
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'mention',
+      sourceActorId: SOURCE,
+      statusId: 'https://other.test/statuses/1',
+      currentTime: NOW
+    })
+    expect(verdict).toBe('filter')
+  })
+
+  it('does not apply for_private_mentions to public mentions', async () => {
+    const { database } = createDatabase(
+      { for_private_mentions: 'drop' },
+      {
+        getStatus: jest.fn().mockResolvedValue({
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: []
+        })
+      }
+    )
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'mention',
+      sourceActorId: SOURCE,
+      statusId: 'https://other.test/statuses/1',
+      currentTime: NOW
+    })
+    expect(verdict).toBe('accept')
+  })
+
+  it('never enforces for_limited_accounts (no-op)', async () => {
+    const { database } = createDatabase({ for_limited_accounts: 'drop' })
+    const verdict = await evaluateNotificationPolicy(database, {
+      actorId: RECIPIENT,
+      type: 'like',
+      sourceActorId: SOURCE,
+      currentTime: NOW
+    })
+    expect(verdict).toBe('accept')
+  })
+})

--- a/lib/services/notifications/evaluateNotificationPolicy.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.ts
@@ -21,8 +21,9 @@ export const addAcceptedSender = async (
   sourceActorId: string
 ): Promise<void> => addAcceptedSenders(database, actorId, [sourceActorId])
 
-// Atomically appends sourceActorIds inside updateActor's transaction to
-// prevent concurrent accept calls clobbering each other's entries.
+// Appends sourceActorIds via updateActor's appendNotificationAcceptedSenders,
+// which re-reads the actor row inside a transaction (with SELECT FOR UPDATE on
+// PostgreSQL) to prevent concurrent accept calls clobbering each other.
 export const addAcceptedSenders = async (
   database: Database,
   actorId: string,

--- a/lib/services/notifications/evaluateNotificationPolicy.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.ts
@@ -21,21 +21,17 @@ export const addAcceptedSender = async (
   sourceActorId: string
 ): Promise<void> => addAcceptedSenders(database, actorId, [sourceActorId])
 
-// Appends all sourceActorIds in a single read-modify-write to avoid racing
-// concurrent accept calls clobbering each other's entries.
+// Atomically appends sourceActorIds inside updateActor's transaction to
+// prevent concurrent accept calls clobbering each other's entries.
 export const addAcceptedSenders = async (
   database: Database,
   actorId: string,
   sourceActorIds: string[]
 ): Promise<void> => {
   if (sourceActorIds.length === 0) return
-  const settings = await database.getActorSettings({ actorId })
-  const existing = new Set(settings?.notificationAcceptedSenders ?? [])
-  const toAdd = sourceActorIds.filter((id) => !existing.has(id))
-  if (toAdd.length === 0) return
   await database.updateActor({
     actorId,
-    notificationAcceptedSenders: [...existing, ...toAdd]
+    appendNotificationAcceptedSenders: sourceActorIds
   })
 }
 
@@ -142,14 +138,25 @@ export const evaluateNotificationPolicy = async (
     (type === 'mention' || type === 'reply')
   ) {
     const status = await database.getStatus({ statusId, withReplies: false })
-    // If the recipient already follows the source, direct messages from them
-    // are not subject to the private-mentions filter.
     if (
       status &&
       getVisibility(status.to, status.cc) === 'direct' &&
       !recipientFollowsSource
     ) {
-      candidates.push(policy.for_private_mentions)
+      // Exempt replies to threads the recipient initiated: if the replied-to
+      // status was authored by actorId, the source is replying to a DM the
+      // recipient sent, so it would be wrong to filter/drop the reply.
+      const replyId = 'reply' in status ? (status.reply as string) : null
+      const repliedToStatus = replyId
+        ? await database
+            .getStatus({ statusId: replyId, withReplies: false })
+            .catch(() => null)
+        : null
+      const isReplyToRecipientStatus = repliedToStatus?.actorId === actorId
+
+      if (!isReplyToRecipientStatus) {
+        candidates.push(policy.for_private_mentions)
+      }
     }
   }
 

--- a/lib/services/notifications/evaluateNotificationPolicy.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.ts
@@ -1,0 +1,100 @@
+import { Database } from '@/lib/database/types'
+import {
+  NotificationPolicyValue,
+  NotificationType
+} from '@/lib/types/database/operations'
+import { getVisibility } from '@/lib/utils/getVisibility'
+
+// Mastodon treats accounts younger than 30 days as "new".
+const NEW_ACCOUNT_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+const RANK: Record<NotificationPolicyValue, number> = {
+  accept: 0,
+  filter: 1,
+  drop: 2
+}
+
+const mostRestrictive = (
+  values: NotificationPolicyValue[]
+): NotificationPolicyValue =>
+  values.reduce<NotificationPolicyValue>(
+    (worst, value) => (RANK[value] > RANK[worst] ? value : worst),
+    'accept'
+  )
+
+export type EvaluateNotificationPolicyParams = {
+  actorId: string
+  type: NotificationType
+  sourceActorId: string
+  statusId?: string
+  currentTime?: number
+}
+
+/**
+ * Resolves whether a notification should be accepted (shown), filtered (routed
+ * to the per-sender requests queue), or dropped (discarded) according to the
+ * recipient's notification policy. When several dimensions match, the most
+ * restrictive verdict wins (drop > filter > accept).
+ *
+ * `for_limited_accounts` is intentionally a no-op: this codebase has no
+ * per-actor silence/limit moderation primitive (only domain-level severities),
+ * so a limited-accounts policy is stored but never enforced.
+ */
+export const evaluateNotificationPolicy = async (
+  database: Database,
+  {
+    actorId,
+    type,
+    sourceActorId,
+    statusId,
+    currentTime = Date.now()
+  }: EvaluateNotificationPolicyParams
+): Promise<NotificationPolicyValue> => {
+  // Notifications from yourself (e.g. activity imports) are never filtered.
+  if (sourceActorId === actorId) return 'accept'
+
+  const policy = await database.getNotificationPolicy({ actorId })
+  if (Object.values(policy).every((value) => value === 'accept')) {
+    return 'accept'
+  }
+
+  const candidates: NotificationPolicyValue[] = []
+
+  if (
+    policy.for_not_following !== 'accept' ||
+    policy.for_not_followers !== 'accept'
+  ) {
+    const [recipientFollowsSource, sourceFollowsRecipient] = await Promise.all([
+      database.isCurrentActorFollowing({
+        currentActorId: actorId,
+        followingActorId: sourceActorId
+      }),
+      database.isCurrentActorFollowing({
+        currentActorId: sourceActorId,
+        followingActorId: actorId
+      })
+    ])
+    if (!recipientFollowsSource) candidates.push(policy.for_not_following)
+    if (!sourceFollowsRecipient) candidates.push(policy.for_not_followers)
+  }
+
+  if (policy.for_new_accounts !== 'accept') {
+    const source = await database.getActorFromId({ id: sourceActorId })
+    if (source && currentTime - source.createdAt < NEW_ACCOUNT_AGE_MS) {
+      candidates.push(policy.for_new_accounts)
+    }
+  }
+
+  if (
+    policy.for_private_mentions !== 'accept' &&
+    statusId &&
+    (type === 'mention' || type === 'reply')
+  ) {
+    const status = await database.getStatus({ statusId, withReplies: false })
+    if (status && getVisibility(status.to, status.cc) === 'direct') {
+      candidates.push(policy.for_private_mentions)
+    }
+  }
+
+  return mostRestrictive(candidates)
+}

--- a/lib/services/notifications/evaluateNotificationPolicy.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.ts
@@ -5,6 +5,30 @@ import {
 } from '@/lib/types/database/operations'
 import { getVisibility } from '@/lib/utils/getVisibility'
 
+export const isAcceptedSender = async (
+  database: Database,
+  actorId: string,
+  sourceActorId: string
+): Promise<boolean> => {
+  const settings = await database.getActorSettings({ actorId })
+  const accepted = settings?.notificationAcceptedSenders ?? []
+  return accepted.includes(sourceActorId)
+}
+
+export const addAcceptedSender = async (
+  database: Database,
+  actorId: string,
+  sourceActorId: string
+): Promise<void> => {
+  const settings = await database.getActorSettings({ actorId })
+  const existing = settings?.notificationAcceptedSenders ?? []
+  if (existing.includes(sourceActorId)) return
+  await database.updateActor({
+    actorId,
+    notificationAcceptedSenders: [...existing, sourceActorId]
+  })
+}
+
 // Mastodon treats accounts younger than 30 days as "new".
 const NEW_ACCOUNT_AGE_MS = 30 * 24 * 60 * 60 * 1000
 
@@ -53,6 +77,9 @@ export const evaluateNotificationPolicy = async (
   // Notifications from yourself (e.g. activity imports) are never filtered.
   if (sourceActorId === actorId) return 'accept'
 
+  // Senders the user has explicitly accepted always bypass all policy dimensions.
+  if (await isAcceptedSender(database, actorId, sourceActorId)) return 'accept'
+
   const policy = await database.getNotificationPolicy({ actorId })
   if (Object.values(policy).every((value) => value === 'accept')) {
     return 'accept'
@@ -60,11 +87,19 @@ export const evaluateNotificationPolicy = async (
 
   const candidates: NotificationPolicyValue[] = []
 
+  // Resolve follow relationships once; used by both for_not_following,
+  // for_not_followers, and for_private_mentions (follows bypass DM filter).
+  let recipientFollowsSource: boolean | undefined
+  let sourceFollowsRecipient: boolean | undefined
+
   if (
     policy.for_not_following !== 'accept' ||
-    policy.for_not_followers !== 'accept'
+    policy.for_not_followers !== 'accept' ||
+    (policy.for_private_mentions !== 'accept' &&
+      statusId &&
+      (type === 'mention' || type === 'reply'))
   ) {
-    const [recipientFollowsSource, sourceFollowsRecipient] = await Promise.all([
+    ;[recipientFollowsSource, sourceFollowsRecipient] = await Promise.all([
       database.isCurrentActorFollowing({
         currentActorId: actorId,
         followingActorId: sourceActorId
@@ -74,6 +109,12 @@ export const evaluateNotificationPolicy = async (
         followingActorId: actorId
       })
     ])
+  }
+
+  if (
+    policy.for_not_following !== 'accept' ||
+    policy.for_not_followers !== 'accept'
+  ) {
     if (!recipientFollowsSource) candidates.push(policy.for_not_following)
     if (!sourceFollowsRecipient) candidates.push(policy.for_not_followers)
   }
@@ -91,7 +132,13 @@ export const evaluateNotificationPolicy = async (
     (type === 'mention' || type === 'reply')
   ) {
     const status = await database.getStatus({ statusId, withReplies: false })
-    if (status && getVisibility(status.to, status.cc) === 'direct') {
+    // If the recipient already follows the source, direct messages from them
+    // are not subject to the private-mentions filter.
+    if (
+      status &&
+      getVisibility(status.to, status.cc) === 'direct' &&
+      !recipientFollowsSource
+    ) {
       candidates.push(policy.for_private_mentions)
     }
   }

--- a/lib/services/notifications/evaluateNotificationPolicy.ts
+++ b/lib/services/notifications/evaluateNotificationPolicy.ts
@@ -19,13 +19,23 @@ export const addAcceptedSender = async (
   database: Database,
   actorId: string,
   sourceActorId: string
+): Promise<void> => addAcceptedSenders(database, actorId, [sourceActorId])
+
+// Appends all sourceActorIds in a single read-modify-write to avoid racing
+// concurrent accept calls clobbering each other's entries.
+export const addAcceptedSenders = async (
+  database: Database,
+  actorId: string,
+  sourceActorIds: string[]
 ): Promise<void> => {
+  if (sourceActorIds.length === 0) return
   const settings = await database.getActorSettings({ actorId })
-  const existing = settings?.notificationAcceptedSenders ?? []
-  if (existing.includes(sourceActorId)) return
+  const existing = new Set(settings?.notificationAcceptedSenders ?? [])
+  const toAdd = sourceActorIds.filter((id) => !existing.has(id))
+  if (toAdd.length === 0) return
   await database.updateActor({
     actorId,
-    notificationAcceptedSenders: [...existing, sourceActorId]
+    notificationAcceptedSenders: [...existing, ...toAdd]
   })
 }
 

--- a/lib/services/notifications/getMastodonNotificationRequest.ts
+++ b/lib/services/notifications/getMastodonNotificationRequest.ts
@@ -1,0 +1,49 @@
+import { Database } from '@/lib/database/types'
+import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { Mastodon } from '@/lib/types/activitypub'
+import { NotificationRequest } from '@/lib/types/database/operations'
+import { urlToId } from '@/lib/utils/urlToId'
+
+// Mastodon NotificationRequest entity. `notifications_count` is serialized as a
+// string by Mastodon; `id` and `account.id` are the source actor's account id.
+export interface MastodonNotificationRequest {
+  id: string
+  created_at: string
+  updated_at: string
+  notifications_count: string
+  account: Mastodon.Account
+  last_status?: Mastodon.Status
+}
+
+export const getMastodonNotificationRequest = async (
+  database: Database,
+  request: NotificationRequest,
+  currentActorId?: string
+): Promise<MastodonNotificationRequest | null> => {
+  const account = await database.getMastodonActorFromId({
+    id: request.sourceActorId
+  })
+  if (!account) return null
+
+  let lastStatus: Mastodon.Status | undefined
+  if (request.lastNotification.statusId) {
+    const statusData = await database.getStatus({
+      statusId: request.lastNotification.statusId,
+      withReplies: false
+    })
+    if (statusData) {
+      lastStatus =
+        (await getMastodonStatus(database, statusData, currentActorId)) ??
+        undefined
+    }
+  }
+
+  return {
+    id: urlToId(request.sourceActorId),
+    created_at: new Date(request.createdAt).toISOString(),
+    updated_at: new Date(request.updatedAt).toISOString(),
+    notifications_count: request.notificationsCount.toString(),
+    account,
+    last_status: lastStatus
+  }
+}

--- a/lib/services/timelines/mention.ts
+++ b/lib/services/timelines/mention.ts
@@ -65,14 +65,19 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
           })
           if (repliedStatus && repliedStatus.actorId === currentActor.id) {
             addToTimeline = true
-            await createNotificationWithPolicy(database, {
-              actorId: currentActor.id,
-              type: NotificationType.enum.reply,
-              sourceActorId: status.actorId,
-              statusId: status.id,
-              groupKey: `reply:${repliedStatus.id}`
-            })
-            alertEvents.push({ type: NotificationType.enum.reply })
+            const replyNotification = await createNotificationWithPolicy(
+              database,
+              {
+                actorId: currentActor.id,
+                type: NotificationType.enum.reply,
+                sourceActorId: status.actorId,
+                statusId: status.id,
+                groupKey: `reply:${repliedStatus.id}`
+              }
+            )
+            if (replyNotification && !replyNotification.filtered) {
+              alertEvents.push({ type: NotificationType.enum.reply })
+            }
           }
         } catch (error) {
           span.setStatus({
@@ -101,8 +106,9 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
         if (!status.isLocalActor) {
           // Error is recorded but not re-thrown: a notification DB failure
           // should not block the mention from being added to the timeline.
+          let mentionNotification = null
           try {
-            await createNotificationWithPolicy(database, {
+            mentionNotification = await createNotificationWithPolicy(database, {
               actorId: currentActor.id,
               type: NotificationType.enum.mention,
               sourceActorId: status.actorId,
@@ -119,18 +125,20 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
             )
           }
 
-          const mentionEvent: NotificationEvent = {
-            type: NotificationType.enum.mention
-          }
-          if (config.email && account && status.actor) {
-            mentionEvent.emailContent = {
-              recipientEmail: account.email,
-              subject: getSubject(status.actor),
-              text: getTextContent(status),
-              html: getHTMLContent(status)
+          if (mentionNotification && !mentionNotification.filtered) {
+            const mentionEvent: NotificationEvent = {
+              type: NotificationType.enum.mention
             }
+            if (config.email && account && status.actor) {
+              mentionEvent.emailContent = {
+                recipientEmail: account.email,
+                subject: getSubject(status.actor),
+                text: getTextContent(status),
+                html: getHTMLContent(status)
+              }
+            }
+            alertEvents.push(mentionEvent)
           }
-          alertEvents.push(mentionEvent)
         }
       }
 

--- a/lib/services/timelines/mention.ts
+++ b/lib/services/timelines/mention.ts
@@ -6,6 +6,7 @@ import {
   getSubject,
   getTextContent
 } from '@/lib/services/email/templates/mention'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import {
   NotificationEvent,
   sendNotificationAlerts
@@ -64,7 +65,7 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
           })
           if (repliedStatus && repliedStatus.actorId === currentActor.id) {
             addToTimeline = true
-            await database.createNotification({
+            await createNotificationWithPolicy(database, {
               actorId: currentActor.id,
               type: NotificationType.enum.reply,
               sourceActorId: status.actorId,
@@ -101,7 +102,7 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
           // Error is recorded but not re-thrown: a notification DB failure
           // should not block the mention from being added to the timeline.
           try {
-            await database.createNotification({
+            await createNotificationWithPolicy(database, {
               actorId: currentActor.id,
               type: NotificationType.enum.mention,
               sourceActorId: status.actorId,

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -99,6 +99,9 @@ export type UpdateActorParams = {
   }
   notificationPolicy?: NotificationPolicy
   notificationAcceptedSenders?: string[]
+  // Atomically appends IDs to notificationAcceptedSenders inside updateActor's
+  // transaction, avoiding the read-modify-write race of separate read + write.
+  appendNotificationAcceptedSenders?: string[]
 
   publicKey?: string
 
@@ -1516,8 +1519,8 @@ export type GetNotificationRequestsParams = {
   actorId: string
   limit: number
   offset?: number
-  maxUpdatedAt?: number
-  sinceUpdatedAt?: number
+  maxCursor?: { updatedAt: number; sourceActorId: string }
+  sinceCursor?: { updatedAt: number; sourceActorId: string }
 }
 
 export type GetNotificationRequestParams = {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -98,6 +98,7 @@ export type UpdateActorParams = {
     }
   }
   notificationPolicy?: NotificationPolicy
+  notificationAcceptedSenders?: string[]
 
   publicKey?: string
 
@@ -1515,6 +1516,8 @@ export type GetNotificationRequestsParams = {
   actorId: string
   limit: number
   offset?: number
+  maxUpdatedAt?: number
+  sinceUpdatedAt?: number
 }
 
 export type GetNotificationRequestParams = {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -97,6 +97,7 @@ export type UpdateActorParams = {
       clientSecret: string
     }
   }
+  notificationPolicy?: NotificationPolicy
 
   publicKey?: string
 
@@ -174,6 +175,14 @@ export interface ActorDatabase {
   getActorSettings(
     params: GetActorSettingsParams
   ): Promise<ActorSettings | undefined>
+  // Notification policy is persisted on actor settings. getNotificationPolicy
+  // always resolves a full policy (Mastodon defaults applied for missing keys).
+  getNotificationPolicy(
+    params: GetActorSettingsParams
+  ): Promise<NotificationPolicy>
+  updateNotificationPolicy(
+    params: UpdateNotificationPolicyParams
+  ): Promise<NotificationPolicy>
   getNodeInfoStats(): Promise<{
     totalUsers: number
     activeMonth: number
@@ -1434,6 +1443,9 @@ export type GetNotificationsCountParams = {
   // 100 by default, max 1000). When omitted, counts all matching rows.
   limit?: number
   includeFiltered?: boolean
+  // Count only policy-filtered notifications (overrides includeFiltered). Used
+  // for the notification policy summary's pending_notifications_count.
+  filteredOnly?: boolean
 }
 
 export type MarkNotificationsReadParams = {
@@ -1487,6 +1499,34 @@ export interface PushSubscriptionDatabase {
   deletePushSubscriptionsForActor(params: { actorId: string }): Promise<void>
 }
 
+// A grouped, per-source-actor view of policy-filtered notifications — the
+// backing data for Mastodon's NotificationRequest entity.
+export interface NotificationRequest {
+  // The source actor id (full URL) the filtered notifications came from.
+  sourceActorId: string
+  notificationsCount: number
+  // The most recent filtered notification from this source actor.
+  lastNotification: Notification
+  createdAt: number
+  updatedAt: number
+}
+
+export type GetNotificationRequestsParams = {
+  actorId: string
+  limit: number
+  offset?: number
+}
+
+export type GetNotificationRequestParams = {
+  actorId: string
+  sourceActorId: string
+}
+
+export type ResolveNotificationRequestsParams = {
+  actorId: string
+  sourceActorIds: string[]
+}
+
 export interface NotificationDatabase {
   createNotification(params: CreateNotificationParams): Promise<Notification>
   getNotifications(params: GetNotificationsParams): Promise<Notification[]>
@@ -1494,7 +1534,52 @@ export interface NotificationDatabase {
   markNotificationsRead(params: MarkNotificationsReadParams): Promise<void>
   updateNotification(params: UpdateNotificationParams): Promise<void>
   deleteNotification(notificationId: string): Promise<void>
+
+  // Notification requests: grouped views over filtered = true notifications.
+  getNotificationRequests(
+    params: GetNotificationRequestsParams
+  ): Promise<NotificationRequest[]>
+  getNotificationRequest(
+    params: GetNotificationRequestParams
+  ): Promise<NotificationRequest | null>
+  getNotificationRequestsCount(params: { actorId: string }): Promise<number>
+  // Accept = clear the filtered flag so the notifications surface in the main
+  // timeline. Dismiss = delete the filtered notifications.
+  acceptNotificationRequests(
+    params: ResolveNotificationRequestsParams
+  ): Promise<void>
+  dismissNotificationRequests(
+    params: ResolveNotificationRequestsParams
+  ): Promise<void>
 }
+
+// ============================================================================
+// Notification Policy (stored on actor settings)
+// ============================================================================
+
+export const NotificationPolicyValue = z.enum(['accept', 'filter', 'drop'])
+export type NotificationPolicyValue = z.infer<typeof NotificationPolicyValue>
+
+export interface NotificationPolicy {
+  for_not_following: NotificationPolicyValue
+  for_not_followers: NotificationPolicyValue
+  for_new_accounts: NotificationPolicyValue
+  for_private_mentions: NotificationPolicyValue
+  for_limited_accounts: NotificationPolicyValue
+}
+
+// Mastodon's default policy accepts everything; filtering is strictly opt-in.
+export const DEFAULT_NOTIFICATION_POLICY: NotificationPolicy = {
+  for_not_following: 'accept',
+  for_not_followers: 'accept',
+  for_new_accounts: 'accept',
+  for_private_mentions: 'accept',
+  for_limited_accounts: 'accept'
+}
+
+export type UpdateNotificationPolicyParams = {
+  actorId: string
+} & Partial<NotificationPolicy>
 
 // ============================================================================
 // OAuth Database

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -36,12 +36,15 @@ export interface ActorSettings {
   // (kept inline here to avoid an operations<->rows import cycle, matching the
   // emailNotifications/pushNotifications pattern).
   notificationPolicy?: {
-    for_not_following: 'accept' | 'filter' | 'drop'
-    for_not_followers: 'accept' | 'filter' | 'drop'
-    for_new_accounts: 'accept' | 'filter' | 'drop'
-    for_private_mentions: 'accept' | 'filter' | 'drop'
-    for_limited_accounts: 'accept' | 'filter' | 'drop'
+    for_not_following?: 'accept' | 'filter' | 'drop'
+    for_not_followers?: 'accept' | 'filter' | 'drop'
+    for_new_accounts?: 'accept' | 'filter' | 'drop'
+    for_private_mentions?: 'accept' | 'filter' | 'drop'
+    for_limited_accounts?: 'accept' | 'filter' | 'drop'
   }
+  // Per-sender accept list: senders in this list always have their notifications
+  // accepted regardless of the notification policy dimensions.
+  notificationAcceptedSenders?: string[]
 }
 
 export type ActorDeletionStatus = 'scheduled' | 'deleting' | null

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -31,6 +31,17 @@ export interface ActorSettings {
     reblog?: boolean
     activity_import?: boolean
   }
+  // Mastodon notification policy. Each value is 'accept' | 'filter' | 'drop'.
+  // Structurally compatible with NotificationPolicy in database/operations.ts
+  // (kept inline here to avoid an operations<->rows import cycle, matching the
+  // emailNotifications/pushNotifications pattern).
+  notificationPolicy?: {
+    for_not_following: 'accept' | 'filter' | 'drop'
+    for_not_followers: 'accept' | 'filter' | 'drop'
+    for_new_accounts: 'accept' | 'filter' | 'drop'
+    for_private_mentions: 'accept' | 'filter' | 'drop'
+    for_limited_accounts: 'accept' | 'filter' | 'drop'
+  }
 }
 
 export type ActorDeletionStatus = 'scheduled' | 'deleting' | null


### PR DESCRIPTION
## Summary

**Phase 2 of 3** toward full [Mastodon notifications API](https://docs.joinmastodon.org/methods/notifications/) compatibility. Builds on the `filtered` flag from Phase 1 (#804) to add the **notification policy** and the **notification requests queue**, with real enforcement at notification-creation time.

> Stacked on #804 — review/merge that first. This PR's base is the Phase 1 branch so the diff is Phase 2 only.

### Notification policy — `GET`/`PATCH /api/v2/notifications/policy`
- Stored on actor settings (no new table); defaults to all-`accept` (filtering is opt-in).
- Response includes the five `accept|filter|drop` dimensions plus `summary: { pending_requests_count, pending_notifications_count }`.
- `getNotificationPolicy`/`updateNotificationPolicy` DB ops merge a partial policy into settings.

### Enforcement — single seam
- `evaluateNotificationPolicy` resolves `accept|filter|drop` from the policy + the recipient/source follow relationship, sender account age (<30d), and direct-message visibility. **Most-restrictive verdict wins.**
- `createNotificationWithPolicy` wraps `createNotification`: `drop` discards, `filter` persists with `filtered=true`, `accept` with `filtered=false`. All ~10 call sites (`lib/actions/*`, `lib/jobs/*`, `lib/services/timelines/mention.ts`) route through it.

### Notification requests — derived from `filtered=true`, grouped by source actor
- `GET /api/v1/notifications/requests` (list), `GET /requests/:id`, `POST /requests/:id/accept`, `POST /requests/:id/dismiss`, `POST /requests/accept` & `POST /requests/dismiss` (bulk `id[]`), `GET /requests/merged`.
- **accept** clears the filtered flag (notifications surface in the main timeline); **dismiss** deletes them.

### Documented compromises (agreed up front)
- `for_limited_accounts` is stored but **never enforced** — this codebase has no per-actor silence/limit moderation primitive (only domain-level severities).
- `/requests/merged` always returns `{ merged: true }` because accept is synchronous here (Mastodon merges asynchronously).

### Test results
- `yarn lint` — 0 errors
- `yarn build` — green
- `yarn test` — 350 suites / 3000 tests pass

Covers: policy evaluation (every dimension, most-restrictive, limited-accounts no-op), the requests DB round-trip (filter → request → accept/dismiss), policy DB defaults/merge, and the policy + accept route handlers.

### Follow-up (separate PR)
- **Phase 3**: v2 grouped notifications (`GET /api/v2/notifications` + group endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)