### PR TITLE
minor: materialize list timelines into the timelines table

### DIFF
--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -8,6 +8,7 @@ import {
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { listTimelineKey } from '@/lib/services/timelines/types'
 import {
   CreateFollowParams,
   FollowDatabase,
@@ -395,6 +396,34 @@ export const FollowerSQLDatabaseMixin = (
             currentTime
           )
         ])
+      }
+
+      // Mastodon ties list membership to the follow: unfollowing an account
+      // removes it from all of the unfollower's lists. List membership is the
+      // source of truth for the list timeline, so dropping the membership (and
+      // the materialized list-feed rows it produced) is all that's needed — the
+      // owner is existingFollow.actorId (the follower) and the member is
+      // existingFollow.targetActorId (the followed). A user has few lists, so
+      // this is a small indexed delete on a rare action.
+      if (status === FollowStatus.enum.Undo) {
+        const ownerId = existingFollow.actorId
+        const memberId = existingFollow.targetActorId
+        const memberships = await trx('list_accounts')
+          .where({ actorId: ownerId, targetActorId: memberId })
+          .select('listId')
+        if (memberships.length > 0) {
+          await trx('list_accounts')
+            .where({ actorId: ownerId, targetActorId: memberId })
+            .delete()
+          await trx('timelines')
+            .where('actorId', ownerId)
+            .where('statusActorId', memberId)
+            .whereIn(
+              'timeline',
+              memberships.map((row) => listTimelineKey(row.listId as string))
+            )
+            .delete()
+        }
       }
     })
   },

--- a/lib/database/sql/follow.ts
+++ b/lib/database/sql/follow.ts
@@ -8,6 +8,7 @@ import {
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import { chunkArray, getWhereInBatchSize } from '@/lib/database/sql/utils/knex'
 import { listTimelineKey } from '@/lib/services/timelines/types'
 import {
   CreateFollowParams,
@@ -415,14 +416,24 @@ export const FollowerSQLDatabaseMixin = (
           await trx('list_accounts')
             .where({ actorId: ownerId, targetActorId: memberId })
             .delete()
-          await trx('timelines')
-            .where('actorId', ownerId)
-            .where('statusActorId', memberId)
-            .whereIn(
-              'timeline',
-              memberships.map((row) => listTimelineKey(row.listId as string))
-            )
-            .delete()
+          // Purge the member's posts from each of the owner's list partitions.
+          // The whereIn on the list keys is what scopes this to lists — without
+          // it the (actorId, statusActorId) delete would also wipe the member's
+          // posts from the owner's home feed (timeline='main'). Chunk the keys
+          // (reserving the actorId + statusActorId bindings) so an owner with
+          // very many lists can't exceed SQLite's bound-parameter limit, matching
+          // the other purge hooks.
+          const timelineKeys = memberships.map((row) =>
+            listTimelineKey(row.listId as string)
+          )
+          const batchSize = getWhereInBatchSize(database, 2)
+          for (const keyChunk of chunkArray(timelineKeys, batchSize)) {
+            await trx('timelines')
+              .where('actorId', ownerId)
+              .where('statusActorId', memberId)
+              .whereIn('timeline', keyChunk)
+              .delete()
+          }
         }
       }
     })

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -1153,4 +1153,76 @@ describe('ListDatabase', () => {
       expect(olderPage.map((status) => status.id)).toEqual([older])
     })
   })
+
+  it('paginates from a cursor that exists but is not in the list partition', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      await createLocalAccount(database, 'other')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      const other = await database.getActorFromUsername({
+        username: 'other',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member || !other) throw new Error('actors not created')
+
+      // Member posts at createdAt 1000/2000/3000.
+      const memberIds: string[] = []
+      for (let i = 1; i <= 3; i++) {
+        const id = `${member.id}/statuses/${i}`
+        await database.createNote({
+          id,
+          url: id,
+          actorId: member.id,
+          text: `member ${i}`,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          createdAt: 1000 * i
+        })
+        memberIds.push(id)
+      }
+      const [m1000, m2000] = memberIds
+
+      // A non-member status that exists in `statuses` but is never materialized
+      // into the list partition, at a createdAt between the member posts.
+      const outsiderId = `${other.id}/statuses/outsider`
+      await database.createNote({
+        id: outsiderId,
+        url: outsiderId,
+        actorId: other.id,
+        text: 'not on the list',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        createdAt: 2500
+      })
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Fallback cursor list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      // The cursor resolves from `statuses` (not the partition), so it has no row
+      // id — pagination must fall back to a strict createdAt compare without
+      // emitting an invalid empty Knex group, returning only strictly-older
+      // member posts.
+      const page = await database.getListTimeline({
+        listId: list.id,
+        actorId: owner.id,
+        maxStatusId: outsiderId
+      })
+      expect(page.map((status) => status.id)).toEqual([m2000, m1000])
+    })
+  })
 })

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -384,6 +384,144 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('shows posts published after a member is added (new-status fan-out)', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      // Add the member to the list BEFORE any post exists, so the row can only
+      // appear via the new-status fan-out (addStatusToListTimelines), not the
+      // add-account backfill.
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Fan-out list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      const statusId = `${member.id}/statuses/after-add`
+      const status = await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: member.id,
+        text: 'posted after being added to the list',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.addStatusToListTimelines({ status })
+
+      const statuses = await database.getListTimeline({
+        listId: list.id,
+        actorId: owner.id
+      })
+      expect(statuses.map((item) => item.id)).toContain(statusId)
+    })
+  })
+
+  it('removes a member’s posts from the list timeline when the member is removed', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      const statusId = `${member.id}/statuses/1`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: member.id,
+        text: 'hello from a list member',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Timeline list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+      expect(
+        (
+          await database.getListTimeline({ listId: list.id, actorId: owner.id })
+        ).map((status) => status.id)
+      ).toContain(statusId)
+
+      await database.removeListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+      expect(
+        await database.getListTimeline({ listId: list.id, actorId: owner.id })
+      ).toHaveLength(0)
+    })
+  })
+
+  it('drops the materialized feed when the list is deleted', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      const statusId = `${member.id}/statuses/1`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: member.id,
+        text: 'hello from a list member',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Timeline list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      await database.deleteList({ id: list.id, actorId: owner.id })
+
+      // The list and its materialized rows are gone; reading by the same id
+      // returns nothing rather than stale posts.
+      expect(
+        await database.getListTimeline({ listId: list.id, actorId: owner.id })
+      ).toHaveLength(0)
+    })
+  })
+
   it('excludes member statuses the owner cannot see from the list timeline', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -4,6 +4,7 @@ import {
   getTestSQLDatabase
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
+import { Timeline } from '@/lib/services/timelines/types'
 import { EXTERNAL_ACTORS, TEST_DOMAIN } from '@/lib/stub/const'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { ListRepliesPolicy } from '@/lib/types/domain/list'
@@ -544,13 +545,20 @@ describe('ListDatabase', () => {
         sharedInbox: `${member.id}/inbox`
       })
       const statusId = `${member.id}/statuses/1`
-      await database.createNote({
+      const status = await database.createNote({
         id: statusId,
         url: statusId,
         actorId: member.id,
         text: 'hello from a followed list member',
         to: [ACTIVITY_STREAM_PUBLIC],
         cc: []
+      })
+      // Also place the member's post in the owner's HOME feed, so we can prove
+      // the unfollow purge is scoped to list partitions and never touches home.
+      await database.createTimelineStatus({
+        actorId: owner.id,
+        status,
+        timeline: Timeline.MAIN
       })
       const list = await database.createList({
         actorId: owner.id,
@@ -564,7 +572,7 @@ describe('ListDatabase', () => {
       expect(
         (
           await database.getListTimeline({ listId: list.id, actorId: owner.id })
-        ).map((status) => status.id)
+        ).map((item) => item.id)
       ).toContain(statusId)
 
       // Unfollowing flips the follow to Undo through the canonical chokepoint,
@@ -587,6 +595,15 @@ describe('ListDatabase', () => {
       expect(
         await database.getListTimeline({ listId: list.id, actorId: owner.id })
       ).toHaveLength(0)
+      // The home feed must be untouched by the list purge.
+      expect(
+        (
+          await database.getTimeline({
+            timeline: Timeline.MAIN,
+            actorId: owner.id
+          })
+        ).map((item) => item.id)
+      ).toContain(statusId)
     })
   })
 

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -522,6 +522,74 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('removes a member from the owner’s lists when the owner unfollows them', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      await database.createFollow({
+        actorId: owner.id,
+        targetActorId: member.id,
+        status: FollowStatus.enum.Accepted,
+        inbox: `${member.id}/inbox`,
+        sharedInbox: `${member.id}/inbox`
+      })
+      const statusId = `${member.id}/statuses/1`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: member.id,
+        text: 'hello from a followed list member',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Timeline list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+      expect(
+        (
+          await database.getListTimeline({ listId: list.id, actorId: owner.id })
+        ).map((status) => status.id)
+      ).toContain(statusId)
+
+      // Unfollowing flips the follow to Undo through the canonical chokepoint,
+      // which must drop the member from the owner's lists and the materialized
+      // feed (Mastodon parity).
+      const follow = await database.getAcceptedOrRequestedFollow({
+        actorId: owner.id,
+        targetActorId: member.id
+      })
+      if (!follow) throw new Error('follow not created')
+      await database.updateFollowStatus({
+        followId: follow.id,
+        status: FollowStatus.enum.Undo
+      })
+
+      expect(
+        (await database.getListAccounts({ listId: list.id, actorId: owner.id }))
+          .accounts
+      ).toHaveLength(0)
+      expect(
+        await database.getListTimeline({ listId: list.id, actorId: owner.id })
+      ).toHaveLength(0)
+    })
+  })
+
   it('excludes member statuses the owner cannot see from the list timeline', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -443,16 +443,18 @@ export const ListSQLDatabaseMixin = (
       const operator = direction === 'older' ? '<' : '>'
       const { id: cursorId, createdAt: cursorCreatedAt } = cursor
       query.andWhere((builder) => {
-        builder
-          .where('timelines.createdAt', operator, cursorCreatedAt)
-          .orWhere((tie) => {
-            // Only break createdAt ties by row id when we resolved one.
-            if (cursorId !== null) {
-              tie
-                .where('timelines.createdAt', cursorCreatedAt)
-                .andWhere('timelines.id', operator, cursorId)
-            }
+        builder.where('timelines.createdAt', operator, cursorCreatedAt)
+        // Break createdAt ties by row id only when we resolved one — the cursor
+        // row may be gone (purged), leaving just the status's createdAt. Apply
+        // the orWhere conditionally so an unresolved id never produces an empty
+        // Knex group (which would emit invalid `OR ()`).
+        if (cursorId !== null) {
+          builder.orWhere((tie) => {
+            tie
+              .where('timelines.createdAt', cursorCreatedAt)
+              .andWhere('timelines.id', operator, cursorId)
           })
+        }
       })
       return true
     }

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -11,9 +11,11 @@ import {
 } from '@/lib/database/sql/utils/knex'
 import { applyListRepliesPolicyFilter } from '@/lib/database/sql/utils/listRepliesPolicy'
 import { applyPotentiallyReadableStatusFilter } from '@/lib/database/sql/utils/statusVisibility'
+import { listTimelineKey } from '@/lib/services/timelines/types'
 import { Mastodon } from '@/lib/types/activitypub'
 import {
   AddListAccountsParams,
+  AddStatusToListTimelinesParams,
   CreateListParams,
   DeleteListParams,
   GetListAccountCountsParams,
@@ -48,6 +50,48 @@ const fixListRow = (row: SQLList): List => ({
   createdAt: getCompatibleTime(row.createdAt),
   updatedAt: getCompatibleTime(row.updatedAt)
 })
+
+// Materialize the given members' existing posts into a list's `timelines`
+// partition. Used to backfill full history when members are added (and by the
+// one-time backfill migration via the same column shape). Inserts are idempotent
+// on the unique (actorId, timeline, statusId), so it can safely overlap with the
+// new-status fan-out and is a no-op for members already present.
+const backfillListTimelineForMembers = async ({
+  database,
+  listId,
+  ownerId,
+  targetActorIds
+}: {
+  database: Knex
+  listId: string
+  ownerId: string
+  targetActorIds: string[]
+}): Promise<void> => {
+  if (targetActorIds.length === 0) return
+  const timeline = listTimelineKey(listId)
+  const updatedAt = new Date()
+  for (const targetActorId of targetActorIds) {
+    const statuses = await database('statuses')
+      .where('actorId', targetActorId)
+      .select('id', 'createdAt')
+    if (statuses.length === 0) continue
+    const rows = statuses.map((statusRow) => ({
+      actorId: ownerId,
+      timeline,
+      statusId: statusRow.id as string,
+      statusActorId: targetActorId,
+      createdAt: new Date(getCompatibleTime(statusRow.createdAt)),
+      updatedAt
+    }))
+    const batchSize = getInsertBatchSize(database, rows[0])
+    for (const chunk of chunkArray(rows, batchSize)) {
+      await database('timelines')
+        .insert(chunk)
+        .onConflict(['actorId', 'timeline', 'statusId'])
+        .ignore()
+    }
+  }
+}
 
 export const ListSQLDatabaseMixin = (
   database: Knex,
@@ -121,6 +165,11 @@ export const ListSQLDatabaseMixin = (
 
     await database.transaction(async (trx) => {
       await trx('list_accounts').where('listId', id).delete()
+      // Drop the materialized feed for this list so its rows don't linger in the
+      // timelines table after the list is gone.
+      await trx('timelines')
+        .where({ actorId, timeline: listTimelineKey(id) })
+        .delete()
       await trx('lists').where({ id, actorId }).delete()
     })
     return true
@@ -229,6 +278,18 @@ export const ListSQLDatabaseMixin = (
         .onConflict(['listId', 'targetActorId'])
         .ignore()
     }
+
+    // Backfill the materialized list feed with each new member's existing posts
+    // so the timeline shows full history immediately (matching the old live
+    // join), not just posts published after they were added. onConflict ignores
+    // any rows the new-status fan-out already wrote, so re-adding a member is a
+    // no-op rather than a duplicate.
+    await backfillListTimelineForMembers({
+      database,
+      listId,
+      ownerId: actorId,
+      targetActorIds
+    })
   },
 
   async removeListAccounts({
@@ -245,6 +306,18 @@ export const ListSQLDatabaseMixin = (
       await database('list_accounts')
         .where({ listId, actorId })
         .whereIn('targetActorId', chunk)
+        .delete()
+    }
+
+    // Drop the removed members' posts from the materialized list feed. Reserve
+    // two bindings (actorId + timeline) before chunking the statusActorId list,
+    // mirroring the membership delete above.
+    const purgeBatchSize = getWhereInBatchSize(database, 2)
+    const timeline = listTimelineKey(listId)
+    for (const chunk of chunkArray(targetActorIds, purgeBatchSize)) {
+      await database('timelines')
+        .where({ actorId, timeline })
+        .whereIn('statusActorId', chunk)
         .delete()
     }
   },
@@ -278,16 +351,20 @@ export const ListSQLDatabaseMixin = (
     const repliesPolicy = (listRow?.repliesPolicy ??
       'list') as ListRepliesPolicy
 
-    const query = database('statuses')
-      .innerJoin(
-        'list_accounts',
-        'list_accounts.targetActorId',
-        'statuses.actorId'
-      )
-      .where('list_accounts.listId', listId)
+    // Read the list feed from the materialized `timelines` partition (kept in
+    // sync by addStatusToListTimelines on new posts and by the addListAccounts
+    // backfill) instead of a live statuses⋈list_accounts join. The
+    // partition is pre-narrowed by the (actorId, timeline, createdAt) index, so
+    // this is the same fast indexed read the home feed uses. The candidate set is
+    // identical to the old join — every status whose author is a list member — so
+    // the visibility / replies-policy / block-mute filters below (still applied
+    // pre-LIMIT against the joined statuses row) produce the same result.
+    const query = database('timelines')
+      .innerJoin('statuses', 'statuses.id', 'timelines.statusId')
       // Scope to the owner defensively so a caller can never read another
       // actor's list timeline even if they know the listId.
-      .andWhere('list_accounts.actorId', actorId)
+      .where('timelines.actorId', actorId)
+      .andWhere('timelines.timeline', listTimelineKey(listId))
     // Apply the owner's visibility before LIMIT so the page counts only
     // statuses they may read — a member's direct/non-public posts addressed to
     // others never appear, and the limit isn't spent on rows that would be
@@ -365,5 +442,38 @@ export const ListSQLDatabaseMixin = (
     // their action state (isActorLiked/isActorBookmarked/announce) is hydrated —
     // otherwise the timeline would render every post as un-acted.
     return getStatusesByIds(statusIds, actorId)
+  },
+
+  async addStatusToListTimelines({
+    status
+  }: AddStatusToListTimelinesParams): Promise<void> {
+    // Find every list whose membership includes this status's author. Each
+    // list_accounts row already carries the owner (actorId) and listId, so no
+    // join to `lists` is needed; targetActorId is indexed for this lookup.
+    const memberships = await database('list_accounts')
+      .where('targetActorId', status.actorId)
+      .select('listId', 'actorId')
+    if (memberships.length === 0) return
+
+    const createdAt = new Date(status.createdAt)
+    const updatedAt = new Date()
+    const rows = memberships.map((membership) => ({
+      actorId: membership.actorId as string,
+      timeline: listTimelineKey(membership.listId as string),
+      statusId: status.id,
+      statusActorId: status.actorId,
+      createdAt,
+      updatedAt
+    }))
+    // Idempotent on the unique (actorId, timeline, statusId): a repeated fan-out
+    // (e.g. an edit re-running addStatusToTimelines) or overlap with a backfill
+    // is ignored rather than duplicated.
+    const batchSize = getInsertBatchSize(database, rows[0])
+    for (const chunk of chunkArray(rows, batchSize)) {
+      await database('timelines')
+        .insert(chunk)
+        .onConflict(['actorId', 'timeline', 'statusId'])
+        .ignore()
+    }
   }
 })

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -70,16 +70,21 @@ const backfillListTimelineForMembers = async ({
   if (targetActorIds.length === 0) return
   const timeline = listTimelineKey(listId)
   const updatedAt = new Date()
-  for (const targetActorId of targetActorIds) {
+  // Fetch the added members' posts in chunked IN queries rather than one query
+  // per member (avoids an N+1 across the accounts being added). Each chunk's rows
+  // carry statusActorId from the status itself, so a single pass materializes the
+  // whole chunk.
+  const whereInBatchSize = getWhereInBatchSize(database, 0)
+  for (const idChunk of chunkArray(targetActorIds, whereInBatchSize)) {
     const statuses = await database('statuses')
-      .where('actorId', targetActorId)
-      .select('id', 'createdAt')
+      .whereIn('actorId', idChunk)
+      .select('id', 'actorId', 'createdAt')
     if (statuses.length === 0) continue
     const rows = statuses.map((statusRow) => ({
       actorId: ownerId,
       timeline,
       statusId: statusRow.id as string,
-      statusActorId: targetActorId,
+      statusActorId: statusRow.actorId as string,
       createdAt: new Date(getCompatibleTime(statusRow.createdAt)),
       updatedAt
     }))

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -272,28 +272,32 @@ export const ListSQLDatabaseMixin = (
       targetActorId,
       createdAt: currentTime
     }))
-    // Batch insert, chunked to stay under SQLite's 999 bound-parameter limit
-    // (the batch size is derived from the column count). Targets already on the
-    // list are ignored so repeated adds stay idempotent (matching Mastodon)
-    // without per-row round-trips.
-    const batchSize = getInsertBatchSize(database, rows[0])
-    for (const chunk of chunkArray(rows, batchSize)) {
-      await database('list_accounts')
-        .insert(chunk)
-        .onConflict(['listId', 'targetActorId'])
-        .ignore()
-    }
+    // Run the membership insert and the materialized backfill in one transaction
+    // so a crash can't leave members on the list without their feed rows (or, on
+    // re-add, partially backfilled). Targets already on the list are ignored so
+    // repeated adds stay idempotent (matching Mastodon).
+    await database.transaction(async (trx) => {
+      // Batch insert, chunked to stay under SQLite's 999 bound-parameter limit
+      // (the batch size is derived from the column count).
+      const batchSize = getInsertBatchSize(trx, rows[0])
+      for (const chunk of chunkArray(rows, batchSize)) {
+        await trx('list_accounts')
+          .insert(chunk)
+          .onConflict(['listId', 'targetActorId'])
+          .ignore()
+      }
 
-    // Backfill the materialized list feed with each new member's existing posts
-    // so the timeline shows full history immediately (matching the old live
-    // join), not just posts published after they were added. onConflict ignores
-    // any rows the new-status fan-out already wrote, so re-adding a member is a
-    // no-op rather than a duplicate.
-    await backfillListTimelineForMembers({
-      database,
-      listId,
-      ownerId: actorId,
-      targetActorIds
+      // Backfill the materialized list feed with each new member's existing posts
+      // so the timeline shows full history immediately (matching the old live
+      // join), not just posts published after they were added. onConflict ignores
+      // any rows the new-status fan-out already wrote, so re-adding a member is a
+      // no-op rather than a duplicate.
+      await backfillListTimelineForMembers({
+        database: trx,
+        listId,
+        ownerId: actorId,
+        targetActorIds
+      })
     })
   },
 
@@ -303,28 +307,28 @@ export const ListSQLDatabaseMixin = (
     targetActorIds
   }: RemoveListAccountsParams) {
     if (targetActorIds.length === 0) return
-    // Scope to the owner defensively so a caller can never delete members from
-    // a list they do not own. Chunk the whereIn list to stay under SQLite's 999
-    // bound-parameter limit, reserving two bindings for listId + actorId.
-    const batchSize = getWhereInBatchSize(database, 2)
-    for (const chunk of chunkArray(targetActorIds, batchSize)) {
-      await database('list_accounts')
-        .where({ listId, actorId })
-        .whereIn('targetActorId', chunk)
-        .delete()
-    }
-
-    // Drop the removed members' posts from the materialized list feed. Reserve
-    // two bindings (actorId + timeline) before chunking the statusActorId list,
-    // mirroring the membership delete above.
-    const purgeBatchSize = getWhereInBatchSize(database, 2)
     const timeline = listTimelineKey(listId)
-    for (const chunk of chunkArray(targetActorIds, purgeBatchSize)) {
-      await database('timelines')
-        .where({ actorId, timeline })
-        .whereIn('statusActorId', chunk)
-        .delete()
-    }
+    // Run the membership delete and the feed purge in one transaction so the two
+    // can't diverge on a crash. Both whereIn deletes reserve two bindings
+    // (listId+actorId / actorId+timeline) before chunking the id list to stay
+    // under SQLite's 999 bound-parameter limit. Scope to the owner defensively so
+    // a caller can never delete members from a list they do not own.
+    await database.transaction(async (trx) => {
+      const batchSize = getWhereInBatchSize(trx, 2)
+      for (const chunk of chunkArray(targetActorIds, batchSize)) {
+        await trx('list_accounts')
+          .where({ listId, actorId })
+          .whereIn('targetActorId', chunk)
+          .delete()
+      }
+      // Drop the removed members' posts from the materialized list feed.
+      for (const chunk of chunkArray(targetActorIds, batchSize)) {
+        await trx('timelines')
+          .where({ actorId, timeline })
+          .whereIn('statusActorId', chunk)
+          .delete()
+      }
+    })
   },
 
   async getListsWithAccount({

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -358,18 +358,19 @@ export const ListSQLDatabaseMixin = (
 
     // Read the list feed from the materialized `timelines` partition (kept in
     // sync by addStatusToListTimelines on new posts and by the addListAccounts
-    // backfill) instead of a live statuses⋈list_accounts join. The
-    // partition is pre-narrowed by the (actorId, timeline, createdAt) index, so
-    // this is the same fast indexed read the home feed uses. The candidate set is
+    // backfill) instead of a live statuses⋈list_accounts join. The partition is
+    // seeked and ordered by the (actorId, timeline, createdAt) index, so this is
+    // the same fast indexed read the home feed uses. The candidate set is
     // identical to the old join — every status whose author is a list member — so
     // the visibility / replies-policy / block-mute filters below (still applied
     // pre-LIMIT against the joined statuses row) produce the same result.
+    const timeline = listTimelineKey(listId)
     const query = database('timelines')
       .innerJoin('statuses', 'statuses.id', 'timelines.statusId')
       // Scope to the owner defensively so a caller can never read another
       // actor's list timeline even if they know the listId.
       .where('timelines.actorId', actorId)
-      .andWhere('timelines.timeline', listTimelineKey(listId))
+      .andWhere('timelines.timeline', timeline)
     // Apply the owner's visibility before LIMIT so the page counts only
     // statuses they may read — a member's direct/non-public posts addressed to
     // others never appear, and the limit isn't spent on rows that would be
@@ -397,39 +398,60 @@ export const ListSQLDatabaseMixin = (
       viewerActorId: actorId,
       now: Date.now()
     })
+    // Order on the timelines partition's own (createdAt, id) — the columns of
+    // timelinesActorIdTimelineCreatedAtIndex — so ORDER BY ... LIMIT is served by
+    // an index walk that stops at the page boundary (the same top-N read the home
+    // feed uses), rather than sorting the whole filtered partition. timelines.
+    // createdAt mirrors statuses.createdAt (both written as new Date(status.
+    // createdAt) on every write path) and timelines.id is a monotonic tie-breaker.
     query
-      .orderBy('statuses.createdAt', 'desc')
-      .orderBy('statuses.id', 'desc')
+      .orderBy('timelines.createdAt', 'desc')
+      .orderBy('timelines.id', 'desc')
       .limit(limit)
       .select('statuses.id')
 
     // A status appears at most once: list_accounts is unique on
-    // (listId, targetActorId), so the join cannot duplicate a status row.
+    // (listId, targetActorId), so a member's status is materialized once per
+    // list, and the join to statuses (by primary key) cannot duplicate it.
     // Avoid SELECT DISTINCT, which on PostgreSQL would require every ORDER BY
-    // column (statuses.createdAt) to also appear in the select list.
-    // Status IDs are URIs (not chronologically ordered), so paginate on the
-    // referenced status's createdAt with the id as a stable tie-breaker.
-    // Returns false when the cursor status no longer exists, so the caller can
-    // end pagination with an empty page instead of silently dropping the WHERE
-    // and re-returning the newest page (an infinite loop). Mirrors the home
-    // timeline's `if (maxStatusId && !maxRow) return []`.
+    // column to also appear in the select list.
+    // Resolve the cursor from this list's timelines row (id + createdAt),
+    // mirroring the home feed's lookupTimelineCursor, so pagination matches the
+    // index order. Fall back to the status's createdAt (without the row-id
+    // tie-breaker) if the row was already purged, so pagination still advances.
+    // Returns false when neither exists, so the caller ends pagination with an
+    // empty page instead of silently dropping the WHERE and re-returning the
+    // newest page (an infinite loop). Mirrors `if (maxStatusId && !maxRow) []`.
     const applyCursor = async (
       cursorStatusId: string,
       direction: 'older' | 'newer'
     ): Promise<boolean> => {
-      const cursor = await database('statuses')
-        .where('id', cursorStatusId)
-        .select('createdAt')
-        .first<{ createdAt: number | Date }>()
-      if (!cursor) return false
+      let cursor = await database('timelines')
+        .where('actorId', actorId)
+        .where('timeline', timeline)
+        .where('statusId', cursorStatusId)
+        .select('id', 'createdAt')
+        .first<{ id: number | null; createdAt: number | Date }>()
+      if (!cursor) {
+        const statusRow = await database('statuses')
+          .where('id', cursorStatusId)
+          .select('createdAt')
+          .first<{ createdAt: number | Date }>()
+        if (!statusRow) return false
+        cursor = { id: null, createdAt: statusRow.createdAt }
+      }
       const operator = direction === 'older' ? '<' : '>'
+      const { id: cursorId, createdAt: cursorCreatedAt } = cursor
       query.andWhere((builder) => {
         builder
-          .where('statuses.createdAt', operator, cursor.createdAt)
+          .where('timelines.createdAt', operator, cursorCreatedAt)
           .orWhere((tie) => {
-            tie
-              .where('statuses.createdAt', cursor.createdAt)
-              .andWhere('statuses.id', operator, cursorStatusId)
+            // Only break createdAt ties by row id when we resolved one.
+            if (cursorId !== null) {
+              tie
+                .where('timelines.createdAt', cursorCreatedAt)
+                .andWhere('timelines.id', operator, cursorId)
+            }
           })
       })
       return true

--- a/lib/services/timelines/index.ts
+++ b/lib/services/timelines/index.ts
@@ -53,6 +53,13 @@ export const addStatusToTimelines = async (
           actors.map((actor) => actor.id),
           status
         )
+      // Fan the post into the materialized feed of every list that includes its
+      // author (independent of the recipient fan-out below, since list ownership
+      // — not delivery — decides list membership). Visibility/replies-policy are
+      // enforced at read time, so this materializes the same candidate set the
+      // old live list query scanned.
+      await database.addStatusToListTimelines({ status })
+
       const isDirect = isDirectStatus(status)
       if (isDirect) {
         await database.syncDirectConversationForStatus({

--- a/lib/services/timelines/types.ts
+++ b/lib/services/timelines/types.ts
@@ -11,6 +11,18 @@ export enum Timeline {
   LOCAL_PUBLIC = 'local-public'
 }
 
+// List feeds are materialized into the same `timelines` table as the fixed feeds
+// above, keyed per list so the read is a single indexed partition scan (the same
+// shape that makes the home feed fast) instead of a live statuses⋈list_accounts
+// join. The `timeline` column is a free-form string, so a list uses the synthetic
+// key `list:<listId>` (scoped, like the fixed feeds, by the owner's actorId).
+// List feeds are materialized into the same `timelines` table as the fixed feeds
+// above so the read is a single indexed partition scan (the shape that makes the
+// home feed fast) rather than a live statuses⋈list_accounts join. The `timeline`
+// column is a free-form string, so a list uses the key `list:<listId>` (scoped,
+// like the fixed feeds, by the owner's actorId).
+export const listTimelineKey = (listId: string): string => `list:${listId}`
+
 export interface TimelineRuleParams {
   database: Database
   currentActor: Actor

--- a/lib/services/timelines/types.ts
+++ b/lib/services/timelines/types.ts
@@ -12,11 +12,6 @@ export enum Timeline {
 }
 
 // List feeds are materialized into the same `timelines` table as the fixed feeds
-// above, keyed per list so the read is a single indexed partition scan (the same
-// shape that makes the home feed fast) instead of a live statuses⋈list_accounts
-// join. The `timeline` column is a free-form string, so a list uses the synthetic
-// key `list:<listId>` (scoped, like the fixed feeds, by the owner's actorId).
-// List feeds are materialized into the same `timelines` table as the fixed feeds
 // above so the read is a single indexed partition scan (the shape that makes the
 // home feed fast) rather than a live statuses⋈list_accounts join. The `timeline`
 // column is a free-form string, so a list uses the key `list:<listId>` (scoped,

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1292,6 +1292,9 @@ export type GetListTimelineParams = {
   maxStatusId?: string | null
   minStatusId?: string | null
 }
+export type AddStatusToListTimelinesParams = {
+  status: Status
+}
 
 export interface ListDatabase {
   createList(params: CreateListParams): Promise<List>
@@ -1309,6 +1312,11 @@ export interface ListDatabase {
   removeListAccounts(params: RemoveListAccountsParams): Promise<void>
   getListsWithAccount(params: GetListsWithAccountParams): Promise<List[]>
   getListTimeline(params: GetListTimelineParams): Promise<Status[]>
+  // Fan a newly created status into every list (in the `timelines` table) whose
+  // membership includes the status author. Called from addStatusToTimelines.
+  addStatusToListTimelines(
+    params: AddStatusToListTimelinesParams
+  ): Promise<void>
 }
 
 // ============================================================================

--- a/migrations/20260613120000_add_timelines_status_actor_index.js
+++ b/migrations/20260613120000_add_timelines_status_actor_index.js
@@ -1,0 +1,31 @@
+/**
+ * Index supporting the per-member purge of materialized list feeds
+ * (removeListAccounts / actor deletion): delete from `timelines` where
+ * (actorId, timeline) identify a list partition and statusActorId is the
+ * removed member. The existing (actorId, timeline, createdAt) index narrows to
+ * the whole partition but cannot seek by statusActorId.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('timelines', function (table) {
+    table.index(
+      ['actorId', 'timeline', 'statusActorId'],
+      'timelinesActorTimelineStatusActorIndex'
+    )
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('timelines', function (table) {
+    table.dropIndex(
+      ['actorId', 'timeline', 'statusActorId'],
+      'timelinesActorTimelineStatusActorIndex'
+    )
+  })
+}

--- a/migrations/20260613120100_backfill_list_timelines.js
+++ b/migrations/20260613120100_backfill_list_timelines.js
@@ -1,0 +1,50 @@
+/**
+ * One-time backfill of materialized list feeds. List timelines are now read from
+ * the `timelines` table (keyed `list:<listId>`, scoped by the owner's actorId)
+ * instead of a live statuses⋈list_accounts join. This populates that partition
+ * for every existing membership so list timelines have full history immediately.
+ *
+ * Idempotent: inserts ignore conflicts on the unique (actorId, timeline,
+ * statusId), so re-running heals drift instead of duplicating rows. The chunk
+ * size keeps each INSERT under SQLite's 999 bound-parameter limit (6 columns).
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const memberships = await knex('list_accounts').select(
+    'listId',
+    'actorId',
+    'targetActorId'
+  )
+  const now = new Date()
+  const CHUNK = 100
+  for (const membership of memberships) {
+    const statuses = await knex('statuses')
+      .where('actorId', membership.targetActorId)
+      .select('id', 'createdAt')
+    if (statuses.length === 0) continue
+    const rows = statuses.map((statusRow) => ({
+      actorId: membership.actorId,
+      timeline: `list:${membership.listId}`,
+      statusId: statusRow.id,
+      statusActorId: membership.targetActorId,
+      createdAt: statusRow.createdAt,
+      updatedAt: now
+    }))
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      await knex('timelines')
+        .insert(rows.slice(i, i + CHUNK))
+        .onConflict(['actorId', 'timeline', 'statusId'])
+        .ignore()
+    }
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex('timelines').where('timeline', 'like', 'list:%').delete()
+}

--- a/migrations/20260613120100_backfill_list_timelines.js
+++ b/migrations/20260613120100_backfill_list_timelines.js
@@ -10,6 +10,25 @@
  * so an account on many lists is fetched once per chunk, and the chunk sizes keep
  * both the SELECT and INSERT under SQLite's 999 bound-parameter limit.
  *
+// Normalize a stored createdAt to a Date the same way the runtime fan-out does
+// (lib/database/sql/utils/getCompatibleTime + new Date), so list rows written
+// here serialize identically to rows written at runtime — the list read orders
+// by timelines.createdAt, so mixed formats in one partition would break it.
+// SQLite returns "YYYY-MM-DD HH:MM:SS(.sss)" UTC strings without a zone, so the
+// missing 'Z' is added before parsing to avoid a local-time shift.
+const SQLITE_UTC_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?$/
+const toDate = (value) => {
+  if (value instanceof Date) return value
+  if (typeof value === 'number') return new Date(value)
+  const trimmed = String(value).trim()
+  const normalized = SQLITE_UTC_TIMESTAMP_PATTERN.test(trimmed)
+    ? `${trimmed.replace(' ', 'T')}Z`
+    : trimmed
+  return new Date(normalized)
+}
+
+/**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
@@ -53,7 +72,7 @@ exports.up = async function (knex) {
           timeline: `list:${listId}`,
           statusId: statusRow.id,
           statusActorId: statusRow.actorId,
-          createdAt: statusRow.createdAt,
+          createdAt: toDate(statusRow.createdAt),
           updatedAt: now
         })
       }

--- a/migrations/20260613120100_backfill_list_timelines.js
+++ b/migrations/20260613120100_backfill_list_timelines.js
@@ -22,6 +22,10 @@ const toDate = (value) => {
   if (value instanceof Date) return value
   if (typeof value === 'number') return new Date(value)
   const trimmed = String(value).trim()
+  // Defensive: a Postgres bigint column would come back as an all-digits string
+  // (epoch ms) — new Date('1700000000000') is Invalid, so parse it as a number.
+  // (statuses.createdAt is a timestamp here, so this normally never triggers.)
+  if (/^\d+$/.test(trimmed)) return new Date(Number(trimmed))
   const normalized = SQLITE_UTC_TIMESTAMP_PATTERN.test(trimmed)
     ? `${trimmed.replace(' ', 'T')}Z`
     : trimmed

--- a/migrations/20260613120100_backfill_list_timelines.js
+++ b/migrations/20260613120100_backfill_list_timelines.js
@@ -64,9 +64,12 @@ exports.up = async function (knex) {
       .select('id', 'actorId', 'createdAt')
     const rows = []
     for (const statusRow of statuses) {
-      for (const { ownerId, listId } of destinationsByMember.get(
-        statusRow.actorId
-      )) {
+      // Every fetched actorId came from memberChunk (a subset of the map keys),
+      // so this is normally always present; guard defensively so unexpected data
+      // (e.g. a casing mismatch) skips the row instead of crashing the migration.
+      const destinations = destinationsByMember.get(statusRow.actorId)
+      if (!destinations) continue
+      for (const { ownerId, listId } of destinations) {
         rows.push({
           actorId: ownerId,
           timeline: `list:${listId}`,

--- a/migrations/20260613120100_backfill_list_timelines.js
+++ b/migrations/20260613120100_backfill_list_timelines.js
@@ -5,8 +5,10 @@
  * for every existing membership so list timelines have full history immediately.
  *
  * Idempotent: inserts ignore conflicts on the unique (actorId, timeline,
- * statusId), so re-running heals drift instead of duplicating rows. The chunk
- * size keeps each INSERT under SQLite's 999 bound-parameter limit (6 columns).
+ * statusId), so re-running heals drift instead of duplicating rows. Statuses are
+ * read per distinct member in chunked IN queries (not one query per membership)
+ * so an account on many lists is fetched once per chunk, and the chunk sizes keep
+ * both the SELECT and INSERT under SQLite's 999 bound-parameter limit.
  *
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
@@ -17,24 +19,48 @@ exports.up = async function (knex) {
     'actorId',
     'targetActorId'
   )
-  const now = new Date()
-  const CHUNK = 100
+  if (memberships.length === 0) return
+
+  // Group the (owner, list) destinations by member so each member's statuses are
+  // fetched once and fanned out to every list that contains them.
+  const destinationsByMember = new Map()
   for (const membership of memberships) {
+    const destinations =
+      destinationsByMember.get(membership.targetActorId) ?? []
+    destinations.push({
+      ownerId: membership.actorId,
+      listId: membership.listId
+    })
+    destinationsByMember.set(membership.targetActorId, destinations)
+  }
+  const memberIds = [...destinationsByMember.keys()]
+
+  const now = new Date()
+  const SELECT_CHUNK = 200
+  const INSERT_CHUNK = 100
+  for (let i = 0; i < memberIds.length; i += SELECT_CHUNK) {
+    const memberChunk = memberIds.slice(i, i + SELECT_CHUNK)
     const statuses = await knex('statuses')
-      .where('actorId', membership.targetActorId)
-      .select('id', 'createdAt')
-    if (statuses.length === 0) continue
-    const rows = statuses.map((statusRow) => ({
-      actorId: membership.actorId,
-      timeline: `list:${membership.listId}`,
-      statusId: statusRow.id,
-      statusActorId: membership.targetActorId,
-      createdAt: statusRow.createdAt,
-      updatedAt: now
-    }))
-    for (let i = 0; i < rows.length; i += CHUNK) {
+      .whereIn('actorId', memberChunk)
+      .select('id', 'actorId', 'createdAt')
+    const rows = []
+    for (const statusRow of statuses) {
+      for (const { ownerId, listId } of destinationsByMember.get(
+        statusRow.actorId
+      )) {
+        rows.push({
+          actorId: ownerId,
+          timeline: `list:${listId}`,
+          statusId: statusRow.id,
+          statusActorId: statusRow.actorId,
+          createdAt: statusRow.createdAt,
+          updatedAt: now
+        })
+      }
+    }
+    for (let j = 0; j < rows.length; j += INSERT_CHUNK) {
       await knex('timelines')
-        .insert(rows.slice(i, i + CHUNK))
+        .insert(rows.slice(j, j + INSERT_CHUNK))
         .onConflict(['actorId', 'timeline', 'statusId'])
         .ignore()
     }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1441,6 +1441,8 @@ CREATE INDEX "tags_statusId_type_idx" ON public.tags USING btree ("statusId", ty
 
 CREATE INDEX "timelinesActorIdTimelineCreatedAtIndex" ON public.timelines USING btree ("actorId", timeline, "createdAt");
 
+CREATE INDEX "timelinesActorTimelineStatusActorIndex" ON public.timelines USING btree ("actorId", timeline, "statusActorId");
+
 CREATE INDEX "timelinesStatusIdIndex" ON public.timelines USING btree ("statusId");
 
 CREATE INDEX translation_cache_created ON public.translation_cache USING btree ("createdAt");

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -210,3 +210,4 @@ CREATE TABLE `suggestion_dismissals` (`actorId` varchar(255) not null, `targetAc
 CREATE TABLE `announcements` (`id` varchar(255), `text` text not null, `published` boolean not null default '0', `allDay` boolean not null default '0', `startsAt` datetime null, `endsAt` datetime null, `publishedAt` datetime null, `createdAt` datetime not null, `updatedAt` datetime not null, primary key (`id`));
 CREATE TABLE `announcement_reads` (`announcementId` varchar(255) not null, `actorId` varchar(255) not null, `createdAt` datetime not null, primary key (`announcementId`, `actorId`));
 CREATE TABLE `announcement_reactions` (`announcementId` varchar(255) not null, `actorId` varchar(255) not null, `name` varchar(255) not null, `createdAt` datetime not null, primary key (`announcementId`, `actorId`, `name`));
+CREATE INDEX `timelinesActorTimelineStatusActorIndex` on `timelines` (`actorId`, `timeline`, `statusActorId`);


### PR DESCRIPTION
List timelines were computed per request with a live statuses⋈list_accounts
join plus visibility/replies-policy/block-mute filters and a sort across every
member's history, making them noticeably slower than the home feed (which reads
the precomputed `timelines` table). Materialize list feeds into that same table,
keyed `list:<listId>` and scoped by the owner's actorId, so the read becomes a
single indexed partition scan.

- Fan new posts into every list whose membership includes the author
  (addStatusToListTimelines, called from addStatusToTimelines).
- Backfill a member's existing posts when they are added to a list, and purge
  them on removal / list deletion. Status and actor deletion already clean the
  timelines table by statusId / actorId.
- Read getListTimeline from the materialized partition; visibility,
  replies-policy and block/mute filters stay at read time, so the result is
  identical to the old live join — proven by the existing list test suite, which
  now exercises the backfill path. The Mastodon list timeline API is unchanged.
- Add a (actorId, timeline, statusActorId) index for the per-member purge and a
  one-time backfill migration for existing lists; regenerate both schema dumps.