### PR TITLE
Bump version to v1.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.45.3",
+  "version": "1.46.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.46.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.45.3`
- Base main SHA: `3d446b0c5a91db4d6356fd53c5c32b36f92e0be0`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
