### PR TITLE
minor: add preferences settings page

### DIFF
--- a/app/(timeline)/settings/layout.tsx
+++ b/app/(timeline)/settings/layout.tsx
@@ -8,6 +8,7 @@ import {
   Image as ImageIcon,
   Monitor,
   Settings as SettingsIcon,
+  SlidersHorizontal,
   User,
   VolumeX
 } from 'lucide-react'
@@ -29,6 +30,11 @@ interface Props {
 const tabs: SectionNavTab[] = [
   { name: 'General', url: '/settings', icon: SettingsIcon },
   { name: 'Account', url: '/settings/account', icon: User },
+  {
+    name: 'Preferences',
+    url: '/settings/preferences',
+    icon: SlidersHorizontal
+  },
   {
     name: 'Featured hashtags',
     url: '/settings/featured-hashtags',

--- a/app/(timeline)/settings/preferences/page.tsx
+++ b/app/(timeline)/settings/preferences/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 const Page = async () => {
   const database = getDatabase()
   if (!database) {
-    throw new Error('Fail to load database')
+    throw new Error('Failed to load database')
   }
 
   const session = await getServerAuthSession()

--- a/app/(timeline)/settings/preferences/page.tsx
+++ b/app/(timeline)/settings/preferences/page.tsx
@@ -1,0 +1,43 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+
+import { PreferencesSettings } from '@/lib/components/settings/PreferencesSettings'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Activities.next: Preferences'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) {
+    throw new Error('Fail to load database')
+  }
+
+  const session = await getServerAuthSession()
+  const actor = await getActorFromSession(database, session)
+  if (!actor || !actor.account) {
+    return redirect('/auth/signin')
+  }
+
+  const settings = await database.getActorSettings({ actorId: actor.id })
+
+  return (
+    <PreferencesSettings
+      initialPreferences={{
+        visibility: settings?.defaultPrivacy ?? 'public',
+        sensitive: settings?.defaultSensitive ?? false,
+        language: settings?.defaultLanguage ?? 'en',
+        expandMedia: settings?.readingExpandMedia ?? 'default',
+        expandSpoilers: settings?.readingExpandSpoilers ?? false,
+        autoplayGifs: settings?.readingAutoplayGifs ?? false
+      }}
+    />
+  )
+}
+
+export default Page

--- a/app/api/v1/accounts/reading-preferences/route.test.ts
+++ b/app/api/v1/accounts/reading-preferences/route.test.ts
@@ -95,6 +95,14 @@ describe('POST /api/v1/accounts/reading-preferences', () => {
     expect(res.status).toBe(400)
   })
 
+  it('returns 400 for an empty body without persisting', async () => {
+    const res = await POST(buildRequest(JSON.stringify({})), {
+      params: Promise.resolve({})
+    })
+    expect(res.status).toBe(400)
+    expect(mockDb.updateActor).not.toHaveBeenCalled()
+  })
+
   it('persists reading preferences for the current actor', async () => {
     const res = await POST(
       buildRequest(

--- a/app/api/v1/accounts/reading-preferences/route.test.ts
+++ b/app/api/v1/accounts/reading-preferences/route.test.ts
@@ -1,0 +1,131 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { POST } from './route'
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+jest.mock('@/lib/config', () => ({
+  getBaseURL: jest.fn().mockReturnValue('https://llun.test'),
+  getConfig: jest.fn().mockReturnValue({
+    host: 'llun.test',
+    allowEmails: [],
+    allowActorDomains: []
+  })
+}))
+
+type MockDatabase = Pick<
+  Database,
+  | 'getAccountFromEmail'
+  | 'getActorsForAccount'
+  | 'getActorFromId'
+  | 'getActorSettings'
+  | 'updateActor'
+>
+
+let mockDatabase: MockDatabase | null = null
+jest.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn().mockResolvedValue({
+    get: () => undefined
+  })
+}))
+
+const actor = { ...seedActor1, id: ACTOR1_ID }
+
+const buildRequest = (body: string) =>
+  new NextRequest('http://localhost/api/v1/accounts/reading-preferences', {
+    method: 'POST',
+    body,
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'https://llun.test'
+    }
+  })
+
+describe('POST /api/v1/accounts/reading-preferences', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getAccountFromEmail: jest.fn(),
+    getActorsForAccount: jest.fn(),
+    getActorFromId: jest.fn(),
+    getActorSettings: jest.fn(),
+    updateActor: jest.fn()
+  }
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockDb.getAccountFromEmail.mockResolvedValue({
+      id: 'account1',
+      email: seedActor1.email,
+      defaultActorId: ACTOR1_ID
+    })
+    mockDb.getActorsForAccount.mockResolvedValue([actor])
+    mockDb.getActorFromId.mockResolvedValue(actor)
+    mockDb.getActorSettings.mockResolvedValue(null)
+    mockDb.updateActor.mockResolvedValue(undefined as never)
+  })
+
+  it('returns 400 for invalid JSON body', async () => {
+    const res = await POST(buildRequest('not-json'), {
+      params: Promise.resolve({})
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for body failing schema validation', async () => {
+    const res = await POST(
+      buildRequest(JSON.stringify({ readingExpandMedia: 'sometimes' })),
+      { params: Promise.resolve({}) }
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('persists reading preferences for the current actor', async () => {
+    const res = await POST(
+      buildRequest(
+        JSON.stringify({
+          readingExpandMedia: 'show_all',
+          readingExpandSpoilers: true,
+          readingAutoplayGifs: false
+        })
+      ),
+      { params: Promise.resolve({}) }
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('OK')
+    expect(mockDb.updateActor).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID,
+      readingExpandMedia: 'show_all',
+      readingExpandSpoilers: true,
+      readingAutoplayGifs: false
+    })
+  })
+
+  it('accepts a partial update', async () => {
+    const res = await POST(
+      buildRequest(JSON.stringify({ readingAutoplayGifs: true })),
+      { params: Promise.resolve({}) }
+    )
+    expect(res.status).toBe(200)
+    expect(mockDb.updateActor).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID,
+      readingAutoplayGifs: true
+    })
+  })
+})

--- a/app/api/v1/accounts/reading-preferences/route.ts
+++ b/app/api/v1/accounts/reading-preferences/route.ts
@@ -9,11 +9,17 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 // GET /api/v1/preferences endpoint stays read-only by design, so the
 // Preferences settings page saves reading defaults here while posting defaults
 // go through the standard PATCH /api/v1/accounts/update_credentials.
-const ReadingPreferencesRequest = z.object({
-  readingExpandMedia: z.enum(['default', 'show_all', 'hide_all']).optional(),
-  readingExpandSpoilers: z.boolean().optional(),
-  readingAutoplayGifs: z.boolean().optional()
-})
+const ReadingPreferencesRequest = z
+  .object({
+    readingExpandMedia: z.enum(['default', 'show_all', 'hide_all']).optional(),
+    readingExpandSpoilers: z.boolean().optional(),
+    readingAutoplayGifs: z.boolean().optional()
+  })
+  // Require at least one known key so an empty (or unknown-only) body doesn't
+  // trigger a no-op updateActor write.
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one reading preference is required'
+  })
 
 export const POST = traceApiRoute(
   'updateReadingPreferences',

--- a/app/api/v1/accounts/reading-preferences/route.ts
+++ b/app/api/v1/accounts/reading-preferences/route.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { apiErrorResponse, apiResponse } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+// Web-internal write path for the Mastodon `reading:*` preferences. These are
+// private per-user settings persisted on the actor; the public
+// GET /api/v1/preferences endpoint stays read-only by design, so the
+// Preferences settings page saves reading defaults here while posting defaults
+// go through the standard PATCH /api/v1/accounts/update_credentials.
+const ReadingPreferencesRequest = z.object({
+  readingExpandMedia: z.enum(['default', 'show_all', 'hide_all']).optional(),
+  readingExpandSpoilers: z.boolean().optional(),
+  readingAutoplayGifs: z.boolean().optional()
+})
+
+export const POST = traceApiRoute(
+  'updateReadingPreferences',
+  AuthenticatedGuard(async (req, { currentActor, database }) => {
+    let body
+    try {
+      body = await req.json()
+    } catch {
+      return apiErrorResponse(400)
+    }
+
+    const parsed = ReadingPreferencesRequest.safeParse(body)
+    if (!parsed.success) {
+      return apiErrorResponse(400)
+    }
+
+    await database.updateActor({
+      actorId: currentActor.id,
+      ...parsed.data
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: ['POST'],
+      data: { status: 'OK' }
+    })
+  })
+)

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2095,6 +2095,51 @@ export const updatePushNotifications = async (
   return response.ok
 }
 
+// --- Preferences ---
+
+export interface PreferencesInput {
+  // Posting defaults — saved through the standard Mastodon credential endpoint.
+  visibility: 'public' | 'unlisted' | 'private' | 'direct'
+  sensitive: boolean
+  language: string
+  // Reading preferences — saved through the web-internal endpoint.
+  expandMedia: 'default' | 'show_all' | 'hide_all'
+  expandSpoilers: boolean
+  autoplayGifs: boolean
+}
+
+// Persists posting defaults and reading preferences. Posting defaults go to
+// PATCH /api/v1/accounts/update_credentials (the documented Mastodon write path
+// third-party clients also use); reading preferences go to the web-internal
+// endpoint since GET /api/v1/preferences is read-only by design.
+export const updatePreferences = async (
+  preferences: PreferencesInput
+): Promise<boolean> => {
+  const [postingResponse, readingResponse] = await Promise.all([
+    fetch('/api/v1/accounts/update_credentials', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: {
+          privacy: preferences.visibility,
+          sensitive: preferences.sensitive,
+          language: preferences.language
+        }
+      })
+    }),
+    fetch('/api/v1/accounts/reading-preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        readingExpandMedia: preferences.expandMedia,
+        readingExpandSpoilers: preferences.expandSpoilers,
+        readingAutoplayGifs: preferences.autoplayGifs
+      })
+    })
+  ])
+  return postingResponse.ok && readingResponse.ok
+}
+
 // Fitness Route Heatmap
 
 export interface FitnessRouteHeatmapPoint {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2112,32 +2112,37 @@ export interface PreferencesInput {
 // PATCH /api/v1/accounts/update_credentials (the documented Mastodon write path
 // third-party clients also use); reading preferences go to the web-internal
 // endpoint since GET /api/v1/preferences is read-only by design.
+//
+// The two writes run sequentially: if the posting-defaults PATCH fails we skip
+// the reading POST entirely, so a failure can't leave a half-applied state.
+// Both writes are idempotent, so retrying after any failure re-applies the
+// identical payloads safely.
 export const updatePreferences = async (
   preferences: PreferencesInput
 ): Promise<boolean> => {
-  const [postingResponse, readingResponse] = await Promise.all([
-    fetch('/api/v1/accounts/update_credentials', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        source: {
-          privacy: preferences.visibility,
-          sensitive: preferences.sensitive,
-          language: preferences.language
-        }
-      })
-    }),
-    fetch('/api/v1/accounts/reading-preferences', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        readingExpandMedia: preferences.expandMedia,
-        readingExpandSpoilers: preferences.expandSpoilers,
-        readingAutoplayGifs: preferences.autoplayGifs
-      })
+  const postingResponse = await fetch('/api/v1/accounts/update_credentials', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      source: {
+        privacy: preferences.visibility,
+        sensitive: preferences.sensitive,
+        language: preferences.language
+      }
     })
-  ])
-  return postingResponse.ok && readingResponse.ok
+  })
+  if (!postingResponse.ok) return false
+
+  const readingResponse = await fetch('/api/v1/accounts/reading-preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      readingExpandMedia: preferences.expandMedia,
+      readingExpandSpoilers: preferences.expandSpoilers,
+      readingAutoplayGifs: preferences.autoplayGifs
+    })
+  })
+  return readingResponse.ok
 }
 
 // Fitness Route Heatmap

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2113,10 +2113,12 @@ export interface PreferencesInput {
 // third-party clients also use); reading preferences go to the web-internal
 // endpoint since GET /api/v1/preferences is read-only by design.
 //
-// The two writes run sequentially: if the posting-defaults PATCH fails we skip
-// the reading POST entirely, so a failure can't leave a half-applied state.
-// Both writes are idempotent, so retrying after any failure re-applies the
-// identical payloads safely.
+// The two writes run sequentially and the reading POST is skipped if the
+// posting PATCH fails. This narrows — but does not eliminate — the partial-
+// update window: if the PATCH succeeds and the POST then fails, the posting
+// defaults are already persisted while the reading prefs are not. Both writes
+// are idempotent, so retrying after any failure re-applies the identical
+// payloads and converges to a consistent state.
 export const updatePreferences = async (
   preferences: PreferencesInput
 ): Promise<boolean> => {

--- a/lib/components/settings/PreferencesSettings.test.tsx
+++ b/lib/components/settings/PreferencesSettings.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { PreferencesInput } from '@/lib/client'
+
+import { PreferencesSettings } from './PreferencesSettings'
+
+const mockUpdatePreferences = jest.fn()
+
+jest.mock('@/lib/client', () => ({
+  updatePreferences: (preferences: unknown) =>
+    mockUpdatePreferences(preferences)
+}))
+
+const initialPreferences: PreferencesInput = {
+  visibility: 'public',
+  sensitive: false,
+  language: 'en',
+  expandMedia: 'default',
+  expandSpoilers: false,
+  autoplayGifs: false
+}
+
+describe('PreferencesSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUpdatePreferences.mockResolvedValue(true)
+  })
+
+  it('renders posting defaults and reading sections', () => {
+    render(<PreferencesSettings initialPreferences={initialPreferences} />)
+
+    expect(screen.getByText('Posting defaults')).toBeInTheDocument()
+    expect(screen.getByText('Reading')).toBeInTheDocument()
+    expect(screen.getByLabelText('Posting privacy')).toBeInTheDocument()
+    expect(screen.getByLabelText('Posting language')).toBeInTheDocument()
+  })
+
+  it('disables Save until a preference changes', () => {
+    render(<PreferencesSettings initialPreferences={initialPreferences} />)
+
+    const save = screen.getByRole('button', { name: 'Save changes' })
+    expect(save).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Posting privacy'), {
+      target: { value: 'unlisted' }
+    })
+    expect(save).toBeEnabled()
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument()
+  })
+
+  it('saves changed preferences and shows the saved badge', async () => {
+    render(<PreferencesSettings initialPreferences={initialPreferences} />)
+
+    fireEvent.change(screen.getByLabelText('Posting language'), {
+      target: { value: 'de' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() =>
+      expect(mockUpdatePreferences).toHaveBeenCalledWith(
+        expect.objectContaining({ language: 'de' })
+      )
+    )
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+
+  it('shows an error message when saving fails', async () => {
+    mockUpdatePreferences.mockResolvedValue(false)
+    render(<PreferencesSettings initialPreferences={initialPreferences} />)
+
+    fireEvent.change(screen.getByLabelText('Posting privacy'), {
+      target: { value: 'private' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    expect(
+      await screen.findByText(/Failed to save preferences/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/lib/components/settings/PreferencesSettings.test.tsx
+++ b/lib/components/settings/PreferencesSettings.test.tsx
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-import { PreferencesInput } from '@/lib/client'
+import type { PreferencesInput } from '@/lib/client'
 
 import { PreferencesSettings } from './PreferencesSettings'
 

--- a/lib/components/settings/PreferencesSettings.test.tsx
+++ b/lib/components/settings/PreferencesSettings.test.tsx
@@ -66,6 +66,9 @@ describe('PreferencesSettings', () => {
       )
     )
     expect(await screen.findByText('Saved')).toBeInTheDocument()
+    // After a successful save the form is no longer dirty, so Save disables
+    // again until the next change.
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled()
   })
 
   it('shows an error message when saving fails', async () => {

--- a/lib/components/settings/PreferencesSettings.tsx
+++ b/lib/components/settings/PreferencesSettings.tsx
@@ -20,7 +20,11 @@ const VISIBILITIES: { value: PostingVisibility; label: string }[] = [
     value: 'unlisted',
     label: 'Unlisted — public, but out of trends and search'
   },
-  { value: 'private', label: 'Followers only' }
+  { value: 'private', label: 'Followers only' },
+  // `direct` is not a typical default, but the account model allows it (e.g. set
+  // by a Mastodon client). Listing it keeps the select from silently rewriting a
+  // stored `direct` default to a different value on save.
+  { value: 'direct', label: 'Direct — only people mentioned' }
 ]
 
 const LANGUAGES: { value: string; label: string }[] = [
@@ -81,6 +85,11 @@ interface Props {
 }
 
 export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
+  // The baseline the form diffs against. Tracked in state (seeded from the
+  // server prop) so a successful save can reset it — otherwise the form would
+  // stay "dirty" against the immutable prop and keep Save enabled.
+  const [savedPreferences, setSavedPreferences] =
+    useState<PreferencesInput>(initialPreferences)
   const [preferences, setPreferences] =
     useState<PreferencesInput>(initialPreferences)
   const [saving, setSaving] = useState(false)
@@ -90,10 +99,27 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
   const dirty = useMemo(
     () =>
       (Object.keys(preferences) as (keyof PreferencesInput)[]).some(
-        (key) => preferences[key] !== initialPreferences[key]
+        (key) => preferences[key] !== savedPreferences[key]
       ),
-    [preferences, initialPreferences]
+    [preferences, savedPreferences]
   )
+
+  // `defaultLanguage` is an arbitrary string in actor settings, so the stored
+  // value may not be in the curated list. Keep it selectable to avoid the
+  // select rendering blank and silently overwriting it on save.
+  const languageOptions = useMemo(() => {
+    if (
+      LANGUAGES.some((option) => option.value === initialPreferences.language)
+    )
+      return LANGUAGES
+    return [
+      {
+        value: initialPreferences.language,
+        label: initialPreferences.language
+      },
+      ...LANGUAGES
+    ]
+  }, [initialPreferences.language])
 
   const update = <K extends keyof PreferencesInput>(
     key: K,
@@ -112,6 +138,7 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
       const ok = await updatePreferences(preferences)
       if (ok) {
         setSaved(true)
+        setSavedPreferences(preferences)
       } else {
         setError('Failed to save preferences. Please try again.')
       }
@@ -162,7 +189,7 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
             value={preferences.language}
             onChange={(event) => update('language', event.target.value)}
           >
-            {LANGUAGES.map((option) => (
+            {languageOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -195,8 +222,11 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
         </div>
 
         <div className="space-y-2">
-          <div className="text-sm font-medium">Media display</div>
+          <div id="media-display-label" className="text-sm font-medium">
+            Media display
+          </div>
           <RadioGroup
+            aria-labelledby="media-display-label"
             value={preferences.expandMedia}
             onValueChange={(value) =>
               update('expandMedia', value as ExpandMedia)
@@ -206,11 +236,10 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
             {MEDIA_DISPLAY.map((option, index) => {
               const active = preferences.expandMedia === option.value
               return (
-                <Label
+                <div
                   key={option.value}
-                  htmlFor={`media-${option.value}`}
                   className={cn(
-                    'flex cursor-pointer items-start gap-3 px-4 py-3 font-normal transition-colors hover:bg-muted/50',
+                    'flex items-start gap-3 px-4 py-3 transition-colors hover:bg-muted/50',
                     index > 0 && 'border-t',
                     active && 'bg-primary/5'
                   )}
@@ -220,15 +249,18 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
                     value={option.value}
                     className="mt-0.5"
                   />
-                  <span className="min-w-0">
+                  <Label
+                    htmlFor={`media-${option.value}`}
+                    className="min-w-0 flex-1 cursor-pointer font-normal"
+                  >
                     <span className="block text-sm font-medium">
                       {option.label}
                     </span>
                     <span className="block text-[0.8rem] text-muted-foreground">
                       {option.help}
                     </span>
-                  </span>
-                </Label>
+                  </Label>
+                </div>
               )
             })}
           </RadioGroup>

--- a/lib/components/settings/PreferencesSettings.tsx
+++ b/lib/components/settings/PreferencesSettings.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { FC, useMemo, useState } from 'react'
+
+import { PreferencesInput, updatePreferences } from '@/lib/client'
+import { PageHeader } from '@/lib/components/page-header'
+import { Button } from '@/lib/components/ui/button'
+import { Label } from '@/lib/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/lib/components/ui/radio-group'
+import { Select } from '@/lib/components/ui/select'
+import { Switch } from '@/lib/components/ui/switch'
+import { cn } from '@/lib/utils'
+
+type PostingVisibility = PreferencesInput['visibility']
+type ExpandMedia = PreferencesInput['expandMedia']
+
+const VISIBILITIES: { value: PostingVisibility; label: string }[] = [
+  { value: 'public', label: 'Public — visible to everyone' },
+  {
+    value: 'unlisted',
+    label: 'Unlisted — public, but out of trends and search'
+  },
+  { value: 'private', label: 'Followers only' }
+]
+
+const LANGUAGES: { value: string; label: string }[] = [
+  { value: 'en', label: 'English' },
+  { value: 'de', label: 'Deutsch' },
+  { value: 'th', label: 'ไทย' },
+  { value: 'ja', label: '日本語' },
+  { value: 'fr', label: 'Français' }
+]
+
+const MEDIA_DISPLAY: { value: ExpandMedia; label: string; help: string }[] = [
+  {
+    value: 'default',
+    label: 'Hide media marked as sensitive',
+    help: 'The default — click to reveal.'
+  },
+  {
+    value: 'show_all',
+    label: 'Show all media',
+    help: 'Including media marked as sensitive.'
+  },
+  {
+    value: 'hide_all',
+    label: 'Hide all media',
+    help: 'Every attachment needs a click to show.'
+  }
+]
+
+// A label/description on the left with its control on the right.
+interface ControlRowProps {
+  label: string
+  description?: string
+  htmlFor?: string
+  children: React.ReactNode
+}
+
+const ControlRow: FC<ControlRowProps> = ({
+  label,
+  description,
+  htmlFor,
+  children
+}) => (
+  <div className="flex items-center justify-between gap-4">
+    <div className="min-w-0 space-y-0.5">
+      <Label htmlFor={htmlFor} className="cursor-pointer">
+        {label}
+      </Label>
+      {description && (
+        <p className="text-[0.8rem] text-muted-foreground">{description}</p>
+      )}
+    </div>
+    <div className="shrink-0">{children}</div>
+  </div>
+)
+
+interface Props {
+  initialPreferences: PreferencesInput
+}
+
+export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
+  const [preferences, setPreferences] =
+    useState<PreferencesInput>(initialPreferences)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const dirty = useMemo(
+    () =>
+      (Object.keys(preferences) as (keyof PreferencesInput)[]).some(
+        (key) => preferences[key] !== initialPreferences[key]
+      ),
+    [preferences, initialPreferences]
+  )
+
+  const update = <K extends keyof PreferencesInput>(
+    key: K,
+    value: PreferencesInput[K]
+  ) => {
+    setPreferences((current) => ({ ...current, [key]: value }))
+    setSaved(false)
+    setError(null)
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setSaved(false)
+    setError(null)
+    try {
+      const ok = await updatePreferences(preferences)
+      if (ok) {
+        setSaved(true)
+      } else {
+        setError('Failed to save preferences. Please try again.')
+      }
+    } catch {
+      setError('Failed to save preferences. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Preferences"
+        description="Defaults for what you post and how your timeline reads. Apps using the Mastodon API pick these up automatically."
+      />
+
+      <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+        <div>
+          <h2 className="text-lg font-semibold">Posting defaults</h2>
+          <p className="text-sm text-muted-foreground">
+            Applied to every new post; you can still change them per post in the
+            composer.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="posting-visibility">Posting privacy</Label>
+          <Select
+            id="posting-visibility"
+            value={preferences.visibility}
+            onChange={(event) =>
+              update('visibility', event.target.value as PostingVisibility)
+            }
+          >
+            {VISIBILITIES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="posting-language">Posting language</Label>
+          <Select
+            id="posting-language"
+            value={preferences.language}
+            onChange={(event) => update('language', event.target.value)}
+          >
+            {LANGUAGES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+          <p className="text-[0.8rem] text-muted-foreground">
+            Lets readers filter public timelines by languages they understand.
+          </p>
+        </div>
+
+        <ControlRow
+          label="Mark media as sensitive by default"
+          description="Every attachment starts hidden behind the sensitive overlay."
+          htmlFor="posting-sensitive"
+        >
+          <Switch
+            id="posting-sensitive"
+            checked={preferences.sensitive}
+            onCheckedChange={(checked) => update('sensitive', checked)}
+          />
+        </ControlRow>
+      </section>
+
+      <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+        <div>
+          <h2 className="text-lg font-semibold">Reading</h2>
+          <p className="text-sm text-muted-foreground">
+            How posts from other people display for you.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Media display</div>
+          <RadioGroup
+            value={preferences.expandMedia}
+            onValueChange={(value) =>
+              update('expandMedia', value as ExpandMedia)
+            }
+            className="gap-0 overflow-hidden rounded-xl border"
+          >
+            {MEDIA_DISPLAY.map((option, index) => {
+              const active = preferences.expandMedia === option.value
+              return (
+                <Label
+                  key={option.value}
+                  htmlFor={`media-${option.value}`}
+                  className={cn(
+                    'flex cursor-pointer items-start gap-3 px-4 py-3 font-normal transition-colors hover:bg-muted/50',
+                    index > 0 && 'border-t',
+                    active && 'bg-primary/5'
+                  )}
+                >
+                  <RadioGroupItem
+                    id={`media-${option.value}`}
+                    value={option.value}
+                    className="mt-0.5"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm font-medium">
+                      {option.label}
+                    </span>
+                    <span className="block text-[0.8rem] text-muted-foreground">
+                      {option.help}
+                    </span>
+                  </span>
+                </Label>
+              )
+            })}
+          </RadioGroup>
+        </div>
+
+        <ControlRow
+          label="Always expand posts marked with content warnings"
+          description="Skip the “show more” click on CW posts."
+          htmlFor="reading-spoilers"
+        >
+          <Switch
+            id="reading-spoilers"
+            checked={preferences.expandSpoilers}
+            onCheckedChange={(checked) => update('expandSpoilers', checked)}
+          />
+        </ControlRow>
+
+        <ControlRow
+          label="Autoplay animated GIFs"
+          description="Off plays them only on hover or tap."
+          htmlFor="reading-gifs"
+        >
+          <Switch
+            id="reading-gifs"
+            checked={preferences.autoplayGifs}
+            onCheckedChange={(checked) => update('autoplayGifs', checked)}
+          />
+        </ControlRow>
+      </section>
+
+      <div className="flex items-center justify-end gap-3">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {!error && saved && (
+          <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+            Saved
+          </span>
+        )}
+        {!error && !saved && dirty && (
+          <span className="text-sm text-muted-foreground">Unsaved changes</span>
+        )}
+        <Button onClick={handleSave} disabled={saving || !dirty}>
+          {saving ? 'Saving…' : 'Save changes'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/components/settings/PreferencesSettings.tsx
+++ b/lib/components/settings/PreferencesSettings.tsx
@@ -293,13 +293,15 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
 
       <div className="flex items-center justify-end gap-3">
         {error && <p className="text-sm text-destructive">{error}</p>}
-        {!error && saved && (
+        {/* Dirty wins over "Saved": if the user edits again (even while a save
+            is in flight) the badge must not claim the form is saved. */}
+        {!error && dirty && (
+          <span className="text-sm text-muted-foreground">Unsaved changes</span>
+        )}
+        {!error && !dirty && saved && (
           <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
             Saved
           </span>
-        )}
-        {!error && !saved && dirty && (
-          <span className="text-sm text-muted-foreground">Unsaved changes</span>
         )}
         <Button onClick={handleSave} disabled={saving || !dirty}>
           {saving ? 'Saving…' : 'Save changes'}

--- a/lib/components/settings/PreferencesSettings.tsx
+++ b/lib/components/settings/PreferencesSettings.tsx
@@ -299,7 +299,7 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
           <span className="text-sm text-muted-foreground">Unsaved changes</span>
         )}
         {!error && !dirty && saved && (
-          <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+          <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
             Saved
           </span>
         )}


### PR DESCRIPTION
## Summary

Implements the **Settings → Preferences** tab from the design-system spec (`ui_kits/web/preferences.html`). It surfaces the posting defaults and reading preferences that the service already backs, mirrored 1:1 to the read-only `GET /api/v1/preferences` payload that third-party Mastodon apps consume.

The design's primary deliverable is the embeddable preferences form (Surface 1). The showcase's live JSON panel and in-context demos are showcase-only by design, so the implementation is the form itself wired to the real API.

## What's included

**New page** — `app/(timeline)/settings/preferences/page.tsx`
- Server component that reads current values from actor settings and renders the form.
- Registered in the settings dropdown sub-nav **after Account** with the Lucide `SlidersHorizontal` icon, matching the design.

**Form** — `lib/components/settings/PreferencesSettings.tsx` (client component)
- **Posting defaults**: posting privacy (select), posting language (select), mark media as sensitive by default (switch).
- **Reading**: media display (radio rows — default / show all / hide all), always expand content warnings (switch), autoplay animated GIFs (switch).
- Save shows an inline **Saved** badge, an **Unsaved changes** hint while dirty, and keeps the form intact on error. Save is disabled until something changes.
- Built entirely from the existing settings primitives (section cards, `Select`, `Switch`, `RadioGroup`, `Button`) so it matches the rest of settings.

**Save paths** (`lib/client.ts` → `updatePreferences`)
- Posting defaults → `PATCH /api/v1/accounts/update_credentials` with `source[privacy|sensitive|language]` — the documented Mastodon write path third-party clients also use.
- Reading preferences → new web-internal `POST /api/v1/accounts/reading-preferences`, since `GET /api/v1/preferences` is read-only by design. The data layer (`updateActor`) already persists all of these fields.

## Scope note

The design also sketches two **web-only** toggles (Group boosts, Slow mode) that it explicitly marks as *not* exposed on the preferences endpoint. The service has no backing for those yet (they'd need new columns + a migration + dual schema-dump regen), so this PR ships the six API-backed Mastodon keys and leaves those two out. They can be a follow-up.

No migrations; no schema changes.

## Testing

- `lib/components/settings/PreferencesSettings.test.tsx` — renders sections, Save gating on dirty state, save success badge, save error message.
- `app/api/v1/accounts/reading-preferences/route.test.ts` — 400 on bad JSON / bad enum, persists full + partial updates to the current actor.
- `yarn lint`, `yarn build`, `yarn test` (4301 tests) all green.
- Verified end-to-end against a local SQLite dev server with a mock user: the page renders all sections, saving posting defaults and reading prefs both return 200, `GET /api/v1/preferences` reflects the saved values, and reloading the page shows the persisted selections.

> Note: ran with Node 22 (the highest available in this environment; the repo targets Node 24).

https://claude.ai/code/session_016u9t31ytJiWSSRajRunboq

---
_Generated by [Claude Code](https://claude.ai/code/session_016u9t31ytJiWSSRajRunboq)_