### PR TITLE
fix: use icons instead of text for the logged-out status stat strip

### DIFF
--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
@@ -10,7 +10,7 @@ describe('StatusStatStrip', () => {
   it('renders the reply, boost, and like counts in icon order', () => {
     render(<StatusStatStrip boosts={14} likes={96} replies={3} />)
 
-    const region = screen.getByLabelText('Engagement')
+    const region = screen.getByRole('group', { name: 'Engagement' })
     const counts = within(region).getAllByText(/^\d+$/)
     expect(counts.map((node) => node.textContent)).toEqual(['3', '14', '96'])
   })

--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
@@ -19,11 +19,16 @@ describe('StatusStatStrip', () => {
     { boosts: 14, likes: 96, replies: 3, noun: 'replies', title: '3 replies' },
     { boosts: 14, likes: 96, replies: 3, noun: 'boosts', title: '14 boosts' },
     { boosts: 14, likes: 96, replies: 3, noun: 'likes', title: '96 likes' }
-  ])('labels the $noun stat for screen readers', ({ noun, ...props }) => {
-    render(<StatusStatStrip {...props} />)
+  ])(
+    'labels the $noun stat for screen readers',
+    ({ noun, title, ...props }) => {
+      render(<StatusStatStrip {...props} />)
 
-    expect(screen.getByText(noun)).toBeInTheDocument()
-  })
+      const label = screen.getByText(noun)
+      expect(label).toBeInTheDocument()
+      expect(label.parentElement).toHaveAttribute('title', title)
+    }
+  )
 
   it('uses singular nouns when a count is one', () => {
     render(<StatusStatStrip boosts={1} likes={1} replies={1} />)

--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.test.tsx
@@ -2,29 +2,41 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 import { StatusStatStrip } from './StatusStatStrip'
 
 describe('StatusStatStrip', () => {
-  it('renders the boost, like, and reply counts with their labels', () => {
+  it('renders the reply, boost, and like counts in icon order', () => {
     render(<StatusStatStrip boosts={14} likes={96} replies={3} />)
 
-    for (const [count, label] of [
-      ['14', 'Boosts'],
-      ['96', 'Likes'],
-      ['3', 'Replies']
-    ]) {
-      const value = screen.getByText(count)
-      expect(value).toBeInTheDocument()
-      expect(value.parentElement).toHaveTextContent(`${count}${label}`)
-    }
+    const region = screen.getByLabelText('Engagement')
+    const counts = within(region).getAllByText(/^\d+$/)
+    expect(counts.map((node) => node.textContent)).toEqual(['3', '14', '96'])
+  })
+
+  it.each([
+    { boosts: 14, likes: 96, replies: 3, noun: 'replies', title: '3 replies' },
+    { boosts: 14, likes: 96, replies: 3, noun: 'boosts', title: '14 boosts' },
+    { boosts: 14, likes: 96, replies: 3, noun: 'likes', title: '96 likes' }
+  ])('labels the $noun stat for screen readers', ({ noun, ...props }) => {
+    render(<StatusStatStrip {...props} />)
+
+    expect(screen.getByText(noun)).toBeInTheDocument()
+  })
+
+  it('uses singular nouns when a count is one', () => {
+    render(<StatusStatStrip boosts={1} likes={1} replies={1} />)
+
+    expect(screen.getByText('reply')).toBeInTheDocument()
+    expect(screen.getByText('boost')).toBeInTheDocument()
+    expect(screen.getByText('like')).toBeInTheDocument()
   })
 
   it('renders zero counts rather than hiding them', () => {
     render(<StatusStatStrip boosts={0} likes={0} replies={0} />)
 
     expect(screen.getAllByText('0')).toHaveLength(3)
-    expect(screen.getByText('Replies')).toBeInTheDocument()
+    expect(screen.getByText('replies')).toBeInTheDocument()
   })
 })

--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.tsx
@@ -43,6 +43,7 @@ export const StatusStatStrip: FC<Props> = ({ boosts, likes, replies }) => {
   return (
     <div
       className="mt-3 flex items-center gap-5 border-t pt-3 text-sm text-muted-foreground sm:gap-6"
+      role="group"
       aria-label="Engagement"
     >
       {stats.map(({ key, icon: Icon, count, noun }) => (

--- a/app/(timeline)/[actor]/[status]/StatusStatStrip.tsx
+++ b/app/(timeline)/[actor]/[status]/StatusStatStrip.tsx
@@ -1,3 +1,4 @@
+import { Heart, type LucideIcon, Repeat2, Reply } from 'lucide-react'
 import { FC } from 'react'
 
 interface Props {
@@ -7,25 +8,52 @@ interface Props {
 }
 
 interface Stat {
+  key: string
+  icon: LucideIcon
   count: number
-  label: string
+  noun: string
 }
 
 // Read-only engagement summary shown on the focused status for logged-out
-// visitors, who don't get the interactive action row. Mirrors the stat strip in
-// the web-public design (Boosts / Likes / Replies).
+// visitors, who don't get the interactive action row. Mirrors the timeline
+// status component's icon row (reply / boost / like) from the web-public
+// design — same order and icon style as `ReadOnlyStats`, but it carries the
+// real reply count, which timeline statuses don't hydrate.
 export const StatusStatStrip: FC<Props> = ({ boosts, likes, replies }) => {
   const stats: Stat[] = [
-    { count: boosts, label: 'Boosts' },
-    { count: likes, label: 'Likes' },
-    { count: replies, label: 'Replies' }
+    {
+      key: 'replies',
+      icon: Reply,
+      count: replies,
+      noun: replies === 1 ? 'reply' : 'replies'
+    },
+    {
+      key: 'boosts',
+      icon: Repeat2,
+      count: boosts,
+      noun: boosts === 1 ? 'boost' : 'boosts'
+    },
+    {
+      key: 'likes',
+      icon: Heart,
+      count: likes,
+      noun: likes === 1 ? 'like' : 'likes'
+    }
   ]
   return (
-    <div className="mt-3 flex gap-5 border-t pt-3 text-sm">
-      {stats.map(({ count, label }) => (
-        <span key={label} className="flex items-baseline gap-1">
-          <strong className="font-semibold tabular-nums">{count}</strong>
-          <span className="text-muted-foreground">{label}</span>
+    <div
+      className="mt-3 flex items-center gap-5 border-t pt-3 text-sm text-muted-foreground sm:gap-6"
+      aria-label="Engagement"
+    >
+      {stats.map(({ key, icon: Icon, count, noun }) => (
+        <span
+          key={key}
+          className="inline-flex items-center gap-1.5"
+          title={`${count} ${noun}`}
+        >
+          <Icon className="size-4" aria-hidden="true" />
+          <span className="tabular-nums">{count}</span>
+          <span className="sr-only">{noun}</span>
         </span>
       ))}
     </div>

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -350,7 +350,9 @@ describe('Page visibility for logged-out visitors', () => {
       screen.getByRole('heading', { level: 1, name: 'Activity' })
     ).toBeInTheDocument()
     expect(screen.getByTestId('status-fitness-status')).toBeInTheDocument()
-    expect(screen.getByLabelText('Engagement')).toBeInTheDocument()
+    expect(
+      screen.getByRole('group', { name: 'Engagement' })
+    ).toBeInTheDocument()
   })
 })
 

--- a/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.visibility.test.tsx
@@ -350,7 +350,7 @@ describe('Page visibility for logged-out visitors', () => {
       screen.getByRole('heading', { level: 1, name: 'Activity' })
     ).toBeInTheDocument()
     expect(screen.getByTestId('status-fitness-status')).toBeInTheDocument()
-    expect(screen.getByText('Boosts')).toBeInTheDocument()
+    expect(screen.getByLabelText('Engagement')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary

The logged-out **focused-status stat strip** rendered plain `14 Boosts · 96 Likes · 3 Replies` **text**, while the rest of the app — and the updated **web-public design system** (`ui_kits/web-public/index.html`, chat transcript #20) — uses the timeline status component's **reply / boost / like icon row**.

This swaps the text labels for the same `Reply` / `Repeat2` / `Heart` Lucide icons used by `ReadOnlyStats`, in matching order (reply → boost → like), while keeping the real reply count that the focused status hydrates (timeline statuses don't).

### Design intent
From the design handoff (`chats/chat20.md`):
> This should use icon the same as status component in timeline instead of text. Apply this to all components/ui kits in public page too.

`StatusStatStrip` was the only remaining text-based stat strip on the public/logged-out pages — the landing feed already uses `ReadOnlyStats` (icons).

## Changes
- `StatusStatStrip.tsx` — render `Reply` / `Repeat2` / `Heart` icons + counts instead of text labels. Accessibility preserved via `aria-label="Engagement"`, `sr-only` nouns (singular/plural aware), and `title` tooltips; icons are `aria-hidden`.
- `StatusStatStrip.test.tsx` — updated to assert icon-order counts and sr-only nouns (table-driven).
- `page.visibility.test.tsx` — the logged-out stat-strip assertion now targets the `Engagement` region instead of the removed `Boosts` label.

## Verification
- `yarn prettier --write`, `yarn lint` (0 errors), `yarn build`, `yarn test` (459 suites / 3871 tests passing).
- Browser-checked the **logged-out** status page on local SQLite: the strip renders the reply/boost/like icons with counts below the focused status, matching the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)