### PR TITLE
feat: log OAuth flow requests to diagnose 400s from Mastodon clients

### DIFF
--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { POST } from './route'
 
 const mockAuthHandler = jest.fn()
+const mockLoggerWarn = jest.fn()
 const mockClients = new Map<string, Record<string, unknown>>()
 let mockClientLookupCount = 0
 let mockClientLookupError: Error | null = null
@@ -37,10 +38,10 @@ jest.mock('@/lib/services/auth/auth', () => ({
 jest.mock('@/lib/utils/logger', () => {
   const logger = {
     error: jest.fn(),
-    warn: jest.fn(),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
     info: jest.fn(),
     debug: jest.fn(),
-    child: jest.fn(() => logger)
+    child: () => logger
   }
   return { logger }
 })
@@ -48,6 +49,7 @@ jest.mock('@/lib/utils/logger', () => {
 describe('OAuth token endpoint', () => {
   beforeEach(() => {
     mockAuthHandler.mockReset()
+    mockLoggerWarn.mockReset()
     mockClients.clear()
     mockClientLookupCount = 0
     mockClientLookupError = null
@@ -613,5 +615,49 @@ describe('OAuth token endpoint', () => {
     })
     expect(response.status).toBe(400)
     expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('logs a redacted request and upstream body when better-auth rejects the exchange', async () => {
+    mockClients.set('non-pkce-client', {
+      clientId: 'non-pkce-client',
+      requirePKCE: false
+    })
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ error: 'invalid_grant' }, { status: 400 })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        cookie: 'session=secret; theme=dark'
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: 'non-pkce-client',
+        code: 'authorization-code',
+        code_verifier: 'pkce-secret',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+    expect(response.status).toBe(400)
+
+    const upstreamLog = mockLoggerWarn.mock.calls.find(
+      ([payload]) => (payload as { reason?: string }).reason === 'upstream'
+    )
+    expect(upstreamLog).toBeDefined()
+    const [payload] = upstreamLog as [Record<string, unknown>, string]
+    // Request secrets and the session cookie are redacted; the non-secret
+    // upstream OAuth error passes through.
+    expect(payload.requestBody).toMatchObject({
+      grant_type: 'authorization_code',
+      client_id: 'non-pkce-client',
+      code: '[REDACTED]',
+      code_verifier: '[REDACTED]'
+    })
+    expect(payload.headers).toMatchObject({ cookie: '[REDACTED]' })
+    expect(payload.upstreamBody).toEqual({ error: 'invalid_grant' })
   })
 })

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -34,13 +34,16 @@ jest.mock('@/lib/services/auth/auth', () => ({
   })
 }))
 
-jest.mock('@/lib/utils/logger', () => ({
-  logger: {
+jest.mock('@/lib/utils/logger', () => {
+  const logger = {
     error: jest.fn(),
     warn: jest.fn(),
-    info: jest.fn()
+    info: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => logger)
   }
-}))
+  return { logger }
+})
 
 describe('OAuth token endpoint', () => {
   beforeEach(() => {

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -3,6 +3,11 @@ import { NextRequest } from 'next/server'
 import { getBaseURL } from '@/lib/config'
 import { getKnex } from '@/lib/database'
 import { getAuth } from '@/lib/services/auth/auth'
+import {
+  oauthLogger,
+  sanitizeFormBody,
+  sanitizeHeaders
+} from '@/lib/services/oauth/logging'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import {
@@ -272,12 +277,46 @@ const validatePkceTokenExchange = async (
 
 export const POST = async (req: NextRequest) => {
   const auth = getAuth()
+
+  oauthLogger.debug(
+    {
+      endpoint: 'token',
+      headers: sanitizeHeaders(req.headers)
+    },
+    'OAuth token request received'
+  )
+
   const { bodyText, params, error } = await getTokenRequestBody(req)
-  if (error) return error
+  if (error) {
+    // Pre-flight rejection (wrong content-type, oversized/unreadable body).
+    // These are the proxy's own 4xx responses and never reach better-auth.
+    oauthLogger.warn(
+      {
+        endpoint: 'token',
+        status: error.status,
+        reason: 'request_body',
+        headers: sanitizeHeaders(req.headers)
+      },
+      `OAuth token request rejected with ${error.status}`
+    )
+    return error
+  }
 
   if (params) {
     const pkceError = await validatePkceTokenExchange(req, params)
-    if (pkceError) return pkceError
+    if (pkceError) {
+      oauthLogger.warn(
+        {
+          endpoint: 'token',
+          status: pkceError.status,
+          reason: 'pkce',
+          headers: sanitizeHeaders(req.headers),
+          requestBody: sanitizeFormBody(bodyText ?? '')
+        },
+        `OAuth token request rejected with ${pkceError.status}`
+      )
+      return pkceError
+    }
   }
 
   // Rewrite the URL to better-auth's token endpoint
@@ -318,6 +357,24 @@ export const POST = async (req: NextRequest) => {
         ? 500
         : 400
   ) as StatusCode
+
+  // Log token exchanges better-auth rejected so 400s from third-party Mastodon
+  // clients can be diagnosed in production: the request the client sent (secrets
+  // redacted) plus the upstream OAuth error body (e.g. invalid_grant /
+  // invalid_client), which is non-secret and exactly what we need.
+  if (!response.ok) {
+    oauthLogger.warn(
+      {
+        endpoint: 'token',
+        status: statusCode,
+        reason: 'upstream',
+        headers: sanitizeHeaders(req.headers),
+        requestBody: sanitizeFormBody(bodyText ?? ''),
+        upstreamBody: data
+      },
+      `OAuth token request failed with ${statusCode}`
+    )
+  }
 
   return apiResponse({
     req,

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -9,7 +9,6 @@ import {
   sanitizeHeaders
 } from '@/lib/services/oauth/logging'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { logger } from '@/lib/utils/logger'
 import {
   HTTP_STATUS,
   StatusCode,
@@ -255,7 +254,10 @@ const validatePkceTokenExchange = async (
       .first()
     if (!client?.requirePKCE) return null
   } catch (e) {
-    logger.error({ message: 'PKCE token preflight failed', error: e })
+    oauthLogger.error(
+      { endpoint: 'token', reason: 'pkce_preflight', err: e },
+      'PKCE token preflight failed'
+    )
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
@@ -331,7 +333,10 @@ export const POST = async (req: NextRequest) => {
   try {
     response = await auth.handler(proxyReq)
   } catch (e) {
-    logger.error({ message: 'Token endpoint handler threw', error: e })
+    oauthLogger.error(
+      { endpoint: 'token', reason: 'handler_threw', err: e },
+      'Token endpoint handler threw'
+    )
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -6,7 +6,8 @@ import { getAuth } from '@/lib/services/auth/auth'
 import {
   oauthLogger,
   sanitizeFormBody,
-  sanitizeHeaders
+  sanitizeHeaders,
+  sanitizeParams
 } from '@/lib/services/oauth/logging'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -366,7 +367,9 @@ export const POST = async (req: NextRequest) => {
   // Log token exchanges better-auth rejected so 400s from third-party Mastodon
   // clients can be diagnosed in production: the request the client sent (secrets
   // redacted) plus the upstream OAuth error body (e.g. invalid_grant /
-  // invalid_client), which is non-secret and exactly what we need.
+  // invalid_client). The error body is non-secret OAuth metadata, but it is run
+  // through sanitizeParams as defense-in-depth in case an upstream error ever
+  // echoes back a sensitive field.
   if (!response.ok) {
     oauthLogger.warn(
       {
@@ -375,7 +378,7 @@ export const POST = async (req: NextRequest) => {
         reason: 'upstream',
         headers: sanitizeHeaders(req.headers),
         requestBody: sanitizeFormBody(bodyText ?? ''),
-        upstreamBody: data
+        upstreamBody: sanitizeParams(data)
       },
       `OAuth token request failed with ${statusCode}`
     )

--- a/app/api/oauth/authorize/route.ts
+++ b/app/api/oauth/authorize/route.ts
@@ -1,13 +1,39 @@
 import { NextRequest } from 'next/server'
 
 import { getBaseURL } from '@/lib/config'
-import { logger } from '@/lib/utils/logger'
+import {
+  oauthLogger,
+  sanitizeHeaders,
+  sanitizeParams
+} from '@/lib/services/oauth/logging'
+
+// Log the authorize params we forward to better-auth. The authorize endpoint
+// itself returns a redirect (302); a downstream 400 is raised by better-auth's
+// /api/auth/oauth2/authorize. Logging the forwarded params (client_id,
+// redirect_uri, response_type, scope, ...) here lets a 400 be correlated to the
+// client request that triggered it.
+const logAuthorizeRequest = (
+  req: NextRequest,
+  url: URL,
+  method: 'GET' | 'POST'
+) => {
+  oauthLogger.debug(
+    {
+      endpoint: 'authorize',
+      method,
+      headers: sanitizeHeaders(req.headers),
+      params: sanitizeParams(Object.fromEntries(url.searchParams))
+    },
+    'OAuth authorize request received'
+  )
+}
 
 // Redirect to better-auth's OAuth2 authorize endpoint for Mastodon compatibility
 // Mastodon clients may hit /api/oauth/authorize directly
 export const GET = (req: NextRequest) => {
   const url = new URL('/api/auth/oauth2/authorize', getBaseURL())
   url.search = req.nextUrl.search
+  logAuthorizeRequest(req, url, 'GET')
   return Response.redirect(url.toString(), 302)
 }
 
@@ -27,7 +53,11 @@ export const POST = async (req: NextRequest) => {
       )
     }
   } catch (e) {
-    logger.error({ message: 'Failed to parse authorize POST body', error: e })
+    oauthLogger.error(
+      { endpoint: 'authorize', method: 'POST', err: e },
+      'Failed to parse authorize POST body'
+    )
   }
+  logAuthorizeRequest(req, url, 'POST')
   return Response.redirect(url.toString(), 302)
 }

--- a/app/api/oauth/authorize/route.ts
+++ b/app/api/oauth/authorize/route.ts
@@ -9,15 +9,16 @@ import {
 
 // Log the authorize params we forward to better-auth. The authorize endpoint
 // itself returns a redirect (302); a downstream 400 is raised by better-auth's
-// /api/auth/oauth2/authorize. Logging the forwarded params (client_id,
-// redirect_uri, response_type, scope, ...) here lets a 400 be correlated to the
-// client request that triggered it.
+// /api/auth/oauth2/authorize. This route only redirects and never observes that
+// failure, so the log is emitted at `info` (not `debug`) — otherwise it would be
+// suppressed at the default production level and there would be nothing to
+// correlate the downstream 400 to the client request that triggered it.
 const logAuthorizeRequest = (
   req: NextRequest,
   url: URL,
   method: 'GET' | 'POST'
 ) => {
-  oauthLogger.debug(
+  oauthLogger.info(
     {
       endpoint: 'authorize',
       method,

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -29,11 +29,16 @@ jest.mock('@/lib/config/trustProxyIpHeaders', () => ({
   getTrustProxyIpHeadersConfig: () => mockGetTrustProxyIpHeadersConfig()
 }))
 
-jest.mock('@/lib/utils/logger', () => ({
-  logger: {
-    warn: (...args: unknown[]) => mockLoggerWarn(...args)
+jest.mock('@/lib/utils/logger', () => {
+  const logger = {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: () => logger
   }
-}))
+  return { logger }
+})
 
 jest.mock('./createApplication', () => ({
   createApplication: (...args: unknown[]) => mockCreateApplication(...args)

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -193,4 +193,38 @@ describe('apps route', () => {
     })
     expect(response.status).toBe(429)
   })
+
+  test('redacts secrets in the logged body when registration validation fails', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer super-secret-token'
+      },
+      // Malformed body (client_name must be a string): exercises the rejection
+      // path that logs the raw, attacker-controlled payload.
+      body: JSON.stringify({
+        client_name: { client_secret: 'leak-me' },
+        password: 'leak-me-too'
+      })
+    })
+
+    const response = await POST(req)
+    expect(response.status).toBe(422)
+
+    const rejectionLog = mockLoggerWarn.mock.calls.find(
+      ([payload]) =>
+        (payload as { endpoint?: string }).endpoint === 'apps' &&
+        (payload as { status?: number }).status === 422
+    )
+    expect(rejectionLog).toBeDefined()
+    const [payload] = rejectionLog as [Record<string, unknown>, string]
+    expect(payload.body).toEqual({
+      client_name: { client_secret: '[REDACTED]' },
+      password: '[REDACTED]'
+    })
+    expect(payload.headers).toMatchObject({
+      authorization: 'Bearer [REDACTED]'
+    })
+  })
 })

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -96,10 +96,7 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
         endpoint: 'apps',
         status: 422,
         headers: sanitizeHeaders(req.headers),
-        body:
-          json && typeof json === 'object'
-            ? sanitizeParams(json as Record<string, unknown>)
-            : json,
+        body: sanitizeParams(json),
         validationErrors: parseResult.error.issues
       },
       'OAuth app registration request rejected'

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -4,6 +4,11 @@ import { NextRequest } from 'next/server'
 import { getConfig } from '@/lib/config'
 import { getTrustProxyIpHeadersConfig } from '@/lib/config/trustProxyIpHeaders'
 import { getDatabase } from '@/lib/database'
+import {
+  oauthLogger,
+  sanitizeHeaders,
+  sanitizeParams
+} from '@/lib/services/oauth/logging'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
@@ -83,6 +88,22 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
   const json = await getRequestBody(req)
   const parseResult = PostRequest.safeParse(json)
   if (!parseResult.success) {
+    // First step of the Mastodon login flow. Log rejected registrations so a
+    // failing third-party client can be diagnosed in production. Secrets are
+    // redacted; client_name / redirect_uris / scopes are not secret.
+    oauthLogger.warn(
+      {
+        endpoint: 'apps',
+        status: 422,
+        headers: sanitizeHeaders(req.headers),
+        body:
+          json && typeof json === 'object'
+            ? sanitizeParams(json as Record<string, unknown>)
+            : json,
+        validationErrors: parseResult.error.issues
+      },
+      'OAuth app registration request rejected'
+    )
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
@@ -95,6 +116,14 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
   })
 
   if (response.type === 'error') {
+    oauthLogger.warn(
+      {
+        endpoint: 'apps',
+        error: response.error,
+        headers: sanitizeHeaders(req.headers)
+      },
+      'OAuth app registration failed'
+    )
     if (response.error === 'Too many application registrations') {
       return apiResponse({
         req,

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -102,11 +102,13 @@ describe('oauth logging sanitizers', () => {
       })
     })
 
-    it('redacts OAuth security params (state, assertion)', () => {
-      const body = 'client_id=abc&state=csrf-binding&assertion=jwt-credential'
+    it('redacts OAuth security params (state, nonce, assertion)', () => {
+      const body =
+        'client_id=abc&state=csrf-binding&nonce=replay-binding&assertion=jwt-credential'
       expect(sanitizeFormBody(body)).toEqual({
         client_id: 'abc',
         state: '[REDACTED]',
+        nonce: '[REDACTED]',
         assertion: '[REDACTED]'
       })
     })
@@ -206,6 +208,40 @@ describe('oauth logging sanitizers', () => {
         redirect_uri: 'https://client.example/cb',
         client_id: 'abc'
       })
+    })
+
+    it('strips query/fragment from each element of a URL-valued array', () => {
+      expect(
+        sanitizeParams({
+          redirect_uris: [
+            'https://client.example/cb?session=secret#token',
+            'https://client.example/cb2?code=leak'
+          ]
+        })
+      ).toEqual({
+        redirect_uris: [
+          'https://client.example/cb',
+          'https://client.example/cb2'
+        ]
+      })
+    })
+
+    it('truncates oversized string values', () => {
+      const big = 'a'.repeat(5000)
+      const result = sanitizeParams({ client_name: big }) as {
+        client_name: string
+      }
+      expect(result.client_name.length).toBeLessThan(big.length)
+      expect(result.client_name).toContain('[truncated 3976 chars]')
+    })
+
+    it('caps the number of keys kept per object', () => {
+      const wide: Record<string, string> = {}
+      for (let i = 0; i < 250; i += 1) wide[`k${i}`] = 'v'
+      const result = sanitizeParams(wide) as Record<string, unknown>
+      // 100 kept keys + 1 truncation summary key.
+      expect(Object.keys(result)).toHaveLength(101)
+      expect(result['…']).toBe('[truncated 150 keys]')
     })
 
     it('bounds recursion depth so a deeply nested body cannot blow the stack', () => {

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -56,6 +56,15 @@ describe('oauth logging sanitizers', () => {
       })
     })
 
+    it('keeps the path of a relative URL-bearing header, dropping query/fragment', () => {
+      const headers = new Headers({
+        referer: '/oauth/callback?code=auth-secret#access_token=tok'
+      })
+      expect(sanitizeHeaders(headers)).toEqual({
+        referer: '/oauth/callback'
+      })
+    })
+
     it('redacts a URL-bearing header that is not a parseable URL', () => {
       const headers = new Headers({ referer: 'not a url' })
       expect(sanitizeHeaders(headers)).toEqual({ referer: '[REDACTED]' })

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -110,6 +110,32 @@ describe('oauth logging sanitizers', () => {
         assertion: '[REDACTED]'
       })
     })
+
+    it('redacts OIDC id_token params', () => {
+      const body = 'id_token=jwt&id_token_hint=jwt-hint&client_id=abc'
+      expect(sanitizeFormBody(body)).toEqual({
+        id_token: '[REDACTED]',
+        id_token_hint: '[REDACTED]',
+        client_id: 'abc'
+      })
+    })
+
+    it('redacts bracket-notation nested secret keys (user[password])', () => {
+      const body = 'user%5Bpassword%5D=secret&user%5Bname%5D=alice'
+      expect(sanitizeFormBody(body)).toEqual({
+        'user[password]': '[REDACTED]',
+        'user[name]': 'alice'
+      })
+    })
+
+    it('strips query/fragment from URL-valued params (redirect_uri)', () => {
+      const body =
+        'grant_type=authorization_code&redirect_uri=https%3A%2F%2Fclient.example%2Fcb%3Fsession%3Dsecret%23frag'
+      expect(sanitizeFormBody(body)).toEqual({
+        grant_type: 'authorization_code',
+        redirect_uri: 'https://client.example/cb'
+      })
+    })
   })
 
   describe('sanitizeParams', () => {
@@ -146,6 +172,40 @@ describe('oauth logging sanitizers', () => {
       expect(sanitizeParams(42)).toBe(42)
       expect(sanitizeParams(null)).toBeNull()
       expect(sanitizeParams(undefined)).toBeUndefined()
+    })
+
+    it('returns non-plain objects as-is instead of flattening them to {}', () => {
+      const date = new Date('2026-01-01T00:00:00.000Z')
+      const regexp = /secret/i
+      expect(sanitizeParams({ created: date, pattern: regexp })).toEqual({
+        created: date,
+        pattern: regexp
+      })
+      // The Date is returned by reference, not coerced to an empty object.
+      expect(
+        (sanitizeParams({ created: date }) as { created: Date }).created
+      ).toBe(date)
+    })
+
+    it('redacts bracket-notation nested secret keys', () => {
+      expect(
+        sanitizeParams({ 'user[password]': 'secret', 'user[name]': 'alice' })
+      ).toEqual({
+        'user[password]': '[REDACTED]',
+        'user[name]': 'alice'
+      })
+    })
+
+    it('strips query/fragment from URL-valued params', () => {
+      expect(
+        sanitizeParams({
+          redirect_uri: 'https://client.example/cb?session=secret#frag',
+          client_id: 'abc'
+        })
+      ).toEqual({
+        redirect_uri: 'https://client.example/cb',
+        client_id: 'abc'
+      })
     })
 
     it('bounds recursion depth so a deeply nested body cannot blow the stack', () => {

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -85,13 +85,24 @@ describe('oauth logging sanitizers', () => {
         'cf-connecting-ip': '203.0.113.10',
         'x-real-ip': '203.0.113.20',
         'x-forwarded-for': '203.0.113.30, 198.51.100.40',
+        forwarded: 'for=203.0.113.10;proto=https',
         'content-type': 'application/x-www-form-urlencoded'
       })
       expect(sanitizeHeaders(headers)).toEqual({
         'cf-connecting-ip': '[REDACTED]',
         'x-real-ip': '[REDACTED]',
         'x-forwarded-for': '[REDACTED]',
+        forwarded: '[REDACTED]',
         'content-type': 'application/x-www-form-urlencoded'
+      })
+    })
+
+    it('strips userinfo from a custom-scheme URL-bearing header', () => {
+      const headers = new Headers({
+        location: 'myapp://user:pass@callback/path?code=secret'
+      })
+      expect(sanitizeHeaders(headers)).toEqual({
+        location: 'myapp://callback/path'
       })
     })
   })
@@ -143,6 +154,14 @@ describe('oauth logging sanitizers', () => {
       expect(sanitizeFormBody(body)).toEqual({
         id_token: '[REDACTED]',
         id_token_hint: '[REDACTED]',
+        client_id: 'abc'
+      })
+    })
+
+    it('redacts the OIDC login_hint param', () => {
+      const body = 'login_hint=alice%40example.test&client_id=abc'
+      expect(sanitizeFormBody(body)).toEqual({
+        login_hint: '[REDACTED]',
         client_id: 'abc'
       })
     })

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -292,6 +292,20 @@ describe('oauth logging sanitizers', () => {
       expect(result.redirect_uri).toContain('[truncated')
     })
 
+    it('caps the breadth of a URL-valued array', () => {
+      const uris = Array.from(
+        { length: 250 },
+        (_, i) => `https://client.example/cb${i}?secret=x`
+      )
+      const result = sanitizeParams({ redirect_uris: uris }) as {
+        redirect_uris: unknown[]
+      }
+      // 100 kept entries (query stripped) + 1 truncation summary entry.
+      expect(result.redirect_uris).toHaveLength(101)
+      expect(result.redirect_uris[0]).toBe('https://client.example/cb0')
+      expect(result.redirect_uris[100]).toBe('[truncated 150 items]')
+    })
+
     it('truncates oversized string values', () => {
       const big = 'a'.repeat(5000)
       const result = sanitizeParams({ client_name: big }) as {

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -44,6 +44,22 @@ describe('oauth logging sanitizers', () => {
         cookie: '[REDACTED]'
       })
     })
+
+    it('strips query and fragment from URL-bearing headers', () => {
+      const headers = new Headers({
+        referer:
+          'https://app.example.test/callback?code=auth-secret&state=xyz#access_token=tok'
+      })
+      // code/access_token/state in the redirect URL must not be logged.
+      expect(sanitizeHeaders(headers)).toEqual({
+        referer: 'https://app.example.test/callback'
+      })
+    })
+
+    it('redacts a URL-bearing header that is not a parseable URL', () => {
+      const headers = new Headers({ referer: 'not a url' })
+      expect(sanitizeHeaders(headers)).toEqual({ referer: '[REDACTED]' })
+    })
   })
 
   describe('sanitizeFormBody', () => {
@@ -66,6 +82,25 @@ describe('oauth logging sanitizers', () => {
         client_id: 'abc'
       })
     })
+
+    it('redacts PII params (username, email)', () => {
+      const body =
+        'grant_type=password&username=alice&email=alice%40example.test'
+      expect(sanitizeFormBody(body)).toEqual({
+        grant_type: 'password',
+        username: '[REDACTED]',
+        email: '[REDACTED]'
+      })
+    })
+
+    it('redacts OAuth security params (state, assertion)', () => {
+      const body = 'client_id=abc&state=csrf-binding&assertion=jwt-credential'
+      expect(sanitizeFormBody(body)).toEqual({
+        client_id: 'abc',
+        state: '[REDACTED]',
+        assertion: '[REDACTED]'
+      })
+    })
   })
 
   describe('sanitizeParams', () => {
@@ -81,6 +116,27 @@ describe('oauth logging sanitizers', () => {
         ' Client_Secret ': '[REDACTED]',
         redirect_uris: ['https://example.test/cb']
       })
+    })
+
+    it('recurses into nested objects and arrays', () => {
+      expect(
+        sanitizeParams({
+          client_name: 'My App',
+          meta: { client_secret: 'shh', note: 'ok' },
+          items: [{ password: 'p' }, { keep: 'v' }]
+        })
+      ).toEqual({
+        client_name: 'My App',
+        meta: { client_secret: '[REDACTED]', note: 'ok' },
+        items: [{ password: '[REDACTED]' }, { keep: 'v' }]
+      })
+    })
+
+    it('returns primitive and nullish values unchanged', () => {
+      expect(sanitizeParams('a string')).toBe('a string')
+      expect(sanitizeParams(42)).toBe(42)
+      expect(sanitizeParams(null)).toBeNull()
+      expect(sanitizeParams(undefined)).toBeUndefined()
     })
   })
 })

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -1,0 +1,76 @@
+import { sanitizeFormBody, sanitizeHeaders, sanitizeParams } from './logging'
+
+jest.mock('@/lib/utils/logger', () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => logger)
+  }
+  return { logger }
+})
+
+describe('oauth logging sanitizers', () => {
+  describe('sanitizeHeaders', () => {
+    it('keeps the auth scheme but redacts the credential', () => {
+      const headers = new Headers({
+        authorization: 'Basic dXNlcjpwYXNz',
+        'content-type': 'application/x-www-form-urlencoded'
+      })
+      expect(sanitizeHeaders(headers)).toEqual({
+        authorization: 'Basic [REDACTED]',
+        'content-type': 'application/x-www-form-urlencoded'
+      })
+    })
+
+    it('fully redacts cookies and schemeless credentials', () => {
+      const headers = new Headers({
+        cookie: 'session=secret',
+        authorization: 'opaque-token-without-scheme'
+      })
+      expect(sanitizeHeaders(headers)).toEqual({
+        cookie: '[REDACTED]',
+        authorization: '[REDACTED]'
+      })
+    })
+  })
+
+  describe('sanitizeFormBody', () => {
+    it('redacts secret params including the PKCE code_verifier', () => {
+      const body =
+        'grant_type=authorization_code&client_id=abc&code=auth-code&code_verifier=pkce-secret&client_secret=shh'
+      expect(sanitizeFormBody(body)).toEqual({
+        grant_type: 'authorization_code',
+        client_id: 'abc',
+        code: '[REDACTED]',
+        code_verifier: '[REDACTED]',
+        client_secret: '[REDACTED]'
+      })
+    })
+
+    it('redacts secret keys that carry surrounding whitespace', () => {
+      const body = '+code_verifier+=pkce-secret&client_id=abc'
+      expect(sanitizeFormBody(body)).toEqual({
+        ' code_verifier ': '[REDACTED]',
+        client_id: 'abc'
+      })
+    })
+  })
+
+  describe('sanitizeParams', () => {
+    it('redacts secret keys regardless of case and whitespace', () => {
+      expect(
+        sanitizeParams({
+          client_id: 'abc',
+          ' Client_Secret ': 'shh',
+          redirect_uris: ['https://example.test/cb']
+        })
+      ).toEqual({
+        client_id: 'abc',
+        ' Client_Secret ': '[REDACTED]',
+        redirect_uris: ['https://example.test/cb']
+      })
+    })
+  })
+})

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -34,6 +34,16 @@ describe('oauth logging sanitizers', () => {
         authorization: '[REDACTED]'
       })
     })
+
+    it('redacts a multi-cookie header in full, not just the last pair', () => {
+      const headers = new Headers({
+        cookie: 'session=secret; theme=dark'
+      })
+      // The space after `;` must not be mistaken for an auth scheme delimiter.
+      expect(sanitizeHeaders(headers)).toEqual({
+        cookie: '[REDACTED]'
+      })
+    })
   })
 
   describe('sanitizeFormBody', () => {

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -69,6 +69,31 @@ describe('oauth logging sanitizers', () => {
       const headers = new Headers({ referer: 'not a url' })
       expect(sanitizeHeaders(headers)).toEqual({ referer: '[REDACTED]' })
     })
+
+    it('keeps the scheme and path of a custom-scheme URL-bearing header', () => {
+      const headers = new Headers({
+        location: 'myapp://callback?code=auth-secret#access_token=tok'
+      })
+      // origin is "null" for non-http schemes; keep scheme+path, drop secrets.
+      expect(sanitizeHeaders(headers)).toEqual({
+        location: 'myapp://callback'
+      })
+    })
+
+    it('fully redacts proxy/CDN client IP headers', () => {
+      const headers = new Headers({
+        'cf-connecting-ip': '203.0.113.10',
+        'x-real-ip': '203.0.113.20',
+        'x-forwarded-for': '203.0.113.30, 198.51.100.40',
+        'content-type': 'application/x-www-form-urlencoded'
+      })
+      expect(sanitizeHeaders(headers)).toEqual({
+        'cf-connecting-ip': '[REDACTED]',
+        'x-real-ip': '[REDACTED]',
+        'x-forwarded-for': '[REDACTED]',
+        'content-type': 'application/x-www-form-urlencoded'
+      })
+    })
   })
 
   describe('sanitizeFormBody', () => {
@@ -118,6 +143,28 @@ describe('oauth logging sanitizers', () => {
       expect(sanitizeFormBody(body)).toEqual({
         id_token: '[REDACTED]',
         id_token_hint: '[REDACTED]',
+        client_id: 'abc'
+      })
+    })
+
+    it('redacts password-confirmation and MFA params', () => {
+      const body =
+        'new_password=p&password_confirmation=p&current_password=old&otp=123456&mfa_token=mt&client_id=abc'
+      expect(sanitizeFormBody(body)).toEqual({
+        new_password: '[REDACTED]',
+        password_confirmation: '[REDACTED]',
+        current_password: '[REDACTED]',
+        otp: '[REDACTED]',
+        mfa_token: '[REDACTED]',
+        client_id: 'abc'
+      })
+    })
+
+    it('keeps scheme and path of a custom-scheme URL-valued param', () => {
+      const body =
+        'redirect_uri=myapp%3A%2F%2Fcallback%3Fcode%3Dsecret%23token&client_id=abc'
+      expect(sanitizeFormBody(body)).toEqual({
+        redirect_uri: 'myapp://callback',
         client_id: 'abc'
       })
     })
@@ -224,6 +271,25 @@ describe('oauth logging sanitizers', () => {
           'https://client.example/cb2'
         ]
       })
+    })
+
+    it('recurses into non-string entries of a URL-valued array', () => {
+      expect(
+        sanitizeParams({
+          redirect_uris: [{ client_secret: 'shh', note: 'ok' }]
+        })
+      ).toEqual({
+        redirect_uris: [{ client_secret: '[REDACTED]', note: 'ok' }]
+      })
+    })
+
+    it('length-caps a sanitized URL-valued param', () => {
+      const longPath = `https://client.example/${'a'.repeat(5000)}`
+      const result = sanitizeParams({ redirect_uri: longPath }) as {
+        redirect_uri: string
+      }
+      expect(result.redirect_uri.length).toBeLessThan(longPath.length)
+      expect(result.redirect_uri).toContain('[truncated')
     })
 
     it('truncates oversized string values', () => {

--- a/lib/services/oauth/logging.test.ts
+++ b/lib/services/oauth/logging.test.ts
@@ -138,5 +138,28 @@ describe('oauth logging sanitizers', () => {
       expect(sanitizeParams(null)).toBeNull()
       expect(sanitizeParams(undefined)).toBeUndefined()
     })
+
+    it('bounds recursion depth so a deeply nested body cannot blow the stack', () => {
+      // Build a payload far deeper than the cap; sanitizing must not throw.
+      let deep: Record<string, unknown> = { secret: 'value' }
+      for (let i = 0; i < 5000; i += 1) {
+        deep = { nested: deep }
+      }
+
+      let result: unknown
+      expect(() => {
+        result = sanitizeParams(deep)
+      }).not.toThrow()
+
+      // The subtree below the depth cap is dropped, not walked.
+      let cursor = result as Record<string, unknown>
+      let depth = 0
+      while (cursor && typeof cursor === 'object' && 'nested' in cursor) {
+        cursor = cursor.nested as Record<string, unknown>
+        depth += 1
+      }
+      expect(cursor).toBe('[TRUNCATED]')
+      expect(depth).toBeLessThanOrEqual(8)
+    })
   })
 })

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -107,23 +107,29 @@ export const sanitizeFormBody = (body: string): Record<string, string> => {
   return result
 }
 
+// Recursion is bounded so a deeply nested, attacker-controlled body (the apps
+// endpoint logs the raw, parse-failed request) cannot blow the stack and turn a
+// 422 into a 500. Beyond this depth the subtree is dropped rather than walked.
+const MAX_SANITIZE_DEPTH = 8
+
 /**
  * Redacts secret keys from an already-parsed value (e.g. a JSON body or
  * query-param record). Recurses into nested objects and arrays so a secret key
  * nested under a non-sensitive parent is still redacted — the apps endpoint
  * logs the raw, parse-failed request body, which is attacker-controlled and may
- * be arbitrarily nested.
+ * be arbitrarily nested. Recursion depth is capped to stay DoS-safe.
  */
-export const sanitizeParams = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeParams(item))
-  }
+export const sanitizeParams = (value: unknown, depth = 0): unknown => {
   if (value && typeof value === 'object') {
+    if (depth >= MAX_SANITIZE_DEPTH) return '[TRUNCATED]'
+    if (Array.isArray(value)) {
+      return value.map((item) => sanitizeParams(item, depth + 1))
+    }
     const result: Record<string, unknown> = {}
     for (const [key, nested] of Object.entries(value)) {
       result[key] = isSensitiveParam(key)
         ? '[REDACTED]'
-        : sanitizeParams(nested)
+        : sanitizeParams(nested, depth + 1)
     }
     return result
   }

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -20,13 +20,26 @@ const SCHEME_PRESERVING_HEADERS = new Set([
 // is safe to log.
 const FULLY_REDACTED_HEADERS = new Set(['cookie', 'set-cookie'])
 
-// Body/query parameter names that carry secrets and must be redacted.
+// Headers whose value is a URL that can carry secret query/fragment params
+// (e.g. an authorization `code` or `access_token` in an OAuth redirect URL).
+// Their query string and fragment are dropped before logging.
+const URL_BEARING_HEADERS = new Set(['referer', 'referrer', 'location'])
+
+// Body/query parameter names that carry secrets or PII and must be redacted.
+// `username`/`email` are not part of the configured grant types, but redacting
+// them keeps PII out of logs if a password/custom grant or the registration
+// body ever carries them. `state` is the client's CSRF binding and `assertion`
+// carries a JWT/SAML credential in assertion grants.
 const SENSITIVE_PARAMS = new Set([
   'client_secret',
   'client_assertion',
+  'assertion',
   'code',
   'code_verifier',
   'password',
+  'username',
+  'email',
+  'state',
   'refresh_token',
   'access_token',
   'token'
@@ -37,6 +50,19 @@ const SENSITIVE_PARAMS = new Set([
 // before comparing so e.g. ` code_verifier ` is still redacted.
 const isSensitiveParam = (key: string): boolean =>
   SENSITIVE_PARAMS.has(key.trim().toLowerCase())
+
+// Strips the query string and fragment from a URL-valued header, keeping only
+// origin + path for diagnostics. OAuth redirect URLs put `code`/`access_token`
+// in exactly those parts, so dropping them avoids persisting secrets. A value
+// that is not a parseable absolute URL is redacted entirely to be safe.
+const sanitizeUrlValue = (value: string): string => {
+  try {
+    const url = new URL(value)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return '[REDACTED]'
+  }
+}
 
 /**
  * Collects request headers into a plain object with credential-bearing values
@@ -56,6 +82,10 @@ export const sanitizeHeaders = (headers: Headers): Record<string, string> => {
       const scheme = value.split(' ')[0]
       result[key] =
         scheme && scheme !== value ? `${scheme} [REDACTED]` : '[REDACTED]'
+      return
+    }
+    if (URL_BEARING_HEADERS.has(normalizedKey)) {
+      result[key] = sanitizeUrlValue(value)
       return
     }
     result[key] = value
@@ -78,15 +108,24 @@ export const sanitizeFormBody = (body: string): Record<string, string> => {
 }
 
 /**
- * Redacts secret keys from an already-parsed params object (e.g. a JSON body or
- * query-param record).
+ * Redacts secret keys from an already-parsed value (e.g. a JSON body or
+ * query-param record). Recurses into nested objects and arrays so a secret key
+ * nested under a non-sensitive parent is still redacted — the apps endpoint
+ * logs the raw, parse-failed request body, which is attacker-controlled and may
+ * be arbitrarily nested.
  */
-export const sanitizeParams = (
-  params: Record<string, unknown>
-): Record<string, unknown> => {
-  const result: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(params)) {
-    result[key] = isSensitiveParam(key) ? '[REDACTED]' : value
+export const sanitizeParams = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeParams(item))
   }
-  return result
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [key, nested] of Object.entries(value)) {
+      result[key] = isSensitiveParam(key)
+        ? '[REDACTED]'
+        : sanitizeParams(nested)
+    }
+    return result
+  }
+  return value
 }

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -180,6 +180,25 @@ const truncateString = (value: string): string =>
 const sanitizeUrlValueCapped = (value: string): string =>
   truncateString(sanitizeUrlValue(value))
 
+// Caps on breadth so an oversized rejected body cannot amplify log volume on the
+// unauthenticated 422 path: at most this many object keys / array items are kept
+// per level, the rest summarized.
+const MAX_SANITIZE_ENTRIES = 100
+
+// Maps at most MAX_SANITIZE_ENTRIES items of an array, appending a summary entry
+// for the remainder. Shared by every array branch so the breadth cap is applied
+// uniformly (including URL-valued arrays like `redirect_uris`).
+const boundedMap = (
+  items: unknown[],
+  mapFn: (item: unknown) => unknown
+): unknown[] => {
+  const kept = items.slice(0, MAX_SANITIZE_ENTRIES).map(mapFn)
+  if (items.length > MAX_SANITIZE_ENTRIES) {
+    kept.push(`[truncated ${items.length - MAX_SANITIZE_ENTRIES} items]`)
+  }
+  return kept
+}
+
 // Redacts a single param value: secret params become [REDACTED]; URL-valued
 // params keep scheme+host+path but drop query/fragment (including each element
 // of an array, e.g. `redirect_uris` — string entries are URL-sanitized, and
@@ -195,7 +214,7 @@ const sanitizeParamValue = (
   if (isUrlValuedParam(key)) {
     if (typeof value === 'string') return sanitizeUrlValueCapped(value)
     if (Array.isArray(value)) {
-      return value.map((item) =>
+      return boundedMap(value, (item) =>
         typeof item === 'string'
           ? sanitizeUrlValueCapped(item)
           : sanitizeParams(item, depth + 1)
@@ -225,11 +244,6 @@ export const sanitizeFormBody = (body: string): Record<string, string> => {
 // 422 into a 500. Beyond this depth the subtree is dropped rather than walked.
 const MAX_SANITIZE_DEPTH = 8
 
-// Caps on breadth so an oversized rejected body cannot amplify log volume on the
-// unauthenticated 422 path: at most this many object keys / array items are kept
-// per level, the rest summarized.
-const MAX_SANITIZE_ENTRIES = 100
-
 /**
  * Redacts secret keys from an already-parsed value (e.g. a JSON body or
  * query-param record). Recurses into arrays and plain objects so a secret key
@@ -245,13 +259,7 @@ export const sanitizeParams = (value: unknown, depth = 0): unknown => {
   if (value && typeof value === 'object') {
     if (depth >= MAX_SANITIZE_DEPTH) return '[TRUNCATED]'
     if (Array.isArray(value)) {
-      const kept = value
-        .slice(0, MAX_SANITIZE_ENTRIES)
-        .map((item) => sanitizeParams(item, depth + 1))
-      if (value.length > MAX_SANITIZE_ENTRIES) {
-        kept.push(`[truncated ${value.length - MAX_SANITIZE_ENTRIES} items]`)
-      }
-      return kept
+      return boundedMap(value, (item) => sanitizeParams(item, depth + 1))
     }
     const proto = Object.getPrototypeOf(value)
     if (proto !== null && proto !== Object.prototype) {

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -21,11 +21,18 @@ const SENSITIVE_PARAMS = new Set([
   'client_secret',
   'client_assertion',
   'code',
+  'code_verifier',
   'password',
   'refresh_token',
   'access_token',
   'token'
 ])
+
+// Keys can carry surrounding whitespace (URLSearchParams and JSON both preserve
+// it), which would slip a secret past an exact-match redaction check. Normalize
+// before comparing so e.g. ` code_verifier ` is still redacted.
+const isSensitiveParam = (key: string): boolean =>
+  SENSITIVE_PARAMS.has(key.trim().toLowerCase())
 
 /**
  * Collects request headers into a plain object with credential-bearing values
@@ -55,7 +62,7 @@ export const sanitizeHeaders = (headers: Headers): Record<string, string> => {
 export const sanitizeFormBody = (body: string): Record<string, string> => {
   const result: Record<string, string> = {}
   new URLSearchParams(body).forEach((value, key) => {
-    result[key] = SENSITIVE_PARAMS.has(key.toLowerCase()) ? '[REDACTED]' : value
+    result[key] = isSensitiveParam(key) ? '[REDACTED]' : value
   })
   return result
 }
@@ -69,7 +76,7 @@ export const sanitizeParams = (
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(params)) {
-    result[key] = SENSITIVE_PARAMS.has(key.toLowerCase()) ? '[REDACTED]' : value
+    result[key] = isSensitiveParam(key) ? '[REDACTED]' : value
   }
   return result
 }

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -1,0 +1,75 @@
+import { logger } from '@/lib/utils/logger'
+
+/**
+ * Child logger scoped to the OAuth flow so production logs can be filtered with
+ * the `module` field. Used to debug the 400 responses third-party Mastodon
+ * clients hit during sign-in (app registration, the authorize redirect and the
+ * token proxy).
+ */
+export const oauthLogger = logger.child({ module: 'oauth' })
+
+// Header names whose values carry credentials and must never be logged in full.
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie'
+])
+
+// Body/query parameter names that carry secrets and must be redacted.
+const SENSITIVE_PARAMS = new Set([
+  'client_secret',
+  'client_assertion',
+  'code',
+  'password',
+  'refresh_token',
+  'access_token',
+  'token'
+])
+
+/**
+ * Collects request headers into a plain object with credential-bearing values
+ * redacted. For `authorization` we keep the auth scheme (e.g. `Basic`,
+ * `Bearer`) since clients frequently send the wrong one, but drop the secret.
+ */
+export const sanitizeHeaders = (headers: Headers): Record<string, string> => {
+  const result: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
+      const scheme = value.split(' ')[0]
+      result[key] =
+        scheme && scheme !== value ? `${scheme} [REDACTED]` : '[REDACTED]'
+      return
+    }
+    result[key] = value
+  })
+  return result
+}
+
+/**
+ * Parses a form-urlencoded (or query string) body into a plain object with
+ * secret parameters redacted, keeping the rest (grant_type, client_id,
+ * redirect_uri, scope, response_type, ...) which is exactly what is needed to
+ * understand a 400.
+ */
+export const sanitizeFormBody = (body: string): Record<string, string> => {
+  const result: Record<string, string> = {}
+  new URLSearchParams(body).forEach((value, key) => {
+    result[key] = SENSITIVE_PARAMS.has(key.toLowerCase()) ? '[REDACTED]' : value
+  })
+  return result
+}
+
+/**
+ * Redacts secret keys from an already-parsed params object (e.g. a JSON body or
+ * query-param record).
+ */
+export const sanitizeParams = (
+  params: Record<string, unknown>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(params)) {
+    result[key] = SENSITIVE_PARAMS.has(key.toLowerCase()) ? '[REDACTED]' : value
+  }
+  return result
+}

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -8,13 +8,17 @@ import { logger } from '@/lib/utils/logger'
  */
 export const oauthLogger = logger.child({ module: 'oauth' })
 
-// Header names whose values carry credentials and must never be logged in full.
-const SENSITIVE_HEADERS = new Set([
+// Authorization headers whose secret is dropped but whose scheme (Basic /
+// Bearer / ...) is kept, since clients frequently send the wrong one.
+const SCHEME_PRESERVING_HEADERS = new Set([
   'authorization',
-  'proxy-authorization',
-  'cookie',
-  'set-cookie'
+  'proxy-authorization'
 ])
+
+// Headers that must be redacted entirely. Cookie values are delimited by
+// `; ` and can carry a browser session token in any pair, so no part of them
+// is safe to log.
+const FULLY_REDACTED_HEADERS = new Set(['cookie', 'set-cookie'])
 
 // Body/query parameter names that carry secrets and must be redacted.
 const SENSITIVE_PARAMS = new Set([
@@ -36,13 +40,19 @@ const isSensitiveParam = (key: string): boolean =>
 
 /**
  * Collects request headers into a plain object with credential-bearing values
- * redacted. For `authorization` we keep the auth scheme (e.g. `Basic`,
- * `Bearer`) since clients frequently send the wrong one, but drop the secret.
+ * redacted. For `authorization`/`proxy-authorization` we keep the auth scheme
+ * (e.g. `Basic`, `Bearer`) since clients frequently send the wrong one, but
+ * drop the secret. Cookie headers are redacted in full.
  */
 export const sanitizeHeaders = (headers: Headers): Record<string, string> => {
   const result: Record<string, string> = {}
   headers.forEach((value, key) => {
-    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
+    const normalizedKey = key.toLowerCase()
+    if (FULLY_REDACTED_HEADERS.has(normalizedKey)) {
+      result[key] = '[REDACTED]'
+      return
+    }
+    if (SCHEME_PRESERVING_HEADERS.has(normalizedKey)) {
       const scheme = value.split(' ')[0]
       result[key] =
         scheme && scheme !== value ? `${scheme} [REDACTED]` : '[REDACTED]'

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -23,6 +23,7 @@ const SCHEME_PRESERVING_HEADERS = new Set([
 const FULLY_REDACTED_HEADERS = new Set([
   'cookie',
   'set-cookie',
+  'forwarded',
   'cf-connecting-ip',
   'x-real-ip',
   'x-forwarded-for',
@@ -58,6 +59,7 @@ const SENSITIVE_PARAMS = new Set([
   'mfa_token',
   'username',
   'email',
+  'login_hint',
   'state',
   'nonce',
   'refresh_token',
@@ -113,6 +115,10 @@ const RELATIVE_URL_BASE = 'http://relative.invalid'
 const sanitizeUrlValue = (value: string): string => {
   try {
     const absolute = new URL(value)
+    // Drop any embedded `user:pass@` credentials before logging, for every
+    // scheme. The http(s) branch already does this implicitly via `origin`.
+    absolute.username = ''
+    absolute.password = ''
     // `origin` is the string "null" for non-http(s) schemes (e.g. a mobile
     // deep link `myapp://callback` or a URN), which would log as "null/...".
     // For those, keep the full href minus the secret-bearing query/fragment so

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -15,10 +15,20 @@ const SCHEME_PRESERVING_HEADERS = new Set([
   'proxy-authorization'
 ])
 
-// Headers that must be redacted entirely. Cookie values are delimited by
-// `; ` and can carry a browser session token in any pair, so no part of them
-// is safe to log.
-const FULLY_REDACTED_HEADERS = new Set(['cookie', 'set-cookie'])
+// Headers that must be redacted entirely. Cookie values can carry a browser
+// session token. The proxy/CDN IP headers are direct client identifiers (raw
+// user IPs); the app-registration path deliberately hashes the same source IP
+// for rate limiting, so logging them verbatim here would defeat that
+// pseudonymization and persist raw IPs in production logs.
+const FULLY_REDACTED_HEADERS = new Set([
+  'cookie',
+  'set-cookie',
+  'cf-connecting-ip',
+  'x-real-ip',
+  'x-forwarded-for',
+  'x-client-ip',
+  'true-client-ip'
+])
 
 // Headers whose value is a URL that can carry secret query/fragment params
 // (e.g. an authorization `code` or `access_token` in an OAuth redirect URL).
@@ -37,6 +47,15 @@ const SENSITIVE_PARAMS = new Set([
   'code',
   'code_verifier',
   'password',
+  'password_confirmation',
+  'password_confirm',
+  'confirm_password',
+  'current_password',
+  'new_password',
+  'otp',
+  'totp',
+  'mfa_code',
+  'mfa_token',
   'username',
   'email',
   'state',
@@ -85,16 +104,23 @@ const isUrlValuedParam = (key: string): boolean =>
 // appears in logs.
 const RELATIVE_URL_BASE = 'http://relative.invalid'
 
-// Strips the query string and fragment from a URL-valued header, keeping only
-// origin + path (absolute) or path (relative) for diagnostics. OAuth redirect
-// URLs put `code`/`access_token` in exactly those parts, so dropping them avoids
-// persisting secrets while keeping the useful routing/redirect target. A value
-// that parses to neither an absolute nor a rooted relative URL is redacted
-// entirely to be safe.
+// Strips the query string and fragment from a URL-valued header/param, keeping
+// only origin + path (http/https), scheme + path (custom schemes / URNs), or
+// path (relative) for diagnostics. OAuth redirect URLs put `code`/`access_token`
+// in exactly those parts, so dropping them avoids persisting secrets while
+// keeping the useful routing/redirect target. A value that parses to neither an
+// absolute nor a rooted relative URL is redacted entirely to be safe.
 const sanitizeUrlValue = (value: string): string => {
   try {
     const absolute = new URL(value)
-    return `${absolute.origin}${absolute.pathname}`
+    // `origin` is the string "null" for non-http(s) schemes (e.g. a mobile
+    // deep link `myapp://callback` or a URN), which would log as "null/...".
+    // For those, keep the full href minus the secret-bearing query/fragment so
+    // a redirect_uri mismatch is still debuggable.
+    if (absolute.protocol === 'http:' || absolute.protocol === 'https:') {
+      return `${absolute.origin}${absolute.pathname}`
+    }
+    return absolute.href.split('#')[0].split('?')[0]
   } catch {
     // Not an absolute URL — try it as a path relative to a dummy base.
   }
@@ -148,17 +174,31 @@ const truncateString = (value: string): string =>
     ? `${value.slice(0, MAX_LOGGED_STRING_LENGTH)}…[truncated ${value.length - MAX_LOGGED_STRING_LENGTH} chars]`
     : value
 
+// A sanitized URL is still length-capped: a malformed redirect_uri with a
+// megabyte-long path can fail schema validation and reach the logger, so it
+// must not bypass the amplification guard that ordinary strings get.
+const sanitizeUrlValueCapped = (value: string): string =>
+  truncateString(sanitizeUrlValue(value))
+
 // Redacts a single param value: secret params become [REDACTED]; URL-valued
 // params keep scheme+host+path but drop query/fragment (including each element
-// of a string array, e.g. `redirect_uris`); plain strings are length-capped;
-// everything else passes through. Shared by sanitizeFormBody and sanitizeParams.
-const sanitizeParamValue = (key: string, value: unknown): unknown => {
+// of an array, e.g. `redirect_uris` — string entries are URL-sanitized, and
+// non-string entries are recursed so nested secrets are still redacted); plain
+// strings are length-capped; everything else passes through. Shared by
+// sanitizeFormBody and sanitizeParams.
+const sanitizeParamValue = (
+  key: string,
+  value: unknown,
+  depth = 0
+): unknown => {
   if (isSensitiveParam(key)) return '[REDACTED]'
   if (isUrlValuedParam(key)) {
-    if (typeof value === 'string') return sanitizeUrlValue(value)
+    if (typeof value === 'string') return sanitizeUrlValueCapped(value)
     if (Array.isArray(value)) {
       return value.map((item) =>
-        typeof item === 'string' ? sanitizeUrlValue(item) : item
+        typeof item === 'string'
+          ? sanitizeUrlValueCapped(item)
+          : sanitizeParams(item, depth + 1)
       )
     }
   }
@@ -226,7 +266,7 @@ export const sanitizeParams = (value: unknown, depth = 0): unknown => {
         isUrlValuedParam(key) &&
         (typeof nested === 'string' || Array.isArray(nested))
       ) {
-        result[key] = sanitizeParamValue(key, nested)
+        result[key] = sanitizeParamValue(key, nested, depth)
       } else {
         result[key] = sanitizeParams(nested, depth + 1)
       }

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -28,8 +28,8 @@ const URL_BEARING_HEADERS = new Set(['referer', 'referrer', 'location'])
 // Body/query parameter names that carry secrets or PII and must be redacted.
 // `username`/`email` are not part of the configured grant types, but redacting
 // them keeps PII out of logs if a password/custom grant or the registration
-// body ever carries them. `state` is the client's CSRF binding and `assertion`
-// carries a JWT/SAML credential in assertion grants.
+// body ever carries them. `state`/`nonce` are the client's CSRF / OIDC replay
+// bindings and `assertion` carries a JWT/SAML credential in assertion grants.
 const SENSITIVE_PARAMS = new Set([
   'client_secret',
   'client_assertion',
@@ -40,6 +40,7 @@ const SENSITIVE_PARAMS = new Set([
   'username',
   'email',
   'state',
+  'nonce',
   'refresh_token',
   'access_token',
   'id_token',
@@ -136,14 +137,32 @@ export const sanitizeHeaders = (headers: Headers): Record<string, string> => {
   return result
 }
 
-// Redacts a single param value: secret params become [REDACTED], URL-valued
-// params keep scheme+host+path but drop query/fragment, everything else passes
-// through. Shared by sanitizeFormBody and sanitizeParams.
+// String values longer than this are truncated before logging. The 422
+// app-registration path logs the raw, unauthenticated request body, so an
+// oversized field (e.g. a multi-megabyte client_name) must not be written to
+// logs near-verbatim.
+const MAX_LOGGED_STRING_LENGTH = 1024
+
+const truncateString = (value: string): string =>
+  value.length > MAX_LOGGED_STRING_LENGTH
+    ? `${value.slice(0, MAX_LOGGED_STRING_LENGTH)}…[truncated ${value.length - MAX_LOGGED_STRING_LENGTH} chars]`
+    : value
+
+// Redacts a single param value: secret params become [REDACTED]; URL-valued
+// params keep scheme+host+path but drop query/fragment (including each element
+// of a string array, e.g. `redirect_uris`); plain strings are length-capped;
+// everything else passes through. Shared by sanitizeFormBody and sanitizeParams.
 const sanitizeParamValue = (key: string, value: unknown): unknown => {
   if (isSensitiveParam(key)) return '[REDACTED]'
-  if (typeof value === 'string' && isUrlValuedParam(key)) {
-    return sanitizeUrlValue(value)
+  if (isUrlValuedParam(key)) {
+    if (typeof value === 'string') return sanitizeUrlValue(value)
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        typeof item === 'string' ? sanitizeUrlValue(item) : item
+      )
+    }
   }
+  if (typeof value === 'string') return truncateString(value)
   return value
 }
 
@@ -166,34 +185,54 @@ export const sanitizeFormBody = (body: string): Record<string, string> => {
 // 422 into a 500. Beyond this depth the subtree is dropped rather than walked.
 const MAX_SANITIZE_DEPTH = 8
 
+// Caps on breadth so an oversized rejected body cannot amplify log volume on the
+// unauthenticated 422 path: at most this many object keys / array items are kept
+// per level, the rest summarized.
+const MAX_SANITIZE_ENTRIES = 100
+
 /**
  * Redacts secret keys from an already-parsed value (e.g. a JSON body or
  * query-param record). Recurses into arrays and plain objects so a secret key
  * nested under a non-sensitive parent is still redacted — the apps endpoint
  * logs the raw, parse-failed request body, which is attacker-controlled and may
- * be arbitrarily nested. Recursion depth is capped to stay DoS-safe, and
- * non-plain objects (Date, RegExp, class instances) are returned as-is rather
- * than being flattened to `{}` by `Object.entries`.
+ * be arbitrarily nested. Recursion depth and breadth are capped and long
+ * strings truncated to stay DoS / log-amplification safe, and non-plain objects
+ * (Date, RegExp, class instances) are returned as-is rather than being flattened
+ * to `{}` by `Object.entries`.
  */
 export const sanitizeParams = (value: unknown, depth = 0): unknown => {
+  if (typeof value === 'string') return truncateString(value)
   if (value && typeof value === 'object') {
     if (depth >= MAX_SANITIZE_DEPTH) return '[TRUNCATED]'
     if (Array.isArray(value)) {
-      return value.map((item) => sanitizeParams(item, depth + 1))
+      const kept = value
+        .slice(0, MAX_SANITIZE_ENTRIES)
+        .map((item) => sanitizeParams(item, depth + 1))
+      if (value.length > MAX_SANITIZE_ENTRIES) {
+        kept.push(`[truncated ${value.length - MAX_SANITIZE_ENTRIES} items]`)
+      }
+      return kept
     }
     const proto = Object.getPrototypeOf(value)
     if (proto !== null && proto !== Object.prototype) {
       return value
     }
     const result: Record<string, unknown> = {}
-    for (const [key, nested] of Object.entries(value)) {
+    const entries = Object.entries(value)
+    for (const [key, nested] of entries.slice(0, MAX_SANITIZE_ENTRIES)) {
       if (isSensitiveParam(key)) {
         result[key] = '[REDACTED]'
-      } else if (typeof nested === 'string' && isUrlValuedParam(key)) {
-        result[key] = sanitizeUrlValue(nested)
+      } else if (
+        isUrlValuedParam(key) &&
+        (typeof nested === 'string' || Array.isArray(nested))
+      ) {
+        result[key] = sanitizeParamValue(key, nested)
       } else {
         result[key] = sanitizeParams(nested, depth + 1)
       }
+    }
+    if (entries.length > MAX_SANITIZE_ENTRIES) {
+      result['…'] = `[truncated ${entries.length - MAX_SANITIZE_ENTRIES} keys]`
     }
     return result
   }

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -51,17 +51,32 @@ const SENSITIVE_PARAMS = new Set([
 const isSensitiveParam = (key: string): boolean =>
   SENSITIVE_PARAMS.has(key.trim().toLowerCase())
 
+// Origin used only to parse relative URL-valued headers (e.g. a `/callback?...`
+// Referer/Location). It is stripped back off before returning, so it never
+// appears in logs.
+const RELATIVE_URL_BASE = 'http://relative.invalid'
+
 // Strips the query string and fragment from a URL-valued header, keeping only
-// origin + path for diagnostics. OAuth redirect URLs put `code`/`access_token`
-// in exactly those parts, so dropping them avoids persisting secrets. A value
-// that is not a parseable absolute URL is redacted entirely to be safe.
+// origin + path (absolute) or path (relative) for diagnostics. OAuth redirect
+// URLs put `code`/`access_token` in exactly those parts, so dropping them avoids
+// persisting secrets while keeping the useful routing/redirect target. A value
+// that parses to neither an absolute nor a rooted relative URL is redacted
+// entirely to be safe.
 const sanitizeUrlValue = (value: string): string => {
   try {
-    const url = new URL(value)
-    return `${url.origin}${url.pathname}`
+    const absolute = new URL(value)
+    return `${absolute.origin}${absolute.pathname}`
   } catch {
-    return '[REDACTED]'
+    // Not an absolute URL — try it as a path relative to a dummy base.
   }
+  if (value.startsWith('/')) {
+    try {
+      return new URL(value, RELATIVE_URL_BASE).pathname
+    } catch {
+      return '[REDACTED]'
+    }
+  }
+  return '[REDACTED]'
 }
 
 /**

--- a/lib/services/oauth/logging.ts
+++ b/lib/services/oauth/logging.ts
@@ -42,14 +42,42 @@ const SENSITIVE_PARAMS = new Set([
   'state',
   'refresh_token',
   'access_token',
+  'id_token',
+  'id_token_hint',
   'token'
 ])
 
+// Param names whose value is a URL. Their value is kept (scheme+host+path is the
+// usual signal for a redirect_uri-mismatch 400) but their query string and
+// fragment are dropped, since a client can append secrets there.
+const URL_VALUED_PARAMS = new Set([
+  'redirect_uri',
+  'redirect_uris',
+  'request_uri'
+])
+
+const normalizeKey = (key: string): string => key.trim().toLowerCase()
+
 // Keys can carry surrounding whitespace (URLSearchParams and JSON both preserve
-// it), which would slip a secret past an exact-match redaction check. Normalize
-// before comparing so e.g. ` code_verifier ` is still redacted.
+// it), which would slip a secret past an exact-match redaction check. Mastodon
+// and Rails clients also use bracket notation for nested params (e.g.
+// `user[password]`), so the key is split on brackets/whitespace and each
+// segment is checked. Normalizing this way redacts ` code_verifier ` and
+// `user[password]` alike.
+const matchesParamSet = (key: string, set: Set<string>): boolean => {
+  const normalized = normalizeKey(key)
+  if (set.has(normalized)) return true
+  return normalized
+    .split(/[[\]\s]+/)
+    .filter(Boolean)
+    .some((segment) => set.has(segment))
+}
+
 const isSensitiveParam = (key: string): boolean =>
-  SENSITIVE_PARAMS.has(key.trim().toLowerCase())
+  matchesParamSet(key, SENSITIVE_PARAMS)
+
+const isUrlValuedParam = (key: string): boolean =>
+  matchesParamSet(key, URL_VALUED_PARAMS)
 
 // Origin used only to parse relative URL-valued headers (e.g. a `/callback?...`
 // Referer/Location). It is stripped back off before returning, so it never
@@ -108,16 +136,27 @@ export const sanitizeHeaders = (headers: Headers): Record<string, string> => {
   return result
 }
 
+// Redacts a single param value: secret params become [REDACTED], URL-valued
+// params keep scheme+host+path but drop query/fragment, everything else passes
+// through. Shared by sanitizeFormBody and sanitizeParams.
+const sanitizeParamValue = (key: string, value: unknown): unknown => {
+  if (isSensitiveParam(key)) return '[REDACTED]'
+  if (typeof value === 'string' && isUrlValuedParam(key)) {
+    return sanitizeUrlValue(value)
+  }
+  return value
+}
+
 /**
  * Parses a form-urlencoded (or query string) body into a plain object with
- * secret parameters redacted, keeping the rest (grant_type, client_id,
- * redirect_uri, scope, response_type, ...) which is exactly what is needed to
- * understand a 400.
+ * secret parameters redacted and URL-valued params (redirect_uri, ...) stripped
+ * of query/fragment, keeping the rest (grant_type, client_id, scope,
+ * response_type, ...) which is exactly what is needed to understand a 400.
  */
 export const sanitizeFormBody = (body: string): Record<string, string> => {
   const result: Record<string, string> = {}
   new URLSearchParams(body).forEach((value, key) => {
-    result[key] = isSensitiveParam(key) ? '[REDACTED]' : value
+    result[key] = sanitizeParamValue(key, value) as string
   })
   return result
 }
@@ -129,10 +168,12 @@ const MAX_SANITIZE_DEPTH = 8
 
 /**
  * Redacts secret keys from an already-parsed value (e.g. a JSON body or
- * query-param record). Recurses into nested objects and arrays so a secret key
+ * query-param record). Recurses into arrays and plain objects so a secret key
  * nested under a non-sensitive parent is still redacted — the apps endpoint
  * logs the raw, parse-failed request body, which is attacker-controlled and may
- * be arbitrarily nested. Recursion depth is capped to stay DoS-safe.
+ * be arbitrarily nested. Recursion depth is capped to stay DoS-safe, and
+ * non-plain objects (Date, RegExp, class instances) are returned as-is rather
+ * than being flattened to `{}` by `Object.entries`.
  */
 export const sanitizeParams = (value: unknown, depth = 0): unknown => {
   if (value && typeof value === 'object') {
@@ -140,11 +181,19 @@ export const sanitizeParams = (value: unknown, depth = 0): unknown => {
     if (Array.isArray(value)) {
       return value.map((item) => sanitizeParams(item, depth + 1))
     }
+    const proto = Object.getPrototypeOf(value)
+    if (proto !== null && proto !== Object.prototype) {
+      return value
+    }
     const result: Record<string, unknown> = {}
     for (const [key, nested] of Object.entries(value)) {
-      result[key] = isSensitiveParam(key)
-        ? '[REDACTED]'
-        : sanitizeParams(nested, depth + 1)
+      if (isSensitiveParam(key)) {
+        result[key] = '[REDACTED]'
+      } else if (typeof nested === 'string' && isUrlValuedParam(key)) {
+        result[key] = sanitizeUrlValue(nested)
+      } else {
+        result[key] = sanitizeParams(nested, depth + 1)
+      }
     }
     return result
   }


### PR DESCRIPTION
## Problem

Third-party Mastodon clients sometimes get a **400 response during sign-in** in production, and there's currently no way to see what they sent or why it failed. The token proxy in particular relayed better-auth's upstream error (including 400s) **without logging the underlying OAuth error**, so the cause was invisible in logs.

## What this adds

A scoped child logger (`module=oauth`) plus header/param sanitizers, wired into the three OAuth entry points a Mastodon client hits during login:

- **`/oauth/token`** (`app/(nosidebar)/oauth/token/route.ts`) — logs the incoming request, the proxy's own pre-flight rejections (wrong content-type / PKCE required), and any upstream non-2xx with the status **plus better-auth's OAuth error body** (e.g. `invalid_grant` / `invalid_client`) and the request that caused it. This is the primary source of the 400.
- **`/api/oauth/authorize`** (`app/api/oauth/authorize/route.ts`) — logs the forwarded authorize params (at `info`, since this route only redirects and never observes the downstream failure) so a 400 from better-auth's authorize endpoint can be correlated to the originating client request.
- **`/api/v1/apps`** (`app/api/v1/apps/route.ts`) — logs rejected app registrations (validation issues and create errors), the first step of the login flow.

## What you'll see in the logs

For a failing token exchange you now get a structured warning containing: the endpoint, HTTP status, **request headers**, the **request body params**, and the **upstream OAuth error body** — exactly the "what headers / what error caused the 400" you wanted.

## Safety (redaction)

Sanitizers strip secrets/PII before anything is logged:

- **Headers**: `authorization`/`proxy-authorization` keep only the auth scheme (`Basic [REDACTED]`) so wrong-scheme clients are still visible; `cookie`/`set-cookie` are redacted in full; URL-bearing headers (`referer`/`referrer`/`location`, absolute or relative) keep only scheme+host+path, dropping the secret-bearing query/fragment.
- **Params** (body, query, JSON): `client_secret`, `code`, `code_verifier`, `password`, `refresh_token`/`access_token`/`id_token`/`id_token_hint`/`token`, `state`, `assertion`, and PII (`username`, `email`) are redacted. Key matching normalizes whitespace/case and handles bracket notation (`user[password]`). URL-valued params (`redirect_uri`, `redirect_uris`, `request_uri`) keep scheme+host+path and drop query/fragment.
- **Nested bodies**: `sanitizeParams` recurses into plain objects/arrays (so a secret nested under a non-sensitive key is still redacted), with a bounded depth so a deeply nested, attacker-controlled body can't blow the stack (a 422 stays a 422). Non-plain objects (`Date`, `RegExp`, class instances) are passed through untouched rather than flattened.

`oauthLogger` uses `logger.child({ module: 'oauth' })` directly — the real pino logger always provides `child`, and the route/unit tests mock the logger faithfully (`child`, `debug`, `warn`, …) so an incomplete mock fails loudly rather than being silently papered over.

## Verification

- `yarn run prettier --write .`, `yarn lint` (0 errors), `yarn build` (✓), `yarn test` (373 suites / 3197 tests, all passing). Sanitizer behavior is covered by `lib/services/oauth/logging.test.ts` plus route-level redaction assertions in the token and apps route tests.

https://claude.ai/code/session_01Uz8NZ4v6CQ3kqbSqxc4gqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz8NZ4v6CQ3kqbSqxc4gqB)_