### PR TITLE
Bump version to v1.56.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.56.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.56.1`
- Base main SHA: `99928564573b1ee95928ee1620920ce9c5fb5ea6`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
