### PR TITLE
Bump version to v1.56.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.56.2",
+  "version": "1.56.3",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.56.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.56.2`
- Base main SHA: `bb705c633107452969ff3ed9bfc68202d2c61ccc`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
