### PR TITLE
Bump version to v1.57.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.57.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.57.1`
- Base main SHA: `1868d4c034b0bfba8c50eaaa264e59128d8aa00e`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
