### PR TITLE
Bump version to v1.70.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.70.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.69.0`
- Base main SHA: `8f9c72a968e196014a9f6bb87bcf0191235c2fef`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
