### PR TITLE
Bump version to v1.45.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.45.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.45.0`
- Base main SHA: `909d15508f58c91633fb1cd5577bfe6723577990`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
