### PR TITLE
fix: ship sharp's libvips .so in the standalone Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,15 @@ COPY --from=build --chown=app:app /opt/activities.next/.next/standalone /opt/act
 COPY --from=build --chown=app:app /opt/activities.next/public /opt/activities.next/public/
 COPY --from=build --chown=app:app /opt/activities.next/.next/static /opt/activities.next/.next/static
 COPY --from=build --chown=app:app /opt/activities.next/data.sqlite /opt/activities.next/data.sqlite
+# The Next.js standalone tracer (@vercel/nft) copies sharp's native *.node
+# binary but cannot follow the libvips shared library it dlopen's via native
+# RPATH. Since sharp 0.35 the runtime @img/sharp-libvips-* package is no longer
+# require()d from JS, so the tracer drops it and libvips-cpp.so.* never reaches
+# the image. Without it the instrumentation hook fails to load and every
+# request 500s. Re-copy the full sharp install so the .node binary and its
+# sibling libvips .so ship together with their original layout intact.
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/sharp /opt/activities.next/node_modules/sharp
+COPY --from=build --chown=app:app /opt/activities.next/node_modules/@img /opt/activities.next/node_modules/@img
 RUN rm -rf /opt/activities.next/.yarn
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,18 @@ import { getStaticSecurityHeaders } from '@/lib/utils/http-headers/static'
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: process.env.BUILD_STANDALONE ? 'standalone' : undefined,
+  // sharp's native *.node binary dlopen's its libvips shared library via a
+  // native RPATH, which the standalone tracer (@vercel/nft) cannot follow.
+  // Since sharp 0.35 the runtime @img/sharp-libvips-* package is no longer
+  // require()d from JS, so the tracer drops libvips-cpp.so from the standalone
+  // output and sharp fails to load at runtime. Force the full sharp + @img
+  // install (both the top-level and the copy nested under node_modules/sharp,
+  // which "node_modules/sharp/**" also covers) into the trace. The Dockerfile
+  // re-copies these as a guaranteed fallback in case hoisting or glob matching
+  // ever changes.
+  outputFileTracingIncludes: {
+    '/**/*': ['./node_modules/sharp/**/*', './node_modules/@img/**/*']
+  },
   assetPrefix: '/activities',
   allowedDevOrigins:
     process.env.NODE_ENV === 'development' ? ['activities.local'] : undefined,


### PR DESCRIPTION
## Problem

Production (Cloud Run) is returning **500 on essentially every request** after the latest deploy. The logs show one root cause repeated ~350 times:

```
Error: An error occurred while loading instrumentation hook: Failed to load external module
sharp-…: Could not load the "sharp" module using the linuxmusl-x64 runtime

ERR_DLOPEN_FAILED: Error loading shared library libvips-cpp.so.8.18.3: No such file or directory
(needed by .../node_modules/sharp/node_modules/@img/sharp-linuxmusl-x64/lib/sharp-linuxmusl-x64-0.35.1.node)
```

`sharp` fails to load during the **instrumentation hook** load, which crashes the server, so every request 500s. Across all 5000 log entries this is the only `ERROR`-severity signature — the rest are unrelated INFO/WARNING noise.

## Root cause

A regression exposed by **#1009 (sharp 0.34.5 → 0.35.1)**:

- The Next.js standalone build traces server dependencies with `@vercel/nft`, which only follows **JS `require`s**.
- sharp's native `*.node` binary loads its bundled `libvips-cpp.so.*` via a native **RPATH** (`$ORIGIN/../../sharp-libvips-<platform>/lib`), not a JS require — invisible to the tracer.
- In **0.34.5**, sharp's JS still referenced the runtime `@img/sharp-libvips-*` package, so nft pulled the whole package (including the `.so`) into the standalone output.
- In **0.35.x**, sharp's `dist/libvips.cjs` only references the build-only `@img/sharp-libvips-dev/*`, so nft no longer discovers the runtime libvips package and **drops `libvips-cpp.so` from the image**. The `.node` binary ships without its libvips dependency → `dlopen` fails.

Reproduced both directions with `@vercel/nft`:

| sharp | `libvips-cpp.so` traced into standalone? |
|------|------|
| 0.34.5 | ✅ yes (`…libvips-…/lib/libvips-cpp.so.8.17.3`) |
| 0.35.1 | ❌ no |

(`next@16.2.6` itself depends on `sharp@^0.34.5` while the app depends on `^0.35.1`, so both coexist and the app's 0.35.1 binary lands nested under `node_modules/sharp/node_modules/@img/…`, matching the production path.)

## Fix

In the Docker `output` stage, re-copy the full `sharp` + `@img` install from the build stage so the `.node` binary and its sibling `libvips-cpp.so` ship together with their original on-disk layout intact (so the RPATH lookup resolves). Verbatim copy → immune to the tracer's gap and to yarn hoisting/nesting decisions.

## Verification

End-to-end simulation of exactly what Next standalone does (nft trace → copy only traced files → run), on the same machine:

- **Before fix:** `SHARP_FAIL: Could not load the "sharp" module using the … runtime` (libvips `.so` absent) — reproduces production.
- **After fix:** libvips `.so` present, `SHARP_OK`.

Also confirmed the `.node`'s `NEEDED libvips-cpp.so.8.18.3` and `RPATH $ORIGIN/../../sharp-libvips-<platform>/lib` resolve to the copied sibling directory. (Repro ran on the glibc `linux-x64` variant; mechanism, RPATH, and fix are identical to the production `linuxmusl-x64` build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiXpz3a444JSY9rEoEDnTP)_