### PR TITLE
Bump version to v1.37.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.37.4",
+  "version": "1.37.5",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.37.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.37.4`
- Base main SHA: `fdf252f4b01853d09864d7854fd4ac54305516c4`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
