### PR TITLE
Bump version to v1.40.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.5",
+  "version": "1.40.6",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.40.5`
- Base main SHA: `2d560c5d240ff24aceab52d81f8adb47d8cf5b59`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
