### PR TITLE
minor: honor exclusive lists in the home timeline

### DIFF
--- a/lib/database/sql/timeline.test.ts
+++ b/lib/database/sql/timeline.test.ts
@@ -443,6 +443,220 @@ describe('TimelineDatabase', () => {
           expect(statuses.map((status) => status.id)).toContain(tiedStatusId)
         }, 10000)
       })
+
+      describe('exclusive lists', () => {
+        const OWNER = `https://${TEST_DOMAIN}/users/excl-owner`
+        const OTHER_OWNER = `https://${TEST_DOMAIN}/users/excl-other-owner`
+        const EXCL_MEMBER = `https://${TEST_DOMAIN}/users/excl-member`
+        const NORMAL_MEMBER = `https://${TEST_DOMAIN}/users/excl-normal`
+        const PLAIN = `https://${TEST_DOMAIN}/users/excl-plain`
+
+        const account = (username: string) =>
+          database.createAccount({
+            email: `${username}@${TEST_DOMAIN}`,
+            username,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: `privateKey-${username}`,
+            publicKey: `publicKey-${username}`
+          })
+
+        const seed = async (
+          authorId: string,
+          localId: string,
+          timeline: Timeline,
+          ownerId = OWNER
+        ) => {
+          const id = `${authorId}/statuses/${localId}`
+          const status = await database.createNote({
+            id,
+            url: id,
+            actorId: authorId,
+            text: `exclusive ${localId}`,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: []
+          })
+          await database.createTimelineStatus({
+            actorId: ownerId,
+            status,
+            timeline
+          })
+          return id
+        }
+
+        beforeAll(async () => {
+          await account('excl-owner')
+          await account('excl-other-owner')
+          await account('excl-member')
+          await account('excl-normal')
+          await account('excl-plain')
+
+          const exclusiveList = await database.createList({
+            actorId: OWNER,
+            title: 'Exclusive',
+            exclusive: true
+          })
+          await database.addListAccounts({
+            listId: exclusiveList.id,
+            actorId: OWNER,
+            targetActorIds: [EXCL_MEMBER]
+          })
+          const normalList = await database.createList({
+            actorId: OWNER,
+            title: 'Normal',
+            exclusive: false
+          })
+          await database.addListAccounts({
+            listId: normalList.id,
+            actorId: OWNER,
+            targetActorIds: [NORMAL_MEMBER]
+          })
+        })
+
+        it('hides exclusive-list members from the home timeline', async () => {
+          const exclId = await seed(EXCL_MEMBER, 'home-excl', Timeline.MAIN)
+          const normalId = await seed(
+            NORMAL_MEMBER,
+            'home-normal',
+            Timeline.MAIN
+          )
+          const plainId = await seed(PLAIN, 'home-plain', Timeline.MAIN)
+
+          const ids = (
+            await database.getTimeline({
+              timeline: Timeline.MAIN,
+              actorId: OWNER
+            })
+          ).map((status) => status.id)
+
+          expect(ids).not.toContain(exclId)
+          expect(ids).toContain(normalId)
+          expect(ids).toContain(plainId)
+        })
+
+        it('hides exclusive-list members from the no-announce timeline', async () => {
+          const exclId = await seed(
+            EXCL_MEMBER,
+            'noann-excl',
+            Timeline.NOANNOUNCE
+          )
+          const plainId = await seed(PLAIN, 'noann-plain', Timeline.NOANNOUNCE)
+
+          const ids = (
+            await database.getTimeline({
+              timeline: Timeline.NOANNOUNCE,
+              actorId: OWNER
+            })
+          ).map((status) => status.id)
+
+          expect(ids).not.toContain(exclId)
+          expect(ids).toContain(plainId)
+        })
+
+        it('still shows exclusive-list members in mention and direct timelines', async () => {
+          const mentionId = await seed(
+            EXCL_MEMBER,
+            'mention-excl',
+            Timeline.MENTION
+          )
+          const directId = await seed(
+            EXCL_MEMBER,
+            'direct-excl',
+            Timeline.DIRECT
+          )
+
+          const mentionIds = (
+            await database.getTimeline({
+              timeline: Timeline.MENTION,
+              actorId: OWNER
+            })
+          ).map((status) => status.id)
+          const directIds = (
+            await database.getTimeline({
+              timeline: Timeline.DIRECT,
+              actorId: OWNER
+            })
+          ).map((status) => status.id)
+
+          expect(mentionIds).toContain(mentionId)
+          expect(directIds).toContain(directId)
+        })
+
+        it("does not apply another owner's exclusive list to this viewer", async () => {
+          // OTHER_OWNER marks EXCL_MEMBER exclusive on their own list; OWNER, who
+          // has no such list for this author, must still see them at home.
+          const otherList = await database.createList({
+            actorId: OTHER_OWNER,
+            title: 'Other exclusive',
+            exclusive: true
+          })
+          await database.addListAccounts({
+            listId: otherList.id,
+            actorId: OTHER_OWNER,
+            targetActorIds: [PLAIN]
+          })
+
+          const plainId = await seed(PLAIN, 'home-cross-owner', Timeline.MAIN)
+
+          const ids = (
+            await database.getTimeline({
+              timeline: Timeline.MAIN,
+              actorId: OWNER
+            })
+          ).map((status) => status.id)
+
+          expect(ids).toContain(plainId)
+        })
+
+        it('reflects exclusive toggles on already-stored statuses at read time', async () => {
+          // Read-time filtering (vs fan-out) must retroactively hide/show posts
+          // that are already in the timelines table when `exclusive` is toggled.
+          const TOGGLE_MEMBER = `https://${TEST_DOMAIN}/users/excl-toggle`
+          await account('excl-toggle')
+          const list = await database.createList({
+            actorId: OWNER,
+            title: 'Toggle',
+            exclusive: false
+          })
+          await database.addListAccounts({
+            listId: list.id,
+            actorId: OWNER,
+            targetActorIds: [TOGGLE_MEMBER]
+          })
+
+          const toggleId = await seed(
+            TOGGLE_MEMBER,
+            'home-toggle',
+            Timeline.MAIN
+          )
+          const homeIds = async () =>
+            (
+              await database.getTimeline({
+                timeline: Timeline.MAIN,
+                actorId: OWNER
+              })
+            ).map((status) => status.id)
+
+          // Non-exclusive: visible.
+          expect(await homeIds()).toContain(toggleId)
+
+          // Flip exclusive on: the already-stored status disappears.
+          await database.updateList({
+            id: list.id,
+            actorId: OWNER,
+            exclusive: true
+          })
+          expect(await homeIds()).not.toContain(toggleId)
+
+          // Flip it back off: the same row reappears, no re-fan-out needed.
+          await database.updateList({
+            id: list.id,
+            actorId: OWNER,
+            exclusive: false
+          })
+          expect(await homeIds()).toContain(toggleId)
+        })
+      })
     })
   })
 })

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex'
 
 import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { applyExclusiveListFilter } from '@/lib/database/sql/utils/exclusiveLists'
 import { Timeline } from '@/lib/services/timelines/types'
 import { StatusDatabase } from '@/lib/types/database/operations'
 import {
@@ -126,6 +127,17 @@ export const TimelineSQLDatabaseMixin = (
         let query = database('timelines')
           .where('actorId', actorId)
           .where('timeline', actualTimeline)
+
+        // Exclusive lists hide their members from the home feed only — the home
+        // tab (MAIN/HOME) and its "no announces" variant — never from the
+        // mention or direct feeds, where such posts must still surface.
+        if (
+          timeline === Timeline.MAIN ||
+          timeline === Timeline.HOME ||
+          timeline === Timeline.NOANNOUNCE
+        ) {
+          applyExclusiveListFilter({ database, query, viewerActorId: actorId })
+        }
 
         if (maxRow) {
           query = query.where((wb) => {

--- a/lib/database/sql/utils/exclusiveLists.ts
+++ b/lib/database/sql/utils/exclusiveLists.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex'
+
+// Hide statuses authored by members of the viewer's *exclusive* lists from the
+// home feed. https://docs.joinmastodon.org/entities/List/#exclusive
+//
+// Applied at read time (a NOT EXISTS over the viewer's exclusive lists) rather
+// than at fan-out, so toggling `exclusive` or changing list membership takes
+// effect immediately for posts already sitting in the timelines table — no
+// stale rows a later toggle could not retract. Scoped to the viewer's own
+// lists, so another owner's exclusive list never affects this viewer.
+export const applyExclusiveListFilter = ({
+  database,
+  query,
+  viewerActorId
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  viewerActorId: string
+}) => {
+  query.whereNotExists(function () {
+    this.select(database.raw('1'))
+      .from('list_accounts as exclusive_list_accounts')
+      .innerJoin(
+        'lists as exclusive_lists',
+        'exclusive_lists.id',
+        'exclusive_list_accounts.listId'
+      )
+      .where('exclusive_lists.actorId', viewerActorId)
+      .where('exclusive_lists.exclusive', true)
+      .whereRaw('?? = ??', [
+        'exclusive_list_accounts.targetActorId',
+        'timelines.statusActorId'
+      ])
+  })
+}


### PR DESCRIPTION
## What

Members of a list marked `exclusive` are now hidden from the owner's home feed. This is **PR2 of the backend follow-ups deferred in [#907](https://github.com/llun/activities.next/pull/907)** (PR1 was [#912](https://github.com/llun/activities.next/pull/912), `replies_policy`) — `exclusive` was persisted and surfaced in the editor there but the timeline query ignored it, so the toggle stored intent only.

## How

- New `applyExclusiveListFilter` in `lib/database/sql/utils/exclusiveLists.ts`: a `NOT EXISTS` over the **viewer's own** exclusive lists, matching `list_accounts.targetActorId` against `timelines.statusActorId`.
- Wired into `getTimeline` **before LIMIT** (so a hidden row can't short a page), gated to the home feed only.

### Why read-time, not fan-out
Applied at read time, not when the status is inserted into the `timelines` table. This is the only approach that stays correct when the owner toggles `exclusive` or changes list membership **after** posts are already in the timeline — fan-out filtering would leave stale rows a later toggle couldn't retract. The "reflects exclusive toggles on already-stored statuses at read time" test locks this: seed under a non-exclusive list → visible → flip exclusive on → hidden → flip back → visible, with no re-fan-out.

## Reviewer notes

- **Scope = home feed.** Applies to the `MAIN`/`HOME` tab **and** its `NOANNOUNCE` ("No Announces") variant; **not** `MENTION` or `DIRECT`, where a post from an exclusive-list member must still surface. Tests assert both directions.
  - **Judgment call:** including `NOANNOUNCE` is my call, not a Mastodon-defined behavior (Mastodon has no such feed) — reasoning is that it's a home-feed tab. Easy to drop to MAIN-only if you'd rather.
- **Per-viewer scoping.** Filter keys on `exclusive_lists.actorId = viewer`, so another owner's exclusive list never affects this viewer (covered by a test).
- **Reblogs not covered.** A boost of an exclusive member's post *by a non-exclusive account* won't be filtered, since `timelines.statusActorId` is the booster. Deferred, not claimed.
- **PG boolean path:** default-config tests are SQLite-only; SQLite passing already exercises knex's `boolean → 0/1` binding, and PG's native boolean is the more permissive side. Low risk.

## Verification

`prettier` / `lint` (0 errors) / `build` / `test` all green — **458 suites, 3863 tests passing** (incl. 5 new exclusive-list tests). No migration touched, so no schema-dump regeneration needed.

## Remaining deferred follow-ups (separate PRs)
- PR3: block/mute parity for `getListTimeline`.
- PR4: stale-cursor fix + keyword filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)