### PR TITLE
minor: add logged-out landing page aligned with the design system

### DIFF
--- a/app/(timeline)/PublicShell.tsx
+++ b/app/(timeline)/PublicShell.tsx
@@ -1,0 +1,37 @@
+import { FC, ReactNode } from 'react'
+
+import { Modal } from '@/app/Modal'
+
+import { PublicFooter } from './PublicFooter'
+import { PublicTopBar } from './PublicTopBar'
+
+interface PublicShellProps {
+  children: ReactNode
+}
+
+/**
+ * Public chrome for logged-out visitors on the federated reading surfaces
+ * (single status, profiles, hashtags): a slim top bar with sign-in CTAs and a
+ * footer in place of the nav sidebar, with a narrow reading column. This used
+ * to live inline in the `(timeline)` layout, but the logged-out home route
+ * renders a full-bleed landing instead, so the chrome moved into the sub-trees
+ * that still need it (`[actor]/*`, `tags/*`).
+ */
+export const PublicShell: FC<PublicShellProps> = ({ children }) => (
+  // min-h-dvh (dynamic viewport height) rather than min-h-screen/100vh so the
+  // footer stays at the bottom without a mobile address-bar gap — same
+  // rationale as the public error pages (lib/components/error-page.tsx).
+  <div className="flex min-h-dvh flex-col">
+    <PublicTopBar />
+    <main className="flex flex-1 flex-col overflow-x-clip">
+      <div className="mx-auto flex w-full max-w-[680px] flex-1 flex-col px-4 py-6">
+        {children}
+      </div>
+    </main>
+    {/* Footer is a sibling of <main> (not nested in it) so its <footer> maps to
+        the contentinfo landmark; main keeps flex-1 to pin it to the bottom on
+        short pages. */}
+    <PublicFooter />
+    <Modal />
+  </div>
+)

--- a/app/(timeline)/[actor]/layout.test.tsx
+++ b/app/(timeline)/[actor]/layout.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Layout from './layout'
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn(() => ({}))
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn()
+}))
+
+jest.mock('../PublicShell', () => ({
+  PublicShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="public-shell">{children}</div>
+  )
+}))
+
+const mockGetServerAuthSession = jest.mocked(getServerAuthSession)
+const mockGetActorFromSession = jest.mocked(getActorFromSession)
+
+const renderLayout = async () => {
+  const element = await Layout({ children: <div data-testid="child" /> })
+  render(element)
+}
+
+describe('[actor] Layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+  })
+
+  it('wraps children in the public shell for logged-out visitors', async () => {
+    mockGetActorFromSession.mockResolvedValue(null)
+
+    await renderLayout()
+
+    expect(screen.getByTestId('public-shell')).toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+
+  it('passes children through for signed-in users', async () => {
+    mockGetActorFromSession.mockResolvedValue({ id: 'actor-1' } as never)
+
+    await renderLayout()
+
+    expect(screen.queryByTestId('public-shell')).not.toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/[actor]/layout.test.tsx
+++ b/app/(timeline)/[actor]/layout.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@/lib/utils/getActorFromSession', () => ({
   getActorFromSession: jest.fn()
 }))
 
-jest.mock('../PublicShell', () => ({
+jest.mock('@/app/(timeline)/PublicShell', () => ({
   PublicShell: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="public-shell">{children}</div>
   )

--- a/app/(timeline)/[actor]/layout.tsx
+++ b/app/(timeline)/[actor]/layout.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode } from 'react'
+
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { PublicShell } from '../PublicShell'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+/**
+ * Profiles, single statuses, followers/following and profile fitness under
+ * `[actor]` are viewable while logged out. Signed-in visitors already get the
+ * nav sidebar from the `(timeline)` layout, so this only adds the public top
+ * bar + footer chrome for logged-out visitors; signed-in renders pass through
+ * untouched.
+ */
+const Layout: FC<LayoutProps> = async ({ children }) => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (actor) return <>{children}</>
+
+  return <PublicShell>{children}</PublicShell>
+}
+
+export default Layout

--- a/app/(timeline)/[actor]/layout.tsx
+++ b/app/(timeline)/[actor]/layout.tsx
@@ -1,10 +1,9 @@
 import { FC, ReactNode } from 'react'
 
+import { PublicShell } from '@/app/(timeline)/PublicShell'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
-
-import { PublicShell } from '../PublicShell'
 
 interface LayoutProps {
   children: ReactNode

--- a/app/(timeline)/landing/Landing.test.tsx
+++ b/app/(timeline)/landing/Landing.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { Status } from '@/lib/types/domain/status'
+
+import { Landing } from './Landing'
+
+// The public feed reuses the timeline `Posts` client component; stub it so the
+// test focuses on the landing's variant selection and prop forwarding.
+jest.mock('@/lib/components/posts/posts', () => ({
+  Posts: ({
+    currentTime,
+    statuses
+  }: {
+    currentTime: number
+    statuses: Status[]
+  }) => (
+    <div
+      data-testid="posts"
+      data-current-time={currentTime}
+      data-current-time-type={typeof currentTime}
+      data-count={statuses.length}
+    />
+  )
+}))
+
+const renderLanding = (statuses: Status[]) =>
+  render(
+    <Landing
+      host="llun.social"
+      currentTime={1_700_000_000_000}
+      statuses={statuses}
+      serviceName="Activities"
+    />
+  )
+
+describe('Landing', () => {
+  it('shows the brand hero when there are no public posts', () => {
+    renderLanding([])
+
+    expect(
+      screen.getByText('Posts and fitness activity, on a server you own.')
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('posts')).not.toBeInTheDocument()
+    // Auth card is always present.
+    expect(screen.getByText('Join Activities')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Create account' })
+    ).toHaveAttribute('href', '/auth/signup')
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/auth/signin'
+    )
+  })
+
+  it('previews the public feed when the server has public posts', () => {
+    renderLanding([{ id: 'p1' }, { id: 'p2' }] as unknown as Status[])
+
+    const posts = screen.getByTestId('posts')
+    expect(posts).toBeInTheDocument()
+    expect(posts).toHaveAttribute('data-count', '2')
+    expect(screen.getByText('llun.social')).toBeInTheDocument()
+    expect(screen.queryByText('happening next.')).not.toBeInTheDocument()
+  })
+
+  it('forwards currentTime to the feed as a number (no in-render Date.now)', () => {
+    renderLanding([{ id: 'p1' }] as unknown as Status[])
+
+    const posts = screen.getByTestId('posts')
+    expect(posts).toHaveAttribute('data-current-time-type', 'number')
+    expect(posts).toHaveAttribute('data-current-time', '1700000000000')
+  })
+})

--- a/app/(timeline)/landing/Landing.tsx
+++ b/app/(timeline)/landing/Landing.tsx
@@ -30,7 +30,7 @@ export const Landing: FC<LandingProps> = ({
   const hasPublicPosts = statuses.length > 0
   return (
     <main className="grid min-h-dvh grid-cols-1 md:h-dvh md:grid-cols-[1.1fr_1fr]">
-      <div className="min-h-0 md:overflow-y-auto">
+      <div className="flex min-h-0 flex-col md:overflow-y-auto">
         {hasPublicPosts ? (
           <LandingPublicFeed
             host={host}
@@ -41,7 +41,7 @@ export const Landing: FC<LandingProps> = ({
           <LandingHero serviceName={serviceName} />
         )}
       </div>
-      <div className="min-h-0 bg-background/80 md:overflow-y-auto">
+      <div className="flex min-h-0 flex-col bg-background/80 md:overflow-y-auto">
         <LandingAuthPanel serviceName={serviceName} />
       </div>
     </main>

--- a/app/(timeline)/landing/Landing.tsx
+++ b/app/(timeline)/landing/Landing.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react'
+
+import { Status } from '@/lib/types/domain/status'
+
+import { LandingAuthPanel } from './LandingAuthPanel'
+import { LandingHero } from './LandingHero'
+import { LandingPublicFeed } from './LandingPublicFeed'
+
+interface LandingProps {
+  host: string
+  currentTime: number
+  /** Recent public statuses to preview. Empty → the brand hero is shown. */
+  statuses: Status[]
+  serviceName: string
+}
+
+/**
+ * Logged-out landing: a full-bleed split with the auth card on the right and,
+ * on the left, either a preview of the server's public timeline (when there are
+ * public posts) or a brand hero. Mirrors the design system's web-landing kit
+ * (`feed.html` / `index.html`). Sits on the body's signature dual-tint gradient;
+ * the auth column is translucent so the backdrop reads through.
+ */
+export const Landing: FC<LandingProps> = ({
+  host,
+  currentTime,
+  statuses,
+  serviceName
+}) => {
+  const hasPublicPosts = statuses.length > 0
+  return (
+    <main className="grid min-h-dvh grid-cols-1 lg:h-dvh lg:grid-cols-[1.1fr_1fr]">
+      <div className="min-h-0 lg:overflow-y-auto">
+        {hasPublicPosts ? (
+          <LandingPublicFeed
+            host={host}
+            currentTime={currentTime}
+            statuses={statuses}
+          />
+        ) : (
+          <LandingHero serviceName={serviceName} />
+        )}
+      </div>
+      <div className="min-h-0 bg-background/80 lg:overflow-y-auto">
+        <LandingAuthPanel serviceName={serviceName} />
+      </div>
+    </main>
+  )
+}

--- a/app/(timeline)/landing/Landing.tsx
+++ b/app/(timeline)/landing/Landing.tsx
@@ -29,8 +29,8 @@ export const Landing: FC<LandingProps> = ({
 }) => {
   const hasPublicPosts = statuses.length > 0
   return (
-    <main className="grid min-h-dvh grid-cols-1 lg:h-dvh lg:grid-cols-[1.1fr_1fr]">
-      <div className="min-h-0 lg:overflow-y-auto">
+    <main className="grid min-h-dvh grid-cols-1 md:h-dvh md:grid-cols-[1.1fr_1fr]">
+      <div className="min-h-0 md:overflow-y-auto">
         {hasPublicPosts ? (
           <LandingPublicFeed
             host={host}
@@ -41,7 +41,7 @@ export const Landing: FC<LandingProps> = ({
           <LandingHero serviceName={serviceName} />
         )}
       </div>
-      <div className="min-h-0 bg-background/80 lg:overflow-y-auto">
+      <div className="min-h-0 bg-background/80 md:overflow-y-auto">
         <LandingAuthPanel serviceName={serviceName} />
       </div>
     </main>

--- a/app/(timeline)/landing/LandingAuthPanel.tsx
+++ b/app/(timeline)/landing/LandingAuthPanel.tsx
@@ -1,0 +1,55 @@
+import { Fingerprint } from 'lucide-react'
+import Link from 'next/link'
+import { FC } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+
+interface LandingAuthPanelProps {
+  serviceName: string
+}
+
+/**
+ * Right column of the logged-out landing: the minimal create/sign-in entry. The
+ * CTAs link to the real auth routes (`/auth/signup`, `/auth/signin`) rather than
+ * re-implementing the credential/passkey flows; the passkey CTA points at the
+ * sign-in page where the WebAuthn button lives.
+ */
+export const LandingAuthPanel: FC<LandingAuthPanelProps> = ({
+  serviceName
+}) => (
+  <div className="flex h-full flex-col justify-center px-7 py-9 sm:px-14 sm:py-14">
+    <div className="mx-auto w-full max-w-[360px]">
+      <h2 className="text-2xl font-semibold tracking-tight">
+        Join {serviceName}
+      </h2>
+      <p className="mt-1.5 text-sm text-muted-foreground">
+        Create an account or sign in to continue.
+      </p>
+
+      <div className="mt-7 flex flex-col gap-2.5">
+        <Button asChild className="h-11 w-full">
+          <Link href="/auth/signup">Create account</Link>
+        </Button>
+        <Button asChild variant="outline" className="h-11 w-full">
+          <Link href="/auth/signin">Sign in</Link>
+        </Button>
+      </div>
+
+      <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
+        <span className="h-px flex-1 bg-border" />
+        or
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      <Button asChild variant="outline" className="h-11 w-full">
+        <Link href="/auth/signin">
+          <Fingerprint className="size-4" /> Continue with a passkey
+        </Link>
+      </Button>
+
+      <p className="mt-7 text-xs leading-relaxed text-muted-foreground">
+        By continuing you agree to the Terms and Privacy Policy.
+      </p>
+    </div>
+  </div>
+)

--- a/app/(timeline)/landing/LandingAuthPanel.tsx
+++ b/app/(timeline)/landing/LandingAuthPanel.tsx
@@ -27,7 +27,7 @@ export const LandingAuthPanel: FC<LandingAuthPanelProps> = ({
       </p>
 
       <div className="mt-7 flex flex-col gap-2.5">
-        <Button asChild className="h-11 w-full">
+        <Button asChild className="h-11 w-full shadow-xs">
           <Link href="/auth/signup">Create account</Link>
         </Button>
         <Button asChild variant="outline" className="h-11 w-full">

--- a/app/(timeline)/landing/LandingHero.tsx
+++ b/app/(timeline)/landing/LandingHero.tsx
@@ -1,0 +1,71 @@
+import { Activity, Globe, Shield } from 'lucide-react'
+import Image from 'next/image'
+import { FC } from 'react'
+
+interface LandingHeroProps {
+  serviceName: string
+}
+
+/**
+ * Left column of the logged-out landing when the server has no public posts to
+ * preview: a copy-light brand hero on the Activity-orange ground with the
+ * signature dual-tint orange gradient and a watermark sparrow mark.
+ */
+export const LandingHero: FC<LandingHeroProps> = ({ serviceName }) => (
+  <div
+    className="relative flex h-full min-h-[60vh] flex-col justify-between overflow-hidden px-7 py-10 text-white sm:px-14 sm:py-14"
+    style={{
+      backgroundColor: 'hsl(24 95% 46%)',
+      backgroundImage:
+        'radial-gradient(700px 420px at 18% 8%, hsl(24 95% 56%), transparent 60%),' +
+        'radial-gradient(680px 520px at 100% 100%, hsl(24 95% 38%), transparent 55%)'
+    }}
+  >
+    {/* Oversized faint mark, watermark style. */}
+    <Image
+      src="/logo.png"
+      alt=""
+      aria-hidden="true"
+      width={540}
+      height={540}
+      className="pointer-events-none absolute -bottom-32 -right-32 h-auto w-[360px] select-none opacity-[0.12] sm:w-[540px]"
+    />
+
+    <div className="relative flex items-center gap-3">
+      <Image
+        src="/logo.png"
+        alt=""
+        aria-hidden="true"
+        width={44}
+        height={44}
+        className="h-11 w-11 rounded-full object-contain ring-2 ring-white/70"
+      />
+      <span className="text-xl font-semibold tracking-tight">
+        {serviceName}
+      </span>
+    </div>
+
+    <div className="relative mt-10">
+      <h1 className="text-[34px] font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[52px]">
+        See what&apos;s
+        <br />
+        happening next.
+      </h1>
+      <p className="mt-4 max-w-sm text-[15px] leading-relaxed text-white/85 sm:text-[17px]">
+        Posts and fitness activity, on a server you own.
+      </p>
+    </div>
+
+    <div className="relative mt-10 flex items-center gap-5 text-[13px] text-white/80">
+      <span className="inline-flex items-center gap-1.5">
+        <Globe className="size-[15px]" /> Fediverse
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <Shield className="size-[15px]" /> Self-hosted
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <Activity className="size-[15px]" /> Fitness
+      </span>
+    </div>
+  </div>
+)

--- a/app/(timeline)/landing/LandingHero.tsx
+++ b/app/(timeline)/landing/LandingHero.tsx
@@ -15,7 +15,7 @@ export const LandingHero: FC<LandingHeroProps> = ({ serviceName }) => (
   <div
     className="relative flex h-full min-h-[60vh] flex-col justify-between overflow-hidden px-7 py-10 text-white sm:px-14 sm:py-14"
     style={{
-      backgroundColor: 'hsl(24 95% 46%)',
+      backgroundColor: 'var(--primary)',
       backgroundImage:
         'radial-gradient(700px 420px at 18% 8%, hsl(24 95% 56%), transparent 60%),' +
         'radial-gradient(680px 520px at 100% 100%, hsl(24 95% 38%), transparent 55%)'
@@ -51,12 +51,12 @@ export const LandingHero: FC<LandingHeroProps> = ({ serviceName }) => (
         <br />
         happening next.
       </h1>
-      <p className="mt-4 max-w-sm text-[15px] leading-relaxed text-white/85 sm:text-[17px]">
+      <p className="mt-4 max-w-sm text-[15px] leading-[1.5] text-white/90 sm:text-[17px]">
         Posts and fitness activity, on a server you own.
       </p>
     </div>
 
-    <div className="relative mt-10 flex items-center gap-5 text-[13px] text-white/80">
+    <div className="relative mt-10 flex items-center gap-5 text-[13px] text-white/90">
       <span className="inline-flex items-center gap-1.5">
         <Globe className="size-[15px]" /> Fediverse
       </span>

--- a/app/(timeline)/landing/LandingPublicFeed.tsx
+++ b/app/(timeline)/landing/LandingPublicFeed.tsx
@@ -1,0 +1,56 @@
+import Image from 'next/image'
+import { FC } from 'react'
+
+import { Posts } from '@/lib/components/posts/posts'
+import { Status } from '@/lib/types/domain/status'
+
+interface LandingPublicFeedProps {
+  host: string
+  currentTime: number
+  statuses: Status[]
+}
+
+/**
+ * Left column of the logged-out landing when the server has public posts: a
+ * read-only preview of the server's recent public timeline. It reuses the same
+ * `Posts` component the signed-in timeline uses, with `showActions={false}` and
+ * no `currentActor`, so logged-out visitors see real posts without interactive
+ * controls. Real interactions live behind sign-in (the right column).
+ */
+export const LandingPublicFeed: FC<LandingPublicFeedProps> = ({
+  host,
+  currentTime,
+  statuses
+}) => (
+  <div className="flex h-full flex-col">
+    <div className="sticky top-0 z-10 flex items-center gap-2.5 border-b bg-background/70 px-5 py-3.5 backdrop-blur">
+      <Image
+        src="/logo-nav.png"
+        alt=""
+        aria-hidden="true"
+        width={28}
+        height={28}
+        className="h-7 w-7 shrink-0 object-contain"
+      />
+      <div className="min-w-0">
+        <h1 className="truncate text-sm font-semibold leading-tight">{host}</h1>
+        <div className="text-xs text-muted-foreground">
+          Recent posts on this server
+        </div>
+      </div>
+    </div>
+
+    <Posts
+      framed={false}
+      host={host}
+      currentTime={currentTime}
+      statuses={statuses}
+      showActions={false}
+      showReadOnlyStats
+    />
+
+    <div className="px-5 py-4 text-center text-xs text-muted-foreground">
+      Sign in to see the full timeline, reply, and follow across the Fediverse.
+    </div>
+  </div>
+)

--- a/app/(timeline)/layout.test.tsx
+++ b/app/(timeline)/layout.test.tsx
@@ -33,12 +33,6 @@ jest.mock('@/lib/types/domain/actor', () => ({
 }))
 
 jest.mock('@/app/Modal', () => ({ Modal: () => <div data-testid="modal" /> }))
-jest.mock('./PublicTopBar', () => ({
-  PublicTopBar: () => <div data-testid="public-topbar" />
-}))
-jest.mock('./PublicFooter', () => ({
-  PublicFooter: () => <div data-testid="public-footer" />
-}))
 jest.mock('@/lib/components/layout/sidebar', () => ({
   Sidebar: () => <div data-testid="sidebar" />
 }))
@@ -64,19 +58,20 @@ describe('(timeline) Layout', () => {
     mockGetNotificationsCount.mockResolvedValue(0)
   })
 
-  it('renders the public chrome and no nav for logged-out visitors', async () => {
+  it('renders children without nav chrome for logged-out visitors', async () => {
+    // Logged-out visitors render chrome-less here: the home route renders a
+    // full-bleed landing, and the federated reading surfaces add the public
+    // top bar + footer via their own sub-layouts (PublicShell).
     mockGetActorFromSession.mockResolvedValue(null)
 
     await renderLayout()
 
-    expect(screen.getByTestId('public-topbar')).toBeInTheDocument()
-    expect(screen.getByTestId('public-footer')).toBeInTheDocument()
     expect(screen.getByTestId('child')).toBeInTheDocument()
     expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument()
     expect(screen.queryByTestId('mobile-nav')).not.toBeInTheDocument()
   })
 
-  it('renders the nav chrome and no public chrome for signed-in users', async () => {
+  it('renders the nav chrome for signed-in users', async () => {
     mockGetActorFromSession.mockResolvedValue({
       id: 'https://localhost/users/testuser',
       username: 'testuser',
@@ -91,7 +86,5 @@ describe('(timeline) Layout', () => {
     expect(screen.getByTestId('sidebar')).toBeInTheDocument()
     expect(screen.getByTestId('mobile-nav')).toBeInTheDocument()
     expect(screen.getByTestId('child')).toBeInTheDocument()
-    expect(screen.queryByTestId('public-topbar')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('public-footer')).not.toBeInTheDocument()
   })
 })

--- a/app/(timeline)/layout.tsx
+++ b/app/(timeline)/layout.tsx
@@ -9,9 +9,6 @@ import { getActorProfile, getMention } from '@/lib/types/domain/actor'
 import { cn } from '@/lib/utils'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
-import { PublicFooter } from './PublicFooter'
-import { PublicTopBar } from './PublicTopBar'
-
 interface LayoutProps {
   children: ReactNode
 }
@@ -25,28 +22,14 @@ const Layout: FC<LayoutProps> = async ({ children }) => {
   const session = await getServerAuthSession()
   const actor = await getActorFromSession(database, session)
 
-  // Logged-out visitors get the public chrome — a slim top bar with sign-in
-  // CTAs and a footer in place of the nav sidebar — matching the web-public
-  // design. The reading column is narrower than the signed-in app width.
+  // Logged-out visitors render without the nav sidebar. The home route renders
+  // a full-bleed landing (see app/(timeline)/page.tsx), so this branch stays
+  // chrome-less; the federated reading surfaces that still need the public top
+  // bar + footer (single status, profiles, hashtags) wrap themselves in
+  // `PublicShell` via their own sub-layouts (`[actor]/layout.tsx`,
+  // `tags/layout.tsx`).
   if (!actor) {
-    return (
-      // min-h-dvh (dynamic viewport height) rather than min-h-screen/100vh so
-      // the footer stays at the bottom without a mobile address-bar gap — same
-      // rationale as the public error pages (lib/components/error-page.tsx).
-      <div className="flex min-h-dvh flex-col">
-        <PublicTopBar />
-        <main className="flex flex-1 flex-col overflow-x-clip">
-          <div className="mx-auto flex w-full max-w-[680px] flex-1 flex-col px-4 py-6">
-            {children}
-          </div>
-        </main>
-        {/* Footer is a sibling of <main> (not nested in it) so its <footer>
-            maps to the contentinfo landmark; main keeps flex-1 to pin it to the
-            bottom on short pages. */}
-        <PublicFooter />
-        <Modal />
-      </div>
-    )
+    return <>{children}</>
   }
 
   // Check if iconUrl is a real user-uploaded avatar (not auto-generated)

--- a/app/(timeline)/page.tsx
+++ b/app/(timeline)/page.tsx
@@ -1,16 +1,22 @@
 import { Metadata } from 'next'
-import { redirect } from 'next/navigation'
 
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
-import { getFilteredTimelinePage } from '@/lib/services/timelines/getFilteredTimelinePage'
+import {
+  getFilteredStatusPage,
+  getFilteredTimelinePage
+} from '@/lib/services/timelines/getFilteredTimelinePage'
 import { Timeline } from '@/lib/services/timelines/types'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { MainPageTimeline } from './MainPageTimeline'
+import { Landing } from './landing/Landing'
+
+// Number of recent public posts previewed in the logged-out landing feed.
+const LANDING_FEED_LIMIT = 5
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
@@ -18,7 +24,7 @@ export const metadata: Metadata = {
 }
 
 const Page = async () => {
-  const { host, mediaStorage } = getConfig()
+  const { host, serviceName, mediaStorage } = getConfig()
   const database = getDatabase()
   if (!database) {
     throw new Error('Fail to load database')
@@ -27,7 +33,27 @@ const Page = async () => {
   const session = await getServerAuthSession()
   const actor = await getActorFromSession(database, session)
   if (!actor) {
-    return redirect('/auth/signin')
+    // Logged-out visitors get the landing. When the server has public posts the
+    // landing previews its recent public timeline; otherwise it shows the brand
+    // hero. Both variants share the create/sign-in card.
+    const { statuses } = await getFilteredStatusPage({
+      database,
+      limit: LANDING_FEED_LIMIT,
+      fetchBatch: ({ maxStatusId, limit }) =>
+        database.getTimeline({
+          timeline: Timeline.LOCAL_PUBLIC,
+          maxStatusId,
+          limit
+        })
+    })
+    return (
+      <Landing
+        host={host}
+        currentTime={Date.now()}
+        statuses={statuses.map((item) => cleanJson(item))}
+        serviceName={serviceName ?? 'Activities'}
+      />
+    )
   }
 
   const settings = await database.getActorSettings({ actorId: actor.id })

--- a/app/(timeline)/page.tsx
+++ b/app/(timeline)/page.tsx
@@ -9,8 +9,10 @@ import {
 } from '@/lib/services/timelines/getFilteredTimelinePage'
 import { Timeline } from '@/lib/services/timelines/types'
 import { getActorProfile } from '@/lib/types/domain/actor'
+import { Status } from '@/lib/types/domain/status'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { logger } from '@/lib/utils/logger'
 
 import { MainPageTimeline } from './MainPageTimeline'
 import { Landing } from './landing/Landing'
@@ -35,22 +37,33 @@ const Page = async () => {
   if (!actor) {
     // Logged-out visitors get the landing. When the server has public posts the
     // landing previews its recent public timeline; otherwise it shows the brand
-    // hero. Both variants share the create/sign-in card.
-    const { statuses } = await getFilteredStatusPage({
-      database,
-      limit: LANDING_FEED_LIMIT,
-      fetchBatch: ({ maxStatusId, limit }) =>
-        database.getTimeline({
-          timeline: Timeline.LOCAL_PUBLIC,
-          maxStatusId,
-          limit
-        })
-    })
+    // hero. Both variants share the create/sign-in card. A failure to load the
+    // public preview degrades to the hero rather than 500-ing the public front
+    // door — but it's logged so an outage isn't silently hidden as "no posts".
+    let publicStatuses: Status[] = []
+    try {
+      const { statuses } = await getFilteredStatusPage({
+        database,
+        limit: LANDING_FEED_LIMIT,
+        fetchBatch: ({ maxStatusId, limit }) =>
+          database.getTimeline({
+            timeline: Timeline.LOCAL_PUBLIC,
+            maxStatusId,
+            limit
+          })
+      })
+      publicStatuses = statuses
+    } catch (error) {
+      logger.error({
+        err: error,
+        message: 'Failed to load public posts for the landing page'
+      })
+    }
     return (
       <Landing
         host={host}
         currentTime={Date.now()}
-        statuses={statuses.map((item) => cleanJson(item))}
+        statuses={publicStatuses.map((item) => cleanJson(item))}
         serviceName={serviceName ?? 'Activities'}
       />
     )

--- a/app/(timeline)/tags/layout.test.tsx
+++ b/app/(timeline)/tags/layout.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Layout from './layout'
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: jest.fn(() => ({}))
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn()
+}))
+
+jest.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: jest.fn()
+}))
+
+jest.mock('@/app/(timeline)/PublicShell', () => ({
+  PublicShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="public-shell">{children}</div>
+  )
+}))
+
+const mockGetServerAuthSession = jest.mocked(getServerAuthSession)
+const mockGetActorFromSession = jest.mocked(getActorFromSession)
+
+const renderLayout = async () => {
+  const element = await Layout({ children: <div data-testid="child" /> })
+  render(element)
+}
+
+describe('tags Layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerAuthSession.mockResolvedValue(null)
+  })
+
+  it('wraps children in the public shell for logged-out visitors', async () => {
+    mockGetActorFromSession.mockResolvedValue(null)
+
+    await renderLayout()
+
+    expect(screen.getByTestId('public-shell')).toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+
+  it('passes children through for signed-in users', async () => {
+    mockGetActorFromSession.mockResolvedValue({ id: 'actor-1' } as never)
+
+    await renderLayout()
+
+    expect(screen.queryByTestId('public-shell')).not.toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/tags/layout.tsx
+++ b/app/(timeline)/tags/layout.tsx
@@ -1,0 +1,32 @@
+import { FC, ReactNode } from 'react'
+
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { PublicShell } from '../PublicShell'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+/**
+ * Hashtag timelines under `tags/*` are viewable while logged out. Signed-in
+ * visitors already get the nav sidebar from the `(timeline)` layout, so this
+ * only adds the public top bar + footer chrome for logged-out visitors;
+ * signed-in renders pass through untouched.
+ */
+const Layout: FC<LayoutProps> = async ({ children }) => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (actor) return <>{children}</>
+
+  return <PublicShell>{children}</PublicShell>
+}
+
+export default Layout

--- a/app/(timeline)/tags/layout.tsx
+++ b/app/(timeline)/tags/layout.tsx
@@ -1,10 +1,9 @@
 import { FC, ReactNode } from 'react'
 
+import { PublicShell } from '@/app/(timeline)/PublicShell'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
-
-import { PublicShell } from '../PublicShell'
 
 interface LayoutProps {
   children: ReactNode

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -34,6 +34,7 @@ import { Attachments, OnMediaSelectedHandle } from './attachments'
 import { CollapsibleContent } from './collapsible-content'
 import { ContentWarning } from './content-warning'
 import { Poll } from './poll'
+import { ReadOnlyStats } from './read-only-stats'
 import { RetryFitnessButton } from './retry-fitness-button'
 
 export interface PostProps {
@@ -43,6 +44,12 @@ export interface PostProps {
   status: Status
   editable?: boolean
   showActions?: boolean
+  /**
+   * Render a non-interactive engagement row (reply/boost/like counts) in place
+   * of the action buttons. Used for read-only previews such as the logged-out
+   * landing feed. Ignored when `showActions` is on.
+   */
+  showReadOnlyStats?: boolean
   onReply?: (status: Status) => void
   onEdit?: (status: EditableStatus) => void
   onPostDeleted?: (status: Status) => void
@@ -305,6 +312,9 @@ export const Post: FC<PostProps> = (props) => {
 
           <div>
             <Actions {...props} />
+            {props.showReadOnlyStats && !props.showActions && (
+              <ReadOnlyStats status={status} />
+            )}
           </div>
         </div>
       </div>

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -30,6 +30,12 @@ interface Props {
   framed?: boolean
   currentActor?: ActorProfile
   showActions?: boolean
+  /**
+   * Render non-interactive engagement counts (reply/boost/like) under each post
+   * instead of action buttons. For read-only previews like the logged-out
+   * landing feed. Ignored when `showActions` is on.
+   */
+  showReadOnlyStats?: boolean
   currentTime: number
   statuses: Status[]
   isMediaUploadEnabled?: boolean
@@ -50,6 +56,7 @@ export const Posts: FC<Props> = ({
   framed = true,
   currentActor,
   showActions = false,
+  showReadOnlyStats = false,
   currentTime,
   statuses,
   isMediaUploadEnabled,
@@ -125,6 +132,7 @@ export const Posts: FC<Props> = ({
               currentActor={currentActor}
               status={status}
               showActions={showActions}
+              showReadOnlyStats={showReadOnlyStats}
               editable={currentActor?.id === status.actorId}
               collapsible
               postLineLimit={postLineLimit}

--- a/lib/components/posts/read-only-stats.test.tsx
+++ b/lib/components/posts/read-only-stats.test.tsx
@@ -22,6 +22,21 @@ describe('ReadOnlyStats', () => {
     expect(screen.getByText('12')).toBeInTheDocument()
   })
 
+  it('pluralizes the screen-reader labels by count', () => {
+    const singular = {
+      type: StatusType.enum.Note,
+      totalShares: 1,
+      totalLikes: 1
+    } as unknown as Status
+    const { rerender } = render(<ReadOnlyStats status={singular} />)
+    expect(screen.getByText('boost')).toBeInTheDocument()
+    expect(screen.getByText('like')).toBeInTheDocument()
+
+    rerender(<ReadOnlyStats status={baseNote} />)
+    expect(screen.getByText('boosts')).toBeInTheDocument()
+    expect(screen.getByText('likes')).toBeInTheDocument()
+  })
+
   it('reads totals from the original status of a boost', () => {
     const announce = {
       type: StatusType.enum.Announce,

--- a/lib/components/posts/read-only-stats.test.tsx
+++ b/lib/components/posts/read-only-stats.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+import { ReadOnlyStats } from './read-only-stats'
+
+const baseNote = {
+  type: StatusType.enum.Note,
+  totalShares: 4,
+  totalLikes: 12
+} as unknown as Status
+
+describe('ReadOnlyStats', () => {
+  it('renders boost and like totals', () => {
+    render(<ReadOnlyStats status={baseNote} />)
+
+    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('reads totals from the original status of a boost', () => {
+    const announce = {
+      type: StatusType.enum.Announce,
+      originalStatus: {
+        type: StatusType.enum.Note,
+        totalShares: 7,
+        totalLikes: 3
+      }
+    } as unknown as Status
+
+    render(<ReadOnlyStats status={announce} />)
+
+    expect(screen.getByText('7')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})

--- a/lib/components/posts/read-only-stats.tsx
+++ b/lib/components/posts/read-only-stats.tsx
@@ -19,16 +19,26 @@ export const ReadOnlyStats: FC<ReadOnlyStatsProps> = ({ status }) => {
   const actualStatus = getActualStatus(status)
   return (
     <div className="mt-3 flex items-center gap-6 text-xs text-muted-foreground">
-      <span className="inline-flex items-center gap-1.5">
-        <Reply className="size-4" />
+      <span className="inline-flex items-center gap-1.5" aria-label="Replies">
+        <Reply className="size-4" aria-hidden="true" />
       </span>
-      <span className="inline-flex items-center gap-1.5">
-        <Repeat2 className="size-4" />
-        <span className="tabular-nums">{actualStatus.totalShares}</span>
+      <span
+        className="inline-flex items-center gap-1.5"
+        aria-label={`${actualStatus.totalShares} boosts`}
+      >
+        <Repeat2 className="size-4" aria-hidden="true" />
+        <span className="tabular-nums" aria-hidden="true">
+          {actualStatus.totalShares}
+        </span>
       </span>
-      <span className="inline-flex items-center gap-1.5">
-        <Heart className="size-4" />
-        <span className="tabular-nums">{actualStatus.totalLikes}</span>
+      <span
+        className="inline-flex items-center gap-1.5"
+        aria-label={`${actualStatus.totalLikes} likes`}
+      >
+        <Heart className="size-4" aria-hidden="true" />
+        <span className="tabular-nums" aria-hidden="true">
+          {actualStatus.totalLikes}
+        </span>
       </span>
     </div>
   )

--- a/lib/components/posts/read-only-stats.tsx
+++ b/lib/components/posts/read-only-stats.tsx
@@ -1,0 +1,35 @@
+import { Heart, Repeat2, Reply } from 'lucide-react'
+import { FC } from 'react'
+
+import { Status } from '@/lib/types/domain/status'
+import { getActualStatus } from '@/lib/utils/text/processStatusText'
+
+interface ReadOnlyStatsProps {
+  status: Status
+}
+
+/**
+ * Non-interactive engagement row for read-only post previews (e.g. the
+ * logged-out landing feed). Mirrors the action row's layout but renders plain
+ * counts instead of buttons. Boost/like come from the status totals; the reply
+ * count is omitted because `replies` isn't hydrated on timeline statuses, so
+ * the reply affordance shows as an icon only.
+ */
+export const ReadOnlyStats: FC<ReadOnlyStatsProps> = ({ status }) => {
+  const actualStatus = getActualStatus(status)
+  return (
+    <div className="mt-3 flex items-center gap-6 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1.5">
+        <Reply className="size-4" />
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <Repeat2 className="size-4" />
+        <span className="tabular-nums">{actualStatus.totalShares}</span>
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <Heart className="size-4" />
+        <span className="tabular-nums">{actualStatus.totalLikes}</span>
+      </span>
+    </div>
+  )
+}

--- a/lib/components/posts/read-only-stats.tsx
+++ b/lib/components/posts/read-only-stats.tsx
@@ -15,8 +15,18 @@ interface ReadOnlyStatsProps {
  * count is omitted because `replies` isn't hydrated on timeline statuses, so
  * the reply affordance shows as an icon only.
  */
+// Pluralize the engagement noun. The count is rendered separately (a visible,
+// screen-reader-read number), so the sr-only span carries only the noun — the
+// reader announces e.g. "4 boosts" without repeating the count.
+const pluralNoun = (count: number, noun: string) =>
+  count === 1 ? noun : `${noun}s`
+
 export const ReadOnlyStats: FC<ReadOnlyStatsProps> = ({ status }) => {
   const actualStatus = getActualStatus(status)
+  const totalShares = actualStatus.totalShares ?? 0
+  const totalLikes = actualStatus.totalLikes ?? 0
+  const boostsNoun = pluralNoun(totalShares, 'boost')
+  const likesNoun = pluralNoun(totalLikes, 'like')
   return (
     <div
       className="mt-3 flex items-center gap-6 text-xs text-muted-foreground"
@@ -28,19 +38,19 @@ export const ReadOnlyStats: FC<ReadOnlyStatsProps> = ({ status }) => {
       </span>
       <span
         className="inline-flex items-center gap-1.5"
-        title={`${actualStatus.totalShares ?? 0} boosts`}
+        title={`${totalShares} ${boostsNoun}`}
       >
         <Repeat2 className="size-4" aria-hidden="true" />
-        <span className="tabular-nums">{actualStatus.totalShares ?? 0}</span>
-        <span className="sr-only">boosts</span>
+        <span className="tabular-nums">{totalShares}</span>
+        <span className="sr-only">{boostsNoun}</span>
       </span>
       <span
         className="inline-flex items-center gap-1.5"
-        title={`${actualStatus.totalLikes ?? 0} likes`}
+        title={`${totalLikes} ${likesNoun}`}
       >
         <Heart className="size-4" aria-hidden="true" />
-        <span className="tabular-nums">{actualStatus.totalLikes ?? 0}</span>
-        <span className="sr-only">likes</span>
+        <span className="tabular-nums">{totalLikes}</span>
+        <span className="sr-only">{likesNoun}</span>
       </span>
     </div>
   )

--- a/lib/components/posts/read-only-stats.tsx
+++ b/lib/components/posts/read-only-stats.tsx
@@ -18,27 +18,29 @@ interface ReadOnlyStatsProps {
 export const ReadOnlyStats: FC<ReadOnlyStatsProps> = ({ status }) => {
   const actualStatus = getActualStatus(status)
   return (
-    <div className="mt-3 flex items-center gap-6 text-xs text-muted-foreground">
-      <span className="inline-flex items-center gap-1.5" aria-label="Replies">
+    <div
+      className="mt-3 flex items-center gap-6 text-xs text-muted-foreground"
+      aria-label="Engagement"
+    >
+      <span className="inline-flex items-center gap-1.5" title="Replies">
         <Reply className="size-4" aria-hidden="true" />
+        <span className="sr-only">Replies</span>
       </span>
       <span
         className="inline-flex items-center gap-1.5"
-        aria-label={`${actualStatus.totalShares} boosts`}
+        title={`${actualStatus.totalShares} boosts`}
       >
         <Repeat2 className="size-4" aria-hidden="true" />
-        <span className="tabular-nums" aria-hidden="true">
-          {actualStatus.totalShares}
-        </span>
+        <span className="tabular-nums">{actualStatus.totalShares}</span>
+        <span className="sr-only">boosts</span>
       </span>
       <span
         className="inline-flex items-center gap-1.5"
-        aria-label={`${actualStatus.totalLikes} likes`}
+        title={`${actualStatus.totalLikes} likes`}
       >
         <Heart className="size-4" aria-hidden="true" />
-        <span className="tabular-nums" aria-hidden="true">
-          {actualStatus.totalLikes}
-        </span>
+        <span className="tabular-nums">{actualStatus.totalLikes}</span>
+        <span className="sr-only">likes</span>
       </span>
     </div>
   )

--- a/lib/components/posts/read-only-stats.tsx
+++ b/lib/components/posts/read-only-stats.tsx
@@ -28,18 +28,18 @@ export const ReadOnlyStats: FC<ReadOnlyStatsProps> = ({ status }) => {
       </span>
       <span
         className="inline-flex items-center gap-1.5"
-        title={`${actualStatus.totalShares} boosts`}
+        title={`${actualStatus.totalShares ?? 0} boosts`}
       >
         <Repeat2 className="size-4" aria-hidden="true" />
-        <span className="tabular-nums">{actualStatus.totalShares}</span>
+        <span className="tabular-nums">{actualStatus.totalShares ?? 0}</span>
         <span className="sr-only">boosts</span>
       </span>
       <span
         className="inline-flex items-center gap-1.5"
-        title={`${actualStatus.totalLikes} likes`}
+        title={`${actualStatus.totalLikes ?? 0} likes`}
       >
         <Heart className="size-4" aria-hidden="true" />
-        <span className="tabular-nums">{actualStatus.totalLikes}</span>
+        <span className="tabular-nums">{actualStatus.totalLikes ?? 0}</span>
         <span className="sr-only">likes</span>
       </span>
     </div>

--- a/lib/services/auth/getSession.ts
+++ b/lib/services/auth/getSession.ts
@@ -1,11 +1,16 @@
 import { headers } from 'next/headers'
+import { cache } from 'react'
 
 import { getAuth } from './auth'
 
-export const getServerAuthSession = async () => {
+// Wrapped in React `cache()` so the better-auth session lookup is deduplicated
+// within a single request. Layouts, nested sub-layouts and the page itself all
+// resolve the viewer per render; without this each call would re-read the
+// session independently.
+export const getServerAuthSession = cache(async () => {
   const auth = getAuth()
   const session = await auth.api.getSession({
     headers: await headers()
   })
   return session
-}
+})

--- a/lib/utils/getActorFromSession.ts
+++ b/lib/utils/getActorFromSession.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers'
+import { cache } from 'react'
 
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
@@ -39,33 +40,37 @@ export const getAccountFromSession = async (
   return database.getAccountFromEmail({ email: session.user.email })
 }
 
-export const getActorFromSession = async (
-  database: Database,
-  session: AuthSession | null
-) => {
-  // Fetch account and its actors once — reused across all resolution steps below
-  const account = await getAccountFromSession(database, session)
-  if (!account) return null
+// Wrapped in React `cache()` so resolving the viewer is deduplicated within a
+// request: the `(timeline)` layout, the public sub-layouts (`[actor]`, `tags`)
+// and the page itself all resolve the actor per render. Keyed on (database,
+// session); both are stable per request (the singleton database and the cached
+// `getServerAuthSession` result), so the account/actor queries run once.
+export const getActorFromSession = cache(
+  async (database: Database, session: AuthSession | null) => {
+    // Fetch account and its actors once — reused across all resolution steps
+    const account = await getAccountFromSession(database, session)
+    if (!account) return null
 
-  const actors = await database.getActorsForAccount({ accountId: account.id })
+    const actors = await database.getActorsForAccount({ accountId: account.id })
 
-  // 1. Check actor selection cookie
-  const actorIdFromCookie = await getActorIdFromCookie()
-  if (actorIdFromCookie) {
-    const cookieActor = actors.find(
-      (a) => a.id === actorIdFromCookie && !a.deletionStatus
-    )
-    if (cookieActor) return cookieActor
+    // 1. Check actor selection cookie
+    const actorIdFromCookie = await getActorIdFromCookie()
+    if (actorIdFromCookie) {
+      const cookieActor = actors.find(
+        (a) => a.id === actorIdFromCookie && !a.deletionStatus
+      )
+      if (cookieActor) return cookieActor
+    }
+
+    // 2. Check default actor
+    if (account.defaultActorId) {
+      const defaultActor = actors.find(
+        (a) => a.id === account.defaultActorId && !a.deletionStatus
+      )
+      if (defaultActor) return defaultActor
+    }
+
+    // 3. Fall back to first actor without pending deletion
+    return actors.find((a) => !a.deletionStatus) ?? null
   }
-
-  // 2. Check default actor
-  if (account.defaultActorId) {
-    const defaultActor = actors.find(
-      (a) => a.id === account.defaultActorId && !a.deletionStatus
-    )
-    if (defaultActor) return defaultActor
-  }
-
-  // 3. Fall back to first actor without pending deletion
-  return actors.find((a) => !a.deletionStatus) ?? null
-}
+)


### PR DESCRIPTION
## Summary

Logged-out visitors at `/` previously redirected straight to `/auth/signin`. They now get a **full-bleed split landing** that mirrors the design system's `web-landing` UI kit (`ui_kits/web-landing/index.html` and `feed.html`):

- **Brand hero** (left) on the Activity-orange ground with the signature dual-tint gradient, watermark sparrow, and the copy-light *"See what's happening next."* — shown when the server has **no** public posts.
- **Public-feed preview** (left) of the server's recent public timeline (`LOCAL_PUBLIC`, 5 posts) — shown when the server **has** public posts. It reuses the timeline `Posts`/`Post` components, so previewed posts render exactly like the real app.
- **Create / sign-in card** (right) shared by both variants, linking to the real `/auth/signup` and `/auth/signin` routes (the passkey CTA points at the sign-in page where the WebAuthn button lives).

The split stacks vertically on mobile and sits on the body's signature gradient backdrop (the auth column is translucent so it reads through).

## Design fidelity notes

- The design's read-only feed shows a reply/boost/like row. I added an **opt-in `showReadOnlyStats` prop** to `Post`/`Posts` that renders non-interactive counts in place of the action buttons (boost = `totalShares`, like = `totalLikes`). The **reply count is shown as an icon only** — `replies` isn't hydrated on timeline statuses, so a number there would be misleading.
- Copy, tone, tokens, Lucide icons, and the system font stack follow the design system README (sentence case, no emoji, Activity-orange only).

## Architecture

`/` is dual-purpose: the signed-in **timeline** and the logged-out **landing** both render through `app/(timeline)/layout.tsx`. To let the landing go full-bleed without the public top bar / footer / narrow column, that chrome moved out of the shared layout into a reusable **`PublicShell`**, now applied only to the federated reading surfaces that still need it — `[actor]/*` (profiles, single status, followers/following, profile fitness) and `tags/*` (hashtags) — via their own thin sub-layouts. Signed-in renders on those routes pass through untouched (they get the nav sidebar from the root layout).

`getServerAuthSession` is wrapped in React `cache()` so the root layout, the new sub-layouts, and the page share **one** session lookup per request.

Accessibility: the landing is a `<main>` landmark; the hero headline and the feed's server-host line are the page `<h1>`.

## Verification

- `prettier`, `yarn lint` (0 errors), `yarn build`, `yarn test` (**424 suites / 3582 tests**) all green.
- Browser-verified logged-out (fresh session) against the design screenshots: feed + hero variants at desktop (1280) and mobile (390), 0 console errors / no hydration warnings.
- Confirmed the refactor preserves the logged-out public **profile/status chrome** (top bar + footer) and that the **signed-in timeline** at `/` still renders.

New tests: `Landing` (hero↔feed switching, `currentTime` forwarded as a number), the `[actor]` sub-layout (public shell when logged-out, passthrough when signed-in), and `ReadOnlyStats`. Updated `(timeline)/layout` test for the slimmed logged-out branch.

> Screenshots of all four variants are shared separately (repo rules forbid committing PR screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a logged-out landing at `/` that matches the design system, replacing the redirect to `/auth/signin`. It shows a brand hero or a read-only public feed, with a shared auth panel on the right.

- New Features
  - Full-bleed landing for logged-out: brand hero when no public posts; otherwise a read-only preview of the recent public timeline (`LOCAL_PUBLIC`, 5 posts) using `Posts`/`Post`.
  - Added `showReadOnlyStats` to `Post`/`Posts` for non-interactive boost/like counts (reply shows icon only), with pluralized sr-only labels, title tooltips, and 0-defaults when totals aren’t hydrated.
  - Shared create/sign-in panel linking to `/auth/signup` and `/auth/signin` (passkey CTA points to sign-in).
  - Reliability & fidelity: landing falls back to the hero and logs on feed query failure; both columns use flex for stable centering; responsive md split; hero styling aligned with the kit.

- Refactors
  - Moved public top bar/footer into `PublicShell`; applied to `[actor]/*` and `tags/*` via sub-layouts. `(timeline)` is chrome-less when logged out.
  - Wrapped `getServerAuthSession` and `getActorFromSession` in React `cache()` to dedupe per-request lookups.
  - `/` now selects between landing (logged out) and timeline (signed in), passing `currentTime` from the server.

<sup>Written for commit 9040948167b39c45abdc492d76299b748c597c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

