### PR TITLE
minor: add v2 grouped notifications (Mastodon)

### DIFF
--- a/app/api/v2/notifications/[group_key]/accounts/route.test.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.test.ts
@@ -5,7 +5,8 @@ import { GET } from './route'
 const mockDatabase = {
   getNotificationsForGroupKey: jest.fn(),
   getMastodonActorsFromIds: jest.fn(),
-  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getStatusesByIds: jest.fn().mockResolvedValue([])
 }
 
 const mockCurrentActor = { id: 'https://llun.test/users/llun' }
@@ -77,5 +78,26 @@ describe('GET /api/v2/notifications/:group_key/accounts', () => {
     expect(
       (mockDatabase.getMastodonActorsFromIds as jest.Mock).mock.calls[0][0].ids
     ).toEqual([ALICE, BOB])
+  })
+
+  it('returns 404 when a referenced status is deleted/invisible (no active filters)', async () => {
+    const ALICE = 'https://other.test/users/alice'
+    mockDatabase.getNotificationsForGroupKey.mockResolvedValueOnce([
+      { id: 'n1', sourceActorId: ALICE, statusId: 'https://other.test/s/1' }
+    ])
+    // No active filters, but the referenced status does not resolve.
+    mockDatabase.getActiveFiltersForActor.mockResolvedValueOnce([])
+    mockDatabase.getStatusesByIds.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/like%3As1/accounts',
+      { method: 'GET' }
+    )
+    const response = await GET(request, {
+      params: Promise.resolve({ group_key: 'like:s1' })
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.getMastodonActorsFromIds).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v2/notifications/[group_key]/accounts/route.test.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.test.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getNotificationsForGroupKey: jest.fn(),
+  getMastodonActorsFromIds: jest.fn()
+}
+
+const mockCurrentActor = { id: 'https://llun.test/users/llun' }
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ group_key: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ group_key: string }> }) =>
+      handle(req, { currentActor: mockCurrentActor, params: context.params })
+}))
+
+describe('GET /api/v2/notifications/:group_key/accounts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 404 when group key is not found', async () => {
+    mockDatabase.getNotificationsForGroupKey.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/unknown:group/accounts',
+      { method: 'GET' }
+    )
+    const response = await GET(request, {
+      params: Promise.resolve({ group_key: 'unknown:group' })
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.getMastodonActorsFromIds).not.toHaveBeenCalled()
+  })
+
+  it('returns deduped accounts for a group key', async () => {
+    const ALICE = 'https://other.test/users/alice'
+    const BOB = 'https://other.test/users/bob'
+    mockDatabase.getNotificationsForGroupKey.mockResolvedValueOnce([
+      { id: 'n1', sourceActorId: ALICE },
+      { id: 'n2', sourceActorId: BOB },
+      { id: 'n3', sourceActorId: ALICE }
+    ])
+    mockDatabase.getMastodonActorsFromIds.mockImplementation(
+      ({ ids }: { ids: string[] }) => Promise.resolve(ids.map((id) => ({ id })))
+    )
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/like%3As1/accounts',
+      { method: 'GET' }
+    )
+    const response = await GET(request, {
+      params: Promise.resolve({ group_key: 'like:s1' })
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    // ALICE appears twice but is deduped
+    expect(data).toHaveLength(2)
+    expect(
+      (mockDatabase.getMastodonActorsFromIds as jest.Mock).mock.calls[0][0].ids
+    ).toEqual([ALICE, BOB])
+  })
+})

--- a/app/api/v2/notifications/[group_key]/accounts/route.test.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.test.ts
@@ -4,7 +4,8 @@ import { GET } from './route'
 
 const mockDatabase = {
   getNotificationsForGroupKey: jest.fn(),
-  getMastodonActorsFromIds: jest.fn()
+  getMastodonActorsFromIds: jest.fn(),
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
 }
 
 const mockCurrentActor = { id: 'https://llun.test/users/llun' }

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -38,10 +38,11 @@ export const GET = traceApiRoute(
       const groupKey = rawGroupKey.startsWith('ungrouped-')
         ? rawGroupKey.slice('ungrouped-'.length)
         : rawGroupKey
+      // Mirror the list endpoint: hide policy-filtered notifications by default.
       const notifications = await database.getNotificationsForGroupKey({
         actorId: currentActor.id,
         groupKey,
-        includeFiltered: true
+        includeFiltered: false
       })
       if (notifications.length === 0) {
         return apiResponse({

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -24,8 +24,11 @@ interface Params {
 
 export const GET = traceApiRoute(
   'getGroupedNotificationAccounts',
+  // Mastodon's grouped-notifications docs require write:notifications for this
+  // endpoint (unusual for a GET, but per spec), unlike the read-scoped list/
+  // single/unread endpoints.
   OAuthGuard<Params>(
-    [Scope.enum.read],
+    [Scope.enum.write],
     async (req, { currentActor, params }) => {
       const database = getDatabase()
       if (!database) {

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -2,7 +2,12 @@ import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_404,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
@@ -34,6 +39,14 @@ export const GET = traceApiRoute(
         groupKey,
         includeFiltered: true
       })
+      if (notifications.length === 0) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
 
       // Distinct source actors, most-recent-first (notifications come ordered).
       const seen = new Set<string>()

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -79,6 +79,16 @@ export const GET = traceApiRoute(
             visibleToActorId: currentActor.id,
             withReplies: false
           })
+          // If any referenced status is deleted/invisible, the envelope suppresses
+          // the group — return 404 here too for consistency.
+          if (statuses.length < statusIds.length) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_404,
+              responseStatusCode: 404
+            })
+          }
           const isHidden = statuses.some((s) =>
             applyFiltersToStatus(s, filterRecords).some(
               (m) => m.filter.filter_action === 'hide'

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -75,6 +75,8 @@ export const GET = traceApiRoute(
         if (statusIds.length > 0) {
           const statuses = await database.getStatusesByIds({
             statusIds,
+            currentActorId: currentActor.id,
+            visibleToActorId: currentActor.id,
             withReplies: false
           })
           const isHidden = statuses.some((s) =>

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -33,7 +33,11 @@ export const GET = traceApiRoute(
         })
       }
 
-      const groupKey = (await params).group_key
+      const rawGroupKey = (await params).group_key
+      // ungrouped-{id} keys use the notification id as the DB lookup key.
+      const groupKey = rawGroupKey.startsWith('ungrouped-')
+        ? rawGroupKey.slice('ungrouped-'.length)
+        : rawGroupKey
       const notifications = await database.getNotificationsForGroupKey({
         actorId: currentActor.id,
         groupKey,

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -1,0 +1,55 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  group_key: string
+}
+
+export const GET = traceApiRoute(
+  'getGroupedNotificationAccounts',
+  OAuthGuard<Params>(
+    [Scope.enum.read],
+    async (req, { currentActor, params }) => {
+      const database = getDatabase()
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const groupKey = decodeURIComponent((await params).group_key)
+      const notifications = await database.getNotificationsForGroupKey({
+        actorId: currentActor.id,
+        groupKey,
+        includeFiltered: true
+      })
+
+      // Distinct source actors, most-recent-first (notifications come ordered).
+      const seen = new Set<string>()
+      const orderedActorIds: string[] = []
+      for (const notification of notifications) {
+        if (seen.has(notification.sourceActorId)) continue
+        seen.add(notification.sourceActorId)
+        orderedActorIds.push(notification.sourceActorId)
+      }
+
+      const accounts =
+        orderedActorIds.length > 0
+          ? await database.getMastodonActorsFromIds({ ids: orderedActorIds })
+          : []
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: accounts })
+    }
+  )
+)

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -122,6 +122,17 @@ export const GET = traceApiRoute(
           ? await database.getMastodonActorsFromIds({ ids: orderedActorIds })
           : []
 
+      // Mirror the envelope: if no sampled account resolves (all deleted), the
+      // group is suppressed everywhere else — return 404 instead of an empty list.
+      if (accounts.length === 0) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: accounts })
     }
   )

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -1,4 +1,8 @@
 import { getDatabase } from '@/lib/database'
+import {
+  applyFiltersToStatus,
+  getActiveFilters
+} from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -51,6 +55,42 @@ export const GET = traceApiRoute(
           data: ERROR_404,
           responseStatusCode: 404
         })
+      }
+
+      // Apply content filters: if the group's status matches a hide filter, return
+      // 404 to match the envelope behaviour (group is suppressed on the list route).
+      const filterRecords = await getActiveFilters(
+        database,
+        currentActor.id,
+        'notifications'
+      )
+      if (filterRecords.length > 0) {
+        const statusIds = [
+          ...new Set(
+            notifications
+              .map((n) => n.statusId)
+              .filter((id): id is string => Boolean(id))
+          )
+        ]
+        if (statusIds.length > 0) {
+          const statuses = await database.getStatusesByIds({
+            statusIds,
+            withReplies: false
+          })
+          const isHidden = statuses.some((s) =>
+            applyFiltersToStatus(s, filterRecords).some(
+              (m) => m.filter.filter_action === 'hide'
+            )
+          )
+          if (isHidden) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_404,
+              responseStatusCode: 404
+            })
+          }
+        }
       }
 
       // Distinct source actors, most-recent-first (notifications come ordered).

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -28,7 +28,7 @@ export const GET = traceApiRoute(
         })
       }
 
-      const groupKey = decodeURIComponent((await params).group_key)
+      const groupKey = (await params).group_key
       const notifications = await database.getNotificationsForGroupKey({
         actorId: currentActor.id,
         groupKey,

--- a/app/api/v2/notifications/[group_key]/accounts/route.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.ts
@@ -57,38 +57,41 @@ export const GET = traceApiRoute(
         })
       }
 
-      // Apply content filters: if the group's status matches a hide filter, return
-      // 404 to match the envelope behaviour (group is suppressed on the list route).
+      // Resolve referenced statuses to mirror the envelope's group suppression.
+      // The envelope drops a group when its status_id is unresolvable (deleted or
+      // not visible) regardless of active filters, so this check must run
+      // unconditionally; the hide-filter check below additionally needs the records.
       const filterRecords = await getActiveFilters(
         database,
         currentActor.id,
         'notifications'
       )
-      if (filterRecords.length > 0) {
-        const statusIds = [
-          ...new Set(
-            notifications
-              .map((n) => n.statusId)
-              .filter((id): id is string => Boolean(id))
-          )
-        ]
-        if (statusIds.length > 0) {
-          const statuses = await database.getStatusesByIds({
-            statusIds,
-            currentActorId: currentActor.id,
-            visibleToActorId: currentActor.id,
-            withReplies: false
+      const statusIds = [
+        ...new Set(
+          notifications
+            .map((n) => n.statusId)
+            .filter((id): id is string => Boolean(id))
+        )
+      ]
+      if (statusIds.length > 0) {
+        const statuses = await database.getStatusesByIds({
+          statusIds,
+          currentActorId: currentActor.id,
+          visibleToActorId: currentActor.id,
+          withReplies: false
+        })
+        // If any referenced status is deleted/invisible, the envelope suppresses
+        // the group — return 404 here too for consistency.
+        if (statuses.length < statusIds.length) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_404,
+            responseStatusCode: 404
           })
-          // If any referenced status is deleted/invisible, the envelope suppresses
-          // the group — return 404 here too for consistency.
-          if (statuses.length < statusIds.length) {
-            return apiResponse({
-              req,
-              allowedMethods: CORS_HEADERS,
-              data: ERROR_404,
-              responseStatusCode: 404
-            })
-          }
+        }
+        // Hide-filter check requires active filter records.
+        if (filterRecords.length > 0) {
           const isHidden = statuses.some((s) =>
             applyFiltersToStatus(s, filterRecords).some(
               (m) => m.filter.filter_action === 'hide'

--- a/app/api/v2/notifications/[group_key]/dismiss/route.ts
+++ b/app/api/v2/notifications/[group_key]/dismiss/route.ts
@@ -28,7 +28,7 @@ export const POST = traceApiRoute(
         })
       }
 
-      const groupKey = decodeURIComponent((await params).group_key)
+      const groupKey = (await params).group_key
       await database.dismissNotificationGroup({
         actorId: currentActor.id,
         groupKey

--- a/app/api/v2/notifications/[group_key]/dismiss/route.ts
+++ b/app/api/v2/notifications/[group_key]/dismiss/route.ts
@@ -1,0 +1,40 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  group_key: string
+}
+
+export const POST = traceApiRoute(
+  'dismissGroupedNotification',
+  OAuthGuard<Params>(
+    [Scope.enum.write],
+    async (req, { currentActor, params }) => {
+      const database = getDatabase()
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const groupKey = decodeURIComponent((await params).group_key)
+      await database.dismissNotificationGroup({
+        actorId: currentActor.id,
+        groupKey
+      })
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+    }
+  )
+)

--- a/app/api/v2/notifications/[group_key]/dismiss/route.ts
+++ b/app/api/v2/notifications/[group_key]/dismiss/route.ts
@@ -28,7 +28,10 @@ export const POST = traceApiRoute(
         })
       }
 
-      const groupKey = (await params).group_key
+      const rawGroupKey = (await params).group_key
+      const groupKey = rawGroupKey.startsWith('ungrouped-')
+        ? rawGroupKey.slice('ungrouped-'.length)
+        : rawGroupKey
       await database.dismissNotificationGroup({
         actorId: currentActor.id,
         groupKey

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -53,9 +53,14 @@ export const GET = traceApiRoute(
         })
       }
 
+      // Disable grouping for ungrouped- keys so the stored groupKey is not used
+      // and the returned group_key matches the client's request.
       const envelope = await getNotificationGroupsEnvelope(
         database,
-        groupNotifications(notifications, true),
+        groupNotifications(
+          notifications,
+          !rawGroupKey.startsWith('ungrouped-')
+        ),
         currentActor.id
       )
 

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -66,15 +66,12 @@ export const GET = traceApiRoute(
       )
 
       // For ungrouped- keys, disable grouping so the stored groupKey is not used
-      // and the returned group_key matches the client's request. Otherwise use
-      // prepareGroupedNotifications so legacy null-key follow rows get the
-      // synthetic 'follow' key and merge into a single group, matching the list.
-      // The client addressed one specific group key, so group all fetched rows
-      // into that single group regardless of the default groupable types (e.g. a
+      // and the returned group_key matches the client's request (legacy null-key
+      // follows surface here as their own ungrouped-<id> entry). Otherwise the
+      // client addressed one specific shared key, so group all fetched rows into
+      // that single group regardless of the default groupable types — e.g. a
       // mention:* key is only ever obtained via an explicit grouped_types=mention
-      // request, where grouping it is correct). prepareGroupedNotifications also
-      // injects the synthetic 'follow' key so legacy null-key rows merge. The
-      // ungrouped- path disables grouping so each entry stays individual.
+      // request, where grouping it is correct.
       const grouped = rawGroupKey.startsWith('ungrouped-')
         ? groupNotifications(notifications, false)
         : prepareGroupedNotifications(notifications)

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -6,6 +6,7 @@ import {
   prepareGroupedNotifications
 } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
+import { DEFAULT_GROUPABLE_TYPES } from '@/lib/services/notifications/notificationTypeMapping'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -69,9 +70,14 @@ export const GET = traceApiRoute(
       // and the returned group_key matches the client's request. Otherwise use
       // prepareGroupedNotifications so legacy null-key follow rows get the
       // synthetic 'follow' key and merge into a single group, matching the list.
+      // Group with the same default types as the list route so mentions/replies
+      // stay individual instead of collapsing under their stored DB group key.
       const grouped = rawGroupKey.startsWith('ungrouped-')
         ? groupNotifications(notifications, false)
-        : prepareGroupedNotifications(notifications)
+        : prepareGroupedNotifications(
+            notifications,
+            new Set(DEFAULT_GROUPABLE_TYPES)
+          )
       const envelope = await getNotificationGroupsEnvelope(
         database,
         grouped,

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -74,6 +74,17 @@ export const GET = traceApiRoute(
         filterRecords
       )
 
+      // If the content filter or missing status removed the only group, return 404
+      // rather than 200 with an empty notification_groups array.
+      if (envelope.notification_groups.length === 0) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: envelope })
     }
   )

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -1,7 +1,10 @@
 import { getDatabase } from '@/lib/database'
 import { getActiveFilters } from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
-import { getNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
+import {
+  getNotificationGroupsEnvelope,
+  prepareGroupedNotifications
+} from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -62,14 +65,16 @@ export const GET = traceApiRoute(
         'notifications'
       )
 
-      // Disable grouping for ungrouped- keys so the stored groupKey is not used
-      // and the returned group_key matches the client's request.
+      // For ungrouped- keys, disable grouping so the stored groupKey is not used
+      // and the returned group_key matches the client's request. Otherwise use
+      // prepareGroupedNotifications so legacy null-key follow rows get the
+      // synthetic 'follow' key and merge into a single group, matching the list.
+      const grouped = rawGroupKey.startsWith('ungrouped-')
+        ? groupNotifications(notifications, false)
+        : prepareGroupedNotifications(notifications)
       const envelope = await getNotificationGroupsEnvelope(
         database,
-        groupNotifications(
-          notifications,
-          !rawGroupKey.startsWith('ungrouped-')
-        ),
+        grouped,
         currentActor.id,
         filterRecords
       )

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -1,0 +1,62 @@
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
+import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_404,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  group_key: string
+}
+
+export const GET = traceApiRoute(
+  'getGroupedNotification',
+  OAuthGuard<Params>(
+    [Scope.enum.read],
+    async (req, { currentActor, params }) => {
+      const database = getDatabase()
+      if (!database) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      const groupKey = decodeURIComponent((await params).group_key)
+      const notifications = await database.getNotificationsForGroupKey({
+        actorId: currentActor.id,
+        groupKey,
+        includeFiltered: true
+      })
+      if (notifications.length === 0) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      const envelope = await getNotificationGroupsEnvelope(
+        database,
+        groupNotifications(notifications, true),
+        currentActor.id
+      )
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: envelope })
+    }
+  )
+)

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -35,7 +35,10 @@ export const GET = traceApiRoute(
         })
       }
 
-      const groupKey = (await params).group_key
+      const rawGroupKey = (await params).group_key
+      const groupKey = rawGroupKey.startsWith('ungrouped-')
+        ? rawGroupKey.slice('ungrouped-'.length)
+        : rawGroupKey
       const notifications = await database.getNotificationsForGroupKey({
         actorId: currentActor.id,
         groupKey,

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -1,4 +1,5 @@
 import { getDatabase } from '@/lib/database'
+import { getActiveFilters } from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
@@ -39,10 +40,11 @@ export const GET = traceApiRoute(
       const groupKey = rawGroupKey.startsWith('ungrouped-')
         ? rawGroupKey.slice('ungrouped-'.length)
         : rawGroupKey
+      // Mirror the list endpoint: hide policy-filtered notifications by default.
       const notifications = await database.getNotificationsForGroupKey({
         actorId: currentActor.id,
         groupKey,
-        includeFiltered: true
+        includeFiltered: false
       })
       if (notifications.length === 0) {
         return apiResponse({
@@ -53,6 +55,13 @@ export const GET = traceApiRoute(
         })
       }
 
+      // Apply the same content filters as the list route.
+      const filterRecords = await getActiveFilters(
+        database,
+        currentActor.id,
+        'notifications'
+      )
+
       // Disable grouping for ungrouped- keys so the stored groupKey is not used
       // and the returned group_key matches the client's request.
       const envelope = await getNotificationGroupsEnvelope(
@@ -61,7 +70,8 @@ export const GET = traceApiRoute(
           notifications,
           !rawGroupKey.startsWith('ungrouped-')
         ),
-        currentActor.id
+        currentActor.id,
+        filterRecords
       )
 
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: envelope })

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -6,7 +6,6 @@ import {
   prepareGroupedNotifications
 } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
-import { DEFAULT_GROUPABLE_TYPES } from '@/lib/services/notifications/notificationTypeMapping'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -70,14 +69,15 @@ export const GET = traceApiRoute(
       // and the returned group_key matches the client's request. Otherwise use
       // prepareGroupedNotifications so legacy null-key follow rows get the
       // synthetic 'follow' key and merge into a single group, matching the list.
-      // Group with the same default types as the list route so mentions/replies
-      // stay individual instead of collapsing under their stored DB group key.
+      // The client addressed one specific group key, so group all fetched rows
+      // into that single group regardless of the default groupable types (e.g. a
+      // mention:* key is only ever obtained via an explicit grouped_types=mention
+      // request, where grouping it is correct). prepareGroupedNotifications also
+      // injects the synthetic 'follow' key so legacy null-key rows merge. The
+      // ungrouped- path disables grouping so each entry stays individual.
       const grouped = rawGroupKey.startsWith('ungrouped-')
         ? groupNotifications(notifications, false)
-        : prepareGroupedNotifications(
-            notifications,
-            new Set(DEFAULT_GROUPABLE_TYPES)
-          )
+        : prepareGroupedNotifications(notifications)
       const envelope = await getNotificationGroupsEnvelope(
         database,
         grouped,

--- a/app/api/v2/notifications/[group_key]/route.ts
+++ b/app/api/v2/notifications/[group_key]/route.ts
@@ -35,7 +35,7 @@ export const GET = traceApiRoute(
         })
       }
 
-      const groupKey = decodeURIComponent((await params).group_key)
+      const groupKey = (await params).group_key
       const notifications = await database.getNotificationsForGroupKey({
         actorId: currentActor.id,
         groupKey,

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getNotifications: jest.fn(),
+  getMastodonActorsFromIds: jest.fn(),
+  getStatus: jest.fn()
+}
+
+const mockCurrentActor = { id: 'https://llun.test/users/llun' }
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/mastodon/getMastodonStatus', () => ({
+  getMastodonStatus: jest.fn().mockResolvedValue({ id: 'status-1' })
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: {
+          currentActor: typeof mockCurrentActor
+          params: Promise<{}>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, { currentActor: mockCurrentActor, params: context.params })
+}))
+
+describe('GET /api/v2/notifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getMastodonActorsFromIds.mockImplementation(
+      ({ ids }: { ids: string[] }) => Promise.resolve(ids.map((id) => ({ id })))
+    )
+    mockDatabase.getStatus.mockResolvedValue({ id: 'status-url' })
+  })
+
+  it('returns the grouped envelope with deduped accounts and statuses', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'n1',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      },
+      {
+        id: 'n2',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/bob',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+    ])
+
+    const request = new NextRequest('https://llun.test/api/v2/notifications', {
+      method: 'GET'
+    })
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    // Two likes on one status collapse into a single group.
+    expect(data.notification_groups).toHaveLength(1)
+    expect(data.notification_groups[0]).toMatchObject({
+      type: 'favourite',
+      notifications_count: 2
+    })
+    expect(data.accounts).toHaveLength(2)
+    expect(data.statuses).toHaveLength(1)
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({ includeFiltered: false })
+    )
+  })
+
+  it('returns 422 for an invalid limit', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications?limit=0',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -46,8 +46,14 @@ jest.mock('@/lib/services/guards/OAuthGuard', () => ({
 describe('GET /api/v2/notifications', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // Return id in urlToId format so sample_account_ids filtering works.
     mockDatabase.getMastodonActorsFromIds.mockImplementation(
-      ({ ids }: { ids: string[] }) => Promise.resolve(ids.map((id) => ({ id })))
+      ({ ids }: { ids: string[] }) =>
+        Promise.resolve(
+          ids.map((id) => ({
+            id: id.replace(/https?:\/\//, '').replaceAll('/', ':')
+          }))
+        )
     )
     mockDatabase.getStatus.mockResolvedValue({ id: 'status-url' })
     mockDatabase.getStatusesByIds.mockImplementation(

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -17,7 +17,14 @@ jest.mock('@/lib/database', () => ({
 }))
 
 jest.mock('@/lib/services/mastodon/getMastodonStatus', () => ({
-  getMastodonStatus: jest.fn().mockResolvedValue({ id: 'status-1' })
+  // Return id matching urlToId(domainStatus.id) so the hide-filter check works.
+  getMastodonStatus: jest
+    .fn()
+    .mockImplementation((_db: unknown, domainStatus: { id: string }) =>
+      Promise.resolve({
+        id: domainStatus.id.replace(/https?:\/\//, '').replaceAll('/', ':')
+      })
+    )
 }))
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -5,7 +5,9 @@ import { GET } from './route'
 const mockDatabase = {
   getNotifications: jest.fn(),
   getMastodonActorsFromIds: jest.fn(),
-  getStatus: jest.fn()
+  getStatus: jest.fn(),
+  getStatusesByIds: jest.fn(),
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
 }
 
 const mockCurrentActor = { id: 'https://llun.test/users/llun' }
@@ -41,6 +43,10 @@ describe('GET /api/v2/notifications', () => {
       ({ ids }: { ids: string[] }) => Promise.resolve(ids.map((id) => ({ id })))
     )
     mockDatabase.getStatus.mockResolvedValue({ id: 'status-url' })
+    mockDatabase.getStatusesByIds.mockImplementation(
+      ({ statusIds }: { statusIds: string[] }) =>
+        Promise.resolve(statusIds.map((id) => ({ id })))
+    )
   })
 
   it('returns the grouped envelope with deduped accounts and statuses', async () => {

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -118,4 +118,45 @@ describe('GET /api/v2/notifications', () => {
     expect(response.status).toBe(422)
     expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
   })
+
+  it('anchors the next (max_id) Link on the last returned group most-recent id', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'like-new',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 3000,
+        updatedAt: 3000
+      },
+      {
+        id: 'follow-old',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/bob',
+        groupKey: 'follow:1',
+        isRead: false,
+        filtered: false,
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+    ])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications?limit=2',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    const link = response.headers.get('Link') ?? ''
+    // next/max_id anchors on the LAST returned group (the follow group).
+    expect(link).toContain('max_id=follow-old')
+    expect(link).toContain('rel="next"')
+    // prev/min_id anchors on the FIRST returned group (the like group).
+    expect(link).toContain('min_id=like-new')
+    expect(link).toContain('rel="prev"')
+  })
 })

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -20,6 +20,9 @@ import { urlToId } from '@/lib/utils/urlToId'
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const DEFAULT_LIMIT = 40
 const MAX_LIMIT = 80
+// Over-fetch row multiplier: ensures that after grouping we have enough distinct
+// groups for the requested page even if many rows share the same groupKey.
+const GROUP_OVERSCAN = 5
 const ARRAY_QUERY_PARAMS = new Set([
   'types',
   'exclude_types',
@@ -110,9 +113,10 @@ export const GET = traceApiRoute(
       include_filtered: includeFiltered = false
     } = parsed.data
 
+    // Over-fetch rows so that after grouping we produce at least `limit` groups.
     const notifications = await database.getNotifications({
       actorId: currentActor.id,
-      limit,
+      limit: limit * GROUP_OVERSCAN,
       maxNotificationId: maxId,
       minNotificationId: minId || sinceId,
       types: mastodonTypesToInternal(types),
@@ -134,16 +138,26 @@ export const GET = traceApiRoute(
       ? []
       : await getActiveFilters(database, currentActor.id, 'notifications')
 
-    const envelope = await buildNotificationGroupsEnvelope(
+    // Build the envelope then truncate groups to the requested limit.
+    // Accounts and statuses are already deduped across all fetched groups;
+    // returning the full set is safe — clients use only those referenced by
+    // the groups they received.
+    const fullEnvelope = await buildNotificationGroupsEnvelope(
       database,
       filtered,
       currentActor.id,
       internalGroupedTypes,
       filterRecords
     )
+    const envelope = {
+      notification_groups: fullEnvelope.notification_groups.slice(0, limit),
+      accounts: fullEnvelope.accounts,
+      statuses: fullEnvelope.statuses
+    }
 
-    // Pagination links from the raw notification page (pre-grouping), mirroring
-    // the v1 list route so clients keep paginating.
+    // Pagination links: cursors come from the most-recent notification ids in the
+    // first and last returned groups. This anchors pagination to group boundaries.
+    const returnedGroups = envelope.notification_groups
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -156,10 +170,14 @@ export const GET = traceApiRoute(
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
     const links =
-      filtered.length > 0
+      returnedGroups.length > 0
         ? [
-            buildLink('max_id', filtered[filtered.length - 1].id),
-            buildLink('min_id', filtered[0].id)
+            buildLink(
+              'max_id',
+              returnedGroups[returnedGroups.length - 1]
+                .most_recent_notification_id
+            ),
+            buildLink('min_id', returnedGroups[0].most_recent_notification_id)
           ].join(', ')
         : ''
 

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -35,6 +35,7 @@ const QueryParams = z.object({
   min_id: z.string().optional(),
   limit: z.coerce
     .number()
+    .int()
     .min(1)
     .max(MAX_LIMIT)
     .default(DEFAULT_LIMIT)
@@ -44,8 +45,11 @@ const QueryParams = z.object({
   grouped_types: z.array(z.string()).optional(),
   account_id: z.string().optional(),
   include_filtered: z
-    .enum(['true', 'false'])
-    .transform((value) => value === 'true')
+    .string()
+    .transform((val) => {
+      const n = val.toLowerCase()
+      return n === 'true' || n === '1' || n === 'on'
+    })
     .optional()
 })
 
@@ -67,10 +71,21 @@ export const GET = traceApiRoute(
     for (const key of new Set(url.searchParams.keys())) {
       const normalizedKey = key.replace(/\[\]$/, '')
       const allValues = url.searchParams.getAll(key)
-      queryParams[normalizedKey] =
+      const normalizedValue =
         ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
           ? allValues
           : allValues[0]
+      const existing = queryParams[normalizedKey]
+      if (existing === undefined) {
+        queryParams[normalizedKey] = normalizedValue
+      } else {
+        queryParams[normalizedKey] = [
+          ...(Array.isArray(existing) ? existing : [existing]),
+          ...(Array.isArray(normalizedValue)
+            ? normalizedValue
+            : [normalizedValue])
+        ]
+      }
     }
 
     const parsed = QueryParams.safeParse(queryParams)

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -158,9 +158,10 @@ export const GET = traceApiRoute(
       filterRecords
     )
 
-    // Pagination links: use groupedSlice (pre-content-filter) as cursor source so
-    // clients keep paginating even when all visible groups on this page were
-    // hide-filtered. "next" uses page_min_id of the last pre-filter group.
+    // Pagination cursors mirror the v1 approach: use the last/first raw notification
+    // in the overscan window. This avoids permanent gaps that would occur if we used
+    // group-member IDs as cursors (groups can span interleaved non-group notifications).
+    // Clients handle boundary group duplication via page_min_id merging.
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -172,21 +173,11 @@ export const GET = traceApiRoute(
       params.set(cursorParam, cursorValue)
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
-    const lastPreFilterGroup = groupedSlice[groupedSlice.length - 1]
     const links =
-      groupedSlice.length > 0
+      filtered.length > 0
         ? [
-            // oldest member of last pre-filter group → safe max_id for next page
-            buildLink(
-              'max_id',
-              lastPreFilterGroup.groupedIds
-                ? lastPreFilterGroup.groupedIds[
-                    lastPreFilterGroup.groupedIds.length - 1
-                  ]
-                : lastPreFilterGroup.id
-            ),
-            // most recent of first pre-filter group → safe min_id for prev page
-            buildLink('min_id', groupedSlice[0].id)
+            buildLink('max_id', filtered[filtered.length - 1].id),
+            buildLink('min_id', filtered[0].id)
           ].join(', ')
         : ''
 

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -158,15 +158,21 @@ export const GET = traceApiRoute(
       filterRecords
     )
 
-    // Pagination cursors: "next" uses the oldest notification that is a member of
-    // any returned group, so we don't skip groups that lie beyond the slice but
-    // within the overscan window. "prev" uses the newest raw notification on the page.
+    // Pagination cursor for "next": use the last raw notification BEFORE the first
+    // gap (first notification not part of any returned group). This prevents
+    // skipping intervening groups when a returned group spans non-contiguous rows.
     const sliceNotificationIds = new Set(
       groupedSlice.flatMap((g) => [g.id, ...(g.groupedIds ?? [])])
     )
-    const lastSliceNotification = filtered
-      .filter((n) => sliceNotificationIds.has(n.id))
-      .at(-1)
+    const firstGapIndex = filtered.findIndex(
+      (n) => !sliceNotificationIds.has(n.id)
+    )
+    const maxIdCursorNotification =
+      firstGapIndex > 0
+        ? filtered[firstGapIndex - 1]
+        : firstGapIndex === -1
+          ? filtered[filtered.length - 1]
+          : filtered[0]
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -179,9 +185,9 @@ export const GET = traceApiRoute(
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
     const links =
-      groupedSlice.length > 0 && lastSliceNotification
+      groupedSlice.length > 0 && maxIdCursorNotification
         ? [
-            buildLink('max_id', lastSliceNotification.id),
+            buildLink('max_id', maxIdCursorNotification.id),
             buildLink('min_id', filtered[0].id)
           ].join(', ')
         : ''

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { buildNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
+import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { urlToId } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 40
+const MAX_LIMIT = 80
+const ARRAY_QUERY_PARAMS = new Set([
+  'types',
+  'exclude_types',
+  'grouped_types',
+  'supported_types'
+])
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const QueryParams = z.object({
+  max_id: z.string().optional(),
+  since_id: z.string().optional(),
+  min_id: z.string().optional(),
+  limit: z.coerce
+    .number()
+    .min(1)
+    .max(MAX_LIMIT)
+    .default(DEFAULT_LIMIT)
+    .optional(),
+  types: z.array(z.string()).optional(),
+  exclude_types: z.array(z.string()).optional(),
+  account_id: z.string().optional(),
+  include_filtered: z
+    .enum(['true', 'false'])
+    .transform((value) => value === 'true')
+    .optional()
+})
+
+export const GET = traceApiRoute(
+  'getGroupedNotifications',
+  OAuthGuard([Scope.enum.read], async (req, { currentActor }) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const url = new URL(req.url)
+    const queryParams: Record<string, string | string[]> = {}
+    for (const key of new Set(url.searchParams.keys())) {
+      const normalizedKey = key.replace(/\[\]$/, '')
+      const allValues = url.searchParams.getAll(key)
+      queryParams[normalizedKey] =
+        ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
+          ? allValues
+          : allValues[0]
+    }
+
+    const parsed = QueryParams.safeParse(queryParams)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const {
+      limit = DEFAULT_LIMIT,
+      max_id: maxId,
+      min_id: minId,
+      since_id: sinceId,
+      types,
+      exclude_types: excludeTypes,
+      account_id: accountId,
+      include_filtered: includeFiltered = false
+    } = parsed.data
+
+    const notifications = await database.getNotifications({
+      actorId: currentActor.id,
+      limit,
+      maxNotificationId: maxId,
+      minNotificationId: minId || sinceId,
+      types: mastodonTypesToInternal(types),
+      excludeTypes: mastodonTypesToInternal(excludeTypes),
+      includeFiltered
+    })
+
+    const filtered = accountId
+      ? notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
+      : notifications
+
+    const envelope = await buildNotificationGroupsEnvelope(
+      database,
+      filtered,
+      currentActor.id
+    )
+
+    // Pagination links from the raw notification page (pre-grouping), mirroring
+    // the v1 list route so clients keep paginating.
+    const host = headerHost(req.headers)
+    const pathBase = '/api/v2/notifications'
+    const buildLink = (cursorParam: string, cursorValue: string) => {
+      const params = new URLSearchParams()
+      params.set('limit', limit.toString())
+      params.set(cursorParam, cursorValue)
+      if (includeFiltered) params.set('include_filtered', 'true')
+      return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
+    }
+    const links =
+      filtered.length > 0
+        ? [
+            buildLink('max_id', filtered[filtered.length - 1].id),
+            buildLink('min_id', filtered[0].id)
+          ].join(', ')
+        : ''
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: envelope,
+      additionalHeaders: links ? [['Link', links] as [string, string]] : []
+    })
+  })
+)

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -4,6 +4,7 @@ import { getDatabase } from '@/lib/database'
 import { getActiveFilters } from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
+import { collectNotificationGroups } from '@/lib/services/notifications/collectNotificationGroups'
 import {
   getNotificationGroupsEnvelope,
   prepareGroupedNotifications
@@ -21,7 +22,6 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { urlToId } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const DEFAULT_LIMIT = 40
@@ -119,21 +119,6 @@ export const GET = traceApiRoute(
       include_filtered: includeFiltered = false
     } = parsed.data
 
-    // Over-fetch rows so that after grouping we produce at least `limit` groups.
-    const notifications = await database.getNotifications({
-      actorId: currentActor.id,
-      limit: limit * GROUP_OVERSCAN,
-      maxNotificationId: maxId,
-      minNotificationId: minId || sinceId,
-      types: mastodonTypesToInternal(types),
-      excludeTypes: mastodonTypesToInternal(excludeTypes),
-      includeFiltered
-    })
-
-    const filtered = accountId
-      ? notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
-      : notifications
-
     // When grouped_types is omitted, fall back to Mastodon's default groupable
     // types (favourite/reblog/follow) so mentions/replies are not collapsed.
     const internalGroupedTypes = groupedTypesMastodon
@@ -141,6 +126,25 @@ export const GET = traceApiRoute(
           mastodonTypesToInternal(groupedTypesMastodon) as NotificationType[]
         )
       : new Set(DEFAULT_GROUPABLE_TYPES)
+
+    // Iteratively fetch+group until we have `limit` distinct groups (or the
+    // source is exhausted), so a single bursty group can't underfill the page
+    // and account_id paging scans past bursts from other accounts.
+    const { rawNotifications: filtered } = await collectNotificationGroups({
+      database,
+      baseQuery: {
+        actorId: currentActor.id,
+        minNotificationId: minId || sinceId,
+        types: mastodonTypesToInternal(types),
+        excludeTypes: mastodonTypesToInternal(excludeTypes),
+        includeFiltered
+      },
+      limit,
+      batchSize: limit * GROUP_OVERSCAN,
+      accountId,
+      groupedTypes: internalGroupedTypes,
+      startCursor: maxId
+    })
 
     // include_filtered controls only the DB-level filter flag (NotificationPolicy).
     // Content filters (keyword/status hide rules) are applied regardless.

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
+import { getActiveFilters } from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { buildNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
-import { Scope } from '@/lib/types/database/operations'
+import { NotificationType, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -40,6 +41,7 @@ const QueryParams = z.object({
     .optional(),
   types: z.array(z.string()).optional(),
   exclude_types: z.array(z.string()).optional(),
+  grouped_types: z.array(z.string()).optional(),
   account_id: z.string().optional(),
   include_filtered: z
     .enum(['true', 'false'])
@@ -88,6 +90,7 @@ export const GET = traceApiRoute(
       since_id: sinceId,
       types,
       exclude_types: excludeTypes,
+      grouped_types: groupedTypesMastodon,
       account_id: accountId,
       include_filtered: includeFiltered = false
     } = parsed.data
@@ -106,10 +109,22 @@ export const GET = traceApiRoute(
       ? notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
       : notifications
 
+    const internalGroupedTypes = groupedTypesMastodon
+      ? new Set(
+          mastodonTypesToInternal(groupedTypesMastodon) as NotificationType[]
+        )
+      : undefined
+
+    const filterRecords = includeFiltered
+      ? []
+      : await getActiveFilters(database, currentActor.id, 'notifications')
+
     const envelope = await buildNotificationGroupsEnvelope(
       database,
       filtered,
-      currentActor.id
+      currentActor.id,
+      internalGroupedTypes,
+      filterRecords
     )
 
     // Pagination links from the raw notification page (pre-grouping), mirroring
@@ -117,10 +132,12 @@ export const GET = traceApiRoute(
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
-      const params = new URLSearchParams()
+      const params = new URLSearchParams(url.searchParams)
+      params.delete('max_id')
+      params.delete('min_id')
+      params.delete('since_id')
       params.set('limit', limit.toString())
       params.set(cursorParam, cursorValue)
-      if (includeFiltered) params.set('include_filtered', 'true')
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
     const links =

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -4,7 +4,10 @@ import { getDatabase } from '@/lib/database'
 import { getActiveFilters } from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
-import { buildNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
+import {
+  getNotificationGroupsEnvelope,
+  prepareGroupedNotifications
+} from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
 import { NotificationType, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -138,25 +141,22 @@ export const GET = traceApiRoute(
       ? []
       : await getActiveFilters(database, currentActor.id, 'notifications')
 
-    // Build the envelope then truncate groups to the requested limit.
-    // Accounts and statuses are already deduped across all fetched groups;
-    // returning the full set is safe — clients use only those referenced by
-    // the groups they received.
-    const fullEnvelope = await buildNotificationGroupsEnvelope(
-      database,
+    // Prepare groups (follow-groupKey injection + groupNotifications) and slice
+    // to limit BEFORE resolving accounts/statuses to avoid unnecessary DB work.
+    const groupedSlice = prepareGroupedNotifications(
       filtered,
+      internalGroupedTypes
+    ).slice(0, limit)
+    const envelope = await getNotificationGroupsEnvelope(
+      database,
+      groupedSlice,
       currentActor.id,
-      internalGroupedTypes,
       filterRecords
     )
-    const envelope = {
-      notification_groups: fullEnvelope.notification_groups.slice(0, limit),
-      accounts: fullEnvelope.accounts,
-      statuses: fullEnvelope.statuses
-    }
 
-    // Pagination links: cursors come from the most-recent notification ids in the
-    // first and last returned groups. This anchors pagination to group boundaries.
+    // Pagination links: "next" (older page) uses page_min_id of the last group
+    // so that all members of that group are excluded from the next fetch.
+    // "prev" (newer page) uses most_recent_notification_id of the first group.
     const returnedGroups = envelope.notification_groups
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
@@ -169,13 +169,13 @@ export const GET = traceApiRoute(
       params.set(cursorParam, cursorValue)
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
+    const lastGroup = returnedGroups[returnedGroups.length - 1]
     const links =
       returnedGroups.length > 0
         ? [
             buildLink(
               'max_id',
-              returnedGroups[returnedGroups.length - 1]
-                .most_recent_notification_id
+              lastGroup.page_min_id ?? lastGroup.most_recent_notification_id
             ),
             buildLink('min_id', returnedGroups[0].most_recent_notification_id)
           ].join(', ')

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -130,22 +130,25 @@ export const GET = traceApiRoute(
     // Iteratively fetch+group until we have `limit` distinct groups (or the
     // source is exhausted), so a single bursty group can't underfill the page
     // and account_id paging scans past bursts from other accounts.
-    const { rawNotifications: filtered, exhausted } =
-      await collectNotificationGroups({
-        database,
-        baseQuery: {
-          actorId: currentActor.id,
-          minNotificationId: minId || sinceId,
-          types: mastodonTypesToInternal(types),
-          excludeTypes: mastodonTypesToInternal(excludeTypes),
-          includeFiltered
-        },
-        limit,
-        batchSize: limit * GROUP_OVERSCAN,
-        accountId,
-        groupedTypes: internalGroupedTypes,
-        startCursor: maxId
-      })
+    const {
+      rawNotifications: filtered,
+      exhausted,
+      lastScannedId
+    } = await collectNotificationGroups({
+      database,
+      baseQuery: {
+        actorId: currentActor.id,
+        minNotificationId: minId || sinceId,
+        types: mastodonTypesToInternal(types),
+        excludeTypes: mastodonTypesToInternal(excludeTypes),
+        includeFiltered
+      },
+      limit,
+      batchSize: limit * GROUP_OVERSCAN,
+      accountId,
+      groupedTypes: internalGroupedTypes,
+      startCursor: maxId
+    })
 
     // include_filtered controls only the DB-level filter flag (NotificationPolicy).
     // Content filters (keyword/status hide rules) are applied regardless.
@@ -209,10 +212,12 @@ export const GET = traceApiRoute(
         buildLink('max_id', lastGroup.most_recent_notification_id),
         buildLink('min_id', firstGroup.most_recent_notification_id)
       ].join(', ')
-    } else if (!exhausted && filtered.length > 0) {
-      // No visible groups on this page but more rows exist: emit only a next link
-      // so the client continues paging instead of stopping prematurely.
-      links = buildLink('max_id', filtered[filtered.length - 1].id)
+    } else if (!exhausted && lastScannedId) {
+      // No visible groups on this page but the source isn't exhausted (e.g. the
+      // iteration cap was hit, or account_id filtered out the whole window): emit
+      // only a next link from the last scanned row so the client keeps paging
+      // toward matching/visible groups further down instead of stopping.
+      links = buildLink('max_id', lastScannedId)
     }
 
     return apiResponse({

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -154,24 +154,43 @@ export const GET = traceApiRoute(
       'notifications'
     )
 
-    // Prepare groups (follow-groupKey injection + groupNotifications) and slice
-    // to limit BEFORE resolving accounts/statuses to avoid unnecessary DB work.
-    const groupedSlice = prepareGroupedNotifications(
+    // Build the envelope over ALL accumulated groups, then slice the SURVIVING
+    // groups to `limit`. Slicing before the envelope would let hide-filtered,
+    // deleted, or actorless groups (which the envelope drops) consume the page
+    // limit and underfill — or empty — a page while visible groups exist later.
+    const allGroups = prepareGroupedNotifications(
       filtered,
       internalGroupedTypes
-    ).slice(0, limit)
-    const envelope = await getNotificationGroupsEnvelope(
+    )
+    const fullEnvelope = await getNotificationGroupsEnvelope(
       database,
-      groupedSlice,
+      allGroups,
       currentActor.id,
       filterRecords
     )
+    const survivingGroups = fullEnvelope.notification_groups.slice(0, limit)
+    const keptStatusIds = new Set(
+      survivingGroups.map((g) => g.status_id).filter(Boolean)
+    )
+    const keptActorIds = new Set(
+      survivingGroups.flatMap((g) => g.sample_account_ids)
+    )
+    const envelope = {
+      notification_groups: survivingGroups,
+      accounts: fullEnvelope.accounts.filter((a) => keptActorIds.has(a.id)),
+      statuses: fullEnvelope.statuses.filter((s) => keptStatusIds.has(s.id))
+    }
 
     // Pagination cursor for "next": use the last raw notification BEFORE the first
     // gap (first notification not part of any returned group). This prevents
     // skipping intervening groups when a returned group spans non-contiguous rows.
+    // Map each surviving group back to its source rows via its group_key.
+    const groupByKey = new Map(allGroups.map((g) => [g.groupKey ?? g.id, g]))
     const sliceNotificationIds = new Set(
-      groupedSlice.flatMap((g) => [g.id, ...(g.groupedIds ?? [])])
+      survivingGroups.flatMap((g) => {
+        const src = groupByKey.get(g.group_key)
+        return src ? [src.id, ...(src.groupedIds ?? [])] : []
+      })
     )
     const firstGapIndex = filtered.findIndex(
       (n) => !sliceNotificationIds.has(n.id)
@@ -194,7 +213,7 @@ export const GET = traceApiRoute(
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
     const links =
-      groupedSlice.length > 0 && maxIdCursorNotification
+      survivingGroups.length > 0 && maxIdCursorNotification
         ? [
             buildLink('max_id', maxIdCursorNotification.id),
             buildLink('min_id', filtered[0].id)

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -158,10 +158,15 @@ export const GET = traceApiRoute(
       filterRecords
     )
 
-    // Pagination cursors mirror the v1 approach: use the last/first raw notification
-    // in the overscan window. This avoids permanent gaps that would occur if we used
-    // group-member IDs as cursors (groups can span interleaved non-group notifications).
-    // Clients handle boundary group duplication via page_min_id merging.
+    // Pagination cursors: "next" uses the oldest notification that is a member of
+    // any returned group, so we don't skip groups that lie beyond the slice but
+    // within the overscan window. "prev" uses the newest raw notification on the page.
+    const sliceNotificationIds = new Set(
+      groupedSlice.flatMap((g) => [g.id, ...(g.groupedIds ?? [])])
+    )
+    const lastSliceNotification = filtered
+      .filter((n) => sliceNotificationIds.has(n.id))
+      .at(-1)
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -174,9 +179,9 @@ export const GET = traceApiRoute(
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
     const links =
-      filtered.length > 0
+      groupedSlice.length > 0 && lastSliceNotification
         ? [
-            buildLink('max_id', filtered[filtered.length - 1].id),
+            buildLink('max_id', lastSliceNotification.id),
             buildLink('min_id', filtered[0].id)
           ].join(', ')
         : ''

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -130,21 +130,22 @@ export const GET = traceApiRoute(
     // Iteratively fetch+group until we have `limit` distinct groups (or the
     // source is exhausted), so a single bursty group can't underfill the page
     // and account_id paging scans past bursts from other accounts.
-    const { rawNotifications: filtered } = await collectNotificationGroups({
-      database,
-      baseQuery: {
-        actorId: currentActor.id,
-        minNotificationId: minId || sinceId,
-        types: mastodonTypesToInternal(types),
-        excludeTypes: mastodonTypesToInternal(excludeTypes),
-        includeFiltered
-      },
-      limit,
-      batchSize: limit * GROUP_OVERSCAN,
-      accountId,
-      groupedTypes: internalGroupedTypes,
-      startCursor: maxId
-    })
+    const { rawNotifications: filtered, exhausted } =
+      await collectNotificationGroups({
+        database,
+        baseQuery: {
+          actorId: currentActor.id,
+          minNotificationId: minId || sinceId,
+          types: mastodonTypesToInternal(types),
+          excludeTypes: mastodonTypesToInternal(excludeTypes),
+          includeFiltered
+        },
+        limit,
+        batchSize: limit * GROUP_OVERSCAN,
+        accountId,
+        groupedTypes: internalGroupedTypes,
+        startCursor: maxId
+      })
 
     // include_filtered controls only the DB-level filter flag (NotificationPolicy).
     // Content filters (keyword/status hide rules) are applied regardless.
@@ -181,26 +182,14 @@ export const GET = traceApiRoute(
       statuses: fullEnvelope.statuses.filter((s) => keptStatusIds.has(s.id))
     }
 
-    // Pagination cursor for "next": use the last raw notification BEFORE the first
-    // gap (first notification not part of any returned group). This prevents
-    // skipping intervening groups when a returned group spans non-contiguous rows.
-    // Map each surviving group back to its source rows via its group_key.
-    const groupByKey = new Map(allGroups.map((g) => [g.groupKey ?? g.id, g]))
-    const sliceNotificationIds = new Set(
-      survivingGroups.flatMap((g) => {
-        const src = groupByKey.get(g.group_key)
-        return src ? [src.id, ...(src.groupedIds ?? [])] : []
-      })
-    )
-    const firstGapIndex = filtered.findIndex(
-      (n) => !sliceNotificationIds.has(n.id)
-    )
-    const maxIdCursorNotification =
-      firstGapIndex > 0
-        ? filtered[firstGapIndex - 1]
-        : firstGapIndex === -1
-          ? filtered[filtered.length - 1]
-          : filtered[0]
+    // Pagination cursors anchor on the returned groups' most-recent notification
+    // ids. Groups are ordered by most-recent member, so the last returned group's
+    // most_recent id is newer than every not-yet-shown group — using it as max_id
+    // never skips a group (it can only re-show the last group's older members,
+    // which clients merge via page_min_id). This also steps past leading rows that
+    // were hidden by envelope suppression. When suppression empties the page but
+    // the source isn't exhausted, fall back to the oldest collected row so the
+    // client keeps paging toward the visible groups further down the timeline.
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -212,13 +201,19 @@ export const GET = traceApiRoute(
       params.set(cursorParam, cursorValue)
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
-    const links =
-      survivingGroups.length > 0 && maxIdCursorNotification
-        ? [
-            buildLink('max_id', maxIdCursorNotification.id),
-            buildLink('min_id', filtered[0].id)
-          ].join(', ')
-        : ''
+    let links = ''
+    if (survivingGroups.length > 0) {
+      const lastGroup = survivingGroups[survivingGroups.length - 1]
+      const firstGroup = survivingGroups[0]
+      links = [
+        buildLink('max_id', lastGroup.most_recent_notification_id),
+        buildLink('min_id', firstGroup.most_recent_notification_id)
+      ].join(', ')
+    } else if (!exhausted && filtered.length > 0) {
+      // No visible groups on this page but more rows exist: emit only a next link
+      // so the client continues paging instead of stopping prematurely.
+      links = buildLink('max_id', filtered[filtered.length - 1].id)
+    }
 
     return apiResponse({
       req,

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -137,9 +137,13 @@ export const GET = traceApiRoute(
         )
       : undefined
 
-    const filterRecords = includeFiltered
-      ? []
-      : await getActiveFilters(database, currentActor.id, 'notifications')
+    // include_filtered controls only the DB-level filter flag (NotificationPolicy).
+    // Content filters (keyword/status hide rules) are applied regardless.
+    const filterRecords = await getActiveFilters(
+      database,
+      currentActor.id,
+      'notifications'
+    )
 
     // Prepare groups (follow-groupKey injection + groupNotifications) and slice
     // to limit BEFORE resolving accounts/statuses to avoid unnecessary DB work.
@@ -154,10 +158,9 @@ export const GET = traceApiRoute(
       filterRecords
     )
 
-    // Pagination links: "next" (older page) uses page_min_id of the last group
-    // so that all members of that group are excluded from the next fetch.
-    // "prev" (newer page) uses most_recent_notification_id of the first group.
-    const returnedGroups = envelope.notification_groups
+    // Pagination links: use groupedSlice (pre-content-filter) as cursor source so
+    // clients keep paginating even when all visible groups on this page were
+    // hide-filtered. "next" uses page_min_id of the last pre-filter group.
     const host = headerHost(req.headers)
     const pathBase = '/api/v2/notifications'
     const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -169,15 +172,21 @@ export const GET = traceApiRoute(
       params.set(cursorParam, cursorValue)
       return `<https://${host}${pathBase}?${params.toString()}>; rel="${cursorParam === 'max_id' ? 'next' : 'prev'}"`
     }
-    const lastGroup = returnedGroups[returnedGroups.length - 1]
+    const lastPreFilterGroup = groupedSlice[groupedSlice.length - 1]
     const links =
-      returnedGroups.length > 0
+      groupedSlice.length > 0
         ? [
+            // oldest member of last pre-filter group → safe max_id for next page
             buildLink(
               'max_id',
-              lastGroup.page_min_id ?? lastGroup.most_recent_notification_id
+              lastPreFilterGroup.groupedIds
+                ? lastPreFilterGroup.groupedIds[
+                    lastPreFilterGroup.groupedIds.length - 1
+                  ]
+                : lastPreFilterGroup.id
             ),
-            buildLink('min_id', returnedGroups[0].most_recent_notification_id)
+            // most recent of first pre-filter group → safe min_id for prev page
+            buildLink('min_id', groupedSlice[0].id)
           ].join(', ')
         : ''
 

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -8,7 +8,10 @@ import {
   getNotificationGroupsEnvelope,
   prepareGroupedNotifications
 } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
-import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
+import {
+  DEFAULT_GROUPABLE_TYPES,
+  mastodonTypesToInternal
+} from '@/lib/services/notifications/notificationTypeMapping'
 import { NotificationType, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -131,11 +134,13 @@ export const GET = traceApiRoute(
       ? notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
       : notifications
 
+    // When grouped_types is omitted, fall back to Mastodon's default groupable
+    // types (favourite/reblog/follow) so mentions/replies are not collapsed.
     const internalGroupedTypes = groupedTypesMastodon
       ? new Set(
           mastodonTypesToInternal(groupedTypesMastodon) as NotificationType[]
         )
-      : undefined
+      : new Set(DEFAULT_GROUPABLE_TYPES)
 
     // include_filtered controls only the DB-level filter flag (NotificationPolicy).
     // Content filters (keyword/status hide rules) are applied regardless.

--- a/app/api/v2/notifications/unread_count/route.test.ts
+++ b/app/api/v2/notifications/unread_count/route.test.ts
@@ -2,15 +2,32 @@ import { NextRequest } from 'next/server'
 
 import { GET } from './route'
 
+const toId = (url: string) =>
+  url.replace(/https?:\/\//, '').replaceAll('/', ':')
+
 const mockDatabase = {
   getNotifications: jest.fn(),
-  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getStatusesByIds: jest.fn(),
+  getMastodonActorsFromIds: jest.fn()
 }
 
 const mockCurrentActor = { id: 'https://llun.test/users/llun' }
 
 jest.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase
+}))
+
+// Resolve statuses/accounts so the envelope keeps (does not suppress) the groups
+// — the count then reflects visible unread groups.
+jest.mock('@/lib/services/mastodon/getMastodonStatus', () => ({
+  getMastodonStatus: jest
+    .fn()
+    .mockImplementation((_db: unknown, domainStatus: { id: string }) =>
+      Promise.resolve({
+        id: domainStatus.id.replace(/https?:\/\//, '').replaceAll('/', ':')
+      })
+    )
 }))
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({
@@ -30,6 +47,14 @@ describe('GET /api/v2/notifications/unread_count', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockDatabase.getNotifications.mockResolvedValue([])
+    mockDatabase.getStatusesByIds.mockImplementation(
+      ({ statusIds }: { statusIds: string[] }) =>
+        Promise.resolve(statusIds.map((id) => ({ id })))
+    )
+    mockDatabase.getMastodonActorsFromIds.mockImplementation(
+      ({ ids }: { ids: string[] }) =>
+        Promise.resolve(ids.map((id) => ({ id: toId(id) })))
+    )
   })
 
   it('returns count of unread groups', async () => {

--- a/app/api/v2/notifications/unread_count/route.test.ts
+++ b/app/api/v2/notifications/unread_count/route.test.ts
@@ -1,0 +1,132 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getNotifications: jest.fn(),
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+}
+
+const mockCurrentActor = { id: 'https://llun.test/users/llun' }
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown[],
+      handle: (
+        req: NextRequest,
+        context: { currentActor: typeof mockCurrentActor; params: Promise<{}> }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{}> }) =>
+      handle(req, { currentActor: mockCurrentActor, params: context.params })
+}))
+
+describe('GET /api/v2/notifications/unread_count', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase.getNotifications.mockResolvedValue([])
+  })
+
+  it('returns count of unread groups', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'n1',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      },
+      {
+        id: 'n2',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/bob',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 1000,
+        updatedAt: 1000
+      },
+      {
+        id: 'n3',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/carol',
+        isRead: false,
+        filtered: false,
+        createdAt: 3000,
+        updatedAt: 3000
+      }
+    ])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/unread_count',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    // 2 likes collapse into 1 group; 1 follow = 1 group → total 2
+    expect(data.count).toBe(2)
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({ onlyUnread: true })
+    )
+  })
+
+  it('returns 422 for invalid limit', async () => {
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/unread_count?limit=0',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
+  })
+
+  it('filters by account_id', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'n1',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:s1',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      },
+      {
+        id: 'n2',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/bob',
+        statusId: 'https://other.test/statuses/2',
+        groupKey: 'like:s2',
+        isRead: false,
+        filtered: false,
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+    ])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications/unread_count?account_id=other.test%3Ausers%3Aalice',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.count).toBe(1)
+  })
+})

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -22,6 +22,9 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 1000
+// Bound on outer collect+suppress rounds so a window full of suppressed unread
+// groups can't make the badge scan unbounded rows.
+const MAX_COLLECT_ROUNDS = 5
 const ARRAY_QUERY_PARAMS = new Set(['types', 'exclude_types', 'grouped_types'])
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
@@ -101,23 +104,6 @@ export const GET = traceApiRoute(
         )
       : new Set(DEFAULT_GROUPABLE_TYPES)
 
-    // Iteratively fetch+group unread notifications until we reach `limit` groups
-    // (or run out), so a single bursty group can't make the badge undercount the
-    // other unread groups that exist just past a fixed raw-row window.
-    const { groups } = await collectNotificationGroups({
-      database,
-      baseQuery: {
-        actorId: currentActor.id,
-        onlyUnread: true,
-        types: mastodonTypesToInternal(types),
-        excludeTypes: mastodonTypesToInternal(excludeTypes)
-      },
-      limit,
-      batchSize: MAX_LIMIT,
-      accountId,
-      groupedTypes: internalGroupedTypes
-    })
-
     // Count only groups the list endpoint would actually show: build the same
     // envelope (with content filters) so hide-filtered, deleted-status, or
     // unresolvable-actor groups don't inflate the unread badge.
@@ -126,13 +112,43 @@ export const GET = traceApiRoute(
       currentActor.id,
       'notifications'
     )
-    const envelope = await getNotificationGroupsEnvelope(
-      database,
-      groups,
-      currentActor.id,
-      filterRecords
-    )
-    const count = Math.min(envelope.notification_groups.length, limit)
+
+    // Iteratively collect+suppress until we reach `limit` SURVIVING unread groups
+    // or run out of rows. Counting survivors (post-envelope) and looping past
+    // suppressed windows prevents both bursty-group undercounts and the case
+    // where the newest unread groups are all hidden/deleted while older visible
+    // unread groups still exist. Survivors are deduped by group_key across loops.
+    const survivingKeys = new Set<string>()
+    let cursor: string | undefined
+    for (let round = 0; round < MAX_COLLECT_ROUNDS; round += 1) {
+      const { groups, exhausted, lastScannedId } =
+        await collectNotificationGroups({
+          database,
+          baseQuery: {
+            actorId: currentActor.id,
+            onlyUnread: true,
+            types: mastodonTypesToInternal(types),
+            excludeTypes: mastodonTypesToInternal(excludeTypes)
+          },
+          limit,
+          batchSize: MAX_LIMIT,
+          accountId,
+          groupedTypes: internalGroupedTypes,
+          startCursor: cursor
+        })
+      const envelope = await getNotificationGroupsEnvelope(
+        database,
+        groups,
+        currentActor.id,
+        filterRecords
+      )
+      for (const group of envelope.notification_groups) {
+        survivingKeys.add(group.group_key)
+      }
+      if (survivingKeys.size >= limit || exhausted || !lastScannedId) break
+      cursor = lastScannedId
+    }
+    const count = Math.min(survivingKeys.size, limit)
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
   })

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -4,7 +4,7 @@ import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
 import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
-import { Scope } from '@/lib/types/database/operations'
+import { NotificationType, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -13,6 +13,7 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { urlToId } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const DEFAULT_LIMIT = 100
@@ -29,7 +30,9 @@ const QueryParams = z.object({
     .default(DEFAULT_LIMIT)
     .optional(),
   types: z.array(z.string()).optional(),
-  exclude_types: z.array(z.string()).optional()
+  exclude_types: z.array(z.string()).optional(),
+  grouped_types: z.array(z.string()).optional(),
+  account_id: z.string().optional()
 })
 
 export const GET = traceApiRoute(
@@ -69,8 +72,16 @@ export const GET = traceApiRoute(
     const {
       limit = DEFAULT_LIMIT,
       types,
-      exclude_types: excludeTypes
+      exclude_types: excludeTypes,
+      grouped_types: groupedTypesMastodon,
+      account_id: accountId
     } = parsed.data
+
+    const internalGroupedTypes = groupedTypesMastodon
+      ? new Set(
+          mastodonTypesToInternal(groupedTypesMastodon) as NotificationType[]
+        )
+      : undefined
 
     // Mastodon's grouped unread_count counts unread groups (capped).
     const notifications = await database.getNotifications({
@@ -80,7 +91,23 @@ export const GET = traceApiRoute(
       types: mastodonTypesToInternal(types),
       excludeTypes: mastodonTypesToInternal(excludeTypes)
     })
-    const count = groupNotifications(notifications, true).length
+    const filtered = accountId
+      ? notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
+      : notifications
+    // Apply same follow-grouping as the main v2 envelope.
+    const canGroupFollows =
+      !internalGroupedTypes ||
+      internalGroupedTypes.has(NotificationType.enum.follow)
+    const prepared = filtered.map((n) =>
+      n.type === NotificationType.enum.follow && !n.groupKey && canGroupFollows
+        ? { ...n, groupKey: 'follow' }
+        : n
+    )
+    const count = groupNotifications(
+      prepared,
+      true,
+      internalGroupedTypes
+    ).length
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
   })

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
+import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+const ARRAY_QUERY_PARAMS = new Set(['types', 'exclude_types', 'grouped_types'])
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const QueryParams = z.object({
+  limit: z.coerce
+    .number()
+    .min(1)
+    .max(MAX_LIMIT)
+    .default(DEFAULT_LIMIT)
+    .optional(),
+  types: z.array(z.string()).optional(),
+  exclude_types: z.array(z.string()).optional()
+})
+
+export const GET = traceApiRoute(
+  'getGroupedUnreadNotificationsCount',
+  OAuthGuard([Scope.enum.read], async (req, { currentActor }) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const url = new URL(req.url)
+    const queryParams: Record<string, string | string[]> = {}
+    for (const key of new Set(url.searchParams.keys())) {
+      const normalizedKey = key.replace(/\[\]$/, '')
+      const allValues = url.searchParams.getAll(key)
+      queryParams[normalizedKey] =
+        ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
+          ? allValues
+          : allValues[0]
+    }
+
+    const parsed = QueryParams.safeParse(queryParams)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const {
+      limit = DEFAULT_LIMIT,
+      types,
+      exclude_types: excludeTypes
+    } = parsed.data
+
+    // Mastodon's grouped unread_count counts unread groups (capped).
+    const notifications = await database.getNotifications({
+      actorId: currentActor.id,
+      limit,
+      onlyUnread: true,
+      types: mastodonTypesToInternal(types),
+      excludeTypes: mastodonTypesToInternal(excludeTypes)
+    })
+    const count = groupNotifications(notifications, true).length
+
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
+  })
+)

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -25,6 +25,7 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 const QueryParams = z.object({
   limit: z.coerce
     .number()
+    .int()
     .min(1)
     .max(MAX_LIMIT)
     .default(DEFAULT_LIMIT)
@@ -53,10 +54,21 @@ export const GET = traceApiRoute(
     for (const key of new Set(url.searchParams.keys())) {
       const normalizedKey = key.replace(/\[\]$/, '')
       const allValues = url.searchParams.getAll(key)
-      queryParams[normalizedKey] =
+      const normalizedValue =
         ARRAY_QUERY_PARAMS.has(normalizedKey) || allValues.length > 1
           ? allValues
           : allValues[0]
+      const existing = queryParams[normalizedKey]
+      if (existing === undefined) {
+        queryParams[normalizedKey] = normalizedValue
+      } else {
+        queryParams[normalizedKey] = [
+          ...(Array.isArray(existing) ? existing : [existing]),
+          ...(Array.isArray(normalizedValue)
+            ? normalizedValue
+            : [normalizedValue])
+        ]
+      }
     }
 
     const parsed = QueryParams.safeParse(queryParams)

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
-import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
+import { collectNotificationGroups } from '@/lib/services/notifications/collectNotificationGroups'
 import {
   DEFAULT_GROUPABLE_TYPES,
   mastodonTypesToInternal
@@ -16,7 +16,6 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { urlToId } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const DEFAULT_LIMIT = 100
@@ -100,31 +99,23 @@ export const GET = traceApiRoute(
         )
       : new Set(DEFAULT_GROUPABLE_TYPES)
 
-    // Fetch MAX_LIMIT rows so grouping produces an accurate group count regardless
-    // of how many individual rows belong to the same group. We cap after grouping.
-    const notifications = await database.getNotifications({
-      actorId: currentActor.id,
-      limit: MAX_LIMIT,
-      onlyUnread: true,
-      types: mastodonTypesToInternal(types),
-      excludeTypes: mastodonTypesToInternal(excludeTypes)
+    // Iteratively fetch+group unread notifications until we reach `limit` groups
+    // (or run out), so a single bursty group can't make the badge undercount the
+    // other unread groups that exist just past a fixed raw-row window.
+    const { groups } = await collectNotificationGroups({
+      database,
+      baseQuery: {
+        actorId: currentActor.id,
+        onlyUnread: true,
+        types: mastodonTypesToInternal(types),
+        excludeTypes: mastodonTypesToInternal(excludeTypes)
+      },
+      limit,
+      batchSize: MAX_LIMIT,
+      accountId,
+      groupedTypes: internalGroupedTypes
     })
-    const filtered = accountId
-      ? notifications.filter((n) => urlToId(n.sourceActorId) === accountId)
-      : notifications
-    // Apply same follow-grouping as the main v2 envelope.
-    const canGroupFollows =
-      !internalGroupedTypes ||
-      internalGroupedTypes.has(NotificationType.enum.follow)
-    const prepared = filtered.map((n) =>
-      n.type === NotificationType.enum.follow && !n.groupKey && canGroupFollows
-        ? { ...n, groupKey: 'follow' }
-        : n
-    )
-    const count = Math.min(
-      groupNotifications(prepared, true, internalGroupedTypes).length,
-      limit
-    )
+    const count = Math.min(groups.length, limit)
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
   })

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -3,7 +3,10 @@ import { z } from 'zod'
 import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
-import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
+import {
+  DEFAULT_GROUPABLE_TYPES,
+  mastodonTypesToInternal
+} from '@/lib/services/notifications/notificationTypeMapping'
 import { NotificationType, Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -89,11 +92,13 @@ export const GET = traceApiRoute(
       account_id: accountId
     } = parsed.data
 
+    // Default to Mastodon's groupable types so mentions/replies are counted
+    // individually when grouped_types is omitted (matches the list endpoint).
     const internalGroupedTypes = groupedTypesMastodon
       ? new Set(
           mastodonTypesToInternal(groupedTypesMastodon) as NotificationType[]
         )
-      : undefined
+      : new Set(DEFAULT_GROUPABLE_TYPES)
 
     // Fetch MAX_LIMIT rows so grouping produces an accurate group count regardless
     // of how many individual rows belong to the same group. We cap after grouping.

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -95,10 +95,11 @@ export const GET = traceApiRoute(
         )
       : undefined
 
-    // Mastodon's grouped unread_count counts unread groups (capped).
+    // Fetch MAX_LIMIT rows so grouping produces an accurate group count regardless
+    // of how many individual rows belong to the same group. We cap after grouping.
     const notifications = await database.getNotifications({
       actorId: currentActor.id,
-      limit,
+      limit: MAX_LIMIT,
       onlyUnread: true,
       types: mastodonTypesToInternal(types),
       excludeTypes: mastodonTypesToInternal(excludeTypes)
@@ -115,11 +116,10 @@ export const GET = traceApiRoute(
         ? { ...n, groupKey: 'follow' }
         : n
     )
-    const count = groupNotifications(
-      prepared,
-      true,
-      internalGroupedTypes
-    ).length
+    const count = Math.min(
+      groupNotifications(prepared, true, internalGroupedTypes).length,
+      limit
+    )
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
   })

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
+import { getActiveFilters } from '@/lib/services/filters/applyFilters'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { collectNotificationGroups } from '@/lib/services/notifications/collectNotificationGroups'
+import { getNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
 import {
   DEFAULT_GROUPABLE_TYPES,
   mastodonTypesToInternal
@@ -115,7 +117,22 @@ export const GET = traceApiRoute(
       accountId,
       groupedTypes: internalGroupedTypes
     })
-    const count = Math.min(groups.length, limit)
+
+    // Count only groups the list endpoint would actually show: build the same
+    // envelope (with content filters) so hide-filtered, deleted-status, or
+    // unresolvable-actor groups don't inflate the unread badge.
+    const filterRecords = await getActiveFilters(
+      database,
+      currentActor.id,
+      'notifications'
+    )
+    const envelope = await getNotificationGroupsEnvelope(
+      database,
+      groups,
+      currentActor.id,
+      filterRecords
+    )
+    const count = Math.min(envelope.notification_groups.length, limit)
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: { count } })
   })

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -13,6 +13,7 @@ import {
   getTextContent as getFollowRequestTextContent
 } from '@/lib/services/email/templates/followRequest'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
+import { followGroupKey } from '@/lib/services/notifications/followGrouping'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { NotificationType } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -108,13 +109,14 @@ export const createFollower = async ({
 
     const [, followNotification] = await Promise.all([
       acceptFollow(targetActor, followerActor.inboxUrl, followRequest),
-      // Create follow notification (auto-accepted)
+      // Create follow notification (auto-accepted). Bucket follows by UTC day so
+      // they group within a bounded window instead of one ever-growing group.
       createNotificationWithPolicy(database, {
         actorId: targetActor.id,
         type: NotificationType.enum.follow,
         sourceActorId: followerActor.id,
         followId: follow.id,
-        groupKey: 'follow'
+        groupKey: followGroupKey(Date.now())
       })
     ])
 

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -113,7 +113,8 @@ export const createFollower = async ({
         actorId: targetActor.id,
         type: NotificationType.enum.follow,
         sourceActorId: followerActor.id,
-        followId: follow.id
+        followId: follow.id,
+        groupKey: 'follow'
       })
     ])
 

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -571,6 +571,53 @@ describe('Notification Database', () => {
         })
         expect(remaining).toHaveLength(0)
       })
+
+      it('resolves legacy and persisted follow rows under the follow key', async () => {
+        // Legacy follow row created before the groupKey backfill (no groupKey).
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: actor2Id
+        })
+        // New follow row with the persisted synthetic key.
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: 'https://example.com/users/actor3',
+          groupKey: 'follow'
+        })
+
+        const notifications = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: 'follow'
+        })
+        expect(notifications).toHaveLength(2)
+      })
+
+      it('dismisses both legacy and persisted follow rows', async () => {
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: actor2Id
+        })
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: 'https://example.com/users/actor3',
+          groupKey: 'follow'
+        })
+
+        await database.dismissNotificationGroup({
+          actorId: actor1Id,
+          groupKey: 'follow'
+        })
+
+        const remaining = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: 'follow'
+        })
+        expect(remaining).toHaveLength(0)
+      })
     })
 
     describe('deleteNotification', () => {

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -572,26 +572,48 @@ describe('Notification Database', () => {
         expect(remaining).toHaveLength(0)
       })
 
-      it('resolves legacy and persisted follow rows under the follow key', async () => {
-        // Legacy follow row created before the groupKey backfill (no groupKey).
+      it('resolves persisted day-bucketed follow rows under their bucket key', async () => {
+        // Two follows in the same day bucket share the persisted key.
         await database.createNotification({
           actorId: actor1Id,
           type: NotificationType.enum.follow,
-          sourceActorId: actor2Id
+          sourceActorId: actor2Id,
+          groupKey: 'follow:20000'
         })
-        // New follow row with the persisted synthetic key.
         await database.createNotification({
           actorId: actor1Id,
           type: NotificationType.enum.follow,
           sourceActorId: 'https://example.com/users/actor3',
-          groupKey: 'follow'
+          groupKey: 'follow:20000'
+        })
+        // A follow in a different day bucket is a separate group.
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: 'https://example.com/users/actor4',
+          groupKey: 'follow:20001'
         })
 
-        const notifications = await database.getNotificationsForGroupKey({
+        const bucket = await database.getNotificationsForGroupKey({
           actorId: actor1Id,
-          groupKey: 'follow'
+          groupKey: 'follow:20000'
         })
-        expect(notifications).toHaveLength(2)
+        expect(bucket).toHaveLength(2)
+      })
+
+      it('resolves a legacy null-key follow row by its notification id', async () => {
+        const legacy = await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: actor2Id
+        })
+
+        const byId = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: legacy.id
+        })
+        expect(byId).toHaveLength(1)
+        expect(byId[0].id).toBe(legacy.id)
       })
 
       it('does not dismiss filtered rows sharing the group key', async () => {
@@ -626,27 +648,28 @@ describe('Notification Database', () => {
         expect(withFiltered[0].filtered).toBe(true)
       })
 
-      it('dismisses both legacy and persisted follow rows', async () => {
+      it('dismisses every follow row in a day bucket', async () => {
         await database.createNotification({
           actorId: actor1Id,
           type: NotificationType.enum.follow,
-          sourceActorId: actor2Id
+          sourceActorId: actor2Id,
+          groupKey: 'follow:20000'
         })
         await database.createNotification({
           actorId: actor1Id,
           type: NotificationType.enum.follow,
           sourceActorId: 'https://example.com/users/actor3',
-          groupKey: 'follow'
+          groupKey: 'follow:20000'
         })
 
         await database.dismissNotificationGroup({
           actorId: actor1Id,
-          groupKey: 'follow'
+          groupKey: 'follow:20000'
         })
 
         const remaining = await database.getNotificationsForGroupKey({
           actorId: actor1Id,
-          groupKey: 'follow'
+          groupKey: 'follow:20000'
         })
         expect(remaining).toHaveLength(0)
       })

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -594,6 +594,38 @@ describe('Notification Database', () => {
         expect(notifications).toHaveLength(2)
       })
 
+      it('does not dismiss filtered rows sharing the group key', async () => {
+        // A pending policy-filtered like sharing the same group key.
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.like,
+          sourceActorId: 'https://example.com/users/actor4',
+          statusId,
+          groupKey: `like:${statusId}`,
+          filtered: true
+        })
+
+        await database.dismissNotificationGroup({
+          actorId: actor1Id,
+          groupKey: `like:${statusId}`
+        })
+
+        // Visible rows are gone, the filtered request row survives.
+        const visible = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: `like:${statusId}`,
+          includeFiltered: false
+        })
+        expect(visible).toHaveLength(0)
+        const withFiltered = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: `like:${statusId}`,
+          includeFiltered: true
+        })
+        expect(withFiltered).toHaveLength(1)
+        expect(withFiltered[0].filtered).toBe(true)
+      })
+
       it('dismisses both legacy and persisted follow rows', async () => {
         await database.createNotification({
           actorId: actor1Id,

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -509,6 +509,70 @@ describe('Notification Database', () => {
       })
     })
 
+    describe('grouped notification lookup', () => {
+      beforeEach(async () => {
+        const existing = await database.getNotifications({
+          actorId: actor1Id,
+          limit: 100,
+          includeFiltered: true
+        })
+        for (const notif of existing) {
+          await database.deleteNotification(notif.id)
+        }
+
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.like,
+          sourceActorId: actor2Id,
+          statusId,
+          groupKey: `like:${statusId}`
+        })
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.like,
+          sourceActorId: 'https://example.com/users/actor3',
+          statusId,
+          groupKey: `like:${statusId}`
+        })
+      })
+
+      it('resolves all notifications for a shared group key', async () => {
+        const notifications = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: `like:${statusId}`
+        })
+        expect(notifications).toHaveLength(2)
+      })
+
+      it('resolves an ungrouped notification by its id', async () => {
+        const created = await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.follow,
+          sourceActorId: actor2Id
+        })
+
+        const notifications = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: created.id
+        })
+        expect(notifications).toHaveLength(1)
+        expect(notifications[0].id).toBe(created.id)
+      })
+
+      it('dismisses every notification in a group', async () => {
+        await database.dismissNotificationGroup({
+          actorId: actor1Id,
+          groupKey: `like:${statusId}`
+        })
+
+        const remaining = await database.getNotificationsForGroupKey({
+          actorId: actor1Id,
+          groupKey: `like:${statusId}`
+        })
+        expect(remaining).toHaveLength(0)
+      })
+    })
+
     describe('deleteNotification', () => {
       it('should delete a notification', async () => {
         const notification = await database.createNotification({

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -27,22 +27,14 @@ const fixNotificationDataDate = (data: Notification): Notification => ({
   readAt: data.readAt ? getCompatibleTime(data.readAt) : undefined
 })
 
-// The synthetic 'follow' group key (see prepareGroupedNotifications) groups every
-// follow notification — including legacy rows persisted before the groupKey
-// backfill, which have a null groupKey. Match those legacy rows too so the
-// detail/accounts/dismiss routes resolve and dismiss the whole follow group.
-const FOLLOW_GROUP_KEY = 'follow'
+// Match a group by its shared groupKey (e.g. 'like:<status>' or 'follow:<day>')
+// or, for ungrouped notifications, by the notification id itself.
 const applyGroupKeyMatch = (
   builder: Knex.QueryBuilder,
   groupKey: string
 ): Knex.QueryBuilder =>
   builder.where(function () {
     this.where('groupKey', groupKey).orWhere('id', groupKey)
-    if (groupKey === FOLLOW_GROUP_KEY) {
-      this.orWhere(function () {
-        this.where('type', FOLLOW_GROUP_KEY).whereNull('groupKey')
-      })
-    }
   })
 
 export const NotificationSQLDatabaseMixin = (

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -433,10 +433,15 @@ export const NotificationSQLDatabaseMixin = (
     actorId,
     groupKey
   }: NotificationGroupKeyParams) {
+    // Only dismiss visible (non-filtered) rows. Policy-filtered notifications can
+    // share a groupKey with visible ones but live in the requests queue; deleting
+    // them here would silently discard pending requests the user never saw.
     await applyGroupKeyMatch(
       database('notifications').where('actorId', actorId),
       groupKey
-    ).delete()
+    )
+      .andWhere('filtered', false)
+      .delete()
   },
 
   async deleteNotification(notificationId: string) {

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -27,6 +27,24 @@ const fixNotificationDataDate = (data: Notification): Notification => ({
   readAt: data.readAt ? getCompatibleTime(data.readAt) : undefined
 })
 
+// The synthetic 'follow' group key (see prepareGroupedNotifications) groups every
+// follow notification — including legacy rows persisted before the groupKey
+// backfill, which have a null groupKey. Match those legacy rows too so the
+// detail/accounts/dismiss routes resolve and dismiss the whole follow group.
+const FOLLOW_GROUP_KEY = 'follow'
+const applyGroupKeyMatch = (
+  builder: Knex.QueryBuilder,
+  groupKey: string
+): Knex.QueryBuilder =>
+  builder.where(function () {
+    this.where('groupKey', groupKey).orWhere('id', groupKey)
+    if (groupKey === FOLLOW_GROUP_KEY) {
+      this.orWhere(function () {
+        this.where('type', FOLLOW_GROUP_KEY).whereNull('groupKey')
+      })
+    }
+  })
+
 export const NotificationSQLDatabaseMixin = (
   database: Knex
 ): NotificationDatabase => ({
@@ -396,11 +414,10 @@ export const NotificationSQLDatabaseMixin = (
     groupKey,
     includeFiltered
   }: NotificationGroupKeyParams) {
-    let query = database('notifications')
-      .where('actorId', actorId)
-      .andWhere(function () {
-        this.where('groupKey', groupKey).orWhere('id', groupKey)
-      })
+    let query = applyGroupKeyMatch(
+      database('notifications').where('actorId', actorId),
+      groupKey
+    )
       .orderBy('createdAt', 'desc')
       .orderBy('id', 'desc')
 
@@ -416,12 +433,10 @@ export const NotificationSQLDatabaseMixin = (
     actorId,
     groupKey
   }: NotificationGroupKeyParams) {
-    await database('notifications')
-      .where('actorId', actorId)
-      .andWhere(function () {
-        this.where('groupKey', groupKey).orWhere('id', groupKey)
-      })
-      .delete()
+    await applyGroupKeyMatch(
+      database('notifications').where('actorId', actorId),
+      groupKey
+    ).delete()
   },
 
   async deleteNotification(notificationId: string) {

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -11,6 +11,7 @@ import {
   MarkNotificationsReadParams,
   Notification,
   NotificationDatabase,
+  NotificationGroupKeyParams,
   NotificationRequest,
   ResolveNotificationRequestsParams,
   UpdateNotificationParams
@@ -388,6 +389,39 @@ export const NotificationSQLDatabaseMixin = (
           .delete()
       )
     )
+  },
+
+  async getNotificationsForGroupKey({
+    actorId,
+    groupKey,
+    includeFiltered
+  }: NotificationGroupKeyParams) {
+    let query = database('notifications')
+      .where('actorId', actorId)
+      .andWhere(function () {
+        this.where('groupKey', groupKey).orWhere('id', groupKey)
+      })
+      .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
+
+    if (!includeFiltered) {
+      query = query.andWhere('filtered', false)
+    }
+
+    const results = await query
+    return results.map(fixNotificationDataDate)
+  },
+
+  async dismissNotificationGroup({
+    actorId,
+    groupKey
+  }: NotificationGroupKeyParams) {
+    await database('notifications')
+      .where('actorId', actorId)
+      .andWhere(function () {
+        this.where('groupKey', groupKey).orWhere('id', groupKey)
+      })
+      .delete()
   },
 
   async deleteNotification(notificationId: string) {

--- a/lib/services/notifications/collectNotificationGroups.test.ts
+++ b/lib/services/notifications/collectNotificationGroups.test.ts
@@ -1,0 +1,153 @@
+import { Database } from '@/lib/database/types'
+import { collectNotificationGroups } from '@/lib/services/notifications/collectNotificationGroups'
+import { Notification, NotificationType } from '@/lib/types/database/operations'
+
+const notif = (overrides: Partial<Notification>): Notification => ({
+  id: 'n',
+  actorId: 'https://llun.test/users/me',
+  type: NotificationType.enum.like,
+  sourceActorId: 'https://other.test/users/alice',
+  isRead: false,
+  filtered: false,
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides
+})
+
+describe('#collectNotificationGroups', () => {
+  it('keeps fetching past a bursty group until it has `limit` groups', async () => {
+    // First batch is entirely one big "like" group; later batches add new groups.
+    const batch1 = Array.from({ length: 5 }, (_, i) =>
+      notif({ id: `a${i}`, groupKey: 'like:s1', createdAt: 1000 - i })
+    )
+    const batch2 = [
+      notif({
+        id: 'b0',
+        type: NotificationType.enum.reblog,
+        groupKey: 'reblog:s2',
+        createdAt: 900
+      }),
+      notif({
+        id: 'b1',
+        type: NotificationType.enum.follow,
+        groupKey: 'follow',
+        createdAt: 899
+      })
+      // Short batch (< batchSize) → source exhausted.
+    ]
+    const getNotifications = jest
+      .fn()
+      .mockResolvedValueOnce(batch1)
+      .mockResolvedValueOnce(batch2)
+    const database = { getNotifications } as unknown as Database
+
+    const result = await collectNotificationGroups({
+      database,
+      baseQuery: { actorId: 'https://llun.test/users/me' },
+      limit: 3,
+      batchSize: 5
+    })
+
+    // Two fetches: first (full batch) didn't yield 3 groups, second did/exhausted.
+    expect(getNotifications).toHaveBeenCalledTimes(2)
+    // Second fetch advanced the cursor to the last id of batch1.
+    expect(getNotifications.mock.calls[1][0]).toMatchObject({
+      maxNotificationId: 'a4'
+    })
+    expect(result.groups).toHaveLength(3)
+    expect(result.exhausted).toBe(true)
+    expect(result.rawNotifications).toHaveLength(7)
+  })
+
+  it('stops once `limit` groups are reached without over-scanning', async () => {
+    const batch1 = [
+      notif({ id: 'a', groupKey: 'like:s1', createdAt: 1000 }),
+      notif({
+        id: 'b',
+        type: NotificationType.enum.reblog,
+        groupKey: 'reblog:s2',
+        createdAt: 999
+      }),
+      notif({
+        id: 'c',
+        type: NotificationType.enum.follow,
+        groupKey: 'follow',
+        createdAt: 998
+      })
+    ]
+    const getNotifications = jest.fn().mockResolvedValue(batch1)
+    const database = { getNotifications } as unknown as Database
+
+    const result = await collectNotificationGroups({
+      database,
+      baseQuery: { actorId: 'https://llun.test/users/me' },
+      limit: 2,
+      batchSize: 3
+    })
+
+    // First full batch already yields >= 2 groups → no second fetch.
+    expect(getNotifications).toHaveBeenCalledTimes(1)
+    expect(result.groups.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('advances the cursor by the raw tail when account filtering empties a batch', async () => {
+    const ALICE = 'https://other.test/users/alice'
+    const BOB = 'https://other.test/users/bob'
+    // First batch is all BOB (filtered out); second has the requested ALICE rows.
+    const batch1 = Array.from({ length: 3 }, (_, i) =>
+      notif({ id: `bob${i}`, sourceActorId: BOB, createdAt: 1000 - i })
+    )
+    const batch2 = [
+      notif({ id: 'alice0', sourceActorId: ALICE, createdAt: 900 })
+    ]
+    const getNotifications = jest
+      .fn()
+      .mockResolvedValueOnce(batch1)
+      .mockResolvedValueOnce(batch2)
+    const database = { getNotifications } as unknown as Database
+
+    const result = await collectNotificationGroups({
+      database,
+      baseQuery: { actorId: 'https://llun.test/users/me' },
+      limit: 1,
+      batchSize: 3,
+      accountId: 'other.test:users:alice'
+    })
+
+    expect(getNotifications).toHaveBeenCalledTimes(2)
+    // Cursor advanced past the all-BOB batch by its raw tail.
+    expect(getNotifications.mock.calls[1][0]).toMatchObject({
+      maxNotificationId: 'bob2'
+    })
+    expect(result.rawNotifications.map((n) => n.id)).toEqual(['alice0'])
+  })
+
+  it('respects the iteration cap to bound DB round-trips', async () => {
+    // Every batch is the same one group; never reaches limit groups.
+    let seq = 0
+    const fullBatch = () =>
+      Array.from({ length: 2 }, (_, i) => {
+        seq += 1
+        return notif({
+          id: `x${seq}`,
+          groupKey: 'like:s1',
+          createdAt: 1000 - i
+        })
+      })
+    const getNotifications = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(fullBatch()))
+    const database = { getNotifications } as unknown as Database
+
+    const result = await collectNotificationGroups({
+      database,
+      baseQuery: { actorId: 'https://llun.test/users/me' },
+      limit: 10,
+      batchSize: 2,
+      maxIterations: 3
+    })
+
+    expect(getNotifications).toHaveBeenCalledTimes(3)
+    expect(result.exhausted).toBe(false)
+  })
+})

--- a/lib/services/notifications/collectNotificationGroups.test.ts
+++ b/lib/services/notifications/collectNotificationGroups.test.ts
@@ -150,4 +150,38 @@ describe('#collectNotificationGroups', () => {
     expect(getNotifications).toHaveBeenCalledTimes(3)
     expect(result.exhausted).toBe(false)
   })
+
+  it('reports lastScannedId even when account filtering drops every row', async () => {
+    const BOB = 'https://other.test/users/bob'
+    // Two full batches entirely from BOB; the requested ALICE account matches none
+    // within the iteration cap, so accumulation is empty but the scan progressed.
+    let seq = 0
+    const bobBatch = () =>
+      Array.from({ length: 2 }, () => {
+        seq += 1
+        return notif({
+          id: `bob${seq}`,
+          sourceActorId: BOB,
+          createdAt: 1000 - seq
+        })
+      })
+    const getNotifications = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(bobBatch()))
+    const database = { getNotifications } as unknown as Database
+
+    const result = await collectNotificationGroups({
+      database,
+      baseQuery: { actorId: 'https://llun.test/users/me' },
+      limit: 1,
+      batchSize: 2,
+      accountId: 'other.test:users:alice',
+      maxIterations: 2
+    })
+
+    expect(result.rawNotifications).toHaveLength(0)
+    expect(result.exhausted).toBe(false)
+    // lastScannedId is the id of the last raw row scanned, so the caller can page on.
+    expect(result.lastScannedId).toBe('bob4')
+  })
 })

--- a/lib/services/notifications/collectNotificationGroups.ts
+++ b/lib/services/notifications/collectNotificationGroups.ts
@@ -42,6 +42,10 @@ interface CollectResult {
   groups: GroupedNotification[]
   // True when the DB ran out of matching rows (no further pages exist).
   exhausted: boolean
+  // The id of the last raw row scanned (the next-page cursor), regardless of
+  // account filtering — set even when every scanned row was filtered out, so the
+  // caller can keep paging toward matching rows further down the timeline.
+  lastScannedId?: string
 }
 
 /**
@@ -65,6 +69,7 @@ export const collectNotificationGroups = async ({
 }: CollectParams): Promise<CollectResult> => {
   const accumulated: Notification[] = []
   let cursor = startCursor
+  let lastScannedId: string | undefined
   let exhausted = false
 
   for (let iteration = 0; iteration < maxIterations; iteration += 1) {
@@ -84,8 +89,10 @@ export const collectNotificationGroups = async ({
     accumulated.push(...filteredBatch)
 
     // Advance the cursor by the raw batch tail regardless of account filtering so
-    // account_id paging keeps scanning past bursts from other accounts.
+    // account_id paging keeps scanning past bursts from other accounts. Track it
+    // even when every row was filtered out, so the caller can keep paging.
     cursor = batch[batch.length - 1].id
+    lastScannedId = cursor
 
     // Fewer rows than requested means the DB has no more matching notifications.
     if (batch.length < batchSize) {
@@ -103,6 +110,7 @@ export const collectNotificationGroups = async ({
   return {
     rawNotifications: accumulated,
     groups: prepareGroupedNotifications(accumulated, groupedTypes),
-    exhausted
+    exhausted,
+    lastScannedId
   }
 }

--- a/lib/services/notifications/collectNotificationGroups.ts
+++ b/lib/services/notifications/collectNotificationGroups.ts
@@ -1,0 +1,108 @@
+import { Database } from '@/lib/database/types'
+import { prepareGroupedNotifications } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
+import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import {
+  GetNotificationsParams,
+  Notification,
+  NotificationType
+} from '@/lib/types/database/operations'
+import { urlToId } from '@/lib/utils/urlToId'
+
+// Per-fetch batch size and the hard cap on raw rows scanned. The cap bounds the
+// number of DB round-trips so a pathological burst can't make a request scan the
+// whole table; once it's hit we return whatever groups we have.
+const DEFAULT_MAX_ITERATIONS = 5
+
+interface CollectParams {
+  database: Database
+  // Base query fields shared across batches (actorId, types, excludeTypes,
+  // onlyUnread, includeFiltered, minNotificationId/sinceNotificationId).
+  baseQuery: Omit<
+    GetNotificationsParams,
+    'limit' | 'maxNotificationId' | 'offset'
+  >
+  // Desired number of distinct groups.
+  limit: number
+  // Rows fetched per DB call.
+  batchSize: number
+  // Optional source-actor filter (Mastodon account_id), applied per batch.
+  accountId?: string
+  // Types eligible for grouping (others stay individual).
+  groupedTypes?: Set<NotificationType>
+  // Cursor to start scanning from (max_id); rows older than this are fetched.
+  startCursor?: string
+  // Overrides the default iteration cap (mainly for tests).
+  maxIterations?: number
+}
+
+interface CollectResult {
+  // Accumulated raw rows (after account filtering), most-recent-first.
+  rawNotifications: Notification[]
+  // Grouped result over the accumulated rows (may exceed limit).
+  groups: GroupedNotification[]
+  // True when the DB ran out of matching rows (no further pages exist).
+  exhausted: boolean
+}
+
+/**
+ * Iteratively fetches and groups notifications until at least `limit` distinct
+ * groups are available or the source is exhausted (or the iteration cap is hit).
+ *
+ * Fixes the bursty-group problem: a single status with thousands of likes no
+ * longer fills an entire page with one group while hiding the other groups that
+ * exist just past a fixed over-fetch window. The cursor advances by the raw row
+ * tail (not the account-filtered tail) so account_id paging also makes progress.
+ */
+export const collectNotificationGroups = async ({
+  database,
+  baseQuery,
+  limit,
+  batchSize,
+  accountId,
+  groupedTypes,
+  startCursor,
+  maxIterations = DEFAULT_MAX_ITERATIONS
+}: CollectParams): Promise<CollectResult> => {
+  const accumulated: Notification[] = []
+  let cursor = startCursor
+  let exhausted = false
+
+  for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+    const batch = await database.getNotifications({
+      ...baseQuery,
+      limit: batchSize,
+      maxNotificationId: cursor
+    })
+    if (batch.length === 0) {
+      exhausted = true
+      break
+    }
+
+    const filteredBatch = accountId
+      ? batch.filter((n) => urlToId(n.sourceActorId) === accountId)
+      : batch
+    accumulated.push(...filteredBatch)
+
+    // Advance the cursor by the raw batch tail regardless of account filtering so
+    // account_id paging keeps scanning past bursts from other accounts.
+    cursor = batch[batch.length - 1].id
+
+    // Fewer rows than requested means the DB has no more matching notifications.
+    if (batch.length < batchSize) {
+      exhausted = true
+      break
+    }
+
+    if (
+      prepareGroupedNotifications(accumulated, groupedTypes).length >= limit
+    ) {
+      break
+    }
+  }
+
+  return {
+    rawNotifications: accumulated,
+    groups: prepareGroupedNotifications(accumulated, groupedTypes),
+    exhausted
+  }
+}

--- a/lib/services/notifications/followGrouping.test.ts
+++ b/lib/services/notifications/followGrouping.test.ts
@@ -1,0 +1,16 @@
+import { followGroupKey } from '@/lib/services/notifications/followGrouping'
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe('#followGroupKey', () => {
+  it('buckets timestamps on the same UTC day into one key', () => {
+    const dayStart = 20000 * DAY
+    expect(followGroupKey(dayStart)).toBe('follow:20000')
+    expect(followGroupKey(dayStart + DAY - 1)).toBe('follow:20000')
+  })
+
+  it('uses a different key on the next day', () => {
+    const dayStart = 20000 * DAY
+    expect(followGroupKey(dayStart + DAY)).toBe('follow:20001')
+  })
+})

--- a/lib/services/notifications/followGrouping.ts
+++ b/lib/services/notifications/followGrouping.ts
@@ -1,0 +1,12 @@
+// Follow notifications are grouped into bounded day-sized buckets rather than a
+// single ever-growing group. The persisted group key encodes the UTC day so the
+// list/detail/dismiss paths can match a bucket by exact string (no DB time-range
+// query, which keeps it portable across SQLite and PostgreSQL).
+const FOLLOW_GROUP_BUCKET_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Builds the follow group key for a notification created at `createdAtMs`
+ * (epoch milliseconds). All follows on the same UTC day share a key.
+ */
+export const followGroupKey = (createdAtMs: number): string =>
+  `follow:${Math.floor(createdAtMs / FOLLOW_GROUP_BUCKET_MS)}`

--- a/lib/services/notifications/getNotificationGroup.test.ts
+++ b/lib/services/notifications/getNotificationGroup.test.ts
@@ -31,6 +31,8 @@ describe('#getNotificationGroup', () => {
       notifications_count: 2,
       type: 'favourite',
       most_recent_notification_id: 'n1',
+      // ISO-8601 of the group's most-recent notification createdAt (1000ms epoch).
+      latest_page_notification_at: '1970-01-01T00:00:01Z',
       status_id: urlToId('https://other.test/statuses/1')
     })
     expect(group.sample_account_ids).toEqual([

--- a/lib/services/notifications/getNotificationGroup.test.ts
+++ b/lib/services/notifications/getNotificationGroup.test.ts
@@ -1,0 +1,66 @@
+import { getNotificationGroup } from '@/lib/services/notifications/getNotificationGroup'
+import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import { urlToId } from '@/lib/utils/urlToId'
+
+const base: GroupedNotification = {
+  id: 'n1',
+  actorId: 'https://llun.test/users/me',
+  type: 'like',
+  sourceActorId: 'https://other.test/users/alice',
+  statusId: 'https://other.test/statuses/1',
+  isRead: false,
+  filtered: false,
+  groupKey: 'like:https://other.test/statuses/1',
+  createdAt: 1000,
+  updatedAt: 1000
+}
+
+describe('#getNotificationGroup', () => {
+  it('maps a grouped notification to a Mastodon NotificationGroup', () => {
+    const { group } = getNotificationGroup({
+      ...base,
+      groupedActors: [
+        'https://other.test/users/alice',
+        'https://other.test/users/bob'
+      ],
+      groupedCount: 2
+    })
+
+    expect(group).toMatchObject({
+      group_key: 'like:https://other.test/statuses/1',
+      notifications_count: 2,
+      type: 'favourite',
+      most_recent_notification_id: 'n1',
+      status_id: urlToId('https://other.test/statuses/1')
+    })
+    expect(group.sample_account_ids).toEqual([
+      urlToId('https://other.test/users/alice'),
+      urlToId('https://other.test/users/bob')
+    ])
+  })
+
+  it('uses the notification id as the group key for ungrouped notifications', () => {
+    const { group, sampleActorIds } = getNotificationGroup({
+      ...base,
+      groupKey: undefined,
+      groupedActors: undefined,
+      groupedCount: 1
+    })
+
+    expect(group.group_key).toBe('n1')
+    expect(group.notifications_count).toBe(1)
+    expect(sampleActorIds).toEqual(['https://other.test/users/alice'])
+  })
+
+  it('omits status_id for notifications without a status', () => {
+    const { group, statusId } = getNotificationGroup({
+      ...base,
+      type: 'follow',
+      statusId: undefined
+    })
+
+    expect(group.status_id).toBeUndefined()
+    expect(group.type).toBe('follow')
+    expect(statusId).toBeUndefined()
+  })
+})

--- a/lib/services/notifications/getNotificationGroup.ts
+++ b/lib/services/notifications/getNotificationGroup.ts
@@ -1,0 +1,68 @@
+import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+import {
+  MastodonNotificationType,
+  internalTypeToMastodon
+} from '@/lib/services/notifications/notificationTypeMapping'
+import { urlToId } from '@/lib/utils/urlToId'
+
+// Up to how many recent actors to surface per group (Mastodon returns a sample,
+// not the full set). Bounds the number of accounts fetched for the envelope.
+const SAMPLE_ACCOUNT_LIMIT = 8
+
+// Mastodon NotificationGroup entity (the subset this codebase can populate).
+export interface MastodonNotificationGroup {
+  group_key: string
+  notifications_count: number
+  type: MastodonNotificationType
+  most_recent_notification_id: string
+  page_min_id?: string
+  page_max_id?: string
+  sample_account_ids: string[]
+  status_id?: string
+}
+
+export interface NotificationGroupResult {
+  group: MastodonNotificationGroup
+  // Full source-actor URLs referenced by sample_account_ids, for the envelope
+  // to resolve into deduped Account objects.
+  sampleActorIds: string[]
+  // Full status id referenced by status_id, if any.
+  statusId?: string
+}
+
+// The stable group key for a grouped notification: the shared groupKey when
+// present, otherwise the (ungrouped) notification's own id.
+export const notificationGroupKey = (
+  notification: GroupedNotification
+): string => notification.groupKey || notification.id
+
+/**
+ * Builds a Mastodon NotificationGroup from a grouped notification. Pure and
+ * synchronous; the caller resolves sampleActorIds/statusId into the envelope's
+ * deduped accounts/statuses arrays.
+ */
+export const getNotificationGroup = (
+  notification: GroupedNotification
+): NotificationGroupResult => {
+  const sampleActorIds = Array.from(
+    new Set(notification.groupedActors ?? [notification.sourceActorId])
+  ).slice(0, SAMPLE_ACCOUNT_LIMIT)
+
+  return {
+    group: {
+      group_key: notificationGroupKey(notification),
+      notifications_count: notification.groupedCount ?? 1,
+      type: internalTypeToMastodon(notification.type),
+      // groupNotifications keeps the most recent notification as the base.
+      most_recent_notification_id: notification.id,
+      page_max_id: notification.id,
+      page_min_id: notification.id,
+      sample_account_ids: sampleActorIds.map((id) => urlToId(id)),
+      ...(notification.statusId
+        ? { status_id: urlToId(notification.statusId) }
+        : null)
+    },
+    sampleActorIds,
+    statusId: notification.statusId
+  }
+}

--- a/lib/services/notifications/getNotificationGroup.ts
+++ b/lib/services/notifications/getNotificationGroup.ts
@@ -3,6 +3,7 @@ import {
   MastodonNotificationType,
   internalTypeToMastodon
 } from '@/lib/services/notifications/notificationTypeMapping'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 // Up to how many recent actors to surface per group (Mastodon returns a sample,
@@ -17,6 +18,11 @@ export interface MastodonNotificationGroup {
   most_recent_notification_id: string
   page_min_id?: string
   page_max_id?: string
+  // ISO-8601 timestamp of the group's most recent notification, so clients can
+  // display/poll by time (esp. follow-only groups with no backing status, and
+  // status-backed groups where the status created_at is the post time, not the
+  // interaction time).
+  latest_page_notification_at: string
   sample_account_ids: string[]
   status_id?: string
 }
@@ -60,6 +66,8 @@ export const getNotificationGroup = (
       page_min_id: notification.groupedIds
         ? notification.groupedIds[notification.groupedIds.length - 1]
         : notification.id,
+      // groupNotifications keeps the group's createdAt as its most-recent member's.
+      latest_page_notification_at: getISOTimeUTC(notification.createdAt),
       sample_account_ids: sampleActorIds.map((id) => urlToId(id)),
       ...(notification.statusId
         ? { status_id: urlToId(notification.statusId) }

--- a/lib/services/notifications/getNotificationGroup.ts
+++ b/lib/services/notifications/getNotificationGroup.ts
@@ -56,7 +56,10 @@ export const getNotificationGroup = (
       // groupNotifications keeps the most recent notification as the base.
       most_recent_notification_id: notification.id,
       page_max_id: notification.id,
-      page_min_id: notification.id,
+      // groupedIds[last] is the oldest notification in the group (DB returns most-recent-first).
+      page_min_id: notification.groupedIds
+        ? notification.groupedIds[notification.groupedIds.length - 1]
+        : notification.id,
       sample_account_ids: sampleActorIds.map((id) => urlToId(id)),
       ...(notification.statusId
         ? { status_id: urlToId(notification.statusId) }

--- a/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
@@ -37,7 +37,12 @@ describe('#getNotificationGroupsEnvelope', () => {
         .mockImplementation(({ ids }: { ids: string[] }) =>
           Promise.resolve(ids.map((id) => ({ id })))
         ),
-      getStatus: jest.fn().mockResolvedValue({ id: STATUS })
+      getStatus: jest.fn().mockResolvedValue({ id: STATUS }),
+      getStatusesByIds: jest
+        .fn()
+        .mockImplementation(({ statusIds }: { statusIds: string[] }) =>
+          Promise.resolve(statusIds.map((id) => ({ id })))
+        )
     } as unknown as Database
     mockGetMastodonStatus.mockResolvedValue({ id: 'status-1' })
 
@@ -81,15 +86,18 @@ describe('#getNotificationGroupsEnvelope', () => {
       .calls[0][0].ids
     expect([...accountIds].sort()).toEqual([ALICE, BOB].sort())
 
-    // The status is fetched once despite two groups referencing it.
-    expect(mockDatabase.getStatus).toHaveBeenCalledTimes(1)
+    // The status is fetched once via batch despite two groups referencing it.
+    expect(mockDatabase.getStatusesByIds).toHaveBeenCalledTimes(1)
+    expect(
+      (mockDatabase.getStatusesByIds as jest.Mock).mock.calls[0][0].statusIds
+    ).toHaveLength(1)
     expect(envelope.statuses).toHaveLength(1)
   })
 
   it('returns empty accounts/statuses when there is nothing to resolve', async () => {
     const mockDatabase = {
       getMastodonActorsFromIds: jest.fn().mockResolvedValue([]),
-      getStatus: jest.fn()
+      getStatusesByIds: jest.fn()
     } as unknown as Database
 
     const envelope = await getNotificationGroupsEnvelope(mockDatabase, [])
@@ -100,6 +108,6 @@ describe('#getNotificationGroupsEnvelope', () => {
       statuses: []
     })
     expect(mockDatabase.getMastodonActorsFromIds).not.toHaveBeenCalled()
-    expect(mockDatabase.getStatus).not.toHaveBeenCalled()
+    expect(mockDatabase.getStatusesByIds).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
@@ -1,0 +1,105 @@
+import { Database } from '@/lib/database/types'
+import { getNotificationGroupsEnvelope } from '@/lib/services/notifications/getNotificationGroupsEnvelope'
+import { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
+
+const mockGetMastodonStatus = jest.fn()
+jest.mock('@/lib/services/mastodon/getMastodonStatus', () => ({
+  getMastodonStatus: (...args: unknown[]) => mockGetMastodonStatus(...args)
+}))
+
+const ALICE = 'https://other.test/users/alice'
+const BOB = 'https://other.test/users/bob'
+const STATUS = 'https://other.test/statuses/1'
+
+const grouped = (
+  overrides: Partial<GroupedNotification>
+): GroupedNotification => ({
+  id: 'n',
+  actorId: 'https://llun.test/users/me',
+  type: 'like',
+  sourceActorId: ALICE,
+  isRead: false,
+  filtered: false,
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides
+})
+
+describe('#getNotificationGroupsEnvelope', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('dedupes accounts and statuses referenced across groups', async () => {
+    const mockDatabase = {
+      getMastodonActorsFromIds: jest
+        .fn()
+        .mockImplementation(({ ids }: { ids: string[] }) =>
+          Promise.resolve(ids.map((id) => ({ id })))
+        ),
+      getStatus: jest.fn().mockResolvedValue({ id: STATUS })
+    } as unknown as Database
+    mockGetMastodonStatus.mockResolvedValue({ id: 'status-1' })
+
+    // Two like groups on the same status from alice and bob (status referenced
+    // twice), plus a follow group from alice (alice referenced again).
+    const groups: GroupedNotification[] = [
+      grouped({
+        id: 'g1',
+        groupKey: `like:${STATUS}`,
+        statusId: STATUS,
+        groupedActors: [ALICE, BOB],
+        groupedCount: 2
+      }),
+      grouped({
+        id: 'g2',
+        type: 'reblog',
+        groupKey: `reblog:${STATUS}`,
+        statusId: STATUS,
+        groupedActors: [ALICE],
+        groupedCount: 1
+      }),
+      grouped({
+        id: 'g3',
+        type: 'follow',
+        sourceActorId: ALICE,
+        groupKey: undefined,
+        groupedCount: 1
+      })
+    ]
+
+    const envelope = await getNotificationGroupsEnvelope(
+      mockDatabase,
+      groups,
+      'https://llun.test/users/me'
+    )
+
+    expect(envelope.notification_groups).toHaveLength(3)
+
+    // alice + bob, deduped despite three references.
+    const accountIds = (mockDatabase.getMastodonActorsFromIds as jest.Mock).mock
+      .calls[0][0].ids
+    expect([...accountIds].sort()).toEqual([ALICE, BOB].sort())
+
+    // The status is fetched once despite two groups referencing it.
+    expect(mockDatabase.getStatus).toHaveBeenCalledTimes(1)
+    expect(envelope.statuses).toHaveLength(1)
+  })
+
+  it('returns empty accounts/statuses when there is nothing to resolve', async () => {
+    const mockDatabase = {
+      getMastodonActorsFromIds: jest.fn().mockResolvedValue([]),
+      getStatus: jest.fn()
+    } as unknown as Database
+
+    const envelope = await getNotificationGroupsEnvelope(mockDatabase, [])
+
+    expect(envelope).toEqual({
+      notification_groups: [],
+      accounts: [],
+      statuses: []
+    })
+    expect(mockDatabase.getMastodonActorsFromIds).not.toHaveBeenCalled()
+    expect(mockDatabase.getStatus).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
@@ -32,10 +32,15 @@ describe('#getNotificationGroupsEnvelope', () => {
 
   it('dedupes accounts and statuses referenced across groups', async () => {
     const mockDatabase = {
+      // Return id in urlToId format so sample_account_ids filtering works.
       getMastodonActorsFromIds: jest
         .fn()
         .mockImplementation(({ ids }: { ids: string[] }) =>
-          Promise.resolve(ids.map((id) => ({ id })))
+          Promise.resolve(
+            ids.map((id) => ({
+              id: id.replace(/https?:\/\//, '').replaceAll('/', ':')
+            }))
+          )
         ),
       getStatus: jest.fn().mockResolvedValue({ id: STATUS }),
       getStatusesByIds: jest

--- a/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.test.ts
@@ -44,7 +44,10 @@ describe('#getNotificationGroupsEnvelope', () => {
           Promise.resolve(statusIds.map((id) => ({ id })))
         )
     } as unknown as Database
-    mockGetMastodonStatus.mockResolvedValue({ id: 'status-1' })
+    // Return id in urlToId format so the hide-filter check in resolveStatuses
+    // can match it against the group's status_id field.
+    // urlToId('https://other.test/statuses/1') = 'other.test:statuses:1'
+    mockGetMastodonStatus.mockResolvedValue({ id: 'other.test:statuses:1' })
 
     // Two like groups on the same status from alice and bob (status referenced
     // twice), plus a follow group from alice (alice referenced again).

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -117,14 +117,18 @@ export const getNotificationGroupsEnvelope = async (
   const accounts = await resolveAccounts(database, actorIds)
 
   // Remove sample_account_ids that are absent from the resolved accounts (e.g.
-  // deleted remote actors). This mirrors the dangling status_id removal above.
+  // deleted remote actors). Drop groups where every sampled actor was deleted so
+  // clients don't receive an unrenderable group with no account object (mirrors
+  // the v1 route which drops notifications whose source account cannot be loaded).
   const resolvedActorIds = new Set(accounts.map((a) => a.id))
-  const notification_groups = survivingResults.map((r) => ({
-    ...r.group,
-    sample_account_ids: r.group.sample_account_ids.filter((id) =>
-      resolvedActorIds.has(id)
-    )
-  }))
+  const notification_groups = survivingResults
+    .map((r) => ({
+      ...r.group,
+      sample_account_ids: r.group.sample_account_ids.filter((id) =>
+        resolvedActorIds.has(id)
+      )
+    }))
+    .filter((g) => g.sample_account_ids.length > 0)
 
   return { notification_groups, accounts, statuses }
 }

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -1,0 +1,90 @@
+import { Database } from '@/lib/database/types'
+import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import {
+  MastodonNotificationGroup,
+  getNotificationGroup
+} from '@/lib/services/notifications/getNotificationGroup'
+import {
+  GroupedNotification,
+  groupNotifications
+} from '@/lib/services/notifications/groupNotifications'
+import { Mastodon } from '@/lib/types/activitypub'
+import { Notification } from '@/lib/types/database/operations'
+
+// Mastodon's dehydrated grouped-notifications response: groups reference shared
+// accounts and statuses by id, deduped into top-level arrays.
+export interface NotificationGroupsEnvelope {
+  notification_groups: MastodonNotificationGroup[]
+  accounts: Mastodon.Account[]
+  statuses: Mastodon.Status[]
+}
+
+const resolveAccounts = async (
+  database: Database,
+  actorIds: string[]
+): Promise<Mastodon.Account[]> => {
+  if (actorIds.length === 0) return []
+  return database.getMastodonActorsFromIds({ ids: actorIds })
+}
+
+const resolveStatuses = async (
+  database: Database,
+  statusIds: string[],
+  currentActorId?: string
+): Promise<Mastodon.Status[]> => {
+  const statuses = await Promise.all(
+    statusIds.map(async (statusId) => {
+      const status = await database.getStatus({ statusId, withReplies: false })
+      if (!status) return null
+      return getMastodonStatus(database, status, currentActorId)
+    })
+  )
+  return statuses.filter((status): status is Mastodon.Status => status !== null)
+}
+
+/**
+ * Builds the Mastodon grouped-notifications envelope from already-grouped
+ * notifications: one NotificationGroup per group, plus the deduped accounts and
+ * statuses they reference.
+ */
+export const getNotificationGroupsEnvelope = async (
+  database: Database,
+  grouped: GroupedNotification[],
+  currentActorId?: string
+): Promise<NotificationGroupsEnvelope> => {
+  const results = grouped.map(getNotificationGroup)
+
+  const actorIds = Array.from(
+    new Set(results.flatMap((result) => result.sampleActorIds))
+  )
+  const statusIds = Array.from(
+    new Set(
+      results
+        .map((result) => result.statusId)
+        .filter((statusId): statusId is string => Boolean(statusId))
+    )
+  )
+
+  const [accounts, statuses] = await Promise.all([
+    resolveAccounts(database, actorIds),
+    resolveStatuses(database, statusIds, currentActorId)
+  ])
+
+  return {
+    notification_groups: results.map((result) => result.group),
+    accounts,
+    statuses
+  }
+}
+
+// Convenience: group raw notifications then build the envelope.
+export const buildNotificationGroupsEnvelope = (
+  database: Database,
+  notifications: Notification[],
+  currentActorId?: string
+): Promise<NotificationGroupsEnvelope> =>
+  getNotificationGroupsEnvelope(
+    database,
+    groupNotifications(notifications, true),
+    currentActorId
+  )

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -47,16 +47,29 @@ const resolveStatuses = async (
   })
   const results: Mastodon.Status[] = []
   for (const domainStatus of domainStatuses) {
-    if (filterRecords && filterRecords.length > 0) {
-      const matches = applyFiltersToStatus(domainStatus, filterRecords)
-      if (matches.some((m) => m.filter.filter_action === 'hide')) continue
-    }
     const mastodonStatus = await getMastodonStatus(
       database,
       domainStatus,
       currentActorId
     )
-    if (mastodonStatus) results.push(mastodonStatus)
+    if (!mastodonStatus) continue
+    if (filterRecords && filterRecords.length > 0) {
+      const matches = applyFiltersToStatus(domainStatus, filterRecords)
+      if (matches.some((m) => m.filter.filter_action === 'hide')) continue
+      if (matches.length > 0) {
+        // Attach warn-filter matches so clients can show the configured warning.
+        results.push(
+          mastodonStatus.reblog
+            ? {
+                ...mastodonStatus,
+                reblog: { ...mastodonStatus.reblog, filtered: matches }
+              }
+            : { ...mastodonStatus, filtered: matches }
+        )
+        continue
+      }
+    }
+    results.push(mastodonStatus)
   }
   return results
 }

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -90,11 +90,14 @@ export const getNotificationGroupsEnvelope = async (
     resolveStatuses(database, statusIds, currentActorId, filterRecords)
   ])
 
-  return {
-    notification_groups: results.map((result) => result.group),
-    accounts,
-    statuses
-  }
+  // Drop groups whose referenced status was removed by a hide filter to avoid
+  // dangling status_id references in the response.
+  const resolvedStatusIds = new Set(statuses.map((s) => s.id))
+  const notification_groups = results
+    .map((result) => result.group)
+    .filter((g) => !g.status_id || resolvedStatusIds.has(g.status_id))
+
+  return { notification_groups, accounts, statuses }
 }
 
 // Groups notifications and injects a synthetic 'follow' groupKey for follow

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -97,16 +97,13 @@ export const getNotificationGroupsEnvelope = async (
   }
 }
 
-// Convenience: group raw notifications then build the envelope.
-// For v2, follow notifications without a groupKey are assigned a synthetic
-// 'follow' groupKey so they appear as a single group (Mastodon v2 behaviour).
-export const buildNotificationGroupsEnvelope = (
-  database: Database,
+// Groups notifications and injects a synthetic 'follow' groupKey for follow
+// notifications that have no DB-level groupKey. Returns the GroupedNotification
+// array without resolving accounts/statuses — callers can slice before hydrating.
+export const prepareGroupedNotifications = (
   notifications: Notification[],
-  currentActorId?: string,
-  groupedTypes?: Set<NotificationType>,
-  filterRecords?: ActiveFilterRecord[]
-): Promise<NotificationGroupsEnvelope> => {
+  groupedTypes?: Set<NotificationType>
+): GroupedNotification[] => {
   const canGroupFollows =
     !groupedTypes || groupedTypes.has(NotificationType.enum.follow)
   const prepared = notifications.map((n) =>
@@ -114,10 +111,20 @@ export const buildNotificationGroupsEnvelope = (
       ? { ...n, groupKey: 'follow' }
       : n
   )
-  return getNotificationGroupsEnvelope(
+  return groupNotifications(prepared, true, groupedTypes)
+}
+
+// Convenience: group raw notifications then build the envelope.
+export const buildNotificationGroupsEnvelope = (
+  database: Database,
+  notifications: Notification[],
+  currentActorId?: string,
+  groupedTypes?: Set<NotificationType>,
+  filterRecords?: ActiveFilterRecord[]
+): Promise<NotificationGroupsEnvelope> =>
+  getNotificationGroupsEnvelope(
     database,
-    groupNotifications(prepared, true, groupedTypes),
+    prepareGroupedNotifications(notifications, groupedTypes),
     currentActorId,
     filterRecords
   )
-}

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -103,11 +103,17 @@ export const getNotificationGroupsEnvelope = async (
   )
   const accounts = await resolveAccounts(database, actorIds)
 
-  return {
-    notification_groups: survivingResults.map((r) => r.group),
-    accounts,
-    statuses
-  }
+  // Remove sample_account_ids that are absent from the resolved accounts (e.g.
+  // deleted remote actors). This mirrors the dangling status_id removal above.
+  const resolvedActorIds = new Set(accounts.map((a) => a.id))
+  const notification_groups = survivingResults.map((r) => ({
+    ...r.group,
+    sample_account_ids: r.group.sample_account_ids.filter((id) =>
+      resolvedActorIds.has(id)
+    )
+  }))
+
+  return { notification_groups, accounts, statuses }
 }
 
 // Groups notifications and injects a synthetic 'follow' groupKey for follow

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -74,9 +74,7 @@ export const getNotificationGroupsEnvelope = async (
 ): Promise<NotificationGroupsEnvelope> => {
   const results = grouped.map(getNotificationGroup)
 
-  const actorIds = Array.from(
-    new Set(results.flatMap((result) => result.sampleActorIds))
-  )
+  // Resolve statuses first so we can filter groups by hide-filter results.
   const statusIds = Array.from(
     new Set(
       results
@@ -84,20 +82,32 @@ export const getNotificationGroupsEnvelope = async (
         .filter((statusId): statusId is string => Boolean(statusId))
     )
   )
-
-  const [accounts, statuses] = await Promise.all([
-    resolveAccounts(database, actorIds),
-    resolveStatuses(database, statusIds, currentActorId, filterRecords)
-  ])
+  const statuses = await resolveStatuses(
+    database,
+    statusIds,
+    currentActorId,
+    filterRecords
+  )
 
   // Drop groups whose referenced status was removed by a hide filter to avoid
   // dangling status_id references in the response.
   const resolvedStatusIds = new Set(statuses.map((s) => s.id))
-  const notification_groups = results
-    .map((result) => result.group)
-    .filter((g) => !g.status_id || resolvedStatusIds.has(g.status_id))
+  const survivingResults = results.filter(
+    (r) => !r.group.status_id || resolvedStatusIds.has(r.group.status_id)
+  )
 
-  return { notification_groups, accounts, statuses }
+  // Resolve accounts only for groups that survived the filter so we don't leak
+  // actor data from hide-filtered notifications.
+  const actorIds = Array.from(
+    new Set(survivingResults.flatMap((result) => result.sampleActorIds))
+  )
+  const accounts = await resolveAccounts(database, actorIds)
+
+  return {
+    notification_groups: survivingResults.map((r) => r.group),
+    accounts,
+    statuses
+  }
 }
 
 // Groups notifications and injects a synthetic 'follow' groupKey for follow

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -130,7 +130,17 @@ export const getNotificationGroupsEnvelope = async (
     }))
     .filter((g) => g.sample_account_ids.length > 0)
 
-  return { notification_groups, accounts, statuses }
+  // Prune top-level statuses to those still referenced by a surviving group so we
+  // don't leak an orphaned status for a group that was dropped (e.g. all its
+  // sampled actors were deleted).
+  const referencedStatusIds = new Set(
+    notification_groups
+      .map((g) => g.status_id)
+      .filter((id): id is string => Boolean(id))
+  )
+  const prunedStatuses = statuses.filter((s) => referencedStatusIds.has(s.id))
+
+  return { notification_groups, accounts, statuses: prunedStatuses }
 }
 
 // Groups notifications and injects a synthetic 'follow' groupKey for follow

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -1,4 +1,5 @@
 import { Database } from '@/lib/database/types'
+import { applyFiltersToStatus } from '@/lib/services/filters/applyFilters'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import {
   MastodonNotificationGroup,
@@ -9,7 +10,11 @@ import {
   groupNotifications
 } from '@/lib/services/notifications/groupNotifications'
 import { Mastodon } from '@/lib/types/activitypub'
-import { Notification } from '@/lib/types/database/operations'
+import {
+  ActiveFilterRecord,
+  Notification,
+  NotificationType
+} from '@/lib/types/database/operations'
 
 // Mastodon's dehydrated grouped-notifications response: groups reference shared
 // accounts and statuses by id, deduped into top-level arrays.
@@ -30,16 +35,30 @@ const resolveAccounts = async (
 const resolveStatuses = async (
   database: Database,
   statusIds: string[],
-  currentActorId?: string
+  currentActorId?: string,
+  filterRecords?: ActiveFilterRecord[]
 ): Promise<Mastodon.Status[]> => {
-  const statuses = await Promise.all(
-    statusIds.map(async (statusId) => {
-      const status = await database.getStatus({ statusId, withReplies: false })
-      if (!status) return null
-      return getMastodonStatus(database, status, currentActorId)
-    })
-  )
-  return statuses.filter((status): status is Mastodon.Status => status !== null)
+  if (statusIds.length === 0) return []
+  const domainStatuses = await database.getStatusesByIds({
+    statusIds,
+    currentActorId,
+    visibleToActorId: currentActorId,
+    withReplies: false
+  })
+  const results: Mastodon.Status[] = []
+  for (const domainStatus of domainStatuses) {
+    if (filterRecords && filterRecords.length > 0) {
+      const matches = applyFiltersToStatus(domainStatus, filterRecords)
+      if (matches.some((m) => m.filter.filter_action === 'hide')) continue
+    }
+    const mastodonStatus = await getMastodonStatus(
+      database,
+      domainStatus,
+      currentActorId
+    )
+    if (mastodonStatus) results.push(mastodonStatus)
+  }
+  return results
 }
 
 /**
@@ -50,7 +69,8 @@ const resolveStatuses = async (
 export const getNotificationGroupsEnvelope = async (
   database: Database,
   grouped: GroupedNotification[],
-  currentActorId?: string
+  currentActorId?: string,
+  filterRecords?: ActiveFilterRecord[]
 ): Promise<NotificationGroupsEnvelope> => {
   const results = grouped.map(getNotificationGroup)
 
@@ -67,7 +87,7 @@ export const getNotificationGroupsEnvelope = async (
 
   const [accounts, statuses] = await Promise.all([
     resolveAccounts(database, actorIds),
-    resolveStatuses(database, statusIds, currentActorId)
+    resolveStatuses(database, statusIds, currentActorId, filterRecords)
   ])
 
   return {
@@ -78,13 +98,26 @@ export const getNotificationGroupsEnvelope = async (
 }
 
 // Convenience: group raw notifications then build the envelope.
+// For v2, follow notifications without a groupKey are assigned a synthetic
+// 'follow' groupKey so they appear as a single group (Mastodon v2 behaviour).
 export const buildNotificationGroupsEnvelope = (
   database: Database,
   notifications: Notification[],
-  currentActorId?: string
-): Promise<NotificationGroupsEnvelope> =>
-  getNotificationGroupsEnvelope(
-    database,
-    groupNotifications(notifications, true),
-    currentActorId
+  currentActorId?: string,
+  groupedTypes?: Set<NotificationType>,
+  filterRecords?: ActiveFilterRecord[]
+): Promise<NotificationGroupsEnvelope> => {
+  const canGroupFollows =
+    !groupedTypes || groupedTypes.has(NotificationType.enum.follow)
+  const prepared = notifications.map((n) =>
+    n.type === NotificationType.enum.follow && !n.groupKey && canGroupFollows
+      ? { ...n, groupKey: 'follow' }
+      : n
   )
+  return getNotificationGroupsEnvelope(
+    database,
+    groupNotifications(prepared, true, groupedTypes),
+    currentActorId,
+    filterRecords
+  )
+}

--- a/lib/services/notifications/getNotificationGroupsEnvelope.ts
+++ b/lib/services/notifications/getNotificationGroupsEnvelope.ts
@@ -143,22 +143,14 @@ export const getNotificationGroupsEnvelope = async (
   return { notification_groups, accounts, statuses: prunedStatuses }
 }
 
-// Groups notifications and injects a synthetic 'follow' groupKey for follow
-// notifications that have no DB-level groupKey. Returns the GroupedNotification
-// array without resolving accounts/statuses — callers can slice before hydrating.
+// Groups notifications for the grouped-notifications envelope. New follow rows
+// carry a day-bucketed 'follow:<day>' key from creation; legacy follows without
+// a stored groupKey stay individual (addressable via their notification id).
 export const prepareGroupedNotifications = (
   notifications: Notification[],
   groupedTypes?: Set<NotificationType>
-): GroupedNotification[] => {
-  const canGroupFollows =
-    !groupedTypes || groupedTypes.has(NotificationType.enum.follow)
-  const prepared = notifications.map((n) =>
-    n.type === NotificationType.enum.follow && !n.groupKey && canGroupFollows
-      ? { ...n, groupKey: 'follow' }
-      : n
-  )
-  return groupNotifications(prepared, true, groupedTypes)
-}
+): GroupedNotification[] =>
+  groupNotifications(notifications, true, groupedTypes)
 
 // Convenience: group raw notifications then build the envelope.
 export const buildNotificationGroupsEnvelope = (

--- a/lib/services/notifications/groupNotifications.ts
+++ b/lib/services/notifications/groupNotifications.ts
@@ -11,10 +11,11 @@ export const groupNotifications = (
   enableGrouping: boolean = true,
   groupedTypes?: Set<NotificationType>
 ): GroupedNotification[] => {
-  // If grouping is disabled, return notifications as-is with minimal GroupedNotification fields
+  // If grouping is disabled, return each notification as its own group.
   if (!enableGrouping) {
     return notifications.map((notification) => ({
       ...notification,
+      groupKey: `ungrouped-${notification.id}`,
       groupedActors: undefined,
       groupedCount: 1,
       groupedIds: undefined
@@ -59,14 +60,14 @@ export const groupNotifications = (
     }
 
     // First notification with this groupKey, not groupable, or no groupKey.
-    // When not grouping a notification that has a shared groupKey, use the
-    // notification's own id as the key so each individual entry gets a unique
-    // group_key in the Mastodon response rather than sharing the original key.
-    const mapKey = canGroup ? notification.groupKey! : notification.id
-    groups.set(mapKey, {
+    // Mastodon specifies ungrouped entries use 'ungrouped-{id}' as the group_key
+    // so clients can address them individually via the single-group endpoints.
+    const ungroupedKey = canGroup
+      ? notification.groupKey!
+      : `ungrouped-${notification.id}`
+    groups.set(ungroupedKey, {
       ...notification,
-      // Override groupKey so the Mastodon group_key is unique per notification.
-      groupKey: canGroup ? notification.groupKey : notification.id,
+      groupKey: ungroupedKey,
       groupedActors: undefined,
       groupedCount: 1,
       groupedIds: undefined

--- a/lib/services/notifications/groupNotifications.ts
+++ b/lib/services/notifications/groupNotifications.ts
@@ -1,4 +1,4 @@
-import { Notification } from '@/lib/types/database/operations'
+import { Notification, NotificationType } from '@/lib/types/database/operations'
 
 export interface GroupedNotification extends Notification {
   groupedActors?: string[]
@@ -8,7 +8,8 @@ export interface GroupedNotification extends Notification {
 
 export const groupNotifications = (
   notifications: Notification[],
-  enableGrouping: boolean = true
+  enableGrouping: boolean = true,
+  groupedTypes?: Set<NotificationType>
 ): GroupedNotification[] => {
   // If grouping is disabled, return notifications as-is with minimal GroupedNotification fields
   if (!enableGrouping) {
@@ -23,9 +24,12 @@ export const groupNotifications = (
   const groups: Map<string, GroupedNotification> = new Map()
 
   for (const notification of notifications) {
-    // Group by groupKey (e.g., "like:statusId" or "reply:statusId")
-    if (notification.groupKey) {
-      const existing = groups.get(notification.groupKey)
+    const canGroup =
+      notification.groupKey &&
+      (!groupedTypes || groupedTypes.has(notification.type))
+
+    if (canGroup) {
+      const existing = groups.get(notification.groupKey!)
       if (existing) {
         // Add to existing group
         if (!existing.groupedActors) {
@@ -54,8 +58,9 @@ export const groupNotifications = (
       }
     }
 
-    // First notification with this groupKey or no groupKey
-    groups.set(notification.groupKey || notification.id, {
+    // First notification with this groupKey, not groupable, or no groupKey
+    const mapKey = canGroup ? notification.groupKey! : notification.id
+    groups.set(mapKey, {
       ...notification,
       groupedActors: undefined,
       groupedCount: 1,

--- a/lib/services/notifications/groupNotifications.ts
+++ b/lib/services/notifications/groupNotifications.ts
@@ -58,10 +58,15 @@ export const groupNotifications = (
       }
     }
 
-    // First notification with this groupKey, not groupable, or no groupKey
+    // First notification with this groupKey, not groupable, or no groupKey.
+    // When not grouping a notification that has a shared groupKey, use the
+    // notification's own id as the key so each individual entry gets a unique
+    // group_key in the Mastodon response rather than sharing the original key.
     const mapKey = canGroup ? notification.groupKey! : notification.id
     groups.set(mapKey, {
       ...notification,
+      // Override groupKey so the Mastodon group_key is unique per notification.
+      groupKey: canGroup ? notification.groupKey : notification.id,
       groupedActors: undefined,
       groupedCount: 1,
       groupedIds: undefined

--- a/lib/services/notifications/notificationTypeMapping.ts
+++ b/lib/services/notifications/notificationTypeMapping.ts
@@ -35,3 +35,43 @@ export const mastodonTypesToInternal = (
   if (!types) return undefined
   return [...new Set(types.flatMap(mastodonTypeToInternal))]
 }
+
+// Mastodon notification entity type names.
+export type MastodonNotificationType =
+  | 'mention'
+  | 'status'
+  | 'reblog'
+  | 'follow'
+  | 'follow_request'
+  | 'favourite'
+  | 'poll'
+  | 'update'
+  | 'admin.sign_up'
+  | 'admin.report'
+
+/**
+ * Maps this codebase's internal NotificationType to the Mastodon entity type.
+ * Inverse direction of mastodonTypeToInternal (see the `status` note there).
+ */
+export const internalTypeToMastodon = (
+  type: NotificationType
+): MastodonNotificationType => {
+  switch (type) {
+    case 'like':
+      return 'favourite'
+    case 'reply':
+      return 'mention'
+    case 'reblog':
+      return 'reblog'
+    case 'follow':
+      return 'follow'
+    case 'follow_request':
+      return 'follow_request'
+    case 'mention':
+      return 'mention'
+    case 'activity_import':
+      return 'status'
+    default:
+      return 'mention'
+  }
+}

--- a/lib/services/notifications/notificationTypeMapping.ts
+++ b/lib/services/notifications/notificationTypeMapping.ts
@@ -1,6 +1,18 @@
 import { NotificationType } from '@/lib/types/database/operations'
 
 /**
+ * The internal notification types Mastodon groups by default when a client does
+ * not pass `grouped_types[]`. Mastodon only groups favourites, reblogs and
+ * follows by default; mentions/replies and "status" (a followed account posted)
+ * stay individual unless the client explicitly opts into grouping them.
+ */
+export const DEFAULT_GROUPABLE_TYPES: ReadonlySet<NotificationType> = new Set([
+  NotificationType.enum.like,
+  NotificationType.enum.reblog,
+  NotificationType.enum.follow
+])
+
+/**
  * Maps a Mastodon notification type name to this codebase's internal
  * NotificationType values. Returns an array because some Mastodon types cover
  * multiple internal types: Mastodon `mention` maps to both internal `mention`

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1576,6 +1576,13 @@ export type ResolveNotificationRequestsParams = {
   sourceActorIds: string[]
 }
 
+export type NotificationGroupKeyParams = {
+  actorId: string
+  // A shared groupKey, or (for ungrouped notifications) a notification id.
+  groupKey: string
+  includeFiltered?: boolean
+}
+
 export interface NotificationDatabase {
   createNotification(params: CreateNotificationParams): Promise<Notification>
   getNotifications(params: GetNotificationsParams): Promise<Notification[]>
@@ -1600,6 +1607,13 @@ export interface NotificationDatabase {
   dismissNotificationRequests(
     params: ResolveNotificationRequestsParams
   ): Promise<void>
+
+  // Grouped notifications (v2): resolve and dismiss by group key (or, for
+  // ungrouped notifications, by notification id).
+  getNotificationsForGroupKey(
+    params: NotificationGroupKeyParams
+  ): Promise<Notification[]>
+  dismissNotificationGroup(params: NotificationGroupKeyParams): Promise<void>
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

**Phase 3 of 3** toward full [Mastodon notifications API](https://docs.joinmastodon.org/methods/grouped_notifications/) compatibility. Adds the real **v2 grouped notifications** envelope and group endpoints.

> Stacked on #805 (which is stacked on #804) — review/merge those first. This PR's base is the Phase 2 branch so the diff is Phase 3 only.

### Endpoints
- **`GET /api/v2/notifications`** — grouped envelope `{ notification_groups, accounts, statuses }`. Params: `max_id`/`since_id`/`min_id`/`limit`/`types[]`/`exclude_types[]`/`account_id`/`include_filtered`, plus `Link` pagination headers.
- **`GET /api/v2/notifications/:group_key`** — a single group (resolved by shared `groupKey`, or by notification id for ungrouped notifications).
- **`POST /api/v2/notifications/:group_key/dismiss`** — dismiss the whole group.
- **`GET /api/v2/notifications/:group_key/accounts`** — the distinct accounts in a group.
- **`GET /api/v2/notifications/unread_count`** — count of unread groups (capped).

### New pieces
- `getNotificationGroup` — transforms a grouped notification into a Mastodon `NotificationGroup` (`group_key`, `notifications_count`, `type`, `most_recent_notification_id`, `sample_account_ids`, `status_id`).
- `getNotificationGroupsEnvelope` — assembles the groups and **dedupes** the referenced accounts/statuses into the top-level arrays.
- `internalTypeToMastodon` type mapper.
- `getNotificationsForGroupKey` / `dismissNotificationGroup` DB ops (match shared `groupKey` OR notification id).

The existing non-standard `grouped=true` extension on the v1 list endpoint is left untouched (v1 stays flat-with-extension; real grouping lives here in v2).

### Test results
- `yarn lint` — 0 errors
- `yarn build` — green
- `yarn test` — 353 suites / 3010 tests pass

Covers: transform mapping (grouped, ungrouped, no-status), envelope account/status dedup across groups, group DB lookup/dismiss round-trip, and the v2 list route (envelope shape + 422).

### Completes the series
With #804 + #805 + this PR, the notifications API now matches Mastodon's documented surface: compat params, notification policy, the requests queue, and v2 grouped notifications (with the two documented compromises noted in #805).

🤖 Generated with [Claude Code](https://claude.com/claude-code)