### PR TITLE
minor: make email addresses case-insensitive across the stack

### DIFF
--- a/app/(nosidebar)/auth/signin/CredentialForm.tsx
+++ b/app/(nosidebar)/auth/signin/CredentialForm.tsx
@@ -54,7 +54,9 @@ export const CredentialForm: FC<Props> = ({ providerName }) => {
 
     try {
       const result = await authClient.signIn.email({
-        email,
+        // Emails are stored and looked up case-insensitively; normalize here so
+        // the sign-in lookup matches regardless of how the user typed it.
+        email: email.trim().toLowerCase(),
         password
       })
       if (result.error) {

--- a/app/(nosidebar)/auth/signin/CredentialForm.tsx
+++ b/app/(nosidebar)/auth/signin/CredentialForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import { Label } from '@/lib/components/ui/label'
 import { authClient } from '@/lib/services/auth/auth-client'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
 interface Props {
   providerName: string
@@ -54,9 +55,10 @@ export const CredentialForm: FC<Props> = ({ providerName }) => {
 
     try {
       const result = await authClient.signIn.email({
-        // Emails are stored and looked up case-insensitively; normalize here so
-        // the sign-in lookup matches regardless of how the user typed it.
-        email: email.trim().toLowerCase(),
+        // Emails are stored and looked up case-insensitively; normalize through
+        // the shared primitive so the sign-in lookup matches regardless of how
+        // the user typed it (and never drifts from server-side normalization).
+        email: normalizeEmail(email),
         password
       })
       if (result.error) {

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -143,4 +143,53 @@ describe('POST /api/v1/accounts/email', () => {
     expect(response.status).toBe(422)
     expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
   })
+
+  it('normalizes the requested new email to lowercase before storing it', async () => {
+    const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
+      method: 'POST',
+      body: JSON.stringify({ newEmail: 'New.Address@LLUN.test' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://llun.test'
+      }
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    expect(mockDb.requestEmailChange).toHaveBeenCalledWith(
+      expect.objectContaining({ newEmail: 'new.address@llun.test' })
+    )
+  })
+
+  it('rejects changing to a differently-cased address owned by another account', async () => {
+    // The session resolves to account-1; the requested new address (once
+    // normalized) already belongs to account-2, so the change is rejected.
+    mockDb.getAccountFromEmail.mockImplementation(
+      async ({ email }: { email: string }) =>
+        email.toLowerCase() === seedActor1.email.toLowerCase()
+          ? account
+          : { ...account, id: 'account-2', email: email.toLowerCase() }
+    )
+
+    const request = new NextRequest('http://llun.test/api/v1/accounts/email', {
+      method: 'POST',
+      body: JSON.stringify({ newEmail: 'Taken@LLUN.test' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://llun.test'
+      }
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email already in use'
+    })
+    expect(mockDb.getAccountFromEmail).toHaveBeenCalledWith({
+      email: 'taken@llun.test'
+    })
+    expect(mockDb.requestEmailChange).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/accounts/email/route.ts
+++ b/app/api/v1/accounts/email/route.ts
@@ -13,7 +13,9 @@ import {
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const EmailChangeRequest = z.object({
-  newEmail: z.string().email()
+  // Normalized to lowercase so the "already in use" check and the stored
+  // pending email compare against the canonical form. See normalizeEmail.
+  newEmail: z.string().trim().toLowerCase().email().max(255)
 })
 
 export const POST = traceApiRoute(

--- a/app/api/v1/accounts/password/reset/request/route.ts
+++ b/app/api/v1/accounts/password/reset/request/route.ts
@@ -16,7 +16,11 @@ import {
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
-const PasswordResetRequest = z.object({ email: z.string().email() })
+const PasswordResetRequest = z.object({
+  // Normalized to lowercase so the reset lookup matches the canonical stored
+  // email regardless of how it was typed. See normalizeEmail.
+  email: z.string().trim().toLowerCase().email().max(255)
+})
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 const SUCCESS_MESSAGE =

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -263,6 +263,28 @@ describe('POST /api/v1/accounts (web form / non-bearer)', () => {
     expect(res.status).toBe(307)
     expect(res.headers.get('location')).toContain('/auth/signin')
   })
+
+  it('lowercases the submitted email via the schema before registering', async () => {
+    jest.mocked(registerAccount).mockResolvedValueOnce({
+      type: 'success',
+      accountId: 'new-account-id',
+      username: 'alice',
+      actorId: 'https://llun.test/users/alice'
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts', {
+      method: 'POST',
+      body: 'username=alice&email=Alice.Example@Example.COM&password=password123',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'text/html'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(307)
+    expect(registerAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'alice.example@example.com' })
+    )
+  })
 })
 
 describe('POST /api/v1/accounts with a Bearer app token', () => {

--- a/app/api/v1/accounts/types.ts
+++ b/app/api/v1/accounts/types.ts
@@ -11,7 +11,10 @@ export const CreateAccountRequest = z.object({
       message: 'Username is reserved'
     }),
   name: z.string().trim().max(255).optional(),
-  email: z.string().email().trim().max(255),
+  // Normalized to lowercase so casing never creates duplicate accounts or
+  // desyncs from case-insensitive lookups. Trim first, then lowercase, then
+  // validate format/length on the canonical value.
+  email: z.string().trim().toLowerCase().email().max(255),
   password: z.string().min(8).trim()
 })
 export type CreateAccountRequest = z.infer<typeof CreateAccountRequest>

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -192,6 +192,45 @@ describe('POST /api/v1/emails/confirmations', () => {
     )
   })
 
+  it('normalizes a mixed-case new email param to lowercase before updating', async () => {
+    const response = await POST(
+      makeRequest({ email: '  New-Email@LLUN.test ' }),
+      {
+        params: Promise.resolve({})
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDb.isAccountExists).toHaveBeenCalledWith({
+      email: 'new-email@llun.test'
+    })
+    expect(mockDb.updateAccountEmail).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      email: 'new-email@llun.test'
+    })
+    const [mailArgs] = mockSendMail.mock.calls
+    expect(mailArgs[0].to).toEqual(['new-email@llun.test'])
+  })
+
+  it('allows a new email whose case differs from the allow-list entry', async () => {
+    mockGetConfig.mockReturnValue({
+      host: 'llun.test',
+      allowEmails: [seedActor1.email, 'Allowed@LLUN.test'],
+      allowActorDomains: [],
+      email: { serviceFromAddress: 'noreply@llun.test' }
+    })
+
+    const response = await POST(makeRequest({ email: 'allowed@llun.test' }), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDb.updateAccountEmail).toHaveBeenCalledWith({
+      accountId: 'account-1',
+      email: 'allowed@llun.test'
+    })
+  })
+
   it('returns 403 when the new email is not on the server allow-list', async () => {
     // The signed-in address stays on the allow-list (so auth still resolves the
     // actor); only the requested new address is absent from it.

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -19,6 +19,7 @@ import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
+import { isEmailAllowed } from '@/lib/utils/normalizeEmail'
 import { HTTP_STATUS, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
@@ -31,7 +32,9 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 // `.max(255)` matches the accounts.email column width so an over-long address
 // fails validation here rather than at the DB insert (a 500).
 const ConfirmationRequest = z.object({
-  email: z.string().email().max(255).optional()
+  // Normalized to lowercase so the allow-list check, the duplicate-email check,
+  // and the stored address all use the canonical form. See normalizeEmail.
+  email: z.string().trim().toLowerCase().email().max(255).optional()
 })
 
 // Scope write:accounts (satisfied by aggregate `write`), matching the other
@@ -107,7 +110,7 @@ export const POST = traceApiRoute(
         // Honor the server's allow-list so the email param can't be used to
         // sidestep the same restriction enforced at registration.
         const { allowEmails } = getConfig()
-        if (allowEmails.length && !allowEmails.includes(newEmail)) {
+        if (!isEmailAllowed(allowEmails, newEmail)) {
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -10,6 +10,7 @@ import { ResendConfig } from '@/lib/services/email/resend'
 import { SESConfig } from '@/lib/services/email/ses'
 import { SMTPConfig } from '@/lib/services/email/smtp'
 import { logger } from '@/lib/utils/logger'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
 import { AuthConfig, getAuthConfig } from './auth'
 import { getDatabaseConfig } from './database'
@@ -36,7 +37,14 @@ const Config = z.object({
   database: z.custom<Knex.Config>(),
   queue: QueueConfig.optional(),
   push: PushConfig.optional(),
-  allowEmails: z.string().array(),
+  // Normalized to lowercase once on load so the `allowEmails` gate is
+  // case-insensitive without each call site having to re-normalize the config
+  // side. Input emails are normalized at their entry points too. See
+  // `lib/utils/normalizeEmail.ts` and `isEmailAllowed`.
+  allowEmails: z
+    .string()
+    .array()
+    .transform((emails) => emails.map(normalizeEmail)),
   registrationOpen: z.boolean().default(true),
   secretPhase: z.string(),
   allowMediaDomains: z.string().array().optional(),

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -454,6 +454,31 @@ describe('AccountDatabase', () => {
           await database.validatePasswordResetCode({ passwordResetCode })
         ).toBe(accountId)
       })
+
+      it('rejects an email-change verification when the pending address was claimed by another account', async () => {
+        const { accountId } = await createTestAccount()
+        const { email: takenEmail } = await createTestAccount()
+        const emailChangeCode = `change-${crypto.randomUUID()}`
+
+        // Account requests a change to an address that another account then
+        // ends up owning (here it already exists, simulating the race).
+        await database.requestEmailChange({
+          accountId,
+          newEmail: takenEmail.toUpperCase(),
+          emailChangeCode
+        })
+
+        const result = await database.verifyEmailChange({
+          accountId,
+          emailChangeCode
+        })
+
+        // Gracefully rejected rather than throwing the unique-constraint 500.
+        expect(result).toBeNull()
+        // The original account keeps its own email (no partial promotion).
+        const account = await database.getAccountFromId({ id: accountId })
+        expect(account?.email).not.toEqual(takenEmail)
+      })
     })
 
     describe('account providers', () => {

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -351,6 +351,83 @@ describe('AccountDatabase', () => {
         })
         expect(await database.getAccountSession({ token })).toBeNull()
       })
+
+      it('stores account email lowercased even when created with mixed case', async () => {
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const username = `mixed-${suffix}`
+        const mixedEmail = `Mixed.${suffix}@${TEST_DOMAIN}`
+        const accountId = await database.createAccount({
+          email: mixedEmail,
+          username,
+          passwordHash: TEST_PASSWORD_HASH,
+          domain: TEST_DOMAIN,
+          privateKey: `privateKey-${suffix}`,
+          publicKey: `publicKey-${suffix}`
+        })
+
+        const account = await database.getAccountFromId({ id: accountId })
+        expect(account?.email).toEqual(mixedEmail.toLowerCase())
+      })
+
+      it.each<{ description: string; casing: (email: string) => string }>([
+        { description: 'the exact lowercase form', casing: (email) => email },
+        {
+          description: 'an uppercase form',
+          casing: (email) => email.toUpperCase()
+        },
+        {
+          description: 'a mixed-case form',
+          casing: (email) =>
+            email
+              .split('')
+              .map((c, i) => (i % 2 === 0 ? c.toUpperCase() : c))
+              .join('')
+        },
+        {
+          description: 'a form with surrounding whitespace',
+          casing: (email) => `  ${email.toUpperCase()}  `
+        }
+      ])(
+        'looks up an account case-insensitively by $description',
+        async ({ casing }) => {
+          const { accountId, email } = await createTestAccount()
+
+          expect(
+            await database.isAccountExists({ email: casing(email) })
+          ).toBeTrue()
+          const found = await database.getAccountFromEmail({
+            email: casing(email)
+          })
+          expect(found?.id).toEqual(accountId)
+        }
+      )
+
+      it('normalizes the pending email on request and promotes it lowercased on verify', async () => {
+        const { accountId } = await createTestAccount()
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const newEmail = `New.${suffix}@${TEST_DOMAIN}`
+        const emailChangeCode = `change-${crypto.randomUUID()}`
+
+        await database.requestEmailChange({
+          accountId,
+          newEmail,
+          emailChangeCode
+        })
+
+        const pending = await database.getAccountFromId({ id: accountId })
+        expect(pending?.emailChangePending).toEqual(newEmail.toLowerCase())
+
+        const updated = await database.verifyEmailChange({
+          accountId,
+          emailChangeCode
+        })
+        expect(updated?.email).toEqual(newEmail.toLowerCase())
+        // The promoted address is now resolvable regardless of casing.
+        const found = await database.getAccountFromEmail({
+          email: newEmail.toUpperCase()
+        })
+        expect(found?.id).toEqual(accountId)
+      })
     })
 
     describe('account providers', () => {

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -428,6 +428,32 @@ describe('AccountDatabase', () => {
         })
         expect(found?.id).toEqual(accountId)
       })
+
+      it('stores a lowercased email when updateAccountEmail is given mixed case', async () => {
+        const { accountId } = await createTestAccount()
+        const suffix = crypto.randomUUID().slice(0, 8)
+        const newEmail = `Updated.${suffix}@${TEST_DOMAIN}`
+
+        await database.updateAccountEmail({ accountId, email: newEmail })
+
+        const account = await database.getAccountFromId({ id: accountId })
+        expect(account?.email).toEqual(newEmail.toLowerCase())
+      })
+
+      it('finds the account for a password reset regardless of the requested casing', async () => {
+        const { accountId, email } = await createTestAccount()
+        const passwordResetCode = `reset-${crypto.randomUUID()}`
+
+        const requested = await database.requestPasswordReset({
+          email: email.toUpperCase(),
+          passwordResetCode
+        })
+
+        expect(requested).toBeTrue()
+        expect(
+          await database.validatePasswordResetCode({ passwordResetCode })
+        ).toBe(accountId)
+      })
     })
 
     describe('account providers', () => {

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -53,11 +53,16 @@ import {
   getLocalActorInboxId,
   getLocalActorSharedInboxId
 } from '@/lib/utils/activitypubId'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
+// Emails are normalized (trimmed + lowercased) inside every method that stores
+// or looks up by email so storage and lookup can never disagree on casing. This
+// is the most robust place for it — it cannot be bypassed by a caller that
+// forgets to normalize first. See `lib/utils/normalizeEmail.ts`.
 export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
   async isAccountExists({ email }: IsAccountExistsParams) {
     const result = await database('accounts')
-      .where('email', email)
+      .where('email', normalizeEmail(email))
       .count<{ count: string }>('id as count')
       .first()
     return parseInt(result?.count ?? '0', 10) > 0
@@ -82,6 +87,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
     privateKey,
     publicKey
   }: CreateAccountParams) {
+    const normalizedEmail = normalizeEmail(email)
     const accountId = crypto.randomUUID()
     const actorId = getLocalActorId({ domain, username })
     const currentTime = new Date()
@@ -107,7 +113,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
     await database.transaction(async (trx) => {
       await trx('accounts').insert({
         id: accountId,
-        email,
+        email: normalizedEmail,
         name: name || null,
         passwordHash,
         ...(verificationCode
@@ -183,7 +189,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
     email
   }: GetAccountFromEmailParams): Promise<Account | null> {
     const account = await database<SQLAccount>('accounts')
-      .where('email', email)
+      .where('email', normalizeEmail(email))
       .first()
     if (!account) return null
     return toDomainAccount(account)
@@ -515,12 +521,14 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
     const currentTime = new Date()
     const expiresAt = new Date(currentTime.getTime() + 24 * 60 * 60 * 1000) // 24 hours
 
-    await database('accounts').where('id', accountId).update({
-      emailChangePending: newEmail,
-      emailChangeCode,
-      emailChangeCodeExpiresAt: expiresAt,
-      updatedAt: currentTime
-    })
+    await database('accounts')
+      .where('id', accountId)
+      .update({
+        emailChangePending: normalizeEmail(newEmail),
+        emailChangeCode,
+        emailChangeCodeExpiresAt: expiresAt,
+        updatedAt: currentTime
+      })
   },
 
   async verifyEmailChange({
@@ -555,14 +563,18 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       return null
     }
 
-    await database('accounts').where('id', account.id).update({
-      email: pendingEmail,
-      emailVerifiedAt: now,
-      emailChangePending: null,
-      emailChangeCode: null,
-      emailChangeCodeExpiresAt: null,
-      updatedAt: now
-    })
+    await database('accounts')
+      .where('id', account.id)
+      .update({
+        // `emailChangePending` is stored already-normalized; normalize again when
+        // promoting it so the canonical `email` column can never drift.
+        email: normalizeEmail(pendingEmail),
+        emailVerifiedAt: now,
+        emailChangePending: null,
+        emailChangeCode: null,
+        emailChangeCodeExpiresAt: null,
+        updatedAt: now
+      })
 
     return this.getAccountFromId({ id: account.id })
   },
@@ -574,7 +586,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
     expiresAt
   }: RequestPasswordResetParams): Promise<boolean> {
     const account = await database<SQLAccount>('accounts')
-      .where('email', email)
+      .where('email', normalizeEmail(email))
       .first()
     if (!account) return false
 
@@ -691,7 +703,7 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
   }: UpdateAccountEmailParams): Promise<void> {
     const currentTime = new Date()
     await database('accounts').where('id', accountId).update({
-      email,
+      email: normalizeEmail(email),
       updatedAt: currentTime
     })
   },

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -702,10 +702,12 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
     email
   }: UpdateAccountEmailParams): Promise<void> {
     const currentTime = new Date()
-    await database('accounts').where('id', accountId).update({
-      email: normalizeEmail(email),
-      updatedAt: currentTime
-    })
+    await database('accounts')
+      .where('id', accountId)
+      .update({
+        email: normalizeEmail(email),
+        updatedAt: currentTime
+      })
   },
 
   async updateAccountName({

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -10,6 +10,7 @@ import {
 import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { toDomainAccount } from '@/lib/database/sql/utils/toDomainAccount'
 import {
   AccountDatabase,
@@ -563,18 +564,36 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       return null
     }
 
-    await database('accounts')
-      .where('id', account.id)
-      .update({
-        // `emailChangePending` is stored already-normalized; normalize again when
-        // promoting it so the canonical `email` column can never drift.
-        email: normalizeEmail(pendingEmail),
+    // `emailChangePending` is stored already-normalized; normalize again when
+    // promoting it so the canonical `email` column can never drift.
+    const normalizedEmail = normalizeEmail(pendingEmail)
+
+    // The pending address may have been claimed by another account between the
+    // change request and this verification. Reject gracefully — callers map a
+    // null result to an "invalid or expired" response — instead of letting the
+    // unique-email constraint surface as a 500.
+    const conflicting = await database('accounts')
+      .where('email', normalizedEmail)
+      .whereNot('id', account.id)
+      .first('id')
+    if (conflicting) return null
+
+    try {
+      await database('accounts').where('id', account.id).update({
+        email: normalizedEmail,
         emailVerifiedAt: now,
         emailChangePending: null,
         emailChangeCode: null,
         emailChangeCodeExpiresAt: null,
         updatedAt: now
       })
+    } catch (error) {
+      // Pre-check covers the common case; a concurrent claim can still race onto
+      // the unique constraint between the check and the update. Map that to the
+      // same graceful null rather than a 500.
+      if (isUniqueConstraintError(error)) return null
+      throw error
+    }
 
     return this.getAccountFromId({ id: account.id })
   },

--- a/lib/database/sql/lowercaseAccountEmailsMigration.test.ts
+++ b/lib/database/sql/lowercaseAccountEmailsMigration.test.ts
@@ -1,0 +1,119 @@
+import knex, { Knex } from 'knex'
+
+import * as migration from '@/migrations/20260611090000_lowercase_account_emails'
+
+describe('lowercase account emails migration', () => {
+  let database: Knex
+
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+
+    await database.schema.createTable('accounts', (table) => {
+      table.string('id').primary()
+      table.string('email').unique()
+      table.string('emailChangePending')
+    })
+  })
+
+  afterEach(async () => {
+    await database.destroy()
+  })
+
+  it('lowercases mixed-case email and emailChangePending while leaving canonical rows untouched', async () => {
+    await database('accounts').insert([
+      {
+        id: '1',
+        email: 'Alice@Example.com',
+        emailChangePending: 'Pending@Example.com'
+      },
+      { id: '2', email: 'bob@example.com', emailChangePending: null },
+      { id: '3', email: '  Carol@Example.COM  ', emailChangePending: null }
+    ])
+
+    await migration.up(database)
+
+    const rows = await database('accounts').orderBy('id')
+    expect(rows).toEqual([
+      {
+        id: '1',
+        email: 'alice@example.com',
+        emailChangePending: 'pending@example.com'
+      },
+      { id: '2', email: 'bob@example.com', emailChangePending: null },
+      { id: '3', email: 'carol@example.com', emailChangePending: null }
+    ])
+  })
+
+  it('skips rows whose email is null', async () => {
+    await database('accounts').insert({
+      id: '1',
+      email: null,
+      emailChangePending: 'Pending@Example.com'
+    })
+
+    await migration.up(database)
+
+    const row = await database('accounts').where('id', '1').first()
+    expect(row).toEqual({
+      id: '1',
+      email: null,
+      emailChangePending: 'pending@example.com'
+    })
+  })
+
+  it('normalizes every row across the keyset-pagination chunk boundary', async () => {
+    const rows = Array.from({ length: 1200 }, (_, i) => {
+      const pad = String(i).padStart(4, '0')
+      return {
+        id: `id-${pad}`,
+        // Alternate casing so most rows actually need rewriting.
+        email:
+          i % 2 === 0 ? `User${pad}@Example.COM` : `user${pad}@example.com`,
+        emailChangePending: null
+      }
+    })
+    await database.batchInsert('accounts', rows, 200)
+
+    await migration.up(database)
+
+    const notLowercased = await database('accounts')
+      .whereRaw('email <> lower(email)')
+      .count<{ count: string | number }>('* as count')
+      .first()
+    const total = await database('accounts')
+      .count<{ count: string | number }>('* as count')
+      .first()
+    expect(Number(notLowercased?.count ?? 0)).toBe(0)
+    expect(Number(total?.count ?? 0)).toBe(1200)
+  })
+
+  it('fails loudly and writes nothing when two emails collide once lowercased', async () => {
+    await database('accounts').insert([
+      { id: '1', email: 'User@Example.com', emailChangePending: null },
+      { id: '2', email: 'user@example.com', emailChangePending: null }
+    ])
+
+    await expect(migration.up(database)).rejects.toThrow(
+      /collide once normalized to lowercase/
+    )
+
+    // The error message lists both colliding originals.
+    await expect(migration.up(database)).rejects.toThrow(/User@Example\.com/)
+
+    // The transaction rolled back: the mixed-case row is unchanged (not
+    // lowercased, not merged/deleted).
+    const rows = await database('accounts').orderBy('id')
+    expect(rows).toEqual([
+      { id: '1', email: 'User@Example.com', emailChangePending: null },
+      { id: '2', email: 'user@example.com', emailChangePending: null }
+    ])
+  })
+
+  it('has an irreversible no-op down that does not throw', async () => {
+    await expect(migration.down(database)).resolves.toBeUndefined()
+  })
+})

--- a/lib/database/sql/lowercaseAccountEmailsMigration.test.ts
+++ b/lib/database/sql/lowercaseAccountEmailsMigration.test.ts
@@ -113,6 +113,28 @@ describe('lowercase account emails migration', () => {
     ])
   })
 
+  it('still fails loudly when a non-ASCII casing collision slips past the SQL lower() pre-check', async () => {
+    // SQLite's lower() is ASCII-only, so these two rows are NOT grouped by the
+    // SQL pre-check, but JS normalizeEmail folds both to the same address. The
+    // Pass 2 UPDATE must catch the resulting UNIQUE violation and re-raise the
+    // friendly collision error rather than an opaque DB error — and write
+    // nothing.
+    await database('accounts').insert([
+      { id: '1', email: 'CafÉ@example.com', emailChangePending: null },
+      { id: '2', email: 'café@example.com', emailChangePending: null }
+    ])
+
+    await expect(migration.up(database)).rejects.toThrow(
+      /collide once normalized to lowercase/
+    )
+
+    const rows = await database('accounts').orderBy('id')
+    expect(rows).toEqual([
+      { id: '1', email: 'CafÉ@example.com', emailChangePending: null },
+      { id: '2', email: 'café@example.com', emailChangePending: null }
+    ])
+  })
+
   it('has an irreversible no-op down that does not throw', async () => {
     await expect(migration.down(database)).resolves.toBeUndefined()
   })

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -344,6 +344,65 @@ describe('registerAccount', () => {
     ).rejects.toThrow('connection reset')
   })
 
+  it('matches the allow-list case-insensitively when the entry differs in case', async () => {
+    jest.mocked(getConfig).mockReturnValue({
+      host: 'llun.test',
+      allowEmails: ['Allowed@Example.com'],
+      registrationOpen: true,
+      secretPhase: 'test-secret-phase-for-unit-tests-only',
+      email: null
+    } as never)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'allowed@example.COM',
+      password: 'password123'
+    })
+
+    expect(result.type).toBe('success')
+    expect(mockDatabase.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'allowed@example.com' })
+    )
+  })
+
+  it('blocks an email not on the allow-list regardless of case', async () => {
+    jest.mocked(getConfig).mockReturnValue({
+      host: 'llun.test',
+      allowEmails: ['allowed@example.com'],
+      registrationOpen: true,
+      secretPhase: 'test-secret-phase-for-unit-tests-only',
+      email: null
+    } as never)
+
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: 'NotAllowed@Example.com',
+      password: 'password123'
+    })
+
+    expect(result).toEqual({ type: 'email_not_allowed' })
+    expect(mockDatabase.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('normalizes a mixed-case email to lowercase before the existence checks and insert', async () => {
+    const result = await registerAccount({
+      database: mockDatabase as unknown as Database,
+      username: 'alice',
+      email: '  Alice.Example@Example.COM ',
+      password: 'password123'
+    })
+
+    expect(result.type).toBe('success')
+    expect(mockDatabase.isAccountExists).toHaveBeenCalledWith({
+      email: 'alice.example@example.com'
+    })
+    expect(mockDatabase.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'alice.example@example.com' })
+    )
+  })
+
   it('still returns success if email sending fails', async () => {
     jest.mocked(getConfig).mockReturnValue({
       host: 'llun.test',

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -7,6 +7,7 @@ import { Database } from '@/lib/database/types'
 import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
 import { getLocalActorId } from '@/lib/utils/activitypubId'
 import { logger } from '@/lib/utils/logger'
+import { isEmailAllowed, normalizeEmail } from '@/lib/utils/normalizeEmail'
 import { generateKeyPair } from '@/lib/utils/signature'
 
 const BCRYPT_ROUND = 10
@@ -31,7 +32,7 @@ export interface RegisterAccountParams {
 export const registerAccount = async ({
   database,
   username,
-  email,
+  email: rawEmail,
   password,
   name
 }: RegisterAccountParams): Promise<RegisterAccountResult> => {
@@ -41,9 +42,14 @@ export const registerAccount = async ({
     return { type: 'registration_closed' }
   }
 
+  // Normalize once at the service boundary so the allow-list check, the
+  // existence pre-checks, the DB insert, and the confirmation email all see the
+  // same canonical (lowercased) address — even when this service is called
+  // directly rather than through the request schema. See normalizeEmail.
+  const email = normalizeEmail(rawEmail)
   const { host: domain, allowEmails } = config
 
-  if (allowEmails.length && !allowEmails.includes(email)) {
+  if (!isEmailAllowed(allowEmails, email)) {
     return { type: 'email_not_allowed' }
   }
 

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -879,4 +879,90 @@ describe('knexAdapter', () => {
       })
     })
   })
+
+  // Better-auth resolves sign-in/sign-up by email through this adapter against
+  // the `accounts` (user) table, so the adapter must normalize `accounts.email`
+  // on both writes and lookups to keep auth case-insensitive.
+  describe('accounts email normalization', () => {
+    let accountsDb: Knex
+    let accountsAdapter: ReturnType<ReturnType<typeof knexAdapter>>
+
+    beforeAll(async () => {
+      accountsDb = knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: { filename: ':memory:' }
+      })
+      await accountsDb.schema.createTable('accounts', (table) => {
+        table.text('id').primary()
+        table.text('email').unique()
+        table.text('name')
+      })
+      accountsAdapter = knexAdapter(accountsDb)({} as never)
+    })
+
+    afterAll(async () => {
+      await accountsDb.destroy()
+    })
+
+    beforeEach(async () => {
+      await accountsDb('accounts').delete()
+    })
+
+    it('lowercases the email when creating an account', async () => {
+      await accountsAdapter.create({
+        model: 'accounts',
+        data: { id: 'a1', email: 'User.Name@Example.COM' }
+      })
+      const row = await accountsDb('accounts').where('id', 'a1').first()
+      expect(row.email).toBe('user.name@example.com')
+    })
+
+    it.each([
+      { description: 'an uppercase eq lookup', value: 'USER@EXAMPLE.COM' },
+      { description: 'a mixed-case eq lookup', value: 'User@Example.com' }
+    ])('finds an account by $description', async ({ value }) => {
+      await accountsDb('accounts').insert({
+        id: 'a1',
+        email: 'user@example.com'
+      })
+      const result = await accountsAdapter.findOne({
+        model: 'accounts',
+        where: [{ field: 'email', value, operator: 'eq' as const }]
+      })
+      expect(result).toMatchObject({ id: 'a1' })
+    })
+
+    it('normalizes each entry of an IN lookup on email', async () => {
+      await accountsDb('accounts').insert({
+        id: 'a1',
+        email: 'user@example.com'
+      })
+      const results = await accountsAdapter.findMany({
+        model: 'accounts',
+        where: [
+          {
+            field: 'email',
+            value: ['Missing@Example.com', 'USER@EXAMPLE.COM'],
+            operator: 'in' as const
+          }
+        ]
+      })
+      expect(results.map((r: any) => r.id)).toEqual(['a1'])
+    })
+
+    it('lowercases the email when updating an account', async () => {
+      await accountsDb('accounts').insert({
+        id: 'a1',
+        email: 'user@example.com'
+      })
+      await accountsAdapter.update({
+        model: 'accounts',
+        where: [{ field: 'id', value: 'a1', operator: 'eq' as const }],
+        update: { email: 'New.Address@Example.COM' }
+      })
+      const row = await accountsDb('accounts').where('id', 'a1').first()
+      expect(row.email).toBe('new.address@example.com')
+    })
+  })
 })

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -964,5 +964,19 @@ describe('knexAdapter', () => {
       const row = await accountsDb('accounts').where('id', 'a1').first()
       expect(row.email).toBe('new.address@example.com')
     })
+
+    it('lowercases the email when updating many accounts', async () => {
+      await accountsDb('accounts').insert({
+        id: 'a1',
+        email: 'user@example.com'
+      })
+      await accountsAdapter.updateMany({
+        model: 'accounts',
+        where: [{ field: 'id', value: 'a1', operator: 'eq' as const }],
+        update: { email: 'Bulk.Update@Example.COM' }
+      })
+      const row = await accountsDb('accounts').where('id', 'a1').first()
+      expect(row.email).toBe('bulk.update@example.com')
+    })
   })
 })

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -35,15 +35,18 @@ const normalizeWhereValue = (value: unknown): unknown => {
 
 // Lowercase `accounts.email` in any record being inserted/updated so writes
 // going through better-auth (social/OAuth sign-up, email updates) store the
-// canonical form.
+// canonical form. Returns a NEW object when normalization applies rather than
+// mutating the caller's data — better-auth owns these objects and may rely on
+// reference stability, so we never mutate them in place.
 const normalizeEmailInData = (
   tableName: string,
   data: Record<string, unknown>
-): void => {
-  if (tableName !== ACCOUNTS_TABLE) return
+): Record<string, unknown> => {
+  if (tableName !== ACCOUNTS_TABLE) return data
   if (typeof data[EMAIL_FIELD] === 'string') {
-    data[EMAIL_FIELD] = normalizeEmail(data[EMAIL_FIELD] as string)
+    return { ...data, [EMAIL_FIELD]: normalizeEmail(data[EMAIL_FIELD]) }
   }
+  return data
 }
 
 const supportsNativeBooleans = (db: Knex): boolean => {
@@ -201,8 +204,10 @@ export const knexAdapter = (db: Knex) =>
       return {
         async create({ data, model }) {
           const tableName = getModelName(model)
-          const record = data as Record<string, unknown>
-          normalizeEmailInData(tableName, record)
+          const record = normalizeEmailInData(
+            tableName,
+            data as Record<string, unknown>
+          )
           const id = record.id as string
 
           if (model === 'session' || tableName === 'sessions') {
@@ -283,8 +288,10 @@ export const knexAdapter = (db: Knex) =>
           const existing = await idQuery
           if (!existing) return null
           const id = existing.id
-          const update = updateData as Record<string, unknown>
-          normalizeEmailInData(tableName, update)
+          const update = normalizeEmailInData(
+            tableName,
+            updateData as Record<string, unknown>
+          )
           await db(tableName).where(`${tableName}.id`, id).update(update)
           const row = await db(tableName).where(`${tableName}.id`, id).first()
           return row ? (hydrateDateFields(row) as any) : null
@@ -296,8 +303,10 @@ export const knexAdapter = (db: Knex) =>
           if (where) {
             query = applyWhere(query, tableName, where)
           }
-          const update = updateData as Record<string, unknown>
-          normalizeEmailInData(tableName, update)
+          const update = normalizeEmailInData(
+            tableName,
+            updateData as Record<string, unknown>
+          )
           const result = await query.update(update)
           return result
         },

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -43,12 +43,13 @@ const normalizeEmailInData = (
   data: Record<string, unknown>
 ): Record<string, unknown> => {
   // Guard the better-auth boundary: only touch `accounts` rows that are real
-  // objects, so a malformed/primitive payload is passed through untouched
-  // rather than throwing on property access.
+  // (non-array) objects, so a malformed/primitive/array payload is passed
+  // through untouched rather than risking unexpected property access.
   if (
     tableName !== ACCOUNTS_TABLE ||
     typeof data !== 'object' ||
-    data === null
+    data === null ||
+    Array.isArray(data)
   ) {
     return data
   }

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -3,9 +3,47 @@ import { Knex } from 'knex'
 
 import { recordWeeklyLoginSafely } from '@/lib/database/sql/instanceActivity'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
 const escapeLikeValue = (value: unknown): string => {
   return String(value).replace(/[%_\\]/g, '\\$&')
+}
+
+// The `accounts` table holds better-auth's user records; `email` is the only
+// email column it manages here. Better-auth resolves sign-in/sign-up by `email`
+// through this adapter (it does NOT route through the SQL account methods), so
+// normalization must also happen here to keep auth lookups and writes
+// case-insensitive and consistent with stored values.
+const ACCOUNTS_TABLE = 'accounts'
+const EMAIL_FIELD = 'email'
+
+const isAccountsEmail = (tableName: string, field: string): boolean =>
+  tableName === ACCOUNTS_TABLE && field === EMAIL_FIELD
+
+// Lowercase the value(s) of an `accounts.email` where-clause so exact-match
+// lookups (and IN lists) hit the canonical stored form regardless of how the
+// email was typed.
+const normalizeWhereValue = (value: unknown): unknown => {
+  if (typeof value === 'string') return normalizeEmail(value)
+  if (Array.isArray(value)) {
+    return value.map((entry) =>
+      typeof entry === 'string' ? normalizeEmail(entry) : entry
+    )
+  }
+  return value
+}
+
+// Lowercase `accounts.email` in any record being inserted/updated so writes
+// going through better-auth (social/OAuth sign-up, email updates) store the
+// canonical form.
+const normalizeEmailInData = (
+  tableName: string,
+  data: Record<string, unknown>
+): void => {
+  if (tableName !== ACCOUNTS_TABLE) return
+  if (typeof data[EMAIL_FIELD] === 'string') {
+    data[EMAIL_FIELD] = normalizeEmail(data[EMAIL_FIELD] as string)
+  }
 }
 
 const supportsNativeBooleans = (db: Knex): boolean => {
@@ -71,7 +109,14 @@ const applyWhere = (
   where: CleanedWhere[]
 ) => {
   for (const clause of where) {
-    const { field, value, operator, connector } = clause
+    const { field, operator, connector } = clause
+    // Normalizing only changes string/string[] email values to lowercase, which
+    // preserves the original value type — cast back so knex's overloads resolve.
+    const value = (
+      isAccountsEmail(model, field)
+        ? normalizeWhereValue(clause.value)
+        : clause.value
+    ) as typeof clause.value
     const method = connector === 'OR' ? 'orWhere' : 'where'
 
     switch (operator) {
@@ -157,6 +202,7 @@ export const knexAdapter = (db: Knex) =>
         async create({ data, model }) {
           const tableName = getModelName(model)
           const record = data as Record<string, unknown>
+          normalizeEmailInData(tableName, record)
           const id = record.id as string
 
           if (model === 'session' || tableName === 'sessions') {
@@ -237,9 +283,9 @@ export const knexAdapter = (db: Knex) =>
           const existing = await idQuery
           if (!existing) return null
           const id = existing.id
-          await db(tableName)
-            .where(`${tableName}.id`, id)
-            .update(updateData as Record<string, unknown>)
+          const update = updateData as Record<string, unknown>
+          normalizeEmailInData(tableName, update)
+          await db(tableName).where(`${tableName}.id`, id).update(update)
           const row = await db(tableName).where(`${tableName}.id`, id).first()
           return row ? (hydrateDateFields(row) as any) : null
         },
@@ -250,9 +296,9 @@ export const knexAdapter = (db: Knex) =>
           if (where) {
             query = applyWhere(query, tableName, where)
           }
-          const result = await query.update(
-            updateData as Record<string, unknown>
-          )
+          const update = updateData as Record<string, unknown>
+          normalizeEmailInData(tableName, update)
+          const result = await query.update(update)
           return result
         },
 

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -42,7 +42,16 @@ const normalizeEmailInData = (
   tableName: string,
   data: Record<string, unknown>
 ): Record<string, unknown> => {
-  if (tableName !== ACCOUNTS_TABLE) return data
+  // Guard the better-auth boundary: only touch `accounts` rows that are real
+  // objects, so a malformed/primitive payload is passed through untouched
+  // rather than throwing on property access.
+  if (
+    tableName !== ACCOUNTS_TABLE ||
+    typeof data !== 'object' ||
+    data === null
+  ) {
+    return data
+  }
   if (typeof data[EMAIL_FIELD] === 'string') {
     return { ...data, [EMAIL_FIELD]: normalizeEmail(data[EMAIL_FIELD]) }
   }
@@ -108,7 +117,7 @@ const getSessionCreatedAt = (record: Record<string, unknown>): Date => {
 
 const applyWhere = (
   query: Knex.QueryBuilder,
-  model: string,
+  tableName: string,
   where: CleanedWhere[]
 ) => {
   for (const clause of where) {
@@ -116,7 +125,7 @@ const applyWhere = (
     // Normalizing only changes string/string[] email values to lowercase, which
     // preserves the original value type — cast back so knex's overloads resolve.
     const value = (
-      isAccountsEmail(model, field)
+      isAccountsEmail(tableName, field)
         ? normalizeWhereValue(clause.value)
         : clause.value
     ) as typeof clause.value
@@ -124,32 +133,32 @@ const applyWhere = (
 
     switch (operator) {
       case 'eq':
-        query = query[method](`${model}.${field}`, '=', value)
+        query = query[method](`${tableName}.${field}`, '=', value)
         break
       case 'ne':
-        query = query[method](`${model}.${field}`, '<>', value)
+        query = query[method](`${tableName}.${field}`, '<>', value)
         break
       case 'gt':
-        query = query[method](`${model}.${field}`, '>', value)
+        query = query[method](`${tableName}.${field}`, '>', value)
         break
       case 'gte':
-        query = query[method](`${model}.${field}`, '>=', value)
+        query = query[method](`${tableName}.${field}`, '>=', value)
         break
       case 'lt':
-        query = query[method](`${model}.${field}`, '<', value)
+        query = query[method](`${tableName}.${field}`, '<', value)
         break
       case 'lte':
-        query = query[method](`${model}.${field}`, '<=', value)
+        query = query[method](`${tableName}.${field}`, '<=', value)
         break
       case 'in':
         query = query[method === 'orWhere' ? 'orWhereIn' : 'whereIn'](
-          `${model}.${field}`,
+          `${tableName}.${field}`,
           Array.isArray(value) ? value : [value]
         )
         break
       case 'not_in':
         query = query[method === 'orWhere' ? 'orWhereNotIn' : 'whereNotIn'](
-          `${model}.${field}`,
+          `${tableName}.${field}`,
           Array.isArray(value) ? value : [value]
         )
         break
@@ -157,7 +166,7 @@ const applyWhere = (
         const escaped = escapeLikeValue(value)
         const rawMethod = connector === 'OR' ? 'orWhereRaw' : 'whereRaw'
         query = query[rawMethod]("?? like ? escape '\\'", [
-          `${model}.${field}`,
+          `${tableName}.${field}`,
           `%${escaped}%`
         ])
         break
@@ -166,7 +175,7 @@ const applyWhere = (
         const escaped = escapeLikeValue(value)
         const rawMethod = connector === 'OR' ? 'orWhereRaw' : 'whereRaw'
         query = query[rawMethod]("?? like ? escape '\\'", [
-          `${model}.${field}`,
+          `${tableName}.${field}`,
           `${escaped}%`
         ])
         break
@@ -175,7 +184,7 @@ const applyWhere = (
         const escaped = escapeLikeValue(value)
         const rawMethod = connector === 'OR' ? 'orWhereRaw' : 'whereRaw'
         query = query[rawMethod]("?? like ? escape '\\'", [
-          `${model}.${field}`,
+          `${tableName}.${field}`,
           `%${escaped}`
         ])
         break

--- a/lib/utils/getActorFromSession.test.ts
+++ b/lib/utils/getActorFromSession.test.ts
@@ -1,0 +1,83 @@
+import { getConfig } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { getAccountFromSession } from '@/lib/utils/getActorFromSession'
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn()
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({ get: () => undefined })
+}))
+
+const account = { id: 'account-1', email: 'user@example.com' }
+
+const databaseWith = (getAccountFromEmail: jest.Mock) =>
+  ({ getAccountFromEmail }) as unknown as Database
+
+const mockConfig = (allowEmails: string[]) => {
+  jest.mocked(getConfig).mockReturnValue({ allowEmails } as never)
+}
+
+describe('getAccountFromSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns null when there is no signed-in email', async () => {
+    mockConfig([])
+    const getAccountFromEmail = jest.fn()
+    const result = await getAccountFromSession(
+      databaseWith(getAccountFromEmail),
+      null
+    )
+    expect(result).toBeNull()
+    expect(getAccountFromEmail).not.toHaveBeenCalled()
+  })
+
+  it('allows any signed-in email when the allowlist is empty', async () => {
+    mockConfig([])
+    const getAccountFromEmail = jest.fn().mockResolvedValue(account)
+    const result = await getAccountFromSession(
+      databaseWith(getAccountFromEmail),
+      { user: { email: 'user@example.com' } }
+    )
+    expect(result).toEqual(account)
+  })
+
+  it.each([
+    {
+      description: 'the session email differs in case from the entry',
+      allowEmails: ['user@example.com'],
+      sessionEmail: 'USER@Example.com'
+    },
+    {
+      description: 'the allowlist entry differs in case from the session email',
+      allowEmails: ['User@Example.COM'],
+      sessionEmail: 'user@example.com'
+    }
+  ])(
+    'allows the account when $description',
+    async ({ allowEmails, sessionEmail }) => {
+      mockConfig(allowEmails)
+      const getAccountFromEmail = jest.fn().mockResolvedValue(account)
+      const result = await getAccountFromSession(
+        databaseWith(getAccountFromEmail),
+        { user: { email: sessionEmail } }
+      )
+      expect(result).toEqual(account)
+      expect(getAccountFromEmail).toHaveBeenCalledWith({ email: sessionEmail })
+    }
+  )
+
+  it('blocks an email that is not in the allowlist regardless of case', async () => {
+    mockConfig(['allowed@example.com'])
+    const getAccountFromEmail = jest.fn()
+    const result = await getAccountFromSession(
+      databaseWith(getAccountFromEmail),
+      { user: { email: 'Blocked@Example.com' } }
+    )
+    expect(result).toBeNull()
+    expect(getAccountFromEmail).not.toHaveBeenCalled()
+  })
+})

--- a/lib/utils/getActorFromSession.ts
+++ b/lib/utils/getActorFromSession.ts
@@ -3,6 +3,7 @@ import { cache } from 'react'
 
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+import { isEmailAllowed } from '@/lib/utils/normalizeEmail'
 
 export interface AuthSession {
   user: { email: string }
@@ -30,10 +31,7 @@ export const getAccountFromSession = async (
   if (!session?.user?.email) return null
 
   const config = getConfig()
-  if (
-    config.allowEmails.length &&
-    !config.allowEmails.includes(session.user.email)
-  ) {
+  if (!isEmailAllowed(config.allowEmails, session.user.email)) {
     return null
   }
 

--- a/lib/utils/normalizeEmail.test.ts
+++ b/lib/utils/normalizeEmail.test.ts
@@ -1,0 +1,79 @@
+import { isEmailAllowed, normalizeEmail } from '@/lib/utils/normalizeEmail'
+
+describe('normalizeEmail', () => {
+  it.each([
+    {
+      description: 'lowercases an uppercase address',
+      input: 'USER@EXAMPLE.COM',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'lowercases a mixed-case address',
+      input: 'User@Example.Com',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'trims surrounding whitespace',
+      input: '  user@example.com  ',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'trims and lowercases together',
+      input: '  User@Example.Com\n',
+      expected: 'user@example.com'
+    },
+    {
+      description: 'leaves an already-canonical address unchanged',
+      input: 'user@example.com',
+      expected: 'user@example.com'
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(normalizeEmail(input)).toEqual(expected)
+  })
+})
+
+describe('isEmailAllowed', () => {
+  it('allows any email when the allowlist is empty', () => {
+    expect(isEmailAllowed([], 'anyone@example.com')).toBeTrue()
+  })
+
+  it.each([
+    {
+      description: 'matches identical casing',
+      allow: ['user@example.com'],
+      email: 'user@example.com'
+    },
+    {
+      description: 'matches when the input differs in case',
+      allow: ['user@example.com'],
+      email: 'USER@Example.com'
+    },
+    {
+      description: 'matches when the config entry differs in case',
+      allow: ['User@Example.COM'],
+      email: 'user@example.com'
+    },
+    {
+      description: 'matches with surrounding whitespace on the input',
+      allow: ['user@example.com'],
+      email: '  user@example.com '
+    }
+  ])('$description', ({ allow, email }) => {
+    expect(isEmailAllowed(allow, email)).toBeTrue()
+  })
+
+  it.each([
+    {
+      description: 'blocks an address not in the list',
+      allow: ['user@example.com'],
+      email: 'other@example.com'
+    },
+    {
+      description: 'blocks a near-miss regardless of case',
+      allow: ['user@example.com'],
+      email: 'USER2@example.com'
+    }
+  ])('$description', ({ allow, email }) => {
+    expect(isEmailAllowed(allow, email)).toBeFalse()
+  })
+})

--- a/lib/utils/normalizeEmail.ts
+++ b/lib/utils/normalizeEmail.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonicalizes an email address for storage, lookup, and comparison.
+ *
+ * Email handling across the stack must be case-insensitive: a single canonical
+ * form prevents casing differences from creating duplicate accounts, failing
+ * sign-ins, or bypassing/false-blocking the `allowEmails` gate. This is the one
+ * primitive every touchpoint (DB methods, the better-auth adapter, request
+ * schemas, and `allowEmails` checks) routes through so they can never disagree.
+ *
+ * Normalization is intentionally minimal — trim surrounding whitespace and
+ * lowercase — so it is reversible-enough to keep emails human-readable and does
+ * not depend on any provider-specific rules.
+ */
+export const normalizeEmail = (email: string): string =>
+  email.trim().toLowerCase()
+
+/**
+ * Case-insensitive `allowEmails` membership check. Normalizes both the input
+ * email and every configured entry so the gate behaves identically regardless
+ * of how the operator wrote the allowlist or how the user typed their address.
+ * An empty allowlist means "no restriction", matching the call sites that only
+ * enforce the gate when `allowEmails.length` is non-zero.
+ */
+export const isEmailAllowed = (
+  allowEmails: string[],
+  email: string
+): boolean => {
+  if (allowEmails.length === 0) return true
+  const normalized = normalizeEmail(email)
+  return allowEmails.some((allowed) => normalizeEmail(allowed) === normalized)
+}

--- a/migrations/20260611090000_lowercase_account_emails.js
+++ b/migrations/20260611090000_lowercase_account_emails.js
@@ -10,8 +10,37 @@
 // `user@x.com`). That is a data problem an operator must resolve by hand —
 // auto-merging accounts would be destructive — so this migration FAILS LOUDLY
 // listing the colliding addresses instead of attempting a merge.
+//
+// Rows are read in keyset-paginated chunks (ordered by id) rather than loaded
+// all at once, to keep peak memory bounded on instances with many accounts.
+// Writes happen inside a single transaction so the backfill is atomic: either
+// every row is normalized or none is, and re-running after a failure is safe.
 
 const normalizeEmail = (email) => String(email).trim().toLowerCase()
+
+const CHUNK_SIZE = 500
+
+// Iterates a table in id-ordered chunks, invoking `handle(rows)` per chunk.
+// Keyset pagination (id > cursor) keeps each query bounded and avoids holding
+// the whole table in memory at once.
+const forEachChunk = async (trx, columns, handle) => {
+  let cursor = null
+  for (;;) {
+    let query = trx('accounts')
+      .select(columns)
+      .orderBy('id', 'asc')
+      .limit(CHUNK_SIZE)
+    if (cursor !== null) query = query.where('id', '>', cursor)
+
+    const rows = await query
+    if (rows.length === 0) break
+
+    await handle(rows)
+
+    if (rows.length < CHUNK_SIZE) break
+    cursor = rows[rows.length - 1].id
+  }
+}
 
 /**
  * @param { import("knex").Knex } knex
@@ -19,23 +48,21 @@ const normalizeEmail = (email) => String(email).trim().toLowerCase()
  */
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {
-    const accounts = await trx('accounts').select(
-      'id',
-      'email',
-      'emailChangePending'
-    )
-
-    // Detect collisions before writing anything: group accounts by their
-    // normalized email and flag any normalized value claimed by more than one
-    // account.
+    // Pass 1 — detect collisions before writing anything. Group accounts by
+    // their normalized email; any normalized value claimed by more than one
+    // account would violate the unique constraint once lowercased. Only the
+    // normalized email strings are retained (not full rows), so memory stays
+    // proportional to the number of distinct emails rather than row size.
     const byNormalized = new Map()
-    for (const account of accounts) {
-      if (account.email == null) continue
-      const normalized = normalizeEmail(account.email)
-      const group = byNormalized.get(normalized) ?? []
-      group.push(account.email)
-      byNormalized.set(normalized, group)
-    }
+    await forEachChunk(trx, ['id', 'email'], (rows) => {
+      for (const account of rows) {
+        if (account.email == null) continue
+        const normalized = normalizeEmail(account.email)
+        const group = byNormalized.get(normalized) ?? []
+        group.push(account.email)
+        byNormalized.set(normalized, group)
+      }
+    })
 
     const collisions = [...byNormalized.entries()].filter(
       ([, originals]) => originals.length > 1
@@ -56,30 +83,42 @@ exports.up = async (knex) => {
       )
     }
 
-    // No collisions — rewrite the rows whose stored value is not already
-    // canonical. Update `email` and the pending-change column independently so
-    // both end up normalized.
-    for (const account of accounts) {
-      const update = {}
+    byNormalized.clear()
 
-      if (account.email != null) {
-        const normalizedEmail = normalizeEmail(account.email)
-        if (normalizedEmail !== account.email) {
-          update.email = normalizedEmail
+    // Pass 2 — rewrite the rows whose stored value is not already canonical.
+    // Update `email` and the pending-change column independently so both end up
+    // normalized. Per-row updates (rather than a set-based `lower()` UPDATE) are
+    // intentional: they apply the exact same JS normalization as the runtime,
+    // which a SQL `lower()` cannot guarantee on SQLite. Only differing rows are
+    // touched, and the read is chunked, so work is proportional to the number of
+    // rows that actually need changing.
+    await forEachChunk(
+      trx,
+      ['id', 'email', 'emailChangePending'],
+      async (rows) => {
+        for (const account of rows) {
+          const update = {}
+
+          if (account.email != null) {
+            const normalizedEmail = normalizeEmail(account.email)
+            if (normalizedEmail !== account.email) {
+              update.email = normalizedEmail
+            }
+          }
+
+          if (account.emailChangePending != null) {
+            const normalizedPending = normalizeEmail(account.emailChangePending)
+            if (normalizedPending !== account.emailChangePending) {
+              update.emailChangePending = normalizedPending
+            }
+          }
+
+          if (Object.keys(update).length > 0) {
+            await trx('accounts').where('id', account.id).update(update)
+          }
         }
       }
-
-      if (account.emailChangePending != null) {
-        const normalizedPending = normalizeEmail(account.emailChangePending)
-        if (normalizedPending !== account.emailChangePending) {
-          update.emailChangePending = normalizedPending
-        }
-      }
-
-      if (Object.keys(update).length > 0) {
-        await trx('accounts').where('id', account.id).update(update)
-      }
-    }
+    )
   })
 }
 

--- a/migrations/20260611090000_lowercase_account_emails.js
+++ b/migrations/20260611090000_lowercase_account_emails.js
@@ -48,28 +48,34 @@ const forEachChunk = async (trx, columns, handle) => {
  */
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {
-    // Pass 1 — detect collisions before writing anything. Group accounts by
-    // their normalized email; any normalized value claimed by more than one
-    // account would violate the unique constraint once lowercased. Only the
-    // normalized email strings are retained (not full rows), so memory stays
-    // proportional to the number of distinct emails rather than row size.
-    const byNormalized = new Map()
+    // Pass 1 — detect collisions before writing anything. Any normalized email
+    // claimed by more than one account would violate the unique constraint once
+    // lowercased. `seen` keeps just the first original per distinct normalized
+    // value (one string per email); the (normally empty) `collisions` map only
+    // grows when an actual duplicate is found, so memory stays minimal even on
+    // instances with many accounts.
+    const seen = new Map()
+    const collisions = new Map()
     await forEachChunk(trx, ['id', 'email'], (rows) => {
       for (const account of rows) {
         if (account.email == null) continue
         const normalized = normalizeEmail(account.email)
-        const group = byNormalized.get(normalized) ?? []
-        group.push(account.email)
-        byNormalized.set(normalized, group)
+        const firstSeen = seen.get(normalized)
+        if (firstSeen === undefined) {
+          seen.set(normalized, account.email)
+          continue
+        }
+        const existing = collisions.get(normalized)
+        if (existing) {
+          existing.push(account.email)
+        } else {
+          collisions.set(normalized, [firstSeen, account.email])
+        }
       }
     })
 
-    const collisions = [...byNormalized.entries()].filter(
-      ([, originals]) => originals.length > 1
-    )
-
-    if (collisions.length > 0) {
-      const details = collisions
+    if (collisions.size > 0) {
+      const details = [...collisions.entries()]
         .map(
           ([normalized, originals]) =>
             `  ${normalized} <- [${originals.join(', ')}]`
@@ -83,7 +89,7 @@ exports.up = async (knex) => {
       )
     }
 
-    byNormalized.clear()
+    seen.clear()
 
     // Pass 2 — rewrite the rows whose stored value is not already canonical.
     // Update `email` and the pending-change column independently so both end up

--- a/migrations/20260611090000_lowercase_account_emails.js
+++ b/migrations/20260611090000_lowercase_account_emails.js
@@ -12,11 +12,12 @@
 // listing the colliding addresses instead of attempting a merge. The collision
 // check is a single set-based SQL aggregate (`GROUP BY ... HAVING count > 1`),
 // so it uses O(number-of-collisions) memory — effectively zero on the common
-// case — rather than buffering every account in the Node process. The UNIQUE
-// constraint plus the wrapping transaction is the ultimate safety net: even if
-// a non-ASCII casing pair slipped past SQL `lower()`, the backfill UPDATE would
-// hit the constraint and roll the whole migration back rather than corrupt
-// data.
+// case — rather than buffering every account in the Node process. Because SQL
+// `lower()` is ASCII-only on SQLite, a non-ASCII casing pair could slip past
+// that pre-check; the backfill UPDATE in Pass 2 then catches the resulting
+// UNIQUE violation and re-raises it as the SAME friendly collision error (and
+// rolls the whole transaction back), so operators get a clear message on every
+// engine and data is never corrupted.
 //
 // The backfill reads rows in keyset-paginated chunks (ordered by id) so peak
 // memory stays bounded, and runs inside a single transaction so it is atomic:
@@ -26,6 +27,28 @@
 const normalizeEmail = (email) => String(email).trim().toLowerCase()
 
 const CHUNK_SIZE = 500
+
+// Self-contained unique-constraint detection (the migration intentionally does
+// not import app code). Mirrors lib/database/sql/utils/isUniqueConstraintError.
+const isUniqueConstraintError = (error) => {
+  if (typeof error !== 'object' || error === null) return false
+  const { code, errno, message } = error
+  return (
+    code === '23505' ||
+    code === 'ER_DUP_ENTRY' ||
+    code === 'SQLITE_CONSTRAINT_UNIQUE' ||
+    errno === 1062 ||
+    (typeof message === 'string' &&
+      message.includes('UNIQUE constraint failed'))
+  )
+}
+
+const collisionError = (details) =>
+  new Error(
+    'Cannot lowercase account emails: the following addresses collide once ' +
+      'normalized to lowercase. Resolve these duplicate accounts manually ' +
+      `before re-running the migration (accounts are NOT auto-merged):\n${details}`
+  )
 
 // Iterates a table in id-ordered chunks, invoking `handle(rows)` per chunk.
 // Keyset pagination (id > cursor) keeps each query bounded and avoids holding
@@ -91,12 +114,7 @@ exports.up = async (knex) => {
             `  ${normalized} <- [${originals.join(', ')}]`
         )
         .join('\n')
-      throw new Error(
-        'Cannot lowercase account emails: the following addresses collide ' +
-          'once normalized to lowercase. Resolve these duplicate accounts ' +
-          'manually before re-running the migration (accounts are NOT ' +
-          `auto-merged):\n${details}`
-      )
+      throw collisionError(details)
     }
 
     // Pass 2 — rewrite the rows whose stored value is not already canonical.
@@ -128,7 +146,20 @@ exports.up = async (knex) => {
           }
 
           if (Object.keys(update).length > 0) {
-            await trx('accounts').where('id', account.id).update(update)
+            try {
+              await trx('accounts').where('id', account.id).update(update)
+            } catch (error) {
+              // The SQL pre-check uses the engine's `lower()`, which is
+              // ASCII-only on SQLite, so a non-ASCII casing pair (e.g.
+              // `CafÉ@x.com` vs `café@x.com`) can slip past it and only collide
+              // here when the Unicode-aware JS normalization is applied. Convert
+              // that raw UNIQUE violation into the same friendly collision error
+              // (and roll back) rather than surfacing an opaque DB error.
+              if (isUniqueConstraintError(error) && update.email) {
+                throw collisionError(`  ${update.email} <- [${account.email}]`)
+              }
+              throw error
+            }
           }
         }
       }

--- a/migrations/20260611090000_lowercase_account_emails.js
+++ b/migrations/20260611090000_lowercase_account_emails.js
@@ -1,20 +1,27 @@
 // Backfills existing account emails to their canonical lowercase form so the
-// whole stack (storage, lookup, comparison) is case-insensitive. Normalization
-// is done in JS with the same `trim().toLowerCase()` rule the runtime uses (see
-// lib/utils/normalizeEmail.ts) rather than SQL `lower()`, so the backfill can
-// never disagree with runtime normalization (SQL `lower()` is ASCII-only on
-// SQLite, while JS `toLowerCase` is Unicode-aware).
+// whole stack (storage, lookup, comparison) is case-insensitive. The backfill
+// itself normalizes in JS with the same `trim().toLowerCase()` rule the runtime
+// uses (see lib/utils/normalizeEmail.ts) so stored values can never disagree
+// with runtime normalization (SQL `lower()` is ASCII-only on SQLite, while JS
+// `toLowerCase` is Unicode-aware).
 //
 // `accounts.email` carries a UNIQUE constraint, so lowercasing could collide if
 // two accounts already differ only by casing (e.g. `User@x.com` and
 // `user@x.com`). That is a data problem an operator must resolve by hand —
 // auto-merging accounts would be destructive — so this migration FAILS LOUDLY
-// listing the colliding addresses instead of attempting a merge.
+// listing the colliding addresses instead of attempting a merge. The collision
+// check is a single set-based SQL aggregate (`GROUP BY ... HAVING count > 1`),
+// so it uses O(number-of-collisions) memory — effectively zero on the common
+// case — rather than buffering every account in the Node process. The UNIQUE
+// constraint plus the wrapping transaction is the ultimate safety net: even if
+// a non-ASCII casing pair slipped past SQL `lower()`, the backfill UPDATE would
+// hit the constraint and roll the whole migration back rather than corrupt
+// data.
 //
-// Rows are read in keyset-paginated chunks (ordered by id) rather than loaded
-// all at once, to keep peak memory bounded on instances with many accounts.
-// Writes happen inside a single transaction so the backfill is atomic: either
-// every row is normalized or none is, and re-running after a failure is safe.
+// The backfill reads rows in keyset-paginated chunks (ordered by id) so peak
+// memory stays bounded, and runs inside a single transaction so it is atomic:
+// either every row is normalized or none is, and re-running after a failure is
+// safe.
 
 const normalizeEmail = (email) => String(email).trim().toLowerCase()
 
@@ -48,34 +55,37 @@ const forEachChunk = async (trx, columns, handle) => {
  */
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {
-    // Pass 1 — detect collisions before writing anything. Any normalized email
-    // claimed by more than one account would violate the unique constraint once
-    // lowercased. `seen` keeps just the first original per distinct normalized
-    // value (one string per email); the (normally empty) `collisions` map only
-    // grows when an actual duplicate is found, so memory stays minimal even on
-    // instances with many accounts.
-    const seen = new Map()
-    const collisions = new Map()
-    await forEachChunk(trx, ['id', 'email'], (rows) => {
-      for (const account of rows) {
-        if (account.email == null) continue
-        const normalized = normalizeEmail(account.email)
-        const firstSeen = seen.get(normalized)
-        if (firstSeen === undefined) {
-          seen.set(normalized, account.email)
-          continue
-        }
-        const existing = collisions.get(normalized)
-        if (existing) {
-          existing.push(account.email)
-        } else {
-          collisions.set(normalized, [firstSeen, account.email])
-        }
-      }
-    })
+    // Pass 1 — detect collisions before writing anything, with a set-based SQL
+    // aggregate so memory does not scale with the number of accounts. Any
+    // normalized email shared by more than one account would violate the unique
+    // constraint once lowercased. `lower(trim(...))` mirrors the runtime
+    // normalization for ASCII addresses (the realistic case); the transaction +
+    // unique constraint cover the rest.
+    const collisionGroups = await trx('accounts')
+      .whereNotNull('email')
+      .groupByRaw('lower(trim(email))')
+      .havingRaw('count(*) > 1')
+      .select(trx.raw('lower(trim(email)) as norm'))
 
-    if (collisions.size > 0) {
-      const details = [...collisions.entries()]
+    if (collisionGroups.length > 0) {
+      // Collisions are exceptional, so only here do we fetch the offending
+      // originals (just the colliding groups) to build a helpful message.
+      const norms = collisionGroups.map((group) => group.norm)
+      const placeholders = norms.map(() => '?').join(', ')
+      const rows = await trx('accounts')
+        .whereNotNull('email')
+        .whereRaw(`lower(trim(email)) in (${placeholders})`, norms)
+        .select('email')
+
+      const byNormalized = new Map()
+      for (const row of rows) {
+        const normalized = normalizeEmail(row.email)
+        const group = byNormalized.get(normalized) ?? []
+        group.push(row.email)
+        byNormalized.set(normalized, group)
+      }
+
+      const details = [...byNormalized.entries()]
         .map(
           ([normalized, originals]) =>
             `  ${normalized} <- [${originals.join(', ')}]`
@@ -88,8 +98,6 @@ exports.up = async (knex) => {
           `auto-merged):\n${details}`
       )
     }
-
-    seen.clear()
 
     // Pass 2 — rewrite the rows whose stored value is not already canonical.
     // Update `email` and the pending-change column independently so both end up

--- a/migrations/20260611090000_lowercase_account_emails.js
+++ b/migrations/20260611090000_lowercase_account_emails.js
@@ -1,0 +1,96 @@
+// Backfills existing account emails to their canonical lowercase form so the
+// whole stack (storage, lookup, comparison) is case-insensitive. Normalization
+// is done in JS with the same `trim().toLowerCase()` rule the runtime uses (see
+// lib/utils/normalizeEmail.ts) rather than SQL `lower()`, so the backfill can
+// never disagree with runtime normalization (SQL `lower()` is ASCII-only on
+// SQLite, while JS `toLowerCase` is Unicode-aware).
+//
+// `accounts.email` carries a UNIQUE constraint, so lowercasing could collide if
+// two accounts already differ only by casing (e.g. `User@x.com` and
+// `user@x.com`). That is a data problem an operator must resolve by hand —
+// auto-merging accounts would be destructive — so this migration FAILS LOUDLY
+// listing the colliding addresses instead of attempting a merge.
+
+const normalizeEmail = (email) => String(email).trim().toLowerCase()
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const accounts = await trx('accounts').select(
+      'id',
+      'email',
+      'emailChangePending'
+    )
+
+    // Detect collisions before writing anything: group accounts by their
+    // normalized email and flag any normalized value claimed by more than one
+    // account.
+    const byNormalized = new Map()
+    for (const account of accounts) {
+      if (account.email == null) continue
+      const normalized = normalizeEmail(account.email)
+      const group = byNormalized.get(normalized) ?? []
+      group.push(account.email)
+      byNormalized.set(normalized, group)
+    }
+
+    const collisions = [...byNormalized.entries()].filter(
+      ([, originals]) => originals.length > 1
+    )
+
+    if (collisions.length > 0) {
+      const details = collisions
+        .map(
+          ([normalized, originals]) =>
+            `  ${normalized} <- [${originals.join(', ')}]`
+        )
+        .join('\n')
+      throw new Error(
+        'Cannot lowercase account emails: the following addresses collide ' +
+          'once normalized to lowercase. Resolve these duplicate accounts ' +
+          'manually before re-running the migration (accounts are NOT ' +
+          `auto-merged):\n${details}`
+      )
+    }
+
+    // No collisions — rewrite the rows whose stored value is not already
+    // canonical. Update `email` and the pending-change column independently so
+    // both end up normalized.
+    for (const account of accounts) {
+      const update = {}
+
+      if (account.email != null) {
+        const normalizedEmail = normalizeEmail(account.email)
+        if (normalizedEmail !== account.email) {
+          update.email = normalizedEmail
+        }
+      }
+
+      if (account.emailChangePending != null) {
+        const normalizedPending = normalizeEmail(account.emailChangePending)
+        if (normalizedPending !== account.emailChangePending) {
+          update.emailChangePending = normalizedPending
+        }
+      }
+
+      if (Object.keys(update).length > 0) {
+        await trx('accounts').where('id', account.id).update(update)
+      }
+    }
+  })
+}
+
+/**
+ * Irreversible: the original (pre-normalization) casing is not retained, so the
+ * rollback cannot restore it. Implemented as a no-op so rolling back later
+ * migrations does not fail on this one.
+ *
+ * @param { import("knex").Knex } _knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (_knex) => {
+  // No-op: cannot restore original email casing.
+}

--- a/scripts/createMockUser.ts
+++ b/scripts/createMockUser.ts
@@ -8,6 +8,7 @@ import crypto from 'crypto'
 
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 import { generateKeyPair } from '@/lib/utils/signature'
 
 const BCRYPT_ROUND = 10
@@ -16,7 +17,8 @@ const SESSION_MAX_AGE_DAYS = 30
 async function createMockUser() {
   const args = process.argv.slice(2)
   const username = args[0] || 'testuser'
-  const email = args[1] || 'test@example.com'
+  // Stored lowercase to match the case-insensitive account email handling.
+  const email = normalizeEmail(args[1] || 'test@example.com')
   const password = args[2] || 'testpassword123'
 
   console.log('Creating test user...')

--- a/scripts/manageAdminRole.ts
+++ b/scripts/manageAdminRole.ts
@@ -8,6 +8,7 @@
 import { loadEnvConfig } from '@next/env'
 
 import { getKnex } from '@/lib/database'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
 const projectDir = process.cwd()
 loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
@@ -15,7 +16,9 @@ loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
 async function manageAdminRole() {
   const args = process.argv.slice(2)
   const action = args[0]
-  const email = args[1]
+  // Stored emails are normalized (trimmed + lowercased); normalize the lookup
+  // key too so a mixed-case argument still matches the canonical row.
+  const email = args[1] ? normalizeEmail(args[1]) : args[1]
 
   if (!action || !email || !['add', 'remove'].includes(action)) {
     console.log('Usage:')


### PR DESCRIPTION
## Summary

Email handling was uniformly **case-sensitive**: `getAccountFromEmail` did `where('email', email)`, better-auth sign-in looked up the raw typed email via the knex adapter, and the `allowEmails` gates compared as-is. This made casing able to create duplicate accounts, fail sign-ins, or bypass/false-block the allowlist.

This PR normalizes emails to **lowercase (trimmed)** holistically — at storage, lookup, and comparison — so casing never desyncs the stack. Follow-up to the deferred gemini-code-assist flags on PR #946 (the case-sensitive `allowEmails`/comparison code), fixed here together with the lookups/auth elsewhere so nothing is left half-normalized.

## Approach

A single primitive, `lib/utils/normalizeEmail.ts` (`normalizeEmail` = `trim().toLowerCase()`, plus `isEmailAllowed` for case-insensitive allowlist membership), is routed through every touchpoint:

- **DB layer** (`lib/database/sql/account.ts`) — normalize the email param **inside** every method that stores or looks up by email (`isAccountExists`, `getAccountFromEmail`, `createAccount`, `requestEmailChange`, the `verifyEmailChange` promotion, `requestPasswordReset`). Chosen over per-call-site normalization because it cannot be bypassed.
- **Auth adapter** (`lib/services/auth/knexAdapter.ts`) — better-auth resolves sign-in/sign-up by email through the adapter (not the SQL account methods), so `accounts.email` is normalized in where-clauses (`eq`/`in`/…) and on `create`/`update`/`updateMany`.
- **allowEmails** — lowercase `config.allowEmails` once on load (`lib/config`) **and** compare via `isEmailAllowed` (normalizes both sides) at the registration route and the session gate in `getActorFromSession`.
- **Request schemas** — `trim().toLowerCase().email().max(255)` on `CreateAccountRequest`, the email-change schema, and the password-reset schema; the sign-in form normalizes client-side too.
- **Other creation paths** — OAuth/social sign-up is covered by the adapter; `scripts/createMockUser.ts` stores the normalized email.

## Migration

`migrations/20260611090000_lowercase_account_emails.js` backfills existing `accounts.email` and `emailChangePending` to lowercase (normalization done in JS so it matches the runtime rule exactly — SQL `lower()` is ASCII-only on SQLite).

`accounts.email` carries a **UNIQUE** constraint, so the migration **detects casing-collisions first and FAILS LOUDLY** listing the colliding addresses rather than auto-merging accounts (destructive). `down` is a no-op (original casing is not retained).

It is **data-only** — verified by running all migrations against a local SQLite **and** a throwaway Postgres 17 and confirming both committed schema dumps (`migrations/schema.sql`, `migrations/schema.sqlite.sql`) are unchanged (only the non-deterministic pg_dump `\restrict` token differed). No dump regeneration needed.

## Tests

End-to-end case-insensitivity:
- DB: lookup/store regardless of casing; pending-email normalize + lowercased promotion on verify.
- Registration: mixed-case email stored lowercase; `allowEmails` matches regardless of case (allow **and** block paths) → 422 on block.
- Email change to a differently-cased address owned by another account → 400.
- Adapter: `accounts.email` normalized on create/update and on `eq`/`in` lookups.
- The `allowEmails` session gate (`getAccountFromSession`).
- `normalizeEmail`/`isEmailAllowed` unit coverage.

## Verification

`prettier --write .`, `yarn lint` (0 errors), `yarn build`, and `yarn test` (3978 passed) all green.