### PR TITLE
feat: align mobile nav labels and selected icon with design system

### DIFF
--- a/lib/components/layout/mobile-nav.test.tsx
+++ b/lib/components/layout/mobile-nav.test.tsx
@@ -20,9 +20,12 @@ describe('MobileNav', () => {
     render(<MobileNav fitnessUrl="/@llun@llun.test/fitness" isAdmin />)
 
     const nav = screen.getByRole('navigation')
-    expect(
-      within(nav).getByRole('link', { name: /timeline/i })
-    ).toHaveAttribute('href', '/')
+    // The bottom bar uses compact labels: Timeline -> Home, Notifications ->
+    // Alerts (see NavItem.shortLabel).
+    expect(within(nav).getByRole('link', { name: /home/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
     expect(within(nav).getByRole('link', { name: /search/i })).toHaveAttribute(
       'href',
       '/search'
@@ -30,9 +33,10 @@ describe('MobileNav', () => {
     expect(
       within(nav).getByRole('link', { name: /messages/i })
     ).toHaveAttribute('href', '/messages')
-    expect(
-      within(nav).getByRole('link', { name: /notifications/i })
-    ).toHaveAttribute('href', '/notifications')
+    expect(within(nav).getByRole('link', { name: /alerts/i })).toHaveAttribute(
+      'href',
+      '/notifications'
+    )
     expect(
       within(nav).queryByRole('link', { name: /bookmarks/i })
     ).not.toBeInTheDocument()
@@ -66,6 +70,43 @@ describe('MobileNav', () => {
       'href',
       '/settings'
     )
+  })
+
+  it('uses compact labels (Home, Alerts) for the bottom-bar direct items', () => {
+    render(<MobileNav />)
+
+    const nav = screen.getByRole('navigation')
+    expect(within(nav).getByText('Home')).toBeInTheDocument()
+    expect(within(nav).getByText('Alerts')).toBeInTheDocument()
+    // The full desktop labels must not leak into the compact bottom bar.
+    expect(within(nav).queryByText('Timeline')).not.toBeInTheDocument()
+    expect(within(nav).queryByText('Notifications')).not.toBeInTheDocument()
+  })
+
+  it('orders Profile before account entries in the overflow menu', async () => {
+    render(
+      <MobileNav
+        fitnessUrl="/@llun@llun.test/fitness"
+        profileUrl="/@llun@llun.test"
+        isAdmin
+      />
+    )
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'More navigation' }), {
+      key: 'ArrowDown'
+    })
+
+    const items = await screen.findAllByRole('menuitem')
+    const names = items.map((item) => item.textContent?.trim())
+    // Design-system overflow order: Bookmarks, Fitness, Profile, Admin,
+    // Settings.
+    expect(names).toEqual([
+      'Bookmarks',
+      'Fitness',
+      'Profile',
+      'Admin',
+      'Settings'
+    ])
   })
 
   it('adds a Profile entry to the overflow menu when profileUrl is provided', async () => {

--- a/lib/components/layout/mobile-nav.test.tsx
+++ b/lib/components/layout/mobile-nav.test.tsx
@@ -109,6 +109,38 @@ describe('MobileNav', () => {
     ])
   })
 
+  it('places Profile before Admin in the overflow menu (no fitness)', async () => {
+    render(<MobileNav profileUrl="/@llun@llun.test" isAdmin />)
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'More navigation' }), {
+      key: 'ArrowDown'
+    })
+
+    const items = await screen.findAllByRole('menuitem')
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      'Bookmarks',
+      'Profile',
+      'Admin',
+      'Settings'
+    ])
+  })
+
+  it('places Profile before Settings in the overflow menu (no admin)', async () => {
+    render(<MobileNav profileUrl="/@llun@llun.test" />)
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'More navigation' }), {
+      key: 'ArrowDown'
+    })
+
+    const items = await screen.findAllByRole('menuitem')
+    // No Admin entry, so Profile anchors directly before Settings.
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      'Bookmarks',
+      'Profile',
+      'Settings'
+    ])
+  })
+
   it('adds a Profile entry to the overflow menu when profileUrl is provided', async () => {
     render(<MobileNav profileUrl="/@llun@llun.test" />)
 

--- a/lib/components/layout/mobile-nav.tsx
+++ b/lib/components/layout/mobile-nav.tsx
@@ -33,10 +33,22 @@ export function MobileNav({
   const profileNavItem: NavItem | null = profileUrl
     ? { href: profileUrl, label: 'Profile', icon: User }
     : null
-  const allNavItems = [
-    ...buildNavItems({ fitnessUrl, isAdmin }),
-    ...(profileNavItem ? [profileNavItem] : [])
-  ]
+  const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
+  if (profileNavItem) {
+    // Match the design system's overflow order: Profile sits with the
+    // account-level entries, just before Admin/Settings.
+    const adminIndex = allNavItems.findIndex((item) => item.href === '/admin')
+    const settingsIndex = allNavItems.findIndex(
+      (item) => item.href === '/settings'
+    )
+    const profileIndex =
+      adminIndex >= 0
+        ? adminIndex
+        : settingsIndex >= 0
+          ? settingsIndex
+          : allNavItems.length
+    allNavItems.splice(profileIndex, 0, profileNavItem)
+  }
   const hasOverflow = allNavItems.length > 5
   const directNavItems = hasOverflow
     ? mobileDirectHrefs.flatMap((href) => {
@@ -70,9 +82,7 @@ export function MobileNav({
                 )}
               >
                 <div className="relative">
-                  <item.icon
-                    className={cn('h-6 w-6', isActive && 'fill-primary')}
-                  />
+                  <item.icon className="h-6 w-6" />
                   {isNotifications && unreadCount > 0 && (
                     <NotificationBadge
                       count={unreadCount}
@@ -80,7 +90,9 @@ export function MobileNav({
                     />
                   )}
                 </div>
-                <span className="max-w-full truncate">{item.label}</span>
+                <span className="max-w-full truncate">
+                  {item.shortLabel ?? item.label}
+                </span>
               </Link>
             </li>
           )

--- a/lib/components/layout/mobile-nav.tsx
+++ b/lib/components/layout/mobile-nav.tsx
@@ -33,21 +33,23 @@ export function MobileNav({
   const profileNavItem: NavItem | null = profileUrl
     ? { href: profileUrl, label: 'Profile', icon: User }
     : null
-  const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
+  const navItems = buildNavItems({ fitnessUrl, isAdmin })
+  let allNavItems = navItems
   if (profileNavItem) {
     // Match the design system's overflow order: Profile sits with the
-    // account-level entries, just before Admin/Settings.
-    const adminIndex = allNavItems.findIndex((item) => item.href === '/admin')
-    const settingsIndex = allNavItems.findIndex(
-      (item) => item.href === '/settings'
+    // account-level entries, just before the first of Admin/Settings.
+    // `buildNavItems` keeps Admin ahead of Settings, so the first match
+    // resolves to Admin when present and Settings otherwise. Build a new
+    // array rather than mutating the one `buildNavItems` returned.
+    const accountIndex = navItems.findIndex(
+      (item) => item.href === '/admin' || item.href === '/settings'
     )
-    const profileIndex =
-      adminIndex >= 0
-        ? adminIndex
-        : settingsIndex >= 0
-          ? settingsIndex
-          : allNavItems.length
-    allNavItems.splice(profileIndex, 0, profileNavItem)
+    const profileIndex = accountIndex >= 0 ? accountIndex : navItems.length
+    allNavItems = [
+      ...navItems.slice(0, profileIndex),
+      profileNavItem,
+      ...navItems.slice(profileIndex)
+    ]
   }
   const hasOverflow = allNavItems.length > 5
   const directNavItems = hasOverflow

--- a/lib/components/layout/nav-items.ts
+++ b/lib/components/layout/nav-items.ts
@@ -13,15 +13,23 @@ import { type LucideIcon } from 'lucide-react'
 export interface NavItem {
   href: string
   label: string
+  // Compact label used by space-constrained surfaces (the mobile bottom bar).
+  // Falls back to `label` when omitted.
+  shortLabel?: string
   icon: LucideIcon
 }
 
 const baseNavItems: NavItem[] = [
-  { href: '/', label: 'Timeline', icon: Home },
+  { href: '/', label: 'Timeline', shortLabel: 'Home', icon: Home },
   { href: '/search', label: 'Search', icon: Search },
   { href: '/messages', label: 'Messages', icon: Mail },
   { href: '/bookmarks', label: 'Bookmarks', icon: Bookmark },
-  { href: '/notifications', label: 'Notifications', icon: Bell },
+  {
+    href: '/notifications',
+    label: 'Notifications',
+    shortLabel: 'Alerts',
+    icon: Bell
+  },
   { href: '/settings', label: 'Settings', icon: Settings }
 ]
 


### PR DESCRIPTION
## Summary

Aligns the primary app navigation with the design-system screenshots across **desktop, tablet, and mobile**, focusing on the two places the implementation diverged: mobile labels and the mobile selected-icon treatment.

> Note: `ui_kits/web/index.html` is not present in the repo (or the main checkout), so the **attached design-system screenshots** were used as the authoritative reference, as provided.

### Changes
- **Mobile bottom bar — compact labels.** Adds an optional `NavItem.shortLabel`. The bottom bar renders `shortLabel ?? label`, so `/` shows **Home** (not "Timeline") and `/notifications` shows **Alerts** (not "Notifications"), matching the design. Desktop/tablet keep the full labels.
- **Mobile selected icon keeps its shape.** Removed `fill-primary` from the active bottom-bar icon, so the selected icon stays an **orange outline** instead of a solid-filled blob — i.e. "keep the shape of the icon instead of full background same color". This matches the desktop/tablet treatment (`bg-primary/10` wash + orange outline icon), which were already correct and are **unchanged**.
- **"More" overflow order.** Profile now sits with the account-level entries (before Admin/Settings): **Bookmarks, Fitness, Profile, Admin, Settings**, matching the design's overflow.

### Out of scope (intentionally untouched)
- Desktop sidebar & tablet rail selected styling already matched the screenshots (light pill / rounded square + orange outline icon).
- `section-nav-dropdown.tsx` (settings/fitness/admin sub-nav) — a different surface governed by separate AGENTS.md rules.

## Verification

Verified in a browser (local SQLite + mock user) at all three breakpoints:

| Breakpoint | Result |
| --- | --- |
| Desktop (1280px) | Timeline/Notifications labels; selected = light pill + orange outline icon ✓ |
| Tablet (800px) | Icon rail; selected = light rounded square + orange outline bell ✓ |
| Mobile (390px) | **Home / Search / Messages / Alerts / More**; selected Home = orange outline (no blob); More order correct ✓ |

No console errors.

### Pre-commit gates
- `prettier --write .` ✓
- `yarn lint` — 0 errors (12 pre-existing warnings in unrelated files) ✓
- `yarn build` ✓
- `yarn test` — 384 suites, 3331 tests passed ✓

### Tests
- Updated `mobile-nav.test.tsx` for the new compact labels (`Home`/`Alerts`).
- Added regressions: compact bottom-bar labels (and that full labels don't leak in), and the "More" overflow order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)