### PR TITLE
Bump version to v1.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.56.4",
+  "version": "1.57.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.57.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.56.4`
- Base main SHA: `20036e74e8fc899f33ddb404275d3815e273548d`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
