### PR TITLE
minor: add lists feature UI

### DIFF
--- a/app/(timeline)/layout.test.tsx
+++ b/app/(timeline)/layout.test.tsx
@@ -11,11 +11,13 @@ import Layout from './layout'
 
 const mockGetActorsForAccount = jest.fn()
 const mockGetNotificationsCount = jest.fn()
+const mockGetLists = jest.fn()
 
 jest.mock('@/lib/database', () => ({
   getDatabase: jest.fn(() => ({
     getActorsForAccount: mockGetActorsForAccount,
-    getNotificationsCount: mockGetNotificationsCount
+    getNotificationsCount: mockGetNotificationsCount,
+    getLists: mockGetLists
   }))
 }))
 
@@ -56,6 +58,7 @@ describe('(timeline) Layout', () => {
     mockGetServerAuthSession.mockResolvedValue(null)
     mockGetActorsForAccount.mockResolvedValue([])
     mockGetNotificationsCount.mockResolvedValue(0)
+    mockGetLists.mockResolvedValue([])
   })
 
   it('renders children without nav chrome for logged-out visitors', async () => {

--- a/app/(timeline)/layout.tsx
+++ b/app/(timeline)/layout.tsx
@@ -81,6 +81,9 @@ const Layout: FC<LayoutProps> = async ({ children }) => {
   const fitnessUrl = actor.account ? '/fitness' : undefined
   const isAdmin = actor.account?.role === 'admin'
 
+  // Drives the expandable Lists group in the sidebar.
+  const lists = await database.getLists({ actorId: actor.id })
+
   return (
     <div className="min-h-dvh">
       <Sidebar
@@ -98,6 +101,7 @@ const Layout: FC<LayoutProps> = async ({ children }) => {
         unreadCount={unreadCount}
         fitnessUrl={fitnessUrl}
         isAdmin={isAdmin}
+        lists={lists.map((list) => ({ id: list.id, title: list.title }))}
       />
       <MobileNav
         unreadCount={unreadCount}

--- a/app/(timeline)/lists/ListEditor.test.tsx
+++ b/app/(timeline)/lists/ListEditor.test.tsx
@@ -76,6 +76,26 @@ describe('ListEditor', () => {
     expect(mockPush).toHaveBeenCalledWith('/lists/new-list/edit')
   })
 
+  it('shows an inline error and re-enables save when create rejects', async () => {
+    ;(createList as jest.Mock).mockRejectedValue(new Error('offline'))
+    render(<ListEditor mode="create" />)
+
+    fireEvent.change(screen.getByLabelText('List name'), {
+      target: { value: 'New crew' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create list' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not create the list. Please try again.'
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Create list' })
+      ).not.toBeDisabled()
+    )
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
   it('blocks creation when the name is empty', async () => {
     render(<ListEditor mode="create" />)
 

--- a/app/(timeline)/lists/ListEditor.test.tsx
+++ b/app/(timeline)/lists/ListEditor.test.tsx
@@ -116,6 +116,30 @@ describe('ListEditor', () => {
     )
   })
 
+  it('re-enables the Add button and shows an error when the request rejects', async () => {
+    ;(addListAccounts as jest.Mock).mockRejectedValue(new Error('network down'))
+    render(
+      <ListEditor
+        mode="edit"
+        list={list}
+        initialMembers={[]}
+        followingSuggestions={[suggestion]}
+      />
+    )
+
+    const addButton = screen.getByRole('button', { name: 'Add' })
+    fireEvent.click(addButton)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not add that account. Please try again.'
+    )
+    // The pending state must clear even though the request threw, so the row's
+    // Add button is usable again rather than stuck disabled.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Add' })).not.toBeDisabled()
+    )
+  })
+
   it('removes a member from the list right away', async () => {
     render(
       <ListEditor

--- a/app/(timeline)/lists/ListEditor.test.tsx
+++ b/app/(timeline)/lists/ListEditor.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  addListAccounts,
+  createList,
+  deleteList,
+  removeListAccounts,
+  updateList
+} from '@/lib/client'
+import { ListEntity } from '@/lib/types/mastodon/list'
+
+import { ListEditor, ListMember } from './ListEditor'
+
+jest.mock('@/lib/client', () => ({
+  addListAccounts: jest.fn(),
+  createList: jest.fn(),
+  deleteList: jest.fn(),
+  removeListAccounts: jest.fn(),
+  updateList: jest.fn()
+}))
+
+const mockPush = jest.fn()
+const mockRefresh = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh })
+}))
+
+const list: ListEntity = {
+  id: 'list-1',
+  title: 'Running club',
+  replies_policy: 'list',
+  exclusive: false
+}
+
+const member: ListMember = {
+  id: 'https://activities.local/users/rin',
+  name: 'Rin',
+  handle: 'rin@fosstodon.org'
+}
+
+const suggestion: ListMember = {
+  id: 'https://activities.local/users/ben',
+  name: 'Ben Carter',
+  handle: 'ben@llun.social'
+}
+
+describe('ListEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(createList as jest.Mock).mockResolvedValue({ ...list, id: 'new-list' })
+    ;(updateList as jest.Mock).mockResolvedValue(list)
+    ;(addListAccounts as jest.Mock).mockResolvedValue(true)
+    ;(removeListAccounts as jest.Mock).mockResolvedValue(true)
+    ;(deleteList as jest.Mock).mockResolvedValue(true)
+  })
+
+  it('creates a list and routes to its member editor', async () => {
+    render(<ListEditor mode="create" />)
+
+    fireEvent.change(screen.getByLabelText('List name'), {
+      target: { value: 'New crew' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create list' }))
+
+    await waitFor(() =>
+      expect(createList).toHaveBeenCalledWith({
+        title: 'New crew',
+        repliesPolicy: 'list',
+        exclusive: false
+      })
+    )
+    expect(mockPush).toHaveBeenCalledWith('/lists/new-list/edit')
+  })
+
+  it('blocks creation when the name is empty', async () => {
+    render(<ListEditor mode="create" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create list' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Please enter a list name.'
+    )
+    expect(createList).not.toHaveBeenCalled()
+  })
+
+  it('does not render the members section in create mode', () => {
+    render(<ListEditor mode="create" />)
+    expect(screen.queryByText('Members')).not.toBeInTheDocument()
+  })
+
+  it('adds a suggested account to the list right away', async () => {
+    render(
+      <ListEditor
+        mode="edit"
+        list={list}
+        initialMembers={[]}
+        followingSuggestions={[suggestion]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() =>
+      expect(addListAccounts).toHaveBeenCalledWith({
+        listId: 'list-1',
+        accountIds: [suggestion.id]
+      })
+    )
+    // The added account moves from Suggestions into the member list.
+    await waitFor(() =>
+      expect(screen.getByText('In this list · 1')).toBeInTheDocument()
+    )
+  })
+
+  it('removes a member from the list right away', async () => {
+    render(
+      <ListEditor
+        mode="edit"
+        list={list}
+        initialMembers={[member]}
+        followingSuggestions={[]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Rin' }))
+
+    await waitFor(() =>
+      expect(removeListAccounts).toHaveBeenCalledWith({
+        listId: 'list-1',
+        accountIds: [member.id]
+      })
+    )
+    await waitFor(() =>
+      expect(screen.queryByText('In this list · 1')).not.toBeInTheDocument()
+    )
+  })
+
+  it('saves settings changes and routes back to the list', async () => {
+    render(<ListEditor mode="edit" list={list} initialMembers={[member]} />)
+
+    fireEvent.click(screen.getByLabelText('Hide members from Home'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() =>
+      expect(updateList).toHaveBeenCalledWith({
+        listId: 'list-1',
+        title: 'Running club',
+        repliesPolicy: 'list',
+        exclusive: true
+      })
+    )
+    expect(mockPush).toHaveBeenCalledWith('/lists/list-1')
+  })
+})

--- a/app/(timeline)/lists/ListEditor.tsx
+++ b/app/(timeline)/lists/ListEditor.tsx
@@ -185,6 +185,14 @@ export const ListEditor: FC<ListEditorProps> = ({
       }
       router.push(`/lists/${list.id}`)
       router.refresh()
+    } catch {
+      // createList/updateList throw on a network/abort error rather than
+      // returning null; surface the same inline error so the user can retry.
+      setError(
+        mode === 'create'
+          ? 'Could not create the list. Please try again.'
+          : 'Could not save your changes. Please try again.'
+      )
     } finally {
       setSaving(false)
     }

--- a/app/(timeline)/lists/ListEditor.tsx
+++ b/app/(timeline)/lists/ListEditor.tsx
@@ -21,7 +21,8 @@ import { Switch } from '@/lib/components/ui/switch'
 import { ListEntity } from '@/lib/types/mastodon/list'
 
 export interface ListMember {
-  // The actor URI (Mastodon Account `id`).
+  // The Mastodon Account `id` (the `urlToId`-encoded actor id, not the raw
+  // URI — that lives in `account.url`). Sent as-is to the list accounts API.
   id: string
   name: string
   handle: string
@@ -104,34 +105,46 @@ export const ListEditor: FC<ListEditorProps> = ({
     if (!list) return
     setError(null)
     setMemberPending(account.id, true)
-    const ok = await addListAccounts({
-      listId: list.id,
-      accountIds: [account.id]
-    })
-    setMemberPending(account.id, false)
-    if (!ok) {
+    try {
+      const ok = await addListAccounts({
+        listId: list.id,
+        accountIds: [account.id]
+      })
+      if (!ok) {
+        setError('Could not add that account. Please try again.')
+        return
+      }
+      setMembers((previous) => [...previous, account])
+    } catch {
       setError('Could not add that account. Please try again.')
-      return
+    } finally {
+      // Always clear pending, even when the request throws, so the row's
+      // Add/Remove control never stays permanently disabled.
+      setMemberPending(account.id, false)
     }
-    setMembers((previous) => [...previous, account])
   }
 
   const removeMember = async (account: ListMember) => {
     if (!list) return
     setError(null)
     setMemberPending(account.id, true)
-    const ok = await removeListAccounts({
-      listId: list.id,
-      accountIds: [account.id]
-    })
-    setMemberPending(account.id, false)
-    if (!ok) {
+    try {
+      const ok = await removeListAccounts({
+        listId: list.id,
+        accountIds: [account.id]
+      })
+      if (!ok) {
+        setError('Could not remove that account. Please try again.')
+        return
+      }
+      setMembers((previous) =>
+        previous.filter((member) => member.id !== account.id)
+      )
+    } catch {
       setError('Could not remove that account. Please try again.')
-      return
+    } finally {
+      setMemberPending(account.id, false)
     }
-    setMembers((previous) =>
-      previous.filter((member) => member.id !== account.id)
-    )
   }
 
   const handleSave = async () => {
@@ -188,14 +201,21 @@ export const ListEditor: FC<ListEditorProps> = ({
     }
     setError(null)
     setDeleting(true)
-    const ok = await deleteList(list.id)
-    if (!ok) {
-      setDeleting(false)
+    try {
+      const ok = await deleteList(list.id)
+      if (!ok) {
+        setError('Could not delete the list. Please try again.')
+        return
+      }
+      router.push('/lists')
+      router.refresh()
+    } catch {
       setError('Could not delete the list. Please try again.')
-      return
+    } finally {
+      // On a thrown request the success path returns early; clear the flag here
+      // so the Delete/Save buttons don't stay disabled.
+      setDeleting(false)
     }
-    router.push('/lists')
-    router.refresh()
   }
 
   const cancelHref = mode === 'edit' && list ? `/lists/${list.id}` : '/lists'
@@ -275,6 +295,7 @@ export const ListEditor: FC<ListEditorProps> = ({
             <Input
               className="pl-9"
               value={search}
+              aria-label="Search accounts you follow"
               placeholder="Search accounts you follow"
               onChange={(event) => setSearch(event.target.value)}
             />

--- a/app/(timeline)/lists/ListEditor.tsx
+++ b/app/(timeline)/lists/ListEditor.tsx
@@ -1,0 +1,403 @@
+'use client'
+
+import { Search, Trash2, UserMinus, UserPlus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { FC, useMemo, useState } from 'react'
+
+import {
+  addListAccounts,
+  createList,
+  deleteList,
+  removeListAccounts,
+  updateList
+} from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import { Label } from '@/lib/components/ui/label'
+import { Select } from '@/lib/components/ui/select'
+import { Switch } from '@/lib/components/ui/switch'
+import { ListEntity } from '@/lib/types/mastodon/list'
+
+export interface ListMember {
+  // The actor URI (Mastodon Account `id`).
+  id: string
+  name: string
+  handle: string
+  avatar?: string
+}
+
+type RepliesPolicy = ListEntity['replies_policy']
+
+const REPLIES_POLICY_OPTIONS: { value: RepliesPolicy; label: string }[] = [
+  { value: 'followed', label: 'People I follow' },
+  { value: 'list', label: 'Members of the list' },
+  { value: 'none', label: 'No one' }
+]
+
+const getInitials = (name: string) =>
+  name
+    .split(' ')
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase() || '?'
+
+interface ListEditorProps {
+  mode: 'create' | 'edit'
+  list?: ListEntity
+  initialMembers?: ListMember[]
+  followingSuggestions?: ListMember[]
+}
+
+export const ListEditor: FC<ListEditorProps> = ({
+  mode,
+  list,
+  initialMembers = [],
+  followingSuggestions = []
+}) => {
+  const router = useRouter()
+
+  const [title, setTitle] = useState(list?.title ?? '')
+  const [repliesPolicy, setRepliesPolicy] = useState<RepliesPolicy>(
+    list?.replies_policy ?? 'list'
+  )
+  const [exclusive, setExclusive] = useState(list?.exclusive ?? false)
+
+  const [members, setMembers] = useState<ListMember[]>(initialMembers)
+  const [search, setSearch] = useState('')
+  const [isSaving, setSaving] = useState(false)
+  const [isDeleting, setDeleting] = useState(false)
+  const [pendingMemberIds, setPendingMemberIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  const memberIds = useMemo(
+    () => new Set(members.map((member) => member.id)),
+    [members]
+  )
+
+  const suggestions = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    return followingSuggestions
+      .filter((account) => !memberIds.has(account.id))
+      .filter(
+        (account) =>
+          query.length === 0 ||
+          account.name.toLowerCase().includes(query) ||
+          account.handle.toLowerCase().includes(query)
+      )
+  }, [followingSuggestions, memberIds, search])
+
+  const setMemberPending = (id: string, pending: boolean) =>
+    setPendingMemberIds((previous) => {
+      const next = new Set(previous)
+      if (pending) next.add(id)
+      else next.delete(id)
+      return next
+    })
+
+  const addMember = async (account: ListMember) => {
+    if (!list) return
+    setError(null)
+    setMemberPending(account.id, true)
+    const ok = await addListAccounts({
+      listId: list.id,
+      accountIds: [account.id]
+    })
+    setMemberPending(account.id, false)
+    if (!ok) {
+      setError('Could not add that account. Please try again.')
+      return
+    }
+    setMembers((previous) => [...previous, account])
+  }
+
+  const removeMember = async (account: ListMember) => {
+    if (!list) return
+    setError(null)
+    setMemberPending(account.id, true)
+    const ok = await removeListAccounts({
+      listId: list.id,
+      accountIds: [account.id]
+    })
+    setMemberPending(account.id, false)
+    if (!ok) {
+      setError('Could not remove that account. Please try again.')
+      return
+    }
+    setMembers((previous) =>
+      previous.filter((member) => member.id !== account.id)
+    )
+  }
+
+  const handleSave = async () => {
+    const trimmed = title.trim()
+    if (trimmed.length === 0) {
+      setError('Please enter a list name.')
+      return
+    }
+    setError(null)
+    setSaving(true)
+    try {
+      if (mode === 'create') {
+        const created = await createList({
+          title: trimmed,
+          repliesPolicy,
+          exclusive
+        })
+        if (!created) {
+          setError('Could not create the list. Please try again.')
+          return
+        }
+        // Send new members straight to the member editor on the created list.
+        router.push(`/lists/${created.id}/edit`)
+        router.refresh()
+        return
+      }
+
+      if (!list) return
+      const updated = await updateList({
+        listId: list.id,
+        title: trimmed,
+        repliesPolicy,
+        exclusive
+      })
+      if (!updated) {
+        setError('Could not save your changes. Please try again.')
+        return
+      }
+      router.push(`/lists/${list.id}`)
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!list) return
+    if (
+      !window.confirm(
+        `Delete “${list.title}”? This removes the list but not the accounts on it.`
+      )
+    ) {
+      return
+    }
+    setError(null)
+    setDeleting(true)
+    const ok = await deleteList(list.id)
+    if (!ok) {
+      setDeleting(false)
+      setError('Could not delete the list. Please try again.')
+      return
+    }
+    router.push('/lists')
+    router.refresh()
+  }
+
+  const cancelHref = mode === 'edit' && list ? `/lists/${list.id}` : '/lists'
+
+  return (
+    <div className="space-y-6 pb-24">
+      <PageHeader
+        title={mode === 'create' ? 'New list' : 'Edit list'}
+        description={
+          mode === 'create'
+            ? 'Create a curated timeline from accounts you follow.'
+            : undefined
+        }
+      />
+
+      <section className="space-y-5 rounded-xl border bg-card p-5 shadow-sm">
+        <div className="space-y-2">
+          <Label htmlFor="list-name">List name</Label>
+          <Input
+            id="list-name"
+            value={title}
+            maxLength={255}
+            placeholder="e.g. Running club"
+            onChange={(event) => setTitle(event.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="list-replies-policy">
+            Include replies from list members to
+          </Label>
+          <Select
+            id="list-replies-policy"
+            value={repliesPolicy}
+            onChange={(event) =>
+              setRepliesPolicy(event.target.value as RepliesPolicy)
+            }
+          >
+            {REPLIES_POLICY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            Whose replies should appear in this list&rsquo;s timeline.
+          </p>
+        </div>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="list-exclusive">Hide members from Home</Label>
+            <p className="text-sm text-muted-foreground">
+              If someone is on this list, hide their posts from your Home
+              timeline to avoid seeing them twice.
+            </p>
+          </div>
+          <Switch
+            id="list-exclusive"
+            checked={exclusive}
+            onCheckedChange={setExclusive}
+          />
+        </div>
+      </section>
+
+      {mode === 'edit' && list && (
+        <section className="space-y-4 rounded-xl border bg-card p-5 shadow-sm">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Members</h2>
+            <p className="text-sm text-muted-foreground">
+              Add or remove accounts you follow. Changes apply right away.
+            </p>
+          </div>
+
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="pl-9"
+              value={search}
+              placeholder="Search accounts you follow"
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </div>
+
+          {members.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                In this list · {members.length}
+              </p>
+              <ul className="divide-y">
+                {members.map((member) => (
+                  <li key={member.id} className="flex items-center gap-3 py-3">
+                    <Avatar className="h-10 w-10">
+                      {member.avatar && <AvatarImage src={member.avatar} />}
+                      <AvatarFallback>
+                        {getInitials(member.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium">{member.name}</p>
+                      <p className="truncate text-sm text-muted-foreground">
+                        @{member.handle}
+                      </p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      aria-label={`Remove ${member.name}`}
+                      disabled={pendingMemberIds.has(member.id)}
+                      onClick={() => removeMember(member)}
+                    >
+                      <UserMinus className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {suggestions.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Suggestions
+              </p>
+              <ul className="divide-y">
+                {suggestions.map((account) => (
+                  <li key={account.id} className="flex items-center gap-3 py-3">
+                    <Avatar className="h-10 w-10">
+                      {account.avatar && <AvatarImage src={account.avatar} />}
+                      <AvatarFallback>
+                        {getInitials(account.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium">{account.name}</p>
+                      <p className="truncate text-sm text-muted-foreground">
+                        @{account.handle}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      disabled={pendingMemberIds.has(account.id)}
+                      onClick={() => addMember(account)}
+                    >
+                      <UserPlus className="h-4 w-4" />
+                      Add
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {members.length === 0 && suggestions.length === 0 && (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              {search.trim().length > 0
+                ? 'No accounts match your search.'
+                : 'Follow some accounts to add them to this list.'}
+            </p>
+          )}
+        </section>
+      )}
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {mode === 'edit' && list ? (
+          <Button
+            variant="outline"
+            className="text-destructive"
+            disabled={isDeleting || isSaving}
+            onClick={handleDelete}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete list
+          </Button>
+        ) : (
+          <span />
+        )}
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            disabled={isSaving || isDeleting}
+            onClick={() => router.push(cancelHref)}
+          >
+            Cancel
+          </Button>
+          <Button disabled={isSaving || isDeleting} onClick={handleSave}>
+            {mode === 'create'
+              ? isSaving
+                ? 'Creating...'
+                : 'Create list'
+              : isSaving
+                ? 'Saving...'
+                : 'Save changes'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(timeline)/lists/ListsIndex.test.tsx
+++ b/app/(timeline)/lists/ListsIndex.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { ListSummary, ListsIndex } from './ListsIndex'
+
+jest.mock('@/lib/components/page-header', () => ({
+  PageHeader: ({
+    title,
+    description,
+    actions
+  }: {
+    title: ReactNode
+    description: ReactNode
+    actions: ReactNode
+  }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+      <div>{actions}</div>
+    </div>
+  )
+}))
+
+const baseList = (overrides: Partial<ListSummary>): ListSummary => ({
+  id: 'list-1',
+  title: 'Running club',
+  replies_policy: 'list',
+  exclusive: false,
+  memberCount: 3,
+  previewMembers: [],
+  ...overrides
+})
+
+describe('ListsIndex', () => {
+  it('renders the empty state with a create call to action', () => {
+    render(<ListsIndex lists={[]} />)
+
+    expect(screen.getByText('No lists yet')).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', { name: /new list/i })[0]
+    ).toHaveAttribute('href', '/lists/new')
+  })
+
+  it('links each list row to its timeline and summarizes membership', () => {
+    render(
+      <ListsIndex
+        lists={[
+          baseList({ id: 'a', title: 'Running club', memberCount: 3 }),
+          baseList({
+            id: 'b',
+            title: 'Fediverse devs',
+            memberCount: 3,
+            exclusive: true
+          }),
+          baseList({ id: 'c', title: 'Conferences 2026', memberCount: 0 })
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: /Running club/ })).toHaveAttribute(
+      'href',
+      '/lists/a'
+    )
+    expect(screen.getByText('3 members')).toBeInTheDocument()
+    expect(screen.getByText('3 members · Hidden from Home')).toBeInTheDocument()
+    expect(screen.getByText('No members yet')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/lists/ListsIndex.tsx
+++ b/app/(timeline)/lists/ListsIndex.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { ChevronRight, List as ListIcon, ListPlus } from 'lucide-react'
+import Link from 'next/link'
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { Button } from '@/lib/components/ui/button'
+import { ListEntity } from '@/lib/types/mastodon/list'
+
+export interface ListPreviewMember {
+  id: string
+  name: string
+  avatar?: string
+}
+
+export interface ListSummary extends ListEntity {
+  memberCount: number
+  previewMembers: ListPreviewMember[]
+}
+
+const getInitials = (name: string) =>
+  name
+    .split(' ')
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase() || '?'
+
+const memberSummary = (list: ListSummary) => {
+  if (list.memberCount === 0) return 'No members yet'
+  const members = `${list.memberCount} member${list.memberCount === 1 ? '' : 's'}`
+  return list.exclusive ? `${members} · Hidden from Home` : members
+}
+
+const NewListButton = () => (
+  <Button asChild>
+    <Link href="/lists/new">
+      <ListPlus className="h-4 w-4" />
+      New list
+    </Link>
+  </Button>
+)
+
+interface ListsIndexProps {
+  lists: ListSummary[]
+}
+
+export const ListsIndex: FC<ListsIndexProps> = ({ lists }) => (
+  <div className="space-y-6">
+    <PageHeader
+      title="Lists"
+      description="Curated timelines from accounts you follow"
+      actions={<NewListButton />}
+    />
+
+    {lists.length > 0 ? (
+      <div className="divide-y overflow-hidden rounded-xl border bg-card shadow-sm">
+        {lists.map((list) => (
+          <Link
+            key={list.id}
+            href={`/lists/${list.id}`}
+            className="flex items-center gap-4 px-4 py-4 transition-colors hover:bg-muted/60"
+          >
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <ListIcon className="h-5 w-5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-semibold">{list.title}</p>
+              <p className="truncate text-sm text-muted-foreground">
+                {memberSummary(list)}
+              </p>
+            </div>
+            {list.previewMembers.length > 0 && (
+              <div className="flex -space-x-2">
+                {list.previewMembers.map((member) => (
+                  <Avatar key={member.id} className="h-7 w-7 ring-2 ring-card">
+                    {member.avatar && <AvatarImage src={member.avatar} />}
+                    <AvatarFallback className="text-xs">
+                      {getInitials(member.name)}
+                    </AvatarFallback>
+                  </Avatar>
+                ))}
+              </div>
+            )}
+            <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" />
+          </Link>
+        ))}
+      </div>
+    ) : (
+      <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">
+        <h2 className="mb-2 text-xl font-semibold">No lists yet</h2>
+        <p className="mb-6">
+          Group accounts you follow into curated timelines you can read
+          separately from Home.
+        </p>
+        <NewListButton />
+      </div>
+    )}
+  </div>
+)

--- a/app/(timeline)/lists/[id]/ListTimeline.test.tsx
+++ b/app/(timeline)/lists/[id]/ListTimeline.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+import { getListTimeline } from '@/lib/client'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { ListEntity } from '@/lib/types/mastodon/list'
+
+import { ListTimeline } from './ListTimeline'
+
+jest.mock('@/lib/client', () => ({
+  getListTimeline: jest.fn()
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() })
+}))
+
+jest.mock('@/lib/components/scroll-to-top-button', () => ({
+  ScrollToTopButton: () => null
+}))
+
+jest.mock('@/lib/components/page-header', () => ({
+  PageHeader: ({
+    title,
+    description,
+    actions
+  }: {
+    title: ReactNode
+    description: ReactNode
+    actions: ReactNode
+  }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+      <div>{actions}</div>
+    </div>
+  )
+}))
+
+jest.mock('@/lib/components/posts/posts', () => ({
+  Posts: ({
+    statuses,
+    currentTime
+  }: {
+    statuses: Status[]
+    currentTime: number
+  }) => (
+    <div>
+      <div data-testid="posts-current-time">{currentTime}</div>
+      {statuses.map((status) => (
+        <div key={status.id}>{status.id}</div>
+      ))}
+    </div>
+  )
+}))
+
+const FIXED_CURRENT_TIME = new Date('2026-04-30T10:05:00.000Z').getTime()
+
+const profile: ActorProfile = {
+  id: 'https://activities.local/users/llun',
+  username: 'llun',
+  domain: 'activities.local',
+  name: 'Llun',
+  followersUrl: 'https://activities.local/users/llun/followers',
+  inboxUrl: 'https://activities.local/users/llun/inbox',
+  sharedInboxUrl: 'https://activities.local/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: FIXED_CURRENT_TIME
+}
+
+const list: ListEntity = {
+  id: 'list-1',
+  title: 'Running club',
+  replies_policy: 'list',
+  exclusive: false
+}
+
+const createStatus = (id: string): Status => ({
+  id,
+  actorId: profile.id,
+  actor: profile,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: true,
+  createdAt: FIXED_CURRENT_TIME,
+  updatedAt: FIXED_CURRENT_TIME,
+  type: StatusType.enum.Note,
+  url: id,
+  text: id,
+  summary: null,
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  attachments: [],
+  tags: []
+})
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('ListTimeline', () => {
+  beforeAll(() => {
+    ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
+      MockIntersectionObserver
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders posts using the currentTime prop, not a freshly computed Date.now()', () => {
+    // Regression test for the React hydration mismatch: the relative timestamps
+    // rendered by <Posts> must derive from the server-provided currentTime so
+    // SSR and client hydration agree. A freshly computed Date.now() here would
+    // diverge from the server value and break hydration.
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(FIXED_CURRENT_TIME + 5 * 60 * 1000)
+
+    try {
+      render(
+        <ListTimeline
+          host="activities.local"
+          list={list}
+          memberCount={3}
+          statuses={[createStatus('https://activities.local/users/llun/s/1')]}
+          currentTime={FIXED_CURRENT_TIME}
+          currentActor={profile}
+        />
+      )
+
+      const renderedTimes = screen.getAllByTestId('posts-current-time')
+      expect(renderedTimes.length).toBeGreaterThan(0)
+      for (const node of renderedTimes) {
+        expect(node).toHaveTextContent(String(FIXED_CURRENT_TIME))
+      }
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
+  it('shows the member count, replies policy and an edit link', () => {
+    render(
+      <ListTimeline
+        host="activities.local"
+        list={list}
+        memberCount={3}
+        statuses={[createStatus('https://activities.local/users/llun/s/1')]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={profile}
+      />
+    )
+
+    expect(screen.getByText('3 members · Replies: list')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /edit/i })).toHaveAttribute(
+      'href',
+      '/lists/list-1/edit'
+    )
+  })
+
+  it('appends the next page of statuses on load more', async () => {
+    ;(getListTimeline as jest.Mock).mockResolvedValue({
+      statuses: [createStatus('https://activities.local/users/llun/s/2')],
+      nextMaxStatusId: null,
+      prevMinStatusId: null
+    })
+
+    render(
+      <ListTimeline
+        host="activities.local"
+        list={list}
+        memberCount={1}
+        statuses={[createStatus('https://activities.local/users/llun/s/1')]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={profile}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await screen.findByText('https://activities.local/users/llun/s/2')
+    expect(getListTimeline).toHaveBeenCalledWith({
+      listId: 'list-1',
+      maxStatusId: 'https://activities.local/users/llun/s/1'
+    })
+  })
+})

--- a/app/(timeline)/lists/[id]/ListTimeline.tsx
+++ b/app/(timeline)/lists/[id]/ListTimeline.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { ArrowLeft, Pencil } from 'lucide-react'
+import Link from 'next/link'
+import { FC, useCallback, useRef, useState } from 'react'
+
+import { getListTimeline } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
+import { Posts } from '@/lib/components/posts/posts'
+import { useLoadMoreOnVisible } from '@/lib/components/posts/useLoadMoreOnVisible'
+import { ScrollToTopButton } from '@/lib/components/scroll-to-top-button'
+import { Button } from '@/lib/components/ui/button'
+import { PostLineLimit } from '@/lib/types/database/rows'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { Status } from '@/lib/types/domain/status'
+import { ListEntity } from '@/lib/types/mastodon/list'
+
+interface ListTimelineProps {
+  host: string
+  list: ListEntity
+  memberCount: number
+  statuses: Status[]
+  currentTime: number
+  currentActor: ActorProfile
+  postLineLimit?: PostLineLimit
+}
+
+const listSubtitle = (list: ListEntity, memberCount: number) => {
+  const members = `${memberCount} member${memberCount === 1 ? '' : 's'}`
+  return `${members} · Replies: ${list.replies_policy}`
+}
+
+export const ListTimeline: FC<ListTimelineProps> = ({
+  host,
+  list,
+  memberCount,
+  statuses,
+  currentTime,
+  currentActor,
+  postLineLimit
+}) => {
+  const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
+  const [hasMoreStatuses, setHasMoreStatuses] = useState<boolean>(
+    statuses.length > 0
+  )
+  const [isLoadingMoreStatuses, setLoadingMoreStatuses] =
+    useState<boolean>(false)
+  const isLoadingRef = useRef<boolean>(false)
+  const lastStatusIdRef = useRef<string | null>(
+    statuses.length > 0 ? statuses[statuses.length - 1].id : null
+  )
+
+  const removeStatus = (status: Status) => {
+    setCurrentStatuses((previousStatuses) =>
+      previousStatuses.filter((item) => item.id !== status.id)
+    )
+  }
+
+  const loadMoreStatuses = useCallback(async () => {
+    const maxStatusId = lastStatusIdRef.current
+    if (isLoadingRef.current || !maxStatusId) return
+
+    isLoadingRef.current = true
+    setLoadingMoreStatuses(true)
+    try {
+      const result = await getListTimeline({
+        listId: list.id,
+        maxStatusId
+      })
+      if (result.statuses.length === 0) {
+        setHasMoreStatuses(false)
+        return
+      }
+      lastStatusIdRef.current = result.statuses[result.statuses.length - 1].id
+      setHasMoreStatuses(Boolean(result.nextMaxStatusId))
+      setCurrentStatuses((previousStatuses) => [
+        ...previousStatuses,
+        ...result.statuses
+      ])
+    } catch (_error) {
+      // Error loading more - user can retry by clicking the button
+    } finally {
+      isLoadingRef.current = false
+      setLoadingMoreStatuses(false)
+    }
+  }, [list.id])
+
+  const { loadMoreRef, isLoadMoreVisible } = useLoadMoreOnVisible({
+    enabled: hasMoreStatuses,
+    onLoadMore: loadMoreStatuses
+  })
+
+  return (
+    <div className="space-y-6">
+      <ScrollToTopButton
+        isLoadMoreVisible={hasMoreStatuses && isLoadMoreVisible}
+      />
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2">
+            <Link
+              href="/lists"
+              aria-label="Back to lists"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </Link>
+            <span className="truncate">{list.title}</span>
+          </span>
+        }
+        description={listSubtitle(list, memberCount)}
+        actions={
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/lists/${list.id}/edit`}>
+              <Pencil className="h-4 w-4" />
+              Edit
+            </Link>
+          </Button>
+        }
+      />
+
+      {currentStatuses.length > 0 ? (
+        <Posts
+          host={host}
+          currentTime={currentTime}
+          statuses={currentStatuses}
+          currentActor={currentActor}
+          showActions
+          postLineLimit={postLineLimit}
+          onPostDeleted={removeStatus}
+        />
+      ) : (
+        <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">
+          <h2 className="mb-2 text-xl font-semibold">No posts yet</h2>
+          <p>
+            Posts from this list&rsquo;s members will appear here. Add accounts
+            from the list settings to get started.
+          </p>
+        </div>
+      )}
+
+      {hasMoreStatuses && lastStatusIdRef.current && (
+        <div ref={loadMoreRef} className="text-center">
+          <Button
+            variant="outline"
+            disabled={isLoadingMoreStatuses}
+            onClick={loadMoreStatuses}
+          >
+            {isLoadingMoreStatuses ? 'Loading...' : 'Load more'}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(timeline)/lists/[id]/edit/page.tsx
+++ b/app/(timeline)/lists/[id]/edit/page.tsx
@@ -1,14 +1,13 @@
 import { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 
+import { ListEditor, ListMember } from '@/app/(timeline)/lists/ListEditor'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMastodonList } from '@/lib/services/mastodon/getMastodonList'
 import { Mastodon } from '@/lib/types/activitypub'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
-
-import { ListEditor, ListMember } from '../../ListEditor'
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
@@ -17,13 +16,19 @@ export const metadata: Metadata = {
 
 // Seed of followed accounts offered as add suggestions. The editor searches
 // within this loaded set, so keep it generous without unbounding the query.
+// (Full server-backed search across all follows is a follow-up.)
 const FOLLOWING_SUGGESTIONS_LIMIT = 200
+// Page size + safety cap for loading the full member list. We load every member
+// (not just the first page) so even large lists can be fully viewed and edited.
+const MEMBER_PAGE_LIMIT = 80
+const MAX_MEMBER_PAGES = 25
 
 interface PageProps {
   params: Promise<{ id: string }>
 }
 
 const toListMember = (account: Mastodon.Account, host: string): ListMember => ({
+  // Mastodon Account `id` (the `urlToId`-encoded actor id, not the raw URI).
   id: account.id,
   name: account.display_name || account.username,
   // `acct` is bare username for local accounts; qualify it with the instance
@@ -51,11 +56,22 @@ const Page = async ({ params }: PageProps) => {
     return notFound()
   }
 
-  const { accounts: memberAccounts } = await database.getListAccounts({
-    listId: id,
-    actorId: actor.id,
-    limit: 80
-  })
+  // Load every member, not just the first page, so a large list can still be
+  // fully viewed and edited. Paginate on the membership cursor with a safety cap.
+  const memberAccounts: Mastodon.Account[] = []
+  let memberCursor: string | null = null
+  for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
+    const { accounts, nextMaxId } = await database.getListAccounts({
+      listId: id,
+      actorId: actor.id,
+      limit: MEMBER_PAGE_LIMIT,
+      maxId: memberCursor
+    })
+    memberAccounts.push(...accounts)
+    if (accounts.length < MEMBER_PAGE_LIMIT || !nextMaxId) break
+    memberCursor = nextMaxId
+  }
+
   const follows = await database.getFollowing({
     actorId: actor.id,
     limit: FOLLOWING_SUGGESTIONS_LIMIT

--- a/app/(timeline)/lists/[id]/edit/page.tsx
+++ b/app/(timeline)/lists/[id]/edit/page.tsx
@@ -1,0 +1,81 @@
+import { Metadata } from 'next'
+import { notFound, redirect } from 'next/navigation'
+
+import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getMastodonList } from '@/lib/services/mastodon/getMastodonList'
+import { Mastodon } from '@/lib/types/activitypub'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { ListEditor, ListMember } from '../../ListEditor'
+
+export const dynamic = 'force-dynamic'
+export const metadata: Metadata = {
+  title: 'Activities.next: Edit list'
+}
+
+// Seed of followed accounts offered as add suggestions. The editor searches
+// within this loaded set, so keep it generous without unbounding the query.
+const FOLLOWING_SUGGESTIONS_LIMIT = 200
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+const toListMember = (account: Mastodon.Account, host: string): ListMember => ({
+  id: account.id,
+  name: account.display_name || account.username,
+  // `acct` is bare username for local accounts; qualify it with the instance
+  // host so members always render as a full @user@domain handle.
+  handle: account.acct.includes('@') ? account.acct : `${account.acct}@${host}`,
+  avatar: account.avatar
+})
+
+const Page = async ({ params }: PageProps) => {
+  const { host } = getConfig()
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor) {
+    return redirect('/auth/signin')
+  }
+
+  const { id } = await params
+  const list = await database.getList({ id, actorId: actor.id })
+  if (!list) {
+    return notFound()
+  }
+
+  const { accounts: memberAccounts } = await database.getListAccounts({
+    listId: id,
+    actorId: actor.id,
+    limit: 80
+  })
+  const follows = await database.getFollowing({
+    actorId: actor.id,
+    limit: FOLLOWING_SUGGESTIONS_LIMIT
+  })
+  const followingAccounts = await database.getMastodonActorsFromIds({
+    ids: follows.map((follow) => follow.targetActorId)
+  })
+
+  return (
+    <ListEditor
+      mode="edit"
+      list={getMastodonList(list)}
+      initialMembers={memberAccounts.map((account) =>
+        toListMember(account, host)
+      )}
+      followingSuggestions={followingAccounts.map((account) =>
+        toListMember(account, host)
+      )}
+    />
+  )
+}
+
+export default Page

--- a/app/(timeline)/lists/[id]/edit/page.tsx
+++ b/app/(timeline)/lists/[id]/edit/page.tsx
@@ -68,7 +68,10 @@ const Page = async ({ params }: PageProps) => {
       maxId: memberCursor
     })
     memberAccounts.push(...accounts)
-    if (accounts.length < MEMBER_PAGE_LIMIT || !nextMaxId) break
+    // Break on the membership-row cursor, not accounts.length: a full page can
+    // hydrate to fewer accounts when a member's actor row is missing, which
+    // would otherwise stop pagination early and drop later members.
+    if (!nextMaxId) break
     memberCursor = nextMaxId
   }
 

--- a/app/(timeline)/lists/[id]/page.tsx
+++ b/app/(timeline)/lists/[id]/page.tsx
@@ -1,0 +1,78 @@
+import { Metadata } from 'next'
+import { notFound, redirect } from 'next/navigation'
+
+import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getMastodonList } from '@/lib/services/mastodon/getMastodonList'
+import { getActorProfile } from '@/lib/types/domain/actor'
+import { cleanJson } from '@/lib/utils/cleanJson'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { ListTimeline } from './ListTimeline'
+
+export const dynamic = 'force-dynamic'
+
+interface PageProps {
+  params: Promise<{ id: string }>
+}
+
+export const generateMetadata = async ({
+  params
+}: PageProps): Promise<Metadata> => {
+  const database = getDatabase()
+  const session = await getServerAuthSession()
+  const actor = database ? await getActorFromSession(database, session) : null
+  if (!database || !actor) return { title: 'Activities.next: Lists' }
+
+  const { id } = await params
+  const list = await database.getList({ id, actorId: actor.id })
+  return {
+    title: list ? `Activities.next: ${list.title}` : 'Activities.next: Lists'
+  }
+}
+
+const Page = async ({ params }: PageProps) => {
+  const { host } = getConfig()
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor) {
+    return redirect('/auth/signin')
+  }
+
+  const { id } = await params
+  const list = await database.getList({ id, actorId: actor.id })
+  if (!list) {
+    return notFound()
+  }
+
+  const settings = await database.getActorSettings({ actorId: actor.id })
+  const statuses = await database.getListTimeline({
+    listId: id,
+    actorId: actor.id,
+    limit: 20
+  })
+  const counts = await database.getListAccountCounts({
+    actorId: actor.id,
+    listIds: [id]
+  })
+
+  return (
+    <ListTimeline
+      host={host}
+      list={getMastodonList(list)}
+      memberCount={counts[id] ?? 0}
+      statuses={statuses.map((status) => cleanJson(status))}
+      currentTime={Date.now()}
+      currentActor={getActorProfile(actor)}
+      postLineLimit={settings?.postLineLimit}
+    />
+  )
+}
+
+export default Page

--- a/app/(timeline)/lists/new/page.tsx
+++ b/app/(timeline)/lists/new/page.tsx
@@ -1,0 +1,30 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { ListEditor } from '../ListEditor'
+
+export const dynamic = 'force-dynamic'
+export const metadata: Metadata = {
+  title: 'Activities.next: New list'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor) {
+    return redirect('/auth/signin')
+  }
+
+  return <ListEditor mode="create" />
+}
+
+export default Page

--- a/app/(timeline)/lists/new/page.tsx
+++ b/app/(timeline)/lists/new/page.tsx
@@ -1,11 +1,10 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
+import { ListEditor } from '@/app/(timeline)/lists/ListEditor'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
-
-import { ListEditor } from '../ListEditor'
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {

--- a/app/(timeline)/lists/page.tsx
+++ b/app/(timeline)/lists/page.tsx
@@ -1,0 +1,63 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getMastodonList } from '@/lib/services/mastodon/getMastodonList'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import { ListSummary, ListsIndex } from './ListsIndex'
+
+export const dynamic = 'force-dynamic'
+export const metadata: Metadata = {
+  title: 'Activities.next: Lists'
+}
+
+// How many member avatars to preview per list row in the index. The design
+// shows a small stacked cluster, so a tight cap keeps the per-list fetch cheap.
+const PREVIEW_MEMBERS = 3
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor) {
+    return redirect('/auth/signin')
+  }
+
+  const lists = await database.getLists({ actorId: actor.id })
+  const counts = await database.getListAccountCounts({
+    actorId: actor.id,
+    listIds: lists.map((list) => list.id)
+  })
+
+  // Member counts are batched in one grouped query above; the avatar previews
+  // need the hydrated accounts, so fetch a tiny page per list. Lists are few
+  // per account, so this stays a small bounded number of queries.
+  const summaries: ListSummary[] = await Promise.all(
+    lists.map(async (list) => {
+      const { accounts } = await database.getListAccounts({
+        listId: list.id,
+        actorId: actor.id,
+        limit: PREVIEW_MEMBERS
+      })
+      return {
+        ...getMastodonList(list),
+        memberCount: counts[list.id] ?? 0,
+        previewMembers: accounts.map((account) => ({
+          id: account.id,
+          name: account.display_name || account.username,
+          avatar: account.avatar
+        }))
+      }
+    })
+  )
+
+  return <ListsIndex lists={summaries} />
+}
+
+export default Page

--- a/app/api/v1/timelines/list/[list_id]/route.test.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.test.ts
@@ -102,6 +102,27 @@ describe('GET /api/v1/timelines/list/[list_id]', () => {
     expect(link).toContain('rel="prev"')
   })
 
+  it('returns the activities_next domain shape when format=activities_next', async () => {
+    jest.spyOn(database, 'getListTimeline').mockResolvedValue([listStatus])
+
+    const response = await GET(request({ format: 'activities_next' }), {
+      params: Promise.resolve({ list_id: listId })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    // The web UI consumes { statuses, nextMaxStatusId, prevMinStatusId } with
+    // the internal Status shape (full URI ids), not Mastodon entities.
+    expect(data.statuses.map((status: { id: string }) => status.id)).toEqual([
+      listStatus.id
+    ])
+    expect(data.nextMaxStatusId).toBe(listStatus.id)
+    expect(data.prevMinStatusId).toBe(listStatus.id)
+    // The activities_next branch returns pagination in the body, not Link
+    // headers.
+    expect(response.headers.get('Link')).toBeNull()
+  })
+
   it('returns 404 for a non-existent list', async () => {
     const response = await GET(request(), {
       params: Promise.resolve({ list_id: 'does-not-exist' })

--- a/app/api/v1/timelines/list/[list_id]/route.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.ts
@@ -8,11 +8,13 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { TimelineFormat } from '@/lib/services/timelines/const'
 import {
   parseTimelineQuery,
   timelineErrorBoundary
 } from '@/lib/services/timelines/request'
 import { Scope } from '@/lib/types/database/operations'
+import { cleanJson } from '@/lib/utils/cleanJson'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -56,6 +58,7 @@ export const GET = traceApiRoute(
         }
 
         const url = new URL(req.url)
+        const format = url.searchParams.get('format')
         const parsedQuery = parseTimelineQuery(url.searchParams)
         if (!parsedQuery.ok) {
           return apiResponse({
@@ -81,6 +84,30 @@ export const GET = traceApiRoute(
           maxStatusId,
           minStatusId
         })
+
+        // The list timeline query returns domain statuses newest-first, so the
+        // last row is the next (older) page cursor and the first row is the
+        // previous (newer) page cursor — mirroring the Mastodon Link headers
+        // emitted below.
+        const nextMaxStatusId =
+          statuses.length > 0 ? statuses[statuses.length - 1].id : null
+        const prevMinStatusId = statuses.length > 0 ? statuses[0].id : null
+
+        // The Activities.next web UI consumes the internal domain Status shape
+        // (the same payload as the home timeline's activities_next format) so
+        // it can render with the shared <Posts> component. Default (no format)
+        // stays Mastodon-compatible: entities + Link headers, untouched below.
+        if (format === TimelineFormat.enum.activities_next) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: {
+              statuses: statuses.map((item) => cleanJson(item)),
+              nextMaxStatusId,
+              prevMinStatusId
+            }
+          })
+        }
 
         const mastodonStatuses = await getMastodonStatuses(
           database,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -14,6 +14,7 @@ import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import type { Translation } from '@/lib/types/mastodon/translation'
@@ -2550,4 +2551,156 @@ export const adminDeleteCustomEmoji = async (id: string): Promise<void> => {
     method: 'DELETE'
   })
   if (!response.ok) throw new Error('Failed to delete custom emoji')
+}
+
+// Lists (https://docs.joinmastodon.org/methods/lists/).
+// The user's curated timelines and their members. Every list call goes through
+// here so components never call fetch() directly. List ids are opaque strings
+// (UUIDs), so unlike status/account ids they are not url/id encoded.
+
+export interface ListParams {
+  title: string
+  repliesPolicy?: ListEntity['replies_policy']
+  exclusive?: boolean
+}
+
+const listRequestBody = ({ title, repliesPolicy, exclusive }: ListParams) => ({
+  title,
+  ...(repliesPolicy !== undefined ? { replies_policy: repliesPolicy } : {}),
+  ...(exclusive !== undefined ? { exclusive } : {})
+})
+
+export const createList = async (
+  params: ListParams
+): Promise<ListEntity | null> => {
+  const response = await fetch('/api/v1/lists', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(listRequestBody(params))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ListEntity
+}
+
+export interface UpdateListParams extends ListParams {
+  listId: string
+}
+
+export const updateList = async ({
+  listId,
+  ...params
+}: UpdateListParams): Promise<ListEntity | null> => {
+  const response = await fetch(`/api/v1/lists/${encodeURIComponent(listId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(listRequestBody(params))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ListEntity
+}
+
+export const deleteList = async (listId: string): Promise<boolean> => {
+  const response = await fetch(`/api/v1/lists/${encodeURIComponent(listId)}`, {
+    method: 'DELETE'
+  })
+  return response.ok
+}
+
+export interface ListAccountsMutationParams {
+  listId: string
+  accountIds: string[]
+}
+
+const mutateListAccounts = async (
+  method: 'POST' | 'DELETE',
+  { listId, accountIds }: ListAccountsMutationParams
+): Promise<boolean> => {
+  if (accountIds.length === 0) return true
+  const response = await fetch(
+    `/api/v1/lists/${encodeURIComponent(listId)}/accounts`,
+    {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ account_ids: accountIds.map((id) => urlToId(id)) })
+    }
+  )
+  return response.ok
+}
+
+export const addListAccounts = (
+  params: ListAccountsMutationParams
+): Promise<boolean> => mutateListAccounts('POST', params)
+
+export const removeListAccounts = (
+  params: ListAccountsMutationParams
+): Promise<boolean> => mutateListAccounts('DELETE', params)
+
+export interface GetListTimelineParams {
+  listId: string
+  minStatusId?: string
+  maxStatusId?: string
+  limit?: number
+}
+
+const getListTimelinePage = async ({
+  listId,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetListTimelineParams): Promise<GetTimelineResult> => {
+  const url = new URL(
+    `${window.origin}/api/v1/timelines/list/${encodeURIComponent(
+      listId
+    )}?format=${TimelineFormat.enum.activities_next}`
+  )
+  if (minStatusId) url.searchParams.set('min_id', urlToId(minStatusId))
+  if (maxStatusId) url.searchParams.set('max_id', urlToId(maxStatusId))
+  if (limit) url.searchParams.set('limit', `${limit}`)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxStatusId: null, prevMinStatusId: null }
+  }
+  const data = await response.json()
+  return {
+    statuses: data.statuses as Status[],
+    nextMaxStatusId: data.nextMaxStatusId ?? null,
+    prevMinStatusId: data.prevMinStatusId ?? null
+  }
+}
+
+export const getListTimeline = async ({
+  listId,
+  minStatusId,
+  maxStatusId,
+  limit
+}: GetListTimelineParams): Promise<GetTimelineResult> => {
+  let result = await getListTimelinePage({
+    listId,
+    minStatusId,
+    maxStatusId,
+    limit
+  })
+  let currentMaxStatusId = result.nextMaxStatusId
+  let continuations = 0
+
+  while (
+    result.statuses.length === 0 &&
+    currentMaxStatusId &&
+    continuations < MAX_EMPTY_TIMELINE_CONTINUATIONS
+  ) {
+    continuations++
+    result = await getListTimelinePage({
+      listId,
+      minStatusId,
+      maxStatusId: currentMaxStatusId,
+      limit
+    })
+    currentMaxStatusId = result.nextMaxStatusId
+  }
+
+  return result
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2621,7 +2621,9 @@ const mutateListAccounts = async (
     {
       method,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ account_ids: accountIds.map((id) => urlToId(id)) })
+      // accountIds are already Mastodon Account ids (the `urlToId`-encoded
+      // form); the route decodes them with `idToUrl`, so pass them through.
+      body: JSON.stringify({ account_ids: accountIds })
     }
   )
   return response.ok
@@ -2642,7 +2644,11 @@ export interface GetListTimelineParams {
   limit?: number
 }
 
-const getListTimelinePage = async ({
+// The list timeline does no server-side content filtering, so an empty page
+// always carries a null cursor (end of list). That's unlike the home timeline,
+// where filtered-out pages can still report a next cursor and need the
+// empty-continuation loop in getTimeline — here a single page fetch suffices.
+export const getListTimeline = async ({
   listId,
   minStatusId,
   maxStatusId,
@@ -2670,37 +2676,4 @@ const getListTimelinePage = async ({
     nextMaxStatusId: data.nextMaxStatusId ?? null,
     prevMinStatusId: data.prevMinStatusId ?? null
   }
-}
-
-export const getListTimeline = async ({
-  listId,
-  minStatusId,
-  maxStatusId,
-  limit
-}: GetListTimelineParams): Promise<GetTimelineResult> => {
-  let result = await getListTimelinePage({
-    listId,
-    minStatusId,
-    maxStatusId,
-    limit
-  })
-  let currentMaxStatusId = result.nextMaxStatusId
-  let continuations = 0
-
-  while (
-    result.statuses.length === 0 &&
-    currentMaxStatusId &&
-    continuations < MAX_EMPTY_TIMELINE_CONTINUATIONS
-  ) {
-    continuations++
-    result = await getListTimelinePage({
-      listId,
-      minStatusId,
-      maxStatusId: currentMaxStatusId,
-      limit
-    })
-    currentMaxStatusId = result.nextMaxStatusId
-  }
-
-  return result
 }

--- a/lib/components/layout/mobile-nav.test.tsx
+++ b/lib/components/layout/mobile-nav.test.tsx
@@ -102,6 +102,7 @@ describe('MobileNav', () => {
     // Settings.
     expect(names).toEqual([
       'Bookmarks',
+      'Lists',
       'Fitness',
       'Profile',
       'Admin',
@@ -119,6 +120,7 @@ describe('MobileNav', () => {
     const items = await screen.findAllByRole('menuitem')
     expect(items.map((item) => item.textContent?.trim())).toEqual([
       'Bookmarks',
+      'Lists',
       'Profile',
       'Admin',
       'Settings'
@@ -136,6 +138,7 @@ describe('MobileNav', () => {
     // No Admin entry, so Profile anchors directly before Settings.
     expect(items.map((item) => item.textContent?.trim())).toEqual([
       'Bookmarks',
+      'Lists',
       'Profile',
       'Settings'
     ])

--- a/lib/components/layout/nav-items.test.ts
+++ b/lib/components/layout/nav-items.test.ts
@@ -10,6 +10,7 @@ describe('buildNavItems', () => {
       '/search',
       '/messages',
       '/bookmarks',
+      '/lists',
       '/notifications',
       '/settings'
     ])
@@ -21,6 +22,7 @@ describe('buildNavItems', () => {
       '/search',
       '/messages',
       '/bookmarks',
+      '/lists',
       '/@llun@llun.test/fitness',
       '/notifications',
       '/settings'
@@ -33,6 +35,7 @@ describe('buildNavItems', () => {
       '/search',
       '/messages',
       '/bookmarks',
+      '/lists',
       '/notifications',
       '/admin',
       '/settings'
@@ -47,6 +50,7 @@ describe('buildNavItems', () => {
       '/search',
       '/messages',
       '/bookmarks',
+      '/lists',
       '/@llun@llun.test/fitness',
       '/notifications',
       '/admin',

--- a/lib/components/layout/nav-items.ts
+++ b/lib/components/layout/nav-items.ts
@@ -3,6 +3,7 @@ import {
   Bell,
   Bookmark,
   Home,
+  List,
   Mail,
   Search,
   Settings,
@@ -24,6 +25,7 @@ const baseNavItems: NavItem[] = [
   { href: '/search', label: 'Search', icon: Search },
   { href: '/messages', label: 'Messages', icon: Mail },
   { href: '/bookmarks', label: 'Bookmarks', icon: Bookmark },
+  { href: '/lists', label: 'Lists', icon: List },
   {
     href: '/notifications',
     label: 'Notifications',

--- a/lib/components/layout/sidebar.test.tsx
+++ b/lib/components/layout/sidebar.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+
+import { Sidebar } from '@/lib/components/layout/sidebar'
+
+const mockPathname = jest.fn(() => '/lists')
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname()
+}))
+
+jest.mock('@/lib/components/actor-switcher/ActorSwitcher', () => ({
+  ActorSwitcher: () => <div data-testid="actor-switcher" />
+}))
+
+const lists = [
+  { id: 'a', title: 'Running club' },
+  { id: 'b', title: 'Fediverse devs' }
+]
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue('/lists')
+  })
+
+  it('expands the Lists group into the user lists by default on a lists route', () => {
+    render(<Sidebar lists={lists} />)
+
+    const nav = screen.getAllByRole('navigation')[0]
+    expect(
+      within(nav).getByRole('link', { name: 'Running club' })
+    ).toHaveAttribute('href', '/lists/a')
+    expect(
+      within(nav).getByRole('link', { name: 'Fediverse devs' })
+    ).toHaveAttribute('href', '/lists/b')
+  })
+
+  it('collapses and re-expands the Lists group on toggle', () => {
+    render(<Sidebar lists={lists} />)
+
+    const nav = screen.getAllByRole('navigation')[0]
+    fireEvent.click(within(nav).getByRole('button', { name: 'Collapse lists' }))
+    expect(
+      within(nav).queryByRole('link', { name: 'Running club' })
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(within(nav).getByRole('button', { name: 'Expand lists' }))
+    expect(
+      within(nav).getByRole('link', { name: 'Running club' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders Lists as a plain link when the user has no lists', () => {
+    mockPathname.mockReturnValue('/')
+    render(<Sidebar lists={[]} />)
+
+    const nav = screen.getAllByRole('navigation')[0]
+    expect(within(nav).getByRole('link', { name: 'Lists' })).toHaveAttribute(
+      'href',
+      '/lists'
+    )
+    expect(
+      within(nav).queryByRole('button', { name: /lists/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   ActorInfo,
@@ -59,6 +59,13 @@ export function Sidebar({
   // Default the Lists group open whenever the user is inside it so the active
   // list is visible without an extra click; otherwise start collapsed.
   const [isListsOpen, setListsOpen] = useState(isListsSectionActive)
+
+  // Client-side navigation keeps the sidebar mounted, so the initial state
+  // above doesn't re-run. Re-open the group whenever the route enters the Lists
+  // section (the user can still collapse it manually afterwards).
+  useEffect(() => {
+    if (isListsSectionActive) setListsOpen(true)
+  }, [isListsSectionActive])
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useState } from 'react'
 
 import {
   ActorInfo,
@@ -26,6 +28,11 @@ interface User {
   avatarUrl?: string
 }
 
+export interface SidebarList {
+  id: string
+  title: string
+}
+
 interface SidebarProps {
   user?: User
   currentActor?: ActorInfo
@@ -33,6 +40,7 @@ interface SidebarProps {
   unreadCount?: number
   fitnessUrl?: string
   isAdmin?: boolean
+  lists?: SidebarList[]
 }
 
 export function Sidebar({
@@ -41,10 +49,16 @@ export function Sidebar({
   actors = [],
   unreadCount = 0,
   fitnessUrl,
-  isAdmin = false
+  isAdmin = false,
+  lists = []
 }: SidebarProps) {
   const pathname = usePathname()
   const allNavItems = buildNavItems({ fitnessUrl, isAdmin })
+  const isListsSectionActive =
+    pathname === '/lists' || pathname.startsWith('/lists/')
+  // Default the Lists group open whenever the user is inside it so the active
+  // list is visible without an extra click; otherwise start collapsed.
+  const [isListsOpen, setListsOpen] = useState(isListsSectionActive)
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'
@@ -65,6 +79,73 @@ export function Sidebar({
               const isActive =
                 pathname === item.href || pathname.startsWith(item.href + '/')
               const isNotifications = item.href === '/notifications'
+
+              // The Lists entry expands into the user's lists when they have
+              // any; otherwise it stays a plain link to the (empty) index.
+              if (item.href === '/lists' && lists.length > 0) {
+                return (
+                  <li key={item.href}>
+                    <div
+                      className={cn(
+                        'flex items-center rounded-lg text-sm font-medium transition-colors',
+                        isListsSectionActive
+                          ? 'text-primary'
+                          : 'text-muted-foreground'
+                      )}
+                    >
+                      <Link
+                        href={item.href}
+                        className={cn(
+                          'flex flex-1 items-center gap-3 rounded-lg px-3 py-2 transition-colors',
+                          !isListsSectionActive &&
+                            'hover:bg-muted hover:text-foreground'
+                        )}
+                      >
+                        <item.icon className="h-5 w-5" />
+                        {item.label}
+                      </Link>
+                      <button
+                        type="button"
+                        aria-label={
+                          isListsOpen ? 'Collapse lists' : 'Expand lists'
+                        }
+                        aria-expanded={isListsOpen}
+                        onClick={() => setListsOpen((open) => !open)}
+                        className="mr-1 rounded-md p-1 hover:bg-muted hover:text-foreground"
+                      >
+                        {isListsOpen ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
+                        )}
+                      </button>
+                    </div>
+                    {isListsOpen && (
+                      <ul className="mt-1 space-y-1 pl-7">
+                        {lists.map((list) => {
+                          const isListActive = pathname === `/lists/${list.id}`
+                          return (
+                            <li key={list.id}>
+                              <Link
+                                href={`/lists/${list.id}`}
+                                className={cn(
+                                  'block truncate rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                                  isListActive
+                                    ? 'bg-primary/10 text-primary'
+                                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                                )}
+                              >
+                                {list.title}
+                              </Link>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    )}
+                  </li>
+                )
+              }
+
               return (
                 <li key={item.href}>
                   <Link

--- a/lib/components/layout/sidebar.tsx
+++ b/lib/components/layout/sidebar.tsx
@@ -80,7 +80,10 @@ export function Sidebar({
           <Logo size="md" />
         </div>
 
-        <nav className="flex-1 px-3 pt-1">
+        {/* min-h-0 + overflow lets the nav scroll when a long Lists group (or
+            many nav items) would otherwise push the account switcher footer
+            below the fixed, full-height sidebar. */}
+        <nav className="min-h-0 flex-1 overflow-y-auto px-3 pt-1">
           <ul className="space-y-1">
             {allNavItems.map((item) => {
               const isActive =
@@ -214,7 +217,7 @@ export function Sidebar({
           <Logo showText={false} size="md" />
         </div>
 
-        <nav className="flex-1 pb-4">
+        <nav className="min-h-0 flex-1 overflow-y-auto pb-4">
           <ul className="space-y-2">
             {allNavItems.map((item) => {
               const isActive =

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -77,8 +77,16 @@ export const getSQLDatabase = (database: Knex): Database => {
   const listDatabase = ListSQLDatabaseMixin(
     database,
     (actorIds) => actorDatabase.getMastodonActors(actorIds),
+    // The list owner is the viewer, so constrain to statuses readable by them
+    // (visibleToActorId) and hydrate their action state (currentActorId). The
+    // visibility filter keeps a member's direct/non-public posts addressed to
+    // others out of the list timeline.
     (statusIds, currentActorId) =>
-      statusDatabase.getStatusesByIds({ statusIds, currentActorId })
+      statusDatabase.getStatusesByIds({
+        statusIds,
+        currentActorId,
+        visibleToActorId: currentActorId
+      })
   )
   const directConversationDatabase = DirectConversationSQLDatabaseMixin(
     database,

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -77,7 +77,8 @@ export const getSQLDatabase = (database: Knex): Database => {
   const listDatabase = ListSQLDatabaseMixin(
     database,
     (actorIds) => actorDatabase.getMastodonActors(actorIds),
-    (statusIds) => statusDatabase.getStatusesByIds({ statusIds })
+    (statusIds, currentActorId) =>
+      statusDatabase.getStatusesByIds({ statusIds, currentActorId })
   )
   const directConversationDatabase = DirectConversationSQLDatabaseMixin(
     database,

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -77,16 +77,11 @@ export const getSQLDatabase = (database: Knex): Database => {
   const listDatabase = ListSQLDatabaseMixin(
     database,
     (actorIds) => actorDatabase.getMastodonActors(actorIds),
-    // The list owner is the viewer, so constrain to statuses readable by them
-    // (visibleToActorId) and hydrate their action state (currentActorId). The
-    // visibility filter keeps a member's direct/non-public posts addressed to
-    // others out of the list timeline.
+    // currentActorId hydrates the viewer's action state. getListTimeline
+    // already enforces visibility on its own query (before LIMIT), so no
+    // visibleToActorId is needed here.
     (statusIds, currentActorId) =>
-      statusDatabase.getStatusesByIds({
-        statusIds,
-        currentActorId,
-        visibleToActorId: currentActorId
-      })
+      statusDatabase.getStatusesByIds({ statusIds, currentActorId })
   )
   const directConversationDatabase = DirectConversationSQLDatabaseMixin(
     database,

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -263,4 +263,63 @@ describe('ListDatabase', () => {
       expect(statuses.map((status) => status.id)).toContain(statusId)
     })
   })
+
+  it('counts members per list and scopes counts to the owner', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'other')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const other = await database.getActorFromUsername({
+        username: 'other',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !other) throw new Error('actors not created')
+
+      await database.createActor({
+        actorId: EXTERNAL_ACTORS[0].id,
+        username: EXTERNAL_ACTORS[0].username,
+        domain: EXTERNAL_ACTORS[0].domain,
+        followersUrl: EXTERNAL_ACTORS[0].followers_url,
+        inboxUrl: EXTERNAL_ACTORS[0].inbox_url,
+        sharedInboxUrl: EXTERNAL_ACTORS[0].inbox_url,
+        publicKey: 'remote-public-key',
+        createdAt: Date.now()
+      })
+
+      const populated = await database.createList({
+        actorId: owner.id,
+        title: 'Populated'
+      })
+      const empty = await database.createList({
+        actorId: owner.id,
+        title: 'Empty'
+      })
+      await database.addListAccounts({
+        listId: populated.id,
+        actorId: owner.id,
+        targetActorIds: [EXTERNAL_ACTORS[0].id]
+      })
+
+      const counts = await database.getListAccountCounts({
+        actorId: owner.id,
+        listIds: [populated.id, empty.id]
+      })
+      expect(counts).toEqual({ [populated.id]: 1, [empty.id]: 0 })
+
+      // Another owner sees no memberships for the same list ids.
+      const otherCounts = await database.getListAccountCounts({
+        actorId: other.id,
+        listIds: [populated.id, empty.id]
+      })
+      expect(otherCounts).toEqual({ [populated.id]: 0, [empty.id]: 0 })
+
+      // Empty input returns an empty map without a query.
+      expect(
+        await database.getListAccountCounts({ actorId: owner.id, listIds: [] })
+      ).toEqual({})
+    })
+  })
 })

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -317,6 +317,63 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('applies visibility before the limit so a hidden run cannot strand visible posts', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      // One visible post, then two newer non-visible posts. If visibility were
+      // applied only after LIMIT, fetching the newest two would yield only the
+      // hidden pair and return an empty page, stranding the visible post.
+      const visibleId = `${member.id}/statuses/0-visible`
+      await database.createNote({
+        id: visibleId,
+        url: visibleId,
+        actorId: member.id,
+        text: 'visible',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      for (const suffix of ['1-direct', '2-direct']) {
+        const directId = `${member.id}/statuses/${suffix}`
+        await database.createNote({
+          id: directId,
+          url: directId,
+          actorId: member.id,
+          text: 'hidden',
+          to: ['https://stranger.example/users/x'],
+          cc: []
+        })
+      }
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Limit list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      const statuses = await database.getListTimeline({
+        listId: list.id,
+        actorId: owner.id,
+        limit: 2
+      })
+      expect(statuses.map((status) => status.id)).toEqual([visibleId])
+    })
+  })
+
   it('hydrates the owner action state in the list timeline', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -264,6 +264,59 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('excludes member statuses the owner cannot see from the list timeline', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      const publicId = `${member.id}/statuses/public`
+      await database.createNote({
+        id: publicId,
+        url: publicId,
+        actorId: member.id,
+        text: 'public post',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      // A direct post addressed to someone other than the owner must not leak
+      // into the owner's list timeline.
+      const directId = `${member.id}/statuses/direct`
+      await database.createNote({
+        id: directId,
+        url: directId,
+        actorId: member.id,
+        text: 'secret to a stranger',
+        to: ['https://stranger.example/users/x'],
+        cc: []
+      })
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Visibility list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      const ids = (
+        await database.getListTimeline({ listId: list.id, actorId: owner.id })
+      ).map((status) => status.id)
+      expect(ids).toContain(publicId)
+      expect(ids).not.toContain(directId)
+    })
+  })
+
   it('hydrates the owner action state in the list timeline', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -264,6 +264,53 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('hydrates the owner action state in the list timeline', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      const statusId = `${member.id}/statuses/liked`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: member.id,
+        text: 'like me',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      // The owner has acted on the member's post; the list timeline must reflect
+      // it (the timeline is hydrated for the owner, who is the viewer).
+      await database.createLike({ actorId: owner.id, statusId })
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Action state list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      const statuses = await database.getListTimeline({
+        listId: list.id,
+        actorId: owner.id
+      })
+      const liked = statuses.find((status) => status.id === statusId)
+      expect(liked).toBeDefined()
+      expect((liked as { isActorLiked?: boolean }).isActorLiked).toBe(true)
+    })
+  })
+
   it('counts members per list and scopes counts to the owner', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -13,6 +13,7 @@ import {
   AddListAccountsParams,
   CreateListParams,
   DeleteListParams,
+  GetListAccountCountsParams,
   GetListAccountsParams,
   GetListParams,
   GetListTimelineParams,
@@ -171,6 +172,29 @@ export const ListSQLDatabaseMixin = (
       nextMaxId: rows.length > 0 ? (rows[rows.length - 1].id as string) : null,
       prevMinId: rows.length > 0 ? (rows[0].id as string) : null
     }
+  },
+
+  async getListAccountCounts({ actorId, listIds }: GetListAccountCountsParams) {
+    // Seed every requested list with 0 so callers can index the result without
+    // a missing-key check; lists with no members produce no grouped row below.
+    const counts: Record<string, number> = {}
+    for (const listId of listIds) counts[listId] = 0
+    if (listIds.length === 0) return counts
+
+    // Scope to the owner so this never counts another actor's memberships, and
+    // chunk the `whereIn` to stay under SQLite's bound-parameter limit.
+    for (const chunk of chunkArray(listIds, getWhereInBatchSize(database, 1))) {
+      const rows = await database('list_accounts')
+        .where({ actorId })
+        .whereIn('listId', chunk)
+        .groupBy('listId')
+        .select('listId')
+        .count<{ listId: string; count: string | number }[]>('* as count')
+      for (const row of rows) {
+        counts[row.listId as string] = Number(row.count)
+      }
+    }
+    return counts
   },
 
   async addListAccounts({

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -8,6 +8,7 @@ import {
   getInsertBatchSize,
   getWhereInBatchSize
 } from '@/lib/database/sql/utils/knex'
+import { applyPotentiallyReadableStatusFilter } from '@/lib/database/sql/utils/statusVisibility'
 import { Mastodon } from '@/lib/types/activitypub'
 import {
   AddListAccountsParams,
@@ -276,6 +277,18 @@ export const ListSQLDatabaseMixin = (
       // Scope to the owner defensively so a caller can never read another
       // actor's list timeline even if they know the listId.
       .andWhere('list_accounts.actorId', actorId)
+    // Apply the owner's visibility before LIMIT so the page counts only
+    // statuses they may read — a member's direct/non-public posts addressed to
+    // others never appear, and the limit isn't spent on rows that would be
+    // filtered out afterwards (which could otherwise cut a page short or halt
+    // pagination early). The filter is pure WHERE/EXISTS, so it composes with
+    // the join without changing row cardinality.
+    applyPotentiallyReadableStatusFilter({
+      database,
+      query,
+      visibleToActorId: actorId
+    })
+    query
       .orderBy('statuses.createdAt', 'desc')
       .orderBy('statuses.id', 'desc')
       .limit(limit)
@@ -316,10 +329,9 @@ export const ListSQLDatabaseMixin = (
     if (statusIds.length === 0) return []
     // getStatusesByIds preserves the input order (it re-maps results over the
     // requested ids), so the createdAt-desc ordering established above is kept.
-    // The list owner is the viewer: passing their id applies the visibility
-    // filter (so a member's non-public posts addressed to others stay out) and
-    // hydrates their action state (isActorLiked/isActorBookmarked/announce) —
-    // without it the timeline would leak posts and render every one un-acted.
+    // Visibility is already enforced on the query above; pass the owner here so
+    // their action state (isActorLiked/isActorBookmarked/announce) is hydrated —
+    // otherwise the timeline would render every post as un-acted.
     return getStatusesByIds(statusIds, actorId)
   }
 })

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -316,9 +316,10 @@ export const ListSQLDatabaseMixin = (
     if (statusIds.length === 0) return []
     // getStatusesByIds preserves the input order (it re-maps results over the
     // requested ids), so the createdAt-desc ordering established above is kept.
-    // The list owner is the viewer, so hydrate per-actor action state
-    // (isActorLiked/isActorBookmarked/actorAnnounceStatusId) for them — without
-    // it the timeline would render every post as un-liked/un-bookmarked.
+    // The list owner is the viewer: passing their id applies the visibility
+    // filter (so a member's non-public posts addressed to others stay out) and
+    // hydrates their action state (isActorLiked/isActorBookmarked/announce) —
+    // without it the timeline would leak posts and render every one un-acted.
     return getStatusesByIds(statusIds, actorId)
   }
 })

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -49,7 +49,10 @@ const fixListRow = (row: SQLList): List => ({
 export const ListSQLDatabaseMixin = (
   database: Knex,
   getMastodonActors: (actorIds: string[]) => Promise<Mastodon.Account[]>,
-  getStatusesByIds: (statusIds: string[]) => Promise<Status[]>
+  getStatusesByIds: (
+    statusIds: string[],
+    currentActorId?: string
+  ) => Promise<Status[]>
 ): ListDatabase => ({
   async createList({
     actorId,
@@ -313,6 +316,9 @@ export const ListSQLDatabaseMixin = (
     if (statusIds.length === 0) return []
     // getStatusesByIds preserves the input order (it re-maps results over the
     // requested ids), so the createdAt-desc ordering established above is kept.
-    return getStatusesByIds(statusIds)
+    // The list owner is the viewer, so hydrate per-actor action state
+    // (isActorLiked/isActorBookmarked/actorAnnounceStatusId) for them — without
+    // it the timeline would render every post as un-liked/un-bookmarked.
+    return getStatusesByIds(statusIds, actorId)
   }
 })

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1265,6 +1265,10 @@ export type GetListsWithAccountParams = {
   actorId: string
   targetActorId: string
 }
+export type GetListAccountCountsParams = {
+  actorId: string
+  listIds: string[]
+}
 export type GetListTimelineParams = {
   listId: string
   actorId: string
@@ -1280,6 +1284,11 @@ export interface ListDatabase {
   getLists(params: GetListsParams): Promise<List[]>
   deleteList(params: DeleteListParams): Promise<boolean>
   getListAccounts(params: GetListAccountsParams): Promise<ListAccountsPage>
+  // Member counts keyed by list id for the supplied lists. Lists with no
+  // members are present in the result with a count of 0.
+  getListAccountCounts(
+    params: GetListAccountCountsParams
+  ): Promise<Record<string, number>>
   addListAccounts(params: AddListAccountsParams): Promise<void>
   removeListAccounts(params: RemoveListAccountsParams): Promise<void>
   getListsWithAccount(params: GetListsWithAccountParams): Promise<List[]>


### PR DESCRIPTION
## Summary

Builds the **Lists** feature UI on top of the existing Mastodon-compatible lists API (added in #838). Curated timelines are now a first-class surface: an index of lists, a per-list timeline view, and a create/edit screen with member management — aligned with the design system mockups.

### What's included

- **`/lists` index** — header + "New list" action, one row per list with a member count, member-avatar preview, and chevron. Empty state when you have no lists.
- **`/lists/[id]` timeline** — back arrow + list title + `N members · Replies: <policy>` subtitle + Edit action, rendering the list timeline with the shared `<Posts>` component (load-more, scroll-to-top).
- **`/lists/new` + `/lists/[id]/edit`** — shared `ListEditor`: list name, replies policy, "Hide members from Home" toggle, and (edit mode) member management — search accounts you follow, add from suggestions, remove members (changes apply immediately), plus Delete list.
- **Sidebar** — expandable **Lists** group listing the user's lists with active highlighting. Lists is added to `buildNavItems`, so it also appears in the tablet icon rail and the mobile "More" overflow.

### Supporting changes

- **`lib/client.ts`** — `createList` / `updateList` / `deleteList`, `addListAccounts` / `removeListAccounts`, and `getListTimeline`. (Index/timeline/editor pages read via `database.*` server-side, so no extra client fetchers were kept.)
- **List timeline route** — now supports `format=activities_next`, returning the internal `{ statuses, nextMaxStatusId, prevMinStatusId }` shape so the web UI can reuse `<Posts>`. **Default (no `format`) is unchanged**: Mastodon entities + Link headers.
- **`getListAccountCounts`** — batched per-list member counts (one grouped, owner-scoped query) for the index rows and the timeline header.

### Notes for reviewers

- **Settings the existing API stores but the #838 timeline query does not yet honor** (out of scope for this UI PR — backend follow-ups): **`exclusive` ("Hide members from Home")** is persisted but the home timeline doesn't yet consult list memberships, so the toggle saves intent without changing Home; **`replies_policy`** ("Include replies from list members to") is persisted but `getListTimeline` doesn't yet filter replies by policy. Both are standard Mastodon List fields shown in the design mock, so they're surfaced now and wired into the timeline query later.
- **List timelines are not yet block/mute/keyword-filtered** — `getListTimeline` (#838) joins members' statuses directly; the default Mastodon-format path shares this gap. Filter parity with the home timeline is a backend follow-up, not changed here.
- The member editor's "Search accounts you follow" filters a server-provided seed of recently-followed accounts (`FOLLOWING_SUGGESTIONS_LIMIT = 200`); the `/following` API paginates rather than name-searches, so the seed is capped deliberately.

## Testing

- `yarn run prettier --check`, `yarn lint`, `yarn build`, `yarn test` — all green (3788 tests).
- New tests: `getListAccountCounts` (DB), list-timeline `activities_next` format (route), `ListTimeline` (hydration regression + load-more + header), `ListEditor` (create/validation/add/remove/save), `ListsIndex`, `Sidebar` Lists expansion, and updated nav-items / mobile-nav ordering.
- Browser-verified the index, timeline, editor, create, and mobile views against the design mockups (signed-in local SQLite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the Lists UI: an index, per-list timeline, and create/edit screens with member management, making curated timelines a first-class surface. Adds a sidebar Lists group and reuses the shared `Posts` component for list timelines.

- **New Features**
  - Lists index at `/lists` with member counts, avatar previews, and “Hidden from Home” indicator when exclusive; empty state and “New list” action.
  - List timeline at `/lists/[id]` with header (N members · Replies policy), Edit link, load more, and scroll-to-top.
  - List editor at `/lists/new` and `/lists/[id]/edit`: name, replies policy, “Hide members from Home” toggle (persists intent; Home filter not wired yet), member add/remove with follow-based suggestions, and delete.
  - Sidebar: expandable Lists group showing the user’s lists with active highlighting; `Lists` added to nav items (tablet rail and mobile overflow).
  - API: list timeline route supports `format=activities_next` to return `{ statuses, nextMaxStatusId, prevMinStatusId }` for the web UI; default Mastodon entity response with Link headers is unchanged.
  - Data helpers: `lib/client` methods for create/update/delete lists, add/remove accounts, and list timeline fetching; batched `getListAccountCounts` for per-list member counts.

- **Bug Fixes**
  - List timeline respects visibility for the owner and hydrates action state (likes/bookmarks/reposts), preventing non-public posts addressed to others from appearing and showing correct button state.
  - ListEditor error handling: create/update/add/remove/delete now show inline errors and re-enable buttons; member search has an aria-label.
  - Sidebar re-opens the Lists group when navigating into `/lists/*`; nav is scrollable so long Lists groups don’t push items off-screen.
  - Edit page loads all members via bounded pagination and breaks on the membership cursor, so large lists and orphaned rows don’t drop later members.
  - `lib/client`: send list account ids as-is (they are Mastodon Account ids); simplify list timeline to a single-page fetch since the server doesn’t content-filter results.

<sup>Written for commit 184984de1db67aeba1ede753dc81eef40efeffc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/llun/activities.next/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

