### PR TITLE
Bump version to v1.46.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.46.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.46.0`
- Base main SHA: `af7396f88a1daa9f41b73e12c0afdee8ab9714cf`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `activities.next` to v1.46.1 for a patch release. Updates the version in package.json only; no code changes.

<sup>Written for commit 3a44785645fb49d9e47f01148614bce05c2f930a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

