### PR TITLE
feat: align admin instance rules editor with design system

### DIFF
--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -6,7 +6,7 @@ import {
   Globe,
   Hash,
   Megaphone,
-  ScrollText,
+  Scale,
   Settings,
   Smile,
   Users
@@ -31,7 +31,7 @@ const tabs: SectionNavTab[] = [
   { name: 'Accounts', url: '/admin/accounts', icon: Users },
   { name: 'Hashtags', url: '/admin/tags', icon: Hash },
   { name: 'Filters', url: '/admin/filters', icon: Filter },
-  { name: 'Rules', url: '/admin/rules', icon: ScrollText },
+  { name: 'Rules', url: '/admin/rules', icon: Scale },
   { name: 'Announcements', url: '/admin/announcements', icon: Megaphone },
   { name: 'Federation', url: '/admin/federation', icon: Globe },
   { name: 'Custom emojis', url: '/admin/emojis', icon: Smile },

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -127,6 +127,25 @@ describe('RulesPanel', () => {
     expect(await screen.findByText('Be excellent')).toBeInTheDocument()
   })
 
+  it('saves the inline edit when the editor form is submitted', async () => {
+    mockUpdate.mockResolvedValue(
+      rule({ id: '1', text: 'Be kinder', hint: '', position: 0 })
+    )
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))
+    const textField = screen.getByLabelText('Rule text')
+    fireEvent.change(textField, { target: { value: 'Be kinder' } })
+    // Submitting the form (e.g. pressing Enter in the text field) saves.
+    fireEvent.submit(textField.closest('form') as HTMLFormElement)
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith('1', {
+        text: 'Be kinder',
+        hint: ''
+      })
+    )
+    expect(await screen.findByText('Be kinder')).toBeInTheDocument()
+  })
+
   it('deletes a rule optimistically', async () => {
     mockDelete.mockResolvedValue(true)
     await renderPanel()

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  type ServerRule,
+  createServerRule,
+  deleteServerRule,
+  getServerRules,
+  updateServerRule
+} from '@/lib/client'
+
+import { RulesPanel } from './RulesPanel'
+
+jest.mock('@/lib/client', () => ({
+  getServerRules: jest.fn(),
+  createServerRule: jest.fn(),
+  updateServerRule: jest.fn(),
+  deleteServerRule: jest.fn()
+}))
+
+const mockGet = getServerRules as jest.MockedFunction<typeof getServerRules>
+const mockCreate = createServerRule as jest.MockedFunction<
+  typeof createServerRule
+>
+const mockUpdate = updateServerRule as jest.MockedFunction<
+  typeof updateServerRule
+>
+const mockDelete = deleteServerRule as jest.MockedFunction<
+  typeof deleteServerRule
+>
+
+const rule = (over: Partial<ServerRule>): ServerRule => ({
+  id: '1',
+  text: 'Be kind',
+  hint: '',
+  position: 0,
+  ...over
+})
+
+const seed: ServerRule[] = [
+  rule({ id: '1', text: 'Be kind', position: 0 }),
+  rule({ id: '2', text: 'No spam', hint: 'Repetitive promotion', position: 1 })
+]
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGet.mockResolvedValue(seed)
+})
+
+const renderPanel = async () => {
+  render(<RulesPanel />)
+  // Wait for the initial load to resolve so the seeded rules are rendered.
+  expect(await screen.findByText('Be kind')).toBeInTheDocument()
+}
+
+describe('RulesPanel', () => {
+  it('renders the loaded rules in order', async () => {
+    await renderPanel()
+    expect(screen.getByText('No spam')).toBeInTheDocument()
+    expect(screen.getByText('Repetitive promotion')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no rules', async () => {
+    mockGet.mockResolvedValue([])
+    render(<RulesPanel />)
+    expect(
+      await screen.findByText(
+        'No rules yet — add one to show it on the about page.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces a load error instead of the empty state', async () => {
+    mockGet.mockRejectedValue(new Error('boom'))
+    render(<RulesPanel />)
+    expect(
+      await screen.findByText('Failed to load rules. Please try again.')
+    ).toBeInTheDocument()
+  })
+
+  it('creates a rule with a trailing position and clears the input', async () => {
+    mockCreate.mockResolvedValue(
+      rule({ id: '3', text: 'No harassment', position: 2 })
+    )
+    await renderPanel()
+    const input = screen.getByLabelText('New rule text')
+    fireEvent.change(input, { target: { value: 'No harassment' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add rule' }))
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        text: 'No harassment',
+        hint: '',
+        position: 2
+      })
+    )
+    expect(await screen.findByText('No harassment')).toBeInTheDocument()
+    expect(input).toHaveValue('')
+  })
+
+  it('edits a rule inline and saves text and hint', async () => {
+    mockUpdate.mockResolvedValue(
+      rule({
+        id: '1',
+        text: 'Be excellent',
+        hint: 'To each other',
+        position: 0
+      })
+    )
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))
+    fireEvent.change(screen.getByLabelText('Rule text'), {
+      target: { value: 'Be excellent' }
+    })
+    fireEvent.change(screen.getByLabelText('Rule hint'), {
+      target: { value: 'To each other' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith('1', {
+        text: 'Be excellent',
+        hint: 'To each other'
+      })
+    )
+    expect(await screen.findByText('Be excellent')).toBeInTheDocument()
+  })
+
+  it('deletes a rule optimistically', async () => {
+    mockDelete.mockResolvedValue(true)
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete rule 1' }))
+    await waitFor(() =>
+      expect(screen.queryByText('Be kind')).not.toBeInTheDocument()
+    )
+    expect(mockDelete).toHaveBeenCalledWith('1')
+  })
+
+  it('restores the rule when a delete fails', async () => {
+    mockDelete.mockResolvedValue(false)
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete rule 1' }))
+    expect(
+      await screen.findByText('Failed to delete rule. Please try again.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Be kind')).toBeInTheDocument()
+  })
+
+  it('reorders rules with the keyboard and persists new positions', async () => {
+    mockUpdate.mockImplementation(async (id, input) =>
+      rule({ id, position: input.position })
+    )
+    await renderPanel()
+    // Move the first rule ("Be kind") down one slot.
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Reorder rule 1: use arrow up and arrow down keys to move'
+      }),
+      { key: 'ArrowDown' }
+    )
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('2', { position: 0 })
+      expect(mockUpdate).toHaveBeenCalledWith('1', { position: 1 })
+    })
+    // The "No spam" rule is now numbered 1.
+    const grips = screen.getAllByRole('button', { name: /^Reorder rule/ })
+    expect(grips).toHaveLength(2)
+  })
+
+  it('does not persist when reordering past the list boundary', async () => {
+    await renderPanel()
+    // ArrowUp on the first rule is a no-op — nothing to move it above.
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Reorder rule 1: use arrow up and arrow down keys to move'
+      }),
+      { key: 'ArrowUp' }
+    )
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -163,9 +163,12 @@ describe('RulesPanel', () => {
       expect(mockUpdate).toHaveBeenCalledWith('2', { position: 0 })
       expect(mockUpdate).toHaveBeenCalledWith('1', { position: 1 })
     })
-    // The "No spam" rule is now numbered 1.
-    const grips = screen.getAllByRole('button', { name: /^Reorder rule/ })
-    expect(grips).toHaveLength(2)
+    // "No spam" now sits above "Be kind" in document order.
+    const beKind = screen.getByText('Be kind')
+    const noSpam = screen.getByText('No spam')
+    expect(
+      noSpam.compareDocumentPosition(beKind) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   it('resyncs from the server when a reorder write fails', async () => {

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -146,6 +146,26 @@ describe('RulesPanel', () => {
     expect(await screen.findByText('Be kinder')).toBeInTheDocument()
   })
 
+  it('keeps the editor Save and Cancel enabled while editing', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
+  })
+
+  it('surfaces an error and keeps the input when creating fails', async () => {
+    mockCreate.mockResolvedValue(null)
+    await renderPanel()
+    const input = screen.getByLabelText('New rule text')
+    fireEvent.change(input, { target: { value: 'No doxxing' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add rule' }))
+    expect(
+      await screen.findByText('Failed to create rule. Please try again.')
+    ).toBeInTheDocument()
+    // The typed text is preserved so the admin can retry.
+    expect(input).toHaveValue('No doxxing')
+  })
+
   it('locks other list actions while a rule is being edited', async () => {
     await renderPanel()
     fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -146,6 +146,20 @@ describe('RulesPanel', () => {
     expect(await screen.findByText('Be kinder')).toBeInTheDocument()
   })
 
+  it('cancels the inline edit when Escape is pressed', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))
+    const textField = screen.getByLabelText('Rule text')
+    fireEvent.change(textField, { target: { value: 'changed' } })
+    fireEvent.keyDown(textField, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Rule text')).not.toBeInTheDocument()
+    )
+    // The editor closed without saving; the original text is still shown.
+    expect(screen.getByText('Be kind')).toBeInTheDocument()
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
   it('keeps the editor Save and Cancel enabled while editing', async () => {
     await renderPanel()
     fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -168,6 +168,27 @@ describe('RulesPanel', () => {
     expect(grips).toHaveLength(2)
   })
 
+  it('resyncs from the server when a reorder write fails', async () => {
+    mockUpdate.mockResolvedValue(null)
+    const serverOrder: ServerRule[] = [
+      rule({ id: '2', text: 'No spam', position: 0 }),
+      rule({ id: '1', text: 'Be kind', position: 1 })
+    ]
+    // First call is the initial load; second is the post-failure resync.
+    mockGet.mockResolvedValueOnce(seed).mockResolvedValueOnce(serverOrder)
+    await renderPanel()
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Reorder rule 1: use arrow up and arrow down keys to move'
+      }),
+      { key: 'ArrowDown' }
+    )
+    expect(
+      await screen.findByText('Failed to reorder rules. Please try again.')
+    ).toBeInTheDocument()
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+  })
+
   it('does not persist when reordering past the list boundary', async () => {
     await renderPanel()
     // ArrowUp on the first rule is a no-op — nothing to move it above.

--- a/lib/components/admin-rules/RulesPanel.test.tsx
+++ b/lib/components/admin-rules/RulesPanel.test.tsx
@@ -146,6 +146,20 @@ describe('RulesPanel', () => {
     expect(await screen.findByText('Be kinder')).toBeInTheDocument()
   })
 
+  it('locks other list actions while a rule is being edited', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rule 1' }))
+    // The other row's Edit/Delete, both reorder grips, and the Add controls
+    // are disabled so the open editor's draft can't be discarded.
+    expect(screen.getByRole('button', { name: 'Edit rule 2' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Delete rule 2' })).toBeDisabled()
+    screen
+      .getAllByRole('button', { name: /^Reorder rule/ })
+      .forEach((grip) => expect(grip).toBeDisabled())
+    expect(screen.getByLabelText('New rule text')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Add rule' })).toBeDisabled()
+  })
+
   it('deletes a rule optimistically', async () => {
     mockDelete.mockResolvedValue(true)
     await renderPanel()

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -342,7 +342,17 @@ export const RulesPanel: FC = () => {
                 </button>
                 <RuleNumber n={index + 1} />
                 {isEditing ? (
-                  <div className="min-w-0 flex-1 space-y-2">
+                  <form
+                    className="min-w-0 flex-1 space-y-2"
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      // Guard explicitly: pressing Enter can submit even when
+                      // the Save button is disabled. handleEditSave re-checks,
+                      // but bail early here too to avoid a no-op round-trip.
+                      if (savingEdit || editText.trim().length === 0) return
+                      handleEditSave(rule)
+                    }}
+                  >
                     <Input
                       aria-label="Rule text"
                       value={editText}
@@ -359,10 +369,9 @@ export const RulesPanel: FC = () => {
                     />
                     <div className="flex gap-2">
                       <Button
-                        type="button"
+                        type="submit"
                         size="sm"
                         disabled={savingEdit || editText.trim().length === 0}
-                        onClick={() => handleEditSave(rule)}
                       >
                         Save
                       </Button>
@@ -376,7 +385,7 @@ export const RulesPanel: FC = () => {
                         Cancel
                       </Button>
                     </div>
-                  </div>
+                  </form>
                 ) : (
                   <div className="min-w-0 flex-1 pt-0.5">
                     <p className="text-sm leading-snug font-medium">

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -357,11 +357,18 @@ export const RulesPanel: FC = () => {
                       if (savingEdit || editText.trim().length === 0) return
                       handleEditSave(rule)
                     }}
+                    onKeyDown={(event) => {
+                      // Escape cancels the edit, the standard inline-edit
+                      // keyboard affordance.
+                      if (event.key === 'Escape' && !savingEdit) cancelEdit()
+                    }}
                   >
                     <Input
                       aria-label="Rule text"
                       value={editText}
                       maxLength={1000}
+                      required
+                      autoFocus
                       onChange={(event) => setEditText(event.target.value)}
                     />
                     <Textarea
@@ -438,6 +445,7 @@ export const RulesPanel: FC = () => {
             placeholder="Add a rule…"
             value={newText}
             maxLength={1000}
+            required
             disabled={busy || editing}
             onChange={(event) => setNewText(event.target.value)}
           />

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -60,6 +60,11 @@ export const RulesPanel: FC = () => {
   // optimistic snapshot and rolls back to it on failure, so overlapping writes
   // could otherwise restore a stale list.
   const busy = saving || deletingId !== null || savingEdit || reordering
+  // A rule is open in the inline editor. While true, every other list action
+  // (drag, keyboard reorder, other rows' Edit/Delete, the Add form) is blocked
+  // so they can't silently discard the unsaved draft or shift the list under
+  // the open editor.
+  const editing = editingId !== null
   // Synchronous in-flight lock. `busy` is captured in each handler's closure at
   // render time, so two events fired in the same tick (e.g. rapid ArrowDown on
   // the grip before the disabled re-render lands) would both read a stale
@@ -88,7 +93,7 @@ export const RulesPanel: FC = () => {
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const text = newText.trim()
-    if (!text || busy || inFlightRef.current) return
+    if (!text || busy || editing || inFlightRef.current) return
     inFlightRef.current = true
     setSaving(true)
     setFormError(null)
@@ -124,7 +129,7 @@ export const RulesPanel: FC = () => {
   }
 
   const beginEdit = (rule: ServerRule) => {
-    if (busy) return
+    if (busy || editing) return
     setListError(null)
     setEditingId(rule.id)
     setEditText(rule.text)
@@ -289,7 +294,7 @@ export const RulesPanel: FC = () => {
         <div className="divide-y rounded-2xl border bg-background/80 shadow-sm backdrop-blur">
           {rules.map((rule, index) => {
             const isEditing = editingId === rule.id
-            const draggable = !isEditing && !busy
+            const draggable = !busy && !editing
             return (
               <div
                 key={rule.id}
@@ -326,7 +331,7 @@ export const RulesPanel: FC = () => {
                 <button
                   type="button"
                   aria-label={`Reorder rule ${index + 1}: use arrow up and arrow down keys to move`}
-                  disabled={busy || isEditing}
+                  disabled={busy || editing}
                   onKeyDown={(event) => {
                     if (event.key === 'ArrowUp') {
                       event.preventDefault()
@@ -403,7 +408,7 @@ export const RulesPanel: FC = () => {
                     <button
                       type="button"
                       aria-label={`Edit rule ${index + 1}`}
-                      disabled={busy}
+                      disabled={busy || editing}
                       onClick={() => beginEdit(rule)}
                       className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
                     >
@@ -412,7 +417,7 @@ export const RulesPanel: FC = () => {
                     <button
                       type="button"
                       aria-label={`Delete rule ${index + 1}`}
-                      disabled={busy}
+                      disabled={busy || editing}
                       onClick={() => handleDelete(rule)}
                       className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-50"
                     >
@@ -433,9 +438,13 @@ export const RulesPanel: FC = () => {
             placeholder="Add a rule…"
             value={newText}
             maxLength={1000}
+            disabled={busy || editing}
             onChange={(event) => setNewText(event.target.value)}
           />
-          <Button type="submit" disabled={busy || newText.trim().length === 0}>
+          <Button
+            type="submit"
+            disabled={busy || editing || newText.trim().length === 0}
+          >
             <Plus className="size-4" />
             Add rule
           </Button>

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { GripVertical, Pencil, Plus, Trash2 } from 'lucide-react'
-import { FC, FormEvent, useEffect, useState } from 'react'
+import { FC, FormEvent, useEffect, useRef, useState } from 'react'
 
 import {
   type ServerRule,
@@ -53,11 +53,18 @@ export const RulesPanel: FC = () => {
   // The row currently picked up by a drag, used to compute the drop target.
   const [dragIndex, setDragIndex] = useState<number | null>(null)
   const [overIndex, setOverIndex] = useState<number | null>(null)
+  // Polite live-region text announcing a reorder to screen readers.
+  const [reorderStatus, setReorderStatus] = useState('')
 
   // Any in-flight mutation blocks the others: every write path takes an
   // optimistic snapshot and rolls back to it on failure, so overlapping writes
   // could otherwise restore a stale list.
   const busy = saving || deletingId !== null || savingEdit || reordering
+  // Synchronous in-flight lock. `busy` is captured in each handler's closure at
+  // render time, so two events fired in the same tick (e.g. rapid ArrowDown on
+  // the grip before the disabled re-render lands) would both read a stale
+  // `busy === false`. This ref flips synchronously to serialize them.
+  const inFlightRef = useRef(false)
 
   useEffect(() => {
     let active = true
@@ -81,7 +88,8 @@ export const RulesPanel: FC = () => {
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const text = newText.trim()
-    if (!text || busy) return
+    if (!text || busy || inFlightRef.current) return
+    inFlightRef.current = true
     setSaving(true)
     setFormError(null)
     // Append the new rule after the current last one. createInstanceRule
@@ -111,6 +119,7 @@ export const RulesPanel: FC = () => {
       )
     } finally {
       setSaving(false)
+      inFlightRef.current = false
     }
   }
 
@@ -131,15 +140,14 @@ export const RulesPanel: FC = () => {
   const handleEditSave = async (rule: ServerRule) => {
     const text = editText.trim()
     // Bail on an emptied required field or while another write is in flight.
-    if (!text || savingEdit || deletingId !== null || saving || reordering) {
-      return
-    }
+    if (!text || busy || inFlightRef.current) return
     const hint = editHint.trim()
     // Nothing changed — close the editor without a doomed round-trip.
     if (text === rule.text && hint === rule.hint) {
       cancelEdit()
       return
     }
+    inFlightRef.current = true
     setSavingEdit(true)
     setListError(null)
     try {
@@ -157,11 +165,13 @@ export const RulesPanel: FC = () => {
       setListError('Failed to update rule. Please try again.')
     } finally {
       setSavingEdit(false)
+      inFlightRef.current = false
     }
   }
 
   const handleDelete = async (rule: ServerRule) => {
-    if (busy) return
+    if (busy || inFlightRef.current) return
+    inFlightRef.current = true
     setListError(null)
     setDeletingId(rule.id)
     const previous = rules
@@ -180,11 +190,16 @@ export const RulesPanel: FC = () => {
       restoreOnFailure()
     } finally {
       setDeletingId(null)
+      inFlightRef.current = false
     }
   }
 
   // Persist a reorder by writing back the new sequential position of every
-  // rule whose position changed. Rolls the whole list back on any failure.
+  // rule whose position changed. Writes run sequentially (not Promise.all) to
+  // avoid concurrent transactions contending for the same table; the first
+  // failure stops the loop. On any failure the local state can no longer be
+  // trusted (some writes may have landed), so resync from the server rather
+  // than blindly restoring the pre-move snapshot.
   const persistReorder = async (
     reordered: ServerRule[],
     previous: ServerRule[]
@@ -193,37 +208,49 @@ export const RulesPanel: FC = () => {
       const before = previous.find((item) => item.id === rule.id)
       return before === undefined || before.position !== index
     })
-    if (changed.length === 0) return
+    if (changed.length === 0) {
+      inFlightRef.current = false
+      return
+    }
     setReordering(true)
     setListError(null)
     try {
-      const results = await Promise.all(
-        changed.map((rule) =>
-          updateServerRule(rule.id, { position: rule.position })
-        )
-      )
-      if (results.some((result) => result === null)) {
-        throw new Error('Failed to reorder rules. Please try again.')
+      for (const rule of changed) {
+        const updated = await updateServerRule(rule.id, {
+          position: rule.position
+        })
+        if (!updated) {
+          throw new Error('Failed to reorder rules. Please try again.')
+        }
       }
     } catch {
-      setRules(previous)
       setListError('Failed to reorder rules. Please try again.')
+      try {
+        // Resync to the server's actual order after a partial write.
+        const fresh = await getServerRules()
+        setRules(sortRules(fresh))
+      } catch {
+        setRules(previous)
+      }
     } finally {
       setReordering(false)
+      inFlightRef.current = false
     }
   }
 
   const moveRule = (from: number, to: number) => {
-    if (busy) return
+    if (busy || inFlightRef.current) return
     // `reorder` returns the same reference for a no-op or out-of-range move
     // (e.g. ArrowUp on the first row), so bail before normalizing — otherwise
     // `normalize` would allocate a fresh array and could trigger a spurious
     // position write.
     const moved = reorder(rules, from, to)
     if (moved === rules) return
+    inFlightRef.current = true
     const reordered = normalize(moved)
     const previous = rules
     setRules(reordered)
+    setReorderStatus(`Moved rule to position ${to + 1} of ${reordered.length}.`)
     void persistReorder(reordered, previous)
   }
 
@@ -243,6 +270,10 @@ export const RulesPanel: FC = () => {
       />
 
       {listError && <p className="text-sm text-destructive">{listError}</p>}
+
+      <p aria-live="polite" className="sr-only">
+        {reorderStatus}
+      </p>
 
       {loading ? (
         <p className="rounded-2xl border bg-background/80 py-10 text-center text-sm text-muted-foreground shadow-sm">
@@ -269,7 +300,17 @@ export const RulesPanel: FC = () => {
                   event.preventDefault()
                   setOverIndex(index)
                 }}
-                onDrop={() => handleDrop(index)}
+                onDragLeave={() => {
+                  // Clear the drop highlight when the cursor leaves this row, so
+                  // dragging off the list doesn't leave a row stuck highlighted.
+                  setOverIndex((current) =>
+                    current === index ? null : current
+                  )
+                }}
+                onDrop={(event) => {
+                  event.preventDefault()
+                  handleDrop(index)
+                }}
                 onDragEnd={() => {
                   setDragIndex(null)
                   setOverIndex(null)

--- a/lib/components/admin-rules/RulesPanel.tsx
+++ b/lib/components/admin-rules/RulesPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Plus, Trash2 } from 'lucide-react'
+import { GripVertical, Pencil, Plus, Trash2 } from 'lucide-react'
 import { FC, FormEvent, useEffect, useState } from 'react'
 
 import {
@@ -10,12 +10,13 @@ import {
   getServerRules,
   updateServerRule
 } from '@/lib/client'
-import { FilterField, FilterSection } from '@/lib/components/filters/filterUi'
+import { reorder } from '@/lib/components/admin-rules/reorder'
 import { PageHeader } from '@/lib/components/page-header'
 import { Button } from '@/lib/components/ui/button'
 import { Input } from '@/lib/components/ui/input'
 import { Textarea } from '@/lib/components/ui/textarea'
 import { MAX_RULE_POSITION } from '@/lib/services/rules/adminRule'
+import { cn } from '@/lib/utils'
 
 // The server returns rules ordered by position ascending (ties broken by
 // creation time). `Array.prototype.sort` is stable, so re-sorting after an
@@ -23,29 +24,46 @@ import { MAX_RULE_POSITION } from '@/lib/services/rules/adminRule'
 const sortRules = (rules: ServerRule[]): ServerRule[] =>
   [...rules].sort((a, b) => a.position - b.position)
 
+// Normalize a reordered list to sequential positions (0, 1, 2, …) so the
+// rule number shown in the UI is also the stored order.
+const normalize = (rules: ServerRule[]): ServerRule[] =>
+  rules.map((rule, index) => ({ ...rule, position: index }))
+
+// The orange numbered chip that fronts every rule, matching the design system.
+const RuleNumber: FC<{ n: number }> = ({ n }) => (
+  <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold tabular-nums text-primary">
+    {n}
+  </span>
+)
+
 export const RulesPanel: FC = () => {
   const [rules, setRules] = useState<ServerRule[]>([])
   const [loading, setLoading] = useState(true)
   const [listError, setListError] = useState<string | null>(null)
   const [formError, setFormError] = useState<string | null>(null)
   const [newText, setNewText] = useState('')
-  const [newHint, setNewHint] = useState('')
   const [saving, setSaving] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
-  // Per-rule uncommitted position input values, keyed by rule id. A rule
-  // without an entry shows its saved position.
-  const [positionDrafts, setPositionDrafts] = useState<Record<string, string>>(
-    {}
-  )
-  const [updatingPositionId, setUpdatingPositionId] = useState<string | null>(
-    null
-  )
+  const [reordering, setReordering] = useState(false)
+  // The rule currently being edited inline, plus its uncommitted field values.
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editText, setEditText] = useState('')
+  const [editHint, setEditHint] = useState('')
+  const [savingEdit, setSavingEdit] = useState(false)
+  // The row currently picked up by a drag, used to compute the drop target.
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [overIndex, setOverIndex] = useState<number | null>(null)
+
+  // Any in-flight mutation blocks the others: every write path takes an
+  // optimistic snapshot and rolls back to it on failure, so overlapping writes
+  // could otherwise restore a stale list.
+  const busy = saving || deletingId !== null || savingEdit || reordering
 
   useEffect(() => {
     let active = true
     getServerRules()
       .then((result) => {
-        if (active) setRules(result)
+        if (active) setRules(sortRules(result))
       })
       .catch(() => {
         // A network/parse failure must surface an error rather than silently
@@ -63,22 +81,28 @@ export const RulesPanel: FC = () => {
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const text = newText.trim()
-    // Also bail while a delete is in flight: the submit button is disabled
-    // then, but a programmatic submit must not slip a create past the
-    // delete-rollback snapshot.
-    if (!text || saving || deletingId !== null) return
+    if (!text || busy) return
     setSaving(true)
     setFormError(null)
+    // Append the new rule after the current last one. createInstanceRule
+    // defaults position to 0 (top), so pass an explicit trailing position.
+    const nextPosition = Math.min(
+      rules.reduce((max, rule) => Math.max(max, rule.position), -1) + 1,
+      MAX_RULE_POSITION
+    )
     try {
       // The client helper returns null on a non-ok response; throw so both
       // that and any network-layer rejection land in the same catch.
-      const created = await createServerRule({ text, hint: newHint.trim() })
+      const created = await createServerRule({
+        text,
+        hint: '',
+        position: nextPosition
+      })
       if (!created) {
         throw new Error('Failed to create rule. Please try again.')
       }
       setRules((current) => sortRules([...current, created]))
       setNewText('')
-      setNewHint('')
     } catch (error) {
       setFormError(
         error instanceof Error
@@ -90,16 +114,59 @@ export const RulesPanel: FC = () => {
     }
   }
 
+  const beginEdit = (rule: ServerRule) => {
+    if (busy) return
+    setListError(null)
+    setEditingId(rule.id)
+    setEditText(rule.text)
+    setEditHint(rule.hint)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditText('')
+    setEditHint('')
+  }
+
+  const handleEditSave = async (rule: ServerRule) => {
+    const text = editText.trim()
+    // Bail on an emptied required field or while another write is in flight.
+    if (!text || savingEdit || deletingId !== null || saving || reordering) {
+      return
+    }
+    const hint = editHint.trim()
+    // Nothing changed — close the editor without a doomed round-trip.
+    if (text === rule.text && hint === rule.hint) {
+      cancelEdit()
+      return
+    }
+    setSavingEdit(true)
+    setListError(null)
+    try {
+      const updated = await updateServerRule(rule.id, { text, hint })
+      if (!updated) {
+        throw new Error('Failed to update rule. Please try again.')
+      }
+      setRules((current) =>
+        sortRules(
+          current.map((item) => (item.id === updated.id ? updated : item))
+        )
+      )
+      cancelEdit()
+    } catch {
+      setListError('Failed to update rule. Please try again.')
+    } finally {
+      setSavingEdit(false)
+    }
+  }
+
   const handleDelete = async (rule: ServerRule) => {
-    // A delete is already in flight — all delete buttons are disabled while
-    // `deletingId` is set, so this guards against any racing invocation.
-    if (deletingId) return
+    if (busy) return
     setListError(null)
     setDeletingId(rule.id)
     const previous = rules
-    // Optimistic removal — restore the row if the request fails. Deletes are
-    // serialized (see the guard above), so `previous` is always the current
-    // list and rolling back to it cannot resurrect a separately-deleted row.
+    // Optimistic removal — restore the row if the request fails. Writes are
+    // serialized (see `busy`), so `previous` is always the current list.
     setRules((current) => current.filter((item) => item.id !== rule.id))
     const restoreOnFailure = () => {
       setRules(previous)
@@ -116,191 +183,215 @@ export const RulesPanel: FC = () => {
     }
   }
 
-  const handlePositionCommit = async (rule: ServerRule) => {
-    // Bail while a delete is in flight. Disabling the input mid-edit fires its
-    // onBlur, which would otherwise commit a position change past the
-    // delete-rollback snapshot.
-    if (deletingId !== null) return
-    const draft = positionDrafts[rule.id]
-    if (draft === undefined) return
-    const clearDraft = () =>
-      setPositionDrafts(({ [rule.id]: _removed, ...rest }) => rest)
-    // An emptied field or an unchanged/invalid value reverts to the saved
-    // position instead of sending an update.
-    const next = Number(draft)
-    // The `max` attribute only styles the field; a typed/pasted out-of-range
-    // value still commits on blur. Reject it here (like negatives) so we revert
-    // instead of firing a doomed request the server would 422.
-    if (
-      draft.trim() === '' ||
-      !Number.isInteger(next) ||
-      next < 0 ||
-      next > MAX_RULE_POSITION ||
-      next === rule.position
-    ) {
-      clearDraft()
-      return
-    }
+  // Persist a reorder by writing back the new sequential position of every
+  // rule whose position changed. Rolls the whole list back on any failure.
+  const persistReorder = async (
+    reordered: ServerRule[],
+    previous: ServerRule[]
+  ) => {
+    const changed = reordered.filter((rule, index) => {
+      const before = previous.find((item) => item.id === rule.id)
+      return before === undefined || before.position !== index
+    })
+    if (changed.length === 0) return
+    setReordering(true)
     setListError(null)
-    setUpdatingPositionId(rule.id)
     try {
-      const updated = await updateServerRule(rule.id, { position: next })
-      if (!updated) {
-        throw new Error('Failed to update rule position. Please try again.')
-      }
-      setRules((current) =>
-        sortRules(
-          current.map((item) => (item.id === updated.id ? updated : item))
+      const results = await Promise.all(
+        changed.map((rule) =>
+          updateServerRule(rule.id, { position: rule.position })
         )
       )
+      if (results.some((result) => result === null)) {
+        throw new Error('Failed to reorder rules. Please try again.')
+      }
     } catch {
-      setListError('Failed to update rule position. Please try again.')
+      setRules(previous)
+      setListError('Failed to reorder rules. Please try again.')
     } finally {
-      setUpdatingPositionId(null)
-      clearDraft()
+      setReordering(false)
     }
   }
 
+  const moveRule = (from: number, to: number) => {
+    if (busy) return
+    // `reorder` returns the same reference for a no-op or out-of-range move
+    // (e.g. ArrowUp on the first row), so bail before normalizing — otherwise
+    // `normalize` would allocate a fresh array and could trigger a spurious
+    // position write.
+    const moved = reorder(rules, from, to)
+    if (moved === rules) return
+    const reordered = normalize(moved)
+    const previous = rules
+    setRules(reordered)
+    void persistReorder(reordered, previous)
+  }
+
+  const handleDrop = (toIndex: number) => {
+    const fromIndex = dragIndex
+    setDragIndex(null)
+    setOverIndex(null)
+    if (fromIndex === null) return
+    moveRule(fromIndex, toIndex)
+  }
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageHeader
-        title="Rules"
-        description="Moderation rules shown on the about page and served from the Mastodon rules API. Lower positions appear first."
+        title="Server rules"
+        description="Displayed on the about page and served from the Mastodon rules API. Keep them short and specific — details go in the hint. Drag to reorder; the order is the rule number everywhere else."
       />
 
       {listError && <p className="text-sm text-destructive">{listError}</p>}
 
-      <FilterSection
-        title="Add a rule"
-        description="Keep rules short and put the longer explanation in the hint."
-      >
-        <form onSubmit={handleCreate} className="space-y-4">
-          <FilterField label="Rule text" htmlFor="rule-text">
-            <Textarea
-              id="rule-text"
-              value={newText}
-              onChange={(event) => setNewText(event.target.value)}
-              maxLength={1000}
-              rows={2}
-              required
-            />
-          </FilterField>
-          <FilterField
-            label="Hint"
-            htmlFor="rule-hint"
-            help="Optional longer explanation rendered under the rule."
-          >
-            <Textarea
-              id="rule-hint"
-              value={newHint}
-              onChange={(event) => setNewHint(event.target.value)}
-              maxLength={2000}
-              rows={2}
-            />
-          </FilterField>
-          {formError && <p className="text-sm text-destructive">{formError}</p>}
-          <div className="flex justify-end">
-            <Button
-              type="submit"
-              // Block creation while a delete is in flight: the delete rollback
-              // restores a pre-create snapshot, which would discard a rule
-              // added mid-delete if the delete then fails.
-              disabled={
-                saving || deletingId !== null || newText.trim().length === 0
-              }
-            >
-              <Plus className="size-4" />
-              Add rule
-            </Button>
-          </div>
-        </form>
-      </FilterSection>
-
-      <FilterSection>
-        {loading ? (
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            Loading rules…
-          </p>
-        ) : rules.length === 0 && !listError ? (
-          // Suppress the empty-state copy when a load error is already shown,
-          // so a failed fetch doesn't read as "you have no rules".
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            No rules yet — add one to show it on the about page.
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {rules.map((rule) => (
+      {loading ? (
+        <p className="rounded-2xl border bg-background/80 py-10 text-center text-sm text-muted-foreground shadow-sm">
+          Loading rules…
+        </p>
+      ) : rules.length === 0 && !listError ? (
+        // Suppress the empty-state copy when a load error is already shown, so a
+        // failed fetch doesn't read as "you have no rules".
+        <p className="rounded-2xl border bg-background/80 py-10 text-center text-sm text-muted-foreground shadow-sm">
+          No rules yet — add one to show it on the about page.
+        </p>
+      ) : (
+        <div className="divide-y rounded-2xl border bg-background/80 shadow-sm backdrop-blur">
+          {rules.map((rule, index) => {
+            const isEditing = editingId === rule.id
+            const draggable = !isEditing && !busy
+            return (
               <div
                 key={rule.id}
-                className="flex items-start gap-3 rounded-lg border p-3"
+                draggable={draggable}
+                onDragStart={() => draggable && setDragIndex(index)}
+                onDragOver={(event) => {
+                  if (dragIndex === null) return
+                  event.preventDefault()
+                  setOverIndex(index)
+                }}
+                onDrop={() => handleDrop(index)}
+                onDragEnd={() => {
+                  setDragIndex(null)
+                  setOverIndex(null)
+                }}
+                className={cn(
+                  'flex items-start gap-2 px-3 py-3 transition-colors',
+                  overIndex === index &&
+                    dragIndex !== null &&
+                    dragIndex !== index &&
+                    'bg-accent'
+                )}
               >
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium">{rule.text}</p>
-                  {rule.hint && (
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {rule.hint}
-                    </p>
-                  )}
-                </div>
-                <label
-                  className="flex shrink-0 items-center gap-2 text-sm text-muted-foreground"
-                  htmlFor={`rule-position-${rule.id}`}
-                >
-                  Position
-                  <Input
-                    id={`rule-position-${rule.id}`}
-                    type="number"
-                    min={0}
-                    // Match the 32-bit integer cap enforced server-side so the
-                    // field flags out-of-range values before submission.
-                    max={MAX_RULE_POSITION}
-                    step={1}
-                    className="w-20"
-                    value={positionDrafts[rule.id] ?? String(rule.position)}
-                    onChange={(event) =>
-                      setPositionDrafts((current) => ({
-                        ...current,
-                        [rule.id]: event.target.value
-                      }))
-                    }
-                    onBlur={() => handlePositionCommit(rule)}
-                    // The input isn't inside a form, so Enter would otherwise do
-                    // nothing. Blur on Enter to commit the position via onBlur.
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        event.currentTarget.blur()
-                      }
-                    }}
-                    // Serialize position updates so two in-flight edits can't
-                    // interleave their list re-sorts, and block edits while a
-                    // delete is in flight so its rollback snapshot can't discard
-                    // a position change committed mid-delete.
-                    disabled={
-                      updatingPositionId !== null || deletingId !== null
-                    }
-                  />
-                </label>
                 <button
                   type="button"
-                  aria-label={`Delete rule ${rule.text}`}
-                  onClick={() => handleDelete(rule)}
-                  // Keep all three mutations mutually exclusive: block deletes
-                  // while any delete, create, or position edit is in flight.
-                  // The delete rollback restores a snapshot captured before
-                  // those writes, so a concurrent create/edit would otherwise be
-                  // discarded if the delete then fails.
-                  disabled={
-                    deletingId !== null || saving || updatingPositionId !== null
-                  }
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[hsl(0_84.2%_60.2%/0.4)] text-[hsl(0_72%_45%)] transition-colors hover:bg-[hsl(0_72%_45%/0.08)] disabled:pointer-events-none disabled:opacity-50"
+                  aria-label={`Reorder rule ${index + 1}: use arrow up and arrow down keys to move`}
+                  disabled={busy || isEditing}
+                  onKeyDown={(event) => {
+                    if (event.key === 'ArrowUp') {
+                      event.preventDefault()
+                      moveRule(index, index - 1)
+                    } else if (event.key === 'ArrowDown') {
+                      event.preventDefault()
+                      moveRule(index, index + 1)
+                    }
+                  }}
+                  className="mt-1.5 cursor-grab rounded text-muted-foreground/70 transition-colors hover:text-foreground focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                  <Trash2 className="size-4" />
+                  <GripVertical className="size-4" />
                 </button>
+                <RuleNumber n={index + 1} />
+                {isEditing ? (
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Input
+                      aria-label="Rule text"
+                      value={editText}
+                      maxLength={1000}
+                      onChange={(event) => setEditText(event.target.value)}
+                    />
+                    <Textarea
+                      aria-label="Rule hint"
+                      value={editHint}
+                      maxLength={2000}
+                      rows={2}
+                      placeholder="Hint (optional) — shown under the rule on the about page"
+                      onChange={(event) => setEditHint(event.target.value)}
+                    />
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={savingEdit || editText.trim().length === 0}
+                        onClick={() => handleEditSave(rule)}
+                      >
+                        Save
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={savingEdit}
+                        onClick={cancelEdit}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="min-w-0 flex-1 pt-0.5">
+                    <p className="text-sm leading-snug font-medium">
+                      {rule.text}
+                    </p>
+                    {rule.hint && (
+                      <p className="mt-0.5 text-[13px] leading-relaxed text-muted-foreground">
+                        {rule.hint}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {!isEditing && (
+                  <div className="flex shrink-0 gap-1">
+                    <button
+                      type="button"
+                      aria-label={`Edit rule ${index + 1}`}
+                      disabled={busy}
+                      onClick={() => beginEdit(rule)}
+                      className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      <Pencil className="size-4" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Delete rule ${index + 1}`}
+                      disabled={busy}
+                      onClick={() => handleDelete(rule)}
+                      className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-50"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  </div>
+                )}
               </div>
-            ))}
-          </div>
-        )}
-      </FilterSection>
+            )
+          })}
+        </div>
+      )}
+
+      <form onSubmit={handleCreate} className="space-y-2">
+        <div className="flex gap-2">
+          <Input
+            aria-label="New rule text"
+            placeholder="Add a rule…"
+            value={newText}
+            maxLength={1000}
+            onChange={(event) => setNewText(event.target.value)}
+          />
+          <Button type="submit" disabled={busy || newText.trim().length === 0}>
+            <Plus className="size-4" />
+            Add rule
+          </Button>
+        </div>
+        {formError && <p className="text-sm text-destructive">{formError}</p>}
+      </form>
     </div>
   )
 }

--- a/lib/components/admin-rules/reorder.test.ts
+++ b/lib/components/admin-rules/reorder.test.ts
@@ -1,0 +1,40 @@
+import { reorder } from '@/lib/components/admin-rules/reorder'
+
+describe('reorder', () => {
+  it.each([
+    {
+      description: 'moves an item down',
+      list: ['a', 'b', 'c', 'd'],
+      from: 0,
+      to: 2,
+      expected: ['b', 'c', 'a', 'd']
+    },
+    {
+      description: 'moves an item up',
+      list: ['a', 'b', 'c', 'd'],
+      from: 3,
+      to: 1,
+      expected: ['a', 'd', 'b', 'c']
+    },
+    {
+      description: 'moves to the first position',
+      list: ['a', 'b', 'c'],
+      from: 2,
+      to: 0,
+      expected: ['c', 'a', 'b']
+    }
+  ])('$description', ({ list, from, to, expected }) => {
+    expect(reorder(list, from, to)).toEqual(expected)
+  })
+
+  it.each([
+    { description: 'no-op when from equals to', from: 1, to: 1 },
+    { description: 'negative from index', from: -1, to: 1 },
+    { description: 'negative to index', from: 1, to: -1 },
+    { description: 'from index out of range', from: 9, to: 1 },
+    { description: 'to index out of range', from: 1, to: 9 }
+  ])('returns the same reference for $description', ({ from, to }) => {
+    const list = ['a', 'b', 'c']
+    expect(reorder(list, from, to)).toBe(list)
+  })
+})

--- a/lib/components/admin-rules/reorder.ts
+++ b/lib/components/admin-rules/reorder.ts
@@ -1,0 +1,17 @@
+// Move the item at `from` to `to`, returning a new array. Out-of-range or
+// no-op moves return the original reference so callers can skip a re-render.
+export const reorder = <T>(list: T[], from: number, to: number): T[] => {
+  if (
+    from === to ||
+    from < 0 ||
+    to < 0 ||
+    from >= list.length ||
+    to >= list.length
+  ) {
+    return list
+  }
+  const next = [...list]
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved)
+  return next
+}


### PR DESCRIPTION
## Summary

Implements the **Instance rules** admin UI to match the design system's `ui_kits/web/rules.html` handoff (Surface 4 — Admin editor), building on the instance rules API that already exists in the service (`/api/v2/admin/rules`, `GET /api/v1/instance/rules`).

The admin **Server rules** editor is redesigned from the old position-number-input list into the design's pattern:

- **Numbered orange chips** (`RuleNumber`) fronting each rule, on a single `divide-y rounded-2xl` section card with the translucent settings chrome.
- **Inline editing** — a pencil opens an in-row editor for the rule text + hint with Save/Cancel (uses `PUT /api/v2/admin/rules/:id`). Details now live in the hint, matching the handoff.
- **Drag & keyboard reordering** replaces the raw position input. Rows are draggable via the grip handle, and the handle is an accessible button supporting <kbd>↑</kbd>/<kbd>↓</kbd>. Reorders persist normalized sequential positions through the existing API; order is the rule number shown everywhere else.
- **Simplified "Add a rule…" row** (single input + Add button), per the design.
- Optimistic updates with rollback and serialized mutations are preserved across add / edit / delete / reorder.
- Admin sub-nav **Rules** icon switched to Lucide `Scale` per the handoff.

### Scope note
The design describes one rule list across four surfaces (About page, sign-up agreement, report flow, admin editor). The About page, sign-up agreement step, and report flow don't exist as routes in the codebase yet, so this PR delivers the **admin editor** surface — the one with an existing route and a complete API. The other surfaces can follow as separate PRs.

## Testing
- `yarn lint` — no new errors (pre-existing warnings only)
- `yarn build` — passes
- `yarn test` — full suite green (4318 tests)
- New tests: `reorder.test.ts` (pure helper) and `RulesPanel.test.tsx` (load/empty/error states, create, inline edit, delete + rollback, keyboard reorder, boundary no-op)

> Note: a browser was not available in the build environment, so verification is via the component tests; the visual layout is a faithful translation of the design spec onto the project's semantic Tailwind tokens (the design's orange = `--primary`).

https://claude.ai/code/session_01249TiVyU37FxKXGkVUic9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01249TiVyU37FxKXGkVUic9j)_