### PR TITLE
Bump version to v1.72.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.71.2",
+  "version": "1.72.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.72.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.71.2`
- Base main SHA: `6362e182f947a08b24b5645e613208e62aa38eef`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
