### PR TITLE
Bump version to v1.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.47.2",
+  "version": "1.48.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.48.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.47.2`
- Base main SHA: `35e7665e419811a8d259def55feffa9ed79b41aa`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
