### PR TITLE
fix: align fitness heatmap labels and mobile/tablet stat boxes with design system

### DIFF
--- a/app/(timeline)/fitness/ActorFitnessDashboard.tsx
+++ b/app/(timeline)/fitness/ActorFitnessDashboard.tsx
@@ -161,7 +161,12 @@ export const ActorFitnessDashboard: FC<Props> = ({ actorId }) => {
   }
 
   return (
-    <div className="space-y-5 p-3 sm:p-4">
+    // Container-query context: the fitness page renders inside the sidebar
+    // layout, so the viewport width is a poor proxy for how much room the
+    // content column actually has. Sizing the cards/calendar against the
+    // container (not the viewport) keeps a narrow desktop column from cramming
+    // four big-number cards side by side — the tablet/mobile complaint.
+    <div className="@container/fitness space-y-5 p-3 sm:p-4">
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex gap-1 rounded border p-0.5">
           {PRESETS.map((item) => (
@@ -223,38 +228,40 @@ export const ActorFitnessDashboard: FC<Props> = ({ actorId }) => {
       )}
       {error && <p className="text-sm text-destructive">{error}</p>}
 
-      <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
-        <Card className="flex flex-col gap-2 p-4">
+      <div className="grid grid-cols-2 gap-2 @2xl/fitness:grid-cols-4">
+        <Card className="flex min-w-0 flex-col gap-2 p-4">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Activity className="size-3.5" />
             Activities
           </div>
-          <div className="text-2xl font-semibold">{totals.count}</div>
+          <div className="whitespace-nowrap text-xl font-semibold tabular-nums @3xl/fitness:text-2xl">
+            {totals.count}
+          </div>
         </Card>
-        <Card className="flex flex-col gap-2 p-4">
+        <Card className="flex min-w-0 flex-col gap-2 p-4">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Route className="size-3.5" />
             Distance
           </div>
-          <div className="text-2xl font-semibold">
+          <div className="whitespace-nowrap text-xl font-semibold tabular-nums @3xl/fitness:text-2xl">
             {formatDistance(totals.totalDistanceMeters)}
           </div>
         </Card>
-        <Card className="flex flex-col gap-2 p-4">
+        <Card className="flex min-w-0 flex-col gap-2 p-4">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Clock className="size-3.5" />
             Duration
           </div>
-          <div className="text-2xl font-semibold">
+          <div className="whitespace-nowrap text-xl font-semibold tabular-nums @3xl/fitness:text-2xl">
             {formatDuration(totals.totalDurationSeconds)}
           </div>
         </Card>
-        <Card className="flex flex-col gap-2 p-4">
+        <Card className="flex min-w-0 flex-col gap-2 p-4">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Mountain className="size-3.5" />
             Elevation
           </div>
-          <div className="text-2xl font-semibold">
+          <div className="whitespace-nowrap text-xl font-semibold tabular-nums @3xl/fitness:text-2xl">
             {Math.round(totals.totalElevationGainMeters)} m
           </div>
         </Card>
@@ -273,7 +280,7 @@ export const ActorFitnessDashboard: FC<Props> = ({ actorId }) => {
       )}
 
       {isRangeValid && !isLoading && !error && summary.length > 0 && (
-        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="grid gap-5 @3xl/fitness:grid-cols-[minmax(0,1fr)_360px]">
           <section>
             <Card className="flex flex-col gap-3 p-4">
               <div className="flex flex-wrap items-center justify-between gap-3">

--- a/app/(timeline)/fitness/ActorFitnessDashboard.tsx
+++ b/app/(timeline)/fitness/ActorFitnessDashboard.tsx
@@ -280,7 +280,7 @@ export const ActorFitnessDashboard: FC<Props> = ({ actorId }) => {
       )}
 
       {isRangeValid && !isLoading && !error && summary.length > 0 && (
-        <div className="grid gap-5 @3xl/fitness:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="grid grid-cols-1 gap-5 @3xl/fitness:grid-cols-[minmax(0,1fr)_360px]">
           <section>
             <Card className="flex flex-col gap-3 p-4">
               <div className="flex flex-wrap items-center justify-between gap-3">

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -1171,6 +1171,8 @@ export const FitnessHeatmapView: FC<Props> = ({
               metric={calendarMetric}
               periodType={periodType}
               periodKey={effectivePeriodKey}
+              // This calendar sits directly on the page background, not a card.
+              surfaceClassName="bg-background"
             />
           </section>
         </main>

--- a/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
@@ -63,11 +63,11 @@ describe('FitnessCalendarHeatmap', () => {
     expect(screen.queryByText('2026')).not.toBeInTheDocument()
   })
 
-  it('collapses to a single label per column when a range starts mid-month', () => {
+  it('keeps both labels without overlap when a range starts mid-month', () => {
     // The range starts Jan 30, so the first week (Jan 26–Feb 1) crosses the
     // Jan→Feb boundary. Both labels would otherwise claim week 0 and overlap;
-    // they collapse into the column keeping the most recent period (Feb), which
-    // owns the bulk of that first partial week. Jan is dropped, not overlapped.
+    // the later one (Feb) is nudged to the next column so Jan, Feb and Mar all
+    // stay visible and none overlap.
     render(
       <FitnessCalendarHeatmap
         days={[day('2026-02-10')]}
@@ -78,9 +78,9 @@ describe('FitnessCalendarHeatmap', () => {
         endDate={Date.UTC(2026, 2, 1)}
       />
     )
+    expect(screen.getByText('Jan')).toBeInTheDocument()
     expect(screen.getByText('Feb')).toBeInTheDocument()
     expect(screen.getByText('Mar')).toBeInTheDocument()
-    expect(screen.queryByText('Jan')).not.toBeInTheDocument()
   })
 
   it('shows year markers alongside month labels for a multi-year span', () => {

--- a/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { FitnessCalendarDay } from '@/lib/client'
+
+import { FitnessCalendarHeatmap } from './FitnessCalendarHeatmap'
+
+const day = (date: string, count = 1): FitnessCalendarDay => ({
+  date,
+  count,
+  totalDistanceMeters: count * 1000,
+  totalDurationSeconds: count * 600
+})
+
+describe('FitnessCalendarHeatmap', () => {
+  it('renders an empty-state message when there is no data', () => {
+    render(
+      <FitnessCalendarHeatmap
+        days={[]}
+        metric="count"
+        periodType="all_time"
+        periodKey="all"
+      />
+    )
+    expect(
+      screen.getByText('No activity data for this period')
+    ).toBeInTheDocument()
+  })
+
+  it('always renders the Mon/Wed/Fri day labels', () => {
+    render(
+      <FitnessCalendarHeatmap
+        days={[day('2026-01-15')]}
+        metric="count"
+        periodType="all_time"
+        periodKey="all"
+        startDate={Date.UTC(2026, 0, 1)}
+        endDate={Date.UTC(2026, 1, 28)}
+      />
+    )
+    expect(screen.getByText('Mon')).toBeInTheDocument()
+    expect(screen.getByText('Wed')).toBeInTheDocument()
+    expect(screen.getByText('Fri')).toBeInTheDocument()
+  })
+
+  it('shows month labels (and no year markers) for a short span', () => {
+    render(
+      <FitnessCalendarHeatmap
+        days={[day('2026-01-15'), day('2026-02-10')]}
+        metric="count"
+        periodType="all_time"
+        periodKey="all"
+        startDate={Date.UTC(2026, 0, 1)}
+        endDate={Date.UTC(2026, 1, 28)}
+      />
+    )
+    expect(screen.getByText('Jan')).toBeInTheDocument()
+    expect(screen.getByText('Feb')).toBeInTheDocument()
+    // A short span must not switch to the year-marker header.
+    expect(screen.queryByText('2026')).not.toBeInTheDocument()
+  })
+
+  it('shows year markers alongside month labels for a multi-year span', () => {
+    render(
+      <FitnessCalendarHeatmap
+        days={[day('2023-06-01'), day('2024-06-01'), day('2025-04-01')]}
+        metric="count"
+        periodType="all_time"
+        periodKey="all"
+        startDate={Date.UTC(2023, 0, 1)}
+        endDate={Date.UTC(2025, 5, 1)}
+      />
+    )
+    // Long spans get a year row...
+    expect(screen.getByText('2023')).toBeInTheDocument()
+    expect(screen.getByText('2024')).toBeInTheDocument()
+    expect(screen.getByText('2025')).toBeInTheDocument()
+    // ...with month labels still rendered beneath it.
+    expect(screen.getAllByText('Jan').length).toBeGreaterThan(0)
+  })
+})

--- a/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
@@ -63,10 +63,11 @@ describe('FitnessCalendarHeatmap', () => {
     expect(screen.queryByText('2026')).not.toBeInTheDocument()
   })
 
-  it('keeps a single label per column when a range starts mid-month', () => {
+  it('collapses to a single label per column when a range starts mid-month', () => {
     // The range starts Jan 30, so the first week (Jan 26–Feb 1) crosses the
     // Jan→Feb boundary. Both labels would otherwise claim week 0 and overlap;
-    // the column keeps the month it starts in (Jan).
+    // they collapse into the column keeping the most recent period (Feb), which
+    // owns the bulk of that first partial week. Jan is dropped, not overlapped.
     render(
       <FitnessCalendarHeatmap
         days={[day('2026-02-10')]}
@@ -77,11 +78,9 @@ describe('FitnessCalendarHeatmap', () => {
         endDate={Date.UTC(2026, 2, 1)}
       />
     )
-    expect(screen.getByText('Jan')).toBeInTheDocument()
+    expect(screen.getByText('Feb')).toBeInTheDocument()
     expect(screen.getByText('Mar')).toBeInTheDocument()
-    // Feb's boundary fell inside the first partial week, so it is collapsed
-    // into the starting column rather than overlapping it.
-    expect(screen.queryByText('Feb')).not.toBeInTheDocument()
+    expect(screen.queryByText('Jan')).not.toBeInTheDocument()
   })
 
   it('shows year markers alongside month labels for a multi-year span', () => {

--- a/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
@@ -63,6 +63,27 @@ describe('FitnessCalendarHeatmap', () => {
     expect(screen.queryByText('2026')).not.toBeInTheDocument()
   })
 
+  it('keeps a single label per column when a range starts mid-month', () => {
+    // The range starts Jan 30, so the first week (Jan 26–Feb 1) crosses the
+    // Jan→Feb boundary. Both labels would otherwise claim week 0 and overlap;
+    // the column keeps the month it starts in (Jan).
+    render(
+      <FitnessCalendarHeatmap
+        days={[day('2026-02-10')]}
+        metric="count"
+        periodType="all_time"
+        periodKey="all"
+        startDate={Date.UTC(2026, 0, 30)}
+        endDate={Date.UTC(2026, 2, 1)}
+      />
+    )
+    expect(screen.getByText('Jan')).toBeInTheDocument()
+    expect(screen.getByText('Mar')).toBeInTheDocument()
+    // Feb's boundary fell inside the first partial week, so it is collapsed
+    // into the starting column rather than overlapping it.
+    expect(screen.queryByText('Feb')).not.toBeInTheDocument()
+  })
+
   it('shows year markers alongside month labels for a multi-year span', () => {
     render(
       <FitnessCalendarHeatmap

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -3,6 +3,7 @@
 import { FC, useMemo } from 'react'
 
 import { FitnessCalendarDay } from '@/lib/client'
+import { cn } from '@/lib/utils'
 
 export type CalendarMetric = 'count' | 'distance' | 'duration'
 
@@ -240,7 +241,11 @@ const StickyLabelRow: FC<{
             style={{ width: segmentWeeks * CELL }}
           >
             <span
-              className={`sticky left-0 inline-block whitespace-nowrap pr-1.5 ${surfaceClassName} ${className}`}
+              className={cn(
+                'sticky left-0 inline-block whitespace-nowrap pr-1.5',
+                surfaceClassName,
+                className
+              )}
             >
               {item.label}
             </span>
@@ -374,7 +379,7 @@ export const FitnessCalendarHeatmap: FC<Props> = ({
                   return (
                     <div
                       key={di}
-                      className={`h-3 w-3 rounded-sm ${colorClass}`}
+                      className={cn('h-3 w-3 rounded-sm', colorClass)}
                       title={tooltip}
                     />
                   )

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -13,6 +13,10 @@ interface Props {
   periodKey: string
   startDate?: number
   endDate?: number
+  // Tailwind background class of the surface the calendar sits on. The sticky
+  // period labels use it to occlude the next label as it scrolls underneath, so
+  // it must match the container behind them (a card vs. the page background).
+  surfaceClassName?: string
 }
 
 const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', '']
@@ -207,13 +211,15 @@ const getDateRange = (
 // viewport: each label is pinned inside a segment spanning its own period, so it
 // stays visible until the next period scrolls in and pushes it out (the same
 // behaviour as a GitHub contribution graph). The label carries an opaque
-// `bg-card` so it cleanly occludes the next label as that one scrolls under it.
+// `surfaceClassName` so it cleanly occludes the next label as that one scrolls
+// under it.
 const StickyLabelRow: FC<{
   items: PeriodLabel[]
   totalWeeks: number
   height: number
   className: string
-}> = ({ items, totalWeeks, height, className }) => {
+  surfaceClassName: string
+}> = ({ items, totalWeeks, height, className, surfaceClassName }) => {
   if (items.length === 0) {
     return <div style={{ height, width: totalWeeks * CELL }} />
   }
@@ -233,7 +239,7 @@ const StickyLabelRow: FC<{
             style={{ width: segmentWeeks * CELL }}
           >
             <span
-              className={`sticky left-0 inline-block whitespace-nowrap bg-card pr-1.5 ${className}`}
+              className={`sticky left-0 inline-block whitespace-nowrap pr-1.5 ${surfaceClassName} ${className}`}
             >
               {item.label}
             </span>
@@ -250,7 +256,8 @@ export const FitnessCalendarHeatmap: FC<Props> = ({
   periodType,
   periodKey,
   startDate,
-  endDate
+  endDate,
+  surfaceClassName = 'bg-card'
 }) => {
   const dayMap = useMemo(() => {
     const map = new Map<string, FitnessCalendarDay>()
@@ -328,12 +335,14 @@ export const FitnessCalendarHeatmap: FC<Props> = ({
                 totalWeeks={totalWeeks}
                 height={16}
                 className="text-[10px] font-semibold text-foreground"
+                surfaceClassName={surfaceClassName}
               />
               <StickyLabelRow
                 items={grid.monthLabels}
                 totalWeeks={totalWeeks}
                 height={14}
                 className="text-[9px] leading-none text-muted-foreground"
+                surfaceClassName={surfaceClassName}
               />
             </div>
           ) : (
@@ -342,6 +351,7 @@ export const FitnessCalendarHeatmap: FC<Props> = ({
               totalWeeks={totalWeeks}
               height={16}
               className="text-[10px] text-muted-foreground"
+              surfaceClassName={surfaceClassName}
             />
           )}
 

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -31,6 +31,15 @@ const MONTH_NAMES = [
   'Dec'
 ]
 
+const MS_DAY = 24 * 60 * 60 * 1000
+// Width of a single week column: a 12px (h-3/w-3) cell plus the 2px (gap-0.5)
+// gutter. The label rows are positioned against this stride so they stay
+// aligned with the grid columns.
+const CELL = 14
+// Spans longer than ~14 months switch from dense month labels to a year row
+// (with a lighter month row beneath it) so a multi-year range stays legible.
+const YEAR_LABEL_SPAN_DAYS = 430
+
 const getMetricValue = (day: FitnessCalendarDay, metric: CalendarMetric) => {
   switch (metric) {
     case 'count':
@@ -73,9 +82,17 @@ const formatTooltipValue = (
   }
 }
 
+// A label pinned to the start of the period it names. `weekIndex` is the grid
+// column where the period begins, so the label can be positioned by stride.
+interface PeriodLabel {
+  label: string
+  weekIndex: number
+}
+
 interface CalendarGrid {
   weeks: Array<Array<{ date: string; day: FitnessCalendarDay | null } | null>>
-  monthLabels: Array<{ label: string; weekIndex: number }>
+  monthLabels: PeriodLabel[]
+  yearLabels: PeriodLabel[]
 }
 
 const formatDate = (date: Date): string => {
@@ -91,7 +108,8 @@ const buildGrid = (
   dayMap: Map<string, FitnessCalendarDay>
 ): CalendarGrid => {
   const weeks: CalendarGrid['weeks'] = []
-  const monthLabels: CalendarGrid['monthLabels'] = []
+  const monthLabels: PeriodLabel[] = []
+  const yearLabels: PeriodLabel[] = []
 
   const current = new Date(startDate)
   const dayOfWeek = current.getUTCDay()
@@ -99,6 +117,7 @@ const buildGrid = (
   current.setUTCDate(current.getUTCDate() + mondayOffset)
 
   let lastMonth = -1
+  let lastYear = -1
 
   while (current <= endDate || weeks.length === 0) {
     const week: CalendarGrid['weeks'][0] = []
@@ -112,16 +131,22 @@ const buildGrid = (
           date: dateStr,
           day: dayMap.get(dateStr) ?? null
         })
+
+        const month = current.getUTCMonth()
+        const year = current.getUTCFullYear()
+        if (year !== lastYear) {
+          lastYear = year
+          yearLabels.push({ label: String(year), weekIndex: weeks.length })
+        }
+        if (month !== lastMonth) {
+          lastMonth = month
+          monthLabels.push({
+            label: MONTH_NAMES[month],
+            weekIndex: weeks.length
+          })
+        }
       } else {
         week.push(null)
-      }
-
-      if (current.getUTCMonth() !== lastMonth && inRange) {
-        lastMonth = current.getUTCMonth()
-        monthLabels.push({
-          label: MONTH_NAMES[lastMonth],
-          weekIndex: weeks.length
-        })
       }
 
       current.setUTCDate(current.getUTCDate() + 1)
@@ -130,7 +155,7 @@ const buildGrid = (
     weeks.push(week)
   }
 
-  return { weeks, monthLabels }
+  return { weeks, monthLabels, yearLabels }
 }
 
 const getDateRange = (
@@ -160,6 +185,47 @@ const getDateRange = (
     Date.UTC(now.getUTCFullYear() - 1, now.getUTCMonth(), now.getUTCDate())
   )
   return { start, end: now }
+}
+
+// A horizontal row of labels that "stick" to the left edge of the scroll
+// viewport: each label is pinned inside a segment spanning its own period, so it
+// stays visible until the next period scrolls in and pushes it out (the same
+// behaviour as a GitHub contribution graph). The label carries an opaque
+// `bg-card` so it cleanly occludes the next label as that one scrolls under it.
+const StickyLabelRow: FC<{
+  items: PeriodLabel[]
+  totalWeeks: number
+  height: number
+  className: string
+}> = ({ items, totalWeeks, height, className }) => {
+  if (items.length === 0) {
+    return <div style={{ height, width: totalWeeks * CELL }} />
+  }
+
+  const lead = items[0].weekIndex
+  return (
+    <div className="flex" style={{ height, width: totalWeeks * CELL }}>
+      {lead > 0 && <div className="shrink-0" style={{ width: lead * CELL }} />}
+      {items.map((item, index) => {
+        const next = items[index + 1]
+        const segmentWeeks =
+          (next ? next.weekIndex : totalWeeks) - item.weekIndex
+        return (
+          <div
+            key={index}
+            className="shrink-0"
+            style={{ width: segmentWeeks * CELL }}
+          >
+            <span
+              className={`sticky left-0 inline-block whitespace-nowrap bg-card pr-1.5 ${className}`}
+            >
+              {item.label}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 export const FitnessCalendarHeatmap: FC<Props> = ({
@@ -208,60 +274,85 @@ export const FitnessCalendarHeatmap: FC<Props> = ({
     )
   }
 
+  const totalWeeks = grid.weeks.length
+  const gridWidth = totalWeeks * CELL
+  const spanDays = (end.getTime() - start.getTime()) / MS_DAY
+  const useYearLabels = spanDays > YEAR_LABEL_SPAN_DAYS
+  // Year mode stacks a 16px year row over a 14px month row (plus the 2px gap),
+  // so the day-label column needs a matching 32px spacer to stay aligned.
+  const headerHeight = useYearLabels ? 32 : 16
+
   return (
-    <div className="overflow-x-auto">
-      <div className="inline-flex flex-col gap-0.5">
-        {/* Month labels — absolute positioning so labels align with week columns */}
-        <div className="relative h-4" style={{ marginLeft: '30px' }}>
-          {grid.monthLabels.map((ml, i) => (
-            <span
+    <div className="flex gap-0.5">
+      {/* Fixed left column — day labels stay out of the horizontal scroll area,
+          so the scrollbar spans only the grid (never runs under the labels). */}
+      <div className="flex shrink-0 flex-col gap-1">
+        <div style={{ height: headerHeight }} />
+        <div className="flex w-7 flex-col gap-0.5">
+          {DAY_LABELS.map((label, i) => (
+            <div
               key={i}
-              className="absolute top-0 text-xs text-muted-foreground"
-              style={{ left: `${ml.weekIndex * 14}px` }}
+              className="flex h-3 items-center text-[10px] leading-none text-muted-foreground"
             >
-              {ml.label}
-            </span>
+              {label}
+            </div>
           ))}
         </div>
+      </div>
 
-        {/* Grid rows (one per day of week) */}
-        <div className="flex gap-0.5">
-          {/* Day labels */}
-          <div className="flex w-7 flex-col gap-0.5">
-            {DAY_LABELS.map((label, i) => (
-              <div
-                key={i}
-                className="flex h-3 items-center text-[10px] leading-none text-muted-foreground"
-              >
-                {label}
+      {/* Scrollable grid with sticky period labels */}
+      <div className="overflow-x-auto">
+        <div className="inline-flex flex-col gap-1">
+          {useYearLabels ? (
+            <div className="flex flex-col gap-0.5" style={{ width: gridWidth }}>
+              <StickyLabelRow
+                items={grid.yearLabels}
+                totalWeeks={totalWeeks}
+                height={16}
+                className="text-[10px] font-semibold text-foreground"
+              />
+              <StickyLabelRow
+                items={grid.monthLabels}
+                totalWeeks={totalWeeks}
+                height={14}
+                className="text-[9px] leading-none text-muted-foreground"
+              />
+            </div>
+          ) : (
+            <StickyLabelRow
+              items={grid.monthLabels}
+              totalWeeks={totalWeeks}
+              height={16}
+              className="text-[10px] text-muted-foreground"
+            />
+          )}
+
+          {/* Week columns */}
+          <div className="flex gap-0.5">
+            {grid.weeks.map((week, wi) => (
+              <div key={wi} className="flex flex-col gap-0.5">
+                {week.map((cell, di) => {
+                  if (!cell) {
+                    return <div key={di} className="h-3 w-3" />
+                  }
+
+                  const value = cell.day ? getMetricValue(cell.day, metric) : 0
+                  const colorClass = getColorClass(value, maxValue)
+                  const tooltip = cell.day
+                    ? formatTooltipValue(cell.day, metric)
+                    : `${cell.date}: No activity`
+
+                  return (
+                    <div
+                      key={di}
+                      className={`h-3 w-3 rounded-sm ${colorClass}`}
+                      title={tooltip}
+                    />
+                  )
+                })}
               </div>
             ))}
           </div>
-
-          {/* Week columns */}
-          {grid.weeks.map((week, wi) => (
-            <div key={wi} className="flex flex-col gap-0.5">
-              {week.map((cell, di) => {
-                if (!cell) {
-                  return <div key={di} className="h-3 w-3" />
-                }
-
-                const value = cell.day ? getMetricValue(cell.day, metric) : 0
-                const colorClass = getColorClass(value, maxValue)
-                const tooltip = cell.day
-                  ? formatTooltipValue(cell.day, metric)
-                  : `${cell.date}: No activity`
-
-                return (
-                  <div
-                    key={di}
-                    className={`h-3 w-3 rounded-sm ${colorClass}`}
-                    title={tooltip}
-                  />
-                )
-              })}
-            </div>
-          ))}
         </div>
       </div>
     </div>

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -106,12 +106,13 @@ const formatDate = (date: Date): string => {
   return `${y}-${m}-${d}`
 }
 
-// Register at most one label per grid column. When the range starts mid-period
-// and the next period also begins inside that first partial week, both would
-// claim the same `weekIndex` and `StickyLabelRow` would render a zero-width
-// segment, overlapping the two labels at the left edge. Collapse them into the
-// column, keeping the most recent period — it owns the bulk of that first
-// partial week (e.g. a range starting Jan 30 is mostly February).
+// Register one label per grid column. When the range starts mid-period and the
+// next period also begins inside that first partial week, both would claim the
+// same `weekIndex` and `StickyLabelRow` would render a zero-width segment,
+// overlapping the two labels at the left edge. Nudge the later label to the
+// next column instead, so both stay visible and neither overlaps. (Only the
+// first partial week can collide, and every range that reaches here spans more
+// than one week, so the shifted column always exists.)
 const pushLabel = (
   labels: PeriodLabel[],
   label: string,
@@ -119,7 +120,7 @@ const pushLabel = (
 ): void => {
   const last = labels[labels.length - 1]
   if (last && last.weekIndex === weekIndex) {
-    last.label = label
+    labels.push({ label, weekIndex: weekIndex + 1 })
     return
   }
   labels.push({ label, weekIndex })

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -105,14 +105,17 @@ const formatDate = (date: Date): string => {
 // Register at most one label per grid column. When the range starts mid-period
 // and the next period also begins inside that first partial week, both would
 // claim the same `weekIndex` and `StickyLabelRow` would render a zero-width
-// segment, overlapping the two labels at the left edge. Keep the first (the
-// period the column starts in).
+// segment, overlapping the two labels at the left edge. Collapse them into the
+// column, keeping the most recent period — it owns the bulk of that first
+// partial week (e.g. a range starting Jan 30 is mostly February).
 const pushLabel = (
   labels: PeriodLabel[],
   label: string,
   weekIndex: number
 ): void => {
-  if (labels.length > 0 && labels[labels.length - 1].weekIndex === weekIndex) {
+  const last = labels[labels.length - 1]
+  if (last && last.weekIndex === weekIndex) {
+    last.label = label
     return
   }
   labels.push({ label, weekIndex })

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -102,6 +102,22 @@ const formatDate = (date: Date): string => {
   return `${y}-${m}-${d}`
 }
 
+// Register at most one label per grid column. When the range starts mid-period
+// and the next period also begins inside that first partial week, both would
+// claim the same `weekIndex` and `StickyLabelRow` would render a zero-width
+// segment, overlapping the two labels at the left edge. Keep the first (the
+// period the column starts in).
+const pushLabel = (
+  labels: PeriodLabel[],
+  label: string,
+  weekIndex: number
+): void => {
+  if (labels.length > 0 && labels[labels.length - 1].weekIndex === weekIndex) {
+    return
+  }
+  labels.push({ label, weekIndex })
+}
+
 const buildGrid = (
   startDate: Date,
   endDate: Date,
@@ -136,14 +152,11 @@ const buildGrid = (
         const year = current.getUTCFullYear()
         if (year !== lastYear) {
           lastYear = year
-          yearLabels.push({ label: String(year), weekIndex: weeks.length })
+          pushLabel(yearLabels, String(year), weeks.length)
         }
         if (month !== lastMonth) {
           lastMonth = month
-          monthLabels.push({
-            label: MONTH_NAMES[month],
-            weekIndex: weeks.length
-          })
+          pushLabel(monthLabels, MONTH_NAMES[month], weeks.length)
         }
       } else {
         week.push(null)
@@ -300,8 +313,10 @@ export const FitnessCalendarHeatmap: FC<Props> = ({
         </div>
       </div>
 
-      {/* Scrollable grid with sticky period labels */}
-      <div className="overflow-x-auto">
+      {/* Scrollable grid with sticky period labels. min-w-0 lets this flex
+          child shrink below its content so it scrolls instead of overflowing
+          the card on narrow screens. */}
+      <div className="min-w-0 overflow-x-auto">
         <div className="inline-flex flex-col gap-1">
           {useYearLabels ? (
             <div className="flex flex-col gap-0.5" style={{ width: gridWidth }}>


### PR DESCRIPTION
## Summary

Aligns the fitness **Overview** page with the Activities.next design system (`ui_kits/web` `Heatmap` + `FitnessPage`). Two areas: the **heat-calendar label behaviour** and the **stat-box sizing on tablet/mobile**.

## Heat calendar (`FitnessCalendarHeatmap`)

- **Year labels for long spans** — a span >430 days (e.g. the **10Y** preset) now renders a **bold year row over a lighter month row** instead of an unreadable run of month names. Short spans keep the single month row.
- **Sticky labels** — each month/year label pins to the left edge of the scroll viewport while its period is in view, then the next one pushes it out (GitHub-contribution-graph style). The label uses a `bg-card` occluder so it stays **dark-mode safe**.
- **Fixed day-label column** — `Mon/Wed/Fri` is lifted out of the horizontal scroll area, so the scrollbar spans only the grid and never runs under the labels.
- **Both consumers preserved** — the dashboard (`startDate`/`endDate`) and the heatmap route (`periodType`/`periodKey`) both still render. The existing **dark-mode-aware** cell colors are unchanged.

## Stat boxes (`ActorFitnessDashboard`)

- **No more value wrapping** — values like `45240.0 km` used to split across two lines; now `whitespace-nowrap` + `tabular-nums` with a responsive value size.
- **Container queries instead of viewport breakpoints** — the page renders inside the sidebar layout, where the **viewport width is a poor proxy for the content-column width** (a 1024px viewport can leave a ~700px column). Sizing against the container (`@container/fitness`) fixes the "tablet, big numbers too tight" complaint directly:
  - narrow column → **2-up** cards (mobile) / **4-up smaller** cards (tablet), calendar + activity-mix **stacked**;
  - full-width column → **larger** values, calendar + activity-mix **side by side**.

  > Note for reviewers: container queries evaluate against the **content-box** (after padding), so the effective breakpoints sit a little below the raw viewport numbers — that's intentional, not an inconsistency.

## Tests

- Adds `FitnessCalendarHeatmap.test.tsx` covering the **month-vs-year label-mode boundary**, the empty state, and the always-present day labels.
- `prettier`, `yarn lint` (0 errors), `yarn build`, and `yarn test` (3306 passing) all green. *(One suite, `oauth/logging`, intermittently SIGSEGVs under parallel load and passes in isolation — unrelated to this change.)*

## Verification

Verified in a local browser (SQLite + mock user + seeded fitness data) at desktop / tablet / mobile widths and on both the dashboard and the heatmap route:

- **Desktop 90D** — month labels, 4-up cards, calendar + mix side by side.
- **Desktop 10Y** — bold year row + month row, labels stick correctly while scrolling (confirmed `2019`/`Apr` pin to the left edge mid-scroll).
- **Mobile 90D** — 2-up cards, values no longer wrap, calendar stacked full-width.
- Heatmap route Activity Calendar still renders via the `periodType`/`periodKey` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)