### PR TITLE
Bump version to v1.37.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.37.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.37.0`
- Base main SHA: `f083a59fe2add5e2bd62c883d13d3fa581e5ff81`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
