### PR TITLE
Bump version to v1.57.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.57.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.57.0`
- Base main SHA: `4da9a28f845d6b0b33c5724427395470b0951614`
- Included commits: `8`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
