### PR TITLE
fix: enforce per-viewer visibility for status replies and ancestors

### DIFF
--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -8,6 +8,10 @@ import { getDatabase } from '@/lib/database'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getQueue } from '@/lib/services/queue'
+import {
+  canActorReadStatus,
+  isStatusPubliclyReadable
+} from '@/lib/services/statusAccess'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import {
@@ -109,11 +113,31 @@ const Page: FC<Props> = async ({ params }) => {
     // If replies are embedded (e.g. temporary status), use them
     replies = status.replies as Status[]
   } else {
-    // Otherwise fetch from database
+    // Otherwise fetch from database. The query filters to statuses the current
+    // viewer may read: logged-out visitors only ever see public/unlisted
+    // replies, while logged-in viewers get replies scoped to their own
+    // visibility (own posts, direct messages addressed to them, and
+    // followers-only posts from authors they have an accepted follow with).
     replies = await database.getStatusReplies({
       statusId,
-      url: statusUrl
+      url: statusUrl,
+      ...(currentActor
+        ? { visibleToActorId: currentActor.id }
+        : { publicOnly: true })
     })
+  }
+
+  // Object-level visibility backstop for logged-out visitors. Covers the
+  // embedded-replies path above (which never hits the query filter) and any
+  // stale/malformed recipient rows the query might miss, so a private reply to
+  // a public status never reaches an anonymous viewer (and isn't counted in the
+  // reply heading). Logged-in viewers rely on the query's `visibleToActorId`
+  // filter instead: it is the authoritative visibility check (it also matches
+  // recipientless replies to the viewer's own posts), so re-filtering with the
+  // simpler `isStatusPubliclyReadable` here would wrongly hide replies they may
+  // read.
+  if (!currentActor) {
+    replies = replies.filter(isStatusPubliclyReadable)
   }
 
   // Check if the status is publicly visible (public or unlisted)
@@ -168,6 +192,20 @@ const Page: FC<Props> = async ({ params }) => {
       withReplies: false
     })
     while (previouses.length < 3 && replyStatus) {
+      // `getStatus` does no visibility filtering, so without this guard a public
+      // reply to a followers-only (or direct) parent would leak that private
+      // ancestor to a viewer who cannot read it. Stop the chain at the first
+      // ancestor the viewer may not read. `canActorReadStatus` collapses to the
+      // public/unlisted check when `currentActor` is null, covering both
+      // logged-out and logged-in viewers.
+      const canReadAncestor = await canActorReadStatus({
+        database,
+        status: replyStatus,
+        currentActor
+      })
+      if (!canReadAncestor) {
+        break
+      }
       previouses.push(replyStatus)
       // This should be impossible
       if (replyStatus.type === StatusType.enum.Announce) {

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { Actor } from '@/lib/types/domain/actor'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { Status } from '@/lib/types/domain/status'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Page from './page'
+import { resolveStatusFromPath } from './resolveStatusFromPath'
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  })
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn(() => ({
+    host: 'activities.local',
+    fitnessStorage: undefined,
+    mediaStorage: undefined
+  }))
+}))
+
+const mockGetStatus = jest.fn()
+const mockGetStatusReplies = jest.fn()
+const mockGetAcceptedOrRequestedFollow = jest.fn()
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn(() => ({
+    getStatus: mockGetStatus,
+    getStatusReplies: mockGetStatusReplies,
+    getAcceptedOrRequestedFollow: mockGetAcceptedOrRequestedFollow
+  }))
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn()
+}))
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn()
+}))
+
+jest.mock('@/lib/utils/mapbox', () => ({
+  getPublicMapboxAccessToken: jest.fn(() => undefined)
+}))
+
+jest.mock('./resolveStatusFromPath', () => ({
+  ...jest.requireActual('./resolveStatusFromPath'),
+  resolveStatusFromPath: jest.fn()
+}))
+
+jest.mock('./Header', () => ({ Header: () => null }))
+jest.mock('./RemoteStatusLoading', () => ({ RemoteStatusLoading: () => null }))
+
+// Render each status as its id so we can assert which statuses reach the page.
+jest.mock('./StatusBox', () => ({
+  StatusBox: ({ status }: { status: { id: string } }) => (
+    <div data-testid={`status-${status.id}`} />
+  )
+}))
+
+const mockResolveStatusFromPath = jest.mocked(resolveStatusFromPath)
+const mockGetServerAuthSession = jest.mocked(getServerAuthSession)
+const mockGetActorFromSession = jest.mocked(getActorFromSession)
+
+const VIEWER_ID = 'https://activities.local/users/viewer'
+const AUTHOR_ID = 'https://activities.local/users/anna'
+
+const buildNote = (overrides: Partial<Status> = {}): Status =>
+  ({
+    id: 'note-id',
+    type: 'Note',
+    actorId: AUTHOR_ID,
+    actor: null,
+    url: `${AUTHOR_ID}/statuses/note-id`,
+    text: 'body',
+    reply: '',
+    replies: [],
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    isLocalActor: true,
+    isActorLiked: false,
+    isActorBookmarked: false,
+    actorAnnounceStatusId: null,
+    totalLikes: 0,
+    totalShares: 0,
+    attachments: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }) as unknown as Status
+
+const buildViewer = (): Actor =>
+  ({
+    id: VIEWER_ID,
+    type: 'Person',
+    username: 'viewer',
+    domain: 'activities.local',
+    followersUrl: `${VIEWER_ID}/followers`,
+    inboxUrl: `${VIEWER_ID}/inbox`,
+    sharedInboxUrl: 'https://activities.local/inbox',
+    publicKey: 'public-key',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1,
+    updatedAt: 1
+  }) as unknown as Actor
+
+const renderPage = async () => {
+  const element = await Page({
+    params: Promise.resolve({
+      actor: '@anna@activities.local',
+      status: 'hash'
+    })
+  })
+  render(element)
+}
+
+describe('Page visibility for logged-out visitors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockGetStatusReplies.mockResolvedValue([])
+  })
+
+  it('does not render a followers-only ancestor of a public reply', async () => {
+    const focused = buildNote({ id: 'public-reply', reply: 'private-parent' })
+    const privateParent = buildNote({
+      id: 'private-parent',
+      reply: '',
+      // followers-only: not addressed to the public collection
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(privateParent)
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('status-private-parent')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a public ancestor of a public reply', async () => {
+    const focused = buildNote({ id: 'public-reply', reply: 'public-parent' })
+    const publicParent = buildNote({
+      id: 'public-parent',
+      reply: '',
+      to: [ACTIVITY_STREAM_PUBLIC_COMPACT],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(publicParent)
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(screen.getByTestId('status-public-parent')).toBeInTheDocument()
+  })
+
+  it('hides private replies and excludes them from the reply count', async () => {
+    const focused = buildNote({ id: 'focused' })
+    const publicReply = buildNote({ id: 'public-reply', reply: 'focused' })
+    const privateReply = buildNote({
+      id: 'private-reply',
+      reply: 'focused',
+      to: ['https://activities.local/users/bob/followers'],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    // getStatusReplies is mocked, so the in-page backstop filter is what must
+    // drop the private reply here.
+    mockGetStatusReplies.mockResolvedValue([publicReply, privateReply])
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(screen.queryByTestId('status-private-reply')).not.toBeInTheDocument()
+    // The reply-count heading reflects only the visible (public) reply.
+    expect(screen.getByText('Replies (1)')).toBeInTheDocument()
+  })
+})
+
+describe('Page visibility for logged-in non-recipient viewers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue({} as never)
+    mockGetActorFromSession.mockResolvedValue(buildViewer())
+    mockGetStatusReplies.mockResolvedValue([])
+    // Default: the viewer does not follow anyone.
+    mockGetAcceptedOrRequestedFollow.mockResolvedValue(null)
+  })
+
+  it('does not render a followers-only ancestor the viewer cannot read', async () => {
+    const focused = buildNote({ id: 'public-reply', reply: 'private-parent' })
+    const privateParent = buildNote({
+      id: 'private-parent',
+      reply: '',
+      // followers-only by another author the viewer does not follow
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(privateParent)
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('status-private-parent')
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not render a direct-message ancestor the viewer is not addressed in', async () => {
+    const focused = buildNote({ id: 'public-reply', reply: 'dm-parent' })
+    const dmParent = buildNote({
+      id: 'dm-parent',
+      reply: '',
+      // direct message to someone other than the viewer
+      to: ['https://activities.local/users/bob'],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(dmParent)
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(screen.queryByTestId('status-dm-parent')).not.toBeInTheDocument()
+  })
+
+  it('renders a followers-only ancestor when the viewer follows the author', async () => {
+    const focused = buildNote({ id: 'public-reply', reply: 'followed-parent' })
+    const followedParent = buildNote({
+      id: 'followed-parent',
+      reply: '',
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(followedParent)
+    mockGetAcceptedOrRequestedFollow.mockResolvedValue({
+      status: FollowStatus.enum.Accepted
+    })
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(screen.getByTestId('status-followed-parent')).toBeInTheDocument()
+  })
+
+  // Reply visibility for logged-in viewers is enforced by the database query
+  // (`visibleToActorId`), which is unit-tested in lib/database/sql/status.test.ts
+  // and correctly includes recipientless replies to the viewer's own posts. The
+  // page-level guarantee is that it forwards the viewer id to that query.
+  it('passes the viewer id to getStatusReplies so the query filters by visibility', async () => {
+    const focused = buildNote({ id: 'focused' })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatusReplies.mockResolvedValue([])
+
+    await renderPage()
+
+    expect(mockGetStatusReplies).toHaveBeenCalledWith(
+      expect.objectContaining({ visibleToActorId: VIEWER_ID })
+    )
+  })
+})

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -192,6 +192,61 @@ describe('Page visibility for logged-out visitors', () => {
     expect(screen.getByTestId('status-public-parent')).toBeInTheDocument()
   })
 
+  it('renders a multi-level public ancestor chain', async () => {
+    const focused = buildNote({ id: 'public-reply', reply: 'public-parent' })
+    const publicParent = buildNote({
+      id: 'public-parent',
+      reply: 'public-grandparent',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const publicGrandparent = buildNote({
+      id: 'public-grandparent',
+      reply: '',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockImplementation(async ({ statusId }) => {
+      if (statusId === 'public-parent') return publicParent
+      if (statusId === 'public-grandparent') return publicGrandparent
+      return null
+    })
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(screen.getByTestId('status-public-parent')).toBeInTheDocument()
+    expect(screen.getByTestId('status-public-grandparent')).toBeInTheDocument()
+  })
+
+  it('queries getStatusReplies with publicOnly and without a viewer id', async () => {
+    const focused = buildNote({ id: 'focused' })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatusReplies.mockResolvedValue([])
+
+    await renderPage()
+
+    expect(mockGetStatusReplies).toHaveBeenCalledWith(
+      expect.objectContaining({ publicOnly: true })
+    )
+    expect(mockGetStatusReplies).toHaveBeenCalledWith(
+      expect.not.objectContaining({ visibleToActorId: expect.anything() })
+    )
+  })
+
   it('hides private replies and excludes them from the reply count', async () => {
     const focused = buildNote({ id: 'focused' })
     const publicReply = buildNote({ id: 'public-reply', reply: 'focused' })
@@ -231,13 +286,27 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
     mockGetAcceptedOrRequestedFollow.mockResolvedValue(null)
   })
 
-  it('does not render a followers-only ancestor the viewer cannot read', async () => {
-    const focused = buildNote({ id: 'public-reply', reply: 'private-parent' })
-    const privateParent = buildNote({
-      id: 'private-parent',
-      reply: '',
+  it.each([
+    {
+      description:
+        'does not render a followers-only ancestor the viewer cannot read',
+      parentId: 'private-parent',
       // followers-only by another author the viewer does not follow
-      to: [`${AUTHOR_ID}/followers`],
+      parentTo: [`${AUTHOR_ID}/followers`]
+    },
+    {
+      description:
+        'does not render a direct-message ancestor the viewer is not addressed in',
+      parentId: 'dm-parent',
+      // direct message to someone other than the viewer
+      parentTo: ['https://activities.local/users/bob']
+    }
+  ])('$description', async ({ parentId, parentTo }) => {
+    const focused = buildNote({ id: 'public-reply', reply: parentId })
+    const unreadableParent = buildNote({
+      id: parentId,
+      reply: '',
+      to: parentTo,
       cc: []
     })
 
@@ -247,7 +316,43 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
       fullStatusId: focused.url,
       isStatusHash: true
     })
-    mockGetStatus.mockResolvedValue(privateParent)
+    mockGetStatus.mockResolvedValue(unreadableParent)
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
+    expect(screen.queryByTestId(`status-${parentId}`)).not.toBeInTheDocument()
+  })
+
+  it('stops climbing the ancestor chain at the first unreadable parent', async () => {
+    // public reply -> followers-only parent (unreadable) -> public grandparent.
+    // The loop must break at the private parent, so neither it nor the readable
+    // grandparent beyond it is rendered.
+    const focused = buildNote({ id: 'public-reply', reply: 'private-parent' })
+    const privateParent = buildNote({
+      id: 'private-parent',
+      reply: 'public-grandparent',
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+    const publicGrandparent = buildNote({
+      id: 'public-grandparent',
+      reply: '',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'public-reply',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockImplementation(async ({ statusId }) => {
+      if (statusId === 'private-parent') return privateParent
+      if (statusId === 'public-grandparent') return publicGrandparent
+      return null
+    })
 
     await renderPage()
 
@@ -255,30 +360,9 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
     expect(
       screen.queryByTestId('status-private-parent')
     ).not.toBeInTheDocument()
-  })
-
-  it('does not render a direct-message ancestor the viewer is not addressed in', async () => {
-    const focused = buildNote({ id: 'public-reply', reply: 'dm-parent' })
-    const dmParent = buildNote({
-      id: 'dm-parent',
-      reply: '',
-      // direct message to someone other than the viewer
-      to: ['https://activities.local/users/bob'],
-      cc: []
-    })
-
-    mockResolveStatusFromPath.mockResolvedValue({
-      status: focused,
-      statusId: 'public-reply',
-      fullStatusId: focused.url,
-      isStatusHash: true
-    })
-    mockGetStatus.mockResolvedValue(dmParent)
-
-    await renderPage()
-
-    expect(screen.getByTestId('status-public-reply')).toBeInTheDocument()
-    expect(screen.queryByTestId('status-dm-parent')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('status-public-grandparent')
+    ).not.toBeInTheDocument()
   })
 
   it('renders a followers-only ancestor when the viewer follows the author', async () => {
@@ -327,5 +411,34 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
     expect(mockGetStatusReplies).toHaveBeenCalledWith(
       expect.objectContaining({ visibleToActorId: VIEWER_ID })
     )
+  })
+
+  it('renders a non-public reply the query returns and does not apply the public-only backstop', async () => {
+    const focused = buildNote({ id: 'focused' })
+    // A direct-message reply addressed to the viewer: not publicly readable,
+    // but `getStatusReplies` returns it via the `visibleToActorId` filter. The
+    // logged-out-only `isStatusPubliclyReadable` backstop must NOT strip it for
+    // an authenticated viewer — dropping the `if (!currentActor)` guard would
+    // hide this reply and fail here.
+    const dmReplyToViewer = buildNote({
+      id: 'dm-to-viewer',
+      reply: 'focused',
+      actorId: 'https://activities.local/users/bob',
+      to: [VIEWER_ID],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatusReplies.mockResolvedValue([dmReplyToViewer])
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-dm-to-viewer')).toBeInTheDocument()
+    expect(screen.getByText('Replies (1)')).toBeInTheDocument()
   })
 })

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -138,6 +138,9 @@ const renderPage = async () => {
 describe('Page visibility for logged-out visitors', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // clearAllMocks does not reset implementations; getStatus is only set by
+    // individual ancestor tests, so reset it to avoid leaking across tests.
+    mockGetStatus.mockReset()
     mockGetServerAuthSession.mockResolvedValue(null)
     mockGetActorFromSession.mockResolvedValue(null)
     mockGetStatusReplies.mockResolvedValue([])
@@ -279,6 +282,9 @@ describe('Page visibility for logged-out visitors', () => {
 describe('Page visibility for logged-in non-recipient viewers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // clearAllMocks does not reset implementations; getStatus is only set by
+    // individual ancestor tests, so reset it to avoid leaking across tests.
+    mockGetStatus.mockReset()
     mockGetServerAuthSession.mockResolvedValue({} as never)
     mockGetActorFromSession.mockResolvedValue(buildViewer())
     mockGetStatusReplies.mockResolvedValue([])


### PR DESCRIPTION
## Summary

The status detail page (`app/(timeline)/[actor]/[status]/page.tsx`) rendered **replies** and the **ancestor (`previouses`) chain** without scoping them to what the current viewer may read. A **logged-in viewer who is not a recipient/follower** could see followers-only or direct-message replies and ancestors of a public status they should not be able to read. This is a pre-existing privacy issue (replies/ancestors were unfiltered for *everyone* on `main`).

## Changes

- **Replies query** — pass `visibleToActorId: currentActor.id` to `getStatusReplies` for logged-in viewers (and `publicOnly: true` for logged-out). The database query (`applyPotentiallyReadableStatusFilter`) is the authoritative visibility check; it is unit-tested in `lib/database/sql/status.test.ts` (public/direct/hidden exclusion + followers-only-with-accepted-follow).
- **Replies backstop** — kept the logged-out-only object-level `isStatusPubliclyReadable` filter to cover the embedded-replies path (temporary statuses, which never hit the query) and stale recipient rows. **Logged-in viewers are intentionally not re-filtered in-page**, so the query's recipientless-reply branch (replies to the viewer's own posts) is preserved — re-running `canActorReadStatus` here would wrongly hide those.
- **Ancestors** — gate each `previouses` entry with the canonical `canActorReadStatus`, which collapses to the public/unlisted check when there is no current actor, covering both logged-out and logged-in viewers.
- **Focused-status gate** — unchanged.

## Tests

New `app/(timeline)/[actor]/[status]/page.visibility.test.tsx` covering logged-out and logged-in non-recipient cases (followers-only / DM ancestors hidden, public/followed ancestors shown, `visibleToActorId` forwarded to the query). Full suite green (3513 tests), lint and build clean.

## Scope notes for reviewers

- **Overlaps open PR #890** (`feat/public-status-logged-out`). Both create `page.visibility.test.tsx` and edit the same `getStatusReplies` call and `previouses` loop. This branch is a **superset** (logged-out + logged-in) built on `main` per request; the two PRs will need reconciliation on merge.
- **Logged-out focused-status Announce-of-private leak is *not* fixed here** — it remains #890's scope (its recursive `isStatusPubliclyReadable(status)` focused-status gate). Note that `previouses` are never built for Announce statuses (`status.type !== Announce` guard), so this change's ancestor gate does not touch the Announce case; the gap is purely the focused status.
- **Embedded-replies path stays unfiltered for logged-in** (the `status.replies` branch). Matches #890 and is low-risk — remote temporary statuses federate public replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)