### PR TITLE
fix: accept form-data/JSON across native-client API endpoints (oauth/token, status edit, mute)

### DIFF
--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -363,19 +363,15 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
 
-  test('rejects token requests that are not form encoded before proxying', async () => {
+  test('rejects token requests with an unsupported content type before proxying', async () => {
     mockAuthHandler.mockResolvedValue(
       Response.json({ access_token: 'should-not-issue' })
     )
 
     const req = new NextRequest('https://llun.test/oauth/token', {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        grant_type: 'authorization_code',
-        client_id: 'pkce-client',
-        code: 'authorization-code'
-      })
+      headers: { 'content-type': 'text/plain' },
+      body: 'grant_type=authorization_code&client_id=pkce-client'
     })
 
     const response = await POST(req)
@@ -383,7 +379,116 @@ describe('OAuth token endpoint', () => {
     await expect(response.json()).resolves.toEqual({
       error: 'invalid_request',
       error_description:
-        'Token requests must use application/x-www-form-urlencoded'
+        'Token requests must use application/x-www-form-urlencoded, multipart/form-data, or application/json'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('normalizes multipart/form-data token requests to urlencoded before proxying', async () => {
+    // Reproduces Ivory: it posts the token request as multipart/form-data, which
+    // the proxy previously rejected with a 400 before better-auth ever saw it.
+    const boundary = '_X__X__X___X_XXXX_____X_X__X_X_XX_'
+    const fields = {
+      grant_type: 'authorization_code',
+      client_id: 'non-pkce-client',
+      client_secret: 'client-secret',
+      code: 'authorization-code',
+      code_verifier: 'verifier',
+      redirect_uri: 'https://client.llun.dev/callback'
+    }
+    const multipartBody = `${Object.entries(fields)
+      .map(
+        ([name, value]) =>
+          `--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${value}\r\n`
+      )
+      .join('')}--${boundary}--\r\n`
+
+    const expectedBody = new URLSearchParams(fields).toString()
+
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      expect(request.headers.get('content-type')).toBe(
+        'application/x-www-form-urlencoded'
+      )
+      await expect(request.text()).resolves.toBe(expectedBody)
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`
+      },
+      body: multipartBody
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
+  test('normalizes application/json token requests to urlencoded before proxying', async () => {
+    const expectedBody = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: 'non-pkce-client',
+      client_secret: 'client-secret',
+      code: 'authorization-code',
+      code_verifier: 'verifier',
+      redirect_uri: 'https://client.llun.dev/callback'
+    }).toString()
+
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      expect(request.headers.get('content-type')).toBe(
+        'application/x-www-form-urlencoded'
+      )
+      await expect(request.text()).resolves.toBe(expectedBody)
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        client_id: 'non-pkce-client',
+        client_secret: 'client-secret',
+        code: 'authorization-code',
+        code_verifier: 'verifier',
+        redirect_uri: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
+  test('rejects malformed JSON token bodies with a 400', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{ not valid json'
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'Unable to read request body'
     })
     expect(response.status).toBe(400)
     expect(mockAuthHandler).not.toHaveBeenCalled()

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -590,6 +590,75 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).toHaveBeenCalled()
   })
 
+  test('normalizes a multipart body with a quoted boundary', async () => {
+    const boundary = 'QUOTED_BOUNDARY'
+    const fields = {
+      grant_type: 'client_credentials',
+      client_id: 'quoted-client',
+      client_secret: 'quoted-secret'
+    }
+    const multipartBody = `${Object.entries(fields)
+      .map(
+        ([name, value]) =>
+          `--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${value}\r\n`
+      )
+      .join('')}--${boundary}--\r\n`
+
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      await expect(request.text()).resolves.toBe(
+        new URLSearchParams(fields).toString()
+      )
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      // RFC 2046 permits a quoted boundary; some middleware re-quotes it.
+      headers: {
+        'content-type': `multipart/form-data; boundary="${boundary}"`
+      },
+      body: multipartBody
+    })
+
+    const response = await POST(req)
+
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
+  test('skips file parts (Content-Disposition with filename) in multipart bodies', async () => {
+    const boundary = 'FILE_BOUNDARY'
+    const multipartBody =
+      `--${boundary}\r\nContent-Disposition: form-data; name="grant_type"\r\n\r\nclient_credentials\r\n` +
+      `--${boundary}\r\nContent-Disposition: form-data; name="upload"; filename="secret.txt"\r\n\r\nSHOULD_BE_IGNORED\r\n` +
+      `--${boundary}\r\nContent-Disposition: form-data; name="client_id"\r\n\r\nfile-client\r\n` +
+      `--${boundary}--\r\n`
+
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      const text = await request.text()
+      const params = new URLSearchParams(text)
+      expect(params.get('grant_type')).toBe('client_credentials')
+      expect(params.get('client_id')).toBe('file-client')
+      // The file part must not leak into the forwarded params.
+      expect(params.has('upload')).toBe(false)
+      expect(text).not.toContain('SHOULD_BE_IGNORED')
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`
+      },
+      body: multipartBody
+    })
+
+    const response = await POST(req)
+
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
   test('does not look up the client during PKCE preflight when code_verifier is present', async () => {
     const body = new URLSearchParams({
       grant_type: 'authorization_code',

--- a/app/(nosidebar)/oauth/token/route.test.ts
+++ b/app/(nosidebar)/oauth/token/route.test.ts
@@ -494,6 +494,102 @@ describe('OAuth token endpoint', () => {
     expect(mockAuthHandler).not.toHaveBeenCalled()
   })
 
+  test.each([
+    ['null', 'null'],
+    ['an array', '[]'],
+    ['a string', '"grant_type=client_credentials"']
+  ])(
+    'rejects a JSON token body that parses to %s with a 400',
+    async (_label, body) => {
+      mockAuthHandler.mockResolvedValue(
+        Response.json({ access_token: 'should-not-issue' })
+      )
+
+      const req = new NextRequest('https://llun.test/oauth/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body
+      })
+
+      const response = await POST(req)
+
+      await expect(response.json()).resolves.toEqual({
+        error: 'invalid_request',
+        error_description: 'Unable to read request body'
+      })
+      expect(response.status).toBe(400)
+      expect(mockAuthHandler).not.toHaveBeenCalled()
+    }
+  )
+
+  test('rejects a multipart body that is missing its declared boundary with a 400', async () => {
+    mockAuthHandler.mockResolvedValue(
+      Response.json({ access_token: 'should-not-issue' })
+    )
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=EXPECTED_BOUNDARY'
+      },
+      // Body never contains `--EXPECTED_BOUNDARY`; a garbled multipart body must
+      // map to the 400 unreadable path, not forward as an empty urlencoded body.
+      body: 'grant_type=client_credentials&client_id=c'
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'invalid_request',
+      error_description: 'Unable to read request body'
+    })
+    expect(response.status).toBe(400)
+    expect(mockAuthHandler).not.toHaveBeenCalled()
+  })
+
+  test('parses a multipart body that uses LF line endings', async () => {
+    const boundary = 'LF_BOUNDARY'
+    const fields = {
+      grant_type: 'client_credentials',
+      client_id: 'lf-client',
+      client_secret: 'lf-secret'
+    }
+    // LF-only line endings (some clients/proxies normalize CRLF to LF).
+    const multipartBody = `${Object.entries(fields)
+      .map(
+        ([name, value]) =>
+          `--${boundary}\nContent-Disposition: form-data; name="${name}"\n\n${value}\n`
+      )
+      .join('')}--${boundary}--\n`
+
+    const expectedBody = new URLSearchParams(fields).toString()
+
+    mockAuthHandler.mockImplementation(async (request: Request) => {
+      expect(request.headers.get('content-type')).toBe(
+        'application/x-www-form-urlencoded'
+      )
+      await expect(request.text()).resolves.toBe(expectedBody)
+      return Response.json({ access_token: 'issued' })
+    })
+
+    const req = new NextRequest('https://llun.test/oauth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`
+      },
+      body: multipartBody
+    })
+
+    const response = await POST(req)
+
+    await expect(response.json()).resolves.toEqual({
+      access_token: 'issued',
+      created_at: expect.any(Number)
+    })
+    expect(response.status).toBe(200)
+    expect(mockAuthHandler).toHaveBeenCalled()
+  })
+
   test('does not look up the client during PKCE preflight when code_verifier is present', async () => {
     const body = new URLSearchParams({
       grant_type: 'authorization_code',

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -21,6 +21,18 @@ import {
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const MAX_TOKEN_REQUEST_BODY_BYTES = 64 * 1024
 const FORM_URLENCODED_MEDIA_TYPE = 'application/x-www-form-urlencoded'
+const MULTIPART_FORM_MEDIA_TYPE = 'multipart/form-data'
+const JSON_MEDIA_TYPE = 'application/json'
+// Native Mastodon clients are inconsistent about how they encode the token
+// request: Ivory posts `multipart/form-data`, others post JSON, the spec default
+// is `application/x-www-form-urlencoded`. Accept all three and normalize the
+// non-urlencoded ones to urlencoded before forwarding, since better-auth's token
+// handler only parses urlencoded/JSON — not multipart boundaries.
+const ACCEPTED_TOKEN_MEDIA_TYPES = new Set([
+  FORM_URLENCODED_MEDIA_TYPE,
+  MULTIPART_FORM_MEDIA_TYPE,
+  JSON_MEDIA_TYPE
+])
 // `cookie` is stripped so a forwarded browser session cookie does not trigger
 // better-auth's cookie-gated CSRF origin check on the token back-channel. Native
 // OAuth clients (e.g. the Mastodon iOS app) send no Origin header, so leaving the
@@ -141,6 +153,100 @@ const readTokenRequestBodyWithLimit = async (
   return Buffer.concat(chunks).toString('utf8')
 }
 
+// OAuth token parameters are flat string fields, so flatten any JSON body into
+// urlencoded params and drop non-primitive values.
+const jsonBodyToParams = (parsed: unknown): URLSearchParams => {
+  const params = new URLSearchParams()
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return params
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    if (value === null || value === undefined || typeof value === 'object') {
+      continue
+    }
+    params.set(key, String(value))
+  }
+  return params
+}
+
+const parseMultipartBoundary = (rawContentType: string): string | null => {
+  const match = rawContentType.match(/;\s*boundary=(?:"([^"]+)"|([^;]+))/i)
+  const boundary = (match?.[1] ?? match?.[2])?.trim()
+  return boundary || null
+}
+
+// Minimal multipart/form-data parser for the simple named text fields an OAuth
+// token request carries. The platform `Response.formData()` parser is not used
+// because it is unavailable in the test runtime; token bodies never contain file
+// parts, so those (Content-Disposition with a `filename`) are skipped.
+const multipartBodyToParams = (
+  rawContentType: string,
+  bodyText: string
+): URLSearchParams => {
+  const boundary = parseMultipartBoundary(rawContentType)
+  if (!boundary) throw new TokenRequestBodyUnreadableError()
+
+  const params = new URLSearchParams()
+  for (const rawSegment of bodyText.split(`--${boundary}`)) {
+    const segment = rawSegment.startsWith('\r\n')
+      ? rawSegment.slice(2)
+      : rawSegment
+    const headerEnd = segment.indexOf('\r\n\r\n')
+    if (headerEnd < 0) continue
+
+    const disposition = segment
+      .slice(0, headerEnd)
+      .split('\r\n')
+      .find((line) => line.toLowerCase().startsWith('content-disposition:'))
+    if (!disposition || /;\s*filename=/i.test(disposition)) continue
+
+    const name = disposition.match(/;\s*name="?([^";]+)"?/i)?.[1]
+    if (!name) continue
+
+    const value = segment.slice(headerEnd + 4)
+    params.set(name, value.endsWith('\r\n') ? value.slice(0, -2) : value)
+  }
+  return params
+}
+
+// Normalize a token request body to urlencoded params. urlencoded bodies are
+// forwarded verbatim (the production-proven path); multipart/JSON bodies are
+// re-serialized to urlencoded and signal a content-type override for the proxy.
+// Malformed JSON / multipart bodies raise TokenRequestBodyUnreadableError so the
+// caller maps them to the existing 400.
+const normalizeTokenRequestBody = (
+  mediaType: string,
+  rawContentType: string,
+  bodyText: string
+): {
+  params: URLSearchParams
+  forwardBodyText: string
+  forwardContentType: string | null
+} => {
+  if (mediaType === FORM_URLENCODED_MEDIA_TYPE) {
+    return {
+      params: new URLSearchParams(bodyText),
+      forwardBodyText: bodyText,
+      forwardContentType: null
+    }
+  }
+
+  try {
+    const params =
+      mediaType === JSON_MEDIA_TYPE
+        ? jsonBodyToParams(JSON.parse(bodyText))
+        : multipartBodyToParams(rawContentType, bodyText)
+    return {
+      params,
+      forwardBodyText: params.toString(),
+      forwardContentType: FORM_URLENCODED_MEDIA_TYPE
+    }
+  } catch (error) {
+    if (error instanceof TokenRequestBodyUnreadableError) throw error
+    throw new TokenRequestBodyUnreadableError()
+  }
+}
+
 const getTokenProxyHeaders = (headers: Headers): Headers => {
   const proxyHeaders = new Headers(headers)
   for (const header of TOKEN_PROXY_EXCLUDED_HEADERS) {
@@ -154,6 +260,7 @@ const getTokenRequestBody = async (
 ): Promise<{
   bodyText: string | null
   params: URLSearchParams | null
+  forwardContentType: string | null
   error: Response | null
 }> => {
   const contentLength = Number(req.headers.get('content-length') ?? 0)
@@ -161,6 +268,7 @@ const getTokenRequestBody = async (
     return {
       bodyText: null,
       params: null,
+      forwardContentType: null,
       error: apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
@@ -173,22 +281,21 @@ const getTokenRequestBody = async (
     }
   }
 
-  const contentType = (req.headers.get('content-type') ?? '')
-    .split(';')[0]
-    .trim()
-    .toLowerCase()
+  const rawContentType = req.headers.get('content-type') ?? ''
+  const mediaType = rawContentType.split(';')[0].trim().toLowerCase()
 
-  if (contentType !== FORM_URLENCODED_MEDIA_TYPE) {
+  if (!ACCEPTED_TOKEN_MEDIA_TYPES.has(mediaType)) {
     return {
       bodyText: null,
       params: null,
+      forwardContentType: null,
       error: apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: {
           error: 'invalid_request',
           error_description:
-            'Token requests must use application/x-www-form-urlencoded'
+            'Token requests must use application/x-www-form-urlencoded, multipart/form-data, or application/json'
         },
         responseStatusCode: HTTP_STATUS.BAD_REQUEST
       })
@@ -197,12 +304,20 @@ const getTokenRequestBody = async (
 
   try {
     const bodyText = await readTokenRequestBodyWithLimit(req)
-    return { bodyText, params: new URLSearchParams(bodyText), error: null }
+    const { params, forwardBodyText, forwardContentType } =
+      normalizeTokenRequestBody(mediaType, rawContentType, bodyText)
+    return {
+      bodyText: forwardBodyText,
+      params,
+      forwardContentType,
+      error: null
+    }
   } catch (error) {
     if (error instanceof TokenRequestBodyUnreadableError) {
       return {
         bodyText: null,
         params: null,
+        forwardContentType: null,
         error: apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -219,6 +334,7 @@ const getTokenRequestBody = async (
     return {
       bodyText: null,
       params: null,
+      forwardContentType: null,
       error: apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
@@ -289,7 +405,8 @@ export const POST = async (req: NextRequest) => {
     'OAuth token request received'
   )
 
-  const { bodyText, params, error } = await getTokenRequestBody(req)
+  const { bodyText, params, forwardContentType, error } =
+    await getTokenRequestBody(req)
   if (error) {
     // Pre-flight rejection (wrong content-type, oversized/unreadable body).
     // These are the proxy's own 4xx responses and never reach better-auth.
@@ -324,9 +441,15 @@ export const POST = async (req: NextRequest) => {
 
   // Rewrite the URL to better-auth's token endpoint
   const url = new URL('/api/auth/oauth2/token', getBaseURL())
+  const proxyHeaders = getTokenProxyHeaders(req.headers)
+  // multipart/JSON bodies were normalized to urlencoded; override the forwarded
+  // content-type to match so better-auth parses the body it actually receives.
+  if (forwardContentType) {
+    proxyHeaders.set('content-type', forwardContentType)
+  }
   const proxyReq = new Request(url.toString(), {
     method: 'POST',
-    headers: getTokenProxyHeaders(req.headers),
+    headers: proxyHeaders,
     body: bodyText ?? ''
   })
 

--- a/app/(nosidebar)/oauth/token/route.ts
+++ b/app/(nosidebar)/oauth/token/route.ts
@@ -154,12 +154,14 @@ const readTokenRequestBodyWithLimit = async (
 }
 
 // OAuth token parameters are flat string fields, so flatten any JSON body into
-// urlencoded params and drop non-primitive values.
+// urlencoded params and drop non-primitive values. A body that parses to a
+// non-object (null, array, string, number) is not a valid token request, so it
+// is rejected rather than silently forwarded as an empty urlencoded body.
 const jsonBodyToParams = (parsed: unknown): URLSearchParams => {
-  const params = new URLSearchParams()
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return params
+    throw new TokenRequestBodyUnreadableError()
   }
+  const params = new URLSearchParams()
   for (const [key, value] of Object.entries(parsed)) {
     if (value === null || value === undefined || typeof value === 'object') {
       continue
@@ -186,25 +188,37 @@ const multipartBodyToParams = (
   const boundary = parseMultipartBoundary(rawContentType)
   if (!boundary) throw new TokenRequestBodyUnreadableError()
 
+  const delimiter = `--${boundary}`
+  // A body that never contains its declared boundary is malformed; reject it
+  // rather than forwarding an empty (and silently wrong) urlencoded body.
+  if (!bodyText.includes(delimiter)) {
+    throw new TokenRequestBodyUnreadableError()
+  }
+
+  // Be lenient about line endings: multipart is CRLF per RFC 2046, but some
+  // clients, proxies, and test harnesses emit LF. Normalize to LF before
+  // splitting so both are parsed identically.
+  const normalizedBody = bodyText.replace(/\r\n/g, '\n')
+
   const params = new URLSearchParams()
-  for (const rawSegment of bodyText.split(`--${boundary}`)) {
-    const segment = rawSegment.startsWith('\r\n')
-      ? rawSegment.slice(2)
+  for (const rawSegment of normalizedBody.split(delimiter)) {
+    const segment = rawSegment.startsWith('\n')
+      ? rawSegment.slice(1)
       : rawSegment
-    const headerEnd = segment.indexOf('\r\n\r\n')
+    const headerEnd = segment.indexOf('\n\n')
     if (headerEnd < 0) continue
 
     const disposition = segment
       .slice(0, headerEnd)
-      .split('\r\n')
+      .split('\n')
       .find((line) => line.toLowerCase().startsWith('content-disposition:'))
     if (!disposition || /;\s*filename=/i.test(disposition)) continue
 
     const name = disposition.match(/;\s*name="?([^";]+)"?/i)?.[1]
     if (!name) continue
 
-    const value = segment.slice(headerEnd + 4)
-    params.set(name, value.endsWith('\r\n') ? value.slice(0, -2) : value)
+    const value = segment.slice(headerEnd + 2)
+    params.set(name, value.endsWith('\n') ? value.slice(0, -1) : value)
   }
   return params
 }

--- a/app/api/v1/accounts/[id]/mute/route.test.ts
+++ b/app/api/v1/accounts/[id]/mute/route.test.ts
@@ -58,6 +58,16 @@ const createRequest = (
   return req
 }
 
+const createFormRequest = (targetActorId: string, body: string) =>
+  new NextRequest(
+    `https://local.test/api/v1/accounts/${urlToId(targetActorId)}/mute`,
+    {
+      method: 'POST',
+      body,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+    }
+  )
+
 describe('POST /api/v1/accounts/:id/mute', () => {
   const applyMuteMock = applyMute as jest.Mock
   const getRelationshipMock = getRelationship as jest.Mock
@@ -163,6 +173,36 @@ describe('POST /api/v1/accounts/:id/mute', () => {
     })
 
     expect(response.status).not.toBe(500)
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ notifications: true, endsAt: null })
+    )
+  })
+
+  it('reads notifications and duration from a urlencoded body (native clients)', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+    const before = Date.now()
+
+    await POST(
+      createFormRequest(targetActorId, 'notifications=false&duration=3600'),
+      { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+    )
+
+    const call = applyMuteMock.mock.calls[0][0]
+    // The string "false" must become boolean false, not be coerced to true.
+    expect(call.notifications).toBe(false)
+    expect(call.endsAt).toBeGreaterThanOrEqual(before + 3600 * 1000)
+    expect(call.endsAt).toBeLessThan(before + 3601 * 1000)
+  })
+
+  it('keeps notifications enabled for a urlencoded notifications=true', async () => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    await POST(createFormRequest(targetActorId, 'notifications=true'), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
     expect(applyMuteMock).toHaveBeenCalledWith(
       expect.objectContaining({ notifications: true, endsAt: null })
     )

--- a/app/api/v1/accounts/[id]/mute/route.test.ts
+++ b/app/api/v1/accounts/[id]/mute/route.test.ts
@@ -208,6 +208,26 @@ describe('POST /api/v1/accounts/:id/mute', () => {
     )
   })
 
+  it.each([
+    ['0', false],
+    ['no', false],
+    ['off', false],
+    ['1', true],
+    ['yes', true],
+    ['on', true]
+  ])('coerces a urlencoded notifications=%s to %s', async (value, expected) => {
+    const targetActorId = 'https://remote.test/users/alice'
+    applyMuteMock.mockResolvedValue({})
+
+    await POST(createFormRequest(targetActorId, `notifications=${value}`), {
+      params: Promise.resolve({ id: urlToId(targetActorId) })
+    })
+
+    expect(applyMuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ notifications: expected })
+    )
+  })
+
   it('returns 404 when target actor does not exist', async () => {
     const targetActorId = 'https://remote.test/users/unknown'
     mockDatabase.getActorFromId.mockResolvedValue(null)

--- a/app/api/v1/accounts/[id]/mute/route.ts
+++ b/app/api/v1/accounts/[id]/mute/route.ts
@@ -4,6 +4,7 @@ import { applyMute } from '@/lib/actions/applyMute'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -18,9 +19,23 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+// Form bodies arrive as strings, so a native client sending `notifications=false`
+// would otherwise be coerced to `true`. Map the textual booleans Mastodon clients
+// send before validating; non-string (JSON) values pass through unchanged.
+const coerceBoolean = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value
+  const normalized = value.trim().toLowerCase()
+  if (['false', '0', 'no', 'off'].includes(normalized)) return false
+  if (['true', '1', 'yes', 'on'].includes(normalized)) return true
+  return value
+}
+
 const MuteBodySchema = z.object({
-  notifications: z.boolean().catch(true).optional(),
-  duration: z
+  notifications: z
+    .preprocess(coerceBoolean, z.boolean())
+    .catch(true)
+    .optional(),
+  duration: z.coerce
     .number()
     .finite()
     .min(0)
@@ -59,7 +74,7 @@ export const POST = traceApiRoute(
           responseStatusCode: 404
         })
 
-      const rawBody = await req.json().catch(() => ({}))
+      const rawBody = await getRequestBody(req).catch(() => ({}))
       const body = MuteBodySchema.safeParse(rawBody).data ?? {}
       const notifications: boolean = body.notifications !== false
       const durationSeconds = body.duration ?? 0

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1737,6 +1737,106 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
     })
 
+    it('edits text from a urlencoded body without wiping unmentioned media (native clients)', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-urlencoded-keep-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Original urlencoded text',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-urlencoded-keep.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-urlencoded-keep.jpg'
+        },
+        description: 'Kept media'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-urlencoded-keep.webp',
+        width: 320,
+        height: 240,
+        name: 'Kept media',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            // Only `status` is sent — `media_ids` is absent. The omit-if-absent
+            // parser must leave it undefined so existing media is preserved
+            // rather than coerced to an empty array and wiped.
+            body: new URLSearchParams({
+              status: 'Edited via urlencoded'
+            }).toString(),
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.content).toContain('Edited via urlencoded')
+      expect(data.media_attachments).toHaveLength(1)
+      const attachments = await database.getAttachments({ statusId })
+      expect(attachments).toHaveLength(1)
+    })
+
+    it('applies a visibility-only edit from a urlencoded body', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-urlencoded-visibility`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Visibility urlencoded target',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: new URLSearchParams({ visibility: 'private' }).toString(),
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.visibility).toBe('private')
+      // Text must survive a visibility-only edit (status omitted, not blanked).
+      expect(data.content).toContain('Visibility urlencoded target')
+    })
+
     it('clears content warning when spoiler_text is null', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-null-cw`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1801,6 +1801,70 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(attachments).toHaveLength(1)
     })
 
+    it('clears media from a urlencoded body with an explicit empty media_ids[]', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-urlencoded-clear-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Keeps text while clearing media',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-urlencoded-clear.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-urlencoded-clear.jpg'
+        },
+        description: 'Cleared media'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-urlencoded-clear.webp',
+        width: 320,
+        height: 240,
+        name: 'Cleared media',
+        mediaId: media!.id
+      })
+
+      // `media_ids[]=` (present but empty) must clear attachments, mirroring a
+      // JSON `media_ids: []`, rather than being dropped as absent.
+      const params = new URLSearchParams({
+        status: 'Keeps text while clearing'
+      })
+      params.append('media_ids[]', '')
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: params.toString(),
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.media_attachments).toEqual([])
+      await expect(database.getAttachments({ statusId })).resolves.toEqual([])
+    })
+
     it('applies a visibility-only edit from a urlencoded body', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-urlencoded-visibility`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1865,6 +1865,42 @@ describe('GET /api/v1/statuses/[id]', () => {
       await expect(database.getAttachments({ statusId })).resolves.toEqual([])
     })
 
+    it('returns 400 for a malformed JSON edit body', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-malformed-json`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Malformed edit target',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            // Syntactically broken JSON must surface as 400 (bad request), not a
+            // 422 from a swallowed empty body.
+            body: '{ "status": "oops" ',
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        {
+          params: Promise.resolve({ id: urlToId(statusId) })
+        }
+      )
+
+      expect(response.status).toBe(400)
+      const updatedStatus = await database.getStatus({ statusId })
+      expect(updatedStatus?.text).toBe('Malformed edit target')
+    })
+
     it('applies a visibility-only edit from a urlencoded body', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-urlencoded-visibility`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -11,6 +11,7 @@ import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
+import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
 import { Scope } from '@/lib/types/database/operations'
 import { isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { StatusType } from '@/lib/types/domain/status'
@@ -140,7 +141,9 @@ export const PUT = traceApiRoute(
       const { database, currentActor } = context
       const statusId = idToUrl(encodedStatusId)
       try {
-        const parsed = EditNoteSchema.safeParse(await req.json())
+        const parsed = EditNoteSchema.safeParse(
+          await parseStatusRequestBody(req)
+        )
         if (!parsed.success) {
           return apiResponse({
             req,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -5,6 +5,7 @@ import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
+import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -32,70 +33,6 @@ const NoteSchema = z
   })
   .refine((note) => note.status.trim().length > 0 || note.media_ids.length > 0)
 
-const FORM_URL_ENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded'
-const FORM_CONTENT_TYPES = [
-  'multipart/form-data',
-  FORM_URL_ENCODED_CONTENT_TYPE
-]
-
-const isFormRequest = (req: Request) => {
-  const contentType = req.headers.get('content-type')?.toLowerCase()
-  return FORM_CONTENT_TYPES.some((type) => contentType?.includes(type))
-}
-
-const getFormString = (form: FormData, name: string) => {
-  const value = form.get(name)
-  return typeof value === 'string' ? value : undefined
-}
-
-const getFormStringArray = (form: FormData, ...names: string[]) =>
-  names
-    .flatMap((name) => form.getAll(name))
-    .filter((value): value is string => typeof value === 'string')
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-
-const getSearchParamString = (params: URLSearchParams, name: string) => {
-  const value = params.get(name)
-  return value === null ? undefined : value
-}
-
-const getSearchParamStringArray = (
-  params: URLSearchParams,
-  ...names: string[]
-) =>
-  names
-    .flatMap((name) => params.getAll(name))
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-
-const getNoteRequestInput = async (req: Request): Promise<unknown> => {
-  if (!isFormRequest(req)) {
-    return req.json()
-  }
-
-  const contentType = req.headers.get('content-type')?.toLowerCase()
-  if (contentType?.includes(FORM_URL_ENCODED_CONTENT_TYPE)) {
-    const params = new URLSearchParams(await req.text())
-    return {
-      status: getSearchParamString(params, 'status') ?? '',
-      in_reply_to_id: getSearchParamString(params, 'in_reply_to_id'),
-      spoiler_text: getSearchParamString(params, 'spoiler_text'),
-      media_ids: getSearchParamStringArray(params, 'media_ids', 'media_ids[]'),
-      visibility: getSearchParamString(params, 'visibility')
-    }
-  }
-
-  const form = await req.formData()
-  return {
-    status: getFormString(form, 'status') ?? '',
-    in_reply_to_id: getFormString(form, 'in_reply_to_id'),
-    spoiler_text: getFormString(form, 'spoiler_text'),
-    media_ids: getFormStringArray(form, 'media_ids', 'media_ids[]'),
-    visibility: getFormString(form, 'visibility')
-  }
-}
-
 export const POST = traceApiRoute(
   'createStatus',
   OAuthGuardAnyScope(
@@ -103,7 +40,7 @@ export const POST = traceApiRoute(
     async (req, context) => {
       const { currentActor, database } = context
       try {
-        const content = await getNoteRequestInput(req)
+        const content = await parseStatusRequestBody(req)
         const parsed = NoteSchema.safeParse(content)
         if (!parsed.success) {
           return apiResponse({

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -62,4 +62,16 @@ describe('parseStatusRequestBody', () => {
     expect(body).toEqual({ status: 'no media' })
     expect('media_ids' in body).toBe(false)
   })
+
+  it('keeps an explicit empty media_ids[] so form clients can clear media', async () => {
+    const params = new URLSearchParams()
+    params.append('media_ids[]', '')
+    const body = await parseStatusRequestBody(
+      createRequest('application/x-www-form-urlencoded', params.toString())
+    )
+    // Present-but-empty differs from absent: this must flow through as an empty
+    // array (clear media), not be omitted (preserve media).
+    expect(body).toEqual({ media_ids: [] })
+    expect('media_ids' in body).toBe(true)
+  })
 })

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -98,6 +98,16 @@ describe('parseStatusRequestBody', () => {
     }
   )
 
+  it('propagates a malformed JSON body so the caller can return 400', async () => {
+    // A syntactically broken body must throw (→ caller's 400), not be swallowed
+    // to {} (which would surface as a misleading 422 for missing fields).
+    await expect(
+      parseStatusRequestBody(
+        createRequest('application/json', '{ not valid json')
+      )
+    ).rejects.toThrow()
+  })
+
   it('keeps an explicit empty media_ids[] so form clients can clear media', async () => {
     const params = new URLSearchParams()
     params.append('media_ids[]', '')

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server'
+
+import { parseStatusRequestBody } from './parseStatusRequestBody'
+
+const createRequest = (contentType: string | undefined, body: string) =>
+  new NextRequest('https://llun.test/api/v1/statuses', {
+    method: 'POST',
+    body,
+    headers: contentType ? { 'content-type': contentType } : {}
+  })
+
+describe('parseStatusRequestBody', () => {
+  it('parses a JSON body verbatim, preserving an explicit empty media_ids', async () => {
+    const body = await parseStatusRequestBody(
+      createRequest(
+        'application/json',
+        JSON.stringify({ status: 'hello', media_ids: [] })
+      )
+    )
+    expect(body).toEqual({ status: 'hello', media_ids: [] })
+  })
+
+  it('returns an empty object for an empty JSON body', async () => {
+    const body = await parseStatusRequestBody(
+      createRequest('application/json', '')
+    )
+    expect(body).toEqual({})
+  })
+
+  it('reads only the fields present in a urlencoded body', async () => {
+    const body = await parseStatusRequestBody(
+      createRequest(
+        'application/x-www-form-urlencoded',
+        new URLSearchParams({
+          status: 'from form',
+          visibility: 'private'
+        }).toString()
+      )
+    )
+    // in_reply_to_id / spoiler_text / media_ids are absent, so they must be
+    // omitted (not present-as-empty) to keep edit semantics non-destructive.
+    expect(body).toEqual({ status: 'from form', visibility: 'private' })
+  })
+
+  it('collects repeated media_ids[] entries from a urlencoded body', async () => {
+    const params = new URLSearchParams()
+    params.append('media_ids[]', '1')
+    params.append('media_ids[]', '2')
+    const body = await parseStatusRequestBody(
+      createRequest('application/x-www-form-urlencoded', params.toString())
+    )
+    expect(body).toEqual({ media_ids: ['1', '2'] })
+  })
+
+  it('omits media_ids when a urlencoded body sends none', async () => {
+    const body = await parseStatusRequestBody(
+      createRequest(
+        'application/x-www-form-urlencoded',
+        new URLSearchParams({ status: 'no media' }).toString()
+      )
+    )
+    expect(body).toEqual({ status: 'no media' })
+    expect('media_ids' in body).toBe(false)
+  })
+})

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -63,6 +63,41 @@ describe('parseStatusRequestBody', () => {
     expect('media_ids' in body).toBe(false)
   })
 
+  it('collects bracket-free repeated media_ids from a urlencoded body', async () => {
+    const params = new URLSearchParams()
+    params.append('media_ids', 'abc')
+    params.append('media_ids', 'def')
+    const body = await parseStatusRequestBody(
+      createRequest('application/x-www-form-urlencoded', params.toString())
+    )
+    expect(body).toEqual({ media_ids: ['abc', 'def'] })
+  })
+
+  it('parses a urlencoded body when content-type carries a charset param', async () => {
+    const body = await parseStatusRequestBody(
+      createRequest(
+        'application/x-www-form-urlencoded; charset=utf-8',
+        new URLSearchParams({ status: 'charset test' }).toString()
+      )
+    )
+    expect(body).toEqual({ status: 'charset test' })
+  })
+
+  it.each([
+    ['an array', '["id1","id2"]'],
+    ['null', 'null'],
+    ['a string', '"status=hello"'],
+    ['a number', '42']
+  ])(
+    'returns an empty object for a JSON body that is %s',
+    async (_label, raw) => {
+      const body = await parseStatusRequestBody(
+        createRequest('application/json', raw)
+      )
+      expect(body).toEqual({})
+    }
+  )
+
   it('keeps an explicit empty media_ids[] so form clients can clear media', async () => {
     const params = new URLSearchParams()
     params.append('media_ids[]', '')

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -72,16 +72,16 @@ export const parseStatusRequestBody = async (
   // caller's schema for validation. An empty body parses to an empty object.
   const text = await req.text()
   if (text.trim() === '') return {}
-  try {
-    const parsed: unknown = JSON.parse(text)
-    // A non-object root (null, array, string, number) is not a status body;
-    // return {} so the function's Record contract holds and the caller's schema
-    // rejects it cleanly rather than receiving an array/primitive.
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {}
-    }
-    return parsed as Record<string, unknown>
-  } catch {
+  // Let a malformed JSON body throw: both callers wrap this in a try/catch that
+  // returns 400, the correct status for unparseable syntax — swallowing it to {}
+  // would instead surface as a misleading 422. This also matches the urlencoded
+  // and multipart paths, whose parse failures already propagate.
+  const parsed: unknown = JSON.parse(text)
+  // A well-formed but non-object root (null, array, string, number) is not a
+  // status body; normalize it to {} so the Record contract holds and the
+  // caller's schema rejects it as unprocessable rather than receiving a primitive.
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return {}
   }
+  return parsed as Record<string, unknown>
 }

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -73,7 +73,14 @@ export const parseStatusRequestBody = async (
   const text = await req.text()
   if (text.trim() === '') return {}
   try {
-    return JSON.parse(text) as Record<string, unknown>
+    const parsed: unknown = JSON.parse(text)
+    // A non-object root (null, array, string, number) is not a status body;
+    // return {} so the function's Record contract holds and the caller's schema
+    // rejects it cleanly rather than receiving an array/primitive.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+    return parsed as Record<string, unknown>
   } catch {
     return {}
   }

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -23,11 +23,18 @@ const collectStatusFields = (
     if (typeof value === 'string') body[field] = value
   }
 
-  const mediaIds = MEDIA_ID_FIELDS.flatMap((field) => getAll(field))
-    .filter((value): value is string => typeof value === 'string')
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-  if (mediaIds.length > 0) body.media_ids = mediaIds
+  const rawMediaIds = MEDIA_ID_FIELDS.flatMap((field) => getAll(field)).filter(
+    (value): value is string => typeof value === 'string'
+  )
+  // Distinguish "client did not mention media_ids" (omit → preserve existing
+  // media on edit) from "client sent an explicit, possibly empty media_ids"
+  // (e.g. `media_ids[]=` to clear all attachments). Only the latter sets the
+  // key, so a form client can clear media just as a JSON `media_ids: []` does.
+  if (rawMediaIds.length > 0) {
+    body.media_ids = rawMediaIds
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+  }
 
   return body
 }

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from 'next/server'
+
+const FORM_URL_ENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded'
+const MULTIPART_FORM_DATA_CONTENT_TYPE = 'multipart/form-data'
+
+const STATUS_STRING_FIELDS = [
+  'status',
+  'in_reply_to_id',
+  'spoiler_text',
+  'visibility'
+] as const
+
+const MEDIA_ID_FIELDS = ['media_ids', 'media_ids[]'] as const
+
+const collectStatusFields = (
+  get: (name: string) => unknown,
+  getAll: (name: string) => unknown[]
+): Record<string, unknown> => {
+  const body: Record<string, unknown> = {}
+
+  for (const field of STATUS_STRING_FIELDS) {
+    const value = get(field)
+    if (typeof value === 'string') body[field] = value
+  }
+
+  const mediaIds = MEDIA_ID_FIELDS.flatMap((field) => getAll(field))
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+  if (mediaIds.length > 0) body.media_ids = mediaIds
+
+  return body
+}
+
+/**
+ * Parses a status create/edit request body across the content types native
+ * Mastodon clients use: JSON, application/x-www-form-urlencoded, and
+ * multipart/form-data. Only the fields the client actually sent are returned,
+ * so an edit request never clobbers columns it did not mention; the caller's
+ * Zod schema applies any defaults. Repeated `media_ids[]` entries are preserved
+ * via getAll — flattening (e.g. Object.fromEntries) would drop all but the last.
+ */
+export const parseStatusRequestBody = async (
+  req: NextRequest
+): Promise<Record<string, unknown>> => {
+  const contentType = req.headers.get('content-type')?.toLowerCase() ?? ''
+
+  if (contentType.includes(FORM_URL_ENCODED_CONTENT_TYPE)) {
+    const params = new URLSearchParams(await req.text())
+    return collectStatusFields(
+      (name) => params.get(name),
+      (name) => params.getAll(name)
+    )
+  }
+
+  if (contentType.includes(MULTIPART_FORM_DATA_CONTENT_TYPE)) {
+    const form = await req.formData()
+    return collectStatusFields(
+      (name) => form.get(name),
+      (name) => form.getAll(name)
+    )
+  }
+
+  // JSON (the spec default for many clients) or an unlabeled body: defer to the
+  // caller's schema for validation. An empty body parses to an empty object.
+  const text = await req.text()
+  if (text.trim() === '') return {}
+  try {
+    return JSON.parse(text) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}

--- a/lib/utils/getRequestBody.test.ts
+++ b/lib/utils/getRequestBody.test.ts
@@ -68,6 +68,18 @@ describe('getRequestBody', () => {
     expect(result).toEqual(mockBody)
   })
 
+  it('keeps the last value for a repeated urlencoded key (last-write-wins)', async () => {
+    const mockRequest = createMockRequest(
+      'https://example.com/api',
+      'application/x-www-form-urlencoded'
+    )
+    ;(mockRequest.text as jest.Mock).mockResolvedValue('key=first&key=second')
+    const result = await getRequestBody(mockRequest)
+    // Object.fromEntries collapses duplicate keys to the last value; the mute
+    // route's fields are single-valued, so this is the intended contract.
+    expect(result).toEqual({ key: 'second' })
+  })
+
   it('should parse multipart/form-data request with formData', async () => {
     const mockBody = {
       client_name: 'Test App',

--- a/lib/utils/getRequestBody.test.ts
+++ b/lib/utils/getRequestBody.test.ts
@@ -12,6 +12,7 @@ const createMockRequest = (
     headers.set('content-type', contentType)
   }
 
+  const entries = Object.entries(body || {})
   const request = {
     url,
     headers,
@@ -19,11 +20,15 @@ const createMockRequest = (
       .fn()
       .mockResolvedValue(
         new Map(
-          Object.entries(body || {}).map(([key, value]) => [
-            key,
-            value as FormDataEntryValue
-          ])
+          entries.map(([key, value]) => [key, value as FormDataEntryValue])
         )
+      ),
+    text: jest
+      .fn()
+      .mockResolvedValue(
+        new URLSearchParams(
+          entries.map(([key, value]) => [key, String(value)])
+        ).toString()
       ),
     json: jest.fn().mockResolvedValue(body || {})
   } as unknown as NextRequest
@@ -47,7 +52,7 @@ describe('getRequestBody', () => {
     expect(result).toEqual(mockBody)
   })
 
-  it('should parse form data request when content-type is not application/json', async () => {
+  it('should parse urlencoded request with URLSearchParams, not formData', async () => {
     const mockBody = {
       client_name: 'Test App',
       redirect_uris: 'https://example.com/callback'
@@ -55,6 +60,22 @@ describe('getRequestBody', () => {
     const mockRequest = createMockRequest(
       'https://example.com/api',
       'application/x-www-form-urlencoded',
+      mockBody
+    )
+    const result = await getRequestBody(mockRequest)
+    expect(mockRequest.text).toHaveBeenCalled()
+    expect(mockRequest.formData).not.toHaveBeenCalled()
+    expect(result).toEqual(mockBody)
+  })
+
+  it('should parse multipart/form-data request with formData', async () => {
+    const mockBody = {
+      client_name: 'Test App',
+      redirect_uris: 'https://example.com/callback'
+    }
+    const mockRequest = createMockRequest(
+      'https://example.com/api',
+      'multipart/form-data; boundary=abc',
       mockBody
     )
     const result = await getRequestBody(mockRequest)

--- a/lib/utils/getRequestBody.ts
+++ b/lib/utils/getRequestBody.ts
@@ -16,6 +16,13 @@ export async function getRequestBody(
     return req.json()
   }
 
+  // Parse urlencoded bodies with URLSearchParams rather than formData(): it is
+  // cheaper and, unlike req.formData(), works on the synthetic request bodies
+  // used in tests. multipart/form-data still needs the formData() parser.
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    return Object.fromEntries(new URLSearchParams(await req.text()))
+  }
+
   const formData = await req.formData()
   return Object.fromEntries(formData.entries())
 }


### PR DESCRIPTION
## Problem

Third-party Mastodon clients (Ivory etc.) were getting **400** from `/oauth/token` in production (`reason: "request_body"`, `content-type: multipart/form-data`). Root cause: the token proxy only accepted `application/x-www-form-urlencoded`. Native clients encode requests inconsistently — multipart, urlencoded, or JSON — and real Mastodon servers accept all three.

This PR fixes the token endpoint **and** audits the rest of the Mastodon client-API surface for the same class of bug.

## `/oauth/token` (commit 1)

- Accept urlencoded, `multipart/form-data`, and `application/json`.
- urlencoded forwards verbatim (production-proven path, untouched); multipart/JSON are normalized to urlencoded and forwarded with an explicit content-type override, because better-auth's token handler only parses urlencoded.
- Dependency-free multipart parser (the platform `Response.formData()` is unavailable in the jest runtime). Malformed bodies still 400; size guards unchanged.

## Rest of the client API (commit 2)

Audited every body-reading handler. **Most of the surface already tolerates JSON + urlencoded + multipart** (statuses create, markers, v2 filters, polls votes, `update_credentials`, media, apps, accounts, push subscription) via dedicated helpers. Only two endpoints genuinely mishandled form bodies:

- **`PUT /api/v1/statuses/[id]` (edit)** — read `req.json()` only, so a form-data edit failed, even though its own `POST` sibling handled all three formats. Extracted the content-type-aware parsing into a shared `parseStatusRequestBody()` used by **both** create and edit. It returns **only the fields the client sent** (omit-if-absent) and preserves repeated `media_ids[]` via `getAll`, so an edit never blanks text or wipes media it didn't mention.
- **`POST /api/v1/accounts/[id]/mute`** — read `req.json().catch(()=>({}))`, silently dropping `notifications`/`duration` from a form body. Now reads via `getRequestBody()`, and `MuteBodySchema` coerces the string booleans/numbers form bodies carry (`notifications=false` must become `false`, not `true`).

Also hardened `getRequestBody()` to parse urlencoded via `URLSearchParams` instead of `req.formData()` — cheaper, and (unlike `formData`) testable on synthetic request bodies. multipart still uses `formData()`. Backward compatible for its six existing callers.

### Deliberately left as-is
- Interaction endpoints (`reblog`, `follow`, account `note`) **ignore** their optional params entirely — that's a separate feature gap (reading params never read = new behavior), not a content-type bug. Flagged as follow-up.
- `/api/oauth/authorize` is urlencoded-only — it's a browser form POST; multipart/JSON there is implausible.
- Internal UI-only endpoints (`/actors/*`, custom `/accounts/*`, fitness/strava) are called by our own React app with JSON; no native-client exposure.

## Tests

- oauth/token: multipart (reproduces Ivory), JSON normalization, malformed-JSON 400.
- Status edit: form-encoded text edit preserves unmentioned media; visibility-only edit preserves text; `parseStatusRequestBody` unit tests.
- Mute: urlencoded `notifications=false` + `duration` reach `applyMute` with the right values.
- `getRequestBody`: updated for the new urlencoded path + multipart case.
- **3222 tests pass** (+10, +1 suite). `prettier`, `lint` (0 errors), `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)