### PR TITLE
Bump version to v1.45.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.45.2",
+  "version": "1.45.3",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.45.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.45.2`
- Base main SHA: `39df68d455491b104f09d432b80e998f5a14d640`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
