### PR TITLE
fix: add top spacing to status detail page

### DIFF
--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -195,7 +195,7 @@ const Page: FC<Props> = async ({ params }) => {
 
   if (isFitnessDashboard) {
     return (
-      <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+      <div className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
         {currentActorProfile ? (
           <Header isFitnessDashboard />
         ) : (
@@ -230,7 +230,7 @@ const Page: FC<Props> = async ({ params }) => {
   }
 
   return (
-    <div className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+    <div className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
       {currentActorProfile ? (
         <Header isFitnessDashboard={false} />
       ) : (

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -18,6 +18,7 @@ import {
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { getPublicMapboxAccessToken } from '@/lib/utils/mapbox'
@@ -195,7 +196,17 @@ const Page: FC<Props> = async ({ params }) => {
 
   if (isFitnessDashboard) {
     return (
-      <div className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+      <div
+        className={cn(
+          // Signed-in viewers render inside the `(timeline)` layout, whose
+          // content wrapper has no top padding, so the card would otherwise sit
+          // flush against the top. Logged-out viewers go through `PublicShell`,
+          // which already supplies its own top padding, so only the signed-in
+          // surface needs this gap.
+          currentActorProfile && 'mt-4',
+          'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
+        )}
+      >
         {currentActorProfile ? (
           <Header isFitnessDashboard />
         ) : (
@@ -230,7 +241,15 @@ const Page: FC<Props> = async ({ params }) => {
   }
 
   return (
-    <div className="mt-4 overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
+    <div
+      className={cn(
+        // Only the signed-in `(timeline)` surface lacks top padding; the
+        // logged-out `PublicShell` already provides its own, so scope the gap
+        // to the signed-in card to keep the spacing consistent across both.
+        currentActorProfile && 'mt-4',
+        'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
+      )}
+    >
       {currentActorProfile ? (
         <Header isFitnessDashboard={false} />
       ) : (


### PR DESCRIPTION
## Summary

The single-status detail page (`/@actor/<status>`) rendered its rounded card flush against the top of the content area, leaving **no spacing at the top**. Every other timeline route leads with sticky `PageHeader` chrome that is meant to sit flush at `top:0`, but the status page uniquely renders a floating rounded card — so it looked cramped against the top edge.

This adds `mt-4` (16px) above the card so it aligns with the design system, where the focused-status view sits below a top gap (the design prototype wraps the status view in a `pt-4` container inside a `py-4` main).

## Changes

- `app/(timeline)/[actor]/[status]/page.tsx`: add `mt-4` to the outer card `<div>` in **both** user-facing return branches — the fitness-dashboard variant and the regular status view.

## Scope

Deliberately narrow: this is a top-spacing fix only. It does **not** restructure the page toward the design prototype's component tree (Back button stays inside the sticky card header; the server/client boundaries, visibility gating, and reply rendering are untouched).

Placed at the page level rather than the layout level on purpose: the `(timeline)` layout wrapper has no top padding because the other routes' `PageHeader` is `sticky top-0` full-width chrome meant to be flush. A layout-level `pt-` would put a gap above all those sticky bars and regress home/bookmarks/favorites/etc.

## Verification

- Browser-verified the logged-in status detail view: the card now sits **16px** from the top (was **0px** / flush). Measured via `getBoundingClientRect().top`.
- `yarn run prettier --write` ✅
- `yarn lint` ✅ (0 errors)
- `yarn build` ✅ (compiled successfully)
- `yarn test` ✅ (459 suites / 3867 tests passing)

### Before / After

Before: the card's top border touched the very top of the scroll area (0px gap).
After: 16px of breathing room above the card, matching the design screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
