### PR TITLE
minor: instance rules (storage, public API, admin UI)

### DIFF
--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -5,6 +5,7 @@ import {
   Filter,
   Globe,
   Hash,
+  ScrollText,
   Settings,
   Smile,
   Users
@@ -29,6 +30,7 @@ const tabs: SectionNavTab[] = [
   { name: 'Accounts', url: '/admin/accounts', icon: Users },
   { name: 'Hashtags', url: '/admin/tags', icon: Hash },
   { name: 'Filters', url: '/admin/filters', icon: Filter },
+  { name: 'Rules', url: '/admin/rules', icon: ScrollText },
   { name: 'Federation', url: '/admin/federation', icon: Globe },
   { name: 'Custom emojis', url: '/admin/emojis', icon: Smile },
   { name: 'System', url: '/admin/system', icon: Settings }

--- a/app/(timeline)/admin/rules/page.tsx
+++ b/app/(timeline)/admin/rules/page.tsx
@@ -1,0 +1,28 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { RulesPanel } from '@/lib/components/admin-rules/RulesPanel'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Rules'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Failed to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  return <RulesPanel />
+}
+
+export default Page

--- a/app/api/v1/instance/rules/route.test.ts
+++ b/app/api/v1/instance/rules/route.test.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
+import { GET } from './route'
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => null
+}))
+
+jest.mock('@/lib/config', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    secretPhase: 'test-secret',
+    allowEmails: []
+  })
+}))
+
+const params = { params: Promise.resolve({}) }
+
+describe('GET /api/v1/instance/rules', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  it('returns stored rules as Mastodon Rule entities in position order', async () => {
+    const second = await database.createInstanceRule({
+      text: 'Be kind to each other',
+      hint: 'Harassment is not tolerated',
+      position: 2
+    })
+    const first = await database.createInstanceRule({
+      text: 'No spam',
+      hint: '',
+      position: 1
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance/rules'),
+      params
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([
+      { id: first.id, text: 'No spam', hint: '' },
+      {
+        id: second.id,
+        text: 'Be kind to each other',
+        hint: 'Harassment is not tolerated'
+      }
+    ])
+  })
+
+  it('returns an error when the database is unavailable', async () => {
+    mockDatabase = null
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v1/instance/rules'),
+        params
+      )
+      expect(response.status).toBe(500)
+    } finally {
+      mockDatabase = database
+    }
+  })
+})

--- a/app/api/v1/instance/rules/route.ts
+++ b/app/api/v1/instance/rules/route.ts
@@ -26,8 +26,8 @@ export const GET = traceApiRoute('getInstanceRules', async (req) => {
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
-    data: rules.map((rule) =>
-      Rule.parse({ id: rule.id, text: rule.text, hint: rule.hint })
+    data: rules.map(
+      (rule): Rule => ({ id: rule.id, text: rule.text, hint: rule.hint })
     )
   })
 })

--- a/app/api/v1/instance/rules/route.ts
+++ b/app/api/v1/instance/rules/route.ts
@@ -1,5 +1,7 @@
+import { getDatabase } from '@/lib/database'
+import { Rule } from '@/lib/types/mastodon/rule'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { HTTP_STATUS, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
@@ -7,8 +9,25 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 // https://docs.joinmastodon.org/methods/instance/#rules
-// This single-user/personal server does not define moderation rules, so the
-// list is empty. Clients render an empty "Server rules" section gracefully.
+// Public, unauthenticated — Mastodon serves GET /api/v1/instance/rules without
+// a token. Rules are stored in the database ordered by position.
 export const GET = traceApiRoute('getInstanceRules', async (req) => {
-  return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
+  const database = getDatabase()
+  if (!database) {
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { error: 'Database unavailable' },
+      responseStatusCode: HTTP_STATUS.INTERNAL_SERVER_ERROR
+    })
+  }
+
+  const rules = await database.getInstanceRules()
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: rules.map((rule) =>
+      Rule.parse({ id: rule.id, text: rule.text, hint: rule.hint })
+    )
+  })
 })

--- a/app/api/v2/admin/rules/[id]/route.test.ts
+++ b/app/api/v2/admin/rules/[id]/route.test.ts
@@ -127,6 +127,10 @@ describe('/api/v2/admin/rules/[id]', () => {
     {
       description: 'returns 422 when the updated position is negative',
       body: { position: -1 }
+    },
+    {
+      description: 'returns 422 when the body has no updatable fields',
+      body: {}
     }
   ])('$description', async ({ body }) => {
     const rule = await database.createInstanceRule({

--- a/app/api/v2/admin/rules/[id]/route.test.ts
+++ b/app/api/v2/admin/rules/[id]/route.test.ts
@@ -117,6 +117,42 @@ describe('/api/v2/admin/rules/[id]', () => {
 
   it.each([
     {
+      description: 'returns 422 when the updated text is empty',
+      body: { text: '' }
+    },
+    {
+      description: 'returns 422 when the updated text exceeds 1000 characters',
+      body: { text: 'a'.repeat(1001) }
+    },
+    {
+      description: 'returns 422 when the updated position is negative',
+      body: { position: -1 }
+    }
+  ])('$description', async ({ body }) => {
+    const rule = await database.createInstanceRule({
+      text: 'Guarded rule',
+      hint: 'Guarded hint',
+      position: 2
+    })
+
+    const response = await PATCH(
+      baseRequest(rule.id, { method: 'PATCH', body }),
+      { params: Promise.resolve({ id: rule.id }) }
+    )
+    expect(response.status).toBe(422)
+
+    const rules = await database.getInstanceRules()
+    expect(rules.find((item) => item.id === rule.id)).toEqual(
+      expect.objectContaining({
+        text: 'Guarded rule',
+        hint: 'Guarded hint',
+        position: 2
+      })
+    )
+  })
+
+  it.each([
+    {
       description: 'returns 404 when updating an unknown rule',
       handler: PATCH,
       init: { method: 'PATCH', body: { text: 'Updated rule' } }

--- a/app/api/v2/admin/rules/[id]/route.test.ts
+++ b/app/api/v2/admin/rules/[id]/route.test.ts
@@ -1,0 +1,135 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
+import { DELETE, PATCH, PUT } from './route'
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => null
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest
+    .fn()
+    .mockResolvedValue({ user: { email: 'admin@llun.test' } })
+}))
+
+const mockGetAdminFromSession = jest.fn()
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: () => mockGetAdminFromSession()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v2/admin/rules/[id]', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAdminFromSession.mockResolvedValue({
+      id: 'admin',
+      email: 'admin@llun.test'
+    })
+  })
+
+  const baseRequest = (id: string, init: { method: string; body?: object }) =>
+    new NextRequest(
+      `https://llun.test/api/v2/admin/rules/${encodeURIComponent(id)}`,
+      {
+        method: init.method,
+        headers: init.body
+          ? {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test',
+              Referer: 'https://llun.test/'
+            }
+          : { Origin: 'https://llun.test' },
+        body: init.body ? JSON.stringify(init.body) : undefined
+      }
+    )
+
+  // Rails `resources` maps update to both PATCH and PUT, so admin clients may
+  // send either. Binding PATCH to the same handler reference guarantees both
+  // verbs behave identically.
+  it('binds PATCH to the same handler as PUT', () => {
+    expect(typeof PATCH).toBe('function')
+    expect(PATCH).toBe(PUT)
+  })
+
+  it('updates the text and position of an existing rule', async () => {
+    const rule = await database.createInstanceRule({
+      text: 'Original rule',
+      hint: 'Original hint',
+      position: 1
+    })
+
+    const response = await PATCH(
+      baseRequest(rule.id, {
+        method: 'PATCH',
+        body: { text: 'Updated rule', position: 5 }
+      }),
+      { params: Promise.resolve({ id: rule.id }) }
+    )
+    expect(response.status).toBe(200)
+    const updated = await response.json()
+    expect(updated).toEqual({
+      id: rule.id,
+      text: 'Updated rule',
+      hint: 'Original hint',
+      position: 5
+    })
+  })
+
+  it('removes a rule with DELETE', async () => {
+    const rule = await database.createInstanceRule({
+      text: 'Temporary rule',
+      hint: '',
+      position: 9
+    })
+
+    const response = await DELETE(baseRequest(rule.id, { method: 'DELETE' }), {
+      params: Promise.resolve({ id: rule.id })
+    })
+    expect(response.status).toBe(200)
+
+    const rules = await database.getInstanceRules()
+    expect(rules.find((item) => item.id === rule.id)).toBeUndefined()
+  })
+
+  it.each([
+    {
+      description: 'returns 404 when updating an unknown rule',
+      handler: PATCH,
+      init: { method: 'PATCH', body: { text: 'Updated rule' } }
+    },
+    {
+      description: 'returns 404 when deleting an unknown rule',
+      handler: DELETE,
+      init: { method: 'DELETE' }
+    }
+  ])('$description', async ({ handler, init }) => {
+    const response = await handler(baseRequest('unknown-rule', init), {
+      params: Promise.resolve({ id: 'unknown-rule' })
+    })
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v2/admin/rules/[id]/route.ts
+++ b/app/api/v2/admin/rules/[id]/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from 'next/server'
+
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { RuleUpdateInput, getAdminRule } from '@/lib/services/rules/adminRule'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_404,
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.PUT,
+  HttpMethod.enum.PATCH,
+  HttpMethod.enum.DELETE
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const PUT = traceApiRoute(
+  'adminUpdateInstanceRule',
+  AdminApiGuard<Params>(
+    CORS_HEADERS,
+    async (req: NextRequest, { database, params }) => {
+      const { id } = await params
+      let rawBody: unknown
+      try {
+        rawBody = await req.json()
+      } catch {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        })
+      }
+      const parsed = RuleUpdateInput.safeParse(rawBody)
+      if (!parsed.success)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+        })
+
+      const updated = await database.updateInstanceRule({
+        id,
+        text: parsed.data.text,
+        hint: parsed.data.hint,
+        position: parsed.data.position
+      })
+      if (!updated)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: HTTP_STATUS.NOT_FOUND
+        })
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: getAdminRule(updated)
+      })
+    }
+  )
+)
+
+// Mastodon clients commonly send PATCH for updates; bind it to the same handler.
+export const PATCH = PUT
+
+export const DELETE = traceApiRoute(
+  'adminDeleteInstanceRule',
+  AdminApiGuard<Params>(CORS_HEADERS, async (req, { database, params }) => {
+    const { id } = await params
+    const deleted = await database.deleteInstanceRule({ id })
+    if (!deleted)
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_404,
+        responseStatusCode: HTTP_STATUS.NOT_FOUND
+      })
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+  })
+)

--- a/app/api/v2/admin/rules/route.test.ts
+++ b/app/api/v2/admin/rules/route.test.ts
@@ -95,11 +95,27 @@ describe('/api/v2/admin/rules', () => {
     expect(entry).toEqual(created)
   })
 
-  it('returns 422 when the text is empty', async () => {
-    const response = await POST(
-      baseRequest({ method: 'POST', body: { text: '', hint: 'something' } }),
-      { params: Promise.resolve({}) }
-    )
+  it.each([
+    {
+      description: 'returns 422 when the text is empty',
+      body: { text: '', hint: 'something' }
+    },
+    {
+      description: 'returns 422 when the text exceeds 1000 characters',
+      body: { text: 'a'.repeat(1001) }
+    },
+    {
+      description: 'returns 422 when the hint exceeds 2000 characters',
+      body: { text: 'ok', hint: 'a'.repeat(2001) }
+    },
+    {
+      description: 'returns 422 when the position is negative',
+      body: { text: 'ok', position: -1 }
+    }
+  ])('$description', async ({ body }) => {
+    const response = await POST(baseRequest({ method: 'POST', body }), {
+      params: Promise.resolve({})
+    })
     expect(response.status).toBe(422)
   })
 })

--- a/app/api/v2/admin/rules/route.test.ts
+++ b/app/api/v2/admin/rules/route.test.ts
@@ -74,6 +74,13 @@ describe('/api/v2/admin/rules', () => {
     expect(response.status).toBe(403)
   })
 
+  it('rejects non-admin list requests', async () => {
+    mockGetAdminFromSession.mockResolvedValue(null)
+
+    const response = await GET(baseRequest(), { params: Promise.resolve({}) })
+    expect(response.status).toBe(403)
+  })
+
   it('creates a rule and lists it with its position', async () => {
     const postResponse = await POST(
       baseRequest({ method: 'POST', body: { text: 'Be kind', hint: '' } }),

--- a/app/api/v2/admin/rules/route.test.ts
+++ b/app/api/v2/admin/rules/route.test.ts
@@ -1,0 +1,105 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
+import { GET, POST } from './route'
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => null
+}))
+
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: jest
+    .fn()
+    .mockResolvedValue({ user: { email: 'admin@llun.test' } })
+}))
+
+const mockGetAdminFromSession = jest.fn()
+jest.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: () => mockGetAdminFromSession()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v2/admin/rules', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAdminFromSession.mockResolvedValue({
+      id: 'admin',
+      email: 'admin@llun.test'
+    })
+  })
+
+  const baseRequest = (init?: { method?: string; body?: object }) =>
+    new NextRequest('https://llun.test/api/v2/admin/rules', {
+      method: init?.method ?? 'GET',
+      headers: init?.body
+        ? {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test',
+            Referer: 'https://llun.test/'
+          }
+        : { Origin: 'https://llun.test' },
+      body: init?.body ? JSON.stringify(init.body) : undefined
+    })
+
+  it('rejects non-admin requests', async () => {
+    mockGetAdminFromSession.mockResolvedValue(null)
+
+    const response = await POST(
+      baseRequest({ method: 'POST', body: { text: 'Be kind', hint: '' } }),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(403)
+  })
+
+  it('creates a rule and lists it with its position', async () => {
+    const postResponse = await POST(
+      baseRequest({ method: 'POST', body: { text: 'Be kind', hint: '' } }),
+      { params: Promise.resolve({}) }
+    )
+    expect(postResponse.status).toBe(200)
+    const created = await postResponse.json()
+    expect(created.id).toEqual(expect.any(String))
+    expect(created.text).toBe('Be kind')
+    expect(created.hint).toBe('')
+    expect(created.position).toBe(0)
+
+    const listResponse = await GET(baseRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(listResponse.status).toBe(200)
+    const list = await listResponse.json()
+    const entry = list.find((item: { id: string }) => item.id === created.id)
+    expect(entry).toEqual(created)
+  })
+
+  it('returns 422 when the text is empty', async () => {
+    const response = await POST(
+      baseRequest({ method: 'POST', body: { text: '', hint: 'something' } }),
+      { params: Promise.resolve({}) }
+    )
+    expect(response.status).toBe(422)
+  })
+})

--- a/app/api/v2/admin/rules/route.ts
+++ b/app/api/v2/admin/rules/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from 'next/server'
+
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import { RuleCreateInput, getAdminRule } from '@/lib/services/rules/adminRule'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_422,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.POST
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminListInstanceRules',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const rules = await database.getInstanceRules()
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: rules.map(getAdminRule)
+    })
+  })
+)
+
+export const POST = traceApiRoute(
+  'adminCreateInstanceRule',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    let rawBody: unknown
+    try {
+      rawBody = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+    const parsed = RuleCreateInput.safeParse(rawBody)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_422,
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    const rule = await database.createInstanceRule({
+      text: parsed.data.text,
+      hint: parsed.data.hint,
+      position: parsed.data.position
+    })
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: getAdminRule(rule)
+    })
+  })
+)

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -1,6 +1,14 @@
 import { NextRequest } from 'next/server'
 
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
 import { GET } from './route'
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => null
+}))
 
 jest.mock('@/lib/config', () => ({
   getConfig: jest.fn().mockReturnValue({
@@ -16,6 +24,18 @@ jest.mock('@/lib/config', () => ({
 const params = { params: Promise.resolve({}) }
 
 describe('GET /api/v2/instance', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
   it('serves the instance payload for an unauthenticated request', async () => {
     // No OAuthGuard mock: the route must work without any Authorization header,
     // matching Mastodon's public v2 instance endpoint. If a guard is ever
@@ -62,5 +82,49 @@ describe('GET /api/v2/instance', () => {
     await expect(response.json()).resolves.toMatchObject({
       domain: 'llun.test'
     })
+  })
+
+  it('includes stored instance rules in position order', async () => {
+    const second = await database.createInstanceRule({
+      text: 'Be kind to each other',
+      hint: 'Harassment is not tolerated',
+      position: 2
+    })
+    const first = await database.createInstanceRule({
+      text: 'No spam',
+      hint: '',
+      position: 1
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.rules).toEqual([
+      { id: first.id, text: 'No spam', hint: '' },
+      {
+        id: second.id,
+        text: 'Be kind to each other',
+        hint: 'Harassment is not tolerated'
+      }
+    ])
+  })
+
+  it('returns empty rules instead of failing when the database is unavailable', async () => {
+    mockDatabase = null
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v2/instance'),
+        params
+      )
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.domain).toBe('llun.test')
+      expect(body.rules).toEqual([])
+    } finally {
+      mockDatabase = database
+    }
   })
 })

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -75,8 +75,8 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
         message: null,
         url: null
       },
-      rules: rules.map((rule) =>
-        Rule.parse({ id: rule.id, text: rule.text, hint: rule.hint })
+      rules: rules.map(
+        (rule): Rule => ({ id: rule.id, text: rule.text, hint: rule.hint })
       )
     }
   })

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MAX_PINNED_STATUSES,
@@ -11,6 +12,7 @@ import {
   MAX_FILE_SIZE
 } from '@/lib/services/medias/constants'
 import { isTranslationEnabled } from '@/lib/services/translation'
+import { Rule } from '@/lib/types/mastodon/rule'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -23,6 +25,10 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 // Public per Mastodon: GET /api/v2/instance is served unauthenticated.
 export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
   const config = getConfig()
+  // The instance payload must stay robust: when the database is unavailable,
+  // serve the static configuration with an empty rules list instead of failing.
+  const database = getDatabase()
+  const rules = database ? await database.getInstanceRules() : []
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
@@ -68,7 +74,10 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
         approval_required: false,
         message: null,
         url: null
-      }
+      },
+      rules: rules.map((rule) =>
+        Rule.parse({ id: rule.id, text: rule.text, hint: rule.hint })
+      )
     }
   })
 })

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -12,8 +12,10 @@ import {
   MAX_FILE_SIZE
 } from '@/lib/services/medias/constants'
 import { isTranslationEnabled } from '@/lib/services/translation'
+import { InstanceRuleData } from '@/lib/types/database/operations'
 import { Rule } from '@/lib/types/mastodon/rule'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { VERSION } from '@/lib/utils/version'
@@ -28,7 +30,19 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
   // The instance payload must stay robust: when the database is unavailable,
   // serve the static configuration with an empty rules list instead of failing.
   const database = getDatabase()
-  const rules = database ? await database.getInstanceRules() : []
+  let rules: InstanceRuleData[] = []
+  if (database) {
+    try {
+      rules = await database.getInstanceRules()
+    } catch (error) {
+      // A query failure (timeout, lock, etc.) must not take down the public
+      // metadata endpoint — fall back to an empty rules list.
+      logger.warn({
+        message: 'Failed to load instance rules for /api/v2/instance',
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,5 +1,6 @@
 import { Duration } from '@/lib/components/post-box/poll-choices'
 import { PresignedUrlOutput } from '@/lib/services/medias/types'
+import type { AdminRule } from '@/lib/services/rules/adminRule'
 import { TimelineFormat } from '@/lib/services/timelines/const'
 import { Timeline } from '@/lib/services/timelines/types'
 import type { DirectConversation } from '@/lib/types/database/operations'
@@ -2957,3 +2958,61 @@ export const updateServerFilter = (
 
 export const deleteServerFilter = (id: string): Promise<boolean> =>
   deleteFilterRequest(`/api/v2/admin/filters/${encodeURIComponent(id)}`)
+
+export type ServerRule = AdminRule
+
+export interface ServerRuleInput {
+  text: string
+  hint: string
+  position?: number
+}
+
+export const getServerRules = async (): Promise<ServerRule[]> => {
+  const response = await fetch('/api/v2/admin/rules', {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  // Throw (rather than returning []) so an HTTP error is surfaced by the
+  // caller's error handling instead of being indistinguishable from an
+  // empty list. Mirrors the throwing pattern used by getServerFilters().
+  if (!response.ok) {
+    throw new Error(`Failed to load rules (${response.status})`)
+  }
+  return (await response.json()) as ServerRule[]
+}
+
+export const createServerRule = async (
+  input: ServerRuleInput
+): Promise<ServerRule | null> => {
+  const response = await fetch('/api/v2/admin/rules', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input)
+  })
+  if (!response.ok) return null
+  return (await response.json()) as ServerRule
+}
+
+export const updateServerRule = async (
+  id: string,
+  input: Partial<ServerRuleInput>
+): Promise<ServerRule | null> => {
+  const response = await fetch(
+    `/api/v2/admin/rules/${encodeURIComponent(id)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input)
+    }
+  )
+  if (!response.ok) return null
+  return (await response.json()) as ServerRule
+}
+
+export const deleteServerRule = async (id: string): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v2/admin/rules/${encodeURIComponent(id)}`,
+    { method: 'DELETE' }
+  )
+  return response.ok
+}

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -262,9 +262,14 @@ export const RulesPanel: FC = () => {
                   type="button"
                   aria-label={`Delete rule ${rule.text}`}
                   onClick={() => handleDelete(rule)}
-                  // Disable every delete button while any delete is in flight
-                  // so deletes stay serialized and optimistic rollback is safe.
-                  disabled={deletingId !== null}
+                  // Keep all three mutations mutually exclusive: block deletes
+                  // while any delete, create, or position edit is in flight.
+                  // The delete rollback restores a snapshot captured before
+                  // those writes, so a concurrent create/edit would otherwise be
+                  // discarded if the delete then fails.
+                  disabled={
+                    deletingId !== null || saving || updatingPositionId !== null
+                  }
                   className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[hsl(0_84.2%_60.2%/0.4)] text-[hsl(0_72%_45%)] transition-colors hover:bg-[hsl(0_72%_45%/0.08)] disabled:pointer-events-none disabled:opacity-50"
                 >
                   <Trash2 className="size-4" />

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -62,7 +62,10 @@ export const RulesPanel: FC = () => {
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const text = newText.trim()
-    if (!text || saving) return
+    // Also bail while a delete is in flight: the submit button is disabled
+    // then, but a programmatic submit must not slip a create past the
+    // delete-rollback snapshot.
+    if (!text || saving || deletingId !== null) return
     setSaving(true)
     setFormError(null)
     try {
@@ -113,6 +116,10 @@ export const RulesPanel: FC = () => {
   }
 
   const handlePositionCommit = async (rule: ServerRule) => {
+    // Bail while a delete is in flight. Disabling the input mid-edit fires its
+    // onBlur, which would otherwise commit a position change past the
+    // delete-rollback snapshot.
+    if (deletingId !== null) return
     const draft = positionDrafts[rule.id]
     if (draft === undefined) return
     const clearDraft = () =>

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -190,7 +190,12 @@ export const RulesPanel: FC = () => {
           <div className="flex justify-end">
             <Button
               type="submit"
-              disabled={saving || newText.trim().length === 0}
+              // Block creation while a delete is in flight: the delete rollback
+              // restores a pre-create snapshot, which would discard a rule
+              // added mid-delete if the delete then fails.
+              disabled={
+                saving || deletingId !== null || newText.trim().length === 0
+              }
             >
               <Plus className="size-4" />
               Add rule
@@ -245,8 +250,12 @@ export const RulesPanel: FC = () => {
                     }
                     onBlur={() => handlePositionCommit(rule)}
                     // Serialize position updates so two in-flight edits can't
-                    // interleave their list re-sorts.
-                    disabled={updatingPositionId !== null}
+                    // interleave their list re-sorts, and block edits while a
+                    // delete is in flight so its rollback snapshot can't discard
+                    // a position change committed mid-delete.
+                    disabled={
+                      updatingPositionId !== null || deletingId !== null
+                    }
                   />
                 </label>
                 <button

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { Plus, Trash2 } from 'lucide-react'
+import { FC, FormEvent, useEffect, useState } from 'react'
+
+import {
+  type ServerRule,
+  createServerRule,
+  deleteServerRule,
+  getServerRules,
+  updateServerRule
+} from '@/lib/client'
+import { FilterField, FilterSection } from '@/lib/components/filters/filterUi'
+import { PageHeader } from '@/lib/components/page-header'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import { Textarea } from '@/lib/components/ui/textarea'
+
+// The server returns rules ordered by position ascending (ties broken by
+// creation time). `Array.prototype.sort` is stable, so re-sorting after an
+// edit preserves that tiebreak order for equal positions.
+const sortRules = (rules: ServerRule[]): ServerRule[] =>
+  [...rules].sort((a, b) => a.position - b.position)
+
+export const RulesPanel: FC = () => {
+  const [rules, setRules] = useState<ServerRule[]>([])
+  const [loading, setLoading] = useState(true)
+  const [listError, setListError] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [newText, setNewText] = useState('')
+  const [newHint, setNewHint] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  // Per-rule uncommitted position input values, keyed by rule id. A rule
+  // without an entry shows its saved position.
+  const [positionDrafts, setPositionDrafts] = useState<Record<string, string>>(
+    {}
+  )
+  const [updatingPositionId, setUpdatingPositionId] = useState<string | null>(
+    null
+  )
+
+  useEffect(() => {
+    let active = true
+    getServerRules()
+      .then((result) => {
+        if (active) setRules(result)
+      })
+      .catch(() => {
+        // A network/parse failure must surface an error rather than silently
+        // showing the "No rules yet" empty state.
+        if (active) setListError('Failed to load rules. Please try again.')
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const text = newText.trim()
+    if (!text || saving) return
+    setSaving(true)
+    setFormError(null)
+    try {
+      // The client helper returns null on a non-ok response; throw so both
+      // that and any network-layer rejection land in the same catch.
+      const created = await createServerRule({ text, hint: newHint.trim() })
+      if (!created) {
+        throw new Error('Failed to create rule. Please try again.')
+      }
+      setRules((current) => sortRules([...current, created]))
+      setNewText('')
+      setNewHint('')
+    } catch (error) {
+      setFormError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to create rule. Please try again.'
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (rule: ServerRule) => {
+    // A delete is already in flight — all delete buttons are disabled while
+    // `deletingId` is set, so this guards against any racing invocation.
+    if (deletingId) return
+    setListError(null)
+    setDeletingId(rule.id)
+    const previous = rules
+    // Optimistic removal — restore the row if the request fails. Deletes are
+    // serialized (see the guard above), so `previous` is always the current
+    // list and rolling back to it cannot resurrect a separately-deleted row.
+    setRules((current) => current.filter((item) => item.id !== rule.id))
+    const restoreOnFailure = () => {
+      setRules(previous)
+      setListError('Failed to delete rule. Please try again.')
+    }
+    try {
+      const ok = await deleteServerRule(rule.id)
+      if (!ok) restoreOnFailure()
+    } catch {
+      // A network-layer throw (connection drop, etc.) must still roll back.
+      restoreOnFailure()
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const handlePositionCommit = async (rule: ServerRule) => {
+    const draft = positionDrafts[rule.id]
+    if (draft === undefined) return
+    const clearDraft = () =>
+      setPositionDrafts(({ [rule.id]: _removed, ...rest }) => rest)
+    // An emptied field or an unchanged/invalid value reverts to the saved
+    // position instead of sending an update.
+    const next = Number(draft)
+    if (
+      draft.trim() === '' ||
+      !Number.isInteger(next) ||
+      next < 0 ||
+      next === rule.position
+    ) {
+      clearDraft()
+      return
+    }
+    setListError(null)
+    setUpdatingPositionId(rule.id)
+    try {
+      const updated = await updateServerRule(rule.id, { position: next })
+      if (!updated) {
+        throw new Error('Failed to update rule position. Please try again.')
+      }
+      setRules((current) =>
+        sortRules(
+          current.map((item) => (item.id === updated.id ? updated : item))
+        )
+      )
+    } catch {
+      setListError('Failed to update rule position. Please try again.')
+    } finally {
+      setUpdatingPositionId(null)
+      clearDraft()
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Rules"
+        description="Moderation rules shown on the about page and served from the Mastodon rules API. Lower positions appear first."
+      />
+
+      {listError && <p className="text-sm text-destructive">{listError}</p>}
+
+      <FilterSection
+        title="Add a rule"
+        description="Keep rules short and put the longer explanation in the hint."
+      >
+        <form onSubmit={handleCreate} className="space-y-4">
+          <FilterField label="Rule text" htmlFor="rule-text">
+            <Textarea
+              id="rule-text"
+              value={newText}
+              onChange={(event) => setNewText(event.target.value)}
+              maxLength={1000}
+              rows={2}
+              required
+            />
+          </FilterField>
+          <FilterField
+            label="Hint"
+            htmlFor="rule-hint"
+            help="Optional longer explanation rendered under the rule."
+          >
+            <Textarea
+              id="rule-hint"
+              value={newHint}
+              onChange={(event) => setNewHint(event.target.value)}
+              maxLength={2000}
+              rows={2}
+            />
+          </FilterField>
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={saving || newText.trim().length === 0}
+            >
+              <Plus className="size-4" />
+              Add rule
+            </Button>
+          </div>
+        </form>
+      </FilterSection>
+
+      <FilterSection>
+        {loading ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Loading rules…
+          </p>
+        ) : rules.length === 0 && !listError ? (
+          // Suppress the empty-state copy when a load error is already shown,
+          // so a failed fetch doesn't read as "you have no rules".
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No rules yet — add one to show it on the about page.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {rules.map((rule) => (
+              <div
+                key={rule.id}
+                className="flex items-start gap-3 rounded-lg border p-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">{rule.text}</p>
+                  {rule.hint && (
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {rule.hint}
+                    </p>
+                  )}
+                </div>
+                <label
+                  className="flex shrink-0 items-center gap-2 text-sm text-muted-foreground"
+                  htmlFor={`rule-position-${rule.id}`}
+                >
+                  Position
+                  <Input
+                    id={`rule-position-${rule.id}`}
+                    type="number"
+                    min={0}
+                    step={1}
+                    className="w-20"
+                    value={positionDrafts[rule.id] ?? String(rule.position)}
+                    onChange={(event) =>
+                      setPositionDrafts((current) => ({
+                        ...current,
+                        [rule.id]: event.target.value
+                      }))
+                    }
+                    onBlur={() => handlePositionCommit(rule)}
+                    // Serialize position updates so two in-flight edits can't
+                    // interleave their list re-sorts.
+                    disabled={updatingPositionId !== null}
+                  />
+                </label>
+                <button
+                  type="button"
+                  aria-label={`Delete rule ${rule.text}`}
+                  onClick={() => handleDelete(rule)}
+                  // Disable every delete button while any delete is in flight
+                  // so deletes stay serialized and optimistic rollback is safe.
+                  disabled={deletingId !== null}
+                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[hsl(0_84.2%_60.2%/0.4)] text-[hsl(0_72%_45%)] transition-colors hover:bg-[hsl(0_72%_45%/0.08)] disabled:pointer-events-none disabled:opacity-50"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </FilterSection>
+    </div>
+  )
+}

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -18,6 +18,7 @@ import { FollowerSQLDatabaseMixin } from '@/lib/database/sql/follow'
 import { FollowedTagSQLDatabaseMixin } from '@/lib/database/sql/followedTag'
 import { IdempotencySQLDatabaseMixin } from '@/lib/database/sql/idempotency'
 import { InstanceActivitySQLDatabaseMixin } from '@/lib/database/sql/instanceActivity'
+import { InstanceRuleSQLDatabaseMixin } from '@/lib/database/sql/instanceRule'
 import { LikeSQLDatabaseMixin } from '@/lib/database/sql/like'
 import { ListSQLDatabaseMixin } from '@/lib/database/sql/list'
 import { MarkerSQLDatabaseMixin } from '@/lib/database/sql/marker'
@@ -61,6 +62,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const followedTagDatabase = FollowedTagSQLDatabaseMixin(database)
   const instanceActivityDatabase = InstanceActivitySQLDatabaseMixin(database)
+  const instanceRuleDatabase = InstanceRuleSQLDatabaseMixin(database)
   const likeDatabase = LikeSQLDatabaseMixin(database)
   const mediaDatabase = MediaSQLDatabaseMixin(database)
   const notificationDatabase = NotificationSQLDatabaseMixin(database)
@@ -110,6 +112,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...fitnessRouteHeatmapDatabase,
     ...fitnessSettingsDatabase,
     ...instanceActivityDatabase,
+    ...instanceRuleDatabase,
     ...bookmarkDatabase,
     ...blockDatabase,
     ...customEmojiDatabase,

--- a/lib/database/sql/instanceRule.test.ts
+++ b/lib/database/sql/instanceRule.test.ts
@@ -129,6 +129,16 @@ describe('updateInstanceRule', () => {
       expected: { text: 'Original text', hint: 'Original hint', position: 5 }
     },
     {
+      description: 'moves the rule to position 0 when position 0 is provided',
+      update: { position: 0 },
+      expected: { text: 'Original text', hint: 'Original hint', position: 0 }
+    },
+    {
+      description: 'clears the hint when an empty hint is provided',
+      update: { hint: '' },
+      expected: { text: 'Original text', hint: '', position: 1 }
+    },
+    {
       description: 'updates every field when all fields are provided',
       update: { text: 'Updated text', hint: 'Updated hint', position: 9 },
       expected: { text: 'Updated text', hint: 'Updated hint', position: 9 }

--- a/lib/database/sql/instanceRule.test.ts
+++ b/lib/database/sql/instanceRule.test.ts
@@ -196,10 +196,18 @@ describe('deleteInstanceRule', () => {
         position: 1
       })
 
-      await database.deleteInstanceRule({ id: remove.id })
+      const deleted = await database.deleteInstanceRule({ id: remove.id })
+      expect(deleted).toBe(true)
 
       const rules = await database.getInstanceRules()
       expect(rules).toEqual([keep])
+    })
+  })
+
+  it('returns false for an unknown id', async () => {
+    await withFreshDatabase(async (database) => {
+      const deleted = await database.deleteInstanceRule({ id: 'no-such-id' })
+      expect(deleted).toBe(false)
     })
   })
 })

--- a/lib/database/sql/instanceRule.test.ts
+++ b/lib/database/sql/instanceRule.test.ts
@@ -1,0 +1,195 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+describe('createInstanceRule', () => {
+  it('creates a rule with the provided text, hint and position', async () => {
+    await withFreshDatabase(async (database) => {
+      const rule = await database.createInstanceRule({
+        text: 'Be excellent to each other',
+        hint: 'No harassment of any kind',
+        position: 3
+      })
+
+      expect(rule.id).toBeTruthy()
+      expect(rule.text).toBe('Be excellent to each other')
+      expect(rule.hint).toBe('No harassment of any kind')
+      expect(rule.position).toBe(3)
+      expect(typeof rule.createdAt).toBe('number')
+      expect(typeof rule.updatedAt).toBe('number')
+
+      const rules = await database.getInstanceRules()
+      expect(rules).toEqual([rule])
+    })
+  })
+
+  it('defaults position to 0 when not provided', async () => {
+    await withFreshDatabase(async (database) => {
+      const rule = await database.createInstanceRule({
+        text: 'No spam',
+        hint: ''
+      })
+      expect(rule.position).toBe(0)
+
+      const rules = await database.getInstanceRules()
+      expect(rules[0].position).toBe(0)
+    })
+  })
+})
+
+describe('getInstanceRules', () => {
+  it('returns an empty list when no rules exist', async () => {
+    await withFreshDatabase(async (database) => {
+      expect(await database.getInstanceRules()).toEqual([])
+    })
+  })
+
+  it('returns all rules ordered by position ascending', async () => {
+    await withFreshDatabase(async (database) => {
+      await database.createInstanceRule({
+        text: 'Third rule',
+        hint: '',
+        position: 2
+      })
+      await database.createInstanceRule({
+        text: 'First rule',
+        hint: '',
+        position: 0
+      })
+      await database.createInstanceRule({
+        text: 'Second rule',
+        hint: '',
+        position: 1
+      })
+
+      const rules = await database.getInstanceRules()
+      expect(rules.map((rule) => rule.text)).toEqual([
+        'First rule',
+        'Second rule',
+        'Third rule'
+      ])
+      expect(rules.map((rule) => rule.position)).toEqual([0, 1, 2])
+    })
+  })
+
+  it('breaks position ties by createdAt ascending', async () => {
+    await withFreshDatabase(async (database) => {
+      await database.createInstanceRule({
+        text: 'Older rule',
+        hint: '',
+        position: 1
+      })
+      // SQLite stores timestamps at millisecond precision — make sure the
+      // second rule's createdAt is strictly later.
+      await sleep(10)
+      await database.createInstanceRule({
+        text: 'Newer rule',
+        hint: '',
+        position: 1
+      })
+
+      const rules = await database.getInstanceRules()
+      expect(rules.map((rule) => rule.text)).toEqual([
+        'Older rule',
+        'Newer rule'
+      ])
+    })
+  })
+})
+
+describe('updateInstanceRule', () => {
+  it.each([
+    {
+      description: 'updates only the text when only text is provided',
+      update: { text: 'Updated text' },
+      expected: { text: 'Updated text', hint: 'Original hint', position: 1 }
+    },
+    {
+      description: 'updates only the hint when only hint is provided',
+      update: { hint: 'Updated hint' },
+      expected: { text: 'Original text', hint: 'Updated hint', position: 1 }
+    },
+    {
+      description: 'updates only the position when only position is provided',
+      update: { position: 5 },
+      expected: { text: 'Original text', hint: 'Original hint', position: 5 }
+    },
+    {
+      description: 'updates every field when all fields are provided',
+      update: { text: 'Updated text', hint: 'Updated hint', position: 9 },
+      expected: { text: 'Updated text', hint: 'Updated hint', position: 9 }
+    }
+  ])('$description', async ({ update, expected }) => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createInstanceRule({
+        text: 'Original text',
+        hint: 'Original hint',
+        position: 1
+      })
+
+      // SQLite stores timestamps at millisecond precision — make sure the
+      // update lands on a strictly later updatedAt.
+      await sleep(10)
+      const updated = await database.updateInstanceRule({
+        id: created.id,
+        ...update
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated).toEqual(
+        expect.objectContaining({ id: created.id, ...expected })
+      )
+      expect(updated?.createdAt).toBe(created.createdAt)
+      expect(updated?.updatedAt).toBeGreaterThan(created.updatedAt)
+
+      const rules = await database.getInstanceRules()
+      expect(rules).toEqual([updated])
+    })
+  })
+
+  it('returns null for an unknown id', async () => {
+    await withFreshDatabase(async (database) => {
+      const updated = await database.updateInstanceRule({
+        id: 'unknown-rule-id',
+        text: 'Does not matter'
+      })
+      expect(updated).toBeNull()
+    })
+  })
+})
+
+describe('deleteInstanceRule', () => {
+  it('removes the rule', async () => {
+    await withFreshDatabase(async (database) => {
+      const keep = await database.createInstanceRule({
+        text: 'Keep this rule',
+        hint: '',
+        position: 0
+      })
+      const remove = await database.createInstanceRule({
+        text: 'Remove this rule',
+        hint: '',
+        position: 1
+      })
+
+      await database.deleteInstanceRule({ id: remove.id })
+
+      const rules = await database.getInstanceRules()
+      expect(rules).toEqual([keep])
+    })
+  })
+})

--- a/lib/database/sql/instanceRule.ts
+++ b/lib/database/sql/instanceRule.ts
@@ -62,13 +62,11 @@ export const InstanceRuleSQLDatabaseMixin = (
     hint,
     position
   }: UpdateInstanceRuleParams) {
-    const existing = await database<SQLInstanceRule>('instance_rules')
-      .where({ id })
-      .first()
-    if (!existing) return null
-
     const updatedAt = new Date()
-    await database('instance_rules')
+    // Update first and use the affected-row count to detect a missing rule;
+    // this drops the extra existence SELECT (3 roundtrips → 2). Knex returns
+    // the affected-row count for update() on SQLite/PostgreSQL/MySQL.
+    const updatedCount = await database('instance_rules')
       .where({ id })
       .update({
         ...(text !== undefined ? { text } : null),
@@ -76,6 +74,7 @@ export const InstanceRuleSQLDatabaseMixin = (
         ...(position !== undefined ? { position } : null),
         updatedAt
       })
+    if (updatedCount === 0) return null
 
     const row = await database<SQLInstanceRule>('instance_rules')
       .where({ id })

--- a/lib/database/sql/instanceRule.ts
+++ b/lib/database/sql/instanceRule.ts
@@ -1,0 +1,97 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  CreateInstanceRuleParams,
+  DeleteInstanceRuleParams,
+  InstanceRuleData,
+  InstanceRuleDatabase,
+  UpdateInstanceRuleParams
+} from '@/lib/types/database/operations'
+
+type SQLInstanceRule = {
+  id: string
+  position: number
+  text: string
+  hint: string
+  createdAt: number | Date | string
+  updatedAt: number | Date | string
+}
+
+const toInstanceRule = (row: SQLInstanceRule): InstanceRuleData => ({
+  id: row.id,
+  position: Number(row.position),
+  text: row.text,
+  hint: row.hint,
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+export const InstanceRuleSQLDatabaseMixin = (
+  database: Knex
+): InstanceRuleDatabase => ({
+  async createInstanceRule({
+    text,
+    hint,
+    position = 0
+  }: CreateInstanceRuleParams) {
+    const currentTime = new Date()
+    const id = randomUUID()
+    await database('instance_rules').insert({
+      id,
+      position,
+      text,
+      hint,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+    return {
+      id,
+      position,
+      text,
+      hint,
+      createdAt: currentTime.getTime(),
+      updatedAt: currentTime.getTime()
+    }
+  },
+
+  async updateInstanceRule({
+    id,
+    text,
+    hint,
+    position
+  }: UpdateInstanceRuleParams) {
+    const existing = await database<SQLInstanceRule>('instance_rules')
+      .where({ id })
+      .first()
+    if (!existing) return null
+
+    const updatedAt = new Date()
+    await database('instance_rules')
+      .where({ id })
+      .update({
+        ...(text !== undefined ? { text } : null),
+        ...(hint !== undefined ? { hint } : null),
+        ...(position !== undefined ? { position } : null),
+        updatedAt
+      })
+
+    const row = await database<SQLInstanceRule>('instance_rules')
+      .where({ id })
+      .first()
+    return row ? toInstanceRule(row) : null
+  },
+
+  async deleteInstanceRule({ id }: DeleteInstanceRuleParams) {
+    const deleted = await database('instance_rules').where({ id }).delete()
+    return deleted > 0
+  },
+
+  async getInstanceRules() {
+    const rows = await database<SQLInstanceRule>('instance_rules')
+      .orderBy('position', 'asc')
+      .orderBy('createdAt', 'asc')
+    return rows.map(toInstanceRule)
+  }
+})

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -19,6 +19,7 @@ import {
   FollowedTagDatabase,
   IdempotencyDatabase,
   InstanceActivityDatabase,
+  InstanceRuleDatabase,
   LikeDatabase,
   ListDatabase,
   MarkerDatabase,
@@ -42,6 +43,7 @@ export type Database = AccountDatabase &
   ActorDatabase &
   AdminDatabase &
   InstanceActivityDatabase &
+  InstanceRuleDatabase &
   FitnessFileDatabase &
   FitnessRouteHeatmapDatabase &
   FitnessSettingsDatabase &

--- a/lib/services/rules/adminRule.ts
+++ b/lib/services/rules/adminRule.ts
@@ -12,12 +12,22 @@ export const RuleCreateInput = z.object({
 })
 
 // Partial update — every field is optional, but present fields must satisfy
-// the same constraints as creation.
-export const RuleUpdateInput = z.object({
-  text: z.string().trim().min(1).max(1000).optional(),
-  hint: z.string().trim().max(2000).optional(),
-  position: z.coerce.number().int().min(0).optional()
-})
+// the same constraints as creation. At least one field must be present so an
+// empty body is rejected with 422 rather than silently performing a
+// timestamp-only no-op update.
+export const RuleUpdateInput = z
+  .object({
+    text: z.string().trim().min(1).max(1000).optional(),
+    hint: z.string().trim().max(2000).optional(),
+    position: z.coerce.number().int().min(0).optional()
+  })
+  .refine(
+    (data) =>
+      data.text !== undefined ||
+      data.hint !== undefined ||
+      data.position !== undefined,
+    { message: 'At least one of text, hint, or position must be provided' }
+  )
 
 // Admin shape — unlike the public Mastodon Rule entity this includes
 // `position` so the admin panel can reorder rules by editing it.

--- a/lib/services/rules/adminRule.ts
+++ b/lib/services/rules/adminRule.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+import { InstanceRuleData } from '@/lib/types/database/operations'
+
+// Body validation for the admin rules endpoints. The instance_rules text
+// columns are unbounded `text`, so the caps here are product limits that keep
+// rules readable rather than database constraints.
+export const RuleCreateInput = z.object({
+  text: z.string().trim().min(1).max(1000),
+  hint: z.string().trim().max(2000).optional().default(''),
+  position: z.coerce.number().int().min(0).optional()
+})
+
+// Partial update — every field is optional, but present fields must satisfy
+// the same constraints as creation.
+export const RuleUpdateInput = z.object({
+  text: z.string().trim().min(1).max(1000).optional(),
+  hint: z.string().trim().max(2000).optional(),
+  position: z.coerce.number().int().min(0).optional()
+})
+
+// Admin shape — unlike the public Mastodon Rule entity this includes
+// `position` so the admin panel can reorder rules by editing it.
+export const getAdminRule = (rule: InstanceRuleData) => ({
+  id: rule.id,
+  text: rule.text,
+  hint: rule.hint,
+  position: rule.position
+})
+export type AdminRule = ReturnType<typeof getAdminRule>

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1478,6 +1478,53 @@ export interface ScheduledStatusDatabase {
 }
 
 // ============================================================================
+// Instance Rule Database
+// ============================================================================
+
+// A moderation rule shown on the instance's about page and returned from
+// GET /api/v1/instance/rules. `position` drives the display order (ascending,
+// with `createdAt` as a stable tiebreaker); `hint` is the optional longer
+// explanation Mastodon 4.3+ renders under the rule. `createdAt`/`updatedAt`
+// are epoch milliseconds in the domain shape regardless of the backend's
+// timestamp storage.
+export type InstanceRuleData = {
+  id: string
+  position: number
+  text: string
+  hint: string
+  createdAt: number
+  updatedAt: number
+}
+
+export type CreateInstanceRuleParams = {
+  text: string
+  hint: string
+  position?: number
+}
+export type UpdateInstanceRuleParams = {
+  id: string
+  text?: string
+  hint?: string
+  position?: number
+}
+export type DeleteInstanceRuleParams = { id: string }
+
+export interface InstanceRuleDatabase {
+  createInstanceRule(
+    params: CreateInstanceRuleParams
+  ): Promise<InstanceRuleData>
+  // Partial update; bumps updatedAt and returns the updated row, or null when
+  // the rule does not exist.
+  updateInstanceRule(
+    params: UpdateInstanceRuleParams
+  ): Promise<InstanceRuleData | null>
+  // True when a row was removed.
+  deleteInstanceRule(params: DeleteInstanceRuleParams): Promise<boolean>
+  // All rules ordered by position ascending, then createdAt ascending.
+  getInstanceRules(): Promise<InstanceRuleData[]>
+}
+
+// ============================================================================
 // Report Database
 // ============================================================================
 

--- a/lib/types/mastodon/index.ts
+++ b/lib/types/mastodon/index.ts
@@ -14,6 +14,7 @@ export * from './tag'
 export * from './marker'
 export * from './list'
 export * from './report'
+export * from './rule'
 export * from './scheduledStatus'
 
 export * from './filter/index'

--- a/lib/types/mastodon/rule.ts
+++ b/lib/types/mastodon/rule.ts
@@ -1,0 +1,9 @@
+// This schema is based on https://docs.joinmastodon.org/entities/Rule/
+import { z } from 'zod'
+
+export const Rule = z.object({
+  id: z.string().describe('An identifier for the rule'),
+  text: z.string().describe('The rule to be followed'),
+  hint: z.string().describe('Longer-form description of the rule')
+})
+export type Rule = z.infer<typeof Rule>

--- a/migrations/20260612071825_add_instance_rules.js
+++ b/migrations/20260612071825_add_instance_rules.js
@@ -1,0 +1,31 @@
+/**
+ * Stores the instance's moderation rules (Mastodon's "instance rules"). Backs
+ * the public GET /api/v1/instance/rules endpoint (and the rules section of
+ * /api/v2/instance) plus the admin management endpoints that create, reorder,
+ * and delete rules.
+ *
+ * `position` drives the display order (ascending, with `createdAt` as a
+ * stable tiebreaker), `text` is the rule itself, and `hint` is the optional
+ * longer explanation Mastodon 4.3+ shows under the rule.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.createTable('instance_rules', (table) => {
+    table.string('id').primary()
+    table.integer('position').notNullable().defaultTo(0)
+    table.text('text').notNullable()
+    table.text('hint').notNullable().defaultTo('')
+    table.timestamp('createdAt').notNullable()
+    table.timestamp('updatedAt').notNullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('instance_rules')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -385,6 +385,15 @@ CREATE TABLE public.idempotency_keys (
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.instance_rules (
+    id character varying(255) NOT NULL,
+    "position" integer DEFAULT 0 NOT NULL,
+    text text NOT NULL,
+    hint text DEFAULT ''::text NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL
+);
+
 CREATE TABLE public.jwks (
     id character varying(255) NOT NULL,
     "publicKey" text NOT NULL,
@@ -1048,6 +1057,9 @@ ALTER TABLE ONLY public.follows
 
 ALTER TABLE ONLY public.idempotency_keys
     ADD CONSTRAINT idempotency_keys_pkey PRIMARY KEY ("actorId", key);
+
+ALTER TABLE ONLY public.instance_rules
+    ADD CONSTRAINT instance_rules_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY public.jwks
     ADD CONSTRAINT jwks_pkey PRIMARY KEY (id);

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -205,3 +205,4 @@ CREATE INDEX `server_filter_keywords_filter_id` on `server_filter_keywords` (`fi
 CREATE TABLE `scheduled_statuses` (`id` varchar(255), `actorId` varchar(255) not null, `scheduledAt` datetime not null, `params` text not null, `createdAt` datetime not null, `updatedAt` datetime not null, primary key (`id`));
 CREATE INDEX `scheduled_statuses_actorid_index` on `scheduled_statuses` (`actorId`);
 CREATE INDEX `scheduled_statuses_scheduledat_index` on `scheduled_statuses` (`scheduledAt`);
+CREATE TABLE `instance_rules` (`id` varchar(255), `position` integer not null default '0', `text` text not null, `hint` text not null default '', `createdAt` datetime not null, `updatedAt` datetime not null, primary key (`id`));


### PR DESCRIPTION
## Summary
- New `instance_rules` table via a Knex migration, with BOTH reference schema dumps (`migrations/schema.sql` and `migrations/schema.sqlite.sql`) regenerated in the same PR per AGENTS.md.
- Mastodon `Rule` type added to `lib/types/mastodon`.
- Database mixin for instance rules: create, update, delete, and list ordered by `position`, then `createdAt`.
- `GET /api/v1/instance/rules` now serves stored rules (previously a hardcoded `[]`), and `GET /api/v2/instance` gains a `rules` field.
- Internal admin CRUD API at `/api/v2/admin/rules` (+ `/api/v2/admin/rules/[id]`) behind `AdminApiGuard`, with zod-validated input (`text` 1-1000 chars, `hint` <= 2000 chars, `position` >= 0).
- Admin UI at `/admin/rules` (`RulesPanel`: create, edit, reorder-by-position, delete) with a new Rules entry in the admin dropdown sub-nav.
- Client-side API functions added to `lib/client.ts`.

## Migration notes
- One new migration (`add_instance_rules`).
- Both `migrations/schema.sql` and `migrations/schema.sqlite.sql` regenerated canonically (Postgres dump formatting churn expected).

## Test plan
- DB mixin tests: ordering, update, and delete round-trips.
- Public route tests: v1 rules ordering + exact response shape; v2 instance `rules` field.
- Admin route tests: 403 for non-admin, CRUD operations, 422 on invalid input.
- Full prettier/lint/build/test battery green.
- Browser-verified end-to-end on a local SQLite dev server: admin created, reordered, and deleted a rule through `/admin/rules`, and `/api/v1/instance/rules` plus `/api/v2/instance` reflected each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)