### PR TITLE
Bump version to v1.40.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.3",
+  "version": "1.40.4",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.40.3`
- Base main SHA: `21a16ace9d075e740fb492aec84ede8a3c954b94`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
