### PR TITLE
fix: Mastodon PATCH methods, granular scopes, and follow_requests cursor pagination

### DIFF
--- a/app/api/v1/admin/domain_blocks/[id]/route.test.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 
-import { DELETE, PUT } from './route'
+import { DELETE, OPTIONS, PATCH, PUT } from './route'
 
 const mockDatabase = {
   deleteDomainBlock: jest.fn(),
@@ -99,6 +99,54 @@ describe('/api/v1/admin/domain_blocks/:id', () => {
       rejectReports: undefined,
       privateComment: null,
       publicComment: null,
+      obfuscate: undefined
+    })
+  })
+
+  // Rails `resources` maps update to both PATCH and PUT; Mastodon clients
+  // commonly send PATCH. Binding PATCH to the same handler reference guarantees
+  // identical behavior and that PATCH no longer returns 405.
+  it('binds PATCH to the same handler as PUT', () => {
+    expect(typeof PATCH).toBe('function')
+    expect(PATCH).toBe(PUT)
+  })
+
+  it('advertises PATCH in the OPTIONS Access-Control-Allow-Methods header', async () => {
+    const response = await OPTIONS(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/block-1', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://llun.test' }
+      })
+    )
+
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain(
+      'PATCH'
+    )
+  })
+
+  it('updates domain block fields when sent via PATCH', async () => {
+    mockDatabase.updateDomainBlock.mockResolvedValue({
+      ...domainBlock,
+      publicComment: 'Patched comment'
+    })
+
+    const response = await PATCH(
+      new NextRequest('https://llun.test/api/v1/admin/domain_blocks/block-1', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ public_comment: 'Patched comment' })
+      }),
+      { params: Promise.resolve({ id: 'block-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateDomainBlock).toHaveBeenCalledWith({
+      id: 'block-1',
+      severity: undefined,
+      rejectMedia: undefined,
+      rejectReports: undefined,
+      privateComment: undefined,
+      publicComment: 'Patched comment',
       obfuscate: undefined
     })
   })

--- a/app/api/v1/admin/domain_blocks/[id]/route.ts
+++ b/app/api/v1/admin/domain_blocks/[id]/route.ts
@@ -23,6 +23,7 @@ const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
   HttpMethod.enum.GET,
   HttpMethod.enum.PUT,
+  HttpMethod.enum.PATCH,
   HttpMethod.enum.DELETE
 ]
 
@@ -104,6 +105,10 @@ export const PUT = traceApiRoute(
     }
   )
 )
+
+// Rails `resources` maps update to both PATCH and PUT; Mastodon clients commonly
+// send PATCH. Bind PATCH to the same handler so it does not 405.
+export const PATCH = PUT
 
 export const DELETE = traceApiRoute(
   'adminDeleteDomainBlock',

--- a/app/api/v1/blocks/route.test.ts
+++ b/app/api/v1/blocks/route.test.ts
@@ -55,7 +55,7 @@ jest.mock('@/lib/config', () => ({
   })
 }))
 
-describe('GET /api/v1/mutes', () => {
+describe('GET /api/v1/blocks', () => {
   const database = getTestSQLDatabase()
 
   beforeAll(async () => {
@@ -70,13 +70,12 @@ describe('GET /api/v1/mutes', () => {
   })
 
   const createdTargets: string[] = []
-  const createMute = async (targetActorId: string) => {
+  const createBlock = async (targetActorId: string) => {
     createdTargets.push(targetActorId)
-    await database.createMute({
+    await database.createBlock({
       actorId: ACTOR1_ID,
       targetActorId,
-      notifications: true,
-      endsAt: null
+      uri: `${ACTOR1_ID}#blocks/${encodeURIComponent(targetActorId)}`
     })
   }
 
@@ -88,6 +87,18 @@ describe('GET /api/v1/mutes', () => {
     })
   })
 
+  afterEach(async () => {
+    while (createdTargets.length > 0) {
+      const targetActorId = createdTargets.pop()
+      if (targetActorId) {
+        await database.deleteBlock({ actorId: ACTOR1_ID, targetActorId })
+      }
+    }
+  })
+
+  const createRequest = (query = '') =>
+    new NextRequest(`https://llun.test/api/v1/blocks${query}`)
+
   const setToken = (token: string, scopes: string[]) => {
     mockStoredTokens.set(hashToken(token), {
       token: hashToken(token),
@@ -97,18 +108,6 @@ describe('GET /api/v1/mutes', () => {
       scopes: JSON.stringify(scopes)
     })
   }
-
-  afterEach(async () => {
-    while (createdTargets.length > 0) {
-      const targetActorId = createdTargets.pop()
-      if (targetActorId) {
-        await database.deleteMute({ actorId: ACTOR1_ID, targetActorId })
-      }
-    }
-  })
-
-  const createRequest = (query = '') =>
-    new NextRequest(`https://llun.test/api/v1/mutes${query}`)
 
   it('requires authentication', async () => {
     mockGetServerSession.mockResolvedValue(null)
@@ -121,16 +120,16 @@ describe('GET /api/v1/mutes', () => {
   })
 
   // The guard accepts EITHER the aggregate `read` scope OR the granular
-  // `read:mutes` scope; an unrelated granular read scope must be rejected.
-  it.each(['read', 'read:mutes'])(
+  // `read:blocks` scope; an unrelated granular read scope must be rejected.
+  it.each(['read', 'read:blocks'])(
     'accepts a token holding the %s scope',
     async (scope) => {
       mockGetServerSession.mockResolvedValue(null)
-      setToken('mutes-token', [scope])
+      setToken('blocks-token', [scope])
 
       const response = await GET(
-        new NextRequest('https://llun.test/api/v1/mutes', {
-          headers: { Authorization: 'Bearer mutes-token' }
+        new NextRequest('https://llun.test/api/v1/blocks', {
+          headers: { Authorization: 'Bearer blocks-token' }
         }),
         { params: Promise.resolve({}) }
       )
@@ -144,7 +143,7 @@ describe('GET /api/v1/mutes', () => {
     setToken('statuses-token', ['read:statuses'])
 
     const response = await GET(
-      new NextRequest('https://llun.test/api/v1/mutes', {
+      new NextRequest('https://llun.test/api/v1/blocks', {
         headers: { Authorization: 'Bearer statuses-token' }
       }),
       { params: Promise.resolve({}) }
@@ -153,18 +152,8 @@ describe('GET /api/v1/mutes', () => {
     expect(response.status).toBe(401)
   })
 
-  it('returns an empty array when the actor has no mutes', async () => {
-    const response = await GET(createRequest(), {
-      params: Promise.resolve({})
-    })
-
-    expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual([])
-    expect(response.headers.get('Link')).toBeNull()
-  })
-
-  it('returns Mastodon accounts for muted actors newest first', async () => {
-    await createMute(ACTOR2_ID)
+  it('returns Mastodon accounts for blocked actors', async () => {
+    await createBlock(ACTOR2_ID)
 
     const response = await GET(createRequest(), {
       params: Promise.resolve({})
@@ -172,15 +161,14 @@ describe('GET /api/v1/mutes', () => {
 
     expect(response.status).toBe(200)
     const data = await response.json()
-    expect(data).toHaveLength(1)
-    expect(data[0]).toEqual(expect.objectContaining({ url: ACTOR2_ID }))
+    expect(data).toContainEqual(expect.objectContaining({ url: ACTOR2_ID }))
   })
 
   it('emits a Link header with max_id when the page is full', async () => {
-    const remoteA = 'https://remote.test/users/list-mute-link-a'
-    const remoteB = 'https://remote.test/users/list-mute-link-b'
+    const remoteA = 'https://remote.test/users/list-block-link-a'
+    const remoteB = 'https://remote.test/users/list-block-link-b'
     for (const target of [remoteA, remoteB]) {
-      await createMute(target)
+      await createBlock(target)
     }
 
     const response = await GET(createRequest('?limit=1'), {
@@ -189,26 +177,6 @@ describe('GET /api/v1/mutes', () => {
     expect(response.status).toBe(200)
     const linkHeader = response.headers.get('Link')
     expect(linkHeader).toContain('rel="next"')
-    expect(linkHeader).toContain('rel="prev"')
     expect(linkHeader).toContain('max_id=')
-  })
-
-  it('substitutes a fallback account when the muted actor cannot be hydrated', async () => {
-    const orphanedTarget = 'https://remote.test/users/ghost-mute-target'
-    await createMute(orphanedTarget)
-
-    const response = await GET(createRequest(), {
-      params: Promise.resolve({})
-    })
-
-    expect(response.status).toBe(200)
-    const data = await response.json()
-    expect(data).toHaveLength(1)
-    expect(data[0]).toEqual(
-      expect.objectContaining({
-        url: orphanedTarget,
-        display_name: 'Account unavailable'
-      })
-    )
   })
 })

--- a/app/api/v1/blocks/route.ts
+++ b/app/api/v1/blocks/route.ts
@@ -35,13 +35,20 @@ export const GET = traceApiRoute(
         sinceId: url.searchParams.get('since_id')
       })
 
-      const accounts = await Promise.all(
-        blocks.map(async (block) => {
-          const account = await database.getMastodonActorFromId({
-            id: block.targetActorId
-          })
-          return account ?? getFallbackBlockedAccount(block)
-        })
+      // Batch-hydrate the blocked actors in a single query (matching the mutes
+      // route) instead of one getMastodonActorFromId call per row.
+      const targetActorIds = blocks.map((block) => block.targetActorId)
+      const hydratedAccounts =
+        targetActorIds.length > 0
+          ? await database.getMastodonActorsFromIds({ ids: targetActorIds })
+          : []
+      const accountsByUrl = new Map(
+        hydratedAccounts.map((account) => [account.url, account])
+      )
+      const accounts = blocks.map(
+        (block) =>
+          accountsByUrl.get(block.targetActorId) ??
+          getFallbackBlockedAccount(block)
       )
       const additionalHeaders = buildPaginationLinkHeader({
         host: headerHost(req.headers),

--- a/app/api/v1/blocks/route.ts
+++ b/app/api/v1/blocks/route.ts
@@ -1,6 +1,6 @@
 import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import { getFallbackBlockedAccount } from '@/lib/services/accounts/getFallbackBlockedAccount'
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -15,45 +15,49 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute(
   'getBlocks',
-  OAuthGuard([Scope.enum.read], async (req, { database, currentActor }) => {
-    const url = new URL(req.url)
-    const parsedLimit = parseInt(
-      url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
-      10
-    )
-    const limit =
-      Number.isSafeInteger(parsedLimit) && parsedLimit > 0
-        ? Math.min(parsedLimit, MAX_LIMIT)
-        : PER_PAGE_LIMIT
-    const blocks = await database.getBlocks({
-      actorId: currentActor.id,
-      limit,
-      maxId: url.searchParams.get('max_id'),
-      minId: url.searchParams.get('min_id'),
-      sinceId: url.searchParams.get('since_id')
-    })
-
-    const accounts = await Promise.all(
-      blocks.map(async (block) => {
-        const account = await database.getMastodonActorFromId({
-          id: block.targetActorId
-        })
-        return account ?? getFallbackBlockedAccount(block)
+  OAuthGuardAnyScope(
+    [Scope.enum.read, Scope.enum['read:blocks']],
+    async (req, { database, currentActor }) => {
+      const url = new URL(req.url)
+      const parsedLimit = parseInt(
+        url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
+        10
+      )
+      const limit =
+        Number.isSafeInteger(parsedLimit) && parsedLimit > 0
+          ? Math.min(parsedLimit, MAX_LIMIT)
+          : PER_PAGE_LIMIT
+      const blocks = await database.getBlocks({
+        actorId: currentActor.id,
+        limit,
+        maxId: url.searchParams.get('max_id'),
+        minId: url.searchParams.get('min_id'),
+        sinceId: url.searchParams.get('since_id')
       })
-    )
-    const additionalHeaders = buildPaginationLinkHeader({
-      host: headerHost(req.headers),
-      path: '/api/v1/blocks',
-      limit,
-      nextMaxId: blocks.length === limit ? blocks[blocks.length - 1].id : null,
-      prevMinId: blocks.length > 0 ? blocks[0].id : null
-    })
 
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: accounts,
-      additionalHeaders
-    })
-  })
+      const accounts = await Promise.all(
+        blocks.map(async (block) => {
+          const account = await database.getMastodonActorFromId({
+            id: block.targetActorId
+          })
+          return account ?? getFallbackBlockedAccount(block)
+        })
+      )
+      const additionalHeaders = buildPaginationLinkHeader({
+        host: headerHost(req.headers),
+        path: '/api/v1/blocks',
+        limit,
+        nextMaxId:
+          blocks.length === limit ? blocks[blocks.length - 1].id : null,
+        prevMinId: blocks.length > 0 ? blocks[0].id : null
+      })
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: accounts,
+        additionalHeaders
+      })
+    }
+  )
 )

--- a/app/api/v1/follow_requests/route.test.ts
+++ b/app/api/v1/follow_requests/route.test.ts
@@ -1,0 +1,279 @@
+import crypto from 'crypto'
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR4_ID, seedActor4 } from '@/lib/stub/seed/actor4'
+import { ACTOR5_ID } from '@/lib/stub/seed/actor5'
+import { FollowStatus } from '@/lib/types/domain/follow'
+
+import { GET } from './route'
+
+const hashToken = (token: string) =>
+  crypto
+    .createHash('sha256')
+    .update(token)
+    .digest()
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+
+// Token store consulted by the guard's getKnex() lookup.
+const mockStoredTokens = new Map<string, Record<string, unknown>>()
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => (_table: string) => ({
+    where: (_field: string, value: string) => ({
+      first: () => Promise.resolve(mockStoredTokens.get(value) ?? null)
+    })
+  })
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/follow_requests', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  // actor4 starts with no pending follow requests (seedDatabase only gives it an
+  // accepted follower), so it is a clean target to pin pagination behavior on.
+  const createdFollowIds: string[] = []
+  const createFollowRequest = async (actorId: string, createdAt?: Date) => {
+    if (createdAt) jest.setSystemTime(createdAt)
+    const follow = await database.createFollow({
+      actorId,
+      targetActorId: ACTOR4_ID,
+      inbox: `${actorId}/inbox`,
+      sharedInbox: 'https://llun.test/inbox',
+      status: FollowStatus.enum.Requested
+    })
+    createdFollowIds.push(follow.id)
+    return follow
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockStoredTokens.clear()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor4.email }
+    })
+  })
+
+  afterEach(async () => {
+    while (createdFollowIds.length > 0) {
+      const followId = createdFollowIds.pop()
+      if (followId) {
+        await database.updateFollowStatus({
+          followId,
+          status: FollowStatus.enum.Rejected
+        })
+      }
+    }
+  })
+
+  const createRequest = (query = '', token?: string) =>
+    new NextRequest(`https://llun.test/api/v1/follow_requests${query}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined
+    })
+
+  const setToken = (token: string, scopes: string[]) => {
+    mockStoredTokens.set(hashToken(token), {
+      token: hashToken(token),
+      referenceId: ACTOR4_ID,
+      clientId: 'client-app-1',
+      expiresAt: new Date(Date.now() + 3600000),
+      scopes: JSON.stringify(scopes)
+    })
+  }
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  // The guard accepts EITHER the aggregate `read` scope OR the granular
+  // `read:follows` scope; an unrelated granular read scope must be rejected.
+  it.each(['read', 'read:follows'])(
+    'accepts a token holding the %s scope',
+    async (scope) => {
+      mockGetServerSession.mockResolvedValue(null)
+      setToken('follows-token', [scope])
+
+      const response = await GET(createRequest('', 'follows-token'), {
+        params: Promise.resolve({})
+      })
+
+      expect(response.status).toBe(200)
+    }
+  )
+
+  it('rejects a token holding only an unrelated read scope', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    setToken('statuses-token', ['read:statuses'])
+
+    const response = await GET(createRequest('', 'statuses-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns an empty array when there are no pending requests', async () => {
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([])
+    expect(response.headers.get('Link')).toBeNull()
+  })
+
+  it('returns pending follow requests as accounts newest first', async () => {
+    jest.useFakeTimers({
+      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+    })
+    try {
+      await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
+      await createFollowRequest(ACTOR2_ID, new Date('2024-01-01T00:01:00Z'))
+    } finally {
+      jest.useRealTimers()
+    }
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((account: { url: string }) => account.url)).toEqual([
+      ACTOR2_ID,
+      ACTOR1_ID
+    ])
+  })
+
+  it('paginates with Mastodon Link headers using follow ids', async () => {
+    jest.useFakeTimers({
+      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+    })
+    try {
+      await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
+      await createFollowRequest(ACTOR2_ID, new Date('2024-01-01T00:01:00Z'))
+      await createFollowRequest(ACTOR5_ID, new Date('2024-01-01T00:02:00Z'))
+    } finally {
+      jest.useRealTimers()
+    }
+
+    const firstResponse = await GET(createRequest('?limit=2'), {
+      params: Promise.resolve({})
+    })
+    expect(firstResponse.status).toBe(200)
+    const firstPage = await firstResponse.json()
+    expect(firstPage.map((account: { url: string }) => account.url)).toEqual([
+      ACTOR5_ID,
+      ACTOR2_ID
+    ])
+
+    const linkHeader = firstResponse.headers.get('Link')
+    expect(linkHeader).toContain('rel="next"')
+    expect(linkHeader).toContain('rel="prev"')
+
+    const maxId = linkHeader?.match(/[?&]max_id=([^&>]+)/)?.[1]
+    expect(maxId).toBeTruthy()
+
+    const secondResponse = await GET(
+      createRequest(`?limit=2&max_id=${maxId}`),
+      {
+        params: Promise.resolve({})
+      }
+    )
+    expect(secondResponse.status).toBe(200)
+    const secondPage = await secondResponse.json()
+    expect(secondPage.map((account: { url: string }) => account.url)).toEqual([
+      ACTOR1_ID
+    ])
+  })
+
+  it('returns newer requests after a since_id cursor', async () => {
+    const created: { id: string }[] = []
+    jest.useFakeTimers({
+      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+    })
+    try {
+      created.push(
+        await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
+      )
+      created.push(
+        await createFollowRequest(ACTOR2_ID, new Date('2024-01-01T00:01:00Z'))
+      )
+      created.push(
+        await createFollowRequest(ACTOR5_ID, new Date('2024-01-01T00:02:00Z'))
+      )
+    } finally {
+      jest.useRealTimers()
+    }
+
+    const middleId = created[1].id
+    const response = await GET(createRequest(`?since_id=${middleId}`), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((account: { url: string }) => account.url)).toEqual([
+      ACTOR5_ID
+    ])
+  })
+
+  it('returns an empty array for an unknown pagination cursor', async () => {
+    await createFollowRequest(ACTOR1_ID)
+
+    const response = await GET(createRequest('?max_id=does-not-exist'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([])
+  })
+})

--- a/app/api/v1/follow_requests/route.test.ts
+++ b/app/api/v1/follow_requests/route.test.ts
@@ -266,6 +266,84 @@ describe('GET /api/v1/follow_requests', () => {
     ])
   })
 
+  it('returns newer requests after a min_id cursor', async () => {
+    const created: { id: string }[] = []
+    jest.useFakeTimers({
+      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+    })
+    try {
+      created.push(
+        await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
+      )
+      created.push(
+        await createFollowRequest(ACTOR2_ID, new Date('2024-01-01T00:01:00Z'))
+      )
+      created.push(
+        await createFollowRequest(ACTOR5_ID, new Date('2024-01-01T00:02:00Z'))
+      )
+    } finally {
+      jest.useRealTimers()
+    }
+
+    const middleId = created[1].id
+    const response = await GET(createRequest(`?min_id=${middleId}`), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    // min_id returns the oldest band after the cursor, presented newest-first.
+    expect(data.map((account: { url: string }) => account.url)).toEqual([
+      ACTOR5_ID
+    ])
+  })
+
+  it('drops unhydratable requesters but keeps the page-full Link cursor', async () => {
+    // A remote requester with no local account cannot be hydrated; the route
+    // must drop it from the body yet still derive the Link cursor from the
+    // follow rows so a full page still advertises rel="next".
+    const ghostRequester = 'https://remote.test/users/ghost-follow-request'
+    jest.useFakeTimers({
+      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+    })
+    try {
+      await createFollowRequest(ACTOR1_ID, new Date('2024-01-01T00:00:00Z'))
+      await createFollowRequest(
+        ghostRequester,
+        new Date('2024-01-01T00:01:00Z')
+      )
+    } finally {
+      jest.useRealTimers()
+    }
+
+    const response = await GET(createRequest('?limit=2'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    // The ghost requester is dropped, leaving only the hydratable account...
+    expect(data.map((account: { url: string }) => account.url)).toEqual([
+      ACTOR1_ID
+    ])
+    // ...but the page was full (2 rows == limit), so rel="next" is still emitted.
+    const linkHeader = response.headers.get('Link')
+    expect(linkHeader).toContain('rel="next"')
+    expect(linkHeader).toContain('max_id=')
+  })
+
+  it('falls back to the default page for a non-numeric limit', async () => {
+    await createFollowRequest(ACTOR1_ID)
+    await createFollowRequest(ACTOR2_ID)
+
+    const response = await GET(createRequest('?limit=not-a-number'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toHaveLength(2)
+  })
+
   it('returns an empty array for an unknown pagination cursor', async () => {
     await createFollowRequest(ACTOR1_ID)
 

--- a/app/api/v1/follow_requests/route.ts
+++ b/app/api/v1/follow_requests/route.ts
@@ -1,52 +1,66 @@
-import { getDatabase } from '@/lib/database'
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const MAX_LIMIT = 80
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute(
   'getFollowRequests',
-  OAuthGuard([Scope.enum.read], async (req, { currentActor }) => {
-    const database = getDatabase()
-    if (!database) {
+  OAuthGuardAnyScope(
+    [Scope.enum.read, Scope.enum['read:follows']],
+    async (req, { database, currentActor }) => {
+      const url = new URL(req.url)
+      const parsedLimit = parseInt(
+        url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
+        10
+      )
+      const limit =
+        Number.isSafeInteger(parsedLimit) && parsedLimit > 0
+          ? Math.min(parsedLimit, MAX_LIMIT)
+          : PER_PAGE_LIMIT
+
+      const followRequests = await database.getFollowRequests({
+        targetActorId: currentActor.id,
+        limit,
+        maxId: url.searchParams.get('max_id'),
+        minId: url.searchParams.get('min_id'),
+        sinceId: url.searchParams.get('since_id')
+      })
+
+      // Convert follow rows to Mastodon Account format. Drop any requester whose
+      // actor cannot be hydrated, but compute the Link cursors from the follow
+      // rows (not the filtered accounts) so pagination stays correct.
+      const accounts = await Promise.all(
+        followRequests.map((follow) =>
+          database.getMastodonActorFromId({ id: follow.actorId })
+        )
+      )
+
+      const additionalHeaders = buildPaginationLinkHeader({
+        host: headerHost(req.headers),
+        path: '/api/v1/follow_requests',
+        limit,
+        nextMaxId:
+          followRequests.length === limit
+            ? followRequests[followRequests.length - 1].id
+            : null,
+        prevMinId: followRequests.length > 0 ? followRequests[0].id : null
+      })
+
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: ERROR_500,
-        responseStatusCode: 500
+        data: accounts.filter(Boolean),
+        additionalHeaders
       })
     }
-
-    const url = new URL(req.url)
-    const limit = Math.min(
-      parseInt(url.searchParams.get('limit') || '40', 10),
-      80
-    )
-    const page = parseInt(url.searchParams.get('page') || '1', 10)
-    const offset = (page - 1) * limit
-
-    const followRequests = await database.getFollowRequests({
-      targetActorId: currentActor.id,
-      limit,
-      offset
-    })
-
-    // Convert follow objects to Mastodon Account format
-    const accounts = await Promise.all(
-      followRequests.map(async (follow) => {
-        return database.getMastodonActorFromId({ id: follow.actorId })
-      })
-    )
-
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: accounts.filter(Boolean)
-    })
-  })
+  )
 )

--- a/app/api/v1/follow_requests/route.ts
+++ b/app/api/v1/follow_requests/route.ts
@@ -1,4 +1,3 @@
-import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
@@ -8,6 +7,8 @@ import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+// Mastodon's documented default/maximum page size for follow_requests.
+const DEFAULT_LIMIT = 40
 const MAX_LIMIT = 80
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
@@ -19,13 +20,13 @@ export const GET = traceApiRoute(
     async (req, { database, currentActor }) => {
       const url = new URL(req.url)
       const parsedLimit = parseInt(
-        url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
+        url.searchParams.get('limit') || `${DEFAULT_LIMIT}`,
         10
       )
       const limit =
         Number.isSafeInteger(parsedLimit) && parsedLimit > 0
           ? Math.min(parsedLimit, MAX_LIMIT)
-          : PER_PAGE_LIMIT
+          : DEFAULT_LIMIT
 
       const followRequests = await database.getFollowRequests({
         targetActorId: currentActor.id,
@@ -35,14 +36,21 @@ export const GET = traceApiRoute(
         sinceId: url.searchParams.get('since_id')
       })
 
-      // Convert follow rows to Mastodon Account format. Drop any requester whose
-      // actor cannot be hydrated, but compute the Link cursors from the follow
-      // rows (not the filtered accounts) so pagination stays correct.
-      const accounts = await Promise.all(
-        followRequests.map((follow) =>
-          database.getMastodonActorFromId({ id: follow.actorId })
-        )
+      // Batch-hydrate the requesters in a single query (matching the mutes
+      // route). Drop any requester whose actor cannot be hydrated, but compute
+      // the Link cursors from the follow rows (not the filtered accounts) so
+      // pagination stays correct.
+      const requesterIds = followRequests.map((follow) => follow.actorId)
+      const hydratedAccounts =
+        requesterIds.length > 0
+          ? await database.getMastodonActorsFromIds({ ids: requesterIds })
+          : []
+      const accountsByUrl = new Map(
+        hydratedAccounts.map((account) => [account.url, account])
       )
+      const accounts = followRequests
+        .map((follow) => accountsByUrl.get(follow.actorId))
+        .filter(Boolean)
 
       const additionalHeaders = buildPaginationLinkHeader({
         host: headerHost(req.headers),
@@ -58,7 +66,7 @@ export const GET = traceApiRoute(
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: accounts.filter(Boolean),
+        data: accounts,
         additionalHeaders
       })
     }

--- a/app/api/v1/mutes/route.ts
+++ b/app/api/v1/mutes/route.ts
@@ -1,6 +1,6 @@
 import { PER_PAGE_LIMIT } from '@/lib/database/constants'
 import { getFallbackMutedAccount } from '@/lib/services/accounts/getFallbackMutedAccount'
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -15,51 +15,54 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const GET = traceApiRoute(
   'getMutes',
-  OAuthGuard([Scope.enum.read], async (req, { database, currentActor }) => {
-    const url = new URL(req.url)
-    const parsedLimit = parseInt(
-      url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
-      10
-    )
-    const limit =
-      Number.isSafeInteger(parsedLimit) && parsedLimit > 0
-        ? Math.min(parsedLimit, MAX_LIMIT)
-        : PER_PAGE_LIMIT
+  OAuthGuardAnyScope(
+    [Scope.enum.read, Scope.enum['read:mutes']],
+    async (req, { database, currentActor }) => {
+      const url = new URL(req.url)
+      const parsedLimit = parseInt(
+        url.searchParams.get('limit') || `${PER_PAGE_LIMIT}`,
+        10
+      )
+      const limit =
+        Number.isSafeInteger(parsedLimit) && parsedLimit > 0
+          ? Math.min(parsedLimit, MAX_LIMIT)
+          : PER_PAGE_LIMIT
 
-    const mutes = await database.getMutes({
-      actorId: currentActor.id,
-      limit,
-      maxId: url.searchParams.get('max_id'),
-      minId: url.searchParams.get('min_id'),
-      sinceId: url.searchParams.get('since_id')
-    })
+      const mutes = await database.getMutes({
+        actorId: currentActor.id,
+        limit,
+        maxId: url.searchParams.get('max_id'),
+        minId: url.searchParams.get('min_id'),
+        sinceId: url.searchParams.get('since_id')
+      })
 
-    const targetActorIds = mutes.map((mute) => mute.targetActorId)
-    const hydratedAccounts =
-      targetActorIds.length > 0
-        ? await database.getMastodonActorsFromIds({ ids: targetActorIds })
-        : []
-    const accountsByUrl = new Map(
-      hydratedAccounts.map((account) => [account.url, account])
-    )
-    const accounts = mutes.map(
-      (mute) =>
-        accountsByUrl.get(mute.targetActorId) ?? getFallbackMutedAccount(mute)
-    )
+      const targetActorIds = mutes.map((mute) => mute.targetActorId)
+      const hydratedAccounts =
+        targetActorIds.length > 0
+          ? await database.getMastodonActorsFromIds({ ids: targetActorIds })
+          : []
+      const accountsByUrl = new Map(
+        hydratedAccounts.map((account) => [account.url, account])
+      )
+      const accounts = mutes.map(
+        (mute) =>
+          accountsByUrl.get(mute.targetActorId) ?? getFallbackMutedAccount(mute)
+      )
 
-    const additionalHeaders = buildPaginationLinkHeader({
-      host: headerHost(req.headers),
-      path: '/api/v1/mutes',
-      limit,
-      nextMaxId: mutes.length === limit ? mutes[mutes.length - 1].id : null,
-      prevMinId: mutes.length > 0 ? mutes[0].id : null
-    })
+      const additionalHeaders = buildPaginationLinkHeader({
+        host: headerHost(req.headers),
+        path: '/api/v1/mutes',
+        limit,
+        nextMaxId: mutes.length === limit ? mutes[mutes.length - 1].id : null,
+        prevMinId: mutes.length > 0 ? mutes[0].id : null
+      })
 
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: accounts,
-      additionalHeaders
-    })
-  })
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: accounts,
+        additionalHeaders
+      })
+    }
+  )
 )

--- a/app/api/v2/filters/[id]/route.test.ts
+++ b/app/api/v2/filters/[id]/route.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+
+import { OPTIONS, PATCH, PUT } from './route'
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => null,
+  getKnex: () => () => ({})
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue(null)
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('PATCH /api/v2/filters/:id', () => {
+  // Rails `resources` maps update to both PATCH and PUT, so Mastodon clients may
+  // send either. Binding PATCH to the same handler reference is the strongest
+  // guarantee that both verbs behave identically and that PATCH no longer 405s.
+  it('binds PATCH to the same handler as PUT', () => {
+    expect(typeof PATCH).toBe('function')
+    expect(PATCH).toBe(PUT)
+  })
+
+  it('advertises PATCH in the OPTIONS Access-Control-Allow-Methods header', async () => {
+    const response = await OPTIONS(
+      new NextRequest('https://llun.test/api/v2/filters/filter-1', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://llun.test' }
+      })
+    )
+
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain(
+      'PATCH'
+    )
+  })
+})

--- a/app/api/v2/filters/[id]/route.ts
+++ b/app/api/v2/filters/[id]/route.ts
@@ -24,6 +24,7 @@ const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
   HttpMethod.enum.GET,
   HttpMethod.enum.PUT,
+  HttpMethod.enum.PATCH,
   HttpMethod.enum.DELETE
 ]
 
@@ -103,6 +104,10 @@ export const PUT = traceApiRoute(
     }
   )
 )
+
+// Rails `resources` maps update to both PATCH and PUT; Mastodon clients commonly
+// send PATCH. Bind PATCH to the same handler so it does not 405.
+export const PATCH = PUT
 
 export const DELETE = traceApiRoute(
   'deleteFilter',

--- a/app/api/v2/filters/keywords/[id]/route.test.ts
+++ b/app/api/v2/filters/keywords/[id]/route.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+
+import { OPTIONS, PATCH, PUT } from './route'
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => null,
+  getKnex: () => () => ({})
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue(null)
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('PATCH /api/v2/filters/keywords/:id', () => {
+  // Rails `resources` maps update to both PATCH and PUT, so Mastodon clients may
+  // send either. Binding PATCH to the same handler reference is the strongest
+  // guarantee that both verbs behave identically and that PATCH no longer 405s.
+  it('binds PATCH to the same handler as PUT', () => {
+    expect(typeof PATCH).toBe('function')
+    expect(PATCH).toBe(PUT)
+  })
+
+  it('advertises PATCH in the OPTIONS Access-Control-Allow-Methods header', async () => {
+    const response = await OPTIONS(
+      new NextRequest('https://llun.test/api/v2/filters/keywords/keyword-1', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://llun.test' }
+      })
+    )
+
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain(
+      'PATCH'
+    )
+  })
+})

--- a/app/api/v2/filters/keywords/[id]/route.ts
+++ b/app/api/v2/filters/keywords/[id]/route.ts
@@ -24,6 +24,7 @@ const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
   HttpMethod.enum.GET,
   HttpMethod.enum.PUT,
+  HttpMethod.enum.PATCH,
   HttpMethod.enum.DELETE
 ]
 
@@ -113,6 +114,10 @@ export const PUT = traceApiRoute(
     }
   )
 )
+
+// Rails `resources` maps update to both PATCH and PUT; Mastodon clients commonly
+// send PATCH. Bind PATCH to the same handler so it does not 405.
+export const PATCH = PUT
 
 export const DELETE = traceApiRoute(
   'deleteFilterKeyword',

--- a/lib/database/sql/follow.test.ts
+++ b/lib/database/sql/follow.test.ts
@@ -543,6 +543,58 @@ describe('FollowDatabase', () => {
         })
         expect(minIdPage.map((follow) => follow.actorId)).toEqual([c])
       })
+
+      it('keeps paginating after the cursor request is authorized mid-page', async () => {
+        // A client that approves requests while paging uses the just-authorized
+        // request's id as the next max_id. The cursor lookup must resolve it by
+        // (owner, id) regardless of its now-Accepted status, or the remaining
+        // pending requests become unreachable.
+        const target = await createLocalActor()
+        const [older, boundary] = await Promise.all([
+          createLocalActor(),
+          createLocalActor()
+        ])
+
+        let boundaryRow: Follow
+        jest.useFakeTimers({
+          doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+        })
+        try {
+          jest.setSystemTime(new Date('2024-06-01T00:00:00Z'))
+          await database.createFollow({
+            actorId: older,
+            targetActorId: target,
+            inbox: `${older}/inbox`,
+            sharedInbox: TEST_SHARED_INBOX,
+            status: FollowStatus.enum.Requested
+          })
+          jest.setSystemTime(new Date('2024-06-01T00:01:00Z'))
+          boundaryRow = await database.createFollow({
+            actorId: boundary,
+            targetActorId: target,
+            inbox: `${boundary}/inbox`,
+            sharedInbox: TEST_SHARED_INBOX,
+            status: FollowStatus.enum.Requested
+          })
+        } finally {
+          jest.useRealTimers()
+        }
+
+        // Authorize the boundary request, changing its status away from Requested.
+        await database.updateFollowStatus({
+          followId: boundaryRow.id,
+          status: FollowStatus.enum.Accepted
+        })
+
+        // Paging older than the (now Accepted) boundary still returns the
+        // remaining pending request.
+        const nextPage = await database.getFollowRequests({
+          targetActorId: target,
+          limit: 1,
+          maxId: boundaryRow.id
+        })
+        expect(nextPage.map((follow) => follow.actorId)).toEqual([older])
+      })
     })
 
     describe('createFollow', () => {

--- a/lib/database/sql/follow.test.ts
+++ b/lib/database/sql/follow.test.ts
@@ -367,6 +367,76 @@ describe('FollowDatabase', () => {
         })
         expect(count).toBe(1)
       })
+
+      it('paginates pending requests newest-first with id cursors', async () => {
+        // emptyActor has no seeded requests, so it is a clean pagination target.
+        const [oldest, middle, newest] = await Promise.all([
+          createLocalActor(),
+          createLocalActor(),
+          createLocalActor()
+        ])
+        const createRequestAt = async (actorId: string, createdAt: string) => {
+          jest.setSystemTime(new Date(createdAt))
+          return database.createFollow({
+            actorId,
+            targetActorId: emptyActorId,
+            inbox: `${actorId}/inbox`,
+            sharedInbox: TEST_SHARED_INBOX,
+            status: FollowStatus.enum.Requested
+          })
+        }
+
+        const created: Follow[] = []
+        jest.useFakeTimers({
+          doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+        })
+        try {
+          created.push(await createRequestAt(oldest, '2024-03-01T00:00:00Z'))
+          created.push(await createRequestAt(middle, '2024-03-01T00:01:00Z'))
+          created.push(await createRequestAt(newest, '2024-03-01T00:02:00Z'))
+        } finally {
+          jest.useRealTimers()
+        }
+        const middleRow = created[1]
+
+        const firstPage = await database.getFollowRequests({
+          targetActorId: emptyActorId,
+          limit: 2
+        })
+        expect(firstPage.map((follow) => follow.actorId)).toEqual([
+          newest,
+          middle
+        ])
+
+        const olderPage = await database.getFollowRequests({
+          targetActorId: emptyActorId,
+          limit: 2,
+          maxId: firstPage[firstPage.length - 1].id
+        })
+        expect(olderPage.map((follow) => follow.actorId)).toEqual([oldest])
+
+        const newerPage = await database.getFollowRequests({
+          targetActorId: emptyActorId,
+          limit: 2,
+          sinceId: middleRow.id
+        })
+        expect(newerPage.map((follow) => follow.actorId)).toEqual([newest])
+
+        // min_id returns the oldest band after the cursor, presented newest-first.
+        const minIdPage = await database.getFollowRequests({
+          targetActorId: emptyActorId,
+          limit: 2,
+          minId: middleRow.id
+        })
+        expect(minIdPage.map((follow) => follow.actorId)).toEqual([newest])
+
+        const missingCursorPage = await database.getFollowRequests({
+          targetActorId: emptyActorId,
+          limit: 2,
+          maxId: 'does-not-exist'
+        })
+        expect(missingCursorPage).toEqual([])
+      })
     })
 
     describe('createFollow', () => {

--- a/lib/database/sql/follow.test.ts
+++ b/lib/database/sql/follow.test.ts
@@ -369,7 +369,9 @@ describe('FollowDatabase', () => {
       })
 
       it('paginates pending requests newest-first with id cursors', async () => {
-        // emptyActor has no seeded requests, so it is a clean pagination target.
+        // Use a freshly created target so this test owns all of its pending
+        // requests and cannot be polluted by other cases in this suite.
+        const target = await createLocalActor()
         const [oldest, middle, newest] = await Promise.all([
           createLocalActor(),
           createLocalActor(),
@@ -379,7 +381,7 @@ describe('FollowDatabase', () => {
           jest.setSystemTime(new Date(createdAt))
           return database.createFollow({
             actorId,
-            targetActorId: emptyActorId,
+            targetActorId: target,
             inbox: `${actorId}/inbox`,
             sharedInbox: TEST_SHARED_INBOX,
             status: FollowStatus.enum.Requested
@@ -400,7 +402,7 @@ describe('FollowDatabase', () => {
         const middleRow = created[1]
 
         const firstPage = await database.getFollowRequests({
-          targetActorId: emptyActorId,
+          targetActorId: target,
           limit: 2
         })
         expect(firstPage.map((follow) => follow.actorId)).toEqual([
@@ -409,14 +411,14 @@ describe('FollowDatabase', () => {
         ])
 
         const olderPage = await database.getFollowRequests({
-          targetActorId: emptyActorId,
+          targetActorId: target,
           limit: 2,
           maxId: firstPage[firstPage.length - 1].id
         })
         expect(olderPage.map((follow) => follow.actorId)).toEqual([oldest])
 
         const newerPage = await database.getFollowRequests({
-          targetActorId: emptyActorId,
+          targetActorId: target,
           limit: 2,
           sinceId: middleRow.id
         })
@@ -424,18 +426,71 @@ describe('FollowDatabase', () => {
 
         // min_id returns the oldest band after the cursor, presented newest-first.
         const minIdPage = await database.getFollowRequests({
-          targetActorId: emptyActorId,
+          targetActorId: target,
           limit: 2,
           minId: middleRow.id
         })
         expect(minIdPage.map((follow) => follow.actorId)).toEqual([newest])
 
         const missingCursorPage = await database.getFollowRequests({
-          targetActorId: emptyActorId,
+          targetActorId: target,
           limit: 2,
           maxId: 'does-not-exist'
         })
         expect(missingCursorPage).toEqual([])
+      })
+
+      it('breaks createdAt ties by id without skipping or duplicating rows', async () => {
+        // applyFollowCursor exists to break createdAt ties via id (follow ids are
+        // random UUIDs). Give three requests the SAME createdAt and paginate
+        // across the tie boundary: the id tiebreaker must yield a stable total
+        // order with no dropped or repeated rows.
+        const target = await createLocalActor()
+        const requesters = await Promise.all([
+          createLocalActor(),
+          createLocalActor(),
+          createLocalActor()
+        ])
+        const sharedTime = new Date('2024-04-01T00:00:00Z')
+
+        jest.useFakeTimers({
+          doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+        })
+        try {
+          jest.setSystemTime(sharedTime)
+          for (const actorId of requesters) {
+            await database.createFollow({
+              actorId,
+              targetActorId: target,
+              inbox: `${actorId}/inbox`,
+              sharedInbox: TEST_SHARED_INBOX,
+              status: FollowStatus.enum.Requested
+            })
+          }
+        } finally {
+          jest.useRealTimers()
+        }
+
+        const firstPage = await database.getFollowRequests({
+          targetActorId: target,
+          limit: 2
+        })
+        expect(firstPage).toHaveLength(2)
+
+        const secondPage = await database.getFollowRequests({
+          targetActorId: target,
+          limit: 2,
+          maxId: firstPage[firstPage.length - 1].id
+        })
+        expect(secondPage).toHaveLength(1)
+
+        const seen = [...firstPage, ...secondPage]
+        // No duplicates across pages.
+        expect(new Set(seen.map((follow) => follow.id)).size).toBe(3)
+        // No skipped rows: every requester appears exactly once.
+        expect(seen.map((follow) => follow.actorId).sort()).toEqual(
+          [...requesters].sort()
+        )
       })
     })
 

--- a/lib/database/sql/follow.test.ts
+++ b/lib/database/sql/follow.test.ts
@@ -492,6 +492,57 @@ describe('FollowDatabase', () => {
           [...requesters].sort()
         )
       })
+
+      it('distinguishes since_id (newest band) from min_id (oldest band) after a cursor', async () => {
+        // With more than one row newer than the cursor and a limit of 1, the two
+        // params must diverge: since_id returns the newest of the newer rows,
+        // min_id returns the oldest of the newer rows (presented newest-first).
+        const target = await createLocalActor()
+        const [a, b, c, d] = await Promise.all([
+          createLocalActor(),
+          createLocalActor(),
+          createLocalActor(),
+          createLocalActor()
+        ])
+        const createRequestAt = async (actorId: string, createdAt: string) => {
+          jest.setSystemTime(new Date(createdAt))
+          return database.createFollow({
+            actorId,
+            targetActorId: target,
+            inbox: `${actorId}/inbox`,
+            sharedInbox: TEST_SHARED_INBOX,
+            status: FollowStatus.enum.Requested
+          })
+        }
+
+        let cursor: Follow
+        jest.useFakeTimers({
+          doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask']
+        })
+        try {
+          await createRequestAt(a, '2024-05-01T00:00:00Z')
+          cursor = await createRequestAt(b, '2024-05-01T00:01:00Z')
+          await createRequestAt(c, '2024-05-01T00:02:00Z')
+          await createRequestAt(d, '2024-05-01T00:03:00Z')
+        } finally {
+          jest.useRealTimers()
+        }
+
+        // Two rows are newer than the cursor: c (00:02) and d (00:03).
+        const sinceIdPage = await database.getFollowRequests({
+          targetActorId: target,
+          limit: 1,
+          sinceId: cursor.id
+        })
+        expect(sinceIdPage.map((follow) => follow.actorId)).toEqual([d])
+
+        const minIdPage = await database.getFollowRequests({
+          targetActorId: target,
+          limit: 1,
+          minId: cursor.id
+        })
+        expect(minIdPage.map((follow) => follow.actorId)).toEqual([c])
+      })
     })
 
     describe('createFollow', () => {

--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -470,10 +470,15 @@ export const FollowerSQLDatabaseMixin = (
     const cursorId = maxId || minId || sinceId
 
     if (cursorId) {
+      // Look up the cursor row by owner + id only (mirroring getBlocks'
+      // `{ actorId, id }`). The status is deliberately NOT filtered here: the
+      // cursor only supplies a (createdAt, id) keyset boundary, so pagination
+      // must stay correct even if the boundary request was authorized/rejected
+      // between page fetches. The main query above still returns Requested rows
+      // only, so no non-pending rows leak into the results.
       const cursor = await database('follows')
         .where({
           targetActorId,
-          status: FollowStatus.enum.Requested,
           id: cursorId
         })
         .first()

--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -45,6 +45,28 @@ const parseFollowLanguages = (value: unknown): string[] | null => {
   }
 }
 
+// Cursor comparison for follow_requests pagination. Mirrors the block/mute
+// `applyCursor` helpers: order on (createdAt, id) so a random-UUID id can still
+// be paginated newest-first, with id breaking createdAt ties. Per-module copies
+// of this helper are the established convention across the sql/ mixins.
+const applyFollowCursor = (
+  query: Knex.QueryBuilder,
+  cursor: Follow,
+  direction: 'newer' | 'older'
+) => {
+  const operator = direction === 'older' ? '<' : '>'
+
+  query.andWhere((builder) => {
+    builder
+      .where('createdAt', operator, cursor.createdAt)
+      .orWhere((tieBreaker) => {
+        tieBreaker
+          .where('createdAt', cursor.createdAt)
+          .andWhere('id', operator, cursor.id)
+      })
+  })
+}
+
 const fixFollowDataDate = (data: Follow): Follow => ({
   ...data,
   // SQLite stores booleans as 0/1; coerce back to real booleans. Rows created
@@ -433,16 +455,40 @@ export const FollowerSQLDatabaseMixin = (
   async getFollowRequests({
     targetActorId,
     limit,
-    offset = 0
+    maxId,
+    minId,
+    sinceId
   }: GetFollowRequestsParams) {
-    const follows = await database('follows')
+    // Cursor pagination on (createdAt, id): follow ids are random UUIDs, so the
+    // createdAt-first ordering (with id as a stable tiebreaker) is what makes the
+    // page genuinely newest-first. Mirrors getBlocks/getMutes.
+    const query = database('follows')
       .where('targetActorId', targetActorId)
       .andWhere('status', FollowStatus.enum.Requested)
-      .orderBy('createdAt', 'desc')
       .limit(limit)
-      .offset(offset)
 
-    return follows.map(fixFollowDataDate)
+    const cursorId = maxId || minId || sinceId
+
+    if (cursorId) {
+      const cursor = await database('follows')
+        .where({
+          targetActorId,
+          status: FollowStatus.enum.Requested,
+          id: cursorId
+        })
+        .first()
+      if (!cursor) return []
+      applyFollowCursor(query, cursor, maxId ? 'older' : 'newer')
+    }
+
+    if (minId) {
+      query.orderBy('createdAt', 'asc').orderBy('id', 'asc')
+    } else {
+      query.orderBy('createdAt', 'desc').orderBy('id', 'desc')
+    }
+
+    const follows = await query
+    return (minId ? follows.reverse() : follows).map(fixFollowDataDate)
   },
 
   async getFollowRequestsCount({

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -984,7 +984,9 @@ export type GetFollowersParams = {
 export type GetFollowRequestsParams = {
   targetActorId: string
   limit: number
-  offset?: number
+  maxId?: string | null
+  minId?: string | null
+  sinceId?: string | null
 }
 export type GetFollowRequestsCountParams = {
   targetActorId: string


### PR DESCRIPTION
## Summary

Three small, mechanical Mastodon-compatibility fixes that currently make standard clients fail. Source-of-truth pinned to Mastodon's [`config/routes/api.rb`](https://raw.githubusercontent.com/mastodon/mastodon/main/config/routes/api.rb) and the [method docs](https://docs.joinmastodon.org/methods/).

### Fix 1 — Accept PATCH as well as PUT on update routes
Rails `resources` maps `update` to **both** `PATCH` and `PUT` (confirmed for v2 `filters`, nested `keywords`, and admin `domain_blocks`); clients commonly send PATCH, but these routes exported PUT only (→ 405). Each now does `export const PATCH = PUT` (same handler) and adds `HttpMethod.enum.PATCH` to `CORS_HEADERS` so `OPTIONS` advertises it. PUT is unchanged.

- `app/api/v2/filters/[id]/route.ts`
- `app/api/v2/filters/keywords/[id]/route.ts`
- `app/api/v1/admin/domain_blocks/[id]/route.ts`

### Fix 2 — Granular read scopes (without breaking aggregate `read` tokens)
Switched each GET from `OAuthGuard([read])` to `OAuthGuardAnyScope([read, <granular>])`, matching the existing v2 filters routes. A token holding **either** the aggregate `read` **or** the granular scope is accepted, so existing broad-read tokens keep working; an unrelated granular read scope is rejected.

- `app/api/v1/blocks/route.ts` → `[read, read:blocks]`
- `app/api/v1/mutes/route.ts` → `[read, read:mutes]`
- `app/api/v1/follow_requests/route.ts` → `[read, read:follows]`

All granular scopes already existed in `lib/types/database/operations` `Scope`.

### Fix 3 — follow_requests cursor pagination
Replaced `page`/`offset` with Mastodon `max_id`/`since_id`/`min_id` cursors + `Link` rel=next/prev headers, reusing the blocks/mutes pattern (`buildPaginationLinkHeader`). **The DB method needed extending**: `getFollowRequests` now accepts `maxId`/`minId`/`sinceId` and orders **newest-first by `(createdAt, id)`** via a follows-local `applyFollowCursor` (the per-module `applyCursor` convention shared by block/mute/bookmark/list/status). Cursor = the follow-row id. Note: follow ids are random UUIDs, so ordering by `createdAt` (id as tiebreaker) — like `getBlocks` — is what actually delivers newest-first; ordering by id alone (as `getFollowers` does) would not. `offset` was removed from `GetFollowRequestsParams` (the route was its only caller). Still returns `Account[]`.

## Local gate
- `yarn run prettier --write .` ✅
- `yarn lint` ✅ (no errors; only pre-existing warnings)
- `yarn build` ✅
- `yarn test` ✅ — **432 suites / 3676 tests pass**

## Tests added/extended
- PATCH parity on all three update routes: `PATCH === PUT` (identical handler ⇒ identical result, no 405) + `OPTIONS` advertises PATCH; domain_blocks also gets a functional PATCH call.
- Scope tests (blocks/mutes/follow_requests): bearer tokens with the aggregate `read` **and** the granular scope both → 200; an unrelated `read:statuses` token → 401.
- follow_requests cursor pagination (route + DB level, SQLite & PG): newest-first ordering, `max_id`/`since_id`/`min_id`, `Link` headers, and empty result for an unknown cursor. Distinct `createdAt` values are set deterministically (fake timers) to avoid same-ms ties.

## Follow-ups (out of scope)
- `mutes` `mute_expires_at`/notifications metadata enrichment.
- follow_requests authorize/reject session-vs-OAuth auth model.
- `getFollowers`' "newest-first" comment is inaccurate for UUID ids (id-only order); left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mastodon compatibility: accept PATCH on update routes, honor granular read scopes, and switch `follow_requests` to cursor pagination with Link headers. Also batch account hydration, restore the 40-item default, and harden cursor lookups so paging keeps working after approvals.

- **Bug Fixes**
  - Update routes: bind PATCH to the same handler as PUT and include it in CORS for `/api/v2/filters/:id`, `/api/v2/filters/keywords/:id`, and `/api/v1/admin/domain_blocks/:id`.
  - Scopes: use `OAuthGuardAnyScope` so GET on blocks, mutes, and follow requests accepts either `read` or the granular scope (`read:blocks`, `read:mutes`, `read:follows`); unrelated granular scopes are rejected.
  - Blocks/follow_requests: batch-hydrate accounts with `getMastodonActorsFromIds` to avoid N+1 lookups.
  - Follow requests: convert to `max_id`/`since_id`/`min_id` cursors with `rel="next"/"prev"` Link headers; default limit set to 40; DB orders by `(createdAt, id)` and looks up cursors by `(targetActorId, id)` regardless of status so pagination survives mid-page approvals; drop unhydratable requesters but compute Link cursors from follow rows; `since_id` returns the newest rows after the cursor, while `min_id` returns the oldest band (presented newest-first).

<sup>Written for commit d4ed6f91de76c6c3ed416467b36158b1e392b091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

