### PR TITLE
minor: add keyword filters (account + server scope)

### DIFF
--- a/app/(timeline)/admin/filters/page.tsx
+++ b/app/(timeline)/admin/filters/page.tsx
@@ -1,0 +1,28 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { FiltersPanel } from '@/lib/components/filters/FiltersPanel'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Server filters'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  return <FiltersPanel scope="server" currentTime={Date.now()} />
+}
+
+export default Page

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { BarChart3, Globe, Hash, Settings, Smile, Users } from 'lucide-react'
+import {
+  BarChart3,
+  Filter,
+  Globe,
+  Hash,
+  Settings,
+  Smile,
+  Users
+} from 'lucide-react'
 import { FC, ReactNode } from 'react'
 
 import {
@@ -20,6 +28,7 @@ const tabs: SectionNavTab[] = [
   { name: 'Overview', url: '/admin', icon: BarChart3 },
   { name: 'Accounts', url: '/admin/accounts', icon: Users },
   { name: 'Hashtags', url: '/admin/tags', icon: Hash },
+  { name: 'Filters', url: '/admin/filters', icon: Filter },
   { name: 'Federation', url: '/admin/federation', icon: Globe },
   { name: 'Custom emojis', url: '/admin/emojis', icon: Smile },
   { name: 'System', url: '/admin/system', icon: Settings }

--- a/app/(timeline)/settings/filters/page.tsx
+++ b/app/(timeline)/settings/filters/page.tsx
@@ -1,0 +1,30 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { FiltersPanel } from '@/lib/components/filters/FiltersPanel'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Filters'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor || !actor.account) {
+    return redirect('/auth/signin')
+  }
+
+  return <FiltersPanel scope="account" currentTime={Date.now()} />
+}
+
+export default Page

--- a/app/(timeline)/settings/layout.tsx
+++ b/app/(timeline)/settings/layout.tsx
@@ -3,6 +3,7 @@
 import {
   Ban,
   Bell,
+  Filter,
   Hash,
   Image as ImageIcon,
   Monitor,
@@ -37,6 +38,7 @@ const tabs: SectionNavTab[] = [
   { name: 'Notifications', url: '/settings/notifications', icon: Bell },
   { name: 'Blocked accounts', url: '/settings/blocks', icon: Ban },
   { name: 'Muted accounts', url: '/settings/mutes', icon: VolumeX },
+  { name: 'Filters', url: '/settings/filters', icon: Filter },
   { name: 'Sessions', url: '/settings/sessions', icon: Monitor }
 ]
 

--- a/app/api/v1/conversations/[id]/statuses/route.test.ts
+++ b/app/api/v1/conversations/[id]/statuses/route.test.ts
@@ -8,7 +8,8 @@ const mockCurrentActor = {
 
 const mockDatabase = {
   getDirectConversationStatuses: jest.fn(),
-  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getActiveServerFilters: jest.fn().mockResolvedValue([])
 }
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -5,7 +5,8 @@ import { GET, POST } from './route'
 const mockDatabase = {
   getNotifications: jest.fn(),
   deleteNotification: jest.fn(),
-  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getActiveServerFilters: jest.fn().mockResolvedValue([])
 }
 
 const mockCurrentActor = {

--- a/app/api/v2/admin/filters/[id]/route.ts
+++ b/app/api/v2/admin/filters/[id]/route.ts
@@ -37,16 +37,15 @@ export const GET = traceApiRoute(
   'adminGetServerFilter',
   AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
     const { id } = await params
-    const keywords = await database.getServerFilterKeywords({ id })
-    const filter = await database.getServerFilter({ id })
-    if (!filter || !keywords)
+    const record = await database.getServerFilterRecord({ id })
+    if (!record)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: ERROR_404,
         responseStatusCode: HTTP_STATUS.NOT_FOUND
       })
-    const data = getMastodonServerFilterFromRecord({ filter, keywords })
+    const data = getMastodonServerFilterFromRecord(record)
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
   })
 )

--- a/app/api/v2/admin/filters/[id]/route.ts
+++ b/app/api/v2/admin/filters/[id]/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest } from 'next/server'
+
+import {
+  parseFilterBody,
+  parseFilterUpdateInput
+} from '@/lib/services/filters/parseFilterInput'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import {
+  getMastodonServerFilter,
+  getMastodonServerFilterFromRecord
+} from '@/lib/services/mastodon/getMastodonFilter'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_404,
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PUT,
+  HttpMethod.enum.PATCH,
+  HttpMethod.enum.DELETE
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const GET = traceApiRoute(
+  'adminGetServerFilter',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const keywords = await database.getServerFilterKeywords({ id })
+    const filter = await database.getServerFilter({ id })
+    if (!filter || !keywords)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    const data = getMastodonServerFilterFromRecord({ filter, keywords })
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+  })
+)
+
+export const PUT = traceApiRoute(
+  'adminUpdateServerFilter',
+  AdminApiGuard<Params>(
+    CORS_HEADERS,
+    async (req: NextRequest, { database, params }) => {
+      const { id } = await params
+      let rawBody: unknown
+      try {
+        rawBody = await parseFilterBody(req)
+      } catch {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        })
+      }
+      const input = parseFilterUpdateInput(rawBody)
+      if (!input)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        })
+
+      const updated = await database.updateServerFilter({
+        id,
+        title: input.title,
+        context: input.context,
+        filterAction: input.filterAction,
+        expiresAt: input.expiresAt,
+        keywords: input.keywords
+      })
+      if (!updated)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: HTTP_STATUS.NOT_FOUND
+        })
+      const data = await getMastodonServerFilter(database, updated)
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+    }
+  )
+)
+
+// Mastodon clients commonly send PATCH for updates; bind it to the same handler.
+export const PATCH = PUT
+
+export const DELETE = traceApiRoute(
+  'adminDeleteServerFilter',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const deleted = await database.deleteServerFilter({ id })
+    if (!deleted)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+  })
+)

--- a/app/api/v2/admin/filters/route.test.ts
+++ b/app/api/v2/admin/filters/route.test.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
+import { GET, POST } from './route'
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => null
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest
+    .fn()
+    .mockResolvedValue({ user: { email: 'admin@llun.test' } })
+}))
+
+const mockGetAdminFromSession = jest.fn()
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: () => mockGetAdminFromSession()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v2/admin/filters', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAdminFromSession.mockResolvedValue({
+      id: 'admin',
+      email: 'admin@llun.test'
+    })
+  })
+
+  const baseRequest = (init?: { method?: string; body?: object }) =>
+    new NextRequest('https://llun.test/api/v2/admin/filters', {
+      method: init?.method ?? 'GET',
+      headers: init?.body
+        ? {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test',
+            Referer: 'https://llun.test/'
+          }
+        : { Origin: 'https://llun.test' },
+      body: init?.body ? JSON.stringify(init.body) : undefined
+    })
+
+  it('rejects non-admin requests', async () => {
+    mockGetAdminFromSession.mockResolvedValue(null)
+
+    const response = await POST(
+      baseRequest({
+        method: 'POST',
+        body: { title: 'Spam', context: ['home'], filter_action: 'hide' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(403)
+  })
+
+  it('creates a server filter flagged read-only and lists it', async () => {
+    const postResponse = await POST(
+      baseRequest({
+        method: 'POST',
+        body: {
+          title: 'Spam campaigns',
+          context: ['home', 'public'],
+          filter_action: 'hide',
+          keywords_attributes: [
+            { keyword: 'free followers', whole_word: false }
+          ]
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+    expect(postResponse.status).toBe(200)
+    const created = await postResponse.json()
+    expect(created.title).toBe('Spam campaigns')
+    expect(created.filter_action).toBe('hide')
+    expect(created.server).toBe(true)
+    expect(created.keywords).toHaveLength(1)
+
+    const listResponse = await GET(baseRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(listResponse.status).toBe(200)
+    const list = await listResponse.json()
+    const entry = list.find((item: { id: string }) => item.id === created.id)
+    expect(entry).toBeTruthy()
+    expect(entry.server).toBe(true)
+  })
+
+  it('returns 422 when the body is missing title or context', async () => {
+    const response = await POST(
+      baseRequest({ method: 'POST', body: { context: ['home'] } }),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(422)
+  })
+})

--- a/app/api/v2/admin/filters/route.ts
+++ b/app/api/v2/admin/filters/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from 'next/server'
+
+import {
+  parseFilterBody,
+  parseFilterCreateInput
+} from '@/lib/services/filters/parseFilterInput'
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import {
+  getMastodonServerFilter,
+  getMastodonServerFilterFromRecord
+} from '@/lib/services/mastodon/getMastodonFilter'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.POST
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminListServerFilters',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const records = await database.getServerFilterRecords()
+    const data = records.map(getMastodonServerFilterFromRecord)
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+  })
+)
+
+export const POST = traceApiRoute(
+  'adminCreateServerFilter',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    let rawBody: unknown
+    try {
+      rawBody = await parseFilterBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+    const input = parseFilterCreateInput(rawBody)
+    if (!input) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const filter = await database.createServerFilter({
+      title: input.title,
+      context: input.context,
+      filterAction: input.filterAction,
+      expiresAt: input.expiresAt,
+      keywords: input.keywords
+    })
+    const data = await getMastodonServerFilter(database, filter)
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+  })
+)

--- a/app/api/v2/filters/route.ts
+++ b/app/api/v2/filters/route.ts
@@ -10,7 +10,8 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import {
   getMastodonFilter,
-  getMastodonFilterFromRecord
+  getMastodonFilterFromRecord,
+  getMastodonServerFilterFromRecord
 } from '@/lib/services/mastodon/getMastodonFilter'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -35,10 +36,18 @@ export const GET = traceApiRoute(
   OAuthGuardAnyScope(
     [Scope.enum.read, Scope.enum['read:filters']],
     async (req, { database, currentActor }) => {
-      const records = await database.getActiveFiltersForActor({
-        actorId: currentActor.id
-      })
-      const data = records.map(getMastodonFilterFromRecord)
+      // The actor's own filters, including expired ones, so the management UI
+      // can list them with an "Expired" badge and let the user reactivate them.
+      const [ownRecords, serverRecords] = await Promise.all([
+        database.getFilterRecordsForActor({ actorId: currentActor.id }),
+        // Active instance-wide rules, merged in flagged read-only so clients
+        // apply them natively (server filters never expose expired entries).
+        database.getActiveServerFilters()
+      ])
+      const data = [
+        ...ownRecords.map(getMastodonFilterFromRecord),
+        ...serverRecords.map(getMastodonServerFilterFromRecord)
+      ]
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
     }
   )

--- a/app/api/v2/notifications/[group_key]/accounts/route.test.ts
+++ b/app/api/v2/notifications/[group_key]/accounts/route.test.ts
@@ -6,6 +6,7 @@ const mockDatabase = {
   getNotificationsForGroupKey: jest.fn(),
   getMastodonActorsFromIds: jest.fn(),
   getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getActiveServerFilters: jest.fn().mockResolvedValue([]),
   getStatusesByIds: jest.fn().mockResolvedValue([])
 }
 

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -7,7 +7,8 @@ const mockDatabase = {
   getMastodonActorsFromIds: jest.fn(),
   getStatus: jest.fn(),
   getStatusesByIds: jest.fn(),
-  getActiveFiltersForActor: jest.fn().mockResolvedValue([])
+  getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getActiveServerFilters: jest.fn().mockResolvedValue([])
 }
 
 const mockCurrentActor = { id: 'https://llun.test/users/llun' }

--- a/app/api/v2/notifications/unread_count/route.test.ts
+++ b/app/api/v2/notifications/unread_count/route.test.ts
@@ -8,6 +8,7 @@ const toId = (url: string) =>
 const mockDatabase = {
   getNotifications: jest.fn(),
   getActiveFiltersForActor: jest.fn().mockResolvedValue([]),
+  getActiveServerFilters: jest.fn().mockResolvedValue([]),
   getStatusesByIds: jest.fn(),
   getMastodonActorsFromIds: jest.fn()
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2833,7 +2833,9 @@ export const getListTimeline = async ({
 // Keyword filters for the account scope (/api/v2/filters) and the instance
 // scope (/api/v2/admin/filters). Server filters are returned merged into the
 // account list flagged read-only via the non-standard `server` field. Filter
-// ids are opaque UUIDs, so they are not url/id encoded.
+// ids are opaque UUIDs (not ActivityPub URLs), so unlike status/account ids
+// they are not transformed with urlToId — they are still escaped with
+// encodeURIComponent when placed in a request path.
 
 export interface ClientFilter extends MastodonFilter {
   // Present and true only on instance-wide server filters merged into the

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2883,7 +2883,12 @@ const requestFilters = async (path: string): Promise<ClientFilter[]> => {
     method: 'GET',
     headers: { Accept: 'application/json' }
   })
-  if (!response.ok) return []
+  // Throw (rather than returning []) so an HTTP error is surfaced by the
+  // caller's error handling instead of being indistinguishable from an
+  // empty list. Mirrors the throwing pattern used by createNote().
+  if (!response.ok) {
+    throw new Error(`Failed to load filters (${response.status})`)
+  }
   return (await response.json()) as ClientFilter[]
 }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -9,11 +9,13 @@ import {
   UploadedAttachment
 } from '@/lib/types/domain/attachment'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
+import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
 import type { FeaturedTag } from '@/lib/types/mastodon/featuredTag'
+import type { Filter as MastodonFilter } from '@/lib/types/mastodon/filter'
 import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import type { Tag } from '@/lib/types/mastodon/tag'
@@ -2826,3 +2828,125 @@ export const getListTimeline = async ({
     prevMinStatusId: data.prevMinStatusId ?? null
   }
 }
+
+// Filters (https://docs.joinmastodon.org/methods/filters/).
+// Keyword filters for the account scope (/api/v2/filters) and the instance
+// scope (/api/v2/admin/filters). Server filters are returned merged into the
+// account list flagged read-only via the non-standard `server` field. Filter
+// ids are opaque UUIDs, so they are not url/id encoded.
+
+export interface ClientFilter extends MastodonFilter {
+  // Present and true only on instance-wide server filters merged into the
+  // account list — these are read-only for regular accounts.
+  server?: boolean
+}
+
+export interface FilterKeywordInput {
+  // Set when editing an existing keyword; omit to create a new one.
+  id?: string
+  keyword: string
+  wholeWord: boolean
+  // Set on an existing keyword to remove it during an update.
+  _destroy?: boolean
+}
+
+export interface FilterInput {
+  title: string
+  context: FilterContext[]
+  filterAction: FilterAction
+  // Seconds until the filter expires, or null for "never".
+  expiresIn: number | null
+  keywords: FilterKeywordInput[]
+}
+
+const filterRequestBody = ({
+  title,
+  context,
+  filterAction,
+  expiresIn,
+  keywords
+}: FilterInput) => ({
+  title,
+  context,
+  filter_action: filterAction,
+  expires_in: expiresIn,
+  keywords_attributes: keywords.map((keyword) => ({
+    ...(keyword.id ? { id: keyword.id } : {}),
+    keyword: keyword.keyword,
+    whole_word: keyword.wholeWord,
+    ...(keyword._destroy ? { _destroy: true } : {})
+  }))
+})
+
+const requestFilters = async (path: string): Promise<ClientFilter[]> => {
+  const response = await fetch(path, {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (!response.ok) return []
+  return (await response.json()) as ClientFilter[]
+}
+
+const createFilterRequest = async (
+  path: string,
+  input: FilterInput
+): Promise<ClientFilter | null> => {
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(filterRequestBody(input))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ClientFilter
+}
+
+const updateFilterRequest = async (
+  path: string,
+  input: FilterInput
+): Promise<ClientFilter | null> => {
+  const response = await fetch(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(filterRequestBody(input))
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ClientFilter
+}
+
+const deleteFilterRequest = async (path: string): Promise<boolean> => {
+  const response = await fetch(path, { method: 'DELETE' })
+  return response.ok
+}
+
+export const getFilters = (): Promise<ClientFilter[]> =>
+  requestFilters('/api/v2/filters')
+
+export const createFilter = (
+  input: FilterInput
+): Promise<ClientFilter | null> => createFilterRequest('/api/v2/filters', input)
+
+export const updateFilter = (
+  id: string,
+  input: FilterInput
+): Promise<ClientFilter | null> =>
+  updateFilterRequest(`/api/v2/filters/${encodeURIComponent(id)}`, input)
+
+export const deleteFilter = (id: string): Promise<boolean> =>
+  deleteFilterRequest(`/api/v2/filters/${encodeURIComponent(id)}`)
+
+export const getServerFilters = (): Promise<ClientFilter[]> =>
+  requestFilters('/api/v2/admin/filters')
+
+export const createServerFilter = (
+  input: FilterInput
+): Promise<ClientFilter | null> =>
+  createFilterRequest('/api/v2/admin/filters', input)
+
+export const updateServerFilter = (
+  id: string,
+  input: FilterInput
+): Promise<ClientFilter | null> =>
+  updateFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`, input)
+
+export const deleteServerFilter = (id: string): Promise<boolean> =>
+  deleteFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`)

--- a/lib/components/filters/FilterEditor.tsx
+++ b/lib/components/filters/FilterEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ArrowLeft, Plus, X } from 'lucide-react'
-import { FC, useRef, useState } from 'react'
+import { FC, type KeyboardEvent, useRef, useState } from 'react'
 
 import type {
   ClientFilter,
@@ -79,6 +79,23 @@ export const FilterEditor: FC<FilterEditorProps> = ({
   const isNew = !initial
   const keywordCounter = useRef(0)
   const nextKey = () => `new-${keywordCounter.current++}`
+  // Refs to the action radio cards for roving-focus arrow-key navigation.
+  const actionRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  const handleActionKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    const forward = event.key === 'ArrowRight' || event.key === 'ArrowDown'
+    const backward = event.key === 'ArrowLeft' || event.key === 'ArrowUp'
+    if (!forward && !backward) return
+    event.preventDefault()
+    const delta = forward ? 1 : -1
+    const nextIndex =
+      (index + delta + ACTION_CARDS.length) % ACTION_CARDS.length
+    setAction(ACTION_CARDS[nextIndex].id)
+    actionRefs.current[nextIndex]?.focus()
+  }
 
   const [title, setTitle] = useState(initial?.title ?? '')
   const [context, setContext] = useState<FilterContext[]>(
@@ -105,6 +122,9 @@ export const FilterEditor: FC<FilterEditorProps> = ({
   )
   // Existing keywords removed from the editor — sent as `_destroy` on save.
   const [removedKeywordIds, setRemovedKeywordIds] = useState<string[]>([])
+
+  // A filter needs at least one non-empty keyword to match anything.
+  const hasKeyword = keywords.some((k) => k.keyword.trim().length > 0)
 
   const toggleContext = (id: FilterContext) =>
     setContext((current) =>
@@ -252,15 +272,20 @@ export const FilterEditor: FC<FilterEditorProps> = ({
           role="radiogroup"
           aria-label="Filter action"
         >
-          {ACTION_CARDS.map((card) => {
+          {ACTION_CARDS.map((card, index) => {
             const selected = action === card.id
             return (
               <button
                 key={card.id}
+                ref={(element) => {
+                  actionRefs.current[index] = element
+                }}
                 type="button"
                 role="radio"
                 aria-checked={selected}
+                tabIndex={selected ? 0 : -1}
                 onClick={() => setAction(card.id)}
+                onKeyDown={(event) => handleActionKeyDown(event, index)}
                 className={cn(
                   'rounded-xl border p-3 text-left transition-colors',
                   selected
@@ -306,7 +331,12 @@ export const FilterEditor: FC<FilterEditorProps> = ({
               <Button variant="outline" onClick={onCancel} disabled={saving}>
                 Cancel
               </Button>
-              <Button onClick={handleSave} disabled={saving}>
+              <Button
+                onClick={handleSave}
+                // A filter with no non-empty keywords matches nothing, so block
+                // saving until at least one keyword has text.
+                disabled={saving || !hasKeyword}
+              >
                 {isNew ? 'Create filter' : 'Save changes'}
               </Button>
             </div>

--- a/lib/components/filters/FilterEditor.tsx
+++ b/lib/components/filters/FilterEditor.tsx
@@ -1,0 +1,368 @@
+'use client'
+
+import { ArrowLeft, Plus, X } from 'lucide-react'
+import { FC, useRef, useState } from 'react'
+
+import type {
+  ClientFilter,
+  FilterInput,
+  FilterKeywordInput
+} from '@/lib/client'
+import { Button } from '@/lib/components/ui/button'
+import { Checkbox } from '@/lib/components/ui/checkbox'
+import { Input } from '@/lib/components/ui/input'
+import { Select } from '@/lib/components/ui/select'
+import { Switch } from '@/lib/components/ui/switch'
+import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
+import { cn } from '@/lib/utils'
+
+import {
+  EXPIRY_OPTIONS,
+  FILTER_CONTEXTS,
+  expiresInFromValue,
+  expiryOptionForExpiresAt
+} from './filterConstants'
+import { FilterField, FilterSection } from './filterUi'
+
+// Editor row for a single keyword. `id` is set only for keywords that already
+// exist server-side (so we can target them for update/delete); `key` is a
+// stable React key for both existing and freshly-added rows.
+interface KeywordDraft {
+  key: string
+  id?: string
+  keyword: string
+  wholeWord: boolean
+}
+
+const ACTION_CARDS: {
+  id: FilterAction
+  label: string
+  hint: (scope: FilterScope) => string
+}[] = [
+  {
+    id: 'warn',
+    label: 'Hide with a warning',
+    hint: () =>
+      'Matching posts collapse behind the filter title, with a “Show anyway” option.'
+  },
+  {
+    id: 'hide',
+    label: 'Hide completely',
+    hint: (scope) =>
+      scope === 'server'
+        ? 'Matching posts are dropped server-side and never delivered.'
+        : 'Matching posts are dropped server-side and never reach your feeds or notifications.'
+  }
+]
+
+export type FilterScope = 'account' | 'server'
+
+interface FilterEditorProps {
+  initial: ClientFilter | null
+  scope: FilterScope
+  currentTime: number
+  saving: boolean
+  error: string | null
+  onCancel: () => void
+  onSave: (input: FilterInput) => void
+}
+
+export const FilterEditor: FC<FilterEditorProps> = ({
+  initial,
+  scope,
+  currentTime,
+  saving,
+  error,
+  onCancel,
+  onSave
+}) => {
+  const isNew = !initial
+  const keywordCounter = useRef(0)
+  const nextKey = () => `new-${keywordCounter.current++}`
+
+  const [title, setTitle] = useState(initial?.title ?? '')
+  const [context, setContext] = useState<FilterContext[]>(
+    initial ? [...initial.context] : ['home']
+  )
+  const [action, setAction] = useState<FilterAction>(
+    initial?.filter_action ?? 'warn'
+  )
+  const [expiryValue, setExpiryValue] = useState(() =>
+    expiryOptionForExpiresAt(
+      initial?.expires_at ? Date.parse(initial.expires_at) : null,
+      currentTime
+    )
+  )
+  const [keywords, setKeywords] = useState<KeywordDraft[]>(() =>
+    initial
+      ? initial.keywords.map((keyword) => ({
+          key: keyword.id,
+          id: keyword.id,
+          keyword: keyword.keyword,
+          wholeWord: keyword.whole_word
+        }))
+      : [{ key: nextKey(), keyword: '', wholeWord: true }]
+  )
+  // Existing keywords removed from the editor — sent as `_destroy` on save.
+  const [removedKeywordIds, setRemovedKeywordIds] = useState<string[]>([])
+
+  const toggleContext = (id: FilterContext) =>
+    setContext((current) =>
+      current.includes(id)
+        ? current.filter((value) => value !== id)
+        : [...current, id]
+    )
+
+  const patchKeyword = (key: string, patch: Partial<KeywordDraft>) =>
+    setKeywords((current) =>
+      current.map((keyword) =>
+        keyword.key === key ? { ...keyword, ...patch } : keyword
+      )
+    )
+
+  const addKeyword = () =>
+    setKeywords((current) => [
+      ...current,
+      { key: nextKey(), keyword: '', wholeWord: true }
+    ])
+
+  const removeKeyword = (key: string) =>
+    setKeywords((current) => {
+      const target = current.find((keyword) => keyword.key === key)
+      if (target?.id)
+        setRemovedKeywordIds((ids) => [...ids, target.id as string])
+      return current.filter((keyword) => keyword.key !== key)
+    })
+
+  const handleSave = () => {
+    const keywordInputs: FilterKeywordInput[] = []
+    for (const draft of keywords) {
+      const trimmed = draft.keyword.trim()
+      if (trimmed.length === 0) {
+        // A cleared existing keyword is removed; a blank new row is dropped.
+        if (draft.id)
+          keywordInputs.push({
+            id: draft.id,
+            keyword: '',
+            wholeWord: draft.wholeWord,
+            _destroy: true
+          })
+        continue
+      }
+      keywordInputs.push({
+        ...(draft.id ? { id: draft.id } : {}),
+        keyword: trimmed,
+        wholeWord: draft.wholeWord
+      })
+    }
+    for (const id of removedKeywordIds) {
+      keywordInputs.push({ id, keyword: '', wholeWord: false, _destroy: true })
+    }
+
+    onSave({
+      title: title.trim() || 'Untitled filter',
+      context: context.length ? context : ['home'],
+      filterAction: action,
+      expiresIn: expiresInFromValue(expiryValue),
+      keywords: keywordInputs
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button variant="outline" size="sm" onClick={onCancel}>
+          <ArrowLeft className="size-3.5" />
+          Back
+        </Button>
+        <h1 className="text-xl font-semibold tracking-tight">
+          {isNew ? 'Add new filter' : `Edit “${initial?.title}”`}
+        </h1>
+      </div>
+
+      <FilterSection
+        title="Filter"
+        description="Name this filter and choose how long it stays active."
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <FilterField
+            label="Title"
+            htmlFor="filterTitle"
+            help="Shown in place of hidden posts, e.g. “Filtered: Spoilers”."
+          >
+            <Input
+              id="filterTitle"
+              value={title}
+              placeholder="e.g. Spoilers"
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </FilterField>
+          <FilterField
+            label="Expire after"
+            htmlFor="filterExpiry"
+            help="Expired filters stop applying but are kept so you can reactivate them."
+          >
+            <Select
+              id="filterExpiry"
+              value={expiryValue}
+              onChange={(event) => setExpiryValue(event.target.value)}
+            >
+              {EXPIRY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+          </FilterField>
+        </div>
+      </FilterSection>
+
+      <FilterSection
+        title="Filter contexts"
+        description="Choose where this filter applies."
+      >
+        <div className="space-y-1">
+          {FILTER_CONTEXTS.map((option) => (
+            <label
+              key={option.id}
+              className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-[hsl(0_0%_97%)]"
+            >
+              <Checkbox
+                className="size-[18px]"
+                checked={context.includes(option.id)}
+                onChange={() => toggleContext(option.id)}
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-medium">{option.label}</div>
+                <div className="text-xs text-muted-foreground">
+                  {option.hint}
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </FilterSection>
+
+      <FilterSection
+        title="Filter action"
+        description="What happens when a post matches."
+      >
+        <div
+          className="grid gap-3 sm:grid-cols-2"
+          role="radiogroup"
+          aria-label="Filter action"
+        >
+          {ACTION_CARDS.map((card) => {
+            const selected = action === card.id
+            return (
+              <button
+                key={card.id}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                onClick={() => setAction(card.id)}
+                className={cn(
+                  'rounded-xl border p-3 text-left transition-colors',
+                  selected
+                    ? 'border-primary bg-[hsl(24_95%_46%/0.04)] shadow-[0_0_0_3px_hsl(24_95%_46%/0.25)]'
+                    : 'bg-background'
+                )}
+              >
+                <div className="text-sm font-medium">{card.label}</div>
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  {card.hint(scope)}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+        {action === 'warn' && (
+          <div className="rounded-lg border border-dashed p-3">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-[hsl(0_0%_55%)]">
+              Preview
+            </div>
+            <div className="mt-2 flex items-center justify-between gap-3 rounded-lg bg-muted px-3 py-2.5">
+              <span className="text-sm text-muted-foreground">
+                Filtered: {title.trim() || 'Untitled filter'}
+              </span>
+              <span className="text-sm font-medium text-primary">
+                Show anyway
+              </span>
+            </div>
+          </div>
+        )}
+      </FilterSection>
+
+      <FilterSection
+        title="Keywords"
+        description="Matched against post text, content warnings, media descriptions, and poll options."
+        footer={
+          <div className="flex w-full items-center justify-between gap-3">
+            <Button variant="outline" size="sm" onClick={addKeyword}>
+              <Plus className="size-3.5" />
+              Add keyword
+            </Button>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" onClick={onCancel} disabled={saving}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={saving}>
+                {isNew ? 'Create filter' : 'Save changes'}
+              </Button>
+            </div>
+          </div>
+        }
+      >
+        {keywords.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No keywords yet — add at least one.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 px-1 text-[11px] font-medium uppercase tracking-wide text-[hsl(0_0%_55%)]">
+              <span className="min-w-0 flex-1">Keyword or phrase</span>
+              <span className="w-24 text-center">Whole word</span>
+              <span className="w-8" />
+            </div>
+            {keywords.map((keyword) => (
+              <div key={keyword.key} className="flex items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <Input
+                    value={keyword.keyword}
+                    placeholder="e.g. spoiler"
+                    onChange={(event) =>
+                      patchKeyword(keyword.key, { keyword: event.target.value })
+                    }
+                  />
+                </div>
+                <div className="flex w-24 justify-center">
+                  <Switch
+                    checked={keyword.wholeWord}
+                    onCheckedChange={(checked) =>
+                      patchKeyword(keyword.key, { wholeWord: checked })
+                    }
+                    aria-label={`Whole word for ${keyword.keyword || 'keyword'}`}
+                  />
+                </div>
+                <button
+                  type="button"
+                  aria-label={`Remove keyword ${keyword.keyword}`}
+                  onClick={() => removeKeyword(keyword.key)}
+                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border text-muted-foreground transition-colors hover:bg-muted"
+                >
+                  <X className="size-[15px]" />
+                </button>
+              </div>
+            ))}
+            <p className="text-[0.8rem] text-muted-foreground">
+              Whole word only matches when the keyword is surrounded by spaces
+              or punctuation — off, it matches anywhere, even inside other
+              words.
+            </p>
+          </div>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </FilterSection>
+    </div>
+  )
+}

--- a/lib/components/filters/FilterEditor.tsx
+++ b/lib/components/filters/FilterEditor.tsx
@@ -146,13 +146,15 @@ export const FilterEditor: FC<FilterEditorProps> = ({
       { key: nextKey(), keyword: '', wholeWord: true }
     ])
 
-  const removeKeyword = (key: string) =>
-    setKeywords((current) => {
-      const target = current.find((keyword) => keyword.key === key)
-      if (target?.id)
-        setRemovedKeywordIds((ids) => [...ids, target.id as string])
-      return current.filter((keyword) => keyword.key !== key)
-    })
+  const removeKeyword = (key: string) => {
+    // Keep both state updates in the event handler — a state updater must be
+    // pure, so the `_destroy` bookkeeping can't live inside setKeywords.
+    const target = keywords.find((keyword) => keyword.key === key)
+    if (target?.id) {
+      setRemovedKeywordIds((ids) => [...ids, target.id as string])
+    }
+    setKeywords((current) => current.filter((keyword) => keyword.key !== key))
+  }
 
   const handleSave = () => {
     const keywordInputs: FilterKeywordInput[] = []
@@ -354,12 +356,13 @@ export const FilterEditor: FC<FilterEditorProps> = ({
               <span className="w-24 text-center">Whole word</span>
               <span className="w-8" />
             </div>
-            {keywords.map((keyword) => (
+            {keywords.map((keyword, index) => (
               <div key={keyword.key} className="flex items-center gap-3">
                 <div className="min-w-0 flex-1">
                   <Input
                     value={keyword.keyword}
                     placeholder="e.g. spoiler"
+                    aria-label={`Keyword or phrase ${index + 1}`}
                     onChange={(event) =>
                       patchKeyword(keyword.key, { keyword: event.target.value })
                     }

--- a/lib/components/filters/FilterRow.tsx
+++ b/lib/components/filters/FilterRow.tsx
@@ -100,7 +100,14 @@ export const FilterRow: FC<FilterRowProps> = ({
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        <Button variant="outline" size="sm" onClick={onEdit}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onEdit}
+          // Freeze edits while any delete is in flight so a failed-delete
+          // rollback can't discard a concurrent edit/create.
+          disabled={deleting}
+        >
           <Pencil className="size-3.5" />
           Edit
         </Button>

--- a/lib/components/filters/FilterRow.tsx
+++ b/lib/components/filters/FilterRow.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { Filter as FilterIcon, Pencil, Trash2 } from 'lucide-react'
+import { FC } from 'react'
+
+import type { ClientFilter } from '@/lib/client'
+import { Button } from '@/lib/components/ui/button'
+import type { FilterContext } from '@/lib/types/domain/filter'
+import { cn } from '@/lib/utils'
+
+import {
+  CONTEXT_SHORT,
+  FILTER_CONTEXTS,
+  formatExpiry,
+  isFilterExpired
+} from './filterConstants'
+
+type BadgeTone = 'orange' | 'red' | 'gray'
+
+const BADGE_TONE_CLASSES: Record<BadgeTone, string> = {
+  orange: 'bg-[hsl(24_95%_46%/0.12)] text-[hsl(24_95%_40%)]',
+  red: 'bg-[hsl(0_84.2%_60.2%/0.12)] text-[hsl(0_72%_45%)]',
+  gray: 'bg-[hsl(0_0%_94%)] text-[hsl(0_0%_35%)]'
+}
+
+const Badge: FC<{ tone: BadgeTone; children: string }> = ({
+  tone,
+  children
+}) => (
+  <span
+    className={cn(
+      'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+      BADGE_TONE_CLASSES[tone]
+    )}
+  >
+    {children}
+  </span>
+)
+
+const ContextChips: FC<{ context: FilterContext[] }> = ({ context }) => {
+  const showsEverywhere = context.length === FILTER_CONTEXTS.length
+  const labels = showsEverywhere
+    ? ['Everywhere']
+    : context.map((value) => CONTEXT_SHORT[value])
+  return (
+    <span className="inline-flex flex-wrap gap-1">
+      {labels.map((label) => (
+        <span
+          key={label}
+          className="inline-flex items-center rounded-full bg-[hsl(0_0%_94%)] px-2 py-0.5 text-[11px] font-medium text-[hsl(0_0%_35%)]"
+        >
+          {label}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+interface FilterRowProps {
+  filter: ClientFilter
+  currentTime: number
+  onEdit: () => void
+  onDelete: () => void
+  deleting?: boolean
+}
+
+export const FilterRow: FC<FilterRowProps> = ({
+  filter,
+  currentTime,
+  onEdit,
+  onDelete,
+  deleting = false
+}) => {
+  const keywordCount = filter.keywords.length
+  const expired = isFilterExpired(filter.expires_at, currentTime)
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border p-3">
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <FilterIcon className="size-[17px]" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="truncate text-sm font-medium">{filter.title}</span>
+          {filter.filter_action === 'hide' ? (
+            <Badge tone="red">Hide completely</Badge>
+          ) : (
+            <Badge tone="orange">Hide with warning</Badge>
+          )}
+          {expired && <Badge tone="gray">Expired</Badge>}
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            {keywordCount} {keywordCount === 1 ? 'keyword' : 'keywords'}
+          </span>
+          <span aria-hidden="true">·</span>
+          <ContextChips context={filter.context} />
+          <span aria-hidden="true">·</span>
+          <span>{formatExpiry(filter.expires_at, currentTime)}</span>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button variant="outline" size="sm" onClick={onEdit}>
+          <Pencil className="size-3.5" />
+          Edit
+        </Button>
+        <button
+          type="button"
+          aria-label={`Delete filter ${filter.title}`}
+          onClick={onDelete}
+          disabled={deleting}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[hsl(0_84.2%_60.2%/0.4)] text-[hsl(0_72%_45%)] transition-colors hover:bg-[hsl(0_72%_45%/0.08)] disabled:pointer-events-none disabled:opacity-50"
+        >
+          <Trash2 className="size-[15px]" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/lib/components/filters/FiltersPanel.tsx
+++ b/lib/components/filters/FiltersPanel.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { Plus } from 'lucide-react'
+import { FC, useEffect, useState } from 'react'
+
+import {
+  type ClientFilter,
+  type FilterInput,
+  createFilter,
+  createServerFilter,
+  deleteFilter,
+  deleteServerFilter,
+  getFilters,
+  getServerFilters,
+  updateFilter,
+  updateServerFilter
+} from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
+import { Button } from '@/lib/components/ui/button'
+
+import { FilterEditor, type FilterScope } from './FilterEditor'
+import { FilterRow } from './FilterRow'
+import { FilterSection } from './filterUi'
+
+interface ScopeClient {
+  list: () => Promise<ClientFilter[]>
+  create: (input: FilterInput) => Promise<ClientFilter | null>
+  update: (id: string, input: FilterInput) => Promise<ClientFilter | null>
+  remove: (id: string) => Promise<boolean>
+}
+
+const ACCOUNT_CLIENT: ScopeClient = {
+  list: getFilters,
+  create: createFilter,
+  update: updateFilter,
+  remove: deleteFilter
+}
+
+const SERVER_CLIENT: ScopeClient = {
+  list: getServerFilters,
+  create: createServerFilter,
+  update: updateServerFilter,
+  remove: deleteServerFilter
+}
+
+const COPY: Record<FilterScope, { title: string; description: string }> = {
+  account: {
+    title: 'Filters',
+    description:
+      'Hide posts containing specific words or phrases across your feeds.'
+  },
+  server: {
+    title: 'Server filters',
+    description:
+      'Keyword rules that apply to everyone on this instance. Delivered through the Mastodon-compatible filter API, so apps show warnings natively.'
+  }
+}
+
+interface FiltersPanelProps {
+  scope: FilterScope
+  currentTime: number
+}
+
+// `null` = list view, 'new' = creating, otherwise the id of the filter editing.
+type EditingState = null | 'new' | string
+
+export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
+  const client = scope === 'server' ? SERVER_CLIENT : ACCOUNT_CLIENT
+  const copy = COPY[scope]
+
+  const [filters, setFilters] = useState<ClientFilter[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState<EditingState>(null)
+  const [saving, setSaving] = useState(false)
+  const [editorError, setEditorError] = useState<string | null>(null)
+  const [listError, setListError] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    client
+      .list()
+      .then((result) => {
+        if (!active) return
+        // The account endpoint merges instance-wide server filters flagged
+        // read-only; Settings manages only the user's own filters.
+        setFilters(
+          scope === 'account'
+            ? result.filter((filter) => !filter.server)
+            : result
+        )
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [client, scope])
+
+  const handleSave = async (input: FilterInput) => {
+    setSaving(true)
+    setEditorError(null)
+    try {
+      if (editing === 'new') {
+        const created = await client.create(input)
+        if (!created) {
+          setEditorError('Failed to create filter. Please try again.')
+          return
+        }
+        // Creation order — newly created filters append at the bottom.
+        setFilters((current) => [...current, created])
+      } else if (editing) {
+        const updated = await client.update(editing, input)
+        if (!updated) {
+          setEditorError('Failed to save changes. Please try again.')
+          return
+        }
+        setFilters((current) =>
+          current.map((filter) => (filter.id === updated.id ? updated : filter))
+        )
+      }
+      setEditing(null)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (filter: ClientFilter) => {
+    setListError(null)
+    setDeletingId(filter.id)
+    const previous = filters
+    // Optimistic removal — restore the row if the request fails.
+    setFilters((current) => current.filter((item) => item.id !== filter.id))
+    const ok = await client.remove(filter.id)
+    if (!ok) {
+      setFilters(previous)
+      setListError('Failed to delete filter. Please try again.')
+    }
+    setDeletingId(null)
+  }
+
+  if (editing !== null) {
+    const initial =
+      editing === 'new'
+        ? null
+        : (filters.find((filter) => filter.id === editing) ?? null)
+    return (
+      <FilterEditor
+        initial={initial}
+        scope={scope}
+        currentTime={currentTime}
+        saving={saving}
+        error={editorError}
+        onCancel={() => {
+          setEditorError(null)
+          setEditing(null)
+        }}
+        onSave={handleSave}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={copy.title}
+        description={copy.description}
+        actions={
+          <Button
+            onClick={() => {
+              setEditorError(null)
+              setEditing('new')
+            }}
+          >
+            <Plus className="size-4" />
+            Add new filter
+          </Button>
+        }
+      />
+
+      {listError && <p className="text-sm text-destructive">{listError}</p>}
+
+      <FilterSection>
+        {loading ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Loading filters…
+          </p>
+        ) : filters.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No filters yet — add one to start hiding unwanted posts.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {filters.map((filter) => (
+              <FilterRow
+                key={filter.id}
+                filter={filter}
+                currentTime={currentTime}
+                onEdit={() => {
+                  setEditorError(null)
+                  setEditing(filter.id)
+                }}
+                onDelete={() => handleDelete(filter)}
+                deleting={deletingId === filter.id}
+              />
+            ))}
+          </div>
+        )}
+      </FilterSection>
+
+      {scope === 'server' && (
+        <FilterSection
+          title="How server filters behave"
+          description="People cannot remove a server filter, but “hide with a warning” still lets them tap through to the post. Use “hide completely” only for spam."
+        />
+      )}
+    </div>
+  )
+}

--- a/lib/components/filters/FiltersPanel.tsx
+++ b/lib/components/filters/FiltersPanel.tsx
@@ -90,6 +90,11 @@ export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
             : result
         )
       })
+      .catch(() => {
+        // A network/parse failure must surface an error rather than silently
+        // showing the "No filters yet" empty state.
+        if (active) setListError('Failed to load filters. Please try again.')
+      })
       .finally(() => {
         if (active) setLoading(false)
       })

--- a/lib/components/filters/FiltersPanel.tsx
+++ b/lib/components/filters/FiltersPanel.tsx
@@ -189,6 +189,9 @@ export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
               setEditorError(null)
               setEditing('new')
             }}
+            // Block creating while a delete is in flight so a failed-delete
+            // rollback can't drop the just-created filter from the list.
+            disabled={deletingId !== null}
           >
             <Plus className="size-4" />
             Add new filter

--- a/lib/components/filters/FiltersPanel.tsx
+++ b/lib/components/filters/FiltersPanel.tsx
@@ -203,7 +203,9 @@ export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
           <p className="py-6 text-center text-sm text-muted-foreground">
             Loading filters…
           </p>
-        ) : filters.length === 0 ? (
+        ) : filters.length === 0 && !listError ? (
+          // Suppress the empty-state copy when a load error is already shown, so
+          // a failed fetch doesn't read as "you have no filters".
           <p className="py-6 text-center text-sm text-muted-foreground">
             No filters yet — add one to start hiding unwanted posts.
           </p>

--- a/lib/components/filters/FiltersPanel.tsx
+++ b/lib/components/filters/FiltersPanel.tsx
@@ -127,17 +127,29 @@ export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
   }
 
   const handleDelete = async (filter: ClientFilter) => {
+    // A delete is already in flight — all delete buttons are disabled while
+    // `deletingId` is set, so this guards against any racing invocation.
+    if (deletingId) return
     setListError(null)
     setDeletingId(filter.id)
     const previous = filters
-    // Optimistic removal — restore the row if the request fails.
+    // Optimistic removal — restore the row if the request fails. Deletes are
+    // serialized (see the guard above), so `previous` is always the current
+    // list and rolling back to it cannot resurrect a separately-deleted row.
     setFilters((current) => current.filter((item) => item.id !== filter.id))
-    const ok = await client.remove(filter.id)
-    if (!ok) {
+    const restoreOnFailure = () => {
       setFilters(previous)
       setListError('Failed to delete filter. Please try again.')
     }
-    setDeletingId(null)
+    try {
+      const ok = await client.remove(filter.id)
+      if (!ok) restoreOnFailure()
+    } catch {
+      // A network-layer throw (connection drop, etc.) must still roll back.
+      restoreOnFailure()
+    } finally {
+      setDeletingId(null)
+    }
   }
 
   if (editing !== null) {
@@ -202,7 +214,9 @@ export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
                   setEditing(filter.id)
                 }}
                 onDelete={() => handleDelete(filter)}
-                deleting={deletingId === filter.id}
+                // Disable every delete button while any delete is in flight so
+                // deletes stay serialized and optimistic rollback is safe.
+                deleting={deletingId !== null}
               />
             ))}
           </div>

--- a/lib/components/filters/FiltersPanel.tsx
+++ b/lib/components/filters/FiltersPanel.tsx
@@ -108,24 +108,30 @@ export const FiltersPanel: FC<FiltersPanelProps> = ({ scope, currentTime }) => {
     setEditorError(null)
     try {
       if (editing === 'new') {
+        // The client helpers return a falsy value on a non-ok response; throw so
+        // both that and any network-layer rejection land in the same catch.
         const created = await client.create(input)
         if (!created) {
-          setEditorError('Failed to create filter. Please try again.')
-          return
+          throw new Error('Failed to create filter. Please try again.')
         }
         // Creation order — newly created filters append at the bottom.
         setFilters((current) => [...current, created])
       } else if (editing) {
         const updated = await client.update(editing, input)
         if (!updated) {
-          setEditorError('Failed to save changes. Please try again.')
-          return
+          throw new Error('Failed to save changes. Please try again.')
         }
         setFilters((current) =>
           current.map((filter) => (filter.id === updated.id ? updated : filter))
         )
       }
       setEditing(null)
+    } catch (error) {
+      setEditorError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to save filter. Please try again.'
+      )
     } finally {
       setSaving(false)
     }

--- a/lib/components/filters/filterConstants.ts
+++ b/lib/components/filters/filterConstants.ts
@@ -1,0 +1,97 @@
+import { format, formatDistance } from 'date-fns'
+
+import type { FilterContext } from '@/lib/types/domain/filter'
+
+export interface FilterContextOption {
+  id: FilterContext
+  label: string
+  hint: string
+}
+
+// Order and copy mirror the Mastodon filter contexts shown in the design.
+export const FILTER_CONTEXTS: FilterContextOption[] = [
+  {
+    id: 'home',
+    label: 'Home and lists',
+    hint: 'Removed from home feeds and lists'
+  },
+  {
+    id: 'notifications',
+    label: 'Notifications',
+    hint: 'Matching notifications are not shown'
+  },
+  {
+    id: 'public',
+    label: 'Public timelines',
+    hint: 'Hidden from local and federated timelines'
+  },
+  {
+    id: 'thread',
+    label: 'Conversations',
+    hint: 'Hidden in threads and detailed views'
+  },
+  { id: 'account', label: 'Profiles', hint: 'Hidden when viewing a profile' }
+]
+
+// Short labels for the context chips on the list row.
+export const CONTEXT_SHORT: Record<FilterContext, string> = {
+  home: 'Home',
+  notifications: 'Notifications',
+  public: 'Public',
+  thread: 'Conversations',
+  account: 'Profiles'
+}
+
+export interface ExpiryOption {
+  value: string
+  label: string
+}
+
+// `value` is the number of seconds for `expires_in`; '0' means never.
+export const EXPIRY_OPTIONS: ExpiryOption[] = [
+  { value: '0', label: 'Never' },
+  { value: '1800', label: '30 minutes' },
+  { value: '3600', label: '1 hour' },
+  { value: '21600', label: '6 hours' },
+  { value: '43200', label: '12 hours' },
+  { value: '86400', label: '1 day' },
+  { value: '604800', label: '1 week' }
+]
+
+// '0' (Never) maps to a null `expires_in`; everything else is seconds.
+export const expiresInFromValue = (value: string): number | null =>
+  value === '0' ? null : Number(value)
+
+// Pick the select option that best represents an existing filter's remaining
+// lifetime. The absolute `expires_at` cannot recover the original `expires_in`,
+// so we choose the smallest option that still covers the remaining time. On
+// save this re-applies the expiry, matching Mastodon's edit behavior.
+export const expiryOptionForExpiresAt = (
+  expiresAt: number | null,
+  now: number
+): string => {
+  if (expiresAt === null) return '0'
+  const remainingSeconds = Math.round((expiresAt - now) / 1000)
+  const match = EXPIRY_OPTIONS.find(
+    (option) => option.value !== '0' && Number(option.value) >= remainingSeconds
+  )
+  return match ? match.value : '604800'
+}
+
+export const isFilterExpired = (
+  expiresAt: string | null,
+  now: number
+): boolean => expiresAt !== null && Date.parse(expiresAt) < now
+
+// The meta-line expiry text: "Never expires" / "Expires in 6 days" /
+// "Expired Apr 2, 2026".
+export const formatExpiry = (expiresAt: string | null, now: number): string => {
+  if (expiresAt === null) return 'Never expires'
+  const expiresDate = new Date(expiresAt)
+  if (Date.parse(expiresAt) < now) {
+    return `Expired ${format(expiresDate, 'MMM d, yyyy')}`
+  }
+  return `Expires ${formatDistance(expiresDate, new Date(now), {
+    addSuffix: true
+  })}`
+}

--- a/lib/components/filters/filterUi.tsx
+++ b/lib/components/filters/filterUi.tsx
@@ -1,0 +1,52 @@
+import { FC, ReactNode } from 'react'
+
+interface FilterSectionProps {
+  title?: ReactNode
+  description?: ReactNode
+  children?: ReactNode
+  footer?: ReactNode
+}
+
+// Settings-style section card, matching the shared chrome used across the
+// settings pages (rounded-2xl, translucent surface, p-6).
+export const FilterSection: FC<FilterSectionProps> = ({
+  title,
+  description,
+  children,
+  footer
+}) => (
+  <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+    {(title || description) && (
+      <div>
+        {title && <h2 className="text-lg font-semibold">{title}</h2>}
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+    )}
+    {children}
+    {footer && <div className="flex justify-end pt-1">{footer}</div>}
+  </section>
+)
+
+interface FilterFieldProps {
+  label: string
+  htmlFor: string
+  help?: ReactNode
+  children: ReactNode
+}
+
+export const FilterField: FC<FilterFieldProps> = ({
+  label,
+  htmlFor,
+  help,
+  children
+}) => (
+  <div className="space-y-2">
+    <label htmlFor={htmlFor} className="block text-sm font-medium">
+      {label}
+    </label>
+    {children}
+    {help && <p className="text-[0.8rem] text-muted-foreground">{help}</p>}
+  </div>
+)

--- a/lib/database/sql/filter.ts
+++ b/lib/database/sql/filter.ts
@@ -9,6 +9,7 @@ import {
   getWhereInBatchSize
 } from '@/lib/database/sql/utils/knex'
 import {
+  ActiveFilterRecord,
   AddFilterKeywordParams,
   AddFilterStatusParams,
   CreateFilterParams,
@@ -20,6 +21,7 @@ import {
   GetFilterKeywordParams,
   GetFilterKeywordsParams,
   GetFilterParams,
+  GetFilterRecordsForActorParams,
   GetFilterStatusParams,
   GetFilterStatusesParams,
   GetFiltersParams,
@@ -97,6 +99,47 @@ export const FilterSQLDatabaseMixin = (database: Knex): FilterDatabase => {
       await trx('filter_keywords').where('filterId', filterId).delete()
       await trx('filters').where('id', filterId).delete()
     })
+  }
+
+  const hydrateFilters = async (
+    filters: Filter[]
+  ): Promise<ActiveFilterRecord[]> => {
+    if (filters.length === 0) return []
+
+    const filterIds = filters.map((filter) => filter.id)
+    const batchSize = getWhereInBatchSize(database)
+    const keywordRows: FilterKeyword[] = []
+    const statusRows: FilterStatus[] = []
+    for (const chunk of chunkArray(filterIds, batchSize)) {
+      const [keywords, statuses] = await Promise.all([
+        database<FilterKeyword>('filter_keywords').whereIn('filterId', chunk),
+        database<FilterStatus>('filter_statuses').whereIn('filterId', chunk)
+      ])
+      keywordRows.push(...keywords)
+      statusRows.push(...statuses)
+    }
+
+    const keywordsByFilter = new Map<string, FilterKeyword[]>()
+    for (const keyword of keywordRows) {
+      const fixed = fixKeywordRow(keyword)
+      const bucket = keywordsByFilter.get(fixed.filterId) ?? []
+      bucket.push(fixed)
+      keywordsByFilter.set(fixed.filterId, bucket)
+    }
+
+    const statusesByFilter = new Map<string, FilterStatus[]>()
+    for (const status of statusRows) {
+      const fixed = fixStatusRow(status)
+      const bucket = statusesByFilter.get(fixed.filterId) ?? []
+      bucket.push(fixed)
+      statusesByFilter.set(fixed.filterId, bucket)
+    }
+
+    return filters.map((filter) => ({
+      filter,
+      keywords: keywordsByFilter.get(filter.id) ?? [],
+      statuses: statusesByFilter.get(filter.id) ?? []
+    }))
   }
 
   return {
@@ -268,42 +311,18 @@ export const FilterSQLDatabaseMixin = (database: Knex): FilterDatabase => {
         .filter((filter) => isFilterActive(filter, now))
         .filter((filter) => !context || filter.context.includes(context))
 
-      if (filters.length === 0) return []
+      return hydrateFilters(filters)
+    },
 
-      const filterIds = filters.map((filter) => filter.id)
-      const batchSize = getWhereInBatchSize(database)
-      const keywordRows: FilterKeyword[] = []
-      const statusRows: FilterStatus[] = []
-      for (const chunk of chunkArray(filterIds, batchSize)) {
-        const [keywords, statuses] = await Promise.all([
-          database<FilterKeyword>('filter_keywords').whereIn('filterId', chunk),
-          database<FilterStatus>('filter_statuses').whereIn('filterId', chunk)
-        ])
-        keywordRows.push(...keywords)
-        statusRows.push(...statuses)
-      }
-
-      const keywordsByFilter = new Map<string, FilterKeyword[]>()
-      for (const keyword of keywordRows) {
-        const fixed = fixKeywordRow(keyword)
-        const bucket = keywordsByFilter.get(fixed.filterId) ?? []
-        bucket.push(fixed)
-        keywordsByFilter.set(fixed.filterId, bucket)
-      }
-
-      const statusesByFilter = new Map<string, FilterStatus[]>()
-      for (const status of statusRows) {
-        const fixed = fixStatusRow(status)
-        const bucket = statusesByFilter.get(fixed.filterId) ?? []
-        bucket.push(fixed)
-        statusesByFilter.set(fixed.filterId, bucket)
-      }
-
-      return filters.map((filter) => ({
-        filter,
-        keywords: keywordsByFilter.get(filter.id) ?? [],
-        statuses: statusesByFilter.get(filter.id) ?? []
-      }))
+    async getFilterRecordsForActor({
+      actorId
+    }: GetFilterRecordsForActorParams) {
+      // Oldest-first (creation order) so the management list is stable as new
+      // filters are appended at the bottom.
+      const rows = await database<FilterRow>('filters')
+        .where({ actorId })
+        .orderBy('createdAt', 'asc')
+      return hydrateFilters(rows.map(fixFilterRow))
     },
 
     async addFilterKeyword({

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -28,6 +28,7 @@ import { OAuthSQLDatabaseMixin } from '@/lib/database/sql/oauth'
 import { PushSubscriptionSQLDatabaseMixin } from '@/lib/database/sql/pushSubscription'
 import { ReportSQLDatabaseMixin } from '@/lib/database/sql/report'
 import { SearchSQLDatabaseMixin } from '@/lib/database/sql/search'
+import { ServerFilterSQLDatabaseMixin } from '@/lib/database/sql/serverFilter'
 import { StatusSQLDatabaseMixin } from '@/lib/database/sql/status'
 import { StatusMuteSQLDatabaseMixin } from '@/lib/database/sql/statusMute'
 import { StravaArchiveImportSQLDatabaseMixin } from '@/lib/database/sql/stravaArchiveImport'
@@ -55,6 +56,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const idempotencyDatabase = IdempotencySQLDatabaseMixin(database)
   const translationCacheDatabase = TranslationCacheSQLDatabaseMixin(database)
   const filterDatabase = FilterSQLDatabaseMixin(database)
+  const serverFilterDatabase = ServerFilterSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const followedTagDatabase = FollowedTagSQLDatabaseMixin(database)
   const instanceActivityDatabase = InstanceActivitySQLDatabaseMixin(database)
@@ -118,6 +120,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...translationCacheDatabase,
     ...listDatabase,
     ...filterDatabase,
+    ...serverFilterDatabase,
     ...followerDatabase,
     ...followedTagDatabase,
     ...likeDatabase,

--- a/lib/database/sql/serverFilter.test.ts
+++ b/lib/database/sql/serverFilter.test.ts
@@ -74,6 +74,26 @@ describe('ServerFilterDatabase', () => {
     expect(remaining?.map((keyword) => keyword.keyword)).toEqual(['airdrop'])
   })
 
+  it('returns a single hydrated record via getServerFilterRecord', async () => {
+    const filter = await database.createServerFilter({
+      title: 'Single record',
+      context: ['home'],
+      filterAction: 'warn',
+      expiresAt: null,
+      keywords: [{ keyword: 'lookup', wholeWord: false }]
+    })
+
+    const record = await database.getServerFilterRecord({ id: filter.id })
+    expect(record?.filter.id).toBe(filter.id)
+    expect(record?.keywords.map((keyword) => keyword.keyword)).toEqual([
+      'lookup'
+    ])
+
+    expect(
+      await database.getServerFilterRecord({ id: 'does-not-exist' })
+    ).toBeNull()
+  })
+
   it('excludes expired server filters from the active set but keeps them in records', async () => {
     const expired = await database.createServerFilter({
       title: 'Old promo',

--- a/lib/database/sql/serverFilter.test.ts
+++ b/lib/database/sql/serverFilter.test.ts
@@ -1,0 +1,132 @@
+import knex, { Knex } from 'knex'
+
+import { getSQLDatabase } from '@/lib/database/sql'
+import { Database } from '@/lib/database/types'
+
+describe('ServerFilterDatabase', () => {
+  let knexDatabase: Knex
+  let database: Database
+
+  beforeAll(async () => {
+    knexDatabase = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+    database = getSQLDatabase(knexDatabase)
+    await database.migrate()
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  it('creates a server filter with keywords and lists it with keywords', async () => {
+    const filter = await database.createServerFilter({
+      title: 'Spam campaigns',
+      context: ['home', 'notifications', 'public', 'thread', 'account'],
+      filterAction: 'hide',
+      expiresAt: null,
+      keywords: [
+        { keyword: 'free followers', wholeWord: false },
+        { keyword: 'dm for promo', wholeWord: false }
+      ]
+    })
+
+    expect(filter.title).toBe('Spam campaigns')
+    expect(filter.context).toHaveLength(5)
+    expect(filter.filterAction).toBe('hide')
+
+    const records = await database.getServerFilterRecords()
+    const record = records.find((entry) => entry.filter.id === filter.id)
+    expect(record).toBeTruthy()
+    expect(record?.keywords).toHaveLength(2)
+    expect(record?.keywords.map((keyword) => keyword.keyword).sort()).toEqual([
+      'dm for promo',
+      'free followers'
+    ])
+  })
+
+  it('updates a server filter and removes a keyword via _destroy', async () => {
+    const filter = await database.createServerFilter({
+      title: 'Known scam links',
+      context: ['public'],
+      filterAction: 'warn',
+      expiresAt: null,
+      keywords: [{ keyword: 'wallet-verify', wholeWord: false }]
+    })
+    const keywords = await database.getServerFilterKeywords({ id: filter.id })
+    const keywordId = keywords?.[0]?.id as string
+
+    const updated = await database.updateServerFilter({
+      id: filter.id,
+      title: 'Scam links',
+      context: ['public', 'notifications'],
+      keywords: [
+        { id: keywordId, _destroy: true },
+        { keyword: 'airdrop', wholeWord: true }
+      ]
+    })
+    expect(updated?.title).toBe('Scam links')
+    expect(updated?.context).toEqual(['public', 'notifications'])
+
+    const remaining = await database.getServerFilterKeywords({ id: filter.id })
+    expect(remaining?.map((keyword) => keyword.keyword)).toEqual(['airdrop'])
+  })
+
+  it('excludes expired server filters from the active set but keeps them in records', async () => {
+    const expired = await database.createServerFilter({
+      title: 'Old promo',
+      context: ['home'],
+      filterAction: 'warn',
+      expiresAt: Date.now() - 1000,
+      keywords: [{ keyword: 'expired-keyword', wholeWord: false }]
+    })
+
+    const active = await database.getActiveServerFilters()
+    expect(active.find((entry) => entry.filter.id === expired.id)).toBeFalsy()
+
+    const records = await database.getServerFilterRecords()
+    expect(records.find((entry) => entry.filter.id === expired.id)).toBeTruthy()
+  })
+
+  it('filters the active set by context', async () => {
+    const filter = await database.createServerFilter({
+      title: 'Notifications only',
+      context: ['notifications'],
+      filterAction: 'warn',
+      expiresAt: null,
+      keywords: [{ keyword: 'ping', wholeWord: false }]
+    })
+
+    const homeActive = await database.getActiveServerFilters({
+      context: 'home'
+    })
+    expect(
+      homeActive.find((entry) => entry.filter.id === filter.id)
+    ).toBeFalsy()
+
+    const notificationsActive = await database.getActiveServerFilters({
+      context: 'notifications'
+    })
+    expect(
+      notificationsActive.find((entry) => entry.filter.id === filter.id)
+    ).toBeTruthy()
+  })
+
+  it('deletes a server filter and cascades its keywords', async () => {
+    const filter = await database.createServerFilter({
+      title: 'Temporary',
+      context: ['home'],
+      filterAction: 'warn',
+      expiresAt: null,
+      keywords: [{ keyword: 'temp', wholeWord: false }]
+    })
+
+    const deleted = await database.deleteServerFilter({ id: filter.id })
+    expect(deleted?.id).toBe(filter.id)
+
+    expect(await database.getServerFilter({ id: filter.id })).toBeNull()
+    expect(await database.getServerFilterKeywords({ id: filter.id })).toBeNull()
+  })
+})

--- a/lib/database/sql/serverFilter.ts
+++ b/lib/database/sql/serverFilter.ts
@@ -1,0 +1,284 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
+import {
+  chunkArray,
+  getInsertBatchSize,
+  getWhereInBatchSize
+} from '@/lib/database/sql/utils/knex'
+import {
+  ActiveServerFilterRecord,
+  CreateServerFilterParams,
+  DeleteServerFilterParams,
+  GetActiveServerFiltersParams,
+  GetServerFilterParams,
+  ServerFilterDatabase,
+  UpdateServerFilterParams
+} from '@/lib/types/database/operations'
+import {
+  FilterAction,
+  FilterContext,
+  FilterKeyword,
+  ServerFilter
+} from '@/lib/types/domain/filter'
+
+type ServerFilterRow = Omit<ServerFilter, 'context'> & { context: string }
+
+const parseContext = (raw: string): FilterContext[] => {
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (value): value is FilterContext =>
+        typeof value === 'string' &&
+        FilterContext.options.includes(value as FilterContext)
+    )
+  } catch {
+    return []
+  }
+}
+
+const fixServerFilterRow = (row: ServerFilterRow): ServerFilter => ({
+  id: row.id,
+  title: row.title,
+  context: parseContext(row.context),
+  filterAction: FilterAction.parse(row.filterAction),
+  expiresAt:
+    row.expiresAt !== null && row.expiresAt !== undefined
+      ? Number(row.expiresAt)
+      : null,
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+const fixKeywordRow = (row: FilterKeyword): FilterKeyword => ({
+  ...row,
+  wholeWord: Boolean(row.wholeWord),
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+const isFilterActive = (filter: ServerFilter, now: number): boolean =>
+  filter.expiresAt === null || filter.expiresAt >= now
+
+export const ServerFilterSQLDatabaseMixin = (
+  database: Knex
+): ServerFilterDatabase => {
+  const getServerFilterById = async (
+    id: string
+  ): Promise<ServerFilter | null> => {
+    const row = await database<ServerFilterRow>('server_filters')
+      .where({ id })
+      .first()
+    if (!row) return null
+    return fixServerFilterRow(row)
+  }
+
+  const hydrate = async (
+    filters: ServerFilter[]
+  ): Promise<ActiveServerFilterRecord[]> => {
+    if (filters.length === 0) return []
+    const filterIds = filters.map((filter) => filter.id)
+    const batchSize = getWhereInBatchSize(database)
+    const keywordRows: FilterKeyword[] = []
+    for (const chunk of chunkArray(filterIds, batchSize)) {
+      const keywords = await database<FilterKeyword>(
+        'server_filter_keywords'
+      ).whereIn('filterId', chunk)
+      keywordRows.push(...keywords)
+    }
+
+    const keywordsByFilter = new Map<string, FilterKeyword[]>()
+    for (const keyword of keywordRows) {
+      const fixed = fixKeywordRow(keyword)
+      const bucket = keywordsByFilter.get(fixed.filterId) ?? []
+      bucket.push(fixed)
+      keywordsByFilter.set(fixed.filterId, bucket)
+    }
+
+    return filters.map((filter) => ({
+      filter,
+      keywords: keywordsByFilter.get(filter.id) ?? []
+    }))
+  }
+
+  return {
+    async createServerFilter({
+      title,
+      context,
+      filterAction,
+      expiresAt,
+      keywords = []
+    }: CreateServerFilterParams) {
+      const now = new Date()
+      const filter: ServerFilter = {
+        id: randomUUID(),
+        title,
+        context,
+        filterAction,
+        expiresAt,
+        createdAt: now.getTime(),
+        updatedAt: now.getTime()
+      }
+
+      await database.transaction(async (trx) => {
+        await trx('server_filters').insert({
+          id: filter.id,
+          title: filter.title,
+          context: JSON.stringify(filter.context),
+          filterAction: filter.filterAction,
+          expiresAt: filter.expiresAt,
+          createdAt: now,
+          updatedAt: now
+        })
+
+        if (keywords.length > 0) {
+          const rows = keywords.map((keyword) => ({
+            id: randomUUID(),
+            filterId: filter.id,
+            keyword: keyword.keyword,
+            wholeWord: Boolean(keyword.wholeWord),
+            createdAt: now,
+            updatedAt: now
+          }))
+          const batchSize = getInsertBatchSize(trx, rows[0])
+          for (const chunk of chunkArray(rows, batchSize)) {
+            await trx('server_filter_keywords')
+              .insert(chunk)
+              .onConflict(['filterId', 'keyword'])
+              .ignore()
+          }
+        }
+      })
+
+      return filter
+    },
+
+    async getServerFilterRecords() {
+      // Oldest-first (creation order) so the admin list is stable as new
+      // server filters are appended at the bottom.
+      const rows = await database<ServerFilterRow>('server_filters').orderBy(
+        'createdAt',
+        'asc'
+      )
+      return hydrate(rows.map(fixServerFilterRow))
+    },
+
+    async getServerFilter({ id }: GetServerFilterParams) {
+      return getServerFilterById(id)
+    },
+
+    async getServerFilterKeywords({ id }: GetServerFilterParams) {
+      const filter = await getServerFilterById(id)
+      if (!filter) return null
+      const rows = await database<FilterKeyword>('server_filter_keywords')
+        .where('filterId', id)
+        .orderBy('createdAt', 'asc')
+      return rows.map(fixKeywordRow)
+    },
+
+    async updateServerFilter({
+      id,
+      title,
+      context,
+      filterAction,
+      expiresAt,
+      keywords
+    }: UpdateServerFilterParams) {
+      const existing = await getServerFilterById(id)
+      if (!existing) return null
+
+      const now = new Date()
+      const updated: ServerFilter = {
+        ...existing,
+        title: title ?? existing.title,
+        context: context ?? existing.context,
+        filterAction: filterAction ?? existing.filterAction,
+        expiresAt: expiresAt === undefined ? existing.expiresAt : expiresAt,
+        updatedAt: now.getTime()
+      }
+
+      await database.transaction(async (trx) => {
+        await trx('server_filters')
+          .where({ id })
+          .update({
+            title: updated.title,
+            context: JSON.stringify(updated.context),
+            filterAction: updated.filterAction,
+            expiresAt: updated.expiresAt,
+            updatedAt: now
+          })
+
+        if (!keywords) return
+
+        for (const change of keywords) {
+          if (change._destroy && change.id) {
+            await trx('server_filter_keywords')
+              .where({ id: change.id, filterId: id })
+              .delete()
+            continue
+          }
+          if (change.id) {
+            const updates: Record<string, unknown> = { updatedAt: now }
+            if (change.keyword !== undefined) updates.keyword = change.keyword
+            if (change.wholeWord !== undefined)
+              updates.wholeWord = change.wholeWord
+            if (Object.keys(updates).length > 1) {
+              try {
+                await trx.transaction((sp) =>
+                  sp('server_filter_keywords')
+                    .where({ id: change.id, filterId: id })
+                    .update(updates)
+                )
+              } catch (error) {
+                if (!isUniqueConstraintError(error)) throw error
+                // Duplicate keyword text — skip silently via savepoint rollback
+              }
+            }
+            continue
+          }
+          if (change.keyword === undefined) continue
+          await trx('server_filter_keywords')
+            .insert({
+              id: randomUUID(),
+              filterId: id,
+              keyword: change.keyword,
+              wholeWord: Boolean(change.wholeWord),
+              createdAt: now,
+              updatedAt: now
+            })
+            .onConflict(['filterId', 'keyword'])
+            .ignore()
+        }
+      })
+
+      return updated
+    },
+
+    async deleteServerFilter({ id }: DeleteServerFilterParams) {
+      const existing = await getServerFilterById(id)
+      if (!existing) return null
+      await database.transaction(async (trx) => {
+        await trx('server_filter_keywords').where('filterId', id).delete()
+        await trx('server_filters').where('id', id).delete()
+      })
+      return existing
+    },
+
+    async getActiveServerFilters(params?: GetActiveServerFiltersParams) {
+      const context = params?.context
+      const rows = await database<ServerFilterRow>('server_filters').orderBy(
+        'createdAt',
+        'desc'
+      )
+      const now = Date.now()
+      const filters = rows
+        .map(fixServerFilterRow)
+        .filter((filter) => isFilterActive(filter, now))
+        .filter((filter) => !context || filter.context.includes(context))
+      return hydrate(filters)
+    }
+  }
+}

--- a/lib/database/sql/serverFilter.ts
+++ b/lib/database/sql/serverFilter.ts
@@ -280,7 +280,9 @@ export const ServerFilterSQLDatabaseMixin = (
         .where((builder) => {
           builder.whereNull('expiresAt').orWhere('expiresAt', '>=', Date.now())
         })
-        .orderBy('createdAt', 'desc')
+        // Oldest-first, consistent with the other server-filter listings
+        // (ordering is irrelevant for matching).
+        .orderBy('createdAt', 'asc')
       const filters = rows
         .map(fixServerFilterRow)
         .filter((filter) => !context || filter.context.includes(context))

--- a/lib/database/sql/serverFilter.ts
+++ b/lib/database/sql/serverFilter.ts
@@ -60,9 +60,6 @@ const fixKeywordRow = (row: FilterKeyword): FilterKeyword => ({
   updatedAt: getCompatibleTime(row.updatedAt)
 })
 
-const isFilterActive = (filter: ServerFilter, now: number): boolean =>
-  filter.expiresAt === null || filter.expiresAt >= now
-
 export const ServerFilterSQLDatabaseMixin = (
   database: Knex
 ): ServerFilterDatabase => {
@@ -170,6 +167,13 @@ export const ServerFilterSQLDatabaseMixin = (
       return getServerFilterById(id)
     },
 
+    async getServerFilterRecord({ id }: GetServerFilterParams) {
+      const filter = await getServerFilterById(id)
+      if (!filter) return null
+      const [record] = await hydrate([filter])
+      return record ?? null
+    },
+
     async getServerFilterKeywords({ id }: GetServerFilterParams) {
       const filter = await getServerFilterById(id)
       if (!filter) return null
@@ -269,14 +273,16 @@ export const ServerFilterSQLDatabaseMixin = (
 
     async getActiveServerFilters(params?: GetActiveServerFiltersParams) {
       const context = params?.context
-      const rows = await database<ServerFilterRow>('server_filters').orderBy(
-        'createdAt',
-        'desc'
-      )
-      const now = Date.now()
+      // Drop expired filters in SQL — this runs on every timeline/notification
+      // request (including signed-out viewers), so expired rows must never be
+      // loaded. Context is a JSON column, so that filter stays in memory.
+      const rows = await database<ServerFilterRow>('server_filters')
+        .where((builder) => {
+          builder.whereNull('expiresAt').orWhere('expiresAt', '>=', Date.now())
+        })
+        .orderBy('createdAt', 'desc')
       const filters = rows
         .map(fixServerFilterRow)
-        .filter((filter) => isFilterActive(filter, now))
         .filter((filter) => !context || filter.context.includes(context))
       return hydrate(filters)
     }

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -29,6 +29,7 @@ import {
   PushSubscriptionDatabase,
   ReportDatabase,
   SearchDatabase,
+  ServerFilterDatabase,
   StatusDatabase,
   StatusMuteDatabase,
   TimelineDatabase,
@@ -51,6 +52,7 @@ export type Database = AccountDatabase &
   ListDatabase &
   FollowedTagDatabase &
   FilterDatabase &
+  ServerFilterDatabase &
   BookmarkDatabase &
   CustomEmojiDatabase &
   DirectConversationDatabase &

--- a/lib/services/filters/applyFilters.ts
+++ b/lib/services/filters/applyFilters.ts
@@ -1,7 +1,10 @@
 import { Database } from '@/lib/database/types'
 import { getMastodonFilterFromRecord } from '@/lib/services/mastodon/getMastodonFilter'
 import { Timeline } from '@/lib/services/timelines/types'
-import { ActiveFilterRecord } from '@/lib/types/database/operations'
+import {
+  ActiveFilterRecord,
+  ActiveServerFilterRecord
+} from '@/lib/types/database/operations'
 import {
   FilterKeyword as DomainFilterKeyword,
   FilterContext
@@ -142,13 +145,34 @@ const getCandidateStatusIds = (status: Status): string[] => {
   return [...ids].filter(Boolean)
 }
 
+// Instance-wide server filters carry no owning actor. Adapt them to the
+// per-actor ActiveFilterRecord shape so the matching pipeline can treat both
+// kinds uniformly; the synthetic empty actorId is never read during matching.
+const serverRecordToActiveFilterRecord = (
+  record: ActiveServerFilterRecord
+): ActiveFilterRecord => ({
+  filter: { ...record.filter, actorId: '' },
+  keywords: record.keywords,
+  statuses: []
+})
+
 export const getActiveFilters = async (
   database: Database,
   actorId: string | undefined,
   context: FilterContext
 ): Promise<ActiveFilterRecord[]> => {
-  if (!actorId) return []
-  return database.getActiveFiltersForActor({ actorId, context })
+  // Server filters apply to everyone — including signed-out viewers — so they
+  // are fetched regardless of `actorId`.
+  const [accountRecords, serverRecords] = await Promise.all([
+    actorId
+      ? database.getActiveFiltersForActor({ actorId, context })
+      : Promise.resolve([] as ActiveFilterRecord[]),
+    database.getActiveServerFilters({ context })
+  ])
+  return [
+    ...accountRecords,
+    ...serverRecords.map(serverRecordToActiveFilterRecord)
+  ]
 }
 
 const matchFilter = (

--- a/lib/services/mastodon/getMastodonFilter.ts
+++ b/lib/services/mastodon/getMastodonFilter.ts
@@ -1,9 +1,13 @@
 import { Database } from '@/lib/database/types'
-import { ActiveFilterRecord } from '@/lib/types/database/operations'
+import {
+  ActiveFilterRecord,
+  ActiveServerFilterRecord
+} from '@/lib/types/database/operations'
 import {
   Filter as DomainFilter,
   FilterKeyword as DomainFilterKeyword,
-  FilterStatus as DomainFilterStatus
+  FilterStatus as DomainFilterStatus,
+  ServerFilter as DomainServerFilter
 } from '@/lib/types/domain/filter'
 import * as Mastodon from '@/lib/types/mastodon'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
@@ -79,3 +83,43 @@ export const getMastodonFilters = async (
 export const getMastodonFilterFromRecord = (
   record: ActiveFilterRecord
 ): Mastodon.Filter => buildMastodonFilter(record)
+
+// ----------------------------------------------------------------------------
+// Server (instance-wide) filters.
+//
+// Returned to clients merged into the account filter list, flagged read-only
+// via the non-standard `server: true` field. Third-party Mastodon clients
+// ignore the unknown field and apply the filter natively; first-party clients
+// use it to hide edit/delete affordances. Server filters are keyword-only, so
+// `statuses` is always empty.
+// ----------------------------------------------------------------------------
+
+export type MastodonServerFilter = Mastodon.Filter & { server: true }
+
+const buildMastodonServerFilter = (
+  filter: DomainServerFilter,
+  keywords: DomainFilterKeyword[]
+): MastodonServerFilter => ({
+  id: filter.id,
+  title: filter.title,
+  context: filter.context,
+  expires_at:
+    filter.expiresAt !== null ? getISOTimeUTC(filter.expiresAt) : null,
+  filter_action: filter.filterAction,
+  keywords: keywords.map(getMastodonFilterKeyword),
+  statuses: [],
+  server: true
+})
+
+export const getMastodonServerFilterFromRecord = (
+  record: ActiveServerFilterRecord
+): MastodonServerFilter =>
+  buildMastodonServerFilter(record.filter, record.keywords)
+
+export const getMastodonServerFilter = async (
+  database: Database,
+  filter: DomainServerFilter
+): Promise<MastodonServerFilter> => {
+  const keywords = await database.getServerFilterKeywords({ id: filter.id })
+  return buildMastodonServerFilter(filter, keywords ?? [])
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -14,7 +14,8 @@ import {
   FilterAction,
   FilterContext,
   FilterKeyword,
-  FilterStatus
+  FilterStatus,
+  ServerFilter
 } from '@/lib/types/domain/filter'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 import { List, ListRepliesPolicy } from '@/lib/types/domain/list'
@@ -1534,6 +1535,10 @@ export type GetActiveFiltersForActorParams = {
   context?: FilterContext
 }
 
+export type GetFilterRecordsForActorParams = {
+  actorId: string
+}
+
 export type ActiveFilterRecord = {
   filter: Filter
   keywords: FilterKeyword[]
@@ -1599,6 +1604,12 @@ export interface FilterDatabase {
   getActiveFiltersForActor(
     params: GetActiveFiltersForActorParams
   ): Promise<ActiveFilterRecord[]>
+  // Like getActiveFiltersForActor but returns ALL of the actor's filters,
+  // including expired ones, so the management UI can list expired filters with
+  // an "Expired" badge and let the user reactivate them.
+  getFilterRecordsForActor(
+    params: GetFilterRecordsForActorParams
+  ): Promise<ActiveFilterRecord[]>
   addFilterKeyword(
     params: AddFilterKeywordParams
   ): Promise<FilterKeyword | null>
@@ -1622,6 +1633,66 @@ export interface FilterDatabase {
   deleteFilterStatus(
     params: DeleteFilterStatusParams
   ): Promise<FilterStatus | null>
+}
+
+// ============================================================================
+// Server Filter Database (instance-wide, admin-authored)
+// ============================================================================
+
+export type CreateServerFilterParams = {
+  title: string
+  context: FilterContext[]
+  filterAction: FilterAction
+  expiresAt: number | null
+  keywords?: CreateFilterKeywordInput[]
+}
+
+export type GetServerFilterParams = {
+  id: string
+}
+
+export type UpdateServerFilterParams = {
+  id: string
+  title?: string
+  context?: FilterContext[]
+  filterAction?: FilterAction
+  expiresAt?: number | null
+  keywords?: UpdateFilterKeywordInput[]
+}
+
+export type DeleteServerFilterParams = {
+  id: string
+}
+
+export type GetActiveServerFiltersParams = {
+  context?: FilterContext
+}
+
+export type ActiveServerFilterRecord = {
+  filter: ServerFilter
+  keywords: FilterKeyword[]
+}
+
+export interface ServerFilterDatabase {
+  createServerFilter(params: CreateServerFilterParams): Promise<ServerFilter>
+  // All server filters (including expired), hydrated with keywords, for the
+  // admin management UI.
+  getServerFilterRecords(): Promise<ActiveServerFilterRecord[]>
+  getServerFilter(params: GetServerFilterParams): Promise<ServerFilter | null>
+  getServerFilterKeywords(
+    params: GetServerFilterParams
+  ): Promise<FilterKeyword[] | null>
+  updateServerFilter(
+    params: UpdateServerFilterParams
+  ): Promise<ServerFilter | null>
+  deleteServerFilter(
+    params: DeleteServerFilterParams
+  ): Promise<ServerFilter | null>
+  // Only active (non-expired) server filters, hydrated with keywords, for
+  // merging into clients' filter lists and applying to timelines.
+  getActiveServerFilters(
+    params?: GetActiveServerFiltersParams
+  ): Promise<ActiveServerFilterRecord[]>
 }
 
 // ============================================================================

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1678,6 +1678,11 @@ export interface ServerFilterDatabase {
   // All server filters (including expired), hydrated with keywords, for the
   // admin management UI.
   getServerFilterRecords(): Promise<ActiveServerFilterRecord[]>
+  // A single server filter (including expired) hydrated with keywords, for the
+  // admin detail endpoint.
+  getServerFilterRecord(
+    params: GetServerFilterParams
+  ): Promise<ActiveServerFilterRecord | null>
   getServerFilter(params: GetServerFilterParams): Promise<ServerFilter | null>
   getServerFilterKeywords(
     params: GetServerFilterParams

--- a/lib/types/domain/filter.ts
+++ b/lib/types/domain/filter.ts
@@ -41,3 +41,18 @@ export const FilterStatus = z.object({
   createdAt: z.number()
 })
 export type FilterStatus = z.infer<typeof FilterStatus>
+
+// Instance-wide filter authored by an admin. Structurally identical to a
+// per-actor Filter minus `actorId` — these rules are not owned by any single
+// account. Server filter keywords reuse the FilterKeyword shape (their
+// `filterId` references a ServerFilter).
+export const ServerFilter = z.object({
+  id: z.string(),
+  title: z.string(),
+  context: FilterContext.array(),
+  filterAction: FilterAction,
+  expiresAt: z.number().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number()
+})
+export type ServerFilter = z.infer<typeof ServerFilter>

--- a/migrations/20260610120000_add_server_filters_tables.js
+++ b/migrations/20260610120000_add_server_filters_tables.js
@@ -17,6 +17,9 @@ exports.up = async (knex) => {
     table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
     table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
 
+    // getActiveServerFilters filters on expiresAt on every timeline/notification
+    // request (a hot path), so index it alongside the ordering column.
+    table.index(['expiresAt'], 'server_filters_expires_at')
     table.index(['createdAt'], 'server_filters_created')
   })
 

--- a/migrations/20260610120000_add_server_filters_tables.js
+++ b/migrations/20260610120000_add_server_filters_tables.js
@@ -1,0 +1,45 @@
+/**
+ * Server (instance-wide) keyword filters. Mirrors the per-actor `filters` /
+ * `filter_keywords` tables but without an `actorId` — these rules are authored
+ * by admins and apply to everyone on the instance. There is intentionally no
+ * `server_filter_statuses` table: server filters are keyword-only.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.createTable('server_filters', (table) => {
+    table.string('id').primary()
+    table.string('title').notNullable()
+    table.text('context').notNullable()
+    table.string('filterAction').notNullable().defaultTo('warn')
+    table.bigInteger('expiresAt').nullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.index(['createdAt'], 'server_filters_created')
+  })
+
+  await knex.schema.createTable('server_filter_keywords', (table) => {
+    table.string('id').primary()
+    table.string('filterId').notNullable()
+    table.text('keyword').notNullable()
+    table.boolean('wholeWord').notNullable().defaultTo(false)
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.unique(['filterId', 'keyword'], {
+      indexName: 'server_filter_keywords_filter_keyword_unique'
+    })
+    table.index(['filterId'], 'server_filter_keywords_filter_id')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('server_filter_keywords')
+  await knex.schema.dropTableIfExists('server_filters')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -715,6 +715,25 @@ CREATE TABLE public.search_documents (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.server_filter_keywords (
+    id character varying(255) NOT NULL,
+    "filterId" character varying(255) NOT NULL,
+    keyword text NOT NULL,
+    "wholeWord" boolean DEFAULT false NOT NULL,
+    "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE public.server_filters (
+    id character varying(255) NOT NULL,
+    title character varying(255) NOT NULL,
+    context text NOT NULL,
+    "filterAction" character varying(255) DEFAULT 'warn'::character varying NOT NULL,
+    "expiresAt" bigint,
+    "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE public.sessions (
     id character varying(255) NOT NULL,
     "accountId" character varying(255),
@@ -1115,6 +1134,15 @@ ALTER TABLE ONLY public.reports
 ALTER TABLE ONLY public.search_documents
     ADD CONSTRAINT search_documents_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY public.server_filter_keywords
+    ADD CONSTRAINT server_filter_keywords_filter_keyword_unique UNIQUE ("filterId", keyword);
+
+ALTER TABLE ONLY public.server_filter_keywords
+    ADD CONSTRAINT server_filter_keywords_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.server_filters
+    ADD CONSTRAINT server_filters_pkey PRIMARY KEY (id);
+
 ALTER TABLE ONLY public.sessions
     ADD CONSTRAINT sessions_pkey PRIMARY KEY (id);
 
@@ -1299,6 +1327,10 @@ CREATE INDEX search_documents_entity_type_entity_id ON public.search_documents U
 CREATE INDEX search_documents_last_post ON public.search_documents USING btree ("lastPostAt");
 
 CREATE INDEX search_documents_post_count ON public.search_documents USING btree ("postCount");
+
+CREATE INDEX server_filter_keywords_filter_id ON public.server_filter_keywords USING btree ("filterId");
+
+CREATE INDEX server_filters_created ON public.server_filters USING btree ("createdAt");
 
 CREATE INDEX "sessions_accountId_token_idx" ON public.sessions USING btree ("accountId", token);
 

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1332,6 +1332,8 @@ CREATE INDEX server_filter_keywords_filter_id ON public.server_filter_keywords U
 
 CREATE INDEX server_filters_created ON public.server_filters USING btree ("createdAt");
 
+CREATE INDEX server_filters_expires_at ON public.server_filters USING btree ("expiresAt");
+
 CREATE INDEX "sessions_accountId_token_idx" ON public.sessions USING btree ("accountId", token);
 
 CREATE INDEX "status_history_statusId_idx" ON public.status_history USING btree ("statusId", "createdAt", "updatedAt");

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -197,6 +197,7 @@ CREATE INDEX `featured_tags_name` on `featured_tags` (`nameNormalized`);
 CREATE TABLE `translation_cache` (`provider` varchar(191) not null, `sourceLanguage` varchar(16) not null, `targetLanguage` varchar(16) not null, `sourceHash` varchar(64) not null, `content` text not null, `detectedSourceLanguage` varchar(16), `createdAt` datetime default CURRENT_TIMESTAMP, primary key (`provider`, `sourceLanguage`, `targetLanguage`, `sourceHash`));
 CREATE INDEX `translation_cache_created` on `translation_cache` (`createdAt`);
 CREATE TABLE `server_filters` (`id` varchar(255), `title` varchar(255) not null, `context` text not null, `filterAction` varchar(255) not null default 'warn', `expiresAt` bigint null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
+CREATE INDEX `server_filters_expires_at` on `server_filters` (`expiresAt`);
 CREATE INDEX `server_filters_created` on `server_filters` (`createdAt`);
 CREATE TABLE `server_filter_keywords` (`id` varchar(255), `filterId` varchar(255) not null, `keyword` text not null, `wholeWord` boolean not null default '0', `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
 CREATE UNIQUE INDEX `server_filter_keywords_filter_keyword_unique` on `server_filter_keywords` (`filterId`, `keyword`);

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -196,3 +196,8 @@ CREATE UNIQUE INDEX `featured_tags_actor_name_unique` on `featured_tags` (`actor
 CREATE INDEX `featured_tags_name` on `featured_tags` (`nameNormalized`);
 CREATE TABLE `translation_cache` (`provider` varchar(191) not null, `sourceLanguage` varchar(16) not null, `targetLanguage` varchar(16) not null, `sourceHash` varchar(64) not null, `content` text not null, `detectedSourceLanguage` varchar(16), `createdAt` datetime default CURRENT_TIMESTAMP, primary key (`provider`, `sourceLanguage`, `targetLanguage`, `sourceHash`));
 CREATE INDEX `translation_cache_created` on `translation_cache` (`createdAt`);
+CREATE TABLE `server_filters` (`id` varchar(255), `title` varchar(255) not null, `context` text not null, `filterAction` varchar(255) not null default 'warn', `expiresAt` bigint null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
+CREATE INDEX `server_filters_created` on `server_filters` (`createdAt`);
+CREATE TABLE `server_filter_keywords` (`id` varchar(255), `filterId` varchar(255) not null, `keyword` text not null, `wholeWord` boolean not null default '0', `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
+CREATE UNIQUE INDEX `server_filter_keywords_filter_keyword_unique` on `server_filter_keywords` (`filterId`, `keyword`);
+CREATE INDEX `server_filter_keywords_filter_id` on `server_filter_keywords` (`filterId`);


### PR DESCRIPTION
## Summary

Implements Mastodon v2-compatible **keyword filters** across two surfaces, matching the hi-fi design pixel-for-pixel.

- **Settings → Filters** (account scope) — new tab after "Muted accounts", wired to the existing `/api/v2/filters` API. List + full-page editor + empty state, optimistic inline delete.
- **Admin → Filters** (server scope) — new tab before "Federation", backed by a **new instance-wide server-filter backend**.

### Backend (new server-filter scope)
- Migration adds `server_filters` / `server_filter_keywords` tables.
- `ServerFilter` domain type + `ServerFilterDatabase` storage mixin.
- Admin-only API: `GET/POST /api/v2/admin/filters`, `GET/PUT/PATCH/DELETE /api/v2/admin/filters/:id` (via `AdminApiGuard`).
- Active server filters are **merged into `GET /api/v2/filters` flagged read-only** (`server: true`) so third-party Mastodon clients apply them, and into timeline matching for **all** viewers (including signed-out).
- The account list now returns **expired** filters so they can show an "Expired" badge and be reactivated (previously excluded).

### Client + UI
- All filter calls added to `lib/client.ts` (account + server scopes).
- Shared components in `lib/components/filters/` (`FiltersPanel`, `FilterRow`, `FilterEditor`).

### Notable design decisions
- **Settings shows only the user's own filters.** Server filters are merged into the API for third-party clients but filtered out of the first-party Settings list to match the design's two-surface separation (Admin manages server filters).
- Admin "Filters" tab placed before "Federation" (the admin nav has no "Reports" tab).
- Lists are ordered oldest-first (creation order) to match the design.

## Testing
- `yarn build` ✅, `yarn lint` (0 errors) ✅, `yarn test` (3930/3930) ✅
- New storage + admin-route tests; updated partial-mock suites for the new `getActiveServerFilters` method.
- **Both** reference schema dumps regenerated against local PostgreSQL 17 + SQLite (purely additive, verified to load).
- Verified screenshot parity at 1280px for all states: settings list, editor, empty, admin list, plus the live warn-preview interaction.

## Migration / config notes
- One new migration (`20260610120000_add_server_filters_tables.js`); both `migrations/schema.sql` and `migrations/schema.sqlite.sql` regenerated in this PR.
- No new runtime config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)