### PR TITLE
Bump version to v1.56.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.56.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.55.0`
- Base main SHA: `af9dc4e85fb134ada4dd8e05c59cb327d8a36d12`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
