### PR TITLE
minor: scheduled statuses support

### DIFF
--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -11,7 +11,10 @@ import {
   SCHEDULED_AT_TOO_SOON_ERROR
 } from '@/lib/services/mastodon/constants'
 import { getQueue } from '@/lib/services/queue'
-import { toMastodonScheduledStatus } from '@/lib/services/statuses/scheduledStatusSerializer'
+import {
+  scheduledDelaySeconds,
+  toMastodonScheduledStatus
+} from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Scope } from '@/lib/types/database/operations'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -149,10 +152,7 @@ export const PUT = traceApiRoute(
         id: getHashFromString(scheduled.id),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
         data: { scheduledStatusId: scheduled.id },
-        delaySeconds: Math.max(
-          0,
-          Math.floor((scheduled.scheduledAt - Date.now()) / 1000)
-        )
+        delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
       })
 
       return apiResponse({

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
+import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import {
   OAuthGuard,
   OAuthGuardAnyScope
@@ -9,8 +10,10 @@ import {
   MIN_SCHEDULED_STATUS_AHEAD_MS,
   SCHEDULED_AT_TOO_SOON_ERROR
 } from '@/lib/services/mastodon/constants'
+import { getQueue } from '@/lib/services/queue'
 import { toMastodonScheduledStatus } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Scope } from '@/lib/types/database/operations'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_404,
@@ -138,6 +141,19 @@ export const PUT = traceApiRoute(
         scheduledAt
       })
       if (!scheduled) return notFound(req)
+
+      // Re-enqueue the publish job with the new delay so the status fires at the
+      // rescheduled time. The deduplication id is stable per scheduled status,
+      // and the job re-reads the row, so the latest scheduledAt always wins.
+      await getQueue().publish({
+        id: getHashFromString(scheduled.id),
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: scheduled.id },
+        delaySeconds: Math.max(
+          0,
+          Math.floor((scheduled.scheduledAt - Date.now()) / 1000)
+        )
+      })
 
       return apiResponse({
         req,

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
 
 import {
   OAuthGuard,
   OAuthGuardAnyScope
 } from '@/lib/services/guards/OAuthGuard'
+import { toMastodonScheduledStatus } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  ERROR_404,
+  ERROR_422,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [
@@ -16,15 +23,17 @@ const CORS_HEADERS = [
   HttpMethod.enum.DELETE
 ]
 
+// Mastodon rejects a scheduled_at less than five minutes in the future.
+const MIN_SCHEDULE_AHEAD_MS = 5 * 60 * 1000
+
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 interface Params {
   id: string
 }
 
-// https://docs.joinmastodon.org/methods/scheduled_statuses/
-// Scheduling is not supported (statuses publish immediately), so no scheduled
-// status can ever be found by id.
+const ScheduleUpdateSchema = z.object({ scheduled_at: z.string() })
+
 const notFound = (req: NextRequest) =>
   apiResponse({
     req,
@@ -33,24 +42,130 @@ const notFound = (req: NextRequest) =>
     responseStatusCode: 404
   })
 
+// Reads the request body across the content types Mastodon clients use (JSON,
+// urlencoded, multipart). Returns null on a malformed body so the caller can
+// surface a 422.
+const readBody = async (
+  req: NextRequest
+): Promise<Record<string, unknown> | null> => {
+  const contentType = req.headers.get('content-type')?.toLowerCase() ?? ''
+  try {
+    if (contentType.includes('application/json')) {
+      const text = await req.text()
+      if (text.trim() === '') return {}
+      const parsed: unknown = JSON.parse(text)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    }
+    const form = await req.formData()
+    return Object.fromEntries(form.entries())
+  } catch {
+    return null
+  }
+}
+
 export const GET = traceApiRoute(
   'getScheduledStatus',
   OAuthGuardAnyScope<Params>(
     [Scope.enum.read, Scope.enum['read:statuses']],
-    async (req) => notFound(req)
+    async (req, { database, currentActor, params }) => {
+      const { id } = (await params) ?? { id: undefined }
+      if (!id) return notFound(req)
+
+      const scheduled = await database.getScheduledStatus({
+        actorId: currentActor.id,
+        id
+      })
+      if (!scheduled) return notFound(req)
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: await toMastodonScheduledStatus(database, scheduled)
+      })
+    }
   )
 )
 
+// https://docs.joinmastodon.org/methods/scheduled_statuses/#update
+// Mastodon's PUT only reschedules; it updates scheduled_at and nothing else.
 export const PUT = traceApiRoute(
   'updateScheduledStatus',
-  OAuthGuard<Params>([Scope.enum['write:statuses']], async (req) =>
-    notFound(req)
+  OAuthGuard<Params>(
+    [Scope.enum['write:statuses']],
+    async (req, { database, currentActor, params }) => {
+      const { id } = (await params) ?? { id: undefined }
+      if (!id) return notFound(req)
+
+      const body = await readBody(req)
+      if (!body) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      const parsed = ScheduleUpdateSchema.safeParse(body)
+      if (!parsed.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      const scheduledAt = Date.parse(parsed.data.scheduled_at)
+      if (
+        Number.isNaN(scheduledAt) ||
+        scheduledAt - Date.now() < MIN_SCHEDULE_AHEAD_MS
+      ) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: {
+            error:
+              'Validation failed: Scheduled at must be at least 5 minutes in the future'
+          },
+          responseStatusCode: 422
+        })
+      }
+
+      const scheduled = await database.updateScheduledStatusAt({
+        actorId: currentActor.id,
+        id,
+        scheduledAt
+      })
+      if (!scheduled) return notFound(req)
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: await toMastodonScheduledStatus(database, scheduled)
+      })
+    }
   )
 )
 
 export const DELETE = traceApiRoute(
   'deleteScheduledStatus',
-  OAuthGuard<Params>([Scope.enum['write:statuses']], async (req) =>
-    notFound(req)
+  OAuthGuard<Params>(
+    [Scope.enum['write:statuses']],
+    async (req, { database, currentActor, params }) => {
+      const { id } = (await params) ?? { id: undefined }
+      if (!id) return notFound(req)
+
+      const deleted = await database.deleteScheduledStatus({
+        actorId: currentActor.id,
+        id
+      })
+      if (!deleted) return notFound(req)
+
+      // Mastodon's destroy renders an empty object with 200.
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+    }
   )
 )

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -146,10 +146,11 @@ export const PUT = traceApiRoute(
       if (!scheduled) return notFound(req)
 
       // Re-enqueue the publish job with the new delay so the status fires at the
-      // rescheduled time. The deduplication id is stable per scheduled status,
-      // and the job re-reads the row, so the latest scheduledAt always wins.
+      // rescheduled time. The dedup id folds in scheduledAt so rescheduling to a
+      // new time (especially an earlier one) produces a different id and is not
+      // dropped by QStash deduplication; retries of the same schedule still are.
       await getQueue().publish({
-        id: getHashFromString(scheduled.id),
+        id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
         data: { scheduledStatusId: scheduled.id },
         delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -18,9 +18,11 @@ import {
 import { Scope } from '@/lib/types/database/operations'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_404,
   ERROR_422,
+  ERROR_500,
   apiResponse,
   defaultOptions
 } from '@/lib/utils/response'
@@ -138,6 +140,14 @@ export const PUT = traceApiRoute(
         })
       }
 
+      // Capture the prior time first so we can roll back if re-enqueue fails.
+      const existing = await database.getScheduledStatus({
+        actorId: currentActor.id,
+        id
+      })
+      if (!existing) return notFound(req)
+      const previousScheduledAt = existing.scheduledAt
+
       const scheduled = await database.updateScheduledStatusAt({
         actorId: currentActor.id,
         id,
@@ -149,12 +159,33 @@ export const PUT = traceApiRoute(
       // rescheduled time. The dedup id folds in scheduledAt so rescheduling to a
       // new time (especially an earlier one) produces a different id and is not
       // dropped by QStash deduplication; retries of the same schedule still are.
-      await getQueue().publish({
-        id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
-        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-        data: { scheduledStatusId: scheduled.id },
-        delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
-      })
+      try {
+        await getQueue().publish({
+          id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
+          name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+          data: { scheduledStatusId: scheduled.id },
+          delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
+        })
+      } catch (error) {
+        // The new time is committed but the delayed job failed to enqueue. Roll
+        // the stored time back so it matches the (failed) enqueue rather than
+        // showing a new time that will never fire, then surface the failure.
+        await database.updateScheduledStatusAt({
+          actorId: currentActor.id,
+          id,
+          scheduledAt: previousScheduledAt
+        })
+        logger.error(
+          { error, scheduledStatusId: id },
+          'rescheduleScheduledStatus: failed to re-enqueue publish job'
+        )
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
 
       return apiResponse({
         req,

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -170,15 +170,24 @@ export const PUT = traceApiRoute(
         // The new time is committed but the delayed job failed to enqueue. Roll
         // the stored time back so it matches the (failed) enqueue rather than
         // showing a new time that will never fire, then surface the failure.
-        await database.updateScheduledStatusAt({
-          actorId: currentActor.id,
-          id,
-          scheduledAt: previousScheduledAt
-        })
+        // Log the enqueue failure first and guard the rollback so a cleanup
+        // failure cannot mask the original error.
         logger.error(
           { error, scheduledStatusId: id },
           'rescheduleScheduledStatus: failed to re-enqueue publish job'
         )
+        try {
+          await database.updateScheduledStatusAt({
+            actorId: currentActor.id,
+            id,
+            scheduledAt: previousScheduledAt
+          })
+        } catch (rollbackError) {
+          logger.error(
+            { rollbackError, scheduledStatusId: id },
+            'rescheduleScheduledStatus: failed to roll back scheduled time'
+          )
+        }
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -5,6 +5,10 @@ import {
   OAuthGuard,
   OAuthGuardAnyScope
 } from '@/lib/services/guards/OAuthGuard'
+import {
+  MIN_SCHEDULED_STATUS_AHEAD_MS,
+  SCHEDULED_AT_TOO_SOON_ERROR
+} from '@/lib/services/mastodon/constants'
 import { toMastodonScheduledStatus } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -22,9 +26,6 @@ const CORS_HEADERS = [
   HttpMethod.enum.PUT,
   HttpMethod.enum.DELETE
 ]
-
-// Mastodon rejects a scheduled_at less than five minutes in the future.
-const MIN_SCHEDULE_AHEAD_MS = 5 * 60 * 1000
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -121,15 +122,12 @@ export const PUT = traceApiRoute(
       const scheduledAt = Date.parse(parsed.data.scheduled_at)
       if (
         Number.isNaN(scheduledAt) ||
-        scheduledAt - Date.now() < MIN_SCHEDULE_AHEAD_MS
+        scheduledAt - Date.now() < MIN_SCHEDULED_STATUS_AHEAD_MS
       ) {
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: {
-            error:
-              'Validation failed: Scheduled at must be at least 5 minutes in the future'
-          },
+          data: { error: SCHEDULED_AT_TOO_SOON_ERROR },
           responseStatusCode: 422
         })
       }

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -91,7 +91,11 @@ export const GET = traceApiRoute(
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: await toMastodonScheduledStatus(database, scheduled)
+        data: await toMastodonScheduledStatus(
+          database,
+          scheduled,
+          currentActor.account?.id
+        )
       })
     }
   )
@@ -199,7 +203,11 @@ export const PUT = traceApiRoute(
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: await toMastodonScheduledStatus(database, scheduled)
+        data: await toMastodonScheduledStatus(
+          database,
+          scheduled,
+          currentActor.account?.id
+        )
       })
     }
   )

--- a/app/api/v1/scheduled_statuses/[id]/route.ts
+++ b/app/api/v1/scheduled_statuses/[id]/route.ts
@@ -167,7 +167,10 @@ export const PUT = traceApiRoute(
         await getQueue().publish({
           id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
           name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-          data: { scheduledStatusId: scheduled.id },
+          data: {
+            scheduledStatusId: scheduled.id,
+            scheduledAt: scheduled.scheduledAt
+          },
           delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
         })
       } catch (error) {

--- a/app/api/v1/scheduled_statuses/route.test.ts
+++ b/app/api/v1/scheduled_statuses/route.test.ts
@@ -6,6 +6,7 @@ import { SCHEDULED_AT_TOO_SOON_ERROR } from '@/lib/services/mastodon/constants'
 import { getQueue } from '@/lib/services/queue'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
@@ -255,6 +256,127 @@ describe('scheduled_statuses CRUD', () => {
       { params: Promise.resolve({ id: created.id }) }
     )
     expect(getResponse.status).toBe(404)
+  })
+
+  it('does not let another actor read, reschedule or delete a scheduled status', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Owned by actor1')
+    })
+
+    // Sign in as actor2 for the next three handler calls.
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+
+    const getResponse = await GET_ID(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        { headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+    expect(getResponse.status).toBe(404)
+
+    const putResponse = await PUT(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            scheduled_at: new Date(Date.now() + 30 * 60 * 1000).toISOString()
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+    expect(putResponse.status).toBe(404)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+
+    const deleteResponse = await DELETE(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        { method: 'DELETE', headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+    expect(deleteResponse.status).toBe(404)
+
+    // The owner's row is untouched.
+    const stillStored = await database.getScheduledStatus({
+      actorId: ACTOR1_ID,
+      id: created.id
+    })
+    expect(stillStored).not.toBeNull()
+  })
+
+  it('rolls back the reschedule and returns 500 when re-enqueue fails', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Reschedule enqueue fails')
+    })
+    const originalScheduledAt = created.scheduledAt
+    ;(getQueue().publish as jest.Mock).mockRejectedValueOnce(
+      new Error('queue unavailable')
+    )
+
+    const response = await PUT(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            scheduled_at: new Date(Date.now() + 45 * 60 * 1000).toISOString()
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+
+    expect(response.status).toBe(500)
+    // The stored time was rolled back to the original schedule.
+    const stored = await database.getScheduledStatus({
+      actorId: ACTOR1_ID,
+      id: created.id
+    })
+    expect(stored?.scheduledAt).toBe(originalScheduledAt)
+  })
+
+  it('emits a next-page Link header when the page is full', async () => {
+    for (let i = 0; i < 3; i++) {
+      await database.createScheduledStatus({
+        actorId: ACTOR2_ID,
+        scheduledAt: tenMinutesAhead() + i * 1000,
+        params: baseParams(`Actor2 paginated ${i}`)
+      })
+    }
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/scheduled_statuses?limit=2', {
+        headers: { Origin: 'https://llun.test', host: 'llun.test' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const list = await response.json()
+    expect(list).toHaveLength(2)
+    const linkHeader = response.headers.get('Link')
+    expect(linkHeader).toContain('rel="next"')
+    expect(linkHeader).toContain(`max_id=${list[1].id}`)
   })
 
   it('returns 404 when deleting an unknown scheduled status id', async () => {

--- a/app/api/v1/scheduled_statuses/route.test.ts
+++ b/app/api/v1/scheduled_statuses/route.test.ts
@@ -1,7 +1,9 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import { SCHEDULED_AT_TOO_SOON_ERROR } from '@/lib/services/mastodon/constants'
+import { getQueue } from '@/lib/services/queue'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
@@ -27,6 +29,12 @@ jest.mock('next/headers', () => ({
 
 jest.mock('better-auth/oauth2', () => ({
   verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn().mockReturnValue({
+    publish: jest.fn().mockResolvedValue(undefined)
+  })
 }))
 
 jest.mock('@/lib/config', () => ({
@@ -163,6 +171,21 @@ describe('scheduled_statuses CRUD', () => {
       id: created.id
     })
     expect(stored?.scheduledAt).toBe(Date.parse(newScheduledAt))
+
+    // The publish job is re-enqueued with the new delay so the status fires at
+    // the rescheduled time.
+    expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: created.id },
+        delaySeconds: expect.any(Number)
+      })
+    )
+    const delaySeconds = (getQueue().publish as jest.Mock).mock.calls[0][0]
+      .delaySeconds
+    // ~30 minutes ahead, comfortably above the five-minute floor.
+    expect(delaySeconds).toBeGreaterThan(20 * 60)
   })
 
   it('returns 422 when PUT scheduled_at is less than five minutes ahead', async () => {

--- a/app/api/v1/scheduled_statuses/route.test.ts
+++ b/app/api/v1/scheduled_statuses/route.test.ts
@@ -1,0 +1,276 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
+
+import { DELETE, GET as GET_ID, PUT } from './[id]/route'
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const baseParams = (text: string): ScheduledStatusParams => ({
+  text,
+  poll: null,
+  media_ids: null,
+  sensitive: false,
+  spoiler_text: null,
+  visibility: 'public',
+  in_reply_to_id: null,
+  language: null,
+  application_id: null,
+  scheduled_at: null,
+  idempotency: null,
+  with_rate_limit: false
+})
+
+const tenMinutesAhead = () => Date.now() + 10 * 60 * 1000
+
+describe('scheduled_statuses CRUD', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('lists the actor scheduled statuses', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Listed scheduled status')
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/scheduled_statuses', {
+        headers: { Origin: 'https://llun.test' }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const list = await response.json()
+    const match = list.find((item: { id: string }) => item.id === created.id)
+    expect(match).toBeTruthy()
+    expect(match.params.text).toBe('Listed scheduled status')
+    expect(match.media_attachments).toEqual([])
+  })
+
+  it('returns a single scheduled status by id', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Single scheduled status')
+    })
+
+    const response = await GET_ID(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        { headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+
+    expect(response.status).toBe(200)
+    const scheduled = await response.json()
+    expect(scheduled.id).toBe(created.id)
+    expect(scheduled.params.text).toBe('Single scheduled status')
+  })
+
+  it('returns 404 for an unknown scheduled status id', async () => {
+    const response = await GET_ID(
+      new NextRequest(
+        'https://llun.test/api/v1/scheduled_statuses/does-not-exist',
+        { headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: 'does-not-exist' }) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  it('reschedules a scheduled status via PUT', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Reschedule me')
+    })
+    const newScheduledAt = new Date(Date.now() + 30 * 60 * 1000).toISOString()
+
+    const response = await PUT(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ scheduled_at: newScheduledAt }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+
+    expect(response.status).toBe(200)
+    const updated = await response.json()
+    expect(updated.scheduled_at).toBe(newScheduledAt)
+
+    const stored = await database.getScheduledStatus({
+      actorId: ACTOR1_ID,
+      id: created.id
+    })
+    expect(stored?.scheduledAt).toBe(Date.parse(newScheduledAt))
+  })
+
+  it('returns 422 when PUT scheduled_at is less than five minutes ahead', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Too soon reschedule')
+    })
+
+    const response = await PUT(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            scheduled_at: new Date(Date.now() + 60 * 1000).toISOString()
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+
+  it('deletes a scheduled status and then 404s on lookup', async () => {
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: baseParams('Delete me')
+    })
+
+    const deleteResponse = await DELETE(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        { method: 'DELETE', headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+
+    expect(deleteResponse.status).toBe(200)
+    expect(await deleteResponse.json()).toEqual({})
+
+    const stored = await database.getScheduledStatus({
+      actorId: ACTOR1_ID,
+      id: created.id
+    })
+    expect(stored).toBeNull()
+
+    const getResponse = await GET_ID(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        { headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+    expect(getResponse.status).toBe(404)
+  })
+
+  it('returns 404 when deleting an unknown scheduled status id', async () => {
+    const response = await DELETE(
+      new NextRequest(
+        'https://llun.test/api/v1/scheduled_statuses/missing-id',
+        { method: 'DELETE', headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: 'missing-id' }) }
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  it('hydrates media_attachments from the stored media ids', async () => {
+    const media = await database.createMedia({
+      actorId: ACTOR1_ID,
+      original: {
+        path: 'medias/scheduled-photo.webp',
+        bytes: 2048,
+        mimeType: 'image/jpeg',
+        metaData: { width: 320, height: 240 },
+        fileName: 'scheduled-photo.jpg'
+      },
+      description: 'Scheduled media description'
+    })
+    expect(media).not.toBeNull()
+
+    const created = await database.createScheduledStatus({
+      actorId: ACTOR1_ID,
+      scheduledAt: tenMinutesAhead(),
+      params: { ...baseParams('With media'), media_ids: [String(media!.id)] }
+    })
+
+    const response = await GET_ID(
+      new NextRequest(
+        `https://llun.test/api/v1/scheduled_statuses/${created.id}`,
+        { headers: { Origin: 'https://llun.test' } }
+      ),
+      { params: Promise.resolve({ id: created.id }) }
+    )
+
+    expect(response.status).toBe(200)
+    const scheduled = await response.json()
+    expect(scheduled.media_attachments).toHaveLength(1)
+    expect(scheduled.media_attachments[0]).toMatchObject({
+      type: 'image',
+      description: 'Scheduled media description'
+    })
+  })
+})

--- a/app/api/v1/scheduled_statuses/route.test.ts
+++ b/app/api/v1/scheduled_statuses/route.test.ts
@@ -180,7 +180,7 @@ describe('scheduled_statuses CRUD', () => {
     expect(getQueue().publish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-        data: { scheduledStatusId: created.id },
+        data: expect.objectContaining({ scheduledStatusId: created.id }),
         delaySeconds: expect.any(Number)
       })
     )
@@ -193,6 +193,9 @@ describe('scheduled_statuses CRUD', () => {
       getHashFromString(`${created.id}-${Date.parse(newScheduledAt)}`)
     )
     expect(publishArgs.id).not.toBe(getHashFromString(created.id))
+    // The payload carries the new scheduledAt so the job can discard itself if
+    // the status is rescheduled again before it fires.
+    expect(publishArgs.data.scheduledAt).toBe(Date.parse(newScheduledAt))
   })
 
   it('returns 422 when PUT scheduled_at is less than five minutes ahead', async () => {

--- a/app/api/v1/scheduled_statuses/route.test.ts
+++ b/app/api/v1/scheduled_statuses/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SCHEDULED_AT_TOO_SOON_ERROR } from '@/lib/services/mastodon/constants'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
@@ -189,6 +190,8 @@ describe('scheduled_statuses CRUD', () => {
     )
 
     expect(response.status).toBe(422)
+    const error = await response.json()
+    expect(error.error).toBe(SCHEDULED_AT_TOO_SOON_ERROR)
   })
 
   it('deletes a scheduled status and then 404s on lookup', async () => {

--- a/app/api/v1/scheduled_statuses/route.test.ts
+++ b/app/api/v1/scheduled_statuses/route.test.ts
@@ -7,6 +7,7 @@ import { getQueue } from '@/lib/services/queue'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 import { DELETE, GET as GET_ID, PUT } from './[id]/route'
 import { GET } from './route'
@@ -182,10 +183,15 @@ describe('scheduled_statuses CRUD', () => {
         delaySeconds: expect.any(Number)
       })
     )
-    const delaySeconds = (getQueue().publish as jest.Mock).mock.calls[0][0]
-      .delaySeconds
+    const publishArgs = (getQueue().publish as jest.Mock).mock.calls[0][0]
     // ~30 minutes ahead, comfortably above the five-minute floor.
-    expect(delaySeconds).toBeGreaterThan(20 * 60)
+    expect(publishArgs.delaySeconds).toBeGreaterThan(20 * 60)
+    // The dedup id folds in the new scheduledAt so a reschedule is not dropped
+    // by QStash deduplication of the original schedule.
+    expect(publishArgs.id).toBe(
+      getHashFromString(`${created.id}-${Date.parse(newScheduledAt)}`)
+    )
+    expect(publishArgs.id).not.toBe(getHashFromString(created.id))
   })
 
   it('returns 422 when PUT scheduled_at is less than five minutes ahead', async () => {

--- a/app/api/v1/scheduled_statuses/route.ts
+++ b/app/api/v1/scheduled_statuses/route.ts
@@ -45,7 +45,11 @@ export const GET = traceApiRoute(
 
       const data = await Promise.all(
         scheduledStatuses.map((scheduled) =>
-          toMastodonScheduledStatus(database, scheduled)
+          toMastodonScheduledStatus(
+            database,
+            scheduled,
+            currentActor.account?.id
+          )
         )
       )
 

--- a/app/api/v1/scheduled_statuses/route.ts
+++ b/app/api/v1/scheduled_statuses/route.ts
@@ -1,24 +1,71 @@
+import { z } from 'zod'
+
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { headerHost } from '@/lib/services/guards/headerHost'
+import { toMastodonScheduledStatus } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 40
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-// https://docs.joinmastodon.org/methods/scheduled_statuses/
-// Scheduling is not supported on this server (statuses are published
-// immediately), so there are never any scheduled statuses. Returning an empty
-// list lets clients show the "Scheduled" view without error. Mastodon scopes
-// this with read:statuses (matching the /:id route).
+const QuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(MAX_LIMIT).optional(),
+  max_id: z.string().optional(),
+  min_id: z.string().optional(),
+  since_id: z.string().optional()
+})
+
+// https://docs.joinmastodon.org/methods/scheduled_statuses/#get
+// Owner-scoped list of the actor's pending scheduled statuses, paginated with
+// Mastodon's id keyset cursors. read:statuses scope (matching the /:id route).
 export const GET = traceApiRoute(
   'getScheduledStatuses',
   OAuthGuardAnyScope(
     [Scope.enum.read, Scope.enum['read:statuses']],
-    async (req) => {
-      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
+    async (req, { database, currentActor }) => {
+      const url = new URL(req.url)
+      const parsed = QuerySchema.safeParse(Object.fromEntries(url.searchParams))
+      const query = parsed.success ? parsed.data : {}
+      const limit = query.limit ?? DEFAULT_LIMIT
+
+      const scheduledStatuses = await database.getScheduledStatuses({
+        actorId: currentActor.id,
+        limit,
+        maxId: query.max_id,
+        minId: query.min_id,
+        sinceId: query.since_id
+      })
+
+      const data = await Promise.all(
+        scheduledStatuses.map((scheduled) =>
+          toMastodonScheduledStatus(database, scheduled)
+        )
+      )
+
+      const additionalHeaders = buildPaginationLinkHeader({
+        host: headerHost(req.headers),
+        path: '/api/v1/scheduled_statuses',
+        limit,
+        nextMaxId:
+          scheduledStatuses.length === limit
+            ? scheduledStatuses[scheduledStatuses.length - 1].id
+            : null,
+        prevMinId: scheduledStatuses.length > 0 ? scheduledStatuses[0].id : null
+      })
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data,
+        additionalHeaders
+      })
     }
   )
 )

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 
 import { getSQLDatabase } from '@/lib/database/sql'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import { hashToken } from '@/lib/services/guards/OAuthGuard'
 import { SCHEDULED_AT_TOO_SOON_ERROR } from '@/lib/services/mastodon/constants'
 import { getQueue } from '@/lib/services/queue'
@@ -567,10 +568,17 @@ describe('POST /api/v1/statuses', () => {
     expect(scheduledStatus.scheduled_at).toBe(scheduledAt)
     expect(scheduledStatus.params.text).toBe('See you in ten minutes')
     expect(scheduledStatus.media_attachments).toEqual([])
-    // No status was published and no publish job was queued.
-    expect(getQueue().publish).not.toHaveBeenCalled()
+    // No status was published, but a delayed publish job was queued.
     const after = await database.getActorStatuses({ actorId: ACTOR1_ID })
     expect(after).toHaveLength(before.length)
+    expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: scheduledStatus.id },
+        delaySeconds: expect.any(Number)
+      })
+    )
 
     // Exactly one scheduled row now exists for the actor.
     const stored = await database.getScheduledStatuses({
@@ -635,8 +643,15 @@ describe('POST /api/v1/statuses', () => {
       expires_in: 3600,
       multiple: true
     })
-    // No status was published and no publish job was queued.
-    expect(getQueue().publish).not.toHaveBeenCalled()
+    // No status was published, but a delayed publish job was queued.
+    expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: scheduledStatus.id },
+        delaySeconds: expect.any(Number)
+      })
+    )
 
     const stored = await database.getScheduledStatuses({
       actorId: ACTOR1_ID,

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -754,7 +754,9 @@ describe('POST /api/v1/statuses', () => {
     expect(getQueue().publish).toHaveBeenCalledWith(
       expect.objectContaining({
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-        data: { scheduledStatusId: scheduledStatus.id },
+        data: expect.objectContaining({
+          scheduledStatusId: scheduledStatus.id
+        }),
         delaySeconds: expect.any(Number)
       })
     )

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -588,6 +588,40 @@ describe('POST /api/v1/statuses', () => {
     expect(stored.map((row) => row.id)).toContain(scheduledStatus.id)
   })
 
+  it('stores a scheduled status with the actor default privacy when visibility is omitted', async () => {
+    await database.updateActor({
+      actorId: ACTOR1_ID,
+      defaultPrivacy: 'private'
+    })
+    try {
+      const scheduledAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+
+      const response = await POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({
+            status: 'Scheduled with default privacy',
+            scheduled_at: scheduledAt
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      const scheduledStatus = await response.json()
+      expect(scheduledStatus.params.visibility).toBe('private')
+    } finally {
+      await database.updateActor({
+        actorId: ACTOR1_ID,
+        defaultPrivacy: 'public'
+      })
+    }
+  })
+
   it('returns 422 when scheduled_at is less than five minutes ahead', async () => {
     const scheduledAt = new Date(Date.now() + 2 * 60 * 1000).toISOString()
 

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { hashToken } from '@/lib/services/guards/OAuthGuard'
+import { SCHEDULED_AT_TOO_SOON_ERROR } from '@/lib/services/mastodon/constants'
 import { getQueue } from '@/lib/services/queue'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
@@ -598,7 +599,52 @@ describe('POST /api/v1/statuses', () => {
     )
 
     expect(response.status).toBe(422)
+    const error = await response.json()
+    expect(error.error).toBe(SCHEDULED_AT_TOO_SOON_ERROR)
     expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('stores a scheduled status with a poll when scheduled_at is far enough ahead', async () => {
+    const scheduledAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Scheduled favourite color?',
+          scheduled_at: scheduledAt,
+          poll: {
+            options: ['Red', 'Green', 'Blue'],
+            expires_in: 3600,
+            multiple: true
+          }
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const scheduledStatus = await response.json()
+    expect(scheduledStatus.scheduled_at).toBe(scheduledAt)
+    expect(scheduledStatus.params.poll).toMatchObject({
+      options: ['Red', 'Green', 'Blue'],
+      expires_in: 3600,
+      multiple: true
+    })
+    // No status was published and no publish job was queued.
+    expect(getQueue().publish).not.toHaveBeenCalled()
+
+    const stored = await database.getScheduledStatuses({
+      actorId: ACTOR1_ID,
+      limit: 40
+    })
+    const storedRow = stored.find((row) => row.id === scheduledStatus.id)
+    expect(storedRow).toBeTruthy()
+    expect(storedRow?.params.poll?.options).toEqual(['Red', 'Green', 'Blue'])
   })
 
   it('does not resurrect a deleted status for a reused Idempotency-Key (orphan cleanup)', async () => {

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -12,6 +12,7 @@ import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
 import { Status } from '@/lib/types/domain/status'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -572,12 +573,16 @@ describe('POST /api/v1/statuses', () => {
     const after = await database.getActorStatuses({ actorId: ACTOR1_ID })
     expect(after).toHaveLength(before.length)
     expect(getQueue().publish).toHaveBeenCalledTimes(1)
-    expect(getQueue().publish).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-        data: { scheduledStatusId: scheduledStatus.id },
-        delaySeconds: expect.any(Number)
-      })
+    const publishArgs = (getQueue().publish as jest.Mock).mock.calls[0][0]
+    expect(publishArgs).toMatchObject({
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduledStatus.id }
+    })
+    expect(publishArgs.delaySeconds).toEqual(expect.any(Number))
+    // The dedup id folds in scheduledAt so a later reschedule is not dropped by
+    // QStash deduplication of the original schedule.
+    expect(publishArgs.id).toBe(
+      getHashFromString(`${scheduledStatus.id}-${Date.parse(scheduledAt)}`)
     )
 
     // Exactly one scheduled row now exists for the actor.
@@ -586,6 +591,40 @@ describe('POST /api/v1/statuses', () => {
       limit: 40
     })
     expect(stored.map((row) => row.id)).toContain(scheduledStatus.id)
+  })
+
+  it('rolls back the stored scheduled status and returns 500 when enqueue fails', async () => {
+    const before = await database.getScheduledStatuses({
+      actorId: ACTOR1_ID,
+      limit: 40
+    })
+    ;(getQueue().publish as jest.Mock).mockRejectedValueOnce(
+      new Error('queue unavailable')
+    )
+    const scheduledAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Enqueue will fail',
+          scheduled_at: scheduledAt
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(500)
+    // The orphan row was rolled back: no new scheduled status remains.
+    const after = await database.getScheduledStatuses({
+      actorId: ACTOR1_ID,
+      limit: 40
+    })
+    expect(after).toHaveLength(before.length)
   })
 
   it('stores a scheduled status with the actor default privacy when visibility is omitted', async () => {

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -542,6 +542,65 @@ describe('POST /api/v1/statuses', () => {
     expect(matching).toHaveLength(1)
   })
 
+  it('stores a scheduled status instead of publishing when scheduled_at is far enough ahead', async () => {
+    const before = await database.getActorStatuses({ actorId: ACTOR1_ID })
+    const scheduledAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'See you in ten minutes',
+          scheduled_at: scheduledAt
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const scheduledStatus = await response.json()
+    expect(scheduledStatus.scheduled_at).toBe(scheduledAt)
+    expect(scheduledStatus.params.text).toBe('See you in ten minutes')
+    expect(scheduledStatus.media_attachments).toEqual([])
+    // No status was published and no publish job was queued.
+    expect(getQueue().publish).not.toHaveBeenCalled()
+    const after = await database.getActorStatuses({ actorId: ACTOR1_ID })
+    expect(after).toHaveLength(before.length)
+
+    // Exactly one scheduled row now exists for the actor.
+    const stored = await database.getScheduledStatuses({
+      actorId: ACTOR1_ID,
+      limit: 40
+    })
+    expect(stored.map((row) => row.id)).toContain(scheduledStatus.id)
+  })
+
+  it('returns 422 when scheduled_at is less than five minutes ahead', async () => {
+    const scheduledAt = new Date(Date.now() + 2 * 60 * 1000).toISOString()
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Too soon to schedule',
+          scheduled_at: scheduledAt
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(422)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
   it('does not resurrect a deleted status for a reused Idempotency-Key (orphan cleanup)', async () => {
     const idempotencyKey = 'idem-key-orphan-456'
     const makeRequest = () =>

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -661,6 +661,39 @@ describe('POST /api/v1/statuses', () => {
     }
   })
 
+  it('treats a blank scheduled_at as an immediate post', async () => {
+    const before = await database.getScheduledStatuses({
+      actorId: ACTOR1_ID,
+      limit: 40
+    })
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Blank schedule posts now',
+          scheduled_at: '   '
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    // A real status was published, not a scheduled one.
+    expect(mastodonStatus.id).toBeTruthy()
+    expect(mastodonStatus.scheduled_at).toBeUndefined()
+    const after = await database.getScheduledStatuses({
+      actorId: ACTOR1_ID,
+      limit: 40
+    })
+    expect(after).toHaveLength(before.length)
+  })
+
   it('returns 422 when scheduled_at is less than five minutes ahead', async () => {
     const scheduledAt = new Date(Date.now() + 2 * 60 * 1000).toISOString()
 

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -32,6 +32,7 @@ import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   ERROR_422,
@@ -223,12 +224,33 @@ export const POST = traceApiRoute(
           // auto-fire when a real queue is configured. The dedup id folds in
           // scheduledAt so a later reschedule to a new time is not dropped by
           // QStash deduplication while retries of the same schedule still are.
-          await getQueue().publish({
-            id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
-            name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-            data: { scheduledStatusId: scheduled.id },
-            delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
-          })
+          try {
+            await getQueue().publish({
+              id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
+              name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+              data: { scheduledStatusId: scheduled.id },
+              delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
+            })
+          } catch (error) {
+            // The row is committed but the delayed job failed to enqueue. With
+            // no cron poller yet it would never fire, so roll the row back and
+            // surface the failure rather than leave an orphan that silently
+            // never publishes.
+            await database.deleteScheduledStatus({
+              id: scheduled.id,
+              actorId: currentActor.id
+            })
+            logger.error(
+              { error, scheduledStatusId: scheduled.id },
+              'createStatus: failed to enqueue scheduled status publish job'
+            )
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_500,
+              responseStatusCode: 500
+            })
+          }
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,
@@ -361,7 +383,8 @@ export const POST = traceApiRoute(
           allowedMethods: CORS_HEADERS,
           data: mastodonStatus
         })
-      } catch {
+      } catch (error) {
+        logger.error({ error }, 'createStatus: request failed')
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -215,7 +215,8 @@ export const POST = traceApiRoute(
             params: buildScheduledParams(
               note,
               idempotencyKey ?? null,
-              actorSettings?.defaultPrivacy ?? 'public'
+              actorSettings?.defaultPrivacy ?? 'public',
+              clientId ?? null
             )
           })
           // Enqueue the publish job with a delay until the scheduled time. On

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -235,15 +235,23 @@ export const POST = traceApiRoute(
             // The row is committed but the delayed job failed to enqueue. With
             // no cron poller yet it would never fire, so roll the row back and
             // surface the failure rather than leave an orphan that silently
-            // never publishes.
-            await database.deleteScheduledStatus({
-              id: scheduled.id,
-              actorId: currentActor.id
-            })
+            // never publishes. Log the enqueue failure first and guard the
+            // rollback so a cleanup failure cannot mask the original error.
             logger.error(
               { error, scheduledStatusId: scheduled.id },
               'createStatus: failed to enqueue scheduled status publish job'
             )
+            try {
+              await database.deleteScheduledStatus({
+                id: scheduled.id,
+                actorId: currentActor.id
+              })
+            } catch (cleanupError) {
+              logger.error(
+                { cleanupError, scheduledStatusId: scheduled.id },
+                'createStatus: failed to roll back orphaned scheduled status'
+              )
+            }
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -13,7 +13,9 @@ import {
   MAX_POLL_OPTION_CHARS,
   MAX_STATUS_MEDIA_ATTACHMENTS,
   MIN_POLL_EXPIRATION_SECONDS,
-  MIN_POLL_OPTIONS
+  MIN_POLL_OPTIONS,
+  MIN_SCHEDULED_STATUS_AHEAD_MS,
+  SCHEDULED_AT_TOO_SOON_ERROR
 } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
@@ -46,9 +48,6 @@ const CORS_HEADERS = [
 // Mastodon does not document a cap; bound the batch to keep per-request work
 // predictable.
 const MAX_BATCH_STATUSES = 100
-
-// Mastodon rejects a scheduled_at less than five minutes in the future.
-const MIN_SCHEDULE_AHEAD_MS = 5 * 60 * 1000
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -164,15 +163,12 @@ export const POST = traceApiRoute(
           const scheduledAt = Date.parse(note.scheduled_at)
           if (
             Number.isNaN(scheduledAt) ||
-            scheduledAt - Date.now() < MIN_SCHEDULE_AHEAD_MS
+            scheduledAt - Date.now() < MIN_SCHEDULED_STATUS_AHEAD_MS
           ) {
             return apiResponse({
               req,
               allowedMethods: CORS_HEADERS,
-              data: {
-                error:
-                  'Validation failed: Scheduled at must be at least 5 minutes in the future'
-              },
+              data: { error: SCHEDULED_AT_TOO_SOON_ERROR },
               responseStatusCode: 422
             })
           }

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -233,7 +233,10 @@ export const POST = traceApiRoute(
             await getQueue().publish({
               id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
               name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-              data: { scheduledStatusId: scheduled.id },
+              data: {
+                scheduledStatusId: scheduled.id,
+                scheduledAt: scheduled.scheduledAt
+              },
               delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
             })
           } catch (error) {

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -263,7 +263,11 @@ export const POST = traceApiRoute(
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,
-            data: await toMastodonScheduledStatus(database, scheduled)
+            data: await toMastodonScheduledStatus(
+              database,
+              scheduled,
+              currentActor.account?.id
+            )
           })
         }
 

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -202,17 +202,29 @@ export const POST = traceApiRoute(
             }
           }
 
+          // Fall back to the actor's configured default privacy when the
+          // client omits visibility, so a scheduled status is stored with the
+          // user's preference instead of always public.
+          const actorSettings = await database.getActorSettings({
+            actorId: currentActor.id
+          })
           const scheduled = await database.createScheduledStatus({
             actorId: currentActor.id,
             scheduledAt,
-            params: buildScheduledParams(note, idempotencyKey ?? null)
+            params: buildScheduledParams(
+              note,
+              idempotencyKey ?? null,
+              actorSettings?.defaultPrivacy ?? 'public'
+            )
           })
           // Enqueue the publish job with a delay until the scheduled time. On
           // QStash the delay is honored natively; the in-process NoQueue has no
           // scheduler and drops delayed messages, so scheduled statuses only
-          // auto-fire when a real queue is configured.
+          // auto-fire when a real queue is configured. The dedup id folds in
+          // scheduledAt so a later reschedule to a new time is not dropped by
+          // QStash deduplication while retries of the same schedule still are.
           await getQueue().publish({
-            id: getHashFromString(scheduled.id),
+            id: getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`),
             name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
             data: { scheduledStatusId: scheduled.id },
             delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -164,8 +164,12 @@ export const POST = traceApiRoute(
         // A scheduled_at at least five minutes ahead stores the status for later
         // publication instead of posting it now. Media is validated
         // here too, so a scheduled status never references nonexistent media.
-        if (note.scheduled_at) {
-          const scheduledAt = Date.parse(note.scheduled_at)
+        // A blank/whitespace-only scheduled_at is treated as "not scheduled"
+        // (immediate post), matching Mastodon's blank-aware check; a non-blank
+        // but unparseable value still falls through to the 422 below.
+        const scheduledAtInput = note.scheduled_at?.trim()
+        if (scheduledAtInput) {
+          const scheduledAt = Date.parse(scheduledAtInput)
           if (
             Number.isNaN(scheduledAt) ||
             scheduledAt - Date.now() < MIN_SCHEDULED_STATUS_AHEAD_MS

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -25,6 +25,7 @@ import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
 import {
   buildScheduledParams,
+  scheduledDelaySeconds,
   toMastodonScheduledStatus
 } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Mastodon } from '@/lib/types/activitypub'
@@ -214,10 +215,7 @@ export const POST = traceApiRoute(
             id: getHashFromString(scheduled.id),
             name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
             data: { scheduledStatusId: scheduled.id },
-            delaySeconds: Math.max(
-              0,
-              Math.floor((scheduled.scheduledAt - Date.now()) / 1000)
-            )
+            delaySeconds: scheduledDelaySeconds(scheduled.scheduledAt)
           })
           return apiResponse({
             req,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { createPollFromUserInput } from '@/lib/actions/createPoll'
+import { Database } from '@/lib/database/types'
 import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import {
   OAuthGuardAnyScope,
@@ -30,6 +31,8 @@ import {
 } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { PostBoxAttachment } from '@/lib/types/domain/attachment'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
@@ -90,6 +93,20 @@ const NoteSchema = z
       note.media_ids.length > 0 ||
       (note.poll?.options.length ?? 0) > 0
   )
+
+// Dedupe, enforce the attachment cap, and resolve media ids to attachments.
+// Returns null when the set exceeds the cap or any id can't be resolved for the
+// actor — both the scheduled and immediate POST paths treat that as a 422.
+// Shared so the two paths can't drift apart.
+const resolveStatusMedia = async (
+  database: Database,
+  currentActor: Actor,
+  mediaIds: string[]
+): Promise<PostBoxAttachment[] | null> => {
+  const uniqueIds = [...new Set(mediaIds)]
+  if (uniqueIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) return null
+  return getAttachmentsFromMediaIds(database, currentActor, uniqueIds)
+}
 
 // GET /api/v1/statuses?id[]=1&id[]=2 — batch-fetch multiple statuses at once.
 // https://docs.joinmastodon.org/methods/statuses/#index
@@ -183,19 +200,13 @@ export const POST = traceApiRoute(
           }
 
           if (!note.poll) {
-            const mediaIds = [...new Set(note.media_ids)]
-            if (mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
-              return apiResponse({
-                req,
-                allowedMethods: CORS_HEADERS,
-                data: ERROR_422,
-                responseStatusCode: 422
-              })
-            }
-            const attachments = await getAttachmentsFromMediaIds(
+            // Validate media up front so a scheduled status never references
+            // media that is missing or over the cap (same rules as an immediate
+            // post). The resolved attachments are rebuilt from params at publish.
+            const attachments = await resolveStatusMedia(
               database,
               currentActor,
-              mediaIds
+              note.media_ids
             )
             if (!attachments) {
               return apiResponse({
@@ -334,19 +345,10 @@ export const POST = traceApiRoute(
             database
           })
         } else {
-          const mediaIds = [...new Set(note.media_ids)]
-          if (mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
-            return apiResponse({
-              req,
-              allowedMethods: CORS_HEADERS,
-              data: ERROR_422,
-              responseStatusCode: 422
-            })
-          }
-          const attachments = await getAttachmentsFromMediaIds(
+          const attachments = await resolveStatusMedia(
             database,
             currentActor,
-            mediaIds
+            note.media_ids
           )
           if (!attachments) {
             return apiResponse({

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { createPollFromUserInput } from '@/lib/actions/createPoll'
+import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import {
   OAuthGuardAnyScope,
   OptionalOAuthGuard,
@@ -18,6 +19,7 @@ import {
   SCHEDULED_AT_TOO_SOON_ERROR
 } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { getQueue } from '@/lib/services/queue'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
@@ -27,6 +29,7 @@ import {
 } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -203,7 +206,19 @@ export const POST = traceApiRoute(
             scheduledAt,
             params: buildScheduledParams(note, idempotencyKey ?? null)
           })
-          // Task 14: enqueue publish job
+          // Enqueue the publish job with a delay until the scheduled time. On
+          // QStash the delay is honored natively; the in-process NoQueue has no
+          // scheduler and drops delayed messages, so scheduled statuses only
+          // auto-fire when a real queue is configured.
+          await getQueue().publish({
+            id: getHashFromString(scheduled.id),
+            name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+            data: { scheduledStatusId: scheduled.id },
+            delaySeconds: Math.max(
+              0,
+              Math.floor((scheduled.scheduledAt - Date.now()) / 1000)
+            )
+          })
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -161,7 +161,7 @@ export const POST = traceApiRoute(
         const idempotencyKey = req.headers.get('Idempotency-Key')?.trim()
 
         // A scheduled_at at least five minutes ahead stores the status for later
-        // publication (Task 14) instead of posting it now. Media is validated
+        // publication instead of posting it now. Media is validated
         // here too, so a scheduled status never references nonexistent media.
         if (note.scheduled_at) {
           const scheduledAt = Date.parse(note.scheduled_at)

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -19,6 +19,10 @@ import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
+import {
+  buildScheduledParams,
+  toMastodonScheduledStatus
+} from '@/lib/services/statuses/scheduledStatusSerializer'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -42,6 +46,9 @@ const CORS_HEADERS = [
 // Mastodon does not document a cap; bound the batch to keep per-request work
 // predictable.
 const MAX_BATCH_STATUSES = 100
+
+// Mastodon rejects a scheduled_at less than five minutes in the future.
+const MIN_SCHEDULE_AHEAD_MS = 5 * 60 * 1000
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -70,6 +77,7 @@ const NoteSchema = z
     visibility: VisibilitySchema.optional(),
     language: z.string().trim().min(1).optional(),
     sensitive: Booleanish.optional().default(false),
+    scheduled_at: z.string().optional(),
     poll: PollSchema.optional()
   })
   .refine(
@@ -147,9 +155,68 @@ export const POST = traceApiRoute(
           })
         }
 
+        const idempotencyKey = req.headers.get('Idempotency-Key')?.trim()
+
+        // A scheduled_at at least five minutes ahead stores the status for later
+        // publication (Task 14) instead of posting it now. Media is validated
+        // here too, so a scheduled status never references nonexistent media.
+        if (note.scheduled_at) {
+          const scheduledAt = Date.parse(note.scheduled_at)
+          if (
+            Number.isNaN(scheduledAt) ||
+            scheduledAt - Date.now() < MIN_SCHEDULE_AHEAD_MS
+          ) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: {
+                error:
+                  'Validation failed: Scheduled at must be at least 5 minutes in the future'
+              },
+              responseStatusCode: 422
+            })
+          }
+
+          if (!note.poll) {
+            const mediaIds = [...new Set(note.media_ids)]
+            if (mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: ERROR_422,
+                responseStatusCode: 422
+              })
+            }
+            const attachments = await getAttachmentsFromMediaIds(
+              database,
+              currentActor,
+              mediaIds
+            )
+            if (!attachments) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: ERROR_422,
+                responseStatusCode: 422
+              })
+            }
+          }
+
+          const scheduled = await database.createScheduledStatus({
+            actorId: currentActor.id,
+            scheduledAt,
+            params: buildScheduledParams(note, idempotencyKey ?? null)
+          })
+          // Task 14: enqueue publish job
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: await toMastodonScheduledStatus(database, scheduled)
+          })
+        }
+
         // Honor Idempotency-Key: a repeated key returns the original status
         // rather than creating a duplicate.
-        const idempotencyKey = req.headers.get('Idempotency-Key')?.trim()
         if (idempotencyKey) {
           const existingStatusId = await database.getIdempotentStatusId({
             actorId: currentActor.id,

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -27,6 +27,7 @@ import { NotificationSQLDatabaseMixin } from '@/lib/database/sql/notification'
 import { OAuthSQLDatabaseMixin } from '@/lib/database/sql/oauth'
 import { PushSubscriptionSQLDatabaseMixin } from '@/lib/database/sql/pushSubscription'
 import { ReportSQLDatabaseMixin } from '@/lib/database/sql/report'
+import { ScheduledStatusSQLDatabaseMixin } from '@/lib/database/sql/scheduledStatus'
 import { SearchSQLDatabaseMixin } from '@/lib/database/sql/search'
 import { ServerFilterSQLDatabaseMixin } from '@/lib/database/sql/serverFilter'
 import { StatusSQLDatabaseMixin } from '@/lib/database/sql/status'
@@ -65,6 +66,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const notificationDatabase = NotificationSQLDatabaseMixin(database)
   const pushSubscriptionDatabase = PushSubscriptionSQLDatabaseMixin(database)
   const reportDatabase = ReportSQLDatabaseMixin(database)
+  const scheduledStatusDatabase = ScheduledStatusSQLDatabaseMixin(database)
   const oauthDatabase = OAuthSQLDatabaseMixin(database)
   const searchDatabase = SearchSQLDatabaseMixin(database)
   const stravaArchiveImportDatabase =
@@ -128,6 +130,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...notificationDatabase,
     ...pushSubscriptionDatabase,
     ...reportDatabase,
+    ...scheduledStatusDatabase,
     ...oauthDatabase,
     ...searchDatabase,
     ...stravaArchiveImportDatabase,

--- a/lib/database/sql/media.test.ts
+++ b/lib/database/sql/media.test.ts
@@ -403,6 +403,85 @@ describe('MediaDatabase', () => {
       })
     })
 
+    describe('getMediaByIdsForAccount', () => {
+      it('returns only the account-owned media for the requested string ids', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        const otherActor = await database.getActorFromId({
+          id: actors.replyAuthor.id
+        })
+
+        const first = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/batch-first.jpg',
+            bytes: 1000,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 }
+          }
+        })
+        const second = await database.createMedia({
+          actorId: actors.primary.id,
+          original: {
+            path: '/test/batch-second.jpg',
+            bytes: 1200,
+            mimeType: 'image/jpeg',
+            metaData: { width: 120, height: 120 }
+          }
+        })
+        const foreign = await database.createMedia({
+          actorId: actors.replyAuthor.id,
+          original: {
+            path: '/test/batch-foreign.jpg',
+            bytes: 1400,
+            mimeType: 'image/jpeg',
+            metaData: { width: 140, height: 140 }
+          }
+        })
+
+        const results = await database.getMediaByIdsForAccount({
+          // Ids arrive as strings (Mastodon API) and include another account's
+          // media plus an unknown id; only the two owned ids should resolve.
+          mediaIds: [
+            String(first!.id),
+            String(second!.id),
+            String(foreign!.id),
+            '999999999'
+          ],
+          accountId: actor!.account!.id
+        })
+
+        const ids = results.map((media) => media.id).sort()
+        expect(ids).toEqual([String(first!.id), String(second!.id)].sort())
+        expect(results.some((media) => media.id === String(foreign!.id))).toBe(
+          false
+        )
+        // The foreign media is still readable by its own owner.
+        const foreignOwned = await database.getMediaByIdsForAccount({
+          mediaIds: [String(foreign!.id)],
+          accountId: otherActor!.account!.id
+        })
+        expect(foreignOwned.map((media) => media.id)).toEqual([
+          String(foreign!.id)
+        ])
+      })
+
+      it('returns an empty array for empty or non-numeric ids', async () => {
+        const actor = await database.getActorFromId({ id: actors.primary.id })
+        expect(
+          await database.getMediaByIdsForAccount({
+            mediaIds: [],
+            accountId: actor!.account!.id
+          })
+        ).toEqual([])
+        expect(
+          await database.getMediaByIdsForAccount({
+            mediaIds: ['', 'not-a-number'],
+            accountId: actor!.account!.id
+          })
+        ).toEqual([])
+      })
+    })
+
     describe('getStorageUsageForAccount', () => {
       it('returns 0 when no media exists', async () => {
         const actor = await database.getActorFromId({

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -21,6 +21,7 @@ import {
   GetAttachmentsParams,
   GetAttachmentsWithMediaParams,
   GetMediaByIdParams,
+  GetMediaByIdsForAccountParams,
   GetMediasForAccountParams,
   GetStorageUsageForAccountParams,
   MarkMediaUploadVerifiedParams,
@@ -514,6 +515,19 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     if (!data) return null
 
     return parseMediaRow(data)
+  },
+
+  async getMediaByIdsForAccount({
+    mediaIds,
+    accountId
+  }: GetMediaByIdsForAccountParams): Promise<Media[]> {
+    if (mediaIds.length === 0) return []
+    const rows = await database('medias')
+      .join('actors', 'medias.actorId', 'actors.id')
+      .whereIn('medias.id', mediaIds)
+      .where('actors.accountId', accountId)
+      .select(MEDIA_COLUMNS.map((column) => `medias.${column}`))
+    return rows.map(parseMediaRow)
   },
 
   async updateMedia({

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -521,10 +521,17 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     mediaIds,
     accountId
   }: GetMediaByIdsForAccountParams): Promise<Media[]> {
-    if (mediaIds.length === 0) return []
+    // medias.id is an integer column. Mastodon clients send ids as strings, so
+    // coerce numeric ids to numbers before the IN query — Postgres rejects
+    // comparing an integer column against text. Drop empty/invalid ids.
+    const numericIds = mediaIds
+      .filter(Boolean)
+      .map((id) => Number(id))
+      .filter((id) => Number.isInteger(id))
+    if (numericIds.length === 0) return []
     const rows = await database('medias')
       .join('actors', 'medias.actorId', 'actors.id')
-      .whereIn('medias.id', mediaIds)
+      .whereIn('medias.id', numericIds)
       .where('actors.accountId', accountId)
       .select(MEDIA_COLUMNS.map((column) => `medias.${column}`))
     return rows.map(parseMediaRow)

--- a/lib/database/sql/media.ts
+++ b/lib/database/sql/media.ts
@@ -527,7 +527,7 @@ export const MediaSQLDatabaseMixin = (database: Knex): MediaDatabase => ({
     const numericIds = mediaIds
       .filter(Boolean)
       .map((id) => Number(id))
-      .filter((id) => Number.isInteger(id))
+      .filter((id) => Number.isInteger(id) && id > 0)
     if (numericIds.length === 0) return []
     const rows = await database('medias')
       .join('actors', 'medias.actorId', 'actors.id')

--- a/lib/database/sql/scheduledStatus.test.ts
+++ b/lib/database/sql/scheduledStatus.test.ts
@@ -116,6 +116,63 @@ describe('ScheduledStatusDatabase', () => {
     })
   })
 
+  it('paginates with max_id, since_id and min_id cursors', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = []
+      for (let i = 0; i < 3; i++) {
+        created.push(
+          await database.createScheduledStatus({
+            actorId: ACTOR_ID,
+            scheduledAt: Date.now() + (i + 1) * 1_000_000,
+            params: baseParams({ text: `Page ${i}` })
+          })
+        )
+      }
+      // Rows are ordered by id (a UUID), so derive the expected ordering by
+      // sorting the actual ids lexicographically rather than by insertion.
+      const ascending = created.map((row) => row.id).sort()
+      const descending = [...ascending].reverse()
+      const middle = ascending[1]
+
+      // Default order is id descending.
+      const all = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20
+      })
+      expect(all.map((row) => row.id)).toEqual(descending)
+
+      // max_id: ids strictly less than the cursor, descending.
+      const older = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20,
+        maxId: middle
+      })
+      expect(older.map((row) => row.id)).toEqual(
+        descending.filter((id) => id < middle)
+      )
+
+      // since_id: ids strictly greater than the cursor, descending.
+      const newerSince = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20,
+        sinceId: middle
+      })
+      expect(newerSince.map((row) => row.id)).toEqual(
+        descending.filter((id) => id > middle)
+      )
+
+      // min_id: ids strictly greater than the cursor, ascending (reversed).
+      const newerMin = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20,
+        minId: middle
+      })
+      expect(newerMin.map((row) => row.id)).toEqual(
+        ascending.filter((id) => id > middle)
+      )
+    })
+  })
+
   it('updates the scheduled time and reflects it on read', async () => {
     await withFreshDatabase(async (database) => {
       const created = await database.createScheduledStatus({

--- a/lib/database/sql/scheduledStatus.test.ts
+++ b/lib/database/sql/scheduledStatus.test.ts
@@ -357,5 +357,33 @@ describe('ScheduledStatusDatabase', () => {
         expect(ids).toContain(otherRow.id)
       })
     })
+
+    it('caps the result set to the optional limit, soonest first', async () => {
+      await withFreshDatabase(async (database) => {
+        const earliest = await database.createScheduledStatus({
+          actorId: ACTOR_ID,
+          scheduledAt: CUTOFF - 30_000,
+          params: baseParams()
+        })
+        await database.createScheduledStatus({
+          actorId: ACTOR_ID,
+          scheduledAt: CUTOFF - 20_000,
+          params: baseParams()
+        })
+        await database.createScheduledStatus({
+          actorId: ACTOR_ID,
+          scheduledAt: CUTOFF - 10_000,
+          params: baseParams()
+        })
+
+        const dueRows = await database.getDueScheduledStatuses({
+          before: CUTOFF,
+          limit: 2
+        })
+        expect(dueRows).toHaveLength(2)
+        // Ordered by scheduledAt ascending, so the earliest is included first.
+        expect(dueRows[0].id).toBe(earliest.id)
+      })
+    })
   })
 })

--- a/lib/database/sql/scheduledStatus.test.ts
+++ b/lib/database/sql/scheduledStatus.test.ts
@@ -116,8 +116,10 @@ describe('ScheduledStatusDatabase', () => {
     })
   })
 
-  it('paginates with max_id, since_id and min_id cursors', async () => {
+  it('paginates chronologically with max_id, since_id and min_id cursors', async () => {
     await withFreshDatabase(async (database) => {
+      // Strictly increasing scheduledAt so ordering is deterministic and
+      // independent of the random UUID ids.
       const created = []
       for (let i = 0; i < 3; i++) {
         created.push(
@@ -128,48 +130,43 @@ describe('ScheduledStatusDatabase', () => {
           })
         )
       }
-      // Rows are ordered by id (a UUID), so derive the expected ordering by
-      // sorting the actual ids lexicographically rather than by insertion.
-      const ascending = created.map((row) => row.id).sort()
-      const descending = [...ascending].reverse()
-      const middle = ascending[1]
+      const [earliest, middleRow, latest] = created
 
-      // Default order is id descending.
+      // Default order is scheduledAt descending (latest scheduled first), NOT
+      // shuffled by UUID id.
       const all = await database.getScheduledStatuses({
         actorId: ACTOR_ID,
         limit: 20
       })
-      expect(all.map((row) => row.id)).toEqual(descending)
+      expect(all.map((row) => row.id)).toEqual([
+        latest.id,
+        middleRow.id,
+        earliest.id
+      ])
 
-      // max_id: ids strictly less than the cursor, descending.
+      // max_id: rows scheduled before the cursor, descending.
       const older = await database.getScheduledStatuses({
         actorId: ACTOR_ID,
         limit: 20,
-        maxId: middle
+        maxId: middleRow.id
       })
-      expect(older.map((row) => row.id)).toEqual(
-        descending.filter((id) => id < middle)
-      )
+      expect(older.map((row) => row.id)).toEqual([earliest.id])
 
-      // since_id: ids strictly greater than the cursor, descending.
+      // since_id: rows scheduled after the cursor, descending.
       const newerSince = await database.getScheduledStatuses({
         actorId: ACTOR_ID,
         limit: 20,
-        sinceId: middle
+        sinceId: middleRow.id
       })
-      expect(newerSince.map((row) => row.id)).toEqual(
-        descending.filter((id) => id > middle)
-      )
+      expect(newerSince.map((row) => row.id)).toEqual([latest.id])
 
-      // min_id: ids strictly greater than the cursor, ascending (reversed).
+      // min_id: rows scheduled after the cursor, ascending (reversed).
       const newerMin = await database.getScheduledStatuses({
         actorId: ACTOR_ID,
         limit: 20,
-        minId: middle
+        minId: middleRow.id
       })
-      expect(newerMin.map((row) => row.id)).toEqual(
-        ascending.filter((id) => id > middle)
-      )
+      expect(newerMin.map((row) => row.id)).toEqual([latest.id])
     })
   })
 
@@ -195,6 +192,28 @@ describe('ScheduledStatusDatabase', () => {
         id: created.id
       })
       expect(fetched?.scheduledAt).toBe(newScheduledAt)
+    })
+  })
+
+  it('returns the row (not null) when rescheduling to the same time', async () => {
+    await withFreshDatabase(async (database) => {
+      const scheduledAt = Date.now() + 1_000_000
+      const created = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt,
+        params: baseParams()
+      })
+
+      // SQLite reports 0 changed rows for a no-op update; the method must still
+      // return the existing row rather than a false null (which would 404).
+      const updated = await database.updateScheduledStatusAt({
+        actorId: ACTOR_ID,
+        id: created.id,
+        scheduledAt
+      })
+      expect(updated).not.toBeNull()
+      expect(updated?.id).toBe(created.id)
+      expect(updated?.scheduledAt).toBe(scheduledAt)
     })
   })
 

--- a/lib/database/sql/scheduledStatus.test.ts
+++ b/lib/database/sql/scheduledStatus.test.ts
@@ -65,6 +65,27 @@ describe('ScheduledStatusDatabase', () => {
     })
   })
 
+  it('reads a scheduled status by id without an actor scope', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 1_000_000,
+        params: baseParams({ text: 'By id' })
+      })
+
+      const fetched = await database.getScheduledStatusById({ id: created.id })
+      expect(fetched).not.toBeNull()
+      expect(fetched?.id).toBe(created.id)
+      expect(fetched?.actorId).toBe(ACTOR_ID)
+      expect(fetched?.params.text).toBe('By id')
+
+      const missing = await database.getScheduledStatusById({
+        id: 'does-not-exist'
+      })
+      expect(missing).toBeNull()
+    })
+  })
+
   it('lists scheduled statuses for an actor', async () => {
     await withFreshDatabase(async (database) => {
       const first = await database.createScheduledStatus({

--- a/lib/database/sql/scheduledStatus.test.ts
+++ b/lib/database/sql/scheduledStatus.test.ts
@@ -195,6 +195,32 @@ describe('ScheduledStatusDatabase', () => {
     })
   })
 
+  it('returns an empty page when the pagination cursor no longer exists', async () => {
+    await withFreshDatabase(async (database) => {
+      await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 1_000_000,
+        params: baseParams({ text: 'Still here' })
+      })
+
+      // A cursor pointing at a deleted/published row must not fall back to the
+      // first page (which would loop the client over duplicates).
+      const olderPage = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20,
+        maxId: 'cursor-that-was-deleted'
+      })
+      expect(olderPage).toEqual([])
+
+      const newerPage = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20,
+        sinceId: 'cursor-that-was-deleted'
+      })
+      expect(newerPage).toEqual([])
+    })
+  })
+
   it('returns the row (not null) when rescheduling to the same time', async () => {
     await withFreshDatabase(async (database) => {
       const scheduledAt = Date.now() + 1_000_000

--- a/lib/database/sql/scheduledStatus.test.ts
+++ b/lib/database/sql/scheduledStatus.test.ts
@@ -1,0 +1,238 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
+
+const ACTOR_ID = 'https://llun.test/users/owner'
+const OTHER_ACTOR_ID = 'https://llun.test/users/other'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const baseParams = (
+  overrides: Partial<ScheduledStatusParams> = {}
+): ScheduledStatusParams => ({
+  text: 'Scheduled post',
+  poll: null,
+  media_ids: null,
+  sensitive: null,
+  spoiler_text: null,
+  visibility: 'public',
+  in_reply_to_id: null,
+  language: null,
+  application_id: null,
+  scheduled_at: null,
+  idempotency: null,
+  with_rate_limit: false,
+  ...overrides
+})
+
+describe('ScheduledStatusDatabase', () => {
+  it('creates a scheduled status and reads it back with parsed params', async () => {
+    await withFreshDatabase(async (database) => {
+      const scheduledAt = Date.now() + 3_600_000
+      const created = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt,
+        params: baseParams({ text: 'Hello future', visibility: 'unlisted' })
+      })
+
+      expect(created.id).toBeTruthy()
+      expect(created.actorId).toBe(ACTOR_ID)
+      expect(created.scheduledAt).toBe(scheduledAt)
+      expect(created.params.text).toBe('Hello future')
+      expect(created.params.visibility).toBe('unlisted')
+      expect(typeof created.createdAt).toBe('number')
+      expect(typeof created.updatedAt).toBe('number')
+
+      const fetched = await database.getScheduledStatus({
+        actorId: ACTOR_ID,
+        id: created.id
+      })
+      expect(fetched).not.toBeNull()
+      expect(fetched?.id).toBe(created.id)
+      expect(fetched?.scheduledAt).toBe(scheduledAt)
+      expect(fetched?.params.text).toBe('Hello future')
+      expect(fetched?.params.visibility).toBe('unlisted')
+    })
+  })
+
+  it('lists scheduled statuses for an actor', async () => {
+    await withFreshDatabase(async (database) => {
+      const first = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 1_000_000,
+        params: baseParams({ text: 'First' })
+      })
+      const second = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 2_000_000,
+        params: baseParams({ text: 'Second' })
+      })
+      await database.createScheduledStatus({
+        actorId: OTHER_ACTOR_ID,
+        scheduledAt: Date.now() + 3_000_000,
+        params: baseParams({ text: 'Other actor' })
+      })
+
+      const list = await database.getScheduledStatuses({
+        actorId: ACTOR_ID,
+        limit: 20
+      })
+      const ids = list.map((row) => row.id)
+      expect(ids).toContain(first.id)
+      expect(ids).toContain(second.id)
+      expect(list).toHaveLength(2)
+      expect(list.every((row) => row.actorId === ACTOR_ID)).toBe(true)
+    })
+  })
+
+  it('updates the scheduled time and reflects it on read', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 1_000_000,
+        params: baseParams()
+      })
+      const newScheduledAt = Date.now() + 5_000_000
+
+      const updated = await database.updateScheduledStatusAt({
+        actorId: ACTOR_ID,
+        id: created.id,
+        scheduledAt: newScheduledAt
+      })
+      expect(updated).not.toBeNull()
+      expect(updated?.scheduledAt).toBe(newScheduledAt)
+
+      const fetched = await database.getScheduledStatus({
+        actorId: ACTOR_ID,
+        id: created.id
+      })
+      expect(fetched?.scheduledAt).toBe(newScheduledAt)
+    })
+  })
+
+  it('scopes get, update and delete to the owning actor', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 1_000_000,
+        params: baseParams()
+      })
+
+      const fetchedAsOther = await database.getScheduledStatus({
+        actorId: OTHER_ACTOR_ID,
+        id: created.id
+      })
+      expect(fetchedAsOther).toBeNull()
+
+      const updatedAsOther = await database.updateScheduledStatusAt({
+        actorId: OTHER_ACTOR_ID,
+        id: created.id,
+        scheduledAt: Date.now() + 9_000_000
+      })
+      expect(updatedAsOther).toBeNull()
+
+      const deletedAsOther = await database.deleteScheduledStatus({
+        actorId: OTHER_ACTOR_ID,
+        id: created.id
+      })
+      expect(deletedAsOther).toBe(false)
+
+      // Still present for the real owner after the failed cross-actor delete.
+      const stillThere = await database.getScheduledStatus({
+        actorId: ACTOR_ID,
+        id: created.id
+      })
+      expect(stillThere).not.toBeNull()
+    })
+  })
+
+  it('deletes a scheduled status so it can no longer be read', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createScheduledStatus({
+        actorId: ACTOR_ID,
+        scheduledAt: Date.now() + 1_000_000,
+        params: baseParams()
+      })
+
+      const deleted = await database.deleteScheduledStatus({
+        actorId: ACTOR_ID,
+        id: created.id
+      })
+      expect(deleted).toBe(true)
+
+      const fetched = await database.getScheduledStatus({
+        actorId: ACTOR_ID,
+        id: created.id
+      })
+      expect(fetched).toBeNull()
+    })
+  })
+
+  describe('getDueScheduledStatuses', () => {
+    const CUTOFF = 1_700_000_000_000
+
+    it.each([
+      {
+        description: 'includes a status scheduled before the cutoff',
+        scheduledAt: CUTOFF - 1_000,
+        due: true
+      },
+      {
+        description: 'includes a status scheduled exactly at the cutoff',
+        scheduledAt: CUTOFF,
+        due: true
+      },
+      {
+        description: 'excludes a status scheduled after the cutoff',
+        scheduledAt: CUTOFF + 1_000,
+        due: false
+      }
+    ])('$description', async ({ scheduledAt, due }) => {
+      await withFreshDatabase(async (database) => {
+        const created = await database.createScheduledStatus({
+          actorId: ACTOR_ID,
+          scheduledAt,
+          params: baseParams()
+        })
+
+        const dueRows = await database.getDueScheduledStatuses({
+          before: CUTOFF
+        })
+        const ids = dueRows.map((row) => row.id)
+        expect(ids.includes(created.id)).toBe(due)
+      })
+    })
+
+    it('returns due rows across all actors', async () => {
+      await withFreshDatabase(async (database) => {
+        const ownerRow = await database.createScheduledStatus({
+          actorId: ACTOR_ID,
+          scheduledAt: CUTOFF - 5_000,
+          params: baseParams()
+        })
+        const otherRow = await database.createScheduledStatus({
+          actorId: OTHER_ACTOR_ID,
+          scheduledAt: CUTOFF - 5_000,
+          params: baseParams()
+        })
+
+        const dueRows = await database.getDueScheduledStatuses({
+          before: CUTOFF
+        })
+        const ids = dueRows.map((row) => row.id)
+        expect(ids).toContain(ownerRow.id)
+        expect(ids).toContain(otherRow.id)
+      })
+    })
+  })
+})

--- a/lib/database/sql/scheduledStatus.ts
+++ b/lib/database/sql/scheduledStatus.ts
@@ -163,11 +163,16 @@ export const ScheduledStatusSQLDatabaseMixin = (
     return deleted > 0
   },
 
-  async getDueScheduledStatuses({ before }: GetDueScheduledStatusesParams) {
-    const rows = await database<SQLScheduledStatus>('scheduled_statuses')
+  async getDueScheduledStatuses({
+    before,
+    limit
+  }: GetDueScheduledStatusesParams) {
+    const query = database<SQLScheduledStatus>('scheduled_statuses')
       .where('scheduledAt', '<=', new Date(before))
       .orderBy('scheduledAt', 'asc')
       .orderBy('id', 'asc')
+    if (limit) query.limit(limit)
+    const rows = await query
     return rows.map(toScheduledStatus)
   }
 })

--- a/lib/database/sql/scheduledStatus.ts
+++ b/lib/database/sql/scheduledStatus.ts
@@ -7,6 +7,7 @@ import {
   CreateScheduledStatusParams,
   DeleteScheduledStatusParams,
   GetDueScheduledStatusesParams,
+  GetScheduledStatusByIdParams,
   GetScheduledStatusParams,
   GetScheduledStatusesParams,
   ScheduledStatusData,
@@ -89,6 +90,14 @@ export const ScheduledStatusSQLDatabaseMixin = (
   async getScheduledStatus({ actorId, id }: GetScheduledStatusParams) {
     const row = await database<SQLScheduledStatus>('scheduled_statuses')
       .where({ actorId, id })
+      .first()
+    if (!row) return null
+    return toScheduledStatus(row)
+  },
+
+  async getScheduledStatusById({ id }: GetScheduledStatusByIdParams) {
+    const row = await database<SQLScheduledStatus>('scheduled_statuses')
+      .where({ id })
       .first()
     if (!row) return null
     return toScheduledStatus(row)

--- a/lib/database/sql/scheduledStatus.ts
+++ b/lib/database/sql/scheduledStatus.ts
@@ -73,14 +73,46 @@ export const ScheduledStatusSQLDatabaseMixin = (
       .where('actorId', actorId)
       .limit(limit)
 
-    if (maxId) query.where('id', '<', maxId)
+    // Cursors are row ids, but ids are random UUIDs, so comparing them directly
+    // would shuffle pagination. Look the cursor row up and keyset on its
+    // scheduledAt, with id as a stable tiebreaker — the same pattern the status
+    // timeline uses on createdAt. The raw cursor value is passed straight into
+    // the comparison (it is already in the column's storage format).
+    if (maxId) {
+      const cursor = await database<SQLScheduledStatus>('scheduled_statuses')
+        .where({ actorId, id: maxId })
+        .first()
+      if (cursor) {
+        query.where((wb) => {
+          wb.where('scheduledAt', '<', cursor.scheduledAt).orWhere((tie) => {
+            tie
+              .where('scheduledAt', '=', cursor.scheduledAt)
+              .where('id', '<', maxId)
+          })
+        })
+      }
+    }
+
     const newerCursorId = minId || sinceId
-    if (newerCursorId) query.where('id', '>', newerCursorId)
+    if (newerCursorId) {
+      const cursor = await database<SQLScheduledStatus>('scheduled_statuses')
+        .where({ actorId, id: newerCursorId })
+        .first()
+      if (cursor) {
+        query.where((wb) => {
+          wb.where('scheduledAt', '>', cursor.scheduledAt).orWhere((tie) => {
+            tie
+              .where('scheduledAt', '=', cursor.scheduledAt)
+              .where('id', '>', newerCursorId)
+          })
+        })
+      }
+    }
 
     if (minId) {
-      query.orderBy('id', 'asc')
+      query.orderBy('scheduledAt', 'asc').orderBy('id', 'asc')
     } else {
-      query.orderBy('id', 'desc')
+      query.orderBy('scheduledAt', 'desc').orderBy('id', 'desc')
     }
 
     const rows = await query
@@ -109,10 +141,13 @@ export const ScheduledStatusSQLDatabaseMixin = (
     scheduledAt
   }: UpdateScheduledStatusAtParams) {
     const updatedAt = new Date()
-    const affected = await database('scheduled_statuses')
+    // Do not key existence off the affected-row count: SQLite reports 0 changed
+    // rows when scheduledAt is updated to its current value, which would falsely
+    // 404 a no-op reschedule. Re-read the row instead — it is null only when the
+    // (actorId, id) pair does not exist.
+    await database('scheduled_statuses')
       .where({ actorId, id })
       .update({ scheduledAt: new Date(scheduledAt), updatedAt })
-    if (!affected) return null
 
     const row = await database<SQLScheduledStatus>('scheduled_statuses')
       .where({ actorId, id })

--- a/lib/database/sql/scheduledStatus.ts
+++ b/lib/database/sql/scheduledStatus.ts
@@ -78,19 +78,21 @@ export const ScheduledStatusSQLDatabaseMixin = (
     // scheduledAt, with id as a stable tiebreaker — the same pattern the status
     // timeline uses on createdAt. The raw cursor value is passed straight into
     // the comparison (it is already in the column's storage format).
+    // A cursor that no longer resolves (the row was published/deleted between
+    // page requests) returns an empty page rather than silently falling back to
+    // the first page, which would loop the client over duplicate results.
     if (maxId) {
       const cursor = await database<SQLScheduledStatus>('scheduled_statuses')
         .where({ actorId, id: maxId })
         .first()
-      if (cursor) {
-        query.where((wb) => {
-          wb.where('scheduledAt', '<', cursor.scheduledAt).orWhere((tie) => {
-            tie
-              .where('scheduledAt', '=', cursor.scheduledAt)
-              .where('id', '<', maxId)
-          })
+      if (!cursor) return []
+      query.where((wb) => {
+        wb.where('scheduledAt', '<', cursor.scheduledAt).orWhere((tie) => {
+          tie
+            .where('scheduledAt', '=', cursor.scheduledAt)
+            .where('id', '<', maxId)
         })
-      }
+      })
     }
 
     const newerCursorId = minId || sinceId
@@ -98,15 +100,14 @@ export const ScheduledStatusSQLDatabaseMixin = (
       const cursor = await database<SQLScheduledStatus>('scheduled_statuses')
         .where({ actorId, id: newerCursorId })
         .first()
-      if (cursor) {
-        query.where((wb) => {
-          wb.where('scheduledAt', '>', cursor.scheduledAt).orWhere((tie) => {
-            tie
-              .where('scheduledAt', '=', cursor.scheduledAt)
-              .where('id', '>', newerCursorId)
-          })
+      if (!cursor) return []
+      query.where((wb) => {
+        wb.where('scheduledAt', '>', cursor.scheduledAt).orWhere((tie) => {
+          tie
+            .where('scheduledAt', '=', cursor.scheduledAt)
+            .where('id', '>', newerCursorId)
         })
-      }
+      })
     }
 
     if (minId) {

--- a/lib/database/sql/scheduledStatus.ts
+++ b/lib/database/sql/scheduledStatus.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex'
 import { randomUUID } from 'node:crypto'
 
+import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   CreateScheduledStatusParams,
@@ -27,7 +28,7 @@ const toScheduledStatus = (row: SQLScheduledStatus): ScheduledStatusData => ({
   id: row.id,
   actorId: row.actorId,
   scheduledAt: getCompatibleTime(row.scheduledAt),
-  params: ScheduledStatusParams.parse(JSON.parse(row.params)),
+  params: ScheduledStatusParams.parse(getCompatibleJSON(row.params)),
   createdAt: getCompatibleTime(row.createdAt),
   updatedAt: getCompatibleTime(row.updatedAt)
 })
@@ -98,21 +99,16 @@ export const ScheduledStatusSQLDatabaseMixin = (
     id,
     scheduledAt
   }: UpdateScheduledStatusAtParams) {
-    const existing = await database<SQLScheduledStatus>('scheduled_statuses')
-      .where({ actorId, id })
-      .first()
-    if (!existing) return null
-
     const updatedAt = new Date()
-    await database('scheduled_statuses')
+    const affected = await database('scheduled_statuses')
       .where({ actorId, id })
       .update({ scheduledAt: new Date(scheduledAt), updatedAt })
+    if (!affected) return null
 
-    return {
-      ...toScheduledStatus(existing),
-      scheduledAt,
-      updatedAt: updatedAt.getTime()
-    }
+    const row = await database<SQLScheduledStatus>('scheduled_statuses')
+      .where({ actorId, id })
+      .first()
+    return row ? toScheduledStatus(row) : null
   },
 
   async deleteScheduledStatus({ actorId, id }: DeleteScheduledStatusParams) {

--- a/lib/database/sql/scheduledStatus.ts
+++ b/lib/database/sql/scheduledStatus.ts
@@ -1,0 +1,132 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  CreateScheduledStatusParams,
+  DeleteScheduledStatusParams,
+  GetDueScheduledStatusesParams,
+  GetScheduledStatusParams,
+  GetScheduledStatusesParams,
+  ScheduledStatusData,
+  ScheduledStatusDatabase,
+  UpdateScheduledStatusAtParams
+} from '@/lib/types/database/operations'
+import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
+
+type SQLScheduledStatus = {
+  id: string
+  actorId: string
+  scheduledAt: number | Date | string
+  params: string
+  createdAt: number | Date | string
+  updatedAt: number | Date | string
+}
+
+const toScheduledStatus = (row: SQLScheduledStatus): ScheduledStatusData => ({
+  id: row.id,
+  actorId: row.actorId,
+  scheduledAt: getCompatibleTime(row.scheduledAt),
+  params: ScheduledStatusParams.parse(JSON.parse(row.params)),
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+export const ScheduledStatusSQLDatabaseMixin = (
+  database: Knex
+): ScheduledStatusDatabase => ({
+  async createScheduledStatus({
+    actorId,
+    scheduledAt,
+    params
+  }: CreateScheduledStatusParams) {
+    const currentTime = new Date()
+    const row = {
+      id: randomUUID(),
+      actorId,
+      scheduledAt: new Date(scheduledAt),
+      params: JSON.stringify(params),
+      createdAt: currentTime,
+      updatedAt: currentTime
+    }
+    await database('scheduled_statuses').insert(row)
+    return {
+      id: row.id,
+      actorId,
+      scheduledAt,
+      params,
+      createdAt: currentTime.getTime(),
+      updatedAt: currentTime.getTime()
+    }
+  },
+
+  async getScheduledStatuses({
+    actorId,
+    limit,
+    maxId,
+    minId,
+    sinceId
+  }: GetScheduledStatusesParams) {
+    const query = database<SQLScheduledStatus>('scheduled_statuses')
+      .where('actorId', actorId)
+      .limit(limit)
+
+    if (maxId) query.where('id', '<', maxId)
+    const newerCursorId = minId || sinceId
+    if (newerCursorId) query.where('id', '>', newerCursorId)
+
+    if (minId) {
+      query.orderBy('id', 'asc')
+    } else {
+      query.orderBy('id', 'desc')
+    }
+
+    const rows = await query
+    return (minId ? rows.reverse() : rows).map(toScheduledStatus)
+  },
+
+  async getScheduledStatus({ actorId, id }: GetScheduledStatusParams) {
+    const row = await database<SQLScheduledStatus>('scheduled_statuses')
+      .where({ actorId, id })
+      .first()
+    if (!row) return null
+    return toScheduledStatus(row)
+  },
+
+  async updateScheduledStatusAt({
+    actorId,
+    id,
+    scheduledAt
+  }: UpdateScheduledStatusAtParams) {
+    const existing = await database<SQLScheduledStatus>('scheduled_statuses')
+      .where({ actorId, id })
+      .first()
+    if (!existing) return null
+
+    const updatedAt = new Date()
+    await database('scheduled_statuses')
+      .where({ actorId, id })
+      .update({ scheduledAt: new Date(scheduledAt), updatedAt })
+
+    return {
+      ...toScheduledStatus(existing),
+      scheduledAt,
+      updatedAt: updatedAt.getTime()
+    }
+  },
+
+  async deleteScheduledStatus({ actorId, id }: DeleteScheduledStatusParams) {
+    const deleted = await database('scheduled_statuses')
+      .where({ actorId, id })
+      .delete()
+    return deleted > 0
+  },
+
+  async getDueScheduledStatuses({ before }: GetDueScheduledStatusesParams) {
+    const rows = await database<SQLScheduledStatus>('scheduled_statuses')
+      .where('scheduledAt', '<=', new Date(before))
+      .orderBy('scheduledAt', 'asc')
+      .orderBy('id', 'asc')
+    return rows.map(toScheduledStatus)
+  }
+})

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -28,6 +28,7 @@ import {
   OAuthDatabase,
   PushSubscriptionDatabase,
   ReportDatabase,
+  ScheduledStatusDatabase,
   SearchDatabase,
   ServerFilterDatabase,
   StatusDatabase,
@@ -64,6 +65,7 @@ export type Database = AccountDatabase &
   OAuthDatabase &
   PushSubscriptionDatabase &
   ReportDatabase &
+  ScheduledStatusDatabase &
   SearchDatabase &
   StatusDatabase &
   StatusMuteDatabase &

--- a/lib/jobs/index.ts
+++ b/lib/jobs/index.ts
@@ -25,6 +25,7 @@ import {
   IMPORT_STRAVA_ACTIVITY_JOB_NAME,
   IMPORT_STRAVA_ARCHIVE_JOB_NAME,
   PROCESS_FITNESS_FILE_JOB_NAME,
+  PUBLISH_SCHEDULED_STATUS_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
   SEND_ANNOUNCE_JOB_NAME,
   SEND_BLOCK_JOB_NAME,
@@ -37,6 +38,7 @@ import {
   UPDATE_POLL_JOB_NAME
 } from './names'
 import { processFitnessFileJob } from './processFitnessFileJob'
+import { publishScheduledStatusJob } from './publishScheduledStatusJob'
 import { regenerateFitnessMapsJob } from './regenerateFitnessMapsJob'
 import { sendAnnounceJob } from './sendAnnounceJob'
 import { sendBlockJob } from './sendBlockJob'
@@ -74,5 +76,6 @@ export const JOBS: Record<string, JobHandle> = {
   [SEND_UNDO_ANNOUNCE_JOB_NAME]: sendUndoAnnounceJob,
   [SEND_UNDO_FOLLOW_JOB_NAME]: sendUndoFollowJob,
   [SEND_UNBLOCK_JOB_NAME]: sendUnblockJob,
-  [FETCH_REMOTE_STATUS_JOB_NAME]: fetchRemoteStatusJob
+  [FETCH_REMOTE_STATUS_JOB_NAME]: fetchRemoteStatusJob,
+  [PUBLISH_SCHEDULED_STATUS_JOB_NAME]: publishScheduledStatusJob
 }

--- a/lib/jobs/names.ts
+++ b/lib/jobs/names.ts
@@ -22,3 +22,4 @@ export const GENERATE_FITNESS_HEATMAP_JOB_NAME = 'GenerateFitnessHeatmapJob'
 export const GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME =
   'GenerateFitnessRouteHeatmapJob'
 export const FETCH_REMOTE_STATUS_JOB_NAME = 'FetchRemoteStatusJob'
+export const PUBLISH_SCHEDULED_STATUS_JOB_NAME = 'PublishScheduledStatusJob'

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -91,6 +91,74 @@ describe('publishScheduledStatusJob', () => {
     expect(row).toBeNull()
   })
 
+  it('publishes a due scheduled poll and removes the scheduled row', async () => {
+    const text = `Due scheduled poll ${Date.now()}`
+    const options = ['Red', 'Green', 'Blue']
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({
+        text,
+        poll: {
+          options,
+          expires_in: 3600,
+          multiple: false,
+          hide_totals: false
+        }
+      })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-poll',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    const published = statuses.find((status) => status.text.includes(text))
+    expect(published).toBeDefined()
+    expect(published?.type).toBe('Poll')
+    const choices = (published as { choices: { title: string }[] }).choices
+    expect(choices.map((choice) => choice.title)).toEqual(options)
+
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
+  it('drops the scheduled row without re-publishing when the idempotency key already maps to a status', async () => {
+    const text = `Idempotent scheduled note ${Date.now()}`
+    const idempotency = `idem-${Date.now()}`
+    // Simulate a prior publish: the idempotency key already maps to a status.
+    await database.saveIdempotencyKey({
+      actorId: actor1.id,
+      key: idempotency,
+      statusId: `${actor1.id}/statuses/already-published`
+    })
+
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text, idempotency })
+    })
+
+    const before = await database.getActorStatuses({ actorId: actor1.id })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-idempotent',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    // No duplicate status was created for the deduped scheduled post.
+    const after = await database.getActorStatuses({ actorId: actor1.id })
+    expect(after).toHaveLength(before.length)
+    expect(after.some((status) => status.text.includes(text))).toBe(false)
+
+    // The scheduled row is cleaned up regardless.
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
   it('is a no-op for an unknown scheduled status id', async () => {
     await expect(
       publishScheduledStatusJob(database, {

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -225,9 +225,12 @@ describe('publishScheduledStatusJob', () => {
       data: { scheduledStatusId: scheduled.id }
     })
     expect(publishArgs.delaySeconds).toBeGreaterThan(60)
-    // The early re-enqueue folds scheduledAt into the dedup id, matching the
-    // create and reschedule enqueue sites.
+    // The early re-enqueue uses a distinct dedup id (suffixed `-reenqueue`) so
+    // QStash does not drop it as a duplicate of the original create enqueue.
     expect(publishArgs.id).toBe(
+      getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}-reenqueue`)
+    )
+    expect(publishArgs.id).not.toBe(
       getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`)
     )
 

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -191,6 +191,54 @@ describe('publishScheduledStatusJob', () => {
     expect(row).toBeNull()
   })
 
+  it('discards an obsolete job whose scheduledAt no longer matches the row', async () => {
+    const text = `Rescheduled away ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-obsolete',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      // A scheduledAt that does not match the stored row — this job is from a
+      // previous schedule and must be discarded without publishing.
+      data: {
+        scheduledStatusId: scheduled.id,
+        scheduledAt: Date.now() - 999_999
+      }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    expect(statuses.some((status) => status.text.includes(text))).toBe(false)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+    // The row is left intact for the current schedule's own job to publish.
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).not.toBeNull()
+  })
+
+  it('publishes when the job scheduledAt matches the row', async () => {
+    const text = `Matching schedule ${Date.now()}`
+    const scheduledAt = Date.now() - 1_000
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt,
+      params: baseParams({ text })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-matching',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id, scheduledAt }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    expect(statuses.some((status) => status.text.includes(text))).toBe(true)
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
   it('is a no-op for an unknown scheduled status id', async () => {
     await expect(
       publishScheduledStatusJob(database, {

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -8,6 +8,7 @@ import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
 import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from './names'
 
@@ -187,21 +188,82 @@ describe('publishScheduledStatusJob', () => {
 
     // Re-enqueued with the remaining delay, not published.
     expect(getQueue().publish).toHaveBeenCalledTimes(1)
-    expect(getQueue().publish).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-        data: { scheduledStatusId: scheduled.id },
-        delaySeconds: expect.any(Number)
-      })
+    const publishArgs = (getQueue().publish as jest.Mock).mock.calls[0][0]
+    expect(publishArgs).toMatchObject({
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+    expect(publishArgs.delaySeconds).toBeGreaterThan(60)
+    // The early re-enqueue folds scheduledAt into the dedup id, matching the
+    // create and reschedule enqueue sites.
+    expect(publishArgs.id).toBe(
+      getHashFromString(`${scheduled.id}-${scheduled.scheduledAt}`)
     )
-    const delaySeconds = (getQueue().publish as jest.Mock).mock.calls[0][0]
-      .delaySeconds
-    expect(delaySeconds).toBeGreaterThan(60)
 
     // No status was published and the scheduled row still exists.
     const statuses = await database.getActorStatuses({ actorId: actor1.id })
     expect(statuses.some((status) => status.text.includes(text))).toBe(false)
     const row = await database.getScheduledStatusById({ id: scheduled.id })
     expect(row).not.toBeNull()
+  })
+
+  it('drops the scheduled row without publishing when the actor no longer exists', async () => {
+    const scheduled = await database.createScheduledStatus({
+      actorId: 'https://llun.test/users/ghost-actor',
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text: `Orphan scheduled note ${Date.now()}` })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-actor-missing',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    expect(getQueue().publish).not.toHaveBeenCalled()
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
+  it('drops the scheduled row without publishing when the media can no longer be resolved', async () => {
+    const text = `Missing media scheduled note ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text, media_ids: ['999999999'] })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-media-missing',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    expect(statuses.some((status) => status.text.includes(text))).toBe(false)
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
+  it('drops the scheduled row without publishing when status creation returns null', async () => {
+    // A direct-visibility note with no resolvable mentions is unpublishable:
+    // createNoteFromUserInput returns null. The job must still clear the row.
+    const text = `Direct with no mentions ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text, visibility: 'direct' })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-null-status',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    expect(statuses.some((status) => status.text.includes(text))).toBe(false)
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
   })
 })

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -160,6 +160,37 @@ describe('publishScheduledStatusJob', () => {
     expect(row).toBeNull()
   })
 
+  it('is idempotent by default (no client key) using a row-derived key', async () => {
+    const text = `Default-idempotent scheduled note ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text, idempotency: null })
+    })
+    // Simulate a prior publish recorded under the row-derived fallback key
+    // (what the job saves when the client supplied no Idempotency-Key).
+    await database.saveIdempotencyKey({
+      actorId: actor1.id,
+      key: `scheduled-${scheduled.id}`,
+      statusId: `${actor1.id}/statuses/already-published-default`
+    })
+
+    const before = await database.getActorStatuses({ actorId: actor1.id })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-default-idempotent',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    // The retry did not publish a duplicate, and the row is cleaned up.
+    const after = await database.getActorStatuses({ actorId: actor1.id })
+    expect(after).toHaveLength(before.length)
+    expect(after.some((status) => status.text.includes(text))).toBe(false)
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
   it('is a no-op for an unknown scheduled status id', async () => {
     await expect(
       publishScheduledStatusJob(database, {

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -1,0 +1,139 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { publishScheduledStatusJob } from '@/lib/jobs/publishScheduledStatusJob'
+import { getQueue } from '@/lib/services/queue'
+import { mockRequests } from '@/lib/stub/activities'
+import { seedDatabase } from '@/lib/stub/database'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { Actor } from '@/lib/types/domain/actor'
+import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
+
+import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from './names'
+
+enableFetchMocks()
+
+jest.mock('@/lib/services/queue', () => ({
+  getQueue: jest.fn().mockReturnValue({
+    publish: jest.fn().mockResolvedValue(undefined)
+  })
+}))
+
+jest.mock('@/lib/services/timelines', () => ({
+  addStatusToTimelines: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('@/lib/services/notifications/sendNotificationAlerts', () => ({
+  sendNotificationAlerts: jest.fn()
+}))
+
+const baseParams = (
+  overrides: Partial<ScheduledStatusParams> = {}
+): ScheduledStatusParams => ({
+  text: 'Scheduled post',
+  poll: null,
+  media_ids: null,
+  sensitive: null,
+  spoiler_text: null,
+  visibility: 'public',
+  in_reply_to_id: null,
+  language: null,
+  application_id: null,
+  scheduled_at: null,
+  idempotency: null,
+  with_rate_limit: false,
+  ...overrides
+})
+
+describe('publishScheduledStatusJob', () => {
+  const database = getTestSQLDatabase()
+  let actor1: Actor
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    actor1 = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    fetchMock.resetMocks()
+    mockRequests(fetchMock)
+  })
+
+  it('publishes a due scheduled status and removes the scheduled row', async () => {
+    const text = `Due scheduled note ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({ text, visibility: 'unlisted' })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-due',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    const published = statuses.find((status) => status.text.includes(text))
+    expect(published).toBeDefined()
+    expect(published?.actorId).toBe(actor1.id)
+
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).toBeNull()
+  })
+
+  it('is a no-op for an unknown scheduled status id', async () => {
+    await expect(
+      publishScheduledStatusJob(database, {
+        id: 'job-missing',
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: 'does-not-exist' }
+      })
+    ).resolves.toBeUndefined()
+
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('re-enqueues without publishing when the scheduled time is still far ahead', async () => {
+    const text = `Future scheduled note ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() + 10 * 60 * 1000,
+      params: baseParams({ text })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-early',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    // Re-enqueued with the remaining delay, not published.
+    expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: scheduled.id },
+        delaySeconds: expect.any(Number)
+      })
+    )
+    const delaySeconds = (getQueue().publish as jest.Mock).mock.calls[0][0]
+      .delaySeconds
+    expect(delaySeconds).toBeGreaterThan(60)
+
+    // No status was published and the scheduled row still exists.
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    expect(statuses.some((status) => status.text.includes(text))).toBe(false)
+    const row = await database.getScheduledStatusById({ id: scheduled.id })
+    expect(row).not.toBeNull()
+  })
+})

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -45,7 +45,7 @@ export const publishScheduledStatusJob = createJobHandle(
     const remainingMs = row.scheduledAt - Date.now()
     if (remainingMs > EARLY_THRESHOLD_MS) {
       await getQueue().publish({
-        id: getHashFromString(row.id),
+        id: getHashFromString(`${row.id}-${row.scheduledAt}`),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
         data: { scheduledStatusId: row.id },
         delaySeconds: scheduledDelaySeconds(row.scheduledAt)

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -4,7 +4,9 @@ import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { createPollFromUserInput } from '@/lib/actions/createPoll'
 import { getQueue } from '@/lib/services/queue'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
+import { scheduledDelaySeconds } from '@/lib/services/statuses/scheduledStatusSerializer'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { logger } from '@/lib/utils/logger'
 
 import { createJobHandle } from './createJobHandle'
 import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from './names'
@@ -46,7 +48,7 @@ export const publishScheduledStatusJob = createJobHandle(
         id: getHashFromString(row.id),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
         data: { scheduledStatusId: row.id },
-        delaySeconds: Math.floor(remainingMs / 1000)
+        delaySeconds: scheduledDelaySeconds(row.scheduledAt)
       })
       return
     }
@@ -54,6 +56,10 @@ export const publishScheduledStatusJob = createJobHandle(
     const actor = await database.getActorFromId({ id: row.actorId })
     // Actor gone: drop the orphaned scheduled row, nothing to publish.
     if (!actor) {
+      logger.warn(
+        { scheduledStatusId: row.id, actorId: row.actorId },
+        'publishScheduledStatusJob: actor missing, dropping scheduled status'
+      )
       await database.deleteScheduledStatus({ id: row.id, actorId: row.actorId })
       return
     }
@@ -103,6 +109,10 @@ export const publishScheduledStatusJob = createJobHandle(
       // Media that no longer resolves (deleted before the status fired) aborts
       // the publish but still clears the row so it is not retried forever.
       if (!attachments) {
+        logger.warn(
+          { scheduledStatusId: row.id, actorId: row.actorId },
+          'publishScheduledStatusJob: media unresolved, dropping scheduled status'
+        )
         await database.deleteScheduledStatus({
           id: row.id,
           actorId: row.actorId
@@ -128,6 +138,13 @@ export const publishScheduledStatusJob = createJobHandle(
         key: idempotencyKey,
         statusId: status.id
       })
+    }
+
+    if (status) {
+      logger.info(
+        { statusId: status.id, scheduledStatusId: row.id },
+        'publishScheduledStatusJob: published scheduled status'
+      )
     }
 
     await database.deleteScheduledStatus({ id: row.id, actorId: row.actorId })

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod'
+
+import { createNoteFromUserInput } from '@/lib/actions/createNote'
+import { createPollFromUserInput } from '@/lib/actions/createPoll'
+import { getQueue } from '@/lib/services/queue'
+import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+
+import { createJobHandle } from './createJobHandle'
+import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from './names'
+
+// Publishes a stored scheduled status once its time arrives.
+//
+// Scheduling backends differ: QStash supports native message delays, so the
+// enqueue carries `delaySeconds` and QStash fires the job at the right time.
+// When QStash invokes the job the scheduled time has effectively arrived, so the
+// time guard below is false and the status publishes. If the job ever runs early
+// (clock skew, a manual replay), the >60s guard re-enqueues it with the
+// remaining delay instead of posting ahead of time. The in-process NoQueue has
+// no scheduler and drops delayed messages outright (see noqueue.ts), so under
+// NoQueue scheduled statuses do not auto-fire and this job never recurses.
+const PublishScheduledStatusData = z.object({
+  scheduledStatusId: z.string()
+})
+
+// A job that fires more than this far before the scheduled time is treated as
+// premature and re-enqueued instead of publishing.
+const EARLY_THRESHOLD_MS = 60_000
+
+export const publishScheduledStatusJob = createJobHandle(
+  PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+  async (database, message) => {
+    const parsed = PublishScheduledStatusData.safeParse(message.data)
+    if (!parsed.success) return
+
+    const { scheduledStatusId } = parsed.data
+    const row = await database.getScheduledStatusById({ id: scheduledStatusId })
+    // Already published or deleted: nothing to do.
+    if (!row) return
+
+    // Too early: re-enqueue with the remaining delay and skip publishing. This
+    // is the path the in-process NoQueue always takes (it ignores delays).
+    const remainingMs = row.scheduledAt - Date.now()
+    if (remainingMs > EARLY_THRESHOLD_MS) {
+      await getQueue().publish({
+        id: getHashFromString(row.id),
+        name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+        data: { scheduledStatusId: row.id },
+        delaySeconds: Math.floor(remainingMs / 1000)
+      })
+      return
+    }
+
+    const actor = await database.getActorFromId({ id: row.actorId })
+    // Actor gone: drop the orphaned scheduled row, nothing to publish.
+    if (!actor) {
+      await database.deleteScheduledStatus({ id: row.id, actorId: row.actorId })
+      return
+    }
+
+    const { params } = row
+    const idempotencyKey = params.idempotency?.trim() || null
+
+    // Honor the stored Idempotency-Key the same way the POST route does: a key
+    // that already maps to a status means this scheduled post was published
+    // already, so just clean up the row.
+    if (idempotencyKey) {
+      const existingStatusId = await database.getIdempotentStatusId({
+        actorId: row.actorId,
+        key: idempotencyKey
+      })
+      if (existingStatusId) {
+        await database.deleteScheduledStatus({
+          id: row.id,
+          actorId: row.actorId
+        })
+        return
+      }
+    }
+
+    let status
+    if (params.poll) {
+      status = await createPollFromUserInput({
+        text: params.text,
+        summary: params.spoiler_text ?? undefined,
+        replyStatusId: params.in_reply_to_id ?? undefined,
+        currentActor: actor,
+        choices: params.poll.options,
+        endAt: Date.now() + params.poll.expires_in * 1000,
+        pollType: params.poll.multiple ? 'anyOf' : 'oneOf',
+        visibility: params.visibility,
+        sensitive: params.sensitive ?? false,
+        language: params.language ?? null,
+        database
+      })
+    } else {
+      const mediaIds = params.media_ids ?? []
+      const attachments = await getAttachmentsFromMediaIds(
+        database,
+        actor,
+        mediaIds
+      )
+      // Media that no longer resolves (deleted before the status fired) aborts
+      // the publish but still clears the row so it is not retried forever.
+      if (!attachments) {
+        await database.deleteScheduledStatus({
+          id: row.id,
+          actorId: row.actorId
+        })
+        return
+      }
+      status = await createNoteFromUserInput({
+        currentActor: actor,
+        text: params.text,
+        summary: params.spoiler_text ?? undefined,
+        replyNoteId: params.in_reply_to_id ?? undefined,
+        visibility: params.visibility,
+        attachments,
+        sensitive: params.sensitive ?? false,
+        language: params.language ?? null,
+        database
+      })
+    }
+
+    if (status && idempotencyKey) {
+      await database.saveIdempotencyKey({
+        actorId: row.actorId,
+        key: idempotencyKey,
+        statusId: status.id
+      })
+    }
+
+    await database.deleteScheduledStatus({ id: row.id, actorId: row.actorId })
+  }
+)

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -44,8 +44,13 @@ export const publishScheduledStatusJob = createJobHandle(
     // is the path the in-process NoQueue always takes (it ignores delays).
     const remainingMs = row.scheduledAt - Date.now()
     if (remainingMs > EARLY_THRESHOLD_MS) {
+      // Use a distinct dedup id from the original create/reschedule enqueue
+      // (which is `${id}-${scheduledAt}`). QStash keeps the dedup window open
+      // for ~1h even after a message is consumed, so reusing the same id here
+      // would let QStash silently drop this re-enqueue and the status would
+      // never fire.
       await getQueue().publish({
-        id: getHashFromString(`${row.id}-${row.scheduledAt}`),
+        id: getHashFromString(`${row.id}-${row.scheduledAt}-reenqueue`),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
         data: { scheduledStatusId: row.id },
         delaySeconds: scheduledDelaySeconds(row.scheduledAt)

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -87,6 +87,15 @@ export const publishScheduledStatusJob = createJobHandle(
       return
     }
 
+    // Re-resolve the OAuth client stored at schedule time so the published
+    // status keeps the same "posted via …" application attribution.
+    const client = params.application_id
+      ? await database.getClientFromId({ clientId: params.application_id })
+      : null
+    const application = client?.name
+      ? { name: client.name, website: client.website ?? null }
+      : undefined
+
     let status
     if (params.poll) {
       status = await createPollFromUserInput({
@@ -100,6 +109,7 @@ export const publishScheduledStatusJob = createJobHandle(
         visibility: params.visibility,
         sensitive: params.sensitive ?? false,
         language: params.language ?? null,
+        application,
         database
       })
     } else {
@@ -131,6 +141,7 @@ export const publishScheduledStatusJob = createJobHandle(
         attachments,
         sensitive: params.sensitive ?? false,
         language: params.language ?? null,
+        application,
         database
       })
     }

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -65,23 +65,26 @@ export const publishScheduledStatusJob = createJobHandle(
     }
 
     const { params } = row
-    const idempotencyKey = params.idempotency?.trim() || null
+    // Fall back to a key derived from the row id when the client supplied no
+    // Idempotency-Key, so the job is idempotent by default: if it is retried
+    // after the status was created but before the row was deleted, the retry
+    // finds the existing mapping below and skips re-publishing rather than
+    // posting a duplicate.
+    const idempotencyKey = params.idempotency?.trim() || `scheduled-${row.id}`
 
-    // Honor the stored Idempotency-Key the same way the POST route does: a key
-    // that already maps to a status means this scheduled post was published
-    // already, so just clean up the row.
-    if (idempotencyKey) {
-      const existingStatusId = await database.getIdempotentStatusId({
-        actorId: row.actorId,
-        key: idempotencyKey
+    // Honor the Idempotency-Key the same way the POST route does: a key that
+    // already maps to a status means this scheduled post was published already,
+    // so just clean up the row.
+    const existingStatusId = await database.getIdempotentStatusId({
+      actorId: row.actorId,
+      key: idempotencyKey
+    })
+    if (existingStatusId) {
+      await database.deleteScheduledStatus({
+        id: row.id,
+        actorId: row.actorId
       })
-      if (existingStatusId) {
-        await database.deleteScheduledStatus({
-          id: row.id,
-          actorId: row.actorId
-        })
-        return
-      }
+      return
     }
 
     let status
@@ -132,7 +135,7 @@ export const publishScheduledStatusJob = createJobHandle(
       })
     }
 
-    if (status && idempotencyKey) {
+    if (status) {
       await database.saveIdempotencyKey({
         actorId: row.actorId,
         key: idempotencyKey,

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -22,7 +22,11 @@ import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from './names'
 // no scheduler and drops delayed messages outright (see noqueue.ts), so under
 // NoQueue scheduled statuses do not auto-fire and this job never recurses.
 const PublishScheduledStatusData = z.object({
-  scheduledStatusId: z.string()
+  scheduledStatusId: z.string(),
+  // The scheduledAt this job was enqueued for. When the row has since been
+  // rescheduled to a different time, the job is obsolete and discarded so a
+  // reschedule-to-later does not leave the old job racing the new one.
+  scheduledAt: z.number().optional()
 })
 
 // A job that fires more than this far before the scheduled time is treated as
@@ -35,10 +39,16 @@ export const publishScheduledStatusJob = createJobHandle(
     const parsed = PublishScheduledStatusData.safeParse(message.data)
     if (!parsed.success) return
 
-    const { scheduledStatusId } = parsed.data
+    const { scheduledStatusId, scheduledAt } = parsed.data
     const row = await database.getScheduledStatusById({ id: scheduledStatusId })
     // Already published or deleted: nothing to do.
     if (!row) return
+
+    // Obsolete job: the row was rescheduled to a different time after this job
+    // was enqueued. Discard it so a reschedule-to-later does not leave the old
+    // job (which would otherwise re-enqueue itself) racing the new one at the
+    // new time. The current schedule's own job still fires.
+    if (scheduledAt !== undefined && row.scheduledAt !== scheduledAt) return
 
     // Too early: re-enqueue with the remaining delay and skip publishing. This
     // is the path the in-process NoQueue always takes (it ignores delays).
@@ -48,11 +58,12 @@ export const publishScheduledStatusJob = createJobHandle(
       // (which is `${id}-${scheduledAt}`). QStash keeps the dedup window open
       // for ~1h even after a message is consumed, so reusing the same id here
       // would let QStash silently drop this re-enqueue and the status would
-      // never fire.
+      // never fire. The payload carries the current scheduledAt so the
+      // re-enqueued job stays valid against the obsolete-job check above.
       await getQueue().publish({
         id: getHashFromString(`${row.id}-${row.scheduledAt}-reenqueue`),
         name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
-        data: { scheduledStatusId: row.id },
+        data: { scheduledStatusId: row.id, scheduledAt: row.scheduledAt },
         delaySeconds: scheduledDelaySeconds(row.scheduledAt)
       })
       return

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -145,6 +145,14 @@ export const publishScheduledStatusJob = createJobHandle(
         { statusId: status.id, scheduledStatusId: row.id },
         'publishScheduledStatusJob: published scheduled status'
       )
+    } else {
+      // createNote/createPoll returns null for an unpublishable status (e.g. a
+      // direct-visibility post with no resolvable mentions). Drop the row like
+      // the other terminal cases, but warn so it is not lost silently.
+      logger.warn(
+        { scheduledStatusId: row.id, actorId: row.actorId },
+        'publishScheduledStatusJob: status creation returned null, dropping scheduled status'
+      )
     }
 
     await database.deleteScheduledStatus({ id: row.id, actorId: row.actorId })

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -9,3 +9,8 @@ export const MAX_POLL_OPTION_CHARS = 50
 // 5 minutes minimum, ~1 month maximum (seconds).
 export const MIN_POLL_EXPIRATION_SECONDS = 5 * 60
 export const MAX_POLL_EXPIRATION_SECONDS = 60 * 60 * 24 * 31
+
+// Mastodon rejects a scheduled_at less than five minutes in the future.
+export const MIN_SCHEDULED_STATUS_AHEAD_MS = 5 * 60 * 1000
+export const SCHEDULED_AT_TOO_SOON_ERROR =
+  'Validation failed: Scheduled at must be at least 5 minutes in the future'

--- a/lib/services/queue/noqueue.test.ts
+++ b/lib/services/queue/noqueue.test.ts
@@ -19,6 +19,19 @@ describe('NoQueue', () => {
       // Should not throw - it will try to run the job but won't find a handler
       await expect(queue.publish(message)).resolves.toBeUndefined()
     })
+
+    it('drops delayed messages instead of running them immediately', async () => {
+      const message: JobMessage = {
+        id: 'job-delayed',
+        name: 'testJob',
+        data: { key: 'value' },
+        delaySeconds: 600
+      }
+      const handle = jest.spyOn(queue, 'handle')
+
+      await expect(queue.publish(message)).resolves.toBeUndefined()
+      expect(handle).not.toHaveBeenCalled()
+    })
   })
 
   describe('handle', () => {

--- a/lib/services/queue/noqueue.ts
+++ b/lib/services/queue/noqueue.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/lib/utils/logger'
+
 import { defaultJobHandle } from './base'
 import { JobMessage, Queue } from './type'
 
@@ -9,7 +11,13 @@ export class NoQueue implements Queue {
     // ahead of time or, because the publish job re-enqueues itself while still
     // early, recurse forever. Without a real queue (QStash) or a cron driving
     // due rows, scheduled statuses simply do not auto-fire under NoQueue.
-    if (message.delaySeconds && message.delaySeconds > 0) return
+    if (message.delaySeconds && message.delaySeconds > 0) {
+      logger.warn(
+        { name: message.name, delaySeconds: message.delaySeconds },
+        'NoQueue: dropping delayed message; scheduled jobs do not auto-fire without a real queue'
+      )
+      return
+    }
     await this.handle(message)
   }
 

--- a/lib/services/queue/noqueue.ts
+++ b/lib/services/queue/noqueue.ts
@@ -3,6 +3,13 @@ import { JobMessage, Queue } from './type'
 
 export class NoQueue implements Queue {
   async publish(message: JobMessage) {
+    // NoQueue runs jobs in-process and has no scheduler, so it cannot honor a
+    // delay. A delayed message (e.g. the scheduled-status publish job) is
+    // dropped rather than run immediately: running it now would either publish
+    // ahead of time or, because the publish job re-enqueues itself while still
+    // early, recurse forever. Without a real queue (QStash) or a cron driving
+    // due rows, scheduled statuses simply do not auto-fire under NoQueue.
+    if (message.delaySeconds && message.delaySeconds > 0) return
     await this.handle(message)
   }
 

--- a/lib/services/queue/qstash.ts
+++ b/lib/services/queue/qstash.ts
@@ -37,7 +37,10 @@ export class QStashQueue implements Queue {
           body: message,
           timeout: MAX_JOB_TIMEOUT_SECONDS,
           retries: MAX_JOB_RETRIES,
-          deduplicationId: Buffer.from(message.id).toString('base64url')
+          deduplicationId: Buffer.from(message.id).toString('base64url'),
+          ...(message.delaySeconds && message.delaySeconds > 0
+            ? { delay: message.delaySeconds }
+            : {})
         })
       } catch (error) {
         const nodeError = error as NodeJS.ErrnoException

--- a/lib/services/queue/type.ts
+++ b/lib/services/queue/type.ts
@@ -6,7 +6,9 @@ export interface JobMessage {
   data: unknown
   verifiedSenderActorId?: string
   // Optional publish delay in seconds. QStash honors this natively; the
-  // in-process NoQueue ignores it and runs immediately.
+  // in-process NoQueue has no scheduler and DROPS any message with a positive
+  // delaySeconds, so delayed jobs (e.g. scheduled statuses) only fire under a
+  // real queue like QStash.
   delaySeconds?: number
 }
 

--- a/lib/services/queue/type.ts
+++ b/lib/services/queue/type.ts
@@ -5,6 +5,9 @@ export interface JobMessage {
   name: string
   data: unknown
   verifiedSenderActorId?: string
+  // Optional publish delay in seconds. QStash honors this natively; the
+  // in-process NoQueue ignores it and runs immediately.
+  delaySeconds?: number
 }
 
 export interface Queue {

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -8,7 +8,8 @@ const STATUS_STRING_FIELDS = [
   'in_reply_to_id',
   'spoiler_text',
   'visibility',
-  'language'
+  'language',
+  'scheduled_at'
 ] as const
 
 const MEDIA_ID_FIELDS = ['media_ids', 'media_ids[]'] as const

--- a/lib/services/statuses/scheduledStatusSerializer.test.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.test.ts
@@ -1,0 +1,50 @@
+import {
+  ScheduledStatusInput,
+  buildScheduledParams
+} from '@/lib/services/statuses/scheduledStatusSerializer'
+
+const baseNote = (
+  overrides: Partial<ScheduledStatusInput> = {}
+): ScheduledStatusInput => ({
+  status: 'Scheduled note',
+  sensitive: false,
+  media_ids: [],
+  ...overrides
+})
+
+describe('buildScheduledParams', () => {
+  it('defaults visibility to public when neither the note nor a default is provided', () => {
+    const params = buildScheduledParams(baseNote(), null)
+    expect(params.visibility).toBe('public')
+  })
+
+  it('falls back to the provided default privacy when the note omits visibility', () => {
+    const params = buildScheduledParams(baseNote(), null, 'private')
+    expect(params.visibility).toBe('private')
+  })
+
+  it('prefers the explicit note visibility over the default privacy', () => {
+    const params = buildScheduledParams(
+      baseNote({ visibility: 'unlisted' }),
+      null,
+      'private'
+    )
+    expect(params.visibility).toBe('unlisted')
+  })
+
+  it('de-duplicates media ids and stores an empty list as null', () => {
+    const withMedia = buildScheduledParams(
+      baseNote({ media_ids: ['1', '1', '2'] }),
+      null
+    )
+    expect(withMedia.media_ids).toEqual(['1', '2'])
+
+    const withoutMedia = buildScheduledParams(baseNote(), null)
+    expect(withoutMedia.media_ids).toBeNull()
+  })
+
+  it('carries the idempotency key through to params', () => {
+    const params = buildScheduledParams(baseNote(), 'idem-key-1')
+    expect(params.idempotency).toBe('idem-key-1')
+  })
+})

--- a/lib/services/statuses/scheduledStatusSerializer.test.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.test.ts
@@ -47,4 +47,12 @@ describe('buildScheduledParams', () => {
     const params = buildScheduledParams(baseNote(), 'idem-key-1')
     expect(params.idempotency).toBe('idem-key-1')
   })
+
+  it('stores the application id when provided and defaults it to null', () => {
+    const withApp = buildScheduledParams(baseNote(), null, 'public', 'client-1')
+    expect(withApp.application_id).toBe('client-1')
+
+    const withoutApp = buildScheduledParams(baseNote(), null)
+    expect(withoutApp.application_id).toBeNull()
+  })
 })

--- a/lib/services/statuses/scheduledStatusSerializer.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.ts
@@ -80,18 +80,25 @@ export const buildScheduledParams = (
 const hydrateMediaAttachments = async (
   database: Database,
   actorId: string,
-  mediaIds: string[]
+  mediaIds: string[],
+  accountId?: string
 ): Promise<MediaAttachment[]> => {
   if (mediaIds.length === 0) return []
 
-  const actor = await database.getActorFromId({ id: actorId })
-  const accountId = actor?.account?.id
-  if (!accountId) return []
+  // Callers that already hold the owning actor (the actor-scoped routes) pass
+  // its accountId so we skip the actor lookup — avoids an extra query per item
+  // when serializing a whole list page.
+  const resolvedAccountId =
+    accountId ?? (await database.getActorFromId({ id: actorId }))?.account?.id
+  if (!resolvedAccountId) return []
 
   const host = getConfig().host
   // Batch the lookup (single WHERE IN) instead of one query per id, then
   // re-order to match the stored media_ids and drop any that no longer resolve.
-  const found = await database.getMediaByIdsForAccount({ mediaIds, accountId })
+  const found = await database.getMediaByIdsForAccount({
+    mediaIds,
+    accountId: resolvedAccountId
+  })
   const byId = new Map(found.map((media) => [String(media.id), media]))
   const attachments: MediaAttachment[] = []
   for (const mediaId of mediaIds) {
@@ -106,12 +113,14 @@ const hydrateMediaAttachments = async (
 // hydrating media_attachments from the persisted params.media_ids.
 export const toMastodonScheduledStatus = async (
   database: Database,
-  scheduled: ScheduledStatusData
+  scheduled: ScheduledStatusData,
+  accountId?: string
 ): Promise<ScheduledStatus> => {
   const mediaAttachments = await hydrateMediaAttachments(
     database,
     scheduled.actorId,
-    scheduled.params.media_ids ?? []
+    scheduled.params.media_ids ?? [],
+    accountId
   )
 
   return ScheduledStatus.parse({

--- a/lib/services/statuses/scheduledStatusSerializer.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.ts
@@ -1,0 +1,105 @@
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
+import { ScheduledStatusData } from '@/lib/types/database/operations'
+import { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
+import {
+  ScheduledStatus,
+  ScheduledStatusParams
+} from '@/lib/types/mastodon/scheduledStatus'
+
+// The subset of the parsed `POST /api/v1/statuses` body the scheduled branch
+// needs to persist. Mirrors the route's NoteSchema output (after Zod defaults).
+export interface ScheduledStatusInput {
+  status: string
+  spoiler_text?: string
+  visibility?: 'public' | 'unlisted' | 'private' | 'direct'
+  language?: string
+  sensitive: boolean
+  in_reply_to_id?: string
+  media_ids: string[]
+  scheduled_at?: string
+  poll?: {
+    options: string[]
+    expires_in: number
+    multiple: boolean
+    hide_totals: boolean
+  }
+}
+
+// Builds the complete Mastodon `params` payload stored alongside a scheduled
+// status. Every key the ScheduledStatusParams schema requires is present;
+// absent client fields are normalised to null and `with_rate_limit` defaults to
+// false. media_ids are de-duplicated (matching the immediate-post path) and an
+// empty list is stored as null so the serializer can short-circuit hydration.
+export const buildScheduledParams = (
+  note: ScheduledStatusInput,
+  idempotencyKey: string | null
+): ScheduledStatusParams => {
+  const mediaIds = [...new Set(note.media_ids)]
+  return {
+    text: note.status,
+    poll: note.poll
+      ? {
+          options: note.poll.options,
+          expires_in: note.poll.expires_in,
+          multiple: note.poll.multiple,
+          hide_totals: note.poll.hide_totals
+        }
+      : null,
+    media_ids: mediaIds.length > 0 ? mediaIds : null,
+    sensitive: note.sensitive,
+    spoiler_text: note.spoiler_text ?? null,
+    visibility: note.visibility ?? 'public',
+    in_reply_to_id: note.in_reply_to_id ?? null,
+    language: note.language ?? null,
+    application_id: null,
+    scheduled_at: note.scheduled_at ?? null,
+    idempotency: idempotencyKey,
+    with_rate_limit: false
+  }
+}
+
+// Resolves the stored media ids to Mastodon MediaAttachment entities using the
+// same lookup + serializer the /api/v1/media routes use. Media that can no
+// longer be found (deleted before the scheduled status fires) is skipped.
+const hydrateMediaAttachments = async (
+  database: Database,
+  actorId: string,
+  mediaIds: string[]
+): Promise<MediaAttachment[]> => {
+  if (mediaIds.length === 0) return []
+
+  const actor = await database.getActorFromId({ id: actorId })
+  const accountId = actor?.account?.id
+  if (!accountId) return []
+
+  const host = getConfig().host
+  const attachments: MediaAttachment[] = []
+  for (const mediaId of mediaIds) {
+    const media = await database.getMediaByIdForAccount({ mediaId, accountId })
+    if (!media) continue
+    attachments.push(MediaAttachment.parse(getMediaAttachment(media, host)))
+  }
+  return attachments
+}
+
+// Maps a stored scheduled status row to the Mastodon ScheduledStatus entity,
+// hydrating media_attachments from the persisted params.media_ids.
+export const toMastodonScheduledStatus = async (
+  database: Database,
+  scheduled: ScheduledStatusData
+): Promise<ScheduledStatus> => {
+  const mediaAttachments = await hydrateMediaAttachments(
+    database,
+    scheduled.actorId,
+    scheduled.params.media_ids ?? []
+  )
+
+  return ScheduledStatus.parse({
+    id: scheduled.id,
+    scheduled_at: new Date(scheduled.scheduledAt).toISOString(),
+    params: scheduled.params,
+    media_attachments: mediaAttachments
+  })
+}

--- a/lib/services/statuses/scheduledStatusSerializer.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.ts
@@ -7,6 +7,7 @@ import {
   ScheduledStatus,
   ScheduledStatusParams
 } from '@/lib/types/mastodon/scheduledStatus'
+import { Visibility } from '@/lib/types/mastodon/visibility'
 
 // Seconds of delay between now and the scheduled time, floored and clamped at
 // zero. Shared by the enqueue sites (POST create, PUT reschedule) and the
@@ -38,9 +39,13 @@ export interface ScheduledStatusInput {
 // absent client fields are normalised to null and `with_rate_limit` defaults to
 // false. media_ids are de-duplicated (matching the immediate-post path) and an
 // empty list is stored as null so the serializer can short-circuit hydration.
+// When the client omits visibility, fall back to the actor's default privacy
+// (passed by the caller) so a scheduled status is stored — and later published
+// — with the user's configured visibility rather than always public.
 export const buildScheduledParams = (
   note: ScheduledStatusInput,
-  idempotencyKey: string | null
+  idempotencyKey: string | null,
+  defaultPrivacy: Visibility = 'public'
 ): ScheduledStatusParams => {
   const mediaIds = [...new Set(note.media_ids)]
   return {
@@ -56,7 +61,7 @@ export const buildScheduledParams = (
     media_ids: mediaIds.length > 0 ? mediaIds : null,
     sensitive: note.sensitive,
     spoiler_text: note.spoiler_text ?? null,
-    visibility: note.visibility ?? 'public',
+    visibility: note.visibility ?? defaultPrivacy,
     in_reply_to_id: note.in_reply_to_id ?? null,
     language: note.language ?? null,
     application_id: null,

--- a/lib/services/statuses/scheduledStatusSerializer.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.ts
@@ -42,10 +42,13 @@ export interface ScheduledStatusInput {
 // When the client omits visibility, fall back to the actor's default privacy
 // (passed by the caller) so a scheduled status is stored — and later published
 // — with the user's configured visibility rather than always public.
+// applicationId persists the OAuth client that scheduled the status so the
+// "posted via …" attribution survives to publish time.
 export const buildScheduledParams = (
   note: ScheduledStatusInput,
   idempotencyKey: string | null,
-  defaultPrivacy: Visibility = 'public'
+  defaultPrivacy: Visibility = 'public',
+  applicationId: string | null = null
 ): ScheduledStatusParams => {
   const mediaIds = [...new Set(note.media_ids)]
   return {
@@ -64,7 +67,7 @@ export const buildScheduledParams = (
     visibility: note.visibility ?? defaultPrivacy,
     in_reply_to_id: note.in_reply_to_id ?? null,
     language: note.language ?? null,
-    application_id: null,
+    application_id: applicationId,
     scheduled_at: note.scheduled_at ?? null,
     idempotency: idempotencyKey,
     with_rate_limit: false
@@ -86,9 +89,13 @@ const hydrateMediaAttachments = async (
   if (!accountId) return []
 
   const host = getConfig().host
+  // Batch the lookup (single WHERE IN) instead of one query per id, then
+  // re-order to match the stored media_ids and drop any that no longer resolve.
+  const found = await database.getMediaByIdsForAccount({ mediaIds, accountId })
+  const byId = new Map(found.map((media) => [String(media.id), media]))
   const attachments: MediaAttachment[] = []
   for (const mediaId of mediaIds) {
-    const media = await database.getMediaByIdForAccount({ mediaId, accountId })
+    const media = byId.get(String(mediaId))
     if (!media) continue
     attachments.push(MediaAttachment.parse(getMediaAttachment(media, host)))
   }

--- a/lib/services/statuses/scheduledStatusSerializer.ts
+++ b/lib/services/statuses/scheduledStatusSerializer.ts
@@ -8,6 +8,12 @@ import {
   ScheduledStatusParams
 } from '@/lib/types/mastodon/scheduledStatus'
 
+// Seconds of delay between now and the scheduled time, floored and clamped at
+// zero. Shared by the enqueue sites (POST create, PUT reschedule) and the
+// publish job's early re-enqueue so the delay is computed identically.
+export const scheduledDelaySeconds = (scheduledAt: number): number =>
+  Math.max(0, Math.floor((scheduledAt - Date.now()) / 1000))
+
 // The subset of the parsed `POST /api/v1/statuses` body the scheduled branch
 // needs to persist. Mirrors the route's NoteSchema output (after Zod defaults).
 export interface ScheduledStatusInput {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1399,6 +1399,69 @@ export interface FeaturedTagDatabase {
 }
 
 // ============================================================================
+// Scheduled Status Database
+// ============================================================================
+
+// A status an actor has scheduled for future publication. `params` is the
+// Mastodon "params" payload (text, visibility, media_ids, poll, …) stored as
+// JSON text; `scheduledAt`/`createdAt`/`updatedAt` are epoch milliseconds in
+// the domain shape regardless of the backend's timestamp storage.
+export type ScheduledStatusData = {
+  id: string
+  actorId: string
+  scheduledAt: number
+  params: Mastodon.ScheduledStatusParams
+  createdAt: number
+  updatedAt: number
+}
+
+export type CreateScheduledStatusParams = {
+  actorId: string
+  scheduledAt: number
+  params: Mastodon.ScheduledStatusParams
+}
+export type GetScheduledStatusesParams = {
+  actorId: string
+  limit: number
+  maxId?: string
+  minId?: string
+  sinceId?: string
+}
+export type GetScheduledStatusParams = { actorId: string; id: string }
+export type UpdateScheduledStatusAtParams = {
+  actorId: string
+  id: string
+  scheduledAt: number
+}
+export type DeleteScheduledStatusParams = { actorId: string; id: string }
+export type GetDueScheduledStatusesParams = { before: number }
+
+export interface ScheduledStatusDatabase {
+  createScheduledStatus(
+    params: CreateScheduledStatusParams
+  ): Promise<ScheduledStatusData>
+  // Owner-scoped list ordered by id for Mastodon's scheduled_statuses cursor
+  // pagination (maxId/minId/sinceId keyset on the id).
+  getScheduledStatuses(
+    params: GetScheduledStatusesParams
+  ): Promise<ScheduledStatusData[]>
+  getScheduledStatus(
+    params: GetScheduledStatusParams
+  ): Promise<ScheduledStatusData | null>
+  // Reschedule; returns the updated row or null when not found/owned.
+  updateScheduledStatusAt(
+    params: UpdateScheduledStatusAtParams
+  ): Promise<ScheduledStatusData | null>
+  // Owner-scoped delete; true when a row was removed.
+  deleteScheduledStatus(params: DeleteScheduledStatusParams): Promise<boolean>
+  // Rows due for publication (scheduledAt <= before) across all actors, for the
+  // background publish job.
+  getDueScheduledStatuses(
+    params: GetDueScheduledStatusesParams
+  ): Promise<ScheduledStatusData[]>
+}
+
+// ============================================================================
 // Report Database
 // ============================================================================
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1435,7 +1435,12 @@ export type UpdateScheduledStatusAtParams = {
   scheduledAt: number
 }
 export type DeleteScheduledStatusParams = { actorId: string; id: string }
-export type GetDueScheduledStatusesParams = { before: number }
+export type GetDueScheduledStatusesParams = {
+  before: number
+  // Optional cap so a future cron poller can drain due rows in bounded batches
+  // rather than loading every overdue scheduled status into memory at once.
+  limit?: number
+}
 
 export interface ScheduledStatusDatabase {
   createScheduledStatus(

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1976,6 +1976,10 @@ export type GetMediaByIdParams = {
   mediaId: string
   accountId: string
 }
+export type GetMediaByIdsForAccountParams = {
+  mediaIds: string[]
+  accountId: string
+}
 export type UpdateMediaParams = {
   mediaId: string
   accountId: string
@@ -2014,6 +2018,9 @@ export interface MediaDatabase {
     params: GetMediasForAccountParams
   ): Promise<PaginatedMediaWithStatus>
   getMediaByIdForAccount(params: GetMediaByIdParams): Promise<Media | null>
+  getMediaByIdsForAccount(
+    params: GetMediaByIdsForAccountParams
+  ): Promise<Media[]>
   updateMedia(params: UpdateMediaParams): Promise<UpdateMediaResult | null>
   getStorageUsageForAccount(
     params: GetStorageUsageForAccountParams

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1428,6 +1428,7 @@ export type GetScheduledStatusesParams = {
   sinceId?: string
 }
 export type GetScheduledStatusParams = { actorId: string; id: string }
+export type GetScheduledStatusByIdParams = { id: string }
 export type UpdateScheduledStatusAtParams = {
   actorId: string
   id: string
@@ -1447,6 +1448,11 @@ export interface ScheduledStatusDatabase {
   ): Promise<ScheduledStatusData[]>
   getScheduledStatus(
     params: GetScheduledStatusParams
+  ): Promise<ScheduledStatusData | null>
+  // Owner-agnostic lookup by id, for the background publish job which only
+  // carries the scheduled status id.
+  getScheduledStatusById(
+    params: GetScheduledStatusByIdParams
   ): Promise<ScheduledStatusData | null>
   // Reschedule; returns the updated row or null when not found/owned.
   updateScheduledStatusAt(

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1446,8 +1446,9 @@ export interface ScheduledStatusDatabase {
   createScheduledStatus(
     params: CreateScheduledStatusParams
   ): Promise<ScheduledStatusData>
-  // Owner-scoped list ordered by id for Mastodon's scheduled_statuses cursor
-  // pagination (maxId/minId/sinceId keyset on the id).
+  // Owner-scoped list ordered by scheduledAt descending (id as a stable
+  // tiebreaker) for Mastodon's scheduled_statuses cursor pagination — the
+  // maxId/minId/sinceId cursors keyset on scheduledAt + id.
   getScheduledStatuses(
     params: GetScheduledStatusesParams
   ): Promise<ScheduledStatusData[]>

--- a/lib/types/mastodon/index.ts
+++ b/lib/types/mastodon/index.ts
@@ -14,6 +14,7 @@ export * from './tag'
 export * from './marker'
 export * from './list'
 export * from './report'
+export * from './scheduledStatus'
 
 export * from './filter/index'
 export * from './filter/keyword'

--- a/lib/types/mastodon/scheduledStatus.ts
+++ b/lib/types/mastodon/scheduledStatus.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+
+import { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
+
+export const ScheduledStatusParams = z.object({
+  text: z.string(),
+  poll: z
+    .object({
+      options: z.string().array(),
+      expires_in: z.number(),
+      multiple: z.boolean(),
+      hide_totals: z.boolean()
+    })
+    .nullable(),
+  media_ids: z.string().array().nullable(),
+  sensitive: z.boolean().nullable(),
+  spoiler_text: z.string().nullable(),
+  visibility: z.enum(['public', 'unlisted', 'private', 'direct']),
+  in_reply_to_id: z.string().nullable(),
+  language: z.string().nullable(),
+  application_id: z.string().nullable(),
+  scheduled_at: z.string().nullable(),
+  idempotency: z.string().nullable(),
+  with_rate_limit: z.boolean()
+})
+export type ScheduledStatusParams = z.infer<typeof ScheduledStatusParams>
+
+export const ScheduledStatus = z.object({
+  id: z.string(),
+  scheduled_at: z.string(),
+  params: ScheduledStatusParams,
+  media_attachments: MediaAttachment.array()
+})
+export type ScheduledStatus = z.infer<typeof ScheduledStatus>

--- a/migrations/20260611042432_add_scheduled_statuses.js
+++ b/migrations/20260611042432_add_scheduled_statuses.js
@@ -1,0 +1,36 @@
+/**
+ * Stores statuses an actor has scheduled for future publication (Mastodon's
+ * "scheduled statuses"). Backs the REST endpoints (GET /api/v1/scheduled_statuses,
+ * GET/PUT/DELETE /scheduled_statuses/:id) and the background publish job that
+ * promotes a row into a real status once `scheduledAt` is due.
+ *
+ * `params` is the serialized Mastodon "params" payload (text, spoiler_text,
+ * visibility, sensitive, language, in_reply_to_id, media_ids, poll,
+ * idempotency, application_id) stored as JSON text so it works on both
+ * SQLite and Postgres. `actorId` is indexed for owner-scoped listing and
+ * `scheduledAt` for the due-query the publish job runs across all actors.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.createTable('scheduled_statuses', (table) => {
+    table.string('id').primary()
+    table.string('actorId').notNullable().index()
+    table.timestamp('scheduledAt').notNullable().index()
+    // Serialized Mastodon "params" payload: text, spoiler_text, visibility,
+    // sensitive, language, in_reply_to_id, media_ids, poll, idempotency,
+    // application_id.
+    table.text('params').notNullable()
+    table.timestamp('createdAt').notNullable()
+    table.timestamp('updatedAt').notNullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('scheduled_statuses')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -700,6 +700,15 @@ CREATE TABLE public.reports (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.scheduled_statuses (
+    id character varying(255) NOT NULL,
+    "actorId" character varying(255) NOT NULL,
+    "scheduledAt" timestamp with time zone NOT NULL,
+    params text NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL
+);
+
 CREATE TABLE public.search_documents (
     id character varying(320) NOT NULL,
     "entityType" character varying(32) NOT NULL,
@@ -1133,6 +1142,9 @@ ALTER TABLE ONLY public.recipients
 ALTER TABLE ONLY public.reports
     ADD CONSTRAINT reports_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY public.scheduled_statuses
+    ADD CONSTRAINT scheduled_statuses_pkey PRIMARY KEY (id);
+
 ALTER TABLE ONLY public.search_documents
     ADD CONSTRAINT search_documents_pkey PRIMARY KEY (id);
 
@@ -1317,6 +1329,10 @@ CREATE INDEX recipients_type_actor_created_status_idx ON public.recipients USING
 CREATE INDEX reports_actor_created ON public.reports USING btree ("actorId", "createdAt");
 
 CREATE INDEX reports_target ON public.reports USING btree ("targetActorId");
+
+CREATE INDEX scheduled_statuses_actorid_index ON public.scheduled_statuses USING btree ("actorId");
+
+CREATE INDEX scheduled_statuses_scheduledat_index ON public.scheduled_statuses USING btree ("scheduledAt");
 
 CREATE INDEX search_documents_actor ON public.search_documents USING btree ("actorId");
 

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -202,3 +202,6 @@ CREATE INDEX `server_filters_created` on `server_filters` (`createdAt`);
 CREATE TABLE `server_filter_keywords` (`id` varchar(255), `filterId` varchar(255) not null, `keyword` text not null, `wholeWord` boolean not null default '0', `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
 CREATE UNIQUE INDEX `server_filter_keywords_filter_keyword_unique` on `server_filter_keywords` (`filterId`, `keyword`);
 CREATE INDEX `server_filter_keywords_filter_id` on `server_filter_keywords` (`filterId`);
+CREATE TABLE `scheduled_statuses` (`id` varchar(255), `actorId` varchar(255) not null, `scheduledAt` datetime not null, `params` text not null, `createdAt` datetime not null, `updatedAt` datetime not null, primary key (`id`));
+CREATE INDEX `scheduled_statuses_actorid_index` on `scheduled_statuses` (`actorId`);
+CREATE INDEX `scheduled_statuses_scheduledat_index` on `scheduled_statuses` (`scheduledAt`);


### PR DESCRIPTION
## Summary

Phase 4 (final) of the Mastodon API compatibility plan — real storage and publishing for **scheduled statuses**, replacing the previous empty stubs. Branches off current `main`.

## Changes

- **Storage.** New migration creates a `scheduled_statuses` table (indexed `actorId` + `scheduledAt`, JSON `params`). New `lib/database/sql/scheduledStatus.ts` provides create / get-by-id / get (actor-scoped) / list / update-scheduled-at / delete / get-due. New Mastodon `ScheduledStatus` / `ScheduledStatusParams` zod types.
- **`POST /api/v1/statuses` accepts `scheduled_at`.** When the time is ≥5 minutes ahead, the request stores a scheduled status (no real status is created) and returns a `ScheduledStatus`; <5 min or unparseable → 422. Media is validated *before* storing, so a scheduled status never references nonexistent media.
- **CRUD endpoints.** The four `scheduled_statuses` stub handlers are replaced with real ones: `GET` (list, Link-header pagination), `GET /:id`, `PUT /:id` (reschedule, ≥5 min), `DELETE /:id` — all actor-scoped, with the existing scopes (`read:statuses` / `write:statuses`).
- **Publish job.** `publishScheduledStatusJob` publishes a scheduled status when its time arrives (reconstructing the note/poll from stored params, resolving media, honoring the stored idempotency key, then deleting the row). It is enqueued with a delay on create and re-enqueued on reschedule. The queue message type gains an optional `delaySeconds` threaded into QStash's native `publishJSON({ delay })`; existing jobs are unaffected.

## Notable design decision — in-process `NoQueue`

The in-process `NoQueue` runs jobs **synchronously**, so a delayed, self-re-enqueuing job would recurse forever. `NoQueue` therefore **drops** messages carrying a positive `delaySeconds` (with a `logger.warn`). Consequence: scheduled statuses fire at their scheduled time under a real queue (QStash) but do **not** auto-publish under `NoQueue` (local dev / queue-less deployments) — storage and CRUD still work, and nothing crashes. `getDueScheduledStatuses` is provided for a future cron poller to close that gap. This is documented at the drop site, in the job, and in both routes.

## Migration & schema dumps

Adds `migrations/20260611042432_add_scheduled_statuses.js` (working `up`/`down`). **Both** reference dumps regenerated against fresh local databases (Postgres 17 via Docker + SQLite); each diff is exactly the new `scheduled_statuses` table + its two indexes.

## Testing

- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors (13 pre-existing warnings)
- `yarn build` — typechecks and succeeds; both `scheduled_statuses` routes present in the manifest
- `yarn test` — 467 suites / 3958 tests pass

Implemented test-first with spec + code-quality review per task (storage, routes, job). The job's three cases (due → publish + delete, missing row → no-op, early → re-enqueue) plus poll and idempotency paths are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
