### PR TITLE
fix: strip forwarded cookies on the OAuth token proxy

### DIFF
--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -428,6 +428,7 @@ describe('OAuth token endpoint', () => {
       )
       expect(request.headers.has('host')).toBe(false)
       expect(request.headers.has('content-length')).toBe(false)
+      expect(request.headers.has('cookie')).toBe(false)
       await expect(request.text()).resolves.toBe(body.toString())
       return Response.json({ access_token: 'issued' })
     })
@@ -438,7 +439,41 @@ describe('OAuth token endpoint', () => {
         authorization: 'Bearer original',
         'content-type': 'application/x-www-form-urlencoded',
         host: 'llun.test',
-        'content-length': '999'
+        'content-length': '999',
+        cookie: 'better-auth.session_token=should-not-forward'
+      },
+      body
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
+  test('strips forwarded cookies so native OAuth clients are not rejected by the CSRF origin check', async () => {
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: 'non-pkce-client',
+      code: 'authorization-code',
+      code_verifier: 'verifier',
+      redirect_uri: 'https://client.llun.dev/callback'
+    })
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      expect(request.headers.has('cookie')).toBe(false)
+      await expect(request.text()).resolves.toBe(body.toString())
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: 'better-auth.session_token=from-in-app-browser'
       },
       body
     })

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -16,7 +16,12 @@ import {
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const MAX_TOKEN_REQUEST_BODY_BYTES = 64 * 1024
 const FORM_URLENCODED_MEDIA_TYPE = 'application/x-www-form-urlencoded'
-const TOKEN_PROXY_EXCLUDED_HEADERS = ['content-length', 'host']
+// `cookie` is stripped so a forwarded browser session cookie does not trigger
+// better-auth's cookie-gated CSRF origin check on the token back-channel. Native
+// OAuth clients (e.g. the Mastodon iOS app) send no Origin header, so leaving the
+// cookie in place makes better-auth reject the request with MISSING_OR_NULL_ORIGIN.
+// The token endpoint is authenticated by client credentials / PKCE, not cookies.
+const TOKEN_PROXY_EXCLUDED_HEADERS = ['content-length', 'host', 'cookie']
 const BASIC_CREDENTIALS_PATTERN = /^basic\s+([A-Za-z0-9+/]+={0,2})$/i
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)


### PR DESCRIPTION
## Problem

Signing in from the official Mastodon iOS app against an activities.next instance fails with:

```
403 https://<host>/oauth/token body={"message":"Missing or null Origin","code":"MISSING_OR_NULL_ORIGIN"}
```

### Root cause

1. The iOS app authorizes the user in an in-app web view, which sets a better-auth **session cookie** on the instance host. iOS's `URLSession` shares the system cookie store, so the app's subsequent back-channel `POST /oauth/token` carries that cookie — but, as a native client, sends **no `Origin`/`Referer` header**.
2. Our token proxy (`app/(nosidebar)/oauth/token/route.ts`) forwarded every header except `content-length` and `host`, so the cookie was forwarded to better-auth's `/api/auth/oauth2/token`.
3. better-auth registers an origin-check middleware on `/**`. Its `validateOrigin` only enforces the Origin requirement when a cookie is present (`useCookies = headers.has("cookie")`); with the cookie forwarded, it required an Origin header and threw `MISSING_OR_NULL_ORIGIN`.

The token endpoint is authenticated by client credentials / PKCE, not by cookies, so forwarding the browser session cookie into this back-channel was both unnecessary and the trigger for a browser-only CSRF guard against a non-browser client.

## Fix

Add `cookie` to the token proxy's excluded headers. With no cookie forwarded, better-auth's cookie-gated origin check short-circuits, and spec-compliant native OAuth clients can complete the token exchange.

## Tests

- New regression test: `strips forwarded cookies so native OAuth clients are not rejected by the CSRF origin check`.
- Extended the existing header-filtering test to assert `cookie` is dropped.
- Full suite: 3135 passed. `yarn lint` (0 errors), `yarn build`, `yarn test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)