### PR TITLE
Bump version to v1.40.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.40.1`
- Base main SHA: `805d1323da995a3d96e3ac4ac31948ca3dccf6ea`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
