### PR TITLE
Bump version to v1.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.40.8",
+  "version": "1.41.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.41.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.40.8`
- Base main SHA: `0b9b0e9a7473f05438134bfdaead42a9d53d98be`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
