### PR TITLE
minor: apply block and mute filtering to the list timeline

### DIFF
--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -620,4 +620,117 @@ describe('ListDatabase', () => {
       })
     }
   )
+
+  it('applies block and mute filtering to the list timeline', async () => {
+    await withFreshDatabase(async (database) => {
+      const usernames = [
+        'mod-owner',
+        'mod-clean',
+        'mod-blocked',
+        'mod-blocked-by',
+        'mod-muted',
+        'mod-muted-expired',
+        'mod-muted-by'
+      ]
+      for (const username of usernames)
+        await createLocalAccount(database, username)
+      const actor = async (username: string) => {
+        const found = await database.getActorFromUsername({
+          username,
+          domain: TEST_DOMAIN
+        })
+        if (!found) throw new Error(`${username} not created`)
+        return found
+      }
+      const owner = await actor('mod-owner')
+      const clean = await actor('mod-clean')
+      const blocked = await actor('mod-blocked')
+      const blockedBy = await actor('mod-blocked-by')
+      const muted = await actor('mod-muted')
+      const mutedExpired = await actor('mod-muted-expired')
+      const mutedBy = await actor('mod-muted-by')
+
+      const post = async (author: { id: string }, localId: string) => {
+        const id = `${author.id}/statuses/${localId}`
+        await database.createNote({
+          id,
+          url: id,
+          actorId: author.id,
+          text: `moderation ${localId}`,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+        return id
+      }
+      const cleanId = await post(clean, 'clean')
+      const blockedId = await post(blocked, 'blocked')
+      const blockedById = await post(blockedBy, 'blocked-by')
+      const mutedId = await post(muted, 'muted')
+      const mutedExpiredId = await post(mutedExpired, 'muted-expired')
+      const mutedById = await post(mutedBy, 'muted-by')
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Moderation list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [
+          clean.id,
+          blocked.id,
+          blockedBy.id,
+          muted.id,
+          mutedExpired.id,
+          mutedBy.id
+        ]
+      })
+
+      // Owner blocks `blocked`; `blockedBy` blocks owner (reverse direction).
+      await database.createBlock({
+        actorId: owner.id,
+        targetActorId: blocked.id,
+        uri: `${owner.id}/blocks/blocked`
+      })
+      await database.createBlock({
+        actorId: blockedBy.id,
+        targetActorId: owner.id,
+        uri: `${blockedBy.id}/blocks/owner`
+      })
+      // Owner mutes `muted` indefinitely, and `mutedExpired` with a past expiry.
+      await database.createMute({
+        actorId: owner.id,
+        targetActorId: muted.id,
+        notifications: true,
+        endsAt: null
+      })
+      await database.createMute({
+        actorId: owner.id,
+        targetActorId: mutedExpired.id,
+        notifications: true,
+        endsAt: Date.now() - 60_000
+      })
+      // `mutedBy` mutes the owner — mutes are one-directional, so this must NOT
+      // hide their posts from the owner's list (unlike blocks).
+      await database.createMute({
+        actorId: mutedBy.id,
+        targetActorId: owner.id,
+        notifications: true,
+        endsAt: null
+      })
+
+      const ids = (
+        await database.getListTimeline({ listId: list.id, actorId: owner.id })
+      ).map((status) => status.id)
+
+      // Active blocks (either direction) and active mutes are hidden.
+      expect(ids).not.toContain(blockedId)
+      expect(ids).not.toContain(blockedById)
+      expect(ids).not.toContain(mutedId)
+      // Unmoderated members, expired mutes, and reverse-only mutes still show.
+      expect(ids).toContain(cleanId)
+      expect(ids).toContain(mutedExpiredId)
+      expect(ids).toContain(mutedById)
+    })
+  })
 })

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -733,4 +733,95 @@ describe('ListDatabase', () => {
       expect(ids).toContain(mutedById)
     })
   })
+
+  it('hides a member reblog of a blocked or muted original author', async () => {
+    await withFreshDatabase(async (database) => {
+      const usernames = [
+        'rb-owner',
+        'rb-member',
+        'rb-blocked',
+        'rb-muted',
+        'rb-clean'
+      ]
+      for (const username of usernames)
+        await createLocalAccount(database, username)
+      const actor = async (username: string) => {
+        const found = await database.getActorFromUsername({
+          username,
+          domain: TEST_DOMAIN
+        })
+        if (!found) throw new Error(`${username} not created`)
+        return found
+      }
+      const owner = await actor('rb-owner')
+      const member = await actor('rb-member')
+      const blocked = await actor('rb-blocked')
+      const muted = await actor('rb-muted')
+      const clean = await actor('rb-clean')
+
+      // Original posts authored by the (to-be) blocked/muted/clean accounts.
+      const original = async (author: { id: string }, localId: string) => {
+        const id = `${author.id}/statuses/${localId}`
+        await database.createNote({
+          id,
+          url: id,
+          actorId: author.id,
+          text: `original ${localId}`,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: []
+        })
+        return id
+      }
+      const origBlocked = await original(blocked, 'orig-blocked')
+      const origMuted = await original(muted, 'orig-muted')
+      const origClean = await original(clean, 'orig-clean')
+
+      // The list member boosts each original post.
+      const announce = async (localId: string, originalStatusId: string) => {
+        const id = `${member.id}/statuses/${localId}`
+        await database.createAnnounce({
+          id,
+          actorId: member.id,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          originalStatusId
+        })
+        return id
+      }
+      const annBlocked = await announce('ann-blocked', origBlocked)
+      const annMuted = await announce('ann-muted', origMuted)
+      const annClean = await announce('ann-clean', origClean)
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Reblog moderation list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+      await database.createBlock({
+        actorId: owner.id,
+        targetActorId: blocked.id,
+        uri: `${owner.id}/blocks/rb-blocked`
+      })
+      await database.createMute({
+        actorId: owner.id,
+        targetActorId: muted.id,
+        notifications: true,
+        endsAt: null
+      })
+
+      const ids = (
+        await database.getListTimeline({ listId: list.id, actorId: owner.id })
+      ).map((status) => status.id)
+
+      // A boost is hidden when its ORIGINAL author is blocked/muted, matching
+      // the home feed's getRelevantStatusActorIds behaviour.
+      expect(ids).not.toContain(annBlocked)
+      expect(ids).not.toContain(annMuted)
+      expect(ids).toContain(annClean)
+    })
+  })
 })

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex'
 import { randomUUID } from 'node:crypto'
 
 import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { applyBlockMuteFilter } from '@/lib/database/sql/utils/blockMuteFilter'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   chunkArray,
@@ -305,6 +306,14 @@ export const ListSQLDatabaseMixin = (
       repliesPolicy,
       listId,
       ownerId: actorId
+    })
+    // Drop statuses from blocked/muted accounts, like the home feed does — also
+    // pre-LIMIT so a filtered author never shortens the page.
+    applyBlockMuteFilter({
+      database,
+      query,
+      viewerActorId: actorId,
+      now: Date.now()
     })
     query
       .orderBy('statuses.createdAt', 'desc')

--- a/lib/database/sql/utils/blockMuteFilter.ts
+++ b/lib/database/sql/utils/blockMuteFilter.ts
@@ -1,5 +1,9 @@
 import { Knex } from 'knex'
 
+// Alias for the original status of a boost, left-joined so block/mute can reach
+// the boosted account, not just the booster.
+const REBLOG_ORIGINAL_ALIAS = 'block_mute_reblog_original'
+
 // Hide statuses authored by accounts the viewer blocks/mutes from a status-table
 // timeline query, applied as pure NOT EXISTS clauses so they compose with the
 // other list filters and run BEFORE LIMIT (no short pages, no backfill loop).
@@ -8,11 +12,18 @@ import { Knex } from 'knex'
 // (filterBlockedStatuses + filterMutedStatuses), brought to the list timeline
 // which queries the statuses table directly:
 //   - Blocks are bidirectional: hide an author the viewer blocks OR who blocks
-//     the viewer (matching getBlockRelations / filterBlockedStatuses).
+//     the viewer (matching getBlockRelations / filterBlockedStatuses). The two
+//     directions are separate NOT EXISTS clauses (not one OR'd subquery) so each
+//     can use its own (actorId|targetActorId) index on the blocks table.
 //   - Mutes are one-directional (only what the viewer mutes) and expire: a mute
 //     is active while endsAt IS NULL or endsAt >= now (matching getMuteRelations).
 // The mute `notifications` flag governs notification muting only, so timeline
 // filtering ignores it — every active mute hides the author's statuses.
+//
+// Like the home feed's getRelevantStatusActorIds, a boost (Announce) is judged
+// by its booster AND its original author, so boosting a blocked/muted account
+// is hidden too. The original author is resolved via a left join on
+// statuses.originalStatusId (NULL for non-boosts, so it never matches).
 export const applyBlockMuteFilter = ({
   database,
   query,
@@ -24,42 +35,51 @@ export const applyBlockMuteFilter = ({
   viewerActorId: string
   now: number
 }) => {
+  query.leftJoin(
+    `statuses as ${REBLOG_ORIGINAL_ALIAS}`,
+    `${REBLOG_ORIGINAL_ALIAS}.id`,
+    'statuses.originalStatusId'
+  )
+
+  // True when `moderationAuthorColumn` (the moderated party's id on a block/mute
+  // row) equals the status author or, for a boost, the original author. Both
+  // compare the same indexed column to a value, so this stays index-friendly.
+  const matchesRelevantAuthor = (
+    builder: Knex.QueryBuilder,
+    moderationAuthorColumn: string
+  ) => {
+    builder.where((author) => {
+      author
+        .whereRaw('?? = ??', [moderationAuthorColumn, 'statuses.actorId'])
+        .orWhereRaw('?? = ??', [
+          moderationAuthorColumn,
+          `${REBLOG_ORIGINAL_ALIAS}.actorId`
+        ])
+    })
+  }
+
   query
     .whereNotExists(function () {
-      this.select(database.raw('1'))
-        .from('blocks as moderation_blocks')
-        .where((relation) => {
-          relation
-            .where((forward) => {
-              forward
-                .where('moderation_blocks.actorId', viewerActorId)
-                .whereRaw('?? = ??', [
-                  'moderation_blocks.targetActorId',
-                  'statuses.actorId'
-                ])
-            })
-            .orWhere((reverse) => {
-              reverse
-                .where('moderation_blocks.targetActorId', viewerActorId)
-                .whereRaw('?? = ??', [
-                  'moderation_blocks.actorId',
-                  'statuses.actorId'
-                ])
-            })
-        })
+      this.select(database.raw('1')).from(
+        'blocks as moderation_blocks_outgoing'
+      )
+      this.where('moderation_blocks_outgoing.actorId', viewerActorId)
+      matchesRelevantAuthor(this, 'moderation_blocks_outgoing.targetActorId')
     })
     .whereNotExists(function () {
-      this.select(database.raw('1'))
-        .from('mutes as moderation_mutes')
-        .where('moderation_mutes.actorId', viewerActorId)
-        .whereRaw('?? = ??', [
-          'moderation_mutes.targetActorId',
-          'statuses.actorId'
-        ])
-        .where((active) => {
-          active
-            .whereNull('moderation_mutes.endsAt')
-            .orWhere('moderation_mutes.endsAt', '>=', now)
-        })
+      this.select(database.raw('1')).from(
+        'blocks as moderation_blocks_incoming'
+      )
+      this.where('moderation_blocks_incoming.targetActorId', viewerActorId)
+      matchesRelevantAuthor(this, 'moderation_blocks_incoming.actorId')
+    })
+    .whereNotExists(function () {
+      this.select(database.raw('1')).from('mutes as moderation_mutes')
+      this.where('moderation_mutes.actorId', viewerActorId).where((active) => {
+        active
+          .whereNull('moderation_mutes.endsAt')
+          .orWhere('moderation_mutes.endsAt', '>=', now)
+      })
+      matchesRelevantAuthor(this, 'moderation_mutes.targetActorId')
     })
 }

--- a/lib/database/sql/utils/blockMuteFilter.ts
+++ b/lib/database/sql/utils/blockMuteFilter.ts
@@ -1,0 +1,65 @@
+import { Knex } from 'knex'
+
+// Hide statuses authored by accounts the viewer blocks/mutes from a status-table
+// timeline query, applied as pure NOT EXISTS clauses so they compose with the
+// other list filters and run BEFORE LIMIT (no short pages, no backfill loop).
+//
+// Mirrors the read-time filtering the home feed applies post-fetch
+// (filterBlockedStatuses + filterMutedStatuses), brought to the list timeline
+// which queries the statuses table directly:
+//   - Blocks are bidirectional: hide an author the viewer blocks OR who blocks
+//     the viewer (matching getBlockRelations / filterBlockedStatuses).
+//   - Mutes are one-directional (only what the viewer mutes) and expire: a mute
+//     is active while endsAt IS NULL or endsAt >= now (matching getMuteRelations).
+// The mute `notifications` flag governs notification muting only, so timeline
+// filtering ignores it — every active mute hides the author's statuses.
+export const applyBlockMuteFilter = ({
+  database,
+  query,
+  viewerActorId,
+  now
+}: {
+  database: Knex
+  query: Knex.QueryBuilder
+  viewerActorId: string
+  now: number
+}) => {
+  query
+    .whereNotExists(function () {
+      this.select(database.raw('1'))
+        .from('blocks as moderation_blocks')
+        .where((relation) => {
+          relation
+            .where((forward) => {
+              forward
+                .where('moderation_blocks.actorId', viewerActorId)
+                .whereRaw('?? = ??', [
+                  'moderation_blocks.targetActorId',
+                  'statuses.actorId'
+                ])
+            })
+            .orWhere((reverse) => {
+              reverse
+                .where('moderation_blocks.targetActorId', viewerActorId)
+                .whereRaw('?? = ??', [
+                  'moderation_blocks.actorId',
+                  'statuses.actorId'
+                ])
+            })
+        })
+    })
+    .whereNotExists(function () {
+      this.select(database.raw('1'))
+        .from('mutes as moderation_mutes')
+        .where('moderation_mutes.actorId', viewerActorId)
+        .whereRaw('?? = ??', [
+          'moderation_mutes.targetActorId',
+          'statuses.actorId'
+        ])
+        .where((active) => {
+          active
+            .whereNull('moderation_mutes.endsAt')
+            .orWhere('moderation_mutes.endsAt', '>=', now)
+        })
+    })
+}


### PR DESCRIPTION
## What

The list timeline now hides statuses from accounts the viewer has **blocked** or **muted**. This is **PR3 of the backend follow-ups deferred in [#907](https://github.com/llun/activities.next/pull/907)** (after [#912](https://github.com/llun/activities.next/pull/912) replies_policy and [#914](https://github.com/llun/activities.next/pull/914) exclusive).

`getListTimeline` queries the `statuses` table directly, so unlike the home feed — which runs `filterBlockedStatuses` + `filterMutedStatuses` post-fetch via `getFilteredStatusPage` — it previously surfaced blocked/muted authors in **both** the Mastodon and `activities_next` response formats.

## How

New `applyBlockMuteFilter` (`lib/database/sql/utils/blockMuteFilter.ts`): pure `NOT EXISTS` clauses applied **pre-LIMIT**, alongside the existing visibility and replies_policy filters, so a filtered author never shortens the page.

- **Blocks — bidirectional:** hidden if the viewer blocks the author OR the author blocks the viewer (matches `getBlockRelations` / `filterBlockedStatuses`).
- **Mutes — one-directional + expiring:** hidden only if the viewer mutes the author, and only while the mute is active (`endsAt IS NULL OR endsAt >= now`). The mute `notifications` flag governs notification muting only, so timeline filtering ignores it (matches `filterMutedStatuses`).

## Reviewer notes

- **Two block/mute implementations now exist** and must stay in sync: the post-fetch helpers (`blockFilter.ts` / `muteFilter.ts`) for the home feed, and this SQL form for the list timeline. A future change to block/mute semantics needs to touch both.
- **Seam for PR4 (keyword filtering):** keyword filtering has no SQL form, and `getFilteredStatusPage` *also* runs the block/mute helpers. To avoid double-filtering, PR4 should apply keyword filtering as a thin post-fetch pass on top of the already-SQL-filtered `getListTimeline` — **not** route the list timeline through `getFilteredStatusPage`.
- **PG bigint path:** the `endsAt >= now` comparison is bigint-on-Postgres but only SQLite-exercised by default-config tests (same class as #914's boolean note). Low risk — SQLite passing exercises the comparison; PG's bigint is the more permissive side.
- Both response formats are fixed at once, since both call `getListTimeline`.

## Test

One test discriminates every branch: owner-blocks (hidden), author-blocks-owner (reverse, hidden), owner-mutes (hidden), expired-mute (shown), **reverse-only mute (shown — locks one-directionality)**, and an unmoderated member (shown).

## Verification

`prettier` / `lint` (0 errors) / `build` / `test` all green — **458 suites, 3865 tests passing**. No migration touched, so no schema-dump regeneration needed.

## Remaining deferred follow-up
- PR4: stale-cursor fix + keyword filtering (per the seam note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)