### PR TITLE
fix: store Strava import link as fitness source instead of status text

### DIFF
--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -2,7 +2,7 @@
 
 import { UTCDate } from '@date-fns/utc'
 import { format } from 'date-fns'
-import { Bike, Footprints, Play, Plus, Waves } from 'lucide-react'
+import { Bike, ExternalLink, Footprints, Play, Plus, Waves } from 'lucide-react'
 import { FC, useEffect, useMemo, useRef, useState } from 'react'
 
 import { BrandedDeviceLink } from '@/lib/components/posts/BrandedDeviceLink'
@@ -15,7 +15,9 @@ import { cn } from '@/lib/utils'
 import {
   formatFitnessDistance,
   formatFitnessDuration,
-  getFitnessPaceOrSpeed
+  getFitnessPaceOrSpeed,
+  getFitnessSourceLabel,
+  normalizeFitnessSourceUrl
 } from '@/lib/utils/fitness'
 import { getDeviceDisplayLabel } from '@/lib/utils/fitnessDeviceBrands'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
@@ -114,6 +116,7 @@ interface StatusFitnessFileItem {
   description: string | null
   deviceManufacturer: string | null
   deviceName: string | null
+  sourceUrl: string | null
 }
 
 interface FitnessFilesByStatusResponse {
@@ -1002,7 +1005,8 @@ export const FitnessStatusDetail: FC<Props> = ({
         hasMapData: status.fitness.hasMapData ?? false,
         description: status.fitness.description ?? null,
         deviceManufacturer: status.fitness.deviceManufacturer ?? null,
-        deviceName: status.fitness.deviceName ?? null
+        deviceName: status.fitness.deviceName ?? null,
+        sourceUrl: status.fitness.sourceUrl ?? null
       }
     ]
   }, [
@@ -1020,7 +1024,8 @@ export const FitnessStatusDetail: FC<Props> = ({
     status.fitness?.hasMapData,
     status.fitness?.description,
     status.fitness?.deviceManufacturer,
-    status.fitness?.deviceName
+    status.fitness?.deviceName,
+    status.fitness?.sourceUrl
   ])
   const [fitnessFiles, setFitnessFiles] =
     useState<StatusFitnessFileItem[]>(defaultFitnessFiles)
@@ -1132,6 +1137,7 @@ export const FitnessStatusDetail: FC<Props> = ({
     durationSeconds: fitness?.totalDurationSeconds ?? undefined,
     activityType: fitness?.activityType ?? undefined
   })
+  const fitnessSourceUrl = normalizeFitnessSourceUrl(fitness?.sourceUrl)
 
   const mapAttachmentIndex = useMemo(() => {
     const routeMapIndex = status.attachments.findIndex((attachment) =>
@@ -1469,6 +1475,19 @@ export const FitnessStatusDetail: FC<Props> = ({
                       deviceName={fitness?.deviceName}
                       deviceManufacturer={fitness?.deviceManufacturer}
                     />
+                  </p>
+                ) : null}
+                {fitnessSourceUrl ? (
+                  <p className="mt-1 text-xs sm:text-sm">
+                    <a
+                      href={fitnessSourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-slate-500 underline-offset-2 hover:text-slate-800 hover:underline"
+                    >
+                      <ExternalLink className="size-3.5 shrink-0" />
+                      {getFitnessSourceLabel(fitnessSourceUrl)}
+                    </a>
                   </p>
                 ) : null}
                 <h2

--- a/app/api/v1/fitness-files/by-status/route.ts
+++ b/app/api/v1/fitness-files/by-status/route.ts
@@ -118,7 +118,8 @@ export const GET = traceApiRoute(
             hasMapData: file.hasMapData ?? false,
             description: file.description ?? null,
             deviceManufacturer: file.deviceManufacturer ?? null,
-            deviceName: file.deviceName ?? null
+            deviceName: file.deviceName ?? null,
+            sourceUrl: file.sourceUrl ?? null
           }))
         }
       })

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -880,4 +880,61 @@ describe('Post', () => {
       screen.getByRole('button', { name: 'Remove bookmark' })
     ).toBeInTheDocument()
   })
+
+  const fitnessBase = {
+    id: 'fitness-1',
+    fileName: 'strava-123.tcx',
+    fileType: 'tcx' as const,
+    mimeType: 'application/vnd.garmin.tcx+xml',
+    bytes: 1024,
+    url: '/api/v1/fitness-files/fitness-1',
+    processingStatus: 'completed' as const
+  }
+
+  it('renders a "View on Strava" source link from the fitness source URL', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            sourceUrl: 'https://www.strava.com/activities/123'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: /View on Strava/i })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.strava.com/activities/123'
+    )
+  })
+
+  it('does not render a source link when the URL uses an unsafe scheme', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            // eslint-disable-next-line no-script-url
+            sourceUrl: 'javascript:alert(1)'
+          }
+        }}
+        onShowAttachment={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('link', { name: /View on Strava|View source/i })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -16,7 +16,8 @@ import {
   formatFitnessDistance,
   formatFitnessDuration,
   formatFitnessElevation,
-  getFitnessPaceOrSpeed
+  getFitnessPaceOrSpeed,
+  getFitnessSourceLabel
 } from '@/lib/utils/fitness'
 import { getDeviceDisplayLabel } from '@/lib/utils/fitnessDeviceBrands'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
@@ -219,6 +220,20 @@ export const Post: FC<PostProps> = (props) => {
                   />
                 </span>
               ) : null}
+            </div>
+          ) : null}
+
+          {fitnessFile.sourceUrl ? (
+            <div className="mt-2">
+              <a
+                href={fitnessFile.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                <ExternalLink className="size-3.5 shrink-0" />
+                {getFitnessSourceLabel(fitnessFile.sourceUrl)}
+              </a>
             </div>
           ) : null}
         </div>

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -17,7 +17,8 @@ import {
   formatFitnessDuration,
   formatFitnessElevation,
   getFitnessPaceOrSpeed,
-  getFitnessSourceLabel
+  getFitnessSourceLabel,
+  normalizeFitnessSourceUrl
 } from '@/lib/utils/fitness'
 import { getDeviceDisplayLabel } from '@/lib/utils/fitnessDeviceBrands'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
@@ -118,6 +119,7 @@ export const Post: FC<PostProps> = (props) => {
     durationSeconds: fitnessFile?.totalDurationSeconds,
     activityType: fitnessFile?.activityType
   })
+  const fitnessSourceUrl = normalizeFitnessSourceUrl(fitnessFile?.sourceUrl)
   const isOwner =
     Boolean(actualStatus.isLocalActor) &&
     props.currentActor?.id === actualStatus.actorId
@@ -223,16 +225,16 @@ export const Post: FC<PostProps> = (props) => {
             </div>
           ) : null}
 
-          {fitnessFile.sourceUrl ? (
+          {fitnessSourceUrl ? (
             <div className="mt-2">
               <a
-                href={fitnessFile.sourceUrl}
+                href={fitnessSourceUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
               >
                 <ExternalLink className="size-3.5 shrink-0" />
-                {getFitnessSourceLabel(fitnessFile.sourceUrl)}
+                {getFitnessSourceLabel(fitnessSourceUrl)}
               </a>
             </div>
           ) : null}

--- a/lib/database/sql/fitnessFile.test.ts
+++ b/lib/database/sql/fitnessFile.test.ts
@@ -59,6 +59,29 @@ describe('FitnessFileDatabase', () => {
         expect(actorFiles.some((item) => item.id === created!.id)).toBe(true)
       })
 
+      it('persists and backfills the import sourceUrl', async () => {
+        const created = await database.createFitnessFile({
+          actorId: actors.primary.id,
+          path: 'fitness/source-url.tcx',
+          fileName: 'source-url.tcx',
+          fileType: 'tcx',
+          mimeType: 'application/vnd.garmin.tcx+xml',
+          bytes: 1024,
+          sourceUrl: 'https://www.strava.com/activities/123'
+        })
+
+        expect(created?.sourceUrl).toBe('https://www.strava.com/activities/123')
+
+        const fetched = await database.getFitnessFile({ id: created!.id })
+        expect(fetched?.sourceUrl).toBe('https://www.strava.com/activities/123')
+
+        await database.updateFitnessFileActivityData(created!.id, {
+          sourceUrl: 'https://www.strava.com/activities/456'
+        })
+        const updated = await database.getFitnessFile({ id: created!.id })
+        expect(updated?.sourceUrl).toBe('https://www.strava.com/activities/456')
+      })
+
       it('uses a deterministic id tiebreaker when files share createdAt', async () => {
         jest.useFakeTimers()
         jest.setSystemTime(new Date('2030-01-01T00:00:00.000Z'))

--- a/lib/database/sql/fitnessFile.ts
+++ b/lib/database/sql/fitnessFile.ts
@@ -29,6 +29,7 @@ export interface CreateFitnessFileParams {
   hasMapData?: boolean
   mapImagePath?: string
   importBatchId?: string
+  sourceUrl?: string
 }
 
 export interface UpdateFitnessFileActivityData {
@@ -41,6 +42,7 @@ export interface UpdateFitnessFileActivityData {
   mapImagePath?: string | null
   deviceManufacturer?: string | null
   deviceName?: string | null
+  sourceUrl?: string | null
 }
 
 export interface GetFitnessFileParams {
@@ -239,6 +241,7 @@ const parseSQLFitnessFile = (row: SQLFitnessFile): FitnessFile => ({
   activityType: row.activityType ?? undefined,
   deviceManufacturer: row.deviceManufacturer ?? undefined,
   deviceName: row.deviceName ?? undefined,
+  sourceUrl: row.sourceUrl ?? undefined,
   activityStartTime: row.activityStartTime
     ? getCompatibleTime(row.activityStartTime)
     : undefined,
@@ -282,6 +285,7 @@ export const FitnessFileSQLDatabaseMixin = (
         elevationGainMeters: null,
         activityType: null,
         activityStartTime: null,
+        sourceUrl: params.sourceUrl ?? null,
         createdAt: currentTime,
         updatedAt: currentTime
       }
@@ -661,6 +665,9 @@ export const FitnessFileSQLDatabaseMixin = (
     }
     if ('deviceName' in data) {
       updateData.deviceName = data.deviceName ?? null
+    }
+    if ('sourceUrl' in data) {
+      updateData.sourceUrl = data.sourceUrl ?? null
     }
 
     const result = await database('fitness_files')

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -463,7 +463,8 @@ describe('StatusDatabase', () => {
           fileName: 'status.fit',
           fileType: 'fit',
           mimeType: 'application/octet-stream',
-          bytes: 4096
+          bytes: 4096,
+          sourceUrl: 'https://www.strava.com/activities/123'
         })
 
         const status = (await database.getStatus({ statusId })) as StatusNote
@@ -473,7 +474,8 @@ describe('StatusDatabase', () => {
           fileType: 'fit',
           mimeType: 'application/octet-stream',
           bytes: 4096,
-          url: `/api/v1/fitness-files/${fitnessFile?.id}`
+          url: `/api/v1/fitness-files/${fitnessFile?.id}`,
+          sourceUrl: 'https://www.strava.com/activities/123'
         })
       })
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -2471,6 +2471,9 @@ export const StatusSQLDatabaseMixin = (
                 : null),
               ...(fitnessFile.deviceName
                 ? { deviceName: fitnessFile.deviceName }
+                : null),
+              ...(fitnessFile.sourceUrl
+                ? { sourceUrl: fitnessFile.sourceUrl }
                 : null)
             }
           }

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -103,6 +103,7 @@ type MockDatabase = Pick<
   | 'getFitnessFilesByBatchId'
   | 'getFitnessFile'
   | 'getFitnessFilesByActor'
+  | 'updateFitnessFileActivityData'
   | 'getStatus'
   | 'updateNote'
   | 'getAttachments'
@@ -120,6 +121,7 @@ describe('importStravaActivityJob', () => {
     getFitnessFilesByBatchId: jest.fn(),
     getFitnessFile: jest.fn(),
     getFitnessFilesByActor: jest.fn(),
+    updateFitnessFileActivityData: jest.fn(),
     getStatus: jest.fn(),
     updateNote: jest.fn(),
     getAttachments: jest.fn(),
@@ -272,7 +274,8 @@ describe('importStravaActivityJob', () => {
       database,
       expect.anything(),
       expect.objectContaining({
-        file: expect.objectContaining({ name: 'strava-123.gpx' })
+        file: expect.objectContaining({ name: 'strava-123.gpx' }),
+        sourceUrl: 'https://www.strava.com/activities/123'
       })
     )
     expect(mockImportFitnessFilesJob).toHaveBeenCalledTimes(1)
@@ -878,6 +881,14 @@ describe('importStravaActivityJob', () => {
     })
 
     expect(database.createNotification).not.toHaveBeenCalled()
+    // The source link is backfilled onto the existing fitness file rather than
+    // injected into the status text.
+    expect(database.updateFitnessFileActivityData).toHaveBeenCalledWith(
+      'existing-file',
+      expect.objectContaining({
+        sourceUrl: 'https://www.strava.com/activities/123'
+      })
+    )
   })
 
   it('does not create duplicate notification on re-import (fallback path)', async () => {

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -522,11 +522,18 @@ export const importStravaActivityJob = createJobHandle(
       }
 
       if (!exportFile) {
+        // This branch only runs for a degenerate activity with no positive
+        // duration and no streams (buildTcxFromStravaStreams otherwise falls
+        // back to the activity's elapsed/moving time). Such a status gets no
+        // fitness_files row, so there is no place to store the source link and
+        // the activity link is intentionally not embedded in the note text.
+        // Log it so the omission is observable rather than silent.
         logger.info({
           message:
-            'No exportable file for Strava activity, creating note from activity data',
+            'No exportable file for Strava activity, creating note from activity data without source link',
           actorId,
-          stravaActivityId
+          stravaActivityId,
+          sourceUrl: getStravaActivityUrl(stravaActivityId)
         })
 
         const { status: createdNote, created: isNewFallback } =

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -6,6 +6,7 @@ import {
   statusRecipientsCC,
   statusRecipientsTo
 } from '@/lib/actions/createNote'
+import { UpdateFitnessFileActivityData } from '@/lib/database/sql/fitnessFile'
 import { Database } from '@/lib/database/types'
 import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
 import {
@@ -29,6 +30,7 @@ import {
   getStravaActivityPhotos,
   getStravaActivityStartTimeMs,
   getStravaActivityStreams,
+  getStravaActivityUrl,
   getValidStravaAccessToken,
   isSupportedStravaPhotoMimeType,
   mapStravaVisibilityToMastodon
@@ -569,7 +571,8 @@ export const importStravaActivityJob = createJobHandle(
       const storedFitnessFile = await saveFitnessFile(database, actor, {
         file: exportFile,
         description: activity.description?.trim() || undefined,
-        importBatchId: batchId
+        importBatchId: batchId,
+        sourceUrl: getStravaActivityUrl(stravaActivityId) ?? undefined
       })
 
       if (!storedFitnessFile) {
@@ -600,27 +603,51 @@ export const importStravaActivityJob = createJobHandle(
       if (!targetFitnessFile) {
         throw new Error('Stored Strava fitness file was not found in database')
       }
-    } else if (
-      activity.device_name &&
-      (!targetFitnessFile.deviceName || !targetFitnessFile.deviceManufacturer)
-    ) {
-      // Re-import: file already existed before this run, device name not yet stored
-      const manufacturerKey = getManufacturerKeyFromDeviceName(
-        activity.device_name
-      )
-      const deviceData = {
-        deviceName: activity.device_name,
-        ...(manufacturerKey !== undefined
-          ? { deviceManufacturer: manufacturerKey }
-          : {})
+    } else {
+      // Re-import: file already existed before this run. Backfill any source
+      // metadata that was not stored on the earlier import.
+      const backfillData: UpdateFitnessFileActivityData = {}
+
+      if (
+        activity.device_name &&
+        (!targetFitnessFile.deviceName || !targetFitnessFile.deviceManufacturer)
+      ) {
+        const manufacturerKey = getManufacturerKeyFromDeviceName(
+          activity.device_name
+        )
+        backfillData.deviceName = activity.device_name
+        if (manufacturerKey !== undefined) {
+          backfillData.deviceManufacturer = manufacturerKey
+        }
       }
-      await database.updateFitnessFileActivityData(
-        targetFitnessFile.id,
-        deviceData
-      )
-      targetFitnessFile =
-        (await database.getFitnessFile({ id: targetFitnessFile.id })) ??
-        targetFitnessFile
+
+      if (!targetFitnessFile.sourceUrl) {
+        const sourceUrl = getStravaActivityUrl(stravaActivityId)
+        if (sourceUrl) {
+          backfillData.sourceUrl = sourceUrl
+        }
+      }
+
+      if (Object.keys(backfillData).length > 0) {
+        await database.updateFitnessFileActivityData(
+          targetFitnessFile.id,
+          backfillData
+        )
+        // Merge the backfilled fields locally instead of re-reading the row, so
+        // the existing statusId (and other state used below) is preserved.
+        targetFitnessFile = {
+          ...targetFitnessFile,
+          ...(backfillData.deviceName
+            ? { deviceName: backfillData.deviceName }
+            : {}),
+          ...(backfillData.deviceManufacturer
+            ? { deviceManufacturer: backfillData.deviceManufacturer }
+            : {}),
+          ...(backfillData.sourceUrl
+            ? { sourceUrl: backfillData.sourceUrl }
+            : {})
+        }
+      }
     }
 
     const isNewImport = !targetFitnessFile.statusId

--- a/lib/jobs/importStravaArchiveJob.test.ts
+++ b/lib/jobs/importStravaArchiveJob.test.ts
@@ -262,6 +262,12 @@ describe('importStravaArchiveJob', () => {
     })
 
     expect(mockSaveFitnessFile).toHaveBeenCalledTimes(1)
+    // activity-1 is a non-numeric (filename-style) id, so no Strava URL is built.
+    expect(mockSaveFitnessFile).toHaveBeenCalledWith(
+      database,
+      expect.anything(),
+      expect.objectContaining({ sourceUrl: undefined })
+    )
     expect(mockQueuePublish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: IMPORT_FITNESS_FILES_JOB_NAME,
@@ -282,6 +288,45 @@ describe('importStravaArchiveJob', () => {
       'archive-file-1',
       expect.objectContaining({
         id: 'archive-file-1'
+      })
+    )
+  })
+
+  it('saves the Strava activity URL as sourceUrl for a numeric activity id', async () => {
+    mockArchiveReaderOpen.mockResolvedValueOnce({
+      close: jest.fn(),
+      hasEntry: jest.fn().mockReturnValue(true),
+      getActivities: jest.fn().mockResolvedValue([
+        {
+          activityId: '987654321',
+          activityName: 'Morning Ride',
+          fitnessFilePath: 'activities/987654321.fit',
+          mediaPaths: []
+        }
+      ]),
+      readEntryBuffer: jest
+        .fn()
+        .mockResolvedValueOnce(Buffer.from('fitness-file'))
+    } as never)
+
+    await importStravaArchiveJob(database as unknown as Database, {
+      id: 'job-numeric',
+      name: IMPORT_STRAVA_ARCHIVE_JOB_NAME,
+      data: {
+        importId: 'import-1',
+        actorId: 'actor-1',
+        archiveId: 'archive-1',
+        archiveFitnessFileId: 'archive-file-1',
+        batchId: 'strava-archive:archive-1',
+        visibility: 'private'
+      }
+    })
+
+    expect(mockSaveFitnessFile).toHaveBeenCalledWith(
+      database,
+      expect.anything(),
+      expect.objectContaining({
+        sourceUrl: 'https://www.strava.com/activities/987654321'
       })
     )
   })

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -21,6 +21,7 @@ import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
 import { saveMedia } from '@/lib/services/medias/index'
 import { getQueue } from '@/lib/services/queue'
 import { createStorageS3Client } from '@/lib/services/storage/s3Client'
+import { getStravaActivityUrl } from '@/lib/services/strava/activity'
 import {
   StravaArchiveActivity,
   StravaArchiveLimitError,
@@ -773,7 +774,9 @@ export const importStravaArchiveJob = createJobHandle(
             importBatchId: batchId,
             description:
               archiveActivity.activityDescription ||
-              archiveActivity.activityName
+              archiveActivity.activityName,
+            sourceUrl:
+              getStravaActivityUrl(archiveActivity.activityId) ?? undefined
           })
           if (!savedFitnessFile) {
             throw new Error('Failed to save imported fitness file from archive')

--- a/lib/services/fitness-files/S3StorageFile.ts
+++ b/lib/services/fitness-files/S3StorageFile.ts
@@ -151,7 +151,7 @@ export class S3FitnessStorage implements FitnessStorage {
   }
 
   async saveFile(actor: Actor, fitnessFile: FitnessFileUploadSchema) {
-    const { file, description, importBatchId } = fitnessFile
+    const { file, description, importBatchId, sourceUrl } = fitnessFile
 
     // Check quota before saving
     const quotaCheck = await checkQuotaAvailable(
@@ -197,7 +197,8 @@ export class S3FitnessStorage implements FitnessStorage {
       mimeType: file.type,
       bytes: file.size,
       description,
-      importBatchId
+      importBatchId,
+      sourceUrl
     })
 
     if (!storedFile) {

--- a/lib/services/fitness-files/localFile.ts
+++ b/lib/services/fitness-files/localFile.ts
@@ -116,7 +116,7 @@ export class LocalFileFitnessStorage implements FitnessStorage {
   }
 
   async saveFile(actor: Actor, fitnessFile: FitnessFileUploadSchema) {
-    const { file, description, importBatchId } = fitnessFile
+    const { file, description, importBatchId, sourceUrl } = fitnessFile
 
     // Check quota before saving
     const quotaCheck = await checkQuotaAvailable(
@@ -157,7 +157,8 @@ export class LocalFileFitnessStorage implements FitnessStorage {
       mimeType: file.type,
       bytes: file.size,
       description,
-      importBatchId
+      importBatchId,
+      sourceUrl
     })
 
     if (!storedFile) {

--- a/lib/services/fitness-files/types.ts
+++ b/lib/services/fitness-files/types.ts
@@ -50,7 +50,8 @@ export type FitnessFileSchema = z.infer<typeof FitnessFileSchema>
 export const FitnessFileUploadSchema = z.object({
   file: FitnessFileSchema,
   description: z.string().optional(),
-  importBatchId: z.string().optional()
+  importBatchId: z.string().optional(),
+  sourceUrl: z.string().optional()
 })
 export type FitnessFileUploadSchema = z.infer<typeof FitnessFileUploadSchema>
 

--- a/lib/services/strava/activity.test.ts
+++ b/lib/services/strava/activity.test.ts
@@ -1,7 +1,9 @@
 import {
   buildGpxFromStravaStreams,
+  buildStravaActivitySummary,
   buildTcxFromStravaStreams,
   getStravaActivityStreams,
+  getStravaActivityUrl,
   getStravaUpload
 } from './activity'
 
@@ -320,5 +322,42 @@ describe('buildTcxFromStravaStreams', () => {
     )
 
     expect(result).toContain('Sport="Run &amp; Bike &lt;test&gt;"')
+  })
+})
+
+describe('buildStravaActivitySummary', () => {
+  it('does not embed the Strava activity link in the status text', () => {
+    const summary = buildStravaActivitySummary({
+      id: 123,
+      name: 'Morning Run',
+      distance: 10000,
+      moving_time: 3000,
+      total_elevation_gain: 50,
+      description: 'Felt great',
+      sport_type: 'Run'
+    })
+
+    expect(summary).not.toContain('strava.com')
+    expect(summary).not.toContain('https://')
+    expect(summary).toContain('Morning Run')
+    expect(summary).toContain('Felt great')
+  })
+})
+
+describe('getStravaActivityUrl', () => {
+  it('builds the public activity URL from a numeric id', () => {
+    expect(getStravaActivityUrl(123)).toBe(
+      'https://www.strava.com/activities/123'
+    )
+    expect(getStravaActivityUrl('456')).toBe(
+      'https://www.strava.com/activities/456'
+    )
+  })
+
+  it('returns null for non-numeric ids (e.g. archive filename fallbacks)', () => {
+    expect(getStravaActivityUrl('activities/run.gpx')).toBeNull()
+    expect(getStravaActivityUrl('')).toBeNull()
+    expect(getStravaActivityUrl(null)).toBeNull()
+    expect(getStravaActivityUrl(undefined)).toBeNull()
   })
 })

--- a/lib/services/strava/activity.ts
+++ b/lib/services/strava/activity.ts
@@ -242,11 +242,26 @@ export const buildStravaActivitySummary = (activity: StravaActivity) => {
 
   const firstLine = title ? `${emoji} ${title}` : `${emoji} ${label}`
   const secondLine = metricParts.length > 0 ? metricParts.join(' • ') : label
-  const stravaUrl = `https://www.strava.com/activities/${activity.id}`
 
-  return [firstLine, secondLine, description, stravaUrl]
+  // The link back to the original Strava activity is intentionally NOT embedded
+  // in the status text. It is stored as the fitness file's `sourceUrl` instead
+  // (see getStravaActivityUrl) and surfaced on the fitness activity display.
+  return [firstLine, secondLine, description]
     .filter((line): line is string => Boolean(line && line.trim()))
     .join('\n')
+}
+
+// Build the public Strava activity URL from an activity id. Returns null when
+// the id is not a positive integer (e.g. a Strava archive falls back to the
+// fitness filename when no numeric Activity ID is present in the CSV), so we
+// never construct a link that points nowhere.
+export const getStravaActivityUrl = (
+  activityId: string | number | null | undefined
+): string | null => {
+  if (activityId === null || activityId === undefined) return null
+  const normalized = String(activityId).trim()
+  if (!/^\d+$/.test(normalized)) return null
+  return `https://www.strava.com/activities/${normalized}`
 }
 
 export const getStravaActivityPhotos = async ({

--- a/lib/types/database/fitnessFile.ts
+++ b/lib/types/database/fitnessFile.ts
@@ -38,6 +38,7 @@ export interface SQLFitnessFile {
   activityStartTime?: number | Date | string | null
   deviceManufacturer?: string | null
   deviceName?: string | null
+  sourceUrl?: string | null
 
   // Timestamps
   createdAt: number | Date
@@ -72,6 +73,7 @@ export interface FitnessFile {
   activityStartTime?: number
   deviceManufacturer?: string
   deviceName?: string
+  sourceUrl?: string
 
   createdAt: number
   updatedAt: number

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -40,7 +40,8 @@ export const StatusFitnessFile = z.object({
   activityType: z.string().optional(),
   hasMapData: z.boolean().optional(),
   deviceName: z.string().optional(),
-  deviceManufacturer: z.string().optional()
+  deviceManufacturer: z.string().optional(),
+  sourceUrl: z.string().optional()
 })
 export type StatusFitnessFile = z.infer<typeof StatusFitnessFile>
 

--- a/lib/utils/fitness.test.ts
+++ b/lib/utils/fitness.test.ts
@@ -2,10 +2,31 @@ import {
   formatFitnessDistance,
   formatFitnessDuration,
   formatFitnessElevation,
-  getFitnessPaceOrSpeed
+  getFitnessPaceOrSpeed,
+  getFitnessSourceLabel
 } from '@/lib/utils/fitness'
 
 describe('#fitness utils', () => {
+  describe('#getFitnessSourceLabel', () => {
+    it('labels Strava-hosted URLs as "View on Strava"', () => {
+      expect(
+        getFitnessSourceLabel('https://www.strava.com/activities/123')
+      ).toBe('View on Strava')
+      expect(getFitnessSourceLabel('https://strava.com/activities/123')).toBe(
+        'View on Strava'
+      )
+    })
+
+    it('falls back to "View source" for other or missing URLs', () => {
+      expect(getFitnessSourceLabel('https://example.com/activity/1')).toBe(
+        'View source'
+      )
+      expect(getFitnessSourceLabel('not a url')).toBe('View source')
+      expect(getFitnessSourceLabel(undefined)).toBe('View source')
+      expect(getFitnessSourceLabel(null)).toBe('View source')
+    })
+  })
+
   describe('#formatFitnessDistance', () => {
     it('formats short and long distances', () => {
       expect(formatFitnessDistance(5_234)).toBe('5.23 km')

--- a/lib/utils/fitness.test.ts
+++ b/lib/utils/fitness.test.ts
@@ -3,7 +3,8 @@ import {
   formatFitnessDuration,
   formatFitnessElevation,
   getFitnessPaceOrSpeed,
-  getFitnessSourceLabel
+  getFitnessSourceLabel,
+  normalizeFitnessSourceUrl
 } from '@/lib/utils/fitness'
 
 describe('#fitness utils', () => {
@@ -24,6 +25,26 @@ describe('#fitness utils', () => {
       expect(getFitnessSourceLabel('not a url')).toBe('View source')
       expect(getFitnessSourceLabel(undefined)).toBe('View source')
       expect(getFitnessSourceLabel(null)).toBe('View source')
+    })
+  })
+
+  describe('#normalizeFitnessSourceUrl', () => {
+    it('returns http(s) URLs unchanged', () => {
+      expect(
+        normalizeFitnessSourceUrl('https://www.strava.com/activities/123')
+      ).toBe('https://www.strava.com/activities/123')
+      expect(normalizeFitnessSourceUrl('http://example.com/a')).toBe(
+        'http://example.com/a'
+      )
+    })
+
+    it('rejects non-http schemes and invalid/empty values', () => {
+      expect(normalizeFitnessSourceUrl('javascript:alert(1)')).toBeNull()
+      expect(normalizeFitnessSourceUrl('data:text/html,x')).toBeNull()
+      expect(normalizeFitnessSourceUrl('not a url')).toBeNull()
+      expect(normalizeFitnessSourceUrl('')).toBeNull()
+      expect(normalizeFitnessSourceUrl(undefined)).toBeNull()
+      expect(normalizeFitnessSourceUrl(null)).toBeNull()
     })
   })
 

--- a/lib/utils/fitness.ts
+++ b/lib/utils/fitness.ts
@@ -111,3 +111,23 @@ export const getFitnessPaceOrSpeed = ({
     speedKmh
   }
 }
+
+// Derive a human-friendly label for an external fitness "source" link from its
+// host. Strava-hosted URLs read as "View on Strava"; anything else falls back to
+// a generic label so the column can hold links from future providers too.
+export const getFitnessSourceLabel = (sourceUrl?: string | null): string => {
+  if (!sourceUrl) return 'View source'
+  try {
+    const { hostname } = new URL(sourceUrl)
+    const normalizedHost = hostname.toLowerCase().replace(/^www\./, '')
+    if (
+      normalizedHost === 'strava.com' ||
+      normalizedHost.endsWith('.strava.com')
+    ) {
+      return 'View on Strava'
+    }
+    return 'View source'
+  } catch {
+    return 'View source'
+  }
+}

--- a/lib/utils/fitness.ts
+++ b/lib/utils/fitness.ts
@@ -112,6 +112,26 @@ export const getFitnessPaceOrSpeed = ({
   }
 }
 
+// Defense-in-depth: only treat an http(s) URL as a renderable fitness source
+// link. Today `sourceUrl` is always server-derived (getStravaActivityUrl yields
+// a hardcoded https Strava URL or null), but the column is generic and rendered
+// as an href, so we never surface a non-http scheme (e.g. javascript:) even if
+// a future writer forwards a less-trusted value.
+export const normalizeFitnessSourceUrl = (
+  sourceUrl?: string | null
+): string | null => {
+  if (!sourceUrl) return null
+  try {
+    const { protocol } = new URL(sourceUrl)
+    if (protocol === 'http:' || protocol === 'https:') {
+      return sourceUrl
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 // Derive a human-friendly label for an external fitness "source" link from its
 // host. Strava-hosted URLs read as "View on Strava"; anything else falls back to
 // a generic label so the column can hold links from future providers too.

--- a/migrations/20260605120000_add_fitness_file_source_url.js
+++ b/migrations/20260605120000_add_fitness_file_source_url.js
@@ -1,0 +1,15 @@
+exports.up = async function (knex) {
+  await knex.schema.alterTable('fitness_files', function (table) {
+    // External source URL the activity was imported from (e.g. the original
+    // Strava activity page). Kept as a record so the link can be surfaced on
+    // the fitness activity display instead of being embedded in the status
+    // text content.
+    table.text('sourceUrl')
+  })
+}
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('fitness_files', function (table) {
+    table.dropColumn('sourceUrl')
+  })
+}


### PR DESCRIPTION
## Summary

The single-activity Strava import used to append the activity link
(`https://www.strava.com/activities/<id>`) as the last line of the imported
status text. This baked an external link into the (federated) note content.

This PR keeps the link as a **record** on the fitness activity instead, and
surfaces it on the fitness activity display — never in the status content.

## Changes

- **Migration** `20260605120000_add_fitness_file_source_url.js`: add a nullable
  `sourceUrl` text column to `fitness_files`.
- Thread `sourceUrl` through `SQLFitnessFile`/`FitnessFile`, `parseSQLFitnessFile`,
  `CreateFitnessFileParams`, `UpdateFitnessFileActivityData`, the create/update SQL
  paths, the fitness-file upload schema + both storage backends' `saveFile`, and the
  `StatusFitnessFile` domain type + `status.ts` mapping.
- Remove the Strava URL from `buildStravaActivitySummary`; add a numeric-id-guarded
  `getStravaActivityUrl()` helper (the Strava archive falls back to a filename when no
  numeric Activity ID is present, which must not become a link).
- Populate `sourceUrl` during single-activity import (on save, and backfilled on
  re-import) and during archive import when the CSV carries a numeric Activity ID.
- Render a **View on Strava** / **View source** link in the `Post` fitness box from
  `fitnessFile.sourceUrl` (label derived from the URL host via `getFitnessSourceLabel`).

## Notes / decisions for reviewers

- **Federation:** fitness attachments are already stripped from the federated object
  (`toActivityPubObject`), so moving the link out of the text makes it **local-UI-only**
  by design — consistent with "never put it in the status content."
- **Fix-forward:** statuses imported *before* this change keep the URL already present
  in their stored text (the empty-text update path only fills blank text). No backfill
  rewrite of old post text is performed.
- **Fallback notes:** when a Strava activity has no exportable TCX/GPX, the import
  creates a plain status note with **no `fitness_files` row**, so there is nowhere to
  store `sourceUrl` and that rare path no longer surfaces the link. Flagging this
  explicitly — happy to add a follow-up (e.g. a lightweight record) if desired.

## Testing

- `yarn run prettier --write .`, `yarn lint` (0 errors), `yarn build` (green),
  `yarn test` (3376 tests pass).
- New/updated unit tests: `buildStravaActivitySummary` no longer emits a URL;
  `getStravaActivityUrl` numeric guard; `getFitnessSourceLabel` host labels;
  `fitness_files` `sourceUrl` round-trip + backfill; import job passes/backfills
  `sourceUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)