### PR TITLE
Bump version to v1.69.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.69.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.68.0`
- Base main SHA: `65799d9fcfb450e65a0131bacb3cbca32b87aef0`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
