### PR TITLE
fix: merge duplicate reply and mention notifications into one

### DIFF
--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -366,6 +366,47 @@ describe('Create note action', () => {
       }
     })
 
+    it('merges into a single reply notification when a reply also mentions the parent author', async () => {
+      await clearSettledNotificationAlerts()
+      const originalStatus = (await createNoteFromUserInput({
+        text: 'Original post from actor2 for reply+mention merge',
+        currentActor: actor2,
+        database
+      })) as StatusNote
+
+      const replyStatus = (await createNoteFromUserInput({
+        text: '@test2@llun.test thanks for the post!',
+        currentActor: actor1,
+        replyNoteId: originalStatus.id,
+        database
+      })) as StatusNote
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      const notifications = await database.getNotifications({
+        actorId: actor2.id,
+        limit: 100
+      })
+      const replyMentionNotifications = notifications.filter(
+        (notification) => notification.statusId === replyStatus.id
+      )
+      // Only the reply notification should be kept — the duplicate mention one
+      // for the same parent author is suppressed.
+      expect(replyMentionNotifications).toHaveLength(1)
+      expect(replyMentionNotifications[0].type).toBe(
+        NotificationType.enum.reply
+      )
+
+      // A single reply alert is dispatched for the parent author.
+      const replyAlertCalls = mockSendNotificationAlerts.mock.calls.filter(
+        ([call]) =>
+          call.actorId === actor2.id && call.statusId === replyStatus.id
+      )
+      expect(replyAlertCalls).toHaveLength(1)
+      expect(replyAlertCalls[0][0].events).toEqual([
+        expect.objectContaining({ type: NotificationType.enum.reply })
+      ])
+    })
+
     it('does not create reply notification when reply target mutes source with notifications=true', async () => {
       await clearSettledNotificationAlerts()
       const originalStatus = (await createNoteFromUserInput({

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -507,15 +507,17 @@ export const createNoteFromUserInput = async ({
   > = []
 
   // Create reply notification if this is a reply
-  if (
+  const replyNotifiedActorId =
     shouldNotifyReply &&
     replyStatus &&
     eligibleNotificationActorIds.has(replyStatus.actorId)
-  ) {
+      ? replyStatus.actorId
+      : null
+  if (replyNotifiedActorId && replyStatus) {
     notificationEntries.push([
-      replyStatus.actorId,
+      replyNotifiedActorId,
       createNotificationWithPolicy(database, {
-        actorId: replyStatus.actorId,
+        actorId: replyNotifiedActorId,
         type: NotificationType.enum.reply,
         sourceActorId: currentActor.id,
         statusId,
@@ -527,6 +529,11 @@ export const createNoteFromUserInput = async ({
   // Create mention notifications
   for (const mention of notificationMentions) {
     const mentionedActorId = mention.href
+    // A reply that also mentions the parent author is a single event: the reply
+    // notification above already covers them, so skip the duplicate mention one.
+    if (mentionedActorId === replyNotifiedActorId) {
+      continue
+    }
     // Don't create notification for self-mentions
     if (eligibleNotificationActorIds.has(mentionedActorId)) {
       notificationEntries.push([

--- a/lib/services/timelines/mention.test.ts
+++ b/lib/services/timelines/mention.test.ts
@@ -636,6 +636,60 @@ describe('mentionTimelineRule', () => {
     }
   })
 
+  it('still creates a mention notification with the mention email when a remote reply to another actor also mentions the recipient', async () => {
+    const actor = (await database.getActorFromId({ id: ACTOR3_ID })) as Actor
+    // Parent post belongs to ACTOR1, not the current actor (ACTOR3).
+    const otherActorPost = await createNote(
+      database,
+      ACTOR1_ID,
+      'Post owned by another actor',
+      `${ACTOR1_ID}/followers`
+    )
+    // Remote actor replies to ACTOR1's post but mentions ACTOR3.
+    const replyMentionStatus = await createNote(
+      database,
+      EXTERNAL_ACTOR1,
+      `Replying to test1 but pinging ${getActorURL(actor)}`,
+      EXTERNAL_ACTOR1_FOLLOWERS,
+      otherActorPost.id
+    )
+    await createMentionTag(
+      database,
+      replyMentionStatus.id,
+      getActorURL(actor),
+      actor.username
+    )
+
+    await mentionTimelineRule({
+      database,
+      currentActor: actor,
+      status: replyMentionStatus
+    })
+
+    // ACTOR3 is not the parent author, so the reply branch does not fire and the
+    // mention must NOT be suppressed: exactly one mention notification, carrying
+    // the mention email template (not the reply one).
+    const notifications = await database.getNotifications({
+      actorId: actor.id,
+      limit: 100
+    })
+    const forStatus = notifications.filter(
+      (n) => n.statusId === replyMentionStatus.id
+    )
+    expect(forStatus).toHaveLength(1)
+    expect(forStatus[0].type).toBe(NotificationType.enum.mention)
+
+    expect(mockSendAlerts).toHaveBeenCalledTimes(1)
+    const { events } = mockSendAlerts.mock.calls[0][0]
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: NotificationType.enum.mention,
+      emailContent: expect.objectContaining({
+        subject: expect.stringContaining('mentions you in')
+      })
+    })
+  })
+
   it('returns null for remote reply to another actor post', async () => {
     const actor = (await database.getActorFromId({ id: ACTOR3_ID })) as Actor
     // Create a post by ACTOR1 (not the current actor)

--- a/lib/services/timelines/mention.test.ts
+++ b/lib/services/timelines/mention.test.ts
@@ -482,7 +482,7 @@ describe('mentionTimelineRule', () => {
     ).toBeUndefined()
   })
 
-  it('sends reply event first when status is both reply and mention', async () => {
+  it('merges into a single reply notification when status is both reply and mention', async () => {
     const actor = (await database.getActorFromId({ id: ACTOR3_ID })) as Actor
     const originalPost = await createNote(
       database,
@@ -511,7 +511,8 @@ describe('mentionTimelineRule', () => {
       status: replyMentionStatus
     })
 
-    // Both notifications should be created in DB
+    // A reply that also mentions the recipient is a single event: keep only the
+    // (more specific) reply notification and suppress the duplicate mention one.
     const notifications = await database.getNotifications({
       actorId: actor.id,
       limit: 100
@@ -525,15 +526,16 @@ describe('mentionTimelineRule', () => {
       notifications.find(
         (n) => n.statusId === replyMentionStatus.id && n.type === 'mention'
       )
-    ).toBeDefined()
+    ).toBeUndefined()
+    expect(
+      notifications.filter((n) => n.statusId === replyMentionStatus.id)
+    ).toHaveLength(1)
 
-    // sendNotificationAlerts called once with reply event first (push priority)
-    // and mention event second (carries email content)
+    // sendNotificationAlerts called once with a single reply event.
     expect(mockSendAlerts).toHaveBeenCalledTimes(1)
     const { events } = mockSendAlerts.mock.calls[0][0]
-    expect(events).toHaveLength(2)
+    expect(events).toHaveLength(1)
     expect(events[0].type).toBe(NotificationType.enum.reply)
-    expect(events[1].type).toBe(NotificationType.enum.mention)
   })
 
   it('returns null for remote reply to another actor post', async () => {

--- a/lib/services/timelines/mention.test.ts
+++ b/lib/services/timelines/mention.test.ts
@@ -538,6 +538,104 @@ describe('mentionTimelineRule', () => {
     expect(events[0].type).toBe(NotificationType.enum.reply)
   })
 
+  it('carries the reply email on the merged reply event for a remote reply that also mentions the recipient', async () => {
+    const actor = (await database.getActorFromId({ id: ACTOR3_ID })) as Actor
+    const originalPost = await createNote(
+      database,
+      ACTOR3_ID,
+      'Reply+mention email post',
+      `${ACTOR3_ID}/followers`
+    )
+    const replyMentionStatus = await createNote(
+      database,
+      EXTERNAL_ACTOR1,
+      `Hey ${getActorURL(actor)} replying to you!`,
+      EXTERNAL_ACTOR1_FOLLOWERS,
+      originalPost.id
+    )
+    await createMentionTag(
+      database,
+      replyMentionStatus.id,
+      getActorURL(actor),
+      actor.username
+    )
+
+    await mentionTimelineRule({
+      database,
+      currentActor: actor,
+      status: replyMentionStatus
+    })
+
+    // The reply email must ride on the surviving reply event — the mention
+    // branch that used to carry it is skipped once the reply is created, so
+    // without this the email channel silently drops for remote reply+mentions.
+    expect(mockSendAlerts).toHaveBeenCalledTimes(1)
+    const { events } = mockSendAlerts.mock.calls[0][0]
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: NotificationType.enum.reply,
+      emailContent: expect.objectContaining({
+        recipientEmail: actor.account?.email,
+        subject: expect.stringContaining('replied to your post')
+      })
+    })
+  })
+
+  it('keeps a single filtered reply notification and sends no alert when a filtered reply also mentions the recipient', async () => {
+    const actor = (await database.getActorFromId({ id: ACTOR3_ID })) as Actor
+    await database.updateNotificationPolicy({
+      actorId: actor.id,
+      for_not_following: 'filter'
+    })
+    try {
+      const originalPost = await createNote(
+        database,
+        ACTOR3_ID,
+        'Filtered reply+mention post',
+        `${ACTOR3_ID}/followers`
+      )
+      const replyMentionStatus = await createNote(
+        database,
+        EXTERNAL_ACTOR1,
+        `Hey ${getActorURL(actor)} replying to you!`,
+        EXTERNAL_ACTOR1_FOLLOWERS,
+        originalPost.id
+      )
+      await createMentionTag(
+        database,
+        replyMentionStatus.id,
+        getActorURL(actor),
+        actor.username
+      )
+
+      await mentionTimelineRule({
+        database,
+        currentActor: actor,
+        status: replyMentionStatus
+      })
+
+      // A filtered reply still collapses to a single (filtered) reply
+      // notification with no duplicate mention, and pushes no alert event.
+      const notifications = await database.getNotifications({
+        actorId: actor.id,
+        limit: 100,
+        includeFiltered: true
+      })
+      const forStatus = notifications.filter(
+        (n) => n.statusId === replyMentionStatus.id
+      )
+      expect(forStatus).toHaveLength(1)
+      expect(forStatus[0].type).toBe(NotificationType.enum.reply)
+      expect(forStatus[0].filtered).toBe(true)
+      expect(mockSendAlerts).not.toHaveBeenCalled()
+    } finally {
+      await database.updateNotificationPolicy({
+        actorId: actor.id,
+        for_not_following: 'accept'
+      })
+    }
+  })
+
   it('returns null for remote reply to another actor post', async () => {
     const actor = (await database.getActorFromId({ id: ACTOR3_ID })) as Actor
     // Create a post by ACTOR1 (not the current actor)

--- a/lib/services/timelines/mention.ts
+++ b/lib/services/timelines/mention.ts
@@ -2,10 +2,15 @@ import { SpanStatusCode } from '@opentelemetry/api'
 
 import { getConfig } from '@/lib/config'
 import {
-  getHTMLContent,
-  getSubject,
-  getTextContent
+  getHTMLContent as getMentionHTMLContent,
+  getSubject as getMentionSubject,
+  getTextContent as getMentionTextContent
 } from '@/lib/services/email/templates/mention'
+import {
+  getHTMLContent as getReplyHTMLContent,
+  getSubject as getReplySubject,
+  getTextContent as getReplyTextContent
+} from '@/lib/services/email/templates/reply'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import {
   NotificationEvent,
@@ -79,11 +84,33 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
                 groupKey: `reply:${repliedStatus.id}`
               }
             )
-            if (replyNotification) {
-              replyNotificationCreated = true
-              if (!replyNotification.filtered) {
-                alertEvents.push({ type: NotificationType.enum.reply })
+            // Mark the reply handled as soon as we know it's a reply to the
+            // current actor — before inspecting the policy verdict — so the
+            // mention branch below is suppressed even when the reply
+            // notification is dropped or filtered by policy. This matches the
+            // local path in createNote.ts (which suppresses unconditionally) and
+            // avoids a redundant mention policy evaluation. The notification
+            // policy returns the same verdict for `reply` and `mention`, so no
+            // duplicate can slip through; this just keeps the two paths aligned.
+            replyNotificationCreated = true
+            if (replyNotification && !replyNotification.filtered) {
+              const replyEvent: NotificationEvent = {
+                type: NotificationType.enum.reply
               }
+              // Carry the reply email on the surviving reply event. The mention
+              // branch below — which used to attach the email for a
+              // reply-that-mentions — is now skipped, so without this the email
+              // channel would silently drop for that case.
+              const account = currentActor.account
+              if (config.email && account && status.actor) {
+                replyEvent.emailContent = {
+                  recipientEmail: account.email,
+                  subject: getReplySubject(status.actor),
+                  text: getReplyTextContent(status),
+                  html: getReplyHTMLContent(status)
+                }
+              }
+              alertEvents.push(replyEvent)
             }
           }
         } catch (error) {
@@ -141,9 +168,9 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
             if (config.email && account && status.actor) {
               mentionEvent.emailContent = {
                 recipientEmail: account.email,
-                subject: getSubject(status.actor),
-                text: getTextContent(status),
-                html: getHTMLContent(status)
+                subject: getMentionSubject(status.actor),
+                text: getMentionTextContent(status),
+                html: getMentionHTMLContent(status)
               }
             }
             alertEvents.push(mentionEvent)

--- a/lib/services/timelines/mention.ts
+++ b/lib/services/timelines/mention.ts
@@ -55,6 +55,10 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
 
       let addToTimeline = false
       const alertEvents: NotificationEvent[] = []
+      // A reply that also mentions the recipient is a single event. Once a reply
+      // notification is created for this status we suppress the duplicate mention
+      // notification below so the recipient sees one entry, not two.
+      let replyNotificationCreated = false
 
       // --- Reply detection ---
       if (status.reply && !status.isLocalActor) {
@@ -75,8 +79,11 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
                 groupKey: `reply:${repliedStatus.id}`
               }
             )
-            if (replyNotification && !replyNotification.filtered) {
-              alertEvents.push({ type: NotificationType.enum.reply })
+            if (replyNotification) {
+              replyNotificationCreated = true
+              if (!replyNotification.filtered) {
+                alertEvents.push({ type: NotificationType.enum.reply })
+              }
             }
           }
         } catch (error) {
@@ -103,7 +110,9 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
         addToTimeline = true
         const account = currentActor.account
 
-        if (!status.isLocalActor) {
+        // Skip the mention notification when a reply notification already covers
+        // this status for the same recipient — they are the same event.
+        if (!status.isLocalActor && !replyNotificationCreated) {
           // Error is recorded but not re-thrown: a notification DB failure
           // should not block the mention from being added to the timeline.
           let mentionNotification = null


### PR DESCRIPTION
## Problem

When someone replies to your post **and** mentions you in that reply, you receive **two** notifications for one event:

- "_<name> replied to your post_" (type `reply`)
- "_<name> mentioned you in a post_" (type `mention`)

This is the common case: a Mastodon-style reply auto-mentions the parent author, so almost every reply to you produced a duplicate. The two rows are created with different group keys (`reply:<parentId>` vs `mention:<statusId>`) and neither is in the default groupable set, so they never merge — in the UI **or** in the Mastodon API (both `reply` and `mention` serialise to the Mastodon `mention` type, so a Mastodon client also saw two "mention" notifications).

## Root cause

Two independent code paths each create a `reply` notification and a separate `mention` notification for the same recipient + status:

- `lib/services/timelines/mention.ts` — incoming **remote** replies.
- `lib/actions/createNote.ts` — **local** replies.

## Fix

Deduplicate at notification-creation time (the root cause), keeping the single, more specific **reply** notification and suppressing the duplicate **mention** one for the replied-to author:

- **Remote path** (`mention.ts`): once a reply notification is created for the recipient, skip creating the mention notification and its alert event for the same status.
- **Local path** (`createNote.ts`): skip the mention notification for the parent author when a reply notification is already created for them.

Why keep `reply` rather than `mention`:
- The native UI message "replied to your post" is more specific/useful than "mentioned you in a post".
- `reply` carries reply-specific email templates.
- `internalTypeToMastodon` maps `reply → mention`, so Mastodon API clients still see exactly one `mention`-type notification — the correct Mastodon behaviour (Mastodon has no separate reply type; a reply *is* a mention).

Actors who are mentioned but are **not** the replied-to author still receive normal `mention` notifications. Block/mute/filter policy behaviour is unchanged.

## Notes / scope

- This prevents **new** duplicates. Pre-existing duplicate rows already in the database are not retroactively cleaned up (no data migration) — that can be a follow-up if desired.
- No schema/migration changes.

## Tests

- Updated `lib/services/timelines/mention.test.ts`: the reply+mention case now asserts a single `reply` notification (no `mention` row) and a single reply alert event.
- Added `lib/actions/createNote.test.ts`: a local reply that also mentions the parent author creates exactly one (`reply`) notification and one reply alert.

## Verification

- `yarn run prettier --write .` ✓
- `yarn lint` ✓ (0 errors; only pre-existing warnings)
- `yarn build` ✓
- `yarn test` ✓ — 497 suites / 4261 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)