### PR TITLE
Bump version to v1.54.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.54.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.53.0`
- Base main SHA: `da7a8b08e7a3e69fdf78c45d7350a55b4735d3dd`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
