### PR TITLE
Bump version to v1.45.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.45.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.45.1`
- Base main SHA: `f0ee44eff9e9e7c3df21b44d1fb2fc9ce77be62e`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
