### PR TITLE
Bump version to v1.73.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 0.0.0.0",


### PR DESCRIPTION
Automated version bump to v1.73.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.72.0`
- Base main SHA: `1643e6be095f4e31708271597a4317e45b20feda`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
