### PR TITLE
fix: clamp fitness heatmap sticky-label segment to avoid a zero-width column

### DIFF
--- a/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
@@ -99,6 +99,11 @@ describe('FitnessCalendarHeatmap', () => {
     )
     expect(screen.getByText('Jan')).toBeInTheDocument()
     expect(screen.getByText('Feb')).toBeInTheDocument()
+    // The nudged Feb label's segment (its span's parent) must keep a non-zero
+    // width — without the clamp it would compute to 0px on this single-week grid.
+    expect(screen.getByText('Feb').parentElement).not.toHaveStyle({
+      width: '0px'
+    })
   })
 
   it('shows year markers alongside month labels for a multi-year span', () => {

--- a/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.test.tsx
@@ -83,6 +83,24 @@ describe('FitnessCalendarHeatmap', () => {
     expect(screen.getByText('Mar')).toBeInTheDocument()
   })
 
+  it('handles a minimum-range week-aligned span that crosses a month', () => {
+    // Jan 29 2024 is a Monday, so this 7-day range is a single grid week that
+    // still crosses Jan→Feb. The nudged Feb label lands past the only column;
+    // it must render both labels without throwing or collapsing the grid.
+    render(
+      <FitnessCalendarHeatmap
+        days={[day('2024-01-30')]}
+        metric="count"
+        periodType="all_time"
+        periodKey="all"
+        startDate={Date.UTC(2024, 0, 29)}
+        endDate={Date.UTC(2024, 1, 4)}
+      />
+    )
+    expect(screen.getByText('Jan')).toBeInTheDocument()
+    expect(screen.getByText('Feb')).toBeInTheDocument()
+  })
+
   it('shows year markers alongside month labels for a multi-year span', () => {
     render(
       <FitnessCalendarHeatmap

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -237,7 +237,7 @@ const StickyLabelRow: FC<{
         // selection) would otherwise compute a zero-width segment.
         const segmentWeeks = Math.max(
           1,
-          (next ? next.weekIndex : totalWeeks) - item.weekIndex
+          (next?.weekIndex ?? totalWeeks) - item.weekIndex
         )
         return (
           <div

--- a/lib/components/fitness/FitnessCalendarHeatmap.tsx
+++ b/lib/components/fitness/FitnessCalendarHeatmap.tsx
@@ -112,8 +112,8 @@ const formatDate = (date: Date): string => {
 // same `weekIndex` and `StickyLabelRow` would render a zero-width segment,
 // overlapping the two labels at the left edge. Nudge the later label to the
 // next column instead, so both stay visible and neither overlaps. (Only the
-// first partial week can collide, and every range that reaches here spans more
-// than one week, so the shifted column always exists.)
+// first partial week can collide; `StickyLabelRow` clamps the trailing segment
+// so a single-week grid can't produce a zero-width column.)
 const pushLabel = (
   labels: PeriodLabel[],
   label: string,
@@ -232,8 +232,13 @@ const StickyLabelRow: FC<{
       {lead > 0 && <div className="shrink-0" style={{ width: lead * CELL }} />}
       {items.map((item, index) => {
         const next = items[index + 1]
-        const segmentWeeks =
+        // Clamp to at least one column: a label nudged off the end of a
+        // single-week grid (a minimum-range, week-aligned, period-crossing
+        // selection) would otherwise compute a zero-width segment.
+        const segmentWeeks = Math.max(
+          1,
           (next ? next.weekIndex : totalWeeks) - item.weekIndex
+        )
         return (
           <div
             key={index}


### PR DESCRIPTION
## Summary

Small follow-up to [#853](https://github.com/llun/activities.next/pull/853) (fitness heatmap / mobile box sizing). That PR was merged before this last edge-case fix from the review loop could land.

A final independent review pass found a reachable degenerate case in the calendar heatmap's sticky labels: after `pushLabel` nudges a colliding label to `weekIndex + 1`, a **minimum 7-day, week-aligned range that still crosses a month boundary** (e.g. `2024-01-29 → 2024-02-04`, where Jan 29 is a Monday) produces a **single grid week**. The nudged `Feb` label then computes a segment width of `(1 - 1) = 0`, so the label overflows the one-column grid.

Reachable only from the dashboard's exact minimum-range selection; the heatmap route's `getDateRange` (month/year-aligned, ~1y all-time) never hits it. No crash and no label overlap — purely a cosmetic overflow — but the `pushLabel` "the shifted column always exists" invariant was simply false for this case.

## Fix

- Clamp the trailing segment to at least one column in `StickyLabelRow` (`Math.max(1, …)`), so **no** input can produce a zero/negative-width segment regardless of range.
- Correct the now-inaccurate `pushLabel` comment.
- Add a regression test for the degenerate single-week, month-crossing range.

## Tests

`prettier --check`, `yarn lint` (0 errors), `yarn build`, and the heatmap test suite (6 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)