### PR TITLE
Bump version to v1.75.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.75.0",
+  "version": "1.75.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.75.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.75.0`
- Base main SHA: `f71b13827e9d26874156c439927acd6d89a5c102`
- Included commits: `21`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
