### PR TITLE
Bump version to v1.44.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.44.1",
+  "version": "1.44.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.44.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.44.1`
- Base main SHA: `f3f6a3b18ad9605f8bdb2a88cc4b079b270a4885`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
