### PR TITLE
Bump version to v1.47.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.47.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.47.0`
- Base main SHA: `50a774001e9973e030aff6355aa12b89bfb03751`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `activities.next` version from 1.47.0 to 1.47.1 to publish the patch release.

<sup>Written for commit 7d871e6382ec83904a37f5b39c3d21935edf6407. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

