### PR TITLE
docs: rework REVIEW.md into a project-specific code review checklist

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,5 @@
+### Handling Unique Constraint Violations
+
+Pre-checks for uniqueness (e.g., checking if an email or username exists before an insert or update) are susceptible to Time-of-Check to Time-of-Use (TOCTOU) race conditions. Concurrent requests can bypass the pre-check and trigger a database unique constraint violation, which surfaces as a 500 Internal Server Error.
+
+To handle this gracefully, wrap database operations that enforce unique constraints and catch specific unique constraint violation errors (e.g., using a helper like `isUniqueConstraintError`). Map these caught violations to a `422 Unprocessable Entity` response to provide a consistent, user-friendly error, rather than allowing the raw database error to propagate.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,5 +1,112 @@
-### Handling Unique Constraint Violations
+# Code Review Checklist
 
-Pre-checks for uniqueness (e.g., checking if an email or username exists before an insert or update) are susceptible to Time-of-Check to Time-of-Use (TOCTOU) race conditions. Concurrent requests can bypass the pre-check and trigger a database unique constraint violation, which surfaces as a 500 Internal Server Error.
+A focused checklist for reviewing changes to **activities.next**. It captures the
+project-specific invariants that are easy to miss in a diff. `AGENTS.md` remains
+the authoritative source for the full rules; this file is the reviewer's
+shortlist. Skip sections that a given change doesn't touch.
 
-To handle this gracefully, wrap database operations that enforce unique constraints and catch specific unique constraint violation errors (e.g., using a helper like `isUniqueConstraintError`). Map these caught violations to a `422 Unprocessable Entity` response to provide a consistent, user-friendly error, rather than allowing the raw database error to propagate.
+## Runtime vs. build-time configuration
+
+- No `ACTIVITIES_*` or `OTEL_EXPORTER_*` reads outside `lib/config/`, and no env
+  var name constants defined elsewhere — callers import a config utility instead.
+- `next.config.ts` stays a thin entrypoint: no runtime deployment config
+  (`images.remotePatterns`, static headers, `allowedDevOrigins`, webpack,
+  `generateBuildId`), and no reusable helpers/parsers/constants. Build-only flags
+  (`NODE_ENV`, `BUILD_STANDALONE`, `NEXT_TELEMETRY_DISABLED`) are fine.
+- Runtime config that affects browser-visible behavior (CSP, security headers,
+  host redirects, upload origins) lives in request-time server code, not static
+  Next config.
+- A build must succeed with `ACTIVITIES_*` missing or set to placeholder values.
+  Changes to runtime-config handling should ship a regression test asserting the
+  build config does not consume those values.
+
+## API routes
+
+- Responses go through `apiResponse` / `apiErrorResponse` from
+  `@/lib/utils/response` — never `Response.json()`. On CORS-enabled routes (those
+  exporting `OPTIONS`), use `apiResponse` even for errors so CORS headers are sent.
+- Request bodies are validated with Zod **`safeParse`**, never `.parse()` (which
+  throws and surfaces as a 500). Invalid input returns a 4xx, not a 500.
+- String fields backed by a sized column (e.g. `varchar(255)`) carry a matching
+  `.max(...)`; nullable text columns normalize empty/whitespace input to `null`
+  via `.transform((v) => v || null)`, consistently across create and update.
+
+## Unique constraints (TOCTOU)
+
+- Pre-checking uniqueness (email/username exists?) before an insert/update is a
+  Time-of-Check to Time-of-Use race: concurrent requests slip past the check and
+  hit a DB unique-constraint violation that surfaces as a 500.
+- Wrap the write and catch the specific violation (e.g. `isUniqueConstraintError`),
+  mapping it to a `422 Unprocessable Entity` instead of letting the raw DB error
+  propagate. The pre-check is a UX nicety; the caught violation is the guarantee.
+
+## Database & migrations
+
+- Queries use the Knex query builder, not raw SQL, unless unavoidable. Operations
+  must work on SQLite (tests + local dev) and PostgreSQL, and avoid breaking
+  MySQL-compatible Knex clients. Use standard SQL types (e.g. `text`, not
+  `varchar[]`).
+- Any PR that adds/edits/removes a migration regenerates **both**
+  `migrations/schema.sql` (PostgreSQL) and `migrations/schema.sqlite.sql` (SQLite)
+  in the same PR, against fresh local DBs — never hand-edited. Commit a
+  schema-only regeneration as `none:`.
+- Better-auth plugins are only registered once their required tables exist in a
+  migration; admin/dashboard plugins are gated with explicit access control.
+
+## Client components & data flow
+
+- React components never call `fetch()` directly — every client→server call is a
+  named, typed, exported function in `lib/client.ts`, imported from there.
+- Server Components never pass `new Date()` to a Client Component. Pass
+  `Date.now()` (a `number`); the client takes `currentTime: number` and builds
+  `new Date(currentTime)` itself.
+- Client Components that render relative timestamps (or fan out to `Posts`/`Post`)
+  never call `Date.now()` / `new Date()` during render — they receive and forward
+  `currentTime` from the server to avoid hydration mismatches.
+- Settings/account forms are client components that POST JSON and show inline
+  success/error, not HTML `<form method="post">` with server redirects; the route
+  returns JSON via `apiResponse()`.
+
+## Page chrome (design system)
+
+- `(timeline)` pages use `PageHeader` from `@/lib/components/page-header` and share
+  the single `max-w-content` (940px) width. No reintroduced `max-w-2xl`/`max-w-4xl`
+  split, `contentWidth` prop, or `data-layout-width="wide"`.
+- Settings-style sections (settings, fitness, admin) use the shared
+  `SectionNavDropdown` on every breakpoint — no re-inlined dropdown markup and no
+  desktop vertical icon rail. Sentence-case labels ("Blocked accounts").
+
+## Logging
+
+- No `console.*` in committed code. Server-side code uses `logger` from
+  `@/lib/utils/logger` (`logger.info({ message })`). Migrations and `scripts/` may
+  use `console.*`. Do not log from React/client code.
+
+## Style, imports & tests
+
+- TypeScript + React, 2-space indent; Prettier (no semicolons, single quotes,
+  import sorting) is clean. Unused vars are `_`-prefixed.
+- Absolute imports (`@/lib/...`) for anything outside the current directory;
+  same-directory `./` only, no `../`. The same rule applies to `jest.mock(...)`
+  paths.
+- Tests are co-located, named `*.test.ts(x)`. `describe`/`it` names are plain
+  descriptive text — no `#`/`.` sigil — and read as behavior statements.
+  Input/expected-only variations use a table-driven `it.each([...])`.
+
+## Docs hygiene
+
+- `docs/` is durable, general-purpose reference only. No implementation plans,
+  design docs, PR/task-specific writeups, gap analyses, or screenshots, and no
+  `docs/plans/`, `docs/specs/`, `docs/pr-screenshots/` scratch dirs — that belongs
+  in the PR description.
+
+## Commits & versioning
+
+- Every commit subject starts with a conventional prefix (`fix:`, `feat:`,
+  `chore:`, `refactor:`, `test:`, `docs:`, `none:`, `minor:`, `major:`).
+- `version` in `package.json` is never edited by hand — CI bumps it from prefixes.
+- For a `minor`/`major` bump the **PR title** carries the prefix (PRs squash-merge,
+  so the title is the commit subject). `.github/`-only changes are no-bump unless
+  explicitly `minor:`/`major:`.
+- Pre-commit gate is green in order: `yarn run prettier --write .`, `yarn lint`,
+  `yarn build`, `yarn test`.


### PR DESCRIPTION
## Summary

Reworks `REVIEW.md` from a single generic section (unique-constraint/TOCTOU handling only) into a focused, project-specific **code-review checklist** for activities.next.

The previous file covered just one review concern out of the many that actually matter in this codebase. This version distills the review-worthy invariants from `AGENTS.md` into a reviewer's shortlist, organized by area:

- Runtime vs. build-time configuration (`lib/config/`, thin `next.config.ts`)
- API routes (`apiResponse`/`apiErrorResponse`, Zod `safeParse`, sized/nullable columns)
- Unique constraints / TOCTOU → `422` (the original section, kept and tightened)
- Database & migrations (Knex builder, SQLite/PG compatibility, regenerate both schema dumps)
- Client components & data flow (`lib/client.ts`, `Date.now()` not `new Date()`, hydration)
- Page chrome / design system (`max-w-content`, `SectionNavDropdown`)
- Logging, style/imports/tests, docs hygiene, commits & versioning

It explicitly defers to `AGENTS.md` as the source of truth, positioning itself as the shortlist rather than a competing rulebook.

## Test results

Docs-only change. `prettier --check REVIEW.md` passes.

https://claude.ai/code/session_01D2EvM31MGKYyZuipC1WyrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2EvM31MGKYyZuipC1WyrY)_