### PR TITLE
Bump version to v1.74.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.74.4",
+  "version": "1.74.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.74.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.74.4`
- Base main SHA: `a8307bc03829d57864f2ffa0f27f3a37647bf0ba`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
