### PR TITLE
minor: read optional Mastodon params on reblog, follow, and note endpoints

### DIFF
--- a/app/api/v1/accounts/[id]/follow/route.test.ts
+++ b/app/api/v1/accounts/[id]/follow/route.test.ts
@@ -1,13 +1,57 @@
+import { NextRequest } from 'next/server'
+
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { seedDatabase } from '@/lib/stub/database'
-import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { urlToId } from '@/lib/utils/urlToId'
 
+import { POST as followAccount } from './route'
+
 jest.mock('@/lib/config', () => ({
-  getConfig: jest.fn().mockReturnValue({ host: 'llun.test' })
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+// Federation side effects are not under test here; stub the network-touching
+// pieces so the route exercises only its body parsing and persistence.
+jest.mock('@/lib/activities', () => ({
+  follow: jest.fn().mockResolvedValue(undefined)
+}))
+jest.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: jest.fn().mockResolvedValue({ id: 'remote-person' })
+}))
+jest.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: jest.fn().mockResolvedValue(null)
+}))
+jest.mock('@/lib/services/federation/domainPolicy', () => ({
+  canFederateWithDomain: jest.fn().mockResolvedValue(true)
 }))
 
 /**
@@ -30,11 +74,166 @@ describe('Account Action Endpoints', () => {
   beforeAll(async () => {
     await database.migrate()
     await seedDatabase(database)
+    mockDatabase = database
   })
 
   afterAll(async () => {
     if (!database) return
+    mockDatabase = null
     await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  describe('POST /api/v1/accounts/:id/follow body params', () => {
+    const createFollowTargetActor = async (suffix: string) => {
+      const actorId = `https://remote.test/users/${suffix}`
+      await database.createActor({
+        actorId,
+        username: suffix,
+        domain: 'remote.test',
+        publicKey: 'key',
+        inboxUrl: `${actorId}/inbox`,
+        sharedInboxUrl: 'https://remote.test/inbox',
+        followersUrl: `${actorId}/followers`,
+        createdAt: Date.now()
+      })
+      return actorId
+    }
+
+    it('persists reblogs/notify/languages from a JSON body', async () => {
+      const targetActorId = await createFollowTargetActor('follow-json')
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              reblogs: false,
+              notify: true,
+              languages: ['en', 'th']
+            })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      expect(relationship.showing_reblogs).toBe(false)
+      expect(relationship.notifying).toBe(true)
+      expect(relationship.languages).toEqual(['en', 'th'])
+
+      const stored = await database.getAcceptedOrRequestedFollow({
+        actorId: ACTOR1_ID,
+        targetActorId
+      })
+      expect(stored?.reblogs).toBe(false)
+      expect(stored?.notify).toBe(true)
+      expect(stored?.languages).toEqual(['en', 'th'])
+    })
+
+    it('persists params from a urlencoded body (booleans + languages[])', async () => {
+      const targetActorId = await createFollowTargetActor('follow-urlencoded')
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: 'reblogs=false&notify=true&languages[]=en&languages[]=th'
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      expect(relationship.showing_reblogs).toBe(false)
+      expect(relationship.notifying).toBe(true)
+      expect(relationship.languages).toEqual(['en', 'th'])
+
+      const stored = await database.getAcceptedOrRequestedFollow({
+        actorId: ACTOR1_ID,
+        targetActorId
+      })
+      expect(stored?.reblogs).toBe(false)
+      expect(stored?.languages).toEqual(['en', 'th'])
+    })
+
+    it('defaults to reblogs=true/notify=false when no body is sent', async () => {
+      const targetActorId = await createFollowTargetActor('follow-default')
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      expect(relationship.showing_reblogs).toBe(true)
+      expect(relationship.notifying).toBe(false)
+    })
+
+    it('updates preferences when re-following an existing follow', async () => {
+      const targetActorId = await createFollowTargetActor('follow-update')
+
+      await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reblogs: true, notify: false })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ notify: true })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      // notify updated, reblogs left untouched from the first follow.
+      expect(relationship.notifying).toBe(true)
+      expect(relationship.showing_reblogs).toBe(true)
+    })
   })
 
   describe('getRelationship helper', () => {

--- a/app/api/v1/accounts/[id]/follow/route.test.ts
+++ b/app/api/v1/accounts/[id]/follow/route.test.ts
@@ -231,8 +231,79 @@ describe('Account Action Endpoints', () => {
       expect(response.status).toBe(200)
       const relationship = await response.json()
       // notify updated, reblogs left untouched from the first follow.
+      // showing_reblogs reflects the stored preference on the follow row (the
+      // value the client set), which the locally-initiated follow keeps in the
+      // Requested state until acceptance; it is not gated on acceptance.
       expect(relationship.notifying).toBe(true)
       expect(relationship.showing_reblogs).toBe(true)
+    })
+
+    it('clears an existing language filter when languages: [] is sent', async () => {
+      const targetActorId = await createFollowTargetActor('follow-clear-langs')
+
+      await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ languages: ['en', 'th'] })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ languages: [] })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const stored = await database.getAcceptedOrRequestedFollow({
+        actorId: ACTOR1_ID,
+        targetActorId
+      })
+      expect(stored?.languages).toBeNull()
+    })
+
+    it('returns 422 for a malformed JSON body', async () => {
+      const targetActorId = await createFollowTargetActor('follow-bad-json')
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: '{ broken json'
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(422)
+      await expect(
+        database.getAcceptedOrRequestedFollow({
+          actorId: ACTOR1_ID,
+          targetActorId
+        })
+      ).resolves.toBeNull()
     })
   })
 

--- a/app/api/v1/accounts/[id]/follow/route.test.ts
+++ b/app/api/v1/accounts/[id]/follow/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { seedDatabase } from '@/lib/stub/database'
@@ -277,6 +278,77 @@ describe('Account Action Endpoints', () => {
         targetActorId
       })
       expect(stored?.languages).toBeNull()
+    })
+
+    it('treats an empty JSON body as a paramless default follow', async () => {
+      const targetActorId = await createFollowTargetActor('follow-empty-json')
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            }
+            // No body — clients sometimes send a default JSON header anyway.
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      expect(relationship.showing_reblogs).toBe(true)
+      const stored = await database.getAcceptedOrRequestedFollow({
+        actorId: ACTOR1_ID,
+        targetActorId
+      })
+      expect(stored).not.toBeNull()
+    })
+
+    it('updates preferences for an existing follow even when the remote actor is unreachable', async () => {
+      const targetActorId = await createFollowTargetActor('follow-offline')
+
+      // First follow succeeds (actor reachable).
+      await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ notify: false })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      // Remote actor now unreachable: getActorPerson would fail / return null.
+      ;(getActorPerson as jest.Mock).mockResolvedValueOnce(null)
+
+      const response = await followAccount(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(targetActorId)}/follow`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ notify: true })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(targetActorId) }) }
+      )
+
+      // The preference update must succeed without consulting the network.
+      expect(response.status).toBe(200)
+      const relationship = await response.json()
+      expect(relationship.notifying).toBe(true)
     })
 
     it('returns 422 for a malformed JSON body', async () => {

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -1,5 +1,8 @@
+import { z } from 'zod'
+
 import { follow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { parseFollowRequestBody } from '@/lib/services/accounts/parseFollowRequestBody'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
@@ -21,6 +24,26 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+// Form bodies carry booleans as strings ("false" must become false, not a
+// truthy non-empty string), so coerce known string forms before validation.
+const TRUE_VALUES = new Set(['true', '1', 'on', 'yes'])
+const FALSE_VALUES = new Set(['false', '0', 'off', 'no'])
+const BooleanParam = z.preprocess((value) => {
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase()
+    if (TRUE_VALUES.has(lower)) return true
+    if (FALSE_VALUES.has(lower)) return false
+  }
+  return value
+}, z.boolean())
+
+// Mastodon's follow endpoint accepts optional reblogs, notify, and languages[].
+const FollowBodySchema = z.object({
+  reblogs: BooleanParam.optional(),
+  notify: BooleanParam.optional(),
+  languages: z.array(z.string().min(1)).optional()
+})
+
 interface Params {
   id: string
 }
@@ -37,6 +60,18 @@ export const POST = traceApiRoute(
         data: ERROR_400,
         responseStatusCode: 400
       })
+
+    const parsedBody = FollowBodySchema.safeParse(
+      await parseFollowRequestBody(req)
+    )
+    if (!parsedBody.success)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    const { reblogs, notify, languages } = parsedBody.data
 
     const targetActorId = idToUrl(encodedAccountId)
     if (!(await canFederateWithDomain(database, targetActorId))) {
@@ -74,9 +109,25 @@ export const POST = traceApiRoute(
         targetActorId,
         status: FollowStatus.enum.Requested,
         inbox: `${currentActor.id}/inbox`,
-        sharedInbox: `https://${currentActor.domain}/inbox`
+        sharedInbox: `https://${currentActor.domain}/inbox`,
+        reblogs,
+        notify,
+        languages
       })
       await follow(followItem.id, currentActor, targetActorId, signingActor)
+    } else if (
+      reblogs !== undefined ||
+      notify !== undefined ||
+      languages !== undefined
+    ) {
+      // Re-following with preferences updates the existing local follow row.
+      await database.updateFollowPreferences({
+        actorId: currentActor.id,
+        targetActorId,
+        reblogs,
+        notify,
+        languages
+      })
     }
 
     const relationship = await getRelationship({

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -13,6 +13,7 @@ import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
   ERROR_404,
+  ERROR_422,
   HTTP_STATUS,
   apiResponse,
   defaultOptions
@@ -61,15 +62,27 @@ export const POST = traceApiRoute(
         responseStatusCode: 400
       })
 
-    const parsedBody = FollowBodySchema.safeParse(
-      await parseFollowRequestBody(req)
-    )
+    // A malformed JSON body rejects in parseFollowRequestBody; treat it as an
+    // unprocessable request rather than letting it surface as a 500 or be
+    // silently coerced into a default (paramless) follow.
+    let rawBody: Record<string, unknown>
+    try {
+      rawBody = await parseFollowRequestBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+    const parsedBody = FollowBodySchema.safeParse(rawBody)
     if (!parsedBody.success)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_400,
-        responseStatusCode: 400
+        data: ERROR_422,
+        responseStatusCode: 422
       })
     const { reblogs, notify, languages } = parsedBody.data
 

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -96,27 +96,44 @@ export const POST = traceApiRoute(
       })
     }
 
-    // Check if target actor exists
-    const signingActor = await getFederationSigningActor(database)
-    const person = await getActorPerson({
-      actorId: targetActorId,
-      signingActor
-    })
-    if (!person)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-
-    // Check if already following
+    // Updating preferences on an account the actor already follows is a purely
+    // local operation, so resolve the existing follow before any network call.
+    // This lets clients change reblogs/notify/languages even when the remote
+    // actor is temporarily unreachable.
     const existingFollow = await database.getAcceptedOrRequestedFollow({
       actorId: currentActor.id,
       targetActorId
     })
 
-    if (!existingFollow) {
+    if (existingFollow) {
+      if (
+        reblogs !== undefined ||
+        notify !== undefined ||
+        languages !== undefined
+      ) {
+        await database.updateFollowPreferences({
+          actorId: currentActor.id,
+          targetActorId,
+          reblogs,
+          notify,
+          languages
+        })
+      }
+    } else {
+      // New follow: confirm the target actor exists (network) before creating.
+      const signingActor = await getFederationSigningActor(database)
+      const person = await getActorPerson({
+        actorId: targetActorId,
+        signingActor
+      })
+      if (!person)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
       const followItem = await database.createFollow({
         actorId: currentActor.id,
         targetActorId,
@@ -128,19 +145,6 @@ export const POST = traceApiRoute(
         languages
       })
       await follow(followItem.id, currentActor, targetActorId, signingActor)
-    } else if (
-      reblogs !== undefined ||
-      notify !== undefined ||
-      languages !== undefined
-    ) {
-      // Re-following with preferences updates the existing local follow row.
-      await database.updateFollowPreferences({
-        actorId: currentActor.id,
-        targetActorId,
-        reblogs,
-        notify,
-        languages
-      })
     }
 
     const relationship = await getRelationship({

--- a/app/api/v1/accounts/[id]/note/route.test.ts
+++ b/app/api/v1/accounts/[id]/note/route.test.ts
@@ -150,6 +150,25 @@ describe('POST /api/v1/accounts/:id/note', () => {
     expect(response.status).toBe(422)
   })
 
+  it('returns 422 for a comment over the length limit', async () => {
+    const response = await updateNote(
+      new NextRequest(
+        `https://llun.test/api/v1/accounts/${urlToId(ACTOR2_ID)}/note`,
+        {
+          method: 'POST',
+          headers: {
+            Origin: 'https://llun.test',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ comment: 'x'.repeat(2001) })
+        }
+      ),
+      { params: Promise.resolve({ id: urlToId(ACTOR2_ID) }) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+
   it('clears the note when an empty comment is sent', async () => {
     await callNote({
       contentType: 'application/json',

--- a/app/api/v1/accounts/[id]/note/route.test.ts
+++ b/app/api/v1/accounts/[id]/note/route.test.ts
@@ -105,6 +105,51 @@ describe('POST /api/v1/accounts/:id/note', () => {
     ).resolves.toBe('A private note from form')
   })
 
+  it('returns 404 for a note on an account that does not exist', async () => {
+    const unknownActorId = 'https://remote.test/users/never-seen-here'
+    const response = await updateNote(
+      new NextRequest(
+        `https://llun.test/api/v1/accounts/${urlToId(unknownActorId)}/note`,
+        {
+          method: 'POST',
+          headers: {
+            Origin: 'https://llun.test',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ comment: 'note for a ghost' })
+        }
+      ),
+      { params: Promise.resolve({ id: urlToId(unknownActorId) }) }
+    )
+
+    expect(response.status).toBe(404)
+    await expect(
+      database.getAccountNote({
+        actorId: ACTOR1_ID,
+        targetActorId: unknownActorId
+      })
+    ).resolves.toBe('')
+  })
+
+  it('returns 422 for a malformed JSON body', async () => {
+    const response = await updateNote(
+      new NextRequest(
+        `https://llun.test/api/v1/accounts/${urlToId(ACTOR2_ID)}/note`,
+        {
+          method: 'POST',
+          headers: {
+            Origin: 'https://llun.test',
+            'Content-Type': 'application/json'
+          },
+          body: '{ broken json'
+        }
+      ),
+      { params: Promise.resolve({ id: urlToId(ACTOR2_ID) }) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+
   it('clears the note when an empty comment is sent', async () => {
     await callNote({
       contentType: 'application/json',

--- a/app/api/v1/accounts/[id]/note/route.test.ts
+++ b/app/api/v1/accounts/[id]/note/route.test.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST as updateNote } from './route'
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+describe('POST /api/v1/accounts/:id/note', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const callNote = (body?: { contentType: string; payload: string }) =>
+    updateNote(
+      new NextRequest(
+        `https://llun.test/api/v1/accounts/${urlToId(ACTOR2_ID)}/note`,
+        {
+          method: 'POST',
+          headers: {
+            Origin: 'https://llun.test',
+            ...(body ? { 'Content-Type': body.contentType } : {})
+          },
+          ...(body ? { body: body.payload } : {})
+        }
+      ),
+      { params: Promise.resolve({ id: urlToId(ACTOR2_ID) }) }
+    )
+
+  it('stores the comment from a JSON body and returns it in the relationship', async () => {
+    const response = await callNote({
+      contentType: 'application/json',
+      payload: JSON.stringify({ comment: 'A private note from JSON' })
+    })
+
+    expect(response.status).toBe(200)
+    const relationship = await response.json()
+    expect(relationship.note).toBe('A private note from JSON')
+
+    await expect(
+      database.getAccountNote({ actorId: ACTOR1_ID, targetActorId: ACTOR2_ID })
+    ).resolves.toBe('A private note from JSON')
+  })
+
+  it('stores the comment from a urlencoded body', async () => {
+    const response = await callNote({
+      contentType: 'application/x-www-form-urlencoded',
+      payload: `comment=${encodeURIComponent('A private note from form')}`
+    })
+
+    expect(response.status).toBe(200)
+    const relationship = await response.json()
+    expect(relationship.note).toBe('A private note from form')
+
+    await expect(
+      database.getAccountNote({ actorId: ACTOR1_ID, targetActorId: ACTOR2_ID })
+    ).resolves.toBe('A private note from form')
+  })
+
+  it('clears the note when an empty comment is sent', async () => {
+    await callNote({
+      contentType: 'application/json',
+      payload: JSON.stringify({ comment: 'to be cleared' })
+    })
+
+    const response = await callNote({
+      contentType: 'application/json',
+      payload: JSON.stringify({ comment: '' })
+    })
+
+    expect(response.status).toBe(200)
+    const relationship = await response.json()
+    expect(relationship.note).toBe('')
+
+    await expect(
+      database.getAccountNote({ actorId: ACTOR1_ID, targetActorId: ACTOR2_ID })
+    ).resolves.toBe('')
+  })
+})

--- a/app/api/v1/accounts/[id]/note/route.ts
+++ b/app/api/v1/accounts/[id]/note/route.ts
@@ -20,9 +20,10 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 // Mastodon's note endpoint takes an optional `comment`; an empty comment clears
-// the note. Omitting it entirely is treated the same as an empty string.
+// the note. Omitting it entirely is treated the same as an empty string. Cap
+// the length (Mastodon's limit) so the text column can't be grown unbounded.
 const NoteBodySchema = z.object({
-  comment: z.string().optional()
+  comment: z.string().max(2000).optional()
 })
 
 interface Params {

--- a/app/api/v1/accounts/[id]/note/route.ts
+++ b/app/api/v1/accounts/[id]/note/route.ts
@@ -1,6 +1,9 @@
+import { z } from 'zod'
+
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -9,6 +12,12 @@ import { idToUrl } from '@/lib/utils/urlToId'
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+// Mastodon's note endpoint takes an optional `comment`; an empty comment clears
+// the note. Omitting it entirely is treated the same as an empty string.
+const NoteBodySchema = z.object({
+  comment: z.string().optional()
+})
 
 interface Params {
   id: string
@@ -27,10 +36,24 @@ export const POST = traceApiRoute(
         responseStatusCode: 400
       })
 
+    const parsedBody = NoteBodySchema.safeParse(await getRequestBody(req))
+    if (!parsedBody.success)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+
     const targetActorId = idToUrl(encodedAccountId)
 
-    // Private notes not yet implemented - return relationship with empty note
-    // TODO: Implement private notes functionality
+    if (targetActorId !== currentActor.id) {
+      await database.upsertAccountNote({
+        actorId: currentActor.id,
+        targetActorId,
+        comment: parsedBody.data.comment ?? ''
+      })
+    }
 
     const relationship = await getRelationship({
       database,

--- a/app/api/v1/accounts/[id]/note/route.ts
+++ b/app/api/v1/accounts/[id]/note/route.ts
@@ -5,7 +5,13 @@ import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_404,
+  ERROR_422,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
@@ -36,18 +42,43 @@ export const POST = traceApiRoute(
         responseStatusCode: 400
       })
 
-    const parsedBody = NoteBodySchema.safeParse(await getRequestBody(req))
+    // getRequestBody calls req.json() for a JSON content type, which rejects on
+    // an empty or malformed body; treat a bad body as a 422 rather than a 500.
+    let rawBody: Record<string, unknown>
+    try {
+      rawBody = await getRequestBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+    const parsedBody = NoteBodySchema.safeParse(rawBody)
     if (!parsedBody.success)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_400,
-        responseStatusCode: 400
+        data: ERROR_422,
+        responseStatusCode: 422
       })
 
     const targetActorId = idToUrl(encodedAccountId)
 
     if (targetActorId !== currentActor.id) {
+      // Mirror the block/mute handlers: only store a note for an account that
+      // actually exists locally, rather than accumulating notes for arbitrary
+      // decodable IDs.
+      const targetActor = await database.getActorFromId({ id: targetActorId })
+      if (!targetActor)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
       await database.upsertAccountNote({
         actorId: currentActor.id,
         targetActorId,

--- a/app/api/v1/statuses/[id]/reblog/route.ts
+++ b/app/api/v1/statuses/[id]/reblog/route.ts
@@ -45,7 +45,21 @@ export const POST = traceApiRoute(
         responseStatusCode: 404
       })
 
-    const parsedBody = ReblogBodySchema.safeParse(await getRequestBody(req))
+    // getRequestBody calls req.json() for a JSON content type, which rejects on
+    // an empty or malformed body; catch it so a bad body yields a 422 rather
+    // than an untraced 500.
+    let rawBody: Record<string, unknown>
+    try {
+      rawBody = await getRequestBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+    const parsedBody = ReblogBodySchema.safeParse(rawBody)
     if (!parsedBody.success)
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/reblog/route.ts
+++ b/app/api/v1/statuses/[id]/reblog/route.ts
@@ -1,8 +1,11 @@
+import { z } from 'zod'
+
 import { userAnnounce } from '@/lib/actions/announce'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_404,
@@ -22,6 +25,13 @@ interface Params {
   id: string
 }
 
+// Mastodon's reblog endpoint accepts an optional visibility param. Boosts can
+// only be public, unlisted, or private (limited/direct are not valid), and the
+// param defaults to the booster's default privacy (public here) when omitted.
+const ReblogBodySchema = z.object({
+  visibility: z.enum(['public', 'unlisted', 'private']).optional()
+})
+
 export const POST = traceApiRoute(
   'reblogStatus',
   OAuthGuard<Params>([Scope.enum.write], async (req, context) => {
@@ -33,6 +43,15 @@ export const POST = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: ERROR_404,
         responseStatusCode: 404
+      })
+
+    const parsedBody = ReblogBodySchema.safeParse(await getRequestBody(req))
+    if (!parsedBody.success)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
       })
 
     const statusId = idToUrl(encodedStatusId)
@@ -53,7 +72,8 @@ export const POST = traceApiRoute(
     const announceStatus = await userAnnounce({
       currentActor,
       statusId,
-      database
+      database,
+      visibility: parsedBody.data.visibility
     })
 
     if (!announceStatus) {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -730,6 +730,44 @@ describe('GET /api/v1/statuses/[id]', () => {
       ).resolves.toBeNull()
     })
 
+    it('treats an empty JSON reblog body as a default public boost', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblog-empty-json`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Reblog empty json target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await reblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblog`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            }
+            // No body.
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const announce = await database.getActorAnnounceStatus({
+        actorId: ACTOR2_ID,
+        statusId
+      })
+      expect(announce?.to).toEqual([ACTIVITY_STREAM_PUBLIC])
+    })
+
     it('bookmarks a readable status and returns bookmarked=true', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor2.email }

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -694,6 +694,42 @@ describe('GET /api/v1/statuses/[id]', () => {
       ).resolves.toBeNull()
     })
 
+    it('rejects a malformed JSON reblog body with 422 (not 500)', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblog-malformed-json`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Reblog malformed json target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await reblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblog`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: '{ broken json'
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(422)
+      await expect(
+        database.getActorAnnounceStatus({ actorId: ACTOR2_ID, statusId })
+      ).resolves.toBeNull()
+    })
+
     it('bookmarks a readable status and returns bookmarked=true', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor2.email }

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -542,6 +542,158 @@ describe('GET /api/v1/statuses/[id]', () => {
       ).resolves.toBe(false)
     })
 
+    it('reblogs with a private visibility from a JSON body and scopes the boost to followers', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblog-visibility-json`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Reblog visibility JSON target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await reblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblog`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ visibility: 'private' })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const announce = await database.getActorAnnounceStatus({
+        actorId: ACTOR2_ID,
+        statusId
+      })
+      expect(announce).not.toBeNull()
+      expect(announce?.to).toEqual([`${ACTOR2_ID}/followers`])
+      expect(announce?.cc).toEqual([ACTOR2_ID])
+    })
+
+    it('reblogs with an unlisted visibility from a urlencoded body', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblog-visibility-urlencoded`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Reblog visibility urlencoded target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await reblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblog`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: 'visibility=unlisted'
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const announce = await database.getActorAnnounceStatus({
+        actorId: ACTOR2_ID,
+        statusId
+      })
+      expect(announce).not.toBeNull()
+      expect(announce?.to).toEqual([`${ACTOR2_ID}/followers`])
+      expect(announce?.cc).toEqual([ACTIVITY_STREAM_PUBLIC, ACTOR2_ID])
+    })
+
+    it('defaults to a public boost when no visibility is sent', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblog-visibility-default`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Reblog visibility default target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await reblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblog`,
+          {
+            method: 'POST',
+            headers: { Origin: 'https://llun.test' }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const announce = await database.getActorAnnounceStatus({
+        actorId: ACTOR2_ID,
+        statusId
+      })
+      expect(announce).not.toBeNull()
+      expect(announce?.to).toEqual([ACTIVITY_STREAM_PUBLIC])
+      expect(announce?.cc).toEqual([ACTOR2_ID, `${ACTOR2_ID}/followers`])
+    })
+
+    it('rejects an invalid reblog visibility with 422', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-reblog-visibility-invalid`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Reblog visibility invalid target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await reblogStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/reblog`,
+          {
+            method: 'POST',
+            headers: {
+              Origin: 'https://llun.test',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ visibility: 'nonsense' })
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(422)
+      await expect(
+        database.getActorAnnounceStatus({ actorId: ACTOR2_ID, statusId })
+      ).resolves.toBeNull()
+    })
+
     it('bookmarks a readable status and returns bookmarked=true', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor2.email }

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -17,18 +17,51 @@ import { Actor } from '@/lib/types/domain/actor'
 import { getOriginalStatus } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { getTracer } from '@/lib/utils/trace'
 
 interface UserAnnounceParams {
   currentActor: Actor
   statusId: string
   database: Database
+  // Mastodon's reblog endpoint accepts an optional visibility for the boost.
+  // Limited/direct are not valid for boosts, so only public/unlisted/private
+  // are honored here; anything else falls back to the default public audience.
+  visibility?: MastodonVisibility
+}
+
+// Derives the announce recipient lists from the requested visibility. The
+// default (public) preserves the historical to/cc exactly so existing boosts
+// are unaffected; unlisted moves Public into cc, and private keeps the boost
+// to followers only.
+const getAnnounceRecipients = (
+  currentActor: Actor,
+  visibility: MastodonVisibility | undefined
+): { to: string[]; cc: string[] } => {
+  switch (visibility) {
+    case 'unlisted':
+      return {
+        to: [currentActor.followersUrl],
+        cc: [ACTIVITY_STREAM_PUBLIC, currentActor.id]
+      }
+    case 'private':
+      return {
+        to: [currentActor.followersUrl],
+        cc: [currentActor.id]
+      }
+    default:
+      return {
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [currentActor.id, currentActor.followersUrl]
+      }
+  }
 }
 
 export const userAnnounce = async ({
   currentActor,
   statusId,
-  database
+  database,
+  visibility
 }: UserAnnounceParams) =>
   getTracer().startActiveSpan('userAnnounce', async (span) => {
     const [originalStatus, actorAnnounceStatus] = await Promise.all([
@@ -45,11 +78,12 @@ export const userAnnounce = async ({
     }
 
     const id = `${currentActor.id}/statuses/${crypto.randomUUID()}`
+    const { to, cc } = getAnnounceRecipients(currentActor, visibility)
     const status = await database.createAnnounce({
       id,
       actorId: currentActor.id,
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [currentActor.id, currentActor.followersUrl],
+      to,
+      cc,
       originalStatusId: originalStatus.id
     })
     if (!status) {

--- a/lib/database/sql/accountNote.ts
+++ b/lib/database/sql/accountNote.ts
@@ -1,0 +1,59 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import {
+  AccountNoteDatabase,
+  GetAccountNoteParams,
+  UpsertAccountNoteParams
+} from '@/lib/types/database/operations'
+
+export const AccountNoteSQLDatabaseMixin = (
+  database: Knex
+): AccountNoteDatabase => ({
+  async upsertAccountNote({
+    actorId,
+    targetActorId,
+    comment
+  }: UpsertAccountNoteParams) {
+    const trimmed = comment.trim()
+    const currentTime = new Date()
+
+    const existingRow = await database('account_notes')
+      .where({ actorId, targetActorId })
+      .first()
+
+    // An empty comment clears the note (Mastodon semantics).
+    if (trimmed === '') {
+      if (existingRow) {
+        await database('account_notes').where({ actorId, targetActorId }).del()
+      }
+      return ''
+    }
+
+    if (existingRow) {
+      await database('account_notes')
+        .where({ actorId, targetActorId })
+        .update({ comment: trimmed, updatedAt: currentTime })
+      return trimmed
+    }
+
+    await database('account_notes').insert({
+      id: randomUUID(),
+      actorId,
+      actorHost: new URL(actorId).host,
+      targetActorId,
+      targetActorHost: new URL(targetActorId).host,
+      comment: trimmed,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+    return trimmed
+  },
+
+  async getAccountNote({ actorId, targetActorId }: GetAccountNoteParams) {
+    const data = await database('account_notes')
+      .where({ actorId, targetActorId })
+      .first()
+    return typeof data?.comment === 'string' ? data.comment : ''
+  }
+})

--- a/lib/database/sql/accountNote.ts
+++ b/lib/database/sql/accountNote.ts
@@ -18,35 +18,29 @@ export const AccountNoteSQLDatabaseMixin = (
     const trimmed = comment.trim()
     const currentTime = new Date()
 
-    const existingRow = await database('account_notes')
-      .where({ actorId, targetActorId })
-      .first()
-
     // An empty comment clears the note (Mastodon semantics).
     if (trimmed === '') {
-      if (existingRow) {
-        await database('account_notes').where({ actorId, targetActorId }).del()
-      }
+      await database('account_notes').where({ actorId, targetActorId }).del()
       return ''
     }
 
-    if (existingRow) {
-      await database('account_notes')
-        .where({ actorId, targetActorId })
-        .update({ comment: trimmed, updatedAt: currentTime })
-      return trimmed
-    }
-
-    await database('account_notes').insert({
-      id: randomUUID(),
-      actorId,
-      actorHost: new URL(actorId).host,
-      targetActorId,
-      targetActorHost: new URL(targetActorId).host,
-      comment: trimmed,
-      createdAt: currentTime,
-      updatedAt: currentTime
-    })
+    // Idempotent upsert on the (actorId, targetActorId) unique index. Using
+    // onConflict().merge() (instead of select-then-insert/update) keeps this
+    // race-condition safe under concurrent requests and avoids the extra
+    // roundtrip.
+    await database('account_notes')
+      .insert({
+        id: randomUUID(),
+        actorId,
+        actorHost: new URL(actorId).host,
+        targetActorId,
+        targetActorHost: new URL(targetActorId).host,
+        comment: trimmed,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      .onConflict(['actorId', 'targetActorId'])
+      .merge({ comment: trimmed, updatedAt: currentTime })
     return trimmed
   },
 

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -1153,6 +1153,54 @@ describe('ActorDatabase', () => {
     })
 
     describe('#deleteActorData', () => {
+      it('removes account notes referencing the deleted actor on either side', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `delete-note-${suffix}`
+        const actorId = `https://${TEST_DOMAIN}/users/${username}`
+        const peerActorId = `https://${TEST_DOMAIN}/users/delete-note-peer-${suffix}`
+
+        await database.createAccount({
+          email: `${username}@${TEST_DOMAIN}`,
+          username,
+          passwordHash: TEST_PASSWORD_HASH,
+          domain: TEST_DOMAIN,
+          privateKey: `privateKey-${suffix}`,
+          publicKey: `publicKey-${suffix}`
+        })
+        await database.createAccount({
+          email: `peer-${suffix}@${TEST_DOMAIN}`,
+          username: `delete-note-peer-${suffix}`,
+          passwordHash: TEST_PASSWORD_HASH,
+          domain: TEST_DOMAIN,
+          privateKey: `privateKey-peer-${suffix}`,
+          publicKey: `publicKey-peer-${suffix}`
+        })
+
+        // Note authored by the actor, and a note targeting the actor.
+        await database.upsertAccountNote({
+          actorId,
+          targetActorId: peerActorId,
+          comment: 'note I wrote'
+        })
+        await database.upsertAccountNote({
+          actorId: peerActorId,
+          targetActorId: actorId,
+          comment: 'note about me'
+        })
+
+        await database.deleteActorData({ actorId })
+
+        await expect(
+          database.getAccountNote({ actorId, targetActorId: peerActorId })
+        ).resolves.toBe('')
+        await expect(
+          database.getAccountNote({
+            actorId: peerActorId,
+            targetActorId: actorId
+          })
+        ).resolves.toBe('')
+      })
+
       it('deletes actor data and keeps related counters consistent', async () => {
         const suffix = crypto.randomUUID().slice(0, 8)
         const username = `delete-data-${suffix}`

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -1465,6 +1465,14 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         })
         .delete()
 
+      // Private account notes reference the actor on either side (author or
+      // target); remove both so a recreated actor URL cannot resurface them.
+      await trx('account_notes')
+        .where((builder) => {
+          builder.where('actorId', actorId).orWhere('targetActorId', actorId)
+        })
+        .delete()
+
       // Subquery avoids hitting the SQLite 999-parameter limit when an
       // actor has accumulated many filters; the mute precedent only
       // touches one table per actor so doesn't need this.

--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -22,13 +22,40 @@ import {
   GetLocalActorsFromFollowerUrlParams,
   GetLocalFollowersForActorIdParams,
   GetLocalFollowsFromInboxUrlParams,
+  UpdateFollowPreferencesParams,
   UpdateFollowStatusParams
 } from '@/lib/types/database/operations'
 import { Account } from '@/lib/types/domain/account'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 
+// languages is persisted as a JSON-encoded text column for cross-backend
+// portability, so it comes back as a string (or null) and must be parsed.
+const parseFollowLanguages = (value: unknown): string[] | null => {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+  if (typeof value !== 'string' || value.trim() === '') return null
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : null
+  } catch {
+    return null
+  }
+}
+
 const fixFollowDataDate = (data: Follow): Follow => ({
   ...data,
+  // SQLite stores booleans as 0/1; coerce back to real booleans. Rows created
+  // before this column existed surface as null, which the DB default (true)
+  // covers for reblogs.
+  reblogs:
+    data.reblogs === null || data.reblogs === undefined
+      ? true
+      : Boolean(data.reblogs),
+  notify: Boolean(data.notify),
+  languages: parseFollowLanguages(data.languages),
   createdAt: getCompatibleTime(data.createdAt),
   updatedAt: getCompatibleTime(data.updatedAt)
 })
@@ -42,7 +69,10 @@ export const FollowerSQLDatabaseMixin = (
     targetActorId,
     status,
     inbox,
-    sharedInbox
+    sharedInbox,
+    reblogs = true,
+    notify = false,
+    languages = null
   }: CreateFollowParams) {
     const existingFollow = await this.getAcceptedOrRequestedFollow({
       actorId,
@@ -62,6 +92,9 @@ export const FollowerSQLDatabaseMixin = (
       status,
       inbox,
       sharedInbox,
+      reblogs,
+      notify,
+      languages,
       createdAt: currentTime.getTime(),
       updatedAt: currentTime.getTime()
     }
@@ -70,6 +103,7 @@ export const FollowerSQLDatabaseMixin = (
         ...follow,
         inbox,
         sharedInbox,
+        languages: languages ? JSON.stringify(languages) : null,
         createdAt: currentTime,
         updatedAt: currentTime
       })
@@ -92,6 +126,43 @@ export const FollowerSQLDatabaseMixin = (
       }
     })
     return follow
+  },
+
+  async updateFollowPreferences({
+    actorId,
+    targetActorId,
+    reblogs,
+    notify,
+    languages
+  }: UpdateFollowPreferencesParams) {
+    const existingFollow = await this.getAcceptedOrRequestedFollow({
+      actorId,
+      targetActorId
+    })
+    if (!existingFollow) return null
+
+    // Only persist the preferences the caller actually provided so an update
+    // never clobbers fields the client did not mention.
+    const updates: Record<string, unknown> = {}
+    if (reblogs !== undefined) updates.reblogs = reblogs
+    if (notify !== undefined) updates.notify = notify
+    if (languages !== undefined) {
+      updates.languages = languages ? JSON.stringify(languages) : null
+    }
+
+    if (Object.keys(updates).length === 0) return existingFollow
+
+    const currentTime = new Date()
+    updates.updatedAt = currentTime
+    await database('follows').where('id', existingFollow.id).update(updates)
+
+    return {
+      ...existingFollow,
+      ...(reblogs !== undefined ? { reblogs } : {}),
+      ...(notify !== undefined ? { notify } : {}),
+      ...(languages !== undefined ? { languages } : {}),
+      updatedAt: currentTime.getTime()
+    }
   },
 
   async getFollowFromId({ followId }: GetFollowFromIdParams) {

--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -103,7 +103,8 @@ export const FollowerSQLDatabaseMixin = (
         ...follow,
         inbox,
         sharedInbox,
-        languages: languages ? JSON.stringify(languages) : null,
+        languages:
+          languages && languages.length > 0 ? JSON.stringify(languages) : null,
         createdAt: currentTime,
         updatedAt: currentTime
       })
@@ -147,7 +148,9 @@ export const FollowerSQLDatabaseMixin = (
     if (reblogs !== undefined) updates.reblogs = reblogs
     if (notify !== undefined) updates.notify = notify
     if (languages !== undefined) {
-      updates.languages = languages ? JSON.stringify(languages) : null
+      // An explicit empty list clears the filter (stored as null).
+      updates.languages =
+        languages && languages.length > 0 ? JSON.stringify(languages) : null
     }
 
     if (Object.keys(updates).length === 0) return existingFollow

--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -163,7 +163,10 @@ export const FollowerSQLDatabaseMixin = (
       ...existingFollow,
       ...(reblogs !== undefined ? { reblogs } : {}),
       ...(notify !== undefined ? { notify } : {}),
-      ...(languages !== undefined ? { languages } : {}),
+      // Mirror what is persisted: an empty list clears the filter (null).
+      ...(languages !== undefined
+        ? { languages: languages && languages.length > 0 ? languages : null }
+        : {}),
       updatedAt: currentTime.getTime()
     }
   },

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex'
 
 import { AccountSQLDatabaseMixin } from '@/lib/database/sql/account'
+import { AccountNoteSQLDatabaseMixin } from '@/lib/database/sql/accountNote'
 import { ActorSQLDatabaseMixin } from '@/lib/database/sql/actor'
 import { AdminSQLDatabaseMixin } from '@/lib/database/sql/admin'
 import { BlockSQLDatabaseMixin } from '@/lib/database/sql/block'
@@ -27,6 +28,7 @@ import { Database } from '@/lib/database/types'
 
 export const getSQLDatabase = (database: Knex): Database => {
   const accountDatabase = AccountSQLDatabaseMixin(database)
+  const accountNoteDatabase = AccountNoteSQLDatabaseMixin(database)
   const actorDatabase = ActorSQLDatabaseMixin(database)
   const adminDatabase = AdminSQLDatabaseMixin(database)
   const fitnessFileDatabase = FitnessFileSQLDatabaseMixin(database)
@@ -71,6 +73,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     },
 
     ...accountDatabase,
+    ...accountNoteDatabase,
     ...actorDatabase,
     ...adminDatabase,
     ...fitnessFileDatabase,

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -4,6 +4,7 @@ import { FitnessSettingsDatabase } from '@/lib/database/sql/fitnessSettings'
 import { StravaArchiveImportDatabase } from '@/lib/database/sql/stravaArchiveImport'
 import {
   AccountDatabase,
+  AccountNoteDatabase,
   ActorDatabase,
   AdminDatabase,
   BaseDatabase,
@@ -26,6 +27,7 @@ import {
 } from '@/lib/types/database/operations'
 
 export type Database = AccountDatabase &
+  AccountNoteDatabase &
   ActorDatabase &
   AdminDatabase &
   InstanceActivityDatabase &

--- a/lib/services/accounts/parseFollowRequestBody.test.ts
+++ b/lib/services/accounts/parseFollowRequestBody.test.ts
@@ -52,4 +52,38 @@ describe('parseFollowRequestBody', () => {
 
     await expect(parseFollowRequestBody(req)).resolves.toEqual({})
   })
+
+  it('keeps an explicitly empty languages array (clear filter) from JSON', async () => {
+    const req = new NextRequest('https://llun.test/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ languages: [] })
+    })
+
+    await expect(parseFollowRequestBody(req)).resolves.toEqual({
+      languages: []
+    })
+  })
+
+  it('keeps an explicitly empty languages[] (clear filter) from urlencoded', async () => {
+    const req = new NextRequest('https://llun.test/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'languages[]='
+    })
+
+    await expect(parseFollowRequestBody(req)).resolves.toEqual({
+      languages: []
+    })
+  })
+
+  it('rejects a malformed JSON body instead of swallowing it', async () => {
+    const req = new NextRequest('https://llun.test/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ not valid json'
+    })
+
+    await expect(parseFollowRequestBody(req)).rejects.toThrow()
+  })
 })

--- a/lib/services/accounts/parseFollowRequestBody.test.ts
+++ b/lib/services/accounts/parseFollowRequestBody.test.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from 'next/server'
+
+import { parseFollowRequestBody } from './parseFollowRequestBody'
+
+describe('parseFollowRequestBody', () => {
+  it('parses a JSON body with booleans and a languages array', async () => {
+    const req = new NextRequest('https://llun.test/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        reblogs: false,
+        notify: true,
+        languages: ['en', 'th']
+      })
+    })
+
+    await expect(parseFollowRequestBody(req)).resolves.toEqual({
+      reblogs: false,
+      notify: true,
+      languages: ['en', 'th']
+    })
+  })
+
+  it('preserves repeated languages[] keys from a urlencoded body', async () => {
+    const req = new NextRequest('https://llun.test/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'reblogs=false&notify=true&languages[]=en&languages[]=th'
+    })
+
+    await expect(parseFollowRequestBody(req)).resolves.toEqual({
+      reblogs: 'false',
+      notify: 'true',
+      languages: ['en', 'th']
+    })
+  })
+
+  it('omits fields the client did not send', async () => {
+    const req = new NextRequest('https://llun.test/follow', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notify: true })
+    })
+
+    await expect(parseFollowRequestBody(req)).resolves.toEqual({
+      notify: true
+    })
+  })
+
+  it('returns an empty object for a bodyless request', async () => {
+    const req = new NextRequest('https://llun.test/follow', { method: 'POST' })
+
+    await expect(parseFollowRequestBody(req)).resolves.toEqual({})
+  })
+})

--- a/lib/services/accounts/parseFollowRequestBody.test.ts
+++ b/lib/services/accounts/parseFollowRequestBody.test.ts
@@ -77,6 +77,17 @@ describe('parseFollowRequestBody', () => {
     })
   })
 
+  it('treats a well-formed non-object JSON body as empty (no throw)', async () => {
+    for (const body of ['123', '"hello"', 'null', '[1,2]']) {
+      const req = new NextRequest('https://llun.test/follow', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body
+      })
+      await expect(parseFollowRequestBody(req)).resolves.toEqual({})
+    }
+  })
+
   it('rejects a malformed JSON body instead of swallowing it', async () => {
     const req = new NextRequest('https://llun.test/follow', {
       method: 'POST',

--- a/lib/services/accounts/parseFollowRequestBody.ts
+++ b/lib/services/accounts/parseFollowRequestBody.ts
@@ -9,7 +9,8 @@ const LANGUAGE_FIELDS = ['languages', 'languages[]'] as const
 
 const collectFollowFields = (
   get: (name: string) => unknown,
-  getAll: (name: string) => unknown[]
+  getAll: (name: string) => unknown[],
+  has: (name: string) => boolean
 ): Record<string, unknown> => {
   const body: Record<string, unknown> = {}
 
@@ -19,11 +20,15 @@ const collectFollowFields = (
   const notify = get('notify')
   if (notify !== null && notify !== undefined) body.notify = notify
 
-  const languages = LANGUAGE_FIELDS.flatMap((field) => getAll(field))
-    .filter((value): value is string => typeof value === 'string')
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-  if (languages.length > 0) body.languages = languages
+  // Distinguish an explicitly-present (possibly empty) languages list from an
+  // absent one: a present empty list means "clear the filter", while an absent
+  // field means "leave it unchanged".
+  if (LANGUAGE_FIELDS.some((field) => has(field))) {
+    body.languages = LANGUAGE_FIELDS.flatMap((field) => getAll(field))
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+  }
 
   return body
 }
@@ -35,6 +40,10 @@ const collectFollowFields = (
  * (omit-if-absent), so re-following with one preference does not reset the
  * others. Repeated `languages[]` entries are preserved via getAll — flattening
  * (e.g. Object.fromEntries) would drop all but the last.
+ *
+ * A malformed JSON body is NOT swallowed: req.json() rejects and the caller is
+ * expected to translate that into a 4xx, rather than silently treating a bad
+ * request as a paramless follow.
  */
 export const parseFollowRequestBody = async (
   req: NextRequest
@@ -45,7 +54,8 @@ export const parseFollowRequestBody = async (
     const params = new URLSearchParams(await req.text())
     return collectFollowFields(
       (name) => params.get(name),
-      (name) => params.getAll(name)
+      (name) => params.getAll(name),
+      (name) => params.has(name)
     )
   }
 
@@ -53,19 +63,21 @@ export const parseFollowRequestBody = async (
     const form = await req.formData()
     return collectFollowFields(
       (name) => form.get(name),
-      (name) => form.getAll(name)
+      (name) => form.getAll(name),
+      (name) => form.has(name)
     )
   }
 
   if (contentType.includes('application/json')) {
-    const json = (await req.json().catch(() => ({}))) as Record<string, unknown>
+    const json = (await req.json()) as Record<string, unknown>
     return collectFollowFields(
       (name) => json[name],
       (name) => {
         const value = json[name]
         if (Array.isArray(value)) return value
         return value === null || value === undefined ? [] : [value]
-      }
+      },
+      (name) => name in json
     )
   }
 

--- a/lib/services/accounts/parseFollowRequestBody.ts
+++ b/lib/services/accounts/parseFollowRequestBody.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server'
+
+const FORM_URL_ENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded'
+const MULTIPART_FORM_DATA_CONTENT_TYPE = 'multipart/form-data'
+
+// Repeated form keys can arrive as either `languages[]` (Rails/Mastodon
+// convention) or bare `languages`; collect both.
+const LANGUAGE_FIELDS = ['languages', 'languages[]'] as const
+
+const collectFollowFields = (
+  get: (name: string) => unknown,
+  getAll: (name: string) => unknown[]
+): Record<string, unknown> => {
+  const body: Record<string, unknown> = {}
+
+  const reblogs = get('reblogs')
+  if (reblogs !== null && reblogs !== undefined) body.reblogs = reblogs
+
+  const notify = get('notify')
+  if (notify !== null && notify !== undefined) body.notify = notify
+
+  const languages = LANGUAGE_FIELDS.flatMap((field) => getAll(field))
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+  if (languages.length > 0) body.languages = languages
+
+  return body
+}
+
+/**
+ * Parses a POST /accounts/:id/follow request body across the content types
+ * native Mastodon clients use: JSON, application/x-www-form-urlencoded, and
+ * multipart/form-data. Only the fields the client actually sent are returned
+ * (omit-if-absent), so re-following with one preference does not reset the
+ * others. Repeated `languages[]` entries are preserved via getAll — flattening
+ * (e.g. Object.fromEntries) would drop all but the last.
+ */
+export const parseFollowRequestBody = async (
+  req: NextRequest
+): Promise<Record<string, unknown>> => {
+  const contentType = req.headers.get('content-type')?.toLowerCase() ?? ''
+
+  if (contentType.includes(FORM_URL_ENCODED_CONTENT_TYPE)) {
+    const params = new URLSearchParams(await req.text())
+    return collectFollowFields(
+      (name) => params.get(name),
+      (name) => params.getAll(name)
+    )
+  }
+
+  if (contentType.includes(MULTIPART_FORM_DATA_CONTENT_TYPE)) {
+    const form = await req.formData()
+    return collectFollowFields(
+      (name) => form.get(name),
+      (name) => form.getAll(name)
+    )
+  }
+
+  if (contentType.includes('application/json')) {
+    const json = (await req.json().catch(() => ({}))) as Record<string, unknown>
+    return collectFollowFields(
+      (name) => json[name],
+      (name) => {
+        const value = json[name]
+        if (Array.isArray(value)) return value
+        return value === null || value === undefined ? [] : [value]
+      }
+    )
+  }
+
+  // No body or an unrecognized content type: nothing to parse.
+  return {}
+}

--- a/lib/services/accounts/parseFollowRequestBody.ts
+++ b/lib/services/accounts/parseFollowRequestBody.ts
@@ -69,7 +69,12 @@ export const parseFollowRequestBody = async (
   }
 
   if (contentType.includes('application/json')) {
-    const json = (await req.json()) as Record<string, unknown>
+    // An empty body (a paramless follow that still carries a default
+    // application/json header) is a valid default follow → {}. A non-empty
+    // malformed body still throws so the route returns 422.
+    const text = await req.text()
+    if (text.trim() === '') return {}
+    const json = JSON.parse(text) as Record<string, unknown>
     // A well-formed but non-object JSON body (null, a number, a string, an
     // array) has no follow fields; treat it as empty rather than letting the
     // `in`/index access below throw.

--- a/lib/services/accounts/parseFollowRequestBody.ts
+++ b/lib/services/accounts/parseFollowRequestBody.ts
@@ -70,6 +70,12 @@ export const parseFollowRequestBody = async (
 
   if (contentType.includes('application/json')) {
     const json = (await req.json()) as Record<string, unknown>
+    // A well-formed but non-object JSON body (null, a number, a string, an
+    // array) has no follow fields; treat it as empty rather than letting the
+    // `in`/index access below throw.
+    if (!json || typeof json !== 'object' || Array.isArray(json)) {
+      return {}
+    }
     return collectFollowFields(
       (name) => json[name],
       (name) => {

--- a/lib/services/accounts/relationship.test.ts
+++ b/lib/services/accounts/relationship.test.ts
@@ -112,8 +112,36 @@ describe('#getRelationship', () => {
       requested_by: false,
       domain_blocking: false,
       endorsed: false,
-      languages: expect.toBeArray()
+      // No stored language filter on this follow -> null (no filter), not a
+      // misleading default.
+      languages: null
     })
+  })
+
+  it('reports the stored language filter, and null once it is cleared', async () => {
+    mockDatabase.isCurrentActorFollowing.mockResolvedValue(true)
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValueOnce({
+      status: FollowStatus.enum.Accepted,
+      languages: ['en', 'th']
+    })
+
+    const withFilter = await getRelationship({
+      database: mockDatabase as unknown as Database,
+      currentActor: mockCurrentActor as unknown as Actor,
+      targetActorId: 'https://example.com/users/target'
+    })
+    expect(withFilter.languages).toEqual(['en', 'th'])
+
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValueOnce({
+      status: FollowStatus.enum.Accepted,
+      languages: null
+    })
+    const cleared = await getRelationship({
+      database: mockDatabase as unknown as Database,
+      currentActor: mockCurrentActor as unknown as Actor,
+      targetActorId: 'https://example.com/users/target'
+    })
+    expect(cleared.languages).toBeNull()
   })
 
   it('sets blocking fields from block relationships in both directions', async () => {

--- a/lib/services/accounts/relationship.test.ts
+++ b/lib/services/accounts/relationship.test.ts
@@ -10,7 +10,8 @@ describe('#getRelationship', () => {
     isCurrentActorFollowing: jest.fn(),
     getAcceptedOrRequestedFollow: jest.fn(),
     isBlocking: jest.fn(),
-    getMute: jest.fn()
+    getMute: jest.fn(),
+    getAccountNote: jest.fn()
   }
 
   const mockCurrentActor = {
@@ -27,6 +28,7 @@ describe('#getRelationship', () => {
     })
     mockDatabase.isBlocking.mockResolvedValue(false)
     mockDatabase.getMute.mockResolvedValue(null)
+    mockDatabase.getAccountNote.mockResolvedValue('')
   })
 
   it('returns relationship with following=true when following', async () => {
@@ -139,13 +141,16 @@ describe('#getRelationship', () => {
     })
   })
 
-  it('includes note from target actor summary', async () => {
+  it('includes the viewer private note about the target', async () => {
+    // note is the viewer's private comment (Mastodon account note), not the
+    // target's public bio/summary.
     mockDatabase.getActorFromId.mockResolvedValue({
       id: 'https://example.com/users/target',
       summary: 'This is my bio'
     })
     mockDatabase.isCurrentActorFollowing.mockResolvedValue(false)
     mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    mockDatabase.getAccountNote.mockResolvedValue('remember to reply')
 
     const relationship = await getRelationship({
       database: mockDatabase as unknown as Database,
@@ -153,16 +158,17 @@ describe('#getRelationship', () => {
       targetActorId: 'https://example.com/users/target'
     })
 
-    expect(relationship.note).toBe('This is my bio')
+    expect(relationship.note).toBe('remember to reply')
   })
 
-  it('returns empty note when actor has no summary', async () => {
+  it('returns empty note when no private note has been set', async () => {
     mockDatabase.getActorFromId.mockResolvedValue({
       id: 'https://example.com/users/target',
-      summary: null
+      summary: 'This is my bio'
     })
     mockDatabase.isCurrentActorFollowing.mockResolvedValue(false)
     mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    mockDatabase.getAccountNote.mockResolvedValue('')
 
     const relationship = await getRelationship({
       database: mockDatabase as unknown as Database,

--- a/lib/services/accounts/relationship.ts
+++ b/lib/services/accounts/relationship.ts
@@ -74,10 +74,12 @@ export const getRelationship = async ({
     requested_by: false,
     domain_blocking: false,
     endorsed: false,
+    // Report the stored language filter honestly: the saved list when set,
+    // or null (no filter) when absent/cleared — never a misleading default.
     languages:
       follow?.languages && follow.languages.length > 0
         ? follow.languages
-        : ['en'],
+        : null,
     // The relationship note is the viewer's private comment about the target
     // (Mastodon's account note), not the target's public bio/summary.
     note

--- a/lib/services/accounts/relationship.ts
+++ b/lib/services/accounts/relationship.ts
@@ -15,15 +15,14 @@ export const getRelationship = async ({
   currentActor,
   targetActorId
 }: GetRelationshipParams): Promise<Mastodon.Relationship> => {
-  const actor = await database.getActorFromId({ id: targetActorId })
-
   const [
     isFollowing,
     isFollowedBy,
     follow,
     isBlocking,
     isBlockedBy,
-    muteRecord
+    muteRecord,
+    note
   ] = await Promise.all([
     database.isCurrentActorFollowing({
       currentActorId: currentActor.id,
@@ -48,6 +47,10 @@ export const getRelationship = async ({
     database.getMute({
       actorId: currentActor.id,
       targetActorId
+    }),
+    database.getAccountNote({
+      actorId: currentActor.id,
+      targetActorId
     })
   ])
 
@@ -58,8 +61,10 @@ export const getRelationship = async ({
   return Mastodon.Relationship.parse({
     id: urlToId(targetActorId),
     following: isFollowing,
-    showing_reblogs: isFollowing,
-    notifying: false,
+    // Fall back to the follow column defaults (reblogs=true, notify=false) when
+    // a follow exists but predates these preferences.
+    showing_reblogs: follow ? (follow.reblogs ?? true) : false,
+    notifying: follow ? (follow.notify ?? false) : false,
     followed_by: isFollowedBy,
     blocking: isBlocking,
     blocked_by: isBlockedBy,
@@ -69,7 +74,12 @@ export const getRelationship = async ({
     requested_by: false,
     domain_blocking: false,
     endorsed: false,
-    languages: ['en'],
-    note: actor?.summary ?? ''
+    languages:
+      follow?.languages && follow.languages.length > 0
+        ? follow.languages
+        : ['en'],
+    // The relationship note is the viewer's private comment about the target
+    // (Mastodon's account note), not the target's public bio/summary.
+    note
   })
 }

--- a/lib/services/timelines/main.test.ts
+++ b/lib/services/timelines/main.test.ts
@@ -268,6 +268,35 @@ describe('#mainTimelineRule', () => {
     )
   })
 
+  it('returns null for announce from a following the viewer set reblogs=false on', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    // Actor3 follows Actor4 (accepted); disable boosts from Actor4.
+    await database.updateFollowPreferences({
+      actorId: ACTOR3_ID,
+      targetActorId: ACTOR4_ID,
+      reblogs: false
+    })
+    try {
+      const status = await createAnnounce(
+        database,
+        ACTOR4_ID,
+        `${ACTOR1_ID}/statuses/post-1`
+      )
+      if (!status) fail('Status must be defined')
+      expect(
+        await mainTimelineRule({ database, currentActor, status })
+      ).toBeNull()
+    } finally {
+      await database.updateFollowPreferences({
+        actorId: ACTOR3_ID,
+        targetActorId: ACTOR4_ID,
+        reblogs: true
+      })
+    }
+  })
+
   it('returns null for announce that from non-following', async () => {
     const currentActor = (await database.getActorFromId({
       id: ACTOR3_ID

--- a/lib/services/timelines/main.test.ts
+++ b/lib/services/timelines/main.test.ts
@@ -268,6 +268,22 @@ describe('#mainTimelineRule', () => {
     )
   })
 
+  it('returns main timeline for the viewer own announce (self-boost)', async () => {
+    const currentActor = (await database.getActorFromId({
+      id: ACTOR3_ID
+    })) as Actor
+    // A self-boost: the viewer is the booster and does not follow themselves.
+    const status = await createAnnounce(
+      database,
+      ACTOR3_ID,
+      `${ACTOR1_ID}/statuses/post-1`
+    )
+    if (!status) fail('Status must be defined')
+    expect(await mainTimelineRule({ database, currentActor, status })).toEqual(
+      Timeline.MAIN
+    )
+  })
+
   it('returns null for announce from a following the viewer set reblogs=false on', async () => {
     const currentActor = (await database.getActorFromId({
       id: ACTOR3_ID

--- a/lib/services/timelines/main.ts
+++ b/lib/services/timelines/main.ts
@@ -38,21 +38,25 @@ export const mainTimelineRule: MainTimelineRule = async ({
     },
     async (span) => {
       if (status.type === StatusType.enum.Announce) {
-        // A single lookup yields both whether the viewer follows the booster
-        // (accepted) and their reblogs preference. Skip the boost when the
-        // viewer isn't an accepted follower, or followed with reblogs=false
-        // (matching the relationship's showing_reblogs=false).
-        const announceFollow = await database.getAcceptedOrRequestedFollow({
-          actorId: currentActor.id,
-          targetActorId: status.actorId
-        })
-        if (
-          !announceFollow ||
-          announceFollow.status !== FollowStatus.enum.Accepted ||
-          announceFollow.reblogs === false
-        ) {
-          span.end()
-          return null
+        // The viewer's own boosts always belong in their home timeline; only
+        // boosts from others are gated on the follow. A single lookup yields
+        // both whether the viewer is an accepted follower of the booster and
+        // their reblogs preference, so skip a boost from someone they don't
+        // accept-follow, or followed with reblogs=false (matching the
+        // relationship's showing_reblogs=false).
+        if (status.actorId !== currentActor.id) {
+          const announceFollow = await database.getAcceptedOrRequestedFollow({
+            actorId: currentActor.id,
+            targetActorId: status.actorId
+          })
+          if (
+            !announceFollow ||
+            announceFollow.status !== FollowStatus.enum.Accepted ||
+            announceFollow.reblogs === false
+          ) {
+            span.end()
+            return null
+          }
         }
 
         const originalStatus = status.originalStatus

--- a/lib/services/timelines/main.ts
+++ b/lib/services/timelines/main.ts
@@ -46,6 +46,18 @@ export const mainTimelineRule: MainTimelineRule = async ({
           return null
         }
 
+        // Honor the follower's reblogs preference: when they followed this
+        // account with reblogs=false, keep that account's boosts out of their
+        // main timeline (matching the relationship's showing_reblogs=false).
+        const announceFollow = await database.getAcceptedOrRequestedFollow({
+          actorId: currentActor.id,
+          targetActorId: status.actorId
+        })
+        if (announceFollow && announceFollow.reblogs === false) {
+          span.end()
+          return null
+        }
+
         const originalStatus = status.originalStatus
         const timeline = await mainTimelineRule({
           database,

--- a/lib/services/timelines/main.ts
+++ b/lib/services/timelines/main.ts
@@ -1,3 +1,4 @@
+import { FollowStatus } from '@/lib/types/domain/follow'
 import { StatusType } from '@/lib/types/domain/status'
 import { getTracer } from '@/lib/utils/trace'
 
@@ -37,23 +38,19 @@ export const mainTimelineRule: MainTimelineRule = async ({
     },
     async (span) => {
       if (status.type === StatusType.enum.Announce) {
-        const isFollowing = await database.isCurrentActorFollowing({
-          currentActorId: currentActor.id,
-          followingActorId: status.actorId
-        })
-        if (!isFollowing) {
-          span.end()
-          return null
-        }
-
-        // Honor the follower's reblogs preference: when they followed this
-        // account with reblogs=false, keep that account's boosts out of their
-        // main timeline (matching the relationship's showing_reblogs=false).
+        // A single lookup yields both whether the viewer follows the booster
+        // (accepted) and their reblogs preference. Skip the boost when the
+        // viewer isn't an accepted follower, or followed with reblogs=false
+        // (matching the relationship's showing_reblogs=false).
         const announceFollow = await database.getAcceptedOrRequestedFollow({
           actorId: currentActor.id,
           targetActorId: status.actorId
         })
-        if (announceFollow && announceFollow.reblogs === false) {
+        if (
+          !announceFollow ||
+          announceFollow.status !== FollowStatus.enum.Accepted ||
+          announceFollow.reblogs === false
+        ) {
           span.end()
           return null
         }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -877,6 +877,19 @@ export type CreateFollowParams = {
   status: FollowStatus
   inbox: string
   sharedInbox: string
+  // Optional local follow preferences (Mastodon follow params). Default when
+  // omitted: reblogs=true, notify=false, languages=null (no language filter).
+  reblogs?: boolean
+  notify?: boolean
+  languages?: string[] | null
+}
+export type UpdateFollowPreferencesParams = {
+  actorId: string
+  targetActorId: string
+  // Only the fields actually provided are updated; omitted fields are left as-is.
+  reblogs?: boolean
+  notify?: boolean
+  languages?: string[] | null
 }
 export type GetLocalFollowersForActorIdParams = { targetActorId: string }
 export type GetLocalActorsFromFollowerUrlParams = { followerUrl: string }
@@ -922,6 +935,9 @@ export type GetFollowRequestsCountParams = {
 
 export interface FollowDatabase {
   createFollow(params: CreateFollowParams): Promise<Follow>
+  updateFollowPreferences(
+    params: UpdateFollowPreferencesParams
+  ): Promise<Follow | null>
   getFollowFromId(params: GetFollowFromIdParams): Promise<Follow | null>
   getLocalFollowersForActorId(
     params: GetLocalFollowersForActorIdParams
@@ -1076,6 +1092,27 @@ export interface MuteDatabase {
   isMuting(params: IsMutingParams): Promise<boolean>
   getMuteRelations(params: GetMuteRelationsParams): Promise<MuteRelation[]>
   getMutes(params: GetMutesParams): Promise<Mute[]>
+}
+
+// ============================================================================
+// Account Note Database
+// ============================================================================
+
+export type UpsertAccountNoteParams = {
+  actorId: string
+  targetActorId: string
+  comment: string
+}
+export type GetAccountNoteParams = {
+  actorId: string
+  targetActorId: string
+}
+
+export interface AccountNoteDatabase {
+  // Sets the private note for (actorId -> targetActorId). An empty comment
+  // clears the note. Returns the stored comment (empty string when cleared).
+  upsertAccountNote(params: UpsertAccountNoteParams): Promise<string>
+  getAccountNote(params: GetAccountNoteParams): Promise<string>
 }
 
 // ============================================================================

--- a/lib/types/domain/follow.ts
+++ b/lib/types/domain/follow.ts
@@ -21,6 +21,14 @@ export const Follow = z.object({
   inbox: z.string(),
   sharedInbox: z.string().optional(),
 
+  // Local follow preferences (Mastodon POST /accounts/:id/follow params).
+  // reblogs: show this account's boosts in the home timeline.
+  // notify: receive a notification on this account's new posts.
+  // languages: only show posts in these languages (null = no filter).
+  reblogs: z.boolean(),
+  notify: z.boolean(),
+  languages: z.string().array().nullable(),
+
   createdAt: z.number(),
   updatedAt: z.number()
 })

--- a/lib/types/mastodon/account/relationship.ts
+++ b/lib/types/mastodon/account/relationship.ts
@@ -17,8 +17,9 @@ export const Relationship = z.object({
   // Have you enabled notifications for this user?
   notifying: z.boolean(),
 
-  // Which languages are you following from this user?
-  languages: z.array(z.string()),
+  // Which languages are you following from this user? null = no language
+  // filter (all languages), matching Mastodon's nullable field.
+  languages: z.array(z.string()).nullable(),
 
   // Are you followed by this user?
   followed_by: z.boolean(),

--- a/lib/utils/getRequestBody.test.ts
+++ b/lib/utils/getRequestBody.test.ts
@@ -14,6 +14,15 @@ const createMockRequest = (
 
   const entries = Object.entries(body || {})
 
+  // Mirror a real NextRequest: text() returns the raw body serialized to match
+  // the content type (JSON for application/json, urlencoded otherwise).
+  const isJson = (contentType || '').includes('application/json')
+  const rawText = isJson
+    ? JSON.stringify(body ?? {})
+    : new URLSearchParams(
+        entries.map(([key, value]) => [key, String(value)])
+      ).toString()
+
   const request = {
     url,
     headers,
@@ -24,13 +33,7 @@ const createMockRequest = (
           entries.map(([key, value]) => [key, value as FormDataEntryValue])
         )
       ),
-    text: jest
-      .fn()
-      .mockResolvedValue(
-        new URLSearchParams(
-          entries.map(([key, value]) => [key, String(value)])
-        ).toString()
-      ),
+    text: jest.fn().mockResolvedValue(rawText),
     json: jest.fn().mockResolvedValue(body || {})
   } as unknown as NextRequest
 
@@ -49,8 +52,26 @@ describe('getRequestBody', () => {
       mockBody
     )
     const result = await getRequestBody(mockRequest)
-    expect(mockRequest.json).toHaveBeenCalled()
     expect(result).toEqual(mockBody)
+  })
+
+  it('should return {} for an empty JSON body (paramless POST)', async () => {
+    const mockRequest = createMockRequest(
+      'https://example.com/api',
+      'application/json'
+    )
+    ;(mockRequest.text as jest.Mock).mockResolvedValue('')
+    const result = await getRequestBody(mockRequest)
+    expect(result).toEqual({})
+  })
+
+  it('should throw on a malformed non-empty JSON body', async () => {
+    const mockRequest = createMockRequest(
+      'https://example.com/api',
+      'application/json'
+    )
+    ;(mockRequest.text as jest.Mock).mockResolvedValue('{ not json')
+    await expect(getRequestBody(mockRequest)).rejects.toThrow()
   })
 
   it('should parse urlencoded request with URLSearchParams, not formData', async () => {

--- a/lib/utils/getRequestBody.test.ts
+++ b/lib/utils/getRequestBody.test.ts
@@ -13,6 +13,7 @@ const createMockRequest = (
   }
 
   const entries = Object.entries(body || {})
+
   const request = {
     url,
     headers,
@@ -87,7 +88,7 @@ describe('getRequestBody', () => {
     }
     const mockRequest = createMockRequest(
       'https://example.com/api',
-      'multipart/form-data; boundary=abc',
+      'multipart/form-data; boundary=----boundary',
       mockBody
     )
     const result = await getRequestBody(mockRequest)
@@ -95,18 +96,16 @@ describe('getRequestBody', () => {
     expect(result).toEqual(mockBody)
   })
 
-  it('should parse form data request when content-type is missing', async () => {
-    const mockBody = {
-      client_name: 'Test App',
-      redirect_uris: 'https://example.com/callback'
-    }
+  it('should return an empty object when content-type is missing', async () => {
     const mockRequest = createMockRequest(
       'https://example.com/api',
       undefined,
-      mockBody
+      {
+        client_name: 'Test App'
+      }
     )
     const result = await getRequestBody(mockRequest)
-    expect(mockRequest.formData).toHaveBeenCalled()
-    expect(result).toEqual(mockBody)
+    expect(mockRequest.formData).not.toHaveBeenCalled()
+    expect(result).toEqual({})
   })
 })

--- a/lib/utils/getRequestBody.ts
+++ b/lib/utils/getRequestBody.ts
@@ -13,7 +13,12 @@ export async function getRequestBody(
   const contentType = req.headers.get('content-type') || ''
 
   if (contentType.includes('application/json')) {
-    return req.json()
+    // Read the raw text so an empty body (a paramless POST that still carries a
+    // default application/json header) resolves to {} instead of throwing;
+    // a non-empty malformed body still throws so the caller can return a 4xx.
+    const text = await req.text()
+    if (text.trim() === '') return {}
+    return JSON.parse(text) as Record<string, unknown>
   }
 
   // Parse urlencoded bodies with URLSearchParams rather than formData(): it is

--- a/lib/utils/getRequestBody.ts
+++ b/lib/utils/getRequestBody.ts
@@ -23,6 +23,14 @@ export async function getRequestBody(
     return Object.fromEntries(new URLSearchParams(await req.text()))
   }
 
-  const formData = await req.formData()
-  return Object.fromEntries(formData.entries())
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await req.formData()
+    return Object.fromEntries(formData.entries())
+  }
+
+  // No body or an unrecognized content type: nothing to parse. Returning an
+  // empty object (rather than calling req.formData(), which rejects on a
+  // bodyless/typeless request) lets endpoints that read optional params handle
+  // a paramless POST without erroring.
+  return {}
 }

--- a/migrations/20260531000000_add_follow_preferences.js
+++ b/migrations/20260531000000_add_follow_preferences.js
@@ -1,0 +1,27 @@
+/**
+ * Adds the local follow preferences Mastodon's POST /accounts/:id/follow
+ * accepts: reblogs (show boosts from this account), notify (alert on new
+ * posts), and languages (filter the followed account's posts by language).
+ * languages is stored as a JSON-encoded text column so it stays portable
+ * across SQLite, PostgreSQL, and MySQL-compatible backends.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) =>
+  knex.schema.alterTable('follows', (table) => {
+    table.boolean('reblogs').notNullable().defaultTo(true)
+    table.boolean('notify').notNullable().defaultTo(false)
+    table.text('languages').nullable()
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) =>
+  knex.schema.alterTable('follows', (table) => {
+    table.dropColumn('reblogs')
+    table.dropColumn('notify')
+    table.dropColumn('languages')
+  })

--- a/migrations/20260531001000_add_account_notes.js
+++ b/migrations/20260531001000_add_account_notes.js
@@ -1,0 +1,31 @@
+/**
+ * Stores the private, per-relationship note Mastodon's POST
+ * /accounts/:id/note endpoint sets (the `comment` param). A note is scoped to
+ * (author actor, target actor); only the author can read it back via the
+ * relationship's `note` field.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) =>
+  knex.schema.createTable('account_notes', (table) => {
+    table.string('id').primary()
+    table.string('actorId').notNullable()
+    table.string('actorHost').notNullable()
+    table.string('targetActorId').notNullable()
+    table.string('targetActorHost').notNullable()
+    table.text('comment').notNullable().defaultTo('')
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['actorId', 'targetActorId'], {
+      indexName: 'account_notes_actor_target_unique'
+    })
+    table.index(['actorId'], 'account_notes_actor')
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => knex.schema.dropTable('account_notes')

--- a/migrations/20260531001000_add_account_notes.js
+++ b/migrations/20260531001000_add_account_notes.js
@@ -18,10 +18,11 @@ exports.up = (knex) =>
     table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
     table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
 
+    // The composite unique index also serves leftmost-prefix lookups by
+    // actorId, so no separate single-column index is needed.
     table.unique(['actorId', 'targetActorId'], {
       indexName: 'account_notes_actor_target_unique'
     })
-    table.index(['actorId'], 'account_notes_actor')
   })
 
 /**


### PR DESCRIPTION
## Summary

Several standard Mastodon client-API POST handlers accepted optional spec params but read **no body at all**, silently dropping them. This wires them through, parsing JSON / urlencoded / multipart bodies. (Feature-completeness gap, distinct from the content-type handling in #829 — overlaps `lib/utils/getRequestBody.ts`; see the merge note below.)

### Endpoints fixed
- **`POST /api/v1/statuses/[id]/reblog`** — now honors `visibility` (`public`/`unlisted`/`private`). `userAnnounce` maps it to the announce `to`/`cc`; the default (omitted) preserves the historical public recipient lists. Invalid values → `422`.
- **`POST /api/v1/accounts/[id]/follow`** — now honors `reblogs`, `notify`, and `languages[]`. New follow columns (migration `20260531000000`) store them; `createFollow` persists them, a new `updateFollowPreferences` applies them when re-following, and `getRelationship` reports them via `showing_reblogs`/`notifying`/`languages`. Form bodies coerce string booleans (`"false"` → `false`) and preserve repeated `languages[]` via `getAll`.
- **`POST /api/v1/accounts/[id]/note`** — now stores `comment` in a new `account_notes` table (migration `20260531001000`) via `upsertAccountNote` (empty comment clears it), replacing the previous unimplemented `TODO`.

### ⚠️ Intentional behavior change
`getRelationship.note` now returns the **viewer's private note** about the target (Mastodon-correct), not the target's public bio/summary. This affects **every** relationship-returning endpoint (follow/unfollow/block/mute/note), not just `note`.

### 🔀 Merge note for #829
`getRequestBody`'s missing/unknown content-type branch must **return `{}`** (not call `req.formData()`); the reblog/note/follow endpoints rely on it for paramless POSTs, and `req.formData()` rejects on a bodyless/typeless request. This deliberately diverges from #829's `else → formData()` fallback — **keep the `{}` version** when the branches meet.

## Test plan
- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors
- `yarn build` — succeeds
- `yarn test` — **3225 passed / 375 suites**

New/updated regression tests: reblog visibility (JSON + urlencoded + default + invalid→422), follow params (JSON + urlencoded `languages[]` + default + re-follow update), note comment (JSON + urlencoded + clear), `parseFollowRequestBody` unit tests, and updated `getRequestBody`/`relationship` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)