### PR TITLE
feat: render messages thread as chat bubbles to match design system

### DIFF
--- a/app/(timeline)/messages/MessageBubble.tsx
+++ b/app/(timeline)/messages/MessageBubble.tsx
@@ -142,10 +142,10 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
-              'flex max-w-full items-center gap-3 rounded-2xl border px-3 py-2.5',
+              'flex max-w-full items-center gap-3 rounded-2xl border px-3 py-2.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
               isOwn
-                ? 'border-transparent bg-primary text-primary-foreground'
-                : 'bg-muted text-foreground'
+                ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'
+                : 'bg-muted text-foreground hover:bg-muted/70'
             )}
           >
             <span
@@ -198,10 +198,10 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                'flex max-w-full items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm',
+                'flex max-w-full items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
                 isOwn
-                  ? 'border-transparent bg-primary text-primary-foreground'
-                  : 'bg-muted text-foreground'
+                  ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'bg-muted text-foreground hover:bg-muted/70'
               )}
             >
               <Download className="size-4 shrink-0" />

--- a/app/(timeline)/messages/MessageBubble.tsx
+++ b/app/(timeline)/messages/MessageBubble.tsx
@@ -1,0 +1,194 @@
+import _ from 'lodash'
+import { Activity, Download } from 'lucide-react'
+import { FC, MouseEvent } from 'react'
+
+import { Media } from '@/lib/components/posts/media'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Attachment } from '@/lib/types/domain/attachment'
+import { Status } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
+import {
+  formatFitnessDistance,
+  formatFitnessDuration,
+  formatFitnessElevation
+} from '@/lib/utils/fitness'
+import { cleanClassName } from '@/lib/utils/text/cleanClassName'
+import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
+import {
+  getActualStatus,
+  processStatusText
+} from '@/lib/utils/text/processStatusText'
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit'
+})
+
+const getInitial = (value: string) =>
+  value.trim().length > 0 ? value.trim()[0].toUpperCase() : '?'
+
+const isVisualMedia = (attachment: Attachment) =>
+  attachment.mediaType.startsWith('image') ||
+  attachment.mediaType.startsWith('video')
+
+interface MessageBubbleProps {
+  host: string
+  status: Status
+  isOwn: boolean
+  onShowAttachment: (attachments: Attachment[], index: number) => void
+}
+
+export const MessageBubble: FC<MessageBubbleProps> = ({
+  host,
+  status,
+  isOwn,
+  onShowAttachment
+}) => {
+  const actualStatus = getActualStatus(status)
+  const actor = actualStatus.actor
+  const authorName = actor?.name || actor?.username || ''
+  const mediaAttachments = actualStatus.attachments.filter(isVisualMedia)
+  const fitnessFile = actualStatus.fitness
+  const hasText = htmlToPlainText(actualStatus.text ?? '').trim().length > 0
+  const processedText = hasText
+    ? _.chain(status)
+        .thru((value) => processStatusText(host, value))
+        .thru(cleanClassName)
+        .value()
+    : null
+  const time = timeFormatter.format(new Date(actualStatus.createdAt))
+
+  const fitnessMeta = fitnessFile
+    ? [
+        formatFitnessDistance(fitnessFile.totalDistanceMeters),
+        formatFitnessDuration(fitnessFile.totalDurationSeconds),
+        formatFitnessElevation(fitnessFile.elevationGainMeters)
+      ]
+        .filter((value): value is string => Boolean(value))
+        .join(' · ')
+    : ''
+  const fitnessLabel = fitnessFile
+    ? [fitnessFile.fileType.toUpperCase(), fitnessMeta]
+        .filter(Boolean)
+        .join(' · ')
+    : ''
+
+  const handleMediaClick = (index: number) => (event: MouseEvent) => {
+    event.stopPropagation()
+    onShowAttachment(mediaAttachments, index)
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-end gap-2',
+        isOwn ? 'justify-end' : 'justify-start'
+      )}
+    >
+      {!isOwn && (
+        <Avatar className="size-7 shrink-0">
+          {actor?.iconUrl && <AvatarImage src={actor.iconUrl} alt="" />}
+          <AvatarFallback>{getInitial(authorName)}</AvatarFallback>
+        </Avatar>
+      )}
+      <div
+        className={cn(
+          'flex max-w-[78%] flex-col gap-1',
+          isOwn ? 'items-end' : 'items-start'
+        )}
+      >
+        {mediaAttachments.length === 1 ? (
+          <button
+            type="button"
+            onClick={handleMediaClick(0)}
+            className="block overflow-hidden rounded-2xl border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          >
+            <Media
+              className="block max-h-72 w-full object-cover"
+              attachment={mediaAttachments[0]}
+            />
+          </button>
+        ) : mediaAttachments.length > 1 ? (
+          <div className="grid w-full max-w-80 grid-cols-2 gap-[3px] overflow-hidden rounded-2xl border">
+            {mediaAttachments.map((attachment, index) => (
+              <button
+                key={attachment.id}
+                type="button"
+                onClick={handleMediaClick(index)}
+                className="block h-32 overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
+              >
+                <Media
+                  className="h-full w-full object-cover"
+                  attachment={attachment}
+                />
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {fitnessFile && (
+          <a
+            href={fitnessFile.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              'flex max-w-full items-center gap-3 rounded-2xl border px-3 py-2.5',
+              isOwn
+                ? 'border-transparent bg-primary text-primary-foreground'
+                : 'bg-muted text-foreground'
+            )}
+          >
+            <span
+              className={cn(
+                'flex size-10 shrink-0 items-center justify-center rounded-lg',
+                isOwn
+                  ? 'bg-primary-foreground/20 text-primary-foreground'
+                  : 'bg-primary/10 text-primary'
+              )}
+            >
+              <Activity className="size-5" />
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium">
+                {fitnessFile.fileName}
+              </span>
+              {fitnessLabel && (
+                <span
+                  className={cn(
+                    'block truncate text-xs',
+                    isOwn
+                      ? 'text-primary-foreground/80'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {fitnessLabel}
+                </span>
+              )}
+            </span>
+            <Download
+              className={cn(
+                'ml-1 size-4 shrink-0',
+                isOwn ? 'text-primary-foreground/90' : 'text-muted-foreground'
+              )}
+            />
+          </a>
+        )}
+
+        {processedText && (
+          <div
+            className={cn(
+              'markdown-content max-w-full overflow-hidden break-words rounded-2xl px-3.5 py-2 text-sm leading-relaxed',
+              isOwn
+                ? 'rounded-br-md bg-primary text-primary-foreground [&_a]:text-primary-foreground [&_a]:underline'
+                : 'rounded-bl-md bg-muted text-foreground'
+            )}
+          >
+            {processedText}
+          </div>
+        )}
+
+        <div className="px-1 text-[11px] text-muted-foreground">{time}</div>
+      </div>
+    </div>
+  )
+}

--- a/app/(timeline)/messages/MessageBubble.tsx
+++ b/app/(timeline)/messages/MessageBubble.tsx
@@ -4,7 +4,7 @@ import { FC, MouseEvent } from 'react'
 
 import { Media } from '@/lib/components/posts/media'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
-import { Attachment } from '@/lib/types/domain/attachment'
+import { Attachment, isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 import {
@@ -51,6 +51,13 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
   const actor = actualStatus.actor
   const authorName = actor?.name || actor?.username || ''
   const mediaAttachments = actualStatus.attachments.filter(isVisualMedia)
+  // Anything that is neither inline visual media nor the parsed fitness file
+  // (e.g. audio, PDFs, generic documents) still needs to surface so it isn't
+  // silently dropped from the bubble.
+  const otherAttachments = actualStatus.attachments.filter(
+    (attachment) =>
+      !isVisualMedia(attachment) && !isFitnessAttachment(attachment)
+  )
   const fitnessFile = actualStatus.fitness
   const hasText = htmlToPlainText(actualStatus.text ?? '').trim().length > 0
   const processedText = hasText
@@ -175,6 +182,34 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
               )}
             />
           </a>
+        )}
+
+        {otherAttachments.map((attachment) =>
+          attachment.mediaType.startsWith('audio') ? (
+            <Media
+              key={attachment.id}
+              className="w-full max-w-80"
+              attachment={attachment}
+            />
+          ) : (
+            <a
+              key={attachment.id}
+              href={attachment.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                'flex max-w-full items-center gap-2 rounded-2xl border px-3 py-2.5 text-sm',
+                isOwn
+                  ? 'border-transparent bg-primary text-primary-foreground'
+                  : 'bg-muted text-foreground'
+              )}
+            >
+              <Download className="size-4 shrink-0" />
+              <span className="truncate">
+                {attachment.name || 'Attachment'}
+              </span>
+            </a>
+          )
         )}
 
         {processedText && (

--- a/app/(timeline)/messages/MessageBubble.tsx
+++ b/app/(timeline)/messages/MessageBubble.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import { Activity, Download } from 'lucide-react'
 import { FC, MouseEvent } from 'react'
 
@@ -61,10 +60,7 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
   const fitnessFile = actualStatus.fitness
   const hasText = htmlToPlainText(actualStatus.text ?? '').trim().length > 0
   const processedText = hasText
-    ? _.chain(status)
-        .thru((value) => processStatusText(host, value))
-        .thru(cleanClassName)
-        .value()
+    ? cleanClassName(processStatusText(host, status))
     : null
   const time = timeFormatter.format(new Date(actualStatus.createdAt))
 

--- a/app/(timeline)/messages/MessageBubble.tsx
+++ b/app/(timeline)/messages/MessageBubble.tsx
@@ -24,8 +24,11 @@ const timeFormatter = new Intl.DateTimeFormat(undefined, {
   minute: '2-digit'
 })
 
-const getInitial = (value: string) =>
-  value.trim().length > 0 ? value.trim()[0].toUpperCase() : '?'
+const getInitial = (value: string) => {
+  const trimmed = value.trim()
+  // Spread to a code-point array so a leading emoji/surrogate pair isn't split.
+  return trimmed ? [...trimmed][0].toUpperCase() : '?'
+}
 
 const isVisualMedia = (attachment: Attachment) =>
   attachment.mediaType.startsWith('image') ||
@@ -187,7 +190,12 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
           </div>
         )}
 
-        <div className="px-1 text-[11px] text-muted-foreground">{time}</div>
+        <div
+          className="px-1 text-[11px] text-muted-foreground"
+          suppressHydrationWarning
+        >
+          {time}
+        </div>
       </div>
     </div>
   )

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -1049,6 +1049,45 @@ describe('MessagesPage', () => {
     expect(bold.tagName).toBe('STRONG')
   })
 
+  it('surfaces non-visual attachments as a download link instead of an empty bubble', async () => {
+    const fileStatus: Status = {
+      ...status('file-1', ''),
+      attachments: [
+        {
+          id: 'att-1',
+          actorId: currentActor.id,
+          statusId: 'file-1',
+          type: 'Document',
+          mediaType: 'application/pdf',
+          url: 'https://example.com/files/plan.pdf',
+          name: 'plan.pdf',
+          createdAt: currentTime,
+          updatedAt: currentTime
+        }
+      ]
+    }
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [fileStatus],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage([conversation({ id: 'first', participantName: 'Ada' })])
+
+    const link = await screen.findByRole('link', { name: /plan\.pdf/ })
+    expect(link).toHaveAttribute('href', 'https://example.com/files/plan.pdf')
+  })
+
+  it('shows "No messages yet" for a selected conversation with no messages', async () => {
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage([conversation({ id: 'first', participantName: 'Ada' })])
+
+    expect(await screen.findByText('No messages yet')).toBeInTheDocument()
+  })
+
   it('prefixes the conversation preview with "You:" for your own last message', () => {
     ;(getConversationStatuses as jest.Mock).mockResolvedValue({
       statuses: [],

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -1077,6 +1077,36 @@ describe('MessagesPage', () => {
     expect(link).toHaveAttribute('href', 'https://example.com/files/plan.pdf')
   })
 
+  it('renders a fitness file as a card with its filename and metrics', async () => {
+    const fitnessStatus: Status = {
+      ...status('fit-1', ''),
+      fitness: {
+        id: 'fitness-1',
+        fileName: 'morning-run.gpx',
+        fileType: 'gpx',
+        mimeType: 'application/gpx+xml',
+        bytes: 2048,
+        url: 'https://example.com/files/morning-run.gpx',
+        totalDistanceMeters: 12000,
+        totalDurationSeconds: 3600
+      }
+    }
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [fitnessStatus],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage([conversation({ id: 'first', participantName: 'Ada' })])
+
+    const link = await screen.findByRole('link', { name: /morning-run\.gpx/ })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://example.com/files/morning-run.gpx'
+    )
+    expect(link).toHaveTextContent('GPX')
+    expect(link).toHaveTextContent(/km/)
+  })
+
   it('shows "No messages yet" for a selected conversation with no messages', async () => {
     ;(getConversationStatuses as jest.Mock).mockResolvedValue({
       statuses: [],

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -1002,13 +1002,53 @@ describe('MessagesPage', () => {
     ).not.toBeInTheDocument()
 
     const messageInput = screen.getByRole('textbox', { name: 'Message text' })
-    expect(messageInput).toHaveClass('w-full')
-    expect(
-      screen.getByRole('button', { name: 'Send message' })
-    ).toHaveTextContent('Send')
-    expect(
-      screen.getByRole('button', { name: 'Send message' }).parentElement
-    ).toHaveClass('justify-end')
+    expect(messageInput).toHaveClass('flex-1')
+    const sendButton = screen.getByRole('button', { name: 'Send message' })
+    expect(sendButton).toHaveTextContent('Send')
+    // The composer is an inline row: the textarea and Send button sit side by
+    // side, bottom-aligned, rather than the button stacked below.
+    expect(sendButton.parentElement).toHaveClass('items-end')
+  })
+
+  it('renders sent and received messages as aligned chat bubbles', async () => {
+    const receivedStatus: Status = {
+      ...status('them-1', 'Theirs'),
+      actorId: 'https://example.com/users/ada',
+      actor: null,
+      isLocalActor: false
+    }
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [status('me-1', 'Mine'), receivedStatus],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage([conversation({ id: 'first', participantName: 'Ada' })])
+
+    const mine = await screen.findByText('Mine')
+    const theirs = await screen.findByText('Theirs')
+
+    // Own messages: orange (primary) bubble, right-aligned.
+    expect(mine.closest('.bg-primary')).not.toBeNull()
+    expect(mine.closest('.justify-end')).not.toBeNull()
+    // Received messages: muted bubble, left-aligned.
+    expect(theirs.closest('.bg-muted')).not.toBeNull()
+    expect(theirs.closest('.justify-start')).not.toBeNull()
+  })
+
+  it('prefixes the conversation preview with "You:" for your own last message', () => {
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage(
+      [conversation({ id: 'first', participantName: 'Ada' })],
+      null
+    )
+
+    expect(screen.getByRole('button', { name: /Ada/i })).toHaveTextContent(
+      'You: Last Ada'
+    )
   })
 
   it('shows an error when the conversation thread fails to load', async () => {

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -1034,6 +1034,21 @@ describe('MessagesPage', () => {
     expect(theirs.closest('.justify-start')).not.toBeNull()
   })
 
+  it('renders message bubble text as rich DOM rather than escaped HTML', async () => {
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [status('rich-1', '**bold**')],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage([conversation({ id: 'first', participantName: 'Ada' })])
+
+    // The markdown is converted to a real <strong> element; if the processed
+    // markup were escaped (e.g. rendered as a raw string), the text node would
+    // read "**bold**" and never resolve to a STRONG tag.
+    const bold = await screen.findByText('bold')
+    expect(bold.tagName).toBe('STRONG')
+  })
+
   it('prefixes the conversation preview with "You:" for your own last message', () => {
     ;(getConversationStatuses as jest.Mock).mockResolvedValue({
       statuses: [],

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -156,7 +156,6 @@ const renderMessagesPage = (
       initialConversationId={initialConversationId}
       initialStatuses={initialStatuses}
       initialNextMaxStatusId={initialNextMaxStatusId}
-      currentTime={currentTime}
       currentActor={currentActor}
       initialHasMoreConversations={initialHasMoreConversations}
     />

--- a/app/(timeline)/messages/MessagesPage.tsx
+++ b/app/(timeline)/messages/MessagesPage.tsx
@@ -1042,11 +1042,13 @@ export const MessagesPage: FC<MessagesPageProps> = ({
         </div>
       </section>
 
-      <MediasModal
-        medias={modalMedias?.medias ?? null}
-        initialSelection={modalMedias?.initialSelection ?? 0}
-        onClosed={() => setModalMedias(null)}
-      />
+      {modalMedias && (
+        <MediasModal
+          medias={modalMedias.medias}
+          initialSelection={modalMedias.initialSelection}
+          onClosed={() => setModalMedias(null)}
+        />
+      )}
     </div>
   )
 }

--- a/app/(timeline)/messages/MessagesPage.tsx
+++ b/app/(timeline)/messages/MessagesPage.tsx
@@ -70,8 +70,11 @@ const accountLabel = (account: MastodonAccount) =>
 const accountHandle = (account: MastodonAccount) =>
   account.acct.startsWith('@') ? account.acct : `@${account.acct}`
 
-const getInitial = (value: string) =>
-  value.trim().length > 0 ? value.trim()[0].toUpperCase() : '?'
+const getInitial = (value: string) => {
+  const trimmed = value.trim()
+  // Spread to a code-point array so a leading emoji/surrogate pair isn't split.
+  return trimmed ? [...trimmed][0].toUpperCase() : '?'
+}
 
 const conversationTitle = (conversation: DirectConversationView) => {
   if (conversation.accounts.length === 0) return 'You'
@@ -772,7 +775,10 @@ export const MessagesPage: FC<MessagesPageProps> = ({
                           ? `You: ${preview}`
                           : preview}
                       </span>
-                      <span className="block text-xs text-muted-foreground md:mt-1">
+                      <span
+                        className="block text-xs text-muted-foreground md:mt-1"
+                        suppressHydrationWarning
+                      >
                         {formatTimestamp(conversation.lastStatusCreatedAt)}
                       </span>
                     </span>

--- a/app/(timeline)/messages/MessagesPage.tsx
+++ b/app/(timeline)/messages/MessagesPage.tsx
@@ -910,7 +910,9 @@ export const MessagesPage: FC<MessagesPageProps> = ({
               </>
             ) : (
               <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground">
-                No conversation selected
+                {selectedConversationId
+                  ? 'No messages yet'
+                  : 'No conversation selected'}
               </div>
             )}
           </div>

--- a/app/(timeline)/messages/MessagesPage.tsx
+++ b/app/(timeline)/messages/MessagesPage.tsx
@@ -29,19 +29,21 @@ import {
   searchAccounts
 } from '@/lib/client'
 import type { DirectConversationView } from '@/lib/client'
+import { MediasModal } from '@/lib/components/medias-modal/medias-modal'
 import { PageHeader } from '@/lib/components/page-header'
-import { Posts } from '@/lib/components/posts/posts'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import { Textarea } from '@/lib/components/ui/textarea'
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
+import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { cn } from '@/lib/utils'
 import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
+import { MessageBubble } from './MessageBubble'
 import { INITIAL_CONVERSATIONS_LIMIT } from './constants'
 
 interface MessagesPageProps {
@@ -120,9 +122,7 @@ export const MessagesPage: FC<MessagesPageProps> = ({
   initialConversationId,
   initialStatuses,
   initialNextMaxStatusId,
-  currentTime,
   currentActor,
-  postLineLimit,
   initialHasMoreConversations = false
 }) => {
   const [currentConversations, setCurrentConversations] =
@@ -156,6 +156,10 @@ export const MessagesPage: FC<MessagesPageProps> = ({
     useState(!initialConversationId)
   const [readRetryNonce, setReadRetryNonce] = useState(0)
   const [error, setError] = useState<string | null>(null)
+  const [modalMedias, setModalMedias] = useState<{
+    medias: Attachment[]
+    initialSelection: number
+  } | null>(null)
   const latestThreadRequestIdRef = useRef(0)
   const selectedConversationIdRef = useRef(selectedConversationId)
   const threadContainerRef = useRef<HTMLDivElement | null>(null)
@@ -211,6 +215,10 @@ export const MessagesPage: FC<MessagesPageProps> = ({
   const composerRecipients = selectedConversation
     ? selectedConversation.accounts
     : selectedRecipients
+  const headerAccount = composerRecipients[0] ?? null
+  const headerTitle = selectedConversation
+    ? conversationTitle(selectedConversation)
+    : 'New message'
 
   const clearRecipientSearchTimeout = useCallback(() => {
     if (recipientSearchTimeoutRef.current === null) return
@@ -709,7 +717,7 @@ export const MessagesPage: FC<MessagesPageProps> = ({
 
       <section
         aria-label="Direct messages"
-        className="grid min-w-0 flex-1 overflow-hidden rounded-lg border bg-background md:min-h-0 md:grid-cols-[minmax(260px,34%)_minmax(0,1fr)] lg:grid-cols-[minmax(320px,30%)_minmax(0,1fr)] 2xl:grid-cols-[380px_minmax(0,1fr)]"
+        className="grid min-w-0 flex-1 overflow-hidden rounded-xl border bg-background shadow-sm md:min-h-0 md:grid-cols-[minmax(260px,34%)_minmax(0,1fr)] lg:grid-cols-[minmax(320px,30%)_minmax(0,1fr)] 2xl:grid-cols-[380px_minmax(0,1fr)]"
       >
         <aside
           aria-label="Conversation list"
@@ -724,6 +732,9 @@ export const MessagesPage: FC<MessagesPageProps> = ({
                 const isSelected = conversation.id === selectedConversationId
                 const title = conversationTitle(conversation)
                 const avatarAccount = conversation.accounts[0]
+                const preview = conversationPreviews.get(conversation.id)
+                const isOwnLastStatus =
+                  conversation.lastStatus.actorId === currentActor.id
                 return (
                   <button
                     key={conversation.id}
@@ -748,17 +759,21 @@ export const MessagesPage: FC<MessagesPageProps> = ({
                         <span
                           className={cn(
                             'truncate text-sm md:text-base',
-                            conversation.unread && 'font-semibold'
+                            conversation.unread
+                              ? 'font-semibold'
+                              : 'font-medium'
                           )}
                         >
                           {title}
                         </span>
                         {conversation.unread && (
-                          <span className="size-2 rounded-full bg-primary" />
+                          <span className="size-2 shrink-0 rounded-full bg-primary" />
                         )}
                       </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {conversationPreviews.get(conversation.id)}
+                      <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                        {isOwnLastStatus && preview
+                          ? `You: ${preview}`
+                          : preview}
                       </span>
                       <span className="block text-xs text-muted-foreground md:mt-1">
                         {formatTimestamp(conversation.lastStatusCreatedAt)}
@@ -810,11 +825,19 @@ export const MessagesPage: FC<MessagesPageProps> = ({
             >
               <ArrowLeft className="size-4" />
             </Button>
+            {headerAccount && (
+              <Avatar className="size-9 shrink-0">
+                {headerAccount.avatar && (
+                  <AvatarImage src={headerAccount.avatar} alt="" />
+                )}
+                <AvatarFallback>
+                  {getInitial(accountLabel(headerAccount))}
+                </AvatarFallback>
+              </Avatar>
+            )}
             <div className="min-w-0 flex-1">
               <h2 className="truncate text-base font-semibold md:text-lg">
-                {selectedConversation
-                  ? conversationTitle(selectedConversation)
-                  : 'New message'}
+                {headerTitle}
               </h2>
               {composerRecipients.length > 0 && (
                 <p className="truncate text-xs text-muted-foreground">
@@ -865,15 +888,22 @@ export const MessagesPage: FC<MessagesPageProps> = ({
                     </Button>
                   </div>
                 )}
-                <Posts
-                  host={host}
-                  framed={false}
-                  currentTime={currentTime}
-                  statuses={displayStatuses}
-                  currentActor={currentActor}
-                  postLineLimit={postLineLimit}
-                  className="md:[&>article]:p-6 xl:[&>article]:px-8"
-                />
+                <div className="space-y-3 px-4 py-4 md:px-6">
+                  {displayStatuses.map((status) => (
+                    <MessageBubble
+                      key={status.id}
+                      host={host}
+                      status={status}
+                      isOwn={status.actorId === currentActor.id}
+                      onShowAttachment={(medias, index) =>
+                        setModalMedias({
+                          medias,
+                          initialSelection: index
+                        })
+                      }
+                    />
+                  ))}
+                </div>
               </>
             ) : (
               <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground">
@@ -968,7 +998,7 @@ export const MessagesPage: FC<MessagesPageProps> = ({
               </div>
             )}
 
-            <div className="space-y-2">
+            <div className="flex items-end gap-2">
               <Textarea
                 value={message}
                 onChange={(event) => setMessage(event.target.value)}
@@ -977,23 +1007,22 @@ export const MessagesPage: FC<MessagesPageProps> = ({
                 aria-label="Message text"
                 autoComplete="off"
                 placeholder="Write a message"
-                className="min-h-24 resize-y md:min-h-28"
+                className="max-h-40 min-h-10 flex-1 resize-none"
               />
-              <div className="flex justify-end">
-                <Button
-                  type="submit"
-                  disabled={isSending || !message.trim()}
-                  aria-label="Send message"
-                  title="Send message"
-                >
-                  {isSending ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Send className="size-4" />
-                  )}
-                  <span>Send</span>
-                </Button>
-              </div>
+              <Button
+                type="submit"
+                disabled={isSending || !message.trim()}
+                aria-label="Send message"
+                title="Send message"
+                className="shrink-0"
+              >
+                {isSending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Send className="size-4" />
+                )}
+                <span>Send</span>
+              </Button>
             </div>
             {error && (
               <p
@@ -1007,6 +1036,12 @@ export const MessagesPage: FC<MessagesPageProps> = ({
           </form>
         </div>
       </section>
+
+      <MediasModal
+        medias={modalMedias?.medias ?? null}
+        initialSelection={modalMedias?.initialSelection ?? 0}
+        onClosed={() => setModalMedias(null)}
+      />
     </div>
   )
 }

--- a/app/(timeline)/messages/MessagesPage.tsx
+++ b/app/(timeline)/messages/MessagesPage.tsx
@@ -35,7 +35,6 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import { Textarea } from '@/lib/components/ui/textarea'
-import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
@@ -52,9 +51,7 @@ interface MessagesPageProps {
   initialConversationId: string | null
   initialStatuses: Status[]
   initialNextMaxStatusId: string | null
-  currentTime: number
   currentActor: ActorProfile
-  postLineLimit?: PostLineLimit
   initialHasMoreConversations?: boolean
 }
 

--- a/app/(timeline)/messages/page.tsx
+++ b/app/(timeline)/messages/page.tsx
@@ -34,7 +34,6 @@ const Page = async () => {
     return redirect('/auth/signin')
   }
 
-  const settings = await database.getActorSettings({ actorId: actor.id })
   const conversationsPage = await database.getDirectConversations({
     actorId: actor.id,
     limit: INITIAL_CONVERSATIONS_LIMIT + 1
@@ -77,9 +76,7 @@ const Page = async () => {
           ? initialStatuses[initialStatuses.length - 1].id
           : null
       }
-      currentTime={Date.now()}
       currentActor={getActorProfile(actor)}
-      postLineLimit={settings?.postLineLimit}
       initialHasMoreConversations={hasMoreInitialConversations}
     />
   )


### PR DESCRIPTION
## Summary

Updates the **Messages** page (`app/(timeline)/messages`) to match the Activities.next design-system handoff (`ui_kits/web/MessagesPage.jsx`). The conversation thread, which previously reused the timeline `Posts` feed, now renders as **chat bubbles**.

## Screenshots

**Desktop — two-pane thread with chat bubbles + image attachment**

<img width="1280" height="920" alt="messages-desktop" src="https://github.com/user-attachments/assets/cbf16850-78b7-4e1d-96ce-851d077f9116" />

**Mobile — single-pane thread (back arrow, pinned composer, bottom nav)**

<img width="390" height="800" alt="messages-mobile-list" src="https://github.com/user-attachments/assets/59aa6bc2-887f-40bb-a1eb-92de3538de82" />

**Image attachment lightbox (shared `MediasModal`)**

<img width="1280" height="920" alt="messages-lightbox" src="https://github.com/user-attachments/assets/cd4e35cb-0b9e-4e39-95f8-9cf2d5061821" />

## What changed

- **New `MessageBubble` component** (`app/(timeline)/messages/MessageBubble.tsx`):
  - Own messages: right-aligned, `bg-primary` / `text-primary-foreground`, asymmetric tail (`rounded-br-md`).
  - Received messages: left-aligned, `bg-muted`, preceded by the sender's avatar.
  - Each bubble shows its own timestamp.
  - Rich text preserved via the existing `processStatusText` + `cleanClassName` pipeline (links/mentions still render as real elements; link contrast handled inside the orange bubble).
  - **Image/video attachments** render as rounded media (single or 2-col grid) that opens the shared `MediasModal` lightbox — reusing `Media` + `MediasModal`, not a bespoke lightbox.
  - **Fitness files** render as a compact card (icon + filename + distance/duration/elevation); **audio** plays inline; **other documents** render as a download link — so no attachment type is silently dropped.
- **`MessagesPage.tsx`**:
  - Thread renders bubbles instead of `<Posts>`; adds the page-level `MediasModal` (rendered only when an attachment is open).
  - Thread header gains an **avatar** next to the name/handle.
  - Composer is now an **inline row** (auto-sizing textarea + Send button) matching the design's compact chat composer.
  - Container picks up the design's `rounded-xl` + `shadow-sm` card chrome.
  - Conversation list prefixes your own last message with **"You:"** and uses `font-medium` for read rows.
  - Empty selected conversation now shows "No messages yet" (vs. "No conversation selected").
  - All existing behavior preserved: recipient search/debounce, load-more (conversations + older messages), mark-as-read with retry, hide/archive, mobile single-pane back navigation, and error handling.

## Tests

- Rewrote the composer-layout assertions for the inline row; added cases for own/received bubble alignment + styling, the "You:" preview prefix, rich-DOM rendering (markdown → real `<strong>`), non-visual attachment download links, the empty-thread copy, and the fitness-file card.
- `yarn lint` ✅ (0 errors) · `yarn build` ✅ · `yarn test` ✅ (382 suites / 3312 tests).

## Verification

Verified locally in a browser (SQLite + two mock users with a seeded direct conversation) at desktop and mobile widths — see screenshots above:
- Own messages render as orange right-aligned bubbles; received messages as muted left-aligned bubbles with the sender avatar.
- Image attachments render in-bubble and open the lightbox on click.
- Inline composer, thread-header avatar, archive action, and the conversation list all render per the design.
- Mobile single-pane view with the back arrow and pinned composer works.

> Note: the composer uses `field-sizing-content` (via the shared `Textarea`) for auto-grow; on non-Chromium browsers it stays at its min height with `resize-none`, matching the design's compact composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)