### PR TITLE
Bump version to v1.74.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.74.3",
+  "version": "1.74.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.74.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.74.3`
- Base main SHA: `74e7de2cbcde3cf1c046d8f4c522bf8fd18adb3c`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
