### PR TITLE
Bump version to v1.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.39.0`
- Base main SHA: `e5a88f32288f5b88dd9b5cd07de16190999d7db6`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
