### PR TITLE
Bump version to v1.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.36.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.35.0`
- Base main SHA: `5ced1c2ff71241c20aa837cbb59f768f45285537`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
