### PR TITLE
fix: self-heal version-bump PRs when a force-push skips CI

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,6 +17,14 @@ env:
   CHECK_REGISTRATION_INTERVAL_SECONDS: 10
   CHECK_REGISTRATION_STABLE_READS: 2
   CHECK_REGISTRATION_TRANSIENT_ERROR_LIMIT: 3
+  # If no required checks have registered after this many attempts, the bot
+  # force-push likely did not trigger the pull_request CI workflows; reopen the
+  # PR once to re-fire them. Kept well below CHECK_REGISTRATION_ATTEMPTS so the
+  # reopened checks still have time to register and pass within the wait window.
+  CHECK_REGISTRATION_KICK_ATTEMPT: 6
+  # How many times to retry reopening the PR after a successful close, so a
+  # transient reopen failure never leaves the bump PR closed.
+  CHECK_REGISTRATION_REOPEN_ATTEMPTS: 3
   DEBOUNCE_SECONDS: 300
   VERSION_BUMP_BRANCH: version-bump/main
 
@@ -411,6 +419,9 @@ jobs:
             local previous_check_names=""
             local required_check
             local stable_reads=0
+            local kicked=0
+            local reopen_attempt
+            local reopened
 
             for attempt in $(seq 1 "$CHECK_REGISTRATION_ATTEMPTS"); do
               : > "$checks_error"
@@ -487,6 +498,48 @@ jobs:
                   fi
                   ;;
               esac
+
+              # Self-heal: a bot force-push that updates the bump PR head
+              # sometimes fails to trigger the pull_request CI workflows, so the
+              # required checks never register and the PR stays blocked forever.
+              # If, after CHECK_REGISTRATION_KICK_ATTEMPT tries, no required
+              # checks have appeared OR a branch-protection check is still
+              # missing (partial registration is just as blocking), close and
+              # reopen the PR once to re-fire those workflows.
+              if [ "$kicked" -eq 0 ] && [ "$attempt" -ge "$CHECK_REGISTRATION_KICK_ATTEMPT" ] && { [ -z "$check_names" ] || [ -n "$missing_checks" ]; }; then
+                if [ -z "$check_names" ]; then
+                  echo "No required PR checks registered after ${attempt} attempts; reopening ${pr_url} to re-trigger CI."
+                else
+                  echo "Required PR checks still missing (${missing_checks}) after ${attempt} attempts; reopening ${pr_url} to re-trigger CI."
+                fi
+
+                if gh pr close "$pr_url"; then
+                  # Once closed, reopening is mandatory: a transient reopen
+                  # failure must not leave the bump PR closed (worse than
+                  # blocked), so retry until it succeeds or the budget is spent.
+                  reopened=0
+                  for reopen_attempt in $(seq 1 "$CHECK_REGISTRATION_REOPEN_ATTEMPTS"); do
+                    if gh pr reopen "$pr_url"; then
+                      reopened=1
+                      break
+                    fi
+                    echo "::warning::Failed to reopen ${pr_url} (reopen ${reopen_attempt}/${CHECK_REGISTRATION_REOPEN_ATTEMPTS}); retrying in ${CHECK_REGISTRATION_INTERVAL_SECONDS}s."
+                    sleep "$CHECK_REGISTRATION_INTERVAL_SECONDS"
+                  done
+
+                  if [ "$reopened" -eq 1 ]; then
+                    kicked=1
+                    stable_reads=0
+                    previous_check_names=""
+                    echo "Reopened ${pr_url}; waiting for pull_request workflows to register."
+                  else
+                    echo "::error::Closed ${pr_url} but could not reopen it after ${CHECK_REGISTRATION_REOPEN_ATTEMPTS} attempts; reopen it manually to resume the version bump."
+                    return 1
+                  fi
+                else
+                  echo "::warning::Failed to close ${pr_url} to re-trigger CI; will retry on the next poll."
+                fi
+              fi
 
               if [ "$attempt" -lt "$CHECK_REGISTRATION_ATTEMPTS" ]; then
                 echo "Retrying required-check registration in ${CHECK_REGISTRATION_INTERVAL_SECONDS}s (${attempt}/${CHECK_REGISTRATION_ATTEMPTS})."


### PR DESCRIPTION
## Problem

Version-bump PR #819 (`Bump version to v1.36.0`) got stuck in `blocked` and never auto-merged.

Root cause: the bump branch (`version-bump/main`) was force-pushed several times in quick succession as #818 → #817 → #816 merged into `main`. The **final bot force-push to the PR head (`aea832c`) did not trigger the `pull_request` CI workflows** — only the `Vercel` check ran on it, while a healthy bump PR (e.g. #815) shows `All Tests`, `Lint and Prettier`, `Analyze (javascript)`, etc.

With the required status checks never registering, the workflow's `wait_for_required_checks` gate timed out and left the PR open *without* enabling auto-merge, so it sat `blocked` indefinitely. (#819 itself was unstuck operationally by closing + reopening it to re-fire CI, then enabling auto-merge — it has since merged.)

## Fix

Add a one-time self-heal to `wait_for_required_checks` in `.github/workflows/version-bump.yml`:

- If, after `CHECK_REGISTRATION_KICK_ATTEMPT` polls (default `6` ≈ 60s), **no required checks have registered** *or* **a branch-protection check is still missing** (partial registration is just as blocking), close and reopen the PR. The `pull_request: reopened` event re-fires the CI workflows.
- The kick happens once (`kicked` guard). After reopening, the loop resets its stability tracking and keeps polling, so the freshly-triggered checks still have time to register and pass within the existing `CHECK_REGISTRATION_ATTEMPTS` (30 ≈ 5 min) window.
- **Reopen is mandatory once closed**: a successful `gh pr close` is followed by `gh pr reopen` retried up to `CHECK_REGISTRATION_REOPEN_ATTEMPTS` (default `3`) times, so a transient reopen failure never leaves the bump PR closed (worse than blocked). If reopen ultimately fails it emits a `::error::` for manual recovery rather than looping into a second close on an already-closed PR.

## Addressed review feedback

- **package.json:** the branch was originally cut from the `v1.36.0` bump commit, which dragged a `1.35.0 → 1.36.0` change into the diff. Rebased onto current `main` (which already has `1.36.0` via the merged #819) so this PR now touches **only** the workflow file — no manual version edit.
- **P1 (reopen must not leave the PR closed):** addressed via the retried, mandatory reopen above.
- **P2 (partial check registration):** the kick condition now also fires when branch-protection checks are still missing, not only when zero checks are observed.

## Notes

- `.github/`-only change → no version bump (correct; this is CI plumbing).
- YAML validated; `prettier --check` clean.

https://claude.ai/code/session_01QkiFfJqJmUUHbi8bS8xwRV