### PR TITLE
Bump version to v1.71.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.71.0",
+  "version": "1.71.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.71.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.71.0`
- Base main SHA: `49721203b7bc0ac4d2866ee9e16d2df080a76847`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
