### PR TITLE
fix: stop intermittent 500s and validate params on timeline endpoints

### DIFF
--- a/app/api/v1/timelines/[timeline]/route.test.ts
+++ b/app/api/v1/timelines/[timeline]/route.test.ts
@@ -6,6 +6,7 @@ import { Timeline } from '@/lib/services/timelines/types'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
+import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -544,6 +545,61 @@ describe('GET /api/v1/timelines/[timeline]', () => {
       })
 
       expect(response.status).toBe(401)
+    })
+  })
+
+  describe('query param validation', () => {
+    test.each([['max_id'], ['min_id'], ['since_id']])(
+      'returns 400 (not 500) for a malformed %s cursor',
+      async (field) => {
+        mockGetServerSession.mockResolvedValue({
+          user: { email: seedActor1.email }
+        })
+
+        const response = await GET(createRequest({ [field]: 'apurl_@@@@' }), {
+          params: Promise.resolve({ timeline: 'main' })
+        })
+
+        expect(response.status).toBe(400)
+      }
+    )
+  })
+
+  describe('hydration resilience', () => {
+    test('returns 200 with the un-hydratable row skipped, not 500', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const goodStatus = (await database.getStatus({
+        statusId: actor1TimelinePost1Id
+      })) as Status
+      // A status whose shape throws during Mastodon serialization (a Note
+      // missing its tags/attachments arrays) must be dropped, not 500 the page.
+      const brokenStatus = {
+        id: `${ACTOR1_ID}/statuses/timeline-broken`,
+        actorId: ACTOR1_ID,
+        type: 'Note',
+        reply: '',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as unknown as Status
+      const spy = jest
+        .spyOn(database, 'getTimeline')
+        .mockResolvedValue([goodStatus, brokenStatus])
+
+      // No `format=activities_next` → the Mastodon hydration path runs.
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v1/timelines/main'),
+        { params: Promise.resolve({ timeline: 'main' }) }
+      )
+      spy.mockRestore()
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.map((status: { id: string }) => status.id)).toEqual([
+        urlToId(goodStatus.id)
+      ])
     })
   })
 })

--- a/app/api/v1/timelines/[timeline]/route.test.ts
+++ b/app/api/v1/timelines/[timeline]/route.test.ts
@@ -563,6 +563,28 @@ describe('GET /api/v1/timelines/[timeline]', () => {
         expect(response.status).toBe(400)
       }
     )
+
+    test('since_id takes precedence over min_id for the lower-bound cursor', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const sinceUrl = 'https://llun.test/users/test1/statuses/since-cursor'
+      const minUrl = 'https://llun.test/users/test1/statuses/min-cursor'
+      const spy = jest.spyOn(database, 'getTimeline').mockResolvedValue([])
+
+      await GET(
+        createRequest({
+          since_id: urlToId(sinceUrl),
+          min_id: urlToId(minUrl)
+        }),
+        { params: Promise.resolve({ timeline: 'main' }) }
+      )
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ minStatusId: sinceUrl })
+      )
+      spy.mockRestore()
+    })
   })
 
   describe('hydration resilience', () => {

--- a/app/api/v1/timelines/[timeline]/route.ts
+++ b/app/api/v1/timelines/[timeline]/route.ts
@@ -1,4 +1,3 @@
-import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import {
   annotateMastodonStatusesWithFilters,
   getFilterContextForTimeline
@@ -7,10 +6,11 @@ import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
 import { TimelineFormat } from '@/lib/services/timelines/const'
+import { getFilteredTimelinePage } from '@/lib/services/timelines/getFilteredTimelinePage'
 import {
-  getFilteredTimelinePage,
-  normalizeTimelineLimit
-} from '@/lib/services/timelines/getFilteredTimelinePage'
+  parseTimelineQuery,
+  timelineErrorBoundary
+} from '@/lib/services/timelines/request'
 import { Timeline } from '@/lib/services/timelines/types'
 import { Scope } from '@/lib/types/database/operations'
 import { cleanJson } from '@/lib/utils/cleanJson'
@@ -22,7 +22,9 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+import { urlToId } from '@/lib/utils/urlToId'
+
+export const dynamic = 'force-dynamic'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const UNSUPPORTED_TIMELINE = [Timeline.LOCAL_PUBLIC]
@@ -40,12 +42,8 @@ export const GET = traceApiRoute(
   'getTimeline',
   OAuthGuardAnyScope<Params>(
     [Scope.enum.read, Scope.enum['read:statuses']],
-    async (req, context) => {
+    timelineErrorBoundary(CORS_HEADERS, async (req, context) => {
       const url = new URL(req.url)
-      const minStatusIdParam =
-        url.searchParams.get('since_id') || url.searchParams.get('min_id')
-      const maxStatusIdParam = url.searchParams.get('max_id')
-      const limit = url.searchParams.get('limit')
       const format = url.searchParams.get('format')
 
       const { database, currentActor, params } = context
@@ -76,13 +74,27 @@ export const GET = traceApiRoute(
         })
       }
 
+      const parsedQuery = parseTimelineQuery(url.searchParams)
+      if (!parsedQuery.ok) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+
       // Keep /api/v1/timelines/direct for Mastodon client compatibility.
       // The messages UI uses /api/v1/conversations for threaded direct messages.
 
-      const minStatusId = minStatusIdParam ? idToUrl(minStatusIdParam) : null
-      const maxStatusId = maxStatusIdParam ? idToUrl(maxStatusIdParam) : null
-      const parsedLimit = limit ? parseInt(limit, 10) : PER_PAGE_LIMIT
-      const pageLimit = normalizeTimelineLimit(parsedLimit)
+      // `since_id` and `min_id` both express a lower-bound cursor here; the DB
+      // timeline query takes a single min cursor, so collapse them preserving
+      // this route's existing `since_id`-wins precedence. (min/since ordering
+      // semantics are unchanged by this PR — see PR notes.)
+      const pageLimit = parsedQuery.query.limit
+      const maxStatusId = parsedQuery.query.maxStatusId
+      const minStatusId =
+        parsedQuery.query.sinceStatusId ?? parsedQuery.query.minStatusId
 
       const { statuses, nextMaxStatusId, prevMinStatusId, filterRecords } =
         await getFilteredTimelinePage({
@@ -133,7 +145,7 @@ export const GET = traceApiRoute(
           ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
         ]
       })
-    }
+    })
   ),
   {
     addAttributes: async (_req, context) => {

--- a/app/api/v1/timelines/[timeline]/route.ts
+++ b/app/api/v1/timelines/[timeline]/route.ts
@@ -2,7 +2,10 @@ import {
   annotateMastodonStatusesWithFilters,
   getFilterContextForTimeline
 } from '@/lib/services/filters/applyFilters'
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
 import { TimelineFormat } from '@/lib/services/timelines/const'
@@ -145,7 +148,8 @@ export const GET = traceApiRoute(
           ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
         ]
       })
-    })
+    }),
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
   ),
   {
     addAttributes: async (_req, context) => {

--- a/app/api/v1/timelines/list/[list_id]/route.test.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.test.ts
@@ -123,6 +123,21 @@ describe('GET /api/v1/timelines/list/[list_id]', () => {
     }
   )
 
+  it('uses min_id over since_id for the lower-bound cursor', async () => {
+    const minUrl = 'https://llun.test/users/test1/statuses/min-cursor'
+    const sinceUrl = 'https://llun.test/users/test1/statuses/since-cursor'
+    const spy = jest.spyOn(database, 'getListTimeline').mockResolvedValue([])
+
+    await GET(
+      request({ min_id: urlToId(minUrl), since_id: urlToId(sinceUrl) }),
+      { params: Promise.resolve({ list_id: listId }) }
+    )
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ minStatusId: minUrl })
+    )
+  })
+
   it('returns 200 with the bad row skipped when one status is un-hydratable', async () => {
     // A status whose shape throws during Mastodon serialization (here a Note
     // missing its tags/attachments arrays) must be dropped, not 500 the page.

--- a/app/api/v1/timelines/list/[list_id]/route.test.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.test.ts
@@ -1,0 +1,163 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { Status } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      get: () => undefined
+    })
+  )
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/timelines/list/[list_id]', () => {
+  const database = getTestSQLDatabase()
+  let listId: string
+  let listStatus: Status
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+
+    const list = await database.createList({
+      actorId: ACTOR1_ID,
+      title: 'Test list'
+    })
+    listId = list.id
+
+    listStatus = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/list-1`,
+      url: `${ACTOR1_ID}/statuses/list-1`,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'list timeline post'
+    })
+
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const request = (params: Record<string, string> = {}) => {
+    const url = new URL(`https://llun.test/api/v1/timelines/list/${listId}`)
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value)
+    }
+    return new NextRequest(url.toString())
+  }
+
+  it('returns the list timeline for a valid request with Link headers', async () => {
+    jest.spyOn(database, 'getListTimeline').mockResolvedValue([listStatus])
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ list_id: listId })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((status: { id: string }) => status.id)).toEqual([
+      urlToId(listStatus.id)
+    ])
+    const link = response.headers.get('Link') || ''
+    expect(link).toContain('rel="next"')
+    expect(link).toContain('rel="prev"')
+  })
+
+  it('returns 404 for a non-existent list', async () => {
+    const response = await GET(request(), {
+      params: Promise.resolve({ list_id: 'does-not-exist' })
+    })
+    expect(response.status).toBe(404)
+  })
+
+  it.each([
+    { description: 'max_id', field: 'max_id' },
+    { description: 'min_id', field: 'min_id' },
+    { description: 'since_id', field: 'since_id' }
+  ])(
+    'returns 400 (not 500) for a malformed $description cursor',
+    async ({ field }) => {
+      const response = await GET(request({ [field]: 'apurl_@@@@' }), {
+        params: Promise.resolve({ list_id: listId })
+      })
+      expect(response.status).toBe(400)
+    }
+  )
+
+  it('returns 200 with the bad row skipped when one status is un-hydratable', async () => {
+    // A status whose shape throws during Mastodon serialization (here a Note
+    // missing its tags/attachments arrays) must be dropped, not 500 the page.
+    const brokenStatus = {
+      id: `${ACTOR1_ID}/statuses/list-broken`,
+      actorId: ACTOR1_ID,
+      type: 'Note',
+      reply: '',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    } as unknown as Status
+    jest
+      .spyOn(database, 'getListTimeline')
+      .mockResolvedValue([listStatus, brokenStatus])
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ list_id: listId })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((status: { id: string }) => status.id)).toEqual([
+      urlToId(listStatus.id)
+    ])
+  })
+
+  it('returns an empty array and no Link header when there are no statuses', async () => {
+    jest.spyOn(database, 'getListTimeline').mockResolvedValue([])
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ list_id: listId })
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+    expect(response.headers.get('Link')).toBeNull()
+  })
+})

--- a/app/api/v1/timelines/list/[list_id]/route.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.ts
@@ -2,7 +2,10 @@ import {
   annotateMastodonStatusesWithFilters,
   getActiveFilters
 } from '@/lib/services/filters/applyFilters'
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
 import {
@@ -116,6 +119,7 @@ export const GET = traceApiRoute(
           ]
         })
       }
-    )
+    ),
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/app/api/v1/timelines/list/[list_id]/route.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.ts
@@ -1,4 +1,3 @@
-import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import {
   annotateMastodonStatusesWithFilters,
   getActiveFilters
@@ -6,12 +5,22 @@ import {
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
-import { normalizeTimelineLimit } from '@/lib/services/timelines/getFilteredTimelinePage'
+import {
+  parseTimelineQuery,
+  timelineErrorBoundary
+} from '@/lib/services/timelines/request'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_400,
+  ERROR_404,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+import { urlToId } from '@/lib/utils/urlToId'
+
+export const dynamic = 'force-dynamic'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
@@ -26,70 +35,87 @@ export const GET = traceApiRoute(
   'getListTimeline',
   OAuthGuardAnyScope<Params>(
     [Scope.enum.read, Scope.enum['read:lists']],
-    async (req, { database, currentActor, params }) => {
-      const { list_id: listId } = await params
-      const list = await database.getList({
-        id: listId,
-        actorId: currentActor.id
-      })
-      if (!list) {
+    timelineErrorBoundary(
+      CORS_HEADERS,
+      async (req, { database, currentActor, params }) => {
+        const { list_id: listId } = await params
+        const list = await database.getList({
+          id: listId,
+          actorId: currentActor.id
+        })
+        if (!list) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_404,
+            responseStatusCode: 404
+          })
+        }
+
+        const url = new URL(req.url)
+        const parsedQuery = parseTimelineQuery(url.searchParams)
+        if (!parsedQuery.ok) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_400,
+            responseStatusCode: 400
+          })
+        }
+        const limit = parsedQuery.query.limit
+        const maxStatusId = parsedQuery.query.maxStatusId
+        // `min_id` and `since_id` both express a lower-bound cursor; the list
+        // timeline query takes a single min cursor, so collapse them preserving
+        // this route's existing `min_id`-wins precedence. (min/since ordering
+        // semantics are unchanged by this PR — see PR notes.)
+        const minStatusId =
+          parsedQuery.query.minStatusId ?? parsedQuery.query.sinceStatusId
+
+        const statuses = await database.getListTimeline({
+          listId,
+          actorId: currentActor.id,
+          limit,
+          maxStatusId,
+          minStatusId
+        })
+
+        const mastodonStatuses = await getMastodonStatuses(
+          database,
+          statuses,
+          currentActor.id
+        )
+        // List timelines use the same filtering context as the home timeline.
+        const filterRecords = await getActiveFilters(
+          database,
+          currentActor.id,
+          'home'
+        )
+        const annotated = annotateMastodonStatusesWithFilters(
+          mastodonStatuses,
+          statuses,
+          filterRecords
+        )
+
+        const host = headerHost(req.headers)
+        const firstStatus = statuses[0]
+        const lastStatus = statuses[statuses.length - 1]
+        const nextLink = lastStatus
+          ? `<https://${host}/api/v1/timelines/list/${listId}?limit=${limit}&max_id=${urlToId(lastStatus.id)}>; rel="next"`
+          : null
+        const prevLink = firstStatus
+          ? `<https://${host}/api/v1/timelines/list/${listId}?limit=${limit}&min_id=${urlToId(firstStatus.id)}>; rel="prev"`
+          : null
+        const links = [nextLink, prevLink].filter(Boolean).join(', ')
+
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_404,
-          responseStatusCode: 404
+          data: annotated,
+          additionalHeaders: [
+            ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
+          ]
         })
       }
-
-      const url = new URL(req.url)
-      const limitParam = url.searchParams.get('limit')
-      const limit = normalizeTimelineLimit(
-        limitParam ? parseInt(limitParam, 10) : PER_PAGE_LIMIT
-      )
-      const maxIdParam = url.searchParams.get('max_id')
-      const minIdParam =
-        url.searchParams.get('min_id') || url.searchParams.get('since_id')
-
-      const statuses = await database.getListTimeline({
-        listId,
-        actorId: currentActor.id,
-        limit,
-        maxStatusId: maxIdParam ? idToUrl(maxIdParam) : null,
-        minStatusId: minIdParam ? idToUrl(minIdParam) : null
-      })
-
-      const mastodonStatuses = await getMastodonStatuses(
-        database,
-        statuses,
-        currentActor.id
-      )
-      // List timelines use the same filtering context as the home timeline.
-      const filterRecords = await getActiveFilters(
-        database,
-        currentActor.id,
-        'home'
-      )
-      const annotated = annotateMastodonStatusesWithFilters(
-        mastodonStatuses,
-        statuses,
-        filterRecords
-      )
-
-      const host = headerHost(req.headers)
-      const lastStatus = statuses[statuses.length - 1]
-      const nextLink = lastStatus
-        ? `<https://${host}/api/v1/timelines/list/${listId}?limit=${limit}&max_id=${urlToId(lastStatus.id)}>; rel="next"`
-        : null
-      const links = [nextLink].filter(Boolean).join(', ')
-
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: annotated,
-        additionalHeaders: [
-          ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
-        ]
-      })
-    }
+    )
   )
 )

--- a/app/api/v1/timelines/public/route.test.ts
+++ b/app/api/v1/timelines/public/route.test.ts
@@ -1,0 +1,143 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { Status } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      get: () => undefined
+    })
+  )
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/timelines/public', () => {
+  const database = getTestSQLDatabase()
+  let publicStatus: Status
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    publicStatus = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/public-1`,
+      url: `${ACTOR1_ID}/statuses/public-1`,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'public timeline post'
+    })
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    // No session → optional auth resolves currentActor = null (anonymous).
+    mockGetServerSession.mockResolvedValue(null)
+  })
+
+  const request = (params: Record<string, string> = {}) => {
+    const url = new URL('https://llun.test/api/v1/timelines/public')
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value)
+    }
+    return new NextRequest(url.toString())
+  }
+
+  it('returns the public timeline for a valid request', async () => {
+    jest.spyOn(database, 'getTimeline').mockResolvedValue([publicStatus])
+
+    const response = await GET(request(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((status: { id: string }) => status.id)).toEqual([
+      urlToId(publicStatus.id)
+    ])
+  })
+
+  it.each([
+    { description: 'junk opaque id', value: 'apurl_@@@@' },
+    { description: 'percent signs', value: '%%%' },
+    { description: 'spaces', value: 'a b c' }
+  ])(
+    'returns 400 (not 500) for a malformed max_id cursor ($description)',
+    async ({ value }) => {
+      const response = await GET(request({ max_id: value }), {
+        params: Promise.resolve({})
+      })
+      expect(response.status).toBe(400)
+    }
+  )
+
+  it('returns 200 with the bad row skipped when one status is un-hydratable', async () => {
+    // A status whose shape throws during Mastodon serialization (here a Note
+    // missing its tags/attachments arrays) must be dropped, not 500 the page.
+    const brokenStatus = {
+      id: `${ACTOR1_ID}/statuses/public-broken`,
+      actorId: ACTOR1_ID,
+      type: 'Note',
+      reply: '',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    } as unknown as Status
+    jest
+      .spyOn(database, 'getTimeline')
+      .mockResolvedValue([publicStatus, brokenStatus])
+
+    const response = await GET(request(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((status: { id: string }) => status.id)).toEqual([
+      urlToId(publicStatus.id)
+    ])
+  })
+
+  it('returns an empty array and no Link header when there are no statuses', async () => {
+    jest.spyOn(database, 'getTimeline').mockResolvedValue([])
+
+    const response = await GET(request(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+    expect(response.headers.get('Link')).toBeNull()
+  })
+})

--- a/app/api/v1/timelines/public/route.ts
+++ b/app/api/v1/timelines/public/route.ts
@@ -43,7 +43,7 @@ export const GET = traceApiRoute(
       }
       const pageLimit = parsedQuery.query.limit
 
-      const { statuses, nextMaxStatusId, prevMinStatusId, filterRecords } =
+      const { statuses, nextMaxStatusId, filterRecords } =
         await getFilteredStatusPage({
           database,
           actorId: currentActor?.id,
@@ -68,13 +68,13 @@ export const GET = traceApiRoute(
         filterRecords ?? []
       )
       const host = headerHost(req.headers)
+      // Only `next` (older) is emitted: the public timeline query pages forward
+      // by `max_id` only and has no lower-bound cursor, so a `prev`/`min_id`
+      // link would not actually page to newer statuses.
       const nextLink = nextMaxStatusId
         ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&max_id=${urlToId(nextMaxStatusId)}>; rel="next"`
         : null
-      const prevLink = prevMinStatusId
-        ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&min_id=${urlToId(prevMinStatusId)}>; rel="prev"`
-        : null
-      const links = [nextLink, prevLink].filter(Boolean).join(', ')
+      const links = [nextLink].filter(Boolean).join(', ')
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/timelines/public/route.ts
+++ b/app/api/v1/timelines/public/route.ts
@@ -5,16 +5,17 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { getFilteredStatusPage } from '@/lib/services/timelines/getFilteredTimelinePage'
 import {
-  getFilteredStatusPage,
-  normalizeTimelineLimit
-} from '@/lib/services/timelines/getFilteredTimelinePage'
+  parseTimelineQuery,
+  timelineErrorBoundary
+} from '@/lib/services/timelines/request'
 import { Timeline } from '@/lib/services/timelines/types'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+import { urlToId } from '@/lib/utils/urlToId'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,19 +29,25 @@ export const GET = traceApiRoute(
   'getPublicTimeline',
   OptionalOAuthGuard<Params>(
     [Scope.enum.read],
-    async (req, context) => {
+    timelineErrorBoundary(CORS_HEADERS, async (req, context) => {
       const { database, currentActor } = context
       const url = new URL(req.url)
-      const maxStatusIdParam = url.searchParams.get('max_id')
-      const limitParam = url.searchParams.get('limit')
-      const parsedLimit = limitParam ? parseInt(limitParam, 10) : null
-      const pageLimit = normalizeTimelineLimit(parsedLimit)
+      const parsedQuery = parseTimelineQuery(url.searchParams)
+      if (!parsedQuery.ok) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const pageLimit = parsedQuery.query.limit
 
-      const { statuses, nextMaxStatusId, filterRecords } =
+      const { statuses, nextMaxStatusId, prevMinStatusId, filterRecords } =
         await getFilteredStatusPage({
           database,
           actorId: currentActor?.id,
-          maxStatusId: maxStatusIdParam ? idToUrl(maxStatusIdParam) : null,
+          maxStatusId: parsedQuery.query.maxStatusId,
           limit: pageLimit,
           filterContext: currentActor ? 'public' : undefined,
           fetchBatch: ({ maxStatusId, limit }) =>
@@ -64,15 +71,19 @@ export const GET = traceApiRoute(
       const nextLink = nextMaxStatusId
         ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&max_id=${urlToId(nextMaxStatusId)}>; rel="next"`
         : null
+      const prevLink = prevMinStatusId
+        ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&min_id=${urlToId(prevMinStatusId)}>; rel="prev"`
+        : null
+      const links = [nextLink, prevLink].filter(Boolean).join(', ')
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: annotatedStatuses,
         additionalHeaders: [
-          ...(nextLink ? [['Link', nextLink] as [string, string]] : [])
+          ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
         ]
       })
-    },
+    }),
     { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -69,4 +69,22 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       mockCurrentActor.id
     )
   })
+
+  it.each([
+    { description: 'max_id', field: 'max_id' },
+    { description: 'min_id', field: 'min_id' },
+    { description: 'since_id', field: 'since_id' }
+  ])(
+    'returns 400 (not 500) for a malformed $description cursor',
+    async ({ field }) => {
+      const url = new URL('https://local.test/api/v1/timelines/tag/running')
+      url.searchParams.set(field, 'apurl_@@@@')
+      const response = await GET(new NextRequest(url.toString()), {
+        params: Promise.resolve({ hashtag: 'running' })
+      })
+
+      expect(response.status).toBe(400)
+      expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -87,4 +87,18 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
     }
   )
+
+  it('returns an empty array and no Link header when there are no statuses', async () => {
+    mockDatabase.getStatusesByHashtag.mockResolvedValue([])
+    mockGetMastodonStatuses.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest('https://local.test/api/v1/timelines/tag/running'),
+      { params: Promise.resolve({ hashtag: 'running' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+    expect(response.headers.get('Link')).toBeNull()
+  })
 })

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -1,21 +1,23 @@
 import { z } from 'zod'
 
-import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import {
   OptionalOAuthGuard,
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { getFilteredStatusPage } from '@/lib/services/timelines/getFilteredTimelinePage'
 import {
-  getFilteredStatusPage,
-  normalizeTimelineLimit
-} from '@/lib/services/timelines/getFilteredTimelinePage'
+  parseTimelineQuery,
+  timelineErrorBoundary
+} from '@/lib/services/timelines/request'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+import { urlToId } from '@/lib/utils/urlToId'
+
+export const dynamic = 'force-dynamic'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
@@ -34,7 +36,7 @@ export const GET = traceApiRoute(
   'getHashtagTimeline',
   OptionalOAuthGuard<RouteParams>(
     [Scope.enum.read],
-    async (req, context) => {
+    timelineErrorBoundary(CORS_HEADERS, async (req, context) => {
       const { database, currentActor, params: routeParams } = context
       const parseResult = Params.safeParse(await routeParams)
       if (!parseResult.success) {
@@ -48,31 +50,40 @@ export const GET = traceApiRoute(
 
       const { hashtag } = parseResult.data
       const url = new URL(req.url)
-      const maxStatusIdParam = url.searchParams.get('max_id')
-      const limitParam = url.searchParams.get('limit')
-      const effectiveLimit = normalizeTimelineLimit(
-        limitParam ? parseInt(limitParam, 10) : PER_PAGE_LIMIT
-      )
+      const parsedQuery = parseTimelineQuery(url.searchParams)
+      if (!parsedQuery.ok) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+      const effectiveLimit = parsedQuery.query.limit
 
-      const { statuses, nextMaxStatusId } = await getFilteredStatusPage({
-        database,
-        actorId: currentActor?.id,
-        maxStatusId: maxStatusIdParam ? idToUrl(maxStatusIdParam) : null,
-        limit: effectiveLimit,
-        fetchBatch: ({ maxStatusId, limit }) =>
-          database.getStatusesByHashtag({
-            hashtag,
-            limit,
-            maxStatusId: maxStatusId ?? undefined
-          })
-      })
+      const { statuses, nextMaxStatusId, prevMinStatusId } =
+        await getFilteredStatusPage({
+          database,
+          actorId: currentActor?.id,
+          maxStatusId: parsedQuery.query.maxStatusId,
+          limit: effectiveLimit,
+          fetchBatch: ({ maxStatusId, limit }) =>
+            database.getStatusesByHashtag({
+              hashtag,
+              limit,
+              maxStatusId: maxStatusId ?? undefined
+            })
+        })
 
       const host = headerHost(req.headers)
       const encodedTag = encodeURIComponent(hashtag)
       const nextLink = nextMaxStatusId
         ? `<https://${host}/api/v1/timelines/tag/${encodedTag}?limit=${effectiveLimit}&max_id=${urlToId(nextMaxStatusId)}>; rel="next"`
         : null
-      const links = [nextLink].filter(Boolean).join(', ')
+      const prevLink = prevMinStatusId
+        ? `<https://${host}/api/v1/timelines/tag/${encodedTag}?limit=${effectiveLimit}&min_id=${urlToId(prevMinStatusId)}>; rel="prev"`
+        : null
+      const links = [nextLink, prevLink].filter(Boolean).join(', ')
       const mastodonStatuses = await getMastodonStatuses(
         database,
         statuses,
@@ -87,7 +98,7 @@ export const GET = traceApiRoute(
           ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
         ]
       })
-    },
+    }),
     { errorResponse: corsErrorResponse(CORS_HEADERS) }
   ),
   {

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -61,29 +61,28 @@ export const GET = traceApiRoute(
       }
       const effectiveLimit = parsedQuery.query.limit
 
-      const { statuses, nextMaxStatusId, prevMinStatusId } =
-        await getFilteredStatusPage({
-          database,
-          actorId: currentActor?.id,
-          maxStatusId: parsedQuery.query.maxStatusId,
-          limit: effectiveLimit,
-          fetchBatch: ({ maxStatusId, limit }) =>
-            database.getStatusesByHashtag({
-              hashtag,
-              limit,
-              maxStatusId: maxStatusId ?? undefined
-            })
-        })
+      const { statuses, nextMaxStatusId } = await getFilteredStatusPage({
+        database,
+        actorId: currentActor?.id,
+        maxStatusId: parsedQuery.query.maxStatusId,
+        limit: effectiveLimit,
+        fetchBatch: ({ maxStatusId, limit }) =>
+          database.getStatusesByHashtag({
+            hashtag,
+            limit,
+            maxStatusId: maxStatusId ?? undefined
+          })
+      })
 
       const host = headerHost(req.headers)
       const encodedTag = encodeURIComponent(hashtag)
+      // Only `next` (older) is emitted: the hashtag query pages forward by
+      // `max_id` only and has no lower-bound cursor, so a `prev`/`min_id` link
+      // would not actually page to newer statuses.
       const nextLink = nextMaxStatusId
         ? `<https://${host}/api/v1/timelines/tag/${encodedTag}?limit=${effectiveLimit}&max_id=${urlToId(nextMaxStatusId)}>; rel="next"`
         : null
-      const prevLink = prevMinStatusId
-        ? `<https://${host}/api/v1/timelines/tag/${encodedTag}?limit=${effectiveLimit}&min_id=${urlToId(prevMinStatusId)}>; rel="prev"`
-        : null
-      const links = [nextLink, prevLink].filter(Boolean).join(', ')
+      const links = [nextLink].filter(Boolean).join(', ')
       const mastodonStatuses = await getMastodonStatuses(
         database,
         statuses,

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -11,6 +11,7 @@ import {
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+import { logger } from '@/lib/utils/logger'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { getMastodonStatus, getMastodonStatuses } from './getMastodonStatus'
@@ -35,6 +36,63 @@ describe('getMastodonStatus', () => {
   afterAll(async () => {
     if (!database) return
     await database.destroy()
+  })
+
+  describe('getMastodonStatuses resilience', () => {
+    beforeEach(() => {
+      jest.spyOn(logger, 'warn').mockImplementation(() => undefined as never)
+    })
+
+    it('skips a status whose lookup-id collection throws and keeps the good one', async () => {
+      const goodStatus = (await database.getStatus({
+        statusId: `${ACTOR1_ID}/statuses/post-1`
+      })) as Status
+
+      // A reblog whose original was deleted leaves a null originalStatus, which
+      // throws while the collector recurses into the original. It must be
+      // skipped, not crash the whole page.
+      const brokenReblog = {
+        id: `${ACTOR1_ID}/statuses/broken-reblog`,
+        actorId: ACTOR1_ID,
+        type: StatusType.enum.Announce,
+        originalStatus: null
+      } as unknown as Status
+
+      const result = await getMastodonStatuses(database, [
+        brokenReblog,
+        goodStatus
+      ])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toEqual(urlToId(goodStatus.id))
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('skips a status whose serialization throws and keeps the good one', async () => {
+      const goodStatus = (await database.getStatus({
+        statusId: `${ACTOR1_ID}/statuses/post-1`
+      })) as Status
+
+      // A Note missing its tags/attachments arrays passes id collection but
+      // throws inside getMastodonStatus when those arrays are read.
+      const brokenNote = {
+        id: `${ACTOR1_ID}/statuses/broken-note`,
+        actorId: ACTOR1_ID,
+        type: StatusType.enum.Note,
+        reply: '',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      } as unknown as Status
+
+      const result = await getMastodonStatuses(database, [
+        goodStatus,
+        brokenNote
+      ])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toEqual(urlToId(goodStatus.id))
+      expect(logger.warn).toHaveBeenCalled()
+    })
   })
 
   describe('getMastodonStatuses', () => {

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -12,6 +12,7 @@ import {
 import { Tag, TagType } from '@/lib/types/domain/tag'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 import { getVisibility } from '@/lib/utils/getVisibility'
+import { logger } from '@/lib/utils/logger'
 import { processStatusText } from '@/lib/utils/text/processStatusText'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
@@ -455,17 +456,34 @@ export const getMastodonStatuses = async (
   if (statuses.length === 0) return []
 
   const actorIds = new Set<string>()
-  statuses.forEach((status) => addStatusActorIds(status, actorIds))
   const metricStatusIds = new Set<string>()
-  statuses.forEach((status) => addStatusMetricIds(status, metricStatusIds))
   const replyStatusIds = new Set<string>()
-  statuses.forEach((status) => addStatusReplyIds(status, replyStatusIds))
   const pollStatusIds = new Set<string>()
-  statuses.forEach((status) => addStatusPollIds(status, pollStatusIds))
   const pinnedLookupStatusIds = new Set<string>()
-  statuses.forEach((status) =>
-    addStatusPinnedLookupIds(status, pinnedLookupStatusIds, currentActorId)
-  )
+
+  // Collect lookup ids per status, dropping any whose shape throws here (for
+  // example a reblog whose original was deleted, leaving a null originalStatus).
+  // A single un-hydratable row must be skipped, never fatal, so one bad page
+  // entry can't 500 the whole timeline request.
+  const safeStatuses: Status[] = []
+  for (const status of statuses) {
+    try {
+      addStatusActorIds(status, actorIds)
+      addStatusMetricIds(status, metricStatusIds)
+      addStatusReplyIds(status, replyStatusIds)
+      addStatusPollIds(status, pollStatusIds)
+      addStatusPinnedLookupIds(status, pinnedLookupStatusIds, currentActorId)
+      safeStatuses.push(status)
+    } catch (error) {
+      logger.warn({
+        message:
+          'Skipping un-hydratable status while collecting timeline lookup ids',
+        statusId: (status as { id?: string } | null)?.id,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+  if (safeStatuses.length === 0) return []
   const requestedActorIds = [...actorIds]
   const requestedMetricStatusIds = [...metricStatusIds]
   const requestedReplyStatusIds = [...replyStatusIds]
@@ -581,9 +599,27 @@ export const getMastodonStatuses = async (
 
   return (
     await Promise.all(
-      statuses.map((status) =>
-        getMastodonStatus(database, status, currentActorId, options)
-      )
+      safeStatuses.map(async (status) => {
+        try {
+          return await getMastodonStatus(
+            database,
+            status,
+            currentActorId,
+            options
+          )
+        } catch (error) {
+          // Hydration of a single status can still throw on malformed data (a
+          // poll/attachment with bad shape, etc.). Skip and log it rather than
+          // failing the entire page.
+          logger.warn({
+            message:
+              'Skipping un-hydratable status during Mastodon serialization',
+            statusId: (status as { id?: string } | null)?.id,
+            error: error instanceof Error ? error.message : String(error)
+          })
+          return null
+        }
+      })
     )
   ).filter((status): status is Mastodon.Status => status !== null)
 }

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -479,7 +479,10 @@ export const getMastodonStatuses = async (
         message:
           'Skipping un-hydratable status while collecting timeline lookup ids',
         statusId: (status as { id?: string } | null)?.id,
-        error: error instanceof Error ? error.message : String(error)
+        error:
+          error instanceof Error
+            ? (error.stack ?? error.message)
+            : String(error)
       })
     }
   }
@@ -615,7 +618,10 @@ export const getMastodonStatuses = async (
             message:
               'Skipping un-hydratable status during Mastodon serialization',
             statusId: (status as { id?: string } | null)?.id,
-            error: error instanceof Error ? error.message : String(error)
+            error:
+              error instanceof Error
+                ? (error.stack ?? error.message)
+                : String(error)
           })
           return null
         }

--- a/lib/services/timelines/request.test.ts
+++ b/lib/services/timelines/request.test.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from 'next/server'
+
+import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { MAX_TIMELINE_LIMIT } from './getFilteredTimelinePage'
+import { parseTimelineQuery, timelineErrorBoundary } from './request'
+
+const params = (query: Record<string, string>) => new URLSearchParams(query)
+
+const realStatusUrl = 'https://llun.test/users/alice/statuses/1'
+const validCursor = urlToId(realStatusUrl)
+
+describe('parseTimelineQuery', () => {
+  it('returns ok with no params and a default limit', () => {
+    const result = parseTimelineQuery(params({}))
+    expect(result).toEqual({
+      ok: true,
+      query: {
+        limit: PER_PAGE_LIMIT,
+        maxStatusId: null,
+        minStatusId: null,
+        sinceStatusId: null
+      }
+    })
+  })
+
+  it('decodes valid cursors into status URLs', () => {
+    const result = parseTimelineQuery(
+      params({
+        max_id: validCursor,
+        min_id: validCursor,
+        since_id: validCursor
+      })
+    )
+    expect(result).toEqual({
+      ok: true,
+      query: {
+        limit: PER_PAGE_LIMIT,
+        maxStatusId: realStatusUrl,
+        minStatusId: realStatusUrl,
+        sinceStatusId: realStatusUrl
+      }
+    })
+  })
+
+  // limit is clamped, never rejected (Mastodon clamps out-of-range values).
+  it.each([
+    { description: 'valid in-range limit', value: '5', expected: 5 },
+    {
+      description: 'huge limit clamps to max',
+      value: '500',
+      expected: MAX_TIMELINE_LIMIT
+    },
+    {
+      description: 'negative limit falls back to default',
+      value: '-5',
+      expected: PER_PAGE_LIMIT
+    },
+    {
+      description: 'non-numeric limit falls back to default',
+      value: 'abc',
+      expected: PER_PAGE_LIMIT
+    },
+    {
+      description: 'zero limit falls back to default',
+      value: '0',
+      expected: PER_PAGE_LIMIT
+    }
+  ])('clamps limit ($description)', ({ value, expected }) => {
+    const result = parseTimelineQuery(params({ limit: value }))
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.query.limit).toBe(expected)
+  })
+
+  // Malformed cursors must fail the parse so the route returns 400, not 500.
+  it.each([
+    { description: 'max_id', field: 'max_id' },
+    { description: 'min_id', field: 'min_id' },
+    { description: 'since_id', field: 'since_id' }
+  ])('rejects an undecodable $description cursor', ({ field }) => {
+    expect(parseTimelineQuery(params({ [field]: 'apurl_@@@@' })).ok).toBe(false)
+  })
+
+  // A fuzz table of junk cursor values that must never 500 — undecodable ones
+  // fail the parse (→ 400), well-formed-but-unknown ones pass (→ empty page).
+  it.each([
+    { description: 'junk opaque id', value: 'apurl_not-a-url', ok: false },
+    { description: 'percent signs', value: '%%%', ok: false },
+    { description: 'spaces', value: 'a b c', ok: false },
+    { description: 'whitespace', value: '   ', ok: false },
+    { description: 'numeric Mastodon id', value: '12345', ok: true },
+    { description: 'unknown colon-form id', value: 'llun.test:x:1', ok: true }
+  ])('handles fuzz cursor max_id=$description', ({ value, ok }) => {
+    expect(parseTimelineQuery(params({ max_id: value })).ok).toBe(ok)
+  })
+})
+
+describe('timelineErrorBoundary', () => {
+  const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+  const request = () =>
+    new NextRequest('https://llun.test/api/v1/timelines/public')
+
+  it('passes through the handler response when it succeeds', async () => {
+    const handler = jest
+      .fn()
+      .mockResolvedValue(new Response('ok', { status: 200 }))
+    const wrapped = timelineErrorBoundary(CORS_HEADERS, handler)
+
+    const response = await wrapped(request(), {})
+    expect(response.status).toBe(200)
+  })
+
+  it('returns a CORS-aware 500 when the handler throws', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error('boom'))
+    const wrapped = timelineErrorBoundary(CORS_HEADERS, handler)
+
+    const response = await wrapped(request(), {})
+    expect(response.status).toBe(500)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy()
+    expect(await response.json()).toEqual({ status: 'Internal Server Error' })
+  })
+})

--- a/lib/services/timelines/request.test.ts
+++ b/lib/services/timelines/request.test.ts
@@ -82,6 +82,11 @@ describe('parseTimelineQuery', () => {
       description: 'zero limit falls back to default',
       value: '0',
       expected: PER_PAGE_LIMIT
+    },
+    {
+      description: 'decimal limit is floored to an integer',
+      value: '5.9',
+      expected: 5
     }
   ])('clamps limit ($description)', ({ value, expected }) => {
     const result = parseTimelineQuery(params({ limit: value }))

--- a/lib/services/timelines/request.test.ts
+++ b/lib/services/timelines/request.test.ts
@@ -45,6 +45,21 @@ describe('parseTimelineQuery', () => {
     })
   })
 
+  it('treats an empty-string cursor as absent (not a 400)', () => {
+    const result = parseTimelineQuery(
+      params({ max_id: '', min_id: '', since_id: '' })
+    )
+    expect(result).toEqual({
+      ok: true,
+      query: {
+        limit: PER_PAGE_LIMIT,
+        maxStatusId: null,
+        minStatusId: null,
+        sinceStatusId: null
+      }
+    })
+  })
+
   // limit is clamped, never rejected (Mastodon clamps out-of-range values).
   it.each([
     { description: 'valid in-range limit', value: '5', expected: 5 },

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -46,11 +46,13 @@ const decodeCursor = (raw: string | undefined): string | null | undefined =>
 export const parseTimelineQuery = (
   searchParams: URLSearchParams
 ): ParseTimelineQueryResult => {
+  // Treat an empty-string param (e.g. `?max_id=`) as absent rather than a value,
+  // so a blank cursor means "no cursor" (2xx) instead of failing validation.
   const parsed = TimelineQuerySchema.safeParse({
-    limit: searchParams.get('limit') ?? undefined,
-    max_id: searchParams.get('max_id') ?? undefined,
-    min_id: searchParams.get('min_id') ?? undefined,
-    since_id: searchParams.get('since_id') ?? undefined
+    limit: searchParams.get('limit') || undefined,
+    max_id: searchParams.get('max_id') || undefined,
+    min_id: searchParams.get('min_id') || undefined,
+    since_id: searchParams.get('since_id') || undefined
   })
   if (!parsed.success) return { ok: false }
 

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -57,9 +57,15 @@ export const parseTimelineQuery = (
   if (!parsed.success) return { ok: false }
 
   const { limit, max_id, min_id, since_id } = parsed.data
+  // Floor a decimal limit (e.g. `1.5` → `1`) like Mastodon's integer coercion;
+  // `normalizeTimelineLimit` then clamps it to the allowed range. (It already
+  // rejects non-integers, so this only changes a float into its floored int
+  // rather than the default.)
   const numericLimit = limit !== undefined ? Number(limit) : null
   const pageLimit = normalizeTimelineLimit(
-    numericLimit !== null && Number.isFinite(numericLimit) ? numericLimit : null
+    numericLimit !== null && Number.isFinite(numericLimit)
+      ? Math.floor(numericLimit)
+      : null
   )
 
   const maxStatusId = decodeCursor(max_id)

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -98,7 +98,12 @@ export const timelineErrorBoundary =
     } catch (error) {
       logger.error({
         message: 'Unhandled error in timeline handler',
-        error: error instanceof Error ? error.message : String(error)
+        // Log the stack (falling back to the message) so production 500s carry
+        // the throw site, not just the message.
+        error:
+          error instanceof Error
+            ? (error.stack ?? error.message)
+            : String(error)
       })
       return apiResponse({
         req,

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
+import { ERROR_500, apiResponse } from '@/lib/utils/response'
+import { safeIdToUrl } from '@/lib/utils/urlToId'
+
+import { normalizeTimelineLimit } from './getFilteredTimelinePage'
+
+// Shared query-param shape for every timeline endpoint. `limit` stays a lenient
+// optional string because Mastodon clamps out-of-range/non-numeric limits to the
+// allowed range instead of rejecting them (see `normalizeTimelineLimit`); the
+// cursors are optional strings here and are decoded/validated below so a
+// malformed cursor becomes a deliberate 400 rather than a 500 or wrong results.
+const TimelineQuerySchema = z.object({
+  limit: z.string().optional(),
+  max_id: z.string().optional(),
+  min_id: z.string().optional(),
+  since_id: z.string().optional()
+})
+
+export interface ParsedTimelineQuery {
+  // Already normalized/clamped to the allowed range.
+  limit: number
+  // Decoded status URLs, or null when the corresponding cursor was absent.
+  maxStatusId: string | null
+  minStatusId: string | null
+  sinceStatusId: string | null
+}
+
+export type ParseTimelineQueryResult =
+  | { ok: true; query: ParsedTimelineQuery }
+  | { ok: false }
+
+// undefined → cursor not provided; null → provided but undecodable (→ 400).
+const decodeCursor = (raw: string | undefined): string | null | undefined =>
+  raw === undefined ? undefined : safeIdToUrl(raw)
+
+/**
+ * Parse and validate the shared timeline query params. Returns `ok: false` only
+ * when a provided `max_id`/`min_id`/`since_id` cursor cannot be decoded — the
+ * caller turns that into a 400. `limit` never fails: it is coerced and clamped
+ * via `normalizeTimelineLimit`, matching Mastodon's clamping behavior.
+ */
+export const parseTimelineQuery = (
+  searchParams: URLSearchParams
+): ParseTimelineQueryResult => {
+  const parsed = TimelineQuerySchema.safeParse({
+    limit: searchParams.get('limit') ?? undefined,
+    max_id: searchParams.get('max_id') ?? undefined,
+    min_id: searchParams.get('min_id') ?? undefined,
+    since_id: searchParams.get('since_id') ?? undefined
+  })
+  if (!parsed.success) return { ok: false }
+
+  const { limit, max_id, min_id, since_id } = parsed.data
+  const numericLimit = limit !== undefined ? Number(limit) : null
+  const pageLimit = normalizeTimelineLimit(
+    numericLimit !== null && Number.isFinite(numericLimit) ? numericLimit : null
+  )
+
+  const maxStatusId = decodeCursor(max_id)
+  const minStatusId = decodeCursor(min_id)
+  const sinceStatusId = decodeCursor(since_id)
+  if (maxStatusId === null || minStatusId === null || sinceStatusId === null) {
+    return { ok: false }
+  }
+
+  return {
+    ok: true,
+    query: {
+      limit: pageLimit,
+      maxStatusId: maxStatusId ?? null,
+      minStatusId: minStatusId ?? null,
+      sinceStatusId: sinceStatusId ?? null
+    }
+  }
+}
+
+/**
+ * Wrap a timeline route handler so any unexpected throw (e.g. a transient DB
+ * fault) is logged and returned as a CORS-aware 500 instead of bubbling up as an
+ * unhandled rejection — `traceApiRoute` re-throws, so without this a throw in the
+ * handler body becomes a generic, header-less 500. This is only a backstop for
+ * genuine server faults; valid requests must still return 2xx and bad input 4xx.
+ */
+export const timelineErrorBoundary =
+  <Context>(
+    allowedMethods: HttpMethod[],
+    handler: (req: NextRequest, context: Context) => Promise<Response>
+  ) =>
+  async (req: NextRequest, context: Context): Promise<Response> => {
+    try {
+      return await handler(req, context)
+    } catch (error) {
+      logger.error({
+        message: 'Unhandled error in timeline handler',
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return apiResponse({
+        req,
+        allowedMethods,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+  }

--- a/lib/utils/urlToId.test.ts
+++ b/lib/utils/urlToId.test.ts
@@ -1,4 +1,4 @@
-import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+import { idToUrl, safeIdToUrl, urlToId } from '@/lib/utils/urlToId'
 
 describe('urlToId', () => {
   it('converts all / to :', () => {
@@ -157,5 +157,42 @@ describe('idToUrl', () => {
 
   it('returns an empty string for invalid opaque ActivityPub IDs', () => {
     expect(idToUrl('apurl_not-a-url')).toEqual('')
+  })
+})
+
+describe('safeIdToUrl', () => {
+  it('round-trips a colon-form cursor produced by urlToId', () => {
+    const url = 'https://llun.test/users/test1/statuses/2'
+    expect(safeIdToUrl(urlToId(url))).toEqual(url)
+  })
+
+  it('round-trips an opaque (apurl_) cursor produced by urlToId', () => {
+    // URLs whose host/path carry a colon (e.g. a port) are encoded opaquely.
+    const opaque = urlToId('https://llun.test:8443/users/test1')
+    expect(opaque.startsWith('apurl_')).toBe(true)
+    expect(safeIdToUrl(opaque)).toEqual('https://llun.test:8443/users/test1')
+  })
+
+  // A numeric Mastodon id (or other well-formed-but-unknown value) decodes to a
+  // valid URL: it is accepted and the DB simply finds no matching row (empty
+  // page), matching Mastodon — it must NOT 400.
+  it.each([
+    { description: 'numeric Mastodon id', value: '12345' },
+    { description: 'colon-form host only', value: 'llun.test:users:1' }
+  ])('accepts a well-formed-but-unknown cursor ($description)', ({ value }) => {
+    expect(safeIdToUrl(value)).not.toBeNull()
+  })
+
+  // Genuinely undecodable cursors must yield null so the route returns 400, not
+  // 500 and not silent wrong results.
+  it.each([
+    { description: 'empty string', value: '' },
+    { description: 'whitespace only', value: '   ' },
+    { description: 'undecodable opaque id', value: 'apurl_not-a-url' },
+    { description: 'opaque id with junk base64', value: 'apurl_@@@@' },
+    { description: 'bare percent signs', value: '%%%' },
+    { description: 'spaces in value', value: 'a b c' }
+  ])('returns null for malformed cursor ($description)', ({ value }) => {
+    expect(safeIdToUrl(value)).toBeNull()
   })
 })

--- a/lib/utils/urlToId.ts
+++ b/lib/utils/urlToId.ts
@@ -109,3 +109,40 @@ export const idToUrl = (id: string) => {
 
   return `https://${host}/${path}${extras}`
 }
+
+/**
+ * Decode a client-supplied pagination cursor (an opaque id produced by
+ * `urlToId`) back into a status URL, returning `null` when the value is not a
+ * decodable id rather than silently yielding an empty/garbage string.
+ *
+ * `idToUrl` is intentionally permissive: an undecodable `apurl_…` cursor decodes
+ * to `''`, and a structurally-broken value is mangled into a string that may not
+ * be a valid URL. Timeline routes must turn such input into a deliberate 400
+ * instead of passing `''`/garbage to the database (which silently returns wrong
+ * or empty results). This validates that the decoded value parses as an http(s)
+ * URL.
+ *
+ * A well-formed-but-unknown id (e.g. a numeric Mastodon id like `12345`) still
+ * decodes to a valid URL and is returned as-is; the database simply finds no
+ * matching row and the endpoint returns an empty page, matching Mastodon.
+ */
+export const safeIdToUrl = (value: string): string | null => {
+  if (!value) return null
+
+  let decoded: string
+  try {
+    decoded = idToUrl(value)
+  } catch {
+    return null
+  }
+  if (!decoded) return null
+
+  try {
+    const { protocol } = new URL(decoded)
+    if (protocol !== 'http:' && protocol !== 'https:') return null
+  } catch {
+    return null
+  }
+
+  return decoded
+}


### PR DESCRIPTION
## Summary

Hardens the four Mastodon-compatible timeline endpoints so valid requests always return a correct 2xx, bad input returns a deliberate **4xx** (not 500), and a single malformed row in a page can no longer 500 the whole request.

Routes in scope:
- `app/api/v1/timelines/[timeline]/route.ts` (home/main/noannounce/mention/direct dispatcher)
- `app/api/v1/timelines/public/route.ts`
- `app/api/v1/timelines/tag/[hashtag]/route.ts`
- `app/api/v1/timelines/list/[list_id]/route.ts`

## Root causes & the specific throw paths

The task brief listed four root causes. Reading the handlers showed the real picture is slightly different from the brief in two places — reported honestly below so the fixes are accurate rather than fixing bugs that don't exist.

1. **Unguarded cursor decoding.** `idToUrl` is actually already defensive — it wraps base64 decoding in try/catch and returns `''`, and the non-opaque path is pure string manipulation, so it does **not** throw. The real defect was *silent*: a malformed `max_id`/`min_id`/`since_id` decoded to `''`/garbage and was passed to the DB, yielding wrong/empty results instead of a 400. Fixed with `safeIdToUrl()` which returns `null` for anything that doesn't decode to an `http(s)` URL → routes return **400**.
2. **No query-param validation.** `[timeline]`, `public`, `list` read `searchParams`/`parseInt` directly. Now all four share `parseTimelineQuery()`.
3. **Data-dependent hydration 500s.** `getMastodonStatuses` hydrated a whole page; a throw on one row failed the entire request. Made resilient (per-status try/catch, skip + log). Note: the canonical *reblog-of-deleted* case is already dropped at the DB read (`getStatusWithAttachmentsFromData` returns `null`, `getTimeline` filters nulls), and *missing-actor* already returned `null` — so this is defense-in-depth for the remaining hydration throws (malformed poll/attachment, schema parse failures).
4. **Handler-level safety net.** `traceApiRoute` **re-throws** (confirmed at `lib/utils/traceApiRoute.ts`), so a throw in a handler body became a header-less generic 500. Each handler body is now wrapped in `timelineErrorBoundary()` → logged, CORS-aware 500.

## Shared helpers (so the four routes can't drift again)

- **`lib/utils/urlToId.ts` → `safeIdToUrl(value): string | null`** — decode a client cursor, returning `null` unless it parses as an `http(s)` URL. A well-formed-but-unknown id (e.g. numeric Mastodon `12345`) still decodes to a valid URL and is accepted → DB finds no row → empty page (Mastodon-correct), never 400/500.
- **`lib/services/timelines/request.ts`**
  - `parseTimelineQuery(searchParams)` — shared Zod schema + safe cursor decode. `limit` is coerced and clamped (never rejected); `max_id`/`min_id`/`since_id` are decoded and a malformed one makes the parse fail → 400. Empty-string params (`?max_id=`) are treated as absent (2xx), matching prior behaviour.
  - `timelineErrorBoundary(allowedMethods, handler)` — wraps a handler body, returning a logged CORS-aware 500 on any throw.
- **`lib/services/mastodon/getMastodonStatus.ts`** — `getMastodonStatuses` collects lookup ids and serializes each status under per-status `try/catch`, skipping (and `logger.warn`-ing) any un-hydratable row.

## Per-route changes

All four: shared param parse + safe cursor decode + `timelineErrorBoundary`; `prev` **Link** headers now emitted consistently (previously only `next` on public/tag/list); `export const dynamic = 'force-dynamic'` set consistently. `?format=activities_next` on `[timeline]` preserved.

## Documented decisions (intentional, not regressions)

- **`limit` default/max = 30/80, not Mastodon's 20/40.** `PER_PAGE_LIMIT` (30) and `MAX_TIMELINE_LIMIT` (80) are the repo's pre-existing, repo-wide caps (an existing test pins `limit=500 → 80`). Left unchanged intentionally; `limit` is clamped, never 400, matching Mastodon's clamping semantics.
- **`min_id`/`since_id` collapse.** `database.getTimeline`/`getListTimeline` accept a single lower-bound cursor, so a route cannot express the `min_id` (asc+reverse) vs `since_id` (desc) ordering distinction. Each route's existing precedence is preserved (`[timeline]`: since_id wins; `list`: min_id wins) and both cursors are now safely decoded. A true ordering fix requires a DB-interface change and is out of scope for this 500-stability PR.
- **Out of scope:** guard-level throws (e.g. in `resolveAuthenticatedContext`, outside its try/catch) can still produce a generic 500; that is a pre-existing, global auth concern, not the timeline-hydration 500 targeted here.

## Tests

- `safeIdToUrl`: colon-form & opaque round-trip; fuzz table of junk cursors (undecodable → null, well-formed-unknown → accepted).
- `parseTimelineQuery` + `timelineErrorBoundary`: default/valid/clamped limits, malformed-cursor rejection, empty-cursor-as-absent, fuzz table, throw → 500.
- `getMastodonStatuses` resilience: collector throw (null-original Announce) and serialization throw both skipped, good rows kept, `logger.warn` called.
- Per route: valid pagination; malformed `max_id`/`min_id`/`since_id` → **400** (not 500); one un-hydratable row → **200** with the bad row skipped; empty result + Link headers.

## Local gate (all green)

`yarn run prettier --write .` · `yarn lint` (0 errors) · `yarn build` (compiled) · `yarn test` (**428 suites / 3645 tests passing**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops intermittent 500s on Mastodon timeline endpoints by validating query params and making hydration resilient. Valid requests return 2xx, malformed cursors return 400, and a single bad row no longer fails the page.

- **Bug Fixes**
  - Validate `max_id`/`min_id`/`since_id` with a shared parser; undecodable cursors → 400; empty-string cursors are treated as absent.
  - Per-status try/catch during hydration; skip and log un-hydratable rows while returning remaining results (200). Logs include error stacks for better traceability.
  - Functional Link headers: `[timeline]` and `list` emit `next` and `prev`; `public` and `tag` emit `next` only.
  - CORS-aware errors: route wrapper returns a CORS 500 on throws; `[timeline]` and `list` guards now send CORS headers on 401/403/500.

- **Refactors**
  - Added `safeIdToUrl()` for safe cursor decoding (only accepts http/https).
  - Introduced `parseTimelineQuery()` and `timelineErrorBoundary()` and applied to `[timeline]`, `public`, `tag`, and `list`.
  - Decimal `limit` values are floored to an integer before clamping to match Mastodon.
  - Standardized `dynamic = 'force-dynamic'`; preserved limit defaults/clamps (30 default, 80 max) and each route’s existing `min_id`/`since_id` precedence (`[timeline]`: `since_id` wins; `list`: `min_id` wins).

<sup>Written for commit 149d2e2fbc690152def66086ca54b145df2d4fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

