### PR TITLE
feat: match poll status and post-box poll editor to the design system

### DIFF
--- a/lib/components/post-box/poll-choices.tsx
+++ b/lib/components/post-box/poll-choices.tsx
@@ -1,28 +1,24 @@
 'use client'
 
-import { XCircle } from 'lucide-react'
+import { BarChart3, Clock, Plus, X } from 'lucide-react'
 import { FC } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from '@/lib/components/ui/dropdown-menu'
 import { Input } from '@/lib/components/ui/input'
+import { Select } from '@/lib/components/ui/select'
+import { Switch } from '@/lib/components/ui/switch'
 
-export const DEFAULT_DURATION = 21_600
+export const DEFAULT_DURATION = 86_400
 
 export const SecondsToDurationText = {
-  300: '5 Minutes',
-  1_800: '30 Minutes',
-  3_600: '1 Hour',
-  21_600: '6 Hours',
-  43_200: '12 Hours',
-  86_400: '1 Day',
-  259_200: '3 Days',
-  604_800: '7 Days'
+  300: '5 minutes',
+  1_800: '30 minutes',
+  3_600: '1 hour',
+  21_600: '6 hours',
+  43_200: '12 hours',
+  86_400: '1 day',
+  259_200: '3 days',
+  604_800: '7 days'
 }
 
 export type Duration = keyof typeof SecondsToDurationText
@@ -31,6 +27,8 @@ export interface Choice {
   key: number
   text: string
 }
+
+const MAX_CHOICES = 5
 
 interface Props {
   show: boolean
@@ -41,6 +39,7 @@ interface Props {
   onRemoveChoice: (index: number) => void
   onChooseDuration: (durationInSeconds: Duration) => void
   onPollTypeChange: (pollType: 'oneOf' | 'anyOf') => void
+  onRemove: () => void
 }
 
 export const PollChoices: FC<Props> = ({
@@ -51,73 +50,106 @@ export const PollChoices: FC<Props> = ({
   onAddChoice,
   onRemoveChoice,
   onChooseDuration,
-  onPollTypeChange
+  onPollTypeChange,
+  onRemove
 }) => {
   if (!show) return null
 
   return (
-    <div className="mb-4 space-y-2">
-      {choices.map((choice, index) => (
-        <div key={choice.key} className="flex flex-row items-center gap-2">
-          <Input
-            type="text"
-            name="poll[]"
-            placeholder={`Choice ${index + 1}`}
-            defaultValue={choice.text}
-            onChange={(e) => {
-              choice.text = e.currentTarget.value
-            }}
-          />
-          <Button
-            disabled={choices.length < 3}
-            variant="link"
-            onClick={() => onRemoveChoice(index)}
-          >
-            <XCircle className="size-4" />
-          </Button>
+    <div className="mt-3 rounded-lg border bg-background p-3">
+      <div className="mb-2.5 flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          <BarChart3 className="size-3" /> Poll
         </div>
-      ))}
-      <div className="flex flex-row items-center gap-2 pt-2">
-        <div className="flex items-center space-x-2">
-          <input
-            className="peer h-4 w-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
-            type="checkbox"
-            checked={pollType === 'anyOf'}
-            id="flexCheckDefault"
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Remove poll"
+          onClick={onRemove}
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {choices.map((choice, index) => (
+          <div key={choice.key} className="flex flex-row items-center gap-2">
+            <span className="w-5 text-center text-xs tabular-nums text-muted-foreground">
+              {index + 1}
+            </span>
+            <Input
+              type="text"
+              name="poll[]"
+              placeholder={`Choice ${index + 1}`}
+              defaultValue={choice.text}
+              onChange={(e) => {
+                choice.text = e.currentTarget.value
+              }}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={choices.length <= 2}
+              aria-label={`Remove choice ${index + 1}`}
+              className="text-muted-foreground hover:text-destructive"
+              onClick={() => onRemoveChoice(index)}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {choices.length < MAX_CHOICES ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="ml-7 mt-2 gap-1.5 text-primary hover:bg-primary/10 hover:text-primary"
+          onClick={() => onAddChoice()}
+        >
+          <Plus className="size-3.5" /> Add choice
+        </Button>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t pt-3">
+        <label
+          htmlFor="poll-duration"
+          className="inline-flex items-center gap-2 text-xs text-muted-foreground"
+        >
+          <Clock className="size-3.5" />
+          <span>Ends in</span>
+          <Select
+            id="poll-duration"
+            value={durationInSeconds}
             onChange={(e) =>
-              onPollTypeChange(e.target.checked ? 'anyOf' : 'oneOf')
+              onChooseDuration(parseInt(e.target.value, 10) as Duration)
+            }
+            className="h-8 w-auto px-2 text-xs font-medium text-foreground md:text-xs"
+          >
+            {Object.keys(SecondsToDurationText).map((duration) => (
+              <option key={duration} value={duration}>
+                {SecondsToDurationText[parseInt(duration, 10) as Duration]}
+              </option>
+            ))}
+          </Select>
+        </label>
+
+        <label
+          htmlFor="poll-multiple"
+          className="inline-flex cursor-pointer items-center gap-2 text-xs font-medium text-muted-foreground"
+        >
+          <Switch
+            id="poll-multiple"
+            checked={pollType === 'anyOf'}
+            onCheckedChange={(checked) =>
+              onPollTypeChange(checked ? 'anyOf' : 'oneOf')
             }
           />
-          <label
-            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-            htmlFor="flexCheckDefault"
-          >
-            Multiple Choices
-          </label>
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button type="button" variant="secondary">
-              {SecondsToDurationText[durationInSeconds]}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            {Object.keys(SecondsToDurationText).map((duration) => (
-              <DropdownMenuItem
-                key={duration}
-                onClick={() => {
-                  onChooseDuration(parseInt(duration) as Duration)
-                }}
-                className="cursor-pointer"
-              >
-                {SecondsToDurationText[parseInt(duration) as Duration]}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <Button disabled={choices.length >= 5} onClick={() => onAddChoice()}>
-          Add choice
-        </Button>
+          Allow multiple choices
+        </label>
       </div>
     </div>
   )

--- a/lib/components/post-box/poll-choices.tsx
+++ b/lib/components/post-box/poll-choices.tsx
@@ -137,10 +137,7 @@ export const PollChoices: FC<Props> = ({
           </Select>
         </label>
 
-        <label
-          htmlFor="poll-multiple"
-          className="inline-flex cursor-pointer items-center gap-2 text-xs font-medium text-muted-foreground"
-        >
+        <div className="inline-flex items-center gap-2 text-xs font-medium text-muted-foreground">
           <Switch
             id="poll-multiple"
             checked={pollType === 'anyOf'}
@@ -148,8 +145,10 @@ export const PollChoices: FC<Props> = ({
               onPollTypeChange(checked ? 'anyOf' : 'oneOf')
             }
           />
-          Allow multiple choices
-        </label>
+          <label htmlFor="poll-multiple" className="cursor-pointer">
+            Allow multiple choices
+          </label>
+        </div>
       </div>
     </div>
   )

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -948,6 +948,7 @@ export const PostBox: FC<Props> = ({
             dispatch(setPollDurationInSeconds(durationInSeconds))
           }
           onPollTypeChange={(pollType) => dispatch(setPollType(pollType))}
+          onRemove={() => dispatch(setPollVisibility(false))}
         />
         <div className="mt-3 flex flex-wrap items-center gap-y-2 border-t pt-3">
           <div className="flex flex-wrap items-center gap-1">

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -153,7 +153,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
           const percentage = Math.round((choice.totalVotes / totalVotes) * 100)
           return (
             <div
-              key={`poll-${index}`}
+              key={`poll-${status.id}-${index}`}
               className={cn(
                 'relative overflow-hidden rounded-lg border px-3 py-2.5 text-sm',
                 mine ? 'border-primary' : 'border-border'

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { formatDistance } from 'date-fns'
+import { Check } from 'lucide-react'
 import { FC, useEffect, useState } from 'react'
 
 import { votePoll } from '@/lib/client'
 import { Status, StatusType } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 
 interface Props {
   status: Status
@@ -50,16 +52,11 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
 
   const isPollClosed = now >= status.endAt
   const choices = status.choices
-  const totalVotes =
-    choices.reduce((sum, choice) => sum + choice.totalVotes, 0) || 1
+  const voteCount = choices.reduce((sum, choice) => sum + choice.totalVotes, 0)
+  const totalVotes = voteCount || 1
 
   const isMultiple = status.pollType === 'anyOf'
   const hasVoted = votedChoices.length > 0
-
-  const backgroundRevertPercentage = choices.map((choice) => {
-    if (choice.totalVotes === 0) return 0
-    return 1 - (choice.totalVotes / totalVotes) * 100
-  })
 
   const handleVote = async () => {
     if (selectedChoices.length === 0) return
@@ -91,70 +88,121 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
 
   const canVote = currentActorId && !hasVoted && !isPollClosed
 
-  return (
-    <div>
-      {choices.map((choice, index) => (
-        <div key={`poll-${index}`} className="mb-2">
-          {canVote ? (
-            <div>
-              <input
-                className="mr-2 align-middle"
-                type={isMultiple ? 'checkbox' : 'radio'}
-                id={`choice-${index}`}
-                checked={selectedChoices.includes(index)}
-                onChange={() => handleChoiceChange(index)}
-                name={`poll-${status.id}`}
-              />
-              <label className="cursor-pointer" htmlFor={`choice-${index}`}>
-                {choice.title}
-              </label>
-            </div>
-          ) : (
-            <div
-              className="flex"
-              style={{
-                background: `linear-gradient(90deg, pink ${
-                  (choice.totalVotes / totalVotes) * 100
-                }%, rgba(255,255,255, 0) ${backgroundRevertPercentage[index]}%)`
-              }}
-            >
-              <label
-                className="flex-1 cursor-pointer"
-                htmlFor={`choice-${index}`}
-              >
-                {choice.title}
-                {votedChoices.includes(index) && ' ✓'}
-              </label>
-              <span>
-                {choice.totalVotes} (
-                {`${Number((choice.totalVotes / totalVotes) * 100).toFixed(2)}%`}
-                )
-              </span>
-            </div>
-          )}
-        </div>
-      ))}
+  const meta = (
+    <div className="text-xs text-muted-foreground">
+      {`${voteCount.toLocaleString()} ${voteCount === 1 ? 'vote' : 'votes'}`}
+      {isMultiple ? ' · Choose multiple' : ''}
+      {' · '}
+      <span>
+        {isPollClosed
+          ? 'Poll closed'
+          : `Poll closes in ${formatDistance(status.endAt, now)}`}
+      </span>
+    </div>
+  )
 
-      {canVote && (
-        <button
-          onClick={handleVote}
-          disabled={isVoting || selectedChoices.length === 0}
-          className="mt-2 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:bg-gray-300"
-        >
-          {isVoting ? 'Voting...' : 'Vote'}
-        </button>
+  return (
+    <div className="mt-2.5">
+      <div className="flex flex-col gap-1.5">
+        {choices.map((choice, index) => {
+          if (canVote) {
+            const checked = selectedChoices.includes(index)
+            return (
+              <label
+                key={`poll-${index}`}
+                htmlFor={`choice-${index}`}
+                className={cn(
+                  'flex cursor-pointer items-center gap-2.5 rounded-lg border px-3 py-2.5 text-sm transition-colors',
+                  checked
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border bg-background hover:bg-muted'
+                )}
+              >
+                <input
+                  className="sr-only"
+                  type={isMultiple ? 'checkbox' : 'radio'}
+                  id={`choice-${index}`}
+                  checked={checked}
+                  onChange={() => handleChoiceChange(index)}
+                  name={`poll-${status.id}`}
+                />
+                <span
+                  aria-hidden
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center border-2 transition-colors',
+                    isMultiple ? 'rounded-[4px]' : 'rounded-full',
+                    checked
+                      ? 'border-primary bg-primary'
+                      : 'border-muted-foreground/60 bg-transparent'
+                  )}
+                >
+                  {checked &&
+                    (isMultiple ? (
+                      <Check className="size-3 text-primary-foreground" />
+                    ) : (
+                      <span className="size-1.5 rounded-full bg-primary-foreground" />
+                    ))}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{choice.title}</span>
+              </label>
+            )
+          }
+
+          const mine = votedChoices.includes(index)
+          const percentage = Math.round((choice.totalVotes / totalVotes) * 100)
+          return (
+            <div
+              key={`poll-${index}`}
+              className={cn(
+                'relative overflow-hidden rounded-lg border px-3 py-2.5 text-sm',
+                mine ? 'border-primary' : 'border-border'
+              )}
+            >
+              <div
+                className={cn(
+                  'absolute inset-y-0 left-0 transition-[width] duration-500',
+                  mine ? 'bg-primary/15' : 'bg-muted'
+                )}
+                style={{ width: `${percentage}%` }}
+              />
+              <div className="relative flex items-center gap-2">
+                <span
+                  className={cn(
+                    'min-w-0 flex-1 truncate',
+                    mine && 'font-semibold'
+                  )}
+                >
+                  {choice.title}
+                  {mine && <span className="text-primary"> ✓</span>}
+                </span>
+                <span className="shrink-0 tabular-nums text-muted-foreground">
+                  {percentage}%
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {canVote ? (
+        <div className="mt-2.5 flex items-center gap-3">
+          <button
+            onClick={handleVote}
+            disabled={isVoting || selectedChoices.length === 0}
+            className="h-8 shrink-0 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isVoting ? 'Voting...' : 'Vote'}
+          </button>
+          {meta}
+        </div>
+      ) : (
+        <div className="mt-2">{meta}</div>
       )}
+
       {voteError ? (
         <p className="mt-2 text-sm text-destructive" role="alert">
           {voteError}
         </p>
-      ) : null}
-
-      {isPollClosed ? <div className="text-sm">Poll closed</div> : null}
-      {!isPollClosed ? (
-        <div className="text-sm">
-          Poll close in {formatDistance(status.endAt, now)}
-        </div>
       ) : null}
     </div>
   )

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -109,10 +109,11 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
             const checked = selectedChoices.includes(index)
             return (
               <label
-                key={`poll-${index}`}
-                htmlFor={`choice-${index}`}
+                key={`poll-${status.id}-${index}`}
+                htmlFor={`choice-${status.id}-${index}`}
                 className={cn(
                   'flex cursor-pointer items-center gap-2.5 rounded-lg border px-3 py-2.5 text-sm transition-colors',
+                  'has-[:focus-visible]:border-ring has-[:focus-visible]:ring-ring/50 has-[:focus-visible]:ring-[3px]',
                   checked
                     ? 'border-primary bg-primary/5'
                     : 'border-border bg-background hover:bg-muted'
@@ -121,7 +122,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
                 <input
                   className="sr-only"
                   type={isMultiple ? 'checkbox' : 'radio'}
-                  id={`choice-${index}`}
+                  id={`choice-${status.id}-${index}`}
                   checked={checked}
                   onChange={() => handleChoiceChange(index)}
                   name={`poll-${status.id}`}


### PR DESCRIPTION
## Summary

Updates the **poll status** (timeline poll display) and the **poll editor in the post box** to match the Activities.next design-system handoff (`ui_kits/web` — `Poll.jsx` and the `Composer.jsx` poll editor). Only the rendered markup/styling changes; all behaviour, state, and data flow are preserved.

### Poll status — `lib/components/posts/poll.tsx`
- Choice cards are now bordered, rounded rows with custom radio/checkbox indicators and a primary-accent **selected** state (orange border + tinted fill + filled dot/check).
- Results render as rows with an accent fill **bar**, an integer **percentage** on the right, bold text + an accent **✓** on the viewer's own votes.
- A meta line below: `N votes · [Choose multiple · ]Poll closes in …` (or `Poll closed`).
- The `Vote` button uses the primary accent and stays disabled until a choice is selected.
- Preserved exactly: the `currentTime: number` prop, both timer effects, `votePoll` + error handling (selection retained on failure), the real `<input>`+`<label>` markup (so `getByLabelText`/`toBeChecked` and the no-`Date.now()`-in-render hydration rule still hold), and the `Poll closed` string.

### Post-box poll editor — `lib/components/post-box/poll-choices.tsx`
- Wrapped in a card with a `POLL` header (bar-chart icon) and a remove (**X**) control.
- Numbered choice inputs with per-row remove buttons (disabled at the 2-choice minimum).
- A text **Add choice** affordance (hidden once the max of 5 is reached, instead of a disabled button).
- Footer divider with an **Ends in** `<Select>` and an **Allow multiple choices** `Switch`.
- Duration labels are sentence-case (`1 day`) and the default duration is now **1 day** to match the design. Choice text inputs stay uncontrolled (`defaultValue`) as before — there is no `setChoiceText` reducer action.
- `post-box.tsx` passes a new `onRemove` that dispatches `setPollVisibility(false)`.

Both components use the existing semantic Tailwind tokens (`primary`, `border`, `muted-foreground`, …), which already resolve to the design's `hsl(24 95% 46%)` accent etc.

## Verification
- `yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test` (3329 tests) all green.
- Browser-verified against a local SQLite instance with seeded polls: unvoted single-choice (radio + selected state + Vote), voted multi-choice (result bars + ✓ + `247 votes · Choose multiple · …`), and the post-box editor (add choice, multiple-choices toggle).

## Notes
- Closing-time text uses date-fns `formatDistance` (the existing behaviour), so it reads e.g. `Poll closes in about 24 hours` rather than the prototype's `1 day` rounding — a pre-existing detail left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)