### PR TITLE
Bump version to v1.61.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.61.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.60.0`
- Base main SHA: `af683d7b8ca50f61adf4f369dfd286d9ee4f0265`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
