### PR TITLE
Bump version to v1.62.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.62.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.61.0`
- Base main SHA: `d8c36194d82206bd33b41bebc0dcab6e40e6d941`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
