### PR TITLE
feat: align status translation control with design system

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -402,7 +402,12 @@ export const getTranslationLanguages = (): Promise<TranslationLanguages> => {
         (data): TranslationLanguages =>
           data && typeof data === 'object' ? data : {}
       )
-      .catch(() => ({}))
+      .catch(() => {
+        // Don't pin a transient failure for the whole session — clear the memo
+        // so a later call can retry once the network/backend recovers.
+        translationLanguagesPromise = null
+        return {}
+      })
   }
   return translationLanguagesPromise
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -397,7 +397,14 @@ export const getTranslationLanguages = (): Promise<TranslationLanguages> => {
     translationLanguagesPromise = fetch(
       '/api/v1/instance/translation_languages'
     )
-      .then((response) => (response.ok ? response.json() : null))
+      .then((response) => {
+        // Throw on a non-OK status so an HTTP 5xx falls through to the catch
+        // and clears the memo too — not just network rejections.
+        if (!response.ok) {
+          throw new Error('Failed to fetch translation languages')
+        }
+        return response.json()
+      })
       .then(
         (data): TranslationLanguages =>
           data && typeof data === 'object' ? data : {}

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -380,6 +380,33 @@ export const getTranslationCapability = (): Promise<TranslationCapability> => {
   return translationCapabilityPromise
 }
 
+// A map of source language (ISO 639-1) → the target languages the configured
+// backend can translate it into.
+export type TranslationLanguages = Record<string, string[]>
+
+let translationLanguagesPromise: Promise<TranslationLanguages> | null = null
+
+/**
+ * Reads the supported source→target language pairs from
+ * `/api/v1/instance/translation_languages`, memoized for the session. Used to
+ * populate the Translate control's target-language picker.
+ * @see https://docs.joinmastodon.org/methods/instance/#translation_languages
+ */
+export const getTranslationLanguages = (): Promise<TranslationLanguages> => {
+  if (!translationLanguagesPromise) {
+    translationLanguagesPromise = fetch(
+      '/api/v1/instance/translation_languages'
+    )
+      .then((response) => (response.ok ? response.json() : null))
+      .then(
+        (data): TranslationLanguages =>
+          data && typeof data === 'object' ? data : {}
+      )
+      .catch(() => ({}))
+  }
+  return translationLanguagesPromise
+}
+
 /**
  * Favourites/likes a status using Mastodon-compatible API
  * @see https://docs.joinmastodon.org/methods/statuses/#favourite

--- a/lib/components/posts/poll.tsx
+++ b/lib/components/posts/poll.tsx
@@ -8,6 +8,8 @@ import { votePoll } from '@/lib/client'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
+import { useTranslationContext } from './translation-context'
+
 interface Props {
   status: Status
   currentTime: number
@@ -15,6 +17,10 @@ interface Props {
 }
 
 export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
+  // When the surrounding status is translated, flip the option titles together
+  // with the body. Mastodon's translate response returns `poll.options[]` in
+  // the same order as the original choices.
+  const translation = useTranslationContext()
   const pollEndAt =
     status.type === StatusType.enum.Poll ? status.endAt : undefined
   const [now, setNow] = useState(currentTime)
@@ -52,6 +58,12 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
 
   const isPollClosed = now >= status.endAt
   const choices = status.choices
+  const translatedOptions =
+    translation?.showingTranslation && translation.translation?.poll
+      ? translation.translation.poll.options
+      : null
+  const titleFor = (index: number) =>
+    translatedOptions?.[index]?.title ?? choices[index].title
   const voteCount = choices.reduce((sum, choice) => sum + choice.totalVotes, 0)
   const totalVotes = voteCount || 1
 
@@ -144,7 +156,9 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
                       <span className="size-1.5 rounded-full bg-primary-foreground" />
                     ))}
                 </span>
-                <span className="min-w-0 flex-1 truncate">{choice.title}</span>
+                <span className="min-w-0 flex-1 truncate">
+                  {titleFor(index)}
+                </span>
               </label>
             )
           }
@@ -173,7 +187,7 @@ export const Poll: FC<Props> = ({ status, currentTime, currentActorId }) => {
                     mine && 'font-semibold'
                   )}
                 >
-                  {choice.title}
+                  {titleFor(index)}
                   {mine && <span className="text-primary"> ✓</span>}
                 </span>
                 <span className="shrink-0 tabular-nums text-muted-foreground">

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -37,6 +37,7 @@ import { Poll } from './poll'
 import { ReadOnlyStats } from './read-only-stats'
 import { RetryFitnessButton } from './retry-fitness-button'
 import { TranslateContent } from './translate-content'
+import { TranslationProvider } from './translation-context'
 
 export interface PostProps {
   host: string
@@ -133,13 +134,17 @@ export const Post: FC<PostProps> = (props) => {
     Boolean(actualStatus.isLocalActor) &&
     props.currentActor?.id === actualStatus.actorId
   const summary = actualStatus.summary?.trim()
+  // Only offer translation to signed-in viewers (the API needs a token); this
+  // keeps the public landing feed free of dead Translate buttons.
+  const translationLanguage = props.currentActor ? actualStatus.language : null
   const statusBody = (
-    <>
+    <TranslationProvider
+      statusId={actualStatus.id}
+      language={translationLanguage}
+    >
       <TranslateContent
         statusId={actualStatus.id}
-        // Only offer translation to signed-in viewers (the API needs a token);
-        // this keeps the public landing feed free of dead Translate buttons.
-        language={props.currentActor ? actualStatus.language : null}
+        language={translationLanguage}
         contentClassName="mt-1 text-sm leading-relaxed break-words markdown-content"
       >
         {collapsible && postLineLimit !== 0 && !summary ? (
@@ -264,7 +269,7 @@ export const Post: FC<PostProps> = (props) => {
         currentActorId={props.currentActor?.id}
       />
       <Attachments status={actualStatus} onMediaSelected={onShowAttachment} />
-    </>
+    </TranslationProvider>
   )
 
   return (

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -139,6 +139,9 @@ export const Post: FC<PostProps> = (props) => {
   const translationLanguage = props.currentActor ? actualStatus.language : null
   const statusBody = (
     <TranslationProvider
+      // Reset translation state cleanly if a mounted Post is reused for a
+      // different status (e.g. in a virtualized feed).
+      key={actualStatus.id}
       statusId={actualStatus.id}
       language={translationLanguage}
     >

--- a/lib/components/posts/status-translation.test.tsx
+++ b/lib/components/posts/status-translation.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import {
+  getTranslationCapability,
+  getTranslationLanguages,
+  translateStatus,
+  votePoll
+} from '@/lib/client'
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+import { Translation } from '@/lib/types/mastodon/translation'
+
+import { Poll } from './poll'
+import { TranslateContent } from './translate-content'
+import { TranslationProvider } from './translation-context'
+
+jest.mock('@/lib/client', () => ({
+  translateStatus: jest.fn(),
+  getTranslationCapability: jest.fn(),
+  getTranslationLanguages: jest.fn(),
+  votePoll: jest.fn()
+}))
+
+const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
+
+const pollStatus: StatusPoll = {
+  id: 'https://activities.local/statuses/poll-de',
+  actorId: 'https://activities.local/actors/rin',
+  actor: null,
+  to: [],
+  cc: [],
+  edits: [],
+  isLocalActor: false,
+  createdAt: currentTime,
+  updatedAt: currentTime,
+  type: StatusType.enum.Poll,
+  url: 'https://activities.local/@rin/poll-de',
+  text: 'Wie zeichnest du deine Aktivitäten auf?',
+  summary: null,
+  language: 'de',
+  reply: '',
+  replies: [],
+  actorAnnounceStatusId: null,
+  isActorLiked: false,
+  totalLikes: 0,
+  totalShares: 0,
+  attachments: [],
+  tags: [],
+  choices: [
+    {
+      statusId: 'https://activities.local/statuses/poll-de',
+      title: 'Dedizierte GPS-Uhr',
+      totalVotes: 10,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    },
+    {
+      statusId: 'https://activities.local/statuses/poll-de',
+      title: 'Handy-App',
+      totalVotes: 5,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
+  ],
+  endAt: currentTime - 30_000,
+  pollType: 'oneOf'
+}
+
+const translation: Translation = {
+  content: '<p>How do you record your activities?</p>',
+  spoiler_text: '',
+  language: 'en',
+  media_attachments: [],
+  poll: {
+    id: pollStatus.id,
+    options: [{ title: 'Dedicated GPS watch' }, { title: 'Phone app' }]
+  },
+  detected_source_language: 'de',
+  provider: 'DeepL.com'
+}
+
+describe('status translation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getTranslationCapability as jest.Mock).mockResolvedValue({
+      enabled: true,
+      defaultLanguage: 'en'
+    })
+    ;(getTranslationLanguages as jest.Mock).mockResolvedValue({
+      de: ['en']
+    })
+    ;(translateStatus as jest.Mock).mockResolvedValue(translation)
+  })
+
+  it('flips the body and the poll option titles together on a single toggle', async () => {
+    render(
+      <TranslationProvider statusId={pollStatus.id} language="de">
+        <TranslateContent statusId={pollStatus.id} language="de">
+          <div>Wie zeichnest du deine Aktivitäten auf?</div>
+        </TranslateContent>
+        <Poll status={pollStatus} currentTime={currentTime} />
+      </TranslationProvider>
+    )
+
+    // Original German option titles render first.
+    expect(screen.getByText('Dedizierte GPS-Uhr')).toBeInTheDocument()
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Translate from German/ })
+    )
+
+    // Body and poll options both flip to the translated copy.
+    expect(
+      await screen.findByText('How do you record your activities?')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Dedicated GPS watch')).toBeInTheDocument()
+    expect(screen.getByText('Phone app')).toBeInTheDocument()
+    expect(screen.queryByText('Dedizierte GPS-Uhr')).not.toBeInTheDocument()
+
+    // Showing the original reverts both the body and the poll together.
+    fireEvent.click(screen.getByRole('button', { name: 'Show original' }))
+    expect(screen.getByText('Dedizierte GPS-Uhr')).toBeInTheDocument()
+    expect(screen.queryByText('Dedicated GPS watch')).not.toBeInTheDocument()
+
+    // Only one backend call despite toggling back and forth.
+    expect(votePoll).not.toHaveBeenCalled()
+    expect(translateStatus).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/components/posts/translate-content.test.tsx
+++ b/lib/components/posts/translate-content.test.tsx
@@ -4,14 +4,19 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-import { getTranslationCapability, translateStatus } from '@/lib/client'
+import {
+  getTranslationCapability,
+  getTranslationLanguages,
+  translateStatus
+} from '@/lib/client'
 import { Translation } from '@/lib/types/mastodon/translation'
 
 import { TranslateContent } from './translate-content'
 
 jest.mock('@/lib/client', () => ({
   translateStatus: jest.fn(),
-  getTranslationCapability: jest.fn()
+  getTranslationCapability: jest.fn(),
+  getTranslationLanguages: jest.fn()
 }))
 
 const translation: Translation = {
@@ -33,6 +38,9 @@ const mockCapability = (
     defaultLanguage
   })
 
+const mockLanguages = (pairs: Record<string, string[]> = {}) =>
+  (getTranslationLanguages as jest.Mock).mockResolvedValue(pairs)
+
 const renderContent = (language: string | null = 'en') =>
   render(
     <TranslateContent
@@ -44,11 +52,12 @@ const renderContent = (language: string | null = 'en') =>
   )
 
 const findTranslateButton = () =>
-  screen.findByRole('button', { name: 'Translate' })
+  screen.findByRole('button', { name: /Translate from/ })
 
 describe('TranslateContent', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockLanguages({})
   })
 
   it('does not offer translation when the status has no language', async () => {
@@ -56,7 +65,7 @@ describe('TranslateContent', () => {
     renderContent(null)
     await Promise.resolve()
     expect(
-      screen.queryByRole('button', { name: 'Translate' })
+      screen.queryByRole('button', { name: /Translate from/ })
     ).not.toBeInTheDocument()
   })
 
@@ -65,7 +74,7 @@ describe('TranslateContent', () => {
     renderContent('en')
     await waitFor(() => expect(getTranslationCapability).toHaveBeenCalled())
     expect(
-      screen.queryByRole('button', { name: 'Translate' })
+      screen.queryByRole('button', { name: /Translate from/ })
     ).not.toBeInTheDocument()
   })
 
@@ -74,11 +83,11 @@ describe('TranslateContent', () => {
     renderContent('en')
     await waitFor(() => expect(getTranslationCapability).toHaveBeenCalled())
     expect(
-      screen.queryByRole('button', { name: 'Translate' })
+      screen.queryByRole('button', { name: /Translate from/ })
     ).not.toBeInTheDocument()
   })
 
-  it('shows the translation and a toggle back to the original', async () => {
+  it('shows the translation, its attribution, and a toggle back to the original', async () => {
     mockCapability(true, 'fr')
     ;(translateStatus as jest.Mock).mockResolvedValue(translation)
     renderContent('en')
@@ -87,18 +96,33 @@ describe('TranslateContent', () => {
 
     expect(await screen.findByText('Bonjour le monde')).toBeInTheDocument()
     expect(screen.queryByText('Hello world')).not.toBeInTheDocument()
-    expect(
-      screen.getByText(/Translated from en · DeepL\.com/)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Translated from English to/)).toBeInTheDocument()
+    expect(screen.getByText('DeepL.com')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Show original' }))
     expect(screen.getByText('Hello world')).toBeInTheDocument()
     expect(screen.queryByText('Bonjour le monde')).not.toBeInTheDocument()
 
-    // Toggling back does not re-request the translation.
-    fireEvent.click(screen.getByRole('button', { name: 'Show translation' }))
-    expect(screen.getByText('Bonjour le monde')).toBeInTheDocument()
+    // Re-translating reuses the cached result without hitting the backend again.
+    fireEvent.click(await findTranslateButton())
+    expect(await screen.findByText('Bonjour le monde')).toBeInTheDocument()
     expect(translateStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers a target-language picker when the backend supports more than one', async () => {
+    mockCapability(true, 'en')
+    mockLanguages({ de: ['en', 'fr', 'es'] })
+    ;(translateStatus as jest.Mock).mockResolvedValue({
+      ...translation,
+      detected_source_language: 'de'
+    })
+    renderContent('de')
+
+    // The default target (server primary language) leads the picker.
+    expect(
+      await screen.findByRole('button', { name: /Translate from German/ })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /English/ })).toBeInTheDocument()
   })
 
   it('reports when the server returns no translation', async () => {
@@ -109,7 +133,7 @@ describe('TranslateContent', () => {
     fireEvent.click(await findTranslateButton())
 
     expect(
-      await screen.findByText('Translation unavailable')
+      await screen.findByText(/Couldn't translate this post/)
     ).toBeInTheDocument()
     expect(screen.getByText('Hello world')).toBeInTheDocument()
   })
@@ -122,7 +146,7 @@ describe('TranslateContent', () => {
     fireEvent.click(await findTranslateButton())
 
     expect(
-      await screen.findByText('Translation unavailable')
+      await screen.findByText(/Couldn't translate this post/)
     ).toBeInTheDocument()
     expect(screen.getByText('Hello world')).toBeInTheDocument()
   })

--- a/lib/components/posts/translate-content.tsx
+++ b/lib/components/posts/translate-content.tsx
@@ -1,12 +1,29 @@
 'use client'
 
-import { FC, ReactNode, useEffect, useState } from 'react'
+import {
+  AlertTriangle,
+  ChevronDown,
+  Languages,
+  LoaderCircle
+} from 'lucide-react'
+import { FC, ReactNode } from 'react'
 
-import { getTranslationCapability, translateStatus } from '@/lib/client'
-import { Translation } from '@/lib/types/mastodon/translation'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger
+} from '@/lib/components/ui/dropdown-menu'
+import { displayLanguageName } from '@/lib/utils/language/displayLanguageName'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 
-type TranslateState = 'idle' | 'loading' | 'translated' | 'error'
+import {
+  StatusTranslation,
+  useStatusTranslation,
+  useTranslationContext
+} from './translation-context'
 
 interface Props {
   statusId: string
@@ -19,128 +36,200 @@ interface Props {
   contentClassName?: string
 }
 
-// Two-letter, lower-case ISO 639-1 normalization (matches the server).
-const normalizeLanguage = (code: string) =>
-  code.trim().slice(0, 2).toLowerCase()
+interface TargetPickerProps {
+  target: string
+  options: string[]
+  onPick: (code: string) => void
+}
+
+// A small "<Language> ▾" trigger that opens a menu of target languages.
+const TargetPicker: FC<TargetPickerProps> = ({ target, options, onPick }) => (
+  <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <button
+        type="button"
+        className="inline-flex min-h-8 -my-1 items-center gap-0.5 rounded-sm py-1 font-medium text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        {displayLanguageName(target)}
+        <ChevronDown className="size-3 shrink-0" />
+      </button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent align="start" className="min-w-44">
+      <DropdownMenuLabel>Translate to</DropdownMenuLabel>
+      <DropdownMenuRadioGroup value={target} onValueChange={onPick}>
+        {options.map((code) => (
+          <DropdownMenuRadioItem key={code} value={code}>
+            {displayLanguageName(code)}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+    </DropdownMenuContent>
+  </DropdownMenu>
+)
 
 /**
- * Adds a Mastodon-style "Translate" / "Show original" toggle beneath a status's
- * content. The translated HTML is rendered through the same `cleanClassName`
- * pipeline used for the original, so links, mentions and hashtags behave
- * identically. The control only appears once the server is known to have a
- * translation backend configured and the status language differs from the
- * server's default target language — otherwise it would be a dead button or an
- * en→en no-op that burns backend quota.
+ * The "Translate from … → … / Translated from … to … using … · Show original"
+ * control. Driven entirely by a status translation state object. Renders
+ * nothing when the status cannot be translated.
  */
-export const TranslateContent: FC<Props> = ({
-  statusId,
-  language,
-  children,
-  contentClassName
+export const TranslateControl: FC<{ translation: StatusTranslation }> = ({
+  translation: t
 }) => {
-  const [state, setState] = useState<TranslateState>('idle')
-  const [translation, setTranslation] = useState<Translation | null>(null)
-  const [showOriginal, setShowOriginal] = useState(false)
-  const [canTranslate, setCanTranslate] = useState(false)
+  if (!t.canTranslate) return null
+  const {
+    state,
+    target,
+    options,
+    detectedSource,
+    provider,
+    request,
+    pickTarget,
+    showOriginal
+  } = t
 
-  useEffect(() => {
-    if (!language) {
-      setCanTranslate(false)
-      return
-    }
-    let active = true
-    getTranslationCapability()
-      .then(({ enabled, defaultLanguage }) => {
-        if (!active) return
-        const isDefaultTarget =
-          defaultLanguage != null &&
-          normalizeLanguage(language) === normalizeLanguage(defaultLanguage)
-        setCanTranslate(enabled && !isDefaultTarget)
-      })
-      .catch(() => {
-        if (active) setCanTranslate(false)
-      })
-    return () => {
-      active = false
-    }
-  }, [language])
+  return (
+    <div className="mt-1 text-xs">
+      {state === 'idle' && (
+        <div className="inline-flex flex-wrap items-center gap-x-1.5 gap-y-1">
+          <button
+            type="button"
+            onClick={() => request()}
+            className="inline-flex min-h-8 -my-1 items-center gap-1.5 py-1 font-medium text-muted-foreground transition-colors hover:text-primary"
+          >
+            <Languages className="size-3.5" />
+            Translate from {displayLanguageName(detectedSource ?? '')}
+          </button>
+          {options.length > 1 && target && (
+            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+              <span aria-hidden="true">→</span>
+              <TargetPicker
+                target={target}
+                options={options}
+                onPick={pickTarget}
+              />
+            </span>
+          )}
+        </div>
+      )}
 
-  const onTranslate = async () => {
-    if (translation) {
-      setShowOriginal(false)
-      return
-    }
-    setState('loading')
-    try {
-      const result = await translateStatus({ statusId })
-      if (!result) {
-        setState('error')
-        return
-      }
-      setTranslation(result)
-      setShowOriginal(false)
-      setState('translated')
-    } catch {
-      setState('error')
-    }
-  }
+      {state === 'loading' && (
+        <span
+          className="inline-flex min-h-8 -my-1 items-center gap-1.5 py-1 font-medium text-muted-foreground"
+          aria-live="polite"
+        >
+          <LoaderCircle className="size-3.5 animate-spin" />
+          Translating to {displayLanguageName(target ?? '')}…
+        </span>
+      )}
 
-  if (!canTranslate) return <>{children}</>
+      {state === 'translated' && (
+        <div
+          className="flex flex-wrap items-center gap-x-2.5 gap-y-1"
+          aria-live="polite"
+        >
+          <span className="inline-flex flex-wrap items-center gap-x-1 gap-y-1 text-muted-foreground">
+            <Languages className="size-3.5 shrink-0" />
+            <span>
+              Translated from {displayLanguageName(detectedSource ?? '')} to
+            </span>
+            {options.length > 1 && target ? (
+              <TargetPicker
+                target={target}
+                options={options}
+                onPick={pickTarget}
+              />
+            ) : (
+              <span className="font-medium text-foreground">
+                {displayLanguageName(target ?? '')}
+              </span>
+            )}
+            {provider ? (
+              <span>
+                using{' '}
+                <span className="font-medium text-foreground">{provider}</span>
+              </span>
+            ) : null}
+          </span>
+          <button
+            type="button"
+            onClick={showOriginal}
+            className="min-h-8 -my-1 py-1 font-medium text-primary transition-colors hover:underline"
+          >
+            Show original
+          </button>
+        </div>
+      )}
 
-  const showingTranslation = state === 'translated' && !showOriginal
+      {state === 'error' && (
+        <div
+          className="flex flex-wrap items-center gap-x-2.5 gap-y-1"
+          aria-live="polite"
+        >
+          <span className="inline-flex items-center gap-1.5 text-destructive">
+            <AlertTriangle className="size-3.5 shrink-0" />
+            Couldn&apos;t translate this post
+          </span>
+          <button
+            type="button"
+            onClick={() => request()}
+            className="min-h-8 -my-1 py-1 font-medium text-primary transition-colors hover:underline"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Renders the body, swapping in the translated HTML when toggled, and appends
+// the Translate control. The translated HTML runs through the same
+// `cleanClassName` pipeline as the original, so links, mentions and hashtags
+// behave identically.
+const TranslateContentView: FC<
+  Pick<Props, 'children' | 'contentClassName'> & { t: StatusTranslation }
+> = ({ t, children, contentClassName }) => {
+  if (!t.canTranslate) return <>{children}</>
 
   return (
     <>
-      {showingTranslation && translation ? (
+      {t.showingTranslation && t.translation ? (
         <div className={contentClassName}>
-          {cleanClassName(translation.content)}
+          {cleanClassName(t.translation.content)}
         </div>
       ) : (
         children
       )}
-      <div className="mt-1 text-xs text-muted-foreground">
-        {state === 'idle' && (
-          <button
-            type="button"
-            className="hover:underline"
-            onClick={onTranslate}
-          >
-            Translate
-          </button>
-        )}
-        {state === 'loading' && <span>Translating…</span>}
-        {state === 'error' && <span>Translation unavailable</span>}
-        {state === 'translated' && (
-          <span>
-            {showOriginal ? (
-              <button
-                type="button"
-                className="hover:underline"
-                onClick={() => setShowOriginal(false)}
-              >
-                Show translation
-              </button>
-            ) : (
-              <>
-                <button
-                  type="button"
-                  className="hover:underline"
-                  onClick={() => setShowOriginal(true)}
-                >
-                  Show original
-                </button>
-                {translation ? (
-                  <span className="ml-2">
-                    Translated from{' '}
-                    {translation.detected_source_language || 'unknown'} ·{' '}
-                    {translation.provider}
-                  </span>
-                ) : null}
-              </>
-            )}
-          </span>
-        )}
-      </div>
+      <TranslateControl translation={t} />
     </>
   )
+}
+
+// Self-managed variant for stand-alone usages with no surrounding provider.
+const StandaloneTranslateContent: FC<Props> = ({
+  statusId,
+  language,
+  ...rest
+}) => {
+  const t = useStatusTranslation(statusId, language)
+  return <TranslateContentView t={t} {...rest} />
+}
+
+/**
+ * Renders a status' body plus a Mastodon-style Translate control. When wrapped
+ * in a `TranslationProvider` it shares that status' translation state (so the
+ * poll flips together); otherwise it self-manages with a local state machine so
+ * stand-alone usages keep working.
+ */
+export const TranslateContent: FC<Props> = (props) => {
+  const context = useTranslationContext()
+  if (context) {
+    const { children, contentClassName } = props
+    return (
+      <TranslateContentView t={context} contentClassName={contentClassName}>
+        {children}
+      </TranslateContentView>
+    )
+  }
+  return <StandaloneTranslateContent {...props} />
 }

--- a/lib/components/posts/translation-context.test.tsx
+++ b/lib/components/posts/translation-context.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import {
+  getTranslationCapability,
+  getTranslationLanguages,
+  translateStatus
+} from '@/lib/client'
+import { Translation } from '@/lib/types/mastodon/translation'
+
+import { useStatusTranslation } from './translation-context'
+
+jest.mock('@/lib/client', () => ({
+  translateStatus: jest.fn(),
+  getTranslationCapability: jest.fn(),
+  getTranslationLanguages: jest.fn()
+}))
+
+const makeTranslation = (language: string): Translation => ({
+  content: `<p>${language}</p>`,
+  spoiler_text: '',
+  language,
+  media_attachments: [],
+  poll: null,
+  detected_source_language: 'de',
+  provider: 'DeepL.com'
+})
+
+describe('useStatusTranslation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getTranslationCapability as jest.Mock).mockResolvedValue({
+      enabled: true,
+      defaultLanguage: 'en'
+    })
+    ;(getTranslationLanguages as jest.Mock).mockResolvedValue({
+      de: ['en', 'es']
+    })
+  })
+
+  it('ignores an out-of-order response from a superseded target', async () => {
+    const resolvers: Record<string, (value: Translation) => void> = {}
+    ;(translateStatus as jest.Mock).mockImplementation(
+      ({ language }: { language: string }) =>
+        new Promise<Translation>((resolve) => {
+          resolvers[language] = resolve
+        })
+    )
+
+    const { result } = renderHook(() => useStatusTranslation('id-1', 'de'))
+    await waitFor(() => expect(result.current.canTranslate).toBe(true))
+
+    // Kick off English, then immediately switch to Spanish — both in flight.
+    act(() => result.current.request('en'))
+    act(() => result.current.request('es'))
+    expect(result.current.state).toBe('loading')
+
+    // The superseded English request resolves last; it must not flip the UI.
+    act(() => resolvers.en(makeTranslation('en')))
+    expect(result.current.state).toBe('loading')
+
+    // The latest target (Spanish) wins and drives the visible state.
+    act(() => resolvers.es(makeTranslation('es')))
+    await waitFor(() => expect(result.current.state).toBe('translated'))
+    expect(result.current.target).toBe('es')
+    expect(result.current.translation?.language).toBe('es')
+  })
+
+  it('caches each target so re-requesting it does not re-hit the backend', async () => {
+    ;(translateStatus as jest.Mock).mockImplementation(
+      ({ language }: { language: string }) =>
+        Promise.resolve(makeTranslation(language))
+    )
+
+    const { result } = renderHook(() => useStatusTranslation('id-2', 'de'))
+    await waitFor(() => expect(result.current.canTranslate).toBe(true))
+
+    await act(async () => result.current.request('en'))
+    await waitFor(() => expect(result.current.state).toBe('translated'))
+
+    act(() => result.current.showOriginal())
+    expect(result.current.state).toBe('idle')
+
+    await act(async () => result.current.request('en'))
+    await waitFor(() => expect(result.current.state).toBe('translated'))
+    expect(translateStatus).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/components/posts/translation-context.test.tsx
+++ b/lib/components/posts/translation-context.test.tsx
@@ -69,6 +69,37 @@ describe('useStatusTranslation', () => {
     expect(result.current.translation?.language).toBe('es')
   })
 
+  it('only offers backend-supported targets and leads with the default', async () => {
+    ;(getTranslationLanguages as jest.Mock).mockResolvedValue({
+      de: ['fr', 'en', 'es']
+    })
+    const { result } = renderHook(() => useStatusTranslation('id-3', 'de'))
+    await waitFor(() => expect(result.current.canTranslate).toBe(true))
+    // Default language ('en') leads; the unsupported direction is never added.
+    expect(result.current.options).toEqual(['en', 'fr', 'es'])
+    expect(result.current.target).toBe('en')
+  })
+
+  it('does not offer the default language when the backend cannot translate into it', async () => {
+    ;(getTranslationLanguages as jest.Mock).mockResolvedValue({
+      de: ['fr', 'es']
+    })
+    const { result } = renderHook(() => useStatusTranslation('id-4', 'de'))
+    await waitFor(() => expect(result.current.canTranslate).toBe(true))
+    // 'en' is the server default but not a supported target for 'de'.
+    expect(result.current.options).toEqual(['fr', 'es'])
+    expect(result.current.options).not.toContain('en')
+    expect(result.current.target).toBe('fr')
+  })
+
+  it('falls back to the default target when no pairs are advertised', async () => {
+    ;(getTranslationLanguages as jest.Mock).mockResolvedValue({})
+    const { result } = renderHook(() => useStatusTranslation('id-5', 'de'))
+    await waitFor(() => expect(result.current.canTranslate).toBe(true))
+    expect(result.current.options).toEqual(['en'])
+    expect(result.current.target).toBe('en')
+  })
+
   it('caches each target so re-requesting it does not re-hit the backend', async () => {
     ;(translateStatus as jest.Mock).mockImplementation(
       ({ language }: { language: string }) =>

--- a/lib/components/posts/translation-context.tsx
+++ b/lib/components/posts/translation-context.tsx
@@ -118,9 +118,14 @@ export const useStatusTranslation = (
   const isDefaultTarget = Boolean(
     defaultLanguage && source && source === defaultLanguage
   )
-  const canTranslate = Boolean(enabled && source && !isDefaultTarget)
 
   const effectiveTarget = target ?? defaultLanguage ?? options[0] ?? null
+
+  // Require a resolvable target too: with a backend enabled but no advertised
+  // target for this source, the control would otherwise be a dead button.
+  const canTranslate = Boolean(
+    enabled && source && !isDefaultTarget && effectiveTarget !== null
+  )
 
   // Tracks the latest state for `pickTarget` without recreating the callback
   // (and without nesting side effects inside a state updater).
@@ -129,11 +134,17 @@ export const useStatusTranslation = (
     stateRef.current = state
   }, [state])
 
+  // The most recently requested target. Rapid target switches fire concurrent
+  // requests that can resolve out of order; only the latest one is allowed to
+  // drive the visible state (every result is still cached for instant reuse).
+  const lastRequestedTargetRef = useRef<string | null>(null)
+
   const request = useCallback(
     (lang?: string) => {
       const to = lang ?? effectiveTarget
       if (!to) return
       setTarget(to)
+      lastRequestedTargetRef.current = to
       if (cache[to]) {
         setState('translated')
         return
@@ -141,14 +152,13 @@ export const useStatusTranslation = (
       setState('loading')
       translateStatus({ statusId, language: to })
         .then((result) => {
-          if (!result) {
-            setState('error')
-            return
-          }
-          setCache((next) => ({ ...next, [to]: result }))
-          setState('translated')
+          if (result) setCache((next) => ({ ...next, [to]: result }))
+          if (lastRequestedTargetRef.current !== to) return
+          setState(result ? 'translated' : 'error')
         })
-        .catch(() => setState('error'))
+        .catch(() => {
+          if (lastRequestedTargetRef.current === to) setState('error')
+        })
     },
     [statusId, effectiveTarget, cache]
   )

--- a/lib/components/posts/translation-context.tsx
+++ b/lib/components/posts/translation-context.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import {
+  FC,
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+
+import {
+  getTranslationCapability,
+  getTranslationLanguages,
+  translateStatus
+} from '@/lib/client'
+import { Translation } from '@/lib/types/mastodon/translation'
+
+// Two-letter, lower-case ISO 639-1 normalization (matches the server's
+// `normalizeLanguageCode`).
+export const normalizeLanguage = (code: string) =>
+  code.trim().slice(0, 2).toLowerCase()
+
+// One control translates the whole status. Mastodon's translate response
+// carries the translated body, poll option titles and media descriptions
+// together, so a single toggle drives every part of a status at once. That
+// shared state lives in this context: the body renders the control and the
+// translated copy, while the poll reads the same context so its option titles
+// flip together with the body (and revert together).
+type TranslateState = 'idle' | 'loading' | 'translated' | 'error'
+
+export interface StatusTranslation {
+  // Whether the Translate control should be offered for this status.
+  canTranslate: boolean
+  state: TranslateState
+  // The currently selected target language (ISO 639-1).
+  target: string | null
+  // Target languages the backend can translate this status into, viewer locale
+  // first. A picker is only shown when there is more than one.
+  options: string[]
+  // The auto-detected source language for the active translation, falling back
+  // to the status's declared language.
+  detectedSource: string | null
+  // Human-readable provider name (e.g. "DeepL.com") of the active translation.
+  provider: string | null
+  // The active translation entity for the selected target, or null.
+  translation: Translation | null
+  // True while the translated copy should be shown instead of the original.
+  showingTranslation: boolean
+  // Translate (or re-translate) into `lang`, defaulting to the current target.
+  request: (lang?: string) => void
+  // Pick a different target; re-requests when already translating/translated.
+  pickTarget: (lang: string) => void
+  // Revert to the original copy (the translation stays cached for re-toggling).
+  showOriginal: () => void
+}
+
+const TranslationContext = createContext<StatusTranslation | null>(null)
+
+/**
+ * The translate state machine for a single status. Loads the server's
+ * translation capability + supported language pairs, gates the control, and
+ * caches each target's translation so re-toggling and switching targets back
+ * does not re-hit the backend.
+ */
+export const useStatusTranslation = (
+  statusId: string,
+  language?: string | null
+): StatusTranslation => {
+  const [enabled, setEnabled] = useState(false)
+  const [defaultLanguage, setDefaultLanguage] = useState<string | null>(null)
+  const [pairs, setPairs] = useState<Record<string, string[]>>({})
+  const [state, setState] = useState<TranslateState>('idle')
+  const [target, setTarget] = useState<string | null>(null)
+  // Cached translations keyed by normalized target language.
+  const [cache, setCache] = useState<Record<string, Translation>>({})
+
+  const source = language ? normalizeLanguage(language) : null
+
+  useEffect(() => {
+    if (!source) return
+    let active = true
+    Promise.all([getTranslationCapability(), getTranslationLanguages()])
+      .then(([capability, languagePairs]) => {
+        if (!active) return
+        setEnabled(capability.enabled)
+        setDefaultLanguage(
+          capability.defaultLanguage
+            ? normalizeLanguage(capability.defaultLanguage)
+            : null
+        )
+        setPairs(languagePairs)
+      })
+      .catch(() => {
+        if (active) setEnabled(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [source])
+
+  const options = useMemo(() => {
+    const targets = (source && pairs[source]) || []
+    const normalized = [
+      ...(defaultLanguage ? [defaultLanguage] : []),
+      ...targets.map(normalizeLanguage)
+    ]
+    return normalized
+      .filter((code) => code !== source)
+      .filter((code, index, all) => all.indexOf(code) === index)
+  }, [pairs, source, defaultLanguage])
+
+  // The control is hidden when the status is already in the server's primary
+  // language — translating it would be an en→en no-op that burns backend quota.
+  const isDefaultTarget = Boolean(
+    defaultLanguage && source && source === defaultLanguage
+  )
+  const canTranslate = Boolean(enabled && source && !isDefaultTarget)
+
+  const effectiveTarget = target ?? defaultLanguage ?? options[0] ?? null
+
+  // Tracks the latest state for `pickTarget` without recreating the callback
+  // (and without nesting side effects inside a state updater).
+  const stateRef = useRef(state)
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
+
+  const request = useCallback(
+    (lang?: string) => {
+      const to = lang ?? effectiveTarget
+      if (!to) return
+      setTarget(to)
+      if (cache[to]) {
+        setState('translated')
+        return
+      }
+      setState('loading')
+      translateStatus({ statusId, language: to })
+        .then((result) => {
+          if (!result) {
+            setState('error')
+            return
+          }
+          setCache((next) => ({ ...next, [to]: result }))
+          setState('translated')
+        })
+        .catch(() => setState('error'))
+    },
+    [statusId, effectiveTarget, cache]
+  )
+
+  const pickTarget = useCallback(
+    (lang: string) => {
+      setTarget(lang)
+      if (stateRef.current === 'translated' || stateRef.current === 'loading') {
+        request(lang)
+      }
+    },
+    [request]
+  )
+
+  const showOriginal = useCallback(() => setState('idle'), [])
+
+  const showingTranslation = state === 'translated'
+  const activeTranslation =
+    showingTranslation && effectiveTarget
+      ? (cache[effectiveTarget] ?? null)
+      : null
+
+  return {
+    canTranslate,
+    state,
+    target: effectiveTarget,
+    options,
+    detectedSource: activeTranslation?.detected_source_language ?? source,
+    provider: activeTranslation?.provider ?? null,
+    translation: activeTranslation,
+    showingTranslation,
+    request,
+    pickTarget,
+    showOriginal
+  }
+}
+
+interface ProviderProps {
+  statusId: string
+  language?: string | null
+  children: ReactNode
+}
+
+/**
+ * Wraps a status' parts so the body and poll share one translate toggle. The
+ * body renders the control; the poll reads the same context to flip its option
+ * titles together with the body.
+ */
+export const TranslationProvider: FC<ProviderProps> = ({
+  statusId,
+  language,
+  children
+}) => {
+  const value = useStatusTranslation(statusId, language)
+  return (
+    <TranslationContext.Provider value={value}>
+      {children}
+    </TranslationContext.Provider>
+  )
+}
+
+// Reads the surrounding status translation, or null when rendered without a
+// provider (e.g. a stand-alone body that self-manages its own state).
+export const useTranslationContext = (): StatusTranslation | null =>
+  useContext(TranslationContext)

--- a/lib/components/posts/translation-context.tsx
+++ b/lib/components/posts/translation-context.tsx
@@ -199,19 +199,37 @@ export const useStatusTranslation = (
       ? (cache[effectiveTarget] ?? null)
       : null
 
-  return {
-    canTranslate,
-    state,
-    target: effectiveTarget,
-    options,
-    detectedSource: activeTranslation?.detected_source_language ?? source,
-    provider: activeTranslation?.provider ?? null,
-    translation: activeTranslation,
-    showingTranslation,
-    request,
-    pickTarget,
-    showOriginal
-  }
+  // Memoize the returned value so the context reference is stable across
+  // unrelated re-renders — otherwise every provider render would re-render all
+  // consumers (the poll and the body) even when nothing translation-related
+  // changed.
+  return useMemo(
+    () => ({
+      canTranslate,
+      state,
+      target: effectiveTarget,
+      options,
+      detectedSource: activeTranslation?.detected_source_language ?? source,
+      provider: activeTranslation?.provider ?? null,
+      translation: activeTranslation,
+      showingTranslation,
+      request,
+      pickTarget,
+      showOriginal
+    }),
+    [
+      canTranslate,
+      state,
+      effectiveTarget,
+      options,
+      activeTranslation,
+      source,
+      showingTranslation,
+      request,
+      pickTarget,
+      showOriginal
+    ]
+  )
 }
 
 interface ProviderProps {

--- a/lib/components/posts/translation-context.tsx
+++ b/lib/components/posts/translation-context.tsx
@@ -102,16 +102,34 @@ export const useStatusTranslation = (
     }
   }, [source])
 
+  // Whether the backend reported concrete source→target pairs. When it did, we
+  // only offer directions it actually supports; otherwise we fall back to a
+  // best-effort single target (the server's default language).
+  const hasPairs = Object.keys(pairs).length > 0
+
   const options = useMemo(() => {
-    const targets = (source && pairs[source]) || []
-    const normalized = [
-      ...(defaultLanguage ? [defaultLanguage] : []),
-      ...targets.map(normalizeLanguage)
-    ]
-    return normalized
-      .filter((code) => code !== source)
-      .filter((code, index, all) => all.indexOf(code) === index)
-  }, [pairs, source, defaultLanguage])
+    if (!source) return []
+    if (hasPairs) {
+      const supported = (pairs[source] || [])
+        .map(normalizeLanguage)
+        .filter((code) => code !== source)
+        .filter((code, index, all) => all.indexOf(code) === index)
+      // Lead with the viewer's default language when the backend supports
+      // translating into it — but never offer an unsupported direction.
+      if (defaultLanguage && supported.includes(defaultLanguage)) {
+        return [
+          defaultLanguage,
+          ...supported.filter((code) => code !== defaultLanguage)
+        ]
+      }
+      return supported
+    }
+    // No pairs data (the backend couldn't report them) — best-effort to the
+    // server's default language and let the server validate it.
+    return defaultLanguage && defaultLanguage !== source
+      ? [defaultLanguage]
+      : []
+  }, [pairs, hasPairs, source, defaultLanguage])
 
   // The control is hidden when the status is already in the server's primary
   // language — translating it would be an en→en no-op that burns backend quota.
@@ -119,7 +137,7 @@ export const useStatusTranslation = (
     defaultLanguage && source && source === defaultLanguage
   )
 
-  const effectiveTarget = target ?? defaultLanguage ?? options[0] ?? null
+  const effectiveTarget = target ?? options[0] ?? null
 
   // Require a resolvable target too: with a backend enabled but no advertised
   // target for this source, the control would otherwise be a dead button.

--- a/lib/utils/language/displayLanguageName.ts
+++ b/lib/utils/language/displayLanguageName.ts
@@ -2,11 +2,16 @@
 // viewer's locale. Uses the platform `Intl.DisplayNames` table so the picker
 // reads "Spanish" / "Japanese" rather than raw codes, and falls back to the
 // upper-cased code when the runtime cannot resolve the name.
-export const displayLanguageName = (code: string, locale = 'en'): string => {
+export const displayLanguageName = (code: string, locale?: string): string => {
   const trimmed = code?.trim()
   if (!trimmed) return 'another language'
   try {
-    const names = new Intl.DisplayNames([locale], { type: 'language' })
+    // Omit the locale so Intl falls back to the viewer's own locale and the
+    // picker reads in the reader's language. Safe here: the translate control
+    // renders client-side only, so there is no SSR hydration concern.
+    const names = new Intl.DisplayNames(locale ? [locale] : undefined, {
+      type: 'language'
+    })
     return names.of(trimmed) ?? trimmed.toUpperCase()
   } catch {
     return trimmed.toUpperCase()

--- a/lib/utils/language/displayLanguageName.ts
+++ b/lib/utils/language/displayLanguageName.ts
@@ -1,0 +1,14 @@
+// Resolves a human-readable language name for an ISO 639-1 code, in the
+// viewer's locale. Uses the platform `Intl.DisplayNames` table so the picker
+// reads "Spanish" / "Japanese" rather than raw codes, and falls back to the
+// upper-cased code when the runtime cannot resolve the name.
+export const displayLanguageName = (code: string, locale = 'en'): string => {
+  const trimmed = code?.trim()
+  if (!trimmed) return 'another language'
+  try {
+    const names = new Intl.DisplayNames([locale], { type: 'language' })
+    return names.of(trimmed) ?? trimmed.toUpperCase()
+  } catch {
+    return trimmed.toUpperCase()
+  }
+}


### PR DESCRIPTION
## Summary

Aligns the per-status **Translate** control with the design system's translation affordance (`ui_kits/web/index.html` → `Translation.jsx`), and makes a single toggle translate the **whole status** (body + poll option titles) instead of just the body. Translation continues to go through the existing Mastodon-compatible `POST /api/v1/statuses/:id/translate` API.

Previously the control was a bare `Translate` / `Show original` link that only swapped the body text and had no target-language choice. This brings it up to the design:

- **Idle:** `🅰 Translate from <source> → <target> ▾` — a Languages icon, the detected source, and a target-language **picker** (shown when the backend supports more than one target).
- **Loading:** spinner + `Translating to <target>…`
- **Translated:** `🅰 Translated from <source> to <target ▾> using <provider> · Show original` — the body (and any poll) swap to the translated copy; switching the target re-requests.
- **Error:** `⚠ Couldn't translate this post · Try again`

## What changed

- **Shared translation state** — new `TranslationProvider` + context (`translation-context.tsx`) holding the translate state machine for a status. The body renders the control; the **poll** reads the same context so its option titles flip and revert together with the body, mirroring Mastodon's translate response (`content` + `poll.options[]` in one call). Each target's result is cached so re-toggling / switching back doesn't re-hit the backend.
- **Rebuilt control** (`translate-content.tsx`) with the four design states and a Radix dropdown **target picker**. It reads the surrounding provider when nested, and self-manages with a local state machine for stand-alone usages.
- **Target languages** — new memoized `getTranslationLanguages()` client helper hitting `GET /api/v1/instance/translation_languages` to populate the picker.
- **`displayLanguageName()`** util resolving human-readable language names via `Intl.DisplayNames`.

## Verification

- `yarn lint`, `yarn build`, `yarn test` all green (3881 tests).
- New tests: rich control states + caching (`translate-content.test.tsx`), and an integration test asserting the body and poll option titles flip/revert together on one toggle (`status-translation.test.tsx`).
- Verified in a browser against a local SQLite instance with a translation backend and a German-language post: the idle control, the "Translate to" picker dropdown, and the translated state with attribution + "Show original" all render as designed.

https://claude.ai/code/session_01Yaxyd6zfyhbC3fo16XvFp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yaxyd6zfyhbC3fo16XvFp7)_