### PR TITLE
Bump version to v1.37.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.37.3",
+  "version": "1.37.4",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.37.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.37.3`
- Base main SHA: `3c1749430d3e3b1819c7bb6f1d48cc10faae6b22`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
