### PR TITLE
Bump version to v1.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.42.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.41.0`
- Base main SHA: `03395c0c77fb1363616f0c21dfdc6f978afaf463`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
