### PR TITLE
minor: follow suggestions (v2 + v1 dismiss)

### DIFF
--- a/app/api/v1/suggestions/[account_id]/route.ts
+++ b/app/api/v1/suggestions/[account_id]/route.ts
@@ -1,0 +1,32 @@
+import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.DELETE]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  account_id: string
+}
+
+// https://docs.joinmastodon.org/methods/suggestions/#remove
+// Dismissal is idempotent, so removing an unknown or already-dismissed
+// account still returns an empty object like Mastodon.
+export const DELETE = traceApiRoute(
+  'removeSuggestion',
+  OAuthGuard<Params>(
+    [Scope.enum.write],
+    async (req, { database, currentActor, params }) => {
+      const { account_id: accountId } = await params
+      await database.dismissSuggestion({
+        actorId: currentActor.id,
+        targetActorId: idToUrl(accountId)
+      })
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
+    }
+  )
+)

--- a/app/api/v1/suggestions/route.test.ts
+++ b/app/api/v1/suggestions/route.test.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
+import { ACTOR4_ID } from '@/lib/stub/seed/actor4'
+import { ACTOR5_ID } from '@/lib/stub/seed/actor5'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v1/suggestions', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    // Same friends-of-friends graph as the v2 route test: actor1 follows
+    // actor2 and actor3; actor2 follows actor4 and actor5; actor3 already
+    // follows actor4 (seedDatabase). Candidates for actor1 are actor4
+    // (2 mutuals) then actor5 (1 mutual).
+    const follows: [string, string][] = [
+      [ACTOR1_ID, ACTOR2_ID],
+      [ACTOR1_ID, ACTOR3_ID],
+      [ACTOR2_ID, ACTOR4_ID],
+      [ACTOR2_ID, ACTOR5_ID]
+    ]
+    for (const [actorId, targetActorId] of follows) {
+      await database.createFollow({
+        actorId,
+        targetActorId,
+        status: FollowStatus.enum.Accepted,
+        inbox: `${actorId}/inbox`,
+        sharedInbox: 'https://llun.test/inbox'
+      })
+    }
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const createRequest = (query = '') =>
+    new NextRequest(`https://llun.test/api/v1/suggestions${query}`)
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('returns plain ranked accounts without suggestion wrappers', async () => {
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((account: { id: string }) => account.id)).toEqual([
+      urlToId(ACTOR4_ID),
+      urlToId(ACTOR5_ID)
+    ])
+    for (const account of data) {
+      // Not wrapped in a Suggestion entity: no `sources` array and no nested
+      // `account`. (A top-level `source` key exists on the Account entity
+      // itself — its posting defaults object — so assert it is not the
+      // Suggestion source string.)
+      expect(account).not.toHaveProperty('sources')
+      expect(account).not.toHaveProperty('account')
+      expect(typeof account.source).not.toBe('string')
+    }
+  })
+})

--- a/app/api/v1/suggestions/route.ts
+++ b/app/api/v1/suggestions/route.ts
@@ -4,7 +4,6 @@ import {
   normalizeSuggestionsLimit
 } from '@/lib/services/suggestions/getSuggestionAccounts'
 import { Scope } from '@/lib/types/database/operations'
-import { Suggestion } from '@/lib/types/mastodon'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -13,9 +12,11 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-// https://docs.joinmastodon.org/methods/suggestions/#v2
+// https://docs.joinmastodon.org/methods/suggestions/#v1
+// Deprecated v1 shape: the same ranked suggestions as /api/v2/suggestions but
+// returned as a plain array of accounts without the suggestion wrapper.
 export const GET = traceApiRoute(
-  'getSuggestions',
+  'getSuggestionsV1',
   OAuthGuard([Scope.enum.read], async (req, { database, currentActor }) => {
     const limit = normalizeSuggestionsLimit(
       new URL(req.url).searchParams.get('limit')
@@ -25,13 +26,6 @@ export const GET = traceApiRoute(
       actorId: currentActor.id,
       limit
     })
-    const suggestions = accounts.map(
-      (account): Suggestion => ({
-        source: 'past_interactions',
-        sources: ['friends_of_friends'],
-        account
-      })
-    )
-    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: suggestions })
+    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: accounts })
   })
 )

--- a/app/api/v2/suggestions/route.test.ts
+++ b/app/api/v2/suggestions/route.test.ts
@@ -1,0 +1,223 @@
+import { NextRequest } from 'next/server'
+
+import { DELETE } from '@/app/api/v1/suggestions/[account_id]/route'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
+import { ACTOR4_ID } from '@/lib/stub/seed/actor4'
+import { ACTOR5_ID } from '@/lib/stub/seed/actor5'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined)
+  })
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('/api/v2/suggestions', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    // Friends-of-friends graph for actor1 on top of the base seed: actor1
+    // follows actor2 and actor3; actor2 follows actor4 and actor5; actor3
+    // already follows actor4 (seedDatabase). Candidates for actor1 are
+    // therefore actor4 (2 mutuals) then actor5 (1 mutual).
+    const follows: [string, string][] = [
+      [ACTOR1_ID, ACTOR2_ID],
+      [ACTOR1_ID, ACTOR3_ID],
+      [ACTOR2_ID, ACTOR4_ID],
+      [ACTOR2_ID, ACTOR5_ID]
+    ]
+    for (const [actorId, targetActorId] of follows) {
+      await database.createFollow({
+        actorId,
+        targetActorId,
+        status: FollowStatus.enum.Accepted,
+        inbox: `${actorId}/inbox`,
+        sharedInbox: 'https://llun.test/inbox'
+      })
+    }
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const createRequest = (query = '') =>
+    new NextRequest(`https://llun.test/api/v2/suggestions${query}`)
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('returns friends-of-friends suggestions ranked by mutual count', async () => {
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual([
+      {
+        source: 'past_interactions',
+        sources: ['friends_of_friends'],
+        account: expect.objectContaining({
+          id: urlToId(ACTOR4_ID),
+          url: ACTOR4_ID
+        })
+      },
+      {
+        source: 'past_interactions',
+        sources: ['friends_of_friends'],
+        account: expect.objectContaining({
+          id: urlToId(ACTOR5_ID),
+          url: ACTOR5_ID
+        })
+      }
+    ])
+  })
+
+  it.each([
+    {
+      description: 'returns only the top ranked suggestion when limit is 1',
+      query: '?limit=1',
+      expectedAccountIds: [urlToId(ACTOR4_ID)]
+    },
+    {
+      description: 'falls back to the default limit for a non-integer limit',
+      query: '?limit=garbage',
+      expectedAccountIds: [urlToId(ACTOR4_ID), urlToId(ACTOR5_ID)]
+    }
+  ])('$description', async ({ query, expectedAccountIds }) => {
+    const response = await GET(createRequest(query), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(
+      data.map((item: { account: { id: string } }) => item.account.id)
+    ).toEqual(expectedAccountIds)
+  })
+
+  it.each([
+    {
+      description: 'excludes a candidate the current actor blocks',
+      blockActorId: ACTOR1_ID,
+      blockTargetActorId: ACTOR4_ID
+    },
+    {
+      description: 'excludes a candidate that blocks the current actor',
+      blockActorId: ACTOR4_ID,
+      blockTargetActorId: ACTOR1_ID
+    }
+  ])('$description', async ({ blockActorId, blockTargetActorId }) => {
+    await database.createBlock({
+      actorId: blockActorId,
+      targetActorId: blockTargetActorId,
+      uri: `${blockActorId}#blocks/${encodeURIComponent(blockTargetActorId)}`
+    })
+    try {
+      const response = await GET(createRequest(), {
+        params: Promise.resolve({})
+      })
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(
+        data.map((item: { account: { id: string } }) => item.account.id)
+      ).toEqual([urlToId(ACTOR5_ID)])
+    } finally {
+      await database.deleteBlock({
+        actorId: blockActorId,
+        targetActorId: blockTargetActorId
+      })
+    }
+  })
+
+  it('excludes a candidate the current actor mutes', async () => {
+    await database.createMute({
+      actorId: ACTOR1_ID,
+      targetActorId: ACTOR5_ID,
+      notifications: false,
+      endsAt: null
+    })
+    try {
+      const response = await GET(createRequest(), {
+        params: Promise.resolve({})
+      })
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(
+        data.map((item: { account: { id: string } }) => item.account.id)
+      ).toEqual([urlToId(ACTOR4_ID)])
+    } finally {
+      await database.deleteMute({
+        actorId: ACTOR1_ID,
+        targetActorId: ACTOR5_ID
+      })
+    }
+  })
+
+  it('removes a candidate dismissed through the v1 endpoint from later responses', async () => {
+    const accountId = urlToId(ACTOR4_ID)
+    const deleteResponse = await DELETE(
+      new NextRequest(`https://llun.test/api/v1/suggestions/${accountId}`, {
+        method: 'DELETE',
+        headers: { origin: 'https://llun.test' }
+      }),
+      { params: Promise.resolve({ account_id: accountId }) }
+    )
+    expect(deleteResponse.status).toBe(200)
+    await expect(deleteResponse.json()).resolves.toEqual({})
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(
+      data.map((item: { account: { id: string } }) => item.account.id)
+    ).toEqual([urlToId(ACTOR5_ID)])
+  })
+})

--- a/docs/features.md
+++ b/docs/features.md
@@ -70,6 +70,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Endorsements** — Feature accounts on your profile
 - ✅ **Account notes & preferences** — Private per-account notes and client preferences
 - ✅ **Featured tags API** — `/api/v1/featured_tags` endpoints backing the profile featured-hashtags feature
+- ✅ **Follow suggestions** — friends-of-friends suggestions via `GET /api/v2/suggestions` (plus deprecated `GET /api/v1/suggestions`), with per-account dismissal via `DELETE /api/v1/suggestions/:account_id`
 - ✅ **Followed hashtags** — Follow and unfollow hashtags and view a followed-tags timeline
 - ✅ **Mutes** — Mute and unmute accounts
 - ✅ **WebFinger** — Actor discovery via `/.well-known/webfinger`
@@ -86,7 +87,6 @@ This document tracks the implemented and planned features for Activity.next.
 
 ## In Progress
 
-- 🚧 **Follow suggestions** — `/api/v2/suggestions` responds for Mastodon client compatibility but currently returns an empty set; a ranking implementation is pending
 - 🚧 **Fitness import hardening** — Repair and resume scripts cover interrupted or legacy Strava imports while the importer continues to mature
 
 ## Planned Features

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -34,6 +34,7 @@ import { ServerFilterSQLDatabaseMixin } from '@/lib/database/sql/serverFilter'
 import { StatusSQLDatabaseMixin } from '@/lib/database/sql/status'
 import { StatusMuteSQLDatabaseMixin } from '@/lib/database/sql/statusMute'
 import { StravaArchiveImportSQLDatabaseMixin } from '@/lib/database/sql/stravaArchiveImport'
+import { SuggestionSQLDatabaseMixin } from '@/lib/database/sql/suggestion'
 import { TimelineSQLDatabaseMixin } from '@/lib/database/sql/timeline'
 import { TranslationCacheSQLDatabaseMixin } from '@/lib/database/sql/translationCache'
 import { Database } from '@/lib/database/types'
@@ -73,6 +74,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const searchDatabase = SearchSQLDatabaseMixin(database)
   const stravaArchiveImportDatabase =
     StravaArchiveImportSQLDatabaseMixin(database)
+  const suggestionDatabase = SuggestionSQLDatabaseMixin(database)
   const statusDatabase = StatusSQLDatabaseMixin(
     database,
     actorDatabase,
@@ -137,6 +139,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...oauthDatabase,
     ...searchDatabase,
     ...stravaArchiveImportDatabase,
+    ...suggestionDatabase,
     ...statusDatabase,
     ...directConversationDatabase,
 

--- a/lib/database/sql/suggestion.test.ts
+++ b/lib/database/sql/suggestion.test.ts
@@ -137,6 +137,62 @@ describe('getFriendsOfFriendsSuggestions', () => {
     })
   })
 
+  it.each([
+    {
+      description: 'excludes a candidate the actor blocks',
+      block: [ACTOR1_ID, ACTOR_C_ID] as const
+    },
+    {
+      description: 'excludes a candidate that blocks the actor',
+      block: [ACTOR_C_ID, ACTOR1_ID] as const
+    }
+  ])('$description', async ({ block }) => {
+    await withFreshDatabase(async (database) => {
+      await seedFriendGraph(database)
+
+      const [blockActorId, blockTargetActorId] = block
+      await database.createBlock({
+        actorId: blockActorId,
+        targetActorId: blockTargetActorId,
+        uri: `${blockActorId}#blocks/1`
+      })
+
+      expect(
+        await database.getFriendsOfFriendsSuggestions({
+          actorId: ACTOR1_ID,
+          limit: 10
+        })
+      ).toEqual([{ targetActorId: ACTOR_D_ID, mutuals: 1 }])
+    })
+  })
+
+  it('excludes an actively muted candidate but keeps an expired mute suggestable', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedFriendGraph(database)
+
+      // Active mute on C hides it; an expired mute on D leaves it suggestable.
+      await database.createMute({
+        actorId: ACTOR1_ID,
+        targetActorId: ACTOR_C_ID,
+        notifications: false,
+        endsAt: null
+      })
+      await database.createMute({
+        actorId: ACTOR1_ID,
+        targetActorId: ACTOR_D_ID,
+        notifications: false,
+        endsAt: Date.now() - 1000
+      })
+
+      expect(
+        await database.getFriendsOfFriendsSuggestions({
+          actorId: ACTOR1_ID,
+          limit: 10
+        })
+      ).toEqual([{ targetActorId: ACTOR_D_ID, mutuals: 1 }])
+    })
+  })
+
   it('returns only the highest ranked accounts when limit is smaller than the candidate count', async () => {
     await withFreshDatabase(async (database) => {
       await seedFriendGraph(database)

--- a/lib/database/sql/suggestion.test.ts
+++ b/lib/database/sql/suggestion.test.ts
@@ -1,0 +1,152 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { FollowStatus } from '@/lib/types/domain/follow'
+
+const ACTOR1_ID = 'https://suggestions.test/users/actor1'
+const ACTOR_A_ID = 'https://suggestions.test/users/actorA'
+const ACTOR_B_ID = 'https://suggestions.test/users/actorB'
+const ACTOR_C_ID = 'https://suggestions.test/users/actorC'
+const ACTOR_D_ID = 'https://suggestions.test/users/actorD'
+const ACTOR_E_ID = 'https://suggestions.test/users/actorE'
+const ACTOR_F_ID = 'https://suggestions.test/users/actorF'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const createFollow = (
+  database: Database,
+  actorId: string,
+  targetActorId: string,
+  status: FollowStatus = FollowStatus.enum.Accepted
+) =>
+  database.createFollow({
+    actorId,
+    targetActorId,
+    status,
+    inbox: `${actorId}/inbox`,
+    sharedInbox: 'https://suggestions.test/inbox'
+  })
+
+// actor1 follows A and B; A and B both follow C; A also follows D.
+// All edges are Accepted, so for actor1 the friends-of-friends candidates
+// are C (2 mutuals) and D (1 mutual).
+const seedFriendGraph = async (database: Database) => {
+  await createFollow(database, ACTOR1_ID, ACTOR_A_ID)
+  await createFollow(database, ACTOR1_ID, ACTOR_B_ID)
+  await createFollow(database, ACTOR_A_ID, ACTOR_C_ID)
+  await createFollow(database, ACTOR_B_ID, ACTOR_C_ID)
+  await createFollow(database, ACTOR_A_ID, ACTOR_D_ID)
+}
+
+describe('getFriendsOfFriendsSuggestions', () => {
+  it('ranks accounts followed by followed accounts by mutual count descending', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedFriendGraph(database)
+
+      const suggestions = await database.getFriendsOfFriendsSuggestions({
+        actorId: ACTOR1_ID,
+        limit: 10
+      })
+      expect(suggestions).toEqual([
+        { targetActorId: ACTOR_C_ID, mutuals: 2 },
+        { targetActorId: ACTOR_D_ID, mutuals: 1 }
+      ])
+    })
+  })
+
+  it.each([
+    {
+      description: 'ignores a pending second-hop edge when counting mutuals',
+      extraFollows: [
+        [ACTOR_B_ID, ACTOR_D_ID, FollowStatus.enum.Requested] as const
+      ]
+    },
+    {
+      description:
+        'ignores a pending first-hop edge and its accepted continuation',
+      extraFollows: [
+        [ACTOR1_ID, ACTOR_E_ID, FollowStatus.enum.Requested] as const,
+        [ACTOR_E_ID, ACTOR_F_ID, FollowStatus.enum.Accepted] as const
+      ]
+    }
+  ])('$description', async ({ extraFollows }) => {
+    await withFreshDatabase(async (database) => {
+      await seedFriendGraph(database)
+      for (const [actorId, targetActorId, status] of extraFollows) {
+        await createFollow(database, actorId, targetActorId, status)
+      }
+
+      const suggestions = await database.getFriendsOfFriendsSuggestions({
+        actorId: ACTOR1_ID,
+        limit: 10
+      })
+      expect(suggestions).toEqual([
+        { targetActorId: ACTOR_C_ID, mutuals: 2 },
+        { targetActorId: ACTOR_D_ID, mutuals: 1 }
+      ])
+    })
+  })
+
+  it('excludes dismissed accounts and accounts the actor now follows', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedFriendGraph(database)
+
+      await database.dismissSuggestion({
+        actorId: ACTOR1_ID,
+        targetActorId: ACTOR_C_ID
+      })
+      expect(
+        await database.getFriendsOfFriendsSuggestions({
+          actorId: ACTOR1_ID,
+          limit: 10
+        })
+      ).toEqual([{ targetActorId: ACTOR_D_ID, mutuals: 1 }])
+
+      await createFollow(database, ACTOR1_ID, ACTOR_D_ID)
+      expect(
+        await database.getFriendsOfFriendsSuggestions({
+          actorId: ACTOR1_ID,
+          limit: 10
+        })
+      ).toEqual([])
+    })
+  })
+
+  it('returns only the highest ranked accounts when limit is smaller than the candidate count', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedFriendGraph(database)
+
+      const suggestions = await database.getFriendsOfFriendsSuggestions({
+        actorId: ACTOR1_ID,
+        limit: 1
+      })
+      expect(suggestions).toEqual([{ targetActorId: ACTOR_C_ID, mutuals: 2 }])
+    })
+  })
+})
+
+describe('dismissSuggestion', () => {
+  it('does not throw when the same pair is dismissed twice', async () => {
+    await withFreshDatabase(async (database) => {
+      await database.dismissSuggestion({
+        actorId: ACTOR1_ID,
+        targetActorId: ACTOR_C_ID
+      })
+      await expect(
+        database.dismissSuggestion({
+          actorId: ACTOR1_ID,
+          targetActorId: ACTOR_C_ID
+        })
+      ).resolves.toBeUndefined()
+    })
+  })
+})

--- a/lib/database/sql/suggestion.test.ts
+++ b/lib/database/sql/suggestion.test.ts
@@ -36,15 +36,18 @@ const createFollow = (
     sharedInbox: 'https://suggestions.test/inbox'
   })
 
-// actor1 follows A and B; A and B both follow C; A also follows D.
-// All edges are Accepted, so for actor1 the friends-of-friends candidates
-// are C (2 mutuals) and D (1 mutual).
+// actor1 follows A and B; A and B both follow C; A also follows D and
+// follows actor1 back (a mutual), making actor1 its own second-hop
+// candidate unless the query excludes the querying actor. All edges are
+// Accepted, so for actor1 the friends-of-friends candidates are
+// C (2 mutuals) and D (1 mutual).
 const seedFriendGraph = async (database: Database) => {
   await createFollow(database, ACTOR1_ID, ACTOR_A_ID)
   await createFollow(database, ACTOR1_ID, ACTOR_B_ID)
   await createFollow(database, ACTOR_A_ID, ACTOR_C_ID)
   await createFollow(database, ACTOR_B_ID, ACTOR_C_ID)
   await createFollow(database, ACTOR_A_ID, ACTOR_D_ID)
+  await createFollow(database, ACTOR_A_ID, ACTOR1_ID)
 }
 
 describe('getFriendsOfFriendsSuggestions', () => {
@@ -68,6 +71,10 @@ describe('getFriendsOfFriendsSuggestions', () => {
       description: 'ignores a pending second-hop edge when counting mutuals',
       extraFollows: [
         [ACTOR_B_ID, ACTOR_D_ID, FollowStatus.enum.Requested] as const
+      ],
+      expected: [
+        { targetActorId: ACTOR_C_ID, mutuals: 2 },
+        { targetActorId: ACTOR_D_ID, mutuals: 1 }
       ]
     },
     {
@@ -76,9 +83,21 @@ describe('getFriendsOfFriendsSuggestions', () => {
       extraFollows: [
         [ACTOR1_ID, ACTOR_E_ID, FollowStatus.enum.Requested] as const,
         [ACTOR_E_ID, ACTOR_F_ID, FollowStatus.enum.Accepted] as const
+      ],
+      expected: [
+        { targetActorId: ACTOR_C_ID, mutuals: 2 },
+        { targetActorId: ACTOR_D_ID, mutuals: 1 }
       ]
+    },
+    {
+      description:
+        'excludes a candidate the actor already has a pending follow request to',
+      extraFollows: [
+        [ACTOR1_ID, ACTOR_D_ID, FollowStatus.enum.Requested] as const
+      ],
+      expected: [{ targetActorId: ACTOR_C_ID, mutuals: 2 }]
     }
-  ])('$description', async ({ extraFollows }) => {
+  ])('$description', async ({ extraFollows, expected }) => {
     await withFreshDatabase(async (database) => {
       await seedFriendGraph(database)
       for (const [actorId, targetActorId, status] of extraFollows) {
@@ -89,10 +108,7 @@ describe('getFriendsOfFriendsSuggestions', () => {
         actorId: ACTOR1_ID,
         limit: 10
       })
-      expect(suggestions).toEqual([
-        { targetActorId: ACTOR_C_ID, mutuals: 2 },
-        { targetActorId: ACTOR_D_ID, mutuals: 1 }
-      ])
+      expect(suggestions).toEqual(expected)
     })
   })
 

--- a/lib/database/sql/suggestion.ts
+++ b/lib/database/sql/suggestion.ts
@@ -22,9 +22,12 @@ export const SuggestionSQLDatabaseMixin = (
     limit
   }: GetFriendsOfFriendsSuggestionsParams) {
     // f1: who actorId follows; f2: who those accounts follow. Only Accepted
-    // edges count on both hops, and candidates the actor already follows,
-    // has a pending follow request to, or has dismissed are excluded
-    // (Undo/Rejected follows remain suggestable).
+    // edges count on both hops. A candidate is excluded when the actor already
+    // follows it, has a pending follow request to it, has dismissed it, is in a
+    // block with it (either direction), or has an active mute on it. Filtering
+    // here — BEFORE LIMIT — mirrors applyBlockMuteFilter so the page is never
+    // returned short (Undo/Rejected follows remain suggestable).
+    const now = Date.now()
     const rows = (await database('follows as f1')
       .join('follows as f2', function () {
         this.on('f2.actorId', 'f1.targetActorId').andOnVal(
@@ -48,6 +51,25 @@ export const SuggestionSQLDatabaseMixin = (
         this.select('targetActorId')
           .from('suggestion_dismissals')
           .where({ actorId })
+      })
+      // Blocks are bidirectional: drop a candidate the actor blocks OR who
+      // blocks the actor. Two separate clauses so each can use its own
+      // (actorId|targetActorId) index on the blocks table.
+      .whereNotIn('f2.targetActorId', function () {
+        this.select('targetActorId').from('blocks').where('actorId', actorId)
+      })
+      .whereNotIn('f2.targetActorId', function () {
+        this.select('actorId').from('blocks').where('targetActorId', actorId)
+      })
+      // Mutes are one-directional (only what the actor mutes) and expire: a
+      // mute is active while endsAt IS NULL or endsAt > now.
+      .whereNotIn('f2.targetActorId', function () {
+        this.select('targetActorId')
+          .from('mutes')
+          .where('actorId', actorId)
+          .andWhere(function () {
+            this.whereNull('endsAt').orWhere('endsAt', '>', now)
+          })
       })
       .groupBy('f2.targetActorId')
       .select('f2.targetActorId as targetActorId')

--- a/lib/database/sql/suggestion.ts
+++ b/lib/database/sql/suggestion.ts
@@ -22,8 +22,9 @@ export const SuggestionSQLDatabaseMixin = (
     limit
   }: GetFriendsOfFriendsSuggestionsParams) {
     // f1: who actorId follows; f2: who those accounts follow. Only Accepted
-    // edges count on both hops, and candidates the actor already follows or
-    // has dismissed are excluded.
+    // edges count on both hops, and candidates the actor already follows,
+    // has a pending follow request to, or has dismissed are excluded
+    // (Undo/Rejected follows remain suggestable).
     const rows = await database('follows as f1')
       .join('follows as f2', function () {
         this.on('f2.actorId', 'f1.targetActorId').andOnVal(
@@ -38,7 +39,11 @@ export const SuggestionSQLDatabaseMixin = (
         builder
           .select('targetActorId')
           .from('follows')
-          .where({ actorId, status: FollowStatus.enum.Accepted })
+          .where('actorId', actorId)
+          .whereIn('status', [
+            FollowStatus.enum.Accepted,
+            FollowStatus.enum.Requested
+          ])
       })
       .whereNotIn('f2.targetActorId', (builder) => {
         builder

--- a/lib/database/sql/suggestion.ts
+++ b/lib/database/sql/suggestion.ts
@@ -62,13 +62,14 @@ export const SuggestionSQLDatabaseMixin = (
         this.select('actorId').from('blocks').where('targetActorId', actorId)
       })
       // Mutes are one-directional (only what the actor mutes) and expire: a
-      // mute is active while endsAt IS NULL or endsAt > now.
+      // mute is active while endsAt IS NULL or endsAt >= now (matching
+      // applyBlockMuteFilter and getMute/isMuting's "expired when endsAt < now").
       .whereNotIn('f2.targetActorId', function () {
         this.select('targetActorId')
           .from('mutes')
           .where('actorId', actorId)
           .andWhere(function () {
-            this.whereNull('endsAt').orWhere('endsAt', '>', now)
+            this.whereNull('endsAt').orWhere('endsAt', '>=', now)
           })
       })
       .groupBy('f2.targetActorId')

--- a/lib/database/sql/suggestion.ts
+++ b/lib/database/sql/suggestion.ts
@@ -1,0 +1,74 @@
+import { Knex } from 'knex'
+
+import {
+  DismissSuggestionParams,
+  FriendsOfFriendsSuggestion,
+  GetFriendsOfFriendsSuggestionsParams,
+  SuggestionDatabase
+} from '@/lib/types/database/operations'
+import { FollowStatus } from '@/lib/types/domain/follow'
+
+type SQLFriendsOfFriendsRow = {
+  targetActorId: string
+  // count() comes back as a string on Postgres but a number on SQLite.
+  mutuals: number | string
+}
+
+export const SuggestionSQLDatabaseMixin = (
+  database: Knex
+): SuggestionDatabase => ({
+  async getFriendsOfFriendsSuggestions({
+    actorId,
+    limit
+  }: GetFriendsOfFriendsSuggestionsParams) {
+    // f1: who actorId follows; f2: who those accounts follow. Only Accepted
+    // edges count on both hops, and candidates the actor already follows or
+    // has dismissed are excluded.
+    const rows = await database('follows as f1')
+      .join('follows as f2', function () {
+        this.on('f2.actorId', 'f1.targetActorId').andOnVal(
+          'f2.status',
+          FollowStatus.enum.Accepted
+        )
+      })
+      .where('f1.actorId', actorId)
+      .where('f1.status', FollowStatus.enum.Accepted)
+      .whereNot('f2.targetActorId', actorId)
+      .whereNotIn('f2.targetActorId', (builder) => {
+        builder
+          .select('targetActorId')
+          .from('follows')
+          .where({ actorId, status: FollowStatus.enum.Accepted })
+      })
+      .whereNotIn('f2.targetActorId', (builder) => {
+        builder
+          .select('targetActorId')
+          .from('suggestion_dismissals')
+          .where({ actorId })
+      })
+      .groupBy('f2.targetActorId')
+      .select('f2.targetActorId as targetActorId')
+      .count<SQLFriendsOfFriendsRow[]>('* as mutuals')
+      .orderBy([
+        { column: 'mutuals', order: 'desc' },
+        { column: 'targetActorId' }
+      ])
+      .limit(limit)
+
+    return rows.map(
+      (row): FriendsOfFriendsSuggestion => ({
+        targetActorId: row.targetActorId,
+        mutuals: Number(row.mutuals)
+      })
+    )
+  },
+
+  async dismissSuggestion({ actorId, targetActorId }: DismissSuggestionParams) {
+    // Idempotent: ignore on the (actorId, targetActorId) primary key so a
+    // repeat dismissal of the same pair is a no-op instead of an error.
+    await database('suggestion_dismissals')
+      .insert({ actorId, targetActorId, createdAt: new Date() })
+      .onConflict(['actorId', 'targetActorId'])
+      .ignore()
+  }
+})

--- a/lib/database/sql/suggestion.ts
+++ b/lib/database/sql/suggestion.ts
@@ -25,7 +25,7 @@ export const SuggestionSQLDatabaseMixin = (
     // edges count on both hops, and candidates the actor already follows,
     // has a pending follow request to, or has dismissed are excluded
     // (Undo/Rejected follows remain suggestable).
-    const rows = await database('follows as f1')
+    const rows = (await database('follows as f1')
       .join('follows as f2', function () {
         this.on('f2.actorId', 'f1.targetActorId').andOnVal(
           'f2.status',
@@ -35,9 +35,8 @@ export const SuggestionSQLDatabaseMixin = (
       .where('f1.actorId', actorId)
       .where('f1.status', FollowStatus.enum.Accepted)
       .whereNot('f2.targetActorId', actorId)
-      .whereNotIn('f2.targetActorId', (builder) => {
-        builder
-          .select('targetActorId')
+      .whereNotIn('f2.targetActorId', function () {
+        this.select('targetActorId')
           .from('follows')
           .where('actorId', actorId)
           .whereIn('status', [
@@ -45,20 +44,19 @@ export const SuggestionSQLDatabaseMixin = (
             FollowStatus.enum.Requested
           ])
       })
-      .whereNotIn('f2.targetActorId', (builder) => {
-        builder
-          .select('targetActorId')
+      .whereNotIn('f2.targetActorId', function () {
+        this.select('targetActorId')
           .from('suggestion_dismissals')
           .where({ actorId })
       })
       .groupBy('f2.targetActorId')
       .select('f2.targetActorId as targetActorId')
-      .count<SQLFriendsOfFriendsRow[]>('* as mutuals')
+      .count({ mutuals: '*' })
       .orderBy([
         { column: 'mutuals', order: 'desc' },
         { column: 'targetActorId' }
       ])
-      .limit(limit)
+      .limit(limit)) as SQLFriendsOfFriendsRow[]
 
     return rows.map(
       (row): FriendsOfFriendsSuggestion => ({

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -34,6 +34,7 @@ import {
   ServerFilterDatabase,
   StatusDatabase,
   StatusMuteDatabase,
+  SuggestionDatabase,
   TimelineDatabase,
   TranslationCacheDatabase
 } from '@/lib/types/database/operations'
@@ -71,6 +72,7 @@ export type Database = AccountDatabase &
   SearchDatabase &
   StatusDatabase &
   StatusMuteDatabase &
+  SuggestionDatabase &
   IdempotencyDatabase &
   TranslationCacheDatabase &
   TimelineDatabase &

--- a/lib/services/suggestions/getSuggestionAccounts.ts
+++ b/lib/services/suggestions/getSuggestionAccounts.ts
@@ -3,9 +3,6 @@ import { Account } from '@/lib/types/mastodon/account'
 
 export const SUGGESTIONS_DEFAULT_LIMIT = 40
 export const SUGGESTIONS_MAX_LIMIT = 80
-// Over-fetch candidates beyond the requested page so block/mute filtering and
-// unresolvable actors don't leave the page short.
-const CANDIDATE_FETCH_CAP = 160
 
 // Mastodon clamps out-of-range or non-numeric limits to the allowed range
 // instead of rejecting them (same behavior as `normalizeTimelineLimit`):
@@ -26,9 +23,10 @@ interface GetSuggestionAccountsParams {
 
 /**
  * Resolve the ranked friends-of-friends follow suggestions for `actorId` into
- * Mastodon accounts, dropping any candidate involved in a block with the
- * current actor (in either direction) or muted by the current actor. The
- * returned accounts preserve the candidate ranking.
+ * Mastodon accounts. Block (either direction) and mute filtering is applied in
+ * SQL by `getFriendsOfFriendsSuggestions`, so the candidate list already
+ * excludes hidden accounts; this layer only hydrates the accounts and preserves
+ * the candidate ranking.
  */
 export const getSuggestionAccounts = async ({
   database,
@@ -37,49 +35,18 @@ export const getSuggestionAccounts = async ({
 }: GetSuggestionAccountsParams): Promise<Account[]> => {
   const candidates = await database.getFriendsOfFriendsSuggestions({
     actorId,
-    limit: Math.min(limit * 2, CANDIDATE_FETCH_CAP)
+    limit
   })
   if (candidates.length === 0) return []
 
   const candidateIds = candidates.map((candidate) => candidate.targetActorId)
-  const [blockRelations, muteRelations] = await Promise.all([
-    // getBlockRelations matches blocks in both directions, so one call covers
-    // both "the actor blocks the candidate" and "the candidate blocks the
-    // actor".
-    database.getBlockRelations({
-      actorIds: [actorId],
-      targetActorIds: candidateIds
-    }),
-    // Mutes are one-directional: only the current actor muting a candidate
-    // hides the suggestion.
-    database.getMuteRelations({
-      actorIds: [actorId],
-      targetActorIds: candidateIds
-    })
-  ])
-
-  const excludedActorIds = new Set<string>()
-  for (const relation of blockRelations) {
-    excludedActorIds.add(
-      relation.actorId === actorId ? relation.targetActorId : relation.actorId
-    )
-  }
-  for (const relation of muteRelations) {
-    if (relation.actorId === actorId) {
-      excludedActorIds.add(relation.targetActorId)
-    }
-  }
-
-  const visibleIds = candidateIds.filter((id) => !excludedActorIds.has(id))
-  if (visibleIds.length === 0) return []
-
   const accounts = await database.getMastodonActorsFromIds({
-    ids: visibleIds
+    ids: candidateIds
   })
   // Re-order by the ranked candidate list (the serializer's output order is
   // not guaranteed) and drop candidates it could not resolve.
   const accountsByUrl = new Map(
     accounts.map((account) => [account.url, account])
   )
-  return visibleIds.flatMap((id) => accountsByUrl.get(id) ?? []).slice(0, limit)
+  return candidateIds.flatMap((id) => accountsByUrl.get(id) ?? [])
 }

--- a/lib/services/suggestions/getSuggestionAccounts.ts
+++ b/lib/services/suggestions/getSuggestionAccounts.ts
@@ -1,0 +1,85 @@
+import { Database } from '@/lib/database/types'
+import { Account } from '@/lib/types/mastodon/account'
+
+export const SUGGESTIONS_DEFAULT_LIMIT = 40
+export const SUGGESTIONS_MAX_LIMIT = 80
+// Over-fetch candidates beyond the requested page so block/mute filtering and
+// unresolvable actors don't leave the page short.
+const CANDIDATE_FETCH_CAP = 160
+
+// Mastodon clamps out-of-range or non-numeric limits to the allowed range
+// instead of rejecting them (same behavior as `normalizeTimelineLimit`):
+// a positive integer is capped at the max, anything else falls back to the
+// default.
+export const normalizeSuggestionsLimit = (rawLimit: string | null): number => {
+  const limit = rawLimit !== null ? Number(rawLimit) : null
+  return Number.isSafeInteger(limit) && limit && limit > 0
+    ? Math.min(limit, SUGGESTIONS_MAX_LIMIT)
+    : SUGGESTIONS_DEFAULT_LIMIT
+}
+
+interface GetSuggestionAccountsParams {
+  database: Database
+  actorId: string
+  limit: number
+}
+
+/**
+ * Resolve the ranked friends-of-friends follow suggestions for `actorId` into
+ * Mastodon accounts, dropping any candidate involved in a block with the
+ * current actor (in either direction) or muted by the current actor. The
+ * returned accounts preserve the candidate ranking.
+ */
+export const getSuggestionAccounts = async ({
+  database,
+  actorId,
+  limit
+}: GetSuggestionAccountsParams): Promise<Account[]> => {
+  const candidates = await database.getFriendsOfFriendsSuggestions({
+    actorId,
+    limit: Math.min(limit * 2, CANDIDATE_FETCH_CAP)
+  })
+  if (candidates.length === 0) return []
+
+  const candidateIds = candidates.map((candidate) => candidate.targetActorId)
+  const [blockRelations, muteRelations] = await Promise.all([
+    // getBlockRelations matches blocks in both directions, so one call covers
+    // both "the actor blocks the candidate" and "the candidate blocks the
+    // actor".
+    database.getBlockRelations({
+      actorIds: [actorId],
+      targetActorIds: candidateIds
+    }),
+    // Mutes are one-directional: only the current actor muting a candidate
+    // hides the suggestion.
+    database.getMuteRelations({
+      actorIds: [actorId],
+      targetActorIds: candidateIds
+    })
+  ])
+
+  const excludedActorIds = new Set<string>()
+  for (const relation of blockRelations) {
+    excludedActorIds.add(
+      relation.actorId === actorId ? relation.targetActorId : relation.actorId
+    )
+  }
+  for (const relation of muteRelations) {
+    if (relation.actorId === actorId) {
+      excludedActorIds.add(relation.targetActorId)
+    }
+  }
+
+  const visibleIds = candidateIds.filter((id) => !excludedActorIds.has(id))
+  if (visibleIds.length === 0) return []
+
+  const accounts = await database.getMastodonActorsFromIds({
+    ids: visibleIds
+  })
+  // Re-order by the ranked candidate list (the serializer's output order is
+  // not guaranteed) and drop candidates it could not resolve.
+  const accountsByUrl = new Map(
+    accounts.map((account) => [account.url, account])
+  )
+  return visibleIds.flatMap((id) => accountsByUrl.get(id) ?? []).slice(0, limit)
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1525,6 +1525,41 @@ export interface InstanceRuleDatabase {
 }
 
 // ============================================================================
+// Suggestion Database
+// ============================================================================
+
+// A friends-of-friends follow suggestion candidate: an account followed by
+// the accounts `actorId` follows. `mutuals` is the number of accepted
+// follow edges from those followed accounts to the candidate, used for
+// ranking (descending).
+export type FriendsOfFriendsSuggestion = {
+  targetActorId: string
+  mutuals: number
+}
+
+export type GetFriendsOfFriendsSuggestionsParams = {
+  actorId: string
+  limit: number
+}
+export type DismissSuggestionParams = {
+  actorId: string
+  targetActorId: string
+}
+
+export interface SuggestionDatabase {
+  // Accounts followed by the accounts `actorId` follows, ranked by mutual
+  // count descending (targetActorId ascending as a stable tiebreaker).
+  // Excludes `actorId` itself, anyone `actorId` already follows (Accepted),
+  // and anyone `actorId` has dismissed. Only Accepted follow edges count on
+  // both hops.
+  getFriendsOfFriendsSuggestions(
+    params: GetFriendsOfFriendsSuggestionsParams
+  ): Promise<FriendsOfFriendsSuggestion[]>
+  // Idempotent: dismissing an already-dismissed pair is a no-op.
+  dismissSuggestion(params: DismissSuggestionParams): Promise<void>
+}
+
+// ============================================================================
 // Report Database
 // ============================================================================
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1549,9 +1549,10 @@ export type DismissSuggestionParams = {
 export interface SuggestionDatabase {
   // Accounts followed by the accounts `actorId` follows, ranked by mutual
   // count descending (targetActorId ascending as a stable tiebreaker).
-  // Excludes `actorId` itself, anyone `actorId` already follows (Accepted),
-  // and anyone `actorId` has dismissed. Only Accepted follow edges count on
-  // both hops.
+  // Excludes `actorId` itself, anyone `actorId` already follows (Accepted) or
+  // has a pending request to, anyone `actorId` has dismissed, anyone in a block
+  // with `actorId` (either direction), and anyone `actorId` actively mutes.
+  // Only Accepted follow edges count on both hops.
   getFriendsOfFriendsSuggestions(
     params: GetFriendsOfFriendsSuggestionsParams
   ): Promise<FriendsOfFriendsSuggestion[]>

--- a/lib/types/mastodon/index.ts
+++ b/lib/types/mastodon/index.ts
@@ -16,6 +16,7 @@ export * from './list'
 export * from './report'
 export * from './rule'
 export * from './scheduledStatus'
+export * from './suggestion'
 
 export * from './filter/index'
 export * from './filter/keyword'

--- a/lib/types/mastodon/suggestion.ts
+++ b/lib/types/mastodon/suggestion.ts
@@ -1,0 +1,19 @@
+// This schema is based on https://docs.joinmastodon.org/entities/Suggestion/
+import { z } from 'zod'
+
+import { Account } from '@/lib/types/mastodon/account'
+
+export const Suggestion = z.object({
+  source: z.enum(['staff', 'past_interactions', 'global']),
+  sources: z
+    .enum([
+      'featured',
+      'most_followed',
+      'most_interactions',
+      'similar_to_recently_followed',
+      'friends_of_friends'
+    ])
+    .array(),
+  account: Account
+})
+export type Suggestion = z.infer<typeof Suggestion>

--- a/migrations/20260612135800_add_suggestion_dismissals.js
+++ b/migrations/20260612135800_add_suggestion_dismissals.js
@@ -1,0 +1,29 @@
+/**
+ * Stores follow suggestions an actor has dismissed (Mastodon's "follow
+ * suggestions"). Backs the DELETE /api/v1/suggestions/:account_id endpoint
+ * and lets GET /api/v1/suggestions and GET /api/v2/suggestions exclude
+ * accounts the actor has already removed from their suggestions.
+ *
+ * `actorId` is the dismissing actor and `targetActorId` is the suggested
+ * account being dismissed; the composite primary key keeps one dismissal
+ * row per (actor, target) pair and makes repeat dismissals idempotent.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.createTable('suggestion_dismissals', (table) => {
+    table.string('actorId').notNullable()
+    table.string('targetActorId').notNullable()
+    table.timestamp('createdAt').notNullable()
+    table.primary(['actorId', 'targetActorId'])
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('suggestion_dismissals')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -833,6 +833,12 @@ CREATE TABLE public.strava_archive_imports (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
+CREATE TABLE public.suggestion_dismissals (
+    "actorId" character varying(255) NOT NULL,
+    "targetActorId" character varying(255) NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL
+);
+
 CREATE TABLE public.tags (
     id character varying(255) NOT NULL,
     "statusId" character varying(255),
@@ -1189,6 +1195,9 @@ ALTER TABLE ONLY public.strava_archive_imports
 
 ALTER TABLE ONLY public.strava_archive_imports
     ADD CONSTRAINT strava_archive_imports_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.suggestion_dismissals
+    ADD CONSTRAINT suggestion_dismissals_pkey PRIMARY KEY ("actorId", "targetActorId");
 
 ALTER TABLE ONLY public.tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -206,3 +206,4 @@ CREATE TABLE `scheduled_statuses` (`id` varchar(255), `actorId` varchar(255) not
 CREATE INDEX `scheduled_statuses_actorid_index` on `scheduled_statuses` (`actorId`);
 CREATE INDEX `scheduled_statuses_scheduledat_index` on `scheduled_statuses` (`scheduledAt`);
 CREATE TABLE `instance_rules` (`id` varchar(255), `position` integer not null default '0', `text` text not null, `hint` text not null default '', `createdAt` datetime not null, `updatedAt` datetime not null, primary key (`id`));
+CREATE TABLE `suggestion_dismissals` (`actorId` varchar(255) not null, `targetActorId` varchar(255) not null, `createdAt` datetime not null, primary key (`actorId`, `targetActorId`));


### PR DESCRIPTION
## Summary

Friends-of-friends follow suggestions computed live from the local follow graph: accounts followed by the people you follow, ranked by mutual count (Accepted edges only), excluding self, already-followed, blocked, muted, and dismissed accounts. Adds a new `suggestion_dismissals` table via a Knex migration, with BOTH reference schema dumps regenerated per AGENTS.md.

- `GET /api/v2/suggestions` (OAuth `read`; `limit` 1-80, default 40) returns Mastodon Suggestion entities with `source` `'past_interactions'` and `sources` `['friends_of_friends']`.
- Deprecated `GET /api/v1/suggestions` returns the plain accounts array.
- `DELETE /api/v1/suggestions/:account_id` (OAuth `write`) records an idempotent dismissal.

## Migration notes

One new migration (`add_suggestion_dismissals`). Both `migrations/schema.sql` and `migrations/schema.sqlite.sql` regenerated canonically (Postgres dump formatting churn expected).

## Test plan

- DB tests for the ranked graph, pending-edge exclusion, dismissal idempotency, and limit.
- Route tests for rank order, limit clamping, block + mute exclusion, the v1 plain-array shape, and the dismiss round-trip.
- Full prettier/lint/build/test battery green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
