### PR TITLE
Bump version to v1.40.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.6",
+  "version": "1.40.7",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.40.6`
- Base main SHA: `e1632bf349d3397baf1f2f819a3db88a2e54f186`
- Included commits: `6`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
