### PR TITLE
minor: announcements banner redesign — pager, emoji reactions, event windows

### DIFF
--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -226,7 +226,7 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
       <ScrollToTopButton
         isLoadMoreVisible={hasMoreStatuses && isLoadMoreVisible}
       />
-      <AnnouncementBanner host={host} currentTime={currentTime} />
+      <AnnouncementBanner currentTime={currentTime} />
       <PageHeader
         title="Timeline"
         description="Latest posts from your network."

--- a/app/(timeline)/admin/announcements/page.tsx
+++ b/app/(timeline)/admin/announcements/page.tsx
@@ -22,7 +22,9 @@ const Page = async () => {
   const admin = await getAdminFromSession(database, session)
   if (!admin) return redirect('/')
 
-  return <AnnouncementsPanel />
+  // Pass the wall clock as a number (never a Date) so the panel can compute
+  // lifecycle status badges without a hydration mismatch.
+  return <AnnouncementsPanel currentTime={Date.now()} />
 }
 
 export default Page

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -3120,3 +3120,46 @@ export const dismissAnnouncement = async (id: string): Promise<boolean> => {
   )
   return response.ok
 }
+
+/**
+ * Adds the current actor's reaction (unicode emoji or custom-emoji shortcode)
+ * to an announcement. Returns true on success. Mirrors `dismissAnnouncement`'s
+ * boolean-ok style so the banner can fall back to its optimistic state.
+ * @see https://docs.joinmastodon.org/methods/announcements/#put-reactions
+ */
+export const addAnnouncementReaction = async (
+  id: string,
+  name: string
+): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/announcements/${encodeURIComponent(id)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.ok
+}
+
+/**
+ * Removes the current actor's reaction from an announcement. Returns true on
+ * success.
+ * @see https://docs.joinmastodon.org/methods/announcements/#delete-reactions
+ */
+export const removeAnnouncementReaction = async (
+  id: string,
+  name: string
+): Promise<boolean> => {
+  const response = await fetch(
+    `/api/v1/announcements/${encodeURIComponent(id)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.ok
+}

--- a/lib/components/admin-announcements/AnnouncementsPanel.test.tsx
+++ b/lib/components/admin-announcements/AnnouncementsPanel.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import type { ServerAnnouncement } from '@/lib/client'
+
+import { AnnouncementsPanel } from './AnnouncementsPanel'
+
+const mockGetServerAnnouncements = jest.fn()
+const mockCreateServerAnnouncement = jest.fn()
+const mockUpdateServerAnnouncement = jest.fn()
+const mockDeleteServerAnnouncement = jest.fn()
+
+jest.mock('@/lib/client', () => ({
+  getServerAnnouncements: () => mockGetServerAnnouncements(),
+  createServerAnnouncement: (input: unknown) =>
+    mockCreateServerAnnouncement(input),
+  updateServerAnnouncement: (id: string, input: unknown) =>
+    mockUpdateServerAnnouncement(id, input),
+  deleteServerAnnouncement: (id: string) => mockDeleteServerAnnouncement(id)
+}))
+
+const NOW = Date.parse('2026-06-13T12:00:00.000Z')
+
+const buildServerAnnouncement = (
+  overrides: Partial<ServerAnnouncement> = {}
+): ServerAnnouncement => ({
+  id: 'announcement-1',
+  text: 'Scheduled maintenance tonight',
+  published: true,
+  all_day: false,
+  starts_at: null,
+  ends_at: null,
+  published_at: NOW,
+  created_at: NOW,
+  updated_at: NOW,
+  ...overrides
+})
+
+const renderPanel = () => render(<AnnouncementsPanel currentTime={NOW} />)
+
+describe('AnnouncementsPanel', () => {
+  beforeEach(() => {
+    mockGetServerAnnouncements.mockReset()
+    mockCreateServerAnnouncement.mockReset()
+    mockUpdateServerAnnouncement.mockReset()
+    mockDeleteServerAnnouncement.mockReset()
+    mockGetServerAnnouncements.mockResolvedValue([])
+    // Radix Switch observes its size; jsdom has no ResizeObserver.
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: jest.fn().mockImplementation(() => ({
+        disconnect: jest.fn(),
+        observe: jest.fn(),
+        unobserve: jest.fn()
+      }))
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'ResizeObserver')
+  })
+
+  it('sends ends_at: null when All-day is on, even after an end value was typed', async () => {
+    mockGetServerAnnouncements.mockResolvedValue([])
+    mockCreateServerAnnouncement.mockResolvedValue(buildServerAnnouncement())
+
+    await act(async () => {
+      renderPanel()
+    })
+    await waitFor(() => {
+      expect(mockGetServerAnnouncements).toHaveBeenCalled()
+    })
+
+    fireEvent.change(screen.getByLabelText('Text'), {
+      target: { value: 'New announcement body' }
+    })
+    // Type an end value first, then flip All-day on — the submit must still
+    // drop the end bound.
+    fireEvent.change(screen.getByLabelText('Event ends'), {
+      target: { value: '2026-06-14T10:00' }
+    })
+    fireEvent.click(screen.getByRole('switch', { name: 'All-day event' }))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save draft/i }))
+    })
+
+    await waitFor(() => {
+      expect(mockCreateServerAnnouncement).toHaveBeenCalled()
+    })
+    const input = mockCreateServerAnnouncement.mock.calls[0][0]
+    expect(input.all_day).toBe(true)
+    expect(input.ends_at).toBeNull()
+  })
+
+  it('disables the Event ends input while All-day is on', async () => {
+    await act(async () => {
+      renderPanel()
+    })
+    await waitFor(() => {
+      expect(mockGetServerAnnouncements).toHaveBeenCalled()
+    })
+
+    const endInput = screen.getByLabelText('Event ends')
+    expect(endInput).not.toBeDisabled()
+
+    fireEvent.click(screen.getByRole('switch', { name: 'All-day event' }))
+    expect(endInput).toBeDisabled()
+  })
+
+  it.each([
+    {
+      description: 'a published, active announcement shows Published',
+      overrides: { published: true, ends_at: null },
+      expectedLabel: 'Published'
+    },
+    {
+      description: 'an unpublished announcement shows Draft',
+      overrides: { published: false, published_at: null },
+      expectedLabel: 'Draft'
+    },
+    {
+      description: 'a published announcement past its end time shows Expired',
+      overrides: { published: true, ends_at: NOW - 60 * 60 * 1000 },
+      expectedLabel: 'Expired'
+    }
+  ])('$description', async ({ overrides, expectedLabel }) => {
+    mockGetServerAnnouncements.mockResolvedValue([
+      buildServerAnnouncement(overrides)
+    ])
+
+    await act(async () => {
+      renderPanel()
+    })
+
+    expect(await screen.findByText(expectedLabel)).toBeInTheDocument()
+  })
+})

--- a/lib/components/admin-announcements/AnnouncementsPanel.test.tsx
+++ b/lib/components/admin-announcements/AnnouncementsPanel.test.tsx
@@ -96,6 +96,58 @@ describe('AnnouncementsPanel', () => {
     expect(input.ends_at).toBeNull()
   })
 
+  // The picked calendar date must be stored as that exact day's UTC midnight
+  // regardless of the runner's local timezone, so the Home banner (which renders
+  // all-day bounds in UTC) never shifts the date across the date line. Each case
+  // pins a different naive `datetime-local` value; the time-of-day component is
+  // intentionally discarded for all-day events.
+  it.each([
+    {
+      description:
+        'an all-day start with a midnight time becomes UTC midnight of that day',
+      input: '2026-06-13T00:00',
+      expected: '2026-06-13T00:00:00.000Z'
+    },
+    {
+      description:
+        'an all-day start with a non-midnight time discards the time and uses UTC midnight',
+      input: '2026-06-13T15:30',
+      expected: '2026-06-13T00:00:00.000Z'
+    }
+  ])(
+    'normalizes starts_at to $description when All-day is on',
+    async ({ input, expected }) => {
+      mockGetServerAnnouncements.mockResolvedValue([])
+      mockCreateServerAnnouncement.mockResolvedValue(buildServerAnnouncement())
+
+      await act(async () => {
+        renderPanel()
+      })
+      await waitFor(() => {
+        expect(mockGetServerAnnouncements).toHaveBeenCalled()
+      })
+
+      fireEvent.change(screen.getByLabelText('Text'), {
+        target: { value: 'New announcement body' }
+      })
+      fireEvent.change(screen.getByLabelText('Event starts'), {
+        target: { value: input }
+      })
+      fireEvent.click(screen.getByRole('switch', { name: 'All-day event' }))
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /save draft/i }))
+      })
+
+      await waitFor(() => {
+        expect(mockCreateServerAnnouncement).toHaveBeenCalled()
+      })
+      const payload = mockCreateServerAnnouncement.mock.calls[0][0]
+      expect(payload.all_day).toBe(true)
+      expect(payload.starts_at).toBe(expected)
+    }
+  )
+
   it('disables the Event ends input while All-day is on', async () => {
     await act(async () => {
       renderPanel()

--- a/lib/components/admin-announcements/AnnouncementsPanel.tsx
+++ b/lib/components/admin-announcements/AnnouncementsPanel.tsx
@@ -99,7 +99,16 @@ export const AnnouncementsPanel: FC<AnnouncementsPanelProps> = ({
     try {
       const input: ServerAnnouncementInput = {
         text,
-        starts_at: fromLocalInputValue(newStartsAt),
+        // For an all-day event the time-of-day is not meaningful and the picked
+        // date must be treated as a zone-less calendar date. The Home banner
+        // renders all-day bounds in UTC, so store UTC midnight of the picked day
+        // rather than converting the naive local input to UTC (which would shift
+        // the calendar date for creators not in UTC). Timed events keep the
+        // local->UTC conversion.
+        starts_at:
+          newAllDay && newStartsAt.trim() !== ''
+            ? `${newStartsAt.trim().slice(0, 10)}T00:00:00.000Z`
+            : fromLocalInputValue(newStartsAt),
         // When the event is all-day, the end bound is not meaningful, so drop
         // whatever was previously typed.
         ends_at: newAllDay ? null : fromLocalInputValue(newEndsAt),

--- a/lib/components/admin-announcements/AnnouncementsPanel.tsx
+++ b/lib/components/admin-announcements/AnnouncementsPanel.tsx
@@ -330,9 +330,17 @@ export const AnnouncementsPanel: FC<AnnouncementsPanelProps> = ({
                       maxLength={5000}
                       rows={2}
                       disabled={busyId !== null || saving}
-                      onBlur={(event) =>
+                      onBlur={(event) => {
+                        // The textarea is uncontrolled (defaultValue), so an
+                        // ignored empty edit would otherwise leave the field
+                        // showing the empty value even though the stored text
+                        // is unchanged. Reset it back to the persisted text so
+                        // the display stays in sync without a reload.
+                        if (event.target.value.trim() === '') {
+                          event.target.value = announcement.text
+                        }
                         handleEditText(announcement, event.target.value)
-                      }
+                      }}
                     />
                   </FilterField>
                   <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">

--- a/lib/components/admin-announcements/AnnouncementsPanel.tsx
+++ b/lib/components/admin-announcements/AnnouncementsPanel.tsx
@@ -11,12 +11,15 @@ import {
   getServerAnnouncements,
   updateServerAnnouncement
 } from '@/lib/client'
+import { AnnouncementBadge } from '@/lib/components/announcements/AnnouncementBanner'
 import { FilterField, FilterSection } from '@/lib/components/filters/filterUi'
 import { PageHeader } from '@/lib/components/page-header'
 import { Button } from '@/lib/components/ui/button'
-import { Checkbox } from '@/lib/components/ui/checkbox'
 import { Input } from '@/lib/components/ui/input'
+import { Switch } from '@/lib/components/ui/switch'
 import { Textarea } from '@/lib/components/ui/textarea'
+
+import { computeAnnouncementStatus } from './announcementStatus'
 
 // The server returns announcements newest-first by createdAt. `Array.prototype
 // .sort` is stable, so re-sorting after an edit preserves that order for rows
@@ -45,7 +48,15 @@ const formatDateTime = (time: number): string =>
     timeStyle: 'short'
   })
 
-export const AnnouncementsPanel: FC = () => {
+interface AnnouncementsPanelProps {
+  // Wall clock as a number (never a Date) from the server component, used to
+  // compute lifecycle status badges without a hydration mismatch.
+  currentTime: number
+}
+
+export const AnnouncementsPanel: FC<AnnouncementsPanelProps> = ({
+  currentTime
+}) => {
   const [announcements, setAnnouncements] = useState<ServerAnnouncement[]>([])
   const [loading, setLoading] = useState(true)
   const [listError, setListError] = useState<string | null>(null)
@@ -89,7 +100,9 @@ export const AnnouncementsPanel: FC = () => {
       const input: ServerAnnouncementInput = {
         text,
         starts_at: fromLocalInputValue(newStartsAt),
-        ends_at: fromLocalInputValue(newEndsAt),
+        // When the event is all-day, the end bound is not meaningful, so drop
+        // whatever was previously typed.
+        ends_at: newAllDay ? null : fromLocalInputValue(newEndsAt),
         all_day: newAllDay,
         published: newPublished
       }
@@ -191,25 +204,29 @@ export const AnnouncementsPanel: FC = () => {
         description="Instance-wide announcements served from the Mastodon announcements API. Published announcements within their active window are shown to everyone."
       />
 
-      {listError && <p className="text-sm text-destructive">{listError}</p>}
+      {listError && <p className="text-destructive text-sm">{listError}</p>}
 
       <FilterSection
         title="Add an announcement"
-        description="Markdown is supported. Leave the start and end empty to show it immediately and indefinitely."
+        description="Markdown is supported. Leave the event window empty to show it immediately and indefinitely."
       >
         <form onSubmit={handleCreate} className="space-y-4">
-          <FilterField label="Text" htmlFor="announcement-text">
+          <FilterField
+            label="Text"
+            htmlFor="announcement-text"
+            help="Plain text with hashtags and mentions; keep it under a few sentences. No attachments."
+          >
             <Textarea
               id="announcement-text"
               value={newText}
               onChange={(event) => setNewText(event.target.value)}
               maxLength={5000}
-              rows={3}
+              rows={4}
               required
             />
           </FilterField>
           <div className="grid gap-4 sm:grid-cols-2">
-            <FilterField label="Starts at" htmlFor="announcement-starts-at">
+            <FilterField label="Event starts" htmlFor="announcement-starts-at">
               <Input
                 id="announcement-starts-at"
                 type="datetime-local"
@@ -217,38 +234,50 @@ export const AnnouncementsPanel: FC = () => {
                 onChange={(event) => setNewStartsAt(event.target.value)}
               />
             </FilterField>
-            <FilterField label="Ends at" htmlFor="announcement-ends-at">
+            <FilterField label="Event ends" htmlFor="announcement-ends-at">
               <Input
                 id="announcement-ends-at"
                 type="datetime-local"
                 value={newEndsAt}
                 onChange={(event) => setNewEndsAt(event.target.value)}
+                disabled={newAllDay}
               />
             </FilterField>
           </div>
-          <label
-            className="flex items-center gap-2 text-sm"
-            htmlFor="announcement-all-day"
-          >
-            <Checkbox
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">All-day event</p>
+              <p className="text-muted-foreground text-sm">
+                Hide the times and show only the dates.
+              </p>
+            </div>
+            <Switch
               id="announcement-all-day"
               checked={newAllDay}
-              onChange={(event) => setNewAllDay(event.target.checked)}
+              onCheckedChange={setNewAllDay}
+              aria-label="All-day event"
             />
-            All day
-          </label>
-          <label
-            className="flex items-center gap-2 text-sm"
-            htmlFor="announcement-published"
-          >
-            <Checkbox
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">Publish now</p>
+              <p className="text-muted-foreground text-sm">
+                Publish immediately. Leave off to save as a draft.
+              </p>
+            </div>
+            <Switch
               id="announcement-published"
               checked={newPublished}
-              onChange={(event) => setNewPublished(event.target.checked)}
+              onCheckedChange={setNewPublished}
+              aria-label="Publish now"
             />
-            Published
-          </label>
-          {formError && <p className="text-sm text-destructive">{formError}</p>}
+          </div>
+          <p className="text-muted-foreground text-[0.8rem]">
+            Times are stored in UTC and display in each reader&apos;s local
+            timezone. The announcement disappears for everyone after the end
+            date.
+          </p>
+          {formError && <p className="text-destructive text-sm">{formError}</p>}
           <div className="flex justify-end">
             <Button
               type="submit"
@@ -257,7 +286,7 @@ export const AnnouncementsPanel: FC = () => {
               }
             >
               <Plus className="size-4" />
-              Add announcement
+              {newPublished ? 'Publish' : 'Save draft'}
             </Button>
           </div>
         </form>
@@ -265,72 +294,83 @@ export const AnnouncementsPanel: FC = () => {
 
       <FilterSection>
         {loading ? (
-          <p className="py-6 text-center text-sm text-muted-foreground">
+          <p className="text-muted-foreground py-6 text-center text-sm">
             Loading announcements…
           </p>
         ) : announcements.length === 0 && !listError ? (
           // Suppress the empty-state copy when a load error is already shown, so
           // a failed fetch doesn't read as "you have no announcements".
-          <p className="py-6 text-center text-sm text-muted-foreground">
+          <p className="text-muted-foreground py-6 text-center text-sm">
             No announcements yet — add one to show it to everyone.
           </p>
         ) : (
           <div className="space-y-4">
-            {announcements.map((announcement) => (
-              <div
-                key={announcement.id}
-                className="space-y-3 rounded-lg border p-3"
-              >
-                <FilterField
-                  label="Text"
-                  htmlFor={`announcement-text-${announcement.id}`}
+            {announcements.map((announcement) => {
+              const status = computeAnnouncementStatus(
+                announcement,
+                currentTime
+              )
+              return (
+                <div
+                  key={announcement.id}
+                  className="space-y-3 rounded-lg border p-3"
                 >
-                  <Textarea
-                    id={`announcement-text-${announcement.id}`}
-                    defaultValue={announcement.text}
-                    maxLength={5000}
-                    rows={2}
-                    disabled={busyId !== null || saving}
-                    onBlur={(event) =>
-                      handleEditText(announcement, event.target.value)
-                    }
-                  />
-                </FilterField>
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                  {announcement.starts_at !== null && (
-                    <span suppressHydrationWarning>
-                      Starts {formatDateTime(announcement.starts_at)}
-                    </span>
-                  )}
-                  {announcement.ends_at !== null && (
-                    <span suppressHydrationWarning>
-                      Ends {formatDateTime(announcement.ends_at)}
-                    </span>
-                  )}
-                  {announcement.all_day && <span>All day</span>}
-                </div>
-                <div className="flex items-center justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleTogglePublished(announcement)}
-                    disabled={busyId !== null || saving}
+                  <div className="flex items-center gap-2">
+                    <AnnouncementBadge tone={status.tone}>
+                      {status.label}
+                    </AnnouncementBadge>
+                  </div>
+                  <FilterField
+                    label="Text"
+                    htmlFor={`announcement-text-${announcement.id}`}
                   >
-                    {announcement.published ? 'Unpublish' : 'Publish'}
-                  </Button>
-                  <button
-                    type="button"
-                    aria-label={`Delete announcement ${announcement.text}`}
-                    onClick={() => handleDelete(announcement)}
-                    disabled={busyId !== null || saving}
-                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[hsl(0_84.2%_60.2%/0.4)] text-[hsl(0_72%_45%)] transition-colors hover:bg-[hsl(0_72%_45%/0.08)] disabled:pointer-events-none disabled:opacity-50"
-                  >
-                    <Trash2 className="size-4" />
-                  </button>
+                    <Textarea
+                      id={`announcement-text-${announcement.id}`}
+                      defaultValue={announcement.text}
+                      maxLength={5000}
+                      rows={2}
+                      disabled={busyId !== null || saving}
+                      onBlur={(event) =>
+                        handleEditText(announcement, event.target.value)
+                      }
+                    />
+                  </FilterField>
+                  <div className="text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+                    {announcement.starts_at !== null && (
+                      <span suppressHydrationWarning>
+                        Starts {formatDateTime(announcement.starts_at)}
+                      </span>
+                    )}
+                    {announcement.ends_at !== null && (
+                      <span suppressHydrationWarning>
+                        Ends {formatDateTime(announcement.ends_at)}
+                      </span>
+                    )}
+                    {announcement.all_day && <span>All day</span>}
+                  </div>
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleTogglePublished(announcement)}
+                      disabled={busyId !== null || saving}
+                    >
+                      {announcement.published ? 'Unpublish' : 'Publish'}
+                    </Button>
+                    <button
+                      type="button"
+                      aria-label={`Delete announcement ${announcement.text}`}
+                      onClick={() => handleDelete(announcement)}
+                      disabled={busyId !== null || saving}
+                      className="border-destructive/40 text-destructive hover:bg-destructive/10 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border transition-colors disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </FilterSection>

--- a/lib/components/admin-announcements/AnnouncementsPanel.tsx
+++ b/lib/components/admin-announcements/AnnouncementsPanel.tsx
@@ -214,7 +214,7 @@ export const AnnouncementsPanel: FC<AnnouncementsPanelProps> = ({
           <FilterField
             label="Text"
             htmlFor="announcement-text"
-            help="Plain text with hashtags and mentions; keep it under a few sentences. No attachments."
+            help="Markdown with hashtags and mentions; keep it under a few sentences. No attachments."
           >
             <Textarea
               id="announcement-text"

--- a/lib/components/admin-announcements/announcementStatus.test.ts
+++ b/lib/components/admin-announcements/announcementStatus.test.ts
@@ -1,0 +1,72 @@
+import type { ServerAnnouncement } from '@/lib/client'
+
+import { computeAnnouncementStatus } from './announcementStatus'
+
+const NOW = Date.parse('2026-06-13T12:00:00.000Z')
+const HOUR = 60 * 60 * 1000
+
+const build = (
+  overrides: Partial<
+    Pick<ServerAnnouncement, 'published' | 'published_at' | 'ends_at'>
+  >
+): Pick<ServerAnnouncement, 'published' | 'published_at' | 'ends_at'> => ({
+  published: false,
+  published_at: null,
+  ends_at: null,
+  ...overrides
+})
+
+describe('computeAnnouncementStatus', () => {
+  it.each([
+    {
+      description: 'unpublished with a future publish time is Scheduled',
+      input: { published: false, published_at: NOW + HOUR },
+      expectedStatus: 'scheduled',
+      expectedLabel: 'Scheduled',
+      expectedTone: 'orange'
+    },
+    {
+      description: 'unpublished with no publish time is Draft',
+      input: { published: false, published_at: null },
+      expectedStatus: 'draft',
+      expectedLabel: 'Draft',
+      expectedTone: 'gray'
+    },
+    {
+      description: 'unpublished with a past publish time is Draft',
+      input: { published: false, published_at: NOW - HOUR },
+      expectedStatus: 'draft',
+      expectedLabel: 'Draft',
+      expectedTone: 'gray'
+    },
+    {
+      description: 'published with no end time is Published',
+      input: { published: true, ends_at: null },
+      expectedStatus: 'published',
+      expectedLabel: 'Published',
+      expectedTone: 'green'
+    },
+    {
+      description: 'published with a future end time is Published',
+      input: { published: true, ends_at: NOW + HOUR },
+      expectedStatus: 'published',
+      expectedLabel: 'Published',
+      expectedTone: 'green'
+    },
+    {
+      description: 'published with a past end time is Expired',
+      input: { published: true, ends_at: NOW - HOUR },
+      expectedStatus: 'expired',
+      expectedLabel: 'Expired',
+      expectedTone: 'gray'
+    }
+  ])(
+    '$description',
+    ({ input, expectedStatus, expectedLabel, expectedTone }) => {
+      const result = computeAnnouncementStatus(build(input), NOW)
+      expect(result.status).toBe(expectedStatus)
+      expect(result.label).toBe(expectedLabel)
+      expect(result.tone).toBe(expectedTone)
+    }
+  )
+})

--- a/lib/components/admin-announcements/announcementStatus.test.ts
+++ b/lib/components/admin-announcements/announcementStatus.test.ts
@@ -6,9 +6,12 @@ const NOW = Date.parse('2026-06-13T12:00:00.000Z')
 const HOUR = 60 * 60 * 1000
 
 const build = (
-  overrides: Partial<Pick<ServerAnnouncement, 'published' | 'ends_at'>>
-): Pick<ServerAnnouncement, 'published' | 'ends_at'> => ({
+  overrides: Partial<
+    Pick<ServerAnnouncement, 'published' | 'starts_at' | 'ends_at'>
+  >
+): Pick<ServerAnnouncement, 'published' | 'starts_at' | 'ends_at'> => ({
   published: false,
+  starts_at: null,
   ends_at: null,
   ...overrides
 })
@@ -39,6 +42,28 @@ describe('computeAnnouncementStatus', () => {
     {
       description: 'published with a past end time is Expired',
       input: { published: true, ends_at: NOW - HOUR },
+      expectedStatus: 'expired',
+      expectedLabel: 'Expired',
+      expectedTone: 'gray'
+    },
+    {
+      description: 'published with a future start time is Scheduled',
+      input: { published: true, starts_at: NOW + HOUR },
+      expectedStatus: 'scheduled',
+      expectedLabel: 'Scheduled',
+      expectedTone: 'orange'
+    },
+    {
+      description: 'published with a past start time is Published',
+      input: { published: true, starts_at: NOW - HOUR },
+      expectedStatus: 'published',
+      expectedLabel: 'Published',
+      expectedTone: 'green'
+    },
+    {
+      description:
+        'expired takes precedence over a future start time (past end wins)',
+      input: { published: true, starts_at: NOW + HOUR, ends_at: NOW - HOUR },
       expectedStatus: 'expired',
       expectedLabel: 'Expired',
       expectedTone: 'gray'

--- a/lib/components/admin-announcements/announcementStatus.test.ts
+++ b/lib/components/admin-announcements/announcementStatus.test.ts
@@ -6,12 +6,9 @@ const NOW = Date.parse('2026-06-13T12:00:00.000Z')
 const HOUR = 60 * 60 * 1000
 
 const build = (
-  overrides: Partial<
-    Pick<ServerAnnouncement, 'published' | 'published_at' | 'ends_at'>
-  >
-): Pick<ServerAnnouncement, 'published' | 'published_at' | 'ends_at'> => ({
+  overrides: Partial<Pick<ServerAnnouncement, 'published' | 'ends_at'>>
+): Pick<ServerAnnouncement, 'published' | 'ends_at'> => ({
   published: false,
-  published_at: null,
   ends_at: null,
   ...overrides
 })
@@ -19,22 +16,8 @@ const build = (
 describe('computeAnnouncementStatus', () => {
   it.each([
     {
-      description: 'unpublished with a future publish time is Scheduled',
-      input: { published: false, published_at: NOW + HOUR },
-      expectedStatus: 'scheduled',
-      expectedLabel: 'Scheduled',
-      expectedTone: 'orange'
-    },
-    {
-      description: 'unpublished with no publish time is Draft',
-      input: { published: false, published_at: null },
-      expectedStatus: 'draft',
-      expectedLabel: 'Draft',
-      expectedTone: 'gray'
-    },
-    {
-      description: 'unpublished with a past publish time is Draft',
-      input: { published: false, published_at: NOW - HOUR },
+      description: 'unpublished is Draft',
+      input: { published: false },
       expectedStatus: 'draft',
       expectedLabel: 'Draft',
       expectedTone: 'gray'

--- a/lib/components/admin-announcements/announcementStatus.ts
+++ b/lib/components/admin-announcements/announcementStatus.ts
@@ -1,0 +1,44 @@
+import type { ServerAnnouncement } from '@/lib/client'
+
+export type AnnouncementStatus = 'published' | 'scheduled' | 'draft' | 'expired'
+
+export interface AnnouncementStatusDescriptor {
+  status: AnnouncementStatus
+  label: string
+  tone: 'green' | 'orange' | 'gray'
+}
+
+const DESCRIPTORS: Record<AnnouncementStatus, AnnouncementStatusDescriptor> = {
+  published: { status: 'published', label: 'Published', tone: 'green' },
+  scheduled: { status: 'scheduled', label: 'Scheduled', tone: 'orange' },
+  draft: { status: 'draft', label: 'Draft', tone: 'gray' },
+  expired: { status: 'expired', label: 'Expired', tone: 'gray' }
+}
+
+// Derives the lifecycle status of an announcement from its existing fields
+// relative to `currentTime` (epoch-ms). No backend support is required:
+// - not published, with a future publish time -> Scheduled
+// - not published, otherwise                   -> Draft
+// - published, with an end time in the past    -> Expired
+// - published, otherwise (active)              -> Published
+export const computeAnnouncementStatus = (
+  announcement: Pick<
+    ServerAnnouncement,
+    'published' | 'published_at' | 'ends_at'
+  >,
+  currentTime: number
+): AnnouncementStatusDescriptor => {
+  if (!announcement.published) {
+    if (
+      announcement.published_at !== null &&
+      announcement.published_at > currentTime
+    ) {
+      return DESCRIPTORS.scheduled
+    }
+    return DESCRIPTORS.draft
+  }
+  if (announcement.ends_at !== null && announcement.ends_at < currentTime) {
+    return DESCRIPTORS.expired
+  }
+  return DESCRIPTORS.published
+}

--- a/lib/components/admin-announcements/announcementStatus.ts
+++ b/lib/components/admin-announcements/announcementStatus.ts
@@ -1,6 +1,6 @@
 import type { ServerAnnouncement } from '@/lib/client'
 
-export type AnnouncementStatus = 'published' | 'scheduled' | 'draft' | 'expired'
+export type AnnouncementStatus = 'published' | 'draft' | 'expired'
 
 export interface AnnouncementStatusDescriptor {
   status: AnnouncementStatus
@@ -10,31 +10,26 @@ export interface AnnouncementStatusDescriptor {
 
 const DESCRIPTORS: Record<AnnouncementStatus, AnnouncementStatusDescriptor> = {
   published: { status: 'published', label: 'Published', tone: 'green' },
-  scheduled: { status: 'scheduled', label: 'Scheduled', tone: 'orange' },
   draft: { status: 'draft', label: 'Draft', tone: 'gray' },
   expired: { status: 'expired', label: 'Expired', tone: 'gray' }
 }
 
 // Derives the lifecycle status of an announcement from its existing fields
 // relative to `currentTime` (epoch-ms). No backend support is required:
-// - not published, with a future publish time -> Scheduled
-// - not published, otherwise                   -> Draft
-// - published, with an end time in the past    -> Expired
-// - published, otherwise (active)              -> Published
+// - not published                          -> Draft
+// - published, with an end time in the past -> Expired
+// - published, otherwise (active)           -> Published
+//
+// A "Scheduled" (future publish-at) state is intentionally not modeled: the
+// backend stamps `published_at` only when an announcement is published
+// (publishedAt = published ? currentTime : null in lib/database/sql), so an
+// unpublished announcement always has `published_at === null` and the admin
+// form exposes no publish-at input. Re-add it when scheduled publishing ships.
 export const computeAnnouncementStatus = (
-  announcement: Pick<
-    ServerAnnouncement,
-    'published' | 'published_at' | 'ends_at'
-  >,
+  announcement: Pick<ServerAnnouncement, 'published' | 'ends_at'>,
   currentTime: number
 ): AnnouncementStatusDescriptor => {
   if (!announcement.published) {
-    if (
-      announcement.published_at !== null &&
-      announcement.published_at > currentTime
-    ) {
-      return DESCRIPTORS.scheduled
-    }
     return DESCRIPTORS.draft
   }
   if (announcement.ends_at !== null && announcement.ends_at < currentTime) {

--- a/lib/components/admin-announcements/announcementStatus.ts
+++ b/lib/components/admin-announcements/announcementStatus.ts
@@ -1,6 +1,6 @@
 import type { ServerAnnouncement } from '@/lib/client'
 
-export type AnnouncementStatus = 'published' | 'draft' | 'expired'
+export type AnnouncementStatus = 'published' | 'scheduled' | 'draft' | 'expired'
 
 export interface AnnouncementStatusDescriptor {
   status: AnnouncementStatus
@@ -10,23 +10,31 @@ export interface AnnouncementStatusDescriptor {
 
 const DESCRIPTORS: Record<AnnouncementStatus, AnnouncementStatusDescriptor> = {
   published: { status: 'published', label: 'Published', tone: 'green' },
+  scheduled: { status: 'scheduled', label: 'Scheduled', tone: 'orange' },
   draft: { status: 'draft', label: 'Draft', tone: 'gray' },
   expired: { status: 'expired', label: 'Expired', tone: 'gray' }
 }
 
 // Derives the lifecycle status of an announcement from its existing fields
 // relative to `currentTime` (epoch-ms). No backend support is required:
-// - not published                          -> Draft
-// - published, with an end time in the past -> Expired
-// - published, otherwise (active)           -> Published
+// - not published                              -> Draft
+// - published, with an end time in the past    -> Expired
+// - published, with a future event start time  -> Scheduled
+// - published, otherwise (active)              -> Published
 //
-// A "Scheduled" (future publish-at) state is intentionally not modeled: the
-// backend stamps `published_at` only when an announcement is published
-// (publishedAt = published ? currentTime : null in lib/database/sql), so an
-// unpublished announcement always has `published_at === null` and the admin
-// form exposes no publish-at input. Re-add it when scheduled publishing ships.
+// The "Scheduled" state matches getActiveAnnouncements' start-window filter
+// (`startsAt IS NULL OR startsAt <= now` in lib/database/sql/announcement.ts):
+// a published announcement whose `starts_at` is still in the future is hidden
+// from the public banner, so the admin badge must not read "Published" for it.
+//
+// A future *publish-at* (as opposed to event start) state is intentionally not
+// modeled: the backend stamps `published_at` only when an announcement is
+// published (publishedAt = published ? currentTime : null in lib/database/sql),
+// so an unpublished announcement always has `published_at === null` and the
+// admin form exposes no publish-at input. Re-add it when scheduled publishing
+// ships.
 export const computeAnnouncementStatus = (
-  announcement: Pick<ServerAnnouncement, 'published' | 'ends_at'>,
+  announcement: Pick<ServerAnnouncement, 'published' | 'starts_at' | 'ends_at'>,
   currentTime: number
 ): AnnouncementStatusDescriptor => {
   if (!announcement.published) {
@@ -34,6 +42,9 @@ export const computeAnnouncementStatus = (
   }
   if (announcement.ends_at !== null && announcement.ends_at < currentTime) {
     return DESCRIPTORS.expired
+  }
+  if (announcement.starts_at !== null && announcement.starts_at > currentTime) {
+    return DESCRIPTORS.scheduled
   }
   return DESCRIPTORS.published
 }

--- a/lib/components/announcements/AnnouncementBanner.test.tsx
+++ b/lib/components/announcements/AnnouncementBanner.test.tsx
@@ -58,7 +58,12 @@ describe('AnnouncementBanner', () => {
   })
 
   afterEach(() => {
-    jest.runOnlyPendingTimers()
+    // Flush any pending mark-read timer inside act() so the timer's
+    // setAnnouncements update is wrapped, avoiding "not wrapped in act(...)"
+    // warnings during teardown.
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
     jest.useRealTimers()
   })
 
@@ -279,6 +284,78 @@ describe('AnnouncementBanner', () => {
     // A reaction at zero disappears.
     expect(
       screen.queryByRole('button', { name: /👍 reaction/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('adds your reaction to an existing chip you do not own, bumping the count and pressing it', async () => {
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({
+        read: true,
+        reactions: [{ name: '👍', count: 2, me: false }]
+      })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    // Read-only list defaults collapsed; expand to reveal the reaction row.
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+
+    const chip = await screen.findByRole('button', {
+      name: /add 👍 reaction/i
+    })
+    await act(async () => {
+      fireEvent.click(chip)
+    })
+
+    expect(mockAddAnnouncementReaction).toHaveBeenCalledWith(
+      'announcement-1',
+      '👍'
+    )
+    // The optimistic update bumps the count and flips ownership on.
+    const pressed = await screen.findByRole('button', {
+      name: /remove 👍 reaction/i
+    })
+    expect(pressed).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('closes the reaction picker when Escape is pressed', async () => {
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({ read: true, reactions: [] })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add reaction/i }))
+    })
+
+    // The picker is open: a quick-emoji button is visible.
+    expect(
+      screen.getByRole('button', { name: /react with 🎉/i })
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' })
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /react with 🎉/i })
     ).not.toBeInTheDocument()
   })
 })

--- a/lib/components/announcements/AnnouncementBanner.test.tsx
+++ b/lib/components/announcements/AnnouncementBanner.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import type { Announcement } from '@/lib/types/mastodon/announcement'
 
@@ -10,10 +10,16 @@ import { AnnouncementBanner } from './AnnouncementBanner'
 
 const mockGetAnnouncements = jest.fn()
 const mockDismissAnnouncement = jest.fn()
+const mockAddAnnouncementReaction = jest.fn()
+const mockRemoveAnnouncementReaction = jest.fn()
 
 jest.mock('@/lib/client', () => ({
   getAnnouncements: () => mockGetAnnouncements(),
-  dismissAnnouncement: (id: string) => mockDismissAnnouncement(id)
+  dismissAnnouncement: (id: string) => mockDismissAnnouncement(id),
+  addAnnouncementReaction: (id: string, name: string) =>
+    mockAddAnnouncementReaction(id, name),
+  removeAnnouncementReaction: (id: string, name: string) =>
+    mockRemoveAnnouncementReaction(id, name)
 }))
 
 const buildAnnouncement = (
@@ -35,73 +41,244 @@ const buildAnnouncement = (
   ...overrides
 })
 
+const renderBanner = () =>
+  render(<AnnouncementBanner host="llun.test" currentTime={1735689600000} />)
+
 describe('AnnouncementBanner', () => {
   beforeEach(() => {
+    jest.useFakeTimers()
     mockGetAnnouncements.mockReset()
     mockDismissAnnouncement.mockReset()
+    mockAddAnnouncementReaction.mockReset()
+    mockRemoveAnnouncementReaction.mockReset()
     mockDismissAnnouncement.mockResolvedValue(true)
+    mockAddAnnouncementReaction.mockResolvedValue(true)
+    mockRemoveAnnouncementReaction.mockResolvedValue(true)
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  it('renders nothing when there are no announcements', async () => {
+    mockGetAnnouncements.mockResolvedValue([])
+
+    let container: HTMLElement
+    await act(async () => {
+      ;({ container } = renderBanner())
+    })
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+
+    expect(container!).toBeEmptyDOMElement()
   })
 
   it('renders an unread announcement content after loading', async () => {
     mockGetAnnouncements.mockResolvedValue([buildAnnouncement()])
 
-    render(<AnnouncementBanner host="llun.test" currentTime={1735689600000} />)
+    await act(async () => {
+      renderBanner()
+    })
 
     expect(
       await screen.findByText('Scheduled maintenance tonight')
     ).toBeInTheDocument()
   })
 
-  it('dismisses an announcement and hides it locally when dismiss is clicked', async () => {
-    mockGetAnnouncements.mockResolvedValue([buildAnnouncement()])
-
-    render(<AnnouncementBanner host="llun.test" currentTime={1735689600000} />)
-
-    const content = await screen.findByText('Scheduled maintenance tonight')
-    expect(content).toBeInTheDocument()
-
-    const dismissButton = screen.getByRole('button', {
-      name: /dismiss announcement/i
-    })
-    fireEvent.click(dismissButton)
-
-    expect(mockDismissAnnouncement).toHaveBeenCalledWith('announcement-1')
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText('Scheduled maintenance tonight')
-      ).not.toBeInTheDocument()
-    })
-  })
-
-  it('renders nothing when all announcements are already read', async () => {
+  it('renders both read and unread active announcements with a pager', async () => {
     mockGetAnnouncements.mockResolvedValue([
-      buildAnnouncement({ read: true, content: '<p>Already read</p>' })
+      buildAnnouncement({ id: 'a1', content: '<p>First</p>', read: false }),
+      buildAnnouncement({ id: 'a2', content: '<p>Second</p>', read: true })
     ])
 
-    const { container } = render(
-      <AnnouncementBanner host="llun.test" currentTime={1735689600000} />
-    )
-
-    await waitFor(() => {
-      expect(mockGetAnnouncements).toHaveBeenCalled()
+    await act(async () => {
+      renderBanner()
     })
 
-    expect(screen.queryByText('Already read')).not.toBeInTheDocument()
-    expect(container).toBeEmptyDOMElement()
+    expect(await screen.findByText('First')).toBeInTheDocument()
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
   })
 
-  it('renders nothing when there are no announcements', async () => {
-    mockGetAnnouncements.mockResolvedValue([])
+  it('pages forward and back across multiple announcements', async () => {
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({ id: 'a1', content: '<p>First</p>' }),
+      buildAnnouncement({ id: 'a2', content: '<p>Second</p>', read: true })
+    ])
 
-    const { container } = render(
-      <AnnouncementBanner host="llun.test" currentTime={1735689600000} />
-    )
+    await act(async () => {
+      renderBanner()
+    })
+
+    expect(await screen.findByText('First')).toBeInTheDocument()
+
+    const next = screen.getByRole('button', { name: /next announcement/i })
+    await act(async () => {
+      fireEvent.click(next)
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+    expect(screen.getByText('2 / 2')).toBeInTheDocument()
+
+    const previous = screen.getByRole('button', {
+      name: /previous announcement/i
+    })
+    await act(async () => {
+      fireEvent.click(previous)
+    })
+    expect(screen.getByText('First')).toBeInTheDocument()
+  })
+
+  it('collapses and expands, persisting the choice to localStorage', async () => {
+    // An unread announcement auto-expands by default, so the body is visible.
+    mockGetAnnouncements.mockResolvedValue([buildAnnouncement({ read: false })])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    expect(
+      await screen.findByText('Scheduled maintenance tonight')
+    ).toBeInTheDocument()
+
+    const header = screen.getByRole('button', { name: /announcements/i })
+    await act(async () => {
+      fireEvent.click(header)
+    })
+
+    expect(
+      screen.queryByText('Scheduled maintenance tonight')
+    ).not.toBeInTheDocument()
+    expect(window.localStorage.getItem('announcements:collapsed')).toBe('true')
+
+    // Expanding again writes the inverse preference.
+    await act(async () => {
+      fireEvent.click(header)
+    })
+    expect(
+      screen.getByText('Scheduled maintenance tonight')
+    ).toBeInTheDocument()
+    expect(window.localStorage.getItem('announcements:collapsed')).toBe('false')
+  })
+
+  it('starts collapsed when localStorage stored a collapsed preference', async () => {
+    window.localStorage.setItem('announcements:collapsed', 'true')
+    mockGetAnnouncements.mockResolvedValue([buildAnnouncement()])
+
+    await act(async () => {
+      renderBanner()
+    })
 
     await waitFor(() => {
       expect(mockGetAnnouncements).toHaveBeenCalled()
     })
 
-    expect(container).toBeEmptyDOMElement()
+    // The header is present, but the body content is hidden while collapsed.
+    expect(screen.getByText('Announcements')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Scheduled maintenance tonight')
+    ).not.toBeInTheDocument()
+  })
+
+  it('marks an unread announcement read on view, draining the count but keeping the item', async () => {
+    mockGetAnnouncements.mockResolvedValue([buildAnnouncement()])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    expect(
+      await screen.findByText('Scheduled maintenance tonight')
+    ).toBeInTheDocument()
+    // The unread badge shows before the mark-read timer fires.
+    expect(screen.getByText('1 new')).toBeInTheDocument()
+
+    await act(async () => {
+      jest.advanceTimersByTime(900)
+    })
+
+    expect(mockDismissAnnouncement).toHaveBeenCalledWith('announcement-1')
+    // The count drains, but the announcement stays in the banner.
+    await waitFor(() => {
+      expect(screen.queryByText('1 new')).not.toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Scheduled maintenance tonight')
+    ).toBeInTheDocument()
+  })
+
+  it('adds a reaction optimistically and calls the add client function', async () => {
+    // Read-only so no mark-read timer competes; the banner defaults collapsed
+    // for an all-read list, so expand it before reacting.
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({ read: true, reactions: [] })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+    expect(
+      await screen.findByText('Scheduled maintenance tonight')
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add reaction/i }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /react with 🎉/i }))
+    })
+
+    expect(mockAddAnnouncementReaction).toHaveBeenCalledWith(
+      'announcement-1',
+      '🎉'
+    )
+    // The new chip appears with a count of 1.
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('toggles off an owned reaction, removing the chip and calling the remove client function', async () => {
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({
+        read: true,
+        reactions: [{ name: '👍', count: 1, me: true }]
+      })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    // Read-only list defaults collapsed; expand to reveal the reaction row.
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+
+    const chip = await screen.findByRole('button', {
+      name: /remove 👍 reaction/i
+    })
+    await act(async () => {
+      fireEvent.click(chip)
+    })
+
+    expect(mockRemoveAnnouncementReaction).toHaveBeenCalledWith(
+      'announcement-1',
+      '👍'
+    )
+    // A reaction at zero disappears.
+    expect(
+      screen.queryByRole('button', { name: /👍 reaction/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/lib/components/announcements/AnnouncementBanner.test.tsx
+++ b/lib/components/announcements/AnnouncementBanner.test.tsx
@@ -42,7 +42,7 @@ const buildAnnouncement = (
 })
 
 const renderBanner = () =>
-  render(<AnnouncementBanner host="llun.test" currentTime={1735689600000} />)
+  render(<AnnouncementBanner currentTime={1735689600000} />)
 
 describe('AnnouncementBanner', () => {
   beforeEach(() => {
@@ -185,6 +185,13 @@ describe('AnnouncementBanner', () => {
     expect(
       screen.queryByText('Scheduled maintenance tonight')
     ).not.toBeInTheDocument()
+
+    // The mark-read-on-view timer must not fire while collapsed, so a collapsed
+    // banner never silently drains the unread count.
+    await act(async () => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(mockDismissAnnouncement).not.toHaveBeenCalled()
   })
 
   it('marks an unread announcement read on view, draining the count but keeping the item', async () => {
@@ -341,14 +348,21 @@ describe('AnnouncementBanner', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
     })
+
+    const addButton = screen.getByRole('button', { name: /add reaction/i })
+    expect(addButton).toHaveAttribute('aria-haspopup', 'dialog')
+    expect(addButton).toHaveAttribute('aria-expanded', 'false')
+
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /add reaction/i }))
+      fireEvent.click(addButton)
     })
 
-    // The picker is open: a quick-emoji button is visible.
+    // The picker is open: a quick-emoji button is visible and the trigger
+    // reports its expanded state to assistive tech.
     expect(
       screen.getByRole('button', { name: /react with 🎉/i })
     ).toBeInTheDocument()
+    expect(addButton).toHaveAttribute('aria-expanded', 'true')
 
     await act(async () => {
       fireEvent.keyDown(document, { key: 'Escape' })
@@ -357,5 +371,110 @@ describe('AnnouncementBanner', () => {
     expect(
       screen.queryByRole('button', { name: /react with 🎉/i })
     ).not.toBeInTheDocument()
+    expect(addButton).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('does not call the add client function when re-picking an emoji you already own', async () => {
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({
+        read: true,
+        reactions: [{ name: '👍', count: 1, me: true }]
+      })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add reaction/i }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /react with 👍/i }))
+    })
+
+    // Re-picking an emoji you already own is a no-op: no PUT and no count bump.
+    expect(mockAddAnnouncementReaction).not.toHaveBeenCalled()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('reverts the optimistic add when the add request fails', async () => {
+    mockAddAnnouncementReaction.mockResolvedValueOnce(false)
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({ read: true, reactions: [] })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add reaction/i }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /react with 🎉/i }))
+    })
+
+    expect(mockAddAnnouncementReaction).toHaveBeenCalledWith(
+      'announcement-1',
+      '🎉'
+    )
+    // The optimistic chip is rolled back to the prior (empty) state.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /🎉 reaction/i })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('reverts the optimistic removal when the remove request fails', async () => {
+    mockRemoveAnnouncementReaction.mockResolvedValueOnce(false)
+    mockGetAnnouncements.mockResolvedValue([
+      buildAnnouncement({
+        read: true,
+        reactions: [{ name: '👍', count: 3, me: true }]
+      })
+    ])
+
+    await act(async () => {
+      renderBanner()
+    })
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalled()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /announcements/i }))
+    })
+
+    const chip = await screen.findByRole('button', {
+      name: /remove 👍 reaction/i
+    })
+    await act(async () => {
+      fireEvent.click(chip)
+    })
+
+    expect(mockRemoveAnnouncementReaction).toHaveBeenCalledWith(
+      'announcement-1',
+      '👍'
+    )
+    // The owned chip reappears with its original count and pressed state.
+    const restored = await screen.findByRole('button', {
+      name: /remove 👍 reaction/i
+    })
+    expect(restored).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('3')).toBeInTheDocument()
   })
 })

--- a/lib/components/announcements/AnnouncementBanner.tsx
+++ b/lib/components/announcements/AnnouncementBanner.tsx
@@ -7,7 +7,7 @@ import {
   Megaphone,
   SmilePlus
 } from 'lucide-react'
-import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   addAnnouncementReaction,
@@ -129,25 +129,41 @@ interface ReactionPickerProps {
   onClose: () => void
 }
 
-const ReactionPicker: FC<ReactionPickerProps> = ({ onPick, onClose }) => (
-  <>
-    {/* Outside-click overlay closes the picker. */}
-    <div className="fixed inset-0 z-30" onClick={onClose} />
-    <div className="bg-popover absolute bottom-9 left-0 z-40 flex gap-1 rounded-xl border p-1.5 shadow-lg">
-      {QUICK_EMOJI.map((emoji) => (
-        <button
-          key={emoji}
-          type="button"
-          aria-label={`React with ${emoji}`}
-          onClick={() => onPick(emoji)}
-          className="hover:bg-muted flex h-8 w-8 items-center justify-center rounded-lg text-lg transition-colors"
-        >
-          {emoji}
-        </button>
-      ))}
-    </div>
-  </>
-)
+const ReactionPicker: FC<ReactionPickerProps> = ({ onPick, onClose }) => {
+  // Escape closes the picker, matching the post-box emoji picker so keyboard
+  // users can dismiss it without clicking the outside overlay.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <>
+      {/* Outside-click overlay closes the picker. */}
+      <div className="fixed inset-0 z-30" onClick={onClose} />
+      <div
+        role="dialog"
+        aria-label="Choose a reaction"
+        className="bg-popover absolute bottom-9 left-0 z-40 flex gap-1 rounded-xl border p-1.5 shadow-lg"
+      >
+        {QUICK_EMOJI.map((emoji) => (
+          <button
+            key={emoji}
+            type="button"
+            aria-label={`React with ${emoji}`}
+            onClick={() => onPick(emoji)}
+            className="hover:bg-muted flex h-8 w-8 items-center justify-center rounded-lg text-lg transition-colors"
+          >
+            {emoji}
+          </button>
+        ))}
+      </div>
+    </>
+  )
+}
 
 interface ReactionRowProps {
   reactions: AnnouncementReaction[]
@@ -188,7 +204,6 @@ const ReactionRow: FC<ReactionRowProps> = ({ reactions, onToggle, onAdd }) => {
 }
 
 interface AnnouncementBannerProps {
-  host: string
   // Forwarded for consistency with other timeline client components and to keep
   // time-dependent output deterministic between SSR and hydration. The banner
   // never reads the wall clock during render — it uses `currentTime` if it ever
@@ -204,8 +219,10 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
   // localStorage during render.
   const [collapsed, setCollapsed] = useState<boolean | null>(null)
   // Ids whose mark-read-on-view timer has already fired, so each announcement
-  // dismisses at most once even as the pager moves back and forth.
-  const [dismissed] = useState<Set<string>>(() => new Set())
+  // dismisses at most once even as the pager moves back and forth. A ref (not
+  // state) — it is only ever mutated in place, and its stable identity keeps it
+  // out of the mark-read effect's dependency array.
+  const dismissed = useRef<Set<string>>(new Set())
 
   // Load the active announcements (read + unread) once on mount; the banner
   // pages across all of them rather than filtering to unread.
@@ -263,10 +280,10 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
   // "New" badge) and the orange "{n} new" count drains live. Fired once per id.
   useEffect(() => {
     if (isCollapsed || !current || current.read !== false) return
-    if (dismissed.has(current.id)) return
+    if (dismissed.current.has(current.id)) return
     const id = current.id
     const timer = setTimeout(() => {
-      dismissed.add(id)
+      dismissed.current.add(id)
       setAnnouncements((previous) =>
         previous.map((announcement) =>
           announcement.id === id
@@ -277,21 +294,22 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
       void dismissAnnouncement(id)
     }, 900)
     return () => clearTimeout(timer)
-  }, [current, isCollapsed, dismissed])
+  }, [current, isCollapsed])
 
   const toggleCollapsed = useCallback(() => {
-    setCollapsed((previous) => {
-      const next = !(previous ?? false)
-      if (typeof window !== 'undefined') {
-        try {
-          window.localStorage.setItem(COLLAPSE_STORAGE_KEY, String(next))
-        } catch {
-          // Ignore storage write failures.
-        }
+    // Compute the next value from current state and set it directly; the
+    // localStorage write is a side effect kept out of the state updater (which
+    // must stay pure — React may re-invoke it under StrictMode/concurrency).
+    const next = !(collapsed ?? false)
+    setCollapsed(next)
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(COLLAPSE_STORAGE_KEY, String(next))
+      } catch {
+        // Ignore storage write failures.
       }
-      return next
-    })
-  }, [])
+    }
+  }, [collapsed])
 
   // Applies a reaction transform to the currently visible announcement only.
   const mutateReactions = useCallback(
@@ -312,14 +330,14 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
   )
 
   // Adding an emoji: bump + set `me` if the chip exists (no-op when already
-  // yours), otherwise append a new chip. Always PUT.
+  // yours), otherwise append a new chip. Always PUT, reverting the optimistic
+  // chip/count if the request fails (mirrors AnnouncementsPanel's rollback).
   const onAdd = useCallback(
-    (name: string) => {
+    async (name: string) => {
       if (!current) return
       const id = current.id
-      const existing = current.reactions.find(
-        (reaction) => reaction.name === name
-      )
+      const previous = current.reactions
+      const existing = previous.find((reaction) => reaction.name === name)
       if (existing?.me) return
       mutateReactions((reactions) =>
         reactions.some((reaction) => reaction.name === name)
@@ -330,20 +348,21 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
             )
           : [...reactions, { name, count: 1, me: true }]
       )
-      void addAnnouncementReaction(id, name)
+      const ok = await addAnnouncementReaction(id, name).catch(() => false)
+      if (!ok) mutateReactions(() => previous)
     },
     [current, mutateReactions]
   )
 
   // Toggling a chip you own removes your reaction (count-1; the chip disappears
   // at 0) and calls DELETE. Toggling one you don't own adds your reaction.
+  // Reverts the optimistic update if the DELETE fails.
   const onToggle = useCallback(
-    (name: string) => {
+    async (name: string) => {
       if (!current) return
       const id = current.id
-      const existing = current.reactions.find(
-        (reaction) => reaction.name === name
-      )
+      const previous = current.reactions
+      const existing = previous.find((reaction) => reaction.name === name)
       if (existing?.me) {
         mutateReactions((reactions) =>
           reactions
@@ -354,9 +373,10 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
             )
             .filter((reaction) => reaction.count > 0)
         )
-        void removeAnnouncementReaction(id, name)
+        const ok = await removeAnnouncementReaction(id, name).catch(() => false)
+        if (!ok) mutateReactions(() => previous)
       } else {
-        onAdd(name)
+        await onAdd(name)
       }
     },
     [current, mutateReactions, onAdd]
@@ -378,10 +398,12 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
   const eventStart = current.starts_at
     ? formatEventBound(current.starts_at, current.all_day)
     : null
-  const eventEnd =
-    !current.all_day && current.ends_at
-      ? formatEventBound(current.ends_at, current.all_day)
-      : null
+  // Render the end bound whenever one exists, including all-day events spanning
+  // multiple days. formatEventBound strips the clock when all_day is true, so an
+  // all-day range shows dates only and never leaks a time.
+  const eventEnd = current.ends_at
+    ? formatEventBound(current.ends_at, current.all_day)
+    : null
 
   return (
     <div className="bg-background/80 rounded-2xl border shadow-sm backdrop-blur">

--- a/lib/components/announcements/AnnouncementBanner.tsx
+++ b/lib/components/announcements/AnnouncementBanner.tsx
@@ -43,18 +43,28 @@ const formatPublishedDate = (iso: string): string => {
   })
 }
 
-// "Sat Jun 13, 09:00" for a timed event; "Sat Jun 13" when all-day. Times are
-// stored in UTC and rendered in the reader's local timezone.
+// "Sat Jun 13, 09:00" for a timed event; "Sat Jun 13" when all-day. Timed
+// events are stored in UTC and rendered in the reader's local timezone. All-day
+// events store a UTC-midnight instant that represents a calendar date, so they
+// are rendered in UTC to show that exact day rather than shifting it across the
+// date line for readers west of UTC.
 const formatEventBound = (iso: string, allDay: boolean): string => {
   const time = Date.parse(iso)
   if (Number.isNaN(time)) return ''
   const date = new Date(time)
+  if (allDay) {
+    return date.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC'
+    })
+  }
   const day = date.toLocaleDateString(undefined, {
     weekday: 'short',
     month: 'short',
     day: 'numeric'
   })
-  if (allDay) return day
   const clock = date.toLocaleTimeString(undefined, {
     hour: '2-digit',
     minute: '2-digit'
@@ -79,7 +89,7 @@ export const AnnouncementBadge: FC<BadgeProps> = ({
   const tones: Record<NonNullable<BadgeProps['tone']>, string> = {
     orange: 'border-primary/30 bg-primary/10 text-primary',
     green:
-      'border-emerald-600/30 bg-emerald-600/10 text-emerald-700 dark:text-emerald-400',
+      'border-green-600/30 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
     gray: 'border-border bg-muted text-muted-foreground'
   }
   return (
@@ -142,8 +152,9 @@ const ReactionPicker: FC<ReactionPickerProps> = ({ onPick, onClose }) => {
 
   return (
     <>
-      {/* Outside-click overlay closes the picker. */}
-      <div className="fixed inset-0 z-30" onClick={onClose} />
+      {/* Outside-click overlay closes the picker. aria-hidden keeps this
+          full-viewport click target out of the accessibility tree. */}
+      <div className="fixed inset-0 z-30" aria-hidden onClick={onClose} />
       <div
         role="dialog"
         aria-label="Choose a reaction"
@@ -185,6 +196,8 @@ const ReactionRow: FC<ReactionRowProps> = ({ reactions, onToggle, onAdd }) => {
       <button
         type="button"
         aria-label="Add reaction"
+        aria-haspopup="dialog"
+        aria-expanded={picking}
         onClick={() => setPicking((previous) => !previous)}
         className="border-border bg-background text-muted-foreground hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors"
       >
@@ -291,7 +304,32 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
             : announcement
         )
       )
+      // Mirror the reaction handlers' guard: swallow a network-layer rejection
+      // so the fired timer never produces an unhandled promise rejection. On
+      // failure, revert the optimistic local read flip and clear the dismissed
+      // marker so a later view retries the dismiss.
       void dismissAnnouncement(id)
+        .then((ok) => {
+          if (ok) return
+          dismissed.current.delete(id)
+          setAnnouncements((previous) =>
+            previous.map((announcement) =>
+              announcement.id === id
+                ? { ...announcement, read: false }
+                : announcement
+            )
+          )
+        })
+        .catch(() => {
+          dismissed.current.delete(id)
+          setAnnouncements((previous) =>
+            previous.map((announcement) =>
+              announcement.id === id
+                ? { ...announcement, read: false }
+                : announcement
+            )
+          )
+        })
     }, 900)
     return () => clearTimeout(timer)
   }, [current, isCollapsed])

--- a/lib/components/announcements/AnnouncementBanner.tsx
+++ b/lib/components/announcements/AnnouncementBanner.tsx
@@ -1,83 +1,220 @@
 'use client'
 
-import { Megaphone, X } from 'lucide-react'
-import { FC, useEffect, useMemo, useState } from 'react'
-
-import { dismissAnnouncement, getAnnouncements } from '@/lib/client'
-import { Button } from '@/lib/components/ui/button'
 import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle
-} from '@/lib/components/ui/card'
-import type { Announcement } from '@/lib/types/mastodon/announcement'
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Megaphone,
+  SmilePlus
+} from 'lucide-react'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+
+import {
+  addAnnouncementReaction,
+  dismissAnnouncement,
+  getAnnouncements,
+  removeAnnouncementReaction
+} from '@/lib/client'
+import type {
+  Announcement,
+  AnnouncementReaction
+} from '@/lib/types/mastodon/announcement'
+import { cn } from '@/lib/utils'
 import { cleanClassName } from '@/lib/utils/text/cleanClassName'
 
-interface AnnouncementCardProps {
-  host: string
-  announcement: Announcement
-  onDismiss: (id: string) => void
+// Quick-access unicode emoji offered by the reaction picker. Instance-level
+// only — no custom per-account stickers (see design spec).
+const QUICK_EMOJI = ['👍', '❤️', '🎉', '🔥', '👋', '🙏', '😂', '🚀']
+
+// Counts of 100+ collapse to "99+" per the design voice rules.
+const formatCount = (count: number): string => (count > 99 ? '99+' : `${count}`)
+
+// localStorage key for the per-device collapse preference.
+const COLLAPSE_STORAGE_KEY = 'announcements:collapsed'
+
+// "Jun 8, 2026" — the published date in the meta row.
+const formatPublishedDate = (iso: string): string => {
+  const time = Date.parse(iso)
+  if (Number.isNaN(time)) return ''
+  return new Date(time).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
 }
 
-const AnnouncementCard: FC<AnnouncementCardProps> = ({
-  announcement,
-  onDismiss
-}) => {
-  // The announcement content is markdown-rendered and sanitized HTML produced
-  // server-side by the same status pipeline (convertMarkdownText -> sanitizeText
-  // -> sanitizeTrustedStatusText in getMastodonAnnouncement), so the only
-  // remaining step is turning that HTML into React nodes — the final
-  // `cleanClassName` step the Post component runs. We never use
-  // dangerouslySetInnerHTML.
-  const content = useMemo(
-    () => cleanClassName(announcement.content),
-    [announcement.content]
-  )
+// "Sat Jun 13, 09:00" for a timed event; "Sat Jun 13" when all-day. Times are
+// stored in UTC and rendered in the reader's local timezone.
+const formatEventBound = (iso: string, allDay: boolean): string => {
+  const time = Date.parse(iso)
+  if (Number.isNaN(time)) return ''
+  const date = new Date(time)
+  const day = date.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  })
+  if (allDay) return day
+  const clock = date.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+  return `${day}, ${clock}`
+}
 
+interface BadgeProps {
+  tone?: 'orange' | 'green' | 'gray'
+  className?: string
+  children: React.ReactNode
+}
+
+// Small inline pill used for the unread count, "New" flag, and admin lifecycle
+// status. The app has no shared shadcn Badge primitive (NotificationBadge is an
+// absolute-positioned overlay), so this maps the design tones to token classes.
+export const AnnouncementBadge: FC<BadgeProps> = ({
+  tone = 'orange',
+  className,
+  children
+}) => {
+  const tones: Record<NonNullable<BadgeProps['tone']>, string> = {
+    orange: 'border-primary/30 bg-primary/10 text-primary',
+    green:
+      'border-emerald-600/30 bg-emerald-600/10 text-emerald-700 dark:text-emerald-400',
+    gray: 'border-border bg-muted text-muted-foreground'
+  }
   return (
-    <Card className="border-primary/30 bg-primary/5">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Megaphone className="size-4 text-primary" />
-          Announcement
-        </CardTitle>
-        <CardAction>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Dismiss announcement"
-            onClick={() => onDismiss(announcement.id)}
-          >
-            <X className="size-4" />
-          </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="text-sm leading-relaxed break-words [&_a]:text-sky-600 dark:[&_a]:text-sky-400 [&_a]:underline [&_a]:underline-offset-2 [&_p]:mb-2 last:[&_p]:mb-0">
-        {content}
-      </CardContent>
-    </Card>
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+        tones[tone],
+        className
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+interface ReactionChipProps {
+  reaction: AnnouncementReaction
+  onToggle: () => void
+}
+
+const ReactionChip: FC<ReactionChipProps> = ({ reaction, onToggle }) => (
+  <button
+    type="button"
+    onClick={onToggle}
+    aria-pressed={reaction.me}
+    aria-label={
+      reaction.me
+        ? `Remove ${reaction.name} reaction`
+        : `Add ${reaction.name} reaction`
+    }
+    className={cn(
+      'flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-[13px] transition-colors',
+      reaction.me
+        ? 'border-primary/45 bg-primary/10 text-primary'
+        : 'border-border bg-background text-foreground hover:bg-muted'
+    )}
+  >
+    <span aria-hidden="true">{reaction.name}</span>
+    <span className="text-xs font-medium tabular-nums">
+      {formatCount(reaction.count)}
+    </span>
+  </button>
+)
+
+interface ReactionPickerProps {
+  onPick: (name: string) => void
+  onClose: () => void
+}
+
+const ReactionPicker: FC<ReactionPickerProps> = ({ onPick, onClose }) => (
+  <>
+    {/* Outside-click overlay closes the picker. */}
+    <div className="fixed inset-0 z-30" onClick={onClose} />
+    <div className="bg-popover absolute bottom-9 left-0 z-40 flex gap-1 rounded-xl border p-1.5 shadow-lg">
+      {QUICK_EMOJI.map((emoji) => (
+        <button
+          key={emoji}
+          type="button"
+          aria-label={`React with ${emoji}`}
+          onClick={() => onPick(emoji)}
+          className="hover:bg-muted flex h-8 w-8 items-center justify-center rounded-lg text-lg transition-colors"
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  </>
+)
+
+interface ReactionRowProps {
+  reactions: AnnouncementReaction[]
+  onToggle: (name: string) => void
+  onAdd: (name: string) => void
+}
+
+const ReactionRow: FC<ReactionRowProps> = ({ reactions, onToggle, onAdd }) => {
+  const [picking, setPicking] = useState(false)
+  return (
+    <div className="relative flex flex-wrap items-center gap-1.5">
+      {reactions.map((reaction) => (
+        <ReactionChip
+          key={reaction.name}
+          reaction={reaction}
+          onToggle={() => onToggle(reaction.name)}
+        />
+      ))}
+      <button
+        type="button"
+        aria-label="Add reaction"
+        onClick={() => setPicking((previous) => !previous)}
+        className="border-border bg-background text-muted-foreground hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors"
+      >
+        <SmilePlus className="size-3.5" />
+      </button>
+      {picking && (
+        <ReactionPicker
+          onClose={() => setPicking(false)}
+          onPick={(emoji) => {
+            onAdd(emoji)
+            setPicking(false)
+          }}
+        />
+      )}
+    </div>
   )
 }
 
 interface AnnouncementBannerProps {
   host: string
-  // Forwarded for consistency with other timeline client components; the banner
-  // does not currently render relative timestamps, so it never reads the wall
-  // clock during render.
+  // Forwarded for consistency with other timeline client components and to keep
+  // time-dependent output deterministic between SSR and hydration. The banner
+  // never reads the wall clock during render — it uses `currentTime` if it ever
+  // needs "now".
   currentTime: number
 }
 
-export const AnnouncementBanner: FC<AnnouncementBannerProps> = ({ host }) => {
+export const AnnouncementBanner: FC<AnnouncementBannerProps> = () => {
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
+  const [index, setIndex] = useState(0)
+  // `null` until the stored preference resolves on mount; until then we render
+  // expanded-by-default to avoid an SSR/first-paint flash from reading
+  // localStorage during render.
+  const [collapsed, setCollapsed] = useState<boolean | null>(null)
+  // Ids whose mark-read-on-view timer has already fired, so each announcement
+  // dismisses at most once even as the pager moves back and forth.
+  const [dismissed] = useState<Set<string>>(() => new Set())
 
+  // Load the active announcements (read + unread) once on mount; the banner
+  // pages across all of them rather than filtering to unread.
   useEffect(() => {
     let active = true
     getAnnouncements()
       .then((loaded) => {
         if (!active) return
-        setAnnouncements(loaded.filter((announcement) => !announcement.read))
+        setAnnouncements(loaded)
       })
       .catch(() => {
         // A failure to load announcements degrades to showing no banner rather
@@ -88,27 +225,254 @@ export const AnnouncementBanner: FC<AnnouncementBannerProps> = ({ host }) => {
     }
   }, [])
 
-  const onDismiss = (id: string) => {
-    // Optimistically hide the dismissed announcement; the server call marks it
-    // read so it does not return on the next load.
-    setAnnouncements((previous) =>
-      previous.filter((announcement) => announcement.id !== id)
-    )
-    void dismissAnnouncement(id)
-  }
+  // Resolve the per-device collapse preference after mount. Default to expanded
+  // when there are unread announcements; otherwise respect the stored value.
+  useEffect(() => {
+    if (collapsed !== null || announcements.length === 0) return
+    let stored: string | null = null
+    if (typeof window !== 'undefined') {
+      try {
+        stored = window.localStorage.getItem(COLLAPSE_STORAGE_KEY)
+      } catch {
+        // Ignore storage access errors (private mode, disabled storage).
+      }
+    }
+    if (stored === 'true' || stored === 'false') {
+      setCollapsed(stored === 'true')
+    } else {
+      const hasUnread = announcements.some(
+        (announcement) => announcement.read === false
+      )
+      setCollapsed(!hasUnread)
+    }
+  }, [announcements, collapsed])
+
+  const isCollapsed = collapsed ?? false
+  const unreadCount = useMemo(
+    () =>
+      announcements.filter((announcement) => announcement.read === false)
+        .length,
+    [announcements]
+  )
+  const safeIndex = Math.min(index, Math.max(announcements.length - 1, 0))
+  const current = announcements[safeIndex]
+
+  // Mark-read-on-view: an unread, expanded announcement that stays visible for
+  // ~900ms fires POST dismiss and flips to read locally. "Dismiss" means mark
+  // READ, not remove — the announcement stays in the pager (it just loses the
+  // "New" badge) and the orange "{n} new" count drains live. Fired once per id.
+  useEffect(() => {
+    if (isCollapsed || !current || current.read !== false) return
+    if (dismissed.has(current.id)) return
+    const id = current.id
+    const timer = setTimeout(() => {
+      dismissed.add(id)
+      setAnnouncements((previous) =>
+        previous.map((announcement) =>
+          announcement.id === id
+            ? { ...announcement, read: true }
+            : announcement
+        )
+      )
+      void dismissAnnouncement(id)
+    }, 900)
+    return () => clearTimeout(timer)
+  }, [current, isCollapsed, dismissed])
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed((previous) => {
+      const next = !(previous ?? false)
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem(COLLAPSE_STORAGE_KEY, String(next))
+        } catch {
+          // Ignore storage write failures.
+        }
+      }
+      return next
+    })
+  }, [])
+
+  // Applies a reaction transform to the currently visible announcement only.
+  const mutateReactions = useCallback(
+    (
+      transform: (reactions: AnnouncementReaction[]) => AnnouncementReaction[]
+    ) => {
+      if (!current) return
+      const id = current.id
+      setAnnouncements((previous) =>
+        previous.map((announcement) =>
+          announcement.id === id
+            ? { ...announcement, reactions: transform(announcement.reactions) }
+            : announcement
+        )
+      )
+    },
+    [current]
+  )
+
+  // Adding an emoji: bump + set `me` if the chip exists (no-op when already
+  // yours), otherwise append a new chip. Always PUT.
+  const onAdd = useCallback(
+    (name: string) => {
+      if (!current) return
+      const id = current.id
+      const existing = current.reactions.find(
+        (reaction) => reaction.name === name
+      )
+      if (existing?.me) return
+      mutateReactions((reactions) =>
+        reactions.some((reaction) => reaction.name === name)
+          ? reactions.map((reaction) =>
+              reaction.name === name
+                ? { ...reaction, me: true, count: reaction.count + 1 }
+                : reaction
+            )
+          : [...reactions, { name, count: 1, me: true }]
+      )
+      void addAnnouncementReaction(id, name)
+    },
+    [current, mutateReactions]
+  )
+
+  // Toggling a chip you own removes your reaction (count-1; the chip disappears
+  // at 0) and calls DELETE. Toggling one you don't own adds your reaction.
+  const onToggle = useCallback(
+    (name: string) => {
+      if (!current) return
+      const id = current.id
+      const existing = current.reactions.find(
+        (reaction) => reaction.name === name
+      )
+      if (existing?.me) {
+        mutateReactions((reactions) =>
+          reactions
+            .map((reaction) =>
+              reaction.name === name
+                ? { ...reaction, me: false, count: reaction.count - 1 }
+                : reaction
+            )
+            .filter((reaction) => reaction.count > 0)
+        )
+        void removeAnnouncementReaction(id, name)
+      } else {
+        onAdd(name)
+      }
+    },
+    [current, mutateReactions, onAdd]
+  )
+
+  // The HTML content is server-rendered and sanitized by the status pipeline
+  // (convertMarkdownText -> sanitizeText -> sanitizeTrustedStatusText). The only
+  // remaining step is turning that HTML into React nodes via cleanClassName — we
+  // never use dangerouslySetInnerHTML.
+  const content = useMemo(
+    () => (current ? cleanClassName(current.content) : null),
+    [current]
+  )
 
   if (announcements.length === 0) return null
+  if (!current) return null
+
+  const hasMultiple = announcements.length > 1
+  const eventStart = current.starts_at
+    ? formatEventBound(current.starts_at, current.all_day)
+    : null
+  const eventEnd =
+    !current.all_day && current.ends_at
+      ? formatEventBound(current.ends_at, current.all_day)
+      : null
 
   return (
-    <div className="space-y-4">
-      {announcements.map((announcement) => (
-        <AnnouncementCard
-          key={announcement.id}
-          host={host}
-          announcement={announcement}
-          onDismiss={onDismiss}
-        />
-      ))}
+    <div className="bg-background/80 rounded-2xl border shadow-sm backdrop-blur">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        aria-expanded={!isCollapsed}
+        className="flex w-full items-center gap-2.5 px-4 py-3 text-left"
+      >
+        <span className="bg-primary/10 text-primary flex h-7 w-7 items-center justify-center rounded-lg">
+          <Megaphone className="size-[15px]" />
+        </span>
+        <span className="text-sm font-semibold">Announcements</span>
+        {unreadCount > 0 && (
+          <AnnouncementBadge tone="orange">
+            {formatCount(unreadCount)} new
+          </AnnouncementBadge>
+        )}
+        <span className="text-muted-foreground ml-auto flex items-center gap-2">
+          {!isCollapsed && hasMultiple && (
+            <span className="text-xs tabular-nums">
+              {safeIndex + 1} / {announcements.length}
+            </span>
+          )}
+          {isCollapsed ? (
+            <ChevronDown className="size-4" />
+          ) : (
+            <ChevronUp className="size-4" />
+          )}
+        </span>
+      </button>
+
+      {!isCollapsed && (
+        <div className="space-y-3 border-t px-4 pt-3 pb-4">
+          <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            <span suppressHydrationWarning>
+              {formatPublishedDate(current.published_at)}
+            </span>
+            {eventStart && (
+              <span className="text-primary flex items-center gap-1 font-medium">
+                <Clock className="size-3" />
+                <span suppressHydrationWarning>
+                  {eventStart}
+                  {eventEnd ? ` – ${eventEnd}` : ''}
+                </span>
+              </span>
+            )}
+            {current.read === false && (
+              <AnnouncementBadge tone="orange">New</AnnouncementBadge>
+            )}
+          </div>
+
+          <div className="text-sm leading-relaxed break-words [&_a]:text-sky-600 [&_a]:underline [&_a]:underline-offset-2 dark:[&_a]:text-sky-400 [&_p]:mb-2 last:[&_p]:mb-0">
+            {content}
+          </div>
+
+          <div className="flex items-end justify-between gap-3">
+            <ReactionRow
+              reactions={current.reactions}
+              onToggle={onToggle}
+              onAdd={onAdd}
+            />
+            {hasMultiple && (
+              <div className="flex shrink-0 gap-1">
+                <button
+                  type="button"
+                  aria-label="Previous announcement"
+                  disabled={safeIndex === 0}
+                  onClick={() => setIndex((value) => Math.max(value - 1, 0))}
+                  className="border-border bg-background hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors disabled:opacity-40"
+                >
+                  <ChevronUp className="size-3.5 -rotate-90" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next announcement"
+                  disabled={safeIndex === announcements.length - 1}
+                  onClick={() =>
+                    setIndex((value) =>
+                      Math.min(value + 1, announcements.length - 1)
+                    )
+                  }
+                  className="border-border bg-background hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors disabled:opacity-40"
+                >
+                  <ChevronDown className="size-3.5 -rotate-90" />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Redesign the Home announcements banner into a single **collapsible box** with a **pager** across all active (non-expired, published) announcements rather than one card per announcement.
- **Mark read on view**: an expanded, unread announcement is dismissed (`POST /api/v1/announcements/:id/dismiss`) after it has been visible briefly; dismiss means mark read, so the item stays in the banner and the orange "{n} new" count drains live.
- Show **event windows** (publish date plus a Clock-prefixed start/end range) and persist the collapse state per device via localStorage (default expanded when there are unread items, otherwise respect the stored preference).
- Add unicode **emoji reactions**: reaction chips with counts, an "Add reaction" quick-emoji picker, and optimistic add/toggle behavior, backed by new `lib/client.ts` wrappers `addAnnouncementReaction` / `removeAnnouncementReaction` over the existing reactions API.
- Align the admin announcements panel to the design system with computed **lifecycle status badges** (Draft / Scheduled / Published / Expired), translating the design kit's raw `hsl()` styles to the app's Tailwind v4 / shadcn token classes and reusing existing primitives (Badge, Button, Switch, Textarea, Input).

## Design source

Anthropic design project "Activities.next Design System", `ui_kits/web/announcements.html`. Note: there were **no design screenshots** for announcements in the design project, so this follows that spec (the kit JSX) directly. The kit's raw `hsl()` inline styles are CDN-only artifacts and are translated to the existing app token classes here.

## Out of scope

Streaming announcement events (`announcement`, `announcement.reaction`, `announcement.delete`) are **not** implemented. The banner still fetches announcements on mount as it does today; live streaming is noted here as future work. No new backend endpoints or migrations — this uses only the API already in the service.

## Test plan

`yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally. New / expanded tests:

- `lib/components/admin-announcements/announcementStatus.test.ts` — table-driven `computeAnnouncementStatus` cases (scheduled / draft / published / expired across publish and end times).
- `lib/components/announcements/AnnouncementBanner.test.tsx` — renders nothing when empty; renders unread content after load; shows a pager for multiple active announcements; pages forward/back; collapse/expand persists to localStorage; starts collapsed from a stored preference; marks unread read on view (drains the count, keeps the item); adds a reaction optimistically; toggles off an owned reaction (removes the chip and calls the remove client function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)