### PR TITLE
minor: make statuses API fully Mastodon-compatible

### DIFF
--- a/app/api/v1/statuses/[id]/context/route.ts
+++ b/app/api/v1/statuses/[id]/context/route.ts
@@ -74,9 +74,10 @@ const collectAncestors = async ({
 
 /**
  * Depth-first pre-order traversal of the reply tree under the status, matching
- * Mastodon's flattened `descendants` ordering. `getStatusReplies` already
- * pre-filters by coarse visibility; a final readable filter applies the precise
- * per-actor check.
+ * Mastodon's flattened `descendants` ordering. Readability is filtered *during*
+ * expansion (not after) so only readable replies count toward `limit` and the
+ * traversal never recurses into — or leaks the structure of — unreadable
+ * branches.
  */
 const collectDescendants = async ({
   database,
@@ -100,7 +101,15 @@ const collectDescendants = async ({
       statusId: parentId,
       visibleToActorId: currentActor?.id ?? null
     })
-    for (const reply of replies) {
+    // getStatusReplies pre-filters by coarse visibility; apply the precise
+    // per-actor readable check before a reply counts toward the limit or is
+    // recursed into.
+    const readableReplies = await filterReadableStatuses({
+      database,
+      statuses: replies,
+      currentActor
+    })
+    for (const reply of readableReplies) {
       if (collected.length >= limit) return
       if (visited.has(reply.id)) continue
       visited.add(reply.id)
@@ -111,11 +120,7 @@ const collectDescendants = async ({
 
   await expand(rootStatusId)
 
-  return filterReadableStatuses({
-    database,
-    statuses: collected,
-    currentActor
-  })
+  return collected
 }
 
 export const GET = traceApiRoute(

--- a/app/api/v1/statuses/[id]/context/route.ts
+++ b/app/api/v1/statuses/[id]/context/route.ts
@@ -1,14 +1,13 @@
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
-import {
-  getMastodonStatus,
-  getMastodonStatuses
-} from '@/lib/services/mastodon/getMastodonStatus'
+import { Database } from '@/lib/database/types'
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
 import {
   filterReadableStatuses,
   getReadableStatus
 } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
-import { StatusType } from '@/lib/types/domain/status'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status, StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -18,13 +17,110 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+// Mirror Mastodon's context limits: authenticated requests can walk a much
+// larger thread than anonymous ones (see Api::V1::Statuses::ContextsController).
+const AUTHENTICATED_CONTEXT_LIMIT = 4096
+const ANONYMOUS_ANCESTORS_LIMIT = 40
+const ANONYMOUS_DESCENDANTS_LIMIT = 60
+
 interface Params {
   id: string
 }
 
+const getReplyId = (status: Status): string =>
+  status.type === StatusType.enum.Announce ? '' : status.reply
+
+/**
+ * Walks the `in_reply_to` chain from the status up to the thread root. The walk
+ * traverses through statuses the requester cannot read (so the chain is not cut
+ * short by a private ancestor), but only readable ancestors are returned. The
+ * result is ordered root-first, matching Mastodon's `ancestors` ordering.
+ */
+const collectAncestors = async ({
+  database,
+  status,
+  currentActor,
+  limit
+}: {
+  database: Database
+  status: Status
+  currentActor: Actor | null
+  limit: number
+}): Promise<Status[]> => {
+  const chain: Status[] = []
+  const seen = new Set<string>([status.id])
+  let parentId = getReplyId(status)
+
+  while (parentId && chain.length < limit) {
+    const parent = await database.getStatus({
+      statusId: parentId,
+      withReplies: false,
+      currentActorId: currentActor?.id
+    })
+    if (!parent || seen.has(parent.id)) break
+    seen.add(parent.id)
+    chain.push(parent)
+    parentId = getReplyId(parent)
+  }
+
+  // chain is direct-parent-first; reverse to root-first for the response.
+  const readable = await filterReadableStatuses({
+    database,
+    statuses: chain,
+    currentActor
+  })
+  return readable.reverse()
+}
+
+/**
+ * Depth-first pre-order traversal of the reply tree under the status, matching
+ * Mastodon's flattened `descendants` ordering. `getStatusReplies` already
+ * pre-filters by coarse visibility; a final readable filter applies the precise
+ * per-actor check.
+ */
+const collectDescendants = async ({
+  database,
+  rootStatusId,
+  currentActor,
+  excludedIds,
+  limit
+}: {
+  database: Database
+  rootStatusId: string
+  currentActor: Actor | null
+  excludedIds: Set<string>
+  limit: number
+}): Promise<Status[]> => {
+  const collected: Status[] = []
+  const visited = new Set<string>(excludedIds)
+
+  const expand = async (parentId: string): Promise<void> => {
+    if (collected.length >= limit) return
+    const replies = await database.getStatusReplies({
+      statusId: parentId,
+      visibleToActorId: currentActor?.id ?? null
+    })
+    for (const reply of replies) {
+      if (collected.length >= limit) return
+      if (visited.has(reply.id)) continue
+      visited.add(reply.id)
+      collected.push(reply)
+      await expand(reply.id)
+    }
+  }
+
+  await expand(rootStatusId)
+
+  return filterReadableStatuses({
+    database,
+    statuses: collected,
+    currentActor
+  })
+}
+
 export const GET = traceApiRoute(
   'getStatusContext',
-  OAuthGuardAnyScope<Params>(
+  OptionalOAuthGuard<Params>(
     [Scope.enum.read, Scope.enum['read:statuses']],
     async (req, context) => {
       const { params } = context
@@ -54,37 +150,40 @@ export const GET = traceApiRoute(
         })
       }
 
-      const [ancestor, descendants] = await Promise.all([
-        status.reply
-          ? getReadableStatus({
-              database,
-              statusId: status.reply,
-              currentActor
-            }).then((status) =>
-              status
-                ? getMastodonStatus(database, status, currentActor.id)
-                : null
-            )
-          : Promise.resolve(null),
-        database
-          .getStatusReplies({
-            statusId,
-            visibleToActorId: currentActor.id
-          })
-          .then((statuses) =>
-            filterReadableStatuses({ database, statuses, currentActor })
-          )
-          .then((statuses) =>
-            getMastodonStatuses(database, statuses, currentActor.id)
-          )
+      const ancestorsLimit = currentActor
+        ? AUTHENTICATED_CONTEXT_LIMIT
+        : ANONYMOUS_ANCESTORS_LIMIT
+      const descendantsLimit = currentActor
+        ? AUTHENTICATED_CONTEXT_LIMIT
+        : ANONYMOUS_DESCENDANTS_LIMIT
+
+      const [ancestorStatuses, descendantStatuses] = await Promise.all([
+        collectAncestors({
+          database,
+          status,
+          currentActor,
+          limit: ancestorsLimit
+        }),
+        collectDescendants({
+          database,
+          rootStatusId: statusId,
+          currentActor,
+          excludedIds: new Set<string>([statusId]),
+          limit: descendantsLimit
+        })
+      ])
+
+      const [ancestors, descendants] = await Promise.all([
+        getMastodonStatuses(database, ancestorStatuses, currentActor?.id),
+        getMastodonStatuses(database, descendantStatuses, currentActor?.id)
       ])
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: {
-          ancestors: ancestor ? [ancestor] : [],
-          descendants: descendants.filter(Boolean)
+          ancestors,
+          descendants
         }
       })
     }

--- a/app/api/v1/statuses/[id]/context/route.ts
+++ b/app/api/v1/statuses/[id]/context/route.ts
@@ -186,7 +186,9 @@ export const GET = traceApiRoute(
           descendants
         }
       })
-    }
+    },
+    // A token scoped read:statuses OR read satisfies the requirement.
+    { matchMode: 'any' }
   ),
   {
     addAttributes: async (_req, context) => {

--- a/app/api/v1/statuses/[id]/favourited_by/route.ts
+++ b/app/api/v1/statuses/[id]/favourited_by/route.ts
@@ -32,95 +32,109 @@ const FavouritedByQueryParams = z.object({
 
 export const GET = traceApiRoute(
   'getStatusFavouritedBy',
-  OptionalOAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, currentActor, params } = context
-    const encodedStatusId = (await params).id
-    if (!encodedStatusId)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-
-    const queryParams = Object.fromEntries(new URL(req.url).searchParams)
-    const parsedParams = FavouritedByQueryParams.safeParse(queryParams)
-    if (!parsedParams.success) {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_400,
-        responseStatusCode: 400
-      })
-    }
-
-    const {
-      limit,
-      max_id: maxId,
-      min_id: minId,
-      since_id: sinceId
-    } = parsedParams.data
-    const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
-      database,
-      statusId,
-      currentActor,
-      withReplies: false
-    })
-    if (!status)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-
-    const favouritesPage = await database.getFavouritedBy({
-      statusId,
-      limit: limit + 1,
-      maxId,
-      minId,
-      sinceId
-    })
-    const hasNextPage = favouritesPage.length > limit
-    const favourites = favouritesPage.slice(0, limit)
-
-    const paginationLink = buildAccountCursorLinkHeader({
-      req,
-      limit,
-      items: favourites,
-      hasNextPage,
-      toCursor: (favourite) =>
-        encodeFavouritedByCursor({
-          createdAt: favourite.createdAt,
-          actorId: favourite.actorId
+  OptionalOAuthGuard<Params>(
+    [Scope.enum.read, Scope.enum['read:accounts']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const encodedStatusId = (await params).id
+      if (!encodedStatusId)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
         })
-    })
 
-    const accounts = await database.getMastodonActorsFromIds({
-      ids: favourites.map(({ actorId }) => actorId)
-    })
-    // Preserve the favourite order: getMastodonActorsFromIds does not guarantee
-    // it, and Mastodon returns accounts newest-favourite-first.
-    const accountById = new Map<string, (typeof accounts)[number]>()
-    for (const account of accounts) {
-      if (typeof account.id === 'string')
-        accountById.set(idToUrl(account.id), account)
-      if (account.url) accountById.set(account.url, account)
-    }
-    const orderedAccounts = favourites
-      .map(({ actorId }) => accountById.get(actorId))
-      .filter((account): account is NonNullable<typeof account> =>
-        Boolean(account)
-      )
+      const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+      const parsedParams = FavouritedByQueryParams.safeParse(queryParams)
+      if (!parsedParams.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
 
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: orderedAccounts,
-      additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
-    })
-  }),
+      const {
+        limit,
+        max_id: maxId,
+        min_id: minId,
+        since_id: sinceId
+      } = parsedParams.data
+      const statusId = idToUrl(encodedStatusId)
+      const status = await getReadableStatus({
+        database,
+        statusId,
+        currentActor,
+        withReplies: false
+      })
+      if (!status)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const favouritesPage = await database.getFavouritedBy({
+        statusId,
+        limit: limit + 1,
+        maxId,
+        minId,
+        sinceId
+      })
+      const hasNextPage = favouritesPage.length > limit
+      // The extra (limit+1)th row is the page-boundary overflow used only to
+      // detect a next page. For descending pages (default/max_id/since_id) it is
+      // the oldest row, at the end. For an ascending min_id page the DB reverses
+      // the rows, so the overflow lands at the front and we must trim there
+      // instead — otherwise the favourite immediately adjacent to the cursor is
+      // dropped and a gap opens.
+      const favourites = minId
+        ? favouritesPage.slice(Math.max(0, favouritesPage.length - limit))
+        : favouritesPage.slice(0, limit)
+
+      const paginationLink = buildAccountCursorLinkHeader({
+        req,
+        limit,
+        items: favourites,
+        hasNextPage,
+        toCursor: (favourite) =>
+          encodeFavouritedByCursor({
+            createdAt: favourite.createdAt,
+            actorId: favourite.actorId
+          })
+      })
+
+      const accounts = await database.getMastodonActorsFromIds({
+        ids: favourites.map(({ actorId }) => actorId)
+      })
+      // Preserve the favourite order: getMastodonActorsFromIds does not guarantee
+      // it, and Mastodon returns accounts newest-favourite-first.
+      const accountById = new Map<string, (typeof accounts)[number]>()
+      for (const account of accounts) {
+        if (typeof account.id === 'string')
+          accountById.set(idToUrl(account.id), account)
+        if (account.url) accountById.set(account.url, account)
+      }
+      const orderedAccounts = favourites
+        .map(({ actorId }) => accountById.get(actorId))
+        .filter((account): account is NonNullable<typeof account> =>
+          Boolean(account)
+        )
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: orderedAccounts,
+        additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
+      })
+    },
+    // read or read:accounts satisfies the requirement (Mastodon's
+    // favourited_by_accounts scope).
+    { matchMode: 'any' }
+  ),
   {
     addAttributes: async (_req, context) => {
       const params = await context.params

--- a/app/api/v1/statuses/[id]/favourited_by/route.ts
+++ b/app/api/v1/statuses/[id]/favourited_by/route.ts
@@ -84,22 +84,33 @@ export const GET = traceApiRoute(
         minId,
         sinceId
       })
-      const hasNextPage = favouritesPage.length > limit
+      const hasOverflow = favouritesPage.length > limit
       // The extra (limit+1)th row is the page-boundary overflow used only to
-      // detect a next page. For descending pages (default/max_id/since_id) it is
-      // the oldest row, at the end. For an ascending min_id page the DB reverses
-      // the rows, so the overflow lands at the front and we must trim there
-      // instead — otherwise the favourite immediately adjacent to the cursor is
-      // dropped and a gap opens.
+      // detect another page. For descending pages (default/max_id/since_id) it
+      // is the oldest row, at the end, so it signals more OLDER results (the
+      // next/max_id link). For an ascending min_id page the DB reverses the
+      // rows, so the overflow lands at the front and signals more NEWER results
+      // (the prev/since_id link); we also trim from the front there so the
+      // favourite immediately adjacent to the cursor is not dropped.
       const favourites = minId
         ? favouritesPage.slice(Math.max(0, favouritesPage.length - limit))
         : favouritesPage.slice(0, limit)
+
+      // Newest-first page: next (older/max_id) and prev (newer/since_id) are
+      // gated independently. A min_id page paged forward toward newer results,
+      // so its overflow indicates more on the prev (newer) side; older results
+      // (the cursor and below) always exist, so next is always offered. Other
+      // pages move older, so overflow indicates more on the next (older) side
+      // and newer results always exist behind them.
+      const hasNext = minId ? true : hasOverflow
+      const hasPrev = minId ? hasOverflow : true
 
       const paginationLink = buildAccountCursorLinkHeader({
         req,
         limit,
         items: favourites,
-        hasNextPage,
+        hasNext,
+        hasPrev,
         toCursor: (favourite) =>
           encodeFavouritedByCursor({
             createdAt: favourite.createdAt,

--- a/app/api/v1/statuses/[id]/favourited_by/route.ts
+++ b/app/api/v1/statuses/[id]/favourited_by/route.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { encodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByCursor'
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { buildAccountCursorLinkHeader } from '@/lib/services/mastodon/accountCursorLinkHeader'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -22,13 +24,15 @@ interface Params {
 }
 
 const FavouritedByQueryParams = z.object({
-  limit: z.coerce.number().min(1).max(200).optional(),
-  offset: z.coerce.number().min(0).default(0).optional()
+  limit: z.coerce.number().int().min(1).max(80).default(40),
+  max_id: z.string().min(1).optional(),
+  min_id: z.string().min(1).optional(),
+  since_id: z.string().min(1).optional()
 })
 
 export const GET = traceApiRoute(
   'getStatusFavouritedBy',
-  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
+  OptionalOAuthGuard<Params>([Scope.enum.read], async (req, context) => {
     const { database, currentActor, params } = context
     const encodedStatusId = (await params).id
     if (!encodedStatusId)
@@ -50,7 +54,12 @@ export const GET = traceApiRoute(
       })
     }
 
-    const { limit, offset = 0 } = parsedParams.data
+    const {
+      limit,
+      max_id: maxId,
+      min_id: minId,
+      since_id: sinceId
+    } = parsedParams.data
     const statusId = idToUrl(encodedStatusId)
     const status = await getReadableStatus({
       database,
@@ -66,22 +75,50 @@ export const GET = traceApiRoute(
         responseStatusCode: 404
       })
 
-    const [actors, totalCount] = await Promise.all([
-      database.getFavouritedBy({ statusId, limit, offset }),
-      database.getLikeCount({ statusId })
-    ])
+    const favouritesPage = await database.getFavouritedBy({
+      statusId,
+      limit: limit + 1,
+      maxId,
+      minId,
+      sinceId
+    })
+    const hasNextPage = favouritesPage.length > limit
+    const favourites = favouritesPage.slice(0, limit)
+
+    const paginationLink = buildAccountCursorLinkHeader({
+      req,
+      limit,
+      items: favourites,
+      hasNextPage,
+      toCursor: (favourite) =>
+        encodeFavouritedByCursor({
+          createdAt: favourite.createdAt,
+          actorId: favourite.actorId
+        })
+    })
+
+    const accounts = await database.getMastodonActorsFromIds({
+      ids: favourites.map(({ actorId }) => actorId)
+    })
+    // Preserve the favourite order: getMastodonActorsFromIds does not guarantee
+    // it, and Mastodon returns accounts newest-favourite-first.
+    const accountById = new Map<string, (typeof accounts)[number]>()
+    for (const account of accounts) {
+      if (typeof account.id === 'string')
+        accountById.set(idToUrl(account.id), account)
+      if (account.url) accountById.set(account.url, account)
+    }
+    const orderedAccounts = favourites
+      .map(({ actorId }) => accountById.get(actorId))
+      .filter((account): account is NonNullable<typeof account> =>
+        Boolean(account)
+      )
 
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: await Promise.all(
-        actors.map((actor) => database.getMastodonActorFromId({ id: actor.id }))
-      ),
-      additionalHeaders: [
-        ['X-Total-Count', `${totalCount}`],
-        ['X-Offset', `${offset}`],
-        ['X-Limit', `${limit ?? totalCount}`]
-      ]
+      data: orderedAccounts,
+      additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
     })
   }),
   {

--- a/app/api/v1/statuses/[id]/history/route.ts
+++ b/app/api/v1/statuses/[id]/history/route.ts
@@ -1,4 +1,4 @@
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatusEdits } from '@/lib/services/mastodon/getMastodonStatusEdits'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
@@ -18,7 +18,7 @@ interface Params {
 
 export const GET = traceApiRoute(
   'getStatusHistory',
-  OAuthGuardAnyScope<Params>(
+  OptionalOAuthGuard<Params>(
     [Scope.enum.read, Scope.enum['read:statuses']],
     async (req, context) => {
       const { database, currentActor, params } = context
@@ -64,7 +64,10 @@ export const GET = traceApiRoute(
       )
 
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: history })
-    }
+    },
+    // Public for public statuses; a read or read:statuses token unlocks private
+    // ones. matchMode 'any' so either scope satisfies the requirement.
+    { matchMode: 'any' }
   ),
   {
     addAttributes: async (_req, context) => {

--- a/app/api/v1/statuses/[id]/history/route.ts
+++ b/app/api/v1/statuses/[id]/history/route.ts
@@ -1,7 +1,8 @@
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonStatusEdits } from '@/lib/services/mastodon/getMastodonStatusEdits'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -45,8 +46,9 @@ export const GET = traceApiRoute(
           responseStatusCode: 404
         })
 
-      // Only note and poll statuses have text content
-      if (status.type === 'Announce') {
+      // Only Note and Poll statuses have editable text content; Announces
+      // (reblogs) have no history.
+      if (status.type === StatusType.enum.Announce) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -55,20 +57,11 @@ export const GET = traceApiRoute(
         })
       }
 
-      // Return current version as history (edit history not tracked)
-      const history = [
-        {
-          content: status.text ?? '',
-          spoiler_text: status.summary ?? '',
-          sensitive: Boolean(status.summary),
-          created_at: getISOTimeUTC(status.createdAt),
-          account: await database.getMastodonActorFromId({
-            id: status.actorId
-          }),
-          emojis: [],
-          media_attachments: []
-        }
-      ]
+      const history = await getMastodonStatusEdits(
+        database,
+        status,
+        currentActor?.id
+      )
 
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: history })
     }

--- a/app/api/v1/statuses/[id]/mute/route.ts
+++ b/app/api/v1/statuses/[id]/mute/route.ts
@@ -1,4 +1,5 @@
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { resolveConversationRootId } from '@/lib/services/mastodon/conversationMute'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
@@ -22,54 +23,65 @@ interface Params {
 
 export const POST = traceApiRoute(
   'muteStatus',
-  OAuthGuard<Params>([Scope.enum.write], async (req, context) => {
-    const { database, currentActor, params } = context
-    const encodedStatusId = (await params).id
-    if (!encodedStatusId)
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:mutes']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const encodedStatusId = (await params).id
+      if (!encodedStatusId)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const statusId = idToUrl(encodedStatusId)
+      const status = await getReadableStatus({
+        database,
+        statusId,
+        currentActor,
+        withReplies: false
+      })
+      if (!status)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      // Mute the whole conversation (thread), keyed on its root, matching
+      // Mastodon's per-conversation mute semantics.
+      const conversationRootId = await resolveConversationRootId(
+        database,
+        status
+      )
+      await database.createStatusMute({
+        actorId: currentActor.id,
+        statusId: conversationRootId
+      })
+
+      const mastodonStatus = await getMastodonStatus(
+        database,
+        status,
+        currentActor.id
+      )
+      if (!mastodonStatus)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
+        data: mastodonStatus
       })
-
-    const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
-      database,
-      statusId,
-      currentActor,
-      withReplies: false
-    })
-    if (!status)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-
-    // Conversation muting not yet implemented
-    // TODO: Implement conversation muting functionality
-
-    const mastodonStatus = await getMastodonStatus(
-      database,
-      status,
-      currentActor.id
-    )
-    if (!mastodonStatus)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_500,
-        responseStatusCode: 500
-      })
-
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: mastodonStatus
-    })
-  }),
+    }
+  ),
   {
     addAttributes: async (_req, context) => {
       const params = await context.params

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -94,11 +94,24 @@ export const GET = traceApiRoute(
       const accounts = await database.getMastodonActorsFromIds({
         ids: reblogs.map(({ actorId }) => actorId)
       })
+      // Preserve the reblog order: getMastodonActorsFromIds does not guarantee
+      // it, and Mastodon returns accounts newest-reblog-first.
+      const accountById = new Map<string, (typeof accounts)[number]>()
+      for (const account of accounts) {
+        if (typeof account.id === 'string')
+          accountById.set(idToUrl(account.id), account)
+        if (account.url) accountById.set(account.url, account)
+      }
+      const orderedAccounts = reblogs
+        .map(({ actorId }) => accountById.get(actorId))
+        .filter((account): account is NonNullable<typeof account> =>
+          Boolean(account)
+        )
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: accounts,
+        data: orderedAccounts,
         additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
       })
     },

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod'
 
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
-import { headerHost } from '@/lib/services/guards/headerHost'
+import { buildAccountCursorLinkHeader } from '@/lib/services/mastodon/accountCursorLinkHeader'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
-import { type RebloggedByAccount, Scope } from '@/lib/types/database/operations'
+import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -27,42 +27,6 @@ const RebloggedByQueryParams = z.object({
   max_id: z.string().min(1).optional(),
   since_id: z.string().min(1).optional()
 })
-
-const getPaginationLinkHeader = ({
-  req,
-  limit,
-  reblogs,
-  hasNextPage
-}: {
-  req: Request
-  limit: number
-  reblogs: RebloggedByAccount[]
-  hasNextPage: boolean
-}) => {
-  if (reblogs.length === 0) return undefined
-
-  const requestUrl = new URL(req.url)
-  const host = headerHost(req.headers)
-  if (!host) return undefined
-
-  const buildUrl = (cursor: 'max_id' | 'since_id', statusId: string) => {
-    const params = new URLSearchParams()
-    params.set('limit', `${limit}`)
-    params.set(cursor, urlToId(statusId))
-
-    const url = new URL(requestUrl.pathname, `https://${host}`)
-    url.search = params.toString()
-    return url.toString()
-  }
-
-  const firstReblog = reblogs[0]
-  const lastReblog = reblogs[reblogs.length - 1]
-  const nextLink = hasNextPage
-    ? `<${buildUrl('max_id', lastReblog.statusId)}>; rel="next"`
-    : null
-  const prevLink = `<${buildUrl('since_id', firstReblog.statusId)}>; rel="prev"`
-  return [nextLink, prevLink].filter(Boolean).join(', ')
-}
 
 export const GET = traceApiRoute(
   'getStatusRebloggedBy',
@@ -114,11 +78,12 @@ export const GET = traceApiRoute(
     const hasNextPage = reblogsPage.length > limit
     const reblogs = reblogsPage.slice(0, limit)
 
-    const paginationLink = getPaginationLinkHeader({
+    const paginationLink = buildAccountCursorLinkHeader({
       req,
       limit,
-      reblogs,
-      hasNextPage
+      items: reblogs,
+      hasNextPage,
+      toCursor: (reblog) => urlToId(reblog.statusId)
     })
 
     const accounts = await database.getMastodonActorsFromIds({

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -84,7 +84,10 @@ export const GET = traceApiRoute(
         req,
         limit,
         items: reblogs,
-        hasNextPage,
+        // Reblog pages are always descending (max_id/since_id), so overflow is
+        // the older boundary (next), and newer results always exist (prev).
+        hasNext: hasNextPage,
+        hasPrev: true,
         toCursor: (reblog) => urlToId(reblog.statusId)
       })
 

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -30,73 +30,79 @@ const RebloggedByQueryParams = z.object({
 
 export const GET = traceApiRoute(
   'getStatusRebloggedBy',
-  OptionalOAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, currentActor, params } = context
-    const encodedStatusId = (await params).id
-    if (!encodedStatusId)
+  OptionalOAuthGuard<Params>(
+    [Scope.enum.read, Scope.enum['read:accounts']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const encodedStatusId = (await params).id
+      if (!encodedStatusId)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const queryParams = Object.fromEntries(new URL(req.url).searchParams)
+      const parsedParams = RebloggedByQueryParams.safeParse(queryParams)
+      if (!parsedParams.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+
+      const { limit, max_id: maxId, since_id: sinceId } = parsedParams.data
+      const statusId = idToUrl(encodedStatusId)
+      const status = await getReadableStatus({
+        database,
+        statusId,
+        currentActor,
+        withReplies: false
+      })
+      if (!status)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const reblogsPage = await database.getRebloggedBy({
+        statusId,
+        limit: limit + 1,
+        maxStatusId: maxId ? idToUrl(maxId) : undefined,
+        sinceStatusId: sinceId ? idToUrl(sinceId) : undefined,
+        visibleToActorId: currentActor?.id ?? null
+      })
+      const hasNextPage = reblogsPage.length > limit
+      const reblogs = reblogsPage.slice(0, limit)
+
+      const paginationLink = buildAccountCursorLinkHeader({
+        req,
+        limit,
+        items: reblogs,
+        hasNextPage,
+        toCursor: (reblog) => urlToId(reblog.statusId)
+      })
+
+      const accounts = await database.getMastodonActorsFromIds({
+        ids: reblogs.map(({ actorId }) => actorId)
+      })
+
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
+        data: accounts,
+        additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
       })
-
-    const queryParams = Object.fromEntries(new URL(req.url).searchParams)
-    const parsedParams = RebloggedByQueryParams.safeParse(queryParams)
-    if (!parsedParams.success) {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_400,
-        responseStatusCode: 400
-      })
-    }
-
-    const { limit, max_id: maxId, since_id: sinceId } = parsedParams.data
-    const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
-      database,
-      statusId,
-      currentActor,
-      withReplies: false
-    })
-    if (!status)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-
-    const reblogsPage = await database.getRebloggedBy({
-      statusId,
-      limit: limit + 1,
-      maxStatusId: maxId ? idToUrl(maxId) : undefined,
-      sinceStatusId: sinceId ? idToUrl(sinceId) : undefined,
-      visibleToActorId: currentActor?.id ?? null
-    })
-    const hasNextPage = reblogsPage.length > limit
-    const reblogs = reblogsPage.slice(0, limit)
-
-    const paginationLink = buildAccountCursorLinkHeader({
-      req,
-      limit,
-      items: reblogs,
-      hasNextPage,
-      toCursor: (reblog) => urlToId(reblog.statusId)
-    })
-
-    const accounts = await database.getMastodonActorsFromIds({
-      ids: reblogs.map(({ actorId }) => actorId)
-    })
-
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: accounts,
-      additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
-    })
-  }),
+    },
+    // read or read:accounts satisfies the requirement (Mastodon's
+    // reblogged_by_accounts scope), consistent with favourited_by.
+    { matchMode: 'any' }
+  ),
   {
     addAttributes: async (_req, context) => {
       const params = await context.params

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -3289,6 +3289,49 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(accounts).toHaveLength(1)
       expect(accounts[0].id).toBe(urlToId(secondOldest.actorId))
     })
+
+    it('emits rel=next (older) but omits rel=prev at the newest edge of a min_id page', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-favourited-by-min-id-edge`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Favourited for min_id edge paging',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createLike({ actorId: ACTOR1_ID, statusId })
+      await database.createLike({ actorId: ACTOR2_ID, statusId })
+      await database.createLike({ actorId: ACTOR3_ID, statusId })
+
+      const ordered = await database.getFavouritedBy({ statusId, limit: 10 })
+      expect(ordered).toHaveLength(3)
+      const secondOldest = ordered[ordered.length - 2]
+
+      // Page forward from the second-oldest: only one newer favourite (the
+      // newest) remains, so the page is full but reaches the newest edge.
+      const minIdCursor = encodeFavouritedByCursor({
+        createdAt: secondOldest.createdAt,
+        actorId: secondOldest.actorId
+      })
+      const page = await getStatusFavouritedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/favourited_by?limit=1&min_id=${encodeURIComponent(minIdCursor)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(page.status).toBe(200)
+      const accounts = await page.json()
+      expect(accounts).toHaveLength(1)
+      expect(accounts[0].id).toBe(urlToId(ordered[0].actorId))
+
+      const linkHeader = page.headers.get('Link') ?? ''
+      // Older favourites still exist (the cursor and below), so next must be
+      // offered; there are no newer ones, so prev must be omitted.
+      expect(linkHeader).toContain('rel="next"')
+      expect(linkHeader).toContain('max_id=')
+      expect(linkHeader).not.toContain('rel="prev"')
+    })
   })
 
   describe('edit sensitive/language', () => {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2,6 +2,7 @@ import knex from 'knex'
 import { NextRequest } from 'next/server'
 
 import { getSQLDatabase } from '@/lib/database/sql'
+import { encodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByCursor'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { MAX_PINNED_STATUSES } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
@@ -3172,6 +3173,14 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(history).toHaveLength(3)
       expect(history[0].content).toContain('Version one')
       expect(history[2].content).toContain('Version three')
+      // created_at is non-decreasing oldest→newest (a bug giving every revision
+      // the same timestamp from the wrong column would break ordering).
+      const timestamps = history.map((edit: { created_at: string }) =>
+        Date.parse(edit.created_at)
+      )
+      for (let i = 1; i < timestamps.length; i++) {
+        expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1])
+      }
       for (const edit of history) {
         expect(edit).toMatchObject({
           spoiler_text: expect.any(String),
@@ -3240,6 +3249,173 @@ describe('GET /api/v1/statuses/[id]', () => {
 
       // No legacy offset/X-* headers remain.
       expect(firstPage.headers.get('X-Total-Count')).toBeNull()
+    })
+
+    it('returns the cursor-adjacent favourite (no gap) when paging forward with min_id', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-favourited-by-min-id`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Favourited for min_id paging',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createLike({ actorId: ACTOR1_ID, statusId })
+      await database.createLike({ actorId: ACTOR2_ID, statusId })
+      await database.createLike({ actorId: ACTOR3_ID, statusId })
+
+      // Learn the descending (newest-first) order directly from storage.
+      const ordered = await database.getFavouritedBy({ statusId, limit: 10 })
+      expect(ordered).toHaveLength(3)
+      const oldest = ordered[ordered.length - 1]
+      const secondOldest = ordered[ordered.length - 2]
+
+      // Page forward from the oldest favourite, one at a time. The item
+      // immediately newer than the cursor must be returned (the off-by-one bug
+      // would skip it and return the newest instead).
+      const minIdCursor = encodeFavouritedByCursor({
+        createdAt: oldest.createdAt,
+        actorId: oldest.actorId
+      })
+      const page = await getStatusFavouritedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/favourited_by?limit=1&min_id=${encodeURIComponent(minIdCursor)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(page.status).toBe(200)
+      const accounts = await page.json()
+      expect(accounts).toHaveLength(1)
+      expect(accounts[0].id).toBe(urlToId(secondOldest.actorId))
+    })
+  })
+
+  describe('edit sensitive/language', () => {
+    it('wires sensitive and language through a PUT edit', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-sensitive-language`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Edit me to mark sensitive',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({ sensitive: true, language: 'th' }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.sensitive).toBe(true)
+      expect(data.language).toBe('th')
+
+      // Persisted through a fresh read.
+      const reread = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      await expect(reread.json()).resolves.toMatchObject({
+        sensitive: true,
+        language: 'th'
+      })
+    })
+  })
+
+  describe('context visibility filtering', () => {
+    it('excludes unreadable ancestors/descendants for a non-follower but keeps readable ones', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor3.email }
+      })
+
+      const publicRootId = `${ACTOR1_ID}/statuses/api-context-vis-root`
+      const privateMidId = `${ACTOR1_ID}/statuses/api-context-vis-private-mid`
+      const publicTargetId = `${ACTOR1_ID}/statuses/api-context-vis-target`
+      const privateDescId = `${ACTOR1_ID}/statuses/api-context-vis-private-desc`
+      const publicDescId = `${ACTOR1_ID}/statuses/api-context-vis-public-desc`
+
+      await database.createNote({
+        id: publicRootId,
+        url: publicRootId,
+        actorId: ACTOR1_ID,
+        text: 'Public root ancestor',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      // A private node in the middle of the chain: must be traversed through but
+      // excluded from the response.
+      await database.createNote({
+        id: privateMidId,
+        url: privateMidId,
+        actorId: ACTOR1_ID,
+        text: 'Private mid ancestor',
+        reply: publicRootId,
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+      await database.createNote({
+        id: publicTargetId,
+        url: publicTargetId,
+        actorId: ACTOR1_ID,
+        text: 'Public target',
+        reply: privateMidId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createNote({
+        id: privateDescId,
+        url: privateDescId,
+        actorId: ACTOR1_ID,
+        text: 'Private descendant',
+        reply: publicTargetId,
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+      await database.createNote({
+        id: publicDescId,
+        url: publicDescId,
+        actorId: ACTOR1_ID,
+        text: 'Public descendant',
+        reply: publicTargetId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await getStatusContext(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(publicTargetId)}/context`
+        ),
+        { params: Promise.resolve({ id: urlToId(publicTargetId) }) }
+      )
+      expect(response.status).toBe(200)
+      const context = await response.json()
+
+      const ancestorIds = context.ancestors.map((s: { id: string }) => s.id)
+      const descendantIds = context.descendants.map((s: { id: string }) => s.id)
+
+      // The private mid ancestor is excluded, but the public root above it
+      // remains (the chain is not cut short).
+      expect(ancestorIds).toContain(urlToId(publicRootId))
+      expect(ancestorIds).not.toContain(urlToId(privateMidId))
+
+      // The private descendant is excluded; the public sibling remains.
+      expect(descendantIds).toContain(urlToId(publicDescId))
+      expect(descendantIds).not.toContain(urlToId(privateDescId))
     })
   })
 })

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -3011,4 +3011,235 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(decoded).toBe(originalUrl)
     })
   })
+
+  describe('conversation mute/unmute', () => {
+    it('mutes and unmutes a conversation, reflecting the muted flag', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const statusId = `${ACTOR1_ID}/statuses/api-mute-conversation`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Conversation root to mute',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const muteResponse = await muteStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/mute`,
+          { method: 'POST', headers: { Origin: 'https://llun.test' } }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(muteResponse.status).toBe(200)
+      await expect(muteResponse.json()).resolves.toMatchObject({
+        id: urlToId(statusId),
+        muted: true
+      })
+
+      const unmuteResponse = await unmuteStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/unmute`,
+          { method: 'POST', headers: { Origin: 'https://llun.test' } }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(unmuteResponse.status).toBe(200)
+      await expect(unmuteResponse.json()).resolves.toMatchObject({
+        id: urlToId(statusId),
+        muted: false
+      })
+    })
+
+    it('marks a reply muted when its thread root is muted', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor2.email }
+      })
+
+      const rootId = `${ACTOR1_ID}/statuses/api-mute-thread-root`
+      const replyId = `${ACTOR1_ID}/statuses/api-mute-thread-reply`
+      await database.createNote({
+        id: rootId,
+        url: rootId,
+        actorId: ACTOR1_ID,
+        text: 'Thread root',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createNote({
+        id: replyId,
+        url: replyId,
+        actorId: ACTOR1_ID,
+        text: 'A reply in the thread',
+        reply: rootId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      // Mute via the reply; Mastodon mutes the whole conversation.
+      await muteStatus(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(replyId)}/mute`,
+          { method: 'POST', headers: { Origin: 'https://llun.test' } }
+        ),
+        { params: Promise.resolve({ id: urlToId(replyId) }) }
+      )
+
+      const rootResponse = await GET(
+        new NextRequest(`https://llun.test/api/v1/statuses/${urlToId(rootId)}`),
+        { params: Promise.resolve({ id: urlToId(rootId) }) }
+      )
+      await expect(rootResponse.json()).resolves.toMatchObject({ muted: true })
+    })
+  })
+
+  describe('full context tree', () => {
+    it('returns the full ancestor chain root-first and recursive descendants', async () => {
+      const rootId = `${ACTOR1_ID}/statuses/api-context-root`
+      const childId = `${ACTOR1_ID}/statuses/api-context-child`
+      const grandchildId = `${ACTOR1_ID}/statuses/api-context-grandchild`
+      await database.createNote({
+        id: rootId,
+        url: rootId,
+        actorId: ACTOR1_ID,
+        text: 'Root',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createNote({
+        id: childId,
+        url: childId,
+        actorId: ACTOR1_ID,
+        text: 'Child',
+        reply: rootId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createNote({
+        id: grandchildId,
+        url: grandchildId,
+        actorId: ACTOR1_ID,
+        text: 'Grandchild',
+        reply: childId,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      // Context of the middle node: one ancestor (root), one descendant (grandchild).
+      const response = await getStatusContext(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(childId)}/context`
+        ),
+        { params: Promise.resolve({ id: urlToId(childId) }) }
+      )
+      expect(response.status).toBe(200)
+      const context = await response.json()
+      expect(context.ancestors.map((s: { id: string }) => s.id)).toEqual([
+        urlToId(rootId)
+      ])
+      expect(context.descendants.map((s: { id: string }) => s.id)).toEqual([
+        urlToId(grandchildId)
+      ])
+    })
+  })
+
+  describe('status edit history', () => {
+    it('returns the full StatusEdit timeline oldest-first including the original', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-history-edits`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Version one',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.updateNote({ statusId, text: 'Version two' })
+      await database.updateNote({ statusId, text: 'Version three' })
+
+      const response = await getStatusHistory(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/history`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(response.status).toBe(200)
+      const history = await response.json()
+      expect(history).toHaveLength(3)
+      expect(history[0].content).toContain('Version one')
+      expect(history[2].content).toContain('Version three')
+      for (const edit of history) {
+        expect(edit).toMatchObject({
+          spoiler_text: expect.any(String),
+          sensitive: expect.any(Boolean),
+          created_at: expect.any(String),
+          account: expect.objectContaining({ id: urlToId(ACTOR1_ID) }),
+          media_attachments: expect.any(Array),
+          emojis: expect.any(Array)
+        })
+      }
+    })
+
+    it('returns a single edit for a never-edited status', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-history-unedited`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Only version',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await getStatusHistory(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/history`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(response.status).toBe(200)
+      const history = await response.json()
+      expect(history).toHaveLength(1)
+      expect(history[0].content).toContain('Only version')
+    })
+  })
+
+  describe('favourited_by id-cursor pagination', () => {
+    it('paginates with limit and emits a Link header with max_id/since_id', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-favourited-by-pagination`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Favourited by several actors',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createLike({ actorId: ACTOR1_ID, statusId })
+      await database.createLike({ actorId: ACTOR2_ID, statusId })
+      await database.createLike({ actorId: ACTOR3_ID, statusId })
+
+      const firstPage = await getStatusFavouritedBy(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}/favourited_by?limit=2`
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+      expect(firstPage.status).toBe(200)
+      const firstAccounts = await firstPage.json()
+      expect(firstAccounts).toHaveLength(2)
+
+      const linkHeader = firstPage.headers.get('Link')
+      expect(linkHeader).toContain('rel="next"')
+      expect(linkHeader).toContain('max_id=')
+      expect(linkHeader).toContain('rel="prev"')
+
+      // No legacy offset/X-* headers remain.
+      expect(firstPage.headers.get('X-Total-Count')).toBeNull()
+    })
+  })
 })

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1223,7 +1223,7 @@ describe('GET /api/v1/statuses/[id]', () => {
       ).resolves.toBe(false)
     })
 
-    it('deletes bookmarks and returns 404 when the original status is no longer readable', async () => {
+    it('deletes the bookmark and returns the Status with bookmarked=false when the original status is no longer readable', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor3.email }
       })
@@ -1255,8 +1255,13 @@ describe('GET /api/v1/statuses/[id]', () => {
         { params: Promise.resolve({ id: urlToId(statusId) }) }
       )
 
-      expect(response.status).toBe(404)
-      await expect(response.json()).resolves.toEqual({ status: 'Not Found' })
+      // Mastodon returns the Status (not a 404) so the client can reconcile its
+      // local bookmark state, even though the post is no longer visible.
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toMatchObject({
+        id: urlToId(statusId),
+        bookmarked: false
+      })
       await expect(
         database.isActorBookmarkedStatus({ actorId: ACTOR3_ID, statusId })
       ).resolves.toBe(false)

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -27,6 +27,7 @@ import {
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 interface Params {
   id: string
@@ -109,7 +110,9 @@ const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().nullish(),
   media_ids: z.array(z.coerce.string()).optional(),
-  visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional()
+  visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional(),
+  language: z.string().trim().min(1).optional(),
+  sensitive: Booleanish.optional()
 })
 
 const isFitnessStatusAttachment = (attachment: {
@@ -174,7 +177,9 @@ export const PUT = traceApiRoute(
         const shouldUpdateContent =
           changes.status !== undefined ||
           changes.spoiler_text !== undefined ||
-          mediaIds !== undefined
+          mediaIds !== undefined ||
+          changes.sensitive !== undefined ||
+          changes.language !== undefined
         const visibility = changes.visibility
 
         if (!shouldUpdateContent && visibility === undefined) {
@@ -269,6 +274,8 @@ export const PUT = traceApiRoute(
             text: changes.status,
             summary: changes.spoiler_text,
             attachments,
+            sensitive: changes.sensitive,
+            language: changes.language,
             publish: true,
             status:
               updatedNote?.type === StatusType.enum.Note

--- a/app/api/v1/statuses/[id]/source/route.test.ts
+++ b/app/api/v1/statuses/[id]/source/route.test.ts
@@ -1,0 +1,129 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET as getStatusSource } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/statuses/[id]/source', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('returns the StatusSource shape { id, text, spoiler_text }', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/api-source-shape`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'The plain-text source of the status',
+      summary: 'A content warning',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const response = await getStatusSource(
+      new NextRequest(
+        `https://llun.test/api/v1/statuses/${urlToId(statusId)}/source`
+      ),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual({
+      id: urlToId(statusId),
+      text: 'The plain-text source of the status',
+      spoiler_text: 'A content warning'
+    })
+  })
+
+  it('returns an empty spoiler_text when the status has no content warning', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/api-source-no-cw`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'No content warning here',
+      summary: null,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const response = await getStatusSource(
+      new NextRequest(
+        `https://llun.test/api/v1/statuses/${urlToId(statusId)}/source`
+      ),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual({
+      id: urlToId(statusId),
+      text: 'No content warning here',
+      spoiler_text: ''
+    })
+  })
+
+  it('returns 404 for a non-existent status', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/api-source-missing`
+    const response = await getStatusSource(
+      new NextRequest(
+        `https://llun.test/api/v1/statuses/${urlToId(statusId)}/source`
+      ),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v1/statuses/[id]/unbookmark/route.ts
+++ b/app/api/v1/statuses/[id]/unbookmark/route.ts
@@ -43,6 +43,10 @@ export const POST = traceApiRoute(
         withReplies: false
       })
       if (!status) {
+        // The status is not readable for the current actor (e.g. its visibility
+        // changed after they bookmarked it). Mastodon still lets the owner of
+        // the bookmark remove it and returns the Status with `bookmarked: false`,
+        // rather than a 404, as long as the underlying status still exists.
         const isBookmarked = await database.isActorBookmarkedStatus({
           actorId: currentActor.id,
           statusId
@@ -57,11 +61,39 @@ export const POST = traceApiRoute(
 
         await database.deleteBookmark({ actorId: currentActor.id, statusId })
 
+        // Build the entity directly from storage, bypassing the visibility
+        // filter, so the response carries the real Status shape with the
+        // now-cleared bookmark flag.
+        const unreadableStatus = await database.getStatus({
+          statusId,
+          withReplies: false,
+          currentActorId: currentActor.id
+        })
+        if (!unreadableStatus)
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_404,
+            responseStatusCode: 404
+          })
+
+        const unreadableMastodonStatus = await getMastodonStatus(
+          database,
+          unreadableStatus,
+          currentActor.id
+        )
+        if (!unreadableMastodonStatus)
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_500,
+            responseStatusCode: 500
+          })
+
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_404,
-          responseStatusCode: 404
+          data: unreadableMastodonStatus
         })
       }
 

--- a/app/api/v1/statuses/[id]/unmute/route.ts
+++ b/app/api/v1/statuses/[id]/unmute/route.ts
@@ -1,4 +1,5 @@
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { resolveConversationRootId } from '@/lib/services/mastodon/conversationMute'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
@@ -22,54 +23,63 @@ interface Params {
 
 export const POST = traceApiRoute(
   'unmuteStatus',
-  OAuthGuard<Params>([Scope.enum.write], async (req, context) => {
-    const { database, currentActor, params } = context
-    const encodedStatusId = (await params).id
-    if (!encodedStatusId)
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:mutes']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const encodedStatusId = (await params).id
+      if (!encodedStatusId)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const statusId = idToUrl(encodedStatusId)
+      const status = await getReadableStatus({
+        database,
+        statusId,
+        currentActor,
+        withReplies: false
+      })
+      if (!status)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+
+      const conversationRootId = await resolveConversationRootId(
+        database,
+        status
+      )
+      await database.deleteStatusMute({
+        actorId: currentActor.id,
+        statusId: conversationRootId
+      })
+
+      const mastodonStatus = await getMastodonStatus(
+        database,
+        status,
+        currentActor.id
+      )
+      if (!mastodonStatus)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
+        data: mastodonStatus
       })
-
-    const statusId = idToUrl(encodedStatusId)
-    const status = await getReadableStatus({
-      database,
-      statusId,
-      currentActor,
-      withReplies: false
-    })
-    if (!status)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-
-    // Conversation unmuting not yet implemented
-    // TODO: Implement conversation muting functionality
-
-    const mastodonStatus = await getMastodonStatus(
-      database,
-      status,
-      currentActor.id
-    )
-    if (!mastodonStatus)
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_500,
-        responseStatusCode: 500
-      })
-
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: mastodonStatus
-    })
-  }),
+    }
+  ),
   {
     addAttributes: async (_req, context) => {
       const params = await context.params

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -524,4 +524,45 @@ describe('POST /api/v1/statuses', () => {
     const matching = owned.filter((status) => status.id === firstStatus.uri)
     expect(matching).toHaveLength(1)
   })
+
+  it('does not resurrect a deleted status for a reused Idempotency-Key (orphan cleanup)', async () => {
+    const idempotencyKey = 'idem-key-orphan-456'
+    const makeRequest = () =>
+      POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({ status: 'Idempotent then deleted' }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test',
+            'Idempotency-Key': idempotencyKey
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+    const firstResponse = await makeRequest()
+    const firstStatus = await firstResponse.json()
+
+    // Deleting the status must also drop the idempotency key pointing at it.
+    await database.deleteStatus({ statusId: firstStatus.uri })
+    await expect(
+      database.getIdempotentStatusId({
+        actorId: ACTOR1_ID,
+        key: idempotencyKey
+      })
+    ).resolves.toBeNull()
+
+    // A retry now creates a fresh status (not a 404/duplicate loop) and re-keys.
+    const secondResponse = await makeRequest()
+    expect(secondResponse.status).toBe(200)
+    const secondStatus = await secondResponse.json()
+    expect(secondStatus.id).not.toBe(firstStatus.id)
+    await expect(
+      database.getIdempotentStatusId({
+        actorId: ACTOR1_ID,
+        key: idempotencyKey
+      })
+    ).resolves.toBe(secondStatus.uri)
+  })
 })

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -336,4 +336,192 @@ describe('POST /api/v1/statuses', () => {
     expect(response.status).toBe(422)
     expect(getQueue().publish).not.toHaveBeenCalled()
   })
+
+  it('honors sensitive and language on a JSON create', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Marked sensitive without a content warning',
+          sensitive: true,
+          language: 'th'
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    // Sensitive is honored even though there is no spoiler_text.
+    expect(mastodonStatus.sensitive).toBe(true)
+    expect(mastodonStatus.spoiler_text).toBe('')
+    expect(mastodonStatus.language).toBe('th')
+  })
+
+  it('coerces a form-encoded sensitive=false into a non-sensitive status', async () => {
+    const body = new URLSearchParams()
+    body.set('status', 'Form sensitive false should not be sensitive')
+    body.set('sensitive', 'false')
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    expect(mastodonStatus.sensitive).toBe(false)
+  })
+
+  it('creates a poll from JSON poll params', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Favourite color?',
+          poll: {
+            options: ['Red', 'Green', 'Blue'],
+            expires_in: 3600,
+            multiple: true
+          }
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    expect(mastodonStatus.poll).not.toBeNull()
+    expect(mastodonStatus.poll.multiple).toBe(true)
+    expect(mastodonStatus.poll.options).toEqual([
+      { title: 'Red', votes_count: 0 },
+      { title: 'Green', votes_count: 0 },
+      { title: 'Blue', votes_count: 0 }
+    ])
+  })
+
+  it('creates a poll from flattened form poll params', async () => {
+    const body = new URLSearchParams()
+    body.set('status', 'Tea or coffee?')
+    body.append('poll[options][]', 'Tea')
+    body.append('poll[options][]', 'Coffee')
+    body.set('poll[expires_in]', '600')
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    expect(mastodonStatus.poll.options).toEqual([
+      { title: 'Tea', votes_count: 0 },
+      { title: 'Coffee', votes_count: 0 }
+    ])
+    expect(mastodonStatus.poll.multiple).toBe(false)
+  })
+
+  it('rejects a status that carries both media and a poll with 422', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/poll-and-media.webp',
+        bytes: 1024,
+        mimeType: 'image/jpeg',
+        metaData: { width: 100, height: 100 },
+        fileName: 'poll-and-media.jpg'
+      }
+    })
+    expect(media).not.toBeNull()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Cannot have both',
+          media_ids: [media!.id],
+          poll: { options: ['a', 'b'], expires_in: 3600 }
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+
+  it('rejects a poll with fewer than two options with 422', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Only one option',
+          poll: { options: ['Lonely'], expires_in: 3600 }
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+
+  it('returns the original status for a repeated Idempotency-Key', async () => {
+    const idempotencyKey = 'idem-key-abc-123'
+    const makeRequest = () =>
+      POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({ status: 'Idempotent create' }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test',
+            'Idempotency-Key': idempotencyKey
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+    const firstResponse = await makeRequest()
+    expect(firstResponse.status).toBe(200)
+    const firstStatus = await firstResponse.json()
+
+    const secondResponse = await makeRequest()
+    expect(secondResponse.status).toBe(200)
+    const secondStatus = await secondResponse.json()
+
+    // Same status id is returned, and no duplicate was created.
+    expect(secondStatus.id).toBe(firstStatus.id)
+    const owned = await database.getActorStatuses({ actorId: ACTOR1_ID })
+    const matching = owned.filter((status) => status.id === firstStatus.uri)
+    expect(matching).toHaveLength(1)
+  })
 })

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -1,8 +1,16 @@
 import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
+import { createPollFromUserInput } from '@/lib/actions/createPoll'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
-import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
+import {
+  MAX_POLL_EXPIRATION_SECONDS,
+  MAX_POLL_OPTIONS,
+  MAX_POLL_OPTION_CHARS,
+  MAX_STATUS_MEDIA_ATTACHMENTS,
+  MIN_POLL_EXPIRATION_SECONDS,
+  MIN_POLL_OPTIONS
+} from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
@@ -16,6 +24,7 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
@@ -23,15 +32,37 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const VisibilitySchema = z.enum(['public', 'unlisted', 'private', 'direct'])
 
+const PollSchema = z.object({
+  options: z
+    .array(z.string().trim().min(1).max(MAX_POLL_OPTION_CHARS))
+    .min(MIN_POLL_OPTIONS)
+    .max(MAX_POLL_OPTIONS),
+  expires_in: z.coerce
+    .number()
+    .int()
+    .min(MIN_POLL_EXPIRATION_SECONDS)
+    .max(MAX_POLL_EXPIRATION_SECONDS),
+  multiple: Booleanish.optional().default(false),
+  hide_totals: Booleanish.optional().default(false)
+})
+
 const NoteSchema = z
   .object({
     status: z.string().optional().default(''),
     in_reply_to_id: z.string().optional(),
     spoiler_text: z.string().optional(),
     media_ids: z.array(z.coerce.string()).optional().default([]),
-    visibility: VisibilitySchema.optional()
+    visibility: VisibilitySchema.optional(),
+    language: z.string().trim().min(1).optional(),
+    sensitive: Booleanish.optional().default(false),
+    poll: PollSchema.optional()
   })
-  .refine((note) => note.status.trim().length > 0 || note.media_ids.length > 0)
+  .refine(
+    (note) =>
+      note.status.trim().length > 0 ||
+      note.media_ids.length > 0 ||
+      (note.poll?.options.length ?? 0) > 0
+  )
 
 export const POST = traceApiRoute(
   'createStatus',
@@ -51,8 +82,9 @@ export const POST = traceApiRoute(
           })
         }
         const note = parsed.data
-        const mediaIds = [...new Set(note.media_ids)]
-        if (mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
+
+        // A status carries either media or a poll, never both.
+        if (note.poll && note.media_ids.length > 0) {
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,
@@ -60,28 +92,87 @@ export const POST = traceApiRoute(
             responseStatusCode: 422
           })
         }
-        const attachments = await getAttachmentsFromMediaIds(
-          database,
-          currentActor,
-          mediaIds
-        )
-        if (!attachments) {
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: ERROR_422,
-            responseStatusCode: 422
+
+        // Honor Idempotency-Key: a repeated key returns the original status
+        // rather than creating a duplicate.
+        const idempotencyKey = req.headers.get('Idempotency-Key')?.trim()
+        if (idempotencyKey) {
+          const existingStatusId = await database.getIdempotentStatusId({
+            actorId: currentActor.id,
+            key: idempotencyKey
+          })
+          if (existingStatusId) {
+            const existingStatus = await database.getStatus({
+              statusId: existingStatusId,
+              currentActorId: currentActor.id
+            })
+            const existingMastodonStatus = existingStatus
+              ? await getMastodonStatus(
+                  database,
+                  existingStatus,
+                  currentActor.id
+                )
+              : null
+            if (existingMastodonStatus) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: existingMastodonStatus
+              })
+            }
+          }
+        }
+
+        let status
+        if (note.poll) {
+          status = await createPollFromUserInput({
+            text: note.status,
+            summary: note.spoiler_text,
+            replyStatusId: note.in_reply_to_id,
+            currentActor,
+            choices: note.poll.options,
+            endAt: Date.now() + note.poll.expires_in * 1000,
+            pollType: note.poll.multiple ? 'anyOf' : 'oneOf',
+            visibility: note.visibility,
+            sensitive: note.sensitive,
+            language: note.language ?? null,
+            database
+          })
+        } else {
+          const mediaIds = [...new Set(note.media_ids)]
+          if (mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_422,
+              responseStatusCode: 422
+            })
+          }
+          const attachments = await getAttachmentsFromMediaIds(
+            database,
+            currentActor,
+            mediaIds
+          )
+          if (!attachments) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_422,
+              responseStatusCode: 422
+            })
+          }
+          status = await createNoteFromUserInput({
+            currentActor,
+            text: note.status,
+            summary: note.spoiler_text,
+            replyNoteId: note.in_reply_to_id,
+            visibility: note.visibility,
+            attachments,
+            sensitive: note.sensitive,
+            language: note.language ?? null,
+            database
           })
         }
-        const status = await createNoteFromUserInput({
-          currentActor,
-          text: note.status,
-          summary: note.spoiler_text,
-          replyNoteId: note.in_reply_to_id,
-          visibility: note.visibility,
-          attachments,
-          database
-        })
         if (!status)
           return apiResponse({
             req,
@@ -102,6 +193,14 @@ export const POST = traceApiRoute(
             data: ERROR_500,
             responseStatusCode: 500
           })
+
+        if (idempotencyKey) {
+          await database.saveIdempotencyKey({
+            actorId: currentActor.id,
+            key: idempotencyKey,
+            statusId: status.id
+          })
+        }
 
         return apiResponse({
           req,

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -286,6 +286,8 @@ interface CreateNoteFromUserInputParams {
   attachments?: PostBoxAttachment[]
   fitnessFileId?: string
   visibility?: MastodonVisibility
+  sensitive?: boolean
+  language?: string | null
   database: Database
 }
 export const createNoteFromUserInput = async ({
@@ -296,6 +298,8 @@ export const createNoteFromUserInput = async ({
   attachments = [],
   fitnessFileId,
   visibility,
+  sensitive = false,
+  language = null,
   database
 }: CreateNoteFromUserInputParams) => {
   const span = getSpan('actions', 'createNoteFromUser', { text, replyNoteId })
@@ -385,7 +389,9 @@ export const createNoteFromUserInput = async ({
     to,
     cc,
 
-    reply: replyStatus?.id || ''
+    reply: replyStatus?.id || '',
+    sensitive,
+    language
   })
 
   // Tags must be persisted before timeline rules run so that

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -26,6 +26,8 @@ interface CreatePollFromUserInputParams {
   endAt: number
   pollType?: 'oneOf' | 'anyOf'
   visibility?: MastodonVisibility
+  sensitive?: boolean
+  language?: string | null
 }
 export const createPollFromUserInput = async ({
   text,
@@ -36,7 +38,9 @@ export const createPollFromUserInput = async ({
   database,
   endAt,
   pollType,
-  visibility
+  visibility,
+  sensitive = false,
+  language = null
 }: CreatePollFromUserInputParams) => {
   const config = getConfig()
   const span = getSpan('actions', 'createPollFromUser', {
@@ -106,7 +110,9 @@ export const createPollFromUserInput = async ({
     reply: replyStatus?.id || '',
     choices,
     endAt,
-    pollType
+    pollType,
+    sensitive,
+    language
   })
 
   await Promise.all([

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -14,6 +14,8 @@ interface UpdateNoteFromUserInput {
   text?: string
   summary?: string | null
   attachments?: PostBoxAttachment[]
+  sensitive?: boolean
+  language?: string | null
   publish?: boolean
   status?: StatusNote
   database: Database
@@ -25,6 +27,8 @@ export const updateNoteFromUserInput = async ({
   text,
   summary,
   attachments,
+  sensitive,
+  language,
   publish = true,
   status: preloadedStatus,
   database
@@ -45,7 +49,9 @@ export const updateNoteFromUserInput = async ({
     statusId,
     summary: summary === undefined ? status.summary : summary?.trim() || null,
     text: text ?? status.text,
-    ...(attachments !== undefined ? { attachments } : {})
+    ...(attachments !== undefined ? { attachments } : {}),
+    ...(sensitive !== undefined ? { sensitive } : {}),
+    ...(language !== undefined ? { language } : {})
   })
   if (!updatedStatus) {
     span.end()

--- a/lib/database/sql/idempotency.ts
+++ b/lib/database/sql/idempotency.ts
@@ -21,16 +21,17 @@ export const IdempotencySQLDatabaseMixin = (
     key,
     statusId
   }: SaveIdempotencyKeyParams) {
-    const existing = await database('idempotency_keys')
-      .where({ actorId, key })
-      .first()
-    if (existing) return
-
-    await database('idempotency_keys').insert({
-      actorId,
-      key,
-      statusId,
-      createdAt: new Date()
-    })
+    // Ignore on conflict so a concurrent request that already recorded the same
+    // (actorId, key) does not surface a primary-key violation. The first writer
+    // wins; this keeps the call safe under retries/races.
+    await database('idempotency_keys')
+      .insert({
+        actorId,
+        key,
+        statusId,
+        createdAt: new Date()
+      })
+      .onConflict(['actorId', 'key'])
+      .ignore()
   }
 })

--- a/lib/database/sql/idempotency.ts
+++ b/lib/database/sql/idempotency.ts
@@ -1,0 +1,36 @@
+import { Knex } from 'knex'
+
+import {
+  GetIdempotentStatusIdParams,
+  IdempotencyDatabase,
+  SaveIdempotencyKeyParams
+} from '@/lib/types/database/operations'
+
+export const IdempotencySQLDatabaseMixin = (
+  database: Knex
+): IdempotencyDatabase => ({
+  async getIdempotentStatusId({ actorId, key }: GetIdempotentStatusIdParams) {
+    const row = await database('idempotency_keys')
+      .where({ actorId, key })
+      .first('statusId')
+    return row ? row.statusId : null
+  },
+
+  async saveIdempotencyKey({
+    actorId,
+    key,
+    statusId
+  }: SaveIdempotencyKeyParams) {
+    const existing = await database('idempotency_keys')
+      .where({ actorId, key })
+      .first()
+    if (existing) return
+
+    await database('idempotency_keys').insert({
+      actorId,
+      key,
+      statusId,
+      createdAt: new Date()
+    })
+  }
+})

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -25,6 +25,7 @@ import { PushSubscriptionSQLDatabaseMixin } from '@/lib/database/sql/pushSubscri
 import { ReportSQLDatabaseMixin } from '@/lib/database/sql/report'
 import { SearchSQLDatabaseMixin } from '@/lib/database/sql/search'
 import { StatusSQLDatabaseMixin } from '@/lib/database/sql/status'
+import { StatusMuteSQLDatabaseMixin } from '@/lib/database/sql/statusMute'
 import { StravaArchiveImportSQLDatabaseMixin } from '@/lib/database/sql/stravaArchiveImport'
 import { TimelineSQLDatabaseMixin } from '@/lib/database/sql/timeline'
 import { Database } from '@/lib/database/types'
@@ -42,6 +43,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const blockDatabase = BlockSQLDatabaseMixin(database)
   const markerDatabase = MarkerSQLDatabaseMixin(database)
   const muteDatabase = MuteSQLDatabaseMixin(database)
+  const statusMuteDatabase = StatusMuteSQLDatabaseMixin(database)
   const filterDatabase = FilterSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const followedTagDatabase = FollowedTagSQLDatabaseMixin(database)
@@ -94,6 +96,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...blockDatabase,
     ...markerDatabase,
     ...muteDatabase,
+    ...statusMuteDatabase,
     ...listDatabase,
     ...filterDatabase,
     ...followerDatabase,

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -13,6 +13,7 @@ import { FitnessRouteHeatmapSQLDatabaseMixin } from '@/lib/database/sql/fitnessR
 import { FitnessSettingsSQLDatabaseMixin } from '@/lib/database/sql/fitnessSettings'
 import { FollowerSQLDatabaseMixin } from '@/lib/database/sql/follow'
 import { FollowedTagSQLDatabaseMixin } from '@/lib/database/sql/followedTag'
+import { IdempotencySQLDatabaseMixin } from '@/lib/database/sql/idempotency'
 import { InstanceActivitySQLDatabaseMixin } from '@/lib/database/sql/instanceActivity'
 import { LikeSQLDatabaseMixin } from '@/lib/database/sql/like'
 import { ListSQLDatabaseMixin } from '@/lib/database/sql/list'
@@ -44,6 +45,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const markerDatabase = MarkerSQLDatabaseMixin(database)
   const muteDatabase = MuteSQLDatabaseMixin(database)
   const statusMuteDatabase = StatusMuteSQLDatabaseMixin(database)
+  const idempotencyDatabase = IdempotencySQLDatabaseMixin(database)
   const filterDatabase = FilterSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const followedTagDatabase = FollowedTagSQLDatabaseMixin(database)
@@ -97,6 +99,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...markerDatabase,
     ...muteDatabase,
     ...statusMuteDatabase,
+    ...idempotencyDatabase,
     ...listDatabase,
     ...filterDatabase,
     ...followerDatabase,

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -1833,6 +1833,32 @@ describe('StatusDatabase', () => {
         })
         expect(favourites).toHaveLength(0)
       })
+
+      it('pages newer favourites with min_id, distinct from max_id direction', async () => {
+        const statusId = statuses.primary.post
+        await database.createLike({ actorId: primaryActorId, statusId })
+        await database.createLike({ actorId: replyAuthorId, statusId })
+        await database.createLike({ actorId: pollAuthorId, statusId })
+
+        const ordered = await database.getFavouritedBy({ statusId, limit: 40 })
+        expect(ordered.length).toBeGreaterThanOrEqual(3)
+        const oldest = ordered[ordered.length - 1]
+
+        // min_id returns favourites strictly newer than the cursor (everything
+        // except the oldest), and never the cursor row itself.
+        const cursor = encodeFavouritedByCursor({
+          createdAt: oldest.createdAt,
+          actorId: oldest.actorId
+        })
+        const newer = await database.getFavouritedBy({
+          statusId,
+          limit: 40,
+          minId: cursor
+        })
+        const newerIds = newer.map((item) => item.actorId)
+        expect(newerIds).not.toContain(oldest.actorId)
+        expect(newerIds).toHaveLength(ordered.length - 1)
+      })
     })
 
     describe('createNote', () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -337,6 +337,8 @@ describe('StatusDatabase', () => {
           url: statuses.primary.post,
           text: 'This is Actor1 post',
           summary: '',
+          sensitive: false,
+          language: null,
           reply: '',
           replies: [],
           actorAnnounceStatusId: null,

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2,6 +2,7 @@ import knex, { Knex } from 'knex'
 
 import { getSQLDatabase } from '@/lib/database/sql'
 import { CounterKey } from '@/lib/database/sql/utils/counter'
+import { encodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByCursor'
 import { SQLITE_MAX_BINDINGS } from '@/lib/database/sql/utils/knex'
 import {
   databaseBeforeAll,
@@ -1772,22 +1773,25 @@ describe('StatusDatabase', () => {
     })
 
     describe('getFavouritedBy', () => {
-      it('returns actors who favourited the status', async () => {
-        const actors = await database.getFavouritedBy({
-          statusId: statuses.primary.post
+      it('returns an empty page when no one favourited the status', async () => {
+        const favourites = await database.getFavouritedBy({
+          statusId: statuses.primary.post,
+          limit: 40
         })
-        expect(actors).toHaveLength(0)
+        expect(favourites).toHaveLength(0)
       })
 
-      it('returns actors who favourited the status', async () => {
-        const actors = await database.getFavouritedBy({
-          statusId: statuses.poll.status
+      it('returns the actors who favourited the status', async () => {
+        const favourites = await database.getFavouritedBy({
+          statusId: statuses.poll.status,
+          limit: 40
         })
-        expect(actors).toHaveLength(1)
-        expect(actors[0].id).toBe(replyAuthorId)
+        expect(favourites).toHaveLength(1)
+        expect(favourites[0].actorId).toBe(replyAuthorId)
+        expect(typeof favourites[0].createdAt).toBe('number')
       })
 
-      it('supports limit and offset pagination', async () => {
+      it('supports id-cursor pagination via max_id', async () => {
         const statusId = statuses.primary.post
         await database.createLike({ actorId: primaryActorId, statusId })
         await database.createLike({ actorId: replyAuthorId, statusId })
@@ -1797,20 +1801,35 @@ describe('StatusDatabase', () => {
           statusId,
           limit: 2
         })
+        expect(firstPage).toHaveLength(2)
+
+        const cursor = encodeFavouritedByCursor({
+          createdAt: firstPage[firstPage.length - 1].createdAt,
+          actorId: firstPage[firstPage.length - 1].actorId
+        })
         const secondPage = await database.getFavouritedBy({
           statusId,
           limit: 2,
-          offset: 2
+          maxId: cursor
         })
-
-        expect(firstPage).toHaveLength(2)
         expect(secondPage).toHaveLength(1)
 
-        const actorIds = [...firstPage, ...secondPage].map((item) => item.id)
+        const actorIds = [...firstPage, ...secondPage].map(
+          (item) => item.actorId
+        )
         expect(new Set(actorIds).size).toBe(3)
         expect(actorIds).toEqual(
           expect.arrayContaining([primaryActorId, replyAuthorId, pollAuthorId])
         )
+      })
+
+      it('returns an empty page for a malformed cursor', async () => {
+        const favourites = await database.getFavouritedBy({
+          statusId: statuses.poll.status,
+          limit: 40,
+          maxId: 'not-a-valid-cursor!!'
+        })
+        expect(favourites).toHaveLength(0)
       })
     })
 

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -408,6 +408,8 @@ export const StatusSQLDatabaseMixin = (
     to,
     cc,
     reply = '',
+    sensitive = false,
+    language = null,
     createdAt
   }: CreateNoteParams) {
     const currentTime = new Date()
@@ -416,7 +418,9 @@ export const StatusSQLDatabaseMixin = (
     const content = {
       url,
       text,
-      summary
+      summary,
+      sensitive,
+      language
     }
     const statusContent = JSON.stringify(content)
     const searchStatus: SQLStatusSearchRow = {
@@ -489,6 +493,8 @@ export const StatusSQLDatabaseMixin = (
       type: StatusType.enum.Note,
       text,
       summary,
+      sensitive,
+      language,
       reply,
       to,
       cc,
@@ -510,7 +516,9 @@ export const StatusSQLDatabaseMixin = (
     statusId,
     text,
     summary,
-    attachments
+    attachments,
+    sensitive,
+    language
   }: UpdateNoteParams): Promise<Status | null> {
     const status = await getStatus({ statusId })
     if (!status) return null
@@ -525,7 +533,10 @@ export const StatusSQLDatabaseMixin = (
     const content = {
       url: status.url,
       text,
-      summary
+      summary,
+      // Preserve the existing flags unless the caller explicitly overrides them.
+      sensitive: sensitive === undefined ? status.sensitive : sensitive,
+      language: language === undefined ? status.language : language
     }
     const statusContent = JSON.stringify(content)
     const searchStatus: SQLStatusSearchRow = {
@@ -768,6 +779,8 @@ export const StatusSQLDatabaseMixin = (
     endAt,
     choices,
     pollType = 'oneOf',
+    sensitive = false,
+    language = null,
     createdAt
   }: CreatePollParams) {
     const currentTime = new Date()
@@ -777,6 +790,8 @@ export const StatusSQLDatabaseMixin = (
       url,
       text,
       summary,
+      sensitive,
+      language,
       endAt,
       pollType
     }
@@ -862,6 +877,8 @@ export const StatusSQLDatabaseMixin = (
       type: StatusType.enum.Poll,
       text,
       summary,
+      sensitive,
+      language,
       reply,
       to,
       cc,
@@ -900,6 +917,8 @@ export const StatusSQLDatabaseMixin = (
       url: data.url,
       text: nextText,
       summary: nextSummary,
+      sensitive: data.sensitive ?? false,
+      language: data.language ?? null,
       endAt: data.endAt,
       pollType: data.pollType
     }
@@ -2393,6 +2412,8 @@ export const StatusSQLDatabaseMixin = (
       type: data.type,
       text: content.text,
       summary: content.summary,
+      sensitive: content.sensitive ?? false,
+      language: content.language ?? null,
       reply: data.reply,
       replies: repliesNote,
       totalLikes,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -11,6 +11,7 @@ import {
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
 import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
+import { decodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByCursor'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import {
@@ -40,6 +41,7 @@ import {
   CreatePollParams,
   CreateTagParams,
   DeleteStatusParams,
+  FavouritedByAccount,
   GetActorPollVotesForStatusesParams,
   GetActorPollVotesParams,
   GetActorStatusesCountParams,
@@ -49,6 +51,7 @@ import {
   GetPinnedStatusIdsParams,
   GetRebloggedByParams,
   GetStatusCountsParams,
+  GetStatusEditHistoryParams,
   GetStatusFromUrlHashParams,
   GetStatusFromUrlParams,
   GetStatusParams,
@@ -64,11 +67,12 @@ import {
   PinStatusParams,
   RecordPollVotesParams,
   StatusDatabase,
+  StatusEditRevision,
   UpdateNoteParams,
   UpdateNoteVisibilityParams,
   UpdatePollParams
 } from '@/lib/types/database/operations'
-import { Actor, getActorProfile } from '@/lib/types/domain/actor'
+import { getActorProfile } from '@/lib/types/domain/actor'
 import { Attachment, isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
 import {
@@ -993,6 +997,26 @@ export const StatusSQLDatabaseMixin = (
   const getActorTargetStatusIds = (actorId: string) =>
     database('statuses').select('statuses.id').where('actorId', actorId)
 
+  async function getStatusEditHistory({
+    statusId
+  }: GetStatusEditHistoryParams): Promise<StatusEditRevision[]> {
+    // Each row holds the content of a prior version; `updatedAt` is when that
+    // version was superseded. Ordered oldest-first (insertion order) so the
+    // serializer can reconstruct the revision timeline.
+    const rows = await database('status_history')
+      .where('statusId', statusId)
+      .orderBy('updatedAt', 'asc')
+      .orderBy('id', 'asc')
+    return rows.map((row) => {
+      const content = getCompatibleJSON(row.data)
+      return {
+        text: content.text ?? '',
+        summary: content.summary ?? null,
+        supersededAt: getCompatibleTime(row.updatedAt)
+      }
+    })
+  }
+
   async function getStatusReplies({
     statusId,
     url,
@@ -1898,26 +1922,60 @@ export const StatusSQLDatabaseMixin = (
   async function getFavouritedBy({
     statusId,
     limit,
-    offset = 0
-  }: GetFavouritedByParams): Promise<Actor[]> {
-    let query = database('likes')
-      .where({ statusId })
-      .orderBy('createdAt', 'desc')
-      .orderBy('actorId', 'asc')
+    maxId,
+    minId,
+    sinceId
+  }: GetFavouritedByParams): Promise<FavouritedByAccount[]> {
+    const olderCursorToken = maxId
+    const newerCursorToken = minId || sinceId
 
-    if (typeof limit === 'number') {
-      query = query.limit(limit)
+    // Reject malformed cursors with an empty page instead of scanning from the
+    // top, matching the favourites/bookmarks pagination contract.
+    if (
+      (olderCursorToken && !decodeFavouritedByCursor(olderCursorToken)) ||
+      (newerCursorToken && !decodeFavouritedByCursor(newerCursorToken))
+    ) {
+      return []
     }
 
-    if (offset > 0) {
-      query = query.offset(offset)
+    const applyCursor = (
+      builder: Knex.QueryBuilder,
+      cursor: { createdAt: number; actorId: string },
+      direction: 'newer' | 'older'
+    ) => {
+      const operator = direction === 'older' ? '<' : '>'
+      const createdAtValue = new Date(cursor.createdAt)
+      builder.andWhere((inner) => {
+        inner
+          .where('createdAt', operator, createdAtValue)
+          .orWhere((tieBreaker) => {
+            tieBreaker
+              .where('createdAt', createdAtValue)
+              .andWhere('actorId', operator, cursor.actorId)
+          })
+      })
     }
 
-    const result = await query
-    const actors = await Promise.all(
-      result.map((item) => actorDatabase.getActorFromId({ id: item.actorId }))
-    )
-    return actors.filter((actor): actor is Actor => Boolean(actor))
+    const query = database('likes').where({ statusId }).limit(limit)
+
+    const olderCursor = decodeFavouritedByCursor(olderCursorToken)
+    if (olderCursor) applyCursor(query, olderCursor, 'older')
+
+    const newerCursor = decodeFavouritedByCursor(newerCursorToken)
+    if (newerCursor) applyCursor(query, newerCursor, 'newer')
+
+    if (minId) {
+      query.orderBy('createdAt', 'asc').orderBy('actorId', 'asc')
+    } else {
+      query.orderBy('createdAt', 'desc').orderBy('actorId', 'desc')
+    }
+
+    const rows = await query
+    const ordered = minId ? rows.reverse() : rows
+    return ordered.map((row) => ({
+      actorId: row.actorId,
+      createdAt: getCompatibleTime(row.createdAt)
+    }))
   }
 
   async function getRebloggedBy({
@@ -2783,6 +2841,7 @@ export const StatusSQLDatabaseMixin = (
     updatePoll,
     getStatus,
     getStatusReplies,
+    getStatusEditHistory,
     getStatusFromUrl,
     getStatusFromUrlHash,
     getActorAnnouncedStatusId,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1029,8 +1029,8 @@ export const StatusSQLDatabaseMixin = (
     return rows.map((row) => {
       const content = getCompatibleJSON(row.data)
       return {
-        text: content.text ?? '',
-        summary: content.summary ?? null,
+        text: content?.text ?? '',
+        summary: content?.summary ?? null,
         supersededAt: getCompatibleTime(row.updatedAt)
       }
     })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1914,6 +1914,22 @@ export const StatusSQLDatabaseMixin = (
       'statusId',
       statusIdsToDelete
     )
+    // Clean up idempotency keys that pointed at the deleted status so a retried
+    // create with the same key does not resolve to a now-missing status (which
+    // would otherwise let the retry create a duplicate). Likewise drop any
+    // conversation mute rows keyed on a deleted thread root.
+    await deleteRowsByColumnChunks(
+      trx,
+      'idempotency_keys',
+      'statusId',
+      statusIdsToDelete
+    )
+    await deleteRowsByColumnChunks(
+      trx,
+      'status_mutes',
+      'statusId',
+      statusIdsToDelete
+    )
     for (const statusIdChunk of chunkArray(
       statusIdsToDelete,
       getWhereInBatchSize(trx)

--- a/lib/database/sql/statusMute.ts
+++ b/lib/database/sql/statusMute.ts
@@ -1,0 +1,48 @@
+import { Knex } from 'knex'
+
+import {
+  CreateStatusMuteParams,
+  DeleteStatusMuteParams,
+  GetActorMutedConversationRootIdsParams,
+  IsConversationMutedParams,
+  StatusMuteDatabase
+} from '@/lib/types/database/operations'
+
+export const StatusMuteSQLDatabaseMixin = (
+  database: Knex
+): StatusMuteDatabase => ({
+  async createStatusMute({ actorId, statusId }: CreateStatusMuteParams) {
+    const existing = await database('status_mutes')
+      .where({ actorId, statusId })
+      .first()
+    if (existing) return
+
+    const currentTime = new Date()
+    await database('status_mutes').insert({
+      actorId,
+      statusId,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+  },
+
+  async deleteStatusMute({ actorId, statusId }: DeleteStatusMuteParams) {
+    await database('status_mutes').where({ actorId, statusId }).delete()
+  },
+
+  async isConversationMuted({ actorId, statusId }: IsConversationMutedParams) {
+    const row = await database('status_mutes')
+      .where({ actorId, statusId })
+      .first()
+    return Boolean(row)
+  },
+
+  async getActorMutedConversationRootIds({
+    actorId
+  }: GetActorMutedConversationRootIdsParams) {
+    const rows = await database('status_mutes')
+      .where({ actorId })
+      .select('statusId')
+    return rows.map((row) => row.statusId)
+  }
+})

--- a/lib/database/sql/statusMute.ts
+++ b/lib/database/sql/statusMute.ts
@@ -12,18 +12,18 @@ export const StatusMuteSQLDatabaseMixin = (
   database: Knex
 ): StatusMuteDatabase => ({
   async createStatusMute({ actorId, statusId }: CreateStatusMuteParams) {
-    const existing = await database('status_mutes')
-      .where({ actorId, statusId })
-      .first()
-    if (existing) return
-
+    // Atomic insert-or-ignore: muting an already-muted conversation is a no-op
+    // and safe under concurrent calls, without a separate existence query.
     const currentTime = new Date()
-    await database('status_mutes').insert({
-      actorId,
-      statusId,
-      createdAt: currentTime,
-      updatedAt: currentTime
-    })
+    await database('status_mutes')
+      .insert({
+        actorId,
+        statusId,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      .onConflict(['actorId', 'statusId'])
+      .ignore()
   },
 
   async deleteStatusMute({ actorId, statusId }: DeleteStatusMuteParams) {

--- a/lib/database/sql/utils/favouritedByCursor.ts
+++ b/lib/database/sql/utils/favouritedByCursor.ts
@@ -1,0 +1,42 @@
+// `favourited_by` paginates the actors who favourited a single status. The
+// `likes` table has a composite primary key `(statusId, actorId)` and no
+// surrogate id, so — for a fixed status — the page cursor is the `(createdAt,
+// actorId)` pair of a like row. Mastodon treats `max_id`/`min_id` as opaque, so
+// the pair is encoded into a single base64url token rather than exposing the
+// raw values. (This is the fixed-status/varying-actor counterpart of
+// `favouriteCursor`, which is fixed-actor/varying-status.)
+
+export interface FavouritedByCursor {
+  createdAt: number
+  actorId: string
+}
+
+export const encodeFavouritedByCursor = ({
+  createdAt,
+  actorId
+}: FavouritedByCursor): string =>
+  Buffer.from(`${createdAt}:${actorId}`, 'utf8').toString('base64url')
+
+export const decodeFavouritedByCursor = (
+  cursor?: string | null
+): FavouritedByCursor | null => {
+  if (!cursor) return null
+
+  let decoded: string
+  try {
+    decoded = Buffer.from(cursor, 'base64url').toString('utf8')
+  } catch {
+    return null
+  }
+
+  const separatorIndex = decoded.indexOf(':')
+  if (separatorIndex <= 0) return null
+
+  const createdAt = Number(decoded.slice(0, separatorIndex))
+  const actorId = decoded.slice(separatorIndex + 1)
+  if (!Number.isSafeInteger(createdAt) || createdAt < 0 || !actorId) {
+    return null
+  }
+
+  return { createdAt, actorId }
+}

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -26,6 +26,7 @@ import {
   ReportDatabase,
   SearchDatabase,
   StatusDatabase,
+  StatusMuteDatabase,
   TimelineDatabase
 } from '@/lib/types/database/operations'
 
@@ -55,5 +56,6 @@ export type Database = AccountDatabase &
   ReportDatabase &
   SearchDatabase &
   StatusDatabase &
+  StatusMuteDatabase &
   TimelineDatabase &
   BaseDatabase

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -14,6 +14,7 @@ import {
   FilterDatabase,
   FollowDatabase,
   FollowedTagDatabase,
+  IdempotencyDatabase,
   InstanceActivityDatabase,
   LikeDatabase,
   ListDatabase,
@@ -57,5 +58,6 @@ export type Database = AccountDatabase &
   SearchDatabase &
   StatusDatabase &
   StatusMuteDatabase &
+  IdempotencyDatabase &
   TimelineDatabase &
   BaseDatabase

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -110,6 +110,7 @@ type MockDatabase = Pick<
   | 'updateFitnessSettings'
   | 'createNote'
   | 'createNotification'
+  | 'getActorMutedConversationRootIds'
 >
 
 describe('importStravaActivityJob', () => {
@@ -125,7 +126,10 @@ describe('importStravaActivityJob', () => {
     createAttachment: jest.fn(),
     updateFitnessSettings: jest.fn(),
     createNote: jest.fn(),
-    createNotification: jest.fn()
+    createNotification: jest.fn(),
+    // createNotificationWithPolicy checks the recipient's conversation-mute
+    // list before persisting; the importer's recipients have none.
+    getActorMutedConversationRootIds: jest.fn().mockResolvedValue([])
   }
 
   beforeEach(() => {

--- a/lib/services/mastodon/accountCursorLinkHeader.ts
+++ b/lib/services/mastodon/accountCursorLinkHeader.ts
@@ -1,0 +1,50 @@
+import { headerHost } from '@/lib/services/guards/headerHost'
+
+/**
+ * Builds a Mastodon-style `Link` header (rel="next"/rel="prev") for the
+ * account-list endpoints that paginate with opaque id cursors —
+ * `reblogged_by` and `favourited_by`. Mastodon treats `max_id`/`since_id` as
+ * opaque tokens, so each endpoint supplies its own `toCursor` to turn a page
+ * item into the cursor string. `max_id` (the last/oldest item) advances to the
+ * next page; `since_id` (the first/newest item) walks back to the previous one.
+ *
+ * Returns `undefined` when there is nothing to page over (empty page) or the
+ * request host cannot be resolved, so callers omit the header entirely.
+ */
+export const buildAccountCursorLinkHeader = <T>({
+  req,
+  limit,
+  items,
+  hasNextPage,
+  toCursor
+}: {
+  req: Request
+  limit: number
+  items: T[]
+  hasNextPage: boolean
+  toCursor: (item: T) => string
+}): string | undefined => {
+  if (items.length === 0) return undefined
+
+  const requestUrl = new URL(req.url)
+  const host = headerHost(req.headers)
+  if (!host) return undefined
+
+  const buildUrl = (cursor: 'max_id' | 'since_id', value: string) => {
+    const params = new URLSearchParams()
+    params.set('limit', `${limit}`)
+    params.set(cursor, value)
+
+    const url = new URL(requestUrl.pathname, `https://${host}`)
+    url.search = params.toString()
+    return url.toString()
+  }
+
+  const firstItem = items[0]
+  const lastItem = items[items.length - 1]
+  const nextLink = hasNextPage
+    ? `<${buildUrl('max_id', toCursor(lastItem))}>; rel="next"`
+    : null
+  const prevLink = `<${buildUrl('since_id', toCursor(firstItem))}>; rel="prev"`
+  return [nextLink, prevLink].filter(Boolean).join(', ')
+}

--- a/lib/services/mastodon/accountCursorLinkHeader.ts
+++ b/lib/services/mastodon/accountCursorLinkHeader.ts
@@ -5,23 +5,28 @@ import { headerHost } from '@/lib/services/guards/headerHost'
  * account-list endpoints that paginate with opaque id cursors —
  * `reblogged_by` and `favourited_by`. Mastodon treats `max_id`/`since_id` as
  * opaque tokens, so each endpoint supplies its own `toCursor` to turn a page
- * item into the cursor string. `max_id` (the last/oldest item) advances to the
- * next page; `since_id` (the first/newest item) walks back to the previous one.
+ * item into the cursor string. Pages are always presented newest-first, so
+ * `max_id` (the last/oldest item) advances to the next/older page and
+ * `since_id` (the first/newest item) walks back to the previous/newer one.
  *
- * Returns `undefined` when there is nothing to page over (empty page) or the
- * request host cannot be resolved, so callers omit the header entirely.
+ * `hasNext`/`hasPrev` gate the two links independently: a forward (`min_id`)
+ * page detects overflow on the newer side, so the caller must wire that to
+ * `hasPrev` rather than `hasNext`. Returns `undefined` when there is nothing to
+ * page over (empty page) or the request host cannot be resolved.
  */
 export const buildAccountCursorLinkHeader = <T>({
   req,
   limit,
   items,
-  hasNextPage,
+  hasNext,
+  hasPrev,
   toCursor
 }: {
   req: Request
   limit: number
   items: T[]
-  hasNextPage: boolean
+  hasNext: boolean
+  hasPrev: boolean
   toCursor: (item: T) => string
 }): string | undefined => {
   if (items.length === 0) return undefined
@@ -42,9 +47,11 @@ export const buildAccountCursorLinkHeader = <T>({
 
   const firstItem = items[0]
   const lastItem = items[items.length - 1]
-  const nextLink = hasNextPage
+  const nextLink = hasNext
     ? `<${buildUrl('max_id', toCursor(lastItem))}>; rel="next"`
     : null
-  const prevLink = `<${buildUrl('since_id', toCursor(firstItem))}>; rel="prev"`
-  return [nextLink, prevLink].filter(Boolean).join(', ')
+  const prevLink = hasPrev
+    ? `<${buildUrl('since_id', toCursor(firstItem))}>; rel="prev"`
+    : null
+  return [nextLink, prevLink].filter(Boolean).join(', ') || undefined
 }

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -1,2 +1,11 @@
 export const MAX_STATUS_MEDIA_ATTACHMENTS = 4
 export const MAX_PINNED_STATUSES = 5
+
+// Poll limits, matching Mastodon's defaults
+// (Poll::Options#options + Status::MIN/MAX expiry).
+export const MIN_POLL_OPTIONS = 2
+export const MAX_POLL_OPTIONS = 4
+export const MAX_POLL_OPTION_CHARS = 50
+// 5 minutes minimum, ~1 month maximum (seconds).
+export const MIN_POLL_EXPIRATION_SECONDS = 5 * 60
+export const MAX_POLL_EXPIRATION_SECONDS = 60 * 60 * 24 * 31

--- a/lib/services/mastodon/conversationMute.ts
+++ b/lib/services/mastodon/conversationMute.ts
@@ -12,27 +12,48 @@ const MAX_THREAD_WALK = 100
  * original status's thread is used. The walk follows `in_reply_to` to the
  * topmost ancestor, ignoring readability (mute state is independent of who can
  * read the thread).
+ *
+ * `cache` (statusId → rootId) memoizes results across a batch render so the
+ * shared ancestors of a thread are walked once, not once per reply.
  */
 export const resolveConversationRootId = async (
   database: Database,
-  status: Status
+  status: Status,
+  cache?: Map<string, string>
 ): Promise<string> => {
   const target =
     status.type === StatusType.enum.Announce ? status.originalStatus : status
 
+  const cachedRoot = cache?.get(target.id)
+  if (cachedRoot) return cachedRoot
+
   let rootId = target.id
   let replyId = target.type === StatusType.enum.Announce ? '' : target.reply
+  // Every node visited on the way up shares the same thread root, so record
+  // them all once the root is known.
+  const visited = [target.id]
   const seen = new Set<string>([target.id])
 
   for (let hops = 0; replyId && hops < MAX_THREAD_WALK; hops++) {
+    const cachedParentRoot = cache?.get(replyId)
+    if (cachedParentRoot) {
+      rootId = cachedParentRoot
+      break
+    }
+
     const parent = await database.getStatus({
       statusId: replyId,
       withReplies: false
     })
     if (!parent || seen.has(parent.id)) break
     seen.add(parent.id)
+    visited.push(parent.id)
     rootId = parent.id
     replyId = parent.type === StatusType.enum.Announce ? '' : parent.reply
+  }
+
+  if (cache) {
+    for (const visitedId of visited) cache.set(visitedId, rootId)
   }
 
   return rootId
@@ -48,17 +69,26 @@ export const isConversationMutedForActor = async (
   database: Database,
   status: Status,
   currentActorId: string | undefined,
-  mutedConversationRootIds?: Set<string>
+  mutedConversationRootIds?: Set<string>,
+  conversationRootCache?: Map<string, string>
 ): Promise<boolean> => {
   if (!currentActorId) return false
 
   if (mutedConversationRootIds) {
     if (mutedConversationRootIds.size === 0) return false
-    const rootId = await resolveConversationRootId(database, status)
+    const rootId = await resolveConversationRootId(
+      database,
+      status,
+      conversationRootCache
+    )
     return mutedConversationRootIds.has(rootId)
   }
 
-  const rootId = await resolveConversationRootId(database, status)
+  const rootId = await resolveConversationRootId(
+    database,
+    status,
+    conversationRootCache
+  )
   return database.isConversationMuted({
     actorId: currentActorId,
     statusId: rootId

--- a/lib/services/mastodon/conversationMute.ts
+++ b/lib/services/mastodon/conversationMute.ts
@@ -1,5 +1,5 @@
 import { Database } from '@/lib/database/types'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, getOriginalStatus } from '@/lib/types/domain/status'
 
 // A defensive cap on how far the reply chain is walked when resolving a thread
 // root, so a malformed (e.g. cyclic) chain can never loop forever.
@@ -21,14 +21,15 @@ export const resolveConversationRootId = async (
   status: Status,
   cache?: Map<string, string>
 ): Promise<string> => {
-  const target =
-    status.type === StatusType.enum.Announce ? status.originalStatus : status
+  // getOriginalStatus recursively unwraps Announces (reblogs) to the underlying
+  // Note/Poll, so even a nested boost resolves to the real thread.
+  const target = getOriginalStatus(status)
 
   const cachedRoot = cache?.get(target.id)
   if (cachedRoot) return cachedRoot
 
   let rootId = target.id
-  let replyId = target.type === StatusType.enum.Announce ? '' : target.reply
+  let replyId = target.reply
   // Every node visited on the way up shares the same thread root, so record
   // them all once the root is known.
   const visited = [target.id]
@@ -46,10 +47,11 @@ export const resolveConversationRootId = async (
       withReplies: false
     })
     if (!parent || seen.has(parent.id)) break
+    const parentTarget = getOriginalStatus(parent)
     seen.add(parent.id)
-    visited.push(parent.id)
-    rootId = parent.id
-    replyId = parent.type === StatusType.enum.Announce ? '' : parent.reply
+    visited.push(parentTarget.id)
+    rootId = parentTarget.id
+    replyId = parentTarget.reply
   }
 
   if (cache) {

--- a/lib/services/mastodon/conversationMute.ts
+++ b/lib/services/mastodon/conversationMute.ts
@@ -1,0 +1,66 @@
+import { Database } from '@/lib/database/types'
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+// A defensive cap on how far the reply chain is walked when resolving a thread
+// root, so a malformed (e.g. cyclic) chain can never loop forever.
+const MAX_THREAD_WALK = 100
+
+/**
+ * Resolves the conversation (thread) root status id for a status. This is the
+ * key a conversation mute is stored under: muting any status in a thread mutes
+ * the whole thread, identified by its root. For an Announce (reblog) the
+ * original status's thread is used. The walk follows `in_reply_to` to the
+ * topmost ancestor, ignoring readability (mute state is independent of who can
+ * read the thread).
+ */
+export const resolveConversationRootId = async (
+  database: Database,
+  status: Status
+): Promise<string> => {
+  const target =
+    status.type === StatusType.enum.Announce ? status.originalStatus : status
+
+  let rootId = target.id
+  let replyId = target.type === StatusType.enum.Announce ? '' : target.reply
+  const seen = new Set<string>([target.id])
+
+  for (let hops = 0; replyId && hops < MAX_THREAD_WALK; hops++) {
+    const parent = await database.getStatus({
+      statusId: replyId,
+      withReplies: false
+    })
+    if (!parent || seen.has(parent.id)) break
+    seen.add(parent.id)
+    rootId = parent.id
+    replyId = parent.type === StatusType.enum.Announce ? '' : parent.reply
+  }
+
+  return rootId
+}
+
+/**
+ * Whether the conversation a status belongs to is muted for the given actor.
+ * When `mutedConversationRootIds` is supplied (the batch path), an empty set
+ * short-circuits to `false` without resolving the thread root — so the common
+ * case (an actor with no conversation mutes) costs nothing per status.
+ */
+export const isConversationMutedForActor = async (
+  database: Database,
+  status: Status,
+  currentActorId: string | undefined,
+  mutedConversationRootIds?: Set<string>
+): Promise<boolean> => {
+  if (!currentActorId) return false
+
+  if (mutedConversationRootIds) {
+    if (mutedConversationRootIds.size === 0) return false
+    const rootId = await resolveConversationRootId(database, status)
+    return mutedConversationRootIds.has(rootId)
+  }
+
+  const rootId = await resolveConversationRootId(database, status)
+  return database.isConversationMuted({
+    actorId: currentActorId,
+    statusId: rootId
+  })
+}

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -56,6 +56,9 @@ interface GetMastodonStatusOptions {
   // The set of thread-root status ids whose conversations the current actor has
   // muted. An empty set means "no mutes", letting per-status checks short-circuit.
   mutedConversationRootIds?: Set<string>
+  // Memoizes thread-root resolution (statusId → rootId) across a batch render so
+  // a thread's shared ancestors are walked once rather than once per status.
+  conversationRootCache?: Map<string, string>
 }
 
 const getMastodonAccount = (
@@ -292,7 +295,8 @@ export const getMastodonStatus = async (
     database,
     status,
     currentActorId,
-    options?.mutedConversationRootIds
+    options?.mutedConversationRootIds,
+    options?.conversationRootCache
   )
 
   const baseData = {
@@ -538,6 +542,8 @@ export const getMastodonStatuses = async (
     mutedConversationRootIds:
       inputOptions.mutedConversationRootIds ??
       new Set<string>(mutedConversationRootIds),
+    conversationRootCache:
+      inputOptions.conversationRootCache ?? new Map<string, string>(),
     accountCache,
     statusMetricsCache: {
       reblogs: new Map(

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+import { isConversationMutedForActor } from '@/lib/services/mastodon/conversationMute'
 import { Mastodon } from '@/lib/types/activitypub'
 import { getMastodonAttachment } from '@/lib/types/domain/attachment'
 import {
@@ -52,6 +53,9 @@ interface GetMastodonStatusOptions {
   statusMetricsCache?: StatusMetricsCache
   pollVoteCache?: PollVoteCache
   pinnedStatusIds?: Set<string>
+  // The set of thread-root status ids whose conversations the current actor has
+  // muted. An empty set means "no mutes", letting per-status checks short-circuit.
+  mutedConversationRootIds?: Set<string>
 }
 
 const getMastodonAccount = (
@@ -284,6 +288,12 @@ export const getMastodonStatus = async (
       ? await getStatusReblogsCount(database, status.id, options)
       : 0
   const pinned = await isStatusPinned(database, status, currentActorId, options)
+  const muted = await isConversationMutedForActor(
+    database,
+    status,
+    currentActorId,
+    options?.mutedConversationRootIds
+  )
 
   const baseData = {
     id: urlToId(status.id),
@@ -307,7 +317,7 @@ export const getMastodonStatus = async (
 
     favourited: false,
     reblogged: false,
-    muted: false,
+    muted,
     bookmarked: isStatusBookmarked(status),
     ...(pinned === undefined ? {} : { pinned }),
 
@@ -461,7 +471,8 @@ export const getMastodonStatuses = async (
     replyCounts,
     replyStatuses,
     pollVotes,
-    pinnedStatusIds
+    pinnedStatusIds,
+    mutedConversationRootIds
   ] = await Promise.all([
     database.getMastodonActorsFromIds({
       ids: requestedActorIds
@@ -489,6 +500,9 @@ export const getMastodonStatuses = async (
           actorId: currentActorId,
           statusIds: requestedPinnedLookupStatusIds
         })
+      : Promise.resolve<string[]>([]),
+    currentActorId
+      ? database.getActorMutedConversationRootIds({ actorId: currentActorId })
       : Promise.resolve<string[]>([])
   ])
   const requestedActorIdSet = new Set(requestedActorIds)
@@ -516,6 +530,9 @@ export const getMastodonStatuses = async (
     ...inputOptions,
     pinnedStatusIds:
       inputOptions.pinnedStatusIds ?? new Set<string>(pinnedStatusIds),
+    mutedConversationRootIds:
+      inputOptions.mutedConversationRootIds ??
+      new Set<string>(mutedConversationRootIds),
     accountCache,
     statusMetricsCache: {
       reblogs: new Map(

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -371,11 +371,16 @@ export const getMastodonStatus = async (
   const emojis = getEmojisFromTags(status.tags)
   const hashtags = getHashtagsFromTags(status.tags, host)
 
-  const sensitive = Boolean(status.summary && status.summary.length > 0)
+  // Mastodon marks a status sensitive when it was explicitly flagged sensitive
+  // OR carries a content warning (spoiler/summary).
+  const sensitive =
+    (status.sensitive ?? false) ||
+    Boolean(status.summary && status.summary.length > 0)
   const mastodonStatus = {
     ...baseData,
     spoiler_text: status.summary ?? '',
     sensitive,
+    language: status.language ?? null,
     url: status.url,
 
     in_reply_to_id: replyStatus ? urlToId(replyStatus.id) : null,

--- a/lib/services/mastodon/getMastodonStatusEdits.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.ts
@@ -1,0 +1,103 @@
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { Mastodon } from '@/lib/types/activitypub'
+import {
+  Status,
+  StatusNote,
+  StatusPoll,
+  StatusType
+} from '@/lib/types/domain/status'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { processStatusText } from '@/lib/utils/text/processStatusText'
+
+import { getMastodonStatus } from './getMastodonStatus'
+
+/**
+ * A Mastodon `StatusEdit` entity (see
+ * app/serializers/rest/status_edit_serializer.rb). The `poll` field is the
+ * reduced edit shape — just the option titles — not the full `Poll` entity.
+ */
+export interface MastodonStatusEdit {
+  content: string
+  spoiler_text: string
+  sensitive: boolean
+  created_at: string
+  account: Mastodon.Account
+  poll: { options: { title: string }[] } | null
+  media_attachments: Mastodon.Status['media_attachments']
+  emojis: Mastodon.Status['emojis']
+}
+
+/**
+ * Reconstructs the full edit timeline for a status as a `StatusEdit[]`,
+ * oldest-first and including the original version, matching
+ * `GET /api/v1/statuses/:id/history`.
+ *
+ * Storage only snapshots the text/summary of each prior version (in
+ * `status_history`), so per-revision media, poll options, and emojis are
+ * approximated with the status's current values. Only the textual content and
+ * timestamps differ between revisions.
+ */
+export const getMastodonStatusEdits = async (
+  database: Database,
+  status: StatusNote | StatusPoll,
+  currentActorId?: string
+): Promise<MastodonStatusEdit[]> => {
+  const current = await getMastodonStatus(database, status, currentActorId)
+  if (!current) return []
+
+  const host = getConfig().host
+  const pollOptions =
+    status.type === StatusType.enum.Poll
+      ? { options: status.choices.map((choice) => ({ title: choice.title })) }
+      : null
+
+  const buildEdit = (
+    text: string,
+    summary: string | null,
+    createdAtMs: number
+  ): MastodonStatusEdit => ({
+    content: processStatusText(host, { ...status, text, summary } as Status),
+    spoiler_text: summary ?? '',
+    sensitive: Boolean(summary && summary.length > 0),
+    created_at: getISOTimeUTC(createdAtMs),
+    account: current.account,
+    poll: pollOptions,
+    media_attachments: current.media_attachments,
+    emojis: current.emojis
+  })
+
+  const revisions = await database.getStatusEditHistory({ statusId: status.id })
+  if (revisions.length === 0) {
+    // Never edited: history is the single original/current version.
+    return [buildEdit(status.text, status.summary ?? null, status.createdAt)]
+  }
+
+  const edits: MastodonStatusEdit[] = []
+  // The original version's content is the oldest snapshot, created when the
+  // status itself was created.
+  edits.push(
+    buildEdit(revisions[0].text, revisions[0].summary, status.createdAt)
+  )
+  // Each later prior version was created at the moment the version before it
+  // was superseded.
+  for (let i = 1; i < revisions.length; i++) {
+    edits.push(
+      buildEdit(
+        revisions[i].text,
+        revisions[i].summary,
+        revisions[i - 1].supersededAt
+      )
+    )
+  }
+  // The current (live) version was created when the last prior version was
+  // superseded.
+  edits.push(
+    buildEdit(
+      status.text,
+      status.summary ?? null,
+      revisions[revisions.length - 1].supersededAt
+    )
+  )
+  return edits
+}

--- a/lib/services/mastodon/getMastodonStatusEdits.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.ts
@@ -23,7 +23,9 @@ export interface MastodonStatusEdit {
   sensitive: boolean
   created_at: string
   account: Mastodon.Account
-  poll: { options: { title: string }[] } | null
+  // Mastodon omits `poll` entirely for non-poll edits (the serializer only emits
+  // it when poll options are present), so the field is optional here.
+  poll?: { options: { title: string }[] }
   media_attachments: Mastodon.Status['media_attachments']
   emojis: Mastodon.Status['emojis']
 }
@@ -50,7 +52,7 @@ export const getMastodonStatusEdits = async (
   const pollOptions =
     status.type === StatusType.enum.Poll
       ? { options: status.choices.map((choice) => ({ title: choice.title })) }
-      : null
+      : undefined
 
   const buildEdit = (
     text: string,
@@ -59,10 +61,14 @@ export const getMastodonStatusEdits = async (
   ): MastodonStatusEdit => ({
     content: processStatusText(host, { ...status, text, summary } as Status),
     spoiler_text: summary ?? '',
-    sensitive: Boolean(summary && summary.length > 0),
+    // Mastodon stores a dedicated sensitive flag per revision; storage here only
+    // snapshots text/summary, so use the status's current sensitive flag,
+    // forced true when this revision carries a content warning.
+    sensitive:
+      (status.sensitive ?? false) || Boolean(summary && summary.length > 0),
     created_at: getISOTimeUTC(createdAtMs),
     account: current.account,
-    poll: pollOptions,
+    ...(pollOptions ? { poll: pollOptions } : {}),
     media_attachments: current.media_attachments,
     emojis: current.emojis
   })

--- a/lib/services/notifications/createConversationMuteSuppression.test.ts
+++ b/lib/services/notifications/createConversationMuteSuppression.test.ts
@@ -1,0 +1,113 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+// Verifies the conversation-mute suppression branch of the single
+// notification-creation seam: a recipient who muted a thread receives no
+// notifications for statuses in that thread.
+describe('createNotificationWithPolicy conversation-mute suppression', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  it('drops a notification for a status whose conversation the recipient muted', async () => {
+    const statusId = `${ACTOR2_ID}/statuses/mute-suppression-target`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR2_ID,
+      text: 'A status in a muted conversation',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    // ACTOR1 mutes the conversation (root == the status itself here).
+    await database.createStatusMute({ actorId: ACTOR1_ID, statusId })
+
+    const notification = await createNotificationWithPolicy(database, {
+      actorId: ACTOR1_ID,
+      type: 'favourite',
+      sourceActorId: ACTOR2_ID,
+      statusId
+    })
+
+    expect(notification).toBeNull()
+    const stored = await database.getNotifications({
+      actorId: ACTOR1_ID,
+      limit: 20
+    })
+    expect(stored.some((item) => item.statusId === statusId)).toBe(false)
+  })
+
+  it('drops a notification for a reply in a muted thread (root resolution)', async () => {
+    const rootId = `${ACTOR2_ID}/statuses/mute-suppression-root`
+    const replyId = `${ACTOR2_ID}/statuses/mute-suppression-reply`
+    await database.createNote({
+      id: rootId,
+      url: rootId,
+      actorId: ACTOR2_ID,
+      text: 'Root of a muted thread',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createNote({
+      id: replyId,
+      url: replyId,
+      actorId: ACTOR2_ID,
+      text: 'A reply inside the muted thread',
+      reply: rootId,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createStatusMute({ actorId: ACTOR1_ID, statusId: rootId })
+
+    const notification = await createNotificationWithPolicy(database, {
+      actorId: ACTOR1_ID,
+      type: 'mention',
+      sourceActorId: ACTOR2_ID,
+      statusId: replyId
+    })
+
+    expect(notification).toBeNull()
+  })
+
+  it('persists a notification for a status in a non-muted conversation', async () => {
+    const statusId = `${ACTOR2_ID}/statuses/mute-suppression-control`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR2_ID,
+      text: 'A status in a non-muted conversation',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const notification = await createNotificationWithPolicy(database, {
+      actorId: ACTOR1_ID,
+      type: 'favourite',
+      sourceActorId: ACTOR2_ID,
+      statusId
+    })
+
+    expect(notification).not.toBeNull()
+  })
+
+  it('never suppresses an account-level notification with no statusId (e.g. follow)', async () => {
+    const notification = await createNotificationWithPolicy(database, {
+      actorId: ACTOR1_ID,
+      type: 'follow',
+      sourceActorId: ACTOR2_ID
+    })
+
+    expect(notification).not.toBeNull()
+  })
+})

--- a/lib/services/notifications/createNotificationWithPolicy.ts
+++ b/lib/services/notifications/createNotificationWithPolicy.ts
@@ -1,4 +1,5 @@
 import { Database } from '@/lib/database/types'
+import { resolveConversationRootId } from '@/lib/services/mastodon/conversationMute'
 import { evaluateNotificationPolicy } from '@/lib/services/notifications/evaluateNotificationPolicy'
 import {
   CreateNotificationParams,
@@ -18,6 +19,28 @@ export const createNotificationWithPolicy = async (
   database: Database,
   params: CreateNotificationParams
 ): Promise<Notification | null> => {
+  // Suppress notifications for conversations the recipient has muted. Only
+  // status-bound notifications (mention, reply, favourite, reblog, poll, …)
+  // belong to a conversation; account-level ones (e.g. follow) carry no
+  // statusId and are never suppressed here.
+  if (params.statusId) {
+    const status = await database.getStatus({
+      statusId: params.statusId,
+      withReplies: false
+    })
+    if (status) {
+      const conversationRootId = await resolveConversationRootId(
+        database,
+        status
+      )
+      const conversationMuted = await database.isConversationMuted({
+        actorId: params.actorId,
+        statusId: conversationRootId
+      })
+      if (conversationMuted) return null
+    }
+  }
+
   const verdict = await evaluateNotificationPolicy(database, {
     actorId: params.actorId,
     type: params.type,

--- a/lib/services/notifications/createNotificationWithPolicy.ts
+++ b/lib/services/notifications/createNotificationWithPolicy.ts
@@ -22,22 +22,24 @@ export const createNotificationWithPolicy = async (
   // Suppress notifications for conversations the recipient has muted. Only
   // status-bound notifications (mention, reply, favourite, reblog, poll, …)
   // belong to a conversation; account-level ones (e.g. follow) carry no
-  // statusId and are never suppressed here.
+  // statusId and are never suppressed here. Check the recipient's (usually
+  // empty) mute list first so the common case skips the thread-root walk.
   if (params.statusId) {
-    const status = await database.getStatus({
-      statusId: params.statusId,
-      withReplies: false
+    const mutedRootIds = await database.getActorMutedConversationRootIds({
+      actorId: params.actorId
     })
-    if (status) {
-      const conversationRootId = await resolveConversationRootId(
-        database,
-        status
-      )
-      const conversationMuted = await database.isConversationMuted({
-        actorId: params.actorId,
-        statusId: conversationRootId
+    if (mutedRootIds.length > 0) {
+      const status = await database.getStatus({
+        statusId: params.statusId,
+        withReplies: false
       })
-      if (conversationMuted) return null
+      if (status) {
+        const conversationRootId = await resolveConversationRootId(
+          database,
+          status
+        )
+        if (mutedRootIds.includes(conversationRootId)) return null
+      }
     }
   }
 

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -7,10 +7,12 @@ const STATUS_STRING_FIELDS = [
   'status',
   'in_reply_to_id',
   'spoiler_text',
-  'visibility'
+  'visibility',
+  'language'
 ] as const
 
 const MEDIA_ID_FIELDS = ['media_ids', 'media_ids[]'] as const
+const POLL_OPTION_FIELDS = ['poll[options][]', 'poll[options]'] as const
 
 const collectStatusFields = (
   get: (name: string) => unknown,
@@ -23,6 +25,10 @@ const collectStatusFields = (
     if (typeof value === 'string') body[field] = value
   }
 
+  // `sensitive` is a boolean in JSON but arrives as a string in form bodies.
+  const sensitive = get('sensitive')
+  if (typeof sensitive === 'string') body.sensitive = sensitive
+
   const rawMediaIds = MEDIA_ID_FIELDS.flatMap((field) => getAll(field)).filter(
     (value): value is string => typeof value === 'string'
   )
@@ -34,6 +40,22 @@ const collectStatusFields = (
     body.media_ids = rawMediaIds
       .map((value) => value.trim())
       .filter((value) => value.length > 0)
+  }
+
+  // Reconstruct the nested `poll` object Mastodon form clients flatten into
+  // `poll[options][]`, `poll[expires_in]`, `poll[multiple]`, `poll[hide_totals]`.
+  const pollOptions = POLL_OPTION_FIELDS.flatMap((field) =>
+    getAll(field)
+  ).filter((value): value is string => typeof value === 'string')
+  if (pollOptions.length > 0) {
+    const poll: Record<string, unknown> = { options: pollOptions }
+    const expiresIn = get('poll[expires_in]')
+    if (typeof expiresIn === 'string') poll.expires_in = expiresIn
+    const multiple = get('poll[multiple]')
+    if (typeof multiple === 'string') poll.multiple = multiple
+    const hideTotals = get('poll[hide_totals]')
+    if (typeof hideTotals === 'string') poll.hide_totals = hideTotals
+    body.poll = poll
   }
 
   return body

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -434,6 +434,16 @@ export type GetStatusRepliesParams = BaseStatusParams & {
   publicOnly?: boolean
   visibleToActorId?: string | null
 }
+export type GetStatusEditHistoryParams = BaseStatusParams
+// A single superseded revision of a status (a row in `status_history`). `text`
+// and `summary` are the content of that prior version; `supersededAt` is when it
+// was replaced by the next version, which is the creation time of that next
+// version.
+export type StatusEditRevision = {
+  text: string
+  summary: string | null
+  supersededAt: number
+}
 export type DeleteStatusParams = BaseStatusParams & {
   actorId?: string
 }
@@ -523,8 +533,16 @@ export type HasActorAnnouncedStatusParams = BaseStatusParams & {
   actorId?: string
 }
 export type GetFavouritedByParams = BaseStatusParams & {
-  limit?: number
-  offset?: number
+  limit: number
+  // Opaque base64url cursors (see favouritedByCursor). `maxId` pages toward
+  // older favourites, `minId`/`sinceId` toward newer ones.
+  maxId?: string | null
+  minId?: string | null
+  sinceId?: string | null
+}
+export type FavouritedByAccount = {
+  actorId: string
+  createdAt: number
 }
 export type GetRebloggedByParams = BaseStatusParams & {
   limit?: number
@@ -626,6 +644,9 @@ export interface StatusDatabase {
   updatePoll(params: UpdatePollParams): Promise<Status | null>
   getStatus(params: GetStatusParams): Promise<Status | null>
   getStatusReplies(params: GetStatusRepliesParams): Promise<Status[]>
+  getStatusEditHistory(
+    params: GetStatusEditHistoryParams
+  ): Promise<StatusEditRevision[]>
   getStatusFromUrl(params: GetStatusFromUrlParams): Promise<Status | null>
   getStatusFromUrlHash(
     params: GetStatusFromUrlHashParams
@@ -651,7 +672,7 @@ export interface StatusDatabase {
   unpinStatus(params: PinStatusParams): Promise<void>
   getPinnedStatusIds(params: GetPinnedStatusIdsParams): Promise<string[]>
   getStatusesByIds(params: GetStatusesByIdsParams): Promise<Status[]>
-  getFavouritedBy(params: GetFavouritedByParams): Promise<Actor[]>
+  getFavouritedBy(params: GetFavouritedByParams): Promise<FavouritedByAccount[]>
   getRebloggedBy(params: GetRebloggedByParams): Promise<RebloggedByAccount[]>
   createTag(params: CreateTagParams): Promise<Tag>
   getTags(params: GetTagsParams): Promise<Tag[]>
@@ -1102,6 +1123,26 @@ export interface MuteDatabase {
   isMuting(params: IsMutingParams): Promise<boolean>
   getMuteRelations(params: GetMuteRelationsParams): Promise<MuteRelation[]>
   getMutes(params: GetMutesParams): Promise<Mute[]>
+}
+
+// ============================================================================
+// Status (conversation) Mute Database
+// ============================================================================
+
+// `statusId` is the thread-root status id that identifies the muted
+// conversation (see resolveConversationRootId).
+export type CreateStatusMuteParams = { actorId: string; statusId: string }
+export type DeleteStatusMuteParams = { actorId: string; statusId: string }
+export type IsConversationMutedParams = { actorId: string; statusId: string }
+export type GetActorMutedConversationRootIdsParams = { actorId: string }
+
+export interface StatusMuteDatabase {
+  createStatusMute(params: CreateStatusMuteParams): Promise<void>
+  deleteStatusMute(params: DeleteStatusMuteParams): Promise<void>
+  isConversationMuted(params: IsConversationMutedParams): Promise<boolean>
+  getActorMutedConversationRootIds(
+    params: GetActorMutedConversationRootIdsParams
+  ): Promise<string[]>
 }
 
 // ============================================================================

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -388,6 +388,10 @@ interface BaseCreateStatusParams {
   summary?: string | null
   reply?: string
 
+  // Mastodon-compatible content flags persisted in the status content blob.
+  sensitive?: boolean
+  language?: string | null
+
   createdAt?: number
 }
 
@@ -400,6 +404,9 @@ type BaseStatusParams = {
 export type UpdateNoteParams = Pick<CreateNoteParams, 'text' | 'summary'> &
   BaseStatusParams & {
     attachments?: PostBoxAttachment[]
+    // Omit to preserve the existing value; provide to overwrite.
+    sensitive?: boolean
+    language?: string | null
   }
 
 export type UpdateNoteVisibilityParams = BaseStatusParams & {
@@ -1143,6 +1150,24 @@ export interface StatusMuteDatabase {
   getActorMutedConversationRootIds(
     params: GetActorMutedConversationRootIdsParams
   ): Promise<string[]>
+}
+
+// ============================================================================
+// Idempotency Key Database
+// ============================================================================
+
+export type GetIdempotentStatusIdParams = { actorId: string; key: string }
+export type SaveIdempotencyKeyParams = {
+  actorId: string
+  key: string
+  statusId: string
+}
+
+export interface IdempotencyDatabase {
+  getIdempotentStatusId(
+    params: GetIdempotentStatusIdParams
+  ): Promise<string | null>
+  saveIdempotencyKey(params: SaveIdempotencyKeyParams): Promise<void>
 }
 
 // ============================================================================

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -73,6 +73,14 @@ export const StatusNote = StatusBase.extend({
   url: z.string(),
   text: z.string(),
   summary: z.string().nullable().optional(),
+  // Explicit "mark media as sensitive" flag. Independent of `summary`: a status
+  // can be sensitive without a content warning, and Mastodon also forces
+  // sensitive=true whenever a spoiler/summary is present (applied in the
+  // Mastodon serializer, not here). Optional so existing status literals and
+  // remote notes that predate the field remain valid; treated as false/null.
+  sensitive: z.boolean().optional(),
+  // ISO 639 Part 1 two-letter language code, or null when unknown.
+  language: z.string().nullable().optional(),
   reply: z.string(),
   replies: z.looseObject(StatusBase.shape).array(),
 

--- a/lib/utils/zodBooleanish.ts
+++ b/lib/utils/zodBooleanish.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+/**
+ * A Zod schema for Mastodon-style boolean params. JSON bodies send real
+ * booleans, but form-encoded/multipart bodies send strings — and `Boolean('false')`
+ * is truthy — so string values are coerced explicitly. Recognized truthy
+ * strings: `true`, `1`, `on`, `yes` (case-insensitive); everything else is false.
+ */
+export const Booleanish = z
+  .union([z.boolean(), z.string()])
+  .transform((value) => {
+    if (typeof value === 'boolean') return value
+    const normalized = value.trim().toLowerCase()
+    return (
+      normalized === 'true' ||
+      normalized === '1' ||
+      normalized === 'on' ||
+      normalized === 'yes'
+    )
+  })

--- a/migrations/20260601000000_add_status_mutes_table.js
+++ b/migrations/20260601000000_add_status_mutes_table.js
@@ -1,0 +1,28 @@
+/**
+ * Conversation (thread) mutes for the Mastodon
+ * `POST /api/v1/statuses/:id/mute` + `/unmute` endpoints. A row mutes the
+ * conversation identified by its thread-root status id for one actor, which
+ * drives the `muted` flag on statuses and suppresses notifications for that
+ * thread.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) =>
+  knex.schema.createTable('status_mutes', (table) => {
+    table.string('actorId').notNullable()
+    // The thread-root status id that identifies the muted conversation.
+    table.string('statusId').notNullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.primary(['actorId', 'statusId'])
+    table.index(['actorId'], 'status_mutes_actor')
+    table.index(['statusId'], 'status_mutes_status')
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => knex.schema.dropTable('status_mutes')

--- a/migrations/20260601000000_add_status_mutes_table.js
+++ b/migrations/20260601000000_add_status_mutes_table.js
@@ -16,8 +16,10 @@ exports.up = (knex) =>
     table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
     table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
 
+    // The composite primary key (actorId, statusId) already serves
+    // actorId-prefix lookups (e.g. getActorMutedConversationRootIds), so no
+    // separate actorId index is needed.
     table.primary(['actorId', 'statusId'])
-    table.index(['actorId'], 'status_mutes_actor')
     table.index(['statusId'], 'status_mutes_status')
   })
 

--- a/migrations/20260601001000_add_idempotency_keys_table.js
+++ b/migrations/20260601001000_add_idempotency_keys_table.js
@@ -1,0 +1,25 @@
+/**
+ * Idempotency keys for `POST /api/v1/statuses`. Mastodon honors an
+ * `Idempotency-Key` header so a retried create returns the original status
+ * instead of duplicating it. A row maps one actor's key to the status it
+ * created.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) =>
+  knex.schema.createTable('idempotency_keys', (table) => {
+    table.string('actorId').notNullable()
+    table.string('key').notNullable()
+    table.string('statusId').notNullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.primary(['actorId', 'key'])
+    table.index(['createdAt'], 'idempotency_keys_created')
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => knex.schema.dropTable('idempotency_keys')

--- a/migrations/20260601001000_add_idempotency_keys_table.js
+++ b/migrations/20260601001000_add_idempotency_keys_table.js
@@ -15,6 +15,9 @@ exports.up = (knex) =>
     table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
 
     table.primary(['actorId', 'key'])
+    // Indexed so deletion by statusId (orphan cleanup when a status is removed)
+    // and expiry sweeps by createdAt stay efficient.
+    table.index(['statusId'], 'idempotency_keys_status')
     table.index(['createdAt'], 'idempotency_keys_created')
   })
 


### PR DESCRIPTION
## Summary

Brings the Statuses API under `app/api/v1/statuses/**` (plus the create route) closer to full Mastodon compatibility: matching params, OAuth scopes, response entity shapes, and id-cursor pagination, and adds previously-missing behavior. Every endpoint's compatibility decision is pinned to the Mastodon source (`config/routes/api.rb`, `app/serializers/rest/*`, and the method docs), cited per-item below.

All response bodies go through the existing Mastodon entity builders (`getMastodonStatus`/`getMastodonStatuses`, plus a new `getMastodonStatusEdits`). `?format=activities_next` overlays are untouched.

## Per-endpoint compatibility checklist

### Create / Edit
- **`POST /api/v1/statuses`** — now wires `poll[options][]`/`poll[expires_in]`/`poll[multiple]`/`poll[hide_totals]` (via the existing `createPollFromUserInput`), `sensitive`, and `language`, and honors the `Idempotency-Key` header (a repeated key returns the original status, no duplicate). Rejects media+poll together (422), matching Mastodon. Scope `write:statuses`. (`scheduled_at` intentionally out of scope.)
  - Source: docs/methods/statuses create params; `status_serializer.rb` (`sensitive`, `language`).
- **`PUT /api/v1/statuses/:id`** — wires `sensitive` and `language`. Edit revisions are persisted (existing `status_history`) so history works. Scope `write:statuses`.
  - Note: editing a Note's poll on `PUT` is **not** implemented (see Deferred).

### Context — `GET /api/v1/statuses/:id/context`
- Now returns the **full** ancestor chain (walks `in_reply_to` to root, ordered root-first) and the **full** recursive descendant tree (DFS pre-order), with per-actor visibility filtering. Anonymous requests are allowed for public statuses (`OptionalOAuthGuard`), with Mastodon's 40-ancestor/60-descendant caps for anonymous and 4096 for authenticated.
  - Source: `contexts_controller.rb` (`CONTEXT_LIMIT`, `ANCESTORS/DESCENDANTS_LIMIT`), `context_serializer.rb`.

### History — `GET /api/v1/statuses/:id/history`
- Returns the real `StatusEdit[]` reconstructed from `status_history`, oldest→newest **including the original**, via a new `getMastodonStatusEdits` serializer (`content`, `spoiler_text`, `sensitive`, `created_at`, `account`, `poll`, `media_attachments`, `emojis`).
  - Source: `status_edit_serializer.rb`.
  - Limitation: only text/summary is snapshotted per revision in storage, so per-revision media/poll/emojis are approximated with the status's current values (documented in the serializer).

### Source — `GET /api/v1/statuses/:id/source`
- Verified `{ id, text, spoiler_text }` still matches; added a co-located regression test. Scope `read:statuses`.

### Favourited-by — `GET /api/v1/statuses/:id/favourited_by`
- Converted from `limit`/`offset` + `X-Total-Count`/`X-Offset`/`X-Limit` to Mastodon id-cursor pagination (`max_id`/`min_id`/`since_id`/`limit`) with a `Link` rel="next"/"prev" header. Extracted a shared `buildAccountCursorLinkHeader` helper now used by **both** `favourited_by` and `reblogged_by`. Opaque `(createdAt, actorId)` cursor (`favouritedByCursor`).
  - Source: docs/methods favourited_by; mirrors the already-correct `reblogged_by`.

### Unbookmark — `POST /api/v1/statuses/:id/unbookmark`
- When the status is no longer readable but a bookmark exists, it now deletes the bookmark and returns the **Status** (`bookmarked: false`) instead of 404 (only 404s when the underlying status truly no longer exists). Scope `write:bookmarks`.
  - Source: docs/methods unbookmark.

### Mute / Unmute — `POST /api/v1/statuses/:id/mute` + `/unmute`
- Implemented real **conversation muting**: a new `status_mutes` table keyed on the thread-root status id, resolved by walking `in_reply_to`. The `muted` flag now flows through both `getMastodonStatus` and the batch `getMastodonStatuses` (with a per-request set short-circuit so the no-mutes common case costs nothing), and muted-conversation notifications are suppressed at the single `createNotificationWithPolicy` seam. Scope corrected from bare `write` to **`write:mutes`**.
  - Source: docs/methods mute/unmute (`write:mutes`); `status_serializer.rb` (`muted`).

### Cross-cutting
- OAuth scopes audited per endpoint (mute/unmute → `write:mutes`; favourited_by → public + `read:statuses`; create/edit → `write:statuses`).
- All list responses use id-cursor + `Link` (no offset/`X-*` on Mastodon routes).
- `sensitive`/`language` persisted in the existing status content blob (no schema migration); `getMastodonStatus` emits `sensitive = explicit || hasSpoiler` and the stored `language`.

## Deferred (no underlying data model; explicitly listed per task instructions)
These exist in current `main` `api.rb` but are large new federation/data-model features out of scope here:
- `GET /api/v1/statuses/:status_id/quotes` and `POST /api/v1/statuses/:status_id/quotes/:id/revoke` — quote posts (FEP-style) have no data model in this codebase.
- `PATCH /api/v1/statuses/:status_id/interaction_policy` — no interaction-policy model.
- Editing a poll via `PUT` (Mastodon allows it only under vote-state constraints) — create-time poll only.
- Outgoing ActivityPub federation of `sensitive`/`language` (API round-trips them; the AP Note generation is unchanged).

## Local verification gates
- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors (12 pre-existing warnings, untouched files)
- `yarn build` — compiled successfully
- `yarn test` — **3420 passed, 393 suites**

New migrations: `status_mutes`, `idempotency_keys`. No `package.json` version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
