### PR TITLE
fix: render orange message-bubble links white for readable contrast

### DIFF
--- a/app/(timeline)/messages/MessageBubble.tsx
+++ b/app/(timeline)/messages/MessageBubble.tsx
@@ -213,7 +213,7 @@ export const MessageBubble: FC<MessageBubbleProps> = ({
             className={cn(
               'markdown-content max-w-full overflow-hidden break-words rounded-2xl px-3.5 py-2 text-sm leading-relaxed',
               isOwn
-                ? 'rounded-br-md bg-primary text-primary-foreground [&_a]:text-primary-foreground [&_a]:underline'
+                ? 'on-primary rounded-br-md bg-primary text-primary-foreground'
                 : 'rounded-bl-md bg-muted text-foreground'
             )}
           >

--- a/app/(timeline)/messages/MessagesPage.test.tsx
+++ b/app/(timeline)/messages/MessagesPage.test.tsx
@@ -1034,6 +1034,31 @@ describe('MessagesPage', () => {
     expect(theirs.closest('.justify-start')).not.toBeNull()
   })
 
+  it('flags own (orange) bubbles with on-primary so inline links flip to white', async () => {
+    const receivedStatus: Status = {
+      ...status('them-1', 'Theirs'),
+      actorId: 'https://example.com/users/ada',
+      actor: null,
+      isLocalActor: false
+    }
+    ;(getConversationStatuses as jest.Mock).mockResolvedValue({
+      statuses: [status('me-1', 'Mine'), receivedStatus],
+      nextMaxStatusId: null
+    })
+
+    renderMessagesPage([conversation({ id: 'first', participantName: 'Ada' })])
+
+    const mine = await screen.findByText('Mine')
+    const theirs = await screen.findByText('Theirs')
+
+    // The own bubble's text container carries `on-primary`, which the
+    // `.markdown-content.on-primary a` rule in globals.css uses to render links
+    // white instead of the default blue that fails contrast on orange.
+    expect(mine.closest('.markdown-content')).toHaveClass('on-primary')
+    // Received bubbles keep the default link treatment (no on-primary).
+    expect(theirs.closest('.markdown-content')).not.toHaveClass('on-primary')
+  })
+
   it('renders message bubble text as rich DOM rather than escaped HTML', async () => {
     ;(getConversationStatuses as jest.Mock).mockResolvedValue({
       statuses: [status('rich-1', '**bold**')],

--- a/app/globals.css
+++ b/app/globals.css
@@ -82,11 +82,16 @@
   --link-color: oklch(0.588 0.158 241.966);
   --link-color-hover: oklch(0.518 0.158 241.966);
   /* Link color for use ON the orange/primary surface (sent chat bubbles). The
-     default blue link fails contrast on orange, so links there render white +
-     underlined, like the rest of the bubble text. White works on orange in
-     both light and dark themes, so it is declared once here. */
-  --link-color-on-primary: hsl(0 0% 100%);
-  --link-color-on-primary-hover: hsl(0 0% 100% / 0.82);
+     default blue link fails contrast on orange, so links there render in the
+     primary foreground color (white) like the rest of the bubble text. Aliased
+     to --primary-foreground so it stays in sync with the theme; that token is
+     white in both light and dark, so it is declared once here. */
+  --link-color-on-primary: var(--primary-foreground);
+  --link-color-on-primary-hover: color-mix(
+    in srgb,
+    var(--primary-foreground) 82%,
+    transparent
+  );
 
   /* Preserve original charts/sidebar defaults to prevent breaking */
   --chart-1: oklch(0.646 0.222 41.116);
@@ -234,6 +239,14 @@
 
 .markdown-content.on-primary a:hover {
   color: var(--link-color-on-primary-hover);
+}
+
+/* The global focus ring (--ring) is orange, so it is invisible against the
+   orange bubble. Give links here an explicit high-contrast outline so the
+   keyboard focus indicator stays visible (WCAG 2.4.7 / 1.4.11). */
+.markdown-content.on-primary a:focus-visible {
+  outline: 2px solid var(--link-color-on-primary);
+  outline-offset: 2px;
 }
 
 .markdown-content p {

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,6 +81,12 @@
   /* Link colors for markdown content */
   --link-color: oklch(0.588 0.158 241.966);
   --link-color-hover: oklch(0.518 0.158 241.966);
+  /* Link color for use ON the orange/primary surface (sent chat bubbles). The
+     default blue link fails contrast on orange, so links there render white +
+     underlined, like the rest of the bubble text. White works on orange in
+     both light and dark themes, so it is declared once here. */
+  --link-color-on-primary: hsl(0 0% 100%);
+  --link-color-on-primary-hover: hsl(0 0% 100% / 0.82);
 
   /* Preserve original charts/sidebar defaults to prevent breaking */
   --chart-1: oklch(0.646 0.222 41.116);
@@ -215,6 +221,19 @@
 
 .markdown-content a:hover {
   color: var(--link-color-hover);
+}
+
+/* Links sitting on the primary/orange surface (sent message bubbles) flip to
+   white so they stay legible against the brand color. The compound
+   `.markdown-content.on-primary` selector outranks `.markdown-content a` above,
+   so it wins regardless of source order. Apply `on-primary` to any
+   orange/primary-filled markdown container. */
+.markdown-content.on-primary a {
+  color: var(--link-color-on-primary);
+}
+
+.markdown-content.on-primary a:hover {
+  color: var(--link-color-on-primary-hover);
 }
 
 .markdown-content p {


### PR DESCRIPTION
## Summary

Inline links inside **sent (orange / primary) chat bubbles** on the Messages page rendered in the default blue link color, which fails contrast against the brand orange and is hard to read. This implements the design-system fix from the `Activities.next Design System` handoff bundle (`ui_kits/web/index.html`, chat transcript "Link color contrast").

Per the design system: links on the orange/primary surface flip to **white + underlined**, while received (muted) bubbles keep the normal **blue** link color so links stay distinguishable everywhere.


## Before / After

Real app-rendered link in a sent (orange / primary) message bubble. **Before**, the inline link inherited the global blue link color — barely legible on orange. **After**, it renders white + underlined, matching the bubble text and the design system.

| Before (blue, low contrast) | After (white + underlined) |
| --- | --- |
| <img width="380" alt="Before: blue link on orange bubble" src="https://github.com/user-attachments/assets/c89e876a-8faf-47e0-bb33-d41216ea3f7b" /> | <img width="380" alt="After: white underlined link on orange bubble" src="https://github.com/user-attachments/assets/2eea262e-110f-4ae3-9a27-c0fd9d5f43e3" /> |

## Root cause

The own bubble already carried a Tailwind `[&_a]:text-primary-foreground` utility, but it lived inside `@layer utilities` and lost to the **unlayered** `.markdown-content a` rule in `app/globals.css` (unlayered styles always beat layered ones regardless of specificity). So links stayed blue.

## Changes

- **`app/globals.css`** — add `--link-color-on-primary` / `--link-color-on-primary-hover` tokens (white; declared once since white works on orange in both themes) and a `.markdown-content.on-primary a` rule. The **compound** selector (`0,2,1`) outranks `.markdown-content a` (`0,1,1`) order-independently. Underline/offset are inherited from the base `.markdown-content a` rule.
- **`app/(timeline)/messages/MessageBubble.tsx`** — replace the ineffective `[&_a]:text-primary-foreground [&_a]:underline` utilities with the `on-primary` class on the own (orange) bubble.
- **`app/(timeline)/messages/MessagesPage.test.tsx`** — regression test asserting own bubbles carry `on-primary` and received bubbles do not.

## Verification

- `yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test` (3334 tests) — all green.
- Browser check against a local SQLite DB: computed link color in the **sent orange bubble = `rgb(255,255,255)` (white)**, in the **received gray bubble = blue** (design-system `--link-color`), both underlined. Matches the design's `link-fix-final.png` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
