### PR TITLE
Bump version to v1.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.37.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.36.0`
- Base main SHA: `66b04553391c41d60c29ba21ef3646423035346f`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
