### PR TITLE
minor: add Mastodon favourites list and media show/update endpoints

### DIFF
--- a/app/api/v1/favourites/route.test.ts
+++ b/app/api/v1/favourites/route.test.ts
@@ -1,0 +1,174 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/favourites', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const createRequest = (query = '') =>
+    new NextRequest(`https://llun.test/api/v1/favourites${query}`)
+
+  const createFavouritedStatus = async (name: string, actorId = ACTOR1_ID) => {
+    const statusId = `${ACTOR2_ID}/statuses/favourite-route-${name}`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR2_ID,
+      text: `Favourited route ${name}`,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createLike({ actorId, statusId })
+    return statusId
+  }
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns favourited statuses with favourited=true', async () => {
+    const statusId = await createFavouritedStatus('list-one')
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toContainEqual(
+      expect.objectContaining({
+        id: urlToId(statusId),
+        favourited: true
+      })
+    )
+  })
+
+  it('returns activities_next statuses with favourite cursors when requested', async () => {
+    const statusId = await createFavouritedStatus('activities-next')
+
+    const response = await GET(
+      createRequest('?format=activities_next&limit=1'),
+      {
+        params: Promise.resolve({})
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual({
+      statuses: [
+        expect.objectContaining({
+          id: statusId,
+          isActorLiked: true
+        })
+      ],
+      nextMaxFavouriteId: expect.any(String),
+      prevMinFavouriteId: expect.any(String)
+    })
+  })
+
+  it('paginates with Mastodon Link headers using favourite cursors', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+
+    await createFavouritedStatus('page-one', ACTOR2_ID)
+    await createFavouritedStatus('page-two', ACTOR2_ID)
+
+    const firstResponse = await GET(createRequest('?limit=1'), {
+      params: Promise.resolve({})
+    })
+    expect(firstResponse.status).toBe(200)
+    const firstPage = await firstResponse.json()
+    expect(firstPage).toHaveLength(1)
+
+    const linkHeader = firstResponse.headers.get('Link')
+    expect(linkHeader).toContain('rel="next"')
+    expect(linkHeader).toContain('rel="prev"')
+
+    const maxId = linkHeader?.match(/[?&]max_id=([^&>]+)/)?.[1]
+    expect(maxId).toBeTruthy()
+
+    const secondResponse = await GET(
+      createRequest(`?limit=1&max_id=${maxId}`),
+      {
+        params: Promise.resolve({})
+      }
+    )
+    expect(secondResponse.status).toBe(200)
+    const secondPage = await secondResponse.json()
+    expect(secondPage).toHaveLength(1)
+    expect(secondPage[0].id).not.toBe(firstPage[0].id)
+  })
+
+  it('returns an empty list for invalid pagination cursors', async () => {
+    await createFavouritedStatus('invalid-cursor')
+
+    const response = await GET(createRequest('?max_id=@@@'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([])
+  })
+})

--- a/app/api/v1/favourites/route.ts
+++ b/app/api/v1/favourites/route.ts
@@ -1,0 +1,91 @@
+import { getFavouritedStatusesPage } from '@/lib/services/favourites/getFavouritedStatusesPage'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { TimelineFormat } from '@/lib/services/timelines/const'
+import { Scope } from '@/lib/types/database/operations'
+import { cleanJson } from '@/lib/utils/cleanJson'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 40
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'getFavourites',
+  OAuthGuardAnyScope(
+    [Scope.enum.read, Scope.enum['read:favourites']],
+    async (req, { database, currentActor }) => {
+      const url = new URL(req.url)
+      const parsedLimit = parseInt(
+        url.searchParams.get('limit') || `${DEFAULT_LIMIT}`,
+        10
+      )
+      const limit =
+        Number.isSafeInteger(parsedLimit) && parsedLimit > 0
+          ? Math.min(parsedLimit, MAX_LIMIT)
+          : DEFAULT_LIMIT
+      const format = url.searchParams.get('format')
+
+      const { statuses, nextMaxFavouriteId, prevMinFavouriteId } =
+        await getFavouritedStatusesPage({
+          database,
+          actorId: currentActor.id,
+          currentActor,
+          limit,
+          maxId: url.searchParams.get('max_id'),
+          minId: url.searchParams.get('min_id'),
+          sinceId: url.searchParams.get('since_id')
+        })
+
+      if (format === TimelineFormat.enum.activities_next) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: {
+            statuses: statuses.map((status) => cleanJson(status)),
+            nextMaxFavouriteId,
+            prevMinFavouriteId
+          }
+        })
+      }
+
+      const mastodonStatuses = await getMastodonStatuses(
+        database,
+        statuses,
+        currentActor.id
+      )
+
+      const host = headerHost(req.headers)
+      const buildPaginationUrl = (cursorParam: string, cursorValue: string) => {
+        const params = new URLSearchParams()
+        params.set('limit', limit.toString())
+        params.set(cursorParam, cursorValue)
+
+        return `<https://${host}/api/v1/favourites?${params.toString()}>; rel="${
+          cursorParam === 'max_id' ? 'next' : 'prev'
+        }"`
+      }
+      const nextLink = nextMaxFavouriteId
+        ? buildPaginationUrl('max_id', nextMaxFavouriteId)
+        : null
+      const prevLink = prevMinFavouriteId
+        ? buildPaginationUrl('min_id', prevMinFavouriteId)
+        : null
+      const links = [nextLink, prevLink].filter(Boolean).join(', ')
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: mastodonStatuses,
+        additionalHeaders: [
+          ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
+        ]
+      })
+    }
+  )
+)

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -146,6 +146,18 @@ describe('/api/v1/media/[id]', () => {
     expect(stored?.description).toBe('a new alt text')
   })
 
+  it('PUT clears the description when null is sent', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-clear')
+
+    const response = await PUT(putRequest(id, { description: null }), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.description).toBe('')
+  })
+
   it('PUT leaves the description untouched when not provided', async () => {
     const id = await createMediaFor(ACTOR1_ID, 'put-omit')
 

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -1,0 +1,170 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+
+import { GET, PUT } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v1/media/[id]', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const createMediaFor = async (actorId: string, name: string) => {
+    const media = await database.createMedia({
+      actorId,
+      description: 'before',
+      original: {
+        path: `medias/route-${name}.jpg`,
+        bytes: 1000,
+        mimeType: 'image/jpeg',
+        metaData: { width: 320, height: 240 }
+      }
+    })
+    // Route params always arrive as strings; normalise to mirror production.
+    return String(media!.id)
+  }
+
+  const putRequest = (id: string, body: Record<string, unknown>) =>
+    new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+      method: 'PUT',
+      // Same-origin proof for the cookie-session path (CSRF protection); bearer
+      // clients bypass this in OAuthGuard.
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://llun.test'
+      },
+      body: JSON.stringify(body)
+    })
+
+  const getRequest = (id: string) =>
+    new NextRequest(`https://llun.test/api/v1/media/${id}`)
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    const id = await createMediaFor(ACTOR1_ID, 'auth')
+
+    const response = await GET(getRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('GET returns the media attachment for the owner', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'get-owner')
+
+    const response = await GET(getRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({
+      id,
+      type: 'image',
+      description: 'before',
+      url: `https://llun.test/api/v1/files/medias/route-get-owner.jpg`
+    })
+  })
+
+  it('GET returns 404 for media owned by another account', async () => {
+    const id = await createMediaFor(ACTOR2_ID, 'get-foreign')
+
+    const response = await GET(getRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(404)
+  })
+
+  it('PUT updates the description', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-update')
+
+    const response = await PUT(
+      putRequest(id, { description: 'a new alt text' }),
+      {
+        params: Promise.resolve({ id })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({ id, description: 'a new alt text' })
+
+    const stored = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: (await database.getActorFromId({ id: ACTOR1_ID }))!.account!.id
+    })
+    expect(stored?.description).toBe('a new alt text')
+  })
+
+  it('PUT leaves the description untouched when not provided', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-omit')
+
+    const response = await PUT(putRequest(id, { focus: '0.0,0.0' }), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.description).toBe('before')
+  })
+
+  it('PUT returns 404 for media owned by another account', async () => {
+    const id = await createMediaFor(ACTOR2_ID, 'put-foreign')
+
+    const response = await PUT(putRequest(id, { description: 'nope' }), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -1,0 +1,188 @@
+import { z } from 'zod'
+
+import {
+  OAuthGuard,
+  OAuthGuardAnyScope
+} from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
+import {
+  ERROR_401,
+  ERROR_404,
+  ERROR_422,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PUT
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+// `description` is stored in a varchar(255) column; cap it to avoid a runtime
+// DB error. Empty/whitespace-only descriptions are normalised to null.
+const UpdateMediaRequest = z.object({
+  description: z
+    .string()
+    .max(255)
+    .optional()
+    .transform((value) => (value && value.trim() ? value : null))
+})
+
+const readPayload = async (
+  req: Request
+): Promise<Record<string, unknown> | null> => {
+  const contentType = req.headers.get('content-type') ?? ''
+  try {
+    if (contentType.includes('application/json')) {
+      const body = await req.json()
+      return body && typeof body === 'object'
+        ? (body as Record<string, unknown>)
+        : {}
+    }
+    const form = await req.formData()
+    return Object.fromEntries(form.entries())
+  } catch {
+    return null
+  }
+}
+
+export const GET = traceApiRoute(
+  'getMedia',
+  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
+    const { database, currentActor, params } = context
+    const account = currentActor.account
+    if (!account) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const { id } = (await params) ?? { id: undefined }
+    if (!id) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+    }
+
+    const media = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: account.id
+    })
+    if (!media) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: getMediaAttachment(media, headerHost(req.headers))
+    })
+  })
+)
+
+export const PUT = traceApiRoute(
+  'updateMedia',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:media']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const account = currentActor.account
+      if (!account) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_401,
+          responseStatusCode: 401
+        })
+      }
+
+      const { id } = (await params) ?? { id: undefined }
+      if (!id) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      const payload = await readPayload(req)
+      if (!payload) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      const parsed = UpdateMediaRequest.safeParse(payload)
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      // Only mutate fields the client actually sent so a metadata-only update
+      // (e.g. focus, which we don't persist yet) doesn't clear the description.
+      const descriptionProvided = 'description' in payload
+      const media = descriptionProvided
+        ? await database.updateMedia({
+            mediaId: id,
+            accountId: account.id,
+            description: parsed.data.description
+          })
+        : await database.getMediaByIdForAccount({
+            mediaId: id,
+            accountId: account.id
+          })
+
+      if (!media) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      logger.info({
+        message: 'Media updated',
+        mediaId: id,
+        accountId: account.id
+      })
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: getMediaAttachment(media, headerHost(req.headers))
+      })
+    }
+  )
+)

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -31,11 +31,13 @@ interface Params {
 }
 
 // `description` is stored in a varchar(255) column; cap it to avoid a runtime
-// DB error. Empty/whitespace-only descriptions are normalised to null.
+// DB error. Empty/whitespace-only (and explicit null) descriptions are
+// normalised to null so clients can clear alt text by sending "" or null.
 const UpdateMediaRequest = z.object({
   description: z
     .string()
     .max(255)
+    .nullable()
     .optional()
     .transform((value) => (value && value.trim() ? value : null))
 })

--- a/lib/database/sql/like.test.ts
+++ b/lib/database/sql/like.test.ts
@@ -1,3 +1,4 @@
+import { encodeFavouriteCursor } from '@/lib/database/sql/utils/favouriteCursor'
 import {
   databaseBeforeAll,
   getTestDatabaseTable
@@ -5,6 +6,7 @@ import {
 import { Database } from '@/lib/database/types'
 import { seedDatabase } from '@/lib/stub/database'
 import { DatabaseSeed } from '@/lib/stub/scenarios/database'
+import { Like } from '@/lib/types/database/operations'
 
 describe('LikeDatabase', () => {
   const { actors, statuses } = DatabaseSeed
@@ -223,6 +225,88 @@ describe('LikeDatabase', () => {
           statusId: 'https://nonexistent.status/id'
         })
         // Just verifying no errors are thrown
+      })
+    })
+
+    describe('getLikes', () => {
+      // `actors.empty` has no seeded likes, so this block is isolated from the
+      // mutations performed by the create/delete suites above.
+      const favouriteActorId = actors.empty.id
+      const likedStatuses = [
+        statuses.primary.post,
+        statuses.primary.secondPost,
+        statuses.primary.postWithAttachments,
+        statuses.replyAuthor.replyToPrimary
+      ]
+
+      beforeAll(async () => {
+        for (const statusId of likedStatuses) {
+          await database.createLike({ actorId: favouriteActorId, statusId })
+        }
+      })
+
+      const cursorFor = (like: Like) =>
+        encodeFavouriteCursor({
+          createdAt: like.createdAt,
+          statusId: like.statusId
+        })
+
+      it('returns every favourite for the actor', async () => {
+        const likes = await database.getLikes({
+          actorId: favouriteActorId,
+          limit: 20
+        })
+        expect(likes.map((like) => like.statusId).sort()).toEqual(
+          [...likedStatuses].sort()
+        )
+        likes.forEach((like) => {
+          expect(like.actorId).toEqual(favouriteActorId)
+          expect(typeof like.createdAt).toBe('number')
+        })
+      })
+
+      it('paginates with max_id without gaps or duplicates', async () => {
+        const collectedIds: string[] = []
+        let cursor: string | null = null
+        for (let page = 0; page < likedStatuses.length + 1; page++) {
+          const likes: Like[] = await database.getLikes({
+            actorId: favouriteActorId,
+            limit: 2,
+            maxId: cursor
+          })
+          if (likes.length === 0) break
+          collectedIds.push(...likes.map((like) => like.statusId))
+          cursor = cursorFor(likes[likes.length - 1])
+          if (likes.length < 2) break
+        }
+        expect(new Set(collectedIds).size).toBe(likedStatuses.length)
+        expect(collectedIds.sort()).toEqual([...likedStatuses].sort())
+      })
+
+      it('returns an empty page for a malformed cursor', async () => {
+        const likes = await database.getLikes({
+          actorId: favouriteActorId,
+          limit: 10,
+          maxId: '@@@'
+        })
+        expect(likes).toEqual([])
+      })
+
+      it('returns only newer favourites with min_id', async () => {
+        const all = await database.getLikes({
+          actorId: favouriteActorId,
+          limit: 20
+        })
+        const oldest = all[all.length - 1]
+        const newer = await database.getLikes({
+          actorId: favouriteActorId,
+          limit: 20,
+          minId: cursorFor(oldest)
+        })
+        expect(newer.map((like) => like.statusId)).not.toContain(
+          oldest.statusId
+        )
+        expect(newer).toHaveLength(all.length - 1)
       })
     })
   })

--- a/lib/database/sql/like.ts
+++ b/lib/database/sql/like.ts
@@ -6,13 +6,41 @@ import {
   getCounterValue,
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
+import { decodeFavouriteCursor } from '@/lib/database/sql/utils/favouriteCursor'
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   CreateLikeParams,
   DeleteLikeParams,
   GetLikeCountParams,
+  GetLikesParams,
   IsActorLikedStatusParams,
+  Like,
   LikeDatabase
 } from '@/lib/types/database/operations'
+
+type LikeRow = {
+  actorId: string
+  statusId: string
+  createdAt: number | Date | string
+}
+
+const applyFavouriteCursor = (
+  query: Knex.QueryBuilder,
+  cursor: { createdAt: number; statusId: string },
+  direction: 'newer' | 'older'
+) => {
+  const operator = direction === 'older' ? '<' : '>'
+  const createdAtValue = new Date(cursor.createdAt)
+  query.andWhere((builder) => {
+    builder
+      .where('createdAt', operator, createdAtValue)
+      .orWhere((tieBreaker) => {
+        tieBreaker
+          .where('createdAt', createdAtValue)
+          .andWhere('statusId', operator, cursor.statusId)
+      })
+  })
+}
 
 export const LikeSQLDatabaseMixin = (database: Knex): LikeDatabase => ({
   async createLike({ actorId, statusId }: CreateLikeParams) {
@@ -66,5 +94,45 @@ export const LikeSQLDatabaseMixin = (database: Knex): LikeDatabase => ({
       .where('actorId', actorId)
       .first()
     return Boolean(result)
+  },
+
+  async getLikes({ actorId, limit, maxId, minId, sinceId }: GetLikesParams) {
+    const olderCursorToken = maxId
+    const newerCursorToken = minId || sinceId
+
+    // Reject malformed cursors with an empty page instead of scanning from the
+    // top, matching the bookmarks pagination contract.
+    if (
+      (olderCursorToken && !decodeFavouriteCursor(olderCursorToken)) ||
+      (newerCursorToken && !decodeFavouriteCursor(newerCursorToken))
+    ) {
+      return []
+    }
+
+    const query = database<LikeRow>('likes')
+      .where('actorId', actorId)
+      .limit(limit)
+
+    const olderCursor = decodeFavouriteCursor(olderCursorToken)
+    if (olderCursor) applyFavouriteCursor(query, olderCursor, 'older')
+
+    const newerCursor = decodeFavouriteCursor(newerCursorToken)
+    if (newerCursor) applyFavouriteCursor(query, newerCursor, 'newer')
+
+    if (minId) {
+      query.orderBy('createdAt', 'asc').orderBy('statusId', 'asc')
+    } else {
+      query.orderBy('createdAt', 'desc').orderBy('statusId', 'desc')
+    }
+
+    const rows = await query
+    const ordered = minId ? rows.reverse() : rows
+    return ordered.map(
+      (row): Like => ({
+        actorId: row.actorId,
+        statusId: row.statusId,
+        createdAt: getCompatibleTime(row.createdAt)
+      })
+    )
   }
 })

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -674,5 +674,90 @@ describe('MediaDatabase', () => {
         expect(retrieved?.original.path).toBe('/test/another-random-xyz789.jpg')
       })
     })
+
+    describe('updateMedia', () => {
+      it('updates the description for media owned by the account', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/update-media-desc.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          description: 'updated alt text'
+        })
+
+        expect(updated?.description).toBe('updated alt text')
+        const retrieved = await database.getMediaByIdForAccount({
+          mediaId: media!.id,
+          accountId
+        })
+        expect(retrieved?.description).toBe('updated alt text')
+      })
+
+      it('clears the description when null is provided', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          description: 'original',
+          original: {
+            path: '/test/update-media-clear.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          description: null
+        })
+
+        expect(updated?.description).toBeUndefined()
+      })
+
+      it('returns null when the media is not owned by the account', async () => {
+        const otherActor = await database.getActorFromId({
+          id: actors.replyAuthor.id
+        })
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/update-media-foreign.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId: otherActor!.account!.id,
+          description: 'should not apply'
+        })
+
+        expect(updated).toBeNull()
+      })
+
+      it('returns null for a nonexistent media id', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const updated = await database.updateMedia({
+          mediaId: '99999999',
+          accountId: actor!.account!.id,
+          description: 'nope'
+        })
+        expect(updated).toBeNull()
+      })
+    })
   })
 })

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -24,7 +24,8 @@ import {
   MarkMediaUploadVerifiedParams,
   Media,
   MediaDatabase,
-  PaginatedMediaWithStatus
+  PaginatedMediaWithStatus,
+  UpdateMediaParams
 } from '@/lib/types/database/operations'
 import { Attachment } from '@/lib/types/domain/attachment'
 
@@ -478,6 +479,45 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         'medias.thumbnailMimeType',
         'medias.thumbnailMetaData',
         'medias.description'
+      )
+      .first()
+
+    if (!data) return null
+
+    return parseMediaRow(data)
+  },
+
+  async updateMedia({
+    mediaId,
+    accountId,
+    description
+  }: UpdateMediaParams): Promise<Media | null> {
+    const owned = await database('medias')
+      .join('actors', 'medias.actorId', 'actors.id')
+      .where('medias.id', mediaId)
+      .where('actors.accountId', accountId)
+      .first('medias.id')
+    if (!owned) return null
+
+    await database('medias')
+      .where('id', mediaId)
+      .update({ description: description ?? null, updatedAt: new Date() })
+
+    const data = await database('medias')
+      .where('id', mediaId)
+      .select(
+        'id',
+        'actorId',
+        'original',
+        'originalBytes',
+        'originalMimeType',
+        'originalMetaData',
+        'originalFileName',
+        'thumbnail',
+        'thumbnailBytes',
+        'thumbnailMimeType',
+        'thumbnailMetaData',
+        'description'
       )
       .first()
 

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -499,9 +499,16 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
       .first('medias.id')
     if (!owned) return null
 
-    await database('medias')
-      .where('id', mediaId)
-      .update({ description: description ?? null, updatedAt: new Date() })
+    // Only touch `description` when the caller actually provided it, so a
+    // partial update can't blank out existing alt text by omitting the field.
+    const updates: { updatedAt: Date; description?: string | null } = {
+      updatedAt: new Date()
+    }
+    if (description !== undefined) {
+      updates.description = description
+    }
+
+    await database('medias').where('id', mediaId).update(updates)
 
     const data = await database('medias')
       .where('id', mediaId)

--- a/lib/database/sql/utils/favouriteCursor.test.ts
+++ b/lib/database/sql/utils/favouriteCursor.test.ts
@@ -1,0 +1,41 @@
+import {
+  decodeFavouriteCursor,
+  encodeFavouriteCursor
+} from '@/lib/database/sql/utils/favouriteCursor'
+
+describe('favouriteCursor', () => {
+  it('round-trips a createdAt/statusId pair', () => {
+    const cursor = {
+      createdAt: 1717459200000,
+      statusId: 'https://llun.test/users/test/statuses/post-1'
+    }
+    expect(decodeFavouriteCursor(encodeFavouriteCursor(cursor))).toEqual(cursor)
+  })
+
+  it('preserves status ids that contain colons', () => {
+    const cursor = {
+      createdAt: 42,
+      statusId: 'https://example.social:8443/notes/abc'
+    }
+    expect(decodeFavouriteCursor(encodeFavouriteCursor(cursor))).toEqual(cursor)
+  })
+
+  // '@' and '%' are outside the base64url alphabet, so these decode to an empty
+  // buffer and must be rejected rather than scanning from the top of the list.
+  it.each([null, undefined, '', '@@@', '%%%%'])(
+    'returns null for malformed cursor %p',
+    (value) => {
+      expect(decodeFavouriteCursor(value)).toBeNull()
+    }
+  )
+
+  it('returns null when the createdAt segment is not a number', () => {
+    const encoded = Buffer.from('abc:status', 'utf8').toString('base64url')
+    expect(decodeFavouriteCursor(encoded)).toBeNull()
+  })
+
+  it('returns null when the status id segment is empty', () => {
+    const encoded = Buffer.from('123:', 'utf8').toString('base64url')
+    expect(decodeFavouriteCursor(encoded)).toBeNull()
+  })
+})

--- a/lib/database/sql/utils/favouriteCursor.ts
+++ b/lib/database/sql/utils/favouriteCursor.ts
@@ -1,0 +1,39 @@
+// The `likes` table has a composite primary key `(statusId, actorId)` and no
+// surrogate id, so favourites are paginated by a composite `(createdAt,
+// statusId)` cursor. Mastodon treats `max_id`/`min_id` as opaque, so we encode
+// the pair into a single base64url token rather than exposing the raw values.
+
+export interface FavouriteCursor {
+  createdAt: number
+  statusId: string
+}
+
+export const encodeFavouriteCursor = ({
+  createdAt,
+  statusId
+}: FavouriteCursor): string =>
+  Buffer.from(`${createdAt}:${statusId}`, 'utf8').toString('base64url')
+
+export const decodeFavouriteCursor = (
+  cursor?: string | null
+): FavouriteCursor | null => {
+  if (!cursor) return null
+
+  let decoded: string
+  try {
+    decoded = Buffer.from(cursor, 'base64url').toString('utf8')
+  } catch {
+    return null
+  }
+
+  const separatorIndex = decoded.indexOf(':')
+  if (separatorIndex <= 0) return null
+
+  const createdAt = Number(decoded.slice(0, separatorIndex))
+  const statusId = decoded.slice(separatorIndex + 1)
+  if (!Number.isSafeInteger(createdAt) || createdAt < 0 || !statusId) {
+    return null
+  }
+
+  return { createdAt, statusId }
+}

--- a/lib/services/favourites/getFavouritedStatusesPage.test.ts
+++ b/lib/services/favourites/getFavouritedStatusesPage.test.ts
@@ -3,61 +3,76 @@ import knex, { Knex } from 'knex'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { encodeFavouriteCursor } from '@/lib/database/sql/utils/favouriteCursor'
 import { Database } from '@/lib/database/types'
-import { getFavouritedStatusesPage } from '@/lib/services/favourites/getFavouritedStatusesPage'
+import {
+  MAX_FAVOURITE_BACKFILL_ITERATIONS,
+  getFavouritedStatusesPage
+} from '@/lib/services/favourites/getFavouritedStatusesPage'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { Actor } from '@/lib/types/domain/actor'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
+const newTestDatabase = async () => {
+  const raw = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+  const database = getSQLDatabase(raw)
+  await database.migrate()
+  await seedDatabase(database)
+  return { raw, database }
+}
+
+// Like a status by ACTOR1 with an explicit createdAt so ordering is
+// deterministic (createLike stamps `now()`, which would tie).
+const likeAt = async (
+  raw: Knex,
+  database: Database,
+  statusId: string,
+  createdAtMs: number
+) => {
+  await database.createLike({ actorId: ACTOR1_ID, statusId })
+  await raw('likes')
+    .where({ actorId: ACTOR1_ID, statusId })
+    .update({ createdAt: new Date(createdAtMs) })
+}
+
+const createNote = (database: Database, statusId: string) =>
+  database.createNote({
+    id: statusId,
+    url: statusId,
+    actorId: ACTOR2_ID,
+    text: `favourite ${statusId}`,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: []
+  })
+
+const idsOf = (statuses: { id: string }[]) => statuses.map((s) => s.id)
+
 describe('getFavouritedStatusesPage', () => {
   let raw: Knex
   let database: Database
   let viewer: Actor
 
-  // Five statuses by ACTOR2, all liked by ACTOR1 with strictly increasing
-  // createdAt so ordering is deterministic (no timestamp ties).
   const statusIds = Array.from(
     { length: 5 },
     (_, index) => `${ACTOR2_ID}/statuses/fav-page-${index + 1}`
   )
 
   beforeAll(async () => {
-    raw = knex({
-      client: 'better-sqlite3',
-      useNullAsDefault: true,
-      connection: { filename: ':memory:' }
-    })
-    database = getSQLDatabase(raw)
-    await database.migrate()
-    await seedDatabase(database)
+    ;({ raw, database } = await newTestDatabase())
     viewer = (await database.getActorFromId({ id: ACTOR1_ID }))!
-
-    for (const statusId of statusIds) {
-      await database.createNote({
-        id: statusId,
-        url: statusId,
-        actorId: ACTOR2_ID,
-        text: `favourite ${statusId}`,
-        to: [ACTIVITY_STREAM_PUBLIC],
-        cc: []
-      })
-      await database.createLike({ actorId: ACTOR1_ID, statusId })
-    }
-
-    // Force deterministic, distinct like timestamps (index i → epoch i+1 sec).
     for (let index = 0; index < statusIds.length; index++) {
-      await raw('likes')
-        .where({ actorId: ACTOR1_ID, statusId: statusIds[index] })
-        .update({ createdAt: new Date((index + 1) * 1000) })
+      await createNote(database, statusIds[index])
+      await likeAt(raw, database, statusIds[index], (index + 1) * 1000)
     }
   })
 
   afterAll(async () => {
     await raw.destroy()
   })
-
-  const idsOf = (statuses: { id: string }[]) => statuses.map((s) => s.id)
 
   it('returns all favourites newest-first', async () => {
     const page = await getFavouritedStatusesPage({
@@ -70,16 +85,16 @@ describe('getFavouritedStatusesPage', () => {
   })
 
   it('backfills past an unreadable status during min_id forward pagination', async () => {
-    // min_id at the oldest favourite (fav-page-1).
     const oldestCursor = encodeFavouriteCursor({
       createdAt: 1000,
       statusId: statusIds[0]
     })
 
-    // Delete fav-page-2: it stays liked but is no longer readable, so the page
-    // immediately after min_id (fav-page-2, fav-page-3) loses one entry and the
-    // service must backfill to reach fav-page-4.
-    await database.deleteStatus({ statusId: statusIds[1], actorId: ACTOR2_ID })
+    // Drop only the status row (not via deleteStatus, which would also delete
+    // the like) so fav-page-2 stays liked but unreadable. The page immediately
+    // after min_id (fav-page-2, fav-page-3) then loses an entry and the service
+    // must backfill into the next band to reach fav-page-4.
+    await raw('statuses').where('id', statusIds[1]).delete()
 
     const page = await getFavouritedStatusesPage({
       database,
@@ -92,5 +107,73 @@ describe('getFavouritedStatusesPage', () => {
     // Closest two readable favourites newer than fav-page-1 are fav-page-3 and
     // fav-page-4 (fav-page-2 is gone), presented newest-first.
     expect(idsOf(page.statuses)).toEqual([statusIds[3], statusIds[2]])
+  })
+})
+
+describe('getFavouritedStatusesPage backfill exhaustion', () => {
+  let raw: Knex
+  let database: Database
+  let viewer: Actor
+
+  // Two readable (oldest) favourites buried under a run of unreadable ones
+  // longer than the backfill budget, so the first page scans only unreadable
+  // likes and must still hand back a resume cursor.
+  const unreadableCount = MAX_FAVOURITE_BACKFILL_ITERATIONS * 2 + 2
+  const readableIds = [
+    `${ACTOR2_ID}/statuses/reachable-1`,
+    `${ACTOR2_ID}/statuses/reachable-2`
+  ]
+
+  beforeAll(async () => {
+    ;({ raw, database } = await newTestDatabase())
+    viewer = (await database.getActorFromId({ id: ACTOR1_ID }))!
+
+    // Oldest: two readable favourites (createdAt 1000, 2000).
+    for (let index = 0; index < readableIds.length; index++) {
+      await createNote(database, readableIds[index])
+      await likeAt(raw, database, readableIds[index], (index + 1) * 1000)
+    }
+    // Newer: a long run of liked-but-unreadable statuses (status rows removed).
+    for (let index = 0; index < unreadableCount; index++) {
+      const statusId = `${ACTOR2_ID}/statuses/unreadable-${index + 1}`
+      await createNote(database, statusId)
+      await likeAt(raw, database, statusId, 10000 + index * 1000)
+      await raw('statuses').where('id', statusId).delete()
+    }
+  })
+
+  afterAll(async () => {
+    await raw.destroy()
+  })
+
+  it('does not strand the client when a full backfill window is unreadable', async () => {
+    const firstPage = await getFavouritedStatusesPage({
+      database,
+      actorId: ACTOR1_ID,
+      currentActor: viewer,
+      limit: 2
+    })
+
+    // The newest window is entirely unreadable, so this page is empty — but it
+    // must still expose a next cursor so the client can keep scanning.
+    expect(firstPage.statuses).toHaveLength(0)
+    expect(firstPage.nextMaxFavouriteId).toEqual(expect.any(String))
+
+    // Following the resume cursor must eventually surface the readable ones
+    // rather than dead-ending.
+    let cursor = firstPage.nextMaxFavouriteId
+    const seen: string[] = []
+    for (let i = 0; i < 10 && cursor; i++) {
+      const page = await getFavouritedStatusesPage({
+        database,
+        actorId: ACTOR1_ID,
+        currentActor: viewer,
+        limit: 2,
+        maxId: cursor
+      })
+      seen.push(...idsOf(page.statuses))
+      cursor = page.nextMaxFavouriteId
+    }
+    expect(seen).toEqual(readableIds.reverse())
   })
 })

--- a/lib/services/favourites/getFavouritedStatusesPage.test.ts
+++ b/lib/services/favourites/getFavouritedStatusesPage.test.ts
@@ -1,0 +1,96 @@
+import knex, { Knex } from 'knex'
+
+import { getSQLDatabase } from '@/lib/database/sql'
+import { encodeFavouriteCursor } from '@/lib/database/sql/utils/favouriteCursor'
+import { Database } from '@/lib/database/types'
+import { getFavouritedStatusesPage } from '@/lib/services/favourites/getFavouritedStatusesPage'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { Actor } from '@/lib/types/domain/actor'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+describe('getFavouritedStatusesPage', () => {
+  let raw: Knex
+  let database: Database
+  let viewer: Actor
+
+  // Five statuses by ACTOR2, all liked by ACTOR1 with strictly increasing
+  // createdAt so ordering is deterministic (no timestamp ties).
+  const statusIds = Array.from(
+    { length: 5 },
+    (_, index) => `${ACTOR2_ID}/statuses/fav-page-${index + 1}`
+  )
+
+  beforeAll(async () => {
+    raw = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+    database = getSQLDatabase(raw)
+    await database.migrate()
+    await seedDatabase(database)
+    viewer = (await database.getActorFromId({ id: ACTOR1_ID }))!
+
+    for (const statusId of statusIds) {
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR2_ID,
+        text: `favourite ${statusId}`,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createLike({ actorId: ACTOR1_ID, statusId })
+    }
+
+    // Force deterministic, distinct like timestamps (index i → epoch i+1 sec).
+    for (let index = 0; index < statusIds.length; index++) {
+      await raw('likes')
+        .where({ actorId: ACTOR1_ID, statusId: statusIds[index] })
+        .update({ createdAt: new Date((index + 1) * 1000) })
+    }
+  })
+
+  afterAll(async () => {
+    await raw.destroy()
+  })
+
+  const idsOf = (statuses: { id: string }[]) => statuses.map((s) => s.id)
+
+  it('returns all favourites newest-first', async () => {
+    const page = await getFavouritedStatusesPage({
+      database,
+      actorId: ACTOR1_ID,
+      currentActor: viewer,
+      limit: 10
+    })
+    expect(idsOf(page.statuses)).toEqual([...statusIds].reverse())
+  })
+
+  it('backfills past an unreadable status during min_id forward pagination', async () => {
+    // min_id at the oldest favourite (fav-page-1).
+    const oldestCursor = encodeFavouriteCursor({
+      createdAt: 1000,
+      statusId: statusIds[0]
+    })
+
+    // Delete fav-page-2: it stays liked but is no longer readable, so the page
+    // immediately after min_id (fav-page-2, fav-page-3) loses one entry and the
+    // service must backfill to reach fav-page-4.
+    await database.deleteStatus({ statusId: statusIds[1], actorId: ACTOR2_ID })
+
+    const page = await getFavouritedStatusesPage({
+      database,
+      actorId: ACTOR1_ID,
+      currentActor: viewer,
+      limit: 2,
+      minId: oldestCursor
+    })
+
+    // Closest two readable favourites newer than fav-page-1 are fav-page-3 and
+    // fav-page-4 (fav-page-2 is gone), presented newest-first.
+    expect(idsOf(page.statuses)).toEqual([statusIds[3], statusIds[2]])
+  })
+})

--- a/lib/services/favourites/getFavouritedStatusesPage.ts
+++ b/lib/services/favourites/getFavouritedStatusesPage.ts
@@ -1,0 +1,129 @@
+import { encodeFavouriteCursor } from '@/lib/database/sql/utils/favouriteCursor'
+import type { Database } from '@/lib/database/types'
+import { filterReadableStatuses } from '@/lib/services/statusRouteAccess'
+import type { Like } from '@/lib/types/database/operations'
+import type { Actor } from '@/lib/types/domain/actor'
+import type { Status } from '@/lib/types/domain/status'
+
+export const MAX_FAVOURITE_BACKFILL_ITERATIONS = 5
+
+interface GetFavouritedStatusesPageParams {
+  database: Database
+  actorId: string
+  currentActor: Actor
+  limit: number
+  maxId?: string | null
+  minId?: string | null
+  sinceId?: string | null
+}
+
+interface FavouritedStatusesPage {
+  statuses: Status[]
+  nextMaxFavouriteId: string | null
+  prevMinFavouriteId: string | null
+}
+
+const likeCursor = (like: Like): string =>
+  encodeFavouriteCursor({ createdAt: like.createdAt, statusId: like.statusId })
+
+export const getFavouritedStatusesPage = async ({
+  database,
+  actorId,
+  currentActor,
+  limit,
+  maxId,
+  minId,
+  sinceId
+}: GetFavouritedStatusesPageParams): Promise<FavouritedStatusesPage> => {
+  const entries: Array<{ like: Like; status: Status }> = []
+  let cursor = maxId ?? null
+  let iterations = 0
+  let lastScannedCursor: string | null = null
+  let exhausted = false
+
+  // Likes can reference statuses that are no longer readable (deleted, blocked,
+  // visibility-narrowed), so backfill across a few pages to fill the requested
+  // limit before giving up.
+  while (
+    entries.length < limit &&
+    iterations < MAX_FAVOURITE_BACKFILL_ITERATIONS
+  ) {
+    iterations++
+    const likes = await database.getLikes({
+      actorId,
+      limit,
+      maxId: cursor,
+      minId,
+      sinceId
+    })
+    if (likes.length === 0) {
+      exhausted = true
+      break
+    }
+
+    const statuses = await database.getStatusesByIds({
+      statusIds: likes.map((like) => like.statusId),
+      currentActorId: actorId,
+      visibleToActorId: currentActor.id,
+      withReplies: false
+    })
+    const statusMap = new Map<string, Status>(
+      statuses.map((status) => [status.id, status])
+    )
+    const orderedEntries = likes
+      .map((like) => {
+        const status = statusMap.get(like.statusId)
+        return status ? { like, status } : null
+      })
+      .filter((entry): entry is { like: Like; status: Status } =>
+        Boolean(entry)
+      )
+    const readableStatuses = await filterReadableStatuses({
+      database,
+      statuses: orderedEntries.map((entry) => entry.status),
+      currentActor
+    })
+    const readableStatusIds = new Set(
+      readableStatuses.map((status) => status.id)
+    )
+    entries.push(
+      ...orderedEntries.filter((entry) =>
+        readableStatusIds.has(entry.status.id)
+      )
+    )
+
+    cursor = likeCursor(likes[likes.length - 1])
+    lastScannedCursor = cursor
+
+    if (likes.length < limit) {
+      exhausted = true
+      break
+    }
+  }
+
+  const visibleEntries = entries.slice(0, limit)
+  const hasBufferedVisibleEntries = entries.length > limit
+  const lastVisibleCursor =
+    visibleEntries.length > 0
+      ? likeCursor(visibleEntries[visibleEntries.length - 1].like)
+      : null
+  let nextMaxFavouriteId: string | null = null
+
+  if (
+    hasBufferedVisibleEntries ||
+    (visibleEntries.length === limit && !exhausted)
+  ) {
+    nextMaxFavouriteId = hasBufferedVisibleEntries
+      ? lastVisibleCursor
+      : (lastScannedCursor ?? lastVisibleCursor)
+  } else if (!exhausted) {
+    nextMaxFavouriteId = lastScannedCursor
+  }
+
+  return {
+    statuses: visibleEntries.map((entry) => entry.status),
+    nextMaxFavouriteId,
+    prevMinFavouriteId:
+      visibleEntries.length > 0 ? likeCursor(visibleEntries[0].like) : null
+  }
+}

--- a/lib/services/favourites/getFavouritedStatusesPage.ts
+++ b/lib/services/favourites/getFavouritedStatusesPage.ts
@@ -35,25 +35,29 @@ export const getFavouritedStatusesPage = async ({
   minId,
   sinceId
 }: GetFavouritedStatusesPageParams): Promise<FavouritedStatusesPage> => {
-  const entries: Array<{ like: Like; status: Status }> = []
-  let cursor = maxId ?? null
+  // `min_id` requests forward (immediately-newer) pagination; every other cursor
+  // (max_id, since_id, none) pages newest-first. The bound we advance between
+  // backfill iterations depends on that direction.
+  const forward = Boolean(minId)
+  const collected: Array<{ like: Like; status: Status }> = []
+  let currentMaxId = maxId ?? null
+  let currentMinId = minId ?? null
   let iterations = 0
-  let lastScannedCursor: string | null = null
   let exhausted = false
 
   // Likes can reference statuses that are no longer readable (deleted, blocked,
   // visibility-narrowed), so backfill across a few pages to fill the requested
   // limit before giving up.
   while (
-    entries.length < limit &&
+    collected.length < limit &&
     iterations < MAX_FAVOURITE_BACKFILL_ITERATIONS
   ) {
     iterations++
     const likes = await database.getLikes({
       actorId,
       limit,
-      maxId: cursor,
-      minId,
+      maxId: currentMaxId,
+      minId: currentMinId,
       sinceId
     })
     if (likes.length === 0) {
@@ -86,14 +90,20 @@ export const getFavouritedStatusesPage = async ({
     const readableStatusIds = new Set(
       readableStatuses.map((status) => status.id)
     )
-    entries.push(
+    collected.push(
       ...orderedEntries.filter((entry) =>
         readableStatusIds.has(entry.status.id)
       )
     )
 
-    cursor = likeCursor(likes[likes.length - 1])
-    lastScannedCursor = cursor
+    // getLikes returns rows newest-first: likes[0] is the newest scanned,
+    // likes[last] the oldest. Advancing the matching bound keeps the next
+    // iteration over a fresh range instead of re-scanning the same band.
+    if (forward) {
+      currentMinId = likeCursor(likes[0])
+    } else {
+      currentMaxId = likeCursor(likes[likes.length - 1])
+    }
 
     if (likes.length < limit) {
       exhausted = true
@@ -101,29 +111,35 @@ export const getFavouritedStatusesPage = async ({
     }
   }
 
-  const visibleEntries = entries.slice(0, limit)
-  const hasBufferedVisibleEntries = entries.length > limit
-  const lastVisibleCursor =
+  // Forward backfill scans bands moving away from `min_id`, so re-select the
+  // favourites closest to the cursor and present them newest-first. The
+  // descending paths are already globally newest-first.
+  const visibleEntries = forward
+    ? [...collected]
+        .sort(
+          (a, b) =>
+            a.like.createdAt - b.like.createdAt ||
+            (a.like.statusId < b.like.statusId
+              ? -1
+              : a.like.statusId > b.like.statusId
+                ? 1
+                : 0)
+        )
+        .slice(0, limit)
+        .reverse()
+    : collected.slice(0, limit)
+
+  const hasMoreOlder = collected.length > limit || !exhausted
+  const newestCursor =
+    visibleEntries.length > 0 ? likeCursor(visibleEntries[0].like) : null
+  const oldestCursor =
     visibleEntries.length > 0
       ? likeCursor(visibleEntries[visibleEntries.length - 1].like)
       : null
-  let nextMaxFavouriteId: string | null = null
-
-  if (
-    hasBufferedVisibleEntries ||
-    (visibleEntries.length === limit && !exhausted)
-  ) {
-    nextMaxFavouriteId = hasBufferedVisibleEntries
-      ? lastVisibleCursor
-      : (lastScannedCursor ?? lastVisibleCursor)
-  } else if (!exhausted) {
-    nextMaxFavouriteId = lastScannedCursor
-  }
 
   return {
     statuses: visibleEntries.map((entry) => entry.status),
-    nextMaxFavouriteId,
-    prevMinFavouriteId:
-      visibleEntries.length > 0 ? likeCursor(visibleEntries[0].like) : null
+    nextMaxFavouriteId: hasMoreOlder ? oldestCursor : null,
+    prevMinFavouriteId: newestCursor
   }
 }

--- a/lib/services/favourites/getFavouritedStatusesPage.ts
+++ b/lib/services/favourites/getFavouritedStatusesPage.ts
@@ -129,7 +129,6 @@ export const getFavouritedStatusesPage = async ({
         .reverse()
     : collected.slice(0, limit)
 
-  const hasMoreOlder = collected.length > limit || !exhausted
   const newestCursor =
     visibleEntries.length > 0 ? likeCursor(visibleEntries[0].like) : null
   const oldestCursor =
@@ -137,9 +136,29 @@ export const getFavouritedStatusesPage = async ({
       ? likeCursor(visibleEntries[visibleEntries.length - 1].like)
       : null
 
+  // When more likes remain past the scanned window we must still hand back a
+  // resume cursor, even if this page produced no visible (readable) entries —
+  // otherwise a run of >= MAX_FAVOURITE_BACKFILL_ITERATIONS * limit unreadable
+  // likes returns an empty page with no Link header and the client dead-ends,
+  // stranding readable favourites beyond it. Resume from where the scan
+  // actually stopped (`currentMax/MinId`) so progress is guaranteed; only fall
+  // back to the visible bound when extra readable entries were buffered.
+  const buffered = collected.length > limit
+  const nextMaxFavouriteId = forward
+    ? oldestCursor
+    : buffered
+      ? oldestCursor
+      : exhausted
+        ? null
+        : (currentMaxId ?? oldestCursor)
+  const prevMinFavouriteId =
+    forward && !buffered && !exhausted
+      ? (currentMinId ?? newestCursor)
+      : newestCursor
+
   return {
     statuses: visibleEntries.map((entry) => entry.status),
-    nextMaxFavouriteId: hasMoreOlder ? oldestCursor : null,
-    prevMinFavouriteId: newestCursor
+    nextMaxFavouriteId,
+    prevMinFavouriteId
   }
 }

--- a/lib/services/medias/getMediaAttachment.test.ts
+++ b/lib/services/medias/getMediaAttachment.test.ts
@@ -1,0 +1,82 @@
+import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
+import { Media } from '@/lib/types/database/operations'
+
+const baseMedia: Media = {
+  id: '42',
+  actorId: 'https://llun.test/users/test',
+  original: {
+    path: 'medias/2026-01-01/image.jpg',
+    bytes: 1000,
+    mimeType: 'image/jpeg',
+    metaData: { width: 800, height: 600 }
+  },
+  description: 'a cat'
+}
+
+describe('getMediaAttachment', () => {
+  it('builds an image attachment served from /api/v1/files', () => {
+    const attachment = getMediaAttachment(baseMedia, 'llun.test')
+    expect(attachment).toMatchObject({
+      id: '42',
+      type: 'image',
+      mime_type: 'image/jpeg',
+      url: 'https://llun.test/api/v1/files/medias/2026-01-01/image.jpg',
+      preview_url: 'https://llun.test/api/v1/files/medias/2026-01-01/image.jpg',
+      description: 'a cat'
+    })
+    expect(attachment.meta.original).toEqual({
+      width: 800,
+      height: 600,
+      size: '800x600',
+      aspect: 800 / 600
+    })
+  })
+
+  it('uses the thumbnail path for preview_url and meta.small when present', () => {
+    const attachment = getMediaAttachment(
+      {
+        ...baseMedia,
+        thumbnail: {
+          path: 'medias/2026-01-01/thumb.jpg',
+          bytes: 500,
+          mimeType: 'image/jpeg',
+          metaData: { width: 200, height: 150 }
+        }
+      },
+      'llun.test'
+    )
+    expect(attachment.preview_url).toBe(
+      'https://llun.test/api/v1/files/medias/2026-01-01/thumb.jpg'
+    )
+    expect(attachment.meta.small).toEqual({
+      width: 200,
+      height: 150,
+      size: '200x150',
+      aspect: 200 / 150
+    })
+  })
+
+  it('classifies video mime types', () => {
+    const attachment = getMediaAttachment(
+      {
+        ...baseMedia,
+        original: { ...baseMedia.original, mimeType: 'video/mp4' }
+      },
+      'llun.test'
+    )
+    expect(attachment.type).toBe('video')
+  })
+
+  it('serves over http for localhost hosts', () => {
+    const attachment = getMediaAttachment(baseMedia, 'localhost:3000')
+    expect(attachment.url).toBe(
+      'http://localhost:3000/api/v1/files/medias/2026-01-01/image.jpg'
+    )
+  })
+
+  it('falls back to an empty description when none is stored', () => {
+    const { description: _description, ...withoutDescription } = baseMedia
+    const attachment = getMediaAttachment(withoutDescription, 'llun.test')
+    expect(attachment.description).toBe('')
+  })
+})

--- a/lib/services/medias/getMediaAttachment.ts
+++ b/lib/services/medias/getMediaAttachment.ts
@@ -1,0 +1,55 @@
+import {
+  MediaStorageSaveFileOutput,
+  MediaType
+} from '@/lib/services/medias/types'
+import { Media } from '@/lib/types/database/operations'
+
+const isLocalHost = (host: string) =>
+  host.startsWith('localhost') ||
+  host.startsWith('127.0.0.1') ||
+  host.startsWith('::1') ||
+  host.startsWith('[::1]')
+
+const mediaMeta = (metaData: Media['original']['metaData']) => {
+  const width = metaData.width ?? 0
+  const height = metaData.height ?? 0
+  return {
+    width,
+    height,
+    size: `${width}x${height}`,
+    aspect: width / (height || 1)
+  }
+}
+
+// Builds the Mastodon MediaAttachment entity for an already-stored media row.
+// Both the local-file and S3 storages serve files through `/api/v1/files/:path`,
+// so the public URL can be reconstructed without going back through the storage
+// driver. Used by GET/PUT /api/v1/media/:id, which operate on persisted media.
+export const getMediaAttachment = (
+  media: Media,
+  host: string
+): MediaStorageSaveFileOutput => {
+  const protocol = isLocalHost(host) ? 'http' : 'https'
+  const url = `${protocol}://${host}/api/v1/files/${media.original.path}`
+  const previewUrl = media.thumbnail
+    ? `${protocol}://${host}/api/v1/files/${media.thumbnail.path}`
+    : url
+  const type = media.original.mimeType.startsWith('video')
+    ? MediaType.enum.video
+    : MediaType.enum.image
+
+  return MediaStorageSaveFileOutput.parse({
+    id: `${media.id}`,
+    type,
+    mime_type: media.original.mimeType,
+    url,
+    preview_url: previewUrl,
+    text_url: null,
+    remote_url: null,
+    meta: {
+      original: mediaMeta(media.original.metaData),
+      ...(media.thumbnail ? { small: mediaMeta(media.thumbnail.metaData) } : {})
+    },
+    description: media.description ?? ''
+  })
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1414,11 +1414,28 @@ export type DeleteLikeParams = BaseLikeParams
 export type GetLikeCountParams = Pick<BaseLikeParams, 'statusId'>
 export type IsActorLikedStatusParams = BaseLikeParams
 
+export interface Like {
+  actorId: string
+  statusId: string
+  createdAt: number
+}
+
+export type GetLikesParams = {
+  actorId: string
+  limit: number
+  // Opaque composite cursors produced by encodeFavouriteCursor; older = max_id,
+  // newer = min_id/since_id. Invalid cursors yield an empty page.
+  maxId?: string | null
+  minId?: string | null
+  sinceId?: string | null
+}
+
 export interface LikeDatabase {
   createLike(params: CreateLikeParams): Promise<void>
   deleteLike(params: DeleteLikeParams): Promise<void>
   getLikeCount(params: GetLikeCountParams): Promise<number>
   isActorLikedStatus(params: IsActorLikedStatusParams): Promise<boolean>
+  getLikes(params: GetLikesParams): Promise<Like[]>
 }
 
 // ============================================================================
@@ -1550,6 +1567,11 @@ export type GetMediaByIdParams = {
   mediaId: string
   accountId: string
 }
+export type UpdateMediaParams = {
+  mediaId: string
+  accountId: string
+  description?: string | null
+}
 export type MarkMediaUploadVerifiedParams = {
   mediaId: string
   accountId: string
@@ -1574,6 +1596,7 @@ export interface MediaDatabase {
     params: GetMediasForAccountParams
   ): Promise<PaginatedMediaWithStatus>
   getMediaByIdForAccount(params: GetMediaByIdParams): Promise<Media | null>
+  updateMedia(params: UpdateMediaParams): Promise<Media | null>
   getStorageUsageForAccount(
     params: GetStorageUsageForAccountParams
   ): Promise<number>


### PR DESCRIPTION
## Summary

Implements the two **Tier-1** Mastodon REST API endpoints that mainstream clients (Ivory, Ice Cubes, Tusky, Elk, official app) call but the service was missing. Closes the highest-impact gaps from the Mastodon client-compatibility audit.

### `GET /api/v1/favourites`
The Favourites / Likes tab — previously 404'd. 
- New `getLikes` DB op paginated by a **composite `(createdAt, statusId)` opaque cursor**. The `likes` table has a composite PK and no surrogate id, so a createdAt-only cursor would drop/duplicate rows at timestamp ties (real risk given the counter-backfill migration inserts many rows with identical timestamps). The cursor is base64url-encoded and treated as opaque, matching Mastodon's contract.
- `getFavouritedStatusesPage` service mirrors `getBookmarkedStatusesPage`, including readable-status backfill (likes can point at deleted/blocked/visibility-narrowed statuses).
- Route mirrors `bookmarks` — `read`/`read:favourites` scopes, `activities_next` format, and Mastodon `Link` header pagination.

### `GET` / `PUT /api/v1/media/:id`
Fetch and update an uploaded media attachment (alt-text editing; clients also PUT media during status edits).
- New `updateMedia` DB op, scoped to the owning account (404 on miss, per Mastodon).
- Storage-agnostic `getMediaAttachment` serializer (both local-file and S3 storages serve via `/api/v1/files/:path`, so the public URL is reconstructable without the storage driver).
- Guarded by `OAuthGuard` / `OAuthGuardAnyScope` (`read`, `write`/`write:media`) so bearer-token clients get proper `401`/scope handling rather than the `307` redirect `AuthenticatedGuard` returns.

## Scope notes
- `description` is capped at the `varchar(255)` column limit (`safeParse`).
- Media **`focus`** is intentionally out of scope (would need a schema migration); a `focus`-only PUT is a no-op that preserves the existing description rather than clearing it.

## Testing
- `yarn prettier --write .`, `yarn lint` (0 errors), `yarn build`, `yarn test` — **389 suites / 3379 tests pass**.
- Added: cursor round-trip unit tests, `getLikes` pagination DB tests (gap/duplicate-free across pages, min_id, malformed cursor), `updateMedia` DB tests (update/clear/ownership/not-found), `getMediaAttachment` serializer tests, and route tests for both endpoints (auth, ownership, pagination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)