### PR TITLE
Bump version to v1.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.37.5",
+  "version": "1.38.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.38.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.37.5`
- Base main SHA: `5b1c892c007334bf5e3818f580efa15535d2e6bd`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
