### PR TITLE
minor: add featured hashtags settings editor and profile block

### DIFF
--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -4,12 +4,14 @@ import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
 import { Bio } from '@/lib/components/bio/Bio'
+import { FeaturedTagsBlock } from '@/lib/components/profile/FeaturedTagsBlock'
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
 import { Button } from '@/lib/components/ui/button'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { ActorTimelines } from './ActorTimelines'
@@ -92,6 +94,21 @@ const Page: FC<Props> = async ({ params }) => {
       : null
 
   const initials = getInitials(person.name || '', person.preferredUsername)
+
+  // Surface the account's featured hashtags inside the profile card. Only local
+  // actors have stored featured tags; remote profiles resolve to an empty list,
+  // so the block hides itself.
+  const bareHost = host.includes('://') ? new URL(host).host : host
+  const featuredTagRows = await database.getFeaturedTags({
+    actorId: person.id
+  })
+  const featuredTags = featuredTagRows.map((tag) =>
+    getMastodonFeaturedTag({
+      host: bareHost,
+      actor: { username: person.preferredUsername, domain: actorDomain },
+      tag
+    })
+  )
 
   const getHeaderImage = () => {
     if (!person.image) return null
@@ -177,6 +194,8 @@ const Page: FC<Props> = async ({ params }) => {
               <span className="text-muted-foreground">Followers</span>
             </Link>
           </div>
+
+          <FeaturedTagsBlock tags={featuredTags} />
         </div>
       </section>
 

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  addFeaturedTag,
+  getFeaturedTagSuggestions,
+  getFeaturedTags,
+  removeFeaturedTag
+} from '@/lib/client'
+import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+
+import { FeaturedTagsEditor } from './FeaturedTagsEditor'
+
+jest.mock('@/lib/client', () => ({
+  getFeaturedTags: jest.fn(),
+  getFeaturedTagSuggestions: jest.fn(),
+  addFeaturedTag: jest.fn(),
+  removeFeaturedTag: jest.fn()
+}))
+
+const mockGetFeaturedTags = getFeaturedTags as jest.Mock
+const mockGetSuggestions = getFeaturedTagSuggestions as jest.Mock
+const mockAddFeaturedTag = addFeaturedTag as jest.Mock
+const mockRemoveFeaturedTag = removeFeaturedTag as jest.Mock
+
+const buildTag = (overrides: Partial<FeaturedTag> = {}): FeaturedTag => ({
+  id: overrides.id ?? 't1',
+  name: overrides.name ?? 'running',
+  url: overrides.url ?? 'https://example.test/@anna/tagged/running',
+  statuses_count: overrides.statuses_count ?? '128',
+  last_status_at:
+    overrides.last_status_at === undefined
+      ? '2026-06-05'
+      : overrides.last_status_at
+})
+
+describe('FeaturedTagsEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetFeaturedTags.mockResolvedValue([])
+    mockGetSuggestions.mockResolvedValue([])
+  })
+
+  it('renders the loaded tags with post count and last-posted date', async () => {
+    mockGetFeaturedTags.mockResolvedValue([buildTag()])
+    render(<FeaturedTagsEditor />)
+
+    expect(await screen.findByText('#running')).toBeInTheDocument()
+    expect(
+      screen.getByText('128 posts · last posted on Jun 5, 2026')
+    ).toBeInTheDocument()
+    expect(screen.getByText('1 of 10 featured')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when the account has no featured tags', async () => {
+    render(<FeaturedTagsEditor />)
+    expect(
+      await screen.findByText('No featured hashtags yet')
+    ).toBeInTheDocument()
+  })
+
+  it('renders "no posts yet" when last_status_at is null', async () => {
+    mockGetFeaturedTags.mockResolvedValue([
+      buildTag({ name: 'trailrun', statuses_count: '0', last_status_at: null })
+    ])
+    render(<FeaturedTagsEditor />)
+    expect(
+      await screen.findByText('0 posts · no posts yet')
+    ).toBeInTheDocument()
+  })
+
+  it('features a hashtag and shows a success message', async () => {
+    mockAddFeaturedTag.mockResolvedValue({
+      tag: buildTag({ id: 't9', name: 'cycling', statuses_count: '5' })
+    })
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('No featured hashtags yet')
+
+    fireEvent.change(screen.getByLabelText('Add a hashtag'), {
+      target: { value: 'cycling' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(await screen.findByText('#cycling')).toBeInTheDocument()
+    expect(mockAddFeaturedTag).toHaveBeenCalledWith('cycling')
+    expect(
+      screen.getByText('#cycling is now featured on your profile.')
+    ).toBeInTheDocument()
+  })
+
+  it('rejects an invalid hashtag name without calling the API', async () => {
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('No featured hashtags yet')
+
+    fireEvent.change(screen.getByLabelText('Add a hashtag'), {
+      target: { value: 'no spaces' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(
+      screen.getByText(
+        'Use letters, numbers, and underscores only — no spaces or symbols.'
+      )
+    ).toBeInTheDocument()
+    expect(mockAddFeaturedTag).not.toHaveBeenCalled()
+  })
+
+  it('blocks an already-featured tag client-side', async () => {
+    mockGetFeaturedTags.mockResolvedValue([buildTag({ name: 'running' })])
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('#running')
+
+    fireEvent.change(screen.getByLabelText('Add a hashtag'), {
+      target: { value: '#Running' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(
+      screen.getByText('#Running is already featured.')
+    ).toBeInTheDocument()
+    expect(mockAddFeaturedTag).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a server error from the add call', async () => {
+    mockAddFeaturedTag.mockResolvedValue({ error: 'Invalid hashtag name' })
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('No featured hashtags yet')
+
+    fireEvent.change(screen.getByLabelText('Add a hashtag'), {
+      target: { value: 'valid' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(await screen.findByText('Invalid hashtag name')).toBeInTheDocument()
+  })
+
+  it('disables the input and shows the helper at the 10-tag limit', async () => {
+    mockGetFeaturedTags.mockResolvedValue(
+      Array.from({ length: 10 }, (_, index) =>
+        buildTag({ id: `t${index}`, name: `tag${index}` })
+      )
+    )
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('#tag0')
+
+    expect(screen.getByText('10 of 10 featured')).toBeInTheDocument()
+    expect(screen.getByLabelText('Add a hashtag')).toBeDisabled()
+    expect(
+      screen.getByText(
+        'You can feature up to 10 hashtags. Remove one to add another.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('removes a featured tag', async () => {
+    mockGetFeaturedTags.mockResolvedValue([buildTag({ name: 'running' })])
+    mockRemoveFeaturedTag.mockResolvedValue(true)
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('#running')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove #running' }))
+
+    await waitFor(() =>
+      expect(screen.queryByText('#running')).not.toBeInTheDocument()
+    )
+    expect(mockRemoveFeaturedTag).toHaveBeenCalledWith('t1')
+    expect(
+      screen.getByText('#running is no longer featured.')
+    ).toBeInTheDocument()
+  })
+
+  it('offers suggestions from the suggestions endpoint and features one on click', async () => {
+    mockGetSuggestions.mockResolvedValue([
+      { name: 'gravel', url: 'https://example.test/tags/gravel', history: [] }
+    ])
+    mockAddFeaturedTag.mockResolvedValue({
+      tag: buildTag({ id: 't7', name: 'gravel', statuses_count: '3' })
+    })
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('No featured hashtags yet')
+
+    fireEvent.focus(screen.getByLabelText('Add a hashtag'))
+    const suggestion = await screen.findByText('#gravel')
+    fireEvent.mouseDown(suggestion)
+
+    await waitFor(() =>
+      expect(mockAddFeaturedTag).toHaveBeenCalledWith('gravel')
+    )
+  })
+})

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
@@ -62,6 +62,20 @@ describe('FeaturedTagsEditor', () => {
     ).toBeInTheDocument()
   })
 
+  it('clears the loading state and shows an error when the initial load fails', async () => {
+    mockGetFeaturedTags.mockRejectedValue(new Error('network'))
+    render(<FeaturedTagsEditor />)
+
+    // The skeleton must not get stuck: the error message renders and the
+    // editor settles out of the loading state.
+    expect(
+      await screen.findByText(
+        'Couldn’t load your featured hashtags. Please refresh to try again.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText('No featured hashtags yet')).toBeInTheDocument()
+  })
+
   it('renders "no posts yet" when last_status_at is null', async () => {
     mockGetFeaturedTags.mockResolvedValue([
       buildTag({ name: 'trailrun', statuses_count: '0', last_status_at: null })

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
@@ -66,14 +66,16 @@ describe('FeaturedTagsEditor', () => {
     mockGetFeaturedTags.mockRejectedValue(new Error('network'))
     render(<FeaturedTagsEditor />)
 
-    // The skeleton must not get stuck: the error message renders and the
-    // editor settles out of the loading state.
+    // The skeleton must not get stuck: a load error renders instead of the
+    // misleading "no featured hashtags yet" empty state.
     expect(
       await screen.findByText(
         'Couldn’t load your featured hashtags. Please refresh to try again.'
       )
     ).toBeInTheDocument()
-    expect(screen.queryByText('No featured hashtags yet')).toBeInTheDocument()
+    expect(
+      screen.queryByText('No featured hashtags yet')
+    ).not.toBeInTheDocument()
   })
 
   it('renders "no posts yet" when last_status_at is null', async () => {
@@ -105,18 +107,23 @@ describe('FeaturedTagsEditor', () => {
     ).toBeInTheDocument()
   })
 
-  it('rejects an invalid hashtag name without calling the API', async () => {
+  it.each([
+    { description: 'a name with spaces or symbols', value: 'no spaces' },
+    // All-numeric / Unicode names pass the server regex but can't be rendered
+    // by the app's ASCII-only /tags/<name> route, so the editor rejects them.
+    { description: 'an all-numeric name', value: '2024' }
+  ])('rejects $description without calling the API', async ({ value }) => {
     render(<FeaturedTagsEditor />)
     await screen.findByText('No featured hashtags yet')
 
     fireEvent.change(screen.getByLabelText('Add a hashtag'), {
-      target: { value: 'no spaces' }
+      target: { value }
     })
     fireEvent.click(screen.getByRole('button', { name: 'Add' }))
 
     expect(
       screen.getByText(
-        'Use letters, numbers, and underscores only — no spaces or symbols.'
+        'Use letters, numbers, and underscores, and include at least one letter.'
       )
     ).toBeInTheDocument()
     expect(mockAddFeaturedTag).not.toHaveBeenCalled()
@@ -184,6 +191,23 @@ describe('FeaturedTagsEditor', () => {
     expect(
       screen.getByText('#running is no longer featured.')
     ).toBeInTheDocument()
+  })
+
+  it('keeps the row and re-enables remove when the remove call fails', async () => {
+    mockGetFeaturedTags.mockResolvedValue([buildTag({ name: 'running' })])
+    mockRemoveFeaturedTag.mockResolvedValue(false)
+    render(<FeaturedTagsEditor />)
+    await screen.findByText('#running')
+
+    const removeButton = screen.getByRole('button', { name: 'Remove #running' })
+    fireEvent.click(removeButton)
+
+    expect(
+      await screen.findByText('Couldn’t remove #running. Please try again.')
+    ).toBeInTheDocument()
+    // The row stays and its remove control is usable again (busy state cleared).
+    expect(screen.getByText('#running')).toBeInTheDocument()
+    expect(removeButton).not.toBeDisabled()
   })
 
   it('offers suggestions from the suggestions endpoint and features one on click', async () => {

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.test.tsx
@@ -78,6 +78,20 @@ describe('FeaturedTagsEditor', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('still shows loaded tags when only the suggestions request fails', async () => {
+    mockGetFeaturedTags.mockResolvedValue([buildTag({ name: 'running' })])
+    mockGetSuggestions.mockRejectedValue(new Error('network'))
+    render(<FeaturedTagsEditor />)
+
+    // Suggestions are best-effort: their failure must not blank the editor.
+    expect(await screen.findByText('#running')).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Couldn’t load your featured hashtags. Please refresh to try again.'
+      )
+    ).not.toBeInTheDocument()
+  })
+
   it('renders "no posts yet" when last_status_at is null', async () => {
     mockGetFeaturedTags.mockResolvedValue([
       buildTag({ name: 'trailrun', statuses_count: '0', last_status_at: null })

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
@@ -15,17 +15,10 @@ import { Input } from '@/lib/components/ui/input'
 import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { cn } from '@/lib/utils'
+import { isRenderableHashtagName } from '@/lib/utils/text/isRenderableHashtagName'
 
 // Mastodon caps featured tags per account at FeaturedTag::LIMIT = 10.
 const FEATURED_TAGS_LIMIT = 10
-// Restrict to hashtag names this app can actually render: the same pattern the
-// in-app hashtag timeline (app/(timeline)/tags/[tag]) and the post hashtag
-// tokenizer use — ASCII word characters with at least one letter or underscore.
-// This is intentionally stricter than the server's Mastodon regex
-// (`^[\p{L}\p{N}_]+$`, which also allows Unicode and all-numeric names like
-// `2024`); featuring a name the app can't render would produce a chip that 404s
-// on /tags/<name>.
-const FEATURED_TAG_NAME_REGEX = /^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/
 const MONTHS = [
   'Jan',
   'Feb',
@@ -220,7 +213,7 @@ export const FeaturedTagsEditor: FC = () => {
     if (submitting) return
     const name = raw.trim().replace(/^#+/, '')
     if (!name) return
-    if (!FEATURED_TAG_NAME_REGEX.test(name)) {
+    if (!isRenderableHashtagName(name)) {
       setMessage({
         tone: 'error',
         text: 'Use letters, numbers, and underscores, and include at least one letter.'

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
@@ -1,0 +1,383 @@
+'use client'
+
+import { AlertTriangle, Check, Hash, Plus, X } from 'lucide-react'
+import { FC, useEffect, useRef, useState } from 'react'
+
+import {
+  addFeaturedTag,
+  getFeaturedTagSuggestions,
+  getFeaturedTags,
+  removeFeaturedTag
+} from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+import type { Tag } from '@/lib/types/mastodon/tag'
+import { cn } from '@/lib/utils'
+
+// Mastodon caps featured tags per account at FeaturedTag::LIMIT = 10.
+const FEATURED_TAGS_LIMIT = 10
+// Word characters only after stripping a leading `#` (matches the server).
+const FEATURED_TAG_NAME_REGEX = /^[\p{L}\p{N}_]+$/u
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
+
+type InlineMessage = { tone: 'success' | 'error'; text: string }
+
+const postsLabel = (count: string): string => {
+  const value = Number(count) || 0
+  return value === 1 ? '1 post' : `${value} posts`
+}
+
+// last_status_at is a UTC `YYYY-MM-DD` string (or null). Parse the parts by hand
+// rather than `new Date(str)` so the rendered day never shifts with the viewer's
+// timezone (and so render stays deterministic — no `Date.now()`).
+const lastPostLabel = (dateStr: string | null): string => {
+  if (!dateStr) return 'no posts yet'
+  const [year, month, day] = dateStr.split('-').map(Number)
+  if (!year || !month || !day) return 'no posts yet'
+  return `last posted on ${MONTHS[month - 1]} ${day}, ${year}`
+}
+
+const normalizeName = (raw: string): string =>
+  raw.trim().replace(/^#+/, '').toLowerCase()
+
+interface SectionProps {
+  title: string
+  description: string
+  children: React.ReactNode
+}
+
+const Section: FC<SectionProps> = ({ title, description, children }) => (
+  <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+    <div>
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+    {children}
+  </section>
+)
+
+const HashTile: FC = () => (
+  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+    <Hash className="size-[18px]" />
+  </span>
+)
+
+const LoadingSkeleton: FC = () => (
+  <div className="space-y-2">
+    {[0, 1, 2].map((index) => (
+      <div
+        key={index}
+        className="flex items-center gap-3 rounded-lg border p-3"
+      >
+        <span className="h-9 w-9 shrink-0 animate-pulse rounded-lg bg-muted" />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="h-3.5 w-28 animate-pulse rounded bg-muted" />
+          <div className="h-3 w-44 animate-pulse rounded bg-muted" />
+        </div>
+        <span className="h-8 w-8 shrink-0 animate-pulse rounded-md bg-muted" />
+      </div>
+    ))}
+  </div>
+)
+
+const InlineMessageLine: FC<{ message: InlineMessage | null }> = ({
+  message
+}) => {
+  if (!message) return null
+  const isSuccess = message.tone === 'success'
+  const Icon = isSuccess ? Check : AlertTriangle
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex items-start gap-2 text-sm',
+        isSuccess ? 'text-green-600' : 'text-destructive'
+      )}
+    >
+      <Icon className="mt-0.5 size-4 shrink-0" />
+      <span>{message.text}</span>
+    </div>
+  )
+}
+
+interface TagRowProps {
+  tag: FeaturedTag
+  onRemove: (tag: FeaturedTag) => void
+  busy: boolean
+}
+
+const TagRow: FC<TagRowProps> = ({ tag, onRemove, busy }) => (
+  <div className="flex items-center gap-3 rounded-lg border p-3">
+    <HashTile />
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-sm font-medium">#{tag.name}</div>
+      <div className="truncate text-xs text-muted-foreground">
+        {postsLabel(tag.statuses_count)} · {lastPostLabel(tag.last_status_at)}
+      </div>
+    </div>
+    <Button
+      type="button"
+      variant="outline"
+      size="icon-sm"
+      aria-label={`Remove #${tag.name}`}
+      onClick={() => onRemove(tag)}
+      disabled={busy}
+      className="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+    >
+      <X className="size-[15px]" />
+    </Button>
+  </div>
+)
+
+export const FeaturedTagsEditor: FC = () => {
+  const [loading, setLoading] = useState(true)
+  const [tags, setTags] = useState<FeaturedTag[]>([])
+  const [suggestions, setSuggestions] = useState<Tag[]>([])
+  const [value, setValue] = useState('')
+  const [open, setOpen] = useState(false)
+  const [message, setMessage] = useState<InlineMessage | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let active = true
+    Promise.all([getFeaturedTags(), getFeaturedTagSuggestions()]).then(
+      ([loadedTags, loadedSuggestions]) => {
+        if (!active) return
+        setTags(loadedTags)
+        setSuggestions(loadedSuggestions)
+        setLoading(false)
+      }
+    )
+    return () => {
+      active = false
+    }
+  }, [])
+
+  // Close the suggestions dropdown on an outside click.
+  useEffect(() => {
+    const onDocumentMouseDown = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocumentMouseDown)
+    return () => document.removeEventListener('mousedown', onDocumentMouseDown)
+  }, [])
+
+  const atLimit = tags.length >= FEATURED_TAGS_LIMIT
+  const featuredNames = new Set(tags.map((tag) => tag.name.toLowerCase()))
+  const query = normalizeName(value)
+  const visibleSuggestions = suggestions
+    .filter((suggestion) => !featuredNames.has(suggestion.name.toLowerCase()))
+    .filter((suggestion) => suggestion.name.toLowerCase().includes(query))
+    .slice(0, 6)
+
+  const commit = async (raw: string) => {
+    const name = raw.trim().replace(/^#+/, '')
+    if (!name) return
+    if (!FEATURED_TAG_NAME_REGEX.test(name)) {
+      setMessage({
+        tone: 'error',
+        text: 'Use letters, numbers, and underscores only — no spaces or symbols.'
+      })
+      return
+    }
+    if (featuredNames.has(name.toLowerCase())) {
+      setMessage({ tone: 'error', text: `#${name} is already featured.` })
+      return
+    }
+    if (atLimit) {
+      setMessage({
+        tone: 'error',
+        text: 'Limit reached. You can feature up to 10 hashtags.'
+      })
+      return
+    }
+
+    setSubmitting(true)
+    const result = await addFeaturedTag(name)
+    setSubmitting(false)
+    if (result.error || !result.tag) {
+      setMessage({
+        tone: 'error',
+        text: result.error ?? 'Failed to feature hashtag.'
+      })
+      return
+    }
+
+    const created = result.tag
+    setTags((current) => [...current, created])
+    setSuggestions((current) =>
+      current.filter(
+        (suggestion) =>
+          suggestion.name.toLowerCase() !== created.name.toLowerCase()
+      )
+    )
+    setValue('')
+    setOpen(false)
+    setMessage({
+      tone: 'success',
+      text: `#${created.name} is now featured on your profile.`
+    })
+  }
+
+  const remove = async (tag: FeaturedTag) => {
+    setBusyId(tag.id)
+    const removed = await removeFeaturedTag(tag.id)
+    setBusyId(null)
+    if (!removed) {
+      setMessage({
+        tone: 'error',
+        text: `Couldn't remove #${tag.name}. Please try again.`
+      })
+      return
+    }
+    setTags((current) => current.filter((item) => item.id !== tag.id))
+    setMessage({
+      tone: 'success',
+      text: `#${tag.name} is no longer featured.`
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Featured hashtags"
+        description="Feature up to 10 hashtags on your profile so visitors can browse your posts on the topics you post about most."
+      />
+
+      <Section
+        title="Add a hashtag"
+        description="Type a hashtag or pick one of your most-used tags. People can tap it to see all of your posts with that tag."
+      >
+        <div ref={wrapRef} className="relative">
+          <div className="flex items-stretch gap-2">
+            <div className="relative flex-1">
+              <Hash className="pointer-events-none absolute left-3 top-1/2 size-[15px] -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={value}
+                disabled={atLimit || submitting}
+                placeholder={
+                  atLimit
+                    ? 'You’ve reached the 10-hashtag limit'
+                    : 'Add a hashtag'
+                }
+                aria-label="Add a hashtag"
+                className="pl-8"
+                onChange={(event) => {
+                  setValue(event.target.value)
+                  setOpen(true)
+                  if (message) setMessage(null)
+                }}
+                onFocus={() => setOpen(true)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    commit(value)
+                  }
+                  if (event.key === 'Escape') setOpen(false)
+                }}
+              />
+            </div>
+            <Button
+              type="button"
+              onClick={() => commit(value)}
+              disabled={atLimit || submitting}
+            >
+              <Plus className="size-4" />
+              Add
+            </Button>
+          </div>
+
+          {open && !atLimit && visibleSuggestions.length > 0 && (
+            <div className="absolute left-0 right-0 top-[42px] z-40 rounded-xl border bg-popover p-1 shadow-lg">
+              <div className="px-2.5 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Your most-used hashtags
+              </div>
+              {visibleSuggestions.map((suggestion) => (
+                <button
+                  key={suggestion.name}
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault()
+                    commit(suggestion.name)
+                  }}
+                  className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent"
+                >
+                  <Hash className="size-[15px] text-primary" />
+                  <span className="font-medium">#{suggestion.name}</span>
+                  <Plus className="ml-auto size-[15px] text-muted-foreground" />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 pt-0.5">
+          <InlineMessageLine message={message} />
+          <span
+            className={cn(
+              'ml-auto shrink-0 text-xs tabular-nums',
+              atLimit ? 'font-medium text-primary' : 'text-muted-foreground'
+            )}
+          >
+            {tags.length} of {FEATURED_TAGS_LIMIT} featured
+          </span>
+        </div>
+        {atLimit && (
+          <p className="text-[0.8rem] text-muted-foreground">
+            You can feature up to 10 hashtags. Remove one to add another.
+          </p>
+        )}
+      </Section>
+
+      <Section
+        title="Your featured hashtags"
+        description="Shown on your profile in the order below. They link to your posts tagged with each hashtag."
+      >
+        {loading ? (
+          <LoadingSkeleton />
+        ) : tags.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-center">
+            <span className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Hash className="size-5" />
+            </span>
+            <p className="text-sm font-medium">No featured hashtags yet</p>
+            <p className="max-w-xs text-[0.8rem] text-muted-foreground">
+              Add a hashtag above to show your best posts on a topic right from
+              your profile.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {tags.map((tag) => (
+              <TagRow
+                key={tag.id}
+                tag={tag}
+                onRemove={remove}
+                busy={busyId === tag.id}
+              />
+            ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  )
+}

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
@@ -165,7 +165,13 @@ export const FeaturedTagsEditor: FC = () => {
 
   useEffect(() => {
     let active = true
-    Promise.all([getFeaturedTags(), getFeaturedTagSuggestions()])
+    // Featured tags are the critical data — a failure rejects and shows the
+    // load error. Suggestions are an optional enhancement, so swallow their
+    // failure (network/parse/HTTP) here; it must never discard loaded tags.
+    Promise.all([
+      getFeaturedTags(),
+      getFeaturedTagSuggestions().catch(() => [] as Tag[])
+    ])
       .then(([loadedTags, loadedSuggestions]) => {
         if (!active) return
         setTags(loadedTags)

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
@@ -98,19 +98,27 @@ const LoadingSkeleton: FC = () => (
 const InlineMessageLine: FC<{ message: InlineMessage | null }> = ({
   message
 }) => {
-  if (!message) return null
-  const isSuccess = message.tone === 'success'
+  const isSuccess = message?.tone === 'success'
   const Icon = isSuccess ? Check : AlertTriangle
+  // Keep the live region mounted at all times and only swap its contents, so a
+  // screen reader reliably announces each new message. Errors use `alert`
+  // (assertive); successes use `status` (polite).
   return (
     <div
-      role="status"
-      className={cn(
-        'flex items-start gap-2 text-sm',
-        isSuccess ? 'text-green-600' : 'text-destructive'
-      )}
+      aria-live={isSuccess ? 'polite' : 'assertive'}
+      role={isSuccess ? 'status' : 'alert'}
     >
-      <Icon className="mt-0.5 size-4 shrink-0" />
-      <span>{message.text}</span>
+      {message && (
+        <div
+          className={cn(
+            'flex items-start gap-2 text-sm',
+            isSuccess ? 'text-green-600' : 'text-destructive'
+          )}
+        >
+          <Icon className="mt-0.5 size-4 shrink-0" />
+          <span>{message.text}</span>
+        </div>
+      )}
     </div>
   )
 }
@@ -157,14 +165,25 @@ export const FeaturedTagsEditor: FC = () => {
 
   useEffect(() => {
     let active = true
-    Promise.all([getFeaturedTags(), getFeaturedTagSuggestions()]).then(
-      ([loadedTags, loadedSuggestions]) => {
+    Promise.all([getFeaturedTags(), getFeaturedTagSuggestions()])
+      .then(([loadedTags, loadedSuggestions]) => {
         if (!active) return
         setTags(loadedTags)
         setSuggestions(loadedSuggestions)
-        setLoading(false)
-      }
-    )
+      })
+      .catch(() => {
+        if (!active) return
+        setMessage({
+          tone: 'error',
+          text: 'Couldn’t load your featured hashtags. Please refresh to try again.'
+        })
+      })
+      .finally(() => {
+        // Always clear the skeleton — otherwise a rejected request (network
+        // error, or a thrown response parse) would leave the editor stuck
+        // loading forever.
+        if (active) setLoading(false)
+      })
     return () => {
       active = false
     }
@@ -190,6 +209,9 @@ export const FeaturedTagsEditor: FC = () => {
     .slice(0, 6)
 
   const commit = async (raw: string) => {
+    // Guard against concurrent submits (e.g. clicking a suggestion while a POST
+    // is already in flight), which could append a duplicate row / duplicate key.
+    if (submitting) return
     const name = raw.trim().replace(/^#+/, '')
     if (!name) return
     if (!FEATURED_TAG_NAME_REGEX.test(name)) {

--- a/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
+++ b/app/(timeline)/settings/featured-hashtags/FeaturedTagsEditor.tsx
@@ -18,8 +18,14 @@ import { cn } from '@/lib/utils'
 
 // Mastodon caps featured tags per account at FeaturedTag::LIMIT = 10.
 const FEATURED_TAGS_LIMIT = 10
-// Word characters only after stripping a leading `#` (matches the server).
-const FEATURED_TAG_NAME_REGEX = /^[\p{L}\p{N}_]+$/u
+// Restrict to hashtag names this app can actually render: the same pattern the
+// in-app hashtag timeline (app/(timeline)/tags/[tag]) and the post hashtag
+// tokenizer use — ASCII word characters with at least one letter or underscore.
+// This is intentionally stricter than the server's Mastodon regex
+// (`^[\p{L}\p{N}_]+$`, which also allows Unicode and all-numeric names like
+// `2024`); featuring a name the app can't render would produce a chip that 404s
+// on /tags/<name>.
+const FEATURED_TAG_NAME_REGEX = /^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/
 const MONTHS = [
   'Jan',
   'Feb',
@@ -161,6 +167,7 @@ export const FeaturedTagsEditor: FC = () => {
   const [message, setMessage] = useState<InlineMessage | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  const [loadFailed, setLoadFailed] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -172,11 +179,10 @@ export const FeaturedTagsEditor: FC = () => {
         setSuggestions(loadedSuggestions)
       })
       .catch(() => {
-        if (!active) return
-        setMessage({
-          tone: 'error',
-          text: 'Couldn’t load your featured hashtags. Please refresh to try again.'
-        })
+        // Flag the failure so the list shows a load error instead of the
+        // "no featured hashtags yet" empty state, which would otherwise be
+        // misleading.
+        if (active) setLoadFailed(true)
       })
       .finally(() => {
         // Always clear the skeleton — otherwise a rejected request (network
@@ -217,7 +223,7 @@ export const FeaturedTagsEditor: FC = () => {
     if (!FEATURED_TAG_NAME_REGEX.test(name)) {
       setMessage({
         tone: 'error',
-        text: 'Use letters, numbers, and underscores only — no spaces or symbols.'
+        text: 'Use letters, numbers, and underscores, and include at least one letter.'
       })
       return
     }
@@ -267,7 +273,7 @@ export const FeaturedTagsEditor: FC = () => {
     if (!removed) {
       setMessage({
         tone: 'error',
-        text: `Couldn't remove #${tag.name}. Please try again.`
+        text: `Couldn’t remove #${tag.name}. Please try again.`
       })
       return
     }
@@ -376,6 +382,10 @@ export const FeaturedTagsEditor: FC = () => {
       >
         {loading ? (
           <LoadingSkeleton />
+        ) : loadFailed ? (
+          <p role="alert" className="py-8 text-center text-sm text-destructive">
+            Couldn’t load your featured hashtags. Please refresh to try again.
+          </p>
         ) : tags.length === 0 ? (
           <div className="flex flex-col items-center gap-2 py-8 text-center">
             <span className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">

--- a/app/(timeline)/settings/featured-hashtags/page.tsx
+++ b/app/(timeline)/settings/featured-hashtags/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { FeaturedTagsEditor } from './FeaturedTagsEditor'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Featured hashtags'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor || !actor.account) {
+    return redirect('/auth/signin')
+  }
+
+  return <FeaturedTagsEditor />
+}
+
+export default Page

--- a/app/(timeline)/settings/layout.test.tsx
+++ b/app/(timeline)/settings/layout.test.tsx
@@ -79,6 +79,7 @@ describe('Settings Layout', () => {
     for (const label of [
       'General',
       'Account',
+      'Featured hashtags',
       'Media',
       'Notifications',
       'Blocked accounts',

--- a/app/(timeline)/settings/layout.tsx
+++ b/app/(timeline)/settings/layout.tsx
@@ -3,6 +3,7 @@
 import {
   Ban,
   Bell,
+  Hash,
   Image as ImageIcon,
   Monitor,
   Settings as SettingsIcon,
@@ -27,6 +28,11 @@ interface Props {
 const tabs: SectionNavTab[] = [
   { name: 'General', url: '/settings', icon: SettingsIcon },
   { name: 'Account', url: '/settings/account', icon: User },
+  {
+    name: 'Featured hashtags',
+    url: '/settings/featured-hashtags',
+    icon: Hash
+  },
   { name: 'Media', url: '/settings/media', icon: ImageIcon },
   { name: 'Notifications', url: '/settings/notifications', icon: Bell },
   { name: 'Blocked accounts', url: '/settings/blocks', icon: Ban },

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -949,6 +949,10 @@ export const getActorStatuses = async ({
 // The hashtags an account pins to its profile. Backed by the featured_tags
 // endpoints; every call goes through here so components never call fetch().
 
+// Throws on a non-OK response (rather than returning []) so the editor's load
+// handler can tell "you have no featured tags" apart from "the request failed"
+// and show its load-error UI. Featured tags are the critical data for the page;
+// suggestions below stay best-effort.
 export const getFeaturedTags = async (): Promise<FeaturedTag[]> => {
   const response = await fetch('/api/v1/featured_tags', {
     method: 'GET',
@@ -956,7 +960,9 @@ export const getFeaturedTags = async (): Promise<FeaturedTag[]> => {
       Accept: 'application/json'
     }
   })
-  if (!response.ok) return []
+  if (!response.ok) {
+    throw new Error(`Failed to load featured tags: ${response.status}`)
+  }
   return (await response.json()) as FeaturedTag[]
 }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -968,33 +968,46 @@ export interface AddFeaturedTagResult {
 export const addFeaturedTag = async (
   name: string
 ): Promise<AddFeaturedTagResult> => {
-  const response = await fetch('/api/v1/featured_tags', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ name })
-  })
-  const data = (await response.json().catch(() => ({}))) as {
-    error?: string
-  } & Partial<FeaturedTag>
-  if (!response.ok) {
-    return { error: data.error || 'Failed to feature hashtag' }
+  try {
+    const response = await fetch('/api/v1/featured_tags', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name })
+    })
+    if (!response.ok) {
+      const data = (await response.json().catch(() => ({}))) as {
+        error?: string
+      }
+      return { error: data.error || 'Failed to feature hashtag' }
+    }
+    // Only treat it as a success when the body parses into a real entity —
+    // a malformed 2xx body must not surface as a tag with missing fields.
+    return { tag: (await response.json()) as FeaturedTag }
+  } catch {
+    // Network failure / unparseable body — surface as an error result rather
+    // than rejecting, so callers can always settle their loading state.
+    return { error: 'Failed to feature hashtag' }
   }
-  return { tag: data as FeaturedTag }
 }
 
 export const removeFeaturedTag = async (id: string): Promise<boolean> => {
-  const response = await fetch(
-    `/api/v1/featured_tags/${encodeURIComponent(id)}`,
-    {
-      method: 'DELETE',
-      headers: {
-        Accept: 'application/json'
+  try {
+    const response = await fetch(
+      `/api/v1/featured_tags/${encodeURIComponent(id)}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json'
+        }
       }
-    }
-  )
-  return response.ok
+    )
+    return response.ok
+  } catch {
+    // Network failure — report as not-removed instead of rejecting.
+    return false
+  }
 }
 
 export const getFeaturedTagSuggestions = async (): Promise<Tag[]> => {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -13,6 +13,7 @@ import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
+import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import { normalizeActorId } from '@/lib/utils/activitypub'
@@ -942,6 +943,69 @@ export const getActorStatuses = async ({
   }
 
   return (await response.json()) as GetActorStatusesResult
+}
+
+// Featured hashtags (https://docs.joinmastodon.org/methods/featured_tags/).
+// The hashtags an account pins to its profile. Backed by the featured_tags
+// endpoints; every call goes through here so components never call fetch().
+
+export const getFeaturedTags = async (): Promise<FeaturedTag[]> => {
+  const response = await fetch('/api/v1/featured_tags', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) return []
+  return (await response.json()) as FeaturedTag[]
+}
+
+export interface AddFeaturedTagResult {
+  tag?: FeaturedTag
+  error?: string
+}
+
+export const addFeaturedTag = async (
+  name: string
+): Promise<AddFeaturedTagResult> => {
+  const response = await fetch('/api/v1/featured_tags', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ name })
+  })
+  const data = (await response.json().catch(() => ({}))) as {
+    error?: string
+  } & Partial<FeaturedTag>
+  if (!response.ok) {
+    return { error: data.error || 'Failed to feature hashtag' }
+  }
+  return { tag: data as FeaturedTag }
+}
+
+export const removeFeaturedTag = async (id: string): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/featured_tags/${encodeURIComponent(id)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json'
+      }
+    }
+  )
+  return response.ok
+}
+
+export const getFeaturedTagSuggestions = async (): Promise<Tag[]> => {
+  const response = await fetch('/api/v1/featured_tags/suggestions', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+  if (!response.ok) return []
+  return (await response.json()) as Tag[]
 }
 
 interface DeleteSessionParams {

--- a/lib/components/profile/FeaturedTagsBlock.test.tsx
+++ b/lib/components/profile/FeaturedTagsBlock.test.tsx
@@ -44,11 +44,10 @@ describe('FeaturedTagsBlock', () => {
 
     expect(screen.getByText('Featured hashtags')).toBeInTheDocument()
 
+    // Chips link to the in-app hashtag timeline (/tags/<name>), not the
+    // account-scoped Mastodon entity URL (which this app does not serve).
     const runningChip = screen.getByRole('link', { name: /#running/ })
-    expect(runningChip).toHaveAttribute(
-      'href',
-      'https://example.test/@anna/tagged/running'
-    )
+    expect(runningChip).toHaveAttribute('href', '/tags/running')
     expect(runningChip).toHaveTextContent('128')
 
     const cyclingChip = screen.getByRole('link', { name: /#cycling/ })

--- a/lib/components/profile/FeaturedTagsBlock.test.tsx
+++ b/lib/components/profile/FeaturedTagsBlock.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+
+import { FeaturedTagsBlock } from './FeaturedTagsBlock'
+
+const buildTag = (overrides: Partial<FeaturedTag>): FeaturedTag => ({
+  id: overrides.id ?? 't1',
+  name: overrides.name ?? 'running',
+  url: overrides.url ?? 'https://example.test/@anna/tagged/running',
+  statuses_count: overrides.statuses_count ?? '128',
+  last_status_at: overrides.last_status_at ?? null
+})
+
+describe('FeaturedTagsBlock', () => {
+  it('renders nothing when there are no featured tags', () => {
+    const { container } = render(<FeaturedTagsBlock tags={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a chip per tag linking to its tagged timeline', () => {
+    render(
+      <FeaturedTagsBlock
+        tags={[
+          buildTag({
+            id: 't1',
+            name: 'running',
+            statuses_count: '128',
+            url: 'https://example.test/@anna/tagged/running'
+          }),
+          buildTag({
+            id: 't2',
+            name: 'cycling',
+            statuses_count: '74',
+            url: 'https://example.test/@anna/tagged/cycling'
+          })
+        ]}
+      />
+    )
+
+    expect(screen.getByText('Featured hashtags')).toBeInTheDocument()
+
+    const runningChip = screen.getByRole('link', { name: /#running/ })
+    expect(runningChip).toHaveAttribute(
+      'href',
+      'https://example.test/@anna/tagged/running'
+    )
+    expect(runningChip).toHaveTextContent('128')
+
+    const cyclingChip = screen.getByRole('link', { name: /#cycling/ })
+    expect(cyclingChip).toHaveTextContent('74')
+  })
+})

--- a/lib/components/profile/FeaturedTagsBlock.test.tsx
+++ b/lib/components/profile/FeaturedTagsBlock.test.tsx
@@ -53,4 +53,18 @@ describe('FeaturedTagsBlock', () => {
     const cyclingChip = screen.getByRole('link', { name: /#cycling/ })
     expect(cyclingChip).toHaveTextContent('74')
   })
+
+  it('renders a non-renderable tag name as a non-link chip', () => {
+    // A name the /tags/<name> route can't render (all-numeric here) would 404,
+    // so it shows as a plain chip instead of a broken link.
+    render(
+      <FeaturedTagsBlock
+        tags={[buildTag({ id: 't1', name: '2024', statuses_count: '9' })]}
+      />
+    )
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('#2024')).toBeInTheDocument()
+    expect(screen.getByText('9')).toBeInTheDocument()
+  })
 })

--- a/lib/components/profile/FeaturedTagsBlock.tsx
+++ b/lib/components/profile/FeaturedTagsBlock.tsx
@@ -3,15 +3,19 @@ import Link from 'next/link'
 import { FC } from 'react'
 
 import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+import { isRenderableHashtagName } from '@/lib/utils/text/isRenderableHashtagName'
 
 interface Props {
   tags: FeaturedTag[]
 }
 
+const CHIP_CLASS =
+  'inline-flex h-8 items-center gap-2 rounded-full border bg-background px-3 text-sm'
+
 // Surface 2 — the compact "Featured hashtags" block shown inside a profile.
 // A wrap of pill chips (#name + statuses_count) linking to each hashtag's
-// account-scoped timeline. Hidden entirely when the account features none, so
-// it never dominates the profile header.
+// timeline. Hidden entirely when the account features none, so it never
+// dominates the profile header.
 export const FeaturedTagsBlock: FC<Props> = ({ tags }) => {
   if (tags.length === 0) return null
   return (
@@ -21,24 +25,37 @@ export const FeaturedTagsBlock: FC<Props> = ({ tags }) => {
         <span>Featured hashtags</span>
       </div>
       <div className="flex flex-wrap gap-2">
-        {tags.map((tag) => (
-          <Link
-            key={tag.id}
-            // The Mastodon entity `tag.url` is the account-scoped
-            // `/@acct/tagged/<name>` URL, which this app does not serve. Link to
-            // the in-app hashtag timeline (`/tags/<name>`) instead — the same
-            // path every in-post hashtag uses — so the chip navigates client-side
-            // instead of 404ing.
-            href={`/tags/${encodeURIComponent(tag.name)}`}
-            prefetch={false}
-            className="group inline-flex h-8 items-center gap-2 rounded-full border bg-background px-3 text-sm transition-colors hover:bg-primary/[0.08] focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-          >
-            <span className="font-medium text-primary">#{tag.name}</span>
-            <span className="text-xs tabular-nums text-muted-foreground">
-              {tag.statuses_count}
+        {tags.map((tag) => {
+          const label = (
+            <>
+              <span className="font-medium text-primary">#{tag.name}</span>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {tag.statuses_count}
+              </span>
+            </>
+          )
+          // The Mastodon entity `tag.url` is the account-scoped
+          // `/@acct/tagged/<name>` URL, which this app does not serve. Link to
+          // the in-app hashtag timeline (`/tags/<name>`) instead — the same path
+          // every in-post hashtag uses — so the chip navigates client-side. A
+          // tag whose name the /tags route can't render (e.g. an all-numeric or
+          // Unicode name created via the raw Mastodon API) would 404, so render
+          // it as a non-link chip rather than a broken link.
+          return isRenderableHashtagName(tag.name) ? (
+            <Link
+              key={tag.id}
+              href={`/tags/${encodeURIComponent(tag.name)}`}
+              prefetch={false}
+              className={`${CHIP_CLASS} transition-colors hover:bg-primary/[0.08] focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50`}
+            >
+              {label}
+            </Link>
+          ) : (
+            <span key={tag.id} className={CHIP_CLASS}>
+              {label}
             </span>
-          </Link>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/lib/components/profile/FeaturedTagsBlock.tsx
+++ b/lib/components/profile/FeaturedTagsBlock.tsx
@@ -24,7 +24,12 @@ export const FeaturedTagsBlock: FC<Props> = ({ tags }) => {
         {tags.map((tag) => (
           <Link
             key={tag.id}
-            href={tag.url}
+            // The Mastodon entity `tag.url` is the account-scoped
+            // `/@acct/tagged/<name>` URL, which this app does not serve. Link to
+            // the in-app hashtag timeline (`/tags/<name>`) instead — the same
+            // path every in-post hashtag uses — so the chip navigates client-side
+            // instead of 404ing.
+            href={`/tags/${encodeURIComponent(tag.name)}`}
             prefetch={false}
             className="group inline-flex h-8 items-center gap-2 rounded-full border bg-background px-3 text-sm transition-colors hover:bg-primary/[0.08] focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >

--- a/lib/components/profile/FeaturedTagsBlock.tsx
+++ b/lib/components/profile/FeaturedTagsBlock.tsx
@@ -1,0 +1,40 @@
+import { Hash } from 'lucide-react'
+import Link from 'next/link'
+import { FC } from 'react'
+
+import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+
+interface Props {
+  tags: FeaturedTag[]
+}
+
+// Surface 2 — the compact "Featured hashtags" block shown inside a profile.
+// A wrap of pill chips (#name + statuses_count) linking to each hashtag's
+// account-scoped timeline. Hidden entirely when the account features none, so
+// it never dominates the profile header.
+export const FeaturedTagsBlock: FC<Props> = ({ tags }) => {
+  if (tags.length === 0) return null
+  return (
+    <div className="mt-5 space-y-2 border-t pt-5">
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <Hash className="size-[13px]" />
+        <span>Featured hashtags</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <Link
+            key={tag.id}
+            href={tag.url}
+            prefetch={false}
+            className="group inline-flex h-8 items-center gap-2 rounded-full border bg-background px-3 text-sm transition-colors hover:bg-primary/[0.08] focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            <span className="font-medium text-primary">#{tag.name}</span>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {tag.statuses_count}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/utils/text/isRenderableHashtagName.ts
+++ b/lib/utils/text/isRenderableHashtagName.ts
@@ -1,0 +1,13 @@
+// A hashtag name the in-app hashtag timeline (app/(timeline)/tags/[tag]) can
+// render: ASCII word characters with at least one letter or underscore. This
+// mirrors that route's TAG_REGEX and the in-post hashtag tokenizer, and is
+// intentionally stricter than the server's Mastodon featured-tag regex
+// (`^[\p{L}\p{N}_]+$`, which also allows Unicode and all-numeric names). A name
+// that fails this can be created via the raw Mastodon API but cannot be linked
+// to /tags/<name> without 404ing, so callers should both block creating it and
+// avoid linking it.
+export const RENDERABLE_HASHTAG_NAME_REGEX =
+  /^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/
+
+export const isRenderableHashtagName = (name: string): boolean =>
+  RENDERABLE_HASHTAG_NAME_REGEX.test(name)


### PR DESCRIPTION
## Summary

Builds the **front end** for featured hashtags on top of the `featured_tags` backend that landed in [#901](https://github.com/llun/activities.next/pull/901) (those REST endpoints already existed and returned real data; this PR wires the UI to them). Matches the design system handoff (`ui_kits/web/featured-hashtags.html`, `FeaturedTags.jsx`, chat17) and the attached screenshots, rendered in this project's tokens (orange `--primary`, `bg-background/80` section cards, Lucide icons, sentence-case copy).

## Surfaces

### 1. Settings editor — `/settings/featured-hashtags`
- New **"Featured hashtags"** tab in the settings dropdown sub-nav (`Hash` icon), placed after Account to match the design's `SETTINGS_TABS` order. Renders with `PageHeader` in section mode like the other settings pages.
- **Add a hashtag** input with a live suggestions dropdown (from `GET /featured_tags/suggestions`), submit via Enter / the Add button / a suggestion click.
- Surfaces the **10-tag cap** (disabled input + helper line + accented `10 of 10 featured` counter), inline success/error messages, an **empty state**, and a **loading skeleton**.
- Client-side validation mirrors the server (`^[\p{L}\p{N}_]+$` after stripping a leading `#`); duplicates are blocked client-side while the server stays idempotent.

### 2. Profile block
- Compact **"Featured hashtags"** chip wrap inside the profile card (`#name` + `statuses_count`, linking to each tag's `/@acct/tagged/<name>` timeline). Server-rendered; hidden entirely when the account features none. Only local actors have stored tags, so remote profiles resolve to an empty list and the block hides itself.

## Notes / conventions
- All network calls go through new `lib/client.ts` functions (`getFeaturedTags`, `addFeaturedTag`, `removeFeaturedTag`, `getFeaturedTagSuggestions`) — no `fetch()` in components.
- `last_status_at` ("YYYY-MM-DD") is parsed by hand and rendered without `new Date()` / `Date.now()`, so there's no SSR→hydration drift and no `currentTime` prop is needed.
- No backend changes — reuses #901's endpoints and `getMastodonFeaturedTag` serializer.

## Tests
- `FeaturedTagsEditor.test.tsx` — load / empty / add (+ success) / invalid name / already-featured / server error / 10-tag limit / remove / suggestions.
- `FeaturedTagsBlock.test.tsx` — hidden when empty; renders a linked chip per tag.
- Updated `settings/layout.test.tsx` to include the new tab.

## Local gate
`yarn run prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (443 suites / 3767 tests). `package.json` not bumped (handled by the version workflow); no docs added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the front end for featured hashtags: a settings editor to add/remove tags with suggestions, and a profile block that shows featured tags. Uses existing `featured_tags` endpoints via `lib/client.ts`; no backend changes, with hardened errors and safe rendering.

- **New Features**
  - Settings editor at `/settings/featured-hashtags` with a “Featured hashtags” tab, add input with suggestions, 10-tag limit, empty state, loading skeleton, and inline success/error messages.
  - Profile block on profile pages showing chips for each featured tag (server-rendered, hidden when empty).

- **Bug Fixes**
  - Chips link to the in-app hashtag timeline (`/tags/<name>`) instead of the account-scoped URL.
  - Load failures (including HTTP 4xx/5xx) now clear the skeleton and show a dedicated error; suggestions errors are swallowed during load so successfully loaded tags still render.
  - Inline message live region stays mounted and uses role="alert" for errors and role="status" for success.
  - More robust client and validation: `lib/client.ts` wraps network errors and only treats parsed bodies as success; shared `lib/utils/text/isRenderableHashtagName` blocks non-renderable names; the profile renders those as non-link chips; add flow guards for concurrent submits.

<sup>Written for commit b1697c075819bad487f68d4a80f2d52ec60e97ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

