### PR TITLE
Bump version to v1.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.44.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.43.0`
- Base main SHA: `a7bde03731eea1bdf749e3e390b0449cbbb411b3`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
