### PR TITLE
Bump version to v1.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.52.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.51.0`
- Base main SHA: `b1e61ea98e60d66e7b3e948958e88628fb0e3660`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
