### PR TITLE
minor: instance + custom emoji support with sticker picker

### DIFF
--- a/app/(timeline)/admin/emojis/page.tsx
+++ b/app/(timeline)/admin/emojis/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from 'next/navigation'
+
+import { CustomEmojiManager } from '@/lib/components/admin/CustomEmojiManager'
+import { PageHeader } from '@/lib/components/page-header'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { toAdminCustomEmoji } from '@/lib/types/domain/customEmoji'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const emojis = await database.getCustomEmojis({ includeDisabled: true })
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Custom emojis"
+        description="Upload instance custom emoji. People type :shortcode: in a post to use them, and they federate to other servers."
+      />
+      <CustomEmojiManager initialEmojis={emojis.map(toAdminCustomEmoji)} />
+    </div>
+  )
+}
+
+export default Page

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { BarChart3, Globe, Hash, Settings, Users } from 'lucide-react'
+import { BarChart3, Globe, Hash, Settings, Smile, Users } from 'lucide-react'
 import { FC, ReactNode } from 'react'
 
 import {
@@ -21,6 +21,7 @@ const tabs: SectionNavTab[] = [
   { name: 'Accounts', url: '/admin/accounts', icon: Users },
   { name: 'Hashtags', url: '/admin/tags', icon: Hash },
   { name: 'Federation', url: '/admin/federation', icon: Globe },
+  { name: 'Custom emojis', url: '/admin/emojis', icon: Smile },
   { name: 'System', url: '/admin/system', icon: Settings }
 ]
 

--- a/app/api/v1/admin/custom_emojis/[id]/route.test.ts
+++ b/app/api/v1/admin/custom_emojis/[id]/route.test.ts
@@ -99,6 +99,31 @@ describe('/api/v1/admin/custom_emojis/[id]', () => {
     expect(data).toMatchObject({ disabled: true, visible_in_picker: false })
   })
 
+  it('clears the category when PATCHed with null', async () => {
+    mockDatabase.updateCustomEmoji.mockResolvedValue({
+      ...emojiRow,
+      category: null
+    })
+
+    const response = await PATCH(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/emoji-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: null })
+      }),
+      { params: Promise.resolve({ id: 'emoji-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateCustomEmoji).toHaveBeenCalledWith({
+      id: 'emoji-1',
+      category: null,
+      visibleInPicker: undefined,
+      disabled: undefined
+    })
+    expect(await response.json()).toMatchObject({ category: null })
+  })
+
   it('returns 422 for an invalid update body', async () => {
     const response = await PATCH(
       new NextRequest('https://llun.test/api/v1/admin/custom_emojis/emoji-1', {

--- a/app/api/v1/admin/custom_emojis/[id]/route.test.ts
+++ b/app/api/v1/admin/custom_emojis/[id]/route.test.ts
@@ -99,6 +99,19 @@ describe('/api/v1/admin/custom_emojis/[id]', () => {
     expect(data).toMatchObject({ disabled: true, visible_in_picker: false })
   })
 
+  it('returns 422 for an invalid update body', async () => {
+    const response = await PATCH(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/emoji-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ visible_in_picker: 12 })
+      }),
+      { params: Promise.resolve({ id: 'emoji-1' }) }
+    )
+    expect(response.status).toBe(422)
+    expect(mockDatabase.updateCustomEmoji).not.toHaveBeenCalled()
+  })
+
   it('returns 404 when updating a missing emoji', async () => {
     mockDatabase.updateCustomEmoji.mockResolvedValue(null)
     const response = await PATCH(

--- a/app/api/v1/admin/custom_emojis/[id]/route.test.ts
+++ b/app/api/v1/admin/custom_emojis/[id]/route.test.ts
@@ -1,0 +1,137 @@
+import { NextRequest } from 'next/server'
+
+import { DELETE, GET, PATCH } from './route'
+
+const mockDatabase = {
+  getCustomEmojiById: jest.fn(),
+  updateCustomEmoji: jest.fn(),
+  deleteCustomEmoji: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue({
+    user: { email: 'admin@llun.test' }
+  })
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: jest.fn().mockResolvedValue({
+    id: 'admin',
+    email: 'admin@llun.test'
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'llun.test', allowEmails: [] })
+}))
+
+const emojiRow = {
+  id: 'emoji-1',
+  shortcode: 'blobcat',
+  url: 'https://llun.test/emojis/blobcat.png',
+  staticUrl: 'https://llun.test/emojis/blobcat.png',
+  category: null,
+  visibleInPicker: true,
+  disabled: false,
+  createdAt: 0,
+  updatedAt: 0
+}
+
+describe('/api/v1/admin/custom_emojis/[id]', () => {
+  beforeEach(() => {
+    mockDatabase.getCustomEmojiById.mockReset()
+    mockDatabase.updateCustomEmoji.mockReset()
+    mockDatabase.deleteCustomEmoji.mockReset()
+  })
+
+  it('gets a single emoji', async () => {
+    mockDatabase.getCustomEmojiById.mockResolvedValue(emojiRow)
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/emoji-1'),
+      { params: Promise.resolve({ id: 'emoji-1' }) }
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ id: 'emoji-1' })
+  })
+
+  it('returns 404 for a missing emoji', async () => {
+    mockDatabase.getCustomEmojiById.mockResolvedValue(null)
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/missing'),
+      { params: Promise.resolve({ id: 'missing' }) }
+    )
+    expect(response.status).toBe(404)
+  })
+
+  it('updates disabled/visibility/category via PATCH', async () => {
+    mockDatabase.updateCustomEmoji.mockResolvedValue({
+      ...emojiRow,
+      disabled: true,
+      visibleInPicker: false,
+      category: 'cats'
+    })
+
+    const response = await PATCH(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/emoji-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          disabled: true,
+          visible_in_picker: false,
+          category: 'cats'
+        })
+      }),
+      { params: Promise.resolve({ id: 'emoji-1' }) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateCustomEmoji).toHaveBeenCalledWith({
+      id: 'emoji-1',
+      disabled: true,
+      visibleInPicker: false,
+      category: 'cats'
+    })
+    expect(data).toMatchObject({ disabled: true, visible_in_picker: false })
+  })
+
+  it('returns 404 when updating a missing emoji', async () => {
+    mockDatabase.updateCustomEmoji.mockResolvedValue(null)
+    const response = await PATCH(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/missing', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ disabled: true })
+      }),
+      { params: Promise.resolve({ id: 'missing' }) }
+    )
+    expect(response.status).toBe(404)
+  })
+
+  it('deletes an emoji', async () => {
+    mockDatabase.deleteCustomEmoji.mockResolvedValue(emojiRow)
+    const response = await DELETE(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/emoji-1', {
+        method: 'DELETE'
+      }),
+      { params: Promise.resolve({ id: 'emoji-1' }) }
+    )
+    expect(response.status).toBe(200)
+    expect(mockDatabase.deleteCustomEmoji).toHaveBeenCalledWith('emoji-1')
+  })
+
+  it('returns 404 when deleting a missing emoji', async () => {
+    mockDatabase.deleteCustomEmoji.mockResolvedValue(null)
+    const response = await DELETE(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis/missing', {
+        method: 'DELETE'
+      }),
+      { params: Promise.resolve({ id: 'missing' }) }
+    )
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v1/admin/custom_emojis/[id]/route.ts
+++ b/app/api/v1/admin/custom_emojis/[id]/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest } from 'next/server'
+
+import { UpdateCustomEmojiRequest } from '@/app/api/v1/admin/custom_emojis/schema'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { toAdminCustomEmoji } from '@/lib/types/domain/customEmoji'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_400,
+  ERROR_404,
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+type Params = {
+  id: string
+}
+
+// PATCH matches Mastodon's admin custom-emoji update; PUT mirrors this repo's
+// existing admin [id] convention (e.g. domain_blocks). Both share one handler.
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PATCH,
+  HttpMethod.enum.PUT,
+  HttpMethod.enum.DELETE
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminGetCustomEmoji',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const emoji = await database.getCustomEmojiById(id)
+    if (!emoji) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminCustomEmoji(emoji)
+    })
+  })
+)
+
+const updateHandler = AdminApiGuard<Params>(
+  CORS_HEADERS,
+  async (req: NextRequest, { database, params }) => {
+    let data: unknown
+    try {
+      data = await getRequestBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const parsed = UpdateCustomEmojiRequest.safeParse(data)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const { id } = await params
+    const emoji = await database.updateCustomEmoji({
+      id,
+      category: parsed.data.category,
+      visibleInPicker: parsed.data.visible_in_picker,
+      disabled: parsed.data.disabled
+    })
+    if (!emoji) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminCustomEmoji(emoji)
+    })
+  }
+)
+
+export const PATCH = traceApiRoute('adminUpdateCustomEmoji', updateHandler)
+export const PUT = traceApiRoute('adminUpdateCustomEmoji', updateHandler)
+
+export const DELETE = traceApiRoute(
+  'adminDeleteCustomEmoji',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const emoji = await database.deleteCustomEmoji(id)
+    if (!emoji) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    }
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminCustomEmoji(emoji)
+    })
+  })
+)

--- a/app/api/v1/admin/custom_emojis/route.test.ts
+++ b/app/api/v1/admin/custom_emojis/route.test.ts
@@ -1,0 +1,202 @@
+import { NextRequest } from 'next/server'
+
+import { GET, POST } from './route'
+
+const mockDatabase = {
+  getCustomEmojis: jest.fn(),
+  getCustomEmojiByShortcode: jest.fn(),
+  createCustomEmoji: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue({
+    user: { email: 'admin@llun.test' }
+  })
+}))
+
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: jest.fn().mockResolvedValue({
+    id: 'admin',
+    email: 'admin@llun.test'
+  })
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn().mockResolvedValue({ id: 'actor-1' })
+}))
+
+const mockSaveMedia = jest.fn()
+jest.mock('@/lib/services/medias', () => ({
+  saveMedia: (...args: unknown[]) => mockSaveMedia(...args)
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'llun.test',
+    allowEmails: [],
+    mediaStorage: { maxFileSize: 1_000_000 }
+  })
+}))
+
+const makeImage = () =>
+  new File([new Uint8Array([1, 2, 3])], 'blobcat.png', { type: 'image/png' })
+
+// NextRequest.formData() is not available in the jest environment, so build the
+// request and stub formData with the FormData instance directly (matching the
+// pattern in app/api/v1/statuses/route.test.ts).
+const makeMultipartRequest = (form: FormData) => {
+  const request = new NextRequest(
+    'https://llun.test/api/v1/admin/custom_emojis',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'multipart/form-data; boundary=test-boundary',
+        Origin: 'https://llun.test'
+      }
+    }
+  )
+  Object.defineProperty(request, 'formData', {
+    value: jest.fn().mockResolvedValue(form)
+  })
+  return request
+}
+
+describe('/api/v1/admin/custom_emojis', () => {
+  beforeEach(() => {
+    mockDatabase.getCustomEmojis.mockReset()
+    mockDatabase.getCustomEmojiByShortcode.mockReset()
+    mockDatabase.createCustomEmoji.mockReset()
+    mockSaveMedia.mockReset()
+  })
+
+  it('lists all emoji including disabled ones with the admin shape', async () => {
+    mockDatabase.getCustomEmojis.mockResolvedValue([
+      {
+        id: 'emoji-1',
+        shortcode: 'blobcat',
+        url: 'https://llun.test/emojis/blobcat.png',
+        staticUrl: 'https://llun.test/emojis/blobcat.png',
+        category: null,
+        visibleInPicker: true,
+        disabled: true,
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/admin/custom_emojis'),
+      { params: Promise.resolve({}) }
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getCustomEmojis).toHaveBeenCalledWith({
+      includeDisabled: true
+    })
+    expect(data[0]).toMatchObject({
+      id: 'emoji-1',
+      shortcode: 'blobcat',
+      static_url: 'https://llun.test/emojis/blobcat.png',
+      visible_in_picker: true,
+      disabled: true
+    })
+  })
+
+  it('creates an emoji from a multipart upload through the media pipeline', async () => {
+    mockDatabase.getCustomEmojiByShortcode.mockResolvedValue(null)
+    mockSaveMedia.mockResolvedValue({
+      url: 'https://llun.test/medias/blobcat.png'
+    })
+    mockDatabase.createCustomEmoji.mockResolvedValue({
+      id: 'emoji-9',
+      shortcode: 'blobcat',
+      url: 'https://llun.test/medias/blobcat.png',
+      staticUrl: 'https://llun.test/medias/blobcat.png',
+      category: 'cats',
+      visibleInPicker: true,
+      disabled: false,
+      createdAt: 0,
+      updatedAt: 0
+    })
+
+    const form = new FormData()
+    form.set('shortcode', 'blobcat')
+    form.set('category', 'cats')
+    form.set('image', makeImage())
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockSaveMedia).toHaveBeenCalled()
+    expect(mockDatabase.createCustomEmoji).toHaveBeenCalledWith({
+      shortcode: 'blobcat',
+      url: 'https://llun.test/medias/blobcat.png',
+      staticUrl: 'https://llun.test/medias/blobcat.png',
+      category: 'cats',
+      visibleInPicker: true
+    })
+    expect(data).toMatchObject({ id: 'emoji-9', shortcode: 'blobcat' })
+  })
+
+  it('rejects an invalid shortcode with 422', async () => {
+    const form = new FormData()
+    form.set('shortcode', 'bad shortcode!')
+    form.set('image', makeImage())
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects a duplicate shortcode with 422', async () => {
+    mockDatabase.getCustomEmojiByShortcode.mockResolvedValue({ id: 'existing' })
+    const form = new FormData()
+    form.set('shortcode', 'blobcat')
+    form.set('image', makeImage())
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-image upload with 422', async () => {
+    mockDatabase.getCustomEmojiByShortcode.mockResolvedValue(null)
+    const form = new FormData()
+    form.set('shortcode', 'blobcat')
+    form.set('image', new File(['x'], 'note.txt', { type: 'text/plain' }))
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects a video upload with 422 even though the media schema allows video', async () => {
+    mockDatabase.getCustomEmojiByShortcode.mockResolvedValue(null)
+    const form = new FormData()
+    form.set('shortcode', 'blobcat')
+    form.set(
+      'image',
+      new File([new Uint8Array([1, 2, 3])], 'clip.mp4', { type: 'video/mp4' })
+    )
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/admin/custom_emojis/route.test.ts
+++ b/app/api/v1/admin/custom_emojis/route.test.ts
@@ -160,6 +160,18 @@ describe('/api/v1/admin/custom_emojis', () => {
     expect(mockSaveMedia).not.toHaveBeenCalled()
   })
 
+  it('rejects a 1-character shortcode with 422 (Mastodon requires >= 2)', async () => {
+    const form = new FormData()
+    form.set('shortcode', 'a')
+    form.set('image', makeImage())
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
   it('rejects a duplicate shortcode with 422', async () => {
     mockDatabase.getCustomEmojiByShortcode.mockResolvedValue({ id: 'existing' })
     const form = new FormData()

--- a/app/api/v1/admin/custom_emojis/route.test.ts
+++ b/app/api/v1/admin/custom_emojis/route.test.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
 import { GET, POST } from './route'
 
 const mockDatabase = {
@@ -181,6 +183,20 @@ describe('/api/v1/admin/custom_emojis', () => {
       params: Promise.resolve({})
     })
     expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the admin has no session actor to own the upload', async () => {
+    mockDatabase.getCustomEmojiByShortcode.mockResolvedValue(null)
+    ;(getActorFromSession as jest.Mock).mockResolvedValueOnce(null)
+    const form = new FormData()
+    form.set('shortcode', 'blobcat')
+    form.set('image', makeImage())
+
+    const response = await POST(makeMultipartRequest(form), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(403)
     expect(mockSaveMedia).not.toHaveBeenCalled()
   })
 

--- a/app/api/v1/admin/custom_emojis/route.ts
+++ b/app/api/v1/admin/custom_emojis/route.ts
@@ -134,20 +134,28 @@ export const POST = traceApiRoute(
         visibleInPicker: parsed.data.visible_in_picker ?? true
       })
     } catch (error) {
-      // The shortcode unique constraint can still fire if a concurrent request
-      // inserted the same shortcode after the pre-check above. Map it to 422 and
-      // best-effort remove the just-saved (now orphaned) media file.
+      // Insert can still fail if a concurrent request inserted the same
+      // shortcode after the pre-check above (unique constraint), or for an
+      // unrelated DB error. In both cases the just-saved media is now orphaned,
+      // so remove it best-effort. Re-query to tell a genuine duplicate (→ 422)
+      // apart from a transient error (→ 500) instead of always blaming the
+      // shortcode.
       await deleteSavedMedia(database, saved.url)
       logger.warn({
         message: 'Failed to create custom emoji after media upload',
         shortcode: parsed.data.shortcode,
         error
       })
+      const duplicate = await database
+        .getCustomEmojiByShortcode(parsed.data.shortcode)
+        .catch(() => null)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: { error: 'Shortcode already exists' },
-        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        data: duplicate ? { error: 'Shortcode already exists' } : ERROR_500,
+        responseStatusCode: duplicate
+          ? HTTP_STATUS.UNPROCESSABLE_ENTITY
+          : HTTP_STATUS.INTERNAL_SERVER_ERROR
       })
     }
 

--- a/app/api/v1/admin/custom_emojis/route.ts
+++ b/app/api/v1/admin/custom_emojis/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest } from 'next/server'
+
+import { CreateCustomEmojiRequest } from '@/app/api/v1/admin/custom_emojis/schema'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { saveMedia } from '@/lib/services/medias'
+import { ACCEPTED_IMAGE_TYPES } from '@/lib/services/medias/constants'
+import { FileSchema } from '@/lib/services/medias/types'
+import { toAdminCustomEmoji } from '@/lib/types/domain/customEmoji'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_403,
+  ERROR_422,
+  ERROR_500,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.POST
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminListCustomEmojis',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const emojis = await database.getCustomEmojis({ includeDisabled: true })
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: emojis.map(toAdminCustomEmoji)
+    })
+  })
+)
+
+export const POST = traceApiRoute(
+  'adminCreateCustomEmoji',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    let form: FormData
+    try {
+      form = await req.formData()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const parsed = CreateCustomEmojiRequest.safeParse({
+      shortcode: form.get('shortcode') ?? undefined,
+      category: form.get('category') ?? undefined,
+      visible_in_picker: form.get('visible_in_picker') ?? undefined
+    })
+    const fileParsed = FileSchema.safeParse(form.get('image'))
+    // Custom emoji are static images only. FileSchema also accepts video/audio,
+    // so narrow to image mime types here (we do not transcode animated emoji).
+    if (
+      !parsed.success ||
+      !fileParsed.success ||
+      !ACCEPTED_IMAGE_TYPES.includes(fileParsed.data.type)
+    ) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const existing = await database.getCustomEmojiByShortcode(
+      parsed.data.shortcode
+    )
+    if (existing) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Shortcode already exists' },
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    // The upload goes through the shared media pipeline, which is actor-scoped.
+    // Use the uploading admin's actor. This requires a browser session; an
+    // OAuth-token-only admin (no session actor) cannot upload here.
+    const session = await getServerAuthSession()
+    const actor = await getActorFromSession(database, session)
+    if (!actor) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: HTTP_STATUS.FORBIDDEN
+      })
+    }
+
+    let saved
+    try {
+      saved = await saveMedia(database, actor, { file: fileParsed.data })
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+    if (!saved) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
+
+    // We do not transcode animated emoji; the static copy equals the upload.
+    const emoji = await database.createCustomEmoji({
+      shortcode: parsed.data.shortcode,
+      url: saved.url,
+      staticUrl: saved.url,
+      category: parsed.data.category,
+      visibleInPicker: parsed.data.visible_in_picker ?? true
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: toAdminCustomEmoji(emoji)
+    })
+  })
+)

--- a/app/api/v1/admin/custom_emojis/route.ts
+++ b/app/api/v1/admin/custom_emojis/route.ts
@@ -1,14 +1,16 @@
 import { NextRequest } from 'next/server'
 
 import { CreateCustomEmojiRequest } from '@/app/api/v1/admin/custom_emojis/schema'
+import { Database } from '@/lib/database/types'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
-import { saveMedia } from '@/lib/services/medias'
+import { deleteMediaFile, saveMedia } from '@/lib/services/medias'
 import { ACCEPTED_IMAGE_TYPES } from '@/lib/services/medias/constants'
 import { FileSchema } from '@/lib/services/medias/types'
 import { toAdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_403,
   ERROR_422,
@@ -122,13 +124,32 @@ export const POST = traceApiRoute(
     }
 
     // We do not transcode animated emoji; the static copy equals the upload.
-    const emoji = await database.createCustomEmoji({
-      shortcode: parsed.data.shortcode,
-      url: saved.url,
-      staticUrl: saved.url,
-      category: parsed.data.category,
-      visibleInPicker: parsed.data.visible_in_picker ?? true
-    })
+    let emoji
+    try {
+      emoji = await database.createCustomEmoji({
+        shortcode: parsed.data.shortcode,
+        url: saved.url,
+        staticUrl: saved.url,
+        category: parsed.data.category,
+        visibleInPicker: parsed.data.visible_in_picker ?? true
+      })
+    } catch (error) {
+      // The shortcode unique constraint can still fire if a concurrent request
+      // inserted the same shortcode after the pre-check above. Map it to 422 and
+      // best-effort remove the just-saved (now orphaned) media file.
+      await deleteSavedMedia(database, saved.url)
+      logger.warn({
+        message: 'Failed to create custom emoji after media upload',
+        shortcode: parsed.data.shortcode,
+        error
+      })
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Shortcode already exists' },
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
 
     return apiResponse({
       req,
@@ -137,3 +158,19 @@ export const POST = traceApiRoute(
     })
   })
 )
+
+// Best-effort cleanup of a media file given its public URL
+// (`.../api/v1/files/<path>`). Storage-specific URL shapes other than the local
+// file backend are ignored; failures are swallowed since this is cleanup only.
+const deleteSavedMedia = async (database: Database, url: string) => {
+  try {
+    const { pathname } = new URL(url)
+    const marker = '/api/v1/files/'
+    const index = pathname.indexOf(marker)
+    if (index === -1) return
+    const path = pathname.slice(index + marker.length)
+    if (path) await deleteMediaFile(database, decodeURIComponent(path))
+  } catch {
+    // ignore cleanup failures
+  }
+}

--- a/app/api/v1/admin/custom_emojis/schema.ts
+++ b/app/api/v1/admin/custom_emojis/schema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+import { CUSTOM_EMOJI_SHORTCODE_REGEX } from '@/lib/types/domain/customEmoji'
+
+// Accepts JSON booleans and the string forms multipart/form-data carries.
+const Booleanish = z.union([z.boolean(), z.string()]).transform((value) => {
+  if (typeof value === 'boolean') return value
+  const normalized = value.toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'on'
+})
+
+// Shortcode without colons. `^[a-zA-Z0-9_]+$` per the Mastodon CustomEmoji
+// entity; capped so it fits the `varchar` column.
+const Shortcode = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(CUSTOM_EMOJI_SHORTCODE_REGEX)
+
+const Category = z
+  .string()
+  .trim()
+  .max(255)
+  .optional()
+  .transform((value) => value || null)
+
+// `POST /api/v1/admin/custom_emojis` — multipart form fields alongside the
+// uploaded `image` file (validated separately through the media pipeline).
+export const CreateCustomEmojiRequest = z.object({
+  shortcode: Shortcode,
+  category: Category,
+  visible_in_picker: Booleanish.optional()
+})
+
+// `PATCH`/`PUT /api/v1/admin/custom_emojis/:id` — update moderation fields.
+export const UpdateCustomEmojiRequest = z.object({
+  category: z
+    .string()
+    .trim()
+    .max(255)
+    .transform((value) => value || null)
+    .optional(),
+  visible_in_picker: Booleanish.optional(),
+  disabled: Booleanish.optional()
+})

--- a/app/api/v1/admin/custom_emojis/schema.ts
+++ b/app/api/v1/admin/custom_emojis/schema.ts
@@ -14,7 +14,7 @@ const Booleanish = z.union([z.boolean(), z.string()]).transform((value) => {
 const Shortcode = z
   .string()
   .trim()
-  .min(1)
+  .min(2)
   .max(64)
   .regex(CUSTOM_EMOJI_SHORTCODE_REGEX)
 

--- a/app/api/v1/admin/custom_emojis/schema.ts
+++ b/app/api/v1/admin/custom_emojis/schema.ts
@@ -35,10 +35,13 @@ export const CreateCustomEmojiRequest = z.object({
 
 // `PATCH`/`PUT /api/v1/admin/custom_emojis/:id` — update moderation fields.
 export const UpdateCustomEmojiRequest = z.object({
+  // Accepts a string, `null` (clear the category), or omitted (preserve). The
+  // admin UI sends `null` when the category field is cleared.
   category: z
     .string()
     .trim()
     .max(255)
+    .nullable()
     .transform((value) => value || null)
     .optional(),
   visible_in_picker: Booleanish.optional(),

--- a/app/api/v1/custom_emojis/route.test.ts
+++ b/app/api/v1/custom_emojis/route.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getCustomEmojis: jest.fn()
+}
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('/api/v1/custom_emojis', () => {
+  beforeEach(() => {
+    mockDatabase.getCustomEmojis.mockReset()
+  })
+
+  it('returns picker-visible emoji as the Mastodon CustomEmoji shape without auth', async () => {
+    mockDatabase.getCustomEmojis.mockResolvedValue([
+      {
+        id: 'emoji-1',
+        shortcode: 'blobcat',
+        url: 'https://llun.test/emojis/blobcat.png',
+        staticUrl: 'https://llun.test/emojis/blobcat-static.png',
+        category: 'cats',
+        visibleInPicker: true,
+        disabled: false,
+        createdAt: 0,
+        updatedAt: 0
+      },
+      {
+        id: 'emoji-2',
+        shortcode: 'hidden',
+        url: 'https://llun.test/emojis/hidden.png',
+        staticUrl: 'https://llun.test/emojis/hidden.png',
+        category: null,
+        visibleInPicker: false,
+        disabled: false,
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/custom_emojis')
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    // Default getCustomEmojis() already excludes disabled; the route filters to
+    // picker-visible (Mastodon's `listed` scope).
+    expect(data).toEqual([
+      {
+        shortcode: 'blobcat',
+        url: 'https://llun.test/emojis/blobcat.png',
+        static_url: 'https://llun.test/emojis/blobcat-static.png',
+        visible_in_picker: true,
+        category: 'cats'
+      }
+    ])
+  })
+
+  it('returns an empty array when there are no emoji', async () => {
+    mockDatabase.getCustomEmojis.mockResolvedValue([])
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/custom_emojis')
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+  })
+})

--- a/app/api/v1/custom_emojis/route.ts
+++ b/app/api/v1/custom_emojis/route.ts
@@ -1,16 +1,38 @@
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
-import { Scope } from '@/lib/types/database/operations'
+import { NextRequest } from 'next/server'
+
+import { getDatabase } from '@/lib/database'
+import { toMastodonCustomEmoji } from '@/lib/types/domain/customEmoji'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { HTTP_STATUS, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+// Public, unauthenticated — Mastodon serves GET /api/v1/custom_emojis without a
+// token. Returns the `listed` set: enabled (`disabled = false`) AND
+// `visible_in_picker = true`, matching Mastodon's `CustomEmoji.listed` scope.
 export const GET = traceApiRoute(
   'getCustomEmojis',
-  OAuthGuard([Scope.enum.read], async (req) => {
-    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
-  })
+  async (req: NextRequest) => {
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Database unavailable' },
+        responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
+
+    const emojis = await database.getCustomEmojis()
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: emojis
+        .filter((emoji) => emoji.visibleInPicker)
+        .map(toMastodonCustomEmoji)
+    })
+  }
 )

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -13,17 +13,23 @@ jest.mock('@/lib/config', () => ({
   })
 }))
 
-// v2 is behind OAuthGuard; pass the request straight through to the handler.
-jest.mock('@/lib/services/guards/OAuthGuard', () => ({
-  OAuthGuard:
-    (_scopes: unknown, handle: (req: unknown, context: unknown) => unknown) =>
-    (req: unknown, context: unknown) =>
-      handle(req, context)
-}))
-
 const params = { params: Promise.resolve({}) }
 
 describe('GET /api/v2/instance', () => {
+  it('serves the instance payload for an unauthenticated request', async () => {
+    // No OAuthGuard mock: the route must work without any Authorization header,
+    // matching Mastodon's public v2 instance endpoint. If a guard is ever
+    // re-added, this tokenless request would fail.
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      domain: 'llun.test'
+    })
+  })
+
   it('reports the configured host by default', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v2/instance'),

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -1,5 +1,6 @@
+import { NextRequest } from 'next/server'
+
 import { getConfig } from '@/lib/config'
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MAX_PINNED_STATUSES,
@@ -9,7 +10,6 @@ import {
   ACCEPTED_FILE_TYPES,
   MAX_FILE_SIZE
 } from '@/lib/services/medias/constants'
-import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -19,57 +19,55 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-export const GET = traceApiRoute(
-  'getInstanceV2',
-  OAuthGuard([Scope.enum.read], async (req) => {
-    const config = getConfig()
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: {
-        domain: headerHost(req.headers),
-        title: config.serviceName ?? 'Activities.next',
-        version: VERSION,
-        source_url: 'https://github.com/llun/activities.next',
-        description:
-          config.serviceDescription ??
-          'Personal activity pub server with Next.js',
-        languages: config.languages,
-        configuration: {
-          accounts: {
-            max_featured_tags: 10,
-            max_pinned_statuses: MAX_PINNED_STATUSES
-          },
-          statuses: {
-            max_characters: 500,
-            max_media_attachments: MAX_STATUS_MEDIA_ATTACHMENTS,
-            characters_reserved_per_url: 23
-          },
-          media_attachments: {
-            supported_mime_types: ACCEPTED_FILE_TYPES,
-            image_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
-            image_matrix_limit: 33177600,
-            video_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
-            video_frame_rate_limit: 120,
-            video_matrix_limit: 8294400
-          },
-          polls: {
-            max_options: 4,
-            max_characters_per_option: 50,
-            min_expiration: 300,
-            max_expiration: 2629746
-          },
-          translation: {
-            enabled: false
-          }
+// Public per Mastodon: GET /api/v2/instance is served unauthenticated.
+export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
+  const config = getConfig()
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: {
+      domain: headerHost(req.headers),
+      title: config.serviceName ?? 'Activities.next',
+      version: VERSION,
+      source_url: 'https://github.com/llun/activities.next',
+      description:
+        config.serviceDescription ??
+        'Personal activity pub server with Next.js',
+      languages: config.languages,
+      configuration: {
+        accounts: {
+          max_featured_tags: 10,
+          max_pinned_statuses: MAX_PINNED_STATUSES
         },
-        registrations: {
-          enabled: false,
-          approval_required: false,
-          message: null,
-          url: null
+        statuses: {
+          max_characters: 500,
+          max_media_attachments: MAX_STATUS_MEDIA_ATTACHMENTS,
+          characters_reserved_per_url: 23
+        },
+        media_attachments: {
+          supported_mime_types: ACCEPTED_FILE_TYPES,
+          image_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
+          image_matrix_limit: 33177600,
+          video_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
+          video_frame_rate_limit: 120,
+          video_matrix_limit: 8294400
+        },
+        polls: {
+          max_options: 4,
+          max_characters_per_option: 50,
+          min_expiration: 300,
+          max_expiration: 2629746
+        },
+        translation: {
+          enabled: false
         }
+      },
+      registrations: {
+        enabled: false,
+        approval_required: false,
+        message: null,
+        url: null
       }
-    })
+    }
   })
-)
+})

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -35,6 +35,7 @@ import {
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 import { MENTION_GLOBAL_REGEX } from '@/lib/utils/text/convertMarkdownText'
+import { getEmojiTags } from '@/lib/utils/text/getEmojiTags'
 import { getHashtags } from '@/lib/utils/text/getHashtags'
 import { getMentions } from '@/lib/utils/text/getMentions'
 import { getSpan } from '@/lib/utils/trace'
@@ -147,6 +148,39 @@ export const getMentionTagsForStatus = ({
   }
 
   return [...mentionsByHref.values()]
+}
+
+/**
+ * Scans status text for `:shortcode:` tokens, resolves them against the
+ * instance's enabled custom-emoji set, and persists matching `emoji` domain
+ * Tags for the status. These tags drive local rendering
+ * (`convertEmojisToImages`) and federate as ActivityPub `Emoji` tags
+ * (`getEmojiFromTag`). Disabled emoji are ignored; `visible_in_picker` is not
+ * considered so a hand-typed non-picker emoji still federates (matching
+ * Mastodon). Returns the number of emoji tags persisted.
+ */
+export const persistEmojiTagsForStatus = async ({
+  database,
+  statusId,
+  text
+}: {
+  database: Database
+  statusId: string
+  text: string
+}): Promise<number> => {
+  const customEmojis = await database.getCustomEmojis()
+  const emojiTags = getEmojiTags(text, customEmojis)
+  await Promise.all(
+    emojiTags.map((emojiTag) =>
+      database.createTag({
+        statusId,
+        name: emojiTag.name,
+        value: emojiTag.value,
+        type: 'emoji'
+      })
+    )
+  )
+  return emojiTags.length
 }
 
 /**
@@ -422,6 +456,8 @@ export const createNoteFromUserInput = async ({
       hashtags: hashtags.map((hashtag) => hashtag.name)
     })
   }
+
+  await persistEmojiTagsForStatus({ database, statusId, text })
 
   await Promise.all([
     addStatusToTimelines(database, createdStatus),

--- a/lib/actions/createNoteEmoji.test.ts
+++ b/lib/actions/createNoteEmoji.test.ts
@@ -1,0 +1,168 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { createNoteFromUserInput } from '@/lib/actions/createNote'
+import { createPollFromUserInput } from '@/lib/actions/createPoll'
+import { updateNoteFromUserInput } from '@/lib/actions/updateNote'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { mockRequests } from '@/lib/stub/activities'
+import { seedDatabase } from '@/lib/stub/database'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { Actor } from '@/lib/types/domain/actor'
+import { StatusType, toActivityPubObject } from '@/lib/types/domain/status'
+import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
+
+enableFetchMocks()
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn().mockReturnValue({
+    publish: jest.fn().mockResolvedValue(undefined)
+  })
+}))
+
+jest.mock('@/lib/services/timelines', () => ({
+  addStatusToTimelines: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('@/lib/services/notifications/sendNotificationAlerts', () => ({
+  sendNotificationAlerts: jest.fn()
+}))
+
+describe('Custom emoji status federation', () => {
+  const database = getTestSQLDatabase()
+  let actor1: Actor
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    actor1 = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    await database.createCustomEmoji({
+      shortcode: 'blobcat',
+      url: 'https://example.com/emojis/blobcat.png',
+      staticUrl: 'https://example.com/emojis/blobcat.png'
+    })
+    await database.createCustomEmoji({
+      shortcode: 'hidden',
+      url: 'https://example.com/emojis/hidden.png',
+      staticUrl: 'https://example.com/emojis/hidden.png',
+      visibleInPicker: false
+    })
+    await database.createCustomEmoji({
+      shortcode: 'gone',
+      url: 'https://example.com/emojis/gone.png',
+      staticUrl: 'https://example.com/emojis/gone.png',
+      disabled: true
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    mockRequests(fetchMock)
+  })
+
+  it('persists an emoji tag for each known shortcode in the text', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'hello :blobcat: and :unknown:',
+      database
+    })
+    if (!status || status.type !== StatusType.enum.Note) {
+      throw new Error('Expected a note status')
+    }
+
+    const emojiTags = status.tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0]).toMatchObject({
+      name: ':blobcat:',
+      value: 'https://example.com/emojis/blobcat.png'
+    })
+  })
+
+  it('federates the emoji tag as an ActivityPub Emoji object in the Note', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'party :blobcat:',
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+
+    const note = getNoteFromStatus(status)
+    const tags = Array.isArray(note?.tag) ? note?.tag : [note?.tag]
+    expect(tags).toContainEqual(
+      expect.objectContaining({
+        type: 'Emoji',
+        name: ':blobcat:',
+        icon: expect.objectContaining({
+          type: 'Image',
+          url: 'https://example.com/emojis/blobcat.png'
+        })
+      })
+    )
+  })
+
+  it('resolves hand-typed non-picker emoji but ignores disabled emoji', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'mix :hidden: :gone:',
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+
+    const emojiNames = status.tags
+      .filter((tag) => tag.type === 'emoji')
+      .map((tag) => tag.name)
+    expect(emojiNames).toContain(':hidden:')
+    expect(emojiNames).not.toContain(':gone:')
+  })
+
+  it('federates the emoji tag as an Emoji object in a poll Question', async () => {
+    const status = await createPollFromUserInput({
+      currentActor: actor1,
+      text: 'vote with :blobcat:',
+      choices: ['yes', 'no'],
+      endAt: 4102444800000,
+      database
+    })
+    if (!status) throw new Error('Expected a poll status')
+
+    const question = toActivityPubObject(status)
+    const tags = Array.isArray(question.tag) ? question.tag : [question.tag]
+    expect(tags).toContainEqual(
+      expect.objectContaining({
+        type: 'Emoji',
+        name: ':blobcat:',
+        icon: expect.objectContaining({
+          type: 'Image',
+          url: 'https://example.com/emojis/blobcat.png'
+        })
+      })
+    )
+  })
+
+  it('re-syncs emoji tags when a note is edited', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'first :blobcat:',
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+
+    const updated = await updateNoteFromUserInput({
+      statusId: status.id,
+      currentActor: actor1,
+      text: 'edited without emoji',
+      database,
+      publish: false
+    })
+    expect(updated).not.toBeNull()
+
+    const tags = await database.getTags({ statusId: status.id })
+    expect(tags.filter((tag) => tag.type === 'emoji')).toHaveLength(0)
+  })
+})

--- a/lib/actions/createNoteEmoji.test.ts
+++ b/lib/actions/createNoteEmoji.test.ts
@@ -179,7 +179,7 @@ describe('Custom emoji status federation', () => {
       )
     ).toHaveLength(0)
 
-    await updateNoteFromUserInput({
+    const updated = await updateNoteFromUserInput({
       statusId: status.id,
       currentActor: actor1,
       text: 'now with :blobcat:',
@@ -191,5 +191,11 @@ describe('Custom emoji status federation', () => {
     const emojiTags = tags.filter((tag) => tag.type === 'emoji')
     expect(emojiTags).toHaveLength(1)
     expect(emojiTags[0].name).toBe(':blobcat:')
+
+    // The returned status (used for the optimistic client render + timeline
+    // cache) must already include the re-synced emoji tag.
+    expect(updated?.tags.filter((tag) => tag.type === 'emoji')).toEqual([
+      expect.objectContaining({ name: ':blobcat:' })
+    ])
   })
 })

--- a/lib/actions/createNoteEmoji.test.ts
+++ b/lib/actions/createNoteEmoji.test.ts
@@ -165,4 +165,31 @@ describe('Custom emoji status federation', () => {
     const tags = await database.getTags({ statusId: status.id })
     expect(tags.filter((tag) => tag.type === 'emoji')).toHaveLength(0)
   })
+
+  it('adds emoji tags when an edit introduces a new shortcode', async () => {
+    const status = await createNoteFromUserInput({
+      currentActor: actor1,
+      text: 'plain text',
+      database
+    })
+    if (!status) throw new Error('Expected a status')
+    expect(
+      (await database.getTags({ statusId: status.id })).filter(
+        (tag) => tag.type === 'emoji'
+      )
+    ).toHaveLength(0)
+
+    await updateNoteFromUserInput({
+      statusId: status.id,
+      currentActor: actor1,
+      text: 'now with :blobcat:',
+      database,
+      publish: false
+    })
+
+    const tags = await database.getTags({ statusId: status.id })
+    const emojiTags = tags.filter((tag) => tag.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toBe(':blobcat:')
+  })
 })

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -4,6 +4,7 @@ import {
   getExplicitMentions,
   getMentionTagsForStatus,
   getVisibilityFromReplyStatus,
+  persistEmojiTagsForStatus,
   statusRecipientsCC,
   statusRecipientsTo
 } from '@/lib/actions/createNote'
@@ -126,6 +127,8 @@ export const createPollFromUserInput = async ({
       })
     )
   ])
+
+  await persistEmojiTagsForStatus({ database, statusId, text })
 
   const status = await database.getStatus({ statusId, withReplies: false })
   if (!status) {

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -46,7 +46,7 @@ export const updateNoteFromUserInput = async ({
     return null
   }
 
-  const updatedStatus = await database.updateNote({
+  let updatedStatus = await database.updateNote({
     statusId,
     summary: summary === undefined ? status.summary : summary?.trim() || null,
     text: text ?? status.text,
@@ -60,10 +60,13 @@ export const updateNoteFromUserInput = async ({
   }
 
   // Re-sync emoji tags when the text changes so newly added `:shortcode:`
-  // tokens federate and removed ones stop federating.
+  // tokens federate and removed ones stop federating, then re-fetch so the
+  // returned status and the timeline cache reflect the re-synced tags (mirroring
+  // createNoteFromUserInput).
   if (text !== undefined) {
     await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
     await persistEmojiTagsForStatus({ database, statusId, text })
+    updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
   }
 
   await addStatusToTimelines(database, updatedStatus)

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -1,3 +1,4 @@
+import { persistEmojiTagsForStatus } from '@/lib/actions/createNote'
 import { Database } from '@/lib/database/types'
 import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
@@ -56,6 +57,13 @@ export const updateNoteFromUserInput = async ({
   if (!updatedStatus) {
     span.end()
     return null
+  }
+
+  // Re-sync emoji tags when the text changes so newly added `:shortcode:`
+  // tokens federate and removed ones stop federating.
+  if (text !== undefined) {
+    await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
+    await persistEmojiTagsForStatus({ database, statusId, text })
   }
 
   await addStatusToTimelines(database, updatedStatus)

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -8,9 +8,11 @@ import {
   PostBoxAttachment,
   UploadedAttachment
 } from '@/lib/types/domain/attachment'
+import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
@@ -2314,4 +2316,95 @@ export const createDirectMessage = async ({
     throw new Error('Failed to send message')
   }
   return (await response.json()) as CreateDirectMessageResult
+}
+
+// ============================================================================
+// Custom emoji
+// ============================================================================
+
+// Public instance custom emoji (picker-visible, enabled). Used by the postbox
+// sticker/emoji picker. Returns [] on failure so the picker degrades to system
+// emoji only.
+export const getCustomEmojis = async (): Promise<CustomEmoji[]> => {
+  try {
+    const response = await fetch('/api/v1/custom_emojis', {
+      headers: { Accept: 'application/json' }
+    })
+    if (!response.ok) return []
+    return (await response.json()) as CustomEmoji[]
+  } catch {
+    return []
+  }
+}
+
+export const adminListCustomEmojis = async (): Promise<AdminCustomEmoji[]> => {
+  const response = await fetch('/api/v1/admin/custom_emojis', {
+    headers: { Accept: 'application/json' }
+  })
+  if (!response.ok) throw new Error('Failed to load custom emoji')
+  return (await response.json()) as AdminCustomEmoji[]
+}
+
+export interface AdminCreateCustomEmojiParams {
+  shortcode: string
+  image: File
+  category?: string
+  visibleInPicker?: boolean
+}
+export const adminCreateCustomEmoji = async ({
+  shortcode,
+  image,
+  category,
+  visibleInPicker
+}: AdminCreateCustomEmojiParams): Promise<AdminCustomEmoji> => {
+  const form = new FormData()
+  form.set('shortcode', shortcode)
+  form.set('image', image)
+  if (category) form.set('category', category)
+  if (visibleInPicker !== undefined) {
+    form.set('visible_in_picker', visibleInPicker ? 'true' : 'false')
+  }
+  const response = await fetch('/api/v1/admin/custom_emojis', {
+    method: 'POST',
+    body: form
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to create custom emoji')
+  }
+  return (await response.json()) as AdminCustomEmoji
+}
+
+export interface AdminUpdateCustomEmojiParams {
+  id: string
+  category?: string | null
+  visibleInPicker?: boolean
+  disabled?: boolean
+}
+export const adminUpdateCustomEmoji = async ({
+  id,
+  category,
+  visibleInPicker,
+  disabled
+}: AdminUpdateCustomEmojiParams): Promise<AdminCustomEmoji> => {
+  const response = await fetch(`/api/v1/admin/custom_emojis/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ...(category !== undefined ? { category } : {}),
+      ...(visibleInPicker !== undefined
+        ? { visible_in_picker: visibleInPicker }
+        : {}),
+      ...(disabled !== undefined ? { disabled } : {})
+    })
+  })
+  if (!response.ok) throw new Error('Failed to update custom emoji')
+  return (await response.json()) as AdminCustomEmoji
+}
+
+export const adminDeleteCustomEmoji = async (id: string): Promise<void> => {
+  const response = await fetch(`/api/v1/admin/custom_emojis/${id}`, {
+    method: 'DELETE'
+  })
+  if (!response.ok) throw new Error('Failed to delete custom emoji')
 }

--- a/lib/components/admin/CustomEmojiManager.tsx
+++ b/lib/components/admin/CustomEmojiManager.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import { Ban, Check, EyeOff, Trash2, Upload } from 'lucide-react'
+import { ChangeEvent, FC, FormEvent, useRef, useState } from 'react'
+
+import {
+  adminCreateCustomEmoji,
+  adminDeleteCustomEmoji,
+  adminUpdateCustomEmoji
+} from '@/lib/client'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import { Label } from '@/lib/components/ui/label'
+import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
+import { CUSTOM_EMOJI_SHORTCODE_REGEX } from '@/lib/types/domain/customEmoji'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  initialEmojis: AdminCustomEmoji[]
+}
+
+const sortByShortcode = (emojis: AdminCustomEmoji[]) =>
+  [...emojis].sort((a, b) => a.shortcode.localeCompare(b.shortcode))
+
+export const CustomEmojiManager: FC<Props> = ({ initialEmojis }) => {
+  const [emojis, setEmojis] = useState<AdminCustomEmoji[]>(
+    sortByShortcode(initialEmojis)
+  )
+  const [shortcode, setShortcode] = useState('')
+  const [category, setCategory] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0] ?? null
+    setFile(selected)
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current)
+      return selected ? URL.createObjectURL(selected) : null
+    })
+  }
+
+  const resetForm = () => {
+    setShortcode('')
+    setCategory('')
+    setFile(null)
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current)
+      return null
+    })
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setNotice(null)
+    if (!file) {
+      setError('Choose an image to upload.')
+      return
+    }
+    if (!CUSTOM_EMOJI_SHORTCODE_REGEX.test(shortcode)) {
+      setError('Shortcode may contain only letters, numbers, and underscores.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const created = await adminCreateCustomEmoji({
+        shortcode,
+        image: file,
+        category: category.trim() || undefined
+      })
+      setEmojis((current) => sortByShortcode([...current, created]))
+      setNotice(`Added :${created.shortcode}:`)
+      resetForm()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Upload failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const applyUpdate = async (
+    id: string,
+    patch: Parameters<typeof adminUpdateCustomEmoji>[0]
+  ) => {
+    setError(null)
+    setNotice(null)
+    try {
+      const updated = await adminUpdateCustomEmoji(patch)
+      setEmojis((current) =>
+        sortByShortcode(
+          current.map((emoji) => (emoji.id === id ? updated : emoji))
+        )
+      )
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Update failed')
+    }
+  }
+
+  const onDelete = async (emoji: AdminCustomEmoji) => {
+    setError(null)
+    setNotice(null)
+    try {
+      await adminDeleteCustomEmoji(emoji.id)
+      setEmojis((current) => current.filter((item) => item.id !== emoji.id))
+      setNotice(`Deleted :${emoji.shortcode}:`)
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Delete failed')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+      {notice ? (
+        <div className="rounded-lg border border-green-500/40 bg-green-500/5 px-4 py-3 text-sm text-green-700 dark:text-green-300">
+          {notice}
+        </div>
+      ) : null}
+
+      {/* Upload form — mirrors the design system's "Add a sticker" section. */}
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <h2 className="text-lg font-semibold">Add a custom emoji</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Upload a PNG or JPEG and give it a shortcode. People type it between
+          colons in a post, e.g. <span className="font-mono">:blobcheer:</span>.
+        </p>
+        <form
+          onSubmit={onSubmit}
+          className="grid items-start gap-4 sm:grid-cols-[auto_1fr]"
+        >
+          <div className="flex flex-col items-center gap-2">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Choose emoji image"
+              className="flex size-24 items-center justify-center overflow-hidden rounded-xl border-2 border-dashed text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+            >
+              {previewUrl ? (
+                <img
+                  src={previewUrl}
+                  alt="Selected emoji preview"
+                  className="size-full object-contain"
+                />
+              ) : (
+                <Upload className="size-6" />
+              )}
+            </button>
+            <span className="text-[11px] text-muted-foreground">
+              PNG or JPEG
+            </span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/png,image/jpeg"
+              className="hidden"
+              onChange={onFileChange}
+            />
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="emoji-shortcode">Shortcode</Label>
+              <Input
+                id="emoji-shortcode"
+                value={shortcode}
+                onChange={(event) => setShortcode(event.target.value)}
+                placeholder="e.g. blobcheer"
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">
+                Lowercase letters, numbers, and underscores. People type it as
+                :shortcode:
+              </p>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="emoji-category">Category (optional)</Label>
+              <Input
+                id="emoji-category"
+                value={category}
+                onChange={(event) => setCategory(event.target.value)}
+                placeholder="e.g. cats"
+                autoComplete="off"
+              />
+            </div>
+            <Button type="submit" disabled={submitting}>
+              <Upload className="size-4" />
+              {submitting ? 'Uploading…' : 'Upload emoji'}
+            </Button>
+          </div>
+        </form>
+      </section>
+
+      {/* Existing emoji list — mirrors the design system's sticker list rows. */}
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <h2 className="text-lg font-semibold">Custom emojis</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          {emojis.length} uploaded.
+        </p>
+        {emojis.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No custom emoji uploaded yet.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {emojis.map((emoji) => (
+              <div
+                key={emoji.id}
+                className={cn(
+                  'flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center',
+                  emoji.disabled && 'opacity-60'
+                )}
+              >
+                <img
+                  src={emoji.static_url}
+                  alt={`:${emoji.shortcode}:`}
+                  className="size-10 shrink-0 object-contain"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                    <span className="font-mono">:{emoji.shortcode}:</span>
+                    {emoji.disabled ? (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                        Disabled
+                      </span>
+                    ) : null}
+                    {!emoji.visible_in_picker ? (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                        Hidden from picker
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-1">
+                    <Input
+                      aria-label={`Category for :${emoji.shortcode}:`}
+                      defaultValue={emoji.category ?? ''}
+                      placeholder="No category"
+                      className="h-8 w-full max-w-56 text-xs"
+                      onBlur={(event) => {
+                        const next = event.target.value.trim() || null
+                        if (next === (emoji.category ?? null)) return
+                        applyUpdate(emoji.id, { id: emoji.id, category: next })
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="flex shrink-0 flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      applyUpdate(emoji.id, {
+                        id: emoji.id,
+                        visibleInPicker: !emoji.visible_in_picker
+                      })
+                    }
+                  >
+                    <EyeOff className="size-4" />
+                    {emoji.visible_in_picker ? 'Hide' : 'Show'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      applyUpdate(emoji.id, {
+                        id: emoji.id,
+                        disabled: !emoji.disabled
+                      })
+                    }
+                  >
+                    {emoji.disabled ? (
+                      <Check className="size-4" />
+                    ) : (
+                      <Ban className="size-4" />
+                    )}
+                    {emoji.disabled ? 'Enable' : 'Disable'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label={`Delete :${emoji.shortcode}:`}
+                    className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onClick={() => onDelete(emoji)}
+                  >
+                    <Trash2 className="size-4" />
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/lib/components/admin/CustomEmojiManager.tsx
+++ b/lib/components/admin/CustomEmojiManager.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Ban, Check, EyeOff, Trash2, Upload } from 'lucide-react'
-import { ChangeEvent, FC, FormEvent, useRef, useState } from 'react'
+import { ChangeEvent, FC, FormEvent, useEffect, useRef, useState } from 'react'
 
 import {
   adminCreateCustomEmoji,
@@ -34,6 +34,14 @@ export const CustomEmojiManager: FC<Props> = ({ initialEmojis }) => {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Revoke the object URL on unmount so the selected-file preview does not leak.
+  useEffect(
+    () => () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    },
+    [previewUrl]
+  )
 
   const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selected = event.target.files?.[0] ?? null
@@ -144,7 +152,7 @@ export const CustomEmojiManager: FC<Props> = ({ initialEmojis }) => {
               type="button"
               onClick={() => fileInputRef.current?.click()}
               aria-label="Choose emoji image"
-              className="flex size-24 items-center justify-center overflow-hidden rounded-xl border-2 border-dashed text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+              className="flex size-24 items-center justify-center overflow-hidden rounded-xl border-2 border-dashed text-muted-foreground transition-colors hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               {previewUrl ? (
                 <img

--- a/lib/components/admin/CustomEmojiManager.tsx
+++ b/lib/components/admin/CustomEmojiManager.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Ban, Check, EyeOff, Trash2, Upload } from 'lucide-react'
-import { ChangeEvent, FC, FormEvent, useEffect, useRef, useState } from 'react'
+import { ChangeEvent, FC, FormEvent, useRef, useState } from 'react'
 
 import {
   adminCreateCustomEmoji,
@@ -29,37 +29,19 @@ export const CustomEmojiManager: FC<Props> = ({ initialEmojis }) => {
   const [shortcode, setShortcode] = useState('')
   const [category, setCategory] = useState('')
   const [file, setFile] = useState<File | null>(null)
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // Revoke the object URL on unmount so the selected-file preview does not leak.
-  useEffect(
-    () => () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl)
-    },
-    [previewUrl]
-  )
-
   const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const selected = event.target.files?.[0] ?? null
-    setFile(selected)
-    setPreviewUrl((current) => {
-      if (current) URL.revokeObjectURL(current)
-      return selected ? URL.createObjectURL(selected) : null
-    })
+    setFile(event.target.files?.[0] ?? null)
   }
 
   const resetForm = () => {
     setShortcode('')
     setCategory('')
     setFile(null)
-    setPreviewUrl((current) => {
-      if (current) URL.revokeObjectURL(current)
-      return null
-    })
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
@@ -154,18 +136,10 @@ export const CustomEmojiManager: FC<Props> = ({ initialEmojis }) => {
               aria-label="Choose emoji image"
               className="flex size-24 items-center justify-center overflow-hidden rounded-xl border-2 border-dashed text-muted-foreground transition-colors hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              {previewUrl ? (
-                <img
-                  src={previewUrl}
-                  alt="Selected emoji preview"
-                  className="size-full object-contain"
-                />
-              ) : (
-                <Upload className="size-6" />
-              )}
+              <Upload className="size-6" />
             </button>
-            <span className="text-[11px] text-muted-foreground">
-              PNG or JPEG
+            <span className="max-w-24 truncate text-[11px] text-muted-foreground">
+              {file ? file.name : 'PNG or JPEG'}
             </span>
             <input
               ref={fileInputRef}

--- a/lib/components/post-box/emoji-data.ts
+++ b/lib/components/post-box/emoji-data.ts
@@ -1,0 +1,335 @@
+// Curated Unicode emoji dataset for the postbox picker. Kept as a small local
+// dataset (rather than a heavy emoji-mart dependency) so the picker stays
+// self-contained; it covers the common emoji grouped by the standard Unicode
+// categories, with search keywords. Custom (instance) emoji come from the API
+// and are presented as a separate "Custom" tab in the picker.
+
+export interface SystemEmoji {
+  char: string
+  name: string
+  keywords: string[]
+}
+
+export interface EmojiGroup {
+  id: string
+  name: string
+  // A representative glyph used as the category tab icon.
+  icon: string
+  emojis: SystemEmoji[]
+}
+
+export const EMOJI_GROUPS: EmojiGroup[] = [
+  {
+    id: 'smileys',
+    name: 'Smileys & Emotion',
+    icon: '😀',
+    emojis: [
+      {
+        char: '😀',
+        name: 'grinning face',
+        keywords: ['smile', 'happy', 'grin']
+      },
+      {
+        char: '😃',
+        name: 'grinning face with big eyes',
+        keywords: ['happy', 'smile']
+      },
+      {
+        char: '😄',
+        name: 'grinning face with smiling eyes',
+        keywords: ['happy', 'laugh']
+      },
+      { char: '😁', name: 'beaming face', keywords: ['grin', 'smile'] },
+      {
+        char: '😆',
+        name: 'grinning squinting face',
+        keywords: ['laugh', 'haha']
+      },
+      {
+        char: '😅',
+        name: 'grinning face with sweat',
+        keywords: ['relief', 'laugh']
+      },
+      {
+        char: '🤣',
+        name: 'rolling on the floor laughing',
+        keywords: ['rofl', 'lol']
+      },
+      {
+        char: '😂',
+        name: 'face with tears of joy',
+        keywords: ['joy', 'lol', 'cry']
+      },
+      { char: '🙂', name: 'slightly smiling face', keywords: ['smile'] },
+      { char: '🙃', name: 'upside-down face', keywords: ['silly', 'sarcasm'] },
+      { char: '😉', name: 'winking face', keywords: ['wink', 'flirt'] },
+      {
+        char: '😊',
+        name: 'smiling face with smiling eyes',
+        keywords: ['blush', 'happy']
+      },
+      {
+        char: '😇',
+        name: 'smiling face with halo',
+        keywords: ['angel', 'innocent']
+      },
+      {
+        char: '🥰',
+        name: 'smiling face with hearts',
+        keywords: ['love', 'adore']
+      },
+      {
+        char: '😍',
+        name: 'smiling face with heart-eyes',
+        keywords: ['love', 'crush']
+      },
+      { char: '😘', name: 'face blowing a kiss', keywords: ['kiss', 'love'] },
+      { char: '😋', name: 'face savoring food', keywords: ['yum', 'tasty'] },
+      {
+        char: '😜',
+        name: 'winking face with tongue',
+        keywords: ['silly', 'tongue']
+      },
+      { char: '🤪', name: 'zany face', keywords: ['crazy', 'silly'] },
+      { char: '🤗', name: 'hugging face', keywords: ['hug'] },
+      { char: '🤔', name: 'thinking face', keywords: ['think', 'hmm'] },
+      { char: '😐', name: 'neutral face', keywords: ['meh', 'neutral'] },
+      {
+        char: '😴',
+        name: 'sleeping face',
+        keywords: ['sleep', 'tired', 'zzz']
+      },
+      {
+        char: '😎',
+        name: 'smiling face with sunglasses',
+        keywords: ['cool', 'sunglasses']
+      },
+      { char: '🥳', name: 'partying face', keywords: ['party', 'celebrate'] },
+      {
+        char: '😭',
+        name: 'loudly crying face',
+        keywords: ['cry', 'sad', 'tears']
+      },
+      {
+        char: '😱',
+        name: 'face screaming in fear',
+        keywords: ['scream', 'shock']
+      },
+      { char: '😡', name: 'enraged face', keywords: ['angry', 'mad'] },
+      { char: '🤯', name: 'exploding head', keywords: ['mind blown', 'shock'] },
+      { char: '🥺', name: 'pleading face', keywords: ['puppy eyes', 'please'] }
+    ]
+  },
+  {
+    id: 'people',
+    name: 'People & Body',
+    icon: '👍',
+    emojis: [
+      { char: '👍', name: 'thumbs up', keywords: ['like', 'approve', 'yes'] },
+      { char: '👎', name: 'thumbs down', keywords: ['dislike', 'no'] },
+      { char: '👏', name: 'clapping hands', keywords: ['clap', 'applause'] },
+      { char: '🙌', name: 'raising hands', keywords: ['celebrate', 'praise'] },
+      {
+        char: '🙏',
+        name: 'folded hands',
+        keywords: ['thanks', 'please', 'pray']
+      },
+      { char: '👋', name: 'waving hand', keywords: ['hello', 'hi', 'bye'] },
+      { char: '🤝', name: 'handshake', keywords: ['deal', 'agree'] },
+      { char: '✌️', name: 'victory hand', keywords: ['peace'] },
+      { char: '🤞', name: 'crossed fingers', keywords: ['luck', 'hope'] },
+      { char: '💪', name: 'flexed biceps', keywords: ['strong', 'muscle'] },
+      { char: '🫶', name: 'heart hands', keywords: ['love', 'heart'] },
+      { char: '👀', name: 'eyes', keywords: ['look', 'see', 'watch'] },
+      { char: '🧠', name: 'brain', keywords: ['smart', 'think'] },
+      { char: '👶', name: 'baby', keywords: ['child', 'infant'] },
+      {
+        char: '🧑‍💻',
+        name: 'technologist',
+        keywords: ['developer', 'coder', 'work']
+      }
+    ]
+  },
+  {
+    id: 'nature',
+    name: 'Animals & Nature',
+    icon: '🐱',
+    emojis: [
+      { char: '🐶', name: 'dog face', keywords: ['dog', 'puppy', 'pet'] },
+      { char: '🐱', name: 'cat face', keywords: ['cat', 'kitten', 'pet'] },
+      { char: '🦊', name: 'fox', keywords: ['fox'] },
+      { char: '🐻', name: 'bear', keywords: ['bear'] },
+      { char: '🐼', name: 'panda', keywords: ['panda'] },
+      { char: '🐨', name: 'koala', keywords: ['koala'] },
+      { char: '🦁', name: 'lion', keywords: ['lion'] },
+      { char: '🐮', name: 'cow face', keywords: ['cow'] },
+      { char: '🐷', name: 'pig face', keywords: ['pig'] },
+      { char: '🐸', name: 'frog', keywords: ['frog'] },
+      { char: '🐵', name: 'monkey face', keywords: ['monkey'] },
+      { char: '🦄', name: 'unicorn', keywords: ['unicorn', 'magic'] },
+      { char: '🐝', name: 'honeybee', keywords: ['bee', 'bug'] },
+      { char: '🦋', name: 'butterfly', keywords: ['butterfly'] },
+      { char: '🌸', name: 'cherry blossom', keywords: ['flower', 'spring'] },
+      { char: '🌹', name: 'rose', keywords: ['flower', 'love'] },
+      { char: '🌳', name: 'deciduous tree', keywords: ['tree', 'nature'] },
+      { char: '🌞', name: 'sun with face', keywords: ['sun', 'sunny'] },
+      { char: '🌙', name: 'crescent moon', keywords: ['moon', 'night'] },
+      { char: '⭐', name: 'star', keywords: ['star'] },
+      { char: '🔥', name: 'fire', keywords: ['fire', 'lit', 'hot'] },
+      { char: '🌈', name: 'rainbow', keywords: ['rainbow', 'pride'] }
+    ]
+  },
+  {
+    id: 'food',
+    name: 'Food & Drink',
+    icon: '🍕',
+    emojis: [
+      { char: '🍎', name: 'red apple', keywords: ['apple', 'fruit'] },
+      { char: '🍌', name: 'banana', keywords: ['banana', 'fruit'] },
+      { char: '🍓', name: 'strawberry', keywords: ['strawberry', 'fruit'] },
+      { char: '🍉', name: 'watermelon', keywords: ['watermelon', 'fruit'] },
+      { char: '🍕', name: 'pizza', keywords: ['pizza', 'food'] },
+      { char: '🍔', name: 'hamburger', keywords: ['burger', 'food'] },
+      { char: '🍟', name: 'french fries', keywords: ['fries', 'food'] },
+      { char: '🌮', name: 'taco', keywords: ['taco', 'food'] },
+      { char: '🍣', name: 'sushi', keywords: ['sushi', 'food'] },
+      { char: '🍜', name: 'steaming bowl', keywords: ['noodles', 'ramen'] },
+      { char: '🍰', name: 'shortcake', keywords: ['cake', 'dessert'] },
+      { char: '🎂', name: 'birthday cake', keywords: ['cake', 'birthday'] },
+      { char: '🍪', name: 'cookie', keywords: ['cookie', 'dessert'] },
+      { char: '☕', name: 'hot beverage', keywords: ['coffee', 'tea'] },
+      { char: '🍺', name: 'beer mug', keywords: ['beer', 'drink'] },
+      { char: '🍷', name: 'wine glass', keywords: ['wine', 'drink'] }
+    ]
+  },
+  {
+    id: 'activities',
+    name: 'Activities',
+    icon: '⚽',
+    emojis: [
+      {
+        char: '⚽',
+        name: 'soccer ball',
+        keywords: ['football', 'soccer', 'sport']
+      },
+      { char: '🏀', name: 'basketball', keywords: ['basketball', 'sport'] },
+      {
+        char: '🏈',
+        name: 'american football',
+        keywords: ['football', 'sport']
+      },
+      { char: '🎾', name: 'tennis', keywords: ['tennis', 'sport'] },
+      { char: '🏃', name: 'person running', keywords: ['run', 'exercise'] },
+      {
+        char: '🚴',
+        name: 'person biking',
+        keywords: ['bike', 'cycle', 'exercise']
+      },
+      { char: '🏆', name: 'trophy', keywords: ['win', 'award', 'champion'] },
+      { char: '🥇', name: 'first place medal', keywords: ['gold', 'win'] },
+      {
+        char: '🎉',
+        name: 'party popper',
+        keywords: ['party', 'celebrate', 'tada']
+      },
+      { char: '🎊', name: 'confetti ball', keywords: ['party', 'celebrate'] },
+      { char: '🎮', name: 'video game', keywords: ['game', 'gaming'] },
+      { char: '🎵', name: 'musical note', keywords: ['music', 'song'] },
+      { char: '🎨', name: 'artist palette', keywords: ['art', 'paint'] }
+    ]
+  },
+  {
+    id: 'travel',
+    name: 'Travel & Places',
+    icon: '✈️',
+    emojis: [
+      { char: '🚗', name: 'car', keywords: ['car', 'drive'] },
+      { char: '✈️', name: 'airplane', keywords: ['plane', 'flight', 'travel'] },
+      { char: '🚀', name: 'rocket', keywords: ['rocket', 'launch', 'space'] },
+      { char: '🚲', name: 'bicycle', keywords: ['bike', 'cycle'] },
+      { char: '🏔️', name: 'snow-capped mountain', keywords: ['mountain'] },
+      {
+        char: '🏖️',
+        name: 'beach with umbrella',
+        keywords: ['beach', 'vacation']
+      },
+      {
+        char: '🌍',
+        name: 'globe showing Europe-Africa',
+        keywords: ['earth', 'world']
+      },
+      { char: '🗺️', name: 'world map', keywords: ['map', 'travel'] },
+      { char: '🏠', name: 'house', keywords: ['home', 'house'] },
+      { char: '🏙️', name: 'cityscape', keywords: ['city'] }
+    ]
+  },
+  {
+    id: 'objects',
+    name: 'Objects',
+    icon: '💡',
+    emojis: [
+      { char: '💡', name: 'light bulb', keywords: ['idea', 'light'] },
+      { char: '📱', name: 'mobile phone', keywords: ['phone', 'mobile'] },
+      { char: '💻', name: 'laptop', keywords: ['computer', 'laptop'] },
+      { char: '⌨️', name: 'keyboard', keywords: ['keyboard', 'type'] },
+      { char: '📷', name: 'camera', keywords: ['camera', 'photo'] },
+      { char: '🔔', name: 'bell', keywords: ['notification', 'alert'] },
+      { char: '🔒', name: 'locked', keywords: ['lock', 'secure', 'private'] },
+      { char: '🔑', name: 'key', keywords: ['key', 'password'] },
+      { char: '📌', name: 'pushpin', keywords: ['pin', 'location'] },
+      { char: '📎', name: 'paperclip', keywords: ['clip', 'attach'] },
+      { char: '✏️', name: 'pencil', keywords: ['write', 'edit'] },
+      { char: '📚', name: 'books', keywords: ['book', 'read'] },
+      { char: '💰', name: 'money bag', keywords: ['money', 'cash'] },
+      { char: '🎁', name: 'wrapped gift', keywords: ['gift', 'present'] }
+    ]
+  },
+  {
+    id: 'symbols',
+    name: 'Symbols',
+    icon: '❤️',
+    emojis: [
+      { char: '❤️', name: 'red heart', keywords: ['love', 'heart'] },
+      { char: '🧡', name: 'orange heart', keywords: ['heart'] },
+      { char: '💛', name: 'yellow heart', keywords: ['heart'] },
+      { char: '💚', name: 'green heart', keywords: ['heart'] },
+      { char: '💙', name: 'blue heart', keywords: ['heart'] },
+      { char: '💜', name: 'purple heart', keywords: ['heart'] },
+      { char: '🖤', name: 'black heart', keywords: ['heart'] },
+      { char: '💔', name: 'broken heart', keywords: ['heartbreak', 'sad'] },
+      { char: '✨', name: 'sparkles', keywords: ['shiny', 'magic', 'new'] },
+      { char: '⭐', name: 'star', keywords: ['star', 'favorite'] },
+      {
+        char: '✅',
+        name: 'check mark button',
+        keywords: ['check', 'done', 'yes']
+      },
+      { char: '❌', name: 'cross mark', keywords: ['x', 'no', 'wrong'] },
+      { char: '❓', name: 'question mark', keywords: ['question'] },
+      {
+        char: '❗',
+        name: 'exclamation mark',
+        keywords: ['important', 'warning']
+      },
+      { char: '💯', name: 'hundred points', keywords: ['100', 'perfect'] }
+    ]
+  }
+]
+
+let allSystemEmojis: SystemEmoji[] | null = null
+export const getAllSystemEmojis = (): SystemEmoji[] => {
+  if (!allSystemEmojis) {
+    allSystemEmojis = EMOJI_GROUPS.flatMap((group) => group.emojis)
+  }
+  return allSystemEmojis
+}
+
+export const searchSystemEmojis = (query: string): SystemEmoji[] => {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return []
+  return getAllSystemEmojis().filter(
+    (emoji) =>
+      emoji.name.includes(normalized) ||
+      emoji.keywords.some((keyword) => keyword.includes(normalized))
+  )
+}

--- a/lib/components/post-box/emoji-picker-button.test.tsx
+++ b/lib/components/post-box/emoji-picker-button.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
+
+import { EmojiPickerButton } from './emoji-picker-button'
+
+const customEmojis: CustomEmoji[] = [
+  {
+    shortcode: 'blobcat',
+    url: 'https://example.com/blobcat.png',
+    static_url: 'https://example.com/blobcat.png',
+    visible_in_picker: true,
+    category: null
+  }
+]
+
+describe('EmojiPickerButton', () => {
+  it('inserts the :shortcode: token when a custom emoji is picked', () => {
+    const onSelect = jest.fn()
+    render(
+      <EmojiPickerButton customEmojis={customEmojis} onSelect={onSelect} />
+    )
+
+    fireEvent.click(screen.getByLabelText('Add emoji or sticker'))
+    // The Custom tab is the default when custom emoji exist.
+    fireEvent.click(screen.getByLabelText('Insert :blobcat:'))
+
+    expect(onSelect).toHaveBeenCalledWith(':blobcat: ')
+  })
+
+  it('inserts the unicode character when a system emoji is picked', () => {
+    const onSelect = jest.fn()
+    render(<EmojiPickerButton customEmojis={[]} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByLabelText('Add emoji or sticker'))
+    // Search surfaces system emoji across all groups.
+    fireEvent.change(screen.getByLabelText('Search emoji and stickers'), {
+      target: { value: 'grinning face' }
+    })
+    fireEvent.click(screen.getByLabelText('Insert grinning face'))
+
+    expect(onSelect).toHaveBeenCalledWith('😀')
+  })
+
+  it('closes on Escape', () => {
+    render(<EmojiPickerButton customEmojis={[]} onSelect={jest.fn()} />)
+    fireEvent.click(screen.getByLabelText('Add emoji or sticker'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/lib/components/post-box/emoji-picker-button.tsx
+++ b/lib/components/post-box/emoji-picker-button.tsx
@@ -197,7 +197,7 @@ export const EmojiPickerButton: FC<Props> = ({
                       aria-label={entry.name}
                       aria-pressed={active}
                       className={cn(
-                        'inline-flex size-8 shrink-0 items-center justify-center rounded-md transition-colors',
+                        'inline-flex size-8 shrink-0 items-center justify-center rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                         active
                           ? 'bg-primary/10 text-primary'
                           : 'text-muted-foreground hover:bg-muted'
@@ -240,7 +240,7 @@ export const EmojiPickerButton: FC<Props> = ({
                           ? `Insert ${item.label}`
                           : `Insert ${item.name}`
                       }
-                      className="inline-flex aspect-square w-full items-center justify-center rounded-md transition-colors hover:bg-muted"
+                      className="inline-flex aspect-square w-full items-center justify-center rounded-md transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <ItemGlyph item={item} />
                     </button>

--- a/lib/components/post-box/emoji-picker-button.tsx
+++ b/lib/components/post-box/emoji-picker-button.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { Search, Smile, Sticker } from 'lucide-react'
+import { FC, useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
+import { cn } from '@/lib/utils'
+
+import { EMOJI_GROUPS, SystemEmoji, searchSystemEmojis } from './emoji-data'
+
+// A picker item normalizes the two kinds (custom sticker image vs. unicode
+// glyph) into one shape for the grid + preview. `insert` is the text inserted at
+// the caret on select: `:shortcode: ` for custom emoji, the character for
+// system emoji.
+type PickerItem =
+  | {
+      kind: 'custom'
+      key: string
+      name: string
+      label: string
+      insert: string
+      url: string
+    }
+  | {
+      kind: 'system'
+      key: string
+      name: string
+      label: string
+      insert: string
+      char: string
+    }
+
+const customItem = (emoji: CustomEmoji): PickerItem => ({
+  kind: 'custom',
+  key: `c:${emoji.shortcode}`,
+  name: emoji.shortcode,
+  label: `:${emoji.shortcode}:`,
+  insert: `:${emoji.shortcode}: `,
+  url: emoji.url
+})
+
+const systemItem = (emoji: SystemEmoji): PickerItem => ({
+  kind: 'system',
+  key: `s:${emoji.char}`,
+  name: emoji.name,
+  label: 'emoji',
+  insert: emoji.char,
+  char: emoji.char
+})
+
+const ItemGlyph: FC<{ item: PickerItem; size?: number }> = ({
+  item,
+  size = 26
+}) =>
+  item.kind === 'custom' ? (
+    <img
+      src={item.url}
+      alt={item.label}
+      className="object-contain"
+      style={{ width: size, height: size }}
+    />
+  ) : (
+    <span style={{ fontSize: Math.round(size * 0.92), lineHeight: 1 }}>
+      {item.char}
+    </span>
+  )
+
+interface Props {
+  customEmojis: CustomEmoji[]
+  onSelect: (insertText: string) => void
+  disabled?: boolean
+}
+
+export const EmojiPickerButton: FC<Props> = ({
+  customEmojis,
+  onSelect,
+  disabled
+}) => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [hover, setHover] = useState<PickerItem | null>(null)
+
+  const hasCustom = customEmojis.length > 0
+  const tabs = useMemo(
+    () => [
+      ...(hasCustom
+        ? [
+            {
+              id: 'custom',
+              name: 'Custom',
+              kind: 'icon' as const,
+              icon: Sticker
+            }
+          ]
+        : []),
+      ...EMOJI_GROUPS.map((group) => ({
+        id: group.id,
+        name: group.name,
+        kind: 'emoji' as const,
+        glyph: group.icon
+      }))
+    ],
+    [hasCustom]
+  )
+  const [tab, setTab] = useState(hasCustom ? 'custom' : EMOJI_GROUPS[0].id)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const items = useMemo<PickerItem[]>(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (trimmed) {
+      const customMatches = customEmojis
+        .filter((emoji) => emoji.shortcode.toLowerCase().includes(trimmed))
+        .map(customItem)
+      const systemMatches = searchSystemEmojis(trimmed).map(systemItem)
+      return [...customMatches, ...systemMatches]
+    }
+    if (tab === 'custom') return customEmojis.map(customItem)
+    const group = EMOJI_GROUPS.find((candidate) => candidate.id === tab)
+    return group ? group.emojis.map(systemItem) : []
+  }, [query, tab, customEmojis])
+
+  const preview = hover ?? items[0] ?? null
+
+  const pick = (item: PickerItem) => {
+    onSelect(item.insert)
+    setOpen(false)
+    setQuery('')
+  }
+
+  return (
+    <div className="relative inline-block">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        disabled={disabled}
+        aria-label="Add emoji or sticker"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title="Add emoji or sticker"
+        className={cn(
+          open
+            ? 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <Smile className="size-4" />
+      </Button>
+
+      {open ? (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            aria-hidden
+            onClick={() => setOpen(false)}
+          />
+          <div
+            role="dialog"
+            aria-label="Emoji and sticker picker"
+            className="absolute left-0 top-full z-50 mt-2 w-80 overflow-hidden rounded-xl border bg-background shadow-lg"
+          >
+            <div className="border-b p-2.5">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  autoFocus
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search emoji & stickers"
+                  aria-label="Search emoji and stickers"
+                  className="h-9 pl-8"
+                />
+              </div>
+            </div>
+
+            {!query.trim() ? (
+              <div className="no-scrollbar flex items-center gap-0.5 overflow-x-auto px-2 pt-1.5">
+                {tabs.map((entry) => {
+                  const active = entry.id === tab
+                  return (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      onClick={() => setTab(entry.id)}
+                      title={entry.name}
+                      aria-label={entry.name}
+                      aria-pressed={active}
+                      className={cn(
+                        'inline-flex size-8 shrink-0 items-center justify-center rounded-md transition-colors',
+                        active
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:bg-muted'
+                      )}
+                    >
+                      {entry.kind === 'icon' ? (
+                        <entry.icon className="size-4" />
+                      ) : (
+                        <span style={{ fontSize: 18, lineHeight: 1 }}>
+                          {entry.glyph}
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+            ) : null}
+
+            <div className="max-h-[220px] overflow-y-auto px-2 py-2">
+              {items.length === 0 ? (
+                <p className="py-6 text-center text-sm text-muted-foreground">
+                  {query.trim()
+                    ? `Nothing matches “${query.trim()}”`
+                    : tab === 'custom'
+                      ? 'No custom emoji on this instance yet.'
+                      : 'Nothing here yet'}
+                </p>
+              ) : (
+                <div className="grid grid-cols-7 gap-1">
+                  {items.map((item) => (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onMouseEnter={() => setHover(item)}
+                      onFocus={() => setHover(item)}
+                      onClick={() => pick(item)}
+                      title={item.kind === 'custom' ? item.label : item.name}
+                      aria-label={
+                        item.kind === 'custom'
+                          ? `Insert ${item.label}`
+                          : `Insert ${item.name}`
+                      }
+                      className="inline-flex aspect-square w-full items-center justify-center rounded-md transition-colors hover:bg-muted"
+                    >
+                      <ItemGlyph item={item} />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex h-11 items-center gap-2 border-t px-3">
+              {preview ? (
+                <>
+                  <ItemGlyph item={preview} size={22} />
+                  <span className="truncate text-sm font-medium">
+                    {preview.name}
+                  </span>
+                  <span className="ml-auto font-mono text-xs text-muted-foreground">
+                    {preview.label}
+                  </span>
+                </>
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  Pick an emoji or sticker
+                </span>
+              )}
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -4,7 +4,12 @@
 import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-import { createNote, updateNote, uploadAttachment } from '@/lib/client'
+import {
+  createNote,
+  getCustomEmojis,
+  updateNote,
+  uploadAttachment
+} from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { EditableStatus, StatusType } from '@/lib/types/domain/status'
@@ -15,6 +20,7 @@ jest.mock('@/lib/client', () => ({
   createNote: jest.fn(),
   createPoll: jest.fn(),
   deleteFitnessFile: jest.fn(),
+  getCustomEmojis: jest.fn().mockResolvedValue([]),
   updateNote: jest.fn(),
   uploadAttachment: jest.fn(),
   uploadFitnessFile: jest.fn()
@@ -956,7 +962,17 @@ describe('PostBox markdown preview', () => {
     jest.clearAllMocks()
   })
 
-  it('passes remarkGfm and remarkBreaks plugins to the preview renderer', async () => {
+  it('renders custom emoji shortcodes as inline images in the preview', async () => {
+    ;(getCustomEmojis as jest.Mock).mockResolvedValueOnce([
+      {
+        shortcode: 'blobcat',
+        url: 'https://activities.local/emojis/blobcat.png',
+        static_url: 'https://activities.local/emojis/blobcat.png',
+        visible_in_picker: true,
+        category: null
+      }
+    ])
+
     render(
       <PostBox
         host="activities.local"
@@ -969,24 +985,13 @@ describe('PostBox markdown preview', () => {
     )
 
     const textarea = screen.getByPlaceholderText('What is on your mind?')
-    fireEvent.change(textarea, { target: { value: '~~strikethrough~~' } })
-
+    fireEvent.change(textarea, { target: { value: 'hi :blobcat:' } })
     fireEvent.click(screen.getByRole('button', { name: 'Toggle preview' }))
 
-    const mockRemarkGfm = jest.requireMock('remark-gfm').default
-    const mockRemarkBreaks = jest.requireMock('remark-breaks').default
-
-    await waitFor(() => {
-      expect(mockReactMarkdown).toHaveBeenCalled()
-    })
-
-    const plugins =
-      mockReactMarkdown.mock.calls[mockReactMarkdown.mock.calls.length - 1][0]
-        .remarkPlugins ?? []
-    expect(plugins).toContain(mockRemarkGfm)
-    expect(plugins).toContain(mockRemarkBreaks)
-    expect(plugins.indexOf(mockRemarkGfm)).toBeLessThan(
-      plugins.indexOf(mockRemarkBreaks)
+    const image = await screen.findByAltText(':blobcat:')
+    expect(image).toHaveAttribute(
+      'src',
+      'https://activities.local/emojis/blobcat.png'
     )
   })
 
@@ -1005,6 +1010,5 @@ describe('PostBox markdown preview', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Toggle preview' }))
 
     expect(screen.getByText('Nothing to preview')).toBeInTheDocument()
-    expect(mockReactMarkdown).not.toHaveBeenCalled()
   })
 })

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -345,16 +345,19 @@ export const PostBox: FC<Props> = ({
   // so the live preview renders custom emoji through the exact same
   // convertEmojisToImages pipeline the rendered Post uses. The synthetic ids are
   // preview-only and never persisted.
-  const buildSyntheticEmojiTags = (value: string): Tag[] =>
-    getEmojiTags(value, customEmojis).map((emojiTag, index) => ({
-      id: `preview-${index}`,
-      statusId: 'preview',
-      type: 'emoji' as const,
-      name: emojiTag.name,
-      value: emojiTag.value,
-      createdAt: 0,
-      updatedAt: 0
-    }))
+  const buildSyntheticEmojiTags = useCallback(
+    (value: string): Tag[] =>
+      getEmojiTags(value, customEmojis).map((emojiTag, index) => ({
+        id: `preview-${index}`,
+        statusId: 'preview',
+        type: 'emoji' as const,
+        name: emojiTag.name,
+        value: emojiTag.value,
+        createdAt: 0,
+        updatedAt: 0
+      })),
+    [customEmojis]
+  )
 
   // Inserts text at the caret of the message textarea (used by the emoji/sticker
   // picker). Falls back to appending when the textarea ref is unavailable.

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -16,15 +16,12 @@ import {
   useRef,
   useState
 } from 'react'
-import ReactMarkdown from 'react-markdown'
-import rehypeSanitize from 'rehype-sanitize'
-import remarkBreaks from 'remark-breaks'
-import remarkGfm from 'remark-gfm'
 
 import {
   createNote,
   createPoll,
   deleteFitnessFile,
+  getCustomEmojis,
   updateNote,
   uploadAttachment,
   uploadFitnessFile
@@ -47,11 +44,16 @@ import {
   StatusNote,
   StatusType
 } from '@/lib/types/domain/status'
+import { Tag } from '@/lib/types/domain/tag'
+import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import { cn } from '@/lib/utils'
 import { formatFileSize } from '@/lib/utils/formatFileSize'
 import { getVisibility } from '@/lib/utils/getVisibility'
-import { SANITIZED_OPTION } from '@/lib/utils/text/sanitizeText'
+import { cleanClassName } from '@/lib/utils/text/cleanClassName'
+import { getEmojiTags } from '@/lib/utils/text/getEmojiTags'
+import { processStatusTextContent } from '@/lib/utils/text/processStatusText'
 
+import { EmojiPickerButton } from './emoji-picker-button'
 import { Duration, PollChoices } from './poll-choices'
 import {
   DEFAULT_STATE,
@@ -327,6 +329,52 @@ export const PostBox: FC<Props> = ({
   useEffect(() => {
     textRef.current = text
   }, [text])
+
+  const [customEmojis, setCustomEmojis] = useState<CustomEmoji[]>([])
+  useEffect(() => {
+    let active = true
+    getCustomEmojis().then((emojis) => {
+      if (active) setCustomEmojis(emojis)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  // Synthesizes emoji domain tags from the shortcodes present in the draft text
+  // so the live preview renders custom emoji through the exact same
+  // convertEmojisToImages pipeline the rendered Post uses. The synthetic ids are
+  // preview-only and never persisted.
+  const buildSyntheticEmojiTags = (value: string): Tag[] =>
+    getEmojiTags(value, customEmojis).map((emojiTag, index) => ({
+      id: `preview-${index}`,
+      statusId: 'preview',
+      type: 'emoji' as const,
+      name: emojiTag.name,
+      value: emojiTag.value,
+      createdAt: 0,
+      updatedAt: 0
+    }))
+
+  // Inserts text at the caret of the message textarea (used by the emoji/sticker
+  // picker). Falls back to appending when the textarea ref is unavailable.
+  const insertAtCaret = (snippet: string) => {
+    const textarea = postBoxRef.current
+    const current = textRef.current
+    if (!textarea) {
+      onTextChange(`${current}${snippet}`)
+      return
+    }
+    const start = textarea.selectionStart ?? current.length
+    const end = textarea.selectionEnd ?? current.length
+    const next = current.slice(0, start) + snippet + current.slice(end)
+    onTextChange(next)
+    const caret = start + snippet.length
+    requestAnimationFrame(() => {
+      textarea.focus()
+      textarea.setSelectionRange(caret, caret)
+    })
+  }
 
   const isEditDirty = (
     value = textRef.current,
@@ -912,20 +960,14 @@ export const PostBox: FC<Props> = ({
                 </div>
                 {text ? (
                   <div className="markdown-content max-w-none text-sm">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm, remarkBreaks]}
-                      rehypePlugins={[
-                        [
-                          rehypeSanitize,
-                          {
-                            tagNames: SANITIZED_OPTION.allowedTags,
-                            attributes: SANITIZED_OPTION.allowedAttributes
-                          }
-                        ]
-                      ]}
-                    >
-                      {text}
-                    </ReactMarkdown>
+                    {cleanClassName(
+                      processStatusTextContent(
+                        host,
+                        text,
+                        buildSyntheticEmojiTags(text),
+                        true
+                      )
+                    )}
                   </div>
                 ) : (
                   <p className="text-sm text-muted-foreground">
@@ -1011,6 +1053,11 @@ export const PostBox: FC<Props> = ({
                 onError={(message) => setWarningMsg(message)}
               />
             ) : null}
+            <EmojiPickerButton
+              customEmojis={customEmojis}
+              onSelect={insertAtCaret}
+              disabled={isPosting}
+            />
             <Button
               type="button"
               variant="ghost"

--- a/lib/database/sql/customEmoji.test.ts
+++ b/lib/database/sql/customEmoji.test.ts
@@ -1,0 +1,113 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
+describe('CustomEmojiSQLDatabaseMixin', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  it('creates a custom emoji with defaults and reads it back', async () => {
+    const created = await database.createCustomEmoji({
+      shortcode: 'blobcat',
+      url: 'https://example.com/emojis/blobcat.png',
+      staticUrl: 'https://example.com/emojis/blobcat.png'
+    })
+    expect(created).toMatchObject({
+      shortcode: 'blobcat',
+      url: 'https://example.com/emojis/blobcat.png',
+      staticUrl: 'https://example.com/emojis/blobcat.png',
+      category: null,
+      visibleInPicker: true,
+      disabled: false
+    })
+    expect(created.id).toEqual(expect.any(String))
+    expect(created.createdAt).toEqual(expect.any(Number))
+
+    const byId = await database.getCustomEmojiById(created.id)
+    expect(byId?.shortcode).toBe('blobcat')
+
+    const byShortcode = await database.getCustomEmojiByShortcode('blobcat')
+    expect(byShortcode?.id).toBe(created.id)
+  })
+
+  it('returns null for a missing emoji', async () => {
+    expect(await database.getCustomEmojiById('missing')).toBeNull()
+    expect(await database.getCustomEmojiByShortcode('missing')).toBeNull()
+  })
+
+  it('omits disabled emoji unless includeDisabled is set', async () => {
+    await database.createCustomEmoji({
+      shortcode: 'enabled_one',
+      url: 'https://example.com/emojis/enabled.png',
+      staticUrl: 'https://example.com/emojis/enabled.png'
+    })
+    const disabled = await database.createCustomEmoji({
+      shortcode: 'disabled_one',
+      url: 'https://example.com/emojis/disabled.png',
+      staticUrl: 'https://example.com/emojis/disabled.png',
+      disabled: true
+    })
+
+    const enabledOnly = await database.getCustomEmojis()
+    expect(enabledOnly.map((emoji) => emoji.shortcode)).toContain('enabled_one')
+    expect(enabledOnly.map((emoji) => emoji.shortcode)).not.toContain(
+      'disabled_one'
+    )
+
+    const all = await database.getCustomEmojis({ includeDisabled: true })
+    expect(all.map((emoji) => emoji.shortcode)).toContain('disabled_one')
+    expect(all.find((emoji) => emoji.id === disabled.id)?.disabled).toBe(true)
+  })
+
+  it('updates category, visibility, and disabled flags', async () => {
+    const created = await database.createCustomEmoji({
+      shortcode: 'updatable',
+      url: 'https://example.com/emojis/updatable.png',
+      staticUrl: 'https://example.com/emojis/updatable.png'
+    })
+
+    const updated = await database.updateCustomEmoji({
+      id: created.id,
+      category: 'cats',
+      visibleInPicker: false,
+      disabled: true
+    })
+    expect(updated).toMatchObject({
+      category: 'cats',
+      visibleInPicker: false,
+      disabled: true
+    })
+
+    // An unrelated update leaves the category untouched.
+    const reEnabled = await database.updateCustomEmoji({
+      id: created.id,
+      disabled: false
+    })
+    expect(reEnabled?.category).toBe('cats')
+    expect(reEnabled?.disabled).toBe(false)
+  })
+
+  it('returns null when updating a missing emoji', async () => {
+    expect(
+      await database.updateCustomEmoji({ id: 'missing', disabled: true })
+    ).toBeNull()
+  })
+
+  it('deletes an emoji and returns the removed row', async () => {
+    const created = await database.createCustomEmoji({
+      shortcode: 'deletable',
+      url: 'https://example.com/emojis/deletable.png',
+      staticUrl: 'https://example.com/emojis/deletable.png'
+    })
+
+    const deleted = await database.deleteCustomEmoji(created.id)
+    expect(deleted?.id).toBe(created.id)
+    expect(await database.getCustomEmojiById(created.id)).toBeNull()
+    expect(await database.deleteCustomEmoji(created.id)).toBeNull()
+  })
+})

--- a/lib/database/sql/customEmoji.ts
+++ b/lib/database/sql/customEmoji.ts
@@ -1,0 +1,108 @@
+import crypto from 'crypto'
+import { Knex } from 'knex'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  CreateCustomEmojiParams,
+  CustomEmojiDatabase,
+  GetCustomEmojisParams,
+  UpdateCustomEmojiParams
+} from '@/lib/types/database/operations'
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
+
+interface SQLCustomEmoji {
+  id: string
+  shortcode: string
+  url: string
+  staticUrl: string
+  category: string | null
+  visibleInPicker: boolean | number
+  disabled: boolean | number
+  createdAt: number | Date
+  updatedAt: number | Date
+}
+
+const toCustomEmojiData = (row: SQLCustomEmoji): CustomEmojiData =>
+  CustomEmojiData.parse({
+    id: row.id,
+    shortcode: row.shortcode,
+    url: row.url,
+    staticUrl: row.staticUrl,
+    category: row.category ?? null,
+    visibleInPicker: Boolean(row.visibleInPicker),
+    disabled: Boolean(row.disabled),
+    createdAt: getCompatibleTime(row.createdAt),
+    updatedAt: getCompatibleTime(row.updatedAt)
+  })
+
+export const CustomEmojiSQLDatabaseMixin = (
+  database: Knex
+): CustomEmojiDatabase => ({
+  async createCustomEmoji(params: CreateCustomEmojiParams) {
+    const currentTime = new Date()
+    const id = crypto.randomUUID()
+    await database('customEmojis').insert({
+      id,
+      shortcode: params.shortcode,
+      url: params.url,
+      staticUrl: params.staticUrl,
+      category: params.category ?? null,
+      visibleInPicker: params.visibleInPicker ?? true,
+      disabled: params.disabled ?? false,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+
+    const created = await this.getCustomEmojiById(id)
+    if (!created) throw new Error('Failed to create custom emoji')
+    return created
+  },
+
+  async getCustomEmojis(params?: GetCustomEmojisParams) {
+    const query = database<SQLCustomEmoji>('customEmojis')
+    if (!params?.includeDisabled) {
+      query.where('disabled', false)
+    }
+    const rows = await query.orderBy('shortcode', 'asc')
+    return rows.map(toCustomEmojiData)
+  },
+
+  async getCustomEmojiById(id: string) {
+    const row = await database<SQLCustomEmoji>('customEmojis')
+      .where('id', id)
+      .first()
+    return row ? toCustomEmojiData(row) : null
+  },
+
+  async getCustomEmojiByShortcode(shortcode: string) {
+    const row = await database<SQLCustomEmoji>('customEmojis')
+      .where('shortcode', shortcode)
+      .first()
+    return row ? toCustomEmojiData(row) : null
+  },
+
+  async updateCustomEmoji(params: UpdateCustomEmojiParams) {
+    const existing = await this.getCustomEmojiById(params.id)
+    if (!existing) return null
+
+    await database('customEmojis')
+      .where('id', params.id)
+      .update({
+        category:
+          params.category === undefined ? existing.category : params.category,
+        visibleInPicker: params.visibleInPicker ?? existing.visibleInPicker,
+        disabled: params.disabled ?? existing.disabled,
+        updatedAt: new Date()
+      })
+
+    return this.getCustomEmojiById(params.id)
+  },
+
+  async deleteCustomEmoji(id: string) {
+    const existing = await this.getCustomEmojiById(id)
+    if (!existing) return null
+
+    await database('customEmojis').where('id', id).delete()
+    return existing
+  }
+})

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -7,6 +7,7 @@ import { AdminSQLDatabaseMixin } from '@/lib/database/sql/admin'
 import { BlockSQLDatabaseMixin } from '@/lib/database/sql/block'
 import { BookmarkSQLDatabaseMixin } from '@/lib/database/sql/bookmark'
 import { DirectConversationSQLDatabaseMixin } from '@/lib/database/sql/conversation'
+import { CustomEmojiSQLDatabaseMixin } from '@/lib/database/sql/customEmoji'
 import { EndorsementSQLDatabaseMixin } from '@/lib/database/sql/endorsement'
 import { FilterSQLDatabaseMixin } from '@/lib/database/sql/filter'
 import { FitnessFileSQLDatabaseMixin } from '@/lib/database/sql/fitnessFile'
@@ -43,6 +44,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const fitnessSettingsDatabase = FitnessSettingsSQLDatabaseMixin(database)
   const bookmarkDatabase = BookmarkSQLDatabaseMixin(database)
   const blockDatabase = BlockSQLDatabaseMixin(database)
+  const customEmojiDatabase = CustomEmojiSQLDatabaseMixin(database)
   const markerDatabase = MarkerSQLDatabaseMixin(database)
   const muteDatabase = MuteSQLDatabaseMixin(database)
   const endorsementDatabase = EndorsementSQLDatabaseMixin(database)
@@ -98,6 +100,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...instanceActivityDatabase,
     ...bookmarkDatabase,
     ...blockDatabase,
+    ...customEmojiDatabase,
     ...markerDatabase,
     ...muteDatabase,
     ...endorsementDatabase,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -41,6 +41,7 @@ import {
   CreatePollParams,
   CreateTagParams,
   DeleteStatusParams,
+  DeleteStatusTagsByTypeParams,
   FavouritedByAccount,
   GetActorPollVotesForStatusesParams,
   GetActorPollVotesParams,
@@ -2182,6 +2183,13 @@ export const StatusSQLDatabaseMixin = (
     )
   }
 
+  async function deleteStatusTagsByType({
+    statusId,
+    type
+  }: DeleteStatusTagsByTypeParams) {
+    await database('tags').where({ statusId, type }).delete()
+  }
+
   function getHashtagLookupNames(hashtag: string): string[] {
     const bare = normalizeHashtagSearchName(hashtag)
     return bare ? [bare, `#${bare}`] : []
@@ -2903,6 +2911,7 @@ export const StatusSQLDatabaseMixin = (
     getRebloggedBy,
     createTag,
     getTags,
+    deleteStatusTagsByType,
     getStatusesByHashtag,
     getHashtagStatusesPage,
     getHashtagCounter,

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -10,6 +10,7 @@ import {
   BaseDatabase,
   BlockDatabase,
   BookmarkDatabase,
+  CustomEmojiDatabase,
   DirectConversationDatabase,
   EndorsementDatabase,
   FilterDatabase,
@@ -48,6 +49,7 @@ export type Database = AccountDatabase &
   FollowedTagDatabase &
   FilterDatabase &
   BookmarkDatabase &
+  CustomEmojiDatabase &
   DirectConversationDatabase &
   FollowDatabase &
   LikeDatabase &

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -525,6 +525,39 @@ describe('createNoteJob', () => {
     expect(hashtagTags[0].value).toEqual('https://somewhere.test/tags/testing')
   })
 
+  it('stores inbound emoji tags so remote custom emoji render locally', async () => {
+    const noteId = `https://${actor1!.domain}/notes/emoji-test-${Date.now()}`
+    const note = MockMastodonActivityPubNote({
+      id: noteId,
+      content: '<p>Hello :blobcat:</p>',
+      tags: [
+        {
+          type: 'Emoji',
+          name: ':blobcat:',
+          updated: new Date().toISOString(),
+          icon: {
+            type: 'Image',
+            mediaType: 'image/png',
+            url: 'https://somewhere.test/emojis/blobcat.png'
+          }
+        }
+      ]
+    })
+    await createNoteJob(database, {
+      id: 'id-emoji',
+      name: CREATE_NOTE_JOB_NAME,
+      data: note
+    })
+
+    const tags = await database.getTags({ statusId: noteId })
+    const emojiTags = tags.filter((t) => t.type === 'emoji')
+    expect(emojiTags).toHaveLength(1)
+    expect(emojiTags[0].name).toEqual(':blobcat:')
+    expect(emojiTags[0].value).toEqual(
+      'https://somewhere.test/emojis/blobcat.png'
+    )
+  })
+
   it('batches hashtag search reindexing after hashtag tags are created', async () => {
     const noteId = `https://${actor1!.domain}/notes/batched-hashtag-test-${Date.now()}`
     const indexHashtagSearchDocuments = jest.spyOn(

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -7,6 +7,7 @@ import { Actor, ActorType } from '@/lib/types/domain/actor'
 import { Attachment, PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { Block } from '@/lib/types/domain/block'
 import { Bookmark } from '@/lib/types/domain/bookmark'
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
 import { Endorsement } from '@/lib/types/domain/endorsement'
 import {
   Filter,
@@ -586,6 +587,10 @@ export type CreateTagParams = {
 export type GetTagsParams = {
   statusId: string
 }
+export type DeleteStatusTagsByTypeParams = {
+  statusId: string
+  type: TagType
+}
 export type GetStatusesByHashtagParams = {
   hashtag: string
   limit?: number
@@ -692,6 +697,7 @@ export interface StatusDatabase {
   getRebloggedBy(params: GetRebloggedByParams): Promise<RebloggedByAccount[]>
   createTag(params: CreateTagParams): Promise<Tag>
   getTags(params: GetTagsParams): Promise<Tag[]>
+  deleteStatusTagsByType(params: DeleteStatusTagsByTypeParams): Promise<void>
   getStatusesByHashtag(params: GetStatusesByHashtagParams): Promise<Status[]>
   getHashtagStatusesPage(
     params: GetHashtagStatusesPageParams
@@ -2341,4 +2347,41 @@ export interface InstanceActivityDatabase {
 
 export type GetInstancePeersParams = {
   localDomain: string
+}
+
+// ============================================================================
+// Custom Emoji Database
+// ============================================================================
+
+export type CreateCustomEmojiParams = {
+  shortcode: string
+  url: string
+  staticUrl: string
+  category?: string | null
+  visibleInPicker?: boolean
+  disabled?: boolean
+}
+
+export type GetCustomEmojisParams = {
+  // When false (default) only enabled emoji are returned. The admin surface
+  // passes `true` to also list disabled emoji.
+  includeDisabled?: boolean
+}
+
+export type UpdateCustomEmojiParams = {
+  id: string
+  category?: string | null
+  visibleInPicker?: boolean
+  disabled?: boolean
+}
+
+export interface CustomEmojiDatabase {
+  createCustomEmoji(params: CreateCustomEmojiParams): Promise<CustomEmojiData>
+  getCustomEmojis(params?: GetCustomEmojisParams): Promise<CustomEmojiData[]>
+  getCustomEmojiById(id: string): Promise<CustomEmojiData | null>
+  getCustomEmojiByShortcode(shortcode: string): Promise<CustomEmojiData | null>
+  updateCustomEmoji(
+    params: UpdateCustomEmojiParams
+  ): Promise<CustomEmojiData | null>
+  deleteCustomEmoji(id: string): Promise<CustomEmojiData | null>
 }

--- a/lib/types/domain/customEmoji.ts
+++ b/lib/types/domain/customEmoji.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+import { CustomEmoji as MastodonCustomEmoji } from '@/lib/types/mastodon/customEmoji'
+
+// Shortcode without the surrounding colons. Matches Mastodon's allowed
+// characters for custom emoji shortcodes.
+export const CUSTOM_EMOJI_SHORTCODE_REGEX = /^[a-zA-Z0-9_]+$/
+
+// Instance-scoped custom emoji as stored in the `customEmojis` table. `name`
+// federation and picker rendering go through the Mastodon/ActivityPub mappers
+// below.
+export const CustomEmojiData = z.object({
+  id: z.string(),
+  shortcode: z.string(),
+  url: z.string(),
+  staticUrl: z.string(),
+  category: z.string().nullable(),
+  visibleInPicker: z.boolean(),
+  disabled: z.boolean(),
+  createdAt: z.number(),
+  updatedAt: z.number()
+})
+export type CustomEmojiData = z.infer<typeof CustomEmojiData>
+
+// Maps a stored custom emoji to the Mastodon `CustomEmoji` entity returned by
+// `GET /api/v1/custom_emojis`. See
+// https://docs.joinmastodon.org/entities/CustomEmoji/.
+export const toMastodonCustomEmoji = (
+  emoji: CustomEmojiData
+): MastodonCustomEmoji => ({
+  shortcode: emoji.shortcode,
+  url: emoji.url,
+  static_url: emoji.staticUrl,
+  visible_in_picker: emoji.visibleInPicker,
+  category: emoji.category
+})
+
+export interface AdminCustomEmoji extends MastodonCustomEmoji {
+  id: string
+  disabled: boolean
+}
+
+// Admin surface representation: the public entity plus the moderation-only `id`
+// and `disabled` fields the admin endpoints and management page need.
+export const toAdminCustomEmoji = (
+  emoji: CustomEmojiData
+): AdminCustomEmoji => ({
+  ...toMastodonCustomEmoji(emoji),
+  id: emoji.id,
+  disabled: emoji.disabled
+})

--- a/lib/types/domain/customEmoji.ts
+++ b/lib/types/domain/customEmoji.ts
@@ -2,9 +2,10 @@ import { z } from 'zod'
 
 import { CustomEmoji as MastodonCustomEmoji } from '@/lib/types/mastodon/customEmoji'
 
-// Shortcode without the surrounding colons. Matches Mastodon's allowed
-// characters for custom emoji shortcodes.
-export const CUSTOM_EMOJI_SHORTCODE_REGEX = /^[a-zA-Z0-9_]+$/
+// Shortcode without the surrounding colons. Matches Mastodon's
+// `SHORTCODE_RE_FRAGMENT` (`[a-zA-Z0-9_]{2,}`) — at least two characters — so we
+// only accept shortcodes a remote Mastodon server would also scan and render.
+export const CUSTOM_EMOJI_SHORTCODE_REGEX = /^[a-zA-Z0-9_]{2,}$/
 
 // Instance-scoped custom emoji as stored in the `customEmojis` table. `name`
 // federation and picker rendering go through the Mastodon/ActivityPub mappers

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -296,10 +296,9 @@ export const toActivityPubObject = (status: Status): Note | Question => {
       cc: status.cc,
       inReplyTo: status.reply || null,
       content: status.text,
-      tag: [
-        ...status.tags.map((tag) => getMentionFromTag(tag)),
-        ...status.tags.map((tag) => getEmojiFromTag(tag))
-      ].filter((tag) => tag !== null),
+      tag: status.tags
+        .map((tag) => getMentionFromTag(tag) ?? getEmojiFromTag(tag))
+        .filter((tag) => tag !== null),
 
       ...(status.pollType === 'anyOf'
         ? { anyOf: pollOptions }
@@ -356,10 +355,9 @@ export const toActivityPubObject = (status: Status): Note | Question => {
     attachment: originalStatus.attachments
       .filter((attachment) => !isFitnessAttachment(attachment))
       .map((attachment) => getDocumentFromAttachment(attachment)),
-    tag: [
-      ...originalStatus.tags.map((tag) => getMentionFromTag(tag)),
-      ...originalStatus.tags.map((tag) => getEmojiFromTag(tag))
-    ].filter((tag) => tag !== null),
+    tag: originalStatus.tags
+      .map((tag) => getMentionFromTag(tag) ?? getEmojiFromTag(tag))
+      .filter((tag) => tag !== null),
     replies: {
       id: `${originalStatus.id}/replies`,
       type: 'Collection',

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -17,7 +17,7 @@ import {
   isFitnessAttachment
 } from '@/lib/types/domain/attachment'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
-import { Tag, getMentionFromTag } from '@/lib/types/domain/tag'
+import { Tag, getEmojiFromTag, getMentionFromTag } from '@/lib/types/domain/tag'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 
 export const StatusType = z.enum(['Note', 'Announce', 'Poll'])
@@ -296,9 +296,10 @@ export const toActivityPubObject = (status: Status): Note | Question => {
       cc: status.cc,
       inReplyTo: status.reply || null,
       content: status.text,
-      tag: status.tags
-        .map((tag) => getMentionFromTag(tag))
-        .filter((tag) => tag !== null),
+      tag: [
+        ...status.tags.map((tag) => getMentionFromTag(tag)),
+        ...status.tags.map((tag) => getEmojiFromTag(tag))
+      ].filter((tag) => tag !== null),
 
       ...(status.pollType === 'anyOf'
         ? { anyOf: pollOptions }
@@ -355,9 +356,10 @@ export const toActivityPubObject = (status: Status): Note | Question => {
     attachment: originalStatus.attachments
       .filter((attachment) => !isFitnessAttachment(attachment))
       .map((attachment) => getDocumentFromAttachment(attachment)),
-    tag: originalStatus.tags
-      .map((tag) => getMentionFromTag(tag))
-      .filter((tag) => tag !== null),
+    tag: [
+      ...originalStatus.tags.map((tag) => getMentionFromTag(tag)),
+      ...originalStatus.tags.map((tag) => getEmojiFromTag(tag))
+    ].filter((tag) => tag !== null),
     replies: {
       id: `${originalStatus.id}/replies`,
       type: 'Collection',

--- a/lib/types/domain/tag.test.ts
+++ b/lib/types/domain/tag.test.ts
@@ -1,0 +1,86 @@
+import { getEmojiFromTag, getMentionFromTag } from '@/lib/types/domain/tag'
+
+const baseTag = {
+  id: 'tag-1',
+  statusId: 'status-1',
+  createdAt: 0,
+  updatedAt: 1700000000000
+}
+
+describe('getEmojiFromTag', () => {
+  it('converts an emoji tag into an ActivityPub Emoji object', () => {
+    const emoji = getEmojiFromTag({
+      ...baseTag,
+      type: 'emoji',
+      name: ':blobcat:',
+      value: 'https://example.com/blobcat.png'
+    })
+    expect(emoji).toEqual({
+      type: 'Emoji',
+      id: 'https://example.com/blobcat.png',
+      name: ':blobcat:',
+      updated: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+      icon: {
+        type: 'Image',
+        url: 'https://example.com/blobcat.png'
+      }
+    })
+  })
+
+  it.each([
+    { description: 'mention', type: 'mention' as const },
+    { description: 'hashtag', type: 'hashtag' as const }
+  ])('returns null for a $description tag', ({ type }) => {
+    expect(
+      getEmojiFromTag({
+        ...baseTag,
+        type,
+        name: type === 'hashtag' ? '#tag' : '@user',
+        value: 'https://example.com'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('getMentionFromTag', () => {
+  it('returns null for an emoji tag so it is not mis-serialized as a Mention', () => {
+    expect(
+      getMentionFromTag({
+        ...baseTag,
+        type: 'emoji',
+        name: ':blobcat:',
+        value: 'https://example.com/blobcat.png'
+      })
+    ).toBeNull()
+  })
+
+  it('converts a hashtag tag, prefixing the name with #', () => {
+    expect(
+      getMentionFromTag({
+        ...baseTag,
+        type: 'hashtag',
+        name: 'cats',
+        value: 'https://example.com/tags/cats'
+      })
+    ).toEqual({
+      type: 'Hashtag',
+      name: '#cats',
+      href: 'https://example.com/tags/cats'
+    })
+  })
+
+  it('converts a mention tag', () => {
+    expect(
+      getMentionFromTag({
+        ...baseTag,
+        type: 'mention',
+        name: '@user@example.com',
+        value: 'https://example.com/users/user'
+      })
+    ).toEqual({
+      type: 'Mention',
+      name: '@user@example.com',
+      href: 'https://example.com/users/user'
+    })
+  })
+})

--- a/lib/types/domain/tag.ts
+++ b/lib/types/domain/tag.ts
@@ -2,9 +2,11 @@ import { z } from 'zod'
 
 import {
   type Tag as ActivityPubTag,
+  Emoji,
   HashTag,
   Mention
 } from '@/lib/types/activitypub/objects'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 
 export const TagType = z.enum(['emoji', 'mention', 'hashtag'])
 export type TagType = z.infer<typeof TagType>
@@ -22,7 +24,12 @@ export const Tag = z.object({
 
 export type Tag = z.infer<typeof Tag>
 
+// Converts mention/hashtag domain tags into their outgoing ActivityPub tag
+// objects. Emoji tags are handled by `getEmojiFromTag` and return `null` here so
+// they are not mis-serialized as `Mention` objects (a `Mention.safeParse` of an
+// emoji tag would otherwise succeed because both have string `name`/`href`).
 export const getMentionFromTag = (tag: Tag): ActivityPubTag | null => {
+  if (tag.type === 'emoji') return null
   if (tag.type === 'hashtag') {
     const result = HashTag.safeParse({
       type: 'Hashtag',
@@ -35,6 +42,26 @@ export const getMentionFromTag = (tag: Tag): ActivityPubTag | null => {
     type: 'Mention',
     name: tag.name,
     href: tag.value
+  })
+  return result.success ? result.data : null
+}
+
+// Converts an emoji domain tag (`name = ':shortcode:'`, `value = image url`)
+// into an ActivityPub `Emoji` tag so Mastodon and other AP servers render the
+// custom emoji. Mastodon matches inbound emoji on `name` + `icon.url`; `id` and
+// `updated` drive caching, so we use the image URL as a stable `id`. See
+// https://docs.joinmastodon.org/spec/activitypub/#Emoji.
+export const getEmojiFromTag = (tag: Tag): Emoji | null => {
+  if (tag.type !== 'emoji') return null
+  const result = Emoji.safeParse({
+    type: 'Emoji',
+    id: tag.value,
+    name: tag.name,
+    updated: getISOTimeUTC(tag.updatedAt),
+    icon: {
+      type: 'Image',
+      url: tag.value
+    }
   })
   return result.success ? result.data : null
 }

--- a/lib/utils/getNoteFromStatus.ts
+++ b/lib/utils/getNoteFromStatus.ts
@@ -40,10 +40,9 @@ export const getNoteFromStatus = (
     attachment: actualStatus.attachments
       .filter((attachment) => !isFitnessAttachment(attachment))
       .map((attachment) => getDocumentFromAttachment(attachment)),
-    tag: [
-      ...actualStatus.tags.map((tag) => getMentionFromTag(tag)),
-      ...actualStatus.tags.map((tag) => getEmojiFromTag(tag))
-    ].filter((tag) => tag !== null),
+    tag: actualStatus.tags
+      .map((tag) => getMentionFromTag(tag) ?? getEmojiFromTag(tag))
+      .filter((tag) => tag !== null),
     replies: {
       id: `${actualStatus.id}/replies`,
       type: 'Collection',

--- a/lib/utils/getNoteFromStatus.ts
+++ b/lib/utils/getNoteFromStatus.ts
@@ -10,7 +10,7 @@ import {
   getOriginalStatus,
   hasStatusBeenEdited
 } from '@/lib/types/domain/status'
-import { getMentionFromTag } from '@/lib/types/domain/tag'
+import { getEmojiFromTag, getMentionFromTag } from '@/lib/types/domain/tag'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 
@@ -40,10 +40,10 @@ export const getNoteFromStatus = (
     attachment: actualStatus.attachments
       .filter((attachment) => !isFitnessAttachment(attachment))
       .map((attachment) => getDocumentFromAttachment(attachment)),
-    tag: actualStatus.tags
-      .filter((tag) => tag.type !== 'emoji')
-      .map((tag) => getMentionFromTag(tag))
-      .filter((tag) => tag !== null),
+    tag: [
+      ...actualStatus.tags.map((tag) => getMentionFromTag(tag)),
+      ...actualStatus.tags.map((tag) => getEmojiFromTag(tag))
+    ].filter((tag) => tag !== null),
     replies: {
       id: `${actualStatus.id}/replies`,
       type: 'Collection',

--- a/lib/utils/text/getEmojiTags.test.ts
+++ b/lib/utils/text/getEmojiTags.test.ts
@@ -1,0 +1,43 @@
+import { getEmojiTags } from '@/lib/utils/text/getEmojiTags'
+
+describe('getEmojiTags', () => {
+  const emojis = [
+    { shortcode: 'blobcat', url: 'https://example.com/blobcat.png' },
+    { shortcode: 'tada', url: 'https://example.com/tada.png' }
+  ]
+
+  it.each([
+    { description: 'no shortcodes', text: 'hello world', expected: [] },
+    {
+      description: 'a single known shortcode',
+      text: 'hi :blobcat:',
+      expected: [
+        { name: ':blobcat:', value: 'https://example.com/blobcat.png' }
+      ]
+    },
+    {
+      description: 'multiple known shortcodes',
+      text: ':blobcat: party :tada:',
+      expected: [
+        { name: ':blobcat:', value: 'https://example.com/blobcat.png' },
+        { name: ':tada:', value: 'https://example.com/tada.png' }
+      ]
+    },
+    {
+      description: 'ignores unknown shortcodes',
+      text: 'unknown :nope: known :tada:',
+      expected: [{ name: ':tada:', value: 'https://example.com/tada.png' }]
+    },
+    {
+      description: 'deduplicates repeated shortcodes',
+      text: ':tada: :tada: :tada:',
+      expected: [{ name: ':tada:', value: 'https://example.com/tada.png' }]
+    }
+  ])('resolves $description', ({ text, expected }) => {
+    expect(getEmojiTags(text, emojis)).toEqual(expected)
+  })
+
+  it('returns an empty list for empty text', () => {
+    expect(getEmojiTags('', emojis)).toEqual([])
+  })
+})

--- a/lib/utils/text/getEmojiTags.test.ts
+++ b/lib/utils/text/getEmojiTags.test.ts
@@ -32,6 +32,17 @@ describe('getEmojiTags', () => {
       description: 'deduplicates repeated shortcodes',
       text: ':tada: :tada: :tada:',
       expected: [{ name: ':tada:', value: 'https://example.com/tada.png' }]
+    },
+    {
+      description:
+        'ignores shortcodes embedded inside a word (Mastodon boundary)',
+      text: 'foo:tada:bar',
+      expected: []
+    },
+    {
+      description: 'matches a shortcode adjacent to punctuation',
+      text: '(:tada:)',
+      expected: [{ name: ':tada:', value: 'https://example.com/tada.png' }]
     }
   ])('resolves $description', ({ text, expected }) => {
     expect(getEmojiTags(text, emojis)).toEqual(expected)

--- a/lib/utils/text/getEmojiTags.test.ts
+++ b/lib/utils/text/getEmojiTags.test.ts
@@ -3,7 +3,10 @@ import { getEmojiTags } from '@/lib/utils/text/getEmojiTags'
 describe('getEmojiTags', () => {
   const emojis = [
     { shortcode: 'blobcat', url: 'https://example.com/blobcat.png' },
-    { shortcode: 'tada', url: 'https://example.com/tada.png' }
+    { shortcode: 'tada', url: 'https://example.com/tada.png' },
+    // A 1-char shortcode that exists in the set but must NOT be scanned, since
+    // Mastodon's SCAN_RE requires a minimum length of 2.
+    { shortcode: 'a', url: 'https://example.com/a.png' }
   ]
 
   it.each([
@@ -43,6 +46,11 @@ describe('getEmojiTags', () => {
       description: 'matches a shortcode adjacent to punctuation',
       text: '(:tada:)',
       expected: [{ name: ':tada:', value: 'https://example.com/tada.png' }]
+    },
+    {
+      description: 'ignores a 1-char shortcode (Mastodon requires >= 2 chars)',
+      text: 'hi :a: there',
+      expected: []
     }
   ])('resolves $description', ({ text, expected }) => {
     expect(getEmojiTags(text, emojis)).toEqual(expected)

--- a/lib/utils/text/getEmojiTags.ts
+++ b/lib/utils/text/getEmojiTags.ts
@@ -1,0 +1,36 @@
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
+
+// Matches `:shortcode:` tokens in status text. Shortcodes are limited to the
+// same character set the custom-emoji table validates (`[a-zA-Z0-9_]+`).
+export const EMOJI_SHORTCODE_REGEX = /:([a-zA-Z0-9_]+):/g
+
+export interface ResolvedEmojiTag {
+  name: string
+  value: string
+}
+
+// Scans `text` for `:shortcode:` tokens and resolves each one against the
+// supplied instance custom-emoji set. Returns the emoji domain-tag fields
+// (`name = ':shortcode:'`, `value = image url`) for every distinct matching
+// shortcode, ready to persist via `createTag({ type: 'emoji' })`. Unknown
+// shortcodes are ignored.
+export const getEmojiTags = (
+  text: string,
+  emojis: Pick<CustomEmojiData, 'shortcode' | 'url'>[]
+): ResolvedEmojiTag[] => {
+  if (!text) return []
+  const emojiByShortcode = new Map(
+    emojis.map((emoji) => [emoji.shortcode, emoji])
+  )
+  const seen = new Set<string>()
+  const tags: ResolvedEmojiTag[] = []
+  for (const match of text.matchAll(EMOJI_SHORTCODE_REGEX)) {
+    const shortcode = match[1]
+    if (seen.has(shortcode)) continue
+    const emoji = emojiByShortcode.get(shortcode)
+    if (!emoji) continue
+    seen.add(shortcode)
+    tags.push({ name: `:${shortcode}:`, value: emoji.url })
+  }
+  return tags
+}

--- a/lib/utils/text/getEmojiTags.ts
+++ b/lib/utils/text/getEmojiTags.ts
@@ -1,8 +1,13 @@
 import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
 
 // Matches `:shortcode:` tokens in status text. Shortcodes are limited to the
-// same character set the custom-emoji table validates (`[a-zA-Z0-9_]+`).
-export const EMOJI_SHORTCODE_REGEX = /:([a-zA-Z0-9_]+):/g
+// same character set the custom-emoji table validates (`[a-zA-Z0-9_]+`). The
+// lookbehind/lookahead require a non-alphanumeric, non-colon boundary on each
+// side, mirroring Mastodon's `CustomEmoji::SCAN_RE` so a shortcode embedded in a
+// word (e.g. `foo:bar:baz`) is not treated as an emoji and we federate exactly
+// the tokens Mastodon would render.
+export const EMOJI_SHORTCODE_REGEX =
+  /(?<![A-Za-z0-9:]):([a-zA-Z0-9_]+):(?![A-Za-z0-9:])/g
 
 export interface ResolvedEmojiTag {
   name: string

--- a/lib/utils/text/getEmojiTags.ts
+++ b/lib/utils/text/getEmojiTags.ts
@@ -1,13 +1,12 @@
 import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
 
-// Matches `:shortcode:` tokens in status text. Shortcodes are limited to the
-// same character set the custom-emoji table validates (`[a-zA-Z0-9_]+`). The
-// lookbehind/lookahead require a non-alphanumeric, non-colon boundary on each
-// side, mirroring Mastodon's `CustomEmoji::SCAN_RE` so a shortcode embedded in a
-// word (e.g. `foo:bar:baz`) is not treated as an emoji and we federate exactly
-// the tokens Mastodon would render.
+// Matches `:shortcode:` tokens in status text, mirroring Mastodon's
+// `CustomEmoji::SCAN_RE`: a `[a-zA-Z0-9_]{2,}` shortcode (minimum two
+// characters, like Mastodon) with a non-alphanumeric, non-colon boundary on
+// each side, so a shortcode embedded in a word (e.g. `foo:bar:baz`) is not
+// treated as an emoji and we federate exactly the tokens Mastodon would render.
 export const EMOJI_SHORTCODE_REGEX =
-  /(?<![A-Za-z0-9:]):([a-zA-Z0-9_]+):(?![A-Za-z0-9:])/g
+  /(?<![A-Za-z0-9:]):([a-zA-Z0-9_]{2,}):(?![A-Za-z0-9:])/g
 
 export interface ResolvedEmojiTag {
   name: string

--- a/lib/utils/text/processStatusText.ts
+++ b/lib/utils/text/processStatusText.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 
 import { Status, getOriginalStatus } from '@/lib/types/domain/status'
+import { Tag } from '@/lib/types/domain/tag'
 import { convertEmojisToImages } from '@/lib/utils/text/convertEmojisToImages'
 import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
 import {
@@ -25,14 +26,34 @@ export const getActualStatus = (status: Status) => {
  * @param status Status object that contains the text to process
  * @returns Processed text as string for use in React components
  */
-export const processStatusText = (host: string, status: Status) => {
-  const actualStatus = getActualStatus(status)
-
-  return _.chain(actualStatus.text)
-    .thru(actualStatus.isLocalActor ? convertMarkdownText(host) : _.identity)
+/**
+ * Core text-processing pipeline shared by the rendered Post and the composer
+ * live preview, so custom emoji (and markdown/sanitization) render identically
+ * in both. Exposed separately from `processStatusText` so callers that have a
+ * raw text + tag list (e.g. the postbox preview) can reuse the exact same
+ * pipeline instead of introducing a second rendering path.
+ */
+export const processStatusTextContent = (
+  host: string,
+  text: string,
+  tags: Tag[],
+  isLocalActor: boolean
+) =>
+  _.chain(text)
+    .thru(isLocalActor ? convertMarkdownText(host) : _.identity)
     .thru(sanitizeText)
-    .thru(_.curryRight(convertEmojisToImages)(actualStatus.tags))
+    .thru(_.curryRight(convertEmojisToImages)(tags))
     .thru(sanitizeTrustedStatusText)
     .thru(_.trim)
     .value()
+
+export const processStatusText = (host: string, status: Status) => {
+  const actualStatus = getActualStatus(status)
+
+  return processStatusTextContent(
+    host,
+    actualStatus.text,
+    actualStatus.tags,
+    actualStatus.isLocalActor
+  )
 }

--- a/migrations/20260606185856_add_custom_emojis.js
+++ b/migrations/20260606185856_add_custom_emojis.js
@@ -1,0 +1,34 @@
+/**
+ * Stores instance-scoped custom emoji (Mastodon's CustomEmoji). Each row is a
+ * `:shortcode:` mapped to an uploaded image, served unauthenticated from
+ * `GET /api/v1/custom_emojis` and federated as ActivityPub `Emoji` tags on any
+ * status whose text contains the shortcode.
+ *
+ * Mirrors the Mastodon CustomEmoji entity
+ * (https://docs.joinmastodon.org/entities/CustomEmoji/): `shortcode`, `url`,
+ * `static_url`, `visible_in_picker`, `category`, plus a `disabled` flag used by
+ * the admin surface (Mastodon's `listed` scope is `disabled = false AND
+ * visible_in_picker = true`).
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) =>
+  knex.schema.createTable('customEmojis', (table) => {
+    table.string('id').primary()
+    // Shortcode without surrounding colons, validated `^[a-zA-Z0-9_]+$`.
+    table.string('shortcode').notNullable().unique()
+    table.text('url').notNullable()
+    table.text('staticUrl').notNullable()
+    table.string('category').nullable()
+    table.boolean('visibleInPicker').notNullable().defaultTo(true)
+    table.boolean('disabled').notNullable().defaultTo(false)
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = (knex) => knex.schema.dropTable('customEmojis')


### PR DESCRIPTION
## Summary

Adds **instance custom emoji** (Mastodon `CustomEmoji`) end to end: storage, public + admin endpoints, ActivityPub federation, a postbox **sticker/emoji picker**, and an **admin management page**. Also makes `GET /api/v2/instance` public to match Mastodon.

A posted status containing `:shortcode:` now (1) renders the emoji locally, (2) federates an ActivityPub `Emoji` tag so Mastodon and other AP servers render it, and (3) is surfaced unauthenticated via `GET /api/v1/custom_emojis`.

## Endpoints — Mastodon compatibility checklist

| Endpoint | Change | Mastodon source |
|---|---|---|
| `GET /api/v1/custom_emojis` | **Now public** (removed `OAuthGuard`); returns the *listed* set: `disabled = false AND visible_in_picker = true` | `custom_emojis_controller.rb` index uses `CustomEmoji.listed`; endpoint is public ([docs](https://docs.joinmastodon.org/methods/custom_emojis/)) |
| `GET /api/v2/instance` | **Now public** (removed `OAuthGuard`) | `/methods/instance/` — served unauthenticated |
| `GET /api/v1/instance` | Unchanged (already public, shape verified) | `/methods/instance/` |
| `POST /api/v1/admin/custom_emojis` | Create via multipart upload (shared media pipeline); 422 on bad mime/dup/shortcode | mirrors Mastodon admin custom emoji create |
| `GET /api/v1/admin/custom_emojis` | List incl. disabled | admin index |
| `PATCH`/`PUT /api/v1/admin/custom_emojis/:id` | Update enable/disable, `visible_in_picker`, `category` | Mastodon admin uses `PATCH`; `PUT` added to match this repo's existing admin `[id]` convention |
| `DELETE /api/v1/admin/custom_emojis/:id` | Delete | admin destroy |

`CustomEmoji` entity fields (`shortcode`, `url`, `static_url`, `visible_in_picker`, `category`) match `custom_emoji_serializer.rb` / [entities/CustomEmoji](https://docs.joinmastodon.org/entities/CustomEmoji/). The admin shape adds `id` + `disabled`.

## ActivityPub Emoji-tag round-trip (verified on a running server)

- **Outbound:** posting `hello :blobcat:` serializes a `tag` entry `{ "type":"Emoji", "name":":blobcat:", "icon":{"type":"Image","url":…}, "id":…, "updated":… }` in the status' AP JSON (confirmed over HTTP: `GET /users/testuser/statuses/:id` with `Accept: application/activity+json`).
- **Inbound:** incoming Notes with `Emoji` tags already parse into stored `emoji` domain Tags (in `createNoteJob`); added a regression test.
- **Bug fixed:** `getMentionFromTag` previously fell through to `Mention.safeParse` for emoji tags, so the two `status.ts` `toActivityPubObject` sites emitted **bogus `Mention` objects** for emoji. It now returns `null` for emoji; new `getEmojiFromTag` emits the `Emoji` object. All three outbound builders (`getNoteFromStatus`, Note + Question in `status.ts`) include emoji uniformly.
- Mastodon REST `status.emojis` is populated automatically by the pre-existing `getEmojisFromTags`.

## How shortcodes become tags

`createNote` / `createPoll` / `updateNote` scan the text for `:shortcode:`, resolve against the **enabled** instance emoji set (ignoring `visible_in_picker`, so hand-typed non-picker emoji still federate, matching Mastodon), and persist `emoji` domain Tags. Edits re-sync (delete + recreate).

## Frontend

- **Postbox picker** (`emoji-picker-button.tsx`): one popover with **system Unicode emoji** (curated local dataset, no new deps) + **instance custom emoji** (via new `getCustomEmojis` in `lib/client.ts`), with search, category tabs, grid, and hover preview per `preview/stickers.html`. System emoji insert the character; custom emoji insert `:shortcode:` at the caret. Keyboard-accessible (labelled controls, Escape to close).
- Custom emoji render as images in the picker and in the **composer live preview** through the existing `convertEmojisToImages`/`processStatusText` pipeline (refactored to a shared `processStatusTextContent`) — no second renderer, no `dangerouslySetInnerHTML`.
- **Admin page** (`/admin/admin/emojis` under the admin section) using the design-system chrome (`SectionNavDropdown`) and the settings/stickers visual design; all network calls go through `lib/client.ts`.

## Design

Implemented from the handoff bundle (`ui_kits/web/StickerPicker.jsx`, `Stickers.jsx`, `Composer.jsx`, `SettingsPage.jsx` → `StickerSettings`): picker grid/categories/search/preview, the dashed-dropzone upload form, and list rows. Adapted to this project's Tailwind tokens and primitives; admin placement + `SectionNavDropdown` follow `CLAUDE.md`/`AGENTS.md` over the kit's settings location.

## Local verification gates

`prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (**3545 passed / 418 suites**)

### Browser verification (local SQLite)
- Public `GET /api/v1/custom_emojis` and `GET /api/v2/instance` return 200 with **no token**.
- Picker opens, shows system categories + Custom tab; inserting a custom emoji puts `:blobcat:` in the textarea; the composer preview renders it as an inline image.
- A posted `:blobcat:` status' AP JSON contains the `Emoji` tag (checked over HTTP).
- Admin page lists/creates/updates/deletes emoji.

(Screenshots shared with the author; per `AGENTS.md` they are not committed to the repo.)

## Tests added
DB CRUD, public route (public + shape + picker filter), admin CRUD (incl. video-upload rejection), `getEmojiTags`, `getEmojiFromTag`/`getMentionFromTag`, create-note + poll shortcode→emoji-Tag resolution, outgoing Note **and** Question Emoji tag, inbound emoji-tag parsing, edit re-sync, and picker insertion (both kinds) + preview image rendering.

## Notes for reviewers
- Custom emoji uploads use the shared (actor-scoped) media pipeline via the uploading admin's session actor; an OAuth-token-only admin (no session actor) cannot upload — documented limitation.
- Animated emoji are not transcoded: `static_url = url` (uploads are PNG/JPEG only; the route rejects video/audio even though `FileSchema` allows them).
- `persistEmojiTagsForStatus` reads the enabled emoji set once per note/poll create/edit — acceptable at instance scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
