### PR TITLE
fix: send Mastodon-compatible Web Push payload for native clients

### DIFF
--- a/app/api/v1/push/subscribe/route.test.ts
+++ b/app/api/v1/push/subscribe/route.test.ts
@@ -36,6 +36,10 @@ jest.mock('@/lib/database', () => ({
 }))
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({
+  getTokenFromHeader: (header: string | null) =>
+    header?.toLowerCase().startsWith('bearer ')
+      ? header.slice('bearer '.length).trim() || null
+      : null,
   OAuthGuard:
     (
       scopes: Scope[],

--- a/app/api/v1/push/subscribe/route.test.ts
+++ b/app/api/v1/push/subscribe/route.test.ts
@@ -36,10 +36,15 @@ jest.mock('@/lib/database', () => ({
 }))
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({
-  getTokenFromHeader: (header: string | null) =>
-    header?.toLowerCase().startsWith('bearer ')
-      ? header.slice('bearer '.length).trim() || null
-      : null,
+  // Mirror the real parser in OAuthGuard.ts exactly (trim + split on \s+,
+  // require exactly two parts, case-insensitive scheme) so the route tests
+  // exercise the same token-extraction behavior as production.
+  getTokenFromHeader: (header: string | null) => {
+    if (!header) return null
+    const parts = header.trim().split(/\s+/)
+    if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') return null
+    return parts[1] || null
+  },
   OAuthGuard:
     (
       scopes: Scope[],

--- a/app/api/v1/push/subscribe/route.ts
+++ b/app/api/v1/push/subscribe/route.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod'
 
 import { ALL_PUSH_ALERTS_ENABLED } from '@/lib/database/sql/pushSubscription'
-import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import {
+  OAuthGuard,
+  getTokenFromHeader
+} from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { apiErrorResponse, apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -45,7 +48,11 @@ export const POST = traceApiRoute(
       // These subscriptions come from the browser PushManager and were always
       // delivered with the standard `aes128gcm` encoding; mark them `standard`
       // so delivery keeps using it now that encoding follows this flag.
-      standard: true
+      standard: true,
+      // Store the bearer token (when present) so a native client subscribing via
+      // this legacy route still receives the Mastodon `access_token` in payloads.
+      accessToken:
+        getTokenFromHeader(req.headers.get('Authorization')) ?? undefined
     })
 
     return apiResponse({

--- a/app/api/v1/push/subscription/route.test.ts
+++ b/app/api/v1/push/subscription/route.test.ts
@@ -36,6 +36,10 @@ jest.mock('@/lib/database', () => ({
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({
   corsErrorResponse: () => () => new Response(null, { status: 401 }),
+  getTokenFromHeader: (header: string | null) =>
+    header?.toLowerCase().startsWith('bearer ')
+      ? header.slice('bearer '.length).trim() || null
+      : null,
   OAuthGuard:
     (
       scopes: Scope[],
@@ -181,6 +185,25 @@ describe('POST /api/v1/push/subscription', () => {
         standard: true,
         policy: 'followed'
       })
+    )
+  })
+
+  it('stores the bearer token as the subscription access token', async () => {
+    const req = new NextRequest('http://localhost/api/v1/push/subscription', {
+      method: 'POST',
+      body: JSON.stringify({
+        subscription: { endpoint, keys: { p256dh, auth }, standard: true }
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://localhost',
+        Authorization: 'Bearer device-access-token'
+      }
+    })
+    const res = await POST(req, { params: Promise.resolve({}) })
+    expect(res.status).toBe(200)
+    expect(mockDatabase!.createPushSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'device-access-token' })
     )
   })
 })

--- a/app/api/v1/push/subscription/route.test.ts
+++ b/app/api/v1/push/subscription/route.test.ts
@@ -36,10 +36,15 @@ jest.mock('@/lib/database', () => ({
 
 jest.mock('@/lib/services/guards/OAuthGuard', () => ({
   corsErrorResponse: () => () => new Response(null, { status: 401 }),
-  getTokenFromHeader: (header: string | null) =>
-    header?.toLowerCase().startsWith('bearer ')
-      ? header.slice('bearer '.length).trim() || null
-      : null,
+  // Mirror the real parser in OAuthGuard.ts exactly (trim + split on \s+,
+  // require exactly two parts, case-insensitive scheme) so the route tests
+  // exercise the same token-extraction behavior as production.
+  getTokenFromHeader: (header: string | null) => {
+    if (!header) return null
+    const parts = header.trim().split(/\s+/)
+    if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') return null
+    return parts[1] || null
+  },
   OAuthGuard:
     (
       scopes: Scope[],

--- a/app/api/v1/push/subscription/route.ts
+++ b/app/api/v1/push/subscription/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
-import { OAuthGuard, corsErrorResponse } from '@/lib/services/guards/OAuthGuard'
+import {
+  OAuthGuard,
+  corsErrorResponse,
+  getTokenFromHeader
+} from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -82,7 +86,11 @@ export const POST = traceApiRoute(
         auth: parsed.auth,
         alerts: parsed.alerts,
         policy: parsed.policy,
-        standard: parsed.standard
+        standard: parsed.standard,
+        // Store the bearer token so the Mastodon Web Push payload can include
+        // it as `access_token`. Null for web-session requests (no bearer token).
+        accessToken:
+          getTokenFromHeader(req.headers.get('Authorization')) ?? undefined
       })
 
       return apiResponse({

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -123,7 +123,7 @@ export const userAnnounce = async ({
               events: [
                 {
                   type: NotificationType.enum.reblog,
-                  notificationId: reblogNotification.id,
+                  notificationId: reblogNotification?.id,
                   emailContent: targetActor?.account
                     ? {
                         recipientEmail: targetActor.account.email,

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -123,6 +123,7 @@ export const userAnnounce = async ({
               events: [
                 {
                   type: NotificationType.enum.reblog,
+                  notificationId: reblogNotification.id,
                   emailContent: targetActor?.account
                     ? {
                         recipientEmail: targetActor.account.email,

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -85,7 +85,7 @@ export const createFollower = async ({
         events: [
           {
             type: NotificationType.enum.follow_request,
-            notificationId: followRequestNotification.id,
+            notificationId: followRequestNotification?.id,
             emailContent: targetActor.account
               ? {
                   recipientEmail: targetActor.account.email,
@@ -130,7 +130,7 @@ export const createFollower = async ({
         events: [
           {
             type: NotificationType.enum.follow,
-            notificationId: followNotification.id,
+            notificationId: followNotification?.id,
             emailContent: targetActor.account
               ? {
                   recipientEmail: targetActor.account.email,

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -85,6 +85,7 @@ export const createFollower = async ({
         events: [
           {
             type: NotificationType.enum.follow_request,
+            notificationId: followRequestNotification.id,
             emailContent: targetActor.account
               ? {
                   recipientEmail: targetActor.account.email,
@@ -129,6 +130,7 @@ export const createFollower = async ({
         events: [
           {
             type: NotificationType.enum.follow,
+            notificationId: followNotification.id,
             emailContent: targetActor.account
               ? {
                   recipientEmail: targetActor.account.email,

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -561,6 +561,17 @@ export const createNoteFromUserInput = async ({
       })
       .map(([actorId]) => actorId)
   )
+  // Map each alerted actor to its accepted notification id so the Mastodon Web
+  // Push payload can carry `notification_id`. Each actor has at most one
+  // accepted notification here (reply and mention to the same actor are deduped
+  // above), so a last-write-wins map is sufficient.
+  const notificationIdByActorId = new Map<string, string>()
+  notificationEntries.forEach(([actorId], i) => {
+    const n = notificationResults[i]
+    if (n !== null && !n.filtered) {
+      notificationIdByActorId.set(actorId, n.id)
+    }
+  })
 
   const status = (await database.getStatus({
     statusId,
@@ -596,6 +607,7 @@ export const createNoteFromUserInput = async ({
           events: [
             {
               type: NotificationType.enum.reply,
+              notificationId: notificationIdByActorId.get(replyStatus.actorId),
               emailContent: targetActor?.account
                 ? {
                     recipientEmail: targetActor.account.email,
@@ -633,6 +645,7 @@ export const createNoteFromUserInput = async ({
             events: [
               {
                 type: NotificationType.enum.mention,
+                notificationId: notificationIdByActorId.get(mentionedActorId),
                 emailContent: targetActor?.account
                   ? {
                       recipientEmail: targetActor.account.email,

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -557,7 +557,7 @@ export const createNoteFromUserInput = async ({
     notificationEntries
       .filter((_, i) => {
         const n = notificationResults[i]
-        return n !== null && !n.filtered
+        return n && !n.filtered
       })
       .map(([actorId]) => actorId)
   )
@@ -568,7 +568,7 @@ export const createNoteFromUserInput = async ({
   const notificationIdByActorId = new Map<string, string>()
   notificationEntries.forEach(([actorId], i) => {
     const n = notificationResults[i]
-    if (n !== null && !n.filtered) {
+    if (n && !n.filtered) {
       notificationIdByActorId.set(actorId, n.id)
     }
   })

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -61,6 +61,7 @@ export const likeRequest = async ({
             events: [
               {
                 type: NotificationType.enum.like,
+                notificationId: likeNotification.id,
                 emailContent: targetActor?.account
                   ? {
                       recipientEmail: targetActor.account.email,

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -61,7 +61,7 @@ export const likeRequest = async ({
             events: [
               {
                 type: NotificationType.enum.like,
-                notificationId: likeNotification.id,
+                notificationId: likeNotification?.id,
                 emailContent: targetActor?.account
                   ? {
                       recipientEmail: targetActor.account.email,

--- a/lib/database/sql/pushSubscription.test.ts
+++ b/lib/database/sql/pushSubscription.test.ts
@@ -58,6 +58,27 @@ describe('PushSubscription Database', () => {
         expect(sub.auth).toBe('auth1')
         expect(sub.createdAt).toBeNumber()
         expect(sub.updatedAt).toBeNumber()
+        // No bearer token was supplied, so the access token stays unset.
+        expect(sub.accessToken).toBeUndefined()
+      })
+
+      it('stores and round-trips the access token', async () => {
+        const endpoint = 'https://push.example.com/endpoint/token-rt'
+        const created = await database.createPushSubscription({
+          actorId: actor1Id,
+          endpoint,
+          p256dh: 'key-token',
+          auth: 'auth-token',
+          accessToken: 'device-access-token'
+        })
+        expect(created.accessToken).toBe('device-access-token')
+
+        const fetched = await database.getPushSubscriptionsForActor({
+          actorId: actor1Id
+        })
+        expect(
+          fetched.find((sub) => sub.endpoint === endpoint)?.accessToken
+        ).toBe('device-access-token')
       })
 
       it('upserts on duplicate endpoint', async () => {

--- a/lib/database/sql/pushSubscription.ts
+++ b/lib/database/sql/pushSubscription.ts
@@ -123,7 +123,23 @@ export const PushSubscriptionSQLDatabaseMixin = (
     const alertsValue = JSON.stringify(normalizeAlerts(alerts))
     const policyValue = policy ?? 'all'
     const standardValue = standard ?? false
-    const accessTokenValue = accessToken ?? null
+
+    const mergeValues: Record<string, unknown> = {
+      actorId,
+      p256dh,
+      auth,
+      alerts: alertsValue,
+      policy: policyValue,
+      standard: standardValue,
+      updatedAt: now
+    }
+    // Only overwrite the stored access token when a new one is supplied. A
+    // tokenless re-subscribe of the same endpoint (e.g. a web-session request)
+    // must not wipe a token a native client previously registered, or its
+    // subsequent payloads would lose `access_token`.
+    if (accessToken) {
+      mergeValues.accessToken = accessToken
+    }
 
     await database('push_subscriptions')
       .insert({
@@ -135,21 +151,12 @@ export const PushSubscriptionSQLDatabaseMixin = (
         alerts: alertsValue,
         policy: policyValue,
         standard: standardValue,
-        accessToken: accessTokenValue,
+        accessToken: accessToken ?? null,
         createdAt: now,
         updatedAt: now
       })
       .onConflict('endpoint')
-      .merge({
-        actorId,
-        p256dh,
-        auth,
-        alerts: alertsValue,
-        policy: policyValue,
-        standard: standardValue,
-        accessToken: accessTokenValue,
-        updatedAt: now
-      })
+      .merge(mergeValues)
 
     const row = await database<SQLPushSubscription>('push_subscriptions')
       .where({ endpoint })

--- a/lib/database/sql/pushSubscription.ts
+++ b/lib/database/sql/pushSubscription.ts
@@ -24,6 +24,7 @@ interface SQLPushSubscription {
   alerts: string | null
   policy: string | null
   standard: boolean | number | null
+  accessToken: string | null
   createdAt: number | Date
   updatedAt: number | Date
 }
@@ -99,6 +100,7 @@ const fixPushSubscription = (row: SQLPushSubscription): PushSubscription => ({
   alerts: parseStoredAlerts(row.alerts),
   policy: (row.policy as PushPolicy) ?? 'all',
   standard: Boolean(row.standard),
+  accessToken: row.accessToken ?? undefined,
   createdAt: getCompatibleTime(row.createdAt),
   updatedAt: getCompatibleTime(row.updatedAt)
 })
@@ -113,13 +115,15 @@ export const PushSubscriptionSQLDatabaseMixin = (
     auth,
     alerts,
     policy,
-    standard
+    standard,
+    accessToken
   }: CreatePushSubscriptionParams): Promise<PushSubscription> {
     const id = randomUUID()
     const now = new Date()
     const alertsValue = JSON.stringify(normalizeAlerts(alerts))
     const policyValue = policy ?? 'all'
     const standardValue = standard ?? false
+    const accessTokenValue = accessToken ?? null
 
     await database('push_subscriptions')
       .insert({
@@ -131,6 +135,7 @@ export const PushSubscriptionSQLDatabaseMixin = (
         alerts: alertsValue,
         policy: policyValue,
         standard: standardValue,
+        accessToken: accessTokenValue,
         createdAt: now,
         updatedAt: now
       })
@@ -142,6 +147,7 @@ export const PushSubscriptionSQLDatabaseMixin = (
         alerts: alertsValue,
         policy: policyValue,
         standard: standardValue,
+        accessToken: accessTokenValue,
         updatedAt: now
       })
 

--- a/lib/services/notifications/pushNotification.test.ts
+++ b/lib/services/notifications/pushNotification.test.ts
@@ -74,6 +74,71 @@ describe('sendPushNotification', () => {
     )
   })
 
+  it('sends a Mastodon-compatible payload with the standard fields', async () => {
+    const db = makeDb({
+      getPushSubscriptionsForActor: jest.fn().mockResolvedValue([
+        {
+          id: 'sub1',
+          actorId: 'https://llun.test/users/test1',
+          endpoint: 'https://push.example.com/endpoint/abc',
+          p256dh: 'key1',
+          auth: 'auth1',
+          policy: 'all',
+          alerts: { favourite: true },
+          standard: true,
+          accessToken: 'token-abc',
+          createdAt: Date.now(),
+          updatedAt: Date.now()
+        }
+      ])
+    } as never)
+
+    await sendPushNotification({
+      database: db,
+      actorId: 'https://llun.test/users/test1',
+      type: NotificationType.enum.like,
+      sourceActor: {
+        id: 'https://llun.test/users/source',
+        username: 'source',
+        name: 'Source User',
+        iconUrl: 'https://llun.test/avatars/source.png'
+      } as never,
+      notificationId: 'notification-123'
+    })
+
+    expect(mockWebpush.sendNotification).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(
+      mockWebpush.sendNotification.mock.calls[0][1] as string
+    )
+    expect(payload).toMatchObject({
+      access_token: 'token-abc',
+      preferred_locale: 'en',
+      notification_id: 'notification-123',
+      // `like` maps to the Mastodon `favourite` notification type.
+      notification_type: 'favourite',
+      icon: 'https://llun.test/avatars/source.png',
+      title: 'New Like',
+      body: 'Source User liked your post'
+    })
+  })
+
+  it('falls back to an empty access_token and notification_id when absent', async () => {
+    const db = makeDb()
+    await sendPushNotification({
+      database: db,
+      actorId: 'https://llun.test/users/test1',
+      type: NotificationType.enum.like,
+      sourceActor
+    })
+
+    const payload = JSON.parse(
+      mockWebpush.sendNotification.mock.calls[0][1] as string
+    )
+    expect(payload.access_token).toBe('')
+    expect(payload.notification_id).toBe('')
+    expect(payload.notification_type).toBe('favourite')
+  })
+
   it('uses standard aes128gcm encoding when the subscription is standard', async () => {
     const db = makeDb({
       getPushSubscriptionsForActor: jest.fn().mockResolvedValue([

--- a/lib/services/notifications/pushNotification.ts
+++ b/lib/services/notifications/pushNotification.ts
@@ -2,10 +2,15 @@ import webpush from 'web-push'
 
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
-import { NotificationType, PushAlerts } from '@/lib/types/database/operations'
+import {
+  NotificationType,
+  PushAlerts,
+  PushSubscription
+} from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 
+import { internalTypeToMastodon } from './notificationTypeMapping'
 import { shouldSendPushForNotification } from './pushNotificationSettings'
 
 // Maps this app's internal NotificationType to the Mastodon WebPushSubscription
@@ -41,7 +46,27 @@ const initVapid = () => {
   vapidInitialized = true
 }
 
-interface PushNotificationPayload {
+interface PushNotificationContent {
+  title: string
+  body: string
+}
+
+// The Mastodon Web Push payload. Mirrors `Web::NotificationSerializer` so native
+// clients (Mastodon iOS, Ivory, …) decode it into their expected struct and can
+// render the notification content, attribute it to the right account via
+// `access_token`, and fetch the full notification via `notification_id`. Without
+// these fields the client's decoder fails and the notification shows only the
+// app icon with no content.
+//
+// `url` is an additive, non-Mastodon field used by this app's own service
+// worker (`public/sw.js`) to deep-link the click; native clients ignore unknown
+// keys, so it is safe to include alongside the standard fields.
+interface MastodonPushPayload {
+  access_token: string
+  preferred_locale: string
+  notification_id: string
+  notification_type: string
+  icon?: string
   title: string
   body: string
   url: string
@@ -50,53 +75,84 @@ interface PushNotificationPayload {
 const getNotificationContent = (
   type: NotificationType,
   sourceActor: Actor
-): PushNotificationPayload => {
+): PushNotificationContent => {
   const displayName = sourceActor.name || sourceActor.username
 
   switch (type) {
     case 'follow':
       return {
         title: 'New Follower',
-        body: `${displayName} followed you`,
-        url: '/notifications'
+        body: `${displayName} followed you`
       }
     case 'follow_request':
       return {
         title: 'Follow Request',
-        body: `${displayName} wants to follow you`,
-        url: '/notifications'
+        body: `${displayName} wants to follow you`
       }
     case 'like':
       return {
         title: 'New Like',
-        body: `${displayName} liked your post`,
-        url: '/notifications'
+        body: `${displayName} liked your post`
       }
     case 'mention':
       return {
         title: 'Mentioned',
-        body: `${displayName} mentioned you`,
-        url: '/notifications'
+        body: `${displayName} mentioned you`
       }
     case 'reply':
       return {
         title: 'New Reply',
-        body: `${displayName} replied to your post`,
-        url: '/notifications'
+        body: `${displayName} replied to your post`
       }
     case 'reblog':
       return {
         title: 'Reblogged',
-        body: `${displayName} reblogged your post`,
-        url: '/notifications'
+        body: `${displayName} reblogged your post`
       }
     default:
       return {
         title: 'New Notification',
-        body: 'You have a new notification',
-        url: '/notifications'
+        body: 'You have a new notification'
       }
   }
+}
+
+// Builds the per-subscription Mastodon Web Push payload. The payload is built
+// per subscription because `access_token` differs between subscriptions (each
+// native client subscribes with its own token).
+const buildPayload = (params: {
+  subscription: PushSubscription
+  type: NotificationType
+  content: PushNotificationContent
+  sourceActor: Actor
+  notificationId?: string
+  preferredLocale: string
+}): string => {
+  const {
+    subscription,
+    type,
+    content,
+    sourceActor,
+    notificationId,
+    preferredLocale
+  } = params
+
+  const payload: MastodonPushPayload = {
+    access_token: subscription.accessToken ?? '',
+    preferred_locale: preferredLocale,
+    // Mastodon's id is an integer; this app uses string ids (matching its
+    // notifications API, like GoToSocial's ULIDs), which mainstream clients
+    // accept. Fall back to the empty string only for the rare delivery path
+    // that has no notification record.
+    notification_id: notificationId ?? '',
+    notification_type: internalTypeToMastodon(type),
+    icon: sourceActor.iconUrl,
+    title: content.title,
+    body: content.body,
+    url: '/notifications'
+  }
+
+  return JSON.stringify(payload)
 }
 
 export const sendPushNotification = async (params: {
@@ -105,9 +161,21 @@ export const sendPushNotification = async (params: {
   type: NotificationType
   sourceActor: Actor
   statusId?: string
+  notificationId?: string
+  preferredLocale?: string
   skipSettingsCheck?: boolean
 }): Promise<void> => {
-  const { database, actorId, type, sourceActor, skipSettingsCheck } = params
+  const {
+    database,
+    actorId,
+    type,
+    sourceActor,
+    notificationId,
+    skipSettingsCheck
+  } = params
+  // Mastodon serializes the recipient's preferred locale; this app does not
+  // track a per-actor UI locale yet, so default to English.
+  const preferredLocale = params.preferredLocale ?? 'en'
 
   const config = getConfig()
   if (!config.push) return
@@ -139,7 +207,7 @@ export const sendPushNotification = async (params: {
 
   initVapid()
 
-  const payload = JSON.stringify(getNotificationContent(type, sourceActor))
+  const content = getNotificationContent(type, sourceActor)
 
   await Promise.allSettled(
     subscriptions.map(async (sub) => {
@@ -149,7 +217,14 @@ export const sendPushNotification = async (params: {
             endpoint: sub.endpoint,
             keys: { p256dh: sub.p256dh, auth: sub.auth }
           },
-          payload,
+          buildPayload({
+            subscription: sub,
+            type,
+            content,
+            sourceActor,
+            notificationId,
+            preferredLocale
+          }),
           {
             // Match the encryption to the encoding advertised in the
             // WebPushSubscription `standard` flag: `true` → RFC8291 standard

--- a/lib/services/notifications/pushNotification.ts
+++ b/lib/services/notifications/pushNotification.ts
@@ -146,7 +146,10 @@ const buildPayload = (params: {
     // that has no notification record.
     notification_id: notificationId ?? '',
     notification_type: internalTypeToMastodon(type),
-    icon: sourceActor.iconUrl,
+    // `iconUrl` is `string | undefined` today, but coerce a possible null to
+    // undefined so JSON.stringify always omits the key (never emits
+    // `"icon": null`) and the assignment stays valid if the type ever widens.
+    icon: sourceActor.iconUrl ?? undefined,
     title: content.title,
     body: content.body,
     url: '/notifications'

--- a/lib/services/notifications/sendNotificationAlerts.test.ts
+++ b/lib/services/notifications/sendNotificationAlerts.test.ts
@@ -108,6 +108,29 @@ describe('sendNotificationAlerts', () => {
     )
   })
 
+  it('forwards the event notificationId to the push sender', async () => {
+    const db = makeDb()
+    sendNotificationAlerts({
+      database: db,
+      actorId: 'actor1',
+      sourceActorId: 'source1',
+      statusId: 'status1',
+      events: [
+        { type: NotificationType.enum.reply, notificationId: 'notification-1' }
+      ]
+    })
+    await flushPromises()
+
+    expect(mockSendPush).toHaveBeenCalledTimes(1)
+    expect(mockSendPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'actor1',
+        type: NotificationType.enum.reply,
+        notificationId: 'notification-1'
+      })
+    )
+  })
+
   it('uses provided sourceActor without DB fetch', async () => {
     const db = makeDb()
     sendNotificationAlerts({

--- a/lib/services/notifications/sendNotificationAlerts.ts
+++ b/lib/services/notifications/sendNotificationAlerts.ts
@@ -19,6 +19,10 @@ export interface EmailContent {
 export interface NotificationEvent {
   type: NotificationType
   emailContent?: EmailContent
+  // The id of the persisted notification record this event corresponds to.
+  // Forwarded into the Mastodon Web Push payload as `notification_id` so native
+  // clients can fetch the full notification via `GET /api/v1/notifications/:id`.
+  notificationId?: string
 }
 
 export interface SendNotificationAlertsParams {
@@ -73,6 +77,7 @@ export const sendNotificationAlerts = (
             type: event.type,
             sourceActor,
             statusId,
+            notificationId: event.notificationId,
             skipSettingsCheck: true
           })
           return

--- a/lib/services/timelines/mention.ts
+++ b/lib/services/timelines/mention.ts
@@ -95,7 +95,8 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
             replyNotificationCreated = true
             if (replyNotification && !replyNotification.filtered) {
               const replyEvent: NotificationEvent = {
-                type: NotificationType.enum.reply
+                type: NotificationType.enum.reply,
+                notificationId: replyNotification.id
               }
               // Carry the reply email on the surviving reply event. The mention
               // branch below — which used to attach the email for a
@@ -163,7 +164,8 @@ export const mentionTimelineRule: MentionTimelineRule = async ({
 
           if (mentionNotification && !mentionNotification.filtered) {
             const mentionEvent: NotificationEvent = {
-              type: NotificationType.enum.mention
+              type: NotificationType.enum.mention,
+              notificationId: mentionNotification.id
             }
             if (config.email && account && status.actor) {
               mentionEvent.emailContent = {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2424,6 +2424,11 @@ export interface PushSubscription {
   alerts: PushAlerts
   policy: PushPolicy
   standard: boolean
+  // The plaintext OAuth access token tied to this subscription, when it was
+  // created via a bearer token. Included in the Mastodon Web Push payload so
+  // native clients can attribute the push and fetch the full notification.
+  // Null for browser PushManager subscriptions (web-session auth, no token).
+  accessToken?: string
   createdAt: number
   updatedAt: number
 }
@@ -2436,6 +2441,7 @@ export type CreatePushSubscriptionParams = {
   alerts?: Partial<PushAlerts>
   policy?: PushPolicy
   standard?: boolean
+  accessToken?: string
 }
 
 export type UpdatePushSubscriptionParams = {

--- a/migrations/20260614120000_add_push_subscription_access_token.js
+++ b/migrations/20260614120000_add_push_subscription_access_token.js
@@ -1,0 +1,34 @@
+/**
+ * Adds an `accessToken` column to `push_subscriptions`.
+ *
+ * Mastodon's Web Push payload (see `Web::NotificationSerializer`) includes the
+ * plaintext OAuth `access_token` tied to the subscription. Native clients (the
+ * Mastodon iOS app, Ivory, …) decode the encrypted payload and use this token
+ * to attribute the push to the right account and to fetch the full notification
+ * via `GET /api/v1/notifications/:id`. Without it the payload fails to decode
+ * into the client's expected struct and the notification renders with no
+ * content (only the app icon).
+ *
+ * The token is captured from the `Authorization: Bearer …` header when a
+ * subscription is created via an OAuth token. Browser PushManager subscriptions
+ * authenticate via the web session (no bearer token) and leave this null — the
+ * built-in service worker does not need it.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('push_subscriptions', function (table) {
+    table.text('accessToken').nullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('push_subscriptions', function (table) {
+    table.dropColumn('accessToken')
+  })
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -708,7 +708,8 @@ CREATE TABLE public.push_subscriptions (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     alerts text,
     policy character varying(255) DEFAULT 'all'::character varying NOT NULL,
-    standard boolean DEFAULT true NOT NULL
+    standard boolean DEFAULT true NOT NULL,
+    "accessToken" text
 );
 
 CREATE TABLE public.recipients (

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -85,7 +85,7 @@ CREATE INDEX `passkey_userid_index` on `passkey` (`userId`);
 CREATE UNIQUE INDEX `passkey_credentialid_unique` on `passkey` (`credentialID`);
 CREATE INDEX `counters_bucket_hour_index` on `counters` (`bucketHour`);
 CREATE INDEX `tags_nameNormalized_type_idx` on `tags` (`nameNormalized`, `type`);
-CREATE TABLE `push_subscriptions` (`id` varchar(255), `actorId` varchar(255) not null, `endpoint` text not null, `p256dh` varchar(255) not null, `auth` varchar(255) not null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, `alerts` text null, `policy` varchar(255) not null default 'all', `standard` boolean not null default '1', primary key (`id`));
+CREATE TABLE `push_subscriptions` (`id` varchar(255), `actorId` varchar(255) not null, `endpoint` text not null, `p256dh` varchar(255) not null, `auth` varchar(255) not null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, `alerts` text null, `policy` varchar(255) not null default 'all', `standard` boolean not null default '1', `accessToken` text null, primary key (`id`));
 CREATE INDEX `push_subscriptions_actor_idx` on `push_subscriptions` (`actorId`);
 CREATE UNIQUE INDEX `push_subscriptions_endpoint_unique` on `push_subscriptions` (`endpoint`);
 CREATE TABLE `twoFactor` (`id` varchar(255), `secret` text not null, `backupCodes` text not null, `userId` varchar(255) not null, `verified` boolean not null default '0', foreign key(`userId`) references `accounts`(`id`) on delete CASCADE, primary key (`id`));

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,10 +10,12 @@ self.addEventListener('push', (event) => {
     data = { body: event.data.text() }
   }
 
+  // Payloads follow the Mastodon Web Push shape: { title, body, icon, url, … }.
+  // `icon` is the sender's avatar; fall back to the app icon when absent.
   const title = data.title || 'Activities'
   const options = {
     body: data.body || '',
-    icon: '/icon-192.png',
+    icon: data.icon || '/icon-192.png',
     badge: '/icon-192.png',
     data: { url: data.url || '/notifications' }
   }


### PR DESCRIPTION
## Problem

Push notifications didn't work with the official **Mastodon iOS app**, and third-party apps like **Ivory** showed the app icon but **no content**.

Native Mastodon clients decode the encrypted Web Push payload into a fixed struct (mirroring Mastodon's `Web::NotificationSerializer`) and render the notification from it. They use `access_token` to attribute the push to the right account and `notification_id` to fetch the full notification via `GET /api/v1/notifications/:id`.

This app was sending a **proprietary** `{ title, body, url }` payload. Because the required Mastodon fields (`access_token`, `notification_id`, `notification_type`) were missing, the clients' decoders failed and fell back to an icon-only notification with no content — exactly the reported symptom.

## Fix

Send the Mastodon-standard Web Push payload, matching `Web::NotificationSerializer`:

```json
{
  "access_token": "…",
  "preferred_locale": "en",
  "notification_id": "…",
  "notification_type": "favourite",
  "icon": "https://…/avatar.png",
  "title": "New Like",
  "body": "Source User liked your post",
  "url": "/notifications"
}
```

(`url` is an additive, non-Mastodon field the built-in service worker uses for click-through; native clients ignore unknown keys.)

### Changes

- **`access_token`**: capture the subscription's bearer token at subscribe time and store it on `push_subscriptions.accessToken` (new migration). Browser PushManager subscriptions authenticate via the web session and leave it null — the built-in service worker doesn't need it.
- **`notification_id`**: thread the persisted notification id through `sendNotificationAlerts` → `sendPushNotification` from every notification-creating action (`like`, `announce`, `createFollower`, `mention`/`reply` in `mention.ts` and `createNote.ts`).
- **`notification_type`**: map the internal type to the Mastodon type via `internalTypeToMastodon`.
- **`icon`**: the sender's avatar (`sourceActor.iconUrl`); the service worker now uses it as the notification icon.
- The payload is built **per subscription** because `access_token` differs between subscriptions.

> Note: Mastodon serializes `notification_id` as an integer (its ids are integers); this app uses string ids, matching its own notifications API — the same approach GoToSocial (ULIDs) takes, which mainstream clients accept.

## Migration & schema

- Adds `migrations/20260614120000_add_push_subscription_access_token.js` (nullable `accessToken` text column).
- Regenerates both reference schema dumps (`migrations/schema.sql` for PostgreSQL via a throwaway PG 17 container, `migrations/schema.sqlite.sql` for SQLite); both diffs are limited to the new column.

## Tests

- `yarn run prettier --write .` ✅
- `yarn lint` ✅ (0 errors)
- `yarn build` ✅
- `yarn test` ✅ — 508 suites / 4358 tests pass

New coverage: Mastodon-payload shape and empty-fallback behavior in `pushNotification.test.ts`, access-token storage in the subscription route test and the DB-layer test.

https://claude.ai/code/session_011SooDmJPaPyVWHQsfmmjF3

---
_Generated by [Claude Code](https://claude.ai/code/session_011SooDmJPaPyVWHQsfmmjF3)_