### PR TITLE
fix: parse litepub (Akkoma/Pleroma) actors in JSON-LD compaction

### DIFF
--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -181,6 +181,30 @@ describe('compactActivityPub', () => {
     expect(result.id).toBe('https://remote.example/notes/1')
   })
 
+  it('still compacts when an inline context sets @direction but no @language', async () => {
+    // Regression: dropping @direction must not synthesize an `@language:
+    // undefined` key, which is invalid JSON-LD and would make compaction throw
+    // and silently return the raw, un-normalized input. We assert compaction
+    // actually ran by checking a side effect of it (recipients arrayified,
+    // @context stripped) rather than a field that survives the raw fallback.
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': [
+          ACTIVITY_STREAMS_CONTEXT_URL,
+          { '@direction': 'ltr', htmlMfm: 'https://w3id.org/fep/c16b#htmlMfm' }
+        ],
+        id: 'https://remote.example/notes/1',
+        type: 'Note',
+        attributedTo: 'https://remote.example/users/alice',
+        published: '2026-01-01T00:00:00Z',
+        to: 'https://www.w3.org/ns/activitystreams#Public'
+      })
+    )
+
+    expect(result.to).toEqual(['as:Public'])
+    expect(result['@context']).toBeUndefined()
+  })
+
   it('keeps scalar actor fields as strings despite a document default language', async () => {
     // Akkoma/Pleroma (litepub) actors set a document-level default language in
     // their inline @context. Left untouched, JSON-LD wraps every scalar string

--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -178,6 +178,70 @@ describe('compactActivityPub', () => {
     expect(result.id).toBe('https://remote.example/notes/1')
   })
 
+  it('keeps scalar actor fields as strings despite a document default language', async () => {
+    // Akkoma/Pleroma (litepub) actors set a document-level default language in
+    // their inline @context. Left untouched, JSON-LD wraps every scalar string
+    // into a language-tagged value object (and maps name/summary into
+    // *Map containers), which breaks the strict Actor schema. The compactor
+    // must strip the default language so these stay plain strings.
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': [
+          ACTIVITY_STREAMS_CONTEXT_URL,
+          'https://litepub.example/schemas/litepub-0.1.jsonld',
+          { '@language': 'und', htmlMfm: 'https://w3id.org/fep/c16b#htmlMfm' }
+        ],
+        id: 'https://litepub.example/users/sukino',
+        type: 'Person',
+        preferredUsername: 'sukino',
+        name: 'Sukino VERSE',
+        summary: 'a litepub actor',
+        inbox: 'https://litepub.example/users/sukino/inbox',
+        outbox: 'https://litepub.example/users/sukino/outbox'
+      })
+    )
+
+    expect(result.preferredUsername).toBe('sukino')
+    expect(result.name).toBe('Sukino VERSE')
+    expect(result.summary).toBe('a litepub actor')
+    expect(result.nameMap).toBeUndefined()
+    expect(result.summaryMap).toBeUndefined()
+  })
+
+  it('recovers an actor public key defined only via a litepub context', async () => {
+    // litepub defines publicKey, but our offline loader cannot resolve the
+    // remote litepub context, and these actors do not list security/v1
+    // themselves. Ensuring security/v1 is part of the expansion context keeps
+    // the publicKey from being dropped.
+    const publicKeyPem =
+      '-----BEGIN PUBLIC KEY-----\nMIIBexample\n-----END PUBLIC KEY-----\n'
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': [
+          ACTIVITY_STREAMS_CONTEXT_URL,
+          'https://litepub.example/schemas/litepub-0.1.jsonld',
+          { '@language': 'und' }
+        ],
+        id: 'https://litepub.example/users/sukino',
+        type: 'Person',
+        preferredUsername: 'sukino',
+        inbox: 'https://litepub.example/users/sukino/inbox',
+        outbox: 'https://litepub.example/users/sukino/outbox',
+        publicKey: {
+          id: 'https://litepub.example/users/sukino#main-key',
+          owner: 'https://litepub.example/users/sukino',
+          publicKeyPem
+        }
+      })
+    )
+
+    expect(result.publicKey).toMatchObject({
+      id: 'https://litepub.example/users/sukino#main-key',
+      owner: 'https://litepub.example/users/sukino',
+      publicKeyPem
+    })
+  })
+
   it('returns non-object input unchanged', async () => {
     await expect(
       compactActivityPub('https://remote.example/notes/1')

--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -297,7 +297,7 @@ describe('normalizeInputContext', () => {
     ])
   })
 
-  it('strips default language/direction but keeps inline term definitions', () => {
+  it('drops an undetermined default language and base direction but keeps inline terms', () => {
     const context = contextOf({
       '@context': [
         ACTIVITY_STREAMS_CONTEXT_URL,
@@ -311,6 +311,19 @@ describe('normalizeInputContext', () => {
 
     expect(context).toContainEqual({ htmlMfm: 'https://x.example#m' })
     expect(JSON.stringify(context)).not.toContain('@language')
+    expect(JSON.stringify(context)).not.toContain('@direction')
+  })
+
+  it('preserves a meaningful default language (note language detection relies on it)', () => {
+    const context = contextOf({
+      '@context': [
+        ACTIVITY_STREAMS_CONTEXT_URL,
+        { '@language': 'th', '@direction': 'ltr' }
+      ]
+    }) as unknown[]
+
+    // The real language stays; only the base direction is dropped.
+    expect(context).toContainEqual({ '@language': 'th' })
     expect(JSON.stringify(context)).not.toContain('@direction')
   })
 

--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -1,6 +1,8 @@
 import {
   ACTIVITY_STREAMS_CONTEXT_URL,
+  SECURITY_V1_CONTEXT_URL,
   compactActivityPub,
+  normalizeInputContext,
   offlineDocumentLoader
 } from '@/lib/activities/jsonld'
 
@@ -281,5 +283,86 @@ describe('offlineDocumentLoader', () => {
       'https://malicious.example/ctx.jsonld'
     )
     expect(loaded.document).toEqual({ '@context': {} })
+  })
+})
+
+describe('normalizeInputContext', () => {
+  const contextOf = (input: Record<string, unknown>) =>
+    normalizeInputContext(input)['@context']
+
+  it('applies the default context when @context is absent', () => {
+    expect(contextOf({ id: 'https://remote.example/notes/1' })).toEqual([
+      ACTIVITY_STREAMS_CONTEXT_URL,
+      SECURITY_V1_CONTEXT_URL
+    ])
+  })
+
+  it('strips default language/direction but keeps inline term definitions', () => {
+    const context = contextOf({
+      '@context': [
+        ACTIVITY_STREAMS_CONTEXT_URL,
+        {
+          '@language': 'und',
+          '@direction': 'ltr',
+          htmlMfm: 'https://x.example#m'
+        }
+      ]
+    }) as unknown[]
+
+    expect(context).toContainEqual({ htmlMfm: 'https://x.example#m' })
+    expect(JSON.stringify(context)).not.toContain('@language')
+    expect(JSON.stringify(context)).not.toContain('@direction')
+  })
+
+  it('adds security/v1 as the lowest-precedence fallback', () => {
+    const context = contextOf({
+      '@context': [
+        ACTIVITY_STREAMS_CONTEXT_URL,
+        { foo: 'https://x.example#foo' }
+      ]
+    }) as unknown[]
+
+    // Prepended, so a sender's own contexts/terms still override it.
+    expect(context[0]).toBe(SECURITY_V1_CONTEXT_URL)
+    expect(context).toContain(ACTIVITY_STREAMS_CONTEXT_URL)
+  })
+
+  it('does not duplicate security/v1 when the sender already lists it', () => {
+    const context = contextOf({
+      '@context': [ACTIVITY_STREAMS_CONTEXT_URL, SECURITY_V1_CONTEXT_URL]
+    }) as unknown[]
+
+    expect(
+      context.filter((entry) => entry === SECURITY_V1_CONTEXT_URL)
+    ).toHaveLength(1)
+  })
+
+  it.each([
+    ['http scheme', 'http://w3id.org/security/v1'],
+    ['trailing slash', 'https://w3id.org/security/v1/'],
+    ['http scheme with trailing slash', 'http://w3id.org/security/v1/']
+  ])('does not add a second security/v1 for the %s variant', (_label, url) => {
+    const context = contextOf({
+      '@context': [ACTIVITY_STREAMS_CONTEXT_URL, url]
+    }) as unknown[]
+
+    expect(context).not.toContain(SECURITY_V1_CONTEXT_URL)
+    expect(context).toContain(url)
+  })
+
+  it('wraps a single string @context into an array with the fallback', () => {
+    expect(contextOf({ '@context': ACTIVITY_STREAMS_CONTEXT_URL })).toEqual([
+      SECURITY_V1_CONTEXT_URL,
+      ACTIVITY_STREAMS_CONTEXT_URL
+    ])
+  })
+
+  it('passes non-object context entries through untouched', () => {
+    const context = contextOf({
+      '@context': [ACTIVITY_STREAMS_CONTEXT_URL, null, ['nested']]
+    }) as unknown[]
+
+    expect(context).toContain(null)
+    expect(context).toContainEqual(['nested'])
   })
 })

--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeInputContext,
   offlineDocumentLoader
 } from '@/lib/activities/jsonld'
+import { BaseNote, getContent, getLanguage } from '@/lib/activities/note'
 
 const asRecord = (value: unknown) => value as Record<string, unknown>
 
@@ -377,5 +378,52 @@ describe('normalizeInputContext', () => {
 
     expect(context).toContain(null)
     expect(context).toContainEqual(['nested'])
+  })
+
+  it('does not mutate the caller input or its inline context objects', () => {
+    const inlineContext = { '@language': 'und', '@direction': 'ltr' }
+    const input = {
+      '@context': [ACTIVITY_STREAMS_CONTEXT_URL, inlineContext],
+      id: 'https://remote.example/users/a'
+    }
+
+    normalizeInputContext(input)
+
+    // The original input and its nested context object are untouched.
+    expect(input['@context']).toEqual([
+      ACTIVITY_STREAMS_CONTEXT_URL,
+      inlineContext
+    ])
+    expect(inlineContext).toEqual({ '@language': 'und', '@direction': 'ltr' })
+  })
+})
+
+describe('compactActivityPub note language handling', () => {
+  const noteWithContextLanguage = (language: string) => ({
+    '@context': [ACTIVITY_STREAMS_CONTEXT_URL, { '@language': language }],
+    id: 'https://remote.example/notes/1',
+    type: 'Note',
+    attributedTo: 'https://remote.example/users/alice',
+    content: '<p>hello</p>',
+    published: '2026-01-01T00:00:00Z'
+  })
+
+  it('keeps content readable and language null for an undetermined default', async () => {
+    const note = (await compactActivityPub(
+      noteWithContextLanguage('und')
+    )) as unknown as BaseNote
+
+    expect(getContent(note)).toBe('<p>hello</p>')
+    // "und" carries no real language, so detection stays null (no regression).
+    expect(getLanguage(note)).toBeNull()
+  })
+
+  it('preserves a meaningful default language for detection', async () => {
+    const note = (await compactActivityPub(
+      noteWithContextLanguage('th')
+    )) as unknown as BaseNote
+
+    expect(getContent(note)).toBe('<p>hello</p>')
+    expect(getLanguage(note)).toBe('th')
   })
 })

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -188,13 +188,16 @@ const stripBlankNodePrefix = (value: unknown): unknown => {
  * default. Documents that carry their own context are normalised so the
  * subsequent expansion does not mangle data we depend on:
  *
- * - **Strip the document-level default language/direction.** Akkoma/Pleroma
- *   (litepub) actors set `{"@language":"und"}` in their inline context. Left in
- *   place, JSON-LD attaches that language tag to every scalar string, so
- *   `preferredUsername` expands to a `{@value,@language}` object and
+ * - **Drop a non-informative document-level default language/direction.**
+ *   Akkoma/Pleroma (litepub) actors set `{"@language":"und"}` in their inline
+ *   context. Left in place, JSON-LD attaches that language tag to every scalar
+ *   string, so `preferredUsername` expands to a `{@value,@language}` object and
  *   `name`/`summary` collapse into `*Map` language containers — none of which
- *   satisfy the strict Actor schema. We never consume these language tags, so
- *   we drop `@language`/`@direction` from inline context objects.
+ *   satisfy the strict Actor schema. We drop the base `@direction` (never
+ *   consumed) and an *undetermined* `@language` (`"und"`), which carries no real
+ *   language. A *meaningful* default language is kept untouched: note language
+ *   detection (`getLanguage`, which reads the `content`/`summary` language maps)
+ *   depends on it, so removing it would silently lose a note's language.
  * - **Ensure `security/v1` is available.** `publicKey` is defined by the litepub
  *   context, which our offline loader cannot resolve, and these actors do not
  *   list `security/v1` themselves — so the key would be dropped during
@@ -215,6 +218,12 @@ const referencesSecurityV1Context = (entry: unknown): boolean =>
   typeof entry === 'string' &&
   SECURITY_V1_CONTEXT_URLS.has(entry.replace(/[/#]+$/, ''))
 
+// A BCP 47 "und" (or empty) default language conveys no real language, so it is
+// safe to drop. Anything else is meaningful and must be preserved.
+const isUndeterminedLanguage = (language: unknown): boolean =>
+  typeof language === 'string' &&
+  (language.trim() === '' || language.trim().toLowerCase() === 'und')
+
 export const normalizeInputContext = (input: Record<string, unknown>) => {
   const context = input['@context']
   if (!context) {
@@ -224,9 +233,13 @@ export const normalizeInputContext = (input: Record<string, unknown>) => {
   const entries = Array.isArray(context) ? context : [context]
   const sanitized = entries.map((entry) => {
     if (!isRecord(entry)) return entry
-    // Keep every inline term definition (e.g. `htmlMfm`); only drop the
-    // document-level language/direction defaults.
-    const { '@language': _language, '@direction': _direction, ...rest } = entry
+    // Keep every inline term definition (e.g. `htmlMfm`) and any meaningful
+    // default language; only drop the base text direction (never consumed) and
+    // an undetermined default language ("und").
+    const { '@direction': _direction, ...rest } = entry
+    if (isUndeterminedLanguage(rest['@language'])) {
+      delete rest['@language']
+    }
     return rest
   })
 

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -242,9 +242,13 @@ export const normalizeInputContext = (input: Record<string, unknown>) => {
     // rather than allocating a copy for every inbound document.
     if (!dropDirection && !dropLanguage) return entry
     // Rebuild without the dropped keys instead of using `delete`, which can
-    // push the object into V8's slow dictionary mode on this hot path.
+    // push the object into V8's slow dictionary mode on this hot path. Never
+    // write `@language` back as `undefined` (the key was simply absent): that
+    // is invalid JSON-LD (`@language` must be a string or null) and would make
+    // the whole compaction throw and fall back to the raw document.
     const { '@direction': _direction, '@language': language, ...rest } = entry
-    return dropLanguage ? rest : { ...rest, '@language': language }
+    if (dropLanguage || language === undefined) return rest
+    return { ...rest, '@language': language }
   })
 
   // Prepend (rather than append) so security/v1 has the LOWEST precedence:

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -198,9 +198,24 @@ const stripBlankNodePrefix = (value: unknown): unknown => {
  * - **Ensure `security/v1` is available.** `publicKey` is defined by the litepub
  *   context, which our offline loader cannot resolve, and these actors do not
  *   list `security/v1` themselves — so the key would be dropped during
- *   expansion. Appending the (bundled) security context keeps it intact.
+ *   expansion. The (bundled) security context is added as a low-precedence
+ *   fallback so it fills the gap without overriding any term the sender
+ *   defines for itself.
  */
-const normalizeInputContext = (input: Record<string, unknown>) => {
+// Recognise an existing security/v1 reference across the dialect variations
+// peers use (http/https scheme, trailing slash or hash) via exact equality on
+// the normalised value — never a substring match — so we neither add a
+// duplicate nor mistake an unrelated URL that merely contains this string.
+const SECURITY_V1_CONTEXT_URLS = new Set([
+  'https://w3id.org/security/v1',
+  'http://w3id.org/security/v1'
+])
+
+const referencesSecurityV1Context = (entry: unknown): boolean =>
+  typeof entry === 'string' &&
+  SECURITY_V1_CONTEXT_URLS.has(entry.replace(/[/#]+$/, ''))
+
+export const normalizeInputContext = (input: Record<string, unknown>) => {
   const context = input['@context']
   if (!context) {
     return { ...input, '@context': DEFAULT_INPUT_CONTEXT }
@@ -215,8 +230,11 @@ const normalizeInputContext = (input: Record<string, unknown>) => {
     return rest
   })
 
-  if (!sanitized.includes(SECURITY_V1_CONTEXT_URL)) {
-    sanitized.push(SECURITY_V1_CONTEXT_URL)
+  // Prepend (rather than append) so security/v1 has the LOWEST precedence:
+  // in JSON-LD later contexts win, so a sender that defines its own
+  // `publicKey`/`owner`/etc. inline must still override our fallback.
+  if (!sanitized.some(referencesSecurityV1Context)) {
+    sanitized.unshift(SECURITY_V1_CONTEXT_URL)
   }
 
   return { ...input, '@context': sanitized }

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -181,8 +181,46 @@ const stripBlankNodePrefix = (value: unknown): unknown => {
   return value
 }
 
-const withInputContext = (input: Record<string, unknown>) =>
-  input['@context'] ? input : { ...input, '@context': DEFAULT_INPUT_CONTEXT }
+/**
+ * Prepare an inbound document's `@context` for expansion.
+ *
+ * Documents that omit `@context` entirely get the ActivityStreams + security
+ * default. Documents that carry their own context are normalised so the
+ * subsequent expansion does not mangle data we depend on:
+ *
+ * - **Strip the document-level default language/direction.** Akkoma/Pleroma
+ *   (litepub) actors set `{"@language":"und"}` in their inline context. Left in
+ *   place, JSON-LD attaches that language tag to every scalar string, so
+ *   `preferredUsername` expands to a `{@value,@language}` object and
+ *   `name`/`summary` collapse into `*Map` language containers — none of which
+ *   satisfy the strict Actor schema. We never consume these language tags, so
+ *   we drop `@language`/`@direction` from inline context objects.
+ * - **Ensure `security/v1` is available.** `publicKey` is defined by the litepub
+ *   context, which our offline loader cannot resolve, and these actors do not
+ *   list `security/v1` themselves — so the key would be dropped during
+ *   expansion. Appending the (bundled) security context keeps it intact.
+ */
+const normalizeInputContext = (input: Record<string, unknown>) => {
+  const context = input['@context']
+  if (!context) {
+    return { ...input, '@context': DEFAULT_INPUT_CONTEXT }
+  }
+
+  const entries = Array.isArray(context) ? context : [context]
+  const sanitized = entries.map((entry) => {
+    if (!isRecord(entry)) return entry
+    // Keep every inline term definition (e.g. `htmlMfm`); only drop the
+    // document-level language/direction defaults.
+    const { '@language': _language, '@direction': _direction, ...rest } = entry
+    return rest
+  })
+
+  if (!sanitized.includes(SECURITY_V1_CONTEXT_URL)) {
+    sanitized.push(SECURITY_V1_CONTEXT_URL)
+  }
+
+  return { ...input, '@context': sanitized }
+}
 
 /**
  * Canonicalise an inbound ActivityPub document by compacting it against the
@@ -201,7 +239,7 @@ export const compactActivityPub = async <T>(input: T): Promise<T> => {
   try {
     const jsonld = await getProcessor()
     const compacted = await jsonld.compact(
-      withInputContext(input) as JsonLdDocument,
+      normalizeInputContext(input) as JsonLdDocument,
       CANONICAL_CONTEXT as unknown as ContextDefinition,
       { documentLoader: offlineDocumentLoader }
     )

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -236,11 +236,15 @@ export const normalizeInputContext = (input: Record<string, unknown>) => {
     // Keep every inline term definition (e.g. `htmlMfm`) and any meaningful
     // default language; only drop the base text direction (never consumed) and
     // an undetermined default language ("und").
-    const { '@direction': _direction, ...rest } = entry
-    if (isUndeterminedLanguage(rest['@language'])) {
-      delete rest['@language']
-    }
-    return rest
+    const dropDirection = Object.hasOwn(entry, '@direction')
+    const dropLanguage = isUndeterminedLanguage(entry['@language'])
+    // Fast path for the common case (nothing to strip): reuse the entry as-is
+    // rather than allocating a copy for every inbound document.
+    if (!dropDirection && !dropLanguage) return entry
+    // Rebuild without the dropped keys instead of using `delete`, which can
+    // push the object into V8's slow dictionary mode on this hot path.
+    const { '@direction': _direction, '@language': language, ...rest } = entry
+    return dropLanguage ? rest : { ...rest, '@language': language }
   })
 
   // Prepend (rather than append) so security/v1 has the LOWEST precedence:


### PR DESCRIPTION
## Problem

Opening a remote Akkoma/Pleroma actor's profile after login 404'd — e.g. `https://llun.social/@sukino@miraiverse.xyz`. `getProfileData` → `getActorPerson` returned `null` because the actor failed `Actor.safeParse` after JSON-LD compaction.

Diagnosed by reproducing on the local `activities.local` federation stack and fetching the live actor doc. The remote side is healthy (webfinger + actor both `200`); the failure is in our compaction of a document that carries its own `@context`:

| Field | Raw from remote | After `compactActivityPub` (before fix) | Schema expects |
|-------|-----------------|------------------------------------------|----------------|
| `preferredUsername` | `"sukino"` | `{"@language":"und","@value":"sukino"}` | string |
| `name` | `"SukinoVERSE …"` | dropped → `nameMap` | string |
| `publicKey` | full object | **`undefined`** (dropped) | object |

Two root causes, both stemming from the litepub `@context` (`["…/activitystreams","https://miraiverse.xyz/schemas/litepub-0.1.jsonld",{"@language":"und",…}]`):

1. **Document-level default language.** `{"@language":"und"}` makes JSON-LD attach a language tag to every scalar string, so `preferredUsername` becomes a value object and `name`/`summary` collapse into `*Map` language containers.
2. **`publicKey` dropped.** It's defined only by the litepub context (which our offline loader can't resolve), and these actors don't list `security/v1` themselves, so the term has no definition during expansion. (Mastodon actors work because they explicitly list `security/v1`, which we bundle.)

This affects **any** Akkoma/Pleroma (litepub) actor with a default `@language` and a litepub-only public key, not just this one.

## Fix

Normalize the input `@context` before expansion in `compactActivityPub`:

- Strip `@language` / `@direction` from inline context objects (keeping other inline terms like `htmlMfm`) — we never consume language tags, and this keeps scalar fields as plain strings.
- Ensure `https://w3id.org/security/v1` is part of the context so `publicKey` survives expansion.
- Documents without an `@context` keep the existing `DEFAULT_INPUT_CONTEXT` behavior.

## Verification

- New regression tests for both failures in `lib/activities/jsonld/index.test.ts`.
- Full suite green (`yarn lint` / `yarn build` / `yarn test`).
- End-to-end: ran the actual shipped `compactActivityPub` + `Actor.safeParse` against the **live** miraiverse actor → parses OK (`preferredUsername` string, `publicKey` present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)