### PR TITLE
Bump version to v1.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.38.1",
+  "version": "1.39.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.39.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.38.1`
- Base main SHA: `c28be87f1d1d07793866bf78d9fdea072a97c063`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
