### PR TITLE
fix: consolidate focused-status visibility gate to canActorReadStatus

### DIFF
--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -13,16 +13,11 @@ import {
   isStatusPubliclyReadable
 } from '@/lib/services/statusAccess'
 import { getActorProfile } from '@/lib/types/domain/actor'
-import { FollowStatus } from '@/lib/types/domain/follow'
 import {
   Status,
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
-import {
-  ACTIVITY_STREAM_PUBLIC,
-  ACTIVITY_STREAM_PUBLIC_COMPACT
-} from '@/lib/utils/activitystream'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { getPublicMapboxAccessToken } from '@/lib/utils/mapbox'
@@ -99,12 +94,16 @@ const Page: FC<Props> = async ({ params }) => {
     return notFound()
   }
 
-  // Logged-out visitors may only view statuses that are publicly readable all
-  // the way down. The per-field `isPublicOrUnlisted` check below inspects only
-  // the top-level recipients — for an Announce those are the boost's, not the
-  // boosted note's — so a public boost of a followers-only post would otherwise
-  // slip through. `isStatusPubliclyReadable` recurses into the original status.
-  if (!currentActor && !isStatusPubliclyReadable(status)) {
+  // Focused-status visibility gate — the single source of truth shared with the
+  // ancestor chain below. `canActorReadStatus` collapses to the public/unlisted
+  // check for logged-out visitors and, for an Announce, recurses into the
+  // boosted status, so a public boost of a followers-only post is rejected
+  // unless the viewer follows the boosted author. It also exact-matches the
+  // author's stored `followersUrl` (rather than a loose `/followers` suffix), so
+  // a remote follower of a followers-only post is no longer misread as a
+  // direct-message non-recipient. Gating here, before the reply fetch, rejects
+  // unreadable statuses for every viewer up front.
+  if (!(await canActorReadStatus({ database, status, currentActor }))) {
     return notFound()
   }
 
@@ -148,51 +147,6 @@ const Page: FC<Props> = async ({ params }) => {
   // read.
   if (!currentActor) {
     replies = replies.filter(isStatusPubliclyReadable)
-  }
-
-  // Check if the status is publicly visible (public or unlisted)
-  const isPublicOrUnlisted =
-    status.to.includes(ACTIVITY_STREAM_PUBLIC) ||
-    status.to.includes(ACTIVITY_STREAM_PUBLIC_COMPACT) ||
-    status.cc.includes(ACTIVITY_STREAM_PUBLIC) ||
-    status.cc.includes(ACTIVITY_STREAM_PUBLIC_COMPACT)
-
-  // If not public/unlisted, check visibility based on privacy level
-  if (!isPublicOrUnlisted) {
-    // Private posts require authentication
-    if (!currentActor) {
-      return notFound()
-    }
-
-    // Authors can always see their own non-public statuses
-    if (currentActor.id !== status.actorId) {
-      // Check if this is a followers-only post (private) or direct message
-      const hasFollowersUrl = [...status.to, ...status.cc].some((item) =>
-        item.endsWith('/followers')
-      )
-
-      if (hasFollowersUrl) {
-        // Private (followers-only) post: Check if user follows the author
-        const follow = await database.getAcceptedOrRequestedFollow({
-          actorId: currentActor.id,
-          targetActorId: status.actorId
-        })
-
-        // Only accepted follows grant access to private posts
-        if (!follow || follow.status !== FollowStatus.enum.Accepted) {
-          return notFound()
-        }
-      } else {
-        // Direct message: Only allow if current user is explicitly mentioned in to/cc
-        const isRecipient =
-          status.to.includes(currentActor.id) ||
-          status.cc.includes(currentActor.id)
-
-        if (!isRecipient) {
-          return notFound()
-        }
-      }
-    }
   }
 
   const previouses = []

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -675,4 +675,121 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
 
     expect(screen.getByTestId('status-public-announce')).toBeInTheDocument()
   })
+
+  // The Announce recursion landing on the direct-recipient branch of the
+  // boosted original (rather than the followers-only branch above).
+  it('renders a focused public boost whose original is a direct message addressed to the viewer', async () => {
+    const dmOriginal = buildNote({
+      id: 'dm-original',
+      actorId: 'https://activities.local/users/anna',
+      to: [VIEWER_ID],
+      cc: []
+    })
+    const announce = {
+      id: 'public-announce',
+      type: 'Announce',
+      actorId: 'https://activities.local/users/booster',
+      actor: null,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: 1,
+      updatedAt: 1,
+      originalStatus: dmOriginal
+    } as unknown as Status
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: announce,
+      statusId: 'public-announce',
+      fullStatusId: dmOriginal.url,
+      isStatusHash: true
+    })
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-announce')).toBeInTheDocument()
+    // Granted by direct-recipient match on the original, not by a follow lookup.
+    expect(mockGetAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
+
+  it('returns notFound for a focused public boost whose original is a direct message the viewer is not addressed in', async () => {
+    const dmOriginal = buildNote({
+      id: 'dm-original',
+      actorId: 'https://activities.local/users/anna',
+      to: ['https://activities.local/users/bob'],
+      cc: []
+    })
+    const announce = {
+      id: 'public-announce',
+      type: 'Announce',
+      actorId: 'https://activities.local/users/booster',
+      actor: null,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: 1,
+      updatedAt: 1,
+      originalStatus: dmOriginal
+    } as unknown as Status
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: announce,
+      statusId: 'public-announce',
+      fullStatusId: dmOriginal.url,
+      isStatusHash: true
+    })
+
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+})
+
+describe('Page visibility for the focused-status author', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetStatus.mockReset()
+    mockGetServerAuthSession.mockResolvedValue({} as never)
+    // The signed-in viewer IS the author of the focused status.
+    mockGetActorFromSession.mockResolvedValue({
+      ...buildViewer(),
+      id: AUTHOR_ID
+    } as unknown as Actor)
+    mockGetStatusReplies.mockResolvedValue([])
+    // If the author branch regressed, a non-public status would fall through to
+    // a follow lookup; this null mock would then deny access (notFound).
+    mockGetAcceptedOrRequestedFollow.mockResolvedValue(null)
+  })
+
+  // The old inline gate had an explicit "authors can always see their own
+  // non-public statuses" rule. `canActorReadStatus` preserves it via the
+  // `currentActor.id === status.actorId` short-circuit; these lock it down so
+  // authors never get a 404 on their own followers-only post or direct message.
+  it.each([
+    {
+      description: 'renders the author own focused followers-only status',
+      id: 'own-followers-only',
+      to: [`${AUTHOR_ID}/followers`]
+    },
+    {
+      description: 'renders the author own focused direct message',
+      id: 'own-dm',
+      to: ['https://activities.local/users/bob']
+    }
+  ])('$description', async ({ id, to }) => {
+    const focused = buildNote({ id, to, cc: [] })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: id,
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+
+    await renderPage()
+
+    expect(screen.getByTestId(`status-${id}`)).toBeInTheDocument()
+    // Access is granted by identity, not by a follow lookup.
+    expect(mockGetAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
 })

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -110,6 +110,25 @@ const buildNote = (overrides: Partial<Status> = {}): Status =>
     ...overrides
   }) as unknown as Status
 
+const buildAnnounce = (
+  originalStatus: Status,
+  overrides: Partial<Status> = {}
+): Status =>
+  ({
+    id: 'public-announce',
+    type: 'Announce',
+    actorId: 'https://activities.local/users/booster',
+    actor: null,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    isLocalActor: true,
+    createdAt: 1,
+    updatedAt: 1,
+    originalStatus,
+    ...overrides
+  }) as unknown as Status
+
 const buildViewer = (): Actor =>
   ({
     id: VIEWER_ID,
@@ -287,19 +306,9 @@ describe('Page visibility for logged-out visitors', () => {
       to: ['https://activities.local/users/anna/followers'],
       cc: []
     })
-    const announce = {
-      id: 'public-announce',
-      type: 'Announce',
-      actorId: 'https://activities.local/users/anna',
-      actor: null,
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [],
-      edits: [],
-      isLocalActor: true,
-      createdAt: 1,
-      updatedAt: 1,
-      originalStatus: privateOriginal
-    } as unknown as Status
+    const announce = buildAnnounce(privateOriginal, {
+      actorId: 'https://activities.local/users/anna'
+    })
 
     mockResolveStatusFromPath.mockResolvedValue({
       status: announce,
@@ -617,19 +626,7 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
       to: [`${AUTHOR_ID}/followers`],
       cc: []
     })
-    const announce = {
-      id: 'public-announce',
-      type: 'Announce',
-      actorId: 'https://activities.local/users/booster',
-      actor: null,
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [],
-      edits: [],
-      isLocalActor: true,
-      createdAt: 1,
-      updatedAt: 1,
-      originalStatus: privateOriginal
-    } as unknown as Status
+    const announce = buildAnnounce(privateOriginal)
 
     mockResolveStatusFromPath.mockResolvedValue({
       status: announce,
@@ -647,19 +644,7 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
       to: [`${AUTHOR_ID}/followers`],
       cc: []
     })
-    const announce = {
-      id: 'public-announce',
-      type: 'Announce',
-      actorId: 'https://activities.local/users/booster',
-      actor: null,
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [],
-      edits: [],
-      isLocalActor: true,
-      createdAt: 1,
-      updatedAt: 1,
-      originalStatus: privateOriginal
-    } as unknown as Status
+    const announce = buildAnnounce(privateOriginal)
 
     mockResolveStatusFromPath.mockResolvedValue({
       status: announce,
@@ -685,19 +670,7 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
       to: [VIEWER_ID],
       cc: []
     })
-    const announce = {
-      id: 'public-announce',
-      type: 'Announce',
-      actorId: 'https://activities.local/users/booster',
-      actor: null,
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [],
-      edits: [],
-      isLocalActor: true,
-      createdAt: 1,
-      updatedAt: 1,
-      originalStatus: dmOriginal
-    } as unknown as Status
+    const announce = buildAnnounce(dmOriginal)
 
     mockResolveStatusFromPath.mockResolvedValue({
       status: announce,
@@ -720,19 +693,7 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
       to: ['https://activities.local/users/bob'],
       cc: []
     })
-    const announce = {
-      id: 'public-announce',
-      type: 'Announce',
-      actorId: 'https://activities.local/users/booster',
-      actor: null,
-      to: [ACTIVITY_STREAM_PUBLIC],
-      cc: [],
-      edits: [],
-      isLocalActor: true,
-      createdAt: 1,
-      updatedAt: 1,
-      originalStatus: dmOriginal
-    } as unknown as Status
+    const announce = buildAnnounce(dmOriginal)
 
     mockResolveStatusFromPath.mockResolvedValue({
       status: announce,

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -80,6 +80,9 @@ const mockGetActorFromSession = jest.mocked(getActorFromSession)
 
 const VIEWER_ID = 'https://activities.local/users/viewer'
 const AUTHOR_ID = 'https://activities.local/users/anna'
+// A remote author whose stored followers collection does NOT end in
+// `/followers` — used to exercise the exact-match followers audience check.
+const REMOTE_AUTHOR_ID = 'https://remote.example/users/anna'
 
 const buildNote = (overrides: Partial<Status> = {}): Status =>
   ({
@@ -509,5 +512,167 @@ describe('Page visibility for logged-in non-recipient viewers', () => {
 
     expect(screen.getByTestId('status-dm-to-viewer')).toBeInTheDocument()
     expect(screen.getByText('Replies (1)')).toBeInTheDocument()
+  })
+
+  // Focused-status visibility gate. These exercise the consolidated
+  // `canActorReadStatus` gate on the focused status itself (not an ancestor),
+  // which previously had a bespoke inline reimplementation.
+  it('renders a focused followers-only status whose followersUrl does not end in /followers when the viewer follows the author', async () => {
+    // Regression: a remote author whose stored followersUrl uses a
+    // non-`/followers` path. The old inline gate detected followers-only
+    // audience with `endsWith('/followers')`, so it misread this as a direct
+    // message and returned notFound for a legitimate follower.
+    // `hasFollowersAudience` exact-matches the actor's stored `followersUrl`.
+    const customFollowersUrl = `${REMOTE_AUTHOR_ID}/followers-collection`
+    const focused = buildNote({
+      id: 'remote-followers-only',
+      actorId: REMOTE_AUTHOR_ID,
+      actor: {
+        followersUrl: customFollowersUrl
+      } as unknown as Status['actor'],
+      isLocalActor: false,
+      // Viewer is NOT addressed in to/cc — only the followers collection is, so
+      // the old DM branch would have rejected this follower.
+      to: [customFollowersUrl],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'remote-followers-only',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetAcceptedOrRequestedFollow.mockResolvedValue({
+      status: FollowStatus.enum.Accepted
+    })
+
+    await renderPage()
+
+    expect(
+      screen.getByTestId('status-remote-followers-only')
+    ).toBeInTheDocument()
+  })
+
+  it('returns notFound for a focused followers-only status when the viewer does not follow the author', async () => {
+    const focused = buildNote({
+      id: 'focused-followers-only',
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused-followers-only',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    // Default follow mock returns null (the viewer is not a follower).
+
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+
+  it('renders a focused direct message addressed to the viewer', async () => {
+    const focused = buildNote({
+      id: 'focused-dm-to-viewer',
+      actorId: 'https://activities.local/users/bob',
+      to: [VIEWER_ID],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused-dm-to-viewer',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+
+    await renderPage()
+
+    expect(
+      screen.getByTestId('status-focused-dm-to-viewer')
+    ).toBeInTheDocument()
+  })
+
+  it('returns notFound for a focused direct message the viewer is not addressed in', async () => {
+    const focused = buildNote({
+      id: 'focused-dm-to-bob',
+      to: ['https://activities.local/users/bob'],
+      cc: []
+    })
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused-dm-to-bob',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+
+  it('returns notFound for a focused public boost of a followers-only original when the viewer does not follow the boosted author', async () => {
+    const privateOriginal = buildNote({
+      id: 'private-original',
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+    const announce = {
+      id: 'public-announce',
+      type: 'Announce',
+      actorId: 'https://activities.local/users/booster',
+      actor: null,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: 1,
+      updatedAt: 1,
+      originalStatus: privateOriginal
+    } as unknown as Status
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: announce,
+      statusId: 'public-announce',
+      fullStatusId: privateOriginal.url,
+      isStatusHash: true
+    })
+
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+
+  it('renders a focused public boost of a followers-only original when the viewer follows the boosted author', async () => {
+    const privateOriginal = buildNote({
+      id: 'private-original',
+      to: [`${AUTHOR_ID}/followers`],
+      cc: []
+    })
+    const announce = {
+      id: 'public-announce',
+      type: 'Announce',
+      actorId: 'https://activities.local/users/booster',
+      actor: null,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      edits: [],
+      isLocalActor: true,
+      createdAt: 1,
+      updatedAt: 1,
+      originalStatus: privateOriginal
+    } as unknown as Status
+
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: announce,
+      statusId: 'public-announce',
+      fullStatusId: privateOriginal.url,
+      isStatusHash: true
+    })
+    mockGetAcceptedOrRequestedFollow.mockResolvedValue({
+      status: FollowStatus.enum.Accepted
+    })
+
+    await renderPage()
+
+    expect(screen.getByTestId('status-public-announce')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

The focused-status visibility gate in [`app/(timeline)/[actor]/[status]/page.tsx`](app/(timeline)/[actor]/[status]/page.tsx) was a bespoke inline reimplementation of visibility logic that diverged from the canonical `canActorReadStatus` / `hasFollowersAudience` helpers in [`lib/services/statusAccess.ts`](lib/services/statusAccess.ts) already used by the ancestor chain and reply backstop.

**The divergence:** the inline gate detected followers-only audience with `item.endsWith('/followers')`, whereas `hasFollowersAudience` exact-matches the actor's stored `followersUrl` (or canonical `${actorId}/followers`). For a remote actor whose stored `followersUrl` does **not** literally end in `/followers`, the inline gate misclassified a followers-only status as a direct message and returned `notFound()` for a legitimate follower — while the same status rendered correctly when it appeared as an ancestor.

This replaces the bespoke block (~44 lines) with a single early `canActorReadStatus` gate, mirroring the ancestor pattern, so all three code paths share one source of truth.

## Behavior changes

- **Fixes the remote-follower false-negative** — exact `followersUrl` match instead of a loose `/followers` suffix.
- **Closes the logged-in Announce-of-private focused-status leak** — `canActorReadStatus` recurses into the boosted original; the old block only checked the public boost wrapper. This is now in scope after #890.
- **Subsumes #890's logged-out gate** into the same unified call (it collapses to `isStatusPubliclyReadable` when `currentActor` is null), and moves the gate before the reply fetch so unreadable statuses are rejected up front for every viewer.
- Direct-recipient-of-followers-only is now allowed even without an accepted follow (matches `canActorReadSingleStatus`, which checks direct recipient before followers audience) — a correctness improvement.

Confirmed `status.actor.followersUrl` is hydrated on the focused status via `getStatus` → `getActorProfile`, so the fix holds in production, not just in tests.

## Tests

Added focused-status regressions in `page.visibility.test.tsx`: the divergence case (remote `followersUrl` not ending in `/followers`, viewer follows → renders), followers-only follow/no-follow, DM recipient/non-recipient, and Announce-of-private follow/no-follow. The divergence test was verified to fail against the old `endsWith('/followers')` logic and pass with the exact-match fix.

- `yarn run prettier --write .` ✅
- `yarn lint` ✅ (0 errors)
- `yarn build` ✅
- `yarn test` ✅ (421 suites, 3581 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)