### PR TITLE
Bump version to v1.74.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.74.2",
+  "version": "1.74.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.74.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.74.2`
- Base main SHA: `505401ef357dbafaeb639bcc869d526bf1609bf0`
- Included commits: `5`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
