### PR TITLE
minor: local trends for tags and statuses

### DIFF
--- a/app/api/v1/trends/route.ts
+++ b/app/api/v1/trends/route.ts
@@ -1,0 +1,4 @@
+// https://docs.joinmastodon.org/methods/trends/#tags
+// Deprecated alias: GET /api/v1/trends serves the identical payload as
+// GET /api/v1/trends/tags.
+export { GET, OPTIONS } from '@/app/api/v1/trends/tags/route'

--- a/app/api/v1/trends/statuses/route.test.ts
+++ b/app/api/v1/trends/statuses/route.test.ts
@@ -1,0 +1,208 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      get: () => undefined
+    })
+  )
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const FIRST_ACTOR_ID = 'https://llun.test/users/first'
+const SECOND_ACTOR_ID = 'https://llun.test/users/second'
+const THIRD_ACTOR_ID = 'https://llun.test/users/third'
+
+const FIRST_STATUS_ID = `${FIRST_ACTOR_ID}/statuses/a`
+const SECOND_STATUS_ID = `${SECOND_ACTOR_ID}/statuses/b`
+const QUIET_STATUS_ID = `${FIRST_ACTOR_ID}/statuses/quiet`
+
+describe('GET /api/v1/trends/statuses', () => {
+  const database = getTestSQLDatabase()
+
+  const createActor = (id: string, username: string) =>
+    database.createActor({
+      actorId: id,
+      username,
+      domain: 'llun.test',
+      inboxUrl: `${id}/inbox`,
+      sharedInboxUrl: 'https://llun.test/inbox',
+      followersUrl: `${id}/followers`,
+      publicKey: 'public-key',
+      privateKey: 'private-key',
+      createdAt: 1
+    })
+
+  const createPublicNote = ({
+    actorId,
+    id,
+    createdAt
+  }: {
+    actorId: string
+    id: string
+    createdAt: number
+  }) =>
+    database.createNote({
+      id,
+      url: id,
+      actorId,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'Trending candidate',
+      createdAt
+    })
+
+  beforeAll(async () => {
+    await database.migrate()
+    await createActor(FIRST_ACTOR_ID, 'first')
+    await createActor(SECOND_ACTOR_ID, 'second')
+    await createActor(THIRD_ACTOR_ID, 'third')
+
+    const now = Date.now()
+    await createPublicNote({
+      actorId: FIRST_ACTOR_ID,
+      id: FIRST_STATUS_ID,
+      createdAt: now - 3000
+    })
+    await createPublicNote({
+      actorId: SECOND_ACTOR_ID,
+      id: SECOND_STATUS_ID,
+      createdAt: now - 2000
+    })
+    // The newest status has no interactions and must stay out of the ranking.
+    await createPublicNote({
+      actorId: FIRST_ACTOR_ID,
+      id: QUIET_STATUS_ID,
+      createdAt: now - 1000
+    })
+
+    // Second status: two likes + one boost → score 4.
+    await database.createLike({
+      actorId: FIRST_ACTOR_ID,
+      statusId: SECOND_STATUS_ID
+    })
+    await database.createLike({
+      actorId: THIRD_ACTOR_ID,
+      statusId: SECOND_STATUS_ID
+    })
+    await database.createAnnounce({
+      id: `${FIRST_ACTOR_ID}/statuses/boost-b`,
+      actorId: FIRST_ACTOR_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      originalStatusId: SECOND_STATUS_ID
+    })
+    // First status: one like → score 1.
+    await database.createLike({
+      actorId: SECOND_ACTOR_ID,
+      statusId: FIRST_STATUS_ID
+    })
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // No session → optional auth resolves currentActor = null (anonymous).
+    mockGetServerSession.mockResolvedValue(null)
+  })
+
+  const request = (query = '') =>
+    new NextRequest(`https://llun.test/api/v1/trends/statuses${query}`)
+
+  it('returns ranked Mastodon status entities for an anonymous request', async () => {
+    const response = await GET(request(), { params: Promise.resolve({}) })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((status: { uri: string }) => status.uri)).toEqual([
+      SECOND_STATUS_ID,
+      FIRST_STATUS_ID
+    ])
+    expect(data[0]).toMatchObject({
+      id: urlToId(SECOND_STATUS_ID),
+      uri: SECOND_STATUS_ID,
+      visibility: 'public',
+      favourites_count: 2,
+      reblogs_count: 1,
+      replies_count: 0,
+      favourited: false,
+      reblogged: false,
+      account: expect.objectContaining({ username: 'second' })
+    })
+    expect(data[1]).toMatchObject({
+      id: urlToId(FIRST_STATUS_ID),
+      favourites_count: 1,
+      reblogs_count: 0,
+      account: expect.objectContaining({ username: 'first' })
+    })
+  })
+
+  it.each([
+    {
+      description: 'returns only the top status when limit is 1',
+      query: '?limit=1',
+      expectedUris: [SECOND_STATUS_ID]
+    },
+    {
+      description: 'falls back to the default limit for a non-integer limit',
+      query: '?limit=garbage',
+      expectedUris: [SECOND_STATUS_ID, FIRST_STATUS_ID]
+    },
+    {
+      description: 'falls back to the default limit for a negative limit',
+      query: '?limit=-5',
+      expectedUris: [SECOND_STATUS_ID, FIRST_STATUS_ID]
+    },
+    {
+      description: 'falls back to the first page for a non-integer offset',
+      query: '?offset=garbage',
+      expectedUris: [SECOND_STATUS_ID, FIRST_STATUS_ID]
+    },
+    {
+      description: 'skips the top status when offset is 1',
+      query: '?offset=1',
+      expectedUris: [FIRST_STATUS_ID]
+    }
+  ])('$description', async ({ query, expectedUris }) => {
+    const response = await GET(request(query), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((status: { uri: string }) => status.uri)).toEqual(
+      expectedUris
+    )
+  })
+})

--- a/app/api/v1/trends/statuses/route.ts
+++ b/app/api/v1/trends/statuses/route.ts
@@ -1,4 +1,10 @@
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import {
+  normalizeTrendsLimit,
+  normalizeTrendsOffset
+} from '@/lib/services/trends/request'
+import { getTrendingStatuses } from '@/lib/services/trends/trendingStatuses'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -9,10 +15,32 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 // https://docs.joinmastodon.org/methods/trends/#statuses
-// Trends are not computed on this personal server; return an empty list.
+// Local trends computed live from public interactions (favourites, boosts,
+// and replies) on this instance over the last seven days.
 export const GET = traceApiRoute(
   'getTrendingStatuses',
-  OptionalOAuthGuard([Scope.enum.read], async (req) => {
-    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
-  })
+  OptionalOAuthGuard(
+    [Scope.enum.read],
+    async (req, { database, currentActor }) => {
+      const searchParams = new URL(req.url).searchParams
+      const limit = normalizeTrendsLimit(searchParams.get('limit'))
+      const offset = normalizeTrendsOffset(searchParams.get('offset'))
+
+      const statuses = await getTrendingStatuses({ database, limit, offset })
+      // Same serialization path as the timeline routes: batch-prefetches the
+      // viewer flags (favourited/reblogged/bookmarked) and preserves the
+      // ranked order.
+      const mastodonStatuses = await getMastodonStatuses(
+        database,
+        statuses,
+        currentActor?.id
+      )
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: mastodonStatuses
+      })
+    }
+  )
 )

--- a/app/api/v1/trends/tags/route.test.ts
+++ b/app/api/v1/trends/tags/route.test.ts
@@ -1,0 +1,213 @@
+import { NextRequest } from 'next/server'
+
+import { GET as TRENDS_ALIAS_GET } from '@/app/api/v1/trends/route'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import { GET } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockImplementation(() =>
+    Promise.resolve({
+      get: () => undefined
+    })
+  )
+}))
+
+jest.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: jest.fn()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const FIRST_ACTOR_ID = 'https://llun.test/users/first'
+const SECOND_ACTOR_ID = 'https://llun.test/users/second'
+
+const DAY_MS = 86_400_000
+
+describe('GET /api/v1/trends/tags', () => {
+  const database = getTestSQLDatabase()
+
+  const createActor = (id: string, username: string) =>
+    database.createActor({
+      actorId: id,
+      username,
+      domain: 'llun.test',
+      inboxUrl: `${id}/inbox`,
+      sharedInboxUrl: 'https://llun.test/inbox',
+      followersUrl: `${id}/followers`,
+      publicKey: 'public-key',
+      privateKey: 'private-key',
+      createdAt: 1
+    })
+
+  const createTaggedNote = async ({
+    actorId,
+    id,
+    tag,
+    createdAt
+  }: {
+    actorId: string
+    id: string
+    tag: string
+    createdAt: number
+  }) => {
+    await database.createNote({
+      id,
+      url: id,
+      actorId,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: `Post about #${tag}`,
+      createdAt
+    })
+    await database.createTag({
+      statusId: id,
+      type: 'hashtag',
+      name: `#${tag}`,
+      value: `https://llun.test/tags/${tag.toLowerCase()}`
+    })
+  }
+
+  beforeAll(async () => {
+    await database.migrate()
+    await createActor(FIRST_ACTOR_ID, 'first')
+    await createActor(SECOND_ACTOR_ID, 'second')
+
+    const now = Date.now()
+    // alpha: three public statuses by two actors today.
+    await createTaggedNote({
+      actorId: FIRST_ACTOR_ID,
+      id: `${FIRST_ACTOR_ID}/statuses/1`,
+      tag: 'alpha',
+      createdAt: now - 1000
+    })
+    await createTaggedNote({
+      actorId: FIRST_ACTOR_ID,
+      id: `${FIRST_ACTOR_ID}/statuses/2`,
+      tag: 'alpha',
+      createdAt: now - 2000
+    })
+    await createTaggedNote({
+      actorId: SECOND_ACTOR_ID,
+      id: `${SECOND_ACTOR_ID}/statuses/1`,
+      tag: 'alpha',
+      createdAt: now - 3000
+    })
+    // beta: one public status by one actor today.
+    await createTaggedNote({
+      actorId: FIRST_ACTOR_ID,
+      id: `${FIRST_ACTOR_ID}/statuses/3`,
+      tag: 'beta',
+      createdAt: now - 4000
+    })
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // No session → optional auth resolves currentActor = null (anonymous).
+    mockGetServerSession.mockResolvedValue(null)
+  })
+
+  const request = (path = '/api/v1/trends/tags', query = '') =>
+    new NextRequest(`https://llun.test${path}${query}`)
+
+  // Seven UTC-day buckets newest first; only today carries the seeded counts,
+  // every other day is zero-filled. All values are strings per the Mastodon
+  // Tag history shape, and `day` is the unix-second start of the UTC day.
+  const expectedHistory = (uses: number, accounts: number) => {
+    const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+    return Array.from({ length: 7 }, (_, index) => ({
+      day: String((todayBucketMs - index * DAY_MS) / 1000),
+      uses: String(index === 0 ? uses : 0),
+      accounts: String(index === 0 ? accounts : 0)
+    }))
+  }
+
+  it('returns trending tag entities with zero-filled seven-day history for an anonymous request', async () => {
+    const response = await GET(request(), { params: Promise.resolve({}) })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toEqual([
+      {
+        name: 'alpha',
+        url: 'https://llun.test/tags/alpha',
+        following: false,
+        history: expectedHistory(3, 2)
+      },
+      {
+        name: 'beta',
+        url: 'https://llun.test/tags/beta',
+        following: false,
+        history: expectedHistory(1, 1)
+      }
+    ])
+  })
+
+  it.each([
+    {
+      description: 'returns only the top tag when limit is 1',
+      query: '?limit=1',
+      expectedNames: ['alpha']
+    },
+    {
+      description: 'falls back to the default limit for a non-integer limit',
+      query: '?limit=garbage',
+      expectedNames: ['alpha', 'beta']
+    },
+    {
+      description: 'falls back to the default limit for a negative limit',
+      query: '?limit=-5',
+      expectedNames: ['alpha', 'beta']
+    },
+    {
+      description: 'falls back to the first page for a non-integer offset',
+      query: '?offset=garbage',
+      expectedNames: ['alpha', 'beta']
+    },
+    {
+      description: 'skips the top tag when offset is 1',
+      query: '?offset=1',
+      expectedNames: ['beta']
+    }
+  ])('$description', async ({ query, expectedNames }) => {
+    const response = await GET(request('/api/v1/trends/tags', query), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.map((tag: { name: string }) => tag.name)).toEqual(expectedNames)
+  })
+
+  it('serves the identical body at the deprecated /api/v1/trends alias', async () => {
+    const aliasResponse = await TRENDS_ALIAS_GET(request('/api/v1/trends'), {
+      params: Promise.resolve({})
+    })
+    expect(aliasResponse.status).toBe(200)
+    const tagsResponse = await GET(request(), { params: Promise.resolve({}) })
+    expect(await aliasResponse.json()).toEqual(await tagsResponse.json())
+  })
+})

--- a/app/api/v1/trends/tags/route.ts
+++ b/app/api/v1/trends/tags/route.ts
@@ -1,5 +1,7 @@
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
-import { Scope } from '@/lib/types/database/operations'
+import { getMastodonTag } from '@/lib/services/mastodon/getMastodonTag'
+import { Scope, TagDailyHistoryPoint } from '@/lib/types/database/operations'
+import { Tag, TagHistory } from '@/lib/types/mastodon/tag'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -8,12 +10,86 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+const TRENDS_DAYS = 7
+const TRENDS_DEFAULT_LIMIT = 10
+const TRENDS_MAX_LIMIT = 20
+const DAY_MS = 86_400_000
+
+// Garbage or absent input falls back to the default; valid input is clamped
+// to the Mastodon maximum of 20. Mirrors normalizeSuggestionsLimit.
+const normalizeTrendsLimit = (rawLimit: string | null): number => {
+  const limit = rawLimit !== null ? Number(rawLimit) : null
+  return Number.isSafeInteger(limit) && limit && limit > 0
+    ? Math.min(limit, TRENDS_MAX_LIMIT)
+    : TRENDS_DEFAULT_LIMIT
+}
+
+const normalizeTrendsOffset = (rawOffset: string | null): number => {
+  const offset = rawOffset !== null ? Number(rawOffset) : null
+  return Number.isSafeInteger(offset) && offset && offset > 0 ? offset : 0
+}
+
+// Seven UTC-day buckets newest first, zero-filled for days without uses.
+// `day` is the unix-second start of the UTC day; all values are strings per
+// the Mastodon Tag history shape.
+const getSevenDayHistory = (
+  todayBucketMs: number,
+  points: TagDailyHistoryPoint[]
+): TagHistory[] => {
+  const pointsByDay = new Map(points.map((point) => [point.dayBucketMs, point]))
+  return Array.from({ length: TRENDS_DAYS }, (_, index) => {
+    const dayBucketMs = todayBucketMs - index * DAY_MS
+    const point = pointsByDay.get(dayBucketMs)
+    return {
+      day: String(dayBucketMs / 1000),
+      uses: String(point?.uses ?? 0),
+      accounts: String(point?.accounts ?? 0)
+    }
+  })
+}
+
 // https://docs.joinmastodon.org/methods/trends/#tags
-// Trends are not computed on this personal server; return an empty list so
-// clients render the Explore tab without error.
+// Local trends computed live from public hashtag usage on this instance over
+// the last seven days.
 export const GET = traceApiRoute(
   'getTrendingTags',
-  OptionalOAuthGuard([Scope.enum.read], async (req) => {
-    return apiResponse({ req, allowedMethods: CORS_HEADERS, data: [] })
-  })
+  OptionalOAuthGuard(
+    [Scope.enum.read],
+    async (req, { database, currentActor }) => {
+      const searchParams = new URL(req.url).searchParams
+      const limit = normalizeTrendsLimit(searchParams.get('limit'))
+      const offset = normalizeTrendsOffset(searchParams.get('offset'))
+
+      const trendingTags = await database.getTrendingTags({
+        days: TRENDS_DAYS,
+        limit,
+        offset
+      })
+      const history = await database.getTagDailyHistory({
+        names: trendingTags.map((trendingTag) => trendingTag.name),
+        days: TRENDS_DAYS
+      })
+
+      const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+      const tags = await Promise.all(
+        trendingTags.map(async (trendingTag): Promise<Tag> => {
+          const following = currentActor
+            ? await database.isFollowingTag({
+                actorId: currentActor.id,
+                name: trendingTag.name
+              })
+            : false
+          return {
+            ...getMastodonTag(trendingTag.name, following),
+            history: getSevenDayHistory(
+              todayBucketMs,
+              history.get(trendingTag.name) ?? []
+            )
+          }
+        })
+      )
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: tags })
+    }
+  )
 )

--- a/app/api/v1/trends/tags/route.ts
+++ b/app/api/v1/trends/tags/route.ts
@@ -1,5 +1,10 @@
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonTag } from '@/lib/services/mastodon/getMastodonTag'
+import {
+  TRENDS_DAYS,
+  normalizeTrendsLimit,
+  normalizeTrendsOffset
+} from '@/lib/services/trends/request'
 import { Scope, TagDailyHistoryPoint } from '@/lib/types/database/operations'
 import { Tag, TagHistory } from '@/lib/types/mastodon/tag'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -10,24 +15,7 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
-const TRENDS_DAYS = 7
-const TRENDS_DEFAULT_LIMIT = 10
-const TRENDS_MAX_LIMIT = 20
 const DAY_MS = 86_400_000
-
-// Garbage or absent input falls back to the default; valid input is clamped
-// to the Mastodon maximum of 20. Mirrors normalizeSuggestionsLimit.
-const normalizeTrendsLimit = (rawLimit: string | null): number => {
-  const limit = rawLimit !== null ? Number(rawLimit) : null
-  return Number.isSafeInteger(limit) && limit && limit > 0
-    ? Math.min(limit, TRENDS_MAX_LIMIT)
-    : TRENDS_DEFAULT_LIMIT
-}
-
-const normalizeTrendsOffset = (rawOffset: string | null): number => {
-  const offset = rawOffset !== null ? Number(rawOffset) : null
-  return Number.isSafeInteger(offset) && offset && offset > 0 ? offset : 0
-}
 
 // Seven UTC-day buckets newest first, zero-filled for days without uses.
 // `day` is the unix-second start of the UTC day; all values are strings per

--- a/docs/features.md
+++ b/docs/features.md
@@ -71,6 +71,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Account notes & preferences** — Private per-account notes and client preferences
 - ✅ **Featured tags API** — `/api/v1/featured_tags` endpoints backing the profile featured-hashtags feature
 - ✅ **Follow suggestions** — friends-of-friends suggestions via `GET /api/v2/suggestions` (plus deprecated `GET /api/v1/suggestions`), with per-account dismissal via `DELETE /api/v1/suggestions/:account_id`
+- ✅ **Trends** — local trending hashtags via `GET /api/v1/trends/tags` (plus deprecated `GET /api/v1/trends`) and trending statuses via `GET /api/v1/trends/statuses`, both computed live from the last seven days of public local activity; `GET /api/v1/trends/links` intentionally stays an empty list (no preview-card storage)
 - ✅ **Followed hashtags** — Follow and unfollow hashtags and view a followed-tags timeline
 - ✅ **Mutes** — Mute and unmute accounts
 - ✅ **WebFinger** — Actor discovery via `/.well-known/webfinger`

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -37,6 +37,7 @@ import { StravaArchiveImportSQLDatabaseMixin } from '@/lib/database/sql/stravaAr
 import { SuggestionSQLDatabaseMixin } from '@/lib/database/sql/suggestion'
 import { TimelineSQLDatabaseMixin } from '@/lib/database/sql/timeline'
 import { TranslationCacheSQLDatabaseMixin } from '@/lib/database/sql/translationCache'
+import { TrendsSQLDatabaseMixin } from '@/lib/database/sql/trends'
 import { Database } from '@/lib/database/types'
 
 export const getSQLDatabase = (database: Knex): Database => {
@@ -75,6 +76,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const stravaArchiveImportDatabase =
     StravaArchiveImportSQLDatabaseMixin(database)
   const suggestionDatabase = SuggestionSQLDatabaseMixin(database)
+  const trendsDatabase = TrendsSQLDatabaseMixin(database)
   const statusDatabase = StatusSQLDatabaseMixin(
     database,
     actorDatabase,
@@ -140,6 +142,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...searchDatabase,
     ...stravaArchiveImportDatabase,
     ...suggestionDatabase,
+    ...trendsDatabase,
     ...statusDatabase,
     ...directConversationDatabase,
 

--- a/lib/database/sql/search/hashtag.ts
+++ b/lib/database/sql/search/hashtag.ts
@@ -86,7 +86,11 @@ const getTagUrl = (name: string) => {
   return `${baseURL}/tags/${encodeURIComponent(name)}`
 }
 
-const getNormalizedHashtagNameSQL = (database: KnexConnection) => {
+// Strips the optional leading `#` from `tags.nameNormalized` in SQL so both
+// stored forms (`bare` and `#bare`) group/match as one normalized tag name.
+// Exported for other tag aggregations (e.g. trends) that must count the same
+// rows hashtag search counts.
+export const getNormalizedHashtagNameSQL = (database: KnexConnection) => {
   if (isSQLiteClient(database)) {
     return {
       sql: 'lower(ltrim(??, ?))',

--- a/lib/database/sql/trends.test.ts
+++ b/lib/database/sql/trends.test.ts
@@ -1,0 +1,255 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+const FIRST_ACTOR_ID = 'https://llun.test/users/first'
+const SECOND_ACTOR_ID = 'https://llun.test/users/second'
+
+const DAY_MS = 86_400_000
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const createActor = (database: Database, id: string, username: string) =>
+  database.createActor({
+    actorId: id,
+    username,
+    domain: 'llun.test',
+    inboxUrl: `${id}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    followersUrl: `${id}/followers`,
+    publicKey: 'public-key',
+    privateKey: 'private-key',
+    createdAt: 1
+  })
+
+const createTaggedNote = async (
+  database: Database,
+  {
+    actorId,
+    id,
+    tag,
+    createdAt,
+    isPublic = true
+  }: {
+    actorId: string
+    id: string
+    tag: string
+    createdAt: number
+    isPublic?: boolean
+  }
+) => {
+  await database.createNote({
+    id,
+    url: id,
+    actorId,
+    to: isPublic ? [ACTIVITY_STREAM_PUBLIC] : [`${actorId}/followers`],
+    cc: [],
+    text: `Post about #${tag}`,
+    createdAt
+  })
+  await database.createTag({
+    statusId: id,
+    type: 'hashtag',
+    name: `#${tag}`,
+    value: `https://llun.test/tags/${tag.toLowerCase()}`
+  })
+}
+
+describe('getTrendingTags', () => {
+  it('ranks tags by distinct status uses with distinct account counts', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+
+      const now = Date.now()
+      // alpha: three statuses by two actors (mixed casing normalizes together).
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/1`,
+        tag: 'Alpha',
+        createdAt: now - 1000
+      })
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/2`,
+        tag: 'alpha',
+        createdAt: now - 2000
+      })
+      await createTaggedNote(database, {
+        actorId: SECOND_ACTOR_ID,
+        id: `${SECOND_ACTOR_ID}/statuses/1`,
+        tag: 'alpha',
+        createdAt: now - 3000
+      })
+      // beta: one status by one actor.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/3`,
+        tag: 'beta',
+        createdAt: now - 4000
+      })
+
+      const tags = await database.getTrendingTags({
+        days: 7,
+        limit: 10,
+        offset: 0
+      })
+      expect(tags).toEqual([
+        { name: 'alpha', uses: 3, accounts: 2 },
+        { name: 'beta', uses: 1, accounts: 1 }
+      ])
+    })
+  })
+
+  it('excludes tag uses outside the day window', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+
+      const now = Date.now()
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/1`,
+        tag: 'fresh',
+        createdAt: now - 1000
+      })
+      // Used eight days ago — outside a seven-day window.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/2`,
+        tag: 'old',
+        createdAt: now - 8 * DAY_MS
+      })
+
+      const tags = await database.getTrendingTags({
+        days: 7,
+        limit: 10,
+        offset: 0
+      })
+      expect(tags).toEqual([{ name: 'fresh', uses: 1, accounts: 1 }])
+    })
+  })
+
+  it('ignores tags carried only by non-public statuses', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+
+      const now = Date.now()
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/1`,
+        tag: 'open',
+        createdAt: now - 1000
+      })
+      // Followers-only status — its tag never trends.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/2`,
+        tag: 'secret',
+        createdAt: now - 2000,
+        isPublic: false
+      })
+
+      const tags = await database.getTrendingTags({
+        days: 7,
+        limit: 10,
+        offset: 0
+      })
+      expect(tags).toEqual([{ name: 'open', uses: 1, accounts: 1 }])
+    })
+  })
+
+  it('slices equally ranked tags deterministically with offset and limit', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+
+      const now = Date.now()
+      // Three tags with one use each — ties order by tag name ascending.
+      for (const [index, tag] of ['ccc', 'aaa', 'bbb'].entries()) {
+        await createTaggedNote(database, {
+          actorId: FIRST_ACTOR_ID,
+          id: `${FIRST_ACTOR_ID}/statuses/${index}`,
+          tag,
+          createdAt: now - 1000 - index
+        })
+      }
+
+      const firstPage = await database.getTrendingTags({
+        days: 7,
+        limit: 1,
+        offset: 0
+      })
+      expect(firstPage).toEqual([{ name: 'aaa', uses: 1, accounts: 1 }])
+
+      const rest = await database.getTrendingTags({
+        days: 7,
+        limit: 2,
+        offset: 1
+      })
+      expect(rest).toEqual([
+        { name: 'bbb', uses: 1, accounts: 1 },
+        { name: 'ccc', uses: 1, accounts: 1 }
+      ])
+    })
+  })
+})
+
+describe('getTagDailyHistory', () => {
+  it('buckets same-day uses together and splits different days apart', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+
+      const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+      // Two uses by two actors inside the same UTC day bucket.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/1`,
+        tag: 'daily',
+        createdAt: todayBucketMs + 1000
+      })
+      await createTaggedNote(database, {
+        actorId: SECOND_ACTOR_ID,
+        id: `${SECOND_ACTOR_ID}/statuses/1`,
+        tag: 'daily',
+        createdAt: todayBucketMs + 2000
+      })
+      // One use the day before lands in its own bucket.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/2`,
+        tag: 'daily',
+        createdAt: todayBucketMs - DAY_MS + 1000
+      })
+
+      const history = await database.getTagDailyHistory({
+        names: ['daily'],
+        days: 7
+      })
+      expect(history.get('daily')).toEqual([
+        { dayBucketMs: todayBucketMs, uses: 2, accounts: 2 },
+        { dayBucketMs: todayBucketMs - DAY_MS, uses: 1, accounts: 1 }
+      ])
+    })
+  })
+
+  it('returns an empty history list for a tag with no uses in the window', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      const history = await database.getTagDailyHistory({
+        names: ['unused'],
+        days: 7
+      })
+      expect(history.get('unused')).toEqual([])
+    })
+  })
+})

--- a/lib/database/sql/trends.test.ts
+++ b/lib/database/sql/trends.test.ts
@@ -314,13 +314,14 @@ describe('getTrendingStatusCandidateIds', () => {
       createdAt
     })
 
-  it('returns every public top-level candidate newest first, ignoring a fixed cap', async () => {
+  it('returns every windowed public top-level candidate newest first', async () => {
     await withFreshDatabase(async (database) => {
       await createActor(database, FIRST_ACTOR_ID, 'first')
 
       const now = Date.now()
-      // Far more than any small newest-N timeline slice would keep, so a cap
-      // would drop the oldest-within-window ones from the candidate set.
+      // Far more than any small newest-N timeline slice would keep, yet well
+      // under the query's 1000-row safety cap, so the whole windowed set is
+      // returned — including the oldest-within-window status.
       const total = 250
       for (let index = 0; index < total; index += 1) {
         await createNote(database, {

--- a/lib/database/sql/trends.test.ts
+++ b/lib/database/sql/trends.test.ts
@@ -285,3 +285,93 @@ describe('getTagDailyHistory', () => {
     })
   })
 })
+
+describe('getTrendingStatusCandidateIds', () => {
+  const createNote = (
+    database: Database,
+    {
+      actorId,
+      id,
+      createdAt,
+      isPublic = true,
+      reply
+    }: {
+      actorId: string
+      id: string
+      createdAt: number
+      isPublic?: boolean
+      reply?: string
+    }
+  ) =>
+    database.createNote({
+      id,
+      url: id,
+      actorId,
+      to: isPublic ? [ACTIVITY_STREAM_PUBLIC] : [`${actorId}/followers`],
+      cc: [],
+      text: 'Candidate',
+      ...(reply ? { reply } : null),
+      createdAt
+    })
+
+  it('returns every public top-level candidate newest first, ignoring a fixed cap', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+
+      const now = Date.now()
+      // Far more than any small newest-N timeline slice would keep, so a cap
+      // would drop the oldest-within-window ones from the candidate set.
+      const total = 250
+      for (let index = 0; index < total; index += 1) {
+        await createNote(database, {
+          actorId: FIRST_ACTOR_ID,
+          id: `${FIRST_ACTOR_ID}/statuses/${index}`,
+          createdAt: now - index * 1000
+        })
+      }
+
+      const ids = await database.getTrendingStatusCandidateIds({ days: 7 })
+      expect(ids).toHaveLength(total)
+      // Newest first, and the oldest-within-window status is still present.
+      expect(ids[0]).toBe(`${FIRST_ACTOR_ID}/statuses/0`)
+      expect(ids).toContain(`${FIRST_ACTOR_ID}/statuses/${total - 1}`)
+    })
+  })
+
+  it('excludes replies, non-public, and out-of-window statuses', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+
+      const now = Date.now()
+      const keptId = `${FIRST_ACTOR_ID}/statuses/kept`
+      await createNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: keptId,
+        createdAt: now - 1000
+      })
+      // A reply is not a top-level candidate.
+      await createNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/reply`,
+        createdAt: now - 2000,
+        reply: keptId
+      })
+      // Followers-only is never public.
+      await createNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/private`,
+        createdAt: now - 3000,
+        isPublic: false
+      })
+      // Eight days old — outside the seven-day window.
+      await createNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/old`,
+        createdAt: now - 8 * DAY_MS
+      })
+
+      const ids = await database.getTrendingStatusCandidateIds({ days: 7 })
+      expect(ids).toEqual([keptId])
+    })
+  })
+})

--- a/lib/database/sql/trends.test.ts
+++ b/lib/database/sql/trends.test.ts
@@ -139,6 +139,38 @@ describe('getTrendingTags', () => {
     })
   })
 
+  it('aligns the window start to the oldest rendered UTC day bucket', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+
+      const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+      const oldestBucketMs = todayBucketMs - 6 * DAY_MS
+      // First instant of the oldest rendered bucket — still counted.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/1`,
+        tag: 'edge',
+        createdAt: oldestBucketMs
+      })
+      // Just before the oldest rendered bucket: inside a rolling 7×24h window
+      // but in an eighth UTC day bucket the route never renders — it must not
+      // count toward the ranking.
+      await createTaggedNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/2`,
+        tag: 'edge',
+        createdAt: oldestBucketMs - 1000
+      })
+
+      const tags = await database.getTrendingTags({
+        days: 7,
+        limit: 10,
+        offset: 0
+      })
+      expect(tags).toEqual([{ name: 'edge', uses: 1, accounts: 1 }])
+    })
+  })
+
   it('ignores tags carried only by non-public statuses', async () => {
     await withFreshDatabase(async (database) => {
       await createActor(database, FIRST_ACTOR_ID, 'first')

--- a/lib/database/sql/trends.ts
+++ b/lib/database/sql/trends.ts
@@ -26,6 +26,16 @@ const PUBLIC_ACTIVITY_RECIPIENTS = [
 
 const DAY_MS = 86_400_000
 
+// Upper bound on the trending-status candidate set. The window already bounds
+// the volume on a personal-scale instance, but a busy or federated instance
+// could accumulate far more public statuses in seven days; without a cap the
+// ids would be loaded into memory and fanned out through getStatusesByIds'
+// single `whereIn` (risking the backend's bind-variable limit). 1000 newest
+// candidates is well above what a personal server produces in the window yet
+// safely bounds memory and the query — the service still ranks and slices to
+// Mastodon's max of 20 from within them.
+const TRENDING_STATUS_CANDIDATE_LIMIT = 1000
+
 type SQLTrendingTagRow = {
   name: string
   // count() comes back as a string on Postgres but a number on SQLite.
@@ -146,7 +156,8 @@ export const TrendsSQLDatabaseMixin = (database: Knex): TrendsDatabase => ({
       .where('statuses.createdAt', '>=', since)
       .distinct('statuses.id as id', 'statuses.createdAt as createdAt')
       .orderBy('statuses.createdAt', 'desc')
-      .orderBy('statuses.id', 'desc')) as { id: string }[]
+      .orderBy('statuses.id', 'desc')
+      .limit(TRENDING_STATUS_CANDIDATE_LIMIT)) as { id: string }[]
     return rows.map((row) => row.id)
   },
 

--- a/lib/database/sql/trends.ts
+++ b/lib/database/sql/trends.ts
@@ -1,0 +1,174 @@
+import { Knex } from 'knex'
+
+import {
+  getNormalizedHashtagNameSQL,
+  normalizeHashtagSearchName
+} from '@/lib/database/sql/search/hashtag'
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  GetTagDailyHistoryParams,
+  GetTrendingTagsParams,
+  TagDailyHistoryPoint,
+  TrendingTag,
+  TrendsDatabase
+} from '@/lib/types/database/operations'
+import { StatusType } from '@/lib/types/domain/status'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
+
+const PUBLIC_ACTIVITY_RECIPIENTS = [
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+]
+
+const DAY_MS = 86_400_000
+
+type SQLTrendingTagRow = {
+  name: string
+  // count() comes back as a string on Postgres but a number on SQLite.
+  uses: number | string
+  accounts: number | string
+}
+
+type SQLTagUsageRow = {
+  name: string
+  statusId: string
+  statusActorId: string
+  // statuses.createdAt is written as a Date binding: better-sqlite3 stores it
+  // as epoch milliseconds, Postgres as timestamptz — normalize on read.
+  statusCreatedAt: number | Date | string
+}
+
+// Both stored forms exist in `tags.nameNormalized` (`bare` and `#bare`); look
+// up both, exactly like the status/search hashtag layer.
+const getHashtagLookupNames = (name: string) => {
+  const bare = normalizeHashtagSearchName(name)
+  return bare ? [bare, `#${bare}`] : []
+}
+
+// Distinct (normalized tag name, statusId, statusActorId[, statusCreatedAt])
+// rows for hashtags on publicly-addressed Note/Poll statuses created within
+// the last `days` days. Mirrors the featured-tag / hashtag-search aggregation
+// (same name normalization and public-recipients EXISTS restriction) but with
+// no per-actor filter — trends are instance-wide.
+const getWindowedPublicTagUsage = (
+  database: Knex,
+  {
+    days,
+    includeCreatedAt = false
+  }: { days: number; includeCreatedAt?: boolean }
+) => {
+  const normalizedNameSQL = getNormalizedHashtagNameSQL(database)
+  // statuses.createdAt is written as a Date; binding a Date keeps the window
+  // predicate portable (epoch milliseconds on SQLite, timestamptz on
+  // Postgres) — same pattern as the nodeinfo active-user window.
+  const since = new Date(Date.now() - days * DAY_MS)
+  return database('tags')
+    .distinct(
+      database.raw(`${normalizedNameSQL.sql} as ??`, [
+        ...normalizedNameSQL.bindings,
+        'name'
+      ]),
+      database.raw('?? as ??', ['statuses.id', 'statusId']),
+      database.raw('?? as ??', ['statuses.actorId', 'statusActorId']),
+      ...(includeCreatedAt
+        ? [database.raw('?? as ??', ['statuses.createdAt', 'statusCreatedAt'])]
+        : [])
+    )
+    .innerJoin('statuses', 'statuses.id', 'tags.statusId')
+    .where('tags.type', 'hashtag')
+    .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
+    .where('statuses.createdAt', '>=', since)
+    .whereExists((builder) => {
+      builder
+        .select(database.raw('1'))
+        .from('recipients')
+        .whereRaw('?? = ??', ['recipients.statusId', 'statuses.id'])
+        .whereIn('recipients.actorId', PUBLIC_ACTIVITY_RECIPIENTS)
+    })
+}
+
+export const TrendsSQLDatabaseMixin = (database: Knex): TrendsDatabase => ({
+  async getTrendingTags({ days, limit, offset }: GetTrendingTagsParams) {
+    const usage = getWindowedPublicTagUsage(database, { days })
+    const rows = (await database
+      .from(usage.as('tag_usage'))
+      .select({ name: 'tag_usage.name' })
+      .countDistinct({ uses: 'tag_usage.statusId' })
+      .countDistinct({ accounts: 'tag_usage.statusActorId' })
+      .groupBy('tag_usage.name')
+      .orderBy([
+        { column: 'uses', order: 'desc' },
+        { column: 'tag_usage.name', order: 'asc' }
+      ])
+      .offset(offset)
+      .limit(limit)) as SQLTrendingTagRow[]
+
+    return rows.map(
+      (row): TrendingTag => ({
+        name: row.name,
+        uses: Number(row.uses),
+        accounts: Number(row.accounts)
+      })
+    )
+  },
+
+  async getTagDailyHistory({ names, days }: GetTagDailyHistoryParams) {
+    // Every requested (normalizable) name gets an entry — possibly an empty
+    // list — so the route can zero-fill without checking key presence.
+    const history = new Map<string, TagDailyHistoryPoint[]>()
+    for (const name of names) {
+      const bare = normalizeHashtagSearchName(name)
+      if (bare) history.set(bare, [])
+    }
+    if (history.size === 0) return history
+
+    const lookupNames = [...history.keys()].flatMap(getHashtagLookupNames)
+    const rows = (await getWindowedPublicTagUsage(database, {
+      days,
+      includeCreatedAt: true
+    }).whereIn('tags.nameNormalized', lookupNames)) as SQLTagUsageRow[]
+
+    // Bucket per UTC day in JS — portable across dialects (no SQL date
+    // functions) and the windowed row volume stays small on a personal
+    // server. Distinct sets guard against double-counting a status that
+    // matched through both stored tag-name forms.
+    type BucketCounter = { statusIds: Set<string>; actorIds: Set<string> }
+    const bucketsByName = new Map<string, Map<number, BucketCounter>>()
+    for (const row of rows) {
+      const bare = normalizeHashtagSearchName(row.name)
+      if (!history.has(bare)) continue
+
+      const dayBucketMs =
+        Math.floor(getCompatibleTime(row.statusCreatedAt) / DAY_MS) * DAY_MS
+      let buckets = bucketsByName.get(bare)
+      if (!buckets) {
+        buckets = new Map()
+        bucketsByName.set(bare, buckets)
+      }
+      let counter = buckets.get(dayBucketMs)
+      if (!counter) {
+        counter = { statusIds: new Set(), actorIds: new Set() }
+        buckets.set(dayBucketMs, counter)
+      }
+      counter.statusIds.add(row.statusId)
+      counter.actorIds.add(row.statusActorId)
+    }
+
+    for (const [bare, buckets] of bucketsByName) {
+      history.set(
+        bare,
+        [...buckets.entries()]
+          .sort(([firstDay], [secondDay]) => secondDay - firstDay)
+          .map(([dayBucketMs, counter]) => ({
+            dayBucketMs,
+            uses: counter.statusIds.size,
+            accounts: counter.actorIds.size
+          }))
+      )
+    }
+    return history
+  }
+})

--- a/lib/database/sql/trends.ts
+++ b/lib/database/sql/trends.ts
@@ -63,8 +63,15 @@ const getWindowedPublicTagUsage = (
   const normalizedNameSQL = getNormalizedHashtagNameSQL(database)
   // statuses.createdAt is written as a Date; binding a Date keeps the window
   // predicate portable (epoch milliseconds on SQLite, timestamptz on
-  // Postgres) — same pattern as the nodeinfo active-user window.
-  const since = new Date(Date.now() - days * DAY_MS)
+  // Postgres) — same pattern as the nodeinfo active-user window. The window
+  // starts at the oldest rendered UTC day bucket (today minus `days - 1`
+  // whole days) so the ranking counts exactly the rows the route's
+  // zero-filled `days` calendar-day history can show — a rolling
+  // `days × 24h` window would also count rows from an older, never-rendered
+  // bucket.
+  const since = new Date(
+    Math.floor(Date.now() / DAY_MS) * DAY_MS - (days - 1) * DAY_MS
+  )
   return database('tags')
     .distinct(
       database.raw(`${normalizedNameSQL.sql} as ??`, [

--- a/lib/database/sql/trends.ts
+++ b/lib/database/sql/trends.ts
@@ -59,6 +59,16 @@ const getHashtagLookupNames = (name: string) => {
   return bare ? [bare, `#${bare}`] : []
 }
 
+// Shared start of the trends window, used by both the tag and status queries
+// so the two endpoints always agree on which rows are "in window". It starts at
+// the oldest rendered UTC day bucket (today minus `days - 1` whole days) rather
+// than a rolling `days × 24h` span, so the tag ranking counts exactly the rows
+// the route's zero-filled `days` calendar-day history can show. Binding a Date
+// keeps the predicate portable (epoch milliseconds on SQLite, timestamptz on
+// Postgres) — the same pattern as the nodeinfo active-user window.
+const getTrendsWindowStart = (days: number): Date =>
+  new Date(Math.floor(Date.now() / DAY_MS) * DAY_MS - (days - 1) * DAY_MS)
+
 // Distinct (normalized tag name, statusId, statusActorId[, statusCreatedAt])
 // rows for hashtags on publicly-addressed Note/Poll statuses created within
 // the last `days` days. Mirrors the featured-tag / hashtag-search aggregation
@@ -72,17 +82,7 @@ const getWindowedPublicTagUsage = (
   }: { days: number; includeCreatedAt?: boolean }
 ) => {
   const normalizedNameSQL = getNormalizedHashtagNameSQL(database)
-  // statuses.createdAt is written as a Date; binding a Date keeps the window
-  // predicate portable (epoch milliseconds on SQLite, timestamptz on
-  // Postgres) — same pattern as the nodeinfo active-user window. The window
-  // starts at the oldest rendered UTC day bucket (today minus `days - 1`
-  // whole days) so the ranking counts exactly the rows the route's
-  // zero-filled `days` calendar-day history can show — a rolling
-  // `days × 24h` window would also count rows from an older, never-rendered
-  // bucket.
-  const since = new Date(
-    Math.floor(Date.now() / DAY_MS) * DAY_MS - (days - 1) * DAY_MS
-  )
+  const since = getTrendsWindowStart(days)
   return database('tags')
     .distinct(
       database.raw(`${normalizedNameSQL.sql} as ??`, [
@@ -139,22 +139,28 @@ export const TrendsSQLDatabaseMixin = (database: Knex): TrendsDatabase => ({
     // Mirror the LOCAL_PUBLIC timeline selection (top-level public statuses by
     // local actors), but restricted to the trends window and to content types
     // that carry their own counters — Announce boosts are skipped, the boosted
-    // original ranks through its own row. Public is encoded directly in SQL via
-    // the `to` recipient on the public collection, so the candidate set needs
-    // no per-status async access check before ranking. Binding a Date keeps the
-    // window predicate portable across SQLite (epoch ms) and Postgres
-    // (timestamptz), matching getWindowedPublicTagUsage.
-    const since = new Date(Date.now() - days * DAY_MS)
-    const rows = (await database('recipients')
-      .where('recipients.type', 'to')
-      .where('recipients.actorId', ACTIVITY_STREAM_PUBLIC)
-      .innerJoin('statuses', 'recipients.statusId', 'statuses.id')
+    // original ranks through its own row. Public is gated with a `whereExists`
+    // on the `to` recipient pointing at the public collection (the strictly
+    // public, non-unlisted addressing the public timeline uses): the candidate
+    // set needs no per-status async access check before ranking, and the
+    // semi-join avoids the row duplication a direct join would need `distinct`
+    // to undo. Shares getTrendsWindowStart so the window matches trending tags.
+    const since = getTrendsWindowStart(days)
+    const rows = (await database('statuses')
       .innerJoin('actors', 'statuses.actorId', 'actors.id')
       .whereNotNull('actors.privateKey')
       .where('statuses.reply', '')
       .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
       .where('statuses.createdAt', '>=', since)
-      .distinct('statuses.id as id', 'statuses.createdAt as createdAt')
+      .whereExists((builder) => {
+        builder
+          .select(database.raw('1'))
+          .from('recipients')
+          .whereRaw('?? = ??', ['recipients.statusId', 'statuses.id'])
+          .where('recipients.type', 'to')
+          .where('recipients.actorId', ACTIVITY_STREAM_PUBLIC)
+      })
+      .select('statuses.id as id')
       .orderBy('statuses.createdAt', 'desc')
       .orderBy('statuses.id', 'desc')
       .limit(TRENDING_STATUS_CANDIDATE_LIMIT)) as { id: string }[]

--- a/lib/database/sql/trends.ts
+++ b/lib/database/sql/trends.ts
@@ -7,6 +7,7 @@ import {
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import {
   GetTagDailyHistoryParams,
+  GetTrendingStatusCandidateIdsParams,
   GetTrendingTagsParams,
   TagDailyHistoryPoint,
   TrendingTag,
@@ -120,6 +121,33 @@ export const TrendsSQLDatabaseMixin = (database: Knex): TrendsDatabase => ({
         accounts: Number(row.accounts)
       })
     )
+  },
+
+  async getTrendingStatusCandidateIds({
+    days
+  }: GetTrendingStatusCandidateIdsParams) {
+    // Mirror the LOCAL_PUBLIC timeline selection (top-level public statuses by
+    // local actors), but restricted to the trends window and to content types
+    // that carry their own counters — Announce boosts are skipped, the boosted
+    // original ranks through its own row. Public is encoded directly in SQL via
+    // the `to` recipient on the public collection, so the candidate set needs
+    // no per-status async access check before ranking. Binding a Date keeps the
+    // window predicate portable across SQLite (epoch ms) and Postgres
+    // (timestamptz), matching getWindowedPublicTagUsage.
+    const since = new Date(Date.now() - days * DAY_MS)
+    const rows = (await database('recipients')
+      .where('recipients.type', 'to')
+      .where('recipients.actorId', ACTIVITY_STREAM_PUBLIC)
+      .innerJoin('statuses', 'recipients.statusId', 'statuses.id')
+      .innerJoin('actors', 'statuses.actorId', 'actors.id')
+      .whereNotNull('actors.privateKey')
+      .where('statuses.reply', '')
+      .whereIn('statuses.type', [StatusType.enum.Note, StatusType.enum.Poll])
+      .where('statuses.createdAt', '>=', since)
+      .distinct('statuses.id as id', 'statuses.createdAt as createdAt')
+      .orderBy('statuses.createdAt', 'desc')
+      .orderBy('statuses.id', 'desc')) as { id: string }[]
+    return rows.map((row) => row.id)
   },
 
   async getTagDailyHistory({ names, days }: GetTagDailyHistoryParams) {

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -36,7 +36,8 @@ import {
   StatusMuteDatabase,
   SuggestionDatabase,
   TimelineDatabase,
-  TranslationCacheDatabase
+  TranslationCacheDatabase,
+  TrendsDatabase
 } from '@/lib/types/database/operations'
 
 export type Database = AccountDatabase &
@@ -73,6 +74,7 @@ export type Database = AccountDatabase &
   StatusDatabase &
   StatusMuteDatabase &
   SuggestionDatabase &
+  TrendsDatabase &
   IdempotencyDatabase &
   TranslationCacheDatabase &
   TimelineDatabase &

--- a/lib/services/trends/request.test.ts
+++ b/lib/services/trends/request.test.ts
@@ -1,0 +1,91 @@
+import {
+  TRENDS_DEFAULT_LIMIT,
+  TRENDS_MAX_LIMIT,
+  normalizeTrendsLimit,
+  normalizeTrendsOffset
+} from './request'
+
+describe('normalizeTrendsLimit', () => {
+  it.each([
+    {
+      description: 'valid in-range limit passes through',
+      value: '5',
+      expected: 5
+    },
+    {
+      description: 'minimum limit of one passes through',
+      value: '1',
+      expected: 1
+    },
+    {
+      description: 'limit above the max clamps to the max',
+      value: '25',
+      expected: TRENDS_MAX_LIMIT
+    },
+    {
+      description: 'limit at the max stays at the max',
+      value: '20',
+      expected: TRENDS_MAX_LIMIT
+    },
+    {
+      description: 'zero limit falls back to the default',
+      value: '0',
+      expected: TRENDS_DEFAULT_LIMIT
+    },
+    {
+      description: 'negative limit falls back to the default',
+      value: '-5',
+      expected: TRENDS_DEFAULT_LIMIT
+    },
+    {
+      description: 'decimal limit falls back to the default',
+      value: '5.9',
+      expected: TRENDS_DEFAULT_LIMIT
+    },
+    {
+      description: 'non-numeric limit falls back to the default',
+      value: 'garbage',
+      expected: TRENDS_DEFAULT_LIMIT
+    },
+    {
+      description: 'absent limit falls back to the default',
+      value: null,
+      expected: TRENDS_DEFAULT_LIMIT
+    }
+  ])('$description', ({ value, expected }) => {
+    expect(normalizeTrendsLimit(value)).toBe(expected)
+  })
+})
+
+describe('normalizeTrendsOffset', () => {
+  it.each([
+    {
+      description: 'valid positive offset passes through',
+      value: '5',
+      expected: 5
+    },
+    { description: 'zero offset stays zero', value: '0', expected: 0 },
+    {
+      description: 'negative offset falls back to zero',
+      value: '-3',
+      expected: 0
+    },
+    {
+      description: 'decimal offset falls back to zero',
+      value: '2.5',
+      expected: 0
+    },
+    {
+      description: 'non-numeric offset falls back to zero',
+      value: 'garbage',
+      expected: 0
+    },
+    {
+      description: 'absent offset falls back to zero',
+      value: null,
+      expected: 0
+    }
+  ])('$description', ({ value, expected }) => {
+    expect(normalizeTrendsOffset(value)).toBe(expected)
+  })
+})

--- a/lib/services/trends/request.ts
+++ b/lib/services/trends/request.ts
@@ -1,0 +1,17 @@
+export const TRENDS_DAYS = 7
+export const TRENDS_DEFAULT_LIMIT = 10
+export const TRENDS_MAX_LIMIT = 20
+
+// Garbage or absent input falls back to the default; valid input is clamped
+// to the Mastodon maximum of 20. Mirrors normalizeSuggestionsLimit.
+export const normalizeTrendsLimit = (rawLimit: string | null): number => {
+  const limit = rawLimit !== null ? Number(rawLimit) : null
+  return Number.isSafeInteger(limit) && limit && limit > 0
+    ? Math.min(limit, TRENDS_MAX_LIMIT)
+    : TRENDS_DEFAULT_LIMIT
+}
+
+export const normalizeTrendsOffset = (rawOffset: string | null): number => {
+  const offset = rawOffset !== null ? Number(rawOffset) : null
+  return Number.isSafeInteger(offset) && offset && offset > 0 ? offset : 0
+}

--- a/lib/services/trends/trendingStatuses.test.ts
+++ b/lib/services/trends/trendingStatuses.test.ts
@@ -1,0 +1,247 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import { getTrendingStatuses } from './trendingStatuses'
+
+const FIRST_ACTOR_ID = 'https://llun.test/users/first'
+const SECOND_ACTOR_ID = 'https://llun.test/users/second'
+const THIRD_ACTOR_ID = 'https://llun.test/users/third'
+
+const DAY_MS = 86_400_000
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const createActor = (database: Database, id: string, username: string) =>
+  database.createActor({
+    actorId: id,
+    username,
+    domain: 'llun.test',
+    inboxUrl: `${id}/inbox`,
+    sharedInboxUrl: 'https://llun.test/inbox',
+    followersUrl: `${id}/followers`,
+    publicKey: 'public-key',
+    privateKey: 'private-key',
+    createdAt: 1
+  })
+
+const createPublicNote = (
+  database: Database,
+  {
+    actorId,
+    id,
+    createdAt,
+    reply
+  }: { actorId: string; id: string; createdAt: number; reply?: string }
+) =>
+  database.createNote({
+    id,
+    url: id,
+    actorId,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    text: 'Trending candidate',
+    ...(reply ? { reply } : null),
+    createdAt
+  })
+
+describe('getTrendingStatuses', () => {
+  it('ranks statuses by interaction score and drops zero-score statuses', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+      await createActor(database, THIRD_ACTOR_ID, 'third')
+
+      const now = Date.now()
+      const statusAId = `${FIRST_ACTOR_ID}/statuses/a`
+      const statusBId = `${FIRST_ACTOR_ID}/statuses/b`
+      const statusCId = `${FIRST_ACTOR_ID}/statuses/c`
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: statusAId,
+        createdAt: now - 3000
+      })
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: statusBId,
+        createdAt: now - 2000
+      })
+      // The newest status has no interactions — it must not outrank scored ones.
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: statusCId,
+        createdAt: now - 1000
+      })
+
+      // B: two likes + one boost → score 2 + 2 × 1 = 4.
+      await database.createLike({
+        actorId: SECOND_ACTOR_ID,
+        statusId: statusBId
+      })
+      await database.createLike({
+        actorId: THIRD_ACTOR_ID,
+        statusId: statusBId
+      })
+      await database.createAnnounce({
+        id: `${SECOND_ACTOR_ID}/statuses/boost-b`,
+        actorId: SECOND_ACTOR_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: statusBId
+      })
+      // A: one like → score 1.
+      await database.createLike({
+        actorId: SECOND_ACTOR_ID,
+        statusId: statusAId
+      })
+
+      const statuses = await getTrendingStatuses({
+        database,
+        limit: 10,
+        offset: 0
+      })
+      expect(statuses.map((status) => status.id)).toEqual([
+        statusBId,
+        statusAId
+      ])
+    })
+  })
+
+  it('counts replies toward the score', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+
+      const now = Date.now()
+      const parentStatusId = `${FIRST_ACTOR_ID}/statuses/parent`
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: parentStatusId,
+        createdAt: now - 2000
+      })
+      await createPublicNote(database, {
+        actorId: SECOND_ACTOR_ID,
+        id: `${SECOND_ACTOR_ID}/statuses/reply`,
+        createdAt: now - 1500,
+        reply: parentStatusId
+      })
+      // A newer status without interactions stays out of the ranking.
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: `${FIRST_ACTOR_ID}/statuses/quiet`,
+        createdAt: now - 1000
+      })
+
+      const statuses = await getTrendingStatuses({
+        database,
+        limit: 10,
+        offset: 0
+      })
+      expect(statuses.map((status) => status.id)).toEqual([parentStatusId])
+    })
+  })
+
+  it('breaks score ties by newest first and slices with offset and limit', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+
+      const now = Date.now()
+      // Three statuses with one like each — ties order newest first.
+      const statusIds = [1, 2, 3].map(
+        (index) => `${FIRST_ACTOR_ID}/statuses/${index}`
+      )
+      for (const [index, statusId] of statusIds.entries()) {
+        await createPublicNote(database, {
+          actorId: FIRST_ACTOR_ID,
+          id: statusId,
+          createdAt: now - 3000 + index * 1000
+        })
+        await database.createLike({
+          actorId: SECOND_ACTOR_ID,
+          statusId
+        })
+      }
+      const [oldest, middle, newest] = statusIds
+
+      const fullPage = await getTrendingStatuses({
+        database,
+        limit: 10,
+        offset: 0
+      })
+      expect(fullPage.map((status) => status.id)).toEqual([
+        newest,
+        middle,
+        oldest
+      ])
+
+      const firstPage = await getTrendingStatuses({
+        database,
+        limit: 2,
+        offset: 0
+      })
+      expect(firstPage.map((status) => status.id)).toEqual([newest, middle])
+
+      const secondPage = await getTrendingStatuses({
+        database,
+        limit: 2,
+        offset: 2
+      })
+      expect(secondPage.map((status) => status.id)).toEqual([oldest])
+
+      const beyondEnd = await getTrendingStatuses({
+        database,
+        limit: 5,
+        offset: 3
+      })
+      expect(beyondEnd).toEqual([])
+    })
+  })
+
+  it('excludes liked statuses created outside the seven-day window', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+
+      const now = Date.now()
+      const freshStatusId = `${FIRST_ACTOR_ID}/statuses/fresh`
+      const oldStatusId = `${FIRST_ACTOR_ID}/statuses/old`
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: freshStatusId,
+        createdAt: now - 1000
+      })
+      // Liked, but eight days old — outside the seven-day window.
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: oldStatusId,
+        createdAt: now - 8 * DAY_MS
+      })
+      await database.createLike({
+        actorId: SECOND_ACTOR_ID,
+        statusId: freshStatusId
+      })
+      await database.createLike({
+        actorId: SECOND_ACTOR_ID,
+        statusId: oldStatusId
+      })
+
+      const statuses = await getTrendingStatuses({
+        database,
+        limit: 10,
+        offset: 0
+      })
+      expect(statuses.map((status) => status.id)).toEqual([freshStatusId])
+    })
+  })
+})

--- a/lib/services/trends/trendingStatuses.test.ts
+++ b/lib/services/trends/trendingStatuses.test.ts
@@ -117,6 +117,62 @@ describe('getTrendingStatuses', () => {
     })
   })
 
+  it('weights reblogs double so a boosted status outranks a more-liked one', async () => {
+    await withFreshDatabase(async (database) => {
+      await createActor(database, FIRST_ACTOR_ID, 'first')
+      await createActor(database, SECOND_ACTOR_ID, 'second')
+      await createActor(database, THIRD_ACTOR_ID, 'third')
+
+      const now = Date.now()
+      const boostedStatusId = `${FIRST_ACTOR_ID}/statuses/boosted`
+      const likedStatusId = `${FIRST_ACTOR_ID}/statuses/liked`
+      // The liked status is newer, so a like-only or tied ordering would put
+      // it first — only the reblog term can flip the order.
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: boostedStatusId,
+        createdAt: now - 2000
+      })
+      await createPublicNote(database, {
+        actorId: FIRST_ACTOR_ID,
+        id: likedStatusId,
+        createdAt: now - 1000
+      })
+
+      // liked: three likes, no boosts → score 3.
+      for (const actorId of [FIRST_ACTOR_ID, SECOND_ACTOR_ID, THIRD_ACTOR_ID]) {
+        await database.createLike({ actorId, statusId: likedStatusId })
+      }
+      // boosted: zero likes, two boosts → weighted score 2 × 2 = 4. At 1×
+      // weight it would score 2 (losing to 3) and with reblogs dropped it
+      // would score 0 (filtered out) — either regression breaks the order.
+      await database.createAnnounce({
+        id: `${SECOND_ACTOR_ID}/statuses/boost-boosted`,
+        actorId: SECOND_ACTOR_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: boostedStatusId
+      })
+      await database.createAnnounce({
+        id: `${THIRD_ACTOR_ID}/statuses/boost-boosted`,
+        actorId: THIRD_ACTOR_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        originalStatusId: boostedStatusId
+      })
+
+      const statuses = await getTrendingStatuses({
+        database,
+        limit: 10,
+        offset: 0
+      })
+      expect(statuses.map((status) => status.id)).toEqual([
+        boostedStatusId,
+        likedStatusId
+      ])
+    })
+  })
+
   it('counts replies toward the score', async () => {
     await withFreshDatabase(async (database) => {
       await createActor(database, FIRST_ACTOR_ID, 'first')

--- a/lib/services/trends/trendingStatuses.ts
+++ b/lib/services/trends/trendingStatuses.ts
@@ -1,0 +1,72 @@
+import { Database } from '@/lib/database/types'
+import { Timeline } from '@/lib/services/timelines/types'
+import {
+  Status,
+  StatusNote,
+  StatusPoll,
+  StatusType
+} from '@/lib/types/domain/status'
+
+const CANDIDATE_WINDOW_DAYS = 7
+const CANDIDATE_LIMIT = 200
+const DAY_MS = 86_400_000
+
+interface GetTrendingStatusesParams {
+  database: Database
+  limit: number
+  offset: number
+}
+
+/**
+ * Local trending statuses computed live from the last seven days of public
+ * interactions on this instance. Candidates come from the local-public
+ * timeline (top-level public statuses by local actors, newest first) and are
+ * ranked app-side: the per-status counters are key-value rows, so joining on
+ * their concatenated keys in SQL would be dialect-fragile.
+ *
+ * The score reads exactly the fields the Mastodon serializer exposes —
+ * `status.totalLikes` (favourites_count) plus the reblog and reply counters
+ * (reblogs_count / replies_count) — so the ranking always matches the counts
+ * clients see. Boosts are skipped: an Announce is not trending content itself
+ * and carries no own counters; the boosted original ranks through its own row.
+ */
+export const getTrendingStatuses = async ({
+  database,
+  limit,
+  offset
+}: GetTrendingStatusesParams): Promise<Status[]> => {
+  const candidates = await database.getTimeline({
+    timeline: Timeline.LOCAL_PUBLIC,
+    limit: CANDIDATE_LIMIT
+  })
+
+  const since = Date.now() - CANDIDATE_WINDOW_DAYS * DAY_MS
+  const windowedStatuses = candidates.filter(
+    (status): status is StatusNote | StatusPoll =>
+      status.type !== StatusType.enum.Announce && status.createdAt >= since
+  )
+  if (windowedStatuses.length === 0) return []
+
+  const statusIds = windowedStatuses.map((status) => status.id)
+  const [reblogCounts, replyCounts] = await Promise.all([
+    database.getStatusReblogsCounts({ statusIds }),
+    database.getStatusRepliesCounts({ statusIds })
+  ])
+
+  return windowedStatuses
+    .map((status) => ({
+      status,
+      score:
+        (status.totalLikes || 0) +
+        2 * (reblogCounts[status.id] ?? 0) +
+        (replyCounts[status.id] ?? 0)
+    }))
+    .filter(({ score }) => score > 0)
+    .sort(
+      (first, second) =>
+        second.score - first.score ||
+        second.status.createdAt - first.status.createdAt
+    )
+    .slice(offset, offset + limit)
+    .map(({ status }) => status)
+}

--- a/lib/services/trends/trendingStatuses.ts
+++ b/lib/services/trends/trendingStatuses.ts
@@ -16,13 +16,13 @@ interface GetTrendingStatusesParams {
 
 /**
  * Local trending statuses computed live from the last seven days of public
- * interactions on this instance. Candidates are the complete windowed set of
- * top-level public statuses by local actors (`getTrendingStatusCandidateIds`
- * resolves the public/window/type filters in SQL), not a fixed newest-N
- * timeline slice — so a highly-interacted older-within-window status is never
- * dropped before ranking. Ranking stays app-side: the per-status counters are
- * key-value rows, so joining on their concatenated keys in SQL would be
- * dialect-fragile.
+ * interactions on this instance. Candidates are the windowed set of top-level
+ * public statuses by local actors (`getTrendingStatusCandidateIds` resolves
+ * the public/window/type filters in SQL and applies a safety cap), not a small
+ * fixed newest-N timeline slice — so a highly-interacted older-within-window
+ * status is not dropped before ranking. Ranking stays app-side: the per-status
+ * counters are key-value rows, so joining on their concatenated keys in SQL
+ * would be dialect-fragile.
  *
  * The score reads exactly the fields the Mastodon serializer exposes —
  * `status.totalLikes` (favourites_count) plus the reblog and reply counters

--- a/lib/services/trends/trendingStatuses.ts
+++ b/lib/services/trends/trendingStatuses.ts
@@ -1,5 +1,4 @@
 import { Database } from '@/lib/database/types'
-import { Timeline } from '@/lib/services/timelines/types'
 import {
   Status,
   StatusNote,
@@ -8,8 +7,6 @@ import {
 } from '@/lib/types/domain/status'
 
 const CANDIDATE_WINDOW_DAYS = 7
-const CANDIDATE_LIMIT = 200
-const DAY_MS = 86_400_000
 
 interface GetTrendingStatusesParams {
   database: Database
@@ -19,10 +16,13 @@ interface GetTrendingStatusesParams {
 
 /**
  * Local trending statuses computed live from the last seven days of public
- * interactions on this instance. Candidates come from the local-public
- * timeline (top-level public statuses by local actors, newest first) and are
- * ranked app-side: the per-status counters are key-value rows, so joining on
- * their concatenated keys in SQL would be dialect-fragile.
+ * interactions on this instance. Candidates are the complete windowed set of
+ * top-level public statuses by local actors (`getTrendingStatusCandidateIds`
+ * resolves the public/window/type filters in SQL), not a fixed newest-N
+ * timeline slice — so a highly-interacted older-within-window status is never
+ * dropped before ranking. Ranking stays app-side: the per-status counters are
+ * key-value rows, so joining on their concatenated keys in SQL would be
+ * dialect-fragile.
  *
  * The score reads exactly the fields the Mastodon serializer exposes —
  * `status.totalLikes` (favourites_count) plus the reblog and reply counters
@@ -35,15 +35,20 @@ export const getTrendingStatuses = async ({
   limit,
   offset
 }: GetTrendingStatusesParams): Promise<Status[]> => {
-  const candidates = await database.getTimeline({
-    timeline: Timeline.LOCAL_PUBLIC,
-    limit: CANDIDATE_LIMIT
+  const candidateIds = await database.getTrendingStatusCandidateIds({
+    days: CANDIDATE_WINDOW_DAYS
   })
+  if (candidateIds.length === 0) return []
 
-  const since = Date.now() - CANDIDATE_WINDOW_DAYS * DAY_MS
+  const candidates = await database.getStatusesByIds({
+    statusIds: candidateIds
+  })
+  // The SQL filter already restricts candidates to Note/Poll; this narrows the
+  // type for the counter lookups below (an Announce carries no own counters).
   const windowedStatuses = candidates.filter(
     (status): status is StatusNote | StatusPoll =>
-      status.type !== StatusType.enum.Announce && status.createdAt >= since
+      status.type === StatusType.enum.Note ||
+      status.type === StatusType.enum.Poll
   )
   if (windowedStatuses.length === 0) return []
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1561,6 +1561,52 @@ export interface SuggestionDatabase {
 }
 
 // ============================================================================
+// Trends Database
+// ============================================================================
+
+// A locally-trending hashtag computed live from the public statuses created
+// within the requested day window. `uses` counts distinct statuses carrying
+// the tag; `accounts` counts distinct status authors. `name` is the bare
+// (no leading `#`) normalized tag name.
+export type TrendingTag = {
+  name: string
+  uses: number
+  accounts: number
+}
+
+// One UTC-day usage bucket for a tag. `dayBucketMs` is the epoch-millisecond
+// start of the UTC day (Math.floor(createdAtMs / DAY_MS) * DAY_MS).
+export type TagDailyHistoryPoint = {
+  dayBucketMs: number
+  uses: number
+  accounts: number
+}
+
+export type GetTrendingTagsParams = {
+  days: number
+  limit: number
+  offset: number
+}
+export type GetTagDailyHistoryParams = {
+  // Bare (no leading `#`) normalized hashtag names.
+  names: string[]
+  days: number
+}
+
+export interface TrendsDatabase {
+  // Hashtags on public Note/Poll statuses created within the last `days`
+  // days, ranked by distinct status uses descending (tag name ascending as
+  // the deterministic tiebreaker), sliced by offset/limit.
+  getTrendingTags(params: GetTrendingTagsParams): Promise<TrendingTag[]>
+  // Per-UTC-day usage buckets (newest first) for each requested name within
+  // the last `days` days. Every requested name maps to an entry — possibly an
+  // empty list — so routes can zero-fill missing days uniformly.
+  getTagDailyHistory(
+    params: GetTagDailyHistoryParams
+  ): Promise<Map<string, TagDailyHistoryPoint[]>>
+}
+
+// ============================================================================
 // Report Database
 // ============================================================================
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1592,12 +1592,24 @@ export type GetTagDailyHistoryParams = {
   names: string[]
   days: number
 }
+export type GetTrendingStatusCandidateIdsParams = {
+  days: number
+}
 
 export interface TrendsDatabase {
   // Hashtags on public Note/Poll statuses created within the last `days`
   // days, ranked by distinct status uses descending (tag name ascending as
   // the deterministic tiebreaker), sliced by offset/limit.
   getTrendingTags(params: GetTrendingTagsParams): Promise<TrendingTag[]>
+  // The complete set of trending-status candidate ids: every public,
+  // top-level (non-reply) Note/Poll authored by a local actor within the last
+  // `days` days, newest first. Unlike a fixed newest-N timeline slice this
+  // never drops a highly-interacted older-within-window status before the
+  // service ranks it. The window bounds the row volume on a personal-scale
+  // instance, matching the tag-trends scan.
+  getTrendingStatusCandidateIds(
+    params: GetTrendingStatusCandidateIdsParams
+  ): Promise<string[]>
   // Per-UTC-day usage buckets (newest first) for each requested name within
   // the last `days` days. Every requested name maps to an entry — possibly an
   // empty list — so routes can zero-fill missing days uniformly.

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1601,12 +1601,13 @@ export interface TrendsDatabase {
   // days, ranked by distinct status uses descending (tag name ascending as
   // the deterministic tiebreaker), sliced by offset/limit.
   getTrendingTags(params: GetTrendingTagsParams): Promise<TrendingTag[]>
-  // The complete set of trending-status candidate ids: every public,
-  // top-level (non-reply) Note/Poll authored by a local actor within the last
-  // `days` days, newest first. Unlike a fixed newest-N timeline slice this
-  // never drops a highly-interacted older-within-window status before the
-  // service ranks it. The window bounds the row volume on a personal-scale
-  // instance, matching the tag-trends scan.
+  // Trending-status candidate ids: public, top-level (non-reply) Note/Poll
+  // statuses authored by a local actor within the last `days` days, newest
+  // first, capped at a safety bound. Unlike a small fixed newest-N timeline
+  // slice this keeps the whole realistic windowed set so a highly-interacted
+  // older-within-window status is not dropped before the service ranks it; the
+  // cap only guards memory and the bind-variable limit against a pathological
+  // backlog on a busy instance.
   getTrendingStatusCandidateIds(
     params: GetTrendingStatusCandidateIdsParams
   ): Promise<string[]>


### PR DESCRIPTION
## Summary

Trends are computed live from the last 7 days of local public data — there is no background aggregation job and no admin review workflow, a deliberate choice for a personal-scale server (no migration in this PR).

- `GET /api/v1/trends/tags` returns Mastodon `Tag` entities ranked by distinct-status uses, each with a per-day, 7-entry, zero-filled `history` (string-typed values per `TagHistory`).
- `GET /api/v1/trends` is kept as the deprecated alias for the tags endpoint.
- `GET /api/v1/trends/statuses` ranks recent public statuses by `likes + 2 × reblogs + replies` (zero-score statuses excluded) and serializes through the standard viewer-aware status path.
- `limit` clamps to Mastodon's 1–20 range (default 10), with `offset` support.

## Design notes

`GET /api/v1/trends/links` intentionally remains an empty array — link preview cards are not stored anywhere in the database, so a real implementation needs a card-fetch + storage feature first. This is an explicit non-goal from the plan.

## Test plan

- DB tests: distinct-count semantics, 7-day window exclusion, non-public exclusion, day bucketing.
- Route tests: history shape / zero-fill / newest-first ordering, limit clamping, deprecated alias parity, anonymous access.
- Trending-statuses service tests: weighted ordering, zero-score and out-of-window exclusion.
- Full prettier / lint / build / test battery green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)