### PR TITLE
minor: add ActivityPub relay support

### DIFF
--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -6,6 +6,7 @@ import {
   Globe,
   Hash,
   Megaphone,
+  Rss,
   Scale,
   Settings,
   Smile,
@@ -34,6 +35,7 @@ const tabs: SectionNavTab[] = [
   { name: 'Rules', url: '/admin/rules', icon: Scale },
   { name: 'Announcements', url: '/admin/announcements', icon: Megaphone },
   { name: 'Federation', url: '/admin/federation', icon: Globe },
+  { name: 'Relays', url: '/admin/relays', icon: Rss },
   { name: 'Custom emojis', url: '/admin/emojis', icon: Smile },
   { name: 'System', url: '/admin/system', icon: Settings }
 ]

--- a/app/(timeline)/admin/relays/actions.test.ts
+++ b/app/(timeline)/admin/relays/actions.test.ts
@@ -156,7 +156,8 @@ describe('unsubscribeRelayAction', () => {
     )
     expect(mockDatabase.updateRelay).toHaveBeenCalledWith({
       id: 'relay-1',
-      state: 'idle'
+      state: 'idle',
+      followActivityId: null
     })
   })
 })

--- a/app/(timeline)/admin/relays/actions.test.ts
+++ b/app/(timeline)/admin/relays/actions.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { followRelay, unfollowRelay } from '@/lib/activities'
+import { Relay } from '@/lib/types/domain/relay'
+
+import {
+  addRelayAction,
+  removeRelayAction,
+  subscribeRelayAction,
+  unsubscribeRelayAction
+} from './actions'
+
+const mockDatabase = {
+  createRelay: vi.fn(),
+  getRelayById: vi.fn(),
+  updateRelay: vi.fn(),
+  deleteRelay: vi.fn(),
+  getRelays: vi.fn()
+}
+
+vi.mock('@/lib/database', () => ({ getDatabase: () => mockDatabase }))
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+vi.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: vi.fn().mockResolvedValue({ id: 'admin' })
+}))
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: vi.fn().mockResolvedValue({
+    id: 'https://local/users/__instance__',
+    domain: 'local'
+  })
+}))
+vi.mock('@/lib/activities', () => ({
+  followRelay: vi.fn(),
+  unfollowRelay: vi.fn()
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`)
+  })
+}))
+
+const buildRelay = (overrides: Partial<Relay> = {}): Relay => ({
+  id: 'relay-1',
+  inboxUrl: 'https://relay.example/inbox',
+  actorId: null,
+  state: 'idle',
+  followActivityId: null,
+  lastError: null,
+  createdAt: 0,
+  updatedAt: 0,
+  ...overrides
+})
+
+const formDataOf = (entries: Record<string, string>): FormData => {
+  const formData = new FormData()
+  for (const [key, value] of Object.entries(entries)) {
+    formData.set(key, value)
+  }
+  return formData
+}
+
+const expectRedirectStatus = async (
+  action: Promise<unknown>,
+  status: string
+) => {
+  await expect(action).rejects.toThrow(
+    `REDIRECT:/admin/relays?status=${status}`
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('addRelayAction', () => {
+  it('creates the relay, sends the Follow, and marks it pending when delivery succeeds', async () => {
+    const relay = buildRelay()
+    mockDatabase.createRelay.mockResolvedValue(relay)
+    vi.mocked(followRelay).mockResolvedValue({
+      followActivityId: 'https://local/follow-1',
+      ok: true
+    })
+
+    await expectRedirectStatus(
+      addRelayAction(formDataOf({ inboxUrl: 'https://relay.example/inbox' })),
+      'relay-added'
+    )
+
+    expect(mockDatabase.createRelay).toHaveBeenCalledWith({
+      inboxUrl: 'https://relay.example/inbox'
+    })
+    expect(followRelay).toHaveBeenCalledWith(
+      relay,
+      expect.objectContaining({ id: 'https://local/users/__instance__' })
+    )
+    expect(mockDatabase.updateRelay).toHaveBeenCalledWith({
+      id: relay.id,
+      state: 'pending',
+      followActivityId: 'https://local/follow-1',
+      lastError: null
+    })
+  })
+
+  it('does not create a relay when the inbox URL is invalid', async () => {
+    await expectRedirectStatus(
+      addRelayAction(formDataOf({ inboxUrl: 'not-a-url' })),
+      'invalid-inbox-url'
+    )
+
+    expect(mockDatabase.createRelay).not.toHaveBeenCalled()
+    expect(followRelay).not.toHaveBeenCalled()
+  })
+})
+
+describe('subscribeRelayAction', () => {
+  it('sends the Follow for an existing relay', async () => {
+    const relay = buildRelay({ state: 'idle' })
+    mockDatabase.getRelayById.mockResolvedValue(relay)
+    vi.mocked(followRelay).mockResolvedValue({
+      followActivityId: 'https://local/follow-2',
+      ok: true
+    })
+
+    await expectRedirectStatus(
+      subscribeRelayAction(formDataOf({ id: 'relay-1' })),
+      'relay-subscribing'
+    )
+
+    expect(followRelay).toHaveBeenCalled()
+    expect(mockDatabase.updateRelay).toHaveBeenCalledWith({
+      id: 'relay-1',
+      state: 'pending',
+      followActivityId: 'https://local/follow-2',
+      lastError: null
+    })
+  })
+})
+
+describe('unsubscribeRelayAction', () => {
+  it('sends the Undo and sets the relay back to idle', async () => {
+    const relay = buildRelay({ state: 'accepted' })
+    mockDatabase.getRelayById.mockResolvedValue(relay)
+    vi.mocked(unfollowRelay).mockResolvedValue(true)
+
+    await expectRedirectStatus(
+      unsubscribeRelayAction(formDataOf({ id: 'relay-1' })),
+      'relay-unsubscribed'
+    )
+
+    expect(unfollowRelay).toHaveBeenCalledWith(
+      relay,
+      expect.objectContaining({ id: 'https://local/users/__instance__' })
+    )
+    expect(mockDatabase.updateRelay).toHaveBeenCalledWith({
+      id: 'relay-1',
+      state: 'idle'
+    })
+  })
+})
+
+describe('removeRelayAction', () => {
+  it('sends the Undo for an accepted relay and deletes it', async () => {
+    const relay = buildRelay({ state: 'accepted' })
+    mockDatabase.getRelayById.mockResolvedValue(relay)
+    vi.mocked(unfollowRelay).mockResolvedValue(true)
+
+    await expectRedirectStatus(
+      removeRelayAction(formDataOf({ id: 'relay-1' })),
+      'relay-removed'
+    )
+
+    expect(unfollowRelay).toHaveBeenCalledWith(
+      relay,
+      expect.objectContaining({ id: 'https://local/users/__instance__' })
+    )
+    expect(mockDatabase.deleteRelay).toHaveBeenCalledWith({ id: 'relay-1' })
+  })
+
+  it('deletes an idle relay without sending an Undo', async () => {
+    const relay = buildRelay({ state: 'idle' })
+    mockDatabase.getRelayById.mockResolvedValue(relay)
+
+    await expectRedirectStatus(
+      removeRelayAction(formDataOf({ id: 'relay-1' })),
+      'relay-removed'
+    )
+
+    expect(unfollowRelay).not.toHaveBeenCalled()
+    expect(mockDatabase.deleteRelay).toHaveBeenCalledWith({ id: 'relay-1' })
+  })
+})

--- a/app/(timeline)/admin/relays/actions.ts
+++ b/app/(timeline)/admin/relays/actions.ts
@@ -94,7 +94,9 @@ export async function unsubscribeRelayAction(formData: FormData) {
   if (relay) {
     const signingActor = await getFederationSigningActor(database)
     if (signingActor) await unfollowRelay(relay, signingActor)
-    await database.updateRelay({ id, state: 'idle' })
+    // Clear the Follow id so a stale/late Accept cannot re-match and resurrect
+    // the subscription (acceptRelayRequest also guards on the pending state).
+    await database.updateRelay({ id, state: 'idle', followActivityId: null })
   }
 
   redirectWithStatus('relay-unsubscribed')

--- a/app/(timeline)/admin/relays/actions.ts
+++ b/app/(timeline)/admin/relays/actions.ts
@@ -1,0 +1,118 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+import { followRelay, unfollowRelay } from '@/lib/activities'
+import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { Relay } from '@/lib/types/domain/relay'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+import { logger } from '@/lib/utils/logger'
+
+const ADMIN_RELAYS_PATH = '/admin/relays'
+
+const getAdminDatabase = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) redirect('/')
+
+  return database
+}
+
+const redirectWithStatus = (status: string): never => {
+  revalidatePath(ADMIN_RELAYS_PATH)
+  redirect(`${ADMIN_RELAYS_PATH}?status=${encodeURIComponent(status)}`)
+}
+
+const getText = (formData: FormData, key: string): string =>
+  String(formData.get(key) ?? '').trim()
+
+const isValidInboxUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+const subscribe = async (database: Database, relay: Relay) => {
+  const signingActor = await getFederationSigningActor(database)
+  if (!signingActor) throw new Error('Failed to load the federation signer')
+
+  const { followActivityId, ok } = await followRelay(relay, signingActor)
+  await database.updateRelay({
+    id: relay.id,
+    state: ok ? 'pending' : 'idle',
+    followActivityId,
+    lastError: ok ? null : 'Failed to deliver the Follow to the relay inbox'
+  })
+}
+
+const createRelayOrRedirect = async (
+  database: Database,
+  inboxUrl: string
+): Promise<Relay> => {
+  try {
+    return await database.createRelay({ inboxUrl })
+  } catch (error) {
+    logger.error({ message: 'Failed to create relay', inboxUrl, error })
+    return redirectWithStatus('duplicate-inbox-url')
+  }
+}
+
+export async function addRelayAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const inboxUrl = getText(formData, 'inboxUrl')
+  if (!isValidInboxUrl(inboxUrl)) redirectWithStatus('invalid-inbox-url')
+
+  const relay = await createRelayOrRedirect(database, inboxUrl)
+  await subscribe(database, relay)
+
+  redirectWithStatus('relay-added')
+}
+
+export async function subscribeRelayAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const id = getText(formData, 'id')
+  const relay = await database.getRelayById({ id })
+  if (relay) await subscribe(database, relay)
+
+  redirectWithStatus('relay-subscribing')
+}
+
+export async function unsubscribeRelayAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const id = getText(formData, 'id')
+  const relay = await database.getRelayById({ id })
+  if (relay) {
+    const signingActor = await getFederationSigningActor(database)
+    if (signingActor) await unfollowRelay(relay, signingActor)
+    await database.updateRelay({ id, state: 'idle' })
+  }
+
+  redirectWithStatus('relay-unsubscribed')
+}
+
+export async function removeRelayAction(formData: FormData) {
+  const database = await getAdminDatabase()
+  const id = getText(formData, 'id')
+  const relay = await database.getRelayById({ id })
+  if (relay && (relay.state === 'accepted' || relay.state === 'pending')) {
+    try {
+      const signingActor = await getFederationSigningActor(database)
+      if (signingActor) await unfollowRelay(relay, signingActor)
+    } catch (error) {
+      logger.warn({ message: 'Failed to send relay Undo on removal', error })
+    }
+  }
+  await database.deleteRelay({ id })
+
+  redirectWithStatus('relay-removed')
+}

--- a/app/(timeline)/admin/relays/page.tsx
+++ b/app/(timeline)/admin/relays/page.tsx
@@ -1,0 +1,176 @@
+import { Trash2 } from 'lucide-react'
+import { redirect } from 'next/navigation'
+
+import {
+  addRelayAction,
+  removeRelayAction,
+  subscribeRelayAction,
+  unsubscribeRelayAction
+} from '@/app/(timeline)/admin/relays/actions'
+import { PageHeader } from '@/lib/components/page-header'
+import { Button } from '@/lib/components/ui/button'
+import { Input } from '@/lib/components/ui/input'
+import { Label } from '@/lib/components/ui/label'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { RelayState } from '@/lib/types/domain/relay'
+import { cn } from '@/lib/utils'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+interface Props {
+  searchParams: Promise<Record<string, string | undefined>>
+}
+
+const STATUS_MESSAGES: Record<string, string> = {
+  'relay-added': 'Relay added and subscription requested',
+  'relay-subscribing': 'Subscription requested',
+  'relay-unsubscribed': 'Unsubscribed from relay',
+  'relay-removed': 'Relay removed',
+  'invalid-inbox-url': 'Enter a valid relay inbox URL',
+  'duplicate-inbox-url': 'A relay with that inbox URL already exists'
+}
+
+const ERROR_STATUSES = new Set(['invalid-inbox-url', 'duplicate-inbox-url'])
+
+const STATE_BADGE_CLASSES: Record<RelayState, string> = {
+  idle: 'border-border bg-muted text-muted-foreground',
+  pending:
+    'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100',
+  accepted:
+    'border-green-200 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-100',
+  rejected:
+    'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100'
+}
+
+const Page = async ({ searchParams }: Props) => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const { status } = await searchParams
+  const statusMessage = status ? (STATUS_MESSAGES[status] ?? null) : null
+  const isErrorStatus = status ? ERROR_STATUSES.has(status) : false
+
+  const relays = await database.getRelays()
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Relays"
+        description="Relays distribute your public posts to other servers and bring their public posts back, so you can federate with instances you do not directly follow."
+      />
+
+      {statusMessage && (
+        <div
+          className={cn(
+            'rounded-lg border px-4 py-3 text-sm',
+            isErrorStatus
+              ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100'
+              : 'border-green-200 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-100'
+          )}
+        >
+          {statusMessage}
+        </div>
+      )}
+
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold">Add relay</h2>
+        <form action={addRelayAction} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="relay-inbox-url">Inbox URL</Label>
+            <Input
+              id="relay-inbox-url"
+              required
+              type="url"
+              name="inboxUrl"
+              placeholder="https://relay.example/inbox"
+            />
+          </div>
+          <Button type="submit">Add relay</Button>
+        </form>
+      </section>
+
+      <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold">Relays</h2>
+        <div className="space-y-2">
+          {relays.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No relays configured
+            </p>
+          ) : (
+            relays.map((relay) => {
+              const canSubscribe =
+                relay.state === 'idle' || relay.state === 'rejected'
+
+              return (
+                <div
+                  key={relay.id}
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate font-medium">{relay.inboxUrl}</p>
+                      <span
+                        className={cn(
+                          'shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium capitalize',
+                          STATE_BADGE_CLASSES[relay.state]
+                        )}
+                      >
+                        {relay.state}
+                      </span>
+                    </div>
+                    {relay.actorId && (
+                      <p className="truncate text-sm text-muted-foreground">
+                        {relay.actorId}
+                      </p>
+                    )}
+                    {relay.lastError && (
+                      <p className="truncate text-sm text-destructive">
+                        {relay.lastError}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {canSubscribe ? (
+                      <form action={subscribeRelayAction}>
+                        <input type="hidden" name="id" value={relay.id} />
+                        <Button type="submit" variant="outline" size="sm">
+                          Subscribe
+                        </Button>
+                      </form>
+                    ) : (
+                      <form action={unsubscribeRelayAction}>
+                        <input type="hidden" name="id" value={relay.id} />
+                        <Button type="submit" variant="outline" size="sm">
+                          Unsubscribe
+                        </Button>
+                      </form>
+                    )}
+                    <form action={removeRelayAction}>
+                      <input type="hidden" name="id" value={relay.id} />
+                      <Button
+                        type="submit"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Remove relay ${relay.inboxUrl}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </form>
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default Page

--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -148,7 +148,7 @@ describe('POST /api/inbox', () => {
       )
     })
 
-    it('does not route a pending relay Announce to the relay ingest job', async () => {
+    it('acknowledges a known-but-not-accepted relay Announce without boosting it', async () => {
       mockCanFederateWithDomain.mockResolvedValue(true)
       mockVerifiedSenderActorId = RELAY_ACTOR
       mockActivityBody = relayAnnounceBody
@@ -158,13 +158,14 @@ describe('POST /api/inbox', () => {
         state: 'pending'
       })
 
-      await POST(createRequest(RELAY_ACTOR), {
+      const response = await POST(createRequest(RELAY_ACTOR), {
         params: Promise.resolve({})
       })
 
-      expect(mockPublish).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'RelayAnnounceJob' })
-      )
+      // A known relay's Announce must never fall through to the boost path, so
+      // no job (relay ingest OR CreateAnnounce) is enqueued.
+      expect(response.status).toBe(202)
+      expect(mockPublish).not.toHaveBeenCalled()
     })
   })
 

--- a/app/api/inbox/route.test.ts
+++ b/app/api/inbox/route.test.ts
@@ -3,7 +3,10 @@ import { NextRequest } from 'next/server'
 import { POST } from './route'
 
 const mockCanFederateWithDomain = vi.fn()
-const mockDatabase = {}
+const mockGetRelayByActorId = vi.fn()
+const mockDatabase = {
+  getRelayByActorId: (...params: unknown[]) => mockGetRelayByActorId(...params)
+}
 const mockPublish = vi.fn()
 const mockDefaultActivityBody = Symbol('defaultActivityBody')
 let mockActivityBody: unknown = mockDefaultActivityBody
@@ -91,6 +94,78 @@ describe('POST /api/inbox', () => {
     mockActivityBody = mockDefaultActivityBody
     mockConsumeRequestBody = false
     mockVerifiedSenderActorId = 'https://allowed.test/users/a'
+    mockGetRelayByActorId.mockResolvedValue(null)
+  })
+
+  describe('relay Announce routing', () => {
+    const RELAY_ACTOR = 'https://relay.example/actor'
+    const relayAnnounceBody = {
+      id: `${RELAY_ACTOR}/announce/1`,
+      type: 'Announce',
+      actor: RELAY_ACTOR,
+      published: '2024-01-01T00:00:00Z',
+      object: 'https://somewhere.test/statuses/relayed',
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: []
+    }
+
+    it('routes an accepted relay Announce to the relay ingest job', async () => {
+      mockCanFederateWithDomain.mockResolvedValue(true)
+      mockVerifiedSenderActorId = RELAY_ACTOR
+      mockActivityBody = relayAnnounceBody
+      mockGetRelayByActorId.mockResolvedValue({
+        id: 'relay-1',
+        actorId: RELAY_ACTOR,
+        state: 'accepted'
+      })
+
+      const response = await POST(createRequest(RELAY_ACTOR), {
+        params: Promise.resolve({})
+      })
+
+      expect(response.status).toBe(202)
+      expect(mockGetRelayByActorId).toHaveBeenCalledWith({
+        actorId: RELAY_ACTOR
+      })
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'RelayAnnounceJob' })
+      )
+    })
+
+    it('does not route an Announce from a non-relay sender to the relay ingest job', async () => {
+      mockCanFederateWithDomain.mockResolvedValue(true)
+      mockVerifiedSenderActorId = RELAY_ACTOR
+      mockActivityBody = relayAnnounceBody
+      mockGetRelayByActorId.mockResolvedValue(null)
+
+      const response = await POST(createRequest(RELAY_ACTOR), {
+        params: Promise.resolve({})
+      })
+
+      expect(response.status).toBe(202)
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'CreateAnnounceJob' })
+      )
+    })
+
+    it('does not route a pending relay Announce to the relay ingest job', async () => {
+      mockCanFederateWithDomain.mockResolvedValue(true)
+      mockVerifiedSenderActorId = RELAY_ACTOR
+      mockActivityBody = relayAnnounceBody
+      mockGetRelayByActorId.mockResolvedValue({
+        id: 'relay-1',
+        actorId: RELAY_ACTOR,
+        state: 'pending'
+      })
+
+      await POST(createRequest(RELAY_ACTOR), {
+        params: Promise.resolve({})
+      })
+
+      expect(mockPublish).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'RelayAnnounceJob' })
+      )
+    })
   })
 
   it('rejects activities from blocked actor domains', async () => {

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -1,9 +1,12 @@
 import { compactActivityPub } from '@/lib/activities/jsonld'
 import { StatusActivity } from '@/lib/activities/statusAction'
+import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { ActivityPubVerifySenderGuard } from '@/lib/services/guards/ActivityPubVerifyGuard'
 import { getQueue } from '@/lib/services/queue'
+import { AnnounceAction } from '@/lib/types/activitypub/activities'
 import { extractActivityPubId, normalizeActorId } from '@/lib/utils/activitypub'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   DEFAULT_202,
@@ -62,6 +65,30 @@ export const POST = traceApiRoute(
           data: ERROR_403,
           responseStatusCode: 403
         })
+      }
+
+      // A relay forwards third-party posts as an Announce signed by the relay
+      // itself (so the signer === actor check already passed). When the verified
+      // sender is an accepted relay, route its Announce to the relay-ingest job
+      // (which re-fetches the wrapped note from origin and federates it) instead
+      // of the normal boost path — we never want a relay-attributed Announce row.
+      if (activity.type === AnnounceAction) {
+        const relay = await database.getRelayByActorId({
+          actorId: verifiedSenderActorId
+        })
+        if (relay?.state === 'accepted') {
+          await getQueue().publish({
+            id: getHashFromString(activity.id),
+            name: RELAY_ANNOUNCE_JOB_NAME,
+            data: activity
+          })
+          return apiResponse({
+            req: request,
+            allowedMethods: CORS_HEADERS,
+            data: DEFAULT_202,
+            responseStatusCode: 202
+          })
+        }
       }
 
       const jobMessage = getJobMessage(activity, verifiedSenderActorId)

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -76,12 +76,19 @@ export const POST = traceApiRoute(
         const relay = await database.getRelayByActorId({
           actorId: verifiedSenderActorId
         })
-        if (relay?.state === 'accepted') {
-          await getQueue().publish({
-            id: getHashFromString(activity.id),
-            name: RELAY_ANNOUNCE_JOB_NAME,
-            data: activity
-          })
+        // Any Announce from a KNOWN relay is relay traffic, never a normal
+        // boost. Accepted relays are ingested into the Federated timeline; a
+        // known-but-not-accepted relay (pending/rejected/unsubscribed) is
+        // acknowledged without falling through to the boost path, so it can
+        // never create a relay-attributed Announce row.
+        if (relay) {
+          if (relay.state === 'accepted') {
+            await getQueue().publish({
+              id: getHashFromString(activity.id),
+              name: RELAY_ANNOUNCE_JOB_NAME,
+              data: activity
+            })
+          }
           return apiResponse({
             req: request,
             allowedMethods: CORS_HEADERS,

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -3,6 +3,8 @@ import { NextRequest } from 'next/server'
 import { POST } from './route'
 
 const mockCanFederateWithDomain = vi.fn()
+const mockAcceptRelayRequest = vi.fn()
+const mockRejectRelayRequest = vi.fn()
 const mockCreateFollower = vi.fn()
 const mockDeleteLike = vi.fn()
 const mockApplyRemoteBlock = vi.fn()
@@ -101,6 +103,13 @@ vi.mock('@/lib/actions/acceptFollowRequest', () => ({
   acceptFollowRequest: vi.fn()
 }))
 
+vi.mock('@/lib/actions/acceptRelayRequest', () => ({
+  acceptRelayRequest: (...params: unknown[]) =>
+    mockAcceptRelayRequest(...params),
+  rejectRelayRequest: (...params: unknown[]) =>
+    mockRejectRelayRequest(...params)
+}))
+
 vi.mock('@/lib/actions/createFollower', () => ({
   createFollower: (...params: unknown[]) => mockCreateFollower(...params)
 }))
@@ -193,6 +202,90 @@ describe('POST /api/users/[username]/inbox', () => {
     expect(mockVerifyAllows).toHaveBeenCalled()
     expect(mockCanFederateWithDomain).not.toHaveBeenCalled()
     expect(mockCreateFollower).not.toHaveBeenCalled()
+  })
+
+  describe('relay handshake on the signer inbox', () => {
+    const asSigner = () => {
+      mockActor = {
+        id: 'https://activities.local/users/__instance__',
+        username: '__instance__',
+        type: 'Service',
+        privateKey: 'private-key'
+      }
+    }
+    const handshakeRequest = (type: 'Accept' | 'Reject', object: unknown) =>
+      new NextRequest('https://activities.local/api/users/__instance__/inbox', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: `https://relay.example/activities/${type.toLowerCase()}`,
+          type,
+          actor: 'https://relay.example/actor',
+          object
+        })
+      })
+
+    it('routes a verified Accept to acceptRelayRequest (object as object)', async () => {
+      asSigner()
+      const response = await POST(
+        handshakeRequest('Accept', {
+          id: 'https://activities.local/relay-follow-1',
+          type: 'Follow',
+          actor: 'https://activities.local/users/__instance__',
+          object: 'https://www.w3.org/ns/activitystreams#Public'
+        }),
+        { params: Promise.resolve({ username: '__instance__' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockAcceptRelayRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          database: mockDatabase,
+          activity: expect.objectContaining({ type: 'Accept' })
+        })
+      )
+      expect(mockRejectRelayRequest).not.toHaveBeenCalled()
+    })
+
+    it('routes a verified Accept whose object is a bare Follow id string', async () => {
+      asSigner()
+      const response = await POST(
+        handshakeRequest('Accept', 'https://activities.local/relay-follow-1'),
+        { params: Promise.resolve({ username: '__instance__' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockAcceptRelayRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('routes a verified Reject to rejectRelayRequest', async () => {
+      asSigner()
+      const response = await POST(
+        handshakeRequest('Reject', {
+          id: 'https://activities.local/relay-follow-1',
+          type: 'Follow',
+          actor: 'https://activities.local/users/__instance__',
+          object: 'https://www.w3.org/ns/activitystreams#Public'
+        }),
+        { params: Promise.resolve({ username: '__instance__' }) }
+      )
+
+      expect(response.status).toBe(202)
+      expect(mockRejectRelayRequest).toHaveBeenCalledTimes(1)
+      expect(mockAcceptRelayRequest).not.toHaveBeenCalled()
+    })
+
+    it('accepts a non-handshake activity on the signer inbox without relay side effects', async () => {
+      asSigner()
+      const response = await POST(createActorInboxActivityRequest('Like'), {
+        params: Promise.resolve({ username: '__instance__' })
+      })
+
+      expect(response.status).toBe(202)
+      expect(mockAcceptRelayRequest).not.toHaveBeenCalled()
+      expect(mockRejectRelayRequest).not.toHaveBeenCalled()
+    })
   })
 
   it('rejects requests before processing when sender verification fails', async () => {

--- a/app/api/users/[username]/inbox/route.ts
+++ b/app/api/users/[username]/inbox/route.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 
 import { acceptFollowRequest } from '@/lib/actions/acceptFollowRequest'
+import {
+  acceptRelayRequest,
+  rejectRelayRequest
+} from '@/lib/actions/acceptRelayRequest'
 import { applyRemoteBlock } from '@/lib/actions/applyRemoteBlock'
 import { applyRemoteUnblock } from '@/lib/actions/applyRemoteUnblock'
 import { createFollower } from '@/lib/actions/createFollower'
@@ -72,6 +76,18 @@ const Activity = z.union([
   GracefullyAcceptedActivity
 ])
 
+// An Accept/Reject delivered to the instance/federation signing actor is a
+// relay handshake response. Parse it leniently: relays echo the Follow we sent
+// either as the full object or as a bare id string.
+const RelayHandshake = z
+  .object({
+    id: z.string(),
+    actor: z.string(),
+    type: z.enum(['Accept', 'Reject']),
+    object: z.union([z.string(), z.object({ id: z.string() }).passthrough()])
+  })
+  .passthrough()
+
 const actorIdsMatch = (firstActorId: string, secondActorId: string) => {
   const normalizedFirstActorId = normalizeActorId(firstActorId)
   const normalizedSecondActorId = normalizeActorId(secondActorId)
@@ -108,6 +124,24 @@ export const POST = traceApiRoute(
         async (database, actor, req) => {
           try {
             if (isFederationSigningActor(actor)) {
+              // The instance/federation signing actor only ever sends relay
+              // Follows, so an Accept/Reject delivered here is a relay handshake
+              // response. The HTTP-signature guard already verified the sender
+              // is the relay (signer === activity.actor). Anything else is
+              // accepted without side effects, preserving prior behaviour.
+              const compactedHandshake = await compactActivityPub(
+                context.activityBody
+              )
+              const relayHandshake =
+                RelayHandshake.safeParse(compactedHandshake)
+              if (relayHandshake.success) {
+                const activity = relayHandshake.data
+                if (activity.type === 'Accept') {
+                  await acceptRelayRequest({ activity, database })
+                } else {
+                  await rejectRelayRequest({ activity, database })
+                }
+              }
               return apiResponse({
                 req,
                 allowedMethods: CORS_HEADERS,

--- a/app/api/v1/timelines/public/route.test.ts
+++ b/app/api/v1/timelines/public/route.test.ts
@@ -141,4 +141,35 @@ describe('GET /api/v1/timelines/public', () => {
     expect(await response.json()).toEqual([])
     expect(response.headers.get('Link')).toBeNull()
   })
+
+  describe('local/remote scope', () => {
+    const timelinesQueried = () => {
+      const spy = vi.spyOn(database, 'getTimeline').mockResolvedValue([])
+      return { spy }
+    }
+
+    it('reads both local and federated sources by default (federated view)', async () => {
+      const { spy } = timelinesQueried()
+      await GET(request(), { params: Promise.resolve({}) })
+      const queried = spy.mock.calls.map((call) => call[0].timeline)
+      expect(queried).toContain('local-public')
+      expect(queried).toContain('federated-public')
+    })
+
+    it('reads only the local source when local=true', async () => {
+      const { spy } = timelinesQueried()
+      await GET(request({ local: 'true' }), { params: Promise.resolve({}) })
+      const queried = spy.mock.calls.map((call) => call[0].timeline)
+      expect(queried).toContain('local-public')
+      expect(queried).not.toContain('federated-public')
+    })
+
+    it('reads only the federated source when remote=true', async () => {
+      const { spy } = timelinesQueried()
+      await GET(request({ remote: 'true' }), { params: Promise.resolve({}) })
+      const queried = spy.mock.calls.map((call) => call[0].timeline)
+      expect(queried).toContain('federated-public')
+      expect(queried).not.toContain('local-public')
+    })
+  })
 })

--- a/app/api/v1/timelines/public/route.test.ts
+++ b/app/api/v1/timelines/public/route.test.ts
@@ -6,6 +6,7 @@ import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { urlToId } from '@/lib/utils/urlToId'
+import { waitFor } from '@/lib/utils/waitFor'
 
 import { GET } from './route'
 
@@ -170,6 +171,69 @@ describe('GET /api/v1/timelines/public', () => {
       const queried = spy.mock.calls.map((call) => call[0].timeline)
       expect(queried).toContain('federated-public')
       expect(queried).not.toContain('local-public')
+    })
+  })
+
+  describe('merged default scope and Link scope', () => {
+    const REMOTE_ACTOR = 'https://somewhere.test/users/bob'
+
+    beforeAll(async () => {
+      await database.createActor({
+        actorId: REMOTE_ACTOR,
+        username: 'bob',
+        domain: 'somewhere.test',
+        followersUrl: `${REMOTE_ACTOR}/followers`,
+        inboxUrl: `${REMOTE_ACTOR}/inbox`,
+        sharedInboxUrl: 'https://somewhere.test/inbox',
+        publicKey: 'publicKey',
+        createdAt: Date.now()
+      })
+    })
+
+    const seedFederated = async (suffix: string) => {
+      const id = `https://somewhere.test/statuses/fed-${suffix}`
+      const status = await database.createNote({
+        id,
+        url: id,
+        actorId: REMOTE_ACTOR,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: `federated ${suffix}`
+      })
+      await database.addStatusToFederatedTimeline({
+        statusId: status.id,
+        statusActorId: status.actorId
+      })
+      return status
+    }
+
+    it('merges local and federated statuses newest-first in the default scope', async () => {
+      const federated = await seedFederated('merge-1')
+
+      const response = await GET(request(), { params: Promise.resolve({}) })
+      expect(response.status).toBe(200)
+      const ids = (await response.json()).map(
+        (status: { id: string }) => status.id
+      )
+      // Both sources present; the federated post (seeded last) is newest-first.
+      expect(ids).toContain(urlToId(federated.id))
+      expect(ids).toContain(urlToId(publicStatus.id))
+      expect(ids[0]).toBe(urlToId(federated.id))
+    })
+
+    it('carries the remote scope into the next Link when paginating', async () => {
+      await seedFederated('link-1')
+      await waitFor(5)
+      await seedFederated('link-2')
+
+      const response = await GET(request({ remote: 'true', limit: '1' }), {
+        params: Promise.resolve({})
+      })
+      expect(response.status).toBe(200)
+      const link = response.headers.get('Link')
+      expect(link).toContain('rel="next"')
+      expect(link).toContain('remote=true')
+      expect(link).not.toContain('local=true')
     })
   })
 })

--- a/app/api/v1/timelines/public/route.ts
+++ b/app/api/v1/timelines/public/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/services/timelines/request'
 import { Timeline } from '@/lib/services/timelines/types'
 import { Scope } from '@/lib/types/database/operations'
+import { Status } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -20,6 +21,25 @@ import { urlToId } from '@/lib/utils/urlToId'
 export const dynamic = 'force-dynamic'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+// Merge local-public and federated (relay-sourced) statuses into one page,
+// newest first, matching getTimeline's (createdAt, id) ordering. The two
+// sources are disjoint by author locality, but dedupe by id defensively.
+const mergePublicStatuses = (
+  local: Status[],
+  remote: Status[],
+  limit: number
+): Status[] => {
+  const byId = new Map<string, Status>()
+  for (const status of [...local, ...remote]) byId.set(status.id, status)
+  return [...byId.values()]
+    .sort((a, b) => {
+      if (b.createdAt !== a.createdAt) return b.createdAt - a.createdAt
+      if (a.id === b.id) return 0
+      return a.id < b.id ? 1 : -1
+    })
+    .slice(0, limit)
+}
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
@@ -42,6 +62,58 @@ export const GET = traceApiRoute(
         })
       }
       const pageLimit = parsedQuery.query.limit
+      const { local, remote } = parsedQuery.query
+
+      // Mastodon scope: local=true → local only, remote=true → federated only,
+      // neither (default) → the federated view (local + relay-sourced remote).
+      const fetchBatch =
+        local && !remote
+          ? ({
+              maxStatusId,
+              limit
+            }: {
+              maxStatusId: string | null
+              limit: number
+            }) =>
+              database.getTimeline({
+                timeline: Timeline.LOCAL_PUBLIC,
+                maxStatusId,
+                limit
+              })
+          : remote && !local
+            ? ({
+                maxStatusId,
+                limit
+              }: {
+                maxStatusId: string | null
+                limit: number
+              }) =>
+                database.getTimeline({
+                  timeline: Timeline.FEDERATED_PUBLIC,
+                  maxStatusId,
+                  limit
+                })
+            : async ({
+                maxStatusId,
+                limit
+              }: {
+                maxStatusId: string | null
+                limit: number
+              }) => {
+                const [localStatuses, remoteStatuses] = await Promise.all([
+                  database.getTimeline({
+                    timeline: Timeline.LOCAL_PUBLIC,
+                    maxStatusId,
+                    limit
+                  }),
+                  database.getTimeline({
+                    timeline: Timeline.FEDERATED_PUBLIC,
+                    maxStatusId,
+                    limit
+                  })
+                ])
+                return mergePublicStatuses(localStatuses, remoteStatuses, limit)
+              }
 
       const { statuses, nextMaxStatusId, filterRecords } =
         await getFilteredStatusPage({
@@ -50,12 +122,7 @@ export const GET = traceApiRoute(
           maxStatusId: parsedQuery.query.maxStatusId,
           limit: pageLimit,
           filterContext: currentActor ? 'public' : undefined,
-          fetchBatch: ({ maxStatusId, limit }) =>
-            database.getTimeline({
-              timeline: Timeline.LOCAL_PUBLIC,
-              maxStatusId,
-              limit
-            })
+          fetchBatch
         })
       const mastodonStatuses = await getMastodonStatuses(
         database,
@@ -71,8 +138,10 @@ export const GET = traceApiRoute(
       // Only `next` (older) is emitted: the public timeline query pages forward
       // by `max_id` only and has no lower-bound cursor, so a `prev`/`min_id`
       // link would not actually page to newer statuses.
+      const scopeParam = local && !remote ? '&local=true' : ''
+      const remoteScopeParam = remote && !local ? '&remote=true' : ''
       const nextLink = nextMaxStatusId
-        ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&max_id=${urlToId(nextMaxStatusId)}>; rel="next"`
+        ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&max_id=${urlToId(nextMaxStatusId)}${scopeParam}${remoteScopeParam}>; rel="next"`
         : null
       const links = [nextLink].filter(Boolean).join(', ')
       return apiResponse({

--- a/lib/actions/acceptRelayRequest.test.ts
+++ b/lib/actions/acceptRelayRequest.test.ts
@@ -1,0 +1,88 @@
+import {
+  acceptRelayRequest,
+  rejectRelayRequest
+} from '@/lib/actions/acceptRelayRequest'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+
+const FOLLOW_ID = 'https://instance.example/relay-follow-1'
+const RELAY_ACTOR = 'https://relay.example/actor'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const seedPendingRelay = async (database: Database) => {
+  const relay = await database.createRelay({
+    inboxUrl: 'https://relay.example/inbox'
+  })
+  await database.updateRelay({
+    id: relay.id,
+    state: 'pending',
+    followActivityId: FOLLOW_ID
+  })
+  return relay
+}
+
+describe('acceptRelayRequest', () => {
+  it('marks the relay accepted and records its actor id (object as object)', async () => {
+    await withFreshDatabase(async (database) => {
+      const relay = await seedPendingRelay(database)
+
+      const updated = await acceptRelayRequest({
+        activity: { actor: RELAY_ACTOR, object: { id: FOLLOW_ID } },
+        database
+      })
+
+      expect(updated?.id).toBe(relay.id)
+      expect(updated?.state).toBe('accepted')
+      expect(updated?.actorId).toBe(RELAY_ACTOR)
+      expect(updated?.lastError).toBeNull()
+    })
+  })
+
+  it('matches when the relay echoes the Follow id as a bare string', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedPendingRelay(database)
+      const updated = await acceptRelayRequest({
+        activity: { actor: RELAY_ACTOR, object: FOLLOW_ID },
+        database
+      })
+      expect(updated?.state).toBe('accepted')
+    })
+  })
+
+  it('returns null when no subscription matches the Follow id', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedPendingRelay(database)
+      const updated = await acceptRelayRequest({
+        activity: { actor: RELAY_ACTOR, object: 'https://other/follow' },
+        database
+      })
+      expect(updated).toBeNull()
+    })
+  })
+})
+
+describe('rejectRelayRequest', () => {
+  it('marks the relay rejected and records the error', async () => {
+    await withFreshDatabase(async (database) => {
+      const relay = await seedPendingRelay(database)
+      const updated = await rejectRelayRequest({
+        activity: { actor: RELAY_ACTOR, object: { id: FOLLOW_ID } },
+        database
+      })
+      expect(updated?.id).toBe(relay.id)
+      expect(updated?.state).toBe('rejected')
+      expect(updated?.lastError).toBeTruthy()
+    })
+  })
+})

--- a/lib/actions/acceptRelayRequest.test.ts
+++ b/lib/actions/acceptRelayRequest.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@/lib/actions/acceptRelayRequest'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
+import { normalizeActorId } from '@/lib/utils/activitypub'
 
 const FOLLOW_ID = 'https://instance.example/relay-follow-1'
 const RELAY_ACTOR = 'https://relay.example/actor'
@@ -68,6 +69,37 @@ describe('acceptRelayRequest', () => {
         database
       })
       expect(updated).toBeNull()
+    })
+  })
+
+  it('does not resurrect an unsubscribed (idle) relay', async () => {
+    await withFreshDatabase(async (database) => {
+      const relay = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+      // Idle (never subscribed / after an Undo) but the Follow id still matches.
+      await database.updateRelay({ id: relay.id, followActivityId: FOLLOW_ID })
+
+      const updated = await acceptRelayRequest({
+        activity: { actor: RELAY_ACTOR, object: { id: FOLLOW_ID } },
+        database
+      })
+      expect(updated).toBeNull()
+
+      const after = await database.getRelayById({ id: relay.id })
+      expect(after?.state).toBe('idle')
+    })
+  })
+
+  it('normalizes the stored relay actor id', async () => {
+    await withFreshDatabase(async (database) => {
+      await seedPendingRelay(database)
+      // A non-canonical actor id (bare host, no trailing slash).
+      const updated = await acceptRelayRequest({
+        activity: { actor: 'https://relay.example', object: { id: FOLLOW_ID } },
+        database
+      })
+      expect(updated?.actorId).toBe(normalizeActorId('https://relay.example'))
     })
   })
 })

--- a/lib/actions/acceptRelayRequest.ts
+++ b/lib/actions/acceptRelayRequest.ts
@@ -1,5 +1,6 @@
 import { Database } from '@/lib/database/types'
 import { RelayData } from '@/lib/types/database/operations'
+import { normalizeActorId } from '@/lib/utils/activitypub'
 
 // A relay confirms (Accept) or declines (Reject) the Follow we sent. The
 // activity is delivered to the instance/federation signing actor's inbox and
@@ -34,29 +35,37 @@ const resolveRelay = async (
 
 // Marks the matching relay subscription accepted and records the relay's actor
 // id (so subsequently forwarded activities are recognised). Returns the updated
-// relay, or null when no subscription matches the Accept.
+// relay, or null when no PENDING subscription matches the Accept.
+//
+// Only a `pending` relay may be accepted. This makes an admin's unsubscribe
+// durable: a delayed, duplicate, or maliciously re-sent Accept cannot resurrect
+// an idle, rejected, or already-accepted relay. The actor id is normalized to
+// the same canonical form the inbound signature guard produces, so the relay is
+// reliably matched when its forwarded activities arrive.
 export const acceptRelayRequest = async ({
   activity,
   database
 }: RelayHandshakeParams): Promise<RelayData | null> => {
   const relay = await resolveRelay(database, activity)
-  if (!relay) return null
+  if (!relay || relay.state !== 'pending') return null
+  const actorId = normalizeActorId(activity.actor)
+  if (!actorId) return null
   return database.updateRelay({
     id: relay.id,
     state: 'accepted',
-    actorId: activity.actor,
+    actorId,
     lastError: null
   })
 }
 
-// Marks the matching relay subscription rejected. Returns the updated relay, or
-// null when no subscription matches the Reject.
+// Marks the matching pending relay subscription rejected. Returns the updated
+// relay, or null when no pending subscription matches the Reject.
 export const rejectRelayRequest = async ({
   activity,
   database
 }: RelayHandshakeParams): Promise<RelayData | null> => {
   const relay = await resolveRelay(database, activity)
-  if (!relay) return null
+  if (!relay || relay.state !== 'pending') return null
   return database.updateRelay({
     id: relay.id,
     state: 'rejected',

--- a/lib/actions/acceptRelayRequest.ts
+++ b/lib/actions/acceptRelayRequest.ts
@@ -1,0 +1,65 @@
+import { Database } from '@/lib/database/types'
+import { RelayData } from '@/lib/types/database/operations'
+
+// A relay confirms (Accept) or declines (Reject) the Follow we sent. The
+// activity is delivered to the instance/federation signing actor's inbox and
+// is HTTP-signature verified as the relay before reaching here. `object` is the
+// Follow we sent — relays echo it either as the full object or as a bare id
+// string, so accept both shapes.
+interface RelayHandshakeActivity {
+  actor: string
+  object: string | { id?: string }
+}
+
+interface RelayHandshakeParams {
+  activity: RelayHandshakeActivity
+  database: Database
+}
+
+const getFollowActivityId = (
+  object: string | { id?: string }
+): string | null => {
+  if (typeof object === 'string') return object
+  return object?.id ?? null
+}
+
+const resolveRelay = async (
+  database: Database,
+  activity: RelayHandshakeActivity
+): Promise<RelayData | null> => {
+  const followActivityId = getFollowActivityId(activity.object)
+  if (!followActivityId) return null
+  return database.getRelayByFollowActivityId({ followActivityId })
+}
+
+// Marks the matching relay subscription accepted and records the relay's actor
+// id (so subsequently forwarded activities are recognised). Returns the updated
+// relay, or null when no subscription matches the Accept.
+export const acceptRelayRequest = async ({
+  activity,
+  database
+}: RelayHandshakeParams): Promise<RelayData | null> => {
+  const relay = await resolveRelay(database, activity)
+  if (!relay) return null
+  return database.updateRelay({
+    id: relay.id,
+    state: 'accepted',
+    actorId: activity.actor,
+    lastError: null
+  })
+}
+
+// Marks the matching relay subscription rejected. Returns the updated relay, or
+// null when no subscription matches the Reject.
+export const rejectRelayRequest = async ({
+  activity,
+  database
+}: RelayHandshakeParams): Promise<RelayData | null> => {
+  const relay = await resolveRelay(database, activity)
+  if (!relay) return null
+  return database.updateRelay({
+    id: relay.id,
+    state: 'rejected',
+    lastError: 'Relay rejected the subscription request'
+  })
+}

--- a/lib/activities/index.test.ts
+++ b/lib/activities/index.test.ts
@@ -5,13 +5,15 @@ import {
   acceptFollow,
   deleteStatus,
   follow,
+  followRelay,
   getNote,
   rejectFollow,
   sendAnnounce,
   sendLike,
   sendNote,
   sendUndoLike,
-  unfollow
+  unfollow,
+  unfollowRelay
 } from '@/lib/activities'
 import { CreateStatus } from '@/lib/activities/createStatus'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
@@ -21,7 +23,22 @@ import { TEST_SHARED_INBOX, seedDatabase } from '@/lib/stub/database'
 import { MockMastodonActivityPubNote } from '@/lib/stub/note'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
+import { Relay } from '@/lib/types/domain/relay'
 import { StatusType } from '@/lib/types/domain/status'
+
+const ACTIVITY_STREAM_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
+
+const mockRelay = (overrides: Partial<Relay> = {}): Relay => ({
+  id: 'relay-1',
+  inboxUrl: 'https://relay.example/inbox',
+  actorId: null,
+  state: 'idle',
+  followActivityId: null,
+  lastError: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  ...overrides
+})
 
 enableFetchMocks()
 
@@ -238,6 +255,53 @@ describe('activities', () => {
       const body = JSON.parse(undoCall![1]?.body as string)
       expect(body.type).toEqual('Undo')
       expect(body.object.type).toEqual('Follow')
+    })
+  })
+
+  describe('followRelay', () => {
+    it('sends a Follow of the Public collection to the relay inbox', async () => {
+      const signingActor = MockActor({})
+      const relay = mockRelay()
+
+      fetchMock.mockResponseOnce('', { status: 202 })
+      const result = await followRelay(relay, signingActor)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const [url, options] = fetchMock.mock.lastCall as any
+      expect(url).toEqual(relay.inboxUrl)
+      expect(options.method).toEqual('POST')
+
+      const body = JSON.parse(options.body)
+      expect(body.type).toEqual('Follow')
+      expect(body.actor).toEqual(signingActor.id)
+      expect(body.object).toEqual(ACTIVITY_STREAM_PUBLIC)
+      expect(body.id).toEqual(result.followActivityId)
+      expect(result.ok).toBe(true)
+    })
+  })
+
+  describe('unfollowRelay', () => {
+    it('sends Undo(Follow) reusing the stored follow id', async () => {
+      const signingActor = MockActor({})
+      const relay = mockRelay({
+        actorId: 'https://relay.example/actor',
+        state: 'accepted',
+        followActivityId: 'https://llun.test/relay-follow-1'
+      })
+
+      fetchMock.mockResponseOnce('', { status: 202 })
+      const ok = await unfollowRelay(relay, signingActor)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const [url, options] = fetchMock.mock.lastCall as any
+      expect(url).toEqual(relay.inboxUrl)
+
+      const body = JSON.parse(options.body)
+      expect(body.type).toEqual('Undo')
+      expect(body.object.type).toEqual('Follow')
+      expect(body.object.id).toEqual('https://llun.test/relay-follow-1')
+      expect(body.object.object).toEqual(ACTIVITY_STREAM_PUBLIC)
+      expect(ok).toBe(true)
     })
   })
 

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -28,6 +28,7 @@ import {
 import { Actor } from '@/lib/types/domain/actor'
 import { Block as DomainBlock } from '@/lib/types/domain/block'
 import { Follow } from '@/lib/types/domain/follow'
+import { Relay } from '@/lib/types/domain/relay'
 import {
   Status,
   StatusAnnounce,
@@ -445,6 +446,77 @@ export const unfollow = async (
         currentActor,
         activity,
         logPrefix: 'unfollow'
+      })
+      span.end()
+      return statusCode === 202
+    }
+  )
+
+// Subscribe to a relay: send a Follow whose object is the ActivityStreams
+// Public collection (the LitePub convention) to the relay's inbox, signed by
+// the instance/federation signing actor. Returns the generated Follow id (to
+// persist so the relay's Accept can be matched back) and whether the relay
+// inbox accepted delivery (HTTP 202). The relay confirms the subscription
+// asynchronously with its own Accept.
+export const followRelay = async (
+  relay: Relay,
+  signingActor: Actor
+): Promise<{ followActivityId: string; ok: boolean }> =>
+  getTracer().startActiveSpan(
+    'activities.followRelay',
+    { attributes: { relayId: relay.id, inbox: relay.inboxUrl } },
+    async (span) => {
+      const followActivityId = `https://${signingActor.domain}/${crypto.randomUUID()}`
+      const activity: FollowRequest = {
+        '@context': ACTIVITY_STREAM_URL,
+        id: followActivityId,
+        type: 'Follow',
+        actor: signingActor.id,
+        object: ACTIVITY_STREAM_PUBLIC
+      }
+      const statusCode = await postActivityToInbox({
+        span,
+        inbox: relay.inboxUrl,
+        currentActor: signingActor,
+        activity,
+        logPrefix: 'followRelay'
+      })
+      span.end()
+      return { followActivityId, ok: statusCode === 202 }
+    }
+  )
+
+// Unsubscribe from a relay: send Undo(Follow) reusing the Follow id we sent
+// (relay.followActivityId), signed by the instance/federation signing actor.
+export const unfollowRelay = async (
+  relay: Relay,
+  signingActor: Actor
+): Promise<boolean> =>
+  getTracer().startActiveSpan(
+    'activities.unfollowRelay',
+    { attributes: { relayId: relay.id, inbox: relay.inboxUrl } },
+    async (span) => {
+      const followActivityId =
+        relay.followActivityId ??
+        `https://${signingActor.domain}/${crypto.randomUUID()}`
+      const activity: UndoFollow = {
+        '@context': ACTIVITY_STREAM_URL,
+        id: `${followActivityId}/undo`,
+        type: 'Undo',
+        actor: signingActor.id,
+        object: {
+          id: followActivityId,
+          type: 'Follow',
+          actor: signingActor.id,
+          object: ACTIVITY_STREAM_PUBLIC
+        }
+      }
+      const statusCode = await postActivityToInbox({
+        span,
+        inbox: relay.inboxUrl,
+        currentActor: signingActor,
+        activity,
+        logPrefix: 'unfollowRelay'
       })
       span.end()
       return statusCode === 202

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -28,6 +28,7 @@ import { MuteSQLDatabaseMixin } from '@/lib/database/sql/mute'
 import { NotificationSQLDatabaseMixin } from '@/lib/database/sql/notification'
 import { OAuthSQLDatabaseMixin } from '@/lib/database/sql/oauth'
 import { PushSubscriptionSQLDatabaseMixin } from '@/lib/database/sql/pushSubscription'
+import { RelaySQLDatabaseMixin } from '@/lib/database/sql/relay'
 import { ReportSQLDatabaseMixin } from '@/lib/database/sql/report'
 import { ScheduledStatusSQLDatabaseMixin } from '@/lib/database/sql/scheduledStatus'
 import { SearchSQLDatabaseMixin } from '@/lib/database/sql/search'
@@ -71,6 +72,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const mediaDatabase = MediaSQLDatabaseMixin(database)
   const notificationDatabase = NotificationSQLDatabaseMixin(database)
   const pushSubscriptionDatabase = PushSubscriptionSQLDatabaseMixin(database)
+  const relayDatabase = RelaySQLDatabaseMixin(database)
   const reportDatabase = ReportSQLDatabaseMixin(database)
   const scheduledStatusDatabase = ScheduledStatusSQLDatabaseMixin(database)
   const oauthDatabase = OAuthSQLDatabaseMixin(database)
@@ -139,6 +141,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...mediaDatabase,
     ...notificationDatabase,
     ...pushSubscriptionDatabase,
+    ...relayDatabase,
     ...reportDatabase,
     ...scheduledStatusDatabase,
     ...oauthDatabase,

--- a/lib/database/sql/relay.test.ts
+++ b/lib/database/sql/relay.test.ts
@@ -1,0 +1,164 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+describe('createRelay', () => {
+  it('creates a relay in the idle state with null discovery fields', async () => {
+    await withFreshDatabase(async (database) => {
+      const relay = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+
+      expect(relay.id).toBeTruthy()
+      expect(relay.inboxUrl).toBe('https://relay.example/inbox')
+      expect(relay.actorId).toBeNull()
+      expect(relay.state).toBe('idle')
+      expect(relay.followActivityId).toBeNull()
+      expect(relay.lastError).toBeNull()
+      expect(typeof relay.createdAt).toBe('number')
+      expect(typeof relay.updatedAt).toBe('number')
+
+      expect(await database.getRelays()).toEqual([relay])
+    })
+  })
+
+  it('rejects a duplicate inboxUrl', async () => {
+    await withFreshDatabase(async (database) => {
+      await database.createRelay({ inboxUrl: 'https://relay.example/inbox' })
+      await expect(
+        database.createRelay({ inboxUrl: 'https://relay.example/inbox' })
+      ).rejects.toThrow()
+    })
+  })
+})
+
+describe('updateRelay', () => {
+  it('updates only the provided fields and bumps updatedAt', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+
+      const updated = await database.updateRelay({
+        id: created.id,
+        state: 'pending',
+        followActivityId: 'https://example.com/activities/follow-1'
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.state).toBe('pending')
+      expect(updated?.followActivityId).toBe(
+        'https://example.com/activities/follow-1'
+      )
+      expect(updated?.actorId).toBeNull()
+      expect(updated?.createdAt).toBe(created.createdAt)
+    })
+  })
+
+  it('clears a column when null is passed', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+      await database.updateRelay({ id: created.id, lastError: 'boom' })
+
+      const cleared = await database.updateRelay({
+        id: created.id,
+        lastError: null
+      })
+      expect(cleared?.lastError).toBeNull()
+    })
+  })
+
+  it('returns null for an unknown id', async () => {
+    await withFreshDatabase(async (database) => {
+      expect(
+        await database.updateRelay({ id: 'unknown', state: 'accepted' })
+      ).toBeNull()
+    })
+  })
+})
+
+describe('getRelayByActorId', () => {
+  it('resolves a relay by its discovered actor id', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+      await database.updateRelay({
+        id: created.id,
+        actorId: 'https://relay.example/actor',
+        state: 'accepted'
+      })
+
+      const found = await database.getRelayByActorId({
+        actorId: 'https://relay.example/actor'
+      })
+      expect(found?.id).toBe(created.id)
+
+      expect(
+        await database.getRelayByActorId({ actorId: 'https://other/actor' })
+      ).toBeNull()
+    })
+  })
+})
+
+describe('getAcceptedRelays', () => {
+  it('returns only relays in the accepted state', async () => {
+    await withFreshDatabase(async (database) => {
+      const accepted = await database.createRelay({
+        inboxUrl: 'https://a.example/inbox'
+      })
+      await database.updateRelay({ id: accepted.id, state: 'accepted' })
+
+      const pending = await database.createRelay({
+        inboxUrl: 'https://b.example/inbox'
+      })
+      await database.updateRelay({ id: pending.id, state: 'pending' })
+
+      const relays = await database.getAcceptedRelays()
+      expect(relays.map((relay) => relay.id)).toEqual([accepted.id])
+    })
+  })
+})
+
+describe('getRelayByInboxUrl', () => {
+  it('resolves a relay by inbox url and returns null when unknown', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+      const found = await database.getRelayByInboxUrl({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+      expect(found?.id).toBe(created.id)
+      expect(
+        await database.getRelayByInboxUrl({ inboxUrl: 'https://nope/inbox' })
+      ).toBeNull()
+    })
+  })
+})
+
+describe('deleteRelay', () => {
+  it('removes the relay and returns false for an unknown id', async () => {
+    await withFreshDatabase(async (database) => {
+      const created = await database.createRelay({
+        inboxUrl: 'https://relay.example/inbox'
+      })
+      expect(await database.deleteRelay({ id: created.id })).toBe(true)
+      expect(await database.getRelays()).toEqual([])
+      expect(await database.deleteRelay({ id: 'no-such-id' })).toBe(false)
+    })
+  })
+})

--- a/lib/database/sql/relay.ts
+++ b/lib/database/sql/relay.ts
@@ -1,0 +1,118 @@
+import { Knex } from 'knex'
+import { randomUUID } from 'node:crypto'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  CreateRelayParams,
+  DeleteRelayParams,
+  GetRelayByActorIdParams,
+  GetRelayByIdParams,
+  GetRelayByInboxUrlParams,
+  RelayData,
+  RelayDatabase,
+  UpdateRelayParams
+} from '@/lib/types/database/operations'
+import { RelayState } from '@/lib/types/domain/relay'
+
+type SQLRelay = {
+  id: string
+  inboxUrl: string
+  actorId: string | null
+  state: string
+  followActivityId: string | null
+  lastError: string | null
+  createdAt: number | Date | string
+  updatedAt: number | Date | string
+}
+
+const toRelay = (row: SQLRelay): RelayData => ({
+  id: row.id,
+  inboxUrl: row.inboxUrl,
+  actorId: row.actorId ?? null,
+  state: RelayState.catch('idle').parse(row.state),
+  followActivityId: row.followActivityId ?? null,
+  lastError: row.lastError ?? null,
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+export const RelaySQLDatabaseMixin = (database: Knex): RelayDatabase => ({
+  async createRelay({ inboxUrl }: CreateRelayParams) {
+    const currentTime = new Date()
+    const id = randomUUID()
+    await database('relays').insert({
+      id,
+      inboxUrl,
+      actorId: null,
+      state: 'idle',
+      followActivityId: null,
+      lastError: null,
+      createdAt: currentTime,
+      updatedAt: currentTime
+    })
+    return {
+      id,
+      inboxUrl,
+      actorId: null,
+      state: 'idle',
+      followActivityId: null,
+      lastError: null,
+      createdAt: currentTime.getTime(),
+      updatedAt: currentTime.getTime()
+    }
+  },
+
+  async updateRelay({
+    id,
+    state,
+    actorId,
+    followActivityId,
+    lastError
+  }: UpdateRelayParams) {
+    const updatedCount = await database('relays')
+      .where({ id })
+      .update({
+        ...(state !== undefined ? { state } : null),
+        ...(actorId !== undefined ? { actorId } : null),
+        ...(followActivityId !== undefined ? { followActivityId } : null),
+        ...(lastError !== undefined ? { lastError } : null),
+        updatedAt: new Date()
+      })
+    if (updatedCount === 0) return null
+
+    const row = await database<SQLRelay>('relays').where({ id }).first()
+    return row ? toRelay(row) : null
+  },
+
+  async deleteRelay({ id }: DeleteRelayParams) {
+    const deleted = await database('relays').where({ id }).delete()
+    return deleted > 0
+  },
+
+  async getRelays() {
+    const rows = await database<SQLRelay>('relays').orderBy('createdAt', 'asc')
+    return rows.map(toRelay)
+  },
+
+  async getRelayById({ id }: GetRelayByIdParams) {
+    const row = await database<SQLRelay>('relays').where({ id }).first()
+    return row ? toRelay(row) : null
+  },
+
+  async getRelayByInboxUrl({ inboxUrl }: GetRelayByInboxUrlParams) {
+    const row = await database<SQLRelay>('relays').where({ inboxUrl }).first()
+    return row ? toRelay(row) : null
+  },
+
+  async getRelayByActorId({ actorId }: GetRelayByActorIdParams) {
+    const row = await database<SQLRelay>('relays').where({ actorId }).first()
+    return row ? toRelay(row) : null
+  },
+
+  async getAcceptedRelays() {
+    const rows = await database<SQLRelay>('relays')
+      .where({ state: 'accepted' })
+      .orderBy('createdAt', 'asc')
+    return rows.map(toRelay)
+  }
+})

--- a/lib/database/sql/relay.ts
+++ b/lib/database/sql/relay.ts
@@ -6,6 +6,7 @@ import {
   CreateRelayParams,
   DeleteRelayParams,
   GetRelayByActorIdParams,
+  GetRelayByFollowActivityIdParams,
   GetRelayByIdParams,
   GetRelayByInboxUrlParams,
   RelayData,
@@ -106,6 +107,15 @@ export const RelaySQLDatabaseMixin = (database: Knex): RelayDatabase => ({
 
   async getRelayByActorId({ actorId }: GetRelayByActorIdParams) {
     const row = await database<SQLRelay>('relays').where({ actorId }).first()
+    return row ? toRelay(row) : null
+  },
+
+  async getRelayByFollowActivityId({
+    followActivityId
+  }: GetRelayByFollowActivityIdParams) {
+    const row = await database<SQLRelay>('relays')
+      .where({ followActivityId })
+      .first()
     return row ? toRelay(row) : null
   },
 

--- a/lib/database/sql/timeline.federated.test.ts
+++ b/lib/database/sql/timeline.federated.test.ts
@@ -109,6 +109,32 @@ describe('Timeline.FEDERATED_PUBLIC', () => {
     })
   })
 
+  it('excludes replies (top-level posts only, like LOCAL_PUBLIC)', async () => {
+    await withFreshDatabase(async (database) => {
+      const topLevel = await seedFederatedStatus(database, 1)
+
+      const replyId = `${REMOTE}/statuses/relayed-reply`
+      const reply = await database.createNote({
+        id: replyId,
+        url: replyId,
+        actorId: REMOTE,
+        text: 'a relayed reply',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        reply: `${REMOTE}/statuses/some-parent`
+      })
+      await database.addStatusToFederatedTimeline({
+        statusId: reply.id,
+        statusActorId: REMOTE
+      })
+
+      const statuses = await database.getTimeline({
+        timeline: Timeline.FEDERATED_PUBLIC
+      })
+      expect(statuses.map((status) => status.id)).toEqual([topLevel.id])
+    })
+  })
+
   it('returns an empty list when nothing has been federated', async () => {
     await withFreshDatabase(async (database) => {
       expect(

--- a/lib/database/sql/timeline.federated.test.ts
+++ b/lib/database/sql/timeline.federated.test.ts
@@ -1,0 +1,119 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { Timeline } from '@/lib/services/timelines/types'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { waitFor } from '@/lib/utils/waitFor'
+
+const REMOTE = 'https://remote.example/users/relayed'
+
+const withFreshDatabase = async (
+  test: (database: Database) => Promise<void>
+) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const seedFederatedStatus = async (database: Database, n: number) => {
+  const id = `${REMOTE}/statuses/relayed-${n}`
+  const status = await database.createNote({
+    id,
+    url: id,
+    actorId: REMOTE,
+    text: `Relayed status ${n}`,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: []
+  })
+  await database.addStatusToFederatedTimeline({
+    statusId: status.id,
+    statusActorId: REMOTE
+  })
+  return status
+}
+
+describe('Timeline.FEDERATED_PUBLIC', () => {
+  it('returns only statuses added to the federated timeline, newest first', async () => {
+    await withFreshDatabase(async (database) => {
+      for (let n = 1; n <= 3; n++) {
+        await seedFederatedStatus(database, n)
+        await waitFor(5)
+      }
+
+      // A remote status that was stored but NOT added to the federated timeline
+      // (e.g. fetched for thread context) must not appear.
+      const notFederatedId = `${REMOTE}/statuses/not-federated`
+      await database.createNote({
+        id: notFederatedId,
+        url: notFederatedId,
+        actorId: REMOTE,
+        text: 'Not in the federated feed',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const statuses = await database.getTimeline({
+        timeline: Timeline.FEDERATED_PUBLIC
+      })
+
+      expect(statuses.map((status) => status.id)).toEqual([
+        `${REMOTE}/statuses/relayed-3`,
+        `${REMOTE}/statuses/relayed-2`,
+        `${REMOTE}/statuses/relayed-1`
+      ])
+    })
+  })
+
+  it('is idempotent — adding the same status twice yields one entry', async () => {
+    await withFreshDatabase(async (database) => {
+      const status = await seedFederatedStatus(database, 1)
+      await database.addStatusToFederatedTimeline({
+        statusId: status.id,
+        statusActorId: REMOTE
+      })
+
+      const statuses = await database.getTimeline({
+        timeline: Timeline.FEDERATED_PUBLIC
+      })
+      expect(statuses).toHaveLength(1)
+    })
+  })
+
+  it('paginates with maxStatusId without repeating', async () => {
+    await withFreshDatabase(async (database) => {
+      for (let n = 1; n <= 3; n++) {
+        await seedFederatedStatus(database, n)
+        await waitFor(5)
+      }
+
+      const firstPage = await database.getTimeline({
+        timeline: Timeline.FEDERATED_PUBLIC,
+        limit: 2
+      })
+      expect(firstPage.map((status) => status.id)).toEqual([
+        `${REMOTE}/statuses/relayed-3`,
+        `${REMOTE}/statuses/relayed-2`
+      ])
+
+      const secondPage = await database.getTimeline({
+        timeline: Timeline.FEDERATED_PUBLIC,
+        maxStatusId: firstPage[firstPage.length - 1].id,
+        limit: 2
+      })
+      expect(secondPage.map((status) => status.id)).toEqual([
+        `${REMOTE}/statuses/relayed-1`
+      ])
+    })
+  })
+
+  it('returns an empty list when nothing has been federated', async () => {
+    await withFreshDatabase(async (database) => {
+      expect(
+        await database.getTimeline({ timeline: Timeline.FEDERATED_PUBLIC })
+      ).toEqual([])
+    })
+  })
+})

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -85,6 +85,65 @@ export const TimelineSQLDatabaseMixin = (
         })
         return statuses
       }
+      case Timeline.FEDERATED_PUBLIC: {
+        // Remote public statuses ingested from accepted relays. Materialized in
+        // `federated_timeline`; we join back to `statuses` and page with the
+        // same (createdAt, id) keyset the LOCAL_PUBLIC branch uses.
+        const lookupCursor = async (
+          statusId: string
+        ): Promise<{ id: string; createdAt: Date } | null> => {
+          const statusRow = await database('statuses')
+            .where('id', statusId)
+            .select('id', 'createdAt')
+            .first<{ id: string; createdAt: Date }>()
+          return statusRow ?? null
+        }
+
+        const [maxRow, minRow] = await Promise.all([
+          maxStatusId ? lookupCursor(maxStatusId) : null,
+          minStatusId ? lookupCursor(minStatusId) : null
+        ])
+
+        if (maxStatusId && !maxRow) return []
+        if (minStatusId && !minRow) return []
+
+        let query = database('federated_timeline')
+          .select('statuses.id as statusId')
+          .innerJoin('statuses', 'federated_timeline.statusId', 'statuses.id')
+          .limit(limit)
+
+        if (maxRow) {
+          query = query.where((wb) => {
+            wb.where('statuses.createdAt', '<', maxRow.createdAt).orWhere(
+              (wb2) => {
+                wb2
+                  .where('statuses.createdAt', '=', maxRow.createdAt)
+                  .where('statuses.id', '<', maxRow.id)
+              }
+            )
+          })
+        }
+
+        if (minRow) {
+          query = query.where((wb) => {
+            wb.where('statuses.createdAt', '>', minRow.createdAt).orWhere(
+              (wb2) => {
+                wb2
+                  .where('statuses.createdAt', '=', minRow.createdAt)
+                  .where('statuses.id', '>', minRow.id)
+              }
+            )
+          })
+        }
+
+        const rows = await query
+          .orderBy('statuses.createdAt', 'desc')
+          .orderBy('statuses.id', 'desc')
+        const statuses = await statusDatabase.getStatusesByIds({
+          statusIds: rows.map((item) => item.statusId)
+        })
+        return statuses
+      }
       case Timeline.MAIN:
       case Timeline.HOME:
       case Timeline.MENTION:
@@ -242,5 +301,18 @@ export const TimelineSQLDatabaseMixin = (
         updatedAt: new Date()
       })
     })
+  },
+
+  async addStatusToFederatedTimeline({ statusId, statusActorId }) {
+    // Idempotent append — a relay can forward the same public status more than
+    // once (e.g. via multiple relays), so ignore a duplicate primary key.
+    await database('federated_timeline')
+      .insert({
+        statusId,
+        statusActorId,
+        createdAt: new Date()
+      })
+      .onConflict('statusId')
+      .ignore()
   }
 })

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -110,6 +110,9 @@ export const TimelineSQLDatabaseMixin = (
         let query = database('federated_timeline')
           .select('statuses.id as statusId')
           .innerJoin('statuses', 'federated_timeline.statusId', 'statuses.id')
+          // Top-level posts only, matching LOCAL_PUBLIC and Mastodon's public
+          // timeline semantics (replies are excluded).
+          .where('statuses.reply', '')
           .limit(limit)
 
         if (maxRow) {

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -29,6 +29,7 @@ import {
   NotificationDatabase,
   OAuthDatabase,
   PushSubscriptionDatabase,
+  RelayDatabase,
   ReportDatabase,
   ScheduledStatusDatabase,
   SearchDatabase,
@@ -70,6 +71,7 @@ export type Database = AccountDatabase &
   NotificationDatabase &
   OAuthDatabase &
   PushSubscriptionDatabase &
+  RelayDatabase &
   ReportDatabase &
   ScheduledStatusDatabase &
   SearchDatabase &

--- a/lib/jobs/createRelayAnnounceJob.test.ts
+++ b/lib/jobs/createRelayAnnounceJob.test.ts
@@ -132,6 +132,21 @@ describe('createRelayAnnounceJob', () => {
     expect(federated.map((status) => status.id)).toContain(note)
   })
 
+  it('ignores an Announce whose object is not an http(s) URL', async () => {
+    await createRelayAnnounceJob(database, {
+      id: 'job-bad',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf('not-a-valid-url', `${RELAY_ACTOR}/announce/bad`)
+    })
+
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).not.toContain(
+      'not-a-valid-url'
+    )
+  })
+
   it('is idempotent across repeated relay deliveries of the same note', async () => {
     const note = 'https://somewhere.test/statuses/relayed-dedupe'
     await createRelayAnnounceJob(database, {

--- a/lib/jobs/createRelayAnnounceJob.test.ts
+++ b/lib/jobs/createRelayAnnounceJob.test.ts
@@ -83,6 +83,30 @@ describe('createRelayAnnounceJob', () => {
     expect(federated.map((status) => status.id)).not.toContain(localNote)
   })
 
+  it('accepts a minimal relay Announce that omits published and cc', async () => {
+    const note = 'https://somewhere.test/statuses/relayed-minimal'
+    // The shape barkshark/Pleroma relays actually send: no published, no cc.
+    await createRelayAnnounceJob(database, {
+      id: 'job-min',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: `${RELAY_ACTOR}/announce/minimal`,
+        type: 'Announce',
+        actor: RELAY_ACTOR,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        object: note
+      }
+    })
+
+    const stored = await database.getStatus({ statusId: note })
+    expect(stored).toBeDefined()
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).toContain(note)
+  })
+
   it('is idempotent across repeated relay deliveries of the same note', async () => {
     const note = 'https://somewhere.test/statuses/relayed-dedupe'
     await createRelayAnnounceJob(database, {

--- a/lib/jobs/createRelayAnnounceJob.test.ts
+++ b/lib/jobs/createRelayAnnounceJob.test.ts
@@ -69,6 +69,31 @@ describe('createRelayAnnounceJob', () => {
     expect(announce).toBeNull()
   })
 
+  it('does not federate a non-public (followers-only) relayed note', async () => {
+    const followersOnly = 'https://somewhere.test/statuses/followers-only'
+    // Pre-store the note so the job uses the existing status and reaches the
+    // public-audience gate without re-fetching.
+    await database.createNote({
+      id: followersOnly,
+      url: followersOnly,
+      actorId: 'https://somewhere.test/users/bob',
+      text: 'followers only',
+      to: ['https://somewhere.test/users/bob/followers'],
+      cc: []
+    })
+
+    await createRelayAnnounceJob(database, {
+      id: 'job-priv',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(followersOnly, `${RELAY_ACTOR}/announce/priv`)
+    })
+
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).not.toContain(followersOnly)
+  })
+
   it('skips our own posts echoed back through the relay (self-echo guard)', async () => {
     const localNote = 'https://test.llun.dev/users/test1/statuses/local-echo'
     await createRelayAnnounceJob(database, {

--- a/lib/jobs/createRelayAnnounceJob.test.ts
+++ b/lib/jobs/createRelayAnnounceJob.test.ts
@@ -1,0 +1,105 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { createRelayAnnounceJob } from '@/lib/jobs/createRelayAnnounceJob'
+import { RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
+import { Timeline } from '@/lib/services/timelines/types'
+import { mockRequests } from '@/lib/stub/activities'
+import { seedDatabase } from '@/lib/stub/database'
+
+enableFetchMocks()
+
+const ACTIVITY_STREAM_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
+const RELAY_ACTOR = 'https://relay.example/actor'
+const REMOTE_NOTE = 'https://somewhere.test/statuses/relayed-note'
+
+const announceOf = (objectId: string, id = `${RELAY_ACTOR}/announce/1`) => ({
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  id,
+  type: 'Announce',
+  actor: RELAY_ACTOR,
+  published: '2024-01-01T00:00:00Z',
+  object: objectId,
+  to: [ACTIVITY_STREAM_PUBLIC],
+  cc: []
+})
+
+describe('createRelayAnnounceJob', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    mockRequests(fetchMock)
+  })
+
+  it('fetches the wrapped note from origin, stores it, and federates it', async () => {
+    await createRelayAnnounceJob(database, {
+      id: 'job-1',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(REMOTE_NOTE)
+    })
+
+    const stored = await database.getStatus({ statusId: REMOTE_NOTE })
+    expect(stored).toBeDefined()
+
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).toContain(REMOTE_NOTE)
+  })
+
+  it('does not create a relay-attributed Announce row', async () => {
+    await createRelayAnnounceJob(database, {
+      id: 'job-2',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(REMOTE_NOTE, `${RELAY_ACTOR}/announce/2`)
+    })
+    const announce = await database.getStatus({
+      statusId: `${RELAY_ACTOR}/announce/2`
+    })
+    expect(announce).toBeNull()
+  })
+
+  it('skips our own posts echoed back through the relay (self-echo guard)', async () => {
+    const localNote = 'https://test.llun.dev/users/test1/statuses/local-echo'
+    await createRelayAnnounceJob(database, {
+      id: 'job-3',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(localNote)
+    })
+
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    expect(federated.map((status) => status.id)).not.toContain(localNote)
+  })
+
+  it('is idempotent across repeated relay deliveries of the same note', async () => {
+    const note = 'https://somewhere.test/statuses/relayed-dedupe'
+    await createRelayAnnounceJob(database, {
+      id: 'job-4a',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(note, `${RELAY_ACTOR}/announce/4a`)
+    })
+    await createRelayAnnounceJob(database, {
+      id: 'job-4b',
+      name: RELAY_ANNOUNCE_JOB_NAME,
+      data: announceOf(note, `${RELAY_ACTOR}/announce/4b`)
+    })
+
+    const federated = await database.getTimeline({
+      timeline: Timeline.FEDERATED_PUBLIC
+    })
+    const matches = federated.filter((status) => status.id === note)
+    expect(matches).toHaveLength(1)
+  })
+})

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 import { getNote } from '@/lib/activities'
 import { getConfig } from '@/lib/config'
 import { createJobHandle } from '@/lib/jobs/createJobHandle'
@@ -5,8 +7,21 @@ import { createNoteJob } from '@/lib/jobs/createNoteJob'
 import { CREATE_NOTE_JOB_NAME, RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
-import { Announce } from '@/lib/types/activitypub'
-import { normalizeActivityPubAnnounce } from '@/lib/utils/activitypub'
+
+// Relays forward third-party posts as a MINIMAL Announce. The common
+// Announce-style relays (Pleroma `relay`, barkshark ActivityRelay) send only
+// `{ @context, id, type, actor, object }` — no `published`, often no `cc` — so
+// the strict AS `Announce` schema (which requires published/to/cc) would reject
+// them and drop every relayed post. Model only the fields this job consumes and
+// stay liberal in what we accept (AGENTS.md).
+const RelayAnnounce = z
+  .object({
+    id: z.string(),
+    type: z.literal('Announce'),
+    actor: z.string(),
+    object: z.union([z.string(), z.object({ id: z.string() }).passthrough()])
+  })
+  .passthrough()
 
 const isLocalUrl = (value: string, host: string): boolean => {
   try {
@@ -33,8 +48,9 @@ const getAnnouncedObjectId = (object: unknown): string | null => {
 export const createRelayAnnounceJob: JobHandle = createJobHandle(
   RELAY_ANNOUNCE_JOB_NAME,
   async (database, message) => {
-    const announce = Announce.parse(normalizeActivityPubAnnounce(message.data))
-    const objectId = getAnnouncedObjectId(announce.object)
+    const parsed = RelayAnnounce.safeParse(message.data)
+    if (!parsed.success) return
+    const objectId = getAnnouncedObjectId(parsed.data.object)
     if (!objectId) return
 
     const { host } = getConfig()

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -1,0 +1,74 @@
+import { getNote } from '@/lib/activities'
+import { getConfig } from '@/lib/config'
+import { createJobHandle } from '@/lib/jobs/createJobHandle'
+import { createNoteJob } from '@/lib/jobs/createNoteJob'
+import { CREATE_NOTE_JOB_NAME, RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { JobHandle } from '@/lib/services/queue/type'
+import { Announce } from '@/lib/types/activitypub'
+import { normalizeActivityPubAnnounce } from '@/lib/utils/activitypub'
+
+const isLocalUrl = (value: string, host: string): boolean => {
+  try {
+    return new URL(value).host === host
+  } catch {
+    return false
+  }
+}
+
+const getAnnouncedObjectId = (object: unknown): string | null => {
+  if (typeof object === 'string') return object
+  if (object && typeof (object as { id?: unknown }).id === 'string') {
+    return (object as { id: string }).id
+  }
+  return null
+}
+
+// Ingests a public status forwarded by an accepted relay's Announce into the
+// Federated timeline. The wrapped note is always re-fetched from its origin
+// (the authenticity anchor — we never trust the relay's framing of third-party
+// content), stored as a normal remote status, then appended to
+// `federated_timeline`. Unlike a real boost this never creates a relay-attributed
+// Announce row. Our own posts echoed back through a relay are skipped.
+export const createRelayAnnounceJob: JobHandle = createJobHandle(
+  RELAY_ANNOUNCE_JOB_NAME,
+  async (database, message) => {
+    const announce = Announce.parse(normalizeActivityPubAnnounce(message.data))
+    const objectId = getAnnouncedObjectId(announce.object)
+    if (!objectId) return
+
+    const { host } = getConfig()
+    // Skip our own posts relayed back to us.
+    if (isLocalUrl(objectId, host)) return
+
+    let status = await database.getStatus({
+      statusId: objectId,
+      withReplies: false
+    })
+    if (!status) {
+      const signingActor = await getFederationSigningActor(database)
+      const note = await getNote({ statusId: objectId, signingActor })
+      if (!note) return
+      // createNoteJob enforces the note author's federation policy and persists
+      // the status; called without verifiedSenderActorId so the relay's
+      // signature does not have to match the note's author.
+      await createNoteJob(database, {
+        id: note.id,
+        name: CREATE_NOTE_JOB_NAME,
+        data: note
+      })
+      status = await database.getStatus({
+        statusId: objectId,
+        withReplies: false
+      })
+    }
+    if (!status) return
+    // Defensive: never federate a local-authored status (self-echo guard #2).
+    if (isLocalUrl(status.actorId, host)) return
+
+    await database.addStatusToFederatedTimeline({
+      statusId: status.id,
+      statusActorId: status.actorId
+    })
+  }
+)

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -89,8 +89,11 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
         name: CREATE_NOTE_JOB_NAME,
         data: note
       })
+      // Look the stored status up by the note's canonical id — a remote server
+      // may canonicalize the requested object id (trailing slash, protocol,
+      // redirect), and createNoteJob persists it under note.id.
       status = await database.getStatus({
-        statusId: objectId,
+        statusId: note.id,
         withReplies: false
       })
     }

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -7,6 +7,11 @@ import { createNoteJob } from '@/lib/jobs/createNoteJob'
 import { CREATE_NOTE_JOB_NAME, RELAY_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { JobHandle } from '@/lib/services/queue/type'
+import { Status } from '@/lib/types/domain/status'
+import {
+  ACTIVITY_STREAM_PUBLIC,
+  ACTIVITY_STREAM_PUBLIC_COMPACT
+} from '@/lib/utils/activitystream'
 
 // Relays forward third-party posts as a MINIMAL Announce. The common
 // Announce-style relays (Pleroma `relay`, barkshark ActivityRelay) send only
@@ -38,6 +43,17 @@ const getAnnouncedObjectId = (object: unknown): string | null => {
   }
   return null
 }
+
+// The Federated timeline is a public surface (the public API serves it
+// unauthenticated). Relays can forward whatever their members emit, so we must
+// independently confirm the re-fetched note is addressed to the public
+// collection before publishing it — never trust the relay's framing.
+const isPublicStatus = (status: Status): boolean =>
+  [...status.to, ...status.cc].some(
+    (recipient) =>
+      recipient === ACTIVITY_STREAM_PUBLIC ||
+      recipient === ACTIVITY_STREAM_PUBLIC_COMPACT
+  )
 
 // Ingests a public status forwarded by an accepted relay's Announce into the
 // Federated timeline. The wrapped note is always re-fetched from its origin
@@ -81,6 +97,9 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
     if (!status) return
     // Defensive: never federate a local-authored status (self-echo guard #2).
     if (isLocalUrl(status.actorId, host)) return
+    // Never expose a non-public (followers-only/direct) note on the public
+    // Federated timeline, even if a relay forwarded it.
+    if (!isPublicStatus(status)) return
 
     await database.addStatusToFederatedTimeline({
       statusId: status.id,

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -79,6 +79,9 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
     })
     if (!status) {
       const signingActor = await getFederationSigningActor(database)
+      // Without the instance signing actor we cannot make the signed origin
+      // fetch most servers require, so skip rather than fetch unsigned.
+      if (!signingActor) return
       const note = await getNote({ statusId: objectId, signingActor })
       if (!note) return
       // createNoteJob enforces the note author's federation policy and persists

--- a/lib/jobs/createRelayAnnounceJob.ts
+++ b/lib/jobs/createRelayAnnounceJob.ts
@@ -36,6 +36,15 @@ const isLocalUrl = (value: string, host: string): boolean => {
   }
 }
 
+const isHttpUrl = (value: string): boolean => {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 const getAnnouncedObjectId = (object: unknown): string | null => {
   if (typeof object === 'string') return object
   if (object && typeof (object as { id?: unknown }).id === 'string') {
@@ -67,7 +76,9 @@ export const createRelayAnnounceJob: JobHandle = createJobHandle(
     const parsed = RelayAnnounce.safeParse(message.data)
     if (!parsed.success) return
     const objectId = getAnnouncedObjectId(parsed.data.object)
-    if (!objectId) return
+    // Guard against a malformed/non-URL object id so we never make a junk
+    // origin fetch for it.
+    if (!objectId || !isHttpUrl(objectId)) return
 
     const { host } = getConfig()
     // Skip our own posts relayed back to us.

--- a/lib/jobs/index.ts
+++ b/lib/jobs/index.ts
@@ -4,6 +4,7 @@ import { createAnnounceJob } from './createAnnounceJob'
 import { createNoteJob } from './createNoteJob'
 import { createPollJob } from './createPollJob'
 import { createPollVoteJob } from './createPollVoteJob'
+import { createRelayAnnounceJob } from './createRelayAnnounceJob'
 import { deleteActorJob } from './deleteActorJob'
 import { deleteObjectJob } from './deleteObjectJob'
 import { fetchRemoteStatusJob } from './fetchRemoteStatusJob'
@@ -27,6 +28,7 @@ import {
   PROCESS_FITNESS_FILE_JOB_NAME,
   PUBLISH_SCHEDULED_STATUS_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
+  RELAY_ANNOUNCE_JOB_NAME,
   SEND_ANNOUNCE_JOB_NAME,
   SEND_BLOCK_JOB_NAME,
   SEND_NOTE_JOB_NAME,
@@ -57,6 +59,7 @@ export const JOBS: Record<string, JobHandle> = {
   [CREATE_NOTE_JOB_NAME]: createNoteJob,
   [UPDATE_NOTE_JOB_NAME]: updateNoteJob,
   [CREATE_ANNOUNCE_JOB_NAME]: createAnnounceJob,
+  [RELAY_ANNOUNCE_JOB_NAME]: createRelayAnnounceJob,
   [CREATE_POLL_JOB_NAME]: createPollJob,
   [CREATE_POLL_VOTE_JOB_NAME]: createPollVoteJob,
   [UPDATE_POLL_JOB_NAME]: updatePollJob,

--- a/lib/jobs/names.ts
+++ b/lib/jobs/names.ts
@@ -1,5 +1,6 @@
 export const CREATE_ANNOUNCE_JOB_NAME = 'CreateAnnounceJob'
 export const CREATE_NOTE_JOB_NAME = 'CreateNoteJob'
+export const RELAY_ANNOUNCE_JOB_NAME = 'RelayAnnounceJob'
 export const CREATE_POLL_JOB_NAME = 'CreatePollJob'
 export const CREATE_POLL_VOTE_JOB_NAME = 'CreatePollVoteJob'
 export const UPDATE_NOTE_JOB_NAME = 'UpdateNoteJob'

--- a/lib/services/federation/statusDelivery.test.ts
+++ b/lib/services/federation/statusDelivery.test.ts
@@ -77,15 +77,13 @@ describe('getFederatedStatusDeliveryInboxes', () => {
       privateKey: 'private-key'
     })
     const database = makeDatabase({
-      getAcceptedRelays: vi
-        .fn()
-        .mockResolvedValue([
-          {
-            id: 'r1',
-            inboxUrl: 'https://relay.example/inbox',
-            state: 'accepted'
-          }
-        ])
+      getAcceptedRelays: vi.fn().mockResolvedValue([
+        {
+          id: 'r1',
+          inboxUrl: 'https://relay.example/inbox',
+          state: 'accepted'
+        }
+      ])
     })
 
     const inboxes = await getFederatedStatusDeliveryInboxes({

--- a/lib/services/federation/statusDelivery.test.ts
+++ b/lib/services/federation/statusDelivery.test.ts
@@ -2,6 +2,7 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 import { getFederatedStatusDeliveryInboxes } from './statusDelivery'
 
@@ -60,6 +61,7 @@ const makeDatabase = (overrides: Partial<Database>): Database =>
   ({
     getActorsFromIds: vi.fn().mockResolvedValue([]),
     getFollowersInbox: vi.fn().mockResolvedValue([]),
+    getAcceptedRelays: vi.fn().mockResolvedValue([]),
     getDomainBlocksForDomains: vi.fn().mockResolvedValue({}),
     getDomainAllowsForDomains: vi.fn().mockResolvedValue({}),
     ...overrides
@@ -68,6 +70,58 @@ const makeDatabase = (overrides: Partial<Database>): Database =>
 describe('getFederatedStatusDeliveryInboxes', () => {
   beforeEach(() => {
     vi.mocked(getActorPerson).mockResolvedValue(null)
+  })
+
+  it('forwards public statuses to accepted relay inboxes', async () => {
+    const currentActor = makeActor('https://local.test/users/alice', {
+      privateKey: 'private-key'
+    })
+    const database = makeDatabase({
+      getAcceptedRelays: vi
+        .fn()
+        .mockResolvedValue([
+          {
+            id: 'r1',
+            inboxUrl: 'https://relay.example/inbox',
+            state: 'accepted'
+          }
+        ])
+    })
+
+    const inboxes = await getFederatedStatusDeliveryInboxes({
+      database,
+      currentActor,
+      status: makeStatus({ to: [ACTIVITY_STREAM_PUBLIC] })
+    })
+
+    expect(inboxes).toContain('https://relay.example/inbox')
+  })
+
+  it('does not forward non-public statuses to relays', async () => {
+    const currentActor = makeActor('https://local.test/users/alice', {
+      privateKey: 'private-key'
+    })
+    const remoteActor = makeActor('https://remote.test/users/bob')
+    const getAcceptedRelays = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'r1', inboxUrl: 'https://relay.example/inbox', state: 'accepted' }
+      ])
+    const database = makeDatabase({
+      getAcceptedRelays,
+      getActorsFromIds: vi.fn(async ({ ids }) =>
+        ids.includes(remoteActor.id) ? [remoteActor] : []
+      )
+    })
+
+    const inboxes = await getFederatedStatusDeliveryInboxes({
+      database,
+      currentActor,
+      status: makeStatus({ to: [remoteActor.id] })
+    })
+
+    expect(inboxes).not.toContain('https://relay.example/inbox')
+    expect(getAcceptedRelays).not.toHaveBeenCalled()
   })
 
   it('delivers direct statuses only to explicit remote recipients', async () => {

--- a/lib/services/federation/statusDelivery.ts
+++ b/lib/services/federation/statusDelivery.ts
@@ -114,6 +114,15 @@ export const getFederatedStatusDeliveryInboxes = async ({
     )
   }
 
+  // Public posts are also forwarded to every accepted relay's inbox so the
+  // relay can redistribute them. Relays only carry public activities, so this
+  // is gated on a public audience. The Set dedup + domain-policy filter below
+  // cover relay inboxes too.
+  if (hasPublicAudience(status)) {
+    const relays = await database.getAcceptedRelays()
+    inboxes.push(...relays.map((relay) => relay.inboxUrl))
+  }
+
   const explicitRecipientActorIds = getExplicitRecipientActorIds(status).filter(
     (actorId) => actorId !== currentActor.id
   )

--- a/lib/services/timelines/request.test.ts
+++ b/lib/services/timelines/request.test.ts
@@ -21,7 +21,9 @@ describe('parseTimelineQuery', () => {
         limit: PER_PAGE_LIMIT,
         maxStatusId: null,
         minStatusId: null,
-        sinceStatusId: null
+        sinceStatusId: null,
+        local: false,
+        remote: false
       }
     })
   })
@@ -40,7 +42,9 @@ describe('parseTimelineQuery', () => {
         limit: PER_PAGE_LIMIT,
         maxStatusId: realStatusUrl,
         minStatusId: realStatusUrl,
-        sinceStatusId: realStatusUrl
+        sinceStatusId: realStatusUrl,
+        local: false,
+        remote: false
       }
     })
   })
@@ -55,9 +59,53 @@ describe('parseTimelineQuery', () => {
         limit: PER_PAGE_LIMIT,
         maxStatusId: null,
         minStatusId: null,
-        sinceStatusId: null
+        sinceStatusId: null,
+        local: false,
+        remote: false
       }
     })
+  })
+
+  it.each([
+    {
+      description: 'local=true sets local scope',
+      param: 'local',
+      value: 'true',
+      field: 'local'
+    },
+    {
+      description: 'local=1 sets local scope',
+      param: 'local',
+      value: '1',
+      field: 'local'
+    },
+    {
+      description: 'remote=true sets remote scope',
+      param: 'remote',
+      value: 'true',
+      field: 'remote'
+    },
+    {
+      description: 'remote=1 sets remote scope',
+      param: 'remote',
+      value: '1',
+      field: 'remote'
+    }
+  ])('$description', ({ param, value, field }) => {
+    const result = parseTimelineQuery(params({ [param]: value }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.query[field as 'local' | 'remote']).toBe(true)
+    }
+  })
+
+  it('treats a non-truthy local/remote value as false', () => {
+    const result = parseTimelineQuery(params({ local: 'false', remote: 'no' }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.query.local).toBe(false)
+      expect(result.query.remote).toBe(false)
+    }
   })
 
   // limit is clamped, never rejected (Mastodon clamps out-of-range values).

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -17,7 +17,11 @@ const TimelineQuerySchema = z.object({
   limit: z.string().optional(),
   max_id: z.string().optional(),
   min_id: z.string().optional(),
-  since_id: z.string().optional()
+  since_id: z.string().optional(),
+  // Mastodon's public-timeline scope filters. Only the public timeline reads
+  // them; other endpoints ignore them.
+  local: z.string().optional(),
+  remote: z.string().optional()
 })
 
 export interface ParsedTimelineQuery {
@@ -27,7 +31,14 @@ export interface ParsedTimelineQuery {
   maxStatusId: string | null
   minStatusId: string | null
   sinceStatusId: string | null
+  // Public-timeline scope (Mastodon `local`/`remote`). Coerced from the truthy
+  // string forms Mastodon accepts (`true`/`1`).
+  local: boolean
+  remote: boolean
 }
+
+const isTruthyParam = (value: string | undefined): boolean =>
+  value === 'true' || value === '1'
 
 export type ParseTimelineQueryResult =
   | { ok: true; query: ParsedTimelineQuery }
@@ -52,7 +63,9 @@ export const parseTimelineQuery = (
     limit: searchParams.get('limit') || undefined,
     max_id: searchParams.get('max_id') || undefined,
     min_id: searchParams.get('min_id') || undefined,
-    since_id: searchParams.get('since_id') || undefined
+    since_id: searchParams.get('since_id') || undefined,
+    local: searchParams.get('local') || undefined,
+    remote: searchParams.get('remote') || undefined
   })
   if (!parsed.success) return { ok: false }
 
@@ -81,7 +94,9 @@ export const parseTimelineQuery = (
       limit: pageLimit,
       maxStatusId: maxStatusId ?? null,
       minStatusId: minStatusId ?? null,
-      sinceStatusId: sinceStatusId ?? null
+      sinceStatusId: sinceStatusId ?? null,
+      local: isTruthyParam(parsed.data.local),
+      remote: isTruthyParam(parsed.data.remote)
     }
   }
 }

--- a/lib/services/timelines/types.ts
+++ b/lib/services/timelines/types.ts
@@ -8,7 +8,10 @@ export enum Timeline {
   NOANNOUNCE = 'noannounce',
   MENTION = 'mention',
   DIRECT = 'direct',
-  LOCAL_PUBLIC = 'local-public'
+  LOCAL_PUBLIC = 'local-public',
+  // The "whole known network" feed: remote public statuses ingested from
+  // accepted relays, materialized into the `federated_timeline` table.
+  FEDERATED_PUBLIC = 'federated-public'
 }
 
 // List feeds are materialized into the same `timelines` table as the fixed feeds

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -20,6 +20,7 @@ import {
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 import { List, ListRepliesPolicy } from '@/lib/types/domain/list'
 import { Mute } from '@/lib/types/domain/mute'
+import { Relay, RelayState } from '@/lib/types/domain/relay'
 import { Session } from '@/lib/types/domain/session'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { Tag, TagType } from '@/lib/types/domain/tag'
@@ -1530,6 +1531,50 @@ export interface InstanceRuleDatabase {
   deleteInstanceRule(params: DeleteInstanceRuleParams): Promise<boolean>
   // All rules ordered by position ascending, then createdAt ascending.
   getInstanceRules(): Promise<InstanceRuleData[]>
+}
+
+// ============================================================================
+// Relay Database
+// ============================================================================
+
+// A subscription to an ActivityPub relay. See lib/types/domain/relay.ts for
+// the field semantics. `createdAt`/`updatedAt` are epoch milliseconds in the
+// domain shape regardless of the backend's timestamp storage.
+export type RelayData = Relay
+
+export type CreateRelayParams = { inboxUrl: string }
+export type UpdateRelayParams = {
+  id: string
+  state?: RelayState
+  actorId?: string | null
+  followActivityId?: string | null
+  lastError?: string | null
+}
+export type DeleteRelayParams = { id: string }
+export type GetRelayByIdParams = { id: string }
+export type GetRelayByInboxUrlParams = { inboxUrl: string }
+export type GetRelayByActorIdParams = { actorId: string }
+
+export interface RelayDatabase {
+  // Creates a relay row in the `idle` state. Throws on a duplicate inboxUrl.
+  createRelay(params: CreateRelayParams): Promise<RelayData>
+  // Partial update; bumps updatedAt and returns the updated row, or null when
+  // the relay does not exist. Passing actorId/followActivityId/lastError as
+  // null clears the column.
+  updateRelay(params: UpdateRelayParams): Promise<RelayData | null>
+  // True when a row was removed.
+  deleteRelay(params: DeleteRelayParams): Promise<boolean>
+  // All relays ordered by createdAt ascending.
+  getRelays(): Promise<RelayData[]>
+  getRelayById(params: GetRelayByIdParams): Promise<RelayData | null>
+  getRelayByInboxUrl(
+    params: GetRelayByInboxUrlParams
+  ): Promise<RelayData | null>
+  // Resolve a relay by its actor id (used to recognise an inbound
+  // relay-forwarded activity's HTTP signer). Returns null when unknown.
+  getRelayByActorId(params: GetRelayByActorIdParams): Promise<RelayData | null>
+  // Accepted relays only — the fan-out targets for local public posts.
+  getAcceptedRelays(): Promise<RelayData[]>
 }
 
 // ============================================================================

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2763,6 +2763,10 @@ export type CreateTimelineStatusParams = {
   actorId: string
   status: Status
 }
+export type AddStatusToFederatedTimelineParams = {
+  statusId: string
+  statusActorId: string
+}
 
 export interface TimelineDatabase {
   getTimeline({
@@ -2773,6 +2777,15 @@ export interface TimelineDatabase {
     limit
   }: GetTimelineParams): Promise<Status[]>
   createTimelineStatus(params: CreateTimelineStatusParams): Promise<void>
+  /**
+   * Appends a remote, relay-ingested status to the materialized
+   * `federated_timeline` (the Federated / "whole known network" feed). Idempotent
+   * — a status already present is left untouched. The timeline read for
+   * `Timeline.FEDERATED_PUBLIC` joins these rows back to `statuses`.
+   */
+  addStatusToFederatedTimeline(
+    params: AddStatusToFederatedTimelineParams
+  ): Promise<void>
   /**
    * Number of statuses visible on the local public timeline (the same set
    * `getTimeline({ timeline: LOCAL_PUBLIC })` pages over). Used to decide

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1554,6 +1554,7 @@ export type DeleteRelayParams = { id: string }
 export type GetRelayByIdParams = { id: string }
 export type GetRelayByInboxUrlParams = { inboxUrl: string }
 export type GetRelayByActorIdParams = { actorId: string }
+export type GetRelayByFollowActivityIdParams = { followActivityId: string }
 
 export interface RelayDatabase {
   // Creates a relay row in the `idle` state. Throws on a duplicate inboxUrl.
@@ -1573,6 +1574,11 @@ export interface RelayDatabase {
   // Resolve a relay by its actor id (used to recognise an inbound
   // relay-forwarded activity's HTTP signer). Returns null when unknown.
   getRelayByActorId(params: GetRelayByActorIdParams): Promise<RelayData | null>
+  // Resolve a relay by the Follow id we sent (used to match the relay's
+  // Accept/Reject back to the subscription). Returns null when unknown.
+  getRelayByFollowActivityId(
+    params: GetRelayByFollowActivityIdParams
+  ): Promise<RelayData | null>
   // Accepted relays only — the fan-out targets for local public posts.
   getAcceptedRelays(): Promise<RelayData[]>
 }

--- a/lib/types/domain/relay.ts
+++ b/lib/types/domain/relay.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+// A relay subscription state machine:
+// - idle: created but not subscribed (or after an Undo).
+// - pending: we sent a Follow and are waiting for the relay's Accept.
+// - accepted: the relay accepted; we forward public posts to it and trust the
+//   activities it forwards to us.
+// - rejected: the relay rejected our Follow.
+export const RelayState = z.enum(['idle', 'pending', 'accepted', 'rejected'])
+export type RelayState = z.infer<typeof RelayState>
+
+export const Relay = z.object({
+  id: z.string(),
+  // The relay inbox URL the admin subscribes to. We POST our Follow here and
+  // forward local public posts to it.
+  inboxUrl: z.string(),
+  // The relay's actor id, learned from the relay's Accept. Matched against the
+  // HTTP signer of inbound relay-forwarded activities.
+  actorId: z.string().nullable(),
+  state: RelayState,
+  // The id of the Follow activity we sent, used to match the relay's Accept.
+  followActivityId: z.string().nullable(),
+  // Last delivery/handshake error, surfaced in the admin UI.
+  lastError: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number()
+})
+
+export type Relay = z.infer<typeof Relay>

--- a/migrations/20260616000000_add_relay_support.js
+++ b/migrations/20260616000000_add_relay_support.js
@@ -1,0 +1,59 @@
+/**
+ * Relay support schema.
+ *
+ * `relays` holds one row per ActivityPub relay subscription. It is kept
+ * deliberately separate from `follows` so relay edges never pollute
+ * follower/following counts or lists. `inboxUrl` is the relay inbox the admin
+ * subscribes to (where we POST our Follow and forward local public posts).
+ * `actorId` is the relay's actor id, learned from the relay's Accept, and is
+ * what we match an inbound relay-forwarded activity's HTTP signer against.
+ * `state` mirrors FollowStatus-like semantics (idle | pending | accepted |
+ * rejected) but as its own column. `followActivityId` is the id of the Follow
+ * activity we sent, used to match the relay's Accept back to the row.
+ *
+ * `federated_timeline` is the dedicated, materialized store for the "Federated"
+ * (whole known network) timeline. We append one row per remote public status
+ * ingested from an accepted relay; the timeline read joins it back to
+ * `statuses`. It holds remote relay-sourced statuses only — local public posts
+ * keep coming from the existing LOCAL_PUBLIC query.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.schema.createTable('relays', (table) => {
+    table.string('id').primary()
+    table.string('inboxUrl').notNullable().unique()
+    table.string('actorId').nullable()
+    table.string('state').notNullable().defaultTo('idle')
+    table.string('followActivityId').nullable()
+    table.text('lastError').nullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.index(['actorId'], 'relays_actor_id')
+    table.index(['state'], 'relays_state')
+  })
+
+  await knex.schema.createTable('federated_timeline', (table) => {
+    table.string('statusId').primary()
+    table.string('statusActorId').notNullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.index(['statusActorId'], 'federated_timeline_status_actor_id')
+    table
+      .foreign('statusId')
+      .references('id')
+      .inTable('statuses')
+      .onDelete('CASCADE')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.schema.dropTableIfExists('federated_timeline')
+  await knex.schema.dropTableIfExists('relays')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -277,6 +277,12 @@ CREATE TABLE public.featured_tags (
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.federated_timeline (
+    "statusId" character varying(255) NOT NULL,
+    "statusActorId" character varying(255) NOT NULL,
+    "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE public.filter_keywords (
     id character varying(255) NOT NULL,
     "filterId" character varying(255) NOT NULL,
@@ -721,6 +727,17 @@ CREATE TABLE public.recipients (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.relays (
+    id character varying(255) NOT NULL,
+    "inboxUrl" character varying(255) NOT NULL,
+    "actorId" character varying(255),
+    state character varying(255) DEFAULT 'idle'::character varying NOT NULL,
+    "followActivityId" character varying(255),
+    "lastError" text,
+    "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE public.reports (
     id character varying(255) NOT NULL,
     "actorId" character varying(255) NOT NULL,
@@ -1060,6 +1077,9 @@ ALTER TABLE ONLY public.featured_tags
 ALTER TABLE ONLY public.featured_tags
     ADD CONSTRAINT featured_tags_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY public.federated_timeline
+    ADD CONSTRAINT federated_timeline_pkey PRIMARY KEY ("statusId");
+
 ALTER TABLE ONLY public.filter_keywords
     ADD CONSTRAINT filter_keywords_filter_keyword_unique UNIQUE ("filterId", keyword);
 
@@ -1192,6 +1212,12 @@ ALTER TABLE ONLY public.push_subscriptions
 ALTER TABLE ONLY public.recipients
     ADD CONSTRAINT recipients_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY public.relays
+    ADD CONSTRAINT relays_inboxurl_unique UNIQUE ("inboxUrl");
+
+ALTER TABLE ONLY public.relays
+    ADD CONSTRAINT relays_pkey PRIMARY KEY (id);
+
 ALTER TABLE ONLY public.reports
     ADD CONSTRAINT reports_pkey PRIMARY KEY (id);
 
@@ -1304,6 +1330,8 @@ CREATE INDEX domain_federation_rules_type_idx ON public.domain_federation_rules 
 
 CREATE INDEX featured_tags_name ON public.featured_tags USING btree ("nameNormalized");
 
+CREATE INDEX federated_timeline_status_actor_id ON public.federated_timeline USING btree ("statusActorId");
+
 CREATE INDEX filter_keywords_filter_id ON public.filter_keywords USING btree ("filterId");
 
 CREATE INDEX filter_statuses_filter_id ON public.filter_statuses USING btree ("filterId");
@@ -1382,6 +1410,10 @@ CREATE INDEX "recipients_actorId_statusId_idx" ON public.recipients USING btree 
 
 CREATE INDEX recipients_type_actor_created_status_idx ON public.recipients USING btree (type, "actorId", "createdAt", "statusId");
 
+CREATE INDEX relays_actor_id ON public.relays USING btree ("actorId");
+
+CREATE INDEX relays_state ON public.relays USING btree (state);
+
 CREATE INDEX reports_actor_created ON public.reports USING btree ("actorId", "createdAt");
 
 CREATE INDEX reports_target ON public.reports USING btree ("targetActorId");
@@ -1455,6 +1487,9 @@ CREATE INDEX verification_identifier_index ON public.verification USING btree (i
 ALTER TABLE ONLY public.actors
     ADD CONSTRAINT actors_accountid_foreign FOREIGN KEY ("accountId") REFERENCES public.accounts(id);
 
+ALTER TABLE ONLY public.federated_timeline
+    ADD CONSTRAINT federated_timeline_statusid_foreign FOREIGN KEY ("statusId") REFERENCES public.statuses(id) ON DELETE CASCADE;
+
 ALTER TABLE ONLY public.fitness_files
     ADD CONSTRAINT fitness_files_actorid_foreign FOREIGN KEY ("actorId") REFERENCES public.actors(id) ON DELETE CASCADE;
 
@@ -1508,3 +1543,4 @@ ALTER TABLE ONLY public.status_pins
 
 ALTER TABLE ONLY public."twoFactor"
     ADD CONSTRAINT twofactor_userid_foreign FOREIGN KEY ("userId") REFERENCES public.accounts(id) ON DELETE CASCADE;
+

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -211,3 +211,9 @@ CREATE TABLE `announcements` (`id` varchar(255), `text` text not null, `publishe
 CREATE TABLE `announcement_reads` (`announcementId` varchar(255) not null, `actorId` varchar(255) not null, `createdAt` datetime not null, primary key (`announcementId`, `actorId`));
 CREATE TABLE `announcement_reactions` (`announcementId` varchar(255) not null, `actorId` varchar(255) not null, `name` varchar(255) not null, `createdAt` datetime not null, primary key (`announcementId`, `actorId`, `name`));
 CREATE INDEX `timelinesActorTimelineStatusActorIndex` on `timelines` (`actorId`, `timeline`, `statusActorId`);
+CREATE TABLE `relays` (`id` varchar(255), `inboxUrl` varchar(255) not null, `actorId` varchar(255) null, `state` varchar(255) not null default 'idle', `followActivityId` varchar(255) null, `lastError` text null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
+CREATE UNIQUE INDEX `relays_inboxurl_unique` on `relays` (`inboxUrl`);
+CREATE INDEX `relays_actor_id` on `relays` (`actorId`);
+CREATE INDEX `relays_state` on `relays` (`state`);
+CREATE TABLE `federated_timeline` (`statusId` varchar(255), `statusActorId` varchar(255) not null, `createdAt` datetime default CURRENT_TIMESTAMP, foreign key(`statusId`) references `statuses`(`id`) on delete CASCADE, primary key (`statusId`));
+CREATE INDEX `federated_timeline_status_actor_id` on `federated_timeline` (`statusActorId`);


### PR DESCRIPTION
## Summary

Adds **ActivityPub relay** support so this instance can participate in relays — both **outbound** (forwarding local public posts to relays for redistribution) and **inbound** (ingesting public posts relays send us into a new **Federated** timeline). Relays are managed by admins; there is no central registry to sign up with — you subscribe to a relay's inbox URL and the handshake is signed by the existing instance/federation signing actor (`__instance__`).

## How it works

**Subscribe handshake (LitePub / Public-collection convention).** An admin adds a relay by its inbox URL. We send a `Follow` whose `object` is the ActivityStreams Public collection, signed by the instance actor; the relay replies with `Accept`, which lands on the instance actor's inbox and flips the subscription to `accepted` (recording the relay's actor id). `Undo{Follow}` unsubscribes.

**Inbound (Federated timeline).** A relay forwards third-party public posts as an `Announce` signed by the relay itself (so the HTTP-signature `signer === actor` check passes natively — no change to the verify guard). When the verified signer is an *accepted* relay, the shared inbox routes the Announce to a dedicated `RelayAnnounceJob` instead of the normal boost path. That job **re-fetches the wrapped note from its origin** (the authenticity anchor — relay framing of third-party content is never trusted), stores it via the normal `createNoteJob` (which enforces the author's federation policy), and appends it to the materialized `federated_timeline`. It never creates a relay-attributed boost row, and skips our own posts echoed back.

**Outbound.** `getFederatedStatusDeliveryInboxes` appends every accepted relay's inbox to the delivery set for public-audience statuses, reusing the existing Set-dedup + domain-policy filter.

**Exposure.** `GET /api/v1/timelines/public` now honors Mastodon's scope params: `local=true` → local-only (prior behaviour), `remote=true` → federated (relay-sourced) only, default → the federated view (local merged with remote by `(createdAt, id)`).

**Admin.** A new **Relays** admin page (+ nav tab) to add / subscribe / unsubscribe / remove relays, showing each relay's state, discovered actor id, and last error.

## Data model

Two new tables (one migration, both reference dumps regenerated):
- `relays` — one row per subscription, deliberately **separate from `follows`** so relay edges never pollute follower/following counts or lists. Tracks inbox URL, discovered actor id, state (`idle`/`pending`/`accepted`/`rejected`), the Follow id we sent, and last error.
- `federated_timeline` — materialized store for the Federated timeline (FK to `statuses`, `ON DELETE CASCADE`).

## Commits (each self-contained, gated)

1. schema (both tables + dumps)
2. `RelayDatabase` storage layer
3. Federated timeline read/write data layer (`Timeline.FEDERATED_PUBLIC`)
4. `followRelay`/`unfollowRelay` outbound senders
5. relay `Accept`/`Reject` handling on the instance inbox
6. relay `Announce` ingest job
7. shared-inbox routing of accepted-relay Announces
8. `/api/v1/timelines/public` `local`/`remote` scoping
9. forward local public posts to accepted relays
10. admin Relays page

## Scope / deferred (intentional, follow-ups)

To keep this reviewable and low-risk, the following are **deferred** and noted here rather than half-built:
- **Bare-`Create` relay forwarding + a signature carve-out.** This v1 supports the dominant convention where relays forward an `Announce` signed by the relay (which passes the existing guard untouched). The rarer style where a relay forwards a third-party `Create` verbatim (signer ≠ author) would require relaxing the `signer === actor` guard; deferred to avoid touching that anti-spoofing control.
- **Web UI "Federated" tab.** The federated timeline is exposed via the Mastodon API (clients can use `remote=true` / the default `/public`); a dedicated tab in the app's own timeline nav is a follow-up.
- **Retention/pruning** of relayed remote statuses (volume is controlled by which relays the admin subscribes to).
- **Periodic re-subscribe keepalive job** (would require QStash, since `NoQueue` drops delayed jobs).
- **Mastodon-compatible `/api/v1/admin/relays` REST API** (admin Server-Actions UI only for now).

## Config / migrations

- One new migration `20260616000000_add_relay_support.js`; **both** `migrations/schema.sql` (Postgres) and `migrations/schema.sqlite.sql` (SQLite) regenerated from the full migration chain.
- **No new required config.** Relays are entirely DB/admin-driven, like domain blocks/allows.

## Testing

- `yarn prettier:check` ✓
- `yarn lint` ✓ (0 errors)
- `yarn build` ✓ (TypeScript clean)
- `yarn test` ✓ — **4426 tests / 514 files passing**

New unit/route tests cover: the relay mixin, federated-timeline read/write + pagination, the outbound senders' activity shapes, the Accept/Reject handshake, the ingest job (origin re-fetch, self-echo skip, dedup, no relay-boost row), shared-inbox relay routing, the `local`/`remote` API scoping, relay fan-out in delivery, and the admin server actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)