### PR TITLE
Bump version to v1.40.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.7",
+  "version": "1.40.8",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.40.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.40.7`
- Base main SHA: `462df32cdd0b724cb7bb9176af78f4e8d0238d38`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
