### PR TITLE
Bump version to v1.67.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.66.0",
+  "version": "1.67.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.67.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.66.0`
- Base main SHA: `bfa9d7cc35eb2dc6c08cf6b367dd79b004388020`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
