### PR TITLE
minor: public chrome for logged-out status page

### DIFF
--- a/app/(timeline)/PublicFooter.tsx
+++ b/app/(timeline)/PublicFooter.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image'
+import { FC } from 'react'
+
+// Public footer shown to logged-out visitors, matching the web-public design:
+// a single bordered card with the brand line and a link to the project source.
+// About/Privacy are omitted since the app has no such pages.
+export const PublicFooter: FC = () => (
+  <footer className="mx-auto w-full max-w-[680px] px-4 py-8">
+    <div className="rounded-xl border bg-background/70 px-5 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Image
+            src="/logo-nav.png"
+            alt=""
+            aria-hidden="true"
+            width={20}
+            height={20}
+            className="h-5 w-5 shrink-0 object-contain"
+          />
+          <span>
+            <strong className="font-semibold text-foreground">
+              Activities
+            </strong>{' '}
+            — a self-hosted social + fitness server on the Fediverse.
+          </span>
+        </div>
+        <a
+          href="https://github.com/llun/activities.next"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          Source
+        </a>
+      </div>
+    </div>
+  </footer>
+)

--- a/app/(timeline)/PublicTopBar.tsx
+++ b/app/(timeline)/PublicTopBar.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import { FC } from 'react'
+
+import { Logo } from '@/lib/components/layout/logo'
+import { Button } from '@/lib/components/ui/button'
+
+// Public top bar shown to logged-out visitors in place of the app nav sidebar:
+// a slim sticky bar with the brand logo and Sign in / Create account links to
+// the real auth routes, matching the web-public design.
+export const PublicTopBar: FC = () => (
+  <header className="sticky top-0 z-30 border-b bg-background/90 backdrop-blur">
+    <div className="mx-auto flex h-16 w-full max-w-[680px] items-center gap-3 px-4">
+      <Logo size="md" />
+      <div className="ml-auto flex items-center gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href="/auth/signin">Sign in</Link>
+        </Button>
+        <Button asChild size="sm">
+          <Link href="/auth/signup">Create account</Link>
+        </Button>
+      </div>
+    </div>
+  </header>
+)

--- a/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.test.tsx
@@ -27,7 +27,7 @@ jest.mock('./FitnessStatusDetail', () => ({
 }))
 
 jest.mock('./StatusLikes', () => ({
-  StatusLikes: () => null
+  StatusLikes: () => <div data-testid="status-likes" />
 }))
 
 jest.mock('next/navigation', () => ({
@@ -83,5 +83,33 @@ describe('StatusBox', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/@llun/poll-1')
     })
+  })
+
+  it('renders the likes list on the detail view for a signed-in actor', () => {
+    render(
+      <StatusBox
+        host="activities.local"
+        currentActor={pollStatusFixture.actor}
+        currentTime={pollStatusCurrentTime}
+        status={pollStatusFixture}
+        variant="detail"
+      />
+    )
+
+    expect(screen.getByTestId('status-likes')).toBeInTheDocument()
+  })
+
+  it('hides the likes list on the detail view for logged-out visitors', () => {
+    render(
+      <StatusBox
+        host="activities.local"
+        currentActor={null}
+        currentTime={pollStatusCurrentTime}
+        status={pollStatusFixture}
+        variant="detail"
+      />
+    )
+
+    expect(screen.queryByTestId('status-likes')).not.toBeInTheDocument()
   })
 })

--- a/app/(timeline)/[actor]/[status]/StatusBox.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusBox.tsx
@@ -101,7 +101,7 @@ export const StatusBox: FC<Props> = ({
             setModalMedias({ medias: allMedias, initialSelection: index })
           }}
         />
-        {variant === 'detail' && (
+        {variant === 'detail' && currentActor && (
           <StatusLikes
             statusId={actualStatus.id}
             totalLikes={actualStatus.totalLikes}

--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { StatusStatStrip } from './StatusStatStrip'
+
+describe('StatusStatStrip', () => {
+  it('renders the boost, like, and reply counts with their labels', () => {
+    render(<StatusStatStrip boosts={14} likes={96} replies={3} />)
+
+    for (const [count, label] of [
+      ['14', 'Boosts'],
+      ['96', 'Likes'],
+      ['3', 'Replies']
+    ]) {
+      const value = screen.getByText(count)
+      expect(value).toBeInTheDocument()
+      expect(value.parentElement).toHaveTextContent(`${count}${label}`)
+    }
+  })
+
+  it('renders zero counts rather than hiding them', () => {
+    render(<StatusStatStrip boosts={0} likes={0} replies={0} />)
+
+    expect(screen.getAllByText('0')).toHaveLength(3)
+    expect(screen.getByText('Replies')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react'
+
+interface Props {
+  boosts: number
+  likes: number
+  replies: number
+}
+
+interface Stat {
+  count: number
+  label: string
+}
+
+// Read-only engagement summary shown on the focused status for logged-out
+// visitors, who don't get the interactive action row. Mirrors the stat strip in
+// the web-public design (Boosts / Likes / Replies).
+export const StatusStatStrip: FC<Props> = ({ boosts, likes, replies }) => {
+  const stats: Stat[] = [
+    { count: boosts, label: 'Boosts' },
+    { count: likes, label: 'Likes' },
+    { count: replies, label: 'Replies' }
+  ]
+  return (
+    <div className="mt-3 flex gap-5 border-t pt-3 text-sm">
+      {stats.map(({ count, label }) => (
+        <span key={label} className="flex items-baseline gap-1">
+          <strong className="font-semibold tabular-nums">{count}</strong>
+          <span className="text-muted-foreground">{label}</span>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -31,6 +31,7 @@ import { Header } from './Header'
 import { RemoteStatusLoading } from './RemoteStatusLoading'
 import { SignInCallout } from './SignInCallout'
 import { StatusBox } from './StatusBox'
+import { StatusStatStrip } from './StatusStatStrip'
 import { decodePathParam, resolveStatusFromPath } from './resolveStatusFromPath'
 
 interface Props {
@@ -95,6 +96,15 @@ const Page: FC<Props> = async ({ params }) => {
   }
 
   if (!status) {
+    return notFound()
+  }
+
+  // Logged-out visitors may only view statuses that are publicly readable all
+  // the way down. The per-field `isPublicOrUnlisted` check below inspects only
+  // the top-level recipients — for an Announce those are the boost's, not the
+  // boosted note's — so a public boost of a followers-only post would otherwise
+  // slip through. `isStatusPubliclyReadable` recurses into the original status.
+  if (!currentActor && !isStatusPubliclyReadable(status)) {
     return notFound()
   }
 
@@ -232,7 +242,13 @@ const Page: FC<Props> = async ({ params }) => {
   if (isFitnessDashboard) {
     return (
       <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <Header isFitnessDashboard />
+        {currentActorProfile ? (
+          <Header isFitnessDashboard />
+        ) : (
+          // Logged-out view has no back-button chrome (matching the web-public
+          // design), but keep a top-level heading for the document outline.
+          <h1 className="sr-only">Activity</h1>
+        )}
 
         <div className="border-b bg-background">
           <StatusBox
@@ -243,6 +259,15 @@ const Page: FC<Props> = async ({ params }) => {
             status={cleanJson(status)}
             variant="detail"
           />
+          {!currentActorProfile ? (
+            <div className="px-4 pb-4">
+              <StatusStatStrip
+                boosts={statusForLayout.totalShares}
+                likes={statusForLayout.totalLikes}
+                replies={replies.length}
+              />
+            </div>
+          ) : null}
         </div>
 
         {!currentActorProfile ? <SignInCallout /> : null}
@@ -252,7 +277,13 @@ const Page: FC<Props> = async ({ params }) => {
 
   return (
     <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-      <Header isFitnessDashboard={false} />
+      {currentActorProfile ? (
+        <Header isFitnessDashboard={false} />
+      ) : (
+        // Logged-out view has no back-button chrome (matching the web-public
+        // design), but keep a top-level heading for the document outline.
+        <h1 className="sr-only">Post</h1>
+      )}
 
       {previouses.reverse().map((item) => (
         <div
@@ -279,6 +310,15 @@ const Page: FC<Props> = async ({ params }) => {
           variant="detail"
           isMediaUploadEnabled={Boolean(mediaStorage)}
         />
+        {!currentActorProfile ? (
+          <div className="px-4 pb-4">
+            <StatusStatStrip
+              boosts={statusForLayout.totalShares}
+              likes={statusForLayout.totalLikes}
+              replies={replies.length}
+            />
+          </div>
+        ) : null}
       </div>
 
       {!currentActorProfile ? <SignInCallout /> : null}

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -277,6 +277,69 @@ describe('Page visibility for logged-out visitors', () => {
     // The reply-count heading reflects only the visible (public) reply.
     expect(screen.getByText('Replies (1)')).toBeInTheDocument()
   })
+
+  it('returns notFound for a public boost wrapping a private original', async () => {
+    const privateOriginal = buildNote({
+      id: 'private-original',
+      to: ['https://activities.local/users/anna/followers'],
+      cc: []
+    })
+    const announce = {
+      id: 'public-announce',
+      type: 'Announce',
+      actorId: 'https://activities.local/users/anna',
+      actor: null,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: 1,
+      updatedAt: 1,
+      originalStatus: privateOriginal
+    } as unknown as Status
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: announce,
+      statusId: 'public-announce',
+      fullStatusId:
+        'https://activities.local/users/anna/statuses/private-original',
+      isStatusHash: true
+    })
+
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+
+  it('renders the logged-out fitness dashboard with an sr-only heading and stat strip', async () => {
+    const focused = buildNote({
+      id: 'fitness-status',
+      fitness: {
+        id: 'fit-1',
+        fileName: 'run.fit',
+        fileType: 'fit',
+        mimeType: 'application/octet-stream',
+        bytes: 1024,
+        url: 'https://activities.local/fit/run.fit',
+        processingStatus: 'completed'
+      }
+    } as unknown as Partial<Status>)
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'fitness-status',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+
+    await renderPage()
+
+    // The back-button Header is gated to signed-in users; logged-out keeps only
+    // a visually-hidden top-level heading for the document outline.
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Activity' })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('status-fitness-status')).toBeInTheDocument()
+    expect(screen.getByText('Boosts')).toBeInTheDocument()
+  })
 })
 
 describe('Page visibility for logged-in non-recipient viewers', () => {

--- a/app/(timeline)/layout.test.tsx
+++ b/app/(timeline)/layout.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Layout from './layout'
+
+const mockGetActorsForAccount = jest.fn()
+const mockGetNotificationsCount = jest.fn()
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn(() => ({
+    getActorsForAccount: mockGetActorsForAccount,
+    getNotificationsCount: mockGetNotificationsCount
+  }))
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn()
+}))
+
+jest.mock('@/lib/types/domain/actor', () => ({
+  getActorProfile: (actor: unknown) => actor,
+  getMention: () => '@testuser@localhost'
+}))
+
+jest.mock('@/app/Modal', () => ({ Modal: () => <div data-testid="modal" /> }))
+jest.mock('./PublicTopBar', () => ({
+  PublicTopBar: () => <div data-testid="public-topbar" />
+}))
+jest.mock('./PublicFooter', () => ({
+  PublicFooter: () => <div data-testid="public-footer" />
+}))
+jest.mock('@/lib/components/layout/sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar" />
+}))
+jest.mock('@/lib/components/layout/mobile-nav', () => ({
+  MobileNav: () => <div data-testid="mobile-nav" />
+}))
+
+const mockGetServerAuthSession = jest.mocked(getServerAuthSession)
+const mockGetActorFromSession = jest.mocked(getActorFromSession)
+
+const renderLayout = async () => {
+  const element = await Layout({
+    children: <div data-testid="child" />
+  })
+  render(element)
+}
+
+describe('(timeline) Layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorsForAccount.mockResolvedValue([])
+    mockGetNotificationsCount.mockResolvedValue(0)
+  })
+
+  it('renders the public chrome and no nav for logged-out visitors', async () => {
+    mockGetActorFromSession.mockResolvedValue(null)
+
+    await renderLayout()
+
+    expect(screen.getByTestId('public-topbar')).toBeInTheDocument()
+    expect(screen.getByTestId('public-footer')).toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+    expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-nav')).not.toBeInTheDocument()
+  })
+
+  it('renders the nav chrome and no public chrome for signed-in users', async () => {
+    mockGetActorFromSession.mockResolvedValue({
+      id: 'https://localhost/users/testuser',
+      username: 'testuser',
+      domain: 'localhost',
+      name: 'Test User',
+      iconUrl: null,
+      account: { id: 'account-1', role: 'user' }
+    } as never)
+
+    await renderLayout()
+
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+    expect(screen.getByTestId('mobile-nav')).toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+    expect(screen.queryByTestId('public-topbar')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('public-footer')).not.toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/layout.tsx
+++ b/app/(timeline)/layout.tsx
@@ -9,6 +9,9 @@ import { getActorProfile, getMention } from '@/lib/types/domain/actor'
 import { cn } from '@/lib/utils'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
+import { PublicFooter } from './PublicFooter'
+import { PublicTopBar } from './PublicTopBar'
+
 interface LayoutProps {
   children: ReactNode
 }
@@ -21,6 +24,30 @@ const Layout: FC<LayoutProps> = async ({ children }) => {
 
   const session = await getServerAuthSession()
   const actor = await getActorFromSession(database, session)
+
+  // Logged-out visitors get the public chrome — a slim top bar with sign-in
+  // CTAs and a footer in place of the nav sidebar — matching the web-public
+  // design. The reading column is narrower than the signed-in app width.
+  if (!actor) {
+    return (
+      // min-h-dvh (dynamic viewport height) rather than min-h-screen/100vh so
+      // the footer stays at the bottom without a mobile address-bar gap — same
+      // rationale as the public error pages (lib/components/error-page.tsx).
+      <div className="flex min-h-dvh flex-col">
+        <PublicTopBar />
+        <main className="flex flex-1 flex-col overflow-x-clip">
+          <div className="mx-auto flex w-full max-w-[680px] flex-1 flex-col px-4 py-6">
+            {children}
+          </div>
+        </main>
+        {/* Footer is a sibling of <main> (not nested in it) so its <footer>
+            maps to the contentinfo landmark; main keeps flex-1 to pin it to the
+            bottom on short pages. */}
+        <PublicFooter />
+        <Modal />
+      </div>
+    )
+  }
 
   // Check if iconUrl is a real user-uploaded avatar (not auto-generated)
   // Auto-generated URLs typically contain service identifiers
@@ -38,77 +65,67 @@ const Layout: FC<LayoutProps> = async ({ children }) => {
     return true
   }
 
-  const user = actor
-    ? {
-        name: actor.name || actor.username,
-        username: actor.username,
-        handle: getMention(getActorProfile(actor), true),
-        avatarUrl: isRealAvatar(actor.iconUrl) ? actor.iconUrl : undefined
-      }
-    : undefined
-  const showNavigation = Boolean(user)
+  // From here on the visitor is signed in (the logged-out branch returned
+  // above), so the nav chrome always renders.
+  const user = {
+    name: actor.name || actor.username,
+    username: actor.username,
+    handle: getMention(getActorProfile(actor), true),
+    avatarUrl: isRealAvatar(actor.iconUrl) ? actor.iconUrl : undefined
+  }
 
   // Get all actors for the account
-  const actors = actor?.account?.id
+  const actors = actor.account?.id
     ? await database.getActorsForAccount({ accountId: actor.account.id })
     : []
 
-  const currentActor = actor
-    ? {
-        id: actor.id,
-        username: actor.username,
-        domain: actor.domain,
-        name: actor.name,
-        iconUrl: isRealAvatar(actor.iconUrl) ? actor.iconUrl : null
-      }
-    : undefined
+  const currentActor = {
+    id: actor.id,
+    username: actor.username,
+    domain: actor.domain,
+    name: actor.name,
+    iconUrl: isRealAvatar(actor.iconUrl) ? actor.iconUrl : null
+  }
 
-  const unreadCount = actor
-    ? await database.getNotificationsCount({
-        actorId: actor.id,
-        onlyUnread: true
-      })
-    : 0
+  const unreadCount = await database.getNotificationsCount({
+    actorId: actor.id,
+    onlyUnread: true
+  })
 
   // Fitness is a first-class section for every signed-in local account (like
   // Bookmarks/Messages), so new users can discover the import/Strava setup even
   // before they have any activity. The Overview itself handles the empty state.
-  const fitnessUrl = actor?.account ? '/fitness' : undefined
-  const isAdmin = actor?.account?.role === 'admin'
+  const fitnessUrl = actor.account ? '/fitness' : undefined
+  const isAdmin = actor.account?.role === 'admin'
 
   return (
-    <div className="min-h-screen">
-      {showNavigation && (
-        <Sidebar
-          user={user}
-          currentActor={currentActor}
-          actors={actors.map((a) => ({
-            id: a.id,
-            username: a.username,
-            domain: a.domain,
-            name: a.name,
-            iconUrl: isRealAvatar(a.iconUrl) ? a.iconUrl : null,
-            deletionStatus: a.deletionStatus ?? null,
-            deletionScheduledAt: a.deletionScheduledAt ?? null
-          }))}
-          unreadCount={unreadCount}
-          fitnessUrl={fitnessUrl}
-          isAdmin={isAdmin}
-        />
-      )}
-      {showNavigation && (
-        <MobileNav
-          unreadCount={unreadCount}
-          fitnessUrl={fitnessUrl}
-          profileUrl={user ? `/${user.handle}` : undefined}
-          isAdmin={isAdmin}
-        />
-      )}
+    <div className="min-h-dvh">
+      <Sidebar
+        user={user}
+        currentActor={currentActor}
+        actors={actors.map((a) => ({
+          id: a.id,
+          username: a.username,
+          domain: a.domain,
+          name: a.name,
+          iconUrl: isRealAvatar(a.iconUrl) ? a.iconUrl : null,
+          deletionStatus: a.deletionStatus ?? null,
+          deletionScheduledAt: a.deletionScheduledAt ?? null
+        }))}
+        unreadCount={unreadCount}
+        fitnessUrl={fitnessUrl}
+        isAdmin={isAdmin}
+      />
+      <MobileNav
+        unreadCount={unreadCount}
+        fitnessUrl={fitnessUrl}
+        profileUrl={`/${user.handle}`}
+        isAdmin={isAdmin}
+      />
       <main
         className={cn(
-          'flex min-h-screen flex-col overflow-x-clip pb-6',
-          showNavigation &&
-            'pb-20 md:pl-[72px] md:pb-0 md:[--sidebar-w:72px] xl:pl-[280px] xl:[--sidebar-w:280px]'
+          'flex min-h-dvh flex-col overflow-x-clip pb-6',
+          'pb-20 md:pl-[72px] md:pb-0 md:[--sidebar-w:72px] xl:pl-[280px] xl:[--sidebar-w:280px]'
         )}
       >
         <div className="mx-auto flex w-full max-w-content flex-1 flex-col px-4 pb-6">


### PR DESCRIPTION
## Summary

Adds **instance custom emoji** (Mastodon `CustomEmoji`) end to end: storage, public + admin endpoints, ActivityPub federation, a postbox **sticker/emoji picker**, and an **admin management page**. Also makes `GET /api/v2/instance` public to match Mastodon.

A posted status containing `:shortcode:` now (1) renders the emoji locally, (2) federates an ActivityPub `Emoji` tag so Mastodon and other AP servers render it, and (3) is surfaced unauthenticated via `GET /api/v1/custom_emojis`.

## Endpoints — Mastodon compatibility checklist

| Endpoint | Change | Mastodon source |
|---|---|---|
| `GET /api/v1/custom_emojis` | **Now public** (removed `OAuthGuard`); returns the *listed* set: `disabled = false AND visible_in_picker = true` | `custom_emojis_controller.rb` index uses `CustomEmoji.listed`; endpoint is public ([docs](https://docs.joinmastodon.org/methods/custom_emojis/)) |
| `GET /api/v2/instance` | **Now public** (removed `OAuthGuard`) | `/methods/instance/` — served unauthenticated |
| `GET /api/v1/instance` | Unchanged (already public, shape verified) | `/methods/instance/` |
| `POST /api/v1/admin/custom_emojis` | Create via multipart upload (shared media pipeline); 422 on bad mime/dup/shortcode | mirrors Mastodon admin custom emoji create |
| `GET /api/v1/admin/custom_emojis` | List incl. disabled | admin index |
| `PATCH`/`PUT /api/v1/admin/custom_emojis/:id` | Update enable/disable, `visible_in_picker`, `category` | Mastodon admin uses `PATCH`; `PUT` added to match this repo's existing admin `[id]` convention |
| `DELETE /api/v1/admin/custom_emojis/:id` | Delete | admin destroy |

`CustomEmoji` entity fields (`shortcode`, `url`, `static_url`, `visible_in_picker`, `category`) match `custom_emoji_serializer.rb` / [entities/CustomEmoji](https://docs.joinmastodon.org/entities/CustomEmoji/). The admin shape adds `id` + `disabled`.

## ActivityPub Emoji-tag round-trip (verified on a running server)

- **Outbound:** posting `hello :blobcat:` serializes a `tag` entry `{ "type":"Emoji", "name":":blobcat:", "icon":{"type":"Image","url":…}, "id":…, "updated":… }` in the status' AP JSON (confirmed over HTTP: `GET /users/testuser/statuses/:id` with `Accept: application/activity+json`).
- **Inbound:** incoming Notes with `Emoji` tags already parse into stored `emoji` domain Tags (in `createNoteJob`); added a regression test.
- **Bug fixed:** `getMentionFromTag` previously fell through to `Mention.safeParse` for emoji tags, so the two `status.ts` `toActivityPubObject` sites emitted **bogus `Mention` objects** for emoji. It now returns `null` for emoji; new `getEmojiFromTag` emits the `Emoji` object. All three outbound builders (`getNoteFromStatus`, Note + Question in `status.ts`) include emoji uniformly.
- Mastodon REST `status.emojis` is populated automatically by the pre-existing `getEmojisFromTags`.

## How shortcodes become tags

`createNote` / `createPoll` / `updateNote` scan the text for `:shortcode:`, resolve against the **enabled** instance emoji set (ignoring `visible_in_picker`, so hand-typed non-picker emoji still federate, matching Mastodon), and persist `emoji` domain Tags. Edits re-sync (delete + recreate).

## Frontend

- **Postbox picker** (`emoji-picker-button.tsx`): one popover with **system Unicode emoji** (curated local dataset, no new deps) + **instance custom emoji** (via new `getCustomEmojis` in `lib/client.ts`), with search, category tabs, grid, and hover preview per `preview/stickers.html`. System emoji insert the character; custom emoji insert `:shortcode:` at the caret. Keyboard-accessible (labelled controls, Escape to close).
- Custom emoji render as images in the picker and in the **composer live preview** through the existing `convertEmojisToImages`/`processStatusText` pipeline (refactored to a shared `processStatusTextContent`) — no second renderer, no `dangerouslySetInnerHTML`.
- **Admin page** (`/admin/admin/emojis` under the admin section) using the design-system chrome (`SectionNavDropdown`) and the settings/stickers visual design; all network calls go through `lib/client.ts`.

## Design

Implemented from the handoff bundle (`ui_kits/web/StickerPicker.jsx`, `Stickers.jsx`, `Composer.jsx`, `SettingsPage.jsx` → `StickerSettings`): picker grid/categories/search/preview, the dashed-dropzone upload form, and list rows. Adapted to this project's Tailwind tokens and primitives; admin placement + `SectionNavDropdown` follow `CLAUDE.md`/`AGENTS.md` over the kit's settings location.

## Local verification gates

`prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (**3545 passed / 418 suites**)

### Browser verification (local SQLite)
- Public `GET /api/v1/custom_emojis` and `GET /api/v2/instance` return 200 with **no token**.
- Picker opens, shows system categories + Custom tab; inserting a custom emoji puts `:blobcat:` in the textarea; the composer preview renders it as an inline image.
- A posted `:blobcat:` status' AP JSON contains the `Emoji` tag (checked over HTTP).
- Admin page lists/creates/updates/deletes emoji.

(Screenshots shared with the author; per `AGENTS.md` they are not committed to the repo.)

## Tests added
DB CRUD, public route (public + shape + picker filter), admin CRUD (incl. video-upload rejection), `getEmojiTags`, `getEmojiFromTag`/`getMentionFromTag`, create-note + poll shortcode→emoji-Tag resolution, outgoing Note **and** Question Emoji tag, inbound emoji-tag parsing, edit re-sync, and picker insertion (both kinds) + preview image rendering.

## Notes for reviewers
- Custom emoji uploads use the shared (actor-scoped) media pipeline via the uploading admin's session actor; an OAuth-token-only admin (no session actor) cannot upload — documented limitation.
- Animated emoji are not transcoded: `static_url = url` (uploads are PNG/JPEG only; the route rejects video/audio even though `FileSchema` allows them).
- `persistEmojiTagsForStatus` reads the enabled emoji set once per note/poll create/edit — acceptable at instance scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Security hardening (added during review)

Review (Gemini + review sub-agents) surfaced a class of **pre-existing** visibility leaks in the status-detail render path that this PR's logged-out view makes prominent. Since they live in exactly the logged-out path this PR owns, the logged-out cases are fixed here (logged-in non-recipient filtering is a broader pre-existing concern, deferred to a follow-up PR):

- **Focused status:** a public `Announce` wrapping a followers-only/direct Note (e.g. a self-boost of a private post) passed the top-level `to`/`cc` check and rendered the private original. Now guarded with the recursive `isStatusPubliclyReadable` (returns `notFound()` for logged-out).
- **Ancestor thread (`previouses`):** built via an unfiltered `getStatus`; a public reply to a private parent leaked that parent. Now the chain stops at the first non-public ancestor for logged-out visitors.
- **Replies (content + count):** fetched/rendered unfiltered. Now fetched with `publicOnly: true` plus an object-level `isStatusPubliclyReadable` backstop (also covering the embedded-replies path), and only visible replies are rendered and counted in the stat strip.

All three reuse the canonical `isStatusPubliclyReadable` from `lib/services/statusAccess.ts`. Regression tests live in `app/(timeline)/[actor]/[status]/page.visibility.test.tsx` (4 cases). Other review fixes: a visually-hidden `<h1>` to preserve the document outline for logged-out visitors, the footer moved to a sibling of `<main>` for the `contentinfo` landmark, and `min-h-dvh` across the layout.
