### PR TITLE
minor: gate landing public feed on post count and add registration-closed variant

### DIFF
--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -33,7 +33,7 @@ const Page: FC = async () => {
     return redirect('/')
   }
 
-  const { auth, serviceName } = getConfig()
+  const { auth, serviceName, registrationOpen } = getConfig()
   const credentialEnabled = auth?.enableCredential !== false
 
   return (
@@ -61,14 +61,16 @@ const Page: FC = async () => {
 
         <PasskeySigninButton />
       </CardContent>
-      <CardFooter className="justify-center">
-        <p className="text-sm text-muted-foreground">
-          Don&apos;t have an account?{' '}
-          <Link href="/auth/signup" className="text-primary hover:underline">
-            Sign up
-          </Link>
-        </p>
-      </CardFooter>
+      {registrationOpen && (
+        <CardFooter className="justify-center">
+          <p className="text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link href="/auth/signup" className="text-primary hover:underline">
+              Sign up
+            </Link>
+          </p>
+        </CardFooter>
+      )}
     </Card>
   )
 }

--- a/app/(nosidebar)/auth/signup/page.tsx
+++ b/app/(nosidebar)/auth/signup/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/components/ui/card'
 import { Input } from '@/lib/components/ui/input'
 import { Label } from '@/lib/components/ui/label'
+import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 
@@ -25,6 +26,12 @@ export const metadata: Metadata = {
 const Page: FC = async () => {
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
+
+  // When the server has closed registration there is no sign-up to show; send
+  // visitors to the landing, whose auth card explains registration is closed.
+  if (!getConfig().registrationOpen) {
+    return redirect('/')
+  }
 
   const session = await getServerAuthSession()
   if (session && session.user) {

--- a/app/(timeline)/PublicTopBar.tsx
+++ b/app/(timeline)/PublicTopBar.tsx
@@ -3,22 +3,29 @@ import { FC } from 'react'
 
 import { Logo } from '@/lib/components/layout/logo'
 import { Button } from '@/lib/components/ui/button'
+import { getConfig } from '@/lib/config'
 
 // Public top bar shown to logged-out visitors in place of the app nav sidebar:
 // a slim sticky bar with the brand logo and Sign in / Create account links to
-// the real auth routes, matching the web-public design.
-export const PublicTopBar: FC = () => (
-  <header className="sticky top-0 z-30 border-b bg-background/90 backdrop-blur">
-    <div className="mx-auto flex h-16 w-full max-w-[680px] items-center gap-3 px-4">
-      <Logo size="md" />
-      <div className="ml-auto flex items-center gap-2">
-        <Button asChild variant="outline" size="sm">
-          <Link href="/auth/signin">Sign in</Link>
-        </Button>
-        <Button asChild size="sm">
-          <Link href="/auth/signup">Create account</Link>
-        </Button>
+// the real auth routes, matching the web-public design. The "Create account"
+// CTA is hidden when the server has closed registration.
+export const PublicTopBar: FC = () => {
+  const { registrationOpen } = getConfig()
+  return (
+    <header className="sticky top-0 z-30 border-b bg-background/90 backdrop-blur">
+      <div className="mx-auto flex h-16 w-full max-w-[680px] items-center gap-3 px-4">
+        <Logo size="md" />
+        <div className="ml-auto flex items-center gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link href="/auth/signin">Sign in</Link>
+          </Button>
+          {registrationOpen && (
+            <Button asChild size="sm">
+              <Link href="/auth/signup">Create account</Link>
+            </Button>
+          )}
+        </div>
       </div>
-    </div>
-  </header>
-)
+    </header>
+  )
+}

--- a/app/(timeline)/[actor]/[status]/SignInCallout.tsx
+++ b/app/(timeline)/[actor]/[status]/SignInCallout.tsx
@@ -6,9 +6,14 @@ import { cn } from '@/lib/utils'
 
 interface Props {
   className?: string
+  /** Whether new-account sign-up is open; hides "Create account" when false. */
+  registrationOpen?: boolean
 }
 
-export const SignInCallout: FC<Props> = ({ className }) => (
+export const SignInCallout: FC<Props> = ({
+  className,
+  registrationOpen = true
+}) => (
   <div className={cn('border-b bg-primary/5 px-5 py-5', className)}>
     <div className="flex flex-wrap items-center justify-between gap-3">
       <div className="min-w-0">
@@ -22,9 +27,11 @@ export const SignInCallout: FC<Props> = ({ className }) => (
         <Button asChild variant="outline" size="sm">
           <Link href="/auth/signin">Sign in</Link>
         </Button>
-        <Button asChild size="sm">
-          <Link href="/auth/signup">Create account</Link>
-        </Button>
+        {registrationOpen && (
+          <Button asChild size="sm">
+            <Link href="/auth/signup">Create account</Link>
+          </Button>
+        )}
       </div>
     </div>
   </div>

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -44,7 +44,7 @@ export const generateMetadata = async ({
 }
 
 const Page: FC<Props> = async ({ params }) => {
-  const { host, fitnessStorage, mediaStorage } = getConfig()
+  const { host, fitnessStorage, mediaStorage, registrationOpen } = getConfig()
   const mapboxAccessToken = getPublicMapboxAccessToken(
     fitnessStorage?.mapboxAccessToken
   )
@@ -235,7 +235,9 @@ const Page: FC<Props> = async ({ params }) => {
           ) : null}
         </div>
 
-        {!currentActorProfile ? <SignInCallout /> : null}
+        {!currentActorProfile ? (
+          <SignInCallout registrationOpen={registrationOpen} />
+        ) : null}
       </div>
     )
   }
@@ -294,7 +296,9 @@ const Page: FC<Props> = async ({ params }) => {
         ) : null}
       </div>
 
-      {!currentActorProfile ? <SignInCallout /> : null}
+      {!currentActorProfile ? (
+        <SignInCallout registrationOpen={registrationOpen} />
+      ) : null}
 
       {replies.length > 0 ? (
         <div>

--- a/app/(timeline)/landing/Landing.test.tsx
+++ b/app/(timeline)/landing/Landing.test.tsx
@@ -27,13 +27,14 @@ jest.mock('@/lib/components/posts/posts', () => ({
   )
 }))
 
-const renderLanding = (statuses: Status[]) =>
+const renderLanding = (statuses: Status[], signupOpen?: boolean) =>
   render(
     <Landing
       host="llun.social"
       currentTime={1_700_000_000_000}
       statuses={statuses}
       serviceName="Activities"
+      signupOpen={signupOpen}
     />
   )
 
@@ -72,5 +73,28 @@ describe('Landing', () => {
     const posts = screen.getByTestId('posts')
     expect(posts).toHaveAttribute('data-current-time-type', 'number')
     expect(posts).toHaveAttribute('data-current-time', '1700000000000')
+  })
+
+  it('shows the registration-closed auth card when sign-up is closed', () => {
+    renderLanding([], false)
+
+    expect(screen.getByText('Welcome back')).toBeInTheDocument()
+    expect(screen.getByText('Registration is closed')).toBeInTheDocument()
+    // Sign-in only — no "Create account" path.
+    expect(
+      screen.queryByRole('link', { name: 'Create account' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/auth/signin'
+    )
+  })
+
+  it('still previews the public feed when sign-up is closed', () => {
+    renderLanding([{ id: 'p1' }] as unknown as Status[], false)
+
+    // The left column (feed vs hero) is independent of the auth card variant.
+    expect(screen.getByTestId('posts')).toBeInTheDocument()
+    expect(screen.getByText('Registration is closed')).toBeInTheDocument()
   })
 })

--- a/app/(timeline)/landing/Landing.tsx
+++ b/app/(timeline)/landing/Landing.tsx
@@ -12,20 +12,28 @@ interface LandingProps {
   /** Recent public statuses to preview. Empty → the brand hero is shown. */
   statuses: Status[]
   serviceName: string
+  /**
+   * Whether the server is accepting new account sign-ups. When `false`, the
+   * auth card drops the "Create account" path for a sign-in-only "registration
+   * closed" notice. Defaults to open.
+   */
+  signupOpen?: boolean
 }
 
 /**
  * Logged-out landing: a full-bleed split with the auth card on the right and,
  * on the left, either a preview of the server's public timeline (when there are
  * public posts) or a brand hero. Mirrors the design system's web-landing kit
- * (`feed.html` / `index.html`). Sits on the body's signature dual-tint gradient;
- * the auth column is translucent so the backdrop reads through.
+ * (`feed.html` / `index.html`, plus the `*-registration-closed.html` variants).
+ * Sits on the body's signature dual-tint gradient; the auth column is
+ * translucent so the backdrop reads through.
  */
 export const Landing: FC<LandingProps> = ({
   host,
   currentTime,
   statuses,
-  serviceName
+  serviceName,
+  signupOpen = true
 }) => {
   const hasPublicPosts = statuses.length > 0
   return (
@@ -42,7 +50,7 @@ export const Landing: FC<LandingProps> = ({
         )}
       </div>
       <div className="flex min-h-0 flex-col bg-background/80 md:overflow-y-auto">
-        <LandingAuthPanel serviceName={serviceName} />
+        <LandingAuthPanel serviceName={serviceName} signupOpen={signupOpen} />
       </div>
     </main>
   )

--- a/app/(timeline)/landing/LandingAuthPanel.tsx
+++ b/app/(timeline)/landing/LandingAuthPanel.tsx
@@ -1,4 +1,4 @@
-import { Fingerprint } from 'lucide-react'
+import { Fingerprint, Lock } from 'lucide-react'
 import Link from 'next/link'
 import { FC } from 'react'
 
@@ -6,6 +6,12 @@ import { Button } from '@/lib/components/ui/button'
 
 interface LandingAuthPanelProps {
   serviceName: string
+  /**
+   * Whether the server accepts new account sign-ups. When `false`, the panel
+   * drops the "Create account" path for a sign-in-only "registration closed"
+   * notice. Defaults to open.
+   */
+  signupOpen?: boolean
 }
 
 /**
@@ -13,43 +19,93 @@ interface LandingAuthPanelProps {
  * CTAs link to the real auth routes (`/auth/signup`, `/auth/signin`) rather than
  * re-implementing the credential/passkey flows; the passkey CTA points at the
  * sign-in page where the WebAuthn button lives.
+ *
+ * When `signupOpen` is `false` (the design's `*-registration-closed.html`
+ * variant) the "Create account" path is replaced by a "registration closed"
+ * notice and sign-in becomes the primary action.
  */
 export const LandingAuthPanel: FC<LandingAuthPanelProps> = ({
-  serviceName
-}) => (
-  <div className="flex h-full flex-col justify-center px-7 py-9 sm:px-14 sm:py-14">
-    <div className="mx-auto w-full max-w-[360px]">
-      <h2 className="text-2xl font-semibold tracking-tight">
-        Join {serviceName}
-      </h2>
-      <p className="mt-1.5 text-sm text-muted-foreground">
-        Create an account or sign in to continue.
-      </p>
+  serviceName,
+  signupOpen = true
+}) => {
+  if (!signupOpen) {
+    return (
+      <div className="flex h-full flex-col justify-center px-7 py-9 sm:px-14 sm:py-14">
+        <div className="mx-auto w-full max-w-[360px]">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Welcome back
+          </h2>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            Sign in to your account to continue.
+          </p>
 
-      <div className="mt-7 flex flex-col gap-2.5">
-        <Button asChild className="h-11 w-full shadow-xs">
-          <Link href="/auth/signup">Create account</Link>
-        </Button>
+          <div className="mt-6 flex items-start gap-3 rounded-lg border bg-muted/40 p-3.5">
+            <span className="mt-px flex size-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <Lock className="size-[15px]" />
+            </span>
+            <div>
+              <p className="text-sm font-medium">Registration is closed</p>
+              <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                This server isn&apos;t accepting new members right now.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-2.5">
+            <Button asChild className="h-11 w-full shadow-xs">
+              <Link href="/auth/signin">Sign in</Link>
+            </Button>
+            <Button asChild variant="outline" className="h-11 w-full">
+              <Link href="/auth/signin">
+                <Fingerprint className="size-4" /> Continue with a passkey
+              </Link>
+            </Button>
+          </div>
+
+          <p className="mt-7 text-xs leading-relaxed text-muted-foreground">
+            Hoping to join {serviceName}? Request an invite from the server
+            admin.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col justify-center px-7 py-9 sm:px-14 sm:py-14">
+      <div className="mx-auto w-full max-w-[360px]">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Join {serviceName}
+        </h2>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          Create an account or sign in to continue.
+        </p>
+
+        <div className="mt-7 flex flex-col gap-2.5">
+          <Button asChild className="h-11 w-full shadow-xs">
+            <Link href="/auth/signup">Create account</Link>
+          </Button>
+          <Button asChild variant="outline" className="h-11 w-full">
+            <Link href="/auth/signin">Sign in</Link>
+          </Button>
+        </div>
+
+        <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="h-px flex-1 bg-border" />
+          or
+          <span className="h-px flex-1 bg-border" />
+        </div>
+
         <Button asChild variant="outline" className="h-11 w-full">
-          <Link href="/auth/signin">Sign in</Link>
+          <Link href="/auth/signin">
+            <Fingerprint className="size-4" /> Continue with a passkey
+          </Link>
         </Button>
+
+        <p className="mt-7 text-xs leading-relaxed text-muted-foreground">
+          By continuing you agree to the Terms and Privacy Policy.
+        </p>
       </div>
-
-      <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
-        <span className="h-px flex-1 bg-border" />
-        or
-        <span className="h-px flex-1 bg-border" />
-      </div>
-
-      <Button asChild variant="outline" className="h-11 w-full">
-        <Link href="/auth/signin">
-          <Fingerprint className="size-4" /> Continue with a passkey
-        </Link>
-      </Button>
-
-      <p className="mt-7 text-xs leading-relaxed text-muted-foreground">
-        By continuing you agree to the Terms and Privacy Policy.
-      </p>
     </div>
-  </div>
-)
+  )
+}

--- a/app/(timeline)/page.tsx
+++ b/app/(timeline)/page.tsx
@@ -48,7 +48,12 @@ const Page = async () => {
     // so an outage isn't silently hidden as "no posts".
     let publicStatuses: Status[] = []
     try {
-      const publicCount = await database.getLocalPublicStatusesCount()
+      // Bounded check: only need to know whether the threshold is reached, so
+      // the count stops at LANDING_FEED_MIN_POSTS rather than scanning every
+      // public post on each anonymous request.
+      const publicCount = await database.getLocalPublicStatusesCount(
+        LANDING_FEED_MIN_POSTS
+      )
       if (publicCount >= LANDING_FEED_MIN_POSTS) {
         const { statuses } = await getFilteredStatusPage({
           database,

--- a/app/(timeline)/page.tsx
+++ b/app/(timeline)/page.tsx
@@ -18,7 +18,11 @@ import { MainPageTimeline } from './MainPageTimeline'
 import { Landing } from './landing/Landing'
 
 // Number of recent public posts previewed in the logged-out landing feed.
-const LANDING_FEED_LIMIT = 5
+const LANDING_FEED_LIMIT = 20
+// The landing only previews the public timeline once the server has at least
+// this many public posts; below the threshold it shows the brand hero instead,
+// so a sparse new server doesn't lead with a near-empty feed.
+const LANDING_FEED_MIN_POSTS = 100
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
@@ -26,7 +30,7 @@ export const metadata: Metadata = {
 }
 
 const Page = async () => {
-  const { host, serviceName, mediaStorage } = getConfig()
+  const { host, serviceName, mediaStorage, registrationOpen } = getConfig()
   const database = getDatabase()
   if (!database) {
     throw new Error('Fail to load database')
@@ -35,24 +39,29 @@ const Page = async () => {
   const session = await getServerAuthSession()
   const actor = await getActorFromSession(database, session)
   if (!actor) {
-    // Logged-out visitors get the landing. When the server has public posts the
-    // landing previews its recent public timeline; otherwise it shows the brand
-    // hero. Both variants share the create/sign-in card. A failure to load the
-    // public preview degrades to the hero rather than 500-ing the public front
-    // door — but it's logged so an outage isn't silently hidden as "no posts".
+    // Logged-out visitors get the landing. The landing only previews the public
+    // timeline once the server has a healthy number of public posts
+    // (LANDING_FEED_MIN_POSTS); below that it shows the brand hero so a sparse
+    // server doesn't lead with a near-empty feed. The right-hand auth card
+    // reflects whether sign-up is open. A failure to load the preview degrades
+    // to the hero rather than 500-ing the public front door — but it's logged
+    // so an outage isn't silently hidden as "no posts".
     let publicStatuses: Status[] = []
     try {
-      const { statuses } = await getFilteredStatusPage({
-        database,
-        limit: LANDING_FEED_LIMIT,
-        fetchBatch: ({ maxStatusId, limit }) =>
-          database.getTimeline({
-            timeline: Timeline.LOCAL_PUBLIC,
-            maxStatusId,
-            limit
-          })
-      })
-      publicStatuses = statuses
+      const publicCount = await database.getLocalPublicStatusesCount()
+      if (publicCount >= LANDING_FEED_MIN_POSTS) {
+        const { statuses } = await getFilteredStatusPage({
+          database,
+          limit: LANDING_FEED_LIMIT,
+          fetchBatch: ({ maxStatusId, limit }) =>
+            database.getTimeline({
+              timeline: Timeline.LOCAL_PUBLIC,
+              maxStatusId,
+              limit
+            })
+        })
+        publicStatuses = statuses
+      }
     } catch (error) {
       logger.error({
         err: error,
@@ -65,6 +74,7 @@ const Page = async () => {
         currentTime={Date.now()}
         statuses={publicStatuses.map((item) => cleanJson(item))}
         serviceName={serviceName ?? 'Activities'}
+        signupOpen={registrationOpen}
       />
     )
   }

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 
 import { GET, POST } from './route'
@@ -7,7 +8,8 @@ import { GET, POST } from './route'
 jest.mock('@/lib/config', () => ({
   getConfig: jest.fn().mockReturnValue({
     host: 'llun.test',
-    allowEmails: []
+    allowEmails: [],
+    registrationOpen: true
   })
 }))
 
@@ -115,6 +117,27 @@ describe('POST /api/v1/accounts', () => {
     })
     const res = await POST(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(501)
+    expect(createAccount).not.toHaveBeenCalled()
+  })
+
+  it('rejects web sign-up with 403 when registration is closed', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: false
+    } as never)
+    const createAccount = jest.fn()
+    mockDatabase = { ...mockDatabase!, createAccount } as never
+    const req = new NextRequest('http://localhost/api/v1/accounts', {
+      method: 'POST',
+      body: 'username=alice&email=alice@example.com&password=password123',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(403)
     expect(createAccount).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -122,6 +122,18 @@ export const POST = traceApiRoute(
       })
     }
 
+    // A closed server accepts no new accounts at all. This is orthogonal to
+    // `allowEmails` below (which restricts *who* may register while open), so
+    // it is checked first and independently.
+    if (!config.registrationOpen) {
+      return apiResponse({
+        req: request,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Registration is closed' },
+        responseStatusCode: 403
+      })
+    }
+
     const { host: domain, allowEmails } = config
     // The web sign-up form posts urlencoded/multipart form data.
     let body: Record<string, unknown>

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -6,16 +6,17 @@ Application configuration is provided through environment variables. Root-level 
 
 ## Core Configuration
 
-| Variable                         | Required | Description                                                                                                           |
-| -------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `ACTIVITIES_HOST`                | **Yes**  | Domain name for your instance (e.g., `social.example.com`). No protocol, no trailing slash.                           |
-| `ACTIVITIES_SECRET_PHASE`        | **Yes**  | Secret string for signing cookies and tokens. Generate with `openssl rand -base64 32`.                                |
-| `ACTIVITIES_SERVICE_NAME`        | No       | Public instance display name used by instance metadata, auth display, and WebAuthn issuer labels.                     |
-| `ACTIVITIES_SERVICE_DESCRIPTION` | No       | Public instance description used by instance metadata endpoints.                                                      |
-| `ACTIVITIES_LANGUAGES`           | No       | JSON array of supported instance languages (e.g., `["en","nl"]`). Defaults to `["en"]`.                               |
-| `ACTIVITIES_ALLOW_EMAILS`        | No       | JSON array of email addresses allowed to register (e.g., `["user@example.com"]`). If unset, registration may be open. |
-| `ACTIVITIES_TRUSTED_HOSTS`       | No       | JSON array of additional public hosts accepted from `X-Forwarded-Host` and `X-Activity-Next-Host`.                    |
-| `ACTIVITIES_INSECURE_AUTH`       | No       | Set to `true` to allow HTTP (non-HTTPS) authentication. Only for local development.                                   |
+| Variable                         | Required | Description                                                                                                                                                                                                                                            |
+| -------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ACTIVITIES_HOST`                | **Yes**  | Domain name for your instance (e.g., `social.example.com`). No protocol, no trailing slash.                                                                                                                                                            |
+| `ACTIVITIES_SECRET_PHASE`        | **Yes**  | Secret string for signing cookies and tokens. Generate with `openssl rand -base64 32`.                                                                                                                                                                 |
+| `ACTIVITIES_SERVICE_NAME`        | No       | Public instance display name used by instance metadata, auth display, and WebAuthn issuer labels.                                                                                                                                                      |
+| `ACTIVITIES_SERVICE_DESCRIPTION` | No       | Public instance description used by instance metadata endpoints.                                                                                                                                                                                       |
+| `ACTIVITIES_LANGUAGES`           | No       | JSON array of supported instance languages (e.g., `["en","nl"]`). Defaults to `["en"]`.                                                                                                                                                                |
+| `ACTIVITIES_ALLOW_EMAILS`        | No       | JSON array of email addresses allowed to register (e.g., `["user@example.com"]`). If unset, registration may be open.                                                                                                                                  |
+| `ACTIVITIES_REGISTRATION_OPEN`   | No       | Set to `false` to close new-account sign-up entirely (sign-in stays available; the logged-out landing shows a "registration closed" notice). Defaults to open. Orthogonal to `ACTIVITIES_ALLOW_EMAILS`, which restricts _who_ may register while open. |
+| `ACTIVITIES_TRUSTED_HOSTS`       | No       | JSON array of additional public hosts accepted from `X-Forwarded-Host` and `X-Activity-Next-Host`.                                                                                                                                                     |
+| `ACTIVITIES_INSECURE_AUTH`       | No       | Set to `true` to allow HTTP (non-HTTPS) authentication. Only for local development.                                                                                                                                                                    |
 
 ## Proxy Configuration
 

--- a/lib/__mocks__/config.ts
+++ b/lib/__mocks__/config.ts
@@ -5,6 +5,7 @@ export const getConfig = jest.fn().mockReturnValue({
   host: TEST_DOMAIN,
   database: {},
   allowEmails: [],
+  registrationOpen: true,
   secretPhase: MOCK_SECRET_PHASES,
   auth: {}
 })

--- a/lib/config/index.test.ts
+++ b/lib/config/index.test.ts
@@ -111,4 +111,40 @@ describe('Config', () => {
       fs.rmSync(tmpDir, { force: true, recursive: true })
     }
   })
+
+  describe('registrationOpen', () => {
+    const loadConfig = async () => {
+      process.env.ACTIVITIES_HOST = 'example.com'
+      process.env.ACTIVITIES_SECRET_PHASE = 'env-secret'
+      process.env.ACTIVITIES_ALLOW_EMAILS = '[]'
+      process.env.ACTIVITIES_DATABASE_CLIENT = 'better-sqlite3'
+      process.env.ACTIVITIES_DATABASE_SQLITE_FILENAME = ':memory:'
+      const { getConfig } = await import('./index')
+      return getConfig()
+    }
+
+    it.each([
+      {
+        description: 'defaults to open when unset',
+        value: undefined,
+        open: true
+      },
+      { description: 'stays open for "true"', value: 'true', open: true },
+      {
+        description: 'closes only for the literal "false"',
+        value: 'false',
+        open: false
+      },
+      { description: 'stays open for any other value', value: 'no', open: true }
+    ])('$description', async ({ value, open }) => {
+      if (value === undefined) {
+        delete process.env.ACTIVITIES_REGISTRATION_OPEN
+      } else {
+        process.env.ACTIVITIES_REGISTRATION_OPEN = value
+      }
+
+      const config = await loadConfig()
+      expect(config.registrationOpen).toBe(open)
+    })
+  })
 })

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -37,6 +37,7 @@ const Config = z.object({
   queue: QueueConfig.optional(),
   push: PushConfig.optional(),
   allowEmails: z.string().array(),
+  registrationOpen: z.boolean().default(true),
   secretPhase: z.string(),
   allowMediaDomains: z.string().array().optional(),
   allowActorDomains: z.string().array().optional(),
@@ -113,6 +114,10 @@ const getConfigFromEnvironment = () => {
       languages: getLanguagesConfig(),
       secretPhase: process.env.ACTIVITIES_SECRET_PHASE || '',
       allowEmails: JSON.parse(process.env.ACTIVITIES_ALLOW_EMAILS || '[]'),
+      // Registration is open unless explicitly disabled. Orthogonal to
+      // `allowEmails` (which restricts *who* may register when open): setting
+      // this to `false` closes new-account sign-up entirely.
+      registrationOpen: process.env.ACTIVITIES_REGISTRATION_OPEN !== 'false',
       allowMediaDomains: JSON.parse(
         process.env.ACTIVITIES_ALLOW_MEDIA_DOMAINS || '[]'
       ),

--- a/lib/database/sql/timeline.test.ts
+++ b/lib/database/sql/timeline.test.ts
@@ -658,5 +658,79 @@ describe('TimelineDatabase', () => {
         })
       })
     })
+
+    describe('getLocalPublicStatusesCount', () => {
+      const COUNT_ACTOR = `https://${TEST_DOMAIN}/users/count-public`
+
+      beforeAll(async () => {
+        await database.createActor({
+          actorId: COUNT_ACTOR,
+          username: 'count-public',
+          domain: TEST_DOMAIN,
+          publicKey: 'publicKey-count-public',
+          privateKey: 'privateKey-count-public',
+          inboxUrl: `${COUNT_ACTOR}/inbox`,
+          sharedInboxUrl: `${COUNT_ACTOR}/inbox`,
+          followersUrl: `${COUNT_ACTOR}/followers`,
+          createdAt: Date.now()
+        })
+      })
+
+      afterAll(async () => {
+        await database.deleteActor({ actorId: COUNT_ACTOR })
+      })
+
+      it('counts only top-level public statuses, ignoring replies and non-public posts', async () => {
+        // Assert on the delta rather than an absolute count: the public
+        // timeline is server-wide and other suites seed public posts too.
+        const before = await database.getLocalPublicStatusesCount()
+
+        await database.createNote({
+          actorId: COUNT_ACTOR,
+          cc: [],
+          to: [ACTIVITY_STREAM_PUBLIC],
+          id: `${COUNT_ACTOR}/statuses/count-public-1`,
+          text: 'Counted public status',
+          url: `${COUNT_ACTOR}/statuses/count-public-1`,
+          reply: '',
+          createdAt: Date.now()
+        })
+        await database.createNote({
+          actorId: COUNT_ACTOR,
+          cc: [],
+          to: [ACTIVITY_STREAM_PUBLIC],
+          id: `${COUNT_ACTOR}/statuses/count-public-2`,
+          text: 'Second counted public status',
+          url: `${COUNT_ACTOR}/statuses/count-public-2`,
+          reply: '',
+          createdAt: Date.now()
+        })
+        // A reply: excluded (reply !== '').
+        await database.createNote({
+          actorId: COUNT_ACTOR,
+          cc: [],
+          to: [ACTIVITY_STREAM_PUBLIC],
+          id: `${COUNT_ACTOR}/statuses/count-reply`,
+          text: 'A public reply that should not count',
+          url: `${COUNT_ACTOR}/statuses/count-reply`,
+          reply: `${COUNT_ACTOR}/statuses/count-public-1`,
+          createdAt: Date.now()
+        })
+        // Followers-only: excluded (not addressed to the public collection).
+        await database.createNote({
+          actorId: COUNT_ACTOR,
+          cc: [`${COUNT_ACTOR}/followers`],
+          to: [],
+          id: `${COUNT_ACTOR}/statuses/count-followers`,
+          text: 'A followers-only status that should not count',
+          url: `${COUNT_ACTOR}/statuses/count-followers`,
+          reply: '',
+          createdAt: Date.now()
+        })
+
+        const after = await database.getLocalPublicStatusesCount()
+        expect(after - before).toBe(2)
+      }, 10000)
+    })
   })
 })

--- a/lib/database/sql/timeline.test.ts
+++ b/lib/database/sql/timeline.test.ts
@@ -731,6 +731,13 @@ describe('TimelineDatabase', () => {
         const after = await database.getLocalPublicStatusesCount()
         expect(after - before).toBe(2)
       }, 10000)
+
+      it('stops counting at the given limit', async () => {
+        // At least the two public posts from the previous case exist, so a
+        // limit of 1 must short-circuit to exactly 1.
+        const limited = await database.getLocalPublicStatusesCount(1)
+        expect(limited).toBe(1)
+      }, 10000)
     })
   })
 })

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -213,7 +213,7 @@ export const TimelineSQLDatabaseMixin = (
     }
 
     const row = await query
-      .countDistinct<{ count: string | number }>('statuses.id as count')
+      .countDistinct<{ count: string | number }>({ count: 'statuses.id' })
       .first()
     // count() returns a string on PostgreSQL and a number on SQLite.
     return row ? Number(row.count) : 0

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -191,6 +191,24 @@ export const TimelineSQLDatabaseMixin = (
     }
   },
 
+  async getLocalPublicStatusesCount(): Promise<number> {
+    // Mirror the LOCAL_PUBLIC selection in getTimeline: top-level (non-reply)
+    // statuses addressed to the public collection and authored by a local actor
+    // (one with a private key). countDistinct guards against a status appearing
+    // under more than one matching recipient row.
+    const row = await database('recipients')
+      .where('recipients.type', 'to')
+      .where('recipients.actorId', ACTIVITY_STREAM_PUBLIC)
+      .innerJoin('statuses', 'recipients.statusId', 'statuses.id')
+      .innerJoin('actors', 'statuses.actorId', 'actors.id')
+      .whereNotNull('actors.privateKey')
+      .where('statuses.reply', '')
+      .countDistinct<{ count: string | number }>('statuses.id as count')
+      .first()
+    // count() returns a string on PostgreSQL and a number on SQLite.
+    return row ? Number(row.count) : 0
+  },
+
   async createTimelineStatus({
     actorId,
     status,

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -191,18 +191,28 @@ export const TimelineSQLDatabaseMixin = (
     }
   },
 
-  async getLocalPublicStatusesCount(): Promise<number> {
+  async getLocalPublicStatusesCount(limit?: number): Promise<number> {
     // Mirror the LOCAL_PUBLIC selection in getTimeline: top-level (non-reply)
     // statuses addressed to the public collection and authored by a local actor
-    // (one with a private key). countDistinct guards against a status appearing
-    // under more than one matching recipient row.
-    const row = await database('recipients')
+    // (one with a private key).
+    const query = database('recipients')
       .where('recipients.type', 'to')
       .where('recipients.actorId', ACTIVITY_STREAM_PUBLIC)
       .innerJoin('statuses', 'recipients.statusId', 'statuses.id')
       .innerJoin('actors', 'statuses.actorId', 'actors.id')
       .whereNotNull('actors.privateKey')
       .where('statuses.reply', '')
+
+    // The landing only needs to know whether the count reaches a threshold, not
+    // the exact total. When `limit` is given, fetch at most `limit` distinct ids
+    // and return how many came back, so the scan stops early instead of counting
+    // every public post on every unauthenticated request (a DoS risk at scale).
+    if (limit !== undefined) {
+      const rows = await query.distinct('statuses.id').limit(limit)
+      return rows.length
+    }
+
+    const row = await query
       .countDistinct<{ count: string | number }>('statuses.id as count')
       .first()
     // count() returns a string on PostgreSQL and a number on SQLite.

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2266,6 +2266,13 @@ export interface TimelineDatabase {
     limit
   }: GetTimelineParams): Promise<Status[]>
   createTimelineStatus(params: CreateTimelineStatusParams): Promise<void>
+  /**
+   * Total number of statuses visible on the local public timeline (the same
+   * set `getTimeline({ timeline: LOCAL_PUBLIC })` pages over). Used to decide
+   * whether the logged-out landing previews the public feed or shows the brand
+   * hero.
+   */
+  getLocalPublicStatusesCount(): Promise<number>
 }
 
 // ============================================================================

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2267,12 +2267,13 @@ export interface TimelineDatabase {
   }: GetTimelineParams): Promise<Status[]>
   createTimelineStatus(params: CreateTimelineStatusParams): Promise<void>
   /**
-   * Total number of statuses visible on the local public timeline (the same
-   * set `getTimeline({ timeline: LOCAL_PUBLIC })` pages over). Used to decide
+   * Number of statuses visible on the local public timeline (the same set
+   * `getTimeline({ timeline: LOCAL_PUBLIC })` pages over). Used to decide
    * whether the logged-out landing previews the public feed or shows the brand
-   * hero.
+   * hero. Pass `limit` to stop counting once that many are found (a bounded,
+   * cheaper check when the caller only needs a threshold, not the exact total).
    */
-  getLocalPublicStatusesCount(): Promise<number>
+  getLocalPublicStatusesCount(limit?: number): Promise<number>
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements the design system's `web-landing` registration-closed variants and adds a post-count threshold for the logged-out landing's public-feed preview.

Two behaviours, driven by the design files `ui_kits/web-landing/registration-closed.html` and `feed-registration-closed.html`:

### 1. Public-feed threshold on the landing
- The logged-out landing only previews the server's public timeline once it has **≥ 100** public posts, and then shows **20** recent posts.
- Below the threshold it shows the brand hero (as before) instead of a near-empty feed.
- New `Database.getLocalPublicStatusesCount()` mirrors the `LOCAL_PUBLIC` selection (top-level, public-addressed, local-actor statuses) and is `Number()`-coerced for the pg/sqlite string/number difference.

### 2. Registration-closed landing + config
- New **`ACTIVITIES_REGISTRATION_OPEN`** flag (defaults to **open**; only the literal `false` closes it). Orthogonal to `ACTIVITIES_ALLOW_EMAILS`, which restricts *who* may register while open.
- When closed, the landing auth card drops "Create account" for a sign-in-only **"Registration is closed"** notice (matching the design).
- Made the flag real, not cosmetic:
  - `POST /api/v1/accounts` rejects new web sign-ups with **403** (checked independently, before the `allowEmails` check).
  - `/auth/signup` redirects to the landing when closed.
  - "Create account" / "Sign up" CTAs are hidden on the public top bar, the single-status sign-in callout, and the sign-in page footer.

The left column (feed vs hero) and the right column (open vs closed auth card) are independent, covering all four design states.

## Config

| Variable | Default | Description |
| --- | --- | --- |
| `ACTIVITIES_REGISTRATION_OPEN` | open | Set to `false` to close new-account sign-up entirely (sign-in stays available; the landing shows a "registration closed" notice). |

Documented in `docs/environment-variables.md`. No migrations changed (the count is a query, the flag is env), so the reference schema dumps are untouched.

## Testing
- `yarn lint` — clean (0 errors)
- `yarn build` — green
- `yarn test` — 461 suites / 3908 tests pass
- New tests: `getLocalPublicStatusesCount` (counts only top-level public local posts, excludes replies/followers-only), `registrationOpen` config parsing (table-driven), `Landing` registration-closed variant (+ feed still shows when closed), accounts API 403-when-closed.

## Browser verification (local SQLite, real app)
Verified all three changed states against the design specs (per the bundle README, the real app was run rather than the prototype HTML):
- **Registration closed, < 100 posts** → hero + "Welcome back / Registration is closed" sign-in-only card (`registration-closed.html`). ✅
- **Registration closed, ≥ 100 posts** → public feed + closed card (`feed-registration-closed.html`). ✅
- **Registration open, ≥ 100 posts** → public feed + "Join Activities / Create account" card (`feed.html`). ✅

No console/hydration errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)