### PR TITLE
fix: resolve account lookup across local domains for multi-domain hosting

### DIFF
--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -117,6 +117,32 @@ describe('GET /api/v1/accounts/lookup', () => {
     expect(await response.json()).toEqual(account)
   })
 
+  it('resolves a mixed-case local host handle in canonical form', async () => {
+    // `acct=test1@LLUN.TEST` must still find the host's own user even though
+    // actors are stored with a lowercase domain.
+    const actor = { id: 'https://llun.test/users/test1' }
+    const account = { id: 'test1', username: 'test1', acct: 'test1' }
+    mockGetActorFromUsername.mockImplementation(
+      ({ username, domain }: { username: string; domain: string }) =>
+        username === 'test1' && domain === 'llun.test' ? actor : null
+    )
+    mockGetMastodonActorFromId.mockResolvedValue(account)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=test1@LLUN.TEST'
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'test1',
+      domain: 'llun.test'
+    })
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual(account)
+  })
+
   it('does not remotely resolve a missing local-domain account', async () => {
     mockGetActorFromUsername.mockResolvedValue(null)
 

--- a/app/api/v1/accounts/lookup/route.test.ts
+++ b/app/api/v1/accounts/lookup/route.test.ts
@@ -40,7 +40,7 @@ jest.mock('@/lib/database', () => ({
 
 jest.mock('@/lib/config', () => ({
   getBaseURL: () => 'https://llun.test',
-  getConfig: () => ({ host: 'llun.test' })
+  getConfig: () => ({ host: 'llun.test', allowActorDomains: ['llun.dev'] })
 }))
 
 jest.mock('better-auth/oauth2', () => ({
@@ -81,6 +81,53 @@ describe('GET /api/v1/accounts/lookup', () => {
       username: 'test1',
       domain: 'llun.test'
     })
+  })
+
+  it('resolves a local username addressed by a different local domain', async () => {
+    // The user `null` lives on the allowed actor domain `llun.dev`, but a client
+    // (e.g. Phanpy) looks them up as `null@llun.test` (the configured host).
+    const actor = { id: 'https://llun.dev/users/null' }
+    const account = {
+      id: 'llun.dev:users:null',
+      username: 'null',
+      acct: 'null@llun.dev'
+    }
+    mockGetActorFromUsername.mockImplementation(
+      ({ username, domain }: { username: string; domain: string }) =>
+        username === 'null' && domain === 'llun.dev' ? actor : null
+    )
+    mockGetMastodonActorFromId.mockResolvedValue(account)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=null@llun.test'
+      )
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'null',
+      domain: 'llun.test'
+    })
+    expect(mockGetActorFromUsername).toHaveBeenCalledWith({
+      username: 'null',
+      domain: 'llun.dev'
+    })
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual(account)
+  })
+
+  it('does not remotely resolve a missing local-domain account', async () => {
+    mockGetActorFromUsername.mockResolvedValue(null)
+
+    const response = await GET(
+      new NextRequest(
+        'https://llun.test/api/v1/accounts/lookup?acct=ghost@llun.dev&resolve=true'
+      )
+    )
+
+    expect(response.status).toBe(404)
+    expect(mockGetWebfingerSelf).not.toHaveBeenCalled()
   })
 
   it('rejects handles with more than one username/domain separator', async () => {

--- a/app/api/v1/accounts/lookup/route.ts
+++ b/app/api/v1/accounts/lookup/route.ts
@@ -99,14 +99,20 @@ export const GET = traceApiRoute('lookupAccount', async (req: NextRequest) => {
   // *different* local domain (e.g. an `ACTIVITIES_ALLOW_ACTOR_DOMAINS` entry
   // while the user signed in via the configured host). When the requested
   // domain is one of our own served domains and the exact match misses,
-  // resolve the username against the instance's other local domains before
-  // giving up. This is what lets Phanpy's account switcher — which looks up
+  // resolve the username against the instance's local domains before giving
+  // up. This is what lets Phanpy's account switcher — which looks up
   // `null@<host>` for the logged-in `null@<other-local-domain>` user — load
   // the profile instead of failing with "Unable to load account".
+  //
+  // `getLocalActorDomains()` is already normalized (lowercase, no wildcards),
+  // so iterating it also re-tries the requested domain in canonical form,
+  // catching mixed-case handles the raw exact match above can miss. Usernames
+  // are unique per domain; if the same username exists on multiple local
+  // domains, this returns the first match in `getLocalActorDomains()` order
+  // (configured host first). The response still carries the actor's own
+  // qualified `acct`, so clients never collapse distinct same-name accounts.
   if (!actor && isLocalFederationDomain(domain)) {
-    const normalizedDomain = domain.toLowerCase()
     for (const localDomain of getLocalActorDomains()) {
-      if (localDomain === normalizedDomain) continue
       actor = await database.getActorFromUsername({
         username,
         domain: localDomain

--- a/app/api/v1/accounts/lookup/route.ts
+++ b/app/api/v1/accounts/lookup/route.ts
@@ -6,6 +6,10 @@ import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import {
+  getLocalActorDomains,
+  isLocalFederationDomain
+} from '@/lib/services/federation/domainPolicy'
+import {
   OptionalOAuthGuard,
   corsErrorResponse,
   isBearerAuthorizationHeader
@@ -89,7 +93,29 @@ export const GET = traceApiRoute('lookupAccount', async (req: NextRequest) => {
 
   const { username, domain } = handle
   let actor = await database.getActorFromUsername({ username, domain })
-  if (!actor && resolve && domain !== config.host) {
+
+  // Multi-domain hosting: clients build the current user's handle as
+  // `username@<instance host>`, but the actor's canonical domain may be a
+  // *different* local domain (e.g. an `ACTIVITIES_ALLOW_ACTOR_DOMAINS` entry
+  // while the user signed in via the configured host). When the requested
+  // domain is one of our own served domains and the exact match misses,
+  // resolve the username against the instance's other local domains before
+  // giving up. This is what lets Phanpy's account switcher — which looks up
+  // `null@<host>` for the logged-in `null@<other-local-domain>` user — load
+  // the profile instead of failing with "Unable to load account".
+  if (!actor && isLocalFederationDomain(domain)) {
+    const normalizedDomain = domain.toLowerCase()
+    for (const localDomain of getLocalActorDomains()) {
+      if (localDomain === normalizedDomain) continue
+      actor = await database.getActorFromUsername({
+        username,
+        domain: localDomain
+      })
+      if (actor) break
+    }
+  }
+
+  if (!actor && resolve && !isLocalFederationDomain(domain)) {
     const hasBearerAuthorization = isBearerAuthorizationHeader(
       req.headers.get('Authorization')
     )

--- a/app/api/v1/accounts/lookup/route.ts
+++ b/app/api/v1/accounts/lookup/route.ts
@@ -104,15 +104,18 @@ export const GET = traceApiRoute('lookupAccount', async (req: NextRequest) => {
   // `null@<host>` for the logged-in `null@<other-local-domain>` user — load
   // the profile instead of failing with "Unable to load account".
   //
-  // `getLocalActorDomains()` is already normalized (lowercase, no wildcards),
-  // so iterating it also re-tries the requested domain in canonical form,
-  // catching mixed-case handles the raw exact match above can miss. Usernames
-  // are unique per domain; if the same username exists on multiple local
-  // domains, this returns the first match in `getLocalActorDomains()` order
-  // (configured host first). The response still carries the actor's own
-  // qualified `acct`, so clients never collapse distinct same-name accounts.
+  // `getLocalActorDomains()` is normalized (lowercase, no wildcards). We skip
+  // the domain already queried above to avoid a redundant roundtrip, but only
+  // by exact string match — a mixed-case handle (e.g. `user@LLUN.TEST`) still
+  // falls through to its canonical `llun.test` entry here, which is how actors
+  // are stored. Usernames are unique per domain; if the same username exists
+  // on multiple local domains this returns the first match in
+  // `getLocalActorDomains()` order (configured host first). The response still
+  // carries the actor's own qualified `acct`, so clients never collapse
+  // distinct same-name accounts.
   if (!actor && isLocalFederationDomain(domain)) {
     for (const localDomain of getLocalActorDomains()) {
+      if (localDomain === domain) continue
       actor = await database.getActorFromUsername({
         username,
         domain: localDomain

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -3,6 +3,7 @@ import { Database } from '@/lib/database/types'
 import {
   canFederateWithDomain,
   filterFederatedUrls,
+  getLocalActorDomains,
   isDomainAllowed,
   isLocalFederationDomain
 } from './domainPolicy'
@@ -132,6 +133,26 @@ describe('domainPolicy', () => {
     expect(isLocalFederationDomain('https://sub.trusted.test/users/a')).toBe(
       true
     )
+  })
+
+  it('lists concrete local actor domains and drops wildcards/duplicates', () => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: ['alias.test', '*.trusted.test', 'local.test'],
+      federationMode: 'open'
+    })
+
+    expect(getLocalActorDomains()).toEqual(['local.test', 'alias.test'])
+  })
+
+  it('lists the configured host when no actor domains are set', () => {
+    mockGetConfig.mockReturnValue({
+      host: 'local.test',
+      allowActorDomains: [],
+      federationMode: 'open'
+    })
+
+    expect(getLocalActorDomains()).toEqual(['local.test'])
   })
 
   it('filters URLs with a batched block lookup', async () => {

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -31,6 +31,24 @@ export const isLocalFederationDomain = (value: string): boolean => {
   })
 }
 
+/**
+ * The instance's concrete (non-wildcard) local domains: the configured host
+ * plus every entry in `allowActorDomains`. Wildcard patterns are dropped since
+ * they cannot be used as a literal domain to query an actor by. Useful for
+ * resolving a local username that may live on a different served domain than
+ * the one a client addressed it by (multi-domain hosting).
+ */
+export const getLocalActorDomains = (): string[] => {
+  const config = getConfig()
+  const domains = [config.host, ...(config.allowActorDomains ?? [])]
+    .map((domain) => normalizeDomain(domain))
+    .filter(
+      (domain): domain is string => domain !== null && !domain.startsWith('*.')
+    )
+
+  return Array.from(new Set(domains))
+}
+
 export const isDomainBlocked = async (
   database: Database,
   value: string


### PR DESCRIPTION
## Problem

Opening the logged-in user's own profile from a Mastodon client such as **phanpy.social** fails with **"Unable to load account. null@llun.social"** (see screenshot in the task), even though the profile header itself renders fine.

## Root cause

This instance uses multi-domain hosting: the configured host is `llun.social` while the user `null` actually lives on the allowed actor domain `llun.dev` (`ACTIVITIES_ALLOW_ACTOR_DOMAINS`). The account is therefore correctly reported with the qualified `acct: "null@llun.dev"`.

Phanpy's account switcher, however, builds the current user's handle from the bare username plus the instance host it logged in through:

```js
// phanpy src/pages/accounts.jsx
states.showAccount = `${account.info.username}@${account.instanceURL}`
```

That produces `null@llun.social`, and phanpy then calls `GET /api/v1/accounts/lookup?acct=null@llun.social`.

The lookup route only matched the **exact** `(username, domain)` pair. Since no actor exists for `(null, llun.social)` — the actor is `(null, llun.dev)` — it returned `404`, surfacing as "Unable to load account". I confirmed this against the live server:

| Request | Result |
| --- | --- |
| `lookup?acct=null@llun.dev` | `200` (acct `null@llun.dev`) |
| `lookup?acct=null@llun.social` | `404` |
| `lookup?acct=null` | `404` |

## Fix

In `GET /api/v1/accounts/lookup`, when the exact match misses **and the requested domain is one of the instance's own served domains**, resolve the username against the instance's other local domains before giving up. This lets `null@llun.social` resolve to the local `null@llun.dev` actor.

- Added `getLocalActorDomains()` to `lib/services/federation/domainPolicy.ts` — the concrete (non-wildcard) local domains: configured host + `allowActorDomains`.
- The remote-resolution path now skips **any** local domain (previously it only excluded the configured host), so a missing local-domain account never triggers a webfinger round-trip.
- Exact matches are still tried first, so genuinely distinct same-username accounts on different local domains keep resolving to themselves — only a miss falls back.

WebFinger is intentionally left strict (canonical domain only) so federation `subject`/handle semantics are unaffected; this leniency is scoped to the client-facing Mastodon lookup endpoint.

## Tests

- `app/api/v1/accounts/lookup/route.test.ts`: resolves a local username addressed by a different local domain; a missing local-domain account 404s without remote resolution.
- `lib/services/federation/domainPolicy.test.ts`: `getLocalActorDomains()` lists concrete local domains and drops wildcards/duplicates.

`yarn run prettier --write`, `yarn lint`, `yarn build`, and `yarn test` (4358 passed) all green.

https://claude.ai/code/session_01493KvXHtUu8f1RSR5XkzNh

---
_Generated by [Claude Code](https://claude.ai/code/session_01493KvXHtUu8f1RSR5XkzNh)_