### PR TITLE
Bump version to v1.37.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.37.1",
+  "version": "1.37.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.37.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.37.1`
- Base main SHA: `8bad9c87def2f05d290d659f5fea4b4a5f6d4056`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
