### PR TITLE
Bump version to v1.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.44.2",
+  "version": "1.45.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.45.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.44.2`
- Base main SHA: `6df716264f7d02922740d745a7288157e80079dc`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
