### PR TITLE
minor: Mastodon API registration token flow and email confirmations

### DIFF
--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -304,7 +304,8 @@ describe('POST /api/v1/accounts with a Bearer app token', () => {
     jest.mocked(registerAccount).mockResolvedValueOnce({
       type: 'success',
       accountId,
-      username: NEW_USERNAME
+      username: NEW_USERNAME,
+      actorId
     })
 
     const res = await postRegister(
@@ -384,6 +385,17 @@ describe('POST /api/v1/accounts with a Bearer app token', () => {
     jest
       .mocked(registerAccount)
       .mockResolvedValueOnce({ type: 'registration_closed' })
+    const res = await postRegister(
+      APP_TOKEN,
+      `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when the email is not allowed to register', async () => {
+    jest
+      .mocked(registerAccount)
+      .mockResolvedValueOnce({ type: 'email_not_allowed' })
     const res = await postRegister(
       APP_TOKEN,
       `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -140,4 +140,26 @@ describe('POST /api/v1/accounts', () => {
     expect(res.status).toBe(403)
     expect(createAccount).not.toHaveBeenCalled()
   })
+
+  it('returns 403 for closed registration even when the body is invalid', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: false
+    } as never)
+    const createAccount = jest.fn()
+    mockDatabase = { ...mockDatabase!, createAccount } as never
+    // Deliberately malformed/schema-invalid body — missing required fields.
+    const req = new NextRequest('http://localhost/api/v1/accounts', {
+      method: 'POST',
+      body: 'not_a_valid_field=garbage',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(403)
+    expect(createAccount).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -1,16 +1,23 @@
+import knex from 'knex'
 import { NextRequest } from 'next/server'
 
+import { GET as verifyCredentials } from '@/app/api/v1/accounts/verify_credentials/route'
 import { getConfig } from '@/lib/config'
+import { getSQLDatabase } from '@/lib/database/sql'
 import { Database } from '@/lib/database/types'
 import { registerAccount } from '@/lib/services/accounts/registerAccount'
+import { hashToken } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
 
 import { GET, POST } from './route'
 
 jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
   getConfig: jest.fn().mockReturnValue({
     host: 'llun.test',
     allowEmails: [],
-    registrationOpen: true
+    registrationOpen: true,
+    secretPhase: 'test-secret'
   })
 }))
 
@@ -18,14 +25,27 @@ jest.mock('@/lib/services/accounts/registerAccount', () => ({
   registerAccount: jest.fn()
 }))
 
-// The route only calls getMastodonActorsFromIds directly; isAccountExists and
-// isUsernameExists moved into registerAccount (the service), which is mocked
-// above for route-level tests.
-type MockDatabase = Pick<Database, 'getMastodonActorsFromIds'>
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue(null)
+}))
 
-let mockDatabase: MockDatabase | null = null
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+// Opaque tokens never reach better-auth's verifier, but the guard imports it.
+jest.mock('better-auth/oauth2', () => ({ verifyAccessToken: jest.fn() }))
+
+// getDatabase/getKnex are read through mutable bindings so the hand-rolled mock
+// (GET + web-form tests) and the real SQLite database (Bearer API tests) can
+// each install themselves per describe block.
+let mockDatabase: unknown = null
+let mockKnex: unknown = undefined
 jest.mock('@/lib/database', () => ({
-  getDatabase: () => mockDatabase
+  getDatabase: () => mockDatabase,
+  getKnex: () => mockKnex
 }))
 
 const mastodonAccount = {
@@ -37,18 +57,25 @@ const mastodonAccount = {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  mockDatabase = {
-    getMastodonActorsFromIds: jest.fn().mockResolvedValue([mastodonAccount])
-  }
 })
 
 describe('GET /api/v1/accounts', () => {
+  beforeEach(() => {
+    mockKnex = undefined
+    mockDatabase = {
+      getMastodonActorsFromIds: jest.fn().mockResolvedValue([mastodonAccount])
+    }
+  })
+
   it('returns an empty array when no ids are provided', async () => {
     const req = new NextRequest('http://localhost/api/v1/accounts')
     const res = await GET(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual([])
-    expect(mockDatabase!.getMastodonActorsFromIds).not.toHaveBeenCalled()
+    expect(
+      (mockDatabase as { getMastodonActorsFromIds: jest.Mock })
+        .getMastodonActorsFromIds
+    ).not.toHaveBeenCalled()
   })
 
   it('returns the requested accounts for id[] params and decodes the ids', async () => {
@@ -60,7 +87,10 @@ describe('GET /api/v1/accounts', () => {
     expect(await res.json()).toEqual([mastodonAccount])
     // Each encoded id is decoded via idToUrl before the DB lookup; a plain
     // (non-`apurl_`) value like `abc` decodes to `https://abc/`.
-    expect(mockDatabase!.getMastodonActorsFromIds).toHaveBeenCalledWith({
+    expect(
+      (mockDatabase as { getMastodonActorsFromIds: jest.Mock })
+        .getMastodonActorsFromIds
+    ).toHaveBeenCalledWith({
       ids: ['https://abc/', 'https://def/']
     })
   })
@@ -73,13 +103,17 @@ describe('GET /api/v1/accounts', () => {
   })
 })
 
-describe('POST /api/v1/accounts', () => {
+describe('POST /api/v1/accounts (web form / non-bearer)', () => {
+  beforeEach(() => {
+    mockKnex = undefined
+    mockDatabase = {
+      getMastodonActorsFromIds: jest.fn().mockResolvedValue([mastodonAccount])
+    }
+  })
+
   it('declines JSON API clients with 501 and does not create an account', async () => {
     const createAccount = jest.fn()
-    mockDatabase = {
-      ...mockDatabase!,
-      createAccount
-    } as never
+    mockDatabase = { ...(mockDatabase as object), createAccount }
     const req = new NextRequest('http://localhost/api/v1/accounts', {
       method: 'POST',
       body: JSON.stringify({
@@ -94,22 +128,9 @@ describe('POST /api/v1/accounts', () => {
     expect(createAccount).not.toHaveBeenCalled()
   })
 
-  it('declines Bearer-authenticated clients with 501', async () => {
-    const req = new NextRequest('http://localhost/api/v1/accounts', {
-      method: 'POST',
-      body: 'username=alice&email=alice@example.com&password=password123',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        Authorization: 'Bearer sometoken'
-      }
-    })
-    const res = await POST(req, { params: Promise.resolve({}) })
-    expect(res.status).toBe(501)
-  })
-
   it('declines form-encoded API clients (no text/html Accept) with 501', async () => {
     const createAccount = jest.fn()
-    mockDatabase = { ...mockDatabase!, createAccount } as never
+    mockDatabase = { ...(mockDatabase as object), createAccount }
     const req = new NextRequest('http://localhost/api/v1/accounts', {
       method: 'POST',
       body: 'username=alice&email=alice@example.com&password=password123',
@@ -130,7 +151,7 @@ describe('POST /api/v1/accounts', () => {
       registrationOpen: false
     } as never)
     const createAccount = jest.fn()
-    mockDatabase = { ...mockDatabase!, createAccount } as never
+    mockDatabase = { ...(mockDatabase as object), createAccount }
     const req = new NextRequest('http://localhost/api/v1/accounts', {
       method: 'POST',
       body: 'username=alice&email=alice@example.com&password=password123',
@@ -151,7 +172,7 @@ describe('POST /api/v1/accounts', () => {
       registrationOpen: false
     } as never)
     const createAccount = jest.fn()
-    mockDatabase = { ...mockDatabase!, createAccount } as never
+    mockDatabase = { ...(mockDatabase as object), createAccount }
     // Deliberately malformed/schema-invalid body — missing required fields.
     const req = new NextRequest('http://localhost/api/v1/accounts', {
       method: 'POST',
@@ -183,5 +204,206 @@ describe('POST /api/v1/accounts', () => {
     const res = await POST(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(307)
     expect(res.headers.get('location')).toContain('/auth/signin')
+  })
+})
+
+describe('POST /api/v1/accounts with a Bearer app token', () => {
+  const DOMAIN = 'llun.test'
+  const CLIENT_ID = 'register-api-client'
+  const APP_TOKEN = 'app-token-value'
+  const USER_TOKEN = 'user-token-value'
+  const NEW_USERNAME = 'newbie'
+
+  const apiKnex = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+  const apiDatabase: Database = getSQLDatabase(apiKnex)
+
+  let accountId: string
+  let actorId: string
+
+  const insertToken = async ({
+    token,
+    referenceId
+  }: {
+    token: string
+    referenceId: string | null
+  }) => {
+    await apiKnex('oauthAccessToken').insert({
+      id: `token-${token}`,
+      token: hashToken(token),
+      clientId: CLIENT_ID,
+      userId: referenceId ? accountId : null,
+      referenceId,
+      scopes: JSON.stringify([Scope.enum.read, Scope.enum.write]),
+      expiresAt: new Date(Date.now() + 3_600_000),
+      createdAt: new Date()
+    })
+  }
+
+  beforeAll(async () => {
+    await apiDatabase.migrate()
+    await apiKnex('oauthClient').insert({
+      id: 'register-api-client-row',
+      clientId: CLIENT_ID,
+      name: 'Register API App',
+      scopes: JSON.stringify([Scope.enum.read, Scope.enum.write]),
+      redirectUris: JSON.stringify(['https://app.test/redirect']),
+      requirePKCE: false,
+      disabled: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+    accountId = await apiDatabase.createAccount({
+      domain: DOMAIN,
+      email: 'newbie@llun.test',
+      username: NEW_USERNAME,
+      name: 'New Bie',
+      passwordHash: 'hashed-password',
+      verificationCode: null,
+      privateKey: 'private-key',
+      publicKey: 'public-key'
+    })
+    const actor = await apiDatabase.getActorFromUsername({
+      username: NEW_USERNAME,
+      domain: DOMAIN
+    })
+    actorId = actor!.id
+
+    // App (client_credentials) token: no bound actor.
+    await insertToken({ token: APP_TOKEN, referenceId: null })
+    // User-bound token: delegates the newly created actor.
+    await insertToken({ token: USER_TOKEN, referenceId: actorId })
+  })
+
+  afterAll(async () => {
+    await apiKnex.destroy()
+  })
+
+  beforeEach(() => {
+    mockDatabase = apiDatabase
+    mockKnex = apiKnex
+  })
+
+  const postRegister = (token: string, body: string) =>
+    POST(
+      new NextRequest('https://llun.test/api/v1/accounts', {
+        method: 'POST',
+        body,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Bearer ${token}`
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+  it('registers an account and returns a usable user token', async () => {
+    jest.mocked(registerAccount).mockResolvedValueOnce({
+      type: 'success',
+      accountId,
+      username: NEW_USERNAME
+    })
+
+    const res = await postRegister(
+      APP_TOKEN,
+      `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`
+    )
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual({
+      access_token: expect.any(String),
+      token_type: 'Bearer',
+      scope: 'read write',
+      created_at: expect.any(Number)
+    })
+
+    // The returned token authenticates as the new user.
+    const verify = await verifyCredentials(
+      new NextRequest('https://llun.test/api/v1/accounts/verify_credentials', {
+        headers: { Authorization: `Bearer ${data.access_token}` }
+      }),
+      { params: Promise.resolve({}) }
+    )
+    expect(verify.status).toBe(200)
+  })
+
+  const deepHasKey = (value: unknown, key: string): boolean => {
+    if (!value || typeof value !== 'object') return false
+    if (key in (value as Record<string, unknown>)) return true
+    return Object.values(value as Record<string, unknown>).some((v) =>
+      deepHasKey(v, key)
+    )
+  }
+
+  const takenUsername: Awaited<ReturnType<typeof registerAccount>> = {
+    type: 'validation_failed',
+    details: {
+      username: [
+        { error: 'ERR_TAKEN', description: 'Username is already taken' }
+      ]
+    }
+  }
+
+  it.each([
+    {
+      description: 'missing agreement',
+      body: `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123`,
+      registerResult: undefined,
+      detailKey: 'agreement'
+    },
+    {
+      description: 'invalid email',
+      body: `username=${NEW_USERNAME}&email=not-an-email&password=password123&agreement=true`,
+      registerResult: undefined,
+      detailKey: 'email'
+    },
+    {
+      description: 'taken username',
+      body: `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`,
+      registerResult: takenUsername,
+      detailKey: 'username'
+    }
+  ])(
+    'returns 422 for $description',
+    async ({ body, registerResult, detailKey }) => {
+      if (registerResult) {
+        jest.mocked(registerAccount).mockResolvedValueOnce(registerResult)
+      }
+      const res = await postRegister(APP_TOKEN, body)
+      expect(res.status).toBe(422)
+      const data = await res.json()
+      expect(deepHasKey(data.details, detailKey)).toBe(true)
+    }
+  )
+
+  it('returns 403 when registration is closed', async () => {
+    jest
+      .mocked(registerAccount)
+      .mockResolvedValueOnce({ type: 'registration_closed' })
+    const res = await postRegister(
+      APP_TOKEN,
+      `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 for an unknown bearer token', async () => {
+    const res = await postRegister(
+      'totally-unknown-token',
+      `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for a user-bound (non-app) token', async () => {
+    const res = await postRegister(
+      USER_TOKEN,
+      `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`
+    )
+    expect(res.status).toBe(403)
   })
 })

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+import { registerAccount } from '@/lib/services/accounts/registerAccount'
 
 import { GET, POST } from './route'
 
@@ -13,10 +14,14 @@ jest.mock('@/lib/config', () => ({
   })
 }))
 
-type MockDatabase = Pick<
-  Database,
-  'getMastodonActorsFromIds' | 'isAccountExists' | 'isUsernameExists'
->
+jest.mock('@/lib/services/accounts/registerAccount', () => ({
+  registerAccount: jest.fn()
+}))
+
+// The route only calls getMastodonActorsFromIds directly; isAccountExists and
+// isUsernameExists moved into registerAccount (the service), which is mocked
+// above for route-level tests.
+type MockDatabase = Pick<Database, 'getMastodonActorsFromIds'>
 
 let mockDatabase: MockDatabase | null = null
 jest.mock('@/lib/database', () => ({
@@ -33,9 +38,7 @@ const mastodonAccount = {
 beforeEach(() => {
   jest.clearAllMocks()
   mockDatabase = {
-    getMastodonActorsFromIds: jest.fn().mockResolvedValue([mastodonAccount]),
-    isAccountExists: jest.fn().mockResolvedValue(false),
-    isUsernameExists: jest.fn().mockResolvedValue(false)
+    getMastodonActorsFromIds: jest.fn().mockResolvedValue([mastodonAccount])
   }
 })
 
@@ -161,5 +164,24 @@ describe('POST /api/v1/accounts', () => {
     const res = await POST(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(403)
     expect(createAccount).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /auth/signin with 307 on successful registration', async () => {
+    jest.mocked(registerAccount).mockResolvedValueOnce({
+      type: 'success',
+      accountId: 'new-account-id',
+      username: 'alice'
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts', {
+      method: 'POST',
+      body: 'username=alice&email=alice@example.com&password=password123',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/auth/signin')
   })
 })

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -187,11 +187,69 @@ describe('POST /api/v1/accounts (web form / non-bearer)', () => {
     expect(createAccount).not.toHaveBeenCalled()
   })
 
+  it('returns 422 with an accurate message when the email is not allowed', async () => {
+    jest.mocked(registerAccount).mockResolvedValueOnce({
+      type: 'email_not_allowed'
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts', {
+      method: 'POST',
+      body: 'username=alice&email=alice@example.com&password=password123',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(422)
+    // The allow-list rejection must not be mislabeled as "already taken".
+    expect(await res.json()).toEqual({
+      error: 'Validation failed',
+      details: {
+        email: [
+          {
+            error: 'ERR_BLOCKED',
+            description: 'Email is not allowed to register on this server'
+          }
+        ]
+      }
+    })
+  })
+
+  it('returns 422 with field details when registration validation fails', async () => {
+    jest.mocked(registerAccount).mockResolvedValueOnce({
+      type: 'validation_failed',
+      details: {
+        username: [
+          { error: 'ERR_TAKEN', description: 'Username is already taken' }
+        ]
+      }
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts', {
+      method: 'POST',
+      body: 'username=alice&email=alice@example.com&password=password123',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({
+      error: 'Validation failed',
+      details: {
+        username: [
+          { error: 'ERR_TAKEN', description: 'Username is already taken' }
+        ]
+      }
+    })
+  })
+
   it('redirects to /auth/signin with 307 on successful registration', async () => {
     jest.mocked(registerAccount).mockResolvedValueOnce({
       type: 'success',
       accountId: 'new-account-id',
-      username: 'alice'
+      username: 'alice',
+      actorId: 'https://llun.test/users/alice'
     })
     const req = new NextRequest('http://localhost/api/v1/accounts', {
       method: 'POST',
@@ -401,6 +459,20 @@ describe('POST /api/v1/accounts with a Bearer app token', () => {
       `username=${NEW_USERNAME}&email=newbie@llun.test&password=password123&agreement=true`
     )
     expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for closed registration before parsing the body', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: false,
+      secretPhase: 'test-secret'
+    } as never)
+    // Malformed body (missing required fields): a closed server must still
+    // answer 403 without reaching schema validation or registerAccount().
+    const res = await postRegister(APP_TOKEN, 'garbage=1')
+    expect(res.status).toBe(403)
+    expect(registerAccount).not.toHaveBeenCalled()
   })
 
   it('returns 401 for an unknown bearer token', async () => {

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -116,9 +116,11 @@ export const POST = traceApiRoute(
       })
     }
 
-    // A closed server accepts no new accounts at all. Check this before
-    // parsing the body so that a POST to a closed server always returns 403
-    // regardless of whether the body is valid.
+    // Guard before parsing the body: a closed server must return 403 even when
+    // the body is malformed, preserving the historical response ordering.
+    // registerAccount() also checks registrationOpen so it is safe to call as a
+    // standalone service; the registration_closed branch in the result handler
+    // below is a defensive fallback for that standalone-caller scenario.
     if (!getConfig().registrationOpen) {
       return apiResponse({
         req: request,
@@ -164,6 +166,11 @@ export const POST = traceApiRoute(
       name: form.name
     })
 
+    // Defensive fallback: the early gate above normally prevents this branch
+    // from being reached in the web-form flow, but registerAccount() re-checks
+    // registrationOpen internally for standalone callers. Keeping this branch
+    // makes the result-union handler exhaustive and avoids a silent gap if the
+    // early gate is ever removed or bypassed.
     if (result.type === 'registration_closed') {
       return apiResponse({
         req: request,

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { registerAccount } from '@/lib/services/accounts/registerAccount'
 import { getRedirectUrl } from '@/lib/services/guards/getRedirectUrl'
@@ -112,6 +113,18 @@ export const POST = traceApiRoute(
           error: 'Account registration via the API is not supported'
         },
         responseStatusCode: 501
+      })
+    }
+
+    // A closed server accepts no new accounts at all. Check this before
+    // parsing the body so that a POST to a closed server always returns 403
+    // regardless of whether the body is valid.
+    if (!getConfig().registrationOpen) {
+      return apiResponse({
+        req: request,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Registration is closed' },
+        responseStatusCode: 403
       })
     }
 

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -150,14 +150,16 @@ const registerViaApi = OAuthAppGuard(
 
     const content = RegisterApiRequest.safeParse(body)
     if (!content.success) {
-      const fields = content.error.flatten((issue) => ({
+      // Mastodon's `details` is a flat field -> errors map, so return only
+      // fieldErrors (dropping flatten()'s separate formErrors bucket).
+      const { fieldErrors } = content.error.flatten((issue) => ({
         error: 'ERR_INVALID',
         description: issue.message
       }))
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: { error: MAIN_ERROR_MESSAGE, details: fields },
+        data: { error: MAIN_ERROR_MESSAGE, details: fieldErrors },
         responseStatusCode: 422
       })
     }
@@ -304,15 +306,14 @@ export const POST = traceApiRoute(
     }
     const content = CreateAccountRequest.safeParse(body)
     if (!content.success) {
-      const error = content.error
-      const fields = error.flatten((issue) => ({
+      const { fieldErrors } = content.error.flatten((issue) => ({
         error: 'ERR_INVALID',
         description: issue.message
       }))
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,
-        data: { error: MAIN_ERROR_MESSAGE, details: fields },
+        data: { error: MAIN_ERROR_MESSAGE, details: fieldErrors },
         responseStatusCode: 422
       })
     }

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
 
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { registerAccount } from '@/lib/services/accounts/registerAccount'
+import {
+  OAuthAppGuard,
+  corsErrorResponse,
+  isBearerAuthorizationHeader
+} from '@/lib/services/guards/OAuthGuard'
 import { getRedirectUrl } from '@/lib/services/guards/getRedirectUrl'
+import { issueAccessToken } from '@/lib/services/oauth/issueAccessToken'
+import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 import { CreateAccountRequest } from './types'
 
@@ -69,16 +78,15 @@ export const GET = traceApiRoute(
   }
 )
 
-// Detects a Mastodon API client (vs. the HTML web sign-up form). The web form
-// is a browser navigation that always sends `Accept: text/html`; any request
-// that does not accept HTML — including form-encoded API registrations with
-// `Accept: */*` — is treated as an API client, as is anything sending a Bearer
-// token or a JSON content type. API clients are declined before any account is
-// created, since the registration Token response is not implemented.
+// Detects a non-bearer Mastodon API client (vs. the HTML web sign-up form). The
+// web form is a browser navigation that always sends `Accept: text/html`; any
+// request that does not accept HTML — including form-encoded API registrations
+// with `Accept: */*` — or that sends a JSON content type is treated as an API
+// client. Bearer-authenticated requests are handled separately (real API
+// registration), so they are intentionally not matched here. Non-bearer API
+// clients are still declined: Mastodon registration needs an app access token,
+// which they did not send.
 const isApiClient = (request: NextRequest): boolean => {
-  const authorization = request.headers.get('authorization') ?? ''
-  if (/^bearer\s/i.test(authorization.trim())) return true
-
   const contentType = request.headers.get('content-type') ?? ''
   if (contentType.includes('application/json')) return true
 
@@ -86,9 +94,155 @@ const isApiClient = (request: NextRequest): boolean => {
   return !accept.includes('text/html')
 }
 
+// Mastodon's "Register an account" body. Extends the web-form schema (keeping
+// the reserved-username and email/password validation) with the API-only
+// `agreement`/`locale`/`reason` fields. `agreement` is optional in the schema
+// so a missing value yields the dedicated ERR_ACCEPTED error below rather than
+// a generic schema failure.
+const RegisterApiRequest = CreateAccountRequest.extend({
+  agreement: Booleanish.optional(),
+  locale: z.string().optional(),
+  reason: z.string().max(5000).optional()
+})
+
+// POST /api/v1/accounts with a Bearer app token — registers an account and
+// returns a user access token bound to it (Mastodon's documented behavior).
+// Requires `write:accounts` (satisfied by the aggregate `write`) and an app
+// (client_credentials) token: a user-bound token must not mint another
+// account's token, so a token carrying an actor is rejected with 403.
+const registerViaApi = OAuthAppGuard(
+  [Scope.enum['write:accounts']],
+  async (req, { client, currentActor, grantedScopes, database }) => {
+    if (currentActor || !client) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'This method requires an app access token' },
+        responseStatusCode: 403
+      })
+    }
+
+    let body: Record<string, unknown>
+    try {
+      body = await getRequestBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: MAIN_ERROR_MESSAGE },
+        responseStatusCode: 422
+      })
+    }
+
+    const content = RegisterApiRequest.safeParse(body)
+    if (!content.success) {
+      const fields = content.error.flatten((issue) => ({
+        error: 'ERR_INVALID',
+        description: issue.message
+      }))
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: MAIN_ERROR_MESSAGE, details: fields },
+        responseStatusCode: 422
+      })
+    }
+
+    const form = content.data
+    if (form.agreement !== true) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {
+          error: `${MAIN_ERROR_MESSAGE}: Agreement must be accepted`,
+          details: {
+            agreement: [
+              {
+                error: 'ERR_ACCEPTED',
+                description: 'Agreement must be accepted'
+              }
+            ]
+          }
+        },
+        responseStatusCode: 422
+      })
+    }
+
+    const result = await registerAccount({
+      database,
+      username: form.username,
+      email: form.email,
+      password: form.password,
+      name: form.name
+    })
+
+    if (result.type === 'registration_closed') {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Registration is closed' },
+        responseStatusCode: 403
+      })
+    }
+
+    if (result.type === 'email_not_allowed') {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Email is not allowed to register on this server' },
+        responseStatusCode: 403
+      })
+    }
+
+    if (result.type === 'validation_failed') {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: MAIN_ERROR_MESSAGE, details: result.details },
+        responseStatusCode: 422
+      })
+    }
+
+    // The new account's actor carries the id OAuthGuard resolves the request
+    // actor from, so the issued token authenticates as the freshly created user.
+    const actor = await database.getActorFromUsername({
+      username: result.username,
+      domain: getConfig().host
+    })
+    if (!actor) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const issued = await issueAccessToken({
+      database,
+      clientId: client.clientId,
+      accountId: result.accountId,
+      actorId: actor.id,
+      scopes: grantedScopes
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: {
+        access_token: issued.token,
+        token_type: 'Bearer',
+        scope: issued.scopes.join(' '),
+        created_at: Math.floor(issued.createdAt / 1000)
+      }
+    })
+  },
+  { errorResponse: corsErrorResponse(CORS_HEADERS) }
+)
+
 export const POST = traceApiRoute(
   'createAccount',
-  async (request: NextRequest) => {
+  async (request: NextRequest, context) => {
     const database = getDatabase()
     if (!database) {
       return apiResponse({
@@ -99,18 +253,22 @@ export const POST = traceApiRoute(
       })
     }
 
-    // Mastodon's "Register an account" returns a Token bound to an OAuth app.
-    // Minting a real access token requires the authorization-code flow (and the
-    // account is unverified at creation), so it is not implemented here. Decline
-    // API clients cleanly *before* creating anything — returning the web-form
-    // 307 redirect would leave them with an account they cannot authenticate and
-    // cannot re-create (username/email already taken).
+    // A Bearer token marks a Mastodon API registration: validate the app token
+    // and return a user access token bound to the new account.
+    if (isBearerAuthorizationHeader(request.headers.get('authorization'))) {
+      return registerViaApi(request, context)
+    }
+
+    // Non-bearer API clients (JSON / non-HTML Accept) can't register: Mastodon
+    // requires an app access token, which they did not send. Decline cleanly
+    // *before* creating anything — returning the web-form 307 redirect would
+    // leave them with an account they cannot authenticate.
     if (isApiClient(request)) {
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,
         data: {
-          error: 'Account registration via the API is not supported'
+          error: 'Account registration via the API requires an app access token'
         },
         responseStatusCode: 501
       })

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -203,26 +203,14 @@ const registerViaApi = OAuthAppGuard(
       })
     }
 
-    // The new account's actor carries the id OAuthGuard resolves the request
-    // actor from, so the issued token authenticates as the freshly created user.
-    const actor = await database.getActorFromUsername({
-      username: result.username,
-      domain: getConfig().host
-    })
-    if (!actor) {
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: ERROR_500,
-        responseStatusCode: 500
-      })
-    }
-
+    // registerAccount returns the new account's actor id (the id OAuthGuard
+    // resolves the request actor from), so the issued token authenticates as
+    // the freshly created user without an extra lookup.
     const issued = await issueAccessToken({
       database,
       clientId: client.clientId,
       accountId: result.accountId,
-      actorId: actor.id,
+      actorId: result.actorId,
       scopes: grantedScopes
     })
 

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -122,6 +122,20 @@ const registerViaApi = OAuthAppGuard(
       })
     }
 
+    // Gate before parsing the body so a closed server returns 403 even when the
+    // body is malformed, matching Mastodon's check_enabled_registrations (which
+    // runs as a before_action) and the web-form path. registerAccount() also
+    // re-checks registrationOpen, so the registration_closed result branch below
+    // remains a defensive fallback.
+    if (!getConfig().registrationOpen) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Registration is closed' },
+        responseStatusCode: 403
+      })
+    }
+
     let body: Record<string, unknown>
     try {
       body = await getRequestBody(req)
@@ -334,7 +348,10 @@ export const POST = traceApiRoute(
           error: MAIN_ERROR_MESSAGE,
           details: {
             email: [
-              { error: 'ERR_TAKEN', description: 'Email is already taken' }
+              {
+                error: 'ERR_BLOCKED',
+                description: 'Email is not allowed to register on this server'
+              }
             ]
           }
         },

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -1,22 +1,16 @@
-import * as bcrypt from 'bcrypt'
-import crypto from 'crypto'
 import { NextRequest } from 'next/server'
 
-import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
-import { sendMail } from '@/lib/services/email'
+import { registerAccount } from '@/lib/services/accounts/registerAccount'
 import { getRedirectUrl } from '@/lib/services/guards/getRedirectUrl'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { logger } from '@/lib/utils/logger'
 import { ERROR_500, apiResponse, defaultOptions } from '@/lib/utils/response'
-import { generateKeyPair } from '@/lib/utils/signature'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
 import { CreateAccountRequest } from './types'
 
-const BCRYPT_ROUND = 10
 const MAIN_ERROR_MESSAGE = 'Validation failed'
 const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
@@ -94,7 +88,6 @@ const isApiClient = (request: NextRequest): boolean => {
 export const POST = traceApiRoute(
   'createAccount',
   async (request: NextRequest) => {
-    const config = getConfig()
     const database = getDatabase()
     if (!database) {
       return apiResponse({
@@ -122,19 +115,6 @@ export const POST = traceApiRoute(
       })
     }
 
-    // A closed server accepts no new accounts at all. This is orthogonal to
-    // `allowEmails` below (which restricts *who* may register while open), so
-    // it is checked first and independently.
-    if (!config.registrationOpen) {
-      return apiResponse({
-        req: request,
-        allowedMethods: CORS_HEADERS,
-        data: { error: 'Registration is closed' },
-        responseStatusCode: 403
-      })
-    }
-
-    const { host: domain, allowEmails } = config
     // The web sign-up form posts urlencoded/multipart form data.
     let body: Record<string, unknown>
     try {
@@ -163,7 +143,24 @@ export const POST = traceApiRoute(
     }
 
     const form = content.data
-    if (allowEmails.length && !allowEmails.includes(form.email)) {
+    const result = await registerAccount({
+      database,
+      username: form.username,
+      email: form.email,
+      password: form.password,
+      name: form.name
+    })
+
+    if (result.type === 'registration_closed') {
+      return apiResponse({
+        req: request,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'Registration is closed' },
+        responseStatusCode: 403
+      })
+    }
+
+    if (result.type === 'email_not_allowed') {
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,
@@ -179,69 +176,13 @@ export const POST = traceApiRoute(
       })
     }
 
-    const [isAccountExists, isUsernameExists] = await Promise.all([
-      database.isAccountExists({ email: form.email }),
-      database.isUsernameExists({ username: form.username, domain })
-    ])
-
-    const errorDetails: {
-      [key in 'email' | 'username']?: { error: string; description: string }[]
-    } = {}
-    if (isAccountExists) {
-      errorDetails.email = [
-        { error: 'ERR_TAKEN', description: 'Email is already taken' }
-      ]
-    }
-
-    if (isUsernameExists) {
-      errorDetails.username = [
-        { error: 'ERR_TAKEN', description: 'Username is already taken' }
-      ]
-    }
-    if (Object.keys(errorDetails).length > 0) {
+    if (result.type === 'validation_failed') {
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,
-        data: { error: MAIN_ERROR_MESSAGE, details: errorDetails },
+        data: { error: MAIN_ERROR_MESSAGE, details: result.details },
         responseStatusCode: 422
       })
-    }
-
-    // TODO: If the request has auth bearer, return 200 instead
-    const [keyPair, passwordHash] = await Promise.all([
-      generateKeyPair(config.secretPhase),
-      bcrypt.hash(form.password, BCRYPT_ROUND)
-    ])
-
-    const verificationCode = config.email
-      ? crypto.randomBytes(32).toString('base64url')
-      : null
-
-    await database.createAccount({
-      domain,
-      email: form.email,
-      username: form.username,
-      name: form.name || null,
-      privateKey: keyPair.privateKey,
-      publicKey: keyPair.publicKey,
-      passwordHash,
-      verificationCode
-    })
-
-    if (config.email) {
-      try {
-        await sendMail({
-          from: config.email.serviceFromAddress,
-          to: [form.email],
-          subject: 'Email verification',
-          content: {
-            text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${verificationCode}`,
-            html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${verificationCode}">this link</a> to verify your email.`
-          }
-        })
-      } catch {
-        logger.error({ to: form.email }, `Fail to send email`)
-      }
     }
 
     return Response.redirect(getRedirectUrl(request, '/auth/signin'), 307)

--- a/app/api/v1/accounts/types.ts
+++ b/app/api/v1/accounts/types.ts
@@ -11,7 +11,7 @@ export const CreateAccountRequest = z.object({
       message: 'Username is reserved'
     }),
   name: z.string().trim().max(255).optional(),
-  email: z.string().email().trim(),
+  email: z.string().email().trim().max(255),
   password: z.string().min(8).trim()
 })
 export type CreateAccountRequest = z.infer<typeof CreateAccountRequest>

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -27,12 +27,16 @@ type MockDatabase = Pick<
   | 'getActorsForAccount'
   | 'updateAccountEmail'
   | 'requestEmailChange'
+  | 'isAccountExists'
 >
 
 let mockDatabase: MockDatabase | null = null
 jest.mock('@/lib/database', () => ({
-  getDatabase: () => mockDatabase
+  getDatabase: () => mockDatabase,
+  getKnex: () => undefined
 }))
+
+jest.mock('better-auth/oauth2', () => ({ verifyAccessToken: jest.fn() }))
 
 jest.mock('next/headers', () => ({
   cookies: jest.fn().mockResolvedValue({
@@ -79,7 +83,8 @@ describe('POST /api/v1/emails/confirmations', () => {
     getAccountFromEmail: jest.fn(),
     getActorsForAccount: jest.fn(),
     updateAccountEmail: jest.fn(),
-    requestEmailChange: jest.fn()
+    requestEmailChange: jest.fn(),
+    isAccountExists: jest.fn()
   }
 
   const setAccount = (account: ReturnType<typeof buildAccount>) => {
@@ -107,6 +112,7 @@ describe('POST /api/v1/emails/confirmations', () => {
     mockSendMail.mockResolvedValue(undefined)
     mockDb.updateAccountEmail.mockResolvedValue(undefined)
     mockDb.requestEmailChange.mockResolvedValue(undefined)
+    mockDb.isAccountExists.mockResolvedValue(false)
     setAccount(buildAccount(PENDING_CODE))
   })
 
@@ -179,6 +185,46 @@ describe('POST /api/v1/emails/confirmations', () => {
     expect(mailArgs[0].content.html).toContain(
       `https://llun.test/auth/confirmation?verificationCode=${PENDING_CODE}`
     )
+  })
+
+  it('returns 403 when the new email is not on the server allow-list', async () => {
+    // The signed-in address stays on the allow-list (so auth still resolves the
+    // actor); only the requested new address is absent from it.
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [seedActor1.email],
+      allowActorDomains: [],
+      email: { serviceFromAddress: 'noreply@llun.test' }
+    })
+
+    const response = await POST(makeRequest({ email: 'blocked@llun.test' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email is not allowed on this server'
+    })
+    expect(mockDb.updateAccountEmail).not.toHaveBeenCalled()
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 when the new email is already registered to another account', async () => {
+    mockDb.isAccountExists.mockResolvedValue(true)
+
+    const response = await POST(makeRequest({ email: 'taken@llun.test' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(422)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email is already taken'
+    })
+    expect(mockDb.isAccountExists).toHaveBeenCalledWith({
+      email: 'taken@llun.test'
+    })
+    expect(mockDb.updateAccountEmail).not.toHaveBeenCalled()
+    expect(mockSendMail).not.toHaveBeenCalled()
   })
 
   it('ignores an invalid email param and resends to the existing address', async () => {

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -227,6 +227,30 @@ describe('POST /api/v1/emails/confirmations', () => {
     expect(mockSendMail).not.toHaveBeenCalled()
   })
 
+  it('honors a form-encoded email param like the registration endpoint', async () => {
+    const request = new NextRequest(
+      'http://llun.test/api/v1/emails/confirmations',
+      {
+        method: 'POST',
+        body: 'email=form-email@llun.test',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Origin: 'https://llun.test'
+        }
+      }
+    )
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    expect(mockDb.updateAccountEmail).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      email: 'form-email@llun.test'
+    })
+    const [mailArgs] = mockSendMail.mock.calls
+    expect(mailArgs[0].to).toEqual(['form-email@llun.test'])
+  })
+
   it('ignores an invalid email param and resends to the existing address', async () => {
     const response = await POST(makeRequest({ email: 'not-an-email' }), {
       params: Promise.resolve({})

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -1,7 +1,11 @@
+import knex from 'knex'
 import { NextRequest } from 'next/server'
 
+import { getSQLDatabase } from '@/lib/database/sql'
 import { Database } from '@/lib/database/types'
+import { hashToken } from '@/lib/services/guards/OAuthGuard'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { Scope } from '@/lib/types/database/operations'
 
 import { POST } from './route'
 
@@ -30,10 +34,11 @@ type MockDatabase = Pick<
   | 'isAccountExists'
 >
 
-let mockDatabase: MockDatabase | null = null
+let mockDatabase: unknown = null
+let mockKnex: unknown = undefined
 jest.mock('@/lib/database', () => ({
   getDatabase: () => mockDatabase,
-  getKnex: () => undefined
+  getKnex: () => mockKnex
 }))
 
 jest.mock('better-auth/oauth2', () => ({ verifyAccessToken: jest.fn() }))
@@ -321,6 +326,107 @@ describe('POST /api/v1/emails/confirmations', () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({})
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+})
+
+// Exercises the route's documented primary path: a freshly-registered client
+// presenting the Bearer access token from POST /api/v1/accounts (OAuthGuard),
+// rather than the cookie-session fallback used by the cases above.
+describe('POST /api/v1/emails/confirmations with a Bearer token', () => {
+  const DOMAIN = 'llun.test'
+  const CLIENT_ID = 'confirmations-client'
+  const USER_TOKEN = 'user-token-value'
+  const USERNAME = 'pendingbie'
+
+  const apiKnex = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+  const apiDatabase: Database = getSQLDatabase(apiKnex)
+
+  const bearerRequest = (token: string) =>
+    new NextRequest('https://llun.test/api/v1/emails/confirmations', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` }
+    })
+
+  beforeAll(async () => {
+    await apiDatabase.migrate()
+    await apiKnex('oauthClient').insert({
+      id: 'confirmations-client-row',
+      clientId: CLIENT_ID,
+      name: 'Confirmations App',
+      scopes: JSON.stringify([Scope.enum.read, Scope.enum.write]),
+      redirectUris: JSON.stringify(['https://app.test/redirect']),
+      requirePKCE: false,
+      disabled: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+    const accountId = await apiDatabase.createAccount({
+      domain: DOMAIN,
+      email: 'pendingbie@llun.test',
+      username: USERNAME,
+      name: 'Pending Bie',
+      passwordHash: 'hashed-password',
+      // Still awaiting confirmation, so the resend is allowed.
+      verificationCode: PENDING_CODE,
+      privateKey: 'private-key',
+      publicKey: 'public-key'
+    })
+    const actor = await apiDatabase.getActorFromUsername({
+      username: USERNAME,
+      domain: DOMAIN
+    })
+    await apiKnex('oauthAccessToken').insert({
+      id: 'confirmations-token-row',
+      token: hashToken(USER_TOKEN),
+      clientId: CLIENT_ID,
+      userId: accountId,
+      referenceId: actor!.id,
+      scopes: JSON.stringify([Scope.enum.read, Scope.enum.write]),
+      expiresAt: new Date(Date.now() + 3_600_000),
+      createdAt: new Date()
+    })
+  })
+
+  afterAll(async () => {
+    await apiKnex.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDatabase = apiDatabase
+    mockKnex = apiKnex
+    mockGetConfig.mockReturnValue({
+      host: DOMAIN,
+      allowEmails: [],
+      allowActorDomains: [],
+      email: { serviceFromAddress: 'noreply@llun.test' }
+    })
+    mockSendMail.mockResolvedValue(undefined)
+  })
+
+  it('resolves the actor from a valid Bearer token and resends the email', async () => {
+    const response = await POST(bearerRequest(USER_TOKEN), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({})
+    expect(mockSendMail).toHaveBeenCalledTimes(1)
+    const [mailArgs] = mockSendMail.mock.calls
+    expect(mailArgs[0].to).toEqual(['pendingbie@llun.test'])
+  })
+
+  it('returns 401 for an unknown Bearer token', async () => {
+    const response = await POST(bearerRequest('totally-unknown-token'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(401)
     expect(mockSendMail).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -1,0 +1,203 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+const mockSendMail = jest.fn()
+jest.mock('@/lib/services/email', () => ({
+  sendMail: (...args: unknown[]) => mockSendMail(...args)
+}))
+
+const mockGetConfig = jest.fn()
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: () => mockGetConfig()
+}))
+
+type MockDatabase = Pick<
+  Database,
+  | 'getAccountFromEmail'
+  | 'getActorsForAccount'
+  | 'getActorFromId'
+  | 'requestEmailChange'
+>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: () => undefined
+  })
+}))
+
+const PENDING_CODE = 'pending-verification-code'
+
+const buildAccount = (verificationCode: string | null) => ({
+  id: 'account-1',
+  email: seedActor1.email,
+  verificationCode,
+  defaultActorId: ACTOR1_ID,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+})
+
+const buildActor = (account: ReturnType<typeof buildAccount>) => ({
+  ...seedActor1,
+  id: ACTOR1_ID,
+  account,
+  followersUrl: `${ACTOR1_ID}/followers`,
+  inboxUrl: `${ACTOR1_ID}/inbox`,
+  sharedInboxUrl: 'https://llun.test/inbox',
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now()
+})
+
+const makeRequest = (body?: unknown) =>
+  new NextRequest('http://llun.test/api/v1/emails/confirmations', {
+    method: 'POST',
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'https://llun.test'
+    }
+  })
+
+describe('POST /api/v1/emails/confirmations', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getAccountFromEmail: jest.fn(),
+    getActorsForAccount: jest.fn(),
+    getActorFromId: jest.fn(),
+    requestEmailChange: jest.fn()
+  }
+
+  const setAccount = (account: ReturnType<typeof buildAccount>) => {
+    mockDb.getAccountFromEmail.mockResolvedValue(account)
+    mockDb.getActorsForAccount.mockResolvedValue([buildActor(account)])
+  }
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [],
+      allowActorDomains: [],
+      email: {
+        serviceFromAddress: 'noreply@llun.test'
+      }
+    })
+    mockSendMail.mockResolvedValue(undefined)
+    mockDb.requestEmailChange.mockResolvedValue(undefined)
+    setAccount(buildAccount(PENDING_CODE))
+  })
+
+  it('resends the confirmation email and returns 200 for an account awaiting confirmation', async () => {
+    const response = await POST(makeRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({})
+
+    expect(mockSendMail).toHaveBeenCalledTimes(1)
+    const [mailArgs] = mockSendMail.mock.calls
+    expect(mailArgs[0].to).toEqual([seedActor1.email])
+    expect(mailArgs[0].content.text).toContain(
+      `https://llun.test/auth/confirmation?verificationCode=${PENDING_CODE}`
+    )
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the account has already confirmed its email', async () => {
+    setAccount(buildAccount(null))
+
+    const response = await POST(makeRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This method is only available while the e-mail is awaiting confirmation'
+    })
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the verification code is an empty string', async () => {
+    setAccount(buildAccount(''))
+
+    const response = await POST(makeRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+
+  it('updates the pending email before sending when an email param is provided', async () => {
+    const response = await POST(makeRequest({ email: 'new-email@llun.test' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({})
+
+    expect(mockDb.requestEmailChange).toHaveBeenCalledTimes(1)
+    expect(mockDb.requestEmailChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: 'account-1',
+        newEmail: 'new-email@llun.test'
+      })
+    )
+
+    expect(mockSendMail).toHaveBeenCalledTimes(1)
+    const [mailArgs] = mockSendMail.mock.calls
+    expect(mailArgs[0].to).toEqual(['new-email@llun.test'])
+  })
+
+  it('ignores an invalid email param and resends to the existing address', async () => {
+    const response = await POST(makeRequest({ email: 'not-an-email' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
+    const [mailArgs] = mockSendMail.mock.calls
+    expect(mailArgs[0].to).toEqual([seedActor1.email])
+  })
+
+  it('returns 200 without sending mail when email is not configured', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [],
+      allowActorDomains: [],
+      email: undefined
+    })
+
+    const response = await POST(makeRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({})
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -251,6 +251,26 @@ describe('POST /api/v1/emails/confirmations', () => {
     expect(mailArgs[0].to).toEqual(['form-email@llun.test'])
   })
 
+  it('returns 422 when a concurrent claim races onto the unique-email constraint', async () => {
+    // Pre-check passes (the racing request committed after it), so the
+    // collision only surfaces when updateAccountEmail hits the DB constraint.
+    mockDb.updateAccountEmail.mockRejectedValueOnce(
+      Object.assign(new Error('UNIQUE constraint failed: accounts.email'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE'
+      })
+    )
+
+    const response = await POST(makeRequest({ email: 'raced@llun.test' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(422)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email is already taken'
+    })
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+
   it('ignores an invalid email param and resends to the existing address', async () => {
     const response = await POST(makeRequest({ email: 'not-an-email' }), {
       params: Promise.resolve({})

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -25,7 +25,7 @@ type MockDatabase = Pick<
   Database,
   | 'getAccountFromEmail'
   | 'getActorsForAccount'
-  | 'getActorFromId'
+  | 'updateAccountEmail'
   | 'requestEmailChange'
 >
 
@@ -78,7 +78,7 @@ describe('POST /api/v1/emails/confirmations', () => {
   const mockDb: jest.Mocked<MockDatabase> = {
     getAccountFromEmail: jest.fn(),
     getActorsForAccount: jest.fn(),
-    getActorFromId: jest.fn(),
+    updateAccountEmail: jest.fn(),
     requestEmailChange: jest.fn()
   }
 
@@ -105,6 +105,7 @@ describe('POST /api/v1/emails/confirmations', () => {
       }
     })
     mockSendMail.mockResolvedValue(undefined)
+    mockDb.updateAccountEmail.mockResolvedValue(undefined)
     mockDb.requestEmailChange.mockResolvedValue(undefined)
     setAccount(buildAccount(PENDING_CODE))
   })
@@ -152,7 +153,7 @@ describe('POST /api/v1/emails/confirmations', () => {
     expect(mockSendMail).not.toHaveBeenCalled()
   })
 
-  it('updates the pending email before sending when an email param is provided', async () => {
+  it('updates the account email directly and confirms the new address when an email param is provided', async () => {
     const response = await POST(makeRequest({ email: 'new-email@llun.test' }), {
       params: Promise.resolve({})
     })
@@ -160,17 +161,24 @@ describe('POST /api/v1/emails/confirmations', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({})
 
-    expect(mockDb.requestEmailChange).toHaveBeenCalledTimes(1)
-    expect(mockDb.requestEmailChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: 'account-1',
-        newEmail: 'new-email@llun.test'
-      })
-    )
+    expect(mockDb.updateAccountEmail).toHaveBeenCalledTimes(1)
+    expect(mockDb.updateAccountEmail).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      email: 'new-email@llun.test'
+    })
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
 
     expect(mockSendMail).toHaveBeenCalledTimes(1)
     const [mailArgs] = mockSendMail.mock.calls
     expect(mailArgs[0].to).toEqual(['new-email@llun.test'])
+    // The resent link must carry the existing verificationCode so clicking it
+    // confirms the NEW address rather than stranding it.
+    expect(mailArgs[0].content.text).toContain(
+      `https://llun.test/auth/confirmation?verificationCode=${PENDING_CODE}`
+    )
+    expect(mailArgs[0].content.html).toContain(
+      `https://llun.test/auth/confirmation?verificationCode=${PENDING_CODE}`
+    )
   })
 
   it('ignores an invalid email param and resends to the existing address', async () => {
@@ -179,9 +187,21 @@ describe('POST /api/v1/emails/confirmations', () => {
     })
 
     expect(response.status).toBe(200)
+    expect(mockDb.updateAccountEmail).not.toHaveBeenCalled()
     expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
     const [mailArgs] = mockSendMail.mock.calls
     expect(mailArgs[0].to).toEqual([seedActor1.email])
+  })
+
+  it('returns 500 when sending the confirmation email fails', async () => {
+    mockSendMail.mockRejectedValueOnce(new Error('SMTP failure'))
+
+    const response = await POST(makeRequest(), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(500)
+    expect(mockSendMail).toHaveBeenCalledTimes(1)
   })
 
   it('returns 200 without sending mail when email is not configured', async () => {

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -271,14 +271,27 @@ describe('POST /api/v1/emails/confirmations', () => {
     expect(mockSendMail).not.toHaveBeenCalled()
   })
 
-  it('ignores an invalid email param and resends to the existing address', async () => {
+  it('returns 422 with field details when the email param is invalid', async () => {
     const response = await POST(makeRequest({ email: 'not-an-email' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(422)
+    const data = await response.json()
+    expect(data.error).toBe('Validation failed')
+    expect(data.details.email).toBeDefined()
+    expect(mockDb.updateAccountEmail).not.toHaveBeenCalled()
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
+    expect(mockSendMail).not.toHaveBeenCalled()
+  })
+
+  it('resends to the existing address when no email param is provided', async () => {
+    const response = await POST(makeRequest({ other: 'field' }), {
       params: Promise.resolve({})
     })
 
     expect(response.status).toBe(200)
     expect(mockDb.updateAccountEmail).not.toHaveBeenCalled()
-    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
     const [mailArgs] = mockSendMail.mock.calls
     expect(mailArgs[0].to).toEqual([seedActor1.email])
   })

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -1,13 +1,11 @@
 // POST /api/v1/emails/confirmations — resend the confirmation email for an
 // account that has not confirmed yet. 403 once confirmed, per Mastodon.
-import crypto from 'crypto'
 import { z } from 'zod'
 
-import { getConfig } from '@/lib/config'
-import { sendMail } from '@/lib/services/email'
+import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { logger } from '@/lib/utils/logger'
-import { HTTP_STATUS, apiCorsError, apiResponse } from '@/lib/utils/response'
+import { HTTP_STATUS, apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const ConfirmationRequest = z.object({
@@ -21,7 +19,12 @@ export const POST = traceApiRoute(
     const account = currentActor.account
 
     if (!account) {
-      return apiCorsError(req, [], HTTP_STATUS.NOT_FOUND)
+      return apiResponse({
+        req,
+        allowedMethods: [],
+        data: { error: 'Account not found' },
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
     }
 
     // `verificationCode` is the pending-confirmation token set at registration
@@ -49,32 +52,33 @@ export const POST = traceApiRoute(
     const parsed = ConfirmationRequest.safeParse(body)
     const newEmail = parsed.success ? parsed.data.email : undefined
 
-    // Optional `email` param updates the pending address before resending.
+    // Optional `email` param updates the unconfirmed account's address directly
+    // before resending. Because the account is still unconfirmed we just point
+    // the existing verificationCode at the new address — verifyAccount then
+    // confirms the new email when the link is clicked. (This is distinct from
+    // the confirmed-user email-change flow in accounts/email, which uses the
+    // pending-change machinery.)
     if (newEmail && newEmail !== account.email) {
-      const emailChangeCode = crypto.randomBytes(32).toString('base64url')
-      await database.requestEmailChange({
+      await database.updateAccountEmail({
         accountId: account.id,
-        newEmail,
-        emailChangeCode
+        email: newEmail
       })
     }
 
-    const config = getConfig()
-    if (config.email) {
-      const recipient = newEmail ?? account.email
-      try {
-        await sendMail({
-          from: config.email.serviceFromAddress,
-          to: [recipient],
-          subject: 'Email verification',
-          content: {
-            text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${account.verificationCode}`,
-            html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${account.verificationCode}">this link</a> to verify your email.`
-          }
-        })
-      } catch {
-        logger.error({ to: recipient }, `Fail to send email`)
-      }
+    const recipient = newEmail ?? account.email
+    try {
+      await sendConfirmationEmail({
+        recipient,
+        verificationCode: account.verificationCode
+      })
+    } catch {
+      logger.error({ to: recipient }, `Fail to send email`)
+      return apiResponse({
+        req,
+        allowedMethods: [],
+        data: { error: 'Failed to send verification email' },
+        responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
     }
 
     return apiResponse({

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -78,8 +78,24 @@ export const POST = traceApiRoute(
         body = {}
       }
 
+      // A malformed `email` param is a client error: return 422 with field
+      // details (like the registration endpoints) rather than silently dropping
+      // it and resending to the old address. An absent `email` still parses
+      // successfully (it is optional) and resends to the current address.
       const parsed = ConfirmationRequest.safeParse(body)
-      const newEmail = parsed.success ? parsed.data.email : undefined
+      if (!parsed.success) {
+        const { fieldErrors } = parsed.error.flatten((issue) => ({
+          error: 'ERR_INVALID',
+          description: issue.message
+        }))
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: { error: 'Validation failed', details: fieldErrors },
+          responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        })
+      }
+      const newEmail = parsed.data.email
 
       // Optional `email` param updates the unconfirmed account's address
       // directly before resending. Because the account is still unconfirmed we

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -1,0 +1,87 @@
+// POST /api/v1/emails/confirmations — resend the confirmation email for an
+// account that has not confirmed yet. 403 once confirmed, per Mastodon.
+import crypto from 'crypto'
+import { z } from 'zod'
+
+import { getConfig } from '@/lib/config'
+import { sendMail } from '@/lib/services/email'
+import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { logger } from '@/lib/utils/logger'
+import { HTTP_STATUS, apiCorsError, apiResponse } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const ConfirmationRequest = z.object({
+  email: z.string().email().optional()
+})
+
+export const POST = traceApiRoute(
+  'resendEmailConfirmation',
+  AuthenticatedGuard(async (req, context) => {
+    const { currentActor, database } = context
+    const account = currentActor.account
+
+    if (!account) {
+      return apiCorsError(req, [], HTTP_STATUS.NOT_FOUND)
+    }
+
+    // `verificationCode` is the pending-confirmation token set at registration
+    // when email is configured; it is cleared (to '') once the account verifies.
+    // An empty/null code means the e-mail is already confirmed.
+    if (!account.verificationCode) {
+      return apiResponse({
+        req,
+        allowedMethods: [],
+        data: {
+          error:
+            'This method is only available while the e-mail is awaiting confirmation'
+        },
+        responseStatusCode: HTTP_STATUS.FORBIDDEN
+      })
+    }
+
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      body = {}
+    }
+
+    const parsed = ConfirmationRequest.safeParse(body)
+    const newEmail = parsed.success ? parsed.data.email : undefined
+
+    // Optional `email` param updates the pending address before resending.
+    if (newEmail && newEmail !== account.email) {
+      const emailChangeCode = crypto.randomBytes(32).toString('base64url')
+      await database.requestEmailChange({
+        accountId: account.id,
+        newEmail,
+        emailChangeCode
+      })
+    }
+
+    const config = getConfig()
+    if (config.email) {
+      const recipient = newEmail ?? account.email
+      try {
+        await sendMail({
+          from: config.email.serviceFromAddress,
+          to: [recipient],
+          subject: 'Email verification',
+          content: {
+            text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${account.verificationCode}`,
+            html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${account.verificationCode}">this link</a> to verify your email.`
+          }
+        })
+      } catch {
+        logger.error({ to: recipient }, `Fail to send email`)
+      }
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: [],
+      data: {},
+      responseStatusCode: HTTP_STATUS.OK
+    })
+  })
+)

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -15,6 +15,7 @@ import {
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import { HTTP_STATUS, apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -26,8 +27,10 @@ const guardOptions = { errorResponse: corsErrorResponse(CORS_HEADERS) }
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+// `.max(255)` matches the accounts.email column width so an over-long address
+// fails validation here rather than at the DB insert (a 500).
 const ConfirmationRequest = z.object({
-  email: z.string().email().optional()
+  email: z.string().email().max(255).optional()
 })
 
 // Scope write:accounts (satisfied by aggregate `write`), matching the other
@@ -64,9 +67,12 @@ export const POST = traceApiRoute(
         })
       }
 
-      let body: unknown
+      // Parse with getRequestBody (JSON + urlencoded + multipart) so a client
+      // posting `email` as form data — like the registration endpoint accepts —
+      // is honored rather than silently dropped by a JSON-only parse.
+      let body: Record<string, unknown>
       try {
-        body = await req.json()
+        body = await getRequestBody(req)
       } catch {
         body = {}
       }

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -1,91 +1,140 @@
 // POST /api/v1/emails/confirmations — resend the confirmation email for an
 // account that has not confirmed yet. 403 once confirmed, per Mastodon.
+//
+// This is a Mastodon-facing endpoint: a client that just registered via
+// `POST /api/v1/accounts` holds a fresh Bearer access token and uses it here to
+// resend (or redirect) its confirmation email. It therefore authenticates with
+// OAuthGuard (Bearer token, with a cookie-session fallback for the web UI) and
+// requires a `write` scope, rather than the cookie-only AuthenticatedGuard.
 import { z } from 'zod'
 
+import { getConfig } from '@/lib/config'
 import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
-import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
-import { HTTP_STATUS, apiResponse } from '@/lib/utils/response'
+import { HTTP_STATUS, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+const guardOptions = { errorResponse: corsErrorResponse(CORS_HEADERS) }
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const ConfirmationRequest = z.object({
   email: z.string().email().optional()
 })
 
+// Scope write:accounts (satisfied by aggregate `write`), matching the other
+// account-mutating Mastodon endpoints.
 export const POST = traceApiRoute(
   'resendEmailConfirmation',
-  AuthenticatedGuard(async (req, context) => {
-    const { currentActor, database } = context
-    const account = currentActor.account
+  OAuthGuardAnyScope(
+    [Scope.enum.write, Scope.enum['write:accounts']],
+    async (req, context) => {
+      const { currentActor, database } = context
+      const account = currentActor.account
 
-    if (!account) {
+      if (!account) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: { error: 'Account not found' },
+          responseStatusCode: HTTP_STATUS.NOT_FOUND
+        })
+      }
+
+      // `verificationCode` is the pending-confirmation token set at registration
+      // when email is configured; it is cleared (to '') once the account
+      // verifies. An empty/null code means the e-mail is already confirmed.
+      if (!account.verificationCode) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: {
+            error:
+              'This method is only available while the e-mail is awaiting confirmation'
+          },
+          responseStatusCode: HTTP_STATUS.FORBIDDEN
+        })
+      }
+
+      let body: unknown
+      try {
+        body = await req.json()
+      } catch {
+        body = {}
+      }
+
+      const parsed = ConfirmationRequest.safeParse(body)
+      const newEmail = parsed.success ? parsed.data.email : undefined
+
+      // Optional `email` param updates the unconfirmed account's address
+      // directly before resending. Because the account is still unconfirmed we
+      // just point the existing verificationCode at the new address —
+      // verifyAccount then confirms the new email when the link is clicked.
+      // (This is distinct from the confirmed-user email-change flow in
+      // accounts/email, which uses the pending-change machinery.)
+      if (newEmail && newEmail !== account.email) {
+        // Honor the server's allow-list so the email param can't be used to
+        // sidestep the same restriction enforced at registration.
+        const { allowEmails } = getConfig()
+        if (allowEmails.length && !allowEmails.includes(newEmail)) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: { error: 'Email is not allowed on this server' },
+            responseStatusCode: HTTP_STATUS.FORBIDDEN
+          })
+        }
+
+        // Guard against the unique-email constraint: updating to an address
+        // already registered by another account would throw at the DB layer and
+        // surface as a 500. Reject with 422 instead.
+        const isEmailTaken = await database.isAccountExists({ email: newEmail })
+        if (isEmailTaken) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: { error: 'Email is already taken' },
+            responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+          })
+        }
+
+        await database.updateAccountEmail({
+          accountId: account.id,
+          email: newEmail
+        })
+      }
+
+      const recipient = newEmail ?? account.email
+      try {
+        await sendConfirmationEmail({
+          recipient,
+          verificationCode: account.verificationCode
+        })
+      } catch {
+        logger.error({ to: recipient }, `Fail to send email`)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: { error: 'Failed to send verification email' },
+          responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+        })
+      }
+
       return apiResponse({
         req,
-        allowedMethods: [],
-        data: { error: 'Account not found' },
-        responseStatusCode: HTTP_STATUS.NOT_FOUND
+        allowedMethods: CORS_HEADERS,
+        data: {},
+        responseStatusCode: HTTP_STATUS.OK
       })
-    }
-
-    // `verificationCode` is the pending-confirmation token set at registration
-    // when email is configured; it is cleared (to '') once the account verifies.
-    // An empty/null code means the e-mail is already confirmed.
-    if (!account.verificationCode) {
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: {
-          error:
-            'This method is only available while the e-mail is awaiting confirmation'
-        },
-        responseStatusCode: HTTP_STATUS.FORBIDDEN
-      })
-    }
-
-    let body: unknown
-    try {
-      body = await req.json()
-    } catch {
-      body = {}
-    }
-
-    const parsed = ConfirmationRequest.safeParse(body)
-    const newEmail = parsed.success ? parsed.data.email : undefined
-
-    // Optional `email` param updates the unconfirmed account's address directly
-    // before resending. Because the account is still unconfirmed we just point
-    // the existing verificationCode at the new address — verifyAccount then
-    // confirms the new email when the link is clicked. (This is distinct from
-    // the confirmed-user email-change flow in accounts/email, which uses the
-    // pending-change machinery.)
-    if (newEmail && newEmail !== account.email) {
-      await database.updateAccountEmail({
-        accountId: account.id,
-        email: newEmail
-      })
-    }
-
-    const recipient = newEmail ?? account.email
-    try {
-      await sendConfirmationEmail({
-        recipient,
-        verificationCode: account.verificationCode
-      })
-    } catch {
-      logger.error({ to: recipient }, `Fail to send email`)
-      return apiResponse({
-        req,
-        allowedMethods: [],
-        data: { error: 'Failed to send verification email' },
-        responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
-      })
-    }
-
-    return apiResponse({
-      req,
-      allowedMethods: [],
-      data: {},
-      responseStatusCode: HTTP_STATUS.OK
-    })
-  })
+    },
+    guardOptions
+  )
 )

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod'
 
 import { getConfig } from '@/lib/config'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
 import {
   OAuthGuardAnyScope,
@@ -112,10 +113,25 @@ export const POST = traceApiRoute(
           })
         }
 
-        await database.updateAccountEmail({
-          accountId: account.id,
-          email: newEmail
-        })
+        try {
+          await database.updateAccountEmail({
+            accountId: account.id,
+            email: newEmail
+          })
+        } catch (error) {
+          // The pre-check above covers the common case, but a concurrent
+          // claim of the same address can still race onto the unique
+          // constraint; map that to 422 rather than a 500.
+          if (isUniqueConstraintError(error)) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: { error: 'Email is already taken' },
+              responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+            })
+          }
+          throw error
+        }
       }
 
       const recipient = newEmail ?? account.email

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -179,6 +179,16 @@ describe('AccountDatabase', () => {
         expect(invalid).toBeNull()
       })
 
+      it('updates the account email', async () => {
+        const { accountId } = await createTestAccount()
+        const newEmail = `updated-${crypto.randomUUID()}@${TEST_DOMAIN}`
+
+        await database.updateAccountEmail({ accountId, email: newEmail })
+
+        const account = await database.getAccountFromId({ id: accountId })
+        expect(account).toMatchObject({ id: accountId, email: newEmail })
+      })
+
       it('creates and consumes password reset codes', async () => {
         const { accountId, email } = await createTestAccount()
         const passwordResetCode = `reset-${crypto.randomUUID()}`

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -35,6 +35,7 @@ import {
   SetDefaultActorParams,
   SetSessionActorParams,
   UnlinkAccountFromProviderParams,
+  UpdateAccountEmailParams,
   UpdateAccountImageParams,
   UpdateAccountNameParams,
   UpdateAccountSessionParams,
@@ -681,6 +682,17 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         .onConflict('id')
         .merge({ password: newPasswordHash, updatedAt: currentTime })
       await trx('sessions').where('accountId', accountId).delete()
+    })
+  },
+
+  async updateAccountEmail({
+    accountId,
+    email
+  }: UpdateAccountEmailParams): Promise<void> {
+    const currentTime = new Date()
+    await database('accounts').where('id', accountId).update({
+      email,
+      updatedAt: currentTime
     })
   },
 

--- a/lib/database/sql/oauth.ts
+++ b/lib/database/sql/oauth.ts
@@ -1,8 +1,10 @@
+import crypto from 'crypto'
 import { Knex } from 'knex'
 
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
+  CreateOAuthAccessTokenParams,
   GetClientFromAccessTokenParams,
   GetClientFromIdParams,
   GetClientFromNameParams,
@@ -50,5 +52,30 @@ export const OAuthSQLDatabaseMixin = (database: Knex): OAuthDatabase => ({
       .first('oauthClient.*')
     if (!row) return null
     return parseClientRow(row)
+  },
+
+  async createOAuthAccessToken({
+    token,
+    clientId,
+    accountId,
+    actorId,
+    scopes,
+    expiresAt
+  }: CreateOAuthAccessTokenParams) {
+    // Mirrors the columns better-auth populates for an issued access token:
+    // `token` holds the SHA-256 hash (the caller hashes it), `userId` the
+    // owning account, and `referenceId` the delegated actor that OAuthGuard
+    // resolves the request actor from. Scopes are stored as a JSON array to
+    // match the existing oauthClient/oauthAccessToken rows.
+    await database('oauthAccessToken').insert({
+      id: crypto.randomUUID(),
+      token,
+      clientId,
+      userId: accountId,
+      referenceId: actorId,
+      scopes: JSON.stringify(scopes),
+      expiresAt: new Date(expiresAt),
+      createdAt: new Date()
+    })
   }
 })

--- a/lib/database/sql/oauth.ts
+++ b/lib/database/sql/oauth.ts
@@ -55,7 +55,7 @@ export const OAuthSQLDatabaseMixin = (database: Knex): OAuthDatabase => ({
   },
 
   async createOAuthAccessToken({
-    token,
+    hashedToken,
     clientId,
     accountId,
     actorId,
@@ -63,13 +63,13 @@ export const OAuthSQLDatabaseMixin = (database: Knex): OAuthDatabase => ({
     expiresAt
   }: CreateOAuthAccessTokenParams) {
     // Mirrors the columns better-auth populates for an issued access token:
-    // `token` holds the SHA-256 hash (the caller hashes it), `userId` the
-    // owning account, and `referenceId` the delegated actor that OAuthGuard
+    // the `token` column holds the SHA-256 hash (the caller hashes it), `userId`
+    // the owning account, and `referenceId` the delegated actor that OAuthGuard
     // resolves the request actor from. Scopes are stored as a JSON array to
     // match the existing oauthClient/oauthAccessToken rows.
     await database('oauthAccessToken').insert({
       id: crypto.randomUUID(),
-      token,
+      token: hashedToken,
       clientId,
       userId: accountId,
       referenceId: actorId,

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -245,14 +245,19 @@ describe('registerAccount', () => {
     )
   })
 
-  it('maps a concurrent unique-constraint collision on createAccount to validation_failed', async () => {
+  it('maps a raced email-constraint collision on createAccount to a 422 email error', async () => {
     // Both pre-checks pass (the racing request inserted after them), so the
-    // collision only surfaces at createAccount.
+    // collision only surfaces at createAccount; the re-check then identifies
+    // email as the now-taken field.
     mockDatabase.createAccount = jest.fn().mockRejectedValue(
       Object.assign(new Error('UNIQUE constraint failed: accounts.email'), {
         code: 'SQLITE_CONSTRAINT_UNIQUE'
       })
     )
+    mockDatabase.isAccountExists = jest
+      .fn()
+      .mockResolvedValueOnce(false) // pre-check
+      .mockResolvedValueOnce(true) // re-check after the collision
 
     const result = await registerAccount({
       database: mockDatabase as unknown as Database,
@@ -265,6 +270,35 @@ describe('registerAccount', () => {
       type: 'validation_failed',
       details: {
         email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }]
+      }
+    })
+  })
+
+  it('maps a raced username-constraint collision on createAccount to a 422 username error', async () => {
+    mockDatabase.createAccount = jest.fn().mockRejectedValue(
+      Object.assign(new Error('UNIQUE constraint failed: actors.username'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE'
+      })
+    )
+    // Email is free on the re-check; the username is the colliding field.
+    mockDatabase.isUsernameExists = jest
+      .fn()
+      .mockResolvedValueOnce(false) // pre-check
+      .mockResolvedValueOnce(true) // re-check after the collision
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({
+      type: 'validation_failed',
+      details: {
+        username: [
+          { error: 'ERR_TAKEN', description: 'Username is already taken' }
+        ]
       }
     })
   })

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -3,14 +3,16 @@ import { Database } from '@/lib/database/types'
 
 import { registerAccount } from './registerAccount'
 
+const DEFAULT_CONFIG = {
+  host: 'llun.test',
+  allowEmails: [] as string[],
+  registrationOpen: true,
+  secretPhase: 'test-secret-phase-for-unit-tests-only',
+  email: null
+}
+
 jest.mock('@/lib/config', () => ({
-  getConfig: jest.fn().mockReturnValue({
-    host: 'llun.test',
-    allowEmails: [],
-    registrationOpen: true,
-    secretPhase: 'test-secret-phase-for-unit-tests-only',
-    email: null
-  })
+  getConfig: jest.fn()
 }))
 
 jest.mock('@/lib/services/email', () => ({
@@ -26,6 +28,10 @@ let mockDatabase: MockDatabase
 
 beforeEach(() => {
   jest.clearAllMocks()
+  // registerAccount and the shared confirmation-mail helper each read config via
+  // getConfig(), so use a stable mockReturnValue (not mockReturnValueOnce) that
+  // every call within a single registration resolves to.
+  jest.mocked(getConfig).mockReturnValue(DEFAULT_CONFIG as never)
   mockDatabase = {
     isAccountExists: jest.fn().mockResolvedValue(false),
     isUsernameExists: jest.fn().mockResolvedValue(false),
@@ -35,7 +41,7 @@ beforeEach(() => {
 
 describe('registerAccount', () => {
   it('returns registration_closed when registration is disabled', async () => {
-    jest.mocked(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValue({
       host: 'llun.test',
       allowEmails: [],
       registrationOpen: false,
@@ -55,7 +61,7 @@ describe('registerAccount', () => {
   })
 
   it('returns email_not_allowed when email is not on the allow-list', async () => {
-    jest.mocked(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValue({
       host: 'llun.test',
       allowEmails: ['allowed@example.com'],
       registrationOpen: true,
@@ -75,7 +81,7 @@ describe('registerAccount', () => {
   })
 
   it('returns email_not_allowed only when the allow-list is non-empty and the email is absent', async () => {
-    jest.mocked(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValue({
       host: 'llun.test',
       allowEmails: [],
       registrationOpen: true,
@@ -210,7 +216,7 @@ describe('registerAccount', () => {
   })
 
   it('sends a verification email when email service is configured', async () => {
-    jest.mocked(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValue({
       host: 'llun.test',
       allowEmails: [],
       registrationOpen: true,
@@ -239,7 +245,7 @@ describe('registerAccount', () => {
   })
 
   it('still returns success if email sending fails', async () => {
-    jest.mocked(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValue({
       host: 'llun.test',
       allowEmails: [],
       registrationOpen: true,

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -168,7 +168,9 @@ describe('registerAccount', () => {
     expect(result).toMatchObject({
       type: 'success',
       accountId: 'new-account-id',
-      username: 'alice'
+      username: 'alice',
+      // Matches the actor createAccount derives from domain/username.
+      actorId: 'https://llun.test/users/alice'
     })
     expect(mockDatabase.createAccount).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -303,6 +303,32 @@ describe('registerAccount', () => {
     })
   })
 
+  it('falls back to a generic email 422 when a raced constraint matches neither re-check', async () => {
+    // The constraint fired (e.g. on an unexpected unique column) but both
+    // re-checks come back free; the caller must still get a 422, not a 500.
+    mockDatabase.createAccount = jest.fn().mockRejectedValue(
+      Object.assign(new Error('UNIQUE constraint failed: accounts.something'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE'
+      })
+    )
+    // isAccountExists/isUsernameExists default mocks already resolve false for
+    // both the pre-check and the re-check.
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({
+      type: 'validation_failed',
+      details: {
+        email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }]
+      }
+    })
+  })
+
   it('rethrows a non-unique-constraint error from createAccount', async () => {
     mockDatabase.createAccount = jest
       .fn()

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -12,7 +12,8 @@ const DEFAULT_CONFIG = {
 }
 
 jest.mock('@/lib/config', () => ({
-  getConfig: jest.fn()
+  getConfig: jest.fn(),
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test')
 }))
 
 jest.mock('@/lib/services/email', () => ({
@@ -242,6 +243,45 @@ describe('registerAccount', () => {
         subject: 'Email verification'
       })
     )
+  })
+
+  it('maps a concurrent unique-constraint collision on createAccount to validation_failed', async () => {
+    // Both pre-checks pass (the racing request inserted after them), so the
+    // collision only surfaces at createAccount.
+    mockDatabase.createAccount = jest.fn().mockRejectedValue(
+      Object.assign(new Error('UNIQUE constraint failed: accounts.email'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE'
+      })
+    )
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({
+      type: 'validation_failed',
+      details: {
+        email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }]
+      }
+    })
+  })
+
+  it('rethrows a non-unique-constraint error from createAccount', async () => {
+    mockDatabase.createAccount = jest
+      .fn()
+      .mockRejectedValue(new Error('connection reset'))
+
+    await expect(
+      registerAccount({
+        database: mockDatabase as unknown as Database,
+        username: 'alice',
+        email: 'alice@example.com',
+        password: 'password123'
+      })
+    ).rejects.toThrow('connection reset')
   })
 
   it('still returns success if email sending fails', async () => {

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -1,0 +1,262 @@
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+
+import { registerAccount } from './registerAccount'
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    allowEmails: [],
+    registrationOpen: true,
+    secretPhase: 'test-secret-phase-for-unit-tests-only',
+    email: null
+  })
+}))
+
+jest.mock('@/lib/services/email', () => ({
+  sendMail: jest.fn().mockResolvedValue(undefined)
+}))
+
+type MockDatabase = Pick<
+  Database,
+  'isAccountExists' | 'isUsernameExists' | 'createAccount'
+>
+
+let mockDatabase: MockDatabase
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockDatabase = {
+    isAccountExists: jest.fn().mockResolvedValue(false),
+    isUsernameExists: jest.fn().mockResolvedValue(false),
+    createAccount: jest.fn().mockResolvedValue('new-account-id')
+  }
+})
+
+describe('registerAccount', () => {
+  it('returns registration_closed when registration is disabled', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: false,
+      secretPhase: 'test-secret',
+      email: null
+    } as never)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({ type: 'registration_closed' })
+    expect(mockDatabase.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns email_not_allowed when email is not on the allow-list', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: ['allowed@example.com'],
+      registrationOpen: true,
+      secretPhase: 'test-secret',
+      email: null
+    } as never)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({ type: 'email_not_allowed' })
+    expect(mockDatabase.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns email_not_allowed only when the allow-list is non-empty and the email is absent', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: true,
+      secretPhase: 'test-secret-phase-for-unit-tests-only',
+      email: null
+    } as never)
+
+    // empty allowEmails means everyone is allowed — should not block
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result.type).toBe('success')
+  })
+
+  it('returns validation_failed with email error when email is already taken', async () => {
+    ;(mockDatabase.isAccountExists as jest.Mock).mockResolvedValue(true)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({
+      type: 'validation_failed',
+      details: {
+        email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }]
+      }
+    })
+    expect(mockDatabase.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns validation_failed with username error when username is already taken', async () => {
+    ;(mockDatabase.isUsernameExists as jest.Mock).mockResolvedValue(true)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({
+      type: 'validation_failed',
+      details: {
+        username: [
+          { error: 'ERR_TAKEN', description: 'Username is already taken' }
+        ]
+      }
+    })
+    expect(mockDatabase.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns validation_failed with both errors when email and username are taken', async () => {
+    ;(mockDatabase.isAccountExists as jest.Mock).mockResolvedValue(true)
+    ;(mockDatabase.isUsernameExists as jest.Mock).mockResolvedValue(true)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({
+      type: 'validation_failed',
+      details: {
+        email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }],
+        username: [
+          { error: 'ERR_TAKEN', description: 'Username is already taken' }
+        ]
+      }
+    })
+    expect(mockDatabase.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('creates an account and returns success on valid registration', async () => {
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result).toMatchObject({
+      type: 'success',
+      accountId: 'new-account-id',
+      username: 'alice'
+    })
+    expect(mockDatabase.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'alice@example.com',
+        username: 'alice',
+        domain: 'llun.test'
+      })
+    )
+  })
+
+  it('creates an account with name when provided', async () => {
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123',
+      name: 'Alice Example'
+    })
+
+    expect(result.type).toBe('success')
+    expect(mockDatabase.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Alice Example' })
+    )
+  })
+
+  it('does not send email when email service is not configured', async () => {
+    const { sendMail } = jest.requireMock('@/lib/services/email')
+
+    await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(sendMail).not.toHaveBeenCalled()
+  })
+
+  it('sends a verification email when email service is configured', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: true,
+      secretPhase: 'test-secret-phase-for-unit-tests-only',
+      email: {
+        serviceFromAddress: 'noreply@llun.test'
+      }
+    } as never)
+
+    const { sendMail } = jest.requireMock('@/lib/services/email')
+
+    await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'noreply@llun.test',
+        to: ['alice@example.com'],
+        subject: 'Email verification'
+      })
+    )
+  })
+
+  it('still returns success if email sending fails', async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      host: 'llun.test',
+      allowEmails: [],
+      registrationOpen: true,
+      secretPhase: 'test-secret-phase-for-unit-tests-only',
+      email: {
+        serviceFromAddress: 'noreply@llun.test'
+      }
+    } as never)
+
+    const { sendMail } = jest.requireMock('@/lib/services/email')
+    sendMail.mockRejectedValueOnce(new Error('SMTP failure'))
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'alice@example.com',
+      password: 'password123'
+    })
+
+    expect(result.type).toBe('success')
+  })
+})

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -24,7 +24,6 @@ export interface RegisterAccountParams {
   email: string
   password: string
   name?: string | null
-  reason?: string | null
 }
 
 export const registerAccount = async ({

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -99,12 +99,35 @@ export const registerAccount = async ({
     })
   } catch (error) {
     if (isUniqueConstraintError(error)) {
-      return {
-        type: 'validation_failed',
-        details: {
-          email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }]
-        }
+      // createAccount inserts both an account (unique email) and an actor
+      // (unique username+domain), so the collision can be on either field.
+      // Re-run the existence checks to report the field(s) that are actually
+      // taken rather than parsing backend-specific constraint text.
+      const [emailTaken, usernameTaken] = await Promise.all([
+        database.isAccountExists({ email }),
+        database.isUsernameExists({ username, domain })
+      ])
+      const details: Record<string, { error: string; description: string }[]> =
+        {}
+      if (emailTaken) {
+        details.email = [
+          { error: 'ERR_TAKEN', description: 'Email is already taken' }
+        ]
       }
+      if (usernameTaken) {
+        details.username = [
+          { error: 'ERR_TAKEN', description: 'Username is already taken' }
+        ]
+      }
+      // A constraint fired but neither lookup confirms a duplicate (an
+      // unexpected unique column): fall back to a generic email collision so
+      // the caller still gets a 422 rather than a 500.
+      if (Object.keys(details).length === 0) {
+        details.email = [
+          { error: 'ERR_TAKEN', description: 'Email is already taken' }
+        ]
+      }
+      return { type: 'validation_failed', details }
     }
     throw error
   }

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -1,0 +1,110 @@
+import * as bcrypt from 'bcrypt'
+import crypto from 'crypto'
+
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { sendMail } from '@/lib/services/email'
+import { logger } from '@/lib/utils/logger'
+import { generateKeyPair } from '@/lib/utils/signature'
+
+const BCRYPT_ROUND = 10
+
+export type RegisterAccountResult =
+  | { type: 'success'; accountId: string; username: string }
+  | { type: 'registration_closed' }
+  | { type: 'email_not_allowed' }
+  | {
+      type: 'validation_failed'
+      details: Record<string, { error: string; description: string }[]>
+    }
+
+export interface RegisterAccountParams {
+  database: Database
+  username: string
+  email: string
+  password: string
+  name?: string | null
+  reason?: string | null
+}
+
+export const registerAccount = async ({
+  database,
+  username,
+  email,
+  password,
+  name
+}: RegisterAccountParams): Promise<RegisterAccountResult> => {
+  const config = getConfig()
+
+  if (!config.registrationOpen) {
+    return { type: 'registration_closed' }
+  }
+
+  const { host: domain, allowEmails } = config
+
+  if (allowEmails.length && !allowEmails.includes(email)) {
+    return { type: 'email_not_allowed' }
+  }
+
+  const [isAccountExists, isUsernameExists] = await Promise.all([
+    database.isAccountExists({ email }),
+    database.isUsernameExists({ username, domain })
+  ])
+
+  const errorDetails: Record<string, { error: string; description: string }[]> =
+    {}
+
+  if (isAccountExists) {
+    errorDetails.email = [
+      { error: 'ERR_TAKEN', description: 'Email is already taken' }
+    ]
+  }
+
+  if (isUsernameExists) {
+    errorDetails.username = [
+      { error: 'ERR_TAKEN', description: 'Username is already taken' }
+    ]
+  }
+
+  if (Object.keys(errorDetails).length > 0) {
+    return { type: 'validation_failed', details: errorDetails }
+  }
+
+  const [keyPair, passwordHash] = await Promise.all([
+    generateKeyPair(config.secretPhase),
+    bcrypt.hash(password, BCRYPT_ROUND)
+  ])
+
+  const verificationCode = config.email
+    ? crypto.randomBytes(32).toString('base64url')
+    : null
+
+  const accountId = await database.createAccount({
+    domain,
+    email,
+    username,
+    name: name || null,
+    privateKey: keyPair.privateKey,
+    publicKey: keyPair.publicKey,
+    passwordHash,
+    verificationCode
+  })
+
+  if (config.email) {
+    try {
+      await sendMail({
+        from: config.email.serviceFromAddress,
+        to: [email],
+        subject: 'Email verification',
+        content: {
+          text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${verificationCode}`,
+          html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${verificationCode}">this link</a> to verify your email.`
+        }
+      })
+    } catch {
+      logger.error({ to: email }, `Fail to send email`)
+    }
+  }
+
+  return { type: 'success', accountId, username }
+}

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -4,13 +4,14 @@ import crypto from 'crypto'
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { sendMail } from '@/lib/services/email'
+import { getLocalActorId } from '@/lib/utils/activitypubId'
 import { logger } from '@/lib/utils/logger'
 import { generateKeyPair } from '@/lib/utils/signature'
 
 const BCRYPT_ROUND = 10
 
 export type RegisterAccountResult =
-  | { type: 'success'; accountId: string; username: string }
+  | { type: 'success'; accountId: string; username: string; actorId: string }
   | { type: 'registration_closed' }
   | { type: 'email_not_allowed' }
   | {
@@ -105,5 +106,11 @@ export const registerAccount = async ({
     }
   }
 
-  return { type: 'success', accountId, username }
+  // createAccount derives the local actor id deterministically from
+  // domain/username (getLocalActorId), so recompute it here instead of issuing
+  // an extra lookup — it is guaranteed to match the actor just created and is
+  // the id OAuthGuard resolves the request actor from.
+  const actorId = getLocalActorId({ domain, username })
+
+  return { type: 'success', accountId, username, actorId }
 }

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
-import { sendMail } from '@/lib/services/email'
+import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
 import { getLocalActorId } from '@/lib/utils/activitypubId'
 import { logger } from '@/lib/utils/logger'
 import { generateKeyPair } from '@/lib/utils/signature'
@@ -90,17 +90,9 @@ export const registerAccount = async ({
     verificationCode
   })
 
-  if (config.email) {
+  if (verificationCode) {
     try {
-      await sendMail({
-        from: config.email.serviceFromAddress,
-        to: [email],
-        subject: 'Email verification',
-        content: {
-          text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${verificationCode}`,
-          html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${verificationCode}">this link</a> to verify your email.`
-        }
-      })
+      await sendConfirmationEmail({ recipient: email, verificationCode })
     } catch {
       logger.error({ to: email }, `Fail to send email`)
     }

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -2,6 +2,7 @@ import * as bcrypt from 'bcrypt'
 import crypto from 'crypto'
 
 import { getConfig } from '@/lib/config'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { Database } from '@/lib/database/types'
 import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
 import { getLocalActorId } from '@/lib/utils/activitypubId'
@@ -79,16 +80,34 @@ export const registerAccount = async ({
     ? crypto.randomBytes(32).toString('base64url')
     : null
 
-  const accountId = await database.createAccount({
-    domain,
-    email,
-    username,
-    name: name || null,
-    privateKey: keyPair.privateKey,
-    publicKey: keyPair.publicKey,
-    passwordHash,
-    verificationCode
-  })
+  // The isAccountExists/isUsernameExists pre-checks above resolve the common
+  // case with field-specific 422s, but two concurrent registrations can still
+  // race past them and collide on the DB unique constraint. Map that collision
+  // back to the same validation_failed result instead of letting it surface as
+  // a 500.
+  let accountId: string
+  try {
+    accountId = await database.createAccount({
+      domain,
+      email,
+      username,
+      name: name || null,
+      privateKey: keyPair.privateKey,
+      publicKey: keyPair.publicKey,
+      passwordHash,
+      verificationCode
+    })
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return {
+        type: 'validation_failed',
+        details: {
+          email: [{ error: 'ERR_TAKEN', description: 'Email is already taken' }]
+        }
+      }
+    }
+    throw error
+  }
 
   if (verificationCode) {
     try {

--- a/lib/services/accounts/sendConfirmationEmail.ts
+++ b/lib/services/accounts/sendConfirmationEmail.ts
@@ -1,0 +1,29 @@
+import { getConfig } from '@/lib/config'
+import { sendMail } from '@/lib/services/email'
+
+export interface SendConfirmationEmailParams {
+  recipient: string
+  verificationCode: string
+}
+
+// Sends (or resends) the registration confirmation email. The link points at
+// /auth/confirmation, which verifyAccount consumes to clear verificationCode.
+// No-ops when email delivery is not configured; rejections from sendMail are
+// allowed to propagate so callers can decide how to handle delivery failures.
+export const sendConfirmationEmail = async ({
+  recipient,
+  verificationCode
+}: SendConfirmationEmailParams): Promise<void> => {
+  const config = getConfig()
+  if (!config.email) return
+
+  await sendMail({
+    from: config.email.serviceFromAddress,
+    to: [recipient],
+    subject: 'Email verification',
+    content: {
+      text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${verificationCode}`,
+      html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${verificationCode}">this link</a> to verify your email.`
+    }
+  })
+}

--- a/lib/services/accounts/sendConfirmationEmail.ts
+++ b/lib/services/accounts/sendConfirmationEmail.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@/lib/config'
+import { getBaseURL, getConfig } from '@/lib/config'
 import { sendMail } from '@/lib/services/email'
 
 export interface SendConfirmationEmailParams {
@@ -17,13 +17,17 @@ export const sendConfirmationEmail = async ({
   const config = getConfig()
   if (!config.email) return
 
+  // getBaseURL() honors the configured scheme/host/port, so confirmation links
+  // are correct on http/local/custom-port deployments rather than assuming https.
+  const confirmationUrl = `${getBaseURL()}/auth/confirmation?verificationCode=${verificationCode}`
+
   await sendMail({
     from: config.email.serviceFromAddress,
     to: [recipient],
     subject: 'Email verification',
     content: {
-      text: `Open this link to verify your email https://${config.host}/auth/confirmation?verificationCode=${verificationCode}`,
-      html: `Open <a href="https://${config.host}/auth/confirmation?verificationCode=${verificationCode}">this link</a> to verify your email.`
+      text: `Open this link to verify your email ${confirmationUrl}`,
+      html: `Open <a href="${confirmationUrl}">this link</a> to verify your email.`
     }
   })
 }

--- a/lib/services/oauth/issueAccessToken.test.ts
+++ b/lib/services/oauth/issueAccessToken.test.ts
@@ -1,0 +1,142 @@
+import knex from 'knex'
+import { NextRequest } from 'next/server'
+
+import { GET as verifyCredentials } from '@/app/api/v1/accounts/verify_credentials/route'
+import { getSQLDatabase } from '@/lib/database/sql'
+import { hashToken } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+
+import { issueAccessToken } from './issueAccessToken'
+
+const mockKnex = knex({
+  client: 'better-sqlite3',
+  useNullAsDefault: true,
+  connection: { filename: ':memory:' }
+})
+const mockDatabase = getSQLDatabase(mockKnex)
+
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => mockKnex
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest.fn().mockResolvedValue(null)
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+// Opaque tokens never reach better-auth's verifier, but the guard imports it.
+jest.mock('better-auth/oauth2', () => ({ verifyAccessToken: jest.fn() }))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const DOMAIN = 'llun.test'
+const CLIENT_ID = 'issue-token-client'
+const USERNAME = 'tokenuser'
+
+describe('issueAccessToken', () => {
+  let accountId: string
+  let actorId: string
+
+  beforeAll(async () => {
+    await mockDatabase.migrate()
+
+    await mockKnex('oauthClient').insert({
+      id: 'oauth-client-row',
+      clientId: CLIENT_ID,
+      name: 'Issue Token App',
+      scopes: JSON.stringify([Scope.enum.read, Scope.enum.write]),
+      redirectUris: JSON.stringify(['https://app.test/redirect']),
+      requirePKCE: false,
+      disabled: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+
+    accountId = await mockDatabase.createAccount({
+      domain: DOMAIN,
+      email: 'tokenuser@llun.test',
+      username: USERNAME,
+      name: 'Token User',
+      passwordHash: 'hashed-password',
+      verificationCode: null,
+      privateKey: 'private-key',
+      publicKey: 'public-key'
+    })
+    const actor = await mockDatabase.getActorFromUsername({
+      username: USERNAME,
+      domain: DOMAIN
+    })
+    actorId = actor!.id
+  })
+
+  afterAll(async () => {
+    await mockKnex.destroy()
+  })
+
+  it('returns a raw token but persists only its hash', async () => {
+    const issued = await issueAccessToken({
+      database: mockDatabase,
+      clientId: CLIENT_ID,
+      accountId,
+      actorId,
+      scopes: [Scope.enum.read, Scope.enum.write]
+    })
+
+    expect(issued.token).toEqual(expect.any(String))
+    expect(issued.scopes).toEqual([Scope.enum.read, Scope.enum.write])
+    expect(issued.createdAt).toEqual(expect.any(Number))
+
+    // The stored row holds the hash, never the raw token.
+    const stored = await mockKnex('oauthAccessToken')
+      .where('token', hashToken(issued.token))
+      .first()
+    expect(stored).toBeDefined()
+    expect(stored.token).toBe(hashToken(issued.token))
+    expect(stored.token).not.toBe(issued.token)
+    expect(stored.userId).toBe(accountId)
+    expect(stored.referenceId).toBe(actorId)
+  })
+
+  it('issues a token the OAuth guard accepts on verify_credentials', async () => {
+    const issued = await issueAccessToken({
+      database: mockDatabase,
+      clientId: CLIENT_ID,
+      accountId,
+      actorId,
+      scopes: [Scope.enum.read, Scope.enum.write]
+    })
+
+    const response = await verifyCredentials(
+      new NextRequest('https://llun.test/api/v1/accounts/verify_credentials', {
+        headers: { Authorization: `Bearer ${issued.token}` }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+  })
+
+  it('rejects an unissued (forged) token', async () => {
+    const response = await verifyCredentials(
+      new NextRequest('https://llun.test/api/v1/accounts/verify_credentials', {
+        headers: { Authorization: 'Bearer not-a-real-token' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/lib/services/oauth/issueAccessToken.ts
+++ b/lib/services/oauth/issueAccessToken.ts
@@ -42,7 +42,7 @@ export const issueAccessToken = async ({
   const expiresAt = createdAt + ACCESS_TOKEN_EXPIRES_IN_MS
 
   await database.createOAuthAccessToken({
-    token: hashToken(token),
+    hashedToken: hashToken(token),
     clientId,
     accountId,
     actorId,

--- a/lib/services/oauth/issueAccessToken.ts
+++ b/lib/services/oauth/issueAccessToken.ts
@@ -1,0 +1,54 @@
+import crypto from 'crypto'
+
+import { Database } from '@/lib/database/types'
+import { hashToken } from '@/lib/services/guards/OAuthGuard'
+
+// Matches `accessTokenExpiresIn` (7 days) in lib/services/auth/auth.ts so
+// directly-issued tokens live as long as better-auth's authorization-code ones.
+const ACCESS_TOKEN_EXPIRES_IN_MS = 7 * 24 * 60 * 60 * 1000
+
+export interface IssueAccessTokenParams {
+  database: Database
+  clientId: string
+  // Owning account id.
+  accountId: string
+  // Actor delegated by the token; OAuthGuard resolves the request actor from it.
+  actorId: string
+  scopes: string[]
+}
+
+export interface IssuedAccessToken {
+  // The raw bearer token to hand back to the client. Only its SHA-256 hash is
+  // persisted (matching OAuthGuard's lookup), so this value is unrecoverable
+  // once it leaves this function.
+  token: string
+  scopes: string[]
+  // Epoch milliseconds.
+  createdAt: number
+}
+
+// Mints an opaque OAuth access token bound to a newly registered account and
+// persists only its hash, the same shape OAuthGuard validates for opaque
+// tokens (DB existence + expiry + scopes + referenceId actor).
+export const issueAccessToken = async ({
+  database,
+  clientId,
+  accountId,
+  actorId,
+  scopes
+}: IssueAccessTokenParams): Promise<IssuedAccessToken> => {
+  const token = crypto.randomBytes(32).toString('base64url')
+  const createdAt = Date.now()
+  const expiresAt = createdAt + ACCESS_TOKEN_EXPIRES_IN_MS
+
+  await database.createOAuthAccessToken({
+    token: hashToken(token),
+    clientId,
+    accountId,
+    actorId,
+    scopes,
+    expiresAt
+  })
+
+  return { token, scopes, createdAt }
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2308,6 +2308,7 @@ export interface OAuthDatabase {
   getClientFromAccessToken(
     params: GetClientFromAccessTokenParams
   ): Promise<Client | null>
+  createOAuthAccessToken(params: CreateOAuthAccessTokenParams): Promise<void>
 }
 
 export const GetClientFromAccessTokenParams = z.object({
@@ -2316,6 +2317,22 @@ export const GetClientFromAccessTokenParams = z.object({
 export type GetClientFromAccessTokenParams = z.infer<
   typeof GetClientFromAccessTokenParams
 >
+
+export type CreateOAuthAccessTokenParams = {
+  // SHA-256 base64url hash of the issued bearer token, matching how
+  // OAuthGuard looks tokens up. Callers MUST pass the hash, never the raw
+  // token, so the raw token never touches the database.
+  token: string
+  clientId: string
+  // The owning account id (stored in `userId`).
+  accountId: string
+  // The actor delegated by the token (stored in `referenceId`); OAuthGuard
+  // resolves the request actor from this column.
+  actorId: string
+  scopes: string[]
+  // Epoch milliseconds.
+  expiresAt: number
+}
 
 // ============================================================================
 // Timeline Database

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2320,9 +2320,10 @@ export type GetClientFromAccessTokenParams = z.infer<
 
 export type CreateOAuthAccessTokenParams = {
   // SHA-256 base64url hash of the issued bearer token, matching how
-  // OAuthGuard looks tokens up. Callers MUST pass the hash, never the raw
-  // token, so the raw token never touches the database.
-  token: string
+  // OAuthGuard looks tokens up (GetClientFromAccessTokenParams.hashedToken).
+  // Callers MUST pass the hash, never the raw token, so the raw token never
+  // touches the database.
+  hashedToken: string
   clientId: string
   // The owning account id (stored in `userId`).
   accountId: string

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -316,6 +316,10 @@ export type ChangePasswordParams = {
   accountId: string
   newPasswordHash: string
 }
+export type UpdateAccountEmailParams = {
+  accountId: string
+  email: string
+}
 export type UpdateAccountNameParams = {
   accountId: string
   name: string | null
@@ -380,6 +384,7 @@ export interface AccountDatabase {
     params: ResetPasswordWithCodeParams
   ): Promise<Account | null>
   changePassword(params: ChangePasswordParams): Promise<void>
+  updateAccountEmail(params: UpdateAccountEmailParams): Promise<void>
   updateAccountName(params: UpdateAccountNameParams): Promise<void>
   updateAccountImage(params: UpdateAccountImageParams): Promise<void>
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Mastodon API compatibility plan — account registration via the API (with a token response) and email-confirmation resend. Builds on Phase 1 ([#945](https://github.com/llun/activities.next/pull/945)); branches independently off `main`.

## Changes

- **Registration service extraction (refactor).** Moved the `POST /api/v1/accounts` registration logic into `lib/services/accounts/registerAccount.ts`, returning a result union (`success` / `registration_closed` / `email_not_allowed` / `validation_failed`). The route delegates and maps results to the existing responses; the web-form flow (307 redirect) and the pre-body-parse `registrationOpen` → 403 gate are preserved exactly.
- **API registration with a token response.** A client using an **app token** (client_credentials, no bound user) as Bearer on `POST /api/v1/accounts` now creates the account and receives a user `Token` (`{access_token, token_type, scope, created_at}`) carrying the app token's scopes. New `lib/services/oauth/issueAccessToken.ts` mints an opaque token, **stores its SHA-256 hash** (matching how `OAuthGuard` verifies), and returns the raw token; new `database.createOAuthAccessToken`. Unknown bearer → 401; a user-bound (non-app) token → 403. The issued token is proven valid by an end-to-end test that drives it through the real `verify_credentials` handler.
- **`POST /api/v1/emails/confirmations`.** Resends the confirmation email while an account is awaiting confirmation; returns 403 once confirmed (per Mastodon). The optional `email` param **directly updates the unconfirmed account's email** (new `database.updateAccountEmail`) and resends confirmation to the new address — so following the link confirms the new address.
- **Shared `sendConfirmationEmail` helper** (`lib/services/accounts/sendConfirmationEmail.ts`) used by both the registration flow and the confirmations route.

## Deviation from the plan (for correctness)

The plan suggested the `email` param reuse `database.requestEmailChange`. Investigation showed that path is semantically wrong for an *unconfirmed* account: `requestEmailChange` queues a separate pending change that the registration confirmation link (`verifyAccount`) never applies, so the new address would be stranded. This PR instead adds a minimal `updateAccountEmail` and updates the unconfirmed account's email directly. (The confirmed-user email-change flow in `accounts/email/route.ts` is unchanged and still uses `requestEmailChange`.)

## Testing

- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors (13 pre-existing warnings)
- `yarn build` — succeeds; `/api/v1/emails/confirmations` present in the route manifest
- `yarn test` — 465 suites / 3953 tests pass

Implemented test-first with spec-compliance + code-quality review per task. The token-issuance path was reviewed specifically for hash-vs-raw handling and the app/user-token gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
