### PR TITLE
Bump version to v1.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.49.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.48.0`
- Base main SHA: `295de3e451017ff7f17f9c01f08b091ffb932433`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `activities.next` to v1.49.0 to prepare a minor release. Updates `package.json` version only.

<sup>Written for commit aba10257af5c35828f8cfd7746332de9dc90db79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

