### PR TITLE
Bump version to v1.64.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.64.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.63.0`
- Base main SHA: `31c0fe1bcedf59c884e903b35ccc41ddeaf44f09`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
