### PR TITLE
Bump version to v1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.31.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.30.0`
- Base main SHA: `282dbd590ae3ef11ae9eef0cdc52c1ade03571dd`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
