### PR TITLE
minor: add design-system error pages (404, 500, generic)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { ErrorPage } from '@/lib/components/error-page'
+
+// Route-segment error boundary. Renders the design-system 500 page; when Next
+// attaches a `digest` to the error we surface it on the technical-detail line so
+// it can be matched against server logs.
+export default function Error({
+  error
+}: {
+  error: Error & { digest?: string }
+}) {
+  return (
+    <ErrorPage
+      code="500"
+      meta={error.digest ? `500 · ${error.digest}` : undefined}
+    />
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,19 +1,14 @@
 'use client'
 
-import { ErrorPage } from '@/lib/components/error-page'
+import { ErrorPage, errorBoundaryMeta } from '@/lib/components/error-page'
 
 // Route-segment error boundary. Renders the design-system 500 page; when Next
 // attaches a `digest` to the error we surface it on the technical-detail line so
-// it can be matched against server logs.
+// it can be matched against server logs (and the raw message in development).
 export default function Error({
   error
 }: {
   error: Error & { digest?: string }
 }) {
-  return (
-    <ErrorPage
-      code="500"
-      meta={error.digest ? `500 · ${error.digest}` : undefined}
-    />
-  )
+  return <ErrorPage code="500" meta={errorBoundaryMeta('500', error)} />
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -10,5 +10,11 @@ export default function Error({
 }: {
   error: Error & { digest?: string }
 }) {
-  return <ErrorPage code="500" meta={errorBoundaryMeta('500', error)} />
+  // Wrap in <main> for the page landmark: this root boundary renders inside the
+  // root layout (which has no <main>), so there is no nesting risk.
+  return (
+    <main>
+      <ErrorPage code="500" meta={errorBoundaryMeta('500', error)} />
+    </main>
+  )
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -5,10 +5,15 @@ import { ErrorPage, errorBoundaryMeta } from '@/lib/components/error-page'
 // Route-segment error boundary. Renders the design-system 500 page; when Next
 // attaches a `digest` to the error we surface it on the technical-detail line so
 // it can be matched against server logs (and the raw message in development).
+//
+// Next also passes `reset` (re-render the segment). It is typed here to document
+// the full boundary contract, but intentionally not wired to a retry button —
+// the design's final state is a card with no actions.
 export default function Error({
   error
 }: {
   error: Error & { digest?: string }
+  reset: () => void
 }) {
   // Wrap in <main> for the page landmark: this root boundary renders inside the
   // root layout (which has no <main>), so there is no nesting risk.

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { ErrorPage } from '@/lib/components/error-page'
+
+import './globals.css'
+
+// Top-level error boundary. Unlike `error.tsx` it replaces the root layout, so
+// it has to render its own `<html>`/`<body>`. Importing `globals.css` here keeps
+// the design-system tokens, fonts, and dual-tint backdrop applied to `body`.
+export default function GlobalError({
+  error
+}: {
+  error: Error & { digest?: string }
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <ErrorPage
+          code="generic"
+          meta={error.digest ? `unexpected error · ${error.digest}` : undefined}
+        />
+      </body>
+    </html>
+  )
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -22,10 +22,8 @@ export default function GlobalError({
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, maximum-scale=2"
-        />
+        {/* No maximum-scale: do not restrict zoom (WCAG 1.4.4 Resize Text). */}
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Something isn&apos;t working · Activities.next</title>
       </head>
       <body>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -5,9 +5,10 @@ import { ErrorPage, errorBoundaryMeta } from '@/lib/components/error-page'
 import './globals.css'
 
 // Top-level error boundary. Unlike `error.tsx` it replaces the root layout, so
-// it has to render its own `<html>`/`<head>`/`<body>` — including the document
-// title, since `app/layout.tsx`'s metadata no longer applies here. Importing
-// `globals.css` keeps the design-system tokens, fonts, and dual-tint backdrop.
+// it has to render its own `<html>`/`<head>`/`<body>` — including the charset,
+// viewport, and document title, since `app/layout.tsx`'s metadata no longer
+// applies here (without the viewport tag the page renders zoomed-out on mobile).
+// Importing `globals.css` keeps the design-system tokens, fonts, and backdrop.
 export default function GlobalError({
   error
 }: {
@@ -16,6 +17,8 @@ export default function GlobalError({
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Something isn&apos;t working · Activities.next</title>
       </head>
       <body>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -18,14 +18,21 @@ export default function GlobalError({
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=2"
+        />
         <title>Something isn&apos;t working · Activities.next</title>
       </head>
       <body>
-        <ErrorPage
-          code="generic"
-          meta={errorBoundaryMeta('unexpected error', error)}
-        />
+        {/* global-error replaces the root layout entirely, so it owns the only
+            <main> landmark on the page. */}
+        <main>
+          <ErrorPage
+            code="generic"
+            meta={errorBoundaryMeta('unexpected error', error)}
+          />
+        </main>
       </body>
     </html>
   )

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { ErrorPage } from '@/lib/components/error-page'
+import { ErrorPage, errorBoundaryMeta } from '@/lib/components/error-page'
 
 import './globals.css'
 
 // Top-level error boundary. Unlike `error.tsx` it replaces the root layout, so
-// it has to render its own `<html>`/`<body>`. Importing `globals.css` here keeps
-// the design-system tokens, fonts, and dual-tint backdrop applied to `body`.
+// it has to render its own `<html>`/`<head>`/`<body>` — including the document
+// title, since `app/layout.tsx`'s metadata no longer applies here. Importing
+// `globals.css` keeps the design-system tokens, fonts, and dual-tint backdrop.
 export default function GlobalError({
   error
 }: {
@@ -14,10 +15,13 @@ export default function GlobalError({
 }) {
   return (
     <html lang="en">
+      <head>
+        <title>Something isn&apos;t working · Activities.next</title>
+      </head>
       <body>
         <ErrorPage
           code="generic"
-          meta={error.digest ? `unexpected error · ${error.digest}` : undefined}
+          meta={errorBoundaryMeta('unexpected error', error)}
         />
       </body>
     </html>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -9,10 +9,14 @@ import './globals.css'
 // viewport, and document title, since `app/layout.tsx`'s metadata no longer
 // applies here (without the viewport tag the page renders zoomed-out on mobile).
 // Importing `globals.css` keeps the design-system tokens, fonts, and backdrop.
+// Next also passes `reset` (re-render the root). It is typed here to document
+// the full boundary contract, but intentionally not wired to a retry button to
+// match the design's card-only final state.
 export default function GlobalError({
   error
 }: {
   error: Error & { digest?: string }
+  reset: () => void
 }) {
   return (
     <html lang="en">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next'
+
+import { ErrorPage } from '@/lib/components/error-page'
+
+export const metadata: Metadata = {
+  title: "We couldn't find that page · Activities.next"
+}
+
+export default function NotFound() {
+  return <ErrorPage code="404" />
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,5 +7,11 @@ export const metadata: Metadata = {
 }
 
 export default function NotFound() {
-  return <ErrorPage code="404" />
+  // Wrap in <main> for the page landmark: this renders at the root boundary
+  // (above the route-group layouts), so there is no parent <main> to nest with.
+  return (
+    <main>
+      <ErrorPage code="404" />
+    </main>
+  )
 }

--- a/lib/components/error-page.test.tsx
+++ b/lib/components/error-page.test.tsx
@@ -79,4 +79,11 @@ describe('errorBoundaryMeta', () => {
       errorBoundaryMeta('500', { name: 'Error', message: 'sensitive detail' })
     ).toBeUndefined()
   })
+
+  it('does not crash on a missing or non-Error throw value', () => {
+    expect(errorBoundaryMeta('500', undefined)).toBeUndefined()
+    expect(errorBoundaryMeta('500', null)).toBeUndefined()
+    // @ts-expect-error — a non-Error value can be thrown; the guard must hold
+    expect(errorBoundaryMeta('500', 'just a string')).toBeUndefined()
+  })
 })

--- a/lib/components/error-page.test.tsx
+++ b/lib/components/error-page.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { ErrorPage } from '@/lib/components/error-page'
+
+describe('ErrorPage', () => {
+  it('renders the 404 page by default with its hero code, reason and copy', () => {
+    render(<ErrorPage />)
+
+    expect(
+      screen.getByRole('heading', { name: "We couldn't find that page" })
+    ).toBeInTheDocument()
+    expect(screen.getByText('404')).toBeInTheDocument()
+    expect(screen.getByText('Not found')).toBeInTheDocument()
+    expect(screen.getByText('404 · not found')).toBeInTheDocument()
+  })
+
+  it('renders the giant status code for a wired error code', () => {
+    render(<ErrorPage code="500" />)
+
+    expect(screen.getByText('500')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Something went wrong on our end' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders a glyph instead of a number for the generic fallback', () => {
+    render(<ErrorPage code="generic" />)
+
+    expect(
+      screen.getByRole('heading', { name: "Something isn't working" })
+    ).toBeInTheDocument()
+    // The fallback has no numeric hero; the eyebrow reason is still present.
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.queryByText('404')).not.toBeInTheDocument()
+  })
+
+  it('overrides the technical-detail line when meta is provided', () => {
+    render(<ErrorPage code="500" meta="500 · req-abc123" />)
+
+    expect(screen.getByText('500 · req-abc123')).toBeInTheDocument()
+    expect(screen.queryByText('500 · server error')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the generic page for an unknown code', () => {
+    // @ts-expect-error — exercising the runtime fallback for an invalid code
+    render(<ErrorPage code="418" />)
+
+    expect(
+      screen.getByRole('heading', { name: "Something isn't working" })
+    ).toBeInTheDocument()
+  })
+})

--- a/lib/components/error-page.test.tsx
+++ b/lib/components/error-page.test.tsx
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 
-import { ErrorPage } from '@/lib/components/error-page'
+import { ErrorPage, errorBoundaryMeta } from '@/lib/components/error-page'
 
 describe('ErrorPage', () => {
   it('renders the 404 page by default with its hero code, reason and copy', () => {
@@ -52,5 +52,31 @@ describe('ErrorPage', () => {
     expect(
       screen.getByRole('heading', { name: "Something isn't working" })
     ).toBeInTheDocument()
+  })
+
+  it('does not introduce a <main> landmark (parent layouts own it)', () => {
+    render(<ErrorPage code="404" />)
+
+    expect(screen.queryByRole('main')).not.toBeInTheDocument()
+  })
+})
+
+describe('errorBoundaryMeta', () => {
+  it('prefers the production-safe digest when present', () => {
+    expect(
+      errorBoundaryMeta('500', {
+        name: 'Error',
+        message: 'boom',
+        digest: 'abc123'
+      })
+    ).toBe('500 · abc123')
+  })
+
+  it('does not leak the raw message outside development', () => {
+    // Jest runs with NODE_ENV=test, so the message branch must stay closed and
+    // the boundary falls back to the per-code default meta (undefined here).
+    expect(
+      errorBoundaryMeta('500', { name: 'Error', message: 'sensitive detail' })
+    ).toBeUndefined()
   })
 })

--- a/lib/components/error-page.tsx
+++ b/lib/components/error-page.tsx
@@ -119,14 +119,6 @@ interface ErrorPageProps {
 }
 
 /**
- * Centered hero error card from the design system's `web-errors` UI kit. The
- * hero is the giant status code in Activity orange (or an alert glyph for the
- * uncategorised fallback), wrapped in a reason pill → title → body → mono
- * technical line. The dual-tint backdrop comes from `body` in `globals.css`, so
- * this component intentionally stays backdrop-free and works in both the server
- * tree (`not-found`) and the client error boundaries (`error`/`global-error`).
- */
-/**
  * Builds the monospace technical-detail line for a Next.js error boundary.
  * Prefers the production-safe `digest` (a hash that maps to a server log entry);
  * when there is no digest, surfaces the raw `error.message` only in development
@@ -147,6 +139,14 @@ export function errorBoundaryMeta(
   return undefined
 }
 
+/**
+ * Centered hero error card from the design system's `web-errors` UI kit. The
+ * hero is the giant status code in Activity orange (or an alert glyph for the
+ * uncategorised fallback), wrapped in a reason pill → title → body → mono
+ * technical line. The dual-tint backdrop comes from `body` in `globals.css`, so
+ * this component intentionally stays backdrop-free and works in both the server
+ * tree (`not-found`) and the client error boundaries (`error`/`global-error`).
+ */
 export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
   const content = ERROR_PAGES[code] ?? ERROR_PAGES.generic
   const ReasonIcon = content.icon
@@ -191,7 +191,7 @@ export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
           </h1>
 
           {/* Body */}
-          <p className="text-muted-foreground mt-2.5 max-w-[380px] text-sm leading-relaxed text-pretty sm:text-[15px]">
+          <p className="text-muted-foreground mt-2.5 max-w-[380px] text-sm leading-[1.6] text-pretty sm:text-[15px]">
             {content.body}
           </p>
 

--- a/lib/components/error-page.tsx
+++ b/lib/components/error-page.tsx
@@ -135,10 +135,13 @@ interface ErrorPageProps {
  */
 export function errorBoundaryMeta(
   prefix: string,
-  error: Error & { digest?: string }
+  error?: (Error & { digest?: string }) | null
 ): string | undefined {
-  if (error.digest) return `${prefix} · ${error.digest}`
-  if (process.env.NODE_ENV === 'development' && error.message) {
+  // Defensive: a thrown non-Error value (or a missing one) must not crash the
+  // boundary itself, so guard every property access and fall back to the
+  // per-code default meta.
+  if (error?.digest) return `${prefix} · ${error.digest}`
+  if (process.env.NODE_ENV === 'development' && error?.message) {
     return `${prefix} · ${error.message}`
   }
   return undefined

--- a/lib/components/error-page.tsx
+++ b/lib/components/error-page.tsx
@@ -126,6 +126,24 @@ interface ErrorPageProps {
  * this component intentionally stays backdrop-free and works in both the server
  * tree (`not-found`) and the client error boundaries (`error`/`global-error`).
  */
+/**
+ * Builds the monospace technical-detail line for a Next.js error boundary.
+ * Prefers the production-safe `digest` (a hash that maps to a server log entry);
+ * when there is no digest, surfaces the raw `error.message` only in development
+ * so it never leaks internal details — or clutters the polished card — in
+ * production. Returns `undefined` to fall back to the per-code default meta.
+ */
+export function errorBoundaryMeta(
+  prefix: string,
+  error: Error & { digest?: string }
+): string | undefined {
+  if (error.digest) return `${prefix} · ${error.digest}`
+  if (process.env.NODE_ENV === 'development' && error.message) {
+    return `${prefix} · ${error.message}`
+  }
+  return undefined
+}
+
 export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
   const content = ERROR_PAGES[code] ?? ERROR_PAGES.generic
   const ReasonIcon = content.icon
@@ -133,7 +151,11 @@ export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <main className="flex flex-1 items-center justify-center p-4 sm:p-6">
+      {/* Neutral wrapper (not <main>): this component renders inside the
+          server tree (not-found) and the client error boundaries, so it must
+          not introduce a second <main> landmark when a parent layout already
+          provides one. */}
+      <div className="flex flex-1 items-center justify-center p-4 sm:p-6">
         <div
           className={cn(
             'bg-card flex w-full flex-col items-center rounded-xl border px-[22px] py-7 text-center shadow-sm',
@@ -177,7 +199,7 @@ export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
             </code>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   )
 }

--- a/lib/components/error-page.tsx
+++ b/lib/components/error-page.tsx
@@ -1,0 +1,185 @@
+import {
+  AlertTriangle,
+  Clock,
+  Key,
+  Lock,
+  type LucideIcon,
+  Search,
+  Settings,
+  Trash2
+} from 'lucide-react'
+import { FC } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export type ErrorCode =
+  | '404'
+  | '403'
+  | '401'
+  | '410'
+  | '429'
+  | '500'
+  | '503'
+  | 'generic'
+
+interface ErrorPageContent {
+  /** Short label shown in the eyebrow pill above the hero. */
+  reason: string
+  /** Lucide icon paired with the reason in the eyebrow pill. */
+  icon: LucideIcon
+  /** Giant status code rendered as the hero. `null` falls back to a glyph. */
+  num: string | null
+  /** Heading shown below the hero. */
+  title: string
+  /** Supporting copy under the heading. */
+  body: string
+  /** Default monospace technical-detail line. Overridable per render. */
+  meta: string
+}
+
+// Content for every 4xx / 5xx page plus the uncategorised fallback. Only 404,
+// the route-segment error boundary, and the global error boundary are wired to
+// real Next.js entry points today; the rest stay here so the design is ready
+// the moment those codes need a dedicated HTML page.
+const ERROR_PAGES: Record<ErrorCode, ErrorPageContent> = {
+  '404': {
+    reason: 'Not found',
+    icon: Search,
+    num: '404',
+    title: "We couldn't find that page",
+    body: "The page you're looking for doesn't exist, or it may have moved. Check the address, or head back to your timeline.",
+    meta: '404 · not found'
+  },
+  '403': {
+    reason: 'Forbidden',
+    icon: Lock,
+    num: '403',
+    title: "You don't have access to this",
+    body: 'This post or page is restricted. You may need to follow the account, or sign in with one that has access.',
+    meta: '403 · access denied'
+  },
+  '401': {
+    reason: 'Sign-in required',
+    icon: Key,
+    num: '401',
+    title: 'Sign in to continue',
+    body: 'This page is only available to signed-in accounts. Sign in to your instance to view it.',
+    meta: '401 · unauthorized'
+  },
+  '410': {
+    reason: 'Gone',
+    icon: Trash2,
+    num: '410',
+    title: 'This post is no longer available',
+    body: 'The author deleted this post, or it was removed from the server. Nothing was kept.',
+    meta: '410 · gone'
+  },
+  '429': {
+    reason: 'Rate limited',
+    icon: Clock,
+    num: '429',
+    title: 'Too many requests',
+    body: "You've hit the rate limit for this instance. Wait a moment, then try again.",
+    meta: '429 · rate limited'
+  },
+  '500': {
+    reason: 'Server error',
+    icon: AlertTriangle,
+    num: '500',
+    title: 'Something went wrong on our end',
+    body: "The server ran into an unexpected error. It's not you — try again in a moment.",
+    meta: '500 · server error'
+  },
+  '503': {
+    reason: 'Unavailable',
+    icon: Settings,
+    num: '503',
+    title: 'Down for maintenance',
+    body: "This instance is temporarily offline for maintenance. It'll be back shortly.",
+    meta: '503 · scheduled maintenance'
+  },
+  generic: {
+    reason: 'Error',
+    icon: AlertTriangle,
+    num: null,
+    title: "Something isn't working",
+    body: 'An unexpected error occurred. Try again, or head back to your timeline.',
+    meta: 'unexpected error'
+  }
+}
+
+interface ErrorPageProps {
+  /** Which error page to render. Defaults to the 404 page. */
+  code?: ErrorCode
+  /**
+   * Overrides the default monospace technical-detail line (e.g. to surface a
+   * request digest from an error boundary). Falls back to the per-code default.
+   */
+  meta?: string
+}
+
+/**
+ * Centered hero error card from the design system's `web-errors` UI kit. The
+ * hero is the giant status code in Activity orange (or an alert glyph for the
+ * uncategorised fallback), wrapped in a reason pill → title → body → mono
+ * technical line. The dual-tint backdrop comes from `body` in `globals.css`, so
+ * this component intentionally stays backdrop-free and works in both the server
+ * tree (`not-found`) and the client error boundaries (`error`/`global-error`).
+ */
+export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
+  const content = ERROR_PAGES[code] ?? ERROR_PAGES.generic
+  const ReasonIcon = content.icon
+  const technicalDetail = meta ?? content.meta
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <main className="flex flex-1 items-center justify-center p-4 sm:p-6">
+        <div
+          className={cn(
+            'bg-card flex w-full flex-col items-center rounded-xl border px-[22px] py-7 text-center shadow-sm',
+            'sm:max-w-[480px] sm:px-10 sm:py-11'
+          )}
+        >
+          {/* Reason eyebrow pill */}
+          <div className="bg-background text-muted-foreground inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs">
+            <ReasonIcon className="size-[13px]" aria-hidden="true" />
+            <span>{content.reason}</span>
+          </div>
+
+          {/* Hero: giant code, or a glyph for the uncategorised fallback */}
+          {content.num ? (
+            <div className="text-primary mt-3.5 text-[76px] font-semibold leading-none tracking-[-0.03em] sm:mt-[18px] sm:text-[112px]">
+              {content.num}
+            </div>
+          ) : (
+            <div className="text-primary mb-1 mt-4 sm:mt-[22px]">
+              <AlertTriangle
+                className="size-16 sm:size-[88px]"
+                aria-hidden="true"
+              />
+            </div>
+          )}
+
+          {/* Title */}
+          <h1 className="mt-3 text-xl font-semibold leading-[1.25] tracking-[-0.01em] text-pretty sm:mt-4 sm:text-2xl">
+            {content.title}
+          </h1>
+
+          {/* Body */}
+          <p className="text-muted-foreground mt-2.5 max-w-[380px] text-sm leading-relaxed text-pretty sm:text-[15px]">
+            {content.body}
+          </p>
+
+          {/* Technical detail */}
+          <div className="mt-[22px] w-full border-t pt-4 sm:mt-7">
+            <code className="text-muted-foreground font-mono text-xs">
+              {technicalDetail}
+            </code>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default ErrorPage

--- a/lib/components/error-page.tsx
+++ b/lib/components/error-page.tsx
@@ -153,11 +153,13 @@ export const ErrorPage: FC<ErrorPageProps> = ({ code = '404', meta }) => {
   const technicalDetail = meta ?? content.meta
 
   return (
-    <div className="flex min-h-screen flex-col">
-      {/* Neutral wrapper (not <main>): this component renders inside the
-          server tree (not-found) and the client error boundaries, so it must
-          not introduce a second <main> landmark when a parent layout already
-          provides one. */}
+    // min-h-dvh (dynamic viewport height) rather than min-h-screen/100vh so the
+    // card stays centered without the mobile address-bar gap.
+    <div className="flex min-h-dvh flex-col">
+      {/* Neutral wrapper (not <main>): this component renders inside the server
+          tree (not-found) and the client error boundaries. Each entry point
+          provides its own <main> landmark, so the component must not add a
+          second one. */}
       <div className="flex flex-1 items-center justify-center p-4 sm:p-6">
         <div
           className={cn(


### PR DESCRIPTION
## Summary

Implements the **web-errors** UI kit from the Activities.next design system (`ui_kits/web-errors/index.html`) as real Next.js error pages.

A single shared, presentational `ErrorPage` component renders the design's centered hero card — **reason pill → giant Activity-orange status code (or alert glyph) → title → body → monospace technical line** — on the existing dual-tint backdrop. It is wired to the three error entry points Next.js actually surfaces as HTML:

| File | Renders |
| --- | --- |
| `app/not-found.tsx` | **404** — unmatched routes & `notFound()` |
| `app/error.tsx` | **500** — route-segment boundary, surfaces the error `digest` on the technical line |
| `app/global-error.tsx` | **generic** — top-level boundary; renders its own `<html>/<body>` and imports `globals.css` |

The component's data map carries content for all **eight** design codes (404/403/401/410/429/500/503/generic). Only the three reachable Next.js entry points are wired today; the rest stay ready in the map for when those codes need a dedicated HTML page. (The app emits 403/401/410/429/503 as JSON API responses via `apiErrorResponse`, not HTML pages, so there is nothing to wire them to yet.)

## Design fidelity

The repo's tokens (`--card`, `--primary`, `--border`, `--muted-foreground`) and the dual-tint gradient on `body` already match the design system 1:1, so the card reuses them via Tailwind utilities and stays **backdrop-free** (the backdrop comes from `body`, which `global-error` re-applies by importing `globals.css`). Verified in a production build (`yarn start`) against the design:

- **404** (default, giant code) — desktop + the real not-found route
- **500** — the real `error.tsx` boundary, with the request digest on the technical line
- **generic** — alert-glyph fallback
- **403** — mobile (390px) responsive render

> Deliberate design decisions, called out to save a review round:
> - **No header / footer / action buttons.** The design's final state (per the design chat transcript) removed them — *"remove header and bottom and all the buttons for now"* — leaving the card-only hero. This faithfully matches the shipped design file, which renders only the card. It does mean `error.tsx` exposes no `reset()` retry button; that is intentional to match the design, and since no `error.tsx` existed before this is a net-add, not a regression.
> - The technical-detail line uses concise real values (`404 · not found`, `500 · <digest>`) rather than the prototype's illustrative placeholders (`GET /@anna/posts/01HZ4K…`).

## Note for the reviewer

The task mentioned design-system screenshots to compare against, but none came through in the request. I verified against the design source file (`ErrorPage.jsx` / `App.jsx`) and the card-only final state from the design chat transcript. If "for now" was meant to be temporary and you want the public chrome (top bar + footer) and action buttons added back, the prototype still defines `EPTopBar`/`EPFooter`/`EPButton` and I can wire them in.

## Testing

- `yarn run prettier --write .` ✅
- `yarn lint` ✅ (0 errors)
- `yarn build` ✅
- `yarn test` ✅ (391 suites / 3388 tests, incl. new `lib/components/error-page.test.tsx`)
- Manual browser verification in a production build for 404, 500 (real throw), generic, and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)