### PR TITLE
minor: real preferences API backed by actor settings

### DIFF
--- a/app/api/v1/preferences/route.test.ts
+++ b/app/api/v1/preferences/route.test.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { seedActor2 } from '@/lib/stub/seed/actor2'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v1/preferences', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('GET requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/preferences'),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(401)
+  })
+
+  it('returns the documented default payload when no preferences are set', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/preferences'),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      'posting:default:visibility': 'public',
+      'posting:default:sensitive': false,
+      'posting:default:language': 'en',
+      'reading:expand:media': 'default',
+      'reading:expand:spoilers': false,
+      'reading:autoplay:gifs': false
+    })
+  })
+
+  it('reflects the actor posting defaults and reading preferences', async () => {
+    await database.updateActor({
+      actorId: ACTOR1_ID,
+      defaultPrivacy: 'private',
+      defaultSensitive: true,
+      defaultLanguage: 'th',
+      readingExpandSpoilers: true
+    })
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/preferences'),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      'posting:default:visibility': 'private',
+      'posting:default:sensitive': true,
+      'posting:default:language': 'th',
+      'reading:expand:media': 'default',
+      'reading:expand:spoilers': true,
+      'reading:autoplay:gifs': false
+    })
+  })
+})

--- a/app/api/v1/preferences/route.test.ts
+++ b/app/api/v1/preferences/route.test.ts
@@ -91,7 +91,9 @@ describe('/api/v1/preferences', () => {
       defaultPrivacy: 'private',
       defaultSensitive: true,
       defaultLanguage: 'th',
-      readingExpandSpoilers: true
+      readingExpandMedia: 'show_all',
+      readingExpandSpoilers: true,
+      readingAutoplayGifs: true
     })
     const response = await GET(
       new NextRequest('https://llun.test/api/v1/preferences'),
@@ -102,9 +104,9 @@ describe('/api/v1/preferences', () => {
       'posting:default:visibility': 'private',
       'posting:default:sensitive': true,
       'posting:default:language': 'th',
-      'reading:expand:media': 'default',
+      'reading:expand:media': 'show_all',
       'reading:expand:spoilers': true,
-      'reading:autoplay:gifs': false
+      'reading:autoplay:gifs': true
     })
   })
 })

--- a/app/api/v1/preferences/route.ts
+++ b/app/api/v1/preferences/route.ts
@@ -8,22 +8,24 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-const DEFAULT_USER_PREFERENCES = {
-  'posting:default:visibility': 'public',
-  'posting:default:sensitive': false,
-  'posting:default:language': 'en',
-  'reading:expand:media': 'default',
-  'reading:expand:spoilers': false,
-  'reading:autoplay:gifs': false
-}
-
 export const GET = traceApiRoute(
   'getPreferences',
-  OAuthGuard([Scope.enum.read], async (req) => {
+  OAuthGuard([Scope.enum.read], async (req, context) => {
+    const { database, currentActor } = context
+    const account = await database.getMastodonActorFromId({
+      id: currentActor.id
+    })
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: DEFAULT_USER_PREFERENCES
+      data: {
+        'posting:default:visibility': account?.source?.privacy ?? 'public',
+        'posting:default:sensitive': account?.source?.sensitive ?? false,
+        'posting:default:language': account?.source?.language ?? 'en',
+        'reading:expand:media': currentActor.readingExpandMedia ?? 'default',
+        'reading:expand:spoilers': currentActor.readingExpandSpoilers ?? false,
+        'reading:autoplay:gifs': currentActor.readingAutoplayGifs ?? false
+      }
     })
   })
 )

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -464,6 +464,15 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
           ? { headerImageUrl: settings.headerImageUrl }
           : null),
         manuallyApprovesFollowers: settings.manuallyApprovesFollowers ?? true,
+        ...(settings.readingExpandMedia !== undefined
+          ? { readingExpandMedia: settings.readingExpandMedia }
+          : null),
+        ...(settings.readingExpandSpoilers !== undefined
+          ? { readingExpandSpoilers: settings.readingExpandSpoilers }
+          : null),
+        ...(settings.readingAutoplayGifs !== undefined
+          ? { readingAutoplayGifs: settings.readingAutoplayGifs }
+          : null),
         followersUrl: settings.followersUrl,
         inboxUrl: settings.inboxUrl,
         sharedInboxUrl: settings.sharedInboxUrl,

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -930,6 +930,45 @@ describe('ActorDatabase', () => {
         expect(settings.manuallyApprovesFollowers).toBe(false)
         expect(settings.defaultPrivacy).toBe('private')
       })
+
+      it('persists and returns reading preferences', async () => {
+        const actorId = `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`
+        await database.updateActor({
+          actorId,
+          readingExpandMedia: 'show_all',
+          readingExpandSpoilers: true,
+          readingAutoplayGifs: true
+        })
+
+        const actor = await database.getActorFromId({ id: actorId })
+        expect(actor?.readingExpandMedia).toEqual('show_all')
+        expect(actor?.readingExpandSpoilers).toEqual(true)
+        expect(actor?.readingAutoplayGifs).toEqual(true)
+      })
+
+      it('round-trips false reading preference values', async () => {
+        const actorId = `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`
+        await database.updateActor({
+          actorId,
+          readingExpandSpoilers: false,
+          readingAutoplayGifs: false
+        })
+
+        const actor = await database.getActorFromId({ id: actorId })
+        expect(actor?.readingExpandSpoilers).toEqual(false)
+        expect(actor?.readingAutoplayGifs).toEqual(false)
+      })
+
+      it('preserves existing settings when updating reading preferences', async () => {
+        const actorId = `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`
+        await database.updateActor({ actorId, defaultPrivacy: 'unlisted' })
+
+        await database.updateActor({ actorId, readingExpandMedia: 'hide_all' })
+
+        const settings = await database.getActorSettings({ actorId })
+        expect(settings.defaultPrivacy).toEqual('unlisted')
+        expect(settings.readingExpandMedia).toEqual('hide_all')
+      })
     })
 
     describe('getActorSettings', () => {

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -712,6 +712,17 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
         ? { headerImageUrl: settings.headerImageUrl }
         : null),
       manuallyApprovesFollowers: settings.manuallyApprovesFollowers ?? true,
+      // Booleans use !== undefined so a persisted `false` survives the
+      // row-to-domain round-trip (a truthy spread would drop it).
+      ...(settings.readingExpandMedia !== undefined
+        ? { readingExpandMedia: settings.readingExpandMedia }
+        : null),
+      ...(settings.readingExpandSpoilers !== undefined
+        ? { readingExpandSpoilers: settings.readingExpandSpoilers }
+        : null),
+      ...(settings.readingAutoplayGifs !== undefined
+        ? { readingAutoplayGifs: settings.readingAutoplayGifs }
+        : null),
       followersUrl: settings.followersUrl,
       inboxUrl: settings.inboxUrl,
       sharedInboxUrl: settings.sharedInboxUrl,
@@ -814,6 +825,9 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     defaultSensitive,
     defaultLanguage,
     postLineLimit,
+    readingExpandMedia,
+    readingExpandSpoilers,
+    readingAutoplayGifs,
     emailNotifications,
     pushNotifications,
     notificationPolicy,
@@ -850,6 +864,11 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(defaultSensitive !== undefined ? { defaultSensitive } : null),
       ...(defaultLanguage !== undefined ? { defaultLanguage } : null),
       ...(postLineLimit !== undefined ? { postLineLimit } : null),
+      ...(readingExpandMedia !== undefined ? { readingExpandMedia } : null),
+      ...(readingExpandSpoilers !== undefined
+        ? { readingExpandSpoilers }
+        : null),
+      ...(readingAutoplayGifs !== undefined ? { readingAutoplayGifs } : null),
       ...(emailNotifications !== undefined ? { emailNotifications } : null),
       ...(pushNotifications !== undefined ? { pushNotifications } : null),
       ...(notificationPolicy !== undefined ? { notificationPolicy } : null),

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -91,6 +91,10 @@ export type UpdateActorParams = {
   defaultSensitive?: boolean
   defaultLanguage?: string
   postLineLimit?: PostLineLimit
+  // Mastodon `reading:*` preferences surfaced by /api/v1/preferences.
+  readingExpandMedia?: 'default' | 'show_all' | 'hide_all'
+  readingExpandSpoilers?: boolean
+  readingAutoplayGifs?: boolean
   emailNotifications?: {
     follow_request?: boolean
     follow?: boolean

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -25,6 +25,10 @@ export interface ActorSettings {
   defaultSensitive?: boolean
   defaultLanguage?: string
   postLineLimit?: PostLineLimit
+  // Mastodon `reading:*` preferences surfaced by /api/v1/preferences.
+  readingExpandMedia?: 'default' | 'show_all' | 'hide_all'
+  readingExpandSpoilers?: boolean
+  readingAutoplayGifs?: boolean
   emailNotifications?: {
     follow_request?: boolean
     follow?: boolean

--- a/lib/types/domain/actor.ts
+++ b/lib/types/domain/actor.ts
@@ -44,6 +44,11 @@ export const Actor = ActorProfile.extend({
   privateKey: z.string().optional(),
   publicKey: z.string(),
   account: Account.optional(),
+  // Mastodon `reading:*` preferences. Private per-user settings: kept on Actor
+  // (not ActorProfile) so they never leak into public profile shapes.
+  readingExpandMedia: z.enum(['default', 'show_all', 'hide_all']).optional(),
+  readingExpandSpoilers: z.boolean().optional(),
+  readingAutoplayGifs: z.boolean().optional(),
   updatedAt: z.number(),
   deletionStatus: z.enum(['scheduled', 'deleting']).nullable().optional(),
   deletionScheduledAt: z.number().nullable().optional()


### PR DESCRIPTION
## Summary

- Persist three reading preferences — `readingExpandMedia`, `readingExpandSpoilers`, and `readingAutoplayGifs` — in the existing `actors.settings` JSON column, so **no migration** is required.
- Expose the reading preferences as optional fields on the domain `Actor`.
- `GET /api/v1/preferences` now returns the actor's real posting defaults (via the Mastodon account `source`) plus the persisted reading preferences, with Mastodon-compatible fallbacks replacing the former static stub.

## Test plan

- New DB round-trip tests in `lib/database/sql/actor.test.ts`, including a false-value round-trip and verification that updating preferences preserves other settings (settings merge).
- New route tests in `app/api/v1/preferences/route.test.ts` covering real persisted values and the default payload.
- Full battery green: `yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test`.
- Review fixes applied after a multi-agent review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)