### PR TITLE
minor: make media API fully Mastodon-compatible

### DIFF
--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { MediaValidationError } from '@/lib/services/medias/errors'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
@@ -353,6 +354,30 @@ describe('/api/v1/media/[id]', () => {
       expect.anything(),
       'medias/route-thumb-old.jpg'
     )
+  })
+
+  it('PUT returns 422 when the thumbnail upload exceeds quota', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-thumb-quota')
+    mockSaveMediaThumbnail.mockRejectedValue(
+      new MediaValidationError('Storage quota exceeded')
+    )
+
+    const form = new FormData()
+    form.set(
+      'thumbnail',
+      new File([new Uint8Array([1, 2, 3])], 'thumb.png', { type: 'image/png' })
+    )
+    const request = new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+      method: 'PUT',
+      headers: { origin: 'https://llun.test' }
+    })
+    Object.defineProperty(request, 'formData', {
+      value: jest.fn().mockResolvedValue(form)
+    })
+
+    const response = await PUT(request, { params: Promise.resolve({ id }) })
+
+    expect(response.status).toBe(422)
   })
 
   it('DELETE removes owner media not attached to a status and deletes its files', async () => {

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -285,10 +285,15 @@ describe('/api/v1/media/[id]', () => {
     expect(stored?.focus).toEqual({ x: 0.5, y: -0.25 })
   })
 
-  it('PUT returns 422 for an out-of-range focus', async () => {
-    const id = await createMediaFor(ACTOR1_ID, 'put-focus-bad')
+  it.each([
+    { description: 'out of range', focus: '2.0,0.0' },
+    { description: 'a missing axis', focus: '0.5,' },
+    { description: 'non-numeric', focus: 'a,b' },
+    { description: 'wrong arity', focus: '0.1,0.2,0.3' }
+  ])('PUT returns 422 for focus that is $description', async ({ focus }) => {
+    const id = await createMediaFor(ACTOR1_ID, `put-focus-bad-${focus}`)
 
-    const response = await PUT(putRequest(id, { focus: '2.0,0.0' }), {
+    const response = await PUT(putRequest(id, { focus }), {
       params: Promise.resolve({ id })
     })
 
@@ -350,8 +355,24 @@ describe('/api/v1/media/[id]', () => {
     )
   })
 
-  it('DELETE removes owner media not attached to a status', async () => {
-    const id = await createMediaFor(ACTOR1_ID, 'delete-ok')
+  it('DELETE removes owner media not attached to a status and deletes its files', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/route-delete-original.jpg',
+        bytes: 1000,
+        mimeType: 'image/jpeg',
+        metaData: { width: 320, height: 240 }
+      },
+      thumbnail: {
+        path: 'medias/route-delete-thumb.jpg',
+        bytes: 200,
+        mimeType: 'image/jpeg',
+        metaData: { width: 40, height: 40 }
+      }
+    })
+    const id = String(media!.id)
+    mockDeleteMediaFile.mockResolvedValue(true)
 
     const response = await DELETE(deleteRequest(id), {
       params: Promise.resolve({ id })
@@ -363,6 +384,26 @@ describe('/api/v1/media/[id]', () => {
       accountId: (await database.getActorFromId({ id: ACTOR1_ID }))!.account!.id
     })
     expect(stored).toBeNull()
+    // The original and thumbnail files are removed from storage.
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(
+      expect.anything(),
+      'medias/route-delete-original.jpg'
+    )
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(
+      expect.anything(),
+      'medias/route-delete-thumb.jpg'
+    )
+  })
+
+  it('DELETE does not touch storage files on the 404 path', async () => {
+    const id = await createMediaFor(ACTOR2_ID, 'delete-foreign-nofiles')
+
+    const response = await DELETE(deleteRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDeleteMediaFile).not.toHaveBeenCalled()
   })
 
   it('DELETE returns 404 for media owned by another account', async () => {

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -5,16 +5,29 @@ import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 
-import { GET, PUT } from './route'
+import { DELETE, GET, PATCH, PUT } from './route'
 
 const mockGetServerSession = jest.fn()
 jest.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: () => mockGetServerSession()
 }))
 
+const mockSaveMediaThumbnail = jest.fn()
+const mockDeleteMediaFile = jest.fn()
+jest.mock('@/lib/services/medias', () => ({
+  saveMediaThumbnail: (...args: unknown[]) => mockSaveMediaThumbnail(...args),
+  deleteMediaFile: (...args: unknown[]) => mockDeleteMediaFile(...args)
+}))
+
 let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+const mockStoredToken = jest.fn()
 jest.mock('@/lib/database', () => ({
-  getDatabase: () => mockDatabase
+  getDatabase: () => mockDatabase,
+  getKnex: () => () => ({
+    where: () => ({
+      first: () => mockStoredToken()
+    })
+  })
 }))
 
 jest.mock('next/headers', () => ({
@@ -55,6 +68,7 @@ describe('/api/v1/media/[id]', () => {
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
+    mockStoredToken.mockResolvedValue(null)
   })
 
   const createMediaFor = async (actorId: string, name: string) => {
@@ -82,6 +96,22 @@ describe('/api/v1/media/[id]', () => {
         origin: 'https://llun.test'
       },
       body: JSON.stringify(body)
+    })
+
+  const patchRequest = (id: string, body: Record<string, unknown>) =>
+    new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://llun.test'
+      },
+      body: JSON.stringify(body)
+    })
+
+  const deleteRequest = (id: string) =>
+    new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+      method: 'DELETE',
+      headers: { origin: 'https://llun.test' }
     })
 
   const getRequest = (id: string) =>
@@ -123,6 +153,44 @@ describe('/api/v1/media/[id]', () => {
     })
 
     expect(response.status).toBe(404)
+  })
+
+  it('GET accepts a bearer token with write:media scope', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+    const id = await createMediaFor(ACTOR1_ID, 'get-bearer-ok')
+
+    const response = await GET(
+      new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+        headers: { Authorization: 'Bearer write-media-token' }
+      }),
+      { params: Promise.resolve({ id }) }
+    )
+
+    expect(response.status).toBe(200)
+  })
+
+  it('GET rejects a bearer token that only has the read scope', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'read'
+    })
+    const id = await createMediaFor(ACTOR1_ID, 'get-bearer-read')
+
+    const response = await GET(
+      new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+        headers: { Authorization: 'Bearer read-only-token' }
+      }),
+      { params: Promise.resolve({ id }) }
+    )
+
+    expect(response.status).toBe(401)
   })
 
   it('PUT updates the description', async () => {
@@ -178,5 +246,167 @@ describe('/api/v1/media/[id]', () => {
     })
 
     expect(response.status).toBe(404)
+  })
+
+  it('PATCH updates the description like PUT (same handler)', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'patch-update')
+
+    const response = await PATCH(
+      patchRequest(id, { description: 'patched alt text' }),
+      { params: Promise.resolve({ id }) }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({ id, description: 'patched alt text' })
+
+    const stored = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: (await database.getActorFromId({ id: ACTOR1_ID }))!.account!.id
+    })
+    expect(stored?.description).toBe('patched alt text')
+  })
+
+  it('PUT persists a focal point into meta.focus', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-focus')
+
+    const response = await PUT(putRequest(id, { focus: '0.5,-0.25' }), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.meta.focus).toEqual({ x: 0.5, y: -0.25 })
+
+    const stored = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: (await database.getActorFromId({ id: ACTOR1_ID }))!.account!.id
+    })
+    expect(stored?.focus).toEqual({ x: 0.5, y: -0.25 })
+  })
+
+  it('PUT returns 422 for an out-of-range focus', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-focus-bad')
+
+    const response = await PUT(putRequest(id, { focus: '2.0,0.0' }), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(422)
+  })
+
+  it('PUT replaces the thumbnail through storage and deletes the old file', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/route-thumb-original.jpg',
+        bytes: 1000,
+        mimeType: 'image/jpeg',
+        metaData: { width: 320, height: 240 }
+      },
+      thumbnail: {
+        path: 'medias/route-thumb-old.jpg',
+        bytes: 200,
+        mimeType: 'image/jpeg',
+        metaData: { width: 40, height: 40 }
+      }
+    })
+    const id = String(media!.id)
+
+    mockSaveMediaThumbnail.mockResolvedValue({
+      path: 'medias/route-thumb-new.webp',
+      bytes: 350,
+      mimeType: 'image/webp',
+      metaData: { width: 60, height: 60 }
+    })
+
+    const form = new FormData()
+    form.set(
+      'thumbnail',
+      new File([new Uint8Array([1, 2, 3])], 'thumb.png', { type: 'image/png' })
+    )
+    const request = new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+      method: 'PUT',
+      headers: { origin: 'https://llun.test' }
+    })
+    // jest / undici cannot materialise a multipart body from a FormData passed
+    // to NextRequest — mock formData() directly (see update_credentials test).
+    Object.defineProperty(request, 'formData', {
+      value: jest.fn().mockResolvedValue(form)
+    })
+
+    const response = await PUT(request, { params: Promise.resolve({ id }) })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.preview_url).toBe(
+      'https://llun.test/api/v1/files/medias/route-thumb-new.webp'
+    )
+    expect(mockSaveMediaThumbnail).toHaveBeenCalledTimes(1)
+    // The previous thumbnail file is cleaned up after the replacement persists.
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(
+      expect.anything(),
+      'medias/route-thumb-old.jpg'
+    )
+  })
+
+  it('DELETE removes owner media not attached to a status', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'delete-ok')
+
+    const response = await DELETE(deleteRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    const stored = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: (await database.getActorFromId({ id: ACTOR1_ID }))!.account!.id
+    })
+    expect(stored).toBeNull()
+  })
+
+  it('DELETE returns 404 for media owned by another account', async () => {
+    const id = await createMediaFor(ACTOR2_ID, 'delete-foreign')
+
+    const response = await DELETE(deleteRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(404)
+  })
+
+  it('DELETE returns 422 when the media is attached to a status', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/route-delete-attached.jpg',
+        bytes: 1000,
+        mimeType: 'image/jpeg',
+        metaData: { width: 320, height: 240 }
+      }
+    })
+    const id = String(media!.id)
+    const statusId = `${ACTOR1_ID}/statuses/media-delete-attached`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'attached media',
+      to: [],
+      cc: []
+    })
+    await database.createAttachment({
+      actorId: ACTOR1_ID,
+      statusId,
+      mediaType: 'image/jpeg',
+      url: media!.original.path,
+      mediaId: id
+    })
+
+    const response = await DELETE(deleteRequest(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(422)
   })
 })

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -413,6 +413,20 @@ describe('/api/v1/media/[id]', () => {
     expect(mockSaveMediaThumbnail).not.toHaveBeenCalled()
   })
 
+  it('PUT returns 422 for a crafted non-File thumbnail object (no 500)', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-thumb-craft')
+
+    // A JSON object mimicking { size, type } must not pass File validation and
+    // crash later — it should be rejected as 422.
+    const response = await PUT(
+      putRequest(id, { thumbnail: { size: 10, type: 'image/png' } }),
+      { params: Promise.resolve({ id }) }
+    )
+
+    expect(response.status).toBe(422)
+    expect(mockSaveMediaThumbnail).not.toHaveBeenCalled()
+  })
+
   it('DELETE removes owner media not attached to a status and deletes its files', async () => {
     const media = await database.createMedia({
       actorId: ACTOR1_ID,

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -380,6 +380,39 @@ describe('/api/v1/media/[id]', () => {
     expect(response.status).toBe(422)
   })
 
+  it('PUT returns 422 for a non-image thumbnail instead of ignoring it', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-thumb-badtype')
+
+    const form = new FormData()
+    form.set(
+      'thumbnail',
+      new File([new Uint8Array([1, 2, 3])], 'note.txt', { type: 'text/plain' })
+    )
+    const request = new NextRequest(`https://llun.test/api/v1/media/${id}`, {
+      method: 'PUT',
+      headers: { origin: 'https://llun.test' }
+    })
+    Object.defineProperty(request, 'formData', {
+      value: jest.fn().mockResolvedValue(form)
+    })
+
+    const response = await PUT(request, { params: Promise.resolve({ id }) })
+
+    expect(response.status).toBe(422)
+    expect(mockSaveMediaThumbnail).not.toHaveBeenCalled()
+  })
+
+  it('PUT returns 422 for a non-file thumbnail value instead of ignoring it', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-thumb-string')
+
+    const response = await PUT(putRequest(id, { thumbnail: 'not-a-file' }), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(422)
+    expect(mockSaveMediaThumbnail).not.toHaveBeenCalled()
+  })
+
   it('DELETE removes owner media not attached to a status and deletes its files', async () => {
     const media = await database.createMedia({
       actorId: ACTOR1_ID,

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
-import {
-  OAuthGuard,
-  OAuthGuardAnyScope
-} from '@/lib/services/guards/OAuthGuard'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
+import { AuthenticatedApiHandle } from '@/lib/services/guards/types'
+import { deleteMediaFile, saveMediaThumbnail } from '@/lib/services/medias'
 import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
+import { FileSchema, FocusSchema } from '@/lib/services/medias/types'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
@@ -21,7 +22,9 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
   HttpMethod.enum.GET,
-  HttpMethod.enum.PUT
+  HttpMethod.enum.PUT,
+  HttpMethod.enum.PATCH,
+  HttpMethod.enum.DELETE
 ]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
@@ -33,13 +36,18 @@ interface Params {
 // `description` is stored in a varchar(255) column; cap it to avoid a runtime
 // DB error. Empty/whitespace-only (and explicit null) descriptions are
 // normalised to null so clients can clear alt text by sending "" or null.
+// `focus` is "x,y" (each axis in [-1.0, 1.0]); a malformed value fails parsing
+// and yields a 422. Both fields are optional; field-level presence is detected
+// from the raw payload so a partial update never clears the field the client
+// omitted.
 const UpdateMediaRequest = z.object({
   description: z
     .string()
     .max(255)
     .nullable()
     .optional()
-    .transform((value) => (value && value.trim() ? value : null))
+    .transform((value) => (value && value.trim() ? value : null)),
+  focus: FocusSchema.optional()
 })
 
 const readPayload = async (
@@ -60,53 +68,11 @@ const readPayload = async (
   }
 }
 
+// Mastodon's MediaController applies `doorkeeper_authorize! :write, :'write:media'`
+// to every action, including `show` (media management happens while composing),
+// so GET requires write/write:media too.
 export const GET = traceApiRoute(
   'getMedia',
-  OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, currentActor, params } = context
-    const account = currentActor.account
-    if (!account) {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_401,
-        responseStatusCode: 401
-      })
-    }
-
-    const { id } = (await params) ?? { id: undefined }
-    if (!id) {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-    }
-
-    const media = await database.getMediaByIdForAccount({
-      mediaId: id,
-      accountId: account.id
-    })
-    if (!media) {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_404,
-        responseStatusCode: 404
-      })
-    }
-
-    return apiResponse({
-      req,
-      allowedMethods: CORS_HEADERS,
-      data: getMediaAttachment(media, headerHost(req.headers))
-    })
-  })
-)
-
-export const PUT = traceApiRoute(
-  'updateMedia',
   OAuthGuardAnyScope<Params>(
     [Scope.enum.write, Scope.enum['write:media']],
     async (req, context) => {
@@ -131,40 +97,10 @@ export const PUT = traceApiRoute(
         })
       }
 
-      const payload = await readPayload(req)
-      if (!payload) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
-        })
-      }
-
-      const parsed = UpdateMediaRequest.safeParse(payload)
-      if (!parsed.success) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
-        })
-      }
-
-      // Only mutate fields the client actually sent so a metadata-only update
-      // (e.g. focus, which we don't persist yet) doesn't clear the description.
-      const descriptionProvided = 'description' in payload
-      const media = descriptionProvided
-        ? await database.updateMedia({
-            mediaId: id,
-            accountId: account.id,
-            description: parsed.data.description
-          })
-        : await database.getMediaByIdForAccount({
-            mediaId: id,
-            accountId: account.id
-          })
-
+      const media = await database.getMediaByIdForAccount({
+        mediaId: id,
+        accountId: account.id
+      })
       if (!media) {
         return apiResponse({
           req,
@@ -174,16 +110,250 @@ export const PUT = traceApiRoute(
         })
       }
 
-      logger.info({
-        message: 'Media updated',
-        mediaId: id,
-        accountId: account.id
-      })
-
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: getMediaAttachment(media, headerHost(req.headers))
+      })
+    }
+  )
+)
+
+// PUT and PATCH both map to Mastodon's `update` action (Rails `resources :media`
+// exposes both verbs); they share one handler. write/write:media scope.
+const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
+  req,
+  context
+) => {
+  const { database, currentActor, params } = context
+  const account = currentActor.account
+  if (!account) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_401,
+      responseStatusCode: 401
+    })
+  }
+
+  const { id } = (await params) ?? { id: undefined }
+  if (!id) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_404,
+      responseStatusCode: 404
+    })
+  }
+
+  const payload = await readPayload(req)
+  if (!payload) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_422,
+      responseStatusCode: 422
+    })
+  }
+
+  const parsed = UpdateMediaRequest.safeParse(payload)
+  if (!parsed.success) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_422,
+      responseStatusCode: 422
+    })
+  }
+
+  // Detect which fields the client actually sent from the raw payload (before
+  // Zod fills omitted optionals) so a partial update only mutates those fields.
+  const descriptionProvided = 'description' in payload
+  const focusProvided = 'focus' in payload
+  const rawThumbnail = payload.thumbnail
+  const thumbnailProvided =
+    rawThumbnail instanceof File && rawThumbnail.size > 0
+
+  if (thumbnailProvided) {
+    const thumbnailCheck = FileSchema.safeParse(rawThumbnail)
+    if (!thumbnailCheck.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+  }
+
+  // Nothing to change — return the current attachment (404 if not owned).
+  if (!descriptionProvided && !focusProvided && !thumbnailProvided) {
+    const media = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: account.id
+    })
+    if (!media) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+    }
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: getMediaAttachment(media, headerHost(req.headers))
+    })
+  }
+
+  // Replacing the thumbnail needs the old path (to delete it after a successful
+  // update) and produces a new stored thumbnail before touching the DB.
+  let oldThumbnailPath: string | undefined
+  let thumbnail
+  if (thumbnailProvided) {
+    const existing = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: account.id
+    })
+    if (!existing) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: 404
+      })
+    }
+    oldThumbnailPath = existing.thumbnail?.path
+    thumbnail = await saveMediaThumbnail(database, rawThumbnail as File)
+    if (!thumbnail) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+  }
+
+  const media = await database.updateMedia({
+    mediaId: id,
+    accountId: account.id,
+    ...(descriptionProvided ? { description: parsed.data.description } : {}),
+    ...(focusProvided ? { focus: parsed.data.focus } : {}),
+    ...(thumbnail ? { thumbnail } : {})
+  })
+
+  if (!media) {
+    // Owner check failed inside updateMedia; clean up the orphaned thumbnail we
+    // just stored so it doesn't leak.
+    if (thumbnail) {
+      await deleteMediaFile(database, thumbnail.path)
+    }
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: ERROR_404,
+      responseStatusCode: 404
+    })
+  }
+
+  // Remove the previous thumbnail file once the replacement is persisted.
+  if (thumbnail && oldThumbnailPath && oldThumbnailPath !== thumbnail.path) {
+    await deleteMediaFile(database, oldThumbnailPath)
+  }
+
+  logger.info({
+    message: 'Media updated',
+    mediaId: id,
+    accountId: account.id
+  })
+
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: getMediaAttachment(media, headerHost(req.headers))
+  })
+}
+
+export const PUT = traceApiRoute(
+  'updateMedia',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:media']],
+    updateMediaHandler
+  )
+)
+
+export const PATCH = traceApiRoute(
+  'updateMedia',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:media']],
+    updateMediaHandler
+  )
+)
+
+export const DELETE = traceApiRoute(
+  'deleteMedia',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:media']],
+    async (req: NextRequest, context) => {
+      const { database, currentActor, params } = context
+      const account = currentActor.account
+      if (!account) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_401,
+          responseStatusCode: 401
+        })
+      }
+
+      const { id } = (await params) ?? { id: undefined }
+      if (!id) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      const result = await database.deleteMediaForAccount({
+        mediaId: id,
+        accountId: account.id
+      })
+
+      // Media already attached to a posted status can't be deleted (Mastodon
+      // returns 422 in_usage_error).
+      if (result === 'in-use') {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      if (result === 'not-found') {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      logger.info({
+        message: 'Media deleted',
+        mediaId: id,
+        accountId: account.id
+      })
+
+      // Mastodon's destroy renders an empty object with 200.
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {}
       })
     }
   )

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -216,9 +216,10 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
     })
   }
 
-  // Replacing the thumbnail needs the old path (to delete it after a successful
-  // update) and produces a new stored thumbnail before touching the DB.
-  let oldThumbnailPath: string | undefined
+  // Produce the new stored thumbnail (if any) before touching the DB. The
+  // owner check happens in updateMedia (returns null when not owned); the early
+  // getMediaByIdForAccount avoids processing a thumbnail for media that isn't
+  // the caller's.
   let thumbnail
   if (thumbnailProvided) {
     const existing = await database.getMediaByIdForAccount({
@@ -233,7 +234,6 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
         responseStatusCode: 404
       })
     }
-    oldThumbnailPath = existing.thumbnail?.path
     try {
       thumbnail = await saveMediaThumbnail(
         database,
@@ -263,9 +263,9 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
     }
   }
 
-  let media
+  let result
   try {
-    media = await database.updateMedia({
+    result = await database.updateMedia({
       mediaId: id,
       accountId: account.id,
       ...(descriptionProvided ? { description: parsed.data.description } : {}),
@@ -280,7 +280,7 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
     throw error
   }
 
-  if (!media) {
+  if (!result) {
     // Owner check failed inside updateMedia; clean up the orphaned thumbnail we
     // just stored so it doesn't leak.
     if (thumbnail) {
@@ -294,16 +294,20 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
     })
   }
 
-  // Remove the previous thumbnail file once the replacement is persisted.
-  // Best-effort: a storage hiccup here must not fail an update that already
-  // committed to the database.
-  if (thumbnail && oldThumbnailPath && oldThumbnailPath !== thumbnail.path) {
+  // Remove the thumbnail this update replaced. The path is captured inside
+  // updateMedia's transaction (not a prefetch), so a concurrent update can't
+  // cause stale-path cleanup. Best-effort: a storage hiccup must not fail an
+  // update that already committed to the database.
+  if (result.replacedThumbnailPath) {
     try {
-      const removed = await deleteMediaFile(database, oldThumbnailPath)
+      const removed = await deleteMediaFile(
+        database,
+        result.replacedThumbnailPath
+      )
       if (!removed) {
         logger.warn({
           message: 'Failed to delete replaced thumbnail file',
-          filePath: oldThumbnailPath,
+          filePath: result.replacedThumbnailPath,
           mediaId: id,
           accountId: account.id
         })
@@ -311,7 +315,7 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
     } catch (error) {
       logger.warn({
         message: 'Error deleting replaced thumbnail file',
-        filePath: oldThumbnailPath,
+        filePath: result.replacedThumbnailPath,
         mediaId: id,
         accountId: account.id,
         error: (error as Error).message
@@ -328,7 +332,7 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
-    data: getMediaAttachment(media, headerHost(req.headers))
+    data: getMediaAttachment(result.media, headerHost(req.headers))
   })
 }
 

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -236,13 +236,22 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
     }
   }
 
-  const media = await database.updateMedia({
-    mediaId: id,
-    accountId: account.id,
-    ...(descriptionProvided ? { description: parsed.data.description } : {}),
-    ...(focusProvided ? { focus: parsed.data.focus } : {}),
-    ...(thumbnail ? { thumbnail } : {})
-  })
+  let media
+  try {
+    media = await database.updateMedia({
+      mediaId: id,
+      accountId: account.id,
+      ...(descriptionProvided ? { description: parsed.data.description } : {}),
+      ...(focusProvided ? { focus: parsed.data.focus } : {}),
+      ...(thumbnail ? { thumbnail } : {})
+    })
+  } catch (error) {
+    // Don't leak the freshly-stored thumbnail if persisting the update failed.
+    if (thumbnail) {
+      await deleteMediaFile(database, thumbnail.path).catch(() => false)
+    }
+    throw error
+  }
 
   if (!media) {
     // Owner check failed inside updateMedia; clean up the orphaned thumbnail we
@@ -318,6 +327,14 @@ export const DELETE = traceApiRoute(
         })
       }
 
+      // Capture the storage paths before deleting the row so the underlying
+      // files can be removed once we know the delete actually happened (and
+      // wasn't rejected as in-use).
+      const media = await database.getMediaByIdForAccount({
+        mediaId: id,
+        accountId: account.id
+      })
+
       const result = await database.deleteMediaForAccount({
         mediaId: id,
         accountId: account.id
@@ -340,6 +357,29 @@ export const DELETE = traceApiRoute(
           allowedMethods: CORS_HEADERS,
           data: ERROR_404,
           responseStatusCode: 404
+        })
+      }
+
+      // Best-effort removal of the original + thumbnail files now that the row
+      // is gone. Storage failures are logged but don't fail the request — the
+      // record is already deleted and the usage counter decremented.
+      if (media) {
+        const filesToDelete = [
+          media.original.path,
+          ...(media.thumbnail ? [media.thumbnail.path] : [])
+        ]
+        const deletions = await Promise.allSettled(
+          filesToDelete.map((filePath) => deleteMediaFile(database, filePath))
+        )
+        deletions.forEach((deletion, index) => {
+          if (deletion.status === 'rejected' || !deletion.value) {
+            logger.warn({
+              message: 'Failed to delete storage file for deleted media',
+              filePath: filesToDelete[index],
+              mediaId: id,
+              accountId: account.id
+            })
+          }
         })
       }
 

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -376,14 +376,6 @@ export const DELETE = traceApiRoute(
         })
       }
 
-      // Capture the storage paths before deleting the row so the underlying
-      // files can be removed once we know the delete actually happened (and
-      // wasn't rejected as in-use).
-      const media = await database.getMediaByIdForAccount({
-        mediaId: id,
-        accountId: account.id
-      })
-
       const result = await database.deleteMediaForAccount({
         mediaId: id,
         accountId: account.id
@@ -391,7 +383,7 @@ export const DELETE = traceApiRoute(
 
       // Media already attached to a posted status can't be deleted (Mastodon
       // returns 422 in_usage_error).
-      if (result === 'in-use') {
+      if (result.status === 'in-use') {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -400,7 +392,7 @@ export const DELETE = traceApiRoute(
         })
       }
 
-      if (result === 'not-found') {
+      if (result.status === 'not-found') {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
@@ -410,27 +402,22 @@ export const DELETE = traceApiRoute(
       }
 
       // Best-effort removal of the original + thumbnail files now that the row
-      // is gone. Storage failures are logged but don't fail the request — the
+      // is gone. The paths come from inside the delete transaction (no racy
+      // prefetch). Storage failures are logged but don't fail the request — the
       // record is already deleted and the usage counter decremented.
-      if (media) {
-        const filesToDelete = [
-          media.original.path,
-          ...(media.thumbnail ? [media.thumbnail.path] : [])
-        ]
-        const deletions = await Promise.allSettled(
-          filesToDelete.map((filePath) => deleteMediaFile(database, filePath))
-        )
-        deletions.forEach((deletion, index) => {
-          if (deletion.status === 'rejected' || !deletion.value) {
-            logger.warn({
-              message: 'Failed to delete storage file for deleted media',
-              filePath: filesToDelete[index],
-              mediaId: id,
-              accountId: account.id
-            })
-          }
-        })
-      }
+      const deletions = await Promise.allSettled(
+        result.files.map((filePath) => deleteMediaFile(database, filePath))
+      )
+      deletions.forEach((deletion, index) => {
+        if (deletion.status === 'rejected' || !deletion.value) {
+          logger.warn({
+            message: 'Failed to delete storage file for deleted media',
+            filePath: result.files[index],
+            mediaId: id,
+            accountId: account.id
+          })
+        }
+      })
 
       logger.info({
         message: 'Media deleted',

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { AuthenticatedApiHandle } from '@/lib/services/guards/types'
 import { deleteMediaFile, saveMediaThumbnail } from '@/lib/services/medias'
@@ -28,6 +31,10 @@ const CORS_HEADERS = [
 ]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+// Attach the route's CORS allow-list to the guard's auth-failure responses so
+// cross-origin clients can read 401/403/500 instead of an opaque CORS error.
+const guardOptions = { errorResponse: corsErrorResponse(CORS_HEADERS) }
 
 interface Params {
   id: string
@@ -115,7 +122,8 @@ export const GET = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: getMediaAttachment(media, headerHost(req.headers))
       })
-    }
+    },
+    guardOptions
   )
 )
 
@@ -289,7 +297,8 @@ export const PUT = traceApiRoute(
   'updateMedia',
   OAuthGuardAnyScope<Params>(
     [Scope.enum.write, Scope.enum['write:media']],
-    updateMediaHandler
+    updateMediaHandler,
+    guardOptions
   )
 )
 
@@ -297,7 +306,8 @@ export const PATCH = traceApiRoute(
   'updateMedia',
   OAuthGuardAnyScope<Params>(
     [Scope.enum.write, Scope.enum['write:media']],
-    updateMediaHandler
+    updateMediaHandler,
+    guardOptions
   )
 )
 
@@ -395,6 +405,7 @@ export const DELETE = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: {}
       })
-    }
+    },
+    guardOptions
   )
 )

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -276,8 +276,28 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
   }
 
   // Remove the previous thumbnail file once the replacement is persisted.
+  // Best-effort: a storage hiccup here must not fail an update that already
+  // committed to the database.
   if (thumbnail && oldThumbnailPath && oldThumbnailPath !== thumbnail.path) {
-    await deleteMediaFile(database, oldThumbnailPath)
+    try {
+      const removed = await deleteMediaFile(database, oldThumbnailPath)
+      if (!removed) {
+        logger.warn({
+          message: 'Failed to delete replaced thumbnail file',
+          filePath: oldThumbnailPath,
+          mediaId: id,
+          accountId: account.id
+        })
+      }
+    } catch (error) {
+      logger.warn({
+        message: 'Error deleting replaced thumbnail file',
+        filePath: oldThumbnailPath,
+        mediaId: id,
+        accountId: account.id,
+        error: (error as Error).message
+      })
+    }
   }
 
   logger.info({

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -292,9 +292,10 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
 
   if (!result) {
     // Owner check failed inside updateMedia; clean up the orphaned thumbnail we
-    // just stored so it doesn't leak.
+    // just stored so it doesn't leak. Best-effort — a cleanup failure must not
+    // turn the 404 into a 500.
     if (thumbnail) {
-      await deleteMediaFile(database, thumbnail.path)
+      await deleteMediaFile(database, thumbnail.path).catch(() => false)
     }
     return apiResponse({
       req,

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -179,11 +179,18 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
   // Zod fills omitted optionals) so a partial update only mutates those fields.
   const descriptionProvided = 'description' in payload
   const focusProvided = 'focus' in payload
-  const rawThumbnail = payload.thumbnail
-  const thumbnailProvided =
-    rawThumbnail instanceof File && rawThumbnail.size > 0
 
-  if (thumbnailProvided) {
+  // A `thumbnail` field carries content when it is a non-empty File or a
+  // non-blank value. An absent field, empty string, or 0-byte file is treated
+  // as "not provided"; any other present value is validated as an image File so
+  // an invalid thumbnail returns 422 instead of being silently ignored.
+  const rawThumbnail = payload.thumbnail
+  const thumbnailFieldHasContent =
+    rawThumbnail != null &&
+    !(typeof rawThumbnail === 'string' && rawThumbnail.trim() === '') &&
+    !(rawThumbnail instanceof File && rawThumbnail.size === 0)
+
+  if (thumbnailFieldHasContent) {
     const thumbnailCheck = FileSchema.safeParse(rawThumbnail)
     if (!thumbnailCheck.success) {
       return apiResponse({
@@ -194,6 +201,9 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
       })
     }
   }
+
+  // After the check above, a present-with-content thumbnail is a valid File.
+  const thumbnailProvided = thumbnailFieldHasContent
 
   // Nothing to change — return the current attachment (404 if not owned).
   if (!descriptionProvided && !focusProvided && !thumbnailProvided) {

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -8,6 +8,7 @@ import {
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { AuthenticatedApiHandle } from '@/lib/services/guards/types'
 import { deleteMediaFile, saveMediaThumbnail } from '@/lib/services/medias'
+import { MediaValidationError } from '@/lib/services/medias/errors'
 import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
 import { FileSchema, FocusSchema } from '@/lib/services/medias/types'
 import { Scope } from '@/lib/types/database/operations'
@@ -233,7 +234,25 @@ const updateMediaHandler: AuthenticatedApiHandle<Params> = async (
       })
     }
     oldThumbnailPath = existing.thumbnail?.path
-    thumbnail = await saveMediaThumbnail(database, rawThumbnail as File)
+    try {
+      thumbnail = await saveMediaThumbnail(
+        database,
+        currentActor,
+        rawThumbnail as File
+      )
+    } catch (error) {
+      // Quota exceeded / invalid media are client errors (422); anything else is
+      // an unexpected storage failure (500).
+      if (error instanceof MediaValidationError) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+      throw error
+    }
     if (!thumbnail) {
       return apiResponse({
         req,

--- a/app/api/v1/media/route.test.ts
+++ b/app/api/v1/media/route.test.ts
@@ -1,0 +1,136 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+const mockStoredToken = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => () => ({
+    where: () => ({
+      first: () => mockStoredToken()
+    })
+  })
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const mockSaveMedia = jest.fn()
+jest.mock('@/lib/services/medias', () => ({
+  saveMedia: (...args: unknown[]) => mockSaveMedia(...args)
+}))
+
+const sampleAttachment = {
+  id: '7',
+  type: 'image',
+  mime_type: 'image/png',
+  url: 'https://llun.test/api/v1/files/medias/sample.webp',
+  preview_url: 'https://llun.test/api/v1/files/medias/sample.webp',
+  text_url: null,
+  remote_url: null,
+  meta: { original: { width: 1, height: 1, size: '1x1', aspect: 1 } },
+  description: '',
+  blurhash: null
+}
+
+const buildForm = () => {
+  const form = new FormData()
+  form.set(
+    'file',
+    new File([new Uint8Array([1, 2, 3])], 'image.png', { type: 'image/png' })
+  )
+  return form
+}
+
+const postRequest = (token?: string) => {
+  const req = new NextRequest('https://llun.test/api/v1/media', {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  })
+  // jest / undici cannot materialise a multipart body from a FormData passed to
+  // NextRequest — mock formData() directly (see update_credentials route test).
+  Object.defineProperty(req, 'formData', {
+    value: jest.fn().mockResolvedValue(buildForm())
+  })
+  return req
+}
+
+describe('POST /api/v1/media', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue(null)
+    mockSaveMedia.mockResolvedValue(sampleAttachment)
+  })
+
+  it('rejects a token that lacks write:media (401)', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'read'
+    })
+
+    const response = await POST(postRequest('read-only-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with a fully-processed attachment for write:media tokens', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+
+    const response = await POST(postRequest('write-media-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({ id: '7', type: 'image', blurhash: null })
+    expect(mockSaveMedia).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/api/v1/media/route.ts
+++ b/app/api/v1/media/route.ts
@@ -1,10 +1,11 @@
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
-import { saveMedia } from '@/lib/services/medias'
-import { MediaSchema } from '@/lib/services/medias/types'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { handleSyncMediaUpload } from '@/lib/services/medias/handleSyncMediaUpload'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { logger } from '@/lib/utils/logger'
-import { ERROR_422, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
@@ -14,50 +15,13 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 // POST /api/v1/media — Mastodon's deprecated synchronous upload. Same parameters
 // and `write:media` scope as v2, but it always finishes processing before
 // responding, so it only ever returns 200 with a fully-processed
-// MediaAttachment (no 202 path). `saveMedia` is synchronous here, matching that
-// contract.
+// MediaAttachment (no 202 path). Shares the upload handler with v2 — the only
+// difference is the trace name.
 export const POST = traceApiRoute(
   'uploadMediaV1',
   OAuthGuardAnyScope(
     [Scope.enum.write, Scope.enum['write:media']],
-    async (req, context) => {
-      try {
-        const { database, currentActor } = context
-        const form = await req.formData()
-        const media = MediaSchema.safeParse(Object.fromEntries(form.entries()))
-        if (!media.success) {
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: ERROR_422,
-            responseStatusCode: 422
-          })
-        }
-
-        const response = await saveMedia(database, currentActor, media.data)
-        if (!response) {
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: ERROR_422,
-            responseStatusCode: 422
-          })
-        }
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: response
-        })
-      } catch (e) {
-        const nodeErr = e as NodeJS.ErrnoException
-        logger.error(nodeErr)
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
-        })
-      }
-    }
+    (req, context) => handleSyncMediaUpload(req, context, CORS_HEADERS),
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/app/api/v1/media/route.ts
+++ b/app/api/v1/media/route.ts
@@ -11,14 +11,13 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-// POST /api/v2/media — Mastodon requires the `write:media` scope (we also accept
-// the coarser `write`). Uploads are processed synchronously by `saveMedia`
-// (LocalFile/S3 store the file and return a fully-populated MediaAttachment), so
-// we always return 200. Mastodon's 202 path applies only when processing is
-// deferred; the deferred flow here is the separate presigned-upload service,
-// which is out of scope for this route.
+// POST /api/v1/media — Mastodon's deprecated synchronous upload. Same parameters
+// and `write:media` scope as v2, but it always finishes processing before
+// responding, so it only ever returns 200 with a fully-processed
+// MediaAttachment (no 202 path). `saveMedia` is synchronous here, matching that
+// contract.
 export const POST = traceApiRoute(
-  'uploadMediaV2',
+  'uploadMediaV1',
   OAuthGuardAnyScope(
     [Scope.enum.write, Scope.enum['write:media']],
     async (req, context) => {

--- a/app/api/v2/media/route.test.ts
+++ b/app/api/v2/media/route.test.ts
@@ -1,0 +1,183 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+const mockStoredToken = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => () => ({
+    where: () => ({
+      first: () => mockStoredToken()
+    })
+  })
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const mockSaveMedia = jest.fn()
+jest.mock('@/lib/services/medias', () => ({
+  saveMedia: (...args: unknown[]) => mockSaveMedia(...args)
+}))
+
+const sampleAttachment = {
+  id: '99',
+  type: 'image',
+  mime_type: 'image/png',
+  url: 'https://llun.test/api/v1/files/medias/sample.webp',
+  preview_url: 'https://llun.test/api/v1/files/medias/sample.webp',
+  text_url: null,
+  remote_url: null,
+  meta: { original: { width: 1, height: 1, size: '1x1', aspect: 1 } },
+  description: 'alt text',
+  blurhash: null
+}
+
+const buildForm = () => {
+  const form = new FormData()
+  form.set(
+    'file',
+    new File([new Uint8Array([1, 2, 3])], 'image.png', { type: 'image/png' })
+  )
+  form.set('description', 'alt text')
+  form.set('focus', '0.1,-0.2')
+  return form
+}
+
+const postRequest = (token?: string, form?: FormData) => {
+  const req = new NextRequest('https://llun.test/api/v2/media', {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  })
+  // jest / undici cannot materialise a multipart body from a FormData passed to
+  // NextRequest — mock formData() directly (see update_credentials route test).
+  Object.defineProperty(req, 'formData', {
+    value: jest.fn().mockResolvedValue(form ?? buildForm())
+  })
+  return req
+}
+
+describe('POST /api/v2/media', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+    mockStoredToken.mockResolvedValue(null)
+    mockSaveMedia.mockResolvedValue(sampleAttachment)
+  })
+
+  it('requires a bearer token (401 when unauthenticated)', async () => {
+    const response = await POST(postRequest(), { params: Promise.resolve({}) })
+    expect(response.status).toBe(401)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects a token that lacks write:media (401)', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'read'
+    })
+
+    const response = await POST(postRequest('read-only-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('accepts a write:media token and returns 200 with the attachment', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+
+    const response = await POST(postRequest('write-media-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toMatchObject({ id: '99', type: 'image', blurhash: null })
+
+    // The parsed focus/description are forwarded to saveMedia.
+    const media = mockSaveMedia.mock.calls[0][2]
+    expect(media.description).toBe('alt text')
+    expect(media.focus).toEqual({ x: 0.1, y: -0.2 })
+  })
+
+  it('accepts the coarser write scope', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write'
+    })
+
+    const response = await POST(postRequest('write-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 422 when the uploaded file is invalid', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+
+    const form = new FormData()
+    form.set(
+      'file',
+      new File([new Uint8Array([1])], 'bad.txt', { type: 'text/plain' })
+    )
+
+    const response = await POST(postRequest('write-media-token', form), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v2/media/route.test.ts
+++ b/app/api/v2/media/route.test.ts
@@ -181,6 +181,29 @@ describe('POST /api/v2/media', () => {
     expect(mockSaveMedia).not.toHaveBeenCalled()
   })
 
+  it('returns 422 for a malformed multipart body', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+
+    const req = new NextRequest('https://llun.test/api/v2/media', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer write-media-token' }
+    })
+    // A malformed multipart body makes formData() throw — a client error (422),
+    // not an internal failure (500).
+    Object.defineProperty(req, 'formData', {
+      value: jest.fn().mockRejectedValue(new Error('Could not parse content'))
+    })
+
+    const response = await POST(req, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
   it('returns 500 when saving throws an unexpected internal error', async () => {
     mockStoredToken.mockResolvedValue({
       expiresAt: new Date(Date.now() + 60_000),

--- a/app/api/v2/media/route.test.ts
+++ b/app/api/v2/media/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { MediaValidationError } from '@/lib/services/medias/errors'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 
@@ -202,6 +203,23 @@ describe('POST /api/v2/media', () => {
 
     expect(response.status).toBe(422)
     expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 for client-actionable upload failures (quota / invalid media)', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+    mockSaveMedia.mockRejectedValue(
+      new MediaValidationError('Storage quota exceeded')
+    )
+
+    const response = await POST(postRequest('write-media-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(422)
   })
 
   it('returns 500 when saving throws an unexpected internal error', async () => {

--- a/app/api/v2/media/route.test.ts
+++ b/app/api/v2/media/route.test.ts
@@ -180,4 +180,19 @@ describe('POST /api/v2/media', () => {
     expect(response.status).toBe(422)
     expect(mockSaveMedia).not.toHaveBeenCalled()
   })
+
+  it('returns 500 when saving throws an unexpected internal error', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+    mockSaveMedia.mockRejectedValue(new Error('storage unavailable'))
+
+    const response = await POST(postRequest('write-media-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(500)
+  })
 })

--- a/app/api/v2/media/route.ts
+++ b/app/api/v2/media/route.ts
@@ -1,10 +1,11 @@
-import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
-import { saveMedia } from '@/lib/services/medias'
-import { MediaSchema } from '@/lib/services/medias/types'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { handleSyncMediaUpload } from '@/lib/services/medias/handleSyncMediaUpload'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { logger } from '@/lib/utils/logger'
-import { ERROR_422, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
@@ -21,44 +22,7 @@ export const POST = traceApiRoute(
   'uploadMediaV2',
   OAuthGuardAnyScope(
     [Scope.enum.write, Scope.enum['write:media']],
-    async (req, context) => {
-      try {
-        const { database, currentActor } = context
-        const form = await req.formData()
-        const media = MediaSchema.safeParse(Object.fromEntries(form.entries()))
-        if (!media.success) {
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: ERROR_422,
-            responseStatusCode: 422
-          })
-        }
-
-        const response = await saveMedia(database, currentActor, media.data)
-        if (!response) {
-          return apiResponse({
-            req,
-            allowedMethods: CORS_HEADERS,
-            data: ERROR_422,
-            responseStatusCode: 422
-          })
-        }
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: response
-        })
-      } catch (e) {
-        const nodeErr = e as NodeJS.ErrnoException
-        logger.error(nodeErr)
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_422,
-          responseStatusCode: 422
-        })
-      }
-    }
+    (req, context) => handleSyncMediaUpload(req, context, CORS_HEADERS),
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -758,6 +758,237 @@ describe('MediaDatabase', () => {
         })
         expect(updated).toBeNull()
       })
+
+      it('persists a focal point and round-trips it exactly', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/update-media-focus.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          focus: { x: 0.5, y: -0.25 }
+        })
+
+        expect(updated?.focus).toEqual({ x: 0.5, y: -0.25 })
+        const retrieved = await database.getMediaByIdForAccount({
+          mediaId: media!.id,
+          accountId
+        })
+        expect(retrieved?.focus).toEqual({ x: 0.5, y: -0.25 })
+      })
+
+      it('keeps focus untouched when only the description is updated', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          description: 'original',
+          focus: { x: 0.1, y: 0.2 },
+          original: {
+            path: '/test/update-media-focus-keep.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          description: 'changed'
+        })
+
+        expect(updated?.description).toBe('changed')
+        expect(updated?.focus).toEqual({ x: 0.1, y: 0.2 })
+      })
+
+      it('keeps the description untouched when only focus is updated', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          description: 'keep me',
+          original: {
+            path: '/test/update-media-desc-keep.jpg',
+            bytes: 1234,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          focus: { x: -1, y: 1 }
+        })
+
+        expect(updated?.focus).toEqual({ x: -1, y: 1 })
+        expect(updated?.description).toBe('keep me')
+      })
+
+      it('replaces the thumbnail and adjusts the usage counter by the byte delta', async () => {
+        const actor = await database.getActorFromId({ id: actors.empty.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.empty.id,
+          original: {
+            path: '/test/update-thumb-original.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          },
+          thumbnail: {
+            path: '/test/update-thumb-old.jpg',
+            bytes: 200,
+            mimeType: 'image/jpeg',
+            metaData: { width: 40, height: 40 }
+          }
+        })
+
+        const usageBefore = await database.getStorageUsageForAccount({
+          accountId
+        })
+
+        const updated = await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          thumbnail: {
+            path: '/test/update-thumb-new.webp',
+            bytes: 350,
+            mimeType: 'image/webp',
+            metaData: { width: 60, height: 60 }
+          }
+        })
+
+        expect(updated?.thumbnail?.path).toBe('/test/update-thumb-new.webp')
+        expect(updated?.thumbnail?.bytes).toBe(350)
+
+        const usageAfter = await database.getStorageUsageForAccount({
+          accountId
+        })
+        // 350 - 200 = +150
+        expect(usageAfter).toBe(usageBefore + 150)
+      })
+    })
+
+    describe('deleteMediaForAccount', () => {
+      it('deletes owner media not attached to a status and decreases usage', async () => {
+        const actor = await database.getActorFromId({ id: actors.empty.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.empty.id,
+          original: {
+            path: '/test/del-for-account.jpg',
+            bytes: 1500,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+
+        const usageBefore = await database.getStorageUsageForAccount({
+          accountId
+        })
+
+        const result = await database.deleteMediaForAccount({
+          mediaId: media!.id,
+          accountId
+        })
+
+        expect(result).toBe('deleted')
+        const usageAfter = await database.getStorageUsageForAccount({
+          accountId
+        })
+        expect(usageAfter).toBe(usageBefore - 1500)
+        const retrieved = await database.getMediaByIdForAccount({
+          mediaId: media!.id,
+          accountId
+        })
+        expect(retrieved).toBeNull()
+      })
+
+      it('returns not-found for a nonexistent media id', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const result = await database.deleteMediaForAccount({
+          mediaId: '99999999',
+          accountId: actor!.account!.id
+        })
+        expect(result).toBe('not-found')
+      })
+
+      it('returns not-found when the media belongs to another account', async () => {
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/del-for-account-foreign.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        const otherActor = await database.getActorFromId({
+          id: actors.replyAuthor.id
+        })
+
+        const result = await database.deleteMediaForAccount({
+          mediaId: media!.id,
+          accountId: otherActor!.account!.id
+        })
+
+        expect(result).toBe('not-found')
+        // The media must still exist for its real owner.
+        const owner = await database.getActorFromId({ id: actors.primary.id })
+        const stillThere = await database.getMediaByIdForAccount({
+          mediaId: media!.id,
+          accountId: owner!.account!.id
+        })
+        expect(stillThere).toBeDefined()
+      })
+
+      it('returns in-use when the media is attached to a posted status', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/del-for-account-attached.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        const statuses = await database.getActorStatuses({
+          actorId: actors.primary.id,
+          limit: 1
+        })
+        await database.createAttachment({
+          actorId: actors.primary.id,
+          statusId: statuses[0].id,
+          mediaType: 'image/jpeg',
+          url: media!.original.path,
+          mediaId: media!.id
+        })
+
+        const result = await database.deleteMediaForAccount({
+          mediaId: media!.id,
+          accountId
+        })
+
+        expect(result).toBe('in-use')
+        const stillThere = await database.getMediaByIdForAccount({
+          mediaId: media!.id,
+          accountId
+        })
+        expect(stillThere).toBeDefined()
+      })
     })
   })
 })

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -944,7 +944,7 @@ describe('MediaDatabase', () => {
           accountId
         })
 
-        expect(result).toBe('deleted')
+        expect(result.status).toBe('deleted')
         const usageAfter = await database.getStorageUsageForAccount({
           accountId
         })
@@ -962,7 +962,7 @@ describe('MediaDatabase', () => {
           mediaId: '99999999',
           accountId: actor!.account!.id
         })
-        expect(result).toBe('not-found')
+        expect(result.status).toBe('not-found')
       })
 
       it('returns not-found when the media belongs to another account', async () => {
@@ -984,7 +984,7 @@ describe('MediaDatabase', () => {
           accountId: otherActor!.account!.id
         })
 
-        expect(result).toBe('not-found')
+        expect(result.status).toBe('not-found')
         // The media must still exist for its real owner.
         const owner = await database.getActorFromId({ id: actors.primary.id })
         const stillThere = await database.getMediaByIdForAccount({
@@ -1023,7 +1023,7 @@ describe('MediaDatabase', () => {
           accountId
         })
 
-        expect(result).toBe('in-use')
+        expect(result.status).toBe('in-use')
         const stillThere = await database.getMediaByIdForAccount({
           mediaId: media!.id,
           accountId

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -878,6 +878,47 @@ describe('MediaDatabase', () => {
         // 350 - 200 = +150
         expect(usageAfter).toBe(usageBefore + 150)
       })
+
+      it('decreases the usage counter when the replacement thumbnail is smaller', async () => {
+        const actor = await database.getActorFromId({ id: actors.empty.id })
+        const accountId = actor!.account!.id
+        const media = await database.createMedia({
+          actorId: actors.empty.id,
+          original: {
+            path: '/test/update-thumb-shrink-original.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          },
+          thumbnail: {
+            path: '/test/update-thumb-shrink-old.jpg',
+            bytes: 400,
+            mimeType: 'image/jpeg',
+            metaData: { width: 40, height: 40 }
+          }
+        })
+
+        const usageBefore = await database.getStorageUsageForAccount({
+          accountId
+        })
+
+        await database.updateMedia({
+          mediaId: media!.id,
+          accountId,
+          thumbnail: {
+            path: '/test/update-thumb-shrink-new.webp',
+            bytes: 100,
+            mimeType: 'image/webp',
+            metaData: { width: 20, height: 20 }
+          }
+        })
+
+        const usageAfter = await database.getStorageUsageForAccount({
+          accountId
+        })
+        // 100 - 400 = -300
+        expect(usageAfter).toBe(usageBefore - 300)
+      })
     })
 
     describe('deleteMediaForAccount', () => {

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -695,7 +695,7 @@ describe('MediaDatabase', () => {
           description: 'updated alt text'
         })
 
-        expect(updated?.description).toBe('updated alt text')
+        expect(updated?.media.description).toBe('updated alt text')
         const retrieved = await database.getMediaByIdForAccount({
           mediaId: media!.id,
           accountId
@@ -723,7 +723,7 @@ describe('MediaDatabase', () => {
           description: null
         })
 
-        expect(updated?.description).toBeUndefined()
+        expect(updated?.media.description).toBeUndefined()
       })
 
       it('returns null when the media is not owned by the account', async () => {
@@ -778,7 +778,7 @@ describe('MediaDatabase', () => {
           focus: { x: 0.5, y: -0.25 }
         })
 
-        expect(updated?.focus).toEqual({ x: 0.5, y: -0.25 })
+        expect(updated?.media.focus).toEqual({ x: 0.5, y: -0.25 })
         const retrieved = await database.getMediaByIdForAccount({
           mediaId: media!.id,
           accountId
@@ -807,8 +807,8 @@ describe('MediaDatabase', () => {
           description: 'changed'
         })
 
-        expect(updated?.description).toBe('changed')
-        expect(updated?.focus).toEqual({ x: 0.1, y: 0.2 })
+        expect(updated?.media.description).toBe('changed')
+        expect(updated?.media.focus).toEqual({ x: 0.1, y: 0.2 })
       })
 
       it('keeps the description untouched when only focus is updated', async () => {
@@ -831,8 +831,8 @@ describe('MediaDatabase', () => {
           focus: { x: -1, y: 1 }
         })
 
-        expect(updated?.focus).toEqual({ x: -1, y: 1 })
-        expect(updated?.description).toBe('keep me')
+        expect(updated?.media.focus).toEqual({ x: -1, y: 1 })
+        expect(updated?.media.description).toBe('keep me')
       })
 
       it('replaces the thumbnail and adjusts the usage counter by the byte delta', async () => {
@@ -869,8 +869,10 @@ describe('MediaDatabase', () => {
           }
         })
 
-        expect(updated?.thumbnail?.path).toBe('/test/update-thumb-new.webp')
-        expect(updated?.thumbnail?.bytes).toBe(350)
+        expect(updated?.media.thumbnail?.path).toBe(
+          '/test/update-thumb-new.webp'
+        )
+        expect(updated?.media.thumbnail?.bytes).toBe(350)
 
         const usageAfter = await database.getStorageUsageForAccount({
           accountId

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -14,6 +14,8 @@ import {
   CreateMediaParams,
   DeleteAttachmentsByIdsParams,
   DeleteMediaByPathParams,
+  DeleteMediaForAccountParams,
+  DeleteMediaForAccountResult,
   DeleteMediaParams,
   GetAttachmentsForActorParams,
   GetAttachmentsParams,
@@ -94,6 +96,8 @@ type MediaRow = {
   thumbnailMimeType?: string | null
   thumbnailMetaData?: string | null
   description?: string | null
+  focusX?: number | string | null
+  focusY?: number | string | null
 }
 
 type MediaMetaData = Media['original']['metaData']
@@ -123,15 +127,40 @@ const parseMediaRow = (data: MediaRow): Media => ({
         }
       }
     : {}),
-  ...(data.description ? { description: data.description } : {})
+  ...(data.description ? { description: data.description } : {}),
+  ...(data.focusX !== null &&
+  data.focusX !== undefined &&
+  data.focusY !== null &&
+  data.focusY !== undefined
+    ? { focus: { x: Number(data.focusX), y: Number(data.focusY) } }
+    : {})
 })
+
+// `medias` columns needed to rebuild a full Media row (used by every read).
+const MEDIA_COLUMNS = [
+  'id',
+  'actorId',
+  'original',
+  'originalBytes',
+  'originalMimeType',
+  'originalMetaData',
+  'originalFileName',
+  'thumbnail',
+  'thumbnailBytes',
+  'thumbnailMimeType',
+  'thumbnailMetaData',
+  'description',
+  'focusX',
+  'focusY'
+] as const
 
 export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
   async createMedia({
     actorId,
     original,
     thumbnail,
-    description
+    description,
+    focus
   }: CreateMediaParams) {
     if (!actorId) return null
 
@@ -156,7 +185,8 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
               thumbnailMetaData: JSON.stringify(thumbnail.metaData)
             }
           : null),
-        ...(description ? { description } : null)
+        ...(description ? { description } : null),
+        ...(focus ? { focusX: focus.x, focusY: focus.y } : null)
       }
 
       const ids = await trx('medias').insert(content, ['id'])
@@ -187,7 +217,8 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         actorId,
         original,
         ...(thumbnail ? { thumbnail } : null),
-        ...(description ? { description } : null)
+        ...(description ? { description } : null),
+        ...(focus ? { focus } : null)
       } as Media
     })
   },
@@ -212,7 +243,9 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         'medias.thumbnailBytes',
         'medias.thumbnailMimeType',
         'medias.thumbnailMetaData',
-        'medias.description'
+        'medias.description',
+        'medias.focusX',
+        'medias.focusY'
       )
       .first<MediaRow>()
 
@@ -412,6 +445,8 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         'medias.thumbnailMimeType',
         'medias.thumbnailMetaData',
         'medias.description',
+        'medias.focusX',
+        'medias.focusY',
         'medias.createdAt',
         'attachments.statusId'
       )
@@ -452,6 +487,12 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
           }
         : {}),
       ...(item.description ? { description: item.description } : {}),
+      ...(item.focusX !== null &&
+      item.focusX !== undefined &&
+      item.focusY !== null &&
+      item.focusY !== undefined
+        ? { focus: { x: Number(item.focusX), y: Number(item.focusY) } }
+        : {}),
       ...(item.statusId ? { statusId: item.statusId } : {})
     }))
 
@@ -466,20 +507,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
       .join('actors', 'medias.actorId', 'actors.id')
       .where('medias.id', mediaId)
       .where('actors.accountId', accountId)
-      .select(
-        'medias.id',
-        'medias.actorId',
-        'medias.original',
-        'medias.originalBytes',
-        'medias.originalMimeType',
-        'medias.originalMetaData',
-        'medias.originalFileName',
-        'medias.thumbnail',
-        'medias.thumbnailBytes',
-        'medias.thumbnailMimeType',
-        'medias.thumbnailMetaData',
-        'medias.description'
-      )
+      .select(MEDIA_COLUMNS.map((column) => `medias.${column}`))
       .first()
 
     if (!data) return null
@@ -490,47 +518,81 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
   async updateMedia({
     mediaId,
     accountId,
-    description
+    description,
+    focus,
+    thumbnail
   }: UpdateMediaParams): Promise<Media | null> {
-    const owned = await database('medias')
-      .join('actors', 'medias.actorId', 'actors.id')
-      .where('medias.id', mediaId)
-      .where('actors.accountId', accountId)
-      .first('medias.id')
-    if (!owned) return null
+    return database.transaction(async (trx) => {
+      const owned = await trx('medias')
+        .join('actors', 'medias.actorId', 'actors.id')
+        .where('medias.id', mediaId)
+        .where('actors.accountId', accountId)
+        .select('medias.id', 'medias.thumbnailBytes')
+        .first<{
+          id: string | number
+          thumbnailBytes: number | string | null
+        }>()
+      if (!owned) return null
 
-    // Only touch `description` when the caller actually provided it, so a
-    // partial update can't blank out existing alt text by omitting the field.
-    const updates: { updatedAt: Date; description?: string | null } = {
-      updatedAt: new Date()
-    }
-    if (description !== undefined) {
-      updates.description = description
-    }
+      // Only touch fields the caller actually provided so a partial update can't
+      // blank out existing metadata (e.g. a description-only update must not
+      // clear focus, and a focus-only update must not clear the description).
+      const updates: {
+        updatedAt: Date
+        description?: string | null
+        focusX?: number
+        focusY?: number
+        thumbnail?: string
+        thumbnailBytes?: number
+        thumbnailMimeType?: string
+        thumbnailMetaData?: string
+      } = { updatedAt: new Date() }
 
-    await database('medias').where('id', mediaId).update(updates)
+      if (description !== undefined) {
+        updates.description = description
+      }
+      if (focus !== undefined) {
+        updates.focusX = focus.x
+        updates.focusY = focus.y
+      }
 
-    const data = await database('medias')
-      .where('id', mediaId)
-      .select(
-        'id',
-        'actorId',
-        'original',
-        'originalBytes',
-        'originalMimeType',
-        'originalMetaData',
-        'originalFileName',
-        'thumbnail',
-        'thumbnailBytes',
-        'thumbnailMimeType',
-        'thumbnailMetaData',
-        'description'
-      )
-      .first()
+      let thumbnailUsageDelta = 0
+      if (thumbnail !== undefined) {
+        updates.thumbnail = thumbnail.path
+        updates.thumbnailBytes = thumbnail.bytes
+        updates.thumbnailMimeType = thumbnail.mimeType
+        updates.thumbnailMetaData = JSON.stringify(thumbnail.metaData)
+        thumbnailUsageDelta =
+          thumbnail.bytes - parseCounterValue(owned.thumbnailBytes)
+      }
 
-    if (!data) return null
+      await trx('medias').where('id', mediaId).update(updates)
 
-    return parseMediaRow(data)
+      // Replacing a thumbnail changes stored bytes; keep the per-account usage
+      // counter (read by getStorageUsageForAccount / quota checks) in sync.
+      if (thumbnailUsageDelta > 0) {
+        await increaseCounterValue(
+          trx,
+          CounterKey.mediaUsage(accountId),
+          thumbnailUsageDelta
+        )
+      } else if (thumbnailUsageDelta < 0) {
+        await decreaseCounterValue(
+          trx,
+          CounterKey.mediaUsage(accountId),
+          -thumbnailUsageDelta
+        )
+      }
+
+      const data = await trx('medias')
+        .where('id', mediaId)
+        .select([...MEDIA_COLUMNS])
+        .first()
+
+      if (!data) return null
+
+      return parseMediaRow(data)
+    })
   },
 
   async getStorageUsageForAccount({
@@ -551,6 +613,55 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
 
   async deleteMedia({ mediaId }: DeleteMediaParams): Promise<boolean> {
     return deleteMediaById(database, mediaId)
+  },
+
+  async deleteMediaForAccount({
+    mediaId,
+    accountId
+  }: DeleteMediaForAccountParams): Promise<DeleteMediaForAccountResult> {
+    return database.transaction(async (trx) => {
+      // Owner scope: only the account that owns the media (via its actors) can
+      // delete it. Mastodon scopes destroy to `current_account.media_attachments`.
+      const media = await trx('medias')
+        .join('actors', 'medias.actorId', 'actors.id')
+        .where('medias.id', mediaId)
+        .where('actors.accountId', accountId)
+        .select('medias.id', 'medias.originalBytes', 'medias.thumbnailBytes')
+        .first<{
+          id: string | number
+          originalBytes: number | string | bigint | null
+          thumbnailBytes: number | string | bigint | null
+        }>()
+      if (!media) return 'not-found'
+
+      // Mastodon's destroy returns 422 (in_usage_error) when the attachment is
+      // already tied to a posted status, rather than deleting it. Match via a
+      // medias↔attachments join (column-to-column) so the comparison is
+      // affinity-safe on SQLite (where attachments.mediaId is TEXT but medias.id
+      // is INTEGER) and works on PostgreSQL too — the same join
+      // getMediasWithStatusForAccount uses.
+      const attached = await trx('attachments')
+        .join('medias', 'medias.id', 'attachments.mediaId')
+        .where('medias.id', media.id)
+        .first('attachments.id')
+      if (attached) return 'in-use'
+
+      const deleted = await trx('medias').where('id', media.id).del()
+      if (!deleted) return 'not-found'
+
+      const usageDelta =
+        parseCounterValue(media.originalBytes) +
+        parseCounterValue(media.thumbnailBytes)
+      if (usageDelta > 0) {
+        await decreaseCounterValue(
+          trx,
+          CounterKey.mediaUsage(accountId),
+          usageDelta
+        )
+      }
+      await decreaseCounterValue(trx, CounterKey.totalMedia(accountId), 1)
+      return 'deleted'
+    })
   },
 
   async deleteMediaByPath({

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -626,13 +626,21 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         .join('actors', 'medias.actorId', 'actors.id')
         .where('medias.id', mediaId)
         .where('actors.accountId', accountId)
-        .select('medias.id', 'medias.originalBytes', 'medias.thumbnailBytes')
+        .select(
+          'medias.id',
+          'medias.original',
+          'medias.thumbnail',
+          'medias.originalBytes',
+          'medias.thumbnailBytes'
+        )
         .first<{
           id: string | number
+          original: string
+          thumbnail: string | null
           originalBytes: number | string | bigint | null
           thumbnailBytes: number | string | bigint | null
         }>()
-      if (!media) return 'not-found'
+      if (!media) return { status: 'not-found' }
 
       // Mastodon's destroy returns 422 (in_usage_error) when the attachment is
       // already tied to a posted status, rather than deleting it. Match via a
@@ -644,10 +652,10 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         .join('medias', 'medias.id', 'attachments.mediaId')
         .where('medias.id', media.id)
         .first('attachments.id')
-      if (attached) return 'in-use'
+      if (attached) return { status: 'in-use' }
 
       const deleted = await trx('medias').where('id', media.id).del()
-      if (!deleted) return 'not-found'
+      if (!deleted) return { status: 'not-found' }
 
       const usageDelta =
         parseCounterValue(media.originalBytes) +
@@ -660,7 +668,14 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
         )
       }
       await decreaseCounterValue(trx, CounterKey.totalMedia(accountId), 1)
-      return 'deleted'
+
+      // Return the paths captured inside the transaction so the caller deletes
+      // exactly the files that belonged to this row (no racy prefetch).
+      const files = [
+        media.original,
+        ...(media.thumbnail ? [media.thumbnail] : [])
+      ]
+      return { status: 'deleted', files }
     })
   },
 

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -27,7 +27,8 @@ import {
   Media,
   MediaDatabase,
   PaginatedMediaWithStatus,
-  UpdateMediaParams
+  UpdateMediaParams,
+  UpdateMediaResult
 } from '@/lib/types/database/operations'
 import { Attachment } from '@/lib/types/domain/attachment'
 
@@ -521,15 +522,16 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     description,
     focus,
     thumbnail
-  }: UpdateMediaParams): Promise<Media | null> {
+  }: UpdateMediaParams): Promise<UpdateMediaResult | null> {
     return database.transaction(async (trx) => {
       const owned = await trx('medias')
         .join('actors', 'medias.actorId', 'actors.id')
         .where('medias.id', mediaId)
         .where('actors.accountId', accountId)
-        .select('medias.id', 'medias.thumbnailBytes')
+        .select('medias.id', 'medias.thumbnail', 'medias.thumbnailBytes')
         .first<{
           id: string | number
+          thumbnail: string | null
           thumbnailBytes: number | string | null
         }>()
       if (!owned) return null
@@ -557,7 +559,13 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
       }
 
       let thumbnailUsageDelta = 0
+      let replacedThumbnailPath: string | null = null
       if (thumbnail !== undefined) {
+        // The path being overwritten, read inside the transaction — the caller
+        // deletes exactly this file, immune to a concurrent thumbnail update.
+        if (owned.thumbnail && owned.thumbnail !== thumbnail.path) {
+          replacedThumbnailPath = owned.thumbnail
+        }
         updates.thumbnail = thumbnail.path
         updates.thumbnailBytes = thumbnail.bytes
         updates.thumbnailMimeType = thumbnail.mimeType
@@ -591,7 +599,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
 
       if (!data) return null
 
-      return parseMediaRow(data)
+      return { media: parseMediaRow(data), replacedThumbnailPath }
     })
   },
 

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -21,6 +21,7 @@ import {
   MAX_HEIGHT,
   MAX_WIDTH
 } from '@/lib/services/medias/constants'
+import { MediaValidationError } from '@/lib/services/medias/errors'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
 import { extractVideoMeta } from '@/lib/services/medias/extractVideoMeta'
 import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
@@ -388,7 +389,7 @@ export class S3FileStorage implements MediaStorage {
       file.size
     )
     if (!quotaCheck.available) {
-      throw new Error(
+      throw new MediaValidationError(
         `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
       )
     }
@@ -562,7 +563,7 @@ export class S3FileStorage implements MediaStorage {
       !videoStream ||
       !(formats?.includes('mp4') || formats?.includes('webm'))
     ) {
-      throw new Error('Invalid video format')
+      throw new MediaValidationError('Invalid video format')
     }
 
     const metaData = videoStream

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -528,9 +528,11 @@ export class S3FileStorage implements MediaStorage {
       `${crypto.randomBytes(8).toString('hex')}.webp`
     )
     // `metadata()` reports the INPUT image; `toFile()` resolves with the OUTPUT
-    // info (post-resize/WebP dimensions and byte size).
+    // info (post-resize/WebP dimensions and byte size). Read metadata from a
+    // separate sharp instance so the two operations don't run concurrently on
+    // the same pipeline.
     const [metaData, outputInfo] = await Promise.all([
-      resizedImage.metadata(),
+      sharp(buffer).metadata(),
       resizedImage.keepExif().toFile(tempFilePath)
     ])
 

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -398,11 +398,11 @@ export class S3FileStorage implements MediaStorage {
         currentTime,
         file
       )
-      const thumbnail = await this._uploadImageBufferToS3(
-        currentTime,
-        previewImage,
-        true
-      )
+      // Video preview extraction can fail (no decodable frame); only build a
+      // thumbnail when we actually have a preview image to avoid sharp(null).
+      const thumbnail = previewImage
+        ? await this._uploadImageBufferToS3(currentTime, previewImage, true)
+        : null
       const storedMedia = await this._database.createMedia({
         actorId: actor.id,
         original: {
@@ -415,15 +415,20 @@ export class S3FileStorage implements MediaStorage {
           },
           fileName: file.name
         },
-        thumbnail: {
-          path: thumbnail.path,
-          bytes: thumbnail.metaData.size ?? 0,
-          mimeType: `image/${thumbnail.metaData.format ?? 'jpg'}`,
-          metaData: {
-            width: thumbnail.metaData.width ?? 0,
-            height: thumbnail.metaData.height ?? 0
-          }
-        },
+        ...(thumbnail
+          ? {
+              // Use the resized WebP's actual size/dimensions (outputInfo).
+              thumbnail: {
+                path: thumbnail.path,
+                bytes: thumbnail.outputInfo.size,
+                mimeType: 'image/webp',
+                metaData: {
+                  width: thumbnail.outputInfo.width,
+                  height: thumbnail.outputInfo.height
+                }
+              }
+            }
+          : null),
         ...(media.description ? { description: media.description } : null),
         ...(media.focus ? { focus: media.focus } : null)
       })
@@ -518,17 +523,22 @@ export class S3FileStorage implements MediaStorage {
     const s3client = this._client
 
     const fd = await fs.open(tempFilePath, 'r')
-    const stream = fd.createReadStream()
-    const command = new PutObjectCommand({
-      Bucket: bucket,
-      Key: path,
-      ContentType: contentType,
-      Body: stream
-    })
-    await s3client.send(command)
-    stream.close()
-    fd.close()
-    await fs.unlink(tempFilePath)
+    try {
+      const stream = fd.createReadStream()
+      const command = new PutObjectCommand({
+        Bucket: bucket,
+        Key: path,
+        ContentType: contentType,
+        Body: stream
+      })
+      await s3client.send(command)
+      stream.close()
+    } finally {
+      // Always release the descriptor and remove the temp file, even if the S3
+      // upload throws, to avoid fd/disk leaks.
+      await fd.close()
+      await fs.unlink(tempFilePath).catch(() => undefined)
+    }
     return { image: resizedImage, metaData, outputInfo, path, contentType }
   }
 

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -23,6 +23,7 @@ import {
 } from '@/lib/services/medias/constants'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
 import { extractVideoMeta } from '@/lib/services/medias/extractVideoMeta'
+import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
 import { checkQuotaAvailable } from '@/lib/services/medias/quota'
 import {
   MediaSchema,
@@ -32,7 +33,8 @@ import {
   MediaStorageSaveFileOutput,
   MediaType,
   PresigedMediaInput,
-  PresignedUrlOutput
+  PresignedUrlOutput,
+  ThumbnailStorageOutput
 } from '@/lib/services/medias/types'
 import { createStorageS3Client } from '@/lib/services/storage/s3Client'
 import { Media } from '@/lib/types/database/operations'
@@ -257,6 +259,7 @@ export class S3FileStorage implements MediaStorage {
         preview_url: null,
         text_url: null,
         remote_url: null,
+        preview_remote_url: null,
         meta: {
           original: {
             width: presignedMedia.width ?? 0,
@@ -265,7 +268,8 @@ export class S3FileStorage implements MediaStorage {
             aspect: presignedMedia.width / presignedMedia.height
           }
         },
-        description: ''
+        description: '',
+        blurhash: null
       },
       headers: {
         'x-amz-checksum-sha1': checksumSha1Base64,
@@ -390,8 +394,10 @@ export class S3FileStorage implements MediaStorage {
     }
 
     if (file.type.startsWith('video')) {
-      const { path, metaData, contentType, previewImage } =
-        await this._uploadVideoToS3(currentTime, file)
+      const { path, metaData, previewImage } = await this._uploadVideoToS3(
+        currentTime,
+        file
+      )
       const thumbnail = await this._uploadImageBufferToS3(
         currentTime,
         previewImage,
@@ -418,12 +424,13 @@ export class S3FileStorage implements MediaStorage {
             height: thumbnail.metaData.height ?? 0
           }
         },
-        ...(media.description ? { description: media.description } : null)
+        ...(media.description ? { description: media.description } : null),
+        ...(media.focus ? { focus: media.focus } : null)
       })
       if (!storedMedia) {
         throw new Error('Fail to store media')
       }
-      return this._getSaveFileOutput(storedMedia, contentType)
+      return this._getSaveFileOutput(storedMedia)
     }
 
     const { metaData, path } = await this._uploadImageToS3(currentTime, file)
@@ -439,12 +446,32 @@ export class S3FileStorage implements MediaStorage {
         },
         fileName: file.name
       },
-      ...(media.description ? { description: media.description } : null)
+      ...(media.description ? { description: media.description } : null),
+      ...(media.focus ? { focus: media.focus } : null)
     })
     if (!storedMedia) {
       throw new Error('Fail to store media')
     }
     return this._getSaveFileOutput(storedMedia)
+  }
+
+  async saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null> {
+    if (!file.type.startsWith('image')) return null
+
+    const { metaData, path } = await this._uploadImageToS3(
+      Date.now(),
+      file,
+      true
+    )
+    return {
+      path,
+      bytes: metaData.size ?? 0,
+      mimeType: 'image/webp',
+      metaData: {
+        width: metaData.width ?? 0,
+        height: metaData.height ?? 0
+      }
+    }
   }
 
   private async _uploadImageToS3(
@@ -544,48 +571,7 @@ export class S3FileStorage implements MediaStorage {
     return { path, metaData, contentType: file.type, previewImage }
   }
 
-  private _getSaveFileOutput(
-    media: Media,
-    contentType?: string
-  ): MediaStorageSaveFileOutput {
-    const mimeType = contentType ?? media.original.mimeType
-    const type = mimeType.startsWith('video')
-      ? MediaType.enum.video
-      : MediaType.enum.image
-    const url = `https://${this._host}/api/v1/files/${media.original.path}`
-    const previewUrl = media.thumbnail
-      ? `https://${this._host}/api/v1/files/${media.thumbnail?.path}`
-      : url
-    return MediaStorageSaveFileOutput.parse({
-      id: `${media.id}`,
-      type,
-      mime_type: mimeType,
-      // TODO: Add config for base image domain?
-      url,
-      preview_url: previewUrl,
-      text_url: null,
-      remote_url: null,
-      meta: {
-        original: {
-          width: media.original.metaData.width,
-          height: media.original.metaData.height,
-          size: `${media.original.metaData.width}x${media.original.metaData.height}`,
-          aspect: media.original.metaData.width / media.original.metaData.height
-        },
-        ...(media.thumbnail
-          ? {
-              small: {
-                width: media.thumbnail.metaData.width,
-                height: media.thumbnail.metaData.height,
-                size: `${media.thumbnail.metaData.width}x${media.thumbnail.metaData.height}`,
-                aspect:
-                  media.thumbnail.metaData.width /
-                  media.thumbnail.metaData.height
-              }
-            }
-          : null)
-      },
-      description: media?.description ?? ''
-    })
+  private _getSaveFileOutput(media: Media): MediaStorageSaveFileOutput {
+    return getMediaAttachment(media, this._host)
   }
 }

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -461,8 +461,24 @@ export class S3FileStorage implements MediaStorage {
     return this._getSaveFileOutput(storedMedia)
   }
 
-  async saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null> {
+  async saveThumbnail(
+    actor: Actor,
+    file: File
+  ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
+
+    // Enforce the account quota like saveFile, so a thumbnail replacement can't
+    // push usage past the limit.
+    const quotaCheck = await checkQuotaAvailable(
+      this._database,
+      actor,
+      file.size
+    )
+    if (!quotaCheck.available) {
+      throw new MediaValidationError(
+        `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
+      )
+    }
 
     // Use the stored WebP's actual size/dimensions (outputInfo), not the input
     // image's metadata.
@@ -536,8 +552,10 @@ export class S3FileStorage implements MediaStorage {
       stream.close()
     } finally {
       // Always release the descriptor and remove the temp file, even if the S3
-      // upload throws, to avoid fd/disk leaks.
-      await fd.close()
+      // upload throws, to avoid fd/disk leaks. `createReadStream` may already
+      // have auto-closed the fd on the success path, so ignore EBADF from a
+      // double close.
+      await fd.close().catch(() => undefined)
       await fs.unlink(tempFilePath).catch(() => undefined)
     }
     return { image: resizedImage, metaData, outputInfo, path, contentType }

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -539,23 +539,25 @@ export class S3FileStorage implements MediaStorage {
     const path = `medias/${timeDirectory}/${randomPrefix}${isThumbnail ? '-thumbnail' : ''}.webp`
     const s3client = this._client
 
-    const fd = await fs.open(tempFilePath, 'r')
+    // Outer finally guarantees the temp file is removed even if fs.open throws;
+    // inner finally releases the fd. `createReadStream` may auto-close the fd on
+    // success, so ignore EBADF from a double close.
     try {
-      const stream = fd.createReadStream()
-      const command = new PutObjectCommand({
-        Bucket: bucket,
-        Key: path,
-        ContentType: contentType,
-        Body: stream
-      })
-      await s3client.send(command)
-      stream.close()
+      const fd = await fs.open(tempFilePath, 'r')
+      try {
+        const stream = fd.createReadStream()
+        const command = new PutObjectCommand({
+          Bucket: bucket,
+          Key: path,
+          ContentType: contentType,
+          Body: stream
+        })
+        await s3client.send(command)
+        stream.close()
+      } finally {
+        await fd.close().catch(() => undefined)
+      }
     } finally {
-      // Always release the descriptor and remove the temp file, even if the S3
-      // upload throws, to avoid fd/disk leaks. `createReadStream` may already
-      // have auto-closed the fd on the success path, so ignore EBADF from a
-      // double close.
-      await fd.close().catch(() => undefined)
       await fs.unlink(tempFilePath).catch(() => undefined)
     }
     return { image: resizedImage, metaData, outputInfo, path, contentType }

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -458,18 +458,20 @@ export class S3FileStorage implements MediaStorage {
   async saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
 
-    const { metaData, path } = await this._uploadImageToS3(
+    // Use the stored WebP's actual size/dimensions (outputInfo), not the input
+    // image's metadata.
+    const { outputInfo, path } = await this._uploadImageToS3(
       Date.now(),
       file,
       true
     )
     return {
       path,
-      bytes: metaData.size ?? 0,
+      bytes: outputInfo.size,
       mimeType: 'image/webp',
       metaData: {
-        width: metaData.width ?? 0,
-        height: metaData.height ?? 0
+        width: outputInfo.width,
+        height: outputInfo.height
       }
     }
   }
@@ -503,7 +505,9 @@ export class S3FileStorage implements MediaStorage {
       tmpdir(),
       `${crypto.randomBytes(8).toString('hex')}.webp`
     )
-    const [metaData] = await Promise.all([
+    // `metadata()` reports the INPUT image; `toFile()` resolves with the OUTPUT
+    // info (post-resize/WebP dimensions and byte size).
+    const [metaData, outputInfo] = await Promise.all([
       resizedImage.metadata(),
       resizedImage.keepExif().toFile(tempFilePath)
     ])
@@ -525,7 +529,7 @@ export class S3FileStorage implements MediaStorage {
     stream.close()
     fd.close()
     await fs.unlink(tempFilePath)
-    return { image: resizedImage, metaData, path, contentType }
+    return { image: resizedImage, metaData, outputInfo, path, contentType }
   }
 
   private async _uploadVideoToS3(currentTime: number, file: File) {

--- a/lib/services/medias/errors.ts
+++ b/lib/services/medias/errors.ts
@@ -1,0 +1,10 @@
+// Raised when an upload fails for a client-actionable reason (storage quota
+// exceeded, unsupported/invalid media) rather than an internal fault. Upload
+// routes map this to 422 (Mastodon's "Validation failed"), while untyped errors
+// fall through to 500. Mirrors the PresignedUploadValidationError pattern.
+export class MediaValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MediaValidationError'
+  }
+}

--- a/lib/services/medias/getMediaAttachment.test.ts
+++ b/lib/services/medias/getMediaAttachment.test.ts
@@ -79,4 +79,68 @@ describe('getMediaAttachment', () => {
     const attachment = getMediaAttachment(withoutDescription, 'llun.test')
     expect(attachment.description).toBe('')
   })
+
+  it.each([
+    {
+      description: 'image/png maps to image',
+      mimeType: 'image/png',
+      type: 'image'
+    },
+    {
+      description: 'video/mp4 maps to video',
+      mimeType: 'video/mp4',
+      type: 'video'
+    },
+    {
+      description: 'audio/mp4 maps to audio',
+      mimeType: 'audio/mp4',
+      type: 'audio'
+    },
+    {
+      description: 'unrecognised mime maps to unknown',
+      mimeType: 'application/zip',
+      type: 'unknown'
+    }
+  ])('$description', ({ mimeType, type }) => {
+    const attachment = getMediaAttachment(
+      { ...baseMedia, original: { ...baseMedia.original, mimeType } },
+      'llun.test'
+    )
+    expect(attachment.type).toBe(type)
+  })
+
+  it('always emits a null blurhash (not yet computed)', () => {
+    const attachment = getMediaAttachment(baseMedia, 'llun.test')
+    expect(attachment.blurhash).toBeNull()
+  })
+
+  it('emits remote_url and preview_remote_url as null for local media', () => {
+    const attachment = getMediaAttachment(baseMedia, 'llun.test')
+    expect(attachment.remote_url).toBeNull()
+    expect(attachment.preview_remote_url).toBeNull()
+  })
+
+  it('emits meta.focus when the media has a focal point', () => {
+    const attachment = getMediaAttachment(
+      { ...baseMedia, focus: { x: 0.5, y: -0.25 } },
+      'llun.test'
+    )
+    expect(attachment.meta.focus).toEqual({ x: 0.5, y: -0.25 })
+  })
+
+  it('omits meta.focus when there is no focal point', () => {
+    const attachment = getMediaAttachment(baseMedia, 'llun.test')
+    expect(attachment.meta.focus).toBeUndefined()
+  })
+
+  it('avoids division by zero when height is missing', () => {
+    const attachment = getMediaAttachment(
+      {
+        ...baseMedia,
+        original: { ...baseMedia.original, metaData: { width: 100, height: 0 } }
+      },
+      'llun.test'
+    )
+    expect(attachment.meta.original.aspect).toBe(100)
+  })
 })

--- a/lib/services/medias/getMediaAttachment.ts
+++ b/lib/services/medias/getMediaAttachment.ts
@@ -21,10 +21,23 @@ const mediaMeta = (metaData: Media['original']['metaData']) => {
   }
 }
 
+// Maps a stored mime type to a Mastodon MediaAttachment `type`. We don't detect
+// animated GIFs, so we never emit `gifv`; anything that isn't image/video/audio
+// is reported as `unknown`.
+// https://docs.joinmastodon.org/entities/MediaAttachment/#type
+const mediaType = (mimeType: string): MediaType => {
+  if (mimeType.startsWith('video')) return MediaType.enum.video
+  if (mimeType.startsWith('audio')) return MediaType.enum.audio
+  if (mimeType.startsWith('image')) return MediaType.enum.image
+  return MediaType.enum.unknown
+}
+
 // Builds the Mastodon MediaAttachment entity for an already-stored media row.
 // Both the local-file and S3 storages serve files through `/api/v1/files/:path`,
 // so the public URL can be reconstructed without going back through the storage
-// driver. Used by GET/PUT /api/v1/media/:id, which operate on persisted media.
+// driver. This is the single source of truth for the entity shape — the upload
+// paths (LocalFile/S3 saveFile) and the GET/PUT/PATCH /api/v1/media/:id routes
+// all build their response body here so every field stays consistent.
 export const getMediaAttachment = (
   media: Media,
   host: string
@@ -34,22 +47,24 @@ export const getMediaAttachment = (
   const previewUrl = media.thumbnail
     ? `${protocol}://${host}/api/v1/files/${media.thumbnail.path}`
     : url
-  const type = media.original.mimeType.startsWith('video')
-    ? MediaType.enum.video
-    : MediaType.enum.image
 
   return MediaStorageSaveFileOutput.parse({
     id: `${media.id}`,
-    type,
+    type: mediaType(media.original.mimeType),
     mime_type: media.original.mimeType,
     url,
     preview_url: previewUrl,
     text_url: null,
     remote_url: null,
+    preview_remote_url: null,
     meta: {
       original: mediaMeta(media.original.metaData),
-      ...(media.thumbnail ? { small: mediaMeta(media.thumbnail.metaData) } : {})
+      ...(media.thumbnail
+        ? { small: mediaMeta(media.thumbnail.metaData) }
+        : {}),
+      ...(media.focus ? { focus: media.focus } : {})
     },
-    description: media.description ?? ''
+    description: media.description ?? '',
+    blurhash: null
   })
 }

--- a/lib/services/medias/handleSyncMediaUpload.ts
+++ b/lib/services/medias/handleSyncMediaUpload.ts
@@ -20,19 +20,33 @@ export const handleSyncMediaUpload = async (
   context: { database: Database; currentActor: Actor },
   corsHeaders: HttpMethod[]
 ) => {
-  try {
-    const { database, currentActor } = context
-    const form = await req.formData()
-    const media = MediaSchema.safeParse(Object.fromEntries(form.entries()))
-    if (!media.success) {
-      return apiResponse({
-        req,
-        allowedMethods: corsHeaders,
-        data: ERROR_422,
-        responseStatusCode: 422
-      })
-    }
+  const { database, currentActor } = context
 
+  // A malformed multipart body is a client error (422), so parse it separately
+  // from the upload work below — only genuine processing failures map to 500.
+  let form: FormData
+  try {
+    form = await req.formData()
+  } catch {
+    return apiResponse({
+      req,
+      allowedMethods: corsHeaders,
+      data: ERROR_422,
+      responseStatusCode: 422
+    })
+  }
+
+  const media = MediaSchema.safeParse(Object.fromEntries(form.entries()))
+  if (!media.success) {
+    return apiResponse({
+      req,
+      allowedMethods: corsHeaders,
+      data: ERROR_422,
+      responseStatusCode: 422
+    })
+  }
+
+  try {
     const response = await saveMedia(database, currentActor, media.data)
     if (!response) {
       return apiResponse({
@@ -48,10 +62,9 @@ export const handleSyncMediaUpload = async (
       data: response
     })
   } catch (e) {
-    // Input validation already returned 422 above (safeParse) and an
-    // unsupported/empty result returns 422 too. Anything that *throws* here is
-    // an unexpected internal/processing failure, so report 500 (matching the
-    // presigned route and Mastodon's 500 "processing failure").
+    // The request was well-formed and valid; a throw here is an unexpected
+    // internal/processing failure → 500 (matching the presigned route and
+    // Mastodon's 500 "processing failure").
     const nodeErr = e as NodeJS.ErrnoException
     logger.error(nodeErr)
     return apiResponse({

--- a/lib/services/medias/handleSyncMediaUpload.ts
+++ b/lib/services/medias/handleSyncMediaUpload.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { saveMedia } from '@/lib/services/medias'
+import { MediaSchema } from '@/lib/services/medias/types'
+import { Actor } from '@/lib/types/domain/actor'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
+import { ERROR_422, apiResponse } from '@/lib/utils/response'
+
+// Shared handler for the two synchronous upload endpoints (POST /api/v1/media
+// and POST /api/v2/media). Both accept the same params (file, thumbnail,
+// description, focus) and, because `saveMedia` is synchronous in every storage
+// driver here, both return 200 with a fully-populated MediaAttachment (there is
+// no async/202 path — that only exists in the separate presigned flow). The
+// only per-route difference is the trace name and CORS allow-list, which stay
+// at the route level.
+export const handleSyncMediaUpload = async (
+  req: NextRequest,
+  context: { database: Database; currentActor: Actor },
+  corsHeaders: HttpMethod[]
+) => {
+  try {
+    const { database, currentActor } = context
+    const form = await req.formData()
+    const media = MediaSchema.safeParse(Object.fromEntries(form.entries()))
+    if (!media.success) {
+      return apiResponse({
+        req,
+        allowedMethods: corsHeaders,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+
+    const response = await saveMedia(database, currentActor, media.data)
+    if (!response) {
+      return apiResponse({
+        req,
+        allowedMethods: corsHeaders,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
+    return apiResponse({
+      req,
+      allowedMethods: corsHeaders,
+      data: response
+    })
+  } catch (e) {
+    const nodeErr = e as NodeJS.ErrnoException
+    logger.error(nodeErr)
+    return apiResponse({
+      req,
+      allowedMethods: corsHeaders,
+      data: ERROR_422,
+      responseStatusCode: 422
+    })
+  }
+}

--- a/lib/services/medias/handleSyncMediaUpload.ts
+++ b/lib/services/medias/handleSyncMediaUpload.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { Database } from '@/lib/database/types'
 import { saveMedia } from '@/lib/services/medias'
+import { MediaValidationError } from '@/lib/services/medias/errors'
 import { MediaSchema } from '@/lib/services/medias/types'
 import { Actor } from '@/lib/types/domain/actor'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -62,9 +63,17 @@ export const handleSyncMediaUpload = async (
       data: response
     })
   } catch (e) {
-    // The request was well-formed and valid; a throw here is an unexpected
-    // internal/processing failure → 500 (matching the presigned route and
-    // Mastodon's 500 "processing failure").
+    // Client-actionable failures (quota exceeded, unsupported/invalid media)
+    // are 422 (Mastodon's "Validation failed"); only genuine internal/processing
+    // faults are 500.
+    if (e instanceof MediaValidationError) {
+      return apiResponse({
+        req,
+        allowedMethods: corsHeaders,
+        data: ERROR_422,
+        responseStatusCode: 422
+      })
+    }
     const nodeErr = e as NodeJS.ErrnoException
     logger.error(nodeErr)
     return apiResponse({

--- a/lib/services/medias/handleSyncMediaUpload.ts
+++ b/lib/services/medias/handleSyncMediaUpload.ts
@@ -6,7 +6,7 @@ import { MediaSchema } from '@/lib/services/medias/types'
 import { Actor } from '@/lib/types/domain/actor'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
-import { ERROR_422, apiResponse } from '@/lib/utils/response'
+import { ERROR_422, ERROR_500, apiResponse } from '@/lib/utils/response'
 
 // Shared handler for the two synchronous upload endpoints (POST /api/v1/media
 // and POST /api/v2/media). Both accept the same params (file, thumbnail,
@@ -48,13 +48,17 @@ export const handleSyncMediaUpload = async (
       data: response
     })
   } catch (e) {
+    // Input validation already returned 422 above (safeParse) and an
+    // unsupported/empty result returns 422 too. Anything that *throws* here is
+    // an unexpected internal/processing failure, so report 500 (matching the
+    // presigned route and Mastodon's 500 "processing failure").
     const nodeErr = e as NodeJS.ErrnoException
     logger.error(nodeErr)
     return apiResponse({
       req,
       allowedMethods: corsHeaders,
-      data: ERROR_422,
-      responseStatusCode: 422
+      data: ERROR_500,
+      responseStatusCode: 500
     })
   }
 }

--- a/lib/services/medias/index.ts
+++ b/lib/services/medias/index.ts
@@ -35,6 +35,29 @@ export const saveMedia = async (
   }
 }
 
+export const saveMediaThumbnail = async (database: Database, file: File) => {
+  const { mediaStorage, host } = getConfig()
+  switch (mediaStorage?.type) {
+    case MediaStorageType.LocalFile: {
+      return LocalFileStorage.getStorage(
+        mediaStorage,
+        host,
+        database
+      ).saveThumbnail(file)
+    }
+    case MediaStorageType.S3Storage:
+    case MediaStorageType.ObjectStorage: {
+      return S3FileStorage.getStorage(
+        mediaStorage,
+        host,
+        database
+      ).saveThumbnail(file)
+    }
+    default:
+      return null
+  }
+}
+
 export const getPresignedUrl = async (
   database: Database,
   actor: Actor,

--- a/lib/services/medias/index.ts
+++ b/lib/services/medias/index.ts
@@ -35,7 +35,11 @@ export const saveMedia = async (
   }
 }
 
-export const saveMediaThumbnail = async (database: Database, file: File) => {
+export const saveMediaThumbnail = async (
+  database: Database,
+  actor: Actor,
+  file: File
+) => {
   const { mediaStorage, host } = getConfig()
   switch (mediaStorage?.type) {
     case MediaStorageType.LocalFile: {
@@ -43,7 +47,7 @@ export const saveMediaThumbnail = async (database: Database, file: File) => {
         mediaStorage,
         host,
         database
-      ).saveThumbnail(file)
+      ).saveThumbnail(actor, file)
     }
     case MediaStorageType.S3Storage:
     case MediaStorageType.ObjectStorage: {
@@ -51,7 +55,7 @@ export const saveMediaThumbnail = async (database: Database, file: File) => {
         mediaStorage,
         host,
         database
-      ).saveThumbnail(file)
+      ).saveThumbnail(actor, file)
     }
     default:
       return null

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -177,8 +177,24 @@ export class LocalFileStorage implements MediaStorage {
     return getMediaAttachment(storedMedia, this._host)
   }
 
-  async saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null> {
+  async saveThumbnail(
+    actor: Actor,
+    file: File
+  ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
+
+    // Enforce the account quota like saveFile, so a thumbnail replacement can't
+    // push usage past the limit.
+    const quotaCheck = await checkQuotaAvailable(
+      this._database,
+      actor,
+      file.size
+    )
+    if (!quotaCheck.available) {
+      throw new MediaValidationError(
+        `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
+      )
+    }
 
     // Use the stored WebP's actual size/dimensions (outputInfo), not the input
     // image's metadata.

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -152,13 +152,15 @@ export class LocalFileStorage implements MediaStorage {
       },
       ...(thumbnail
         ? {
+            // Use the resized WebP's actual size/dimensions (outputInfo), not
+            // the input image's metadata.
             thumbnail: {
               path: thumbnail.path,
-              bytes: thumbnail.metaData.size ?? 0,
-              mimeType: `image/${thumbnail.metaData.format ?? 'jpg'}`,
+              bytes: thumbnail.outputInfo.size,
+              mimeType: 'image/webp',
               metaData: {
-                width: thumbnail.metaData.width ?? 0,
-                height: thumbnail.metaData.height ?? 0
+                width: thumbnail.outputInfo.width,
+                height: thumbnail.outputInfo.height
               }
             }
           }

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -13,13 +13,13 @@ import { logger } from '@/lib/utils/logger'
 import { MAX_HEIGHT, MAX_WIDTH } from './constants'
 import { extractVideoImage } from './extractVideoImage'
 import { extractVideoMeta } from './extractVideoMeta'
+import { getMediaAttachment } from './getMediaAttachment'
 import { checkQuotaAvailable } from './quota'
 import {
   MediaSchema,
   MediaStorage,
   MediaStorageGetFileOutput,
-  MediaStorageSaveFileOutput,
-  MediaType
+  ThumbnailStorageOutput
 } from './types'
 
 export class LocalFileStorage implements MediaStorage {
@@ -163,60 +163,30 @@ export class LocalFileStorage implements MediaStorage {
             }
           }
         : null),
-      ...(media.description ? { description: media.description } : null)
+      ...(media.description ? { description: media.description } : null),
+      ...(media.focus ? { focus: media.focus } : null)
     })
 
     if (!storedMedia) {
       throw new Error('Fail to store media')
     }
 
-    const protocol =
-      this._host.startsWith('localhost') ||
-      this._host.startsWith('127.0.0.1') ||
-      this._host.startsWith('::1') ||
-      this._host.startsWith('[::1]')
-        ? 'http'
-        : 'https'
-    const url = `${protocol}://${this._host}/api/v1/files/${storedMedia.original.path}`
+    return getMediaAttachment(storedMedia, this._host)
+  }
 
-    const previewUrl = thumbnail
-      ? `${protocol}://${this._host}/api/v1/files/${thumbnail?.path}`
-      : url
-    return MediaStorageSaveFileOutput.parse({
-      id: `${storedMedia.id}`,
-      type: media.file.type.startsWith('image')
-        ? MediaType.enum.image
-        : MediaType.enum.video,
-      mime_type: media.file.type,
-      // TODO: Add config for base image domain?
-      url,
-      preview_url: previewUrl,
-      text_url: null,
-      remote_url: null,
-      meta: {
-        original: {
-          width: storedMedia.original.metaData.width,
-          height: storedMedia.original.metaData.height,
-          size: `${storedMedia.original.metaData.width}x${storedMedia.original.metaData.height}`,
-          aspect:
-            storedMedia.original.metaData.width /
-            storedMedia.original.metaData.height
-        },
-        ...(storedMedia.thumbnail
-          ? {
-              small: {
-                width: storedMedia.thumbnail.metaData.width,
-                height: storedMedia.thumbnail.metaData.height,
-                size: `${storedMedia.thumbnail.metaData.width}x${storedMedia.thumbnail.metaData.height}`,
-                aspect:
-                  storedMedia.thumbnail.metaData.width /
-                  storedMedia.thumbnail.metaData.height
-              }
-            }
-          : null)
-      },
-      description: media?.description ?? ''
-    })
+  async saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null> {
+    if (!file.type.startsWith('image')) return null
+
+    const { metaData, path } = await this._saveImageFile(file, true)
+    return {
+      path,
+      bytes: metaData.size ?? 0,
+      mimeType: `image/${metaData.format ?? 'webp'}`,
+      metaData: {
+        width: metaData.width ?? 0,
+        height: metaData.height ?? 0
+      }
+    }
   }
 
   private async _saveImageFile(imageFile: File, isThumbnail = false) {

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -11,6 +11,7 @@ import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 
 import { MAX_HEIGHT, MAX_WIDTH } from './constants'
+import { MediaValidationError } from './errors'
 import { extractVideoImage } from './extractVideoImage'
 import { extractVideoMeta } from './extractVideoMeta'
 import { getMediaAttachment } from './getMediaAttachment'
@@ -125,7 +126,7 @@ export class LocalFileStorage implements MediaStorage {
       file.size
     )
     if (!quotaCheck.available) {
-      throw new Error(
+      throw new MediaValidationError(
         `Storage quota exceeded. Used: ${quotaCheck.used} bytes, Limit: ${quotaCheck.limit} bytes`
       )
     }
@@ -245,7 +246,7 @@ export class LocalFileStorage implements MediaStorage {
       !videoStream ||
       !(formats?.includes('mp4') || formats?.includes('webm'))
     ) {
-      throw new Error('Invalid video format')
+      throw new MediaValidationError('Invalid video format')
     }
 
     const metaData = videoStream

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -177,14 +177,16 @@ export class LocalFileStorage implements MediaStorage {
   async saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
 
-    const { metaData, path } = await this._saveImageFile(file, true)
+    // Use the stored WebP's actual size/dimensions (outputInfo), not the input
+    // image's metadata.
+    const { outputInfo, path } = await this._saveImageFile(file, true)
     return {
       path,
-      bytes: metaData.size ?? 0,
-      mimeType: `image/${metaData.format ?? 'webp'}`,
+      bytes: outputInfo.size,
+      mimeType: 'image/webp',
       metaData: {
-        width: metaData.width ?? 0,
-        height: metaData.height ?? 0
+        width: outputInfo.width,
+        height: outputInfo.height
       }
     }
   }
@@ -211,7 +213,10 @@ export class LocalFileStorage implements MediaStorage {
       .resize(MAX_WIDTH, MAX_HEIGHT, { fit: 'inside' })
       .rotate()
       .webp({ quality: 95, smartSubsample: true, nearLossless: true })
-    const [metaData] = await Promise.all([
+    // `metadata()` reports the INPUT image; `toFile()` resolves with the OUTPUT
+    // info (post-resize/WebP dimensions and byte size). Callers that need the
+    // stored file's real size/dimensions (e.g. thumbnails) use `outputInfo`.
+    const [metaData, outputInfo] = await Promise.all([
       resizedImage.metadata(),
       resizedImage.keepExif().toFile(filePath)
     ])
@@ -219,6 +224,7 @@ export class LocalFileStorage implements MediaStorage {
     return {
       image: resizedImage,
       metaData,
+      outputInfo,
       path: filename,
       contentType: 'image/webp',
       previewImage: null

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -235,8 +235,10 @@ export class LocalFileStorage implements MediaStorage {
     // `metadata()` reports the INPUT image; `toFile()` resolves with the OUTPUT
     // info (post-resize/WebP dimensions and byte size). Callers that need the
     // stored file's real size/dimensions (e.g. thumbnails) use `outputInfo`.
+    // Read metadata from a separate sharp instance so the two operations don't
+    // run concurrently on the same pipeline.
     const [metaData, outputInfo] = await Promise.all([
-      resizedImage.metadata(),
+      sharp(imageBuffer).metadata(),
       resizedImage.keepExif().toFile(filePath)
     ])
 

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -20,10 +20,30 @@ export const FileSchema = z
   )
 export type FileSchema = z.infer<typeof FileSchema>
 
+// Mastodon's `focus` parameter: two comma-delimited floats "x,y", each in
+// [-1.0, 1.0]. Parses the wire string into the stored { x, y } shape and rejects
+// malformed input (wrong arity, non-numeric, or out of range) so routes can
+// return 422. See https://docs.joinmastodon.org/methods/media/#focal-points
+export const FocusSchema = z
+  .string()
+  .transform((value) => value.split(','))
+  .refine(
+    (parts) =>
+      parts.length === 2 &&
+      parts.every((part) => {
+        const value = Number(part)
+        return Number.isFinite(value) && value >= -1 && value <= 1
+      }),
+    'Focus must be two comma-separated floats in the range -1.0 to 1.0'
+  )
+  .transform((parts) => ({ x: Number(parts[0]), y: Number(parts[1]) }))
+export type FocusSchema = z.infer<typeof FocusSchema>
+
 export const MediaSchema = z.object({
   file: FileSchema,
   thumbnail: FileSchema.optional(),
-  description: z.string().optional()
+  description: z.string().optional(),
+  focus: FocusSchema.optional()
 })
 export type MediaSchema = z.infer<typeof MediaSchema>
 
@@ -35,7 +55,11 @@ const MediaMeta = z.object({
 })
 type MediaMeta = z.infer<typeof MediaMeta>
 
-export const MediaType = z.enum(['image', 'video'])
+// Mastodon MediaAttachment `type` values. We currently produce image/video/
+// audio from stored mime types and fall back to `unknown`; `gifv` is part of the
+// Mastodon vocabulary but is not generated here (we don't transcode GIFs).
+// https://docs.joinmastodon.org/entities/MediaAttachment/#type
+export const MediaType = z.enum(['image', 'gifv', 'video', 'audio', 'unknown'])
 export type MediaType = z.infer<typeof MediaType>
 
 export const MediaStorageSaveFileOutput = z.object({
@@ -46,11 +70,16 @@ export const MediaStorageSaveFileOutput = z.object({
   preview_url: z.string().url().nullish(),
   text_url: z.string().url().nullish(),
   remote_url: z.string().url().nullish(),
+  preview_remote_url: z.string().url().nullish(),
   meta: z.object({
     original: MediaMeta,
-    small: MediaMeta.optional()
+    small: MediaMeta.optional(),
+    focus: z.object({ x: z.number(), y: z.number() }).optional()
   }),
-  description: z.string()
+  description: z.string(),
+  // BlurHash for blurred placeholders. We do not compute it yet, so it is always
+  // null, but the field is always present to match Mastodon's serializer.
+  blurhash: z.string().nullable()
 })
 export type MediaStorageSaveFileOutput = z.infer<
   typeof MediaStorageSaveFileOutput
@@ -101,12 +130,25 @@ export const PresignedUrlOutput = z.object({
 })
 export type PresignedUrlOutput = z.infer<typeof PresignedUrlOutput>
 
+// A processed thumbnail ready to persist on an existing media row. Mirrors the
+// `thumbnail` shape `createMedia`/`updateMedia` accept.
+export interface ThumbnailStorageOutput {
+  path: string
+  bytes: number
+  mimeType: string
+  metaData: { width: number; height: number }
+}
+
 export interface MediaStorage {
   isPresigedSupported(): boolean
   saveFile(
     actor: Actor,
     media: MediaSchema
   ): Promise<MediaStorageSaveFileOutput | null>
+  // Processes and stores a standalone thumbnail image (used by PUT/PATCH
+  // /api/v1/media/:id to replace a custom thumbnail). Returns null for
+  // non-image input.
+  saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null>
   getPresigedForSaveFileUrl(
     actor: Actor,
     media: PresigedMediaInput

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -9,7 +9,10 @@ const FILE_TYPE_ERROR_MESSAGE = `Only ${ACCEPTED_FILE_TYPES.join(',')} are accep
 const FILE_SIZE_ERROR_MESSAGE = 'File is larger than the limit.'
 
 export const FileSchema = z
-  .custom<File>()
+  // Enforce a real File first — z.custom with no guard accepts anything, so a
+  // crafted JSON object like { size, type } would otherwise satisfy the refines
+  // below and crash later when File methods (arrayBuffer) are called.
+  .custom<File>((value) => value instanceof File, 'Expected a file upload')
   .refine((file) => {
     const config = getConfig()
     return file.size <= (config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE)

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -149,9 +149,13 @@ export interface MediaStorage {
     media: MediaSchema
   ): Promise<MediaStorageSaveFileOutput | null>
   // Processes and stores a standalone thumbnail image (used by PUT/PATCH
-  // /api/v1/media/:id to replace a custom thumbnail). Returns null for
-  // non-image input.
-  saveThumbnail(file: File): Promise<ThumbnailStorageOutput | null>
+  // /api/v1/media/:id to replace a custom thumbnail). Enforces the account
+  // storage quota (throws MediaValidationError when exceeded) and returns null
+  // for non-image input.
+  saveThumbnail(
+    actor: Actor,
+    file: File
+  ): Promise<ThumbnailStorageOutput | null>
   getPresigedForSaveFileUrl(
     actor: Actor,
     media: PresigedMediaInput

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -31,6 +31,9 @@ export const FocusSchema = z
     (parts) =>
       parts.length === 2 &&
       parts.every((part) => {
+        // Reject empty/whitespace axes — Number('') is 0, which would otherwise
+        // sneak "0.5," through as { x: 0.5, y: 0 }.
+        if (part.trim() === '') return false
         const value = Number(part)
         return Number.isFinite(value) && value >= -1 && value <= 1
       }),

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1700,8 +1700,13 @@ export type DeleteMediaForAccountParams = {
 }
 // Mirrors Mastodon's destroy semantics: `not-found` (missing or owned by another
 // account) → 404, `in-use` (still attached to a posted status) → 422, `deleted`
-// → 200.
-export type DeleteMediaForAccountResult = 'deleted' | 'not-found' | 'in-use'
+// → 200. On `deleted`, `files` carries the storage paths captured inside the
+// delete transaction so the caller can remove them without a separate (racy)
+// prefetch.
+export type DeleteMediaForAccountResult =
+  | { status: 'deleted'; files: string[] }
+  | { status: 'not-found' }
+  | { status: 'in-use' }
 export type DeleteMediaByPathParams = {
   actorId: string
   path: string

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1628,6 +1628,18 @@ interface BaseMedia {
     metaData: MetaData
   }
   description?: string
+  // Focal point for cropping previews, each axis in [-1.0, 1.0]. Mastodon's
+  // MediaAttachment `meta.focus`.
+  focus?: { x: number; y: number }
+}
+
+// A processed thumbnail ready to persist on an existing media row. Mirrors the
+// shape `createMedia` already accepts for `thumbnail`.
+export type MediaThumbnailInput = {
+  path: string
+  bytes: number
+  mimeType: string
+  metaData: { width: number; height: number }
 }
 
 export interface Media extends BaseMedia {
@@ -1682,6 +1694,14 @@ export type GetStorageUsageForAccountParams = {
 export type DeleteMediaParams = {
   mediaId: string
 }
+export type DeleteMediaForAccountParams = {
+  mediaId: string
+  accountId: string
+}
+// Mirrors Mastodon's destroy semantics: `not-found` (missing or owned by another
+// account) → 404, `in-use` (still attached to a posted status) → 422, `deleted`
+// → 200.
+export type DeleteMediaForAccountResult = 'deleted' | 'not-found' | 'in-use'
 export type DeleteMediaByPathParams = {
   actorId: string
   path: string
@@ -1697,6 +1717,8 @@ export type UpdateMediaParams = {
   mediaId: string
   accountId: string
   description?: string | null
+  focus?: { x: number; y: number }
+  thumbnail?: MediaThumbnailInput
 }
 export type MarkMediaUploadVerifiedParams = {
   mediaId: string
@@ -1728,6 +1750,12 @@ export interface MediaDatabase {
   ): Promise<number>
   deleteAttachmentsByIds(params: DeleteAttachmentsByIdsParams): Promise<number>
   deleteMedia(params: DeleteMediaParams): Promise<boolean>
+  // Owner-scoped delete that only removes media not yet attached to a status.
+  // Returns `not-found` when missing/owned by another account, `in-use` when
+  // already attached to a posted status, and `deleted` on success.
+  deleteMediaForAccount(
+    params: DeleteMediaForAccountParams
+  ): Promise<DeleteMediaForAccountResult>
   deleteMediaByPath(params: DeleteMediaByPathParams): Promise<boolean>
 }
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1725,6 +1725,13 @@ export type UpdateMediaParams = {
   focus?: { x: number; y: number }
   thumbnail?: MediaThumbnailInput
 }
+export type UpdateMediaResult = {
+  media: Media
+  // Path of the thumbnail this update replaced, captured inside the update
+  // transaction so the caller can delete it race-free. null when no existing
+  // thumbnail was replaced.
+  replacedThumbnailPath: string | null
+}
 export type MarkMediaUploadVerifiedParams = {
   mediaId: string
   accountId: string
@@ -1749,7 +1756,7 @@ export interface MediaDatabase {
     params: GetMediasForAccountParams
   ): Promise<PaginatedMediaWithStatus>
   getMediaByIdForAccount(params: GetMediaByIdParams): Promise<Media | null>
-  updateMedia(params: UpdateMediaParams): Promise<Media | null>
+  updateMedia(params: UpdateMediaParams): Promise<UpdateMediaResult | null>
   getStorageUsageForAccount(
     params: GetStorageUsageForAccountParams
   ): Promise<number>

--- a/migrations/20260607000000_add_medias_focus.js
+++ b/migrations/20260607000000_add_medias_focus.js
@@ -1,0 +1,26 @@
+/**
+ * Adds focal-point columns to `medias` so the Mastodon-compatible media API can
+ * persist `meta.focus` ({ x, y }, each in [-1.0, 1.0]). Stored as two nullable
+ * `double` columns (SQLite + PostgreSQL + MySQL compatible). `double` avoids the
+ * float32 rounding that `float` introduces, so values round-trip exactly.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('medias', function (table) {
+    table.double('focusX').nullable()
+    table.double('focusY').nullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('medias', function (table) {
+    table.dropColumn('focusX')
+    table.dropColumn('focusY')
+  })
+}


### PR DESCRIPTION
## Summary

Brings the media endpoints to **full Mastodon compatibility** — HTTP methods, OAuth scopes, request params, metadata persistence, and entity shape. Every decision is pinned to upstream source (routes / serializer / controller), cited inline.

Sources:
- Routes: `config/routes/api.rb` — `namespace :v1 { resources :media, only: [:create, :update, :show, :destroy] }`, `namespace :v2 { resources :media, only: [:create] }`
- Controller: `app/controllers/api/v1/media_controller.rb`
- Serializer: `app/serializers/rest/media_attachment_serializer.rb` (`id, type, url, preview_url, remote_url, preview_remote_url, text_url, meta, description, blurhash`)
- Docs: https://docs.joinmastodon.org/methods/media/ , /entities/MediaAttachment/

## Per-endpoint compatibility checklist

### `POST /api/v2/media`
- [x] Scope: `OAuthGuardAnyScope([write, write:media])` (was session `AuthenticatedGuard`) — Bearer clients now work like Mastodon.
- [x] Params: `file` (required), `thumbnail`, `description`, `focus` ("x,y", each in [-1.0, 1.0]).
- [x] **200** with a fully-populated MediaAttachment. **No 202 path** — see "Sync vs async" below.

### `POST /api/v1/media` (new — Mastodon's deprecated synchronous upload)
- [x] Scope `write:media`; same params as v2.
- [x] Always **200** with a fully-processed attachment (no 202).

### `GET /api/v1/media/:id`
- [x] Scope changed `read` → `write:media`. The upstream controller authorizes `doorkeeper_authorize! :write, :'write:media'` with **no `only:`/`except:`**, so *every* action (including `show`) requires `write:media`. Covered by new bearer tests (accepts `write:media`, rejects `read`).
- [x] 200 with the attachment; 404 when missing/not-owned.

### `PUT` + `PATCH /api/v1/media/:id`
- [x] **Both** verbs map to the same handler (Rails `resources` `update` accepts PUT and PATCH; many clients send PATCH). Added `PATCH` to exports and CORS.
- [x] Persists `description`, **`focus`**, and a **replacement `thumbnail`** (multipart) — previously only `description`.
- [x] **Field isolation**: a description-only update doesn't clear focus, a focus-only update doesn't clear the description, etc. (raw-payload presence detection + per-column conditional update).
- [x] `description` capped at varchar(255); out-of-range `focus` → 422.

### `DELETE /api/v1/media/:id` (new)
- [x] Scope `write:media`.
- [x] **200 with empty `{}`** on success (`render_empty`).
- [x] **404** when missing or owned by another account.
- [x] **422** when the media is already attached to a posted status. This is deliberate and source-backed — `MediaController#destroy`:
  ```ruby
  @media_attachment = current_account.media_attachments.find(params[:id])
  return render json: in_usage_error, status: 422 unless @media_attachment.status_id.nil?
  @media_attachment.destroy
  render_empty
  ```
  (The gap brief said "404 if not found / not owned"; attached-media is the one case it didn't enumerate, and upstream returns 422, not 404.)

## MediaAttachment entity shape
`getMediaAttachment` is now the **single** entity builder, used by the routes **and** both storage drivers (LocalFile / S3) so the shape can never drift. Emits:
- `id`, `type` (`image`/`gifv`/`video`/`audio`/`unknown` — `gifv` not generated, we don't transcode GIFs), `url`, `preview_url`, `remote_url`, **`preview_remote_url`**, `text_url`, `description`
- `meta`: `original`/`small` (`width`/`height`/`size`/`aspect`), and **`focus: {x,y}`** once persisted
- **`blurhash`** — always present, currently `null` (not yet computed)

## Sync vs async (v2 status code)
`saveMedia` is **synchronous** in both drivers (LocalFile and S3 store the file and return a fully-populated attachment before responding), so v2/v1 POST always return **200**. Mastodon's **202** applies only when processing is deferred; the only deferred flow here is the separate **presigned-upload service** (`/api/v1/medias/presigned`), which is out of scope. No fabricated async path.

## 206 (GET while-processing)
**Not added.** Synchronous uploads have no processing state; the only "pending" state is the presigned upload flow (out of scope), and surfacing it would require making the entity `url` nullable. The task explicitly makes 206 conditional ("only if an async/processing state actually exists"), so it's intentionally skipped.

## Storage / migration
- Migration `20260607000000_add_medias_focus.js`: adds nullable `focusX` / `focusY` **`double`** columns (SQLite + PostgreSQL + MySQL compatible; `double` avoids float32 rounding so focus round-trips exactly).
- `createMedia` / `updateMedia` / reads persist & return `focus`; `updateMedia` also replaces the thumbnail and keeps the per-account `mediaUsage` counter in sync by the byte delta.
- New owner-scoped `deleteMediaForAccount` (returns `deleted` / `not-found` / `in-use`); the attached-status check uses a `medias↔attachments` **column-to-column join** so it's affinity-safe on SQLite (TEXT `attachments.mediaId` vs INTEGER `medias.id`) and correct on PostgreSQL.
- New `saveThumbnail` on the `MediaStorage` interface (LocalFile + S3); the PUT/PATCH handler deletes the previous thumbnail file after a successful replacement.

## Local gate results
- `yarn run prettier --write .` ✓
- `yarn lint` ✓ (0 errors; only pre-existing `any` warnings in untouched files)
- `yarn build` ✓
- `yarn test` ✓ — **430 suites / 3683 tests pass**

New co-located tests: PUT/PATCH equivalence; focus persistence + field isolation (route + DB); thumbnail replacement + counter delta; DELETE owner-scoped (200 / 404 / 422-in-use); v1 & v2 OAuth `write:media` accept + scope rejection; GET bearer scope accept/reject; entity shape incl. `type` mapping, `meta.focus`, `blurhash`, `preview_remote_url`.

## Deferred
- `blurhash` value (always `null` — not computed).
- `meta` video/audio `duration`/`fps`/`bitrate` — not stored, so not emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings our media API to full Mastodon compatibility so clients can upload, edit, fetch, and delete media via OAuth. Unifies the `MediaAttachment` shape, tightens scopes and validation, and hardens storage with race-free file cleanup.

- New Features
  - OAuth/scopes: v2 `POST /api/v2/media` requires bearer `write:media` (or `write`); v1 `POST/GET/PUT/PATCH/DELETE /api/v1/media/:id` also accept `write:media` (or `write`); `GET` now requires a write-level scope (`write` or `write:media`).
  - Uploads: added `POST /api/v1/media` (sync 200). v1/v2 accept `file`, optional `thumbnail`, `description`, `focus` ("x,y" in [-1.0, 1.0]); malformed multipart → 422; quota/invalid-media → 422; unexpected processing faults → 500.
  - Updates: `PUT`/`PATCH /api/v1/media/:id` persist `description`, `focus`, and thumbnail replacement; partial updates don’t clear other fields; strict `focus` parsing → 422; invalid thumbnail (non-image or non-file) → 422; thumbnail over quota → 422; on replacement, the old thumbnail is deleted best-effort using the path captured inside the update transaction; if the DB update fails or the media is not owned (404), a newly stored thumbnail is cleaned up best-effort.
  - Deletion: `DELETE /api/v1/media/:id` returns 200 `{}` on success, 404 when missing/not-owned, 422 when attached to a posted status; on success, also deletes original and thumbnail files (best-effort) using paths captured inside the delete transaction.
  - Response shape: single builder returns Mastodon `MediaAttachment` with correct `type` (image/gifv/video/audio/unknown), `meta.small`, `meta.focus`, `preview_remote_url`, and `blurhash: null`.
  - Validation and storage: `FileSchema` enforces a real `File`; thumbnail saves enforce quota and store resized WebP output size/dimensions (both upload and thumbnail-replace paths); per-account usage counters adjust on thumbnail replace and delete; S3 uploads close FDs, unlink temp files even if `fs.open` fails, and ignore double-close errors; sharp metadata reads use a separate instance; OAuth guard error responses include route CORS headers.

- Migration
  - Run DB migrations (adds `focusX`/`focusY` to `medias` for `meta.focus`).

<sup>Written for commit 34e2b7e7c5f8f84703d06ba33c3dacbf9f2d6fa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

