### PR TITLE
fix: keep OAuth sign-in redirect on the request host

### DIFF
--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -1,5 +1,6 @@
-import { getConfig } from '@/lib/config'
+import { getBaseURL, getConfig } from '@/lib/config'
 import { TEST_DOMAIN } from '@/lib/stub/const'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import Page from './page'
 
@@ -39,35 +40,66 @@ const searchParams = {
   response_type: 'code' as const
 }
 
-describe('/oauth/authorize sign-in redirect host', () => {
+describe('/oauth/authorize redirect host', () => {
   beforeEach(() => {
     redirectMock.mockClear()
     vi.mocked(getConfig).mockReturnValue({
       host: TEST_DOMAIN,
       trustedHosts: [ALIAS_HOST]
     } as ReturnType<typeof getConfig>)
+    vi.mocked(getBaseURL).mockReturnValue(`https://${TEST_DOMAIN}`)
+    vi.mocked(getActorFromSession).mockResolvedValue(null)
   })
 
-  it('keeps an unauthenticated login on the trusted request host', async () => {
-    headersMock.mockReturnValue(new Headers({ 'x-forwarded-host': ALIAS_HOST }))
-
-    await Page({ searchParams: Promise.resolve(searchParams) })
-
-    expect(redirectMock).toHaveBeenCalledTimes(1)
-    const target = new URL(redirectMock.mock.calls[0][0])
-    expect(target.host).toBe(ALIAS_HOST)
-    expect(target.pathname).toBe('/auth/signin')
-  })
-
-  it('falls back to the configured host for an untrusted request host', async () => {
+  it.each([
+    {
+      description: 'keeps an unauthenticated login on the trusted request host',
+      requestHost: ALIAS_HOST,
+      expectedHost: ALIAS_HOST
+    },
+    {
+      description:
+        'falls back to the configured host for an untrusted request host',
+      requestHost: 'evil.example',
+      expectedHost: TEST_DOMAIN
+    }
+  ])('sign-in redirect $description', async ({ requestHost, expectedHost }) => {
     headersMock.mockReturnValue(
-      new Headers({ 'x-forwarded-host': 'evil.example' })
+      new Headers({ 'x-forwarded-host': requestHost })
     )
 
     await Page({ searchParams: Promise.resolve(searchParams) })
 
     expect(redirectMock).toHaveBeenCalledTimes(1)
     const target = new URL(redirectMock.mock.calls[0][0])
-    expect(target.host).toBe(TEST_DOMAIN)
+    expect(target.host).toBe(expectedHost)
+    expect(target.pathname).toBe('/auth/signin')
+  })
+
+  it('uses the configured scheme rather than hardcoding https', async () => {
+    vi.mocked(getBaseURL).mockReturnValue(`http://${TEST_DOMAIN}`)
+    headersMock.mockReturnValue(new Headers({ 'x-forwarded-host': ALIAS_HOST }))
+
+    await Page({ searchParams: Promise.resolve(searchParams) })
+
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.protocol).toBe('http:')
+    expect(target.host).toBe(ALIAS_HOST)
+  })
+
+  it('delegates an authenticated consent redirect to the trusted request host', async () => {
+    vi.mocked(getActorFromSession).mockResolvedValue({
+      id: 'actor-id',
+      account: { id: 'account-id' }
+    } as Awaited<ReturnType<typeof getActorFromSession>>)
+    headersMock.mockReturnValue(new Headers({ 'x-forwarded-host': ALIAS_HOST }))
+
+    // No sig/exp -> shouldDelegateToBetterAuth is true.
+    await Page({ searchParams: Promise.resolve(searchParams) })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.host).toBe(ALIAS_HOST)
+    expect(target.pathname).toBe('/api/auth/oauth2/authorize')
   })
 })

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -1,0 +1,73 @@
+import { getConfig } from '@/lib/config'
+import { TEST_DOMAIN } from '@/lib/stub/const'
+
+import Page from './page'
+
+vi.mock('@/lib/config')
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(() => ({}))
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue(null)
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn().mockResolvedValue(null)
+}))
+
+const redirectMock = vi.fn((path: string) => path)
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('Unexpected notFound')
+  }),
+  redirect: (path: string) => redirectMock(path)
+}))
+
+const headersMock = vi.fn()
+vi.mock('next/headers', () => ({
+  headers: () => headersMock()
+}))
+
+const ALIAS_HOST = 'alias.llun.dev'
+
+const searchParams = {
+  client_id: 'client-id',
+  scope: 'read',
+  redirect_uri: 'https://app.example/callback',
+  response_type: 'code' as const
+}
+
+describe('/oauth/authorize sign-in redirect host', () => {
+  beforeEach(() => {
+    redirectMock.mockClear()
+    vi.mocked(getConfig).mockReturnValue({
+      host: TEST_DOMAIN,
+      trustedHosts: [ALIAS_HOST]
+    } as ReturnType<typeof getConfig>)
+  })
+
+  it('keeps an unauthenticated login on the trusted request host', async () => {
+    headersMock.mockReturnValue(new Headers({ 'x-forwarded-host': ALIAS_HOST }))
+
+    await Page({ searchParams: Promise.resolve(searchParams) })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.host).toBe(ALIAS_HOST)
+    expect(target.pathname).toBe('/auth/signin')
+  })
+
+  it('falls back to the configured host for an untrusted request host', async () => {
+    headersMock.mockReturnValue(
+      new Headers({ 'x-forwarded-host': 'evil.example' })
+    )
+
+    await Page({ searchParams: Promise.resolve(searchParams) })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.host).toBe(TEST_DOMAIN)
+  })
+})

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -87,6 +87,21 @@ describe('/oauth/authorize redirect host', () => {
     expect(target.host).toBe(ALIAS_HOST)
   })
 
+  it('does not carry over the configured host port to a portless request host', async () => {
+    vi.mocked(getBaseURL).mockReturnValue(`https://${TEST_DOMAIN}:8443`)
+    vi.mocked(getConfig).mockReturnValue({
+      host: `${TEST_DOMAIN}:8443`,
+      trustedHosts: [ALIAS_HOST]
+    } as ReturnType<typeof getConfig>)
+    headersMock.mockReturnValue(new Headers({ 'x-forwarded-host': ALIAS_HOST }))
+
+    await Page({ searchParams: Promise.resolve(searchParams) })
+
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.host).toBe(ALIAS_HOST)
+    expect(target.port).toBe('')
+  })
+
   it('delegates an authenticated consent redirect to the trusted request host', async () => {
     vi.mocked(getActorFromSession).mockResolvedValue({
       id: 'actor-id',

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -41,17 +41,12 @@ const Page: FC<Props> = async ({ searchParams }) => {
 
   // Keep sign-in/consent redirects on the host the request actually arrived on
   // (a trusted alias domain falls back to the configured host otherwise) so a
-  // login started on a custom domain isn't bounced to ACTIVITIES_HOST. Start
-  // from getBaseURL() to inherit the configured scheme (http for
-  // ACTIVITIES_INSECURE_AUTH) and swap in the request host via the URL API.
+  // login started on a custom domain isn't bounced to ACTIVITIES_HOST. Inherit
+  // only the configured scheme (http for ACTIVITIES_INSECURE_AUTH) from
+  // getBaseURL(); the validated request host is authoritative for host+port.
   const requestHost = headerHost(await headers())
-  const requestUrl = new URL(getBaseURL())
-  requestUrl.host = requestHost
-  // The `.host` setter keeps the base port when requestHost omits one (verified
-  // on Node/V8: it does not clear an existing port); the request host is
-  // authoritative, so drop any inherited port in that case.
-  if (requestUrl.host !== requestHost) requestUrl.port = ''
-  const requestBaseURL = requestUrl.toString()
+  const { protocol } = new URL(getBaseURL())
+  const requestBaseURL = `${protocol}//${requestHost}`
 
   if (!actor || !actor.account) {
     const url = new URL('/auth/signin', requestBaseURL)

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -41,10 +41,12 @@ const Page: FC<Props> = async ({ searchParams }) => {
 
   // Keep sign-in/consent redirects on the host the request actually arrived on
   // (a trusted alias domain falls back to the configured host otherwise) so a
-  // login started on a custom domain isn't bounced to ACTIVITIES_HOST. Reuse
-  // getBaseURL() only for the configured scheme (http for ACTIVITIES_INSECURE_AUTH).
-  const requestHost = headerHost(await headers())
-  const requestBaseURL = `${new URL(getBaseURL()).protocol}//${requestHost}`
+  // login started on a custom domain isn't bounced to ACTIVITIES_HOST. Start
+  // from getBaseURL() to inherit the configured scheme (http for
+  // ACTIVITIES_INSECURE_AUTH) and swap only the host via the URL API.
+  const requestBaseUrl = new URL(getBaseURL())
+  requestBaseUrl.host = headerHost(await headers())
+  const requestBaseURL = requestBaseUrl.toString()
 
   if (!actor || !actor.account) {
     const url = new URL('/auth/signin', requestBaseURL)

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -1,9 +1,11 @@
+import { headers } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
 import { FC } from 'react'
 
 import { getBaseURL } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { headerHost } from '@/lib/services/guards/headerHost'
 import { Actor } from '@/lib/types/domain/actor'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
@@ -37,14 +39,21 @@ const Page: FC<Props> = async ({ searchParams }) => {
 
   const actor = await getActorFromSession(database, session)
 
+  // Keep sign-in/consent redirects on the host the request actually arrived on
+  // (a trusted alias domain falls back to the configured host otherwise) so a
+  // login started on a custom domain isn't bounced to ACTIVITIES_HOST. Reuse
+  // getBaseURL() only for the configured scheme (http for ACTIVITIES_INSECURE_AUTH).
+  const requestHost = headerHost(await headers())
+  const requestBaseURL = `${new URL(getBaseURL()).protocol}//${requestHost}`
+
   if (!actor || !actor.account) {
-    const url = new URL('/auth/signin', getBaseURL())
+    const url = new URL('/auth/signin', requestBaseURL)
     url.searchParams.append('redirectBack', buildOAuthAuthorizePath(params))
     return redirect(url.toString())
   }
 
   if (shouldDelegateToBetterAuth(params)) {
-    return redirect(buildBetterAuthAuthorizeUrl(params, getBaseURL()))
+    return redirect(buildBetterAuthAuthorizeUrl(params, requestBaseURL))
   }
 
   const client = await database.getClientFromId({ clientId: params.client_id })

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -45,12 +45,13 @@ const Page: FC<Props> = async ({ searchParams }) => {
   // from getBaseURL() to inherit the configured scheme (http for
   // ACTIVITIES_INSECURE_AUTH) and swap in the request host via the URL API.
   const requestHost = headerHost(await headers())
-  const requestBaseUrl = new URL(getBaseURL())
-  requestBaseUrl.host = requestHost
-  // The `.host` setter keeps the base port when requestHost omits one; the
-  // request host is authoritative, so drop any inherited port in that case.
-  if (requestBaseUrl.host !== requestHost) requestBaseUrl.port = ''
-  const requestBaseURL = requestBaseUrl.toString()
+  const requestUrl = new URL(getBaseURL())
+  requestUrl.host = requestHost
+  // The `.host` setter keeps the base port when requestHost omits one (verified
+  // on Node/V8: it does not clear an existing port); the request host is
+  // authoritative, so drop any inherited port in that case.
+  if (requestUrl.host !== requestHost) requestUrl.port = ''
+  const requestBaseURL = requestUrl.toString()
 
   if (!actor || !actor.account) {
     const url = new URL('/auth/signin', requestBaseURL)

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -43,9 +43,13 @@ const Page: FC<Props> = async ({ searchParams }) => {
   // (a trusted alias domain falls back to the configured host otherwise) so a
   // login started on a custom domain isn't bounced to ACTIVITIES_HOST. Start
   // from getBaseURL() to inherit the configured scheme (http for
-  // ACTIVITIES_INSECURE_AUTH) and swap only the host via the URL API.
+  // ACTIVITIES_INSECURE_AUTH) and swap in the request host via the URL API.
+  const requestHost = headerHost(await headers())
   const requestBaseUrl = new URL(getBaseURL())
-  requestBaseUrl.host = headerHost(await headers())
+  requestBaseUrl.host = requestHost
+  // The `.host` setter keeps the base port when requestHost omits one; the
+  // request host is authoritative, so drop any inherited port in that case.
+  if (requestBaseUrl.host !== requestHost) requestBaseUrl.port = ''
   const requestBaseURL = requestBaseUrl.toString()
 
   if (!actor || !actor.account) {


### PR DESCRIPTION
## Problem

Logging in via a domain that isn't `ACTIVITIES_HOST` still bounced the user to the `ACTIVITIES_HOST` domain.

The redirect originated in the **OAuth authorize flow** (`app/(nosidebar)/oauth/authorize/page.tsx`) — the path Mastodon/iOS/OAuth clients use to sign in. For an unauthenticated request it built the sign-in redirect (and the better-auth consent delegation) from `getBaseURL()`, which always returns the static `ACTIVITIES_HOST`:

```ts
const url = new URL('/auth/signin', getBaseURL())   // always ACTIVITIES_HOST
```

Recent multi-domain work (#1010 / #1018 / #1019) made the actor/API boundaries host-aware, but this OAuth page was never touched (last changed in #763) — a missed boundary.

## Fix

Resolve the redirect base from the **incoming request host** using the existing `headerHost` helper (which validates against trusted hosts and falls back to the configured host for anything untrusted), reusing `getBaseURL()` only for the scheme:

```ts
const requestHost = headerHost(await headers())
const requestBaseURL = `${new URL(getBaseURL()).protocol}//${requestHost}`
```

Both the sign-in redirect and the better-auth consent delegation now use `requestBaseURL`, so a login stays on the domain it started on. Untrusted hosts still fall back to the configured host (no open redirect).

## Tests

- New `app/(nosidebar)/oauth/authorize/page.test.tsx`: confirmed it **fails** against the old code and **passes** with the fix — covers trusted-host preservation and untrusted-host fallback.
- `yarn lint` (0 errors), `yarn build`, and the OAuth/host test groups all pass.

## Note for later

better-auth's server `baseURL` is still globally fixed to `ACTIVITIES_HOST`, so deeper better-auth-internal absolute URLs (cookie/callback construction) remain host-static. That didn't cause this symptom, but it's the next boundary to make request-aware if cookie/session oddities appear across alias domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)