### PR TITLE
test: consolidate uniform pure-function tests with it.each

### DIFF
--- a/lib/utils/getAttachmentMediaPath.test.ts
+++ b/lib/utils/getAttachmentMediaPath.test.ts
@@ -1,25 +1,29 @@
 import { getAttachmentMediaPath } from '@/lib/utils/getAttachmentMediaPath'
 
 describe('#getAttachmentMediaPath', () => {
-  it('extracts media path from local API URLs', () => {
-    expect(
-      getAttachmentMediaPath('https://example.com/api/v1/files/medias/a.webp')
-    ).toBe('medias/a.webp')
-  })
-
-  it('extracts and decodes path from generic absolute URLs', () => {
-    expect(
-      getAttachmentMediaPath('https://cdn.example.com/media%20files/a.webp')
-    ).toBe('media files/a.webp')
-  })
-
-  it('handles relative paths and strips leading slashes', () => {
-    expect(getAttachmentMediaPath('/media/a.webp')).toBe('media/a.webp')
-  })
-
-  it('returns undecoded fallback when decodeURIComponent throws', () => {
-    expect(getAttachmentMediaPath('/media/%E0%A4%A.webp')).toBe(
-      'media/%E0%A4%A.webp'
-    )
+  it.each([
+    {
+      description: 'extracts the media path from local API URLs',
+      url: 'https://example.com/api/v1/files/medias/a.webp',
+      expected: 'medias/a.webp'
+    },
+    {
+      description: 'extracts and decodes the path from generic absolute URLs',
+      url: 'https://cdn.example.com/media%20files/a.webp',
+      expected: 'media files/a.webp'
+    },
+    {
+      description: 'handles relative paths and strips leading slashes',
+      url: '/media/a.webp',
+      expected: 'media/a.webp'
+    },
+    {
+      description:
+        'returns the undecoded fallback when decodeURIComponent throws',
+      url: '/media/%E0%A4%A.webp',
+      expected: 'media/%E0%A4%A.webp'
+    }
+  ])('$description', ({ url, expected }) => {
+    expect(getAttachmentMediaPath(url)).toBe(expected)
   })
 })

--- a/lib/utils/text/getHashtags.test.ts
+++ b/lib/utils/text/getHashtags.test.ts
@@ -2,82 +2,90 @@ import { getHashtags } from './getHashtags'
 
 describe('#getHashtags', () => {
   const host = 'test.llun.dev'
-
-  it('extracts a single hashtag', () => {
-    expect(getHashtags('Hello #world', host)).toEqual([
-      { name: '#world', value: 'https://test.llun.dev/tags/world' }
-    ])
+  const tag = (name: string, slug: string) => ({
+    name,
+    value: `https://${host}/tags/${slug}`
   })
 
-  it('extracts multiple hashtags', () => {
-    expect(getHashtags('#hello world #test', host)).toEqual([
-      { name: '#hello', value: 'https://test.llun.dev/tags/hello' },
-      { name: '#test', value: 'https://test.llun.dev/tags/test' }
-    ])
-  })
-
-  it('deduplicates hashtags by lowercase', () => {
-    expect(getHashtags('#Hello #hello #HELLO', host)).toEqual([
-      { name: '#Hello', value: 'https://test.llun.dev/tags/hello' }
-    ])
-  })
-
-  it('returns empty array when no hashtags', () => {
-    expect(getHashtags('No hashtags here', host)).toEqual([])
-  })
-
-  it('handles hashtags with numbers and underscores', () => {
-    expect(getHashtags('#test_123', host)).toEqual([
-      { name: '#test_123', value: 'https://test.llun.dev/tags/test_123' }
-    ])
-  })
-
-  it('does not match bare hash symbol', () => {
-    expect(getHashtags('# not a tag', host)).toEqual([])
-  })
-
-  it('extracts hashtag at start of text', () => {
-    expect(getHashtags('#first post', host)).toEqual([
-      { name: '#first', value: 'https://test.llun.dev/tags/first' }
-    ])
-  })
-
-  it('extracts hashtag at end of text', () => {
-    expect(getHashtags('my post #last', host)).toEqual([
-      { name: '#last', value: 'https://test.llun.dev/tags/last' }
-    ])
-  })
-
-  it('does not match hash fragments in URLs', () => {
-    expect(
-      getHashtags('Check https://example.com/page#section here', host)
-    ).toEqual([])
-  })
-
-  it('does not match hex color codes', () => {
-    expect(getHashtags('color:#ff0000', host)).toEqual([])
-  })
-
-  it('extracts hashtag after newline', () => {
-    expect(getHashtags('line one\n#tag', host)).toEqual([
-      { name: '#tag', value: 'https://test.llun.dev/tags/tag' }
-    ])
-  })
-
-  it('does not match purely numeric hashtags', () => {
-    expect(getHashtags('#123', host)).toEqual([])
-    expect(getHashtags('#456789', host)).toEqual([])
-  })
-
-  it('matches hashtags with numbers and at least one letter', () => {
-    expect(getHashtags('#2024election', host)).toEqual([
-      {
-        name: '#2024election',
-        value: 'https://test.llun.dev/tags/2024election'
-      }
-    ])
-    expect(getHashtags('#covid19', host)).toEqual([
-      { name: '#covid19', value: 'https://test.llun.dev/tags/covid19' }
-    ])
+  it.each([
+    {
+      description: 'extracts a single hashtag',
+      text: 'Hello #world',
+      expected: [tag('#world', 'world')]
+    },
+    {
+      description: 'extracts multiple hashtags',
+      text: '#hello world #test',
+      expected: [tag('#hello', 'hello'), tag('#test', 'test')]
+    },
+    {
+      description:
+        'deduplicates hashtags by lowercase, keeping the first casing',
+      text: '#Hello #hello #HELLO',
+      expected: [tag('#Hello', 'hello')]
+    },
+    {
+      description: 'returns an empty array when there are no hashtags',
+      text: 'No hashtags here',
+      expected: []
+    },
+    {
+      description: 'keeps numbers and underscores in a hashtag',
+      text: '#test_123',
+      expected: [tag('#test_123', 'test_123')]
+    },
+    {
+      description: 'does not match a bare hash symbol',
+      text: '# not a tag',
+      expected: []
+    },
+    {
+      description: 'extracts a hashtag at the start of the text',
+      text: '#first post',
+      expected: [tag('#first', 'first')]
+    },
+    {
+      description: 'extracts a hashtag at the end of the text',
+      text: 'my post #last',
+      expected: [tag('#last', 'last')]
+    },
+    {
+      description: 'does not match hash fragments in URLs',
+      text: 'Check https://example.com/page#section here',
+      expected: []
+    },
+    {
+      description: 'does not match hex color codes',
+      text: 'color:#ff0000',
+      expected: []
+    },
+    {
+      description: 'extracts a hashtag after a newline',
+      text: 'line one\n#tag',
+      expected: [tag('#tag', 'tag')]
+    },
+    {
+      description: 'does not match a short purely numeric hashtag',
+      text: '#123',
+      expected: []
+    },
+    {
+      description: 'does not match a long purely numeric hashtag',
+      text: '#456789',
+      expected: []
+    },
+    {
+      description:
+        'matches a hashtag that starts with numbers but contains a letter',
+      text: '#2024election',
+      expected: [tag('#2024election', '2024election')]
+    },
+    {
+      description: 'matches a hashtag that ends with numbers',
+      text: '#covid19',
+      expected: [tag('#covid19', 'covid19')]
+    }
+  ])('$description', ({ text, expected }) => {
+    expect(getHashtags(text, host)).toEqual(expected)
   })
 })

--- a/lib/utils/text/htmlToPlainText.test.ts
+++ b/lib/utils/text/htmlToPlainText.test.ts
@@ -1,34 +1,38 @@
 import { htmlToPlainText } from './htmlToPlainText'
 
 describe('htmlToPlainText', () => {
-  it('decodes entities after stripping HTML tags', () => {
-    expect(htmlToPlainText('<p>Tom &amp; Jerry &lt;run&gt; fast</p>')).toBe(
-      'Tom & Jerry <run> fast'
-    )
-  })
-
-  it('separates adjacent block tags with spaces', () => {
-    expect(htmlToPlainText('<p>Line one</p><p>Line two</p>')).toBe(
-      'Line one Line two'
-    )
-  })
-
-  it('separates line breaks with spaces', () => {
-    expect(htmlToPlainText('<p>Line one<br>Line two</p>')).toBe(
-      'Line one Line two'
-    )
-  })
-
-  it('treats empty input as empty text', () => {
-    expect(htmlToPlainText(null)).toBe('')
-    expect(htmlToPlainText(undefined)).toBe('')
-  })
-
-  it('drops script and style contents', () => {
-    expect(
-      htmlToPlainText(
-        '<p>Hello</p><script>alert("x")</script><style>.hidden{display:none}</style>'
-      )
-    ).toBe('Hello')
+  it.each([
+    {
+      description: 'decodes entities after stripping HTML tags',
+      html: '<p>Tom &amp; Jerry &lt;run&gt; fast</p>',
+      expected: 'Tom & Jerry <run> fast'
+    },
+    {
+      description: 'separates adjacent block tags with spaces',
+      html: '<p>Line one</p><p>Line two</p>',
+      expected: 'Line one Line two'
+    },
+    {
+      description: 'separates line breaks with spaces',
+      html: '<p>Line one<br>Line two</p>',
+      expected: 'Line one Line two'
+    },
+    {
+      description: 'treats null input as empty text',
+      html: null,
+      expected: ''
+    },
+    {
+      description: 'treats undefined input as empty text',
+      html: undefined,
+      expected: ''
+    },
+    {
+      description: 'drops script and style contents',
+      html: '<p>Hello</p><script>alert("x")</script><style>.hidden{display:none}</style>',
+      expected: 'Hello'
+    }
+  ])('$description', ({ html, expected }) => {
+    expect(htmlToPlainText(html)).toBe(expected)
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #879. Converts three pure-function test files whose cases differ **only by input/expected value** into table-driven `it.each` tests. Same coverage, less boilerplate, and each case stays individually named and reportable in the test output.

- **`lib/utils/text/getHashtags.test.ts`** (15 cases) — one table over `getHashtags(text, host)`, with a small `tag()` helper for the repeated tag-URL shape. The two original multi-input cases are split into one row each, so every input is named.
- **`lib/utils/text/htmlToPlainText.test.ts`** (6 cases) — the combined `null`/`undefined` empty-input case is split into two named rows.
- **`lib/utils/getAttachmentMediaPath.test.ts`** (4 cases).

## Deliberately left alone

`it.each` only helps when every case shares the same assertion shape. I measured `it`-vs-`expect` counts and matcher variety across all pure-function util/config tests; the rest are **not** candidates and were left untouched to avoid churn:

- Heterogeneous matchers / multiple functions per test (e.g. `getHashFromString`, `acceptContentTypes`, `activitypubActor`) — a flat table would read worse.
- Already-optimally-grouped mappings (e.g. `getVisibility`, which groups full/compact ActivityStreams forms per case).
- Integration-style tests in `lib/database`, `lib/jobs`, `lib/services` with per-test setup — never table candidates.

## Coverage safety

Each converted file was run individually to confirm no table rows were silently dropped: **15 + 6 + 4 = 25** cases, all passing.

## Test results
- `yarn lint` — green (0 errors)
- `yarn build` — green
- `yarn test` — 394 suites / 3444 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)