### PR TITLE
Bump version to v1.65.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.65.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.64.0`
- Base main SHA: `38ae7d067d7d7ec3a1869ab1d71c20cf6beb2efc`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
