### PR TITLE
Bump version to v1.40.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.2",
+  "version": "1.40.3",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.40.2`
- Base main SHA: `9856ecb63a50b7c6dd6be72489836de981bd8936`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
