### PR TITLE
test: clarify test names and remove trivial constant-export tests

### DIFF
--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -46,7 +46,7 @@ describe('createApplication', () => {
     await knexDatabase.destroy()
   })
 
-  test('it generates secret and create application in database and returns application response', async () => {
+  test('generates a secret, persists the application, and returns the application response', async () => {
     const response = (await createApplication(
       {
         redirect_uris: 'https://test.llun.dev/apps/redirect',

--- a/lib/actions/like.test.ts
+++ b/lib/actions/like.test.ts
@@ -18,7 +18,7 @@ jest.mock('@/lib/services/email', () => ({
   sendMail: jest.fn()
 }))
 
-describe('Accept follow action', () => {
+describe('Like action', () => {
   const database = getTestSQLDatabase()
 
   beforeAll(async () => {

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -643,7 +643,7 @@ describe('MediaDatabase', () => {
         expect(retrieved?.original.path).toBe('/test/random-abc123.jpg')
       })
 
-      it('works without fileName for backward compatibility', async () => {
+      it('creates media without a fileName for backward compatibility', async () => {
         const actor = await database.getActorFromId({
           id: actors.primary.id
         })

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -245,7 +245,7 @@ describe('Notification Database', () => {
         expect(notifications[0].type).toBe('mention')
       })
 
-      it('should work with cursor pagination and excludeTypes together', async () => {
+      it('combines cursor pagination with excludeTypes filtering', async () => {
         const allNotifications = await database.getNotifications({
           actorId: actor1Id,
           limit: 10

--- a/lib/utils/trace.test.ts
+++ b/lib/utils/trace.test.ts
@@ -1,22 +1,6 @@
-import {
-  TRACE_APPLICATION_SCOPE,
-  TRACE_APPLICATION_VERSION,
-  Trace,
-  getSpan,
-  getTracer
-} from './trace'
+import { Trace, getSpan, getTracer } from './trace'
 
 describe('trace utilities', () => {
-  describe('TRACE constants', () => {
-    it('exports APPLICATION_SCOPE', () => {
-      expect(TRACE_APPLICATION_SCOPE).toBe('activities.next')
-    })
-
-    it('exports APPLICATION_VERSION', () => {
-      expect(TRACE_APPLICATION_VERSION).toBeDefined()
-    })
-  })
-
   describe('getTracer', () => {
     it('returns a tracer', () => {
       const tracer = getTracer()


### PR DESCRIPTION
## Summary

A targeted readability cleanup of the Jest test suite. All 394 test files were audited; the suite was already in very good shape (clear behavioral names, clean Arrange-Act-Assert bodies, no `console.*`/`.only`/`.skip` cruft), so the changes are intentionally minimal — no blanket rewrite.

### Clarified test names
- `lib/actions/like.test.ts` — fixed a misleading copy-paste describe: `Accept follow action` → `Like action` (the file tests `likeRequest`).
- `lib/database/sql/notification.test.ts` — `should work with cursor pagination and excludeTypes together` → `combines cursor pagination with excludeTypes filtering`.
- `lib/database/sql/media.test.ts` — `works without fileName for backward compatibility` → `creates media without a fileName for backward compatibility`.
- `app/api/v1/apps/createApplication.test.ts` — fixed a mixed-tense name.

### Removed trivial tests
- `lib/utils/trace.test.ts` — removed the `TRACE constants` block (two export/`toBeDefined` assertions with no behavioral value) and pruned the now-unused imports.

### Deliberately left alone
- The `describe('#name')` vs `describe('name')` style mix — cosmetic only, large churn for no value.
- Apparent "duplicates" (`getHashFromString`/`...Client`, `getStatusDetailPath`/`...Client`, `sendNoteJob`/`sendAnnounceJob` not-found cases) — these are intentional separate server/client or per-job coverage.

## Test results
- `yarn lint` — green (0 errors)
- `yarn build` — green
- `yarn test` — 394 suites / 3439 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)