### PR TITLE
Bump version to v1.47.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.47.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.47.1`
- Base main SHA: `d468afced38eee7a08d4b6d3df95f3bd9b0f20a9`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `activities.next` to v1.47.2 (patch) to cut a new release from main. Only updates the `package.json` version; no functional changes.

<sup>Written for commit 107cc28c8e8337ad55b388320b891c7142bffe4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

