### PR TITLE
minor: honor list replies_policy in list timeline

### DIFF
--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -5,6 +5,8 @@ import {
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
 import { EXTERNAL_ACTORS, TEST_DOMAIN } from '@/lib/stub/const'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { ListRepliesPolicy } from '@/lib/types/domain/list'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 const withFreshDatabase = async (
@@ -28,6 +30,124 @@ const createLocalAccount = (database: Database, username: string) =>
     privateKey: `privateKey-${username}`,
     publicKey: `publicKey-${username}`
   })
+
+// Replies-policy scenarios: a list member (memberFollowed) authors one reply of
+// each kind. The PARENT's author is what the policy filters on.
+type ReplyScenario =
+  | 'nonReply'
+  | 'selfReply'
+  | 'replyToOwner'
+  | 'replyToMember'
+  | 'replyToFollowed'
+  | 'replyToStranger'
+  | 'replyToAbsent'
+
+const ALL_REPLY_SCENARIOS: ReplyScenario[] = [
+  'nonReply',
+  'selfReply',
+  'replyToOwner',
+  'replyToMember',
+  'replyToFollowed',
+  'replyToStranger',
+  'replyToAbsent'
+]
+
+const setupRepliesPolicyFixture = async (
+  database: Database,
+  repliesPolicy: ListRepliesPolicy
+) => {
+  for (const username of [
+    'owner',
+    'memberFollowed',
+    'memberUnfollowed',
+    'followedNonMember',
+    'stranger'
+  ]) {
+    await createLocalAccount(database, username)
+  }
+  const actor = async (username: string) => {
+    const found = await database.getActorFromUsername({
+      username,
+      domain: TEST_DOMAIN
+    })
+    if (!found) throw new Error(`${username} not created`)
+    return found
+  }
+  const owner = await actor('owner')
+  const memberFollowed = await actor('memberFollowed')
+  const memberUnfollowed = await actor('memberUnfollowed')
+  const followedNonMember = await actor('followedNonMember')
+  const stranger = await actor('stranger')
+
+  // Owner follows memberFollowed and followedNonMember (Accepted).
+  for (const target of [memberFollowed, followedNonMember]) {
+    await database.createFollow({
+      actorId: owner.id,
+      targetActorId: target.id,
+      status: FollowStatus.enum.Accepted,
+      inbox: `${target.id}/inbox`,
+      sharedInbox: `${target.id}/inbox`
+    })
+  }
+
+  const note = async (actorId: string, localId: string, reply = '') => {
+    const id = `${actorId}/statuses/${localId}`
+    await database.createNote({
+      id,
+      url: id,
+      actorId,
+      text: 'reply policy candidate',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      reply
+    })
+    return id
+  }
+
+  // Parent statuses authored by each kind of actor.
+  const parentSelf = await note(memberFollowed.id, 'parent-self')
+  const parentOwner = await note(owner.id, 'parent-owner')
+  const parentMember = await note(memberUnfollowed.id, 'parent-member')
+  const parentFollowed = await note(followedNonMember.id, 'parent-followed')
+  const parentStranger = await note(stranger.id, 'parent-stranger')
+  const absentParent = `https://nowhere.${TEST_DOMAIN}/statuses/missing`
+
+  // Reply candidates, all authored by a list member so they reach the join.
+  const ids: Record<ReplyScenario, string> = {
+    nonReply: await note(memberFollowed.id, 'non-reply'),
+    selfReply: await note(memberFollowed.id, 'self-reply', parentSelf),
+    replyToOwner: await note(memberFollowed.id, 'reply-owner', parentOwner),
+    replyToMember: await note(memberFollowed.id, 'reply-member', parentMember),
+    replyToFollowed: await note(
+      memberFollowed.id,
+      'reply-followed',
+      parentFollowed
+    ),
+    replyToStranger: await note(
+      memberFollowed.id,
+      'reply-stranger',
+      parentStranger
+    ),
+    replyToAbsent: await note(memberFollowed.id, 'reply-absent', absentParent)
+  }
+
+  const list = await database.createList({
+    actorId: owner.id,
+    title: 'Reply policy list',
+    repliesPolicy
+  })
+  await database.addListAccounts({
+    listId: list.id,
+    actorId: owner.id,
+    targetActorIds: [memberFollowed.id, memberUnfollowed.id]
+  })
+
+  const timeline = await database.getListTimeline({
+    listId: list.id,
+    actorId: owner.id
+  })
+  return { ids, timelineIds: new Set(timeline.map((status) => status.id)) }
+}
 
 describe('ListDatabase', () => {
   const table = getTestDatabaseTable()
@@ -479,4 +599,25 @@ describe('ListDatabase', () => {
       ).toEqual({})
     })
   })
+
+  it.each([
+    ['none', ['nonReply', 'selfReply', 'replyToOwner']],
+    ['list', ['nonReply', 'selfReply', 'replyToOwner', 'replyToMember']],
+    ['followed', ['nonReply', 'selfReply', 'replyToOwner', 'replyToFollowed']]
+  ] as [ListRepliesPolicy, ReplyScenario[]][])(
+    'honors repliesPolicy=%s in the list timeline',
+    async (repliesPolicy, visibleScenarios) => {
+      await withFreshDatabase(async (database) => {
+        const { ids, timelineIds } = await setupRepliesPolicyFixture(
+          database,
+          repliesPolicy
+        )
+        for (const scenario of ALL_REPLY_SCENARIOS) {
+          expect(timelineIds.has(ids[scenario])).toBe(
+            visibleScenarios.includes(scenario)
+          )
+        }
+      })
+    }
+  )
 })

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -8,6 +8,7 @@ import {
   getInsertBatchSize,
   getWhereInBatchSize
 } from '@/lib/database/sql/utils/knex'
+import { applyListRepliesPolicyFilter } from '@/lib/database/sql/utils/listRepliesPolicy'
 import { applyPotentiallyReadableStatusFilter } from '@/lib/database/sql/utils/statusVisibility'
 import { Mastodon } from '@/lib/types/activitypub'
 import {
@@ -24,7 +25,7 @@ import {
   RemoveListAccountsParams,
   UpdateListParams
 } from '@/lib/types/database/operations'
-import { List } from '@/lib/types/domain/list'
+import { List, ListRepliesPolicy } from '@/lib/types/domain/list'
 import { Status } from '@/lib/types/domain/status'
 
 type SQLList = {
@@ -267,6 +268,15 @@ export const ListSQLDatabaseMixin = (
     maxStatusId,
     minStatusId
   }: GetListTimelineParams) {
+    // The list's replies_policy governs which replies appear. Default to 'list'
+    // (Mastodon's default) when the row is missing so behaviour is well-defined.
+    const listRow = await database('lists')
+      .where('id', listId)
+      .andWhere('actorId', actorId)
+      .first<{ repliesPolicy: string | null }>()
+    const repliesPolicy = (listRow?.repliesPolicy ??
+      'list') as ListRepliesPolicy
+
     const query = database('statuses')
       .innerJoin(
         'list_accounts',
@@ -287,6 +297,14 @@ export const ListSQLDatabaseMixin = (
       database,
       query,
       visibleToActorId: actorId
+    })
+    // Honour the list's replies_policy on the same pre-LIMIT pass.
+    applyListRepliesPolicyFilter({
+      database,
+      query,
+      repliesPolicy,
+      listId,
+      ownerId: actorId
     })
     query
       .orderBy('statuses.createdAt', 'desc')

--- a/lib/database/sql/utils/listRepliesPolicy.ts
+++ b/lib/database/sql/utils/listRepliesPolicy.ts
@@ -1,0 +1,110 @@
+import { Knex } from 'knex'
+
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { ListRepliesPolicy } from '@/lib/types/domain/list'
+
+// Enforce a list's Mastodon "replies_policy" on a list-timeline query, applied
+// as a pure WHERE so it composes with the existing visibility filter and runs
+// BEFORE LIMIT. https://docs.joinmastodon.org/entities/List/#replies_policy
+//
+// Mirrors FeedManager#filter_from_list?: a status always passes when it is not
+// a reply, when it is a self-reply (thread continuation), or when it replies to
+// the list owner. Only the *remaining* replies are governed by the policy:
+//   - 'none':     no further replies are shown.
+//   - 'list':     show replies whose parent author is also a list member.
+//   - 'followed': show replies whose parent author the owner follows.
+// A reply whose parent is not stored locally (e.g. a reply to a remote post we
+// never fetched) has no resolvable parent author, so it is treated as neither a
+// member nor followed and is filtered out under every policy.
+export const applyListRepliesPolicyFilter = ({
+  database,
+  query,
+  repliesPolicy,
+  listId,
+  ownerId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  repliesPolicy: ListRepliesPolicy
+  listId: string
+  ownerId: string
+}) => {
+  // Match the parent status by its id, or by its url (with the indexed hash) so
+  // replies that reference the parent's url resolve too — same dual lookup the
+  // visibility filter and resolveParentStatusIdByReply use.
+  const applyParentReference = (
+    builder: Knex.QueryBuilder,
+    referenceColumn: string,
+    referenceHashColumn?: string
+  ) => {
+    if (referenceHashColumn) {
+      builder.whereRaw('?? = ??', ['statuses.replyHash', referenceHashColumn])
+    }
+    builder.whereRaw('?? = ??', ['statuses.reply', referenceColumn])
+  }
+
+  // Author conditions that let a reply through given a resolved parent row.
+  const applyPermittedParentAuthor = (builder: Knex.QueryBuilder) => {
+    builder.where((authorQb) => {
+      authorQb
+        // Self-reply: parent author is the reply author (thread continuation).
+        .whereRaw('?? = ??', [
+          'reply_policy_parent.actorId',
+          'statuses.actorId'
+        ])
+        // Reply addressed to the list owner.
+        .orWhere('reply_policy_parent.actorId', ownerId)
+
+      if (repliesPolicy === 'list') {
+        authorQb.orWhereExists(function () {
+          this.select(database.raw('1'))
+            .from('list_accounts as reply_policy_members')
+            .where('reply_policy_members.listId', listId)
+            .where('reply_policy_members.actorId', ownerId)
+            .whereRaw('?? = ??', [
+              'reply_policy_members.targetActorId',
+              'reply_policy_parent.actorId'
+            ])
+        })
+      } else if (repliesPolicy === 'followed') {
+        authorQb.orWhereExists(function () {
+          this.select(database.raw('1'))
+            .from('follows as reply_policy_follows')
+            .where('reply_policy_follows.actorId', ownerId)
+            .where('reply_policy_follows.status', FollowStatus.enum.Accepted)
+            .whereRaw('?? = ??', [
+              'reply_policy_follows.targetActorId',
+              'reply_policy_parent.actorId'
+            ])
+        })
+      }
+      // 'none': only self-replies and replies to the owner pass.
+    })
+  }
+
+  const applyPermittedReplyExists = (
+    builder: Knex.QueryBuilder,
+    referenceColumn: string,
+    referenceHashColumn?: string
+  ) => {
+    builder.select(database.raw('1')).from('statuses as reply_policy_parent')
+    applyParentReference(builder, referenceColumn, referenceHashColumn)
+    applyPermittedParentAuthor(builder)
+  }
+
+  return query.where((qb) => {
+    // Non-replies always pass.
+    qb.where('statuses.reply', '')
+      .orWhereNull('statuses.reply')
+      .orWhereExists(function () {
+        applyPermittedReplyExists(this, 'reply_policy_parent.id')
+      })
+      .orWhereExists(function () {
+        applyPermittedReplyExists(
+          this,
+          'reply_policy_parent.url',
+          'reply_policy_parent.urlHash'
+        )
+      })
+  })
+}


### PR DESCRIPTION
## What

Enforces each list's Mastodon `replies_policy` (`followed` | `list` | `none`) in the list timeline. This is **PR1 of the backend follow-ups deferred in [#907](https://github.com/llun/activities.next/pull/907)** — `replies_policy` was persisted and surfaced in the editor there, but the timeline query ignored it, so the setting stored intent only.

## How

- New `applyListRepliesPolicyFilter` in `lib/database/sql/utils/listRepliesPolicy.ts`, applied in `getListTimeline` as a pure pre-LIMIT `WHERE`, **after** the existing visibility filter (so the page still counts only rows the owner will actually see, and pagination can't be cut short).
- Mirrors Mastodon `FeedManager#filter_from_list?`:
  - Non-replies, **self-replies** (thread continuations), and **replies to the list owner** always pass.
  - Only the *remaining* replies are governed by the policy: `none` shows none, `list` shows replies whose parent author is a fellow list member, `followed` shows replies whose parent author the owner follows.

## Reviewer notes

- **No denormalized in-reply-to actor.** Statuses store only `reply` (the parent URI) + `replyHash`, not an in-reply-to account id. So the filter resolves the parent `statuses` row by `id` **and** by `url`+`urlHash` (the same dual lookup the visibility filter and `resolveParentStatusIdByReply` use).
- **Both formats covered.** The route `app/api/v1/timelines/list/[list_id]` fetches through the single `getListTimeline` path for both the default Mastodon format and `format=activities_next`, so this fixes both at once.
- **Known limitation:** a reply whose parent isn't stored locally (e.g. a reply to a never-federated remote post) has no resolvable parent author and is filtered out under every policy. This also means a *remote* member's self-reply drops if its parent wasn't federated here — even under `none`, where Mastodon would keep it. The eventual cleanup is denormalizing `inReplyToActorId` at insert time (a schema change with backfill), which would also simplify the later block/mute follow-up; out of scope here.

## Follow-ups (rest of the deferred plan, separate PRs)

- PR2: `exclusive` ("hide list members from Home") — read-time filter on the home query.
- PR3: block/mute parity for `getListTimeline`.
- PR4: stale-cursor fix + keyword filtering.

## Verification

`prettier` / `lint` (0 errors) / `build` / `test` all green — **458 suites, 3859 tests passing**. No migration touched, so no schema-dump regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)