### PR TITLE
fix: Mastodon iOS account/timeline compatibility (timestamps, acct, instance host, trusted origins)

### DIFF
--- a/app/api/v1/instance/route.test.ts
+++ b/app/api/v1/instance/route.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    trustedHosts: ['alias.llun.test'],
+    serviceName: undefined,
+    serviceDescription: undefined,
+    languages: ['en'],
+    mediaStorage: undefined
+  })
+}))
+
+const params = { params: Promise.resolve({}) }
+
+describe('GET /api/v1/instance', () => {
+  it('reports the configured host by default', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance'),
+      params
+    )
+    await expect(response.json()).resolves.toMatchObject({ uri: 'llun.test' })
+  })
+
+  it('reports a trusted forwarded host', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance', {
+        headers: { 'x-forwarded-host': 'alias.llun.test' }
+      }),
+      params
+    )
+    await expect(response.json()).resolves.toMatchObject({
+      uri: 'alias.llun.test'
+    })
+  })
+
+  it('ignores an untrusted forwarded host', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance', {
+        headers: { 'x-forwarded-host': 'evil.example' }
+      }),
+      params
+    )
+    await expect(response.json()).resolves.toMatchObject({ uri: 'llun.test' })
+  })
+})

--- a/app/api/v1/instance/route.ts
+++ b/app/api/v1/instance/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MAX_PINNED_STATUSES,
   MAX_STATUS_MEDIA_ATTACHMENTS
@@ -21,7 +22,7 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
   const config = getConfig()
   const data = {
-    uri: config.host,
+    uri: headerHost(req.headers),
     title: config.serviceName ?? 'Activities.next',
     short_description:
       config.serviceDescription ?? 'Personal activity pub server with Next.js',

--- a/app/api/v1/reports/route.ts
+++ b/app/api/v1/reports/route.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { ReportCategory, Scope } from '@/lib/types/database/operations'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_404,
@@ -86,7 +86,7 @@ export const POST = traceApiRoute(
           category: report.category,
           comment: report.comment,
           forwarded: report.forward,
-          created_at: getISOTimeUTC(report.createdAt),
+          created_at: getMastodonTimeUTC(report.createdAt),
           // Echo ids back in the Mastodon short form clients sent, not the
           // internal URL form we persist.
           status_ids: report.statusIds.map((id) => urlToId(id)),

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    trustedHosts: ['alias.llun.test'],
+    serviceName: undefined,
+    serviceDescription: undefined,
+    languages: ['en'],
+    mediaStorage: undefined
+  })
+}))
+
+// v2 is behind OAuthGuard; pass the request straight through to the handler.
+jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (_scopes: unknown, handle: (req: unknown, context: unknown) => unknown) =>
+    (req: unknown, context: unknown) =>
+      handle(req, context)
+}))
+
+const params = { params: Promise.resolve({}) }
+
+describe('GET /api/v2/instance', () => {
+  it('reports the configured host by default', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    await expect(response.json()).resolves.toMatchObject({
+      domain: 'llun.test'
+    })
+  })
+
+  it('reports a trusted forwarded host', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance', {
+        headers: { 'x-forwarded-host': 'alias.llun.test' }
+      }),
+      params
+    )
+    await expect(response.json()).resolves.toMatchObject({
+      domain: 'alias.llun.test'
+    })
+  })
+
+  it('ignores an untrusted forwarded host', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance', {
+        headers: { 'x-forwarded-host': 'evil.example' }
+      }),
+      params
+    )
+    await expect(response.json()).resolves.toMatchObject({
+      domain: 'llun.test'
+    })
+  })
+})

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@/lib/config'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MAX_PINNED_STATUSES,
   MAX_STATUS_MEDIA_ATTACHMENTS
@@ -26,7 +27,7 @@ export const GET = traceApiRoute(
       req,
       allowedMethods: CORS_HEADERS,
       data: {
-        domain: config.host,
+        domain: headerHost(req.headers),
         title: config.serviceName ?? 'Activities.next',
         version: VERSION,
         source_url: 'https://github.com/llun/activities.next',

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -89,7 +89,7 @@ describe('AccountDatabase', () => {
       expect(actor).toMatchObject({
         id: urlToId(`https://${TEST_DOMAIN}/users/${TEST_USERNAME2}`),
         username: TEST_USERNAME2,
-        acct: `${TEST_USERNAME2}@${TEST_DOMAIN}`,
+        acct: TEST_USERNAME2,
         url: `https://${TEST_DOMAIN}/users/${TEST_USERNAME2}`,
         display_name: '',
         note: '',

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -27,7 +27,7 @@ import {
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { type StatusPoll } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getISOTimeUTC, getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 const withFreshDatabase = async (
@@ -323,7 +323,7 @@ describe('ActorDatabase', () => {
         expect(actor).toMatchObject({
           id: urlToId(`https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`),
           username: TEST_USERNAME3,
-          acct: `${TEST_USERNAME3}@${TEST_DOMAIN}`,
+          acct: TEST_USERNAME3,
           url: `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`,
           display_name: '',
           note: '',
@@ -466,7 +466,7 @@ describe('ActorDatabase', () => {
         expect(actor).toMatchObject({
           id: urlToId(`https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`),
           username: TEST_USERNAME3,
-          acct: `${TEST_USERNAME3}@${TEST_DOMAIN}`,
+          acct: TEST_USERNAME3,
           url: `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`,
           display_name: '',
           note: '',
@@ -497,7 +497,7 @@ describe('ActorDatabase', () => {
         expect(actor).toMatchObject({
           id: urlToId(`https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`),
           username: TEST_USERNAME3,
-          acct: `${TEST_USERNAME3}@${TEST_DOMAIN}`,
+          acct: TEST_USERNAME3,
           url: `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`,
           display_name: '',
           note: '',
@@ -579,17 +579,121 @@ describe('ActorDatabase', () => {
           })
 
           expect(serviceActor).toMatchObject({
+            acct: `service@remote-${suffix}.example`,
             bot: true,
             group: false,
             discoverable: true,
             noindex: false
           })
           expect(groupActor).toMatchObject({
+            acct: `group@remote-${suffix}.example`,
             bot: false,
             group: true,
             discoverable: true,
             noindex: false
           })
+        })
+      })
+
+      it('qualifies the acct of a hosted actor on a non-configured domain', async () => {
+        await withFreshDatabase(async (database) => {
+          const suffix = crypto.randomUUID().slice(0, 8)
+          const username = `multi-${suffix}`
+          await database.createAccount({
+            email: `${username}@${TEST_DOMAIN}`,
+            username,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: `privateKey-${suffix}`,
+            publicKey: `publicKey-${suffix}`
+          })
+          const account = await database.getAccountFromEmail({
+            email: `${username}@${TEST_DOMAIN}`
+          })
+          const aliasActorId = await database.createActorForAccount({
+            accountId: account!.id,
+            username,
+            domain: TEST_DOMAIN_2,
+            privateKey: `aliasPriv-${suffix}`,
+            publicKey: `aliasPub-${suffix}`
+          })
+
+          const homeActor = await database.getMastodonActorFromUsername({
+            username,
+            domain: TEST_DOMAIN
+          })
+          const aliasActor = await database.getMastodonActorFromId({
+            id: aliasActorId
+          })
+
+          // The actor on the configured host keeps a bare acct...
+          expect(homeActor?.acct).toBe(username)
+          // ...but the same account's actor on a different domain must be
+          // qualified, so a Mastodon client treats them as distinct accounts
+          // instead of collapsing them into one (blank) switcher row.
+          expect(aliasActor?.acct).toBe(`${username}@${TEST_DOMAIN_2}`)
+        })
+      })
+
+      it('treats a configured-host actor as local case-insensitively', async () => {
+        await withFreshDatabase(async (database) => {
+          const suffix = crypto.randomUUID().slice(0, 8)
+          const username = `case-${suffix}`
+          await database.createAccount({
+            email: `${username}@${TEST_DOMAIN}`,
+            username,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: `privateKey-${suffix}`,
+            publicKey: `publicKey-${suffix}`
+          })
+          const account = await database.getAccountFromEmail({
+            email: `${username}@${TEST_DOMAIN}`
+          })
+          // Same domain as the configured host but in a different letter case.
+          const upperActorId = await database.createActorForAccount({
+            accountId: account!.id,
+            username,
+            domain: TEST_DOMAIN.toUpperCase(),
+            privateKey: `upperPriv-${suffix}`,
+            publicKey: `upperPub-${suffix}`
+          })
+
+          const actor = await database.getMastodonActorFromId({
+            id: upperActorId
+          })
+          // Domains are case-insensitive, so this is still a local actor → bare.
+          expect(actor?.acct).toBe(username)
+        })
+      })
+
+      it('lowercases the domain in a qualified acct', async () => {
+        await withFreshDatabase(async (database) => {
+          const suffix = crypto.randomUUID().slice(0, 8)
+          const username = `mixed-${suffix}`
+          const mixedDomain = `Alias-${suffix}.Example`
+          await database.createAccount({
+            email: `${username}@${TEST_DOMAIN}`,
+            username,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: `privateKey-${suffix}`,
+            publicKey: `publicKey-${suffix}`
+          })
+          const account = await database.getAccountFromEmail({
+            email: `${username}@${TEST_DOMAIN}`
+          })
+          const actorId = await database.createActorForAccount({
+            accountId: account!.id,
+            username,
+            domain: mixedDomain,
+            privateKey: `mixedPriv-${suffix}`,
+            publicKey: `mixedPub-${suffix}`
+          })
+
+          const actor = await database.getMastodonActorFromId({ id: actorId })
+          // Non-configured domain → qualified, with the domain canonicalized.
+          expect(actor?.acct).toBe(`${username}@${mixedDomain.toLowerCase()}`)
         })
       })
     })
@@ -651,7 +755,7 @@ describe('ActorDatabase', () => {
             sensitive: false
           },
 
-          created_at: getISOTimeUTC(currentTime),
+          created_at: getMastodonTimeUTC(currentTime),
           last_status_at: null,
 
           statuses_count: 0,
@@ -719,7 +823,7 @@ describe('ActorDatabase', () => {
         expect(actor).toMatchObject({
           id: urlToId(`https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`),
           username: TEST_USERNAME3,
-          acct: `${TEST_USERNAME3}@${TEST_DOMAIN}`,
+          acct: TEST_USERNAME3,
           url: `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`,
           display_name: 'name',
           note: 'summary',

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -66,7 +66,7 @@ import { ActorSettings, SQLAccount, SQLActor } from '@/lib/types/database/rows'
 import { Account } from '@/lib/types/domain/account'
 import { Actor, ActorType } from '@/lib/types/domain/actor'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getISOTimeUTC, getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { logger } from '@/lib/utils/logger'
 import { generateKeyPair } from '@/lib/utils/signature'
 import { urlToId } from '@/lib/utils/urlToId'
@@ -255,6 +255,19 @@ const getMastodonAccountFromSQLActor = ({
     getConfiguredActorDomain()
   )
 
+  // Mastodon `acct` is bare only for actors whose domain is the instance's own
+  // (configured) host; every other actor — remote, OR one we host on a
+  // *different* domain — must use the `username@domain` form. Comparing against
+  // the configured host (not merely "do we host this actor") keeps a Mastodon
+  // client from collapsing two same-username actors on different local domains
+  // into one account (which renders as a blank account-switcher row). Domains
+  // are case-insensitive, so compare case-insensitively.
+  const isLocalActor =
+    sqlActor.domain.toLowerCase() === getConfiguredActorDomain().toLowerCase()
+  // Canonicalize the domain part to lowercase: Mastodon normalizes domains, and
+  // some clients/servers string-match `acct` strictly.
+  const qualifiedAcct = `${sqlActor.username}@${sqlActor.domain.toLowerCase()}`
+
   // Profile metadata fields are stored as plain name/value pairs; URLs are not
   // server-verified, so verified_at is always null.
   const profileFields = (settings.fields ?? []).map((field) => ({
@@ -267,7 +280,7 @@ const getMastodonAccountFromSQLActor = ({
   return Mastodon.Account.parse({
     id: urlToId(sqlActor.id),
     username: sqlActor.username,
-    acct: `${sqlActor.username}@${sqlActor.domain}`,
+    acct: isLocalActor ? sqlActor.username : qualifiedAcct,
     url: sqlActor.id,
     display_name: sqlActor.name ?? '',
     note,
@@ -300,7 +313,7 @@ const getMastodonAccountFromSQLActor = ({
       follow_requests_count: 0
     },
 
-    created_at: getISOTimeUTC(getCompatibleTime(sqlActor.createdAt)),
+    created_at: getMastodonTimeUTC(getCompatibleTime(sqlActor.createdAt)),
     last_status_at: lastStatusCreatedAt
       ? getISOTimeUTC(getCompatibleTime(lastStatusCreatedAt), true)
       : null,

--- a/lib/services/accounts/getFallbackBlockedAccount.ts
+++ b/lib/services/accounts/getFallbackBlockedAccount.ts
@@ -1,6 +1,6 @@
 import { Block } from '@/lib/types/domain/block'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 const UUID_LIKE_PATTERN =
@@ -61,7 +61,7 @@ export const getFallbackBlockedAccount = (block: Block): MastodonAccount => {
     group: false,
     discoverable: false,
     noindex: true,
-    created_at: getISOTimeUTC(0),
+    created_at: getMastodonTimeUTC(0),
     last_status_at: null,
     statuses_count: 0,
     followers_count: 0,

--- a/lib/services/accounts/getFallbackMutedAccount.ts
+++ b/lib/services/accounts/getFallbackMutedAccount.ts
@@ -1,6 +1,6 @@
 import { Mute } from '@/lib/types/domain/mute'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 const UUID_LIKE_PATTERN =
@@ -61,7 +61,7 @@ export const getFallbackMutedAccount = (mute: Mute): MastodonAccount => {
     group: false,
     discoverable: false,
     noindex: true,
-    created_at: getISOTimeUTC(0),
+    created_at: getMastodonTimeUTC(0),
     last_status_at: null,
     statuses_count: 0,
     followers_count: 0,

--- a/lib/services/auth/auth.ts
+++ b/lib/services/auth/auth.ts
@@ -11,6 +11,7 @@ import { UsableScopes } from '@/lib/types/database/operations'
 import { logger } from '@/lib/utils/logger'
 
 import { knexAdapter } from './knexAdapter'
+import { buildTrustedOrigins } from './trustedOrigins'
 
 export const AUTH_COOKIE_PREFIX = 'better-auth'
 export const AUTH_SESSION_COOKIE_NAME = 'session_token'
@@ -28,6 +29,10 @@ export const getAuth = memoize(() => {
     },
     secret: config.secretPhase,
     baseURL,
+    // Trust the configured host plus any ACTIVITIES_TRUSTED_HOSTS so a Mastodon
+    // client logging into a served alias/custom domain isn't rejected with
+    // `403 Invalid origin` on credential sign-in.
+    trustedOrigins: buildTrustedOrigins(baseURL, config.trustedHosts ?? []),
     basePath: '/api/auth',
     database: knexAdapter(db),
     disabledPaths: ['/token'], // Disable jwt plugin's /api/auth/token;

--- a/lib/services/auth/trustedOrigins.test.ts
+++ b/lib/services/auth/trustedOrigins.test.ts
@@ -1,0 +1,44 @@
+import { buildTrustedOrigins } from './trustedOrigins'
+
+describe('buildTrustedOrigins', () => {
+  it('returns just the base origin when there are no trusted hosts', () => {
+    expect(buildTrustedOrigins('https://activities.local')).toEqual([
+      'https://activities.local'
+    ])
+  })
+
+  it('adds trusted hosts using the base URL scheme', () => {
+    expect(
+      buildTrustedOrigins('https://activities.local', ['alias.local'])
+    ).toEqual(['https://activities.local', 'https://alias.local'])
+  })
+
+  it('keeps an explicit scheme on a trusted host, preserves ports, and dedupes', () => {
+    expect(
+      buildTrustedOrigins('http://localhost:3000', [
+        'alias.local:3000',
+        'https://other.local',
+        'localhost:3000'
+      ])
+    ).toEqual([
+      'http://localhost:3000',
+      'http://alias.local:3000',
+      'https://other.local'
+    ])
+  })
+
+  it('ignores blank entries', () => {
+    expect(buildTrustedOrigins('https://activities.local', ['', '  '])).toEqual(
+      ['https://activities.local']
+    )
+  })
+
+  it('skips malformed host entries instead of throwing', () => {
+    expect(
+      buildTrustedOrigins('https://activities.local', [
+        'alias.local',
+        'http://[oops'
+      ])
+    ).toEqual(['https://activities.local', 'https://alias.local'])
+  })
+})

--- a/lib/services/auth/trustedOrigins.ts
+++ b/lib/services/auth/trustedOrigins.ts
@@ -1,0 +1,37 @@
+import { logger } from '@/lib/utils/logger'
+
+// Build the better-auth `trustedOrigins` list. better-auth only accepts
+// state-changing auth requests (e.g. credential sign-in) whose Origin matches a
+// trusted origin; by default that is only the configured base URL. When the
+// deployment serves additional local domains (ACTIVITIES_TRUSTED_HOSTS) — e.g.
+// a custom domain a Mastodon client logs into directly — those origins must be
+// trusted too, otherwise sign-in returns `403 Invalid origin`.
+export const buildTrustedOrigins = (
+  baseURL: string,
+  trustedHosts: readonly string[] = []
+): string[] => {
+  const base = new URL(baseURL)
+  const origins = [base.origin]
+
+  for (const raw of trustedHosts) {
+    const host = raw.trim()
+    if (!host) continue
+    // Parsing via `new URL(...).origin` normalizes the value (strips any path or
+    // trailing slash). Skip malformed entries so a bad config value can't crash
+    // auth initialization.
+    try {
+      const origin = new URL(
+        host.includes('://') ? host : `${base.protocol}//${host}`
+      ).origin
+      origins.push(origin)
+    } catch {
+      // Skip the bad entry rather than crash auth init, but log it so a
+      // misconfigured ACTIVITIES_TRUSTED_HOSTS value isn't an invisible 403.
+      logger.warn({
+        message: `Ignoring invalid ACTIVITIES_TRUSTED_HOSTS entry: ${raw}`
+      })
+    }
+  }
+
+  return Array.from(new Set(origins))
+}

--- a/lib/services/mastodon/getMastodonFilter.test.ts
+++ b/lib/services/mastodon/getMastodonFilter.test.ts
@@ -50,7 +50,9 @@ describe('getMastodonFilter', () => {
     expect(result.title).toBe('Apple')
     expect(result.context.sort()).toEqual(['home', 'public'])
     expect(result.filter_action).toBe('warn')
-    expect(result.expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+    expect(result.expires_at).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+    )
     expect(result.keywords).toHaveLength(1)
     expect(result.keywords[0]).toMatchObject({
       keyword: 'apple',

--- a/lib/services/mastodon/getMastodonFilter.ts
+++ b/lib/services/mastodon/getMastodonFilter.ts
@@ -6,7 +6,7 @@ import {
   FilterStatus as DomainFilterStatus
 } from '@/lib/types/domain/filter'
 import * as Mastodon from '@/lib/types/mastodon'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 
 export const getMastodonFilterKeyword = (
   keyword: DomainFilterKeyword
@@ -29,7 +29,7 @@ const buildMastodonFilter = (record: ActiveFilterRecord): Mastodon.Filter => ({
   context: record.filter.context,
   expires_at:
     record.filter.expiresAt !== null
-      ? getISOTimeUTC(record.filter.expiresAt)
+      ? getMastodonTimeUTC(record.filter.expiresAt)
       : null,
   filter_action: record.filter.filterAction,
   keywords: record.keywords.map(getMastodonFilterKeyword),

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -10,7 +10,7 @@ import {
   ACTIVITY_STREAM_PUBLIC,
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { getMastodonStatus, getMastodonStatuses } from './getMastodonStatus'
@@ -456,7 +456,7 @@ describe('getMastodonStatus', () => {
     const mastodonStatus = await getMastodonStatus(database, editedStatus)
 
     expect(mastodonStatus?.edited_at).toBe(
-      getISOTimeUTC(editedStatus.updatedAt)
+      getMastodonTimeUTC(editedStatus.updatedAt)
     )
   })
 

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -10,7 +10,7 @@ import {
   hasStatusBeenEdited
 } from '@/lib/types/domain/status'
 import { Tag, TagType } from '@/lib/types/domain/tag'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
@@ -301,10 +301,10 @@ export const getMastodonStatus = async (
 
   const baseData = {
     id: urlToId(status.id),
-    created_at: getISOTimeUTC(status.createdAt),
+    created_at: getMastodonTimeUTC(status.createdAt),
     edited_at:
       status.type !== StatusType.enum.Announce && hasStatusBeenEdited(status)
-        ? getISOTimeUTC(status.updatedAt)
+        ? getMastodonTimeUTC(status.updatedAt)
         : null,
 
     sensitive: false,
@@ -422,7 +422,7 @@ export const getMastodonStatus = async (
 
     pollData = Mastodon.Poll.parse({
       id: urlToId(status.id),
-      expires_at: getISOTimeUTC(status.endAt),
+      expires_at: getMastodonTimeUTC(status.endAt),
       expired: Date.now() > status.endAt,
       multiple: status.pollType === 'anyOf',
       votes_count: status.choices.reduce(

--- a/lib/services/mastodon/getMastodonStatusEdits.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.ts
@@ -7,7 +7,7 @@ import {
   StatusPoll,
   StatusType
 } from '@/lib/types/domain/status'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 
 import { getMastodonStatus } from './getMastodonStatus'
@@ -66,7 +66,7 @@ export const getMastodonStatusEdits = async (
     // forced true when this revision carries a content warning.
     sensitive:
       (status.sensitive ?? false) || Boolean(summary && summary.length > 0),
-    created_at: getISOTimeUTC(createdAtMs),
+    created_at: getMastodonTimeUTC(createdAtMs),
     account: current.account,
     ...(pollOptions ? { poll: pollOptions } : {}),
     media_attachments: current.media_attachments,

--- a/lib/services/notifications/getNotificationGroup.test.ts
+++ b/lib/services/notifications/getNotificationGroup.test.ts
@@ -32,7 +32,7 @@ describe('getNotificationGroup', () => {
       type: 'favourite',
       most_recent_notification_id: 'n1',
       // ISO-8601 of the group's most-recent notification createdAt (1000ms epoch).
-      latest_page_notification_at: '1970-01-01T00:00:01Z',
+      latest_page_notification_at: '1970-01-01T00:00:01.000Z',
       status_id: urlToId('https://other.test/statuses/1')
     })
     expect(group.sample_account_ids).toEqual([

--- a/lib/services/notifications/getNotificationGroup.ts
+++ b/lib/services/notifications/getNotificationGroup.ts
@@ -3,7 +3,7 @@ import {
   MastodonNotificationType,
   internalTypeToMastodon
 } from '@/lib/services/notifications/notificationTypeMapping'
-import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { getMastodonTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { urlToId } from '@/lib/utils/urlToId'
 
 // Up to how many recent actors to surface per group (Mastodon returns a sample,
@@ -67,7 +67,7 @@ export const getNotificationGroup = (
         ? notification.groupedIds[notification.groupedIds.length - 1]
         : notification.id,
       // groupNotifications keeps the group's createdAt as its most-recent member's.
-      latest_page_notification_at: getISOTimeUTC(notification.createdAt),
+      latest_page_notification_at: getMastodonTimeUTC(notification.createdAt),
       sample_account_ids: sampleActorIds.map((id) => urlToId(id)),
       ...(notification.statusId
         ? { status_id: urlToId(notification.statusId) }

--- a/lib/utils/getISOTimeUTC.test.ts
+++ b/lib/utils/getISOTimeUTC.test.ts
@@ -1,4 +1,4 @@
-import { getISOTimeUTC } from './getISOTimeUTC'
+import { getISOTimeUTC, getMastodonTimeUTC } from './getISOTimeUTC'
 
 describe('getISOTimeUTC', () => {
   it('returns date time in +0 timezone with date', () => {
@@ -11,5 +11,19 @@ describe('getISOTimeUTC', () => {
     const timestamp = 1630702800000
     const result = getISOTimeUTC(timestamp, true)
     expect(result).toBe('2021-09-03')
+  })
+})
+
+describe('getMastodonTimeUTC', () => {
+  // Mastodon clients (e.g. the official iOS app) decode REST `Date` fields with
+  // an ISO8601 formatter that requires fractional seconds; a timestamp without
+  // them fails to decode and blanks the whole entity. Always emit `.SSS`.
+  it('returns ISO8601 in +0 timezone WITH fractional seconds', () => {
+    const timestamp = 1630702800000
+    expect(getMastodonTimeUTC(timestamp)).toBe('2021-09-03T21:00:00.000Z')
+  })
+
+  it('keeps millisecond precision', () => {
+    expect(getMastodonTimeUTC(1630702800123)).toBe('2021-09-03T21:00:00.123Z')
   })
 })

--- a/lib/utils/getISOTimeUTC.ts
+++ b/lib/utils/getISOTimeUTC.ts
@@ -7,3 +7,13 @@ export const getISOTimeUTC = (timestamp: number, onlyDate: boolean = false) => {
   }
   return format(new UTCDate(timestamp), `yyyy-MM-dd'T'HH:mm:ss'Z'`)
 }
+
+// Timestamp formatter for Mastodon REST API entities. Unlike ActivityPub
+// `published` (which omits fractional seconds), Mastodon always emits
+// millisecond precision (e.g. `2021-09-03T21:00:00.000Z`). The official
+// Mastodon iOS decoder rejects full datetimes WITHOUT fractional seconds, which
+// makes a required `Date` field (e.g. account/status `created_at`) fail to
+// decode and blanks the entire entity. Use this for Mastodon datetime fields;
+// keep `getISOTimeUTC` for ActivityPub.
+export const getMastodonTimeUTC = (timestamp: number) =>
+  format(new UTCDate(timestamp), `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`)


### PR DESCRIPTION
## Summary

Fixes a set of Mastodon REST API serialization issues that prevented the official **Mastodon iOS app** from rendering accounts (the account switcher showed a blank row) and broke status decoding, plus related per-request-host handling needed for multi/alias-domain setups. Root causes were verified against the Mastodon iOS source (`mastodon-ios`), not guessed.

## What changed (each commit is an independent fix)

1. **`fix: serialize local Mastodon accounts with bare acct`** — local accounts no longer carry a `@domain` suffix on `acct` (Mastodon contract: bare for local, `username@domain` for remote).
2. **`fix: report request host in v1/v2 instance endpoints`** — `/api/v1/instance` and `/api/v2/instance` now derive their advertised host from the request via `headerHost()` (falling back to the configured host), instead of always `config.host`.
3. **`fix: emit fractional seconds in Mastodon REST timestamps`** — **the main account/timeline decode bug.** The Mastodon iOS JSON decoder only accepts ISO-8601 with fractional seconds, date-only, or numeric; our `created_at` was `…:35Z` (no `.SSS`). Because `Account.createdAt`/`Status.createdAt` are required `Date`s, the whole entity failed to decode and was dropped → blank account + broken timelines. Added `getMastodonTimeUTC` (`.SSS`) for Mastodon REST timestamps; ActivityPub `published` and the date-only `last_status_at` keep the existing formatter.
4. **`fix: qualify Mastodon acct for hosted actors off the configured host`** — when one account owns actors on multiple local domains, `acct` is bare only when the actor's domain equals the instance's configured host; an actor hosted on a different domain serializes as `username@domain`.
5. **`fix: trust ACTIVITIES_TRUSTED_HOSTS origins for better-auth sign-in`** — better-auth `trustedOrigins` now includes the configured host plus `ACTIVITIES_TRUSTED_HOSTS`, so credential sign-in from a served alias/custom domain isn't rejected with `403 Invalid origin`.

## Why

The Mastodon iOS app fully decodes and renders an account only when:
- every Mastodon REST `Date` parses (→ fix #3), and
- the cached account's `url` host equals the domain the app logged into (`PersistenceManager.cachedAccount` matches on host) — which requires the account's domain to be a served, sign-in-trusted instance (→ fixes #2, #5).

## Testing

- `yarn lint`, `yarn build`, `yarn test` (3389 tests) all green; new regression tests for the `acct` rule, instance host selection, fractional timestamps, and `buildTrustedOrigins`.
- Verified end-to-end in the **Mastodon iOS simulator** against a local `activities.local` stack: the signed-in account and timeline render correctly; with a second served domain trusted via `ACTIVITIES_TRUSTED_HOSTS`, logging the app into that domain renders `@user@that-domain`.

## Notes for reviewers

- The `acct` rule (#4) compares the actor domain to the **configured** host. Full per-request-host serialization (bare for whichever served domain the client connected to) is a reasonable follow-up; current behavior renders correctly because the client keys the cached account on the `url` host.
- **Custom/alias domains in a Mastodon client are not purely a code change**: the domain must be served as its own reachable instance (DNS + reverse-proxy route + TLS SAN) so the account's `url` host matches the login domain. #5 only removes the auth-origin blocker.
- A separate pre-existing issue (profile statuses endpoint returning `400`/`404` for `endorsements`/`familiar_followers`/pinned statuses) is **out of scope** here.
- This branch was cut from an older `main` (`v1.41.0`); a rebase may be wanted before merge.
