### PR TITLE
fix: resolve fitness dashboard for actor IDs with a port (browser base64url polyfill)

### DIFF
--- a/lib/utils/urlToId.test.ts
+++ b/lib/utils/urlToId.test.ts
@@ -51,7 +51,46 @@ describe('#urlToId', () => {
     expect(idToUrl(urlToId(statusId))).toEqual(statusId)
   })
 
-  it('uses Buffer base64url support in Node before browser fallbacks', () => {
+  it('round trips port-bearing IDs when Buffer lacks base64url support', () => {
+    // Reproduces the browser bundle (Turbopack injects the `buffer` polyfill,
+    // which supports `base64` but NOT `base64url`). Without the fix, urlToId's
+    // bare catch swallows the throw and returns the raw URL with slashes.
+    const actorId = 'https://localhost:3100/users/testuser'
+    const RealBuffer = globalThis.Buffer
+
+    const PolyfillBuffer = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      from(value: string, encoding?: any) {
+        if (encoding === 'base64url') {
+          throw new TypeError('Unknown encoding: base64url')
+        }
+        const buffer = RealBuffer.from(value, encoding)
+        return {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          toString(outEncoding?: any) {
+            if (outEncoding === 'base64url') {
+              throw new TypeError('Unknown encoding: base64url')
+            }
+            return buffer.toString(outEncoding)
+          }
+        }
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).Buffer = PolyfillBuffer
+
+    try {
+      const encoded = urlToId(actorId)
+      expect(encoded.startsWith('apurl_')).toBe(true)
+      expect(encoded).not.toContain('/')
+      expect(idToUrl(encoded)).toEqual(actorId)
+    } finally {
+      globalThis.Buffer = RealBuffer
+    }
+  })
+
+  it('uses Buffer (not the btoa/atob fallbacks) when Buffer is available', () => {
     const originalBtoa = globalThis.btoa
     const originalAtob = globalThis.atob
     const actorId = 'https://bsky.brid.gy/ap/did:plc:abc123/statuses/post-1'

--- a/lib/utils/urlToId.ts
+++ b/lib/utils/urlToId.ts
@@ -10,8 +10,13 @@ const fromBase64Url = (value: string) =>
     .replaceAll('_', '/')
 
 const encodeBase64Url = (value: string) => {
+  // Use plain `base64` rather than `base64url`: the browser `buffer` polyfill
+  // that Turbopack injects exposes a global `Buffer` but does NOT implement the
+  // `base64url` encoding, so `toString('base64url')` throws `Unknown encoding`
+  // in the bundle. Encode as `base64` (supported everywhere) and convert to the
+  // url-safe alphabet ourselves via toBase64Url.
   if (typeof Buffer !== 'undefined') {
-    return Buffer.from(value, 'utf8').toString('base64url')
+    return toBase64Url(Buffer.from(value, 'utf8').toString('base64'))
   }
 
   if (typeof btoa === 'function' && typeof TextEncoder !== 'undefined') {
@@ -26,8 +31,11 @@ const encodeBase64Url = (value: string) => {
 }
 
 const decodeBase64Url = (value: string) => {
+  // Mirror encodeBase64Url: decode via the universally supported `base64`
+  // encoding after restoring padding/alphabet, since the browser Buffer
+  // polyfill cannot parse `base64url`.
   if (typeof Buffer !== 'undefined') {
-    return Buffer.from(value, 'base64url').toString('utf8')
+    return Buffer.from(fromBase64Url(value), 'base64').toString('utf8')
   }
 
   if (typeof atob !== 'function' || typeof TextDecoder === 'undefined') {


### PR DESCRIPTION
## What

Fixes the fitness Overview dashboard showing **"Failed to load fitness overview"** with zero stats whenever the current actor's id host carries a port (e.g. a local dev actor `https://localhost:3100/users/testuser`).

## Why / Root cause

`urlToId` (`lib/utils/urlToId.ts`) encodes port-bearing ActivityPub ids as the opaque `apurl_<base64url>` form via its `encodeBase64Url` helper, which is guarded by `typeof Buffer !== 'undefined'`.

In the **Turbopack browser bundle**, `Buffer` is the injected `buffer` npm polyfill — it exposes a global `Buffer` (so the guard passes) but **does not implement the `base64url` encoding**. So `Buffer.from(v).toString('base64url')` throws `TypeError: Unknown encoding: base64url`. `urlToId`'s bare `catch { return idInURLFormat }` swallowed the throw and returned the **raw URL**, so the client requested:

```
/api/v1/accounts/https://localhost:3100/users/testuser/fitness-summary  → 308 → https:/... → 404
```

against the single-segment `[id]` route. The `.catch()` in `ActorFitnessDashboard` then rendered the error banner.

This was latent because Node unit tests pass — real Node `Buffer` supports `base64url` — so it only reproduces in a real browser, and only when the actor id host has a `:port` (production hosts without a port are unaffected). It is pre-existing and not introduced by the `/fitness` page move.

## Fix

Encode/decode through the universally supported `base64` encoding and convert to/from the url-safe alphabet using the existing `toBase64Url`/`fromBase64Url` helpers (the same ones the btoa fallback already used).

**Provably safe, no regression surface:** in real Node, `toBase64Url(Buffer.from(v).toString('base64'))` is byte-identical to the old `.toString('base64url')` output (strip `=`, map `+/`→`-_`) — the browser now emits the exact same `apurl_aHR0cHM6…` strings. So all server-side encoding (stored ids, Mastodon markers, pagination `Link` headers, etc.) is unchanged. The only behavior that changes is the previously-broken browser path. The fix removes the environment-dependent feature entirely, so it's robust across dev and prod bundles by construction.

## Tests

Added a regression test simulating the browser polyfill (a `Buffer` whose `base64url` encoding throws but `base64` works) that asserts a port-bearing id round-trips to a single-segment `apurl_` id (no slashes) — red before the fix, green after. Renamed a now-misleading sibling test.

## Verification

- End-to-end in a real browser (SQLite + seeded `fitness_files`): requests now return **200**; stat cards (Activities 6, Distance 92.3 km, Duration 6h 20m, Elevation 1110 m), Training Calendar, and Activity Mix all populate; no error banner.
- `yarn run prettier --write` clean, `yarn lint` 0 errors, `yarn build` succeeds, `yarn test` → **3172/3172** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)