### PR TITLE
Bump version to v1.44.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.44.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.44.0`
- Base main SHA: `639cc8f168e28c254de2f85771ef52401962f682`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
