### PR TITLE
Bump version to v1.55.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.55.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.54.0`
- Base main SHA: `d36f0fd2d0807275ab7ccf24a33befbad6fc18c2`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
