### PR TITLE
fix: keep Corepack cache outside ESM project tree in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,20 @@ ENV ACTIVITIES_HOST=${ACTIVITIES_HOST}
 ENV ACTIVITIES_DATABASE_TYPE=${ACTIVITIES_DATABASE_TYPE}
 ENV ACTIVITIES_DATABASE_CLIENT=${ACTIVITIES_DATABASE_CLIENT}
 ENV ACTIVITIES_DATABASE_SQLITE_FILENAME=${ACTIVITIES_DATABASE_SQLITE_FILENAME}
+# Keep Corepack's download cache outside the project tree. The app user's HOME is
+# /opt/activities.next (the project root), so the default COREPACK_HOME of
+# $HOME/.cache/node/corepack would place the downloaded yarn.js inside a package
+# whose package.json has "type": "module". Node would then load Corepack's
+# CommonJS yarn bundle as ESM and fail with `Dynamic require of "util" is not
+# supported`. Pointing COREPACK_HOME at a directory with no "type": "module"
+# ancestor lets Node load yarn as CommonJS.
+ENV COREPACK_HOME="/opt/corepack"
 RUN apk add ffmpeg
 RUN \
-  mkdir -p /opt/activities.next; \
+  mkdir -p /opt/activities.next /opt/corepack; \
   addgroup --system --gid "${GID}" app; \
-  adduser --system --uid "${UID}" --home /opt/activities.next app
+  adduser --system --uid "${UID}" --home /opt/activities.next app; \
+  chown app:app /opt/corepack
 RUN corepack enable
 WORKDIR /opt/activities.next
 USER app


### PR DESCRIPTION
## Summary

The Docker image build (`package.yml` → *Build amd64/arm64 image*) started failing on the very first Yarn invocation:

```
#12 0.512 Error: Dynamic require of "util" is not supported
#12 ERROR: process "/bin/sh -c yarn config set -H enableGlobalCache true" did not complete successfully: exit code: 1
ERROR: failed to build: failed to solve: ... exit code: 1
```

(see the failing run: <https://github.com/llun/activities.next/actions/runs/27597846054/job/81591793341>)

## Root cause

The `Dockerfile` creates the `app` user with `--home /opt/activities.next` (the project root). Corepack's cache defaults to `$HOME/.cache/node/corepack`, so the downloaded Yarn lands at:

```
/opt/activities.next/.cache/node/corepack/v1/yarn/4.15.0/yarn.js
```

That path is **inside** a package whose `package.json` declares `"type": "module"` (the project is ESM-only). A newer Corepack — pulled in transparently via the moving `node:24-alpine` tag — now stores and launches Yarn from that location, so Node resolves the nearest `package.json`, treats Corepack's **CommonJS** Yarn bundle as **ESM**, and crashes on its internal dynamic `require("util")`.

This is why the build broke without any change to the `Dockerfile` (the offending line is unchanged since 2024) and why it still builds fine locally — on a dev machine `HOME` is outside the project, so the cached Yarn has no `"type": "module"` ancestor.

This matches the upstream reports:
- nodejs/corepack#604 — "Corepack doesn't properly set up Yarn in an ESM project"
- yarnpkg/berry#5831 / #6773

## Fix

Set `COREPACK_HOME=/opt/corepack` (created and `chown`ed to `app`), outside the project tree, so the downloaded Yarn has no `"type": "module"` ancestor and Node loads it as CommonJS. No `.yarn` artifacts are committed — the repo's existing corepack-provisioning approach is preserved.

## Verification

- Reproduced the original failure with a minimal `node:24-alpine` image (HOME = ESM project root) → same `Dynamic require of "util"` crash.
- Applied the fix to the same harness → `yarn config set` and `yarn --version` succeed.
- Built the **real** image end-to-end (`docker build --platform linux/amd64 .`): `yarn install --immutable`, `yarn dedupe`, `yarn knex migrate:latest`, and `yarn build` all pass; final image produced (487 MB), exit code 0.
- `yarn lint` green (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)