### PR TITLE
fix: close unclosed doc comment in list timelines backfill migration

### DIFF
--- a/migrations/20260613120100_backfill_list_timelines.js
+++ b/migrations/20260613120100_backfill_list_timelines.js
@@ -9,7 +9,7 @@
  * read per distinct member in chunked IN queries (not one query per membership)
  * so an account on many lists is fetched once per chunk, and the chunk sizes keep
  * both the SELECT and INSERT under SQLite's 999 bound-parameter limit.
- *
+ */
 // Normalize a stored createdAt to a Date the same way the runtime fan-out does
 // (lib/database/sql/utils/getCompatibleTime + new Date), so list rows written
 // here serialize identically to rows written at runtime — the list read orders


### PR DESCRIPTION
## Summary

`NODE_ENV=production yarn migrate` failed with:

```
migration file "20260613120100_backfill_list_timelines.js" failed
migration failed with error: toDate is not defined
ReferenceError: toDate is not defined
    at exports.up (migrations/20260613120100_backfill_list_timelines.js:82:22)
```

**Root cause:** the file's opening JSDoc block comment (`/**` on line 1) was never closed with `*/` before the `// Normalize…` line. As a result the `SQLITE_UTC_TIMESTAMP_PATTERN` regex and the `toDate` helper were swallowed into the doc comment and never defined as runnable code, while `exports.up` still referenced `toDate` at the `createdAt` normalization call.

**Fix:** close the doc comment (`*/`) so `toDate` becomes live code again. One-character change.

## Testing

- `NODE_ENV=production yarn migrate` — now runs to completion (`Batch 71 run: 2 migrations`), `migrate:list` shows no pending migrations.
- `yarn lint` — 0 errors (pre-existing warnings only).
- `yarn build` — passes.
- `yarn test` — 4261 tests pass. (The test suite runs migrations against in-memory SQLite, exercising this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)