### PR TITLE
fix: truncate long handles in post action menu items

### DIFF
--- a/lib/components/posts/actions/post-menu.tsx
+++ b/lib/components/posts/actions/post-menu.tsx
@@ -278,28 +278,32 @@ export const PostMenu: FC<Props> = ({
             <>
               <DropdownMenuItem onSelect={() => onReply?.(status)}>
                 <AtSign className="size-4" />
-                Mention {mention}
+                <span className="min-w-0 break-words">Mention {mention}</span>
               </DropdownMenuItem>
               {relationship?.muting ? (
                 <DropdownMenuItem onSelect={() => void handleUnmute()}>
                   <VolumeX className="size-4" />
-                  Unmute {actorName}
+                  <span className="min-w-0 break-words">
+                    Unmute {actorName}
+                  </span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => setDialog('mute')}>
                   <VolumeX className="size-4" />
-                  Mute {actorName}
+                  <span className="min-w-0 break-words">Mute {actorName}</span>
                 </DropdownMenuItem>
               )}
               {relationship?.blocking ? (
                 <DropdownMenuItem onSelect={() => void handleUnblock()}>
                   <Ban className="size-4" />
-                  Unblock {actorName}
+                  <span className="min-w-0 break-words">
+                    Unblock {actorName}
+                  </span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => setDialog('block')}>
                   <Ban className="size-4" />
-                  Block {actorName}
+                  <span className="min-w-0 break-words">Block {actorName}</span>
                 </DropdownMenuItem>
               )}
             </>

--- a/lib/components/posts/actions/post-menu.tsx
+++ b/lib/components/posts/actions/post-menu.tsx
@@ -278,28 +278,50 @@ export const PostMenu: FC<Props> = ({
             <>
               <DropdownMenuItem onSelect={() => onReply?.(status)}>
                 <AtSign className="size-4" />
-                <span className="min-w-0 truncate">Mention {mention}</span>
+                <span className="min-w-0 truncate" title={`Mention ${mention}`}>
+                  Mention {mention}
+                </span>
               </DropdownMenuItem>
               {relationship?.muting ? (
                 <DropdownMenuItem onSelect={() => void handleUnmute()}>
                   <VolumeX className="size-4" />
-                  <span className="min-w-0 truncate">Unmute {actorName}</span>
+                  <span
+                    className="min-w-0 truncate"
+                    title={`Unmute ${actorName}`}
+                  >
+                    Unmute {actorName}
+                  </span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => setDialog('mute')}>
                   <VolumeX className="size-4" />
-                  <span className="min-w-0 truncate">Mute {actorName}</span>
+                  <span
+                    className="min-w-0 truncate"
+                    title={`Mute ${actorName}`}
+                  >
+                    Mute {actorName}
+                  </span>
                 </DropdownMenuItem>
               )}
               {relationship?.blocking ? (
                 <DropdownMenuItem onSelect={() => void handleUnblock()}>
                   <Ban className="size-4" />
-                  <span className="min-w-0 truncate">Unblock {actorName}</span>
+                  <span
+                    className="min-w-0 truncate"
+                    title={`Unblock ${actorName}`}
+                  >
+                    Unblock {actorName}
+                  </span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => setDialog('block')}>
                   <Ban className="size-4" />
-                  <span className="min-w-0 truncate">Block {actorName}</span>
+                  <span
+                    className="min-w-0 truncate"
+                    title={`Block ${actorName}`}
+                  >
+                    Block {actorName}
+                  </span>
                 </DropdownMenuItem>
               )}
             </>

--- a/lib/components/posts/actions/post-menu.tsx
+++ b/lib/components/posts/actions/post-menu.tsx
@@ -278,32 +278,28 @@ export const PostMenu: FC<Props> = ({
             <>
               <DropdownMenuItem onSelect={() => onReply?.(status)}>
                 <AtSign className="size-4" />
-                <span className="min-w-0 break-words">Mention {mention}</span>
+                <span className="min-w-0 truncate">Mention {mention}</span>
               </DropdownMenuItem>
               {relationship?.muting ? (
                 <DropdownMenuItem onSelect={() => void handleUnmute()}>
                   <VolumeX className="size-4" />
-                  <span className="min-w-0 break-words">
-                    Unmute {actorName}
-                  </span>
+                  <span className="min-w-0 truncate">Unmute {actorName}</span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => setDialog('mute')}>
                   <VolumeX className="size-4" />
-                  <span className="min-w-0 break-words">Mute {actorName}</span>
+                  <span className="min-w-0 truncate">Mute {actorName}</span>
                 </DropdownMenuItem>
               )}
               {relationship?.blocking ? (
                 <DropdownMenuItem onSelect={() => void handleUnblock()}>
                   <Ban className="size-4" />
-                  <span className="min-w-0 break-words">
-                    Unblock {actorName}
-                  </span>
+                  <span className="min-w-0 truncate">Unblock {actorName}</span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => setDialog('block')}>
                   <Ban className="size-4" />
-                  <span className="min-w-0 break-words">Block {actorName}</span>
+                  <span className="min-w-0 truncate">Block {actorName}</span>
                 </DropdownMenuItem>
               )}
             </>


### PR DESCRIPTION
The post overflow menu's Mention/Mute/Block items are flex rows whose text
node defaulted to `min-width: auto`. A long unbroken handle like
`@macrumors@mastodon.social` couldn't shrink and overflowed the menu's fixed
width, getting clipped at the edge.

Each dynamic-name label (Mention/Mute/Unmute/Block/Unblock) is now wrapped in
a `<span className="min-w-0 truncate">` so the label stays on a single line
and a long handle is cut off with an ellipsis (`…`) instead of wrapping or
being hard-clipped. A `title` attribute mirroring each label is also added so
mouse users can hover to see the full handle/name; the visible text is
unchanged so screen-reader accessible names are preserved.

### Behavior
- Single line, ellipsis on overflow (per design preference — no multi-line wrap).
- Icons stay fixed (`shrink-0`); only the label shrinks/truncates.
- Existing `post-menu.test.tsx` accessible-name assertions still pass.