### PR TITLE
fix: clamp Mastodon pagination limits instead of returning 400 (+ clearer passkey errors)

### DIFF
--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -17,13 +17,15 @@ const passkeyErrorMessage = (code?: string): string | null => {
     // ERROR_CEREMONY_ABORTED, which is only a programmatic abort), and
     // better-auth reports AUTH_CANCELLED when no WebAuthnError is thrown. Stay
     // silent for all of these so dismissing the prompt isn't shown as an error.
+    // (AUTH_CANCELLED is also reused for a rare post-ceremony network failure of
+    // verify-authentication; we accept staying silent there too.)
     case 'AUTH_CANCELLED':
     case 'ERROR_CEREMONY_ABORTED':
     case 'ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY':
       return null
     case 'ERROR_INVALID_RP_ID':
     case 'ERROR_INVALID_DOMAIN':
-      return 'This passkey cannot be used on this domain. Sign in with your email and password instead.'
+      return 'This passkey cannot be used on this domain. Please use another sign-in method.'
     default:
       return 'Passkey sign in failed. Please try again.'
   }

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -6,30 +6,7 @@ import { FC, useState } from 'react'
 import { Button } from '@/lib/components/ui/button'
 import { authClient } from '@/lib/services/auth/auth-client'
 
-// better-auth's passkey client always sets `message` to "Auth cancelled"
-// regardless of the real failure and only varies the `code`, so the raw message
-// is misleading. Map the meaningful WebAuthn error codes to actionable text, and
-// stay silent only when the user genuinely dismissed the system prompt.
-const passkeyErrorMessage = (code?: string): string | null => {
-  switch (code) {
-    // Genuine user dismissal/timeout: @simplewebauthn maps the browser's
-    // NotAllowedError to ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY (not
-    // ERROR_CEREMONY_ABORTED, which is only a programmatic abort), and
-    // better-auth reports AUTH_CANCELLED when no WebAuthnError is thrown. Stay
-    // silent for all of these so dismissing the prompt isn't shown as an error.
-    // (AUTH_CANCELLED is also reused for a rare post-ceremony network failure of
-    // verify-authentication; we accept staying silent there too.)
-    case 'AUTH_CANCELLED':
-    case 'ERROR_CEREMONY_ABORTED':
-    case 'ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY':
-      return null
-    case 'ERROR_INVALID_RP_ID':
-    case 'ERROR_INVALID_DOMAIN':
-      return 'This passkey cannot be used on this domain. Please use another sign-in method.'
-    default:
-      return 'Passkey sign in failed. Please try again.'
-  }
-}
+import { passkeyErrorMessage } from './passkeyErrorMessage'
 
 export const PasskeySigninButton: FC = () => {
   const [error, setError] = useState<string>()

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -6,6 +6,23 @@ import { FC, useState } from 'react'
 import { Button } from '@/lib/components/ui/button'
 import { authClient } from '@/lib/services/auth/auth-client'
 
+// better-auth's passkey client always sets `message` to "Auth cancelled"
+// regardless of the real failure and only varies the `code`, so the raw message
+// is misleading. Map the meaningful WebAuthn error codes to actionable text, and
+// stay silent only when the user genuinely dismissed the system prompt.
+const passkeyErrorMessage = (code?: string): string | null => {
+  switch (code) {
+    case 'AUTH_CANCELLED':
+    case 'ERROR_CEREMONY_ABORTED':
+      return null
+    case 'ERROR_INVALID_RP_ID':
+    case 'ERROR_INVALID_DOMAIN':
+      return 'This passkey cannot be used on this domain. Sign in with your email and password instead.'
+    default:
+      return 'Passkey sign in failed. Please try again.'
+  }
+}
+
 export const PasskeySigninButton: FC = () => {
   const [error, setError] = useState<string>()
   const [loading, setLoading] = useState(false)
@@ -21,14 +38,9 @@ export const PasskeySigninButton: FC = () => {
     try {
       const result = await authClient.signIn.passkey({ autoFill: false })
       if (!result || result.error) {
-        const error = result?.error as
-          | { code?: string; message?: unknown }
-          | undefined
-        const code = error?.code
-        const msg = error?.message
-        if (code !== 'AUTH_CANCELLED' && typeof msg === 'string') {
-          setError(msg)
-        }
+        const code = (result?.error as { code?: string } | undefined)?.code
+        const message = passkeyErrorMessage(code)
+        if (message) setError(message)
         setLoading(false)
         return
       }

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -12,8 +12,14 @@ import { authClient } from '@/lib/services/auth/auth-client'
 // stay silent only when the user genuinely dismissed the system prompt.
 const passkeyErrorMessage = (code?: string): string | null => {
   switch (code) {
+    // Genuine user dismissal/timeout: @simplewebauthn maps the browser's
+    // NotAllowedError to ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY (not
+    // ERROR_CEREMONY_ABORTED, which is only a programmatic abort), and
+    // better-auth reports AUTH_CANCELLED when no WebAuthnError is thrown. Stay
+    // silent for all of these so dismissing the prompt isn't shown as an error.
     case 'AUTH_CANCELLED':
     case 'ERROR_CEREMONY_ABORTED':
+    case 'ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY':
       return null
     case 'ERROR_INVALID_RP_ID':
     case 'ERROR_INVALID_DOMAIN':

--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -12,7 +12,7 @@ import {
   CardHeader,
   CardTitle
 } from '@/lib/components/ui/card'
-import { getConfig } from '@/lib/config'
+import { getBaseURL, getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 
@@ -36,11 +36,17 @@ const Page: FC = async () => {
   const { auth, serviceName, registrationOpen } = getConfig()
   const credentialEnabled = auth?.enableCredential !== false
 
+  // Use an absolute URL on the configured host (ACTIVITIES_HOST) so the logo
+  // resolves against the canonical origin instead of the request host. When the
+  // instance is served behind a CDN on an alias domain, a root-relative
+  // `/logo-nav.png` can be intercepted and redirected away from the app origin.
+  const logoSrc = `${getBaseURL()}/logo-nav.png`
+
   return (
     <Card>
       <CardHeader className="items-center text-center">
         <Image
-          src="/logo-nav.png"
+          src={logoSrc}
           alt=""
           aria-hidden="true"
           width={48}

--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -40,7 +40,7 @@ const Page: FC = async () => {
   // resolves against the canonical origin instead of the request host. When the
   // instance is served behind a CDN on an alias domain, a root-relative
   // `/logo-nav.png` can be intercepted and redirected away from the app origin.
-  const logoSrc = `${getBaseURL()}/logo-nav.png`
+  const logoSrc = new URL('/logo-nav.png', getBaseURL()).toString()
 
   return (
     <Card>

--- a/app/(nosidebar)/auth/signin/passkeyErrorMessage.test.ts
+++ b/app/(nosidebar)/auth/signin/passkeyErrorMessage.test.ts
@@ -1,0 +1,30 @@
+import { passkeyErrorMessage } from './passkeyErrorMessage'
+
+describe('passkeyErrorMessage', () => {
+  it.each([
+    'AUTH_CANCELLED',
+    'ERROR_CEREMONY_ABORTED',
+    'ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY'
+  ])('stays silent for the cancellation code %s', (code) => {
+    expect(passkeyErrorMessage(code)).toBeNull()
+  })
+
+  it.each(['ERROR_INVALID_RP_ID', 'ERROR_INVALID_DOMAIN'])(
+    'returns the domain-mismatch message for %s',
+    (code) => {
+      expect(passkeyErrorMessage(code)).toBe(
+        'This passkey cannot be used on this domain. Please use another sign-in method.'
+      )
+    }
+  )
+
+  it.each([
+    ['a WebAuthn error not in the map', 'ERROR_AUTHENTICATOR_GENERAL_ERROR'],
+    ['an unknown code', 'SOMETHING_ELSE'],
+    ['an undefined code', undefined]
+  ])('returns the generic message for %s', (_label, code) => {
+    expect(passkeyErrorMessage(code)).toBe(
+      'Passkey sign in failed. Please try again.'
+    )
+  })
+})

--- a/app/(nosidebar)/auth/signin/passkeyErrorMessage.ts
+++ b/app/(nosidebar)/auth/signin/passkeyErrorMessage.ts
@@ -1,0 +1,24 @@
+// better-auth's passkey client always sets `message` to "Auth cancelled"
+// regardless of the real failure and only varies the `code`, so the raw message
+// is misleading. Map the meaningful WebAuthn error codes to actionable text, and
+// stay silent only when the user genuinely dismissed the system prompt.
+export const passkeyErrorMessage = (code?: string): string | null => {
+  switch (code) {
+    // Genuine user dismissal/timeout: @simplewebauthn maps the browser's
+    // NotAllowedError to ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY (not
+    // ERROR_CEREMONY_ABORTED, which is only a programmatic abort), and
+    // better-auth reports AUTH_CANCELLED when no WebAuthnError is thrown. Stay
+    // silent for all of these so dismissing the prompt isn't shown as an error.
+    // (AUTH_CANCELLED is also reused for a rare post-ceremony network failure of
+    // verify-authentication; we accept staying silent there too.)
+    case 'AUTH_CANCELLED':
+    case 'ERROR_CEREMONY_ABORTED':
+    case 'ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY':
+      return null
+    case 'ERROR_INVALID_RP_ID':
+    case 'ERROR_INVALID_DOMAIN':
+      return 'This passkey cannot be used on this domain. Please use another sign-in method.'
+    default:
+      return 'Passkey sign in failed. Please try again.'
+  }
+}

--- a/app/(timeline)/PublicFooter.tsx
+++ b/app/(timeline)/PublicFooter.tsx
@@ -1,38 +1,46 @@
 import Image from 'next/image'
 import { FC } from 'react'
 
+import { getBaseURL } from '@/lib/config'
+
 // Public footer shown to logged-out visitors, matching the web-public design:
 // a single bordered card with the brand line and a link to the project source.
 // About/Privacy are omitted since the app has no such pages.
-export const PublicFooter: FC = () => (
-  <footer className="mx-auto w-full max-w-[680px] px-4 py-8">
-    <div className="rounded-xl border bg-background/70 px-5 py-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <Image
-            src="/logo-nav.png"
-            alt=""
-            aria-hidden="true"
-            width={20}
-            height={20}
-            className="h-5 w-5 shrink-0 object-contain"
-          />
-          <span>
-            <strong className="font-semibold text-foreground">
-              Activities
-            </strong>{' '}
-            — a self-hosted social + fitness server on the Fediverse.
-          </span>
+export const PublicFooter: FC = () => {
+  // Absolute URL on the configured host (ACTIVITIES_HOST) so the logo resolves
+  // against the canonical origin even when served behind a CDN on an alias
+  // domain, where a root-relative `/logo-nav.png` may be redirected away.
+  const logoSrc = `${getBaseURL()}/logo-nav.png`
+  return (
+    <footer className="mx-auto w-full max-w-[680px] px-4 py-8">
+      <div className="rounded-xl border bg-background/70 px-5 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Image
+              src={logoSrc}
+              alt=""
+              aria-hidden="true"
+              width={20}
+              height={20}
+              className="h-5 w-5 shrink-0 object-contain"
+            />
+            <span>
+              <strong className="font-semibold text-foreground">
+                Activities
+              </strong>{' '}
+              — a self-hosted social + fitness server on the Fediverse.
+            </span>
+          </div>
+          <a
+            href="https://github.com/llun/activities.next"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            Source
+          </a>
         </div>
-        <a
-          href="https://github.com/llun/activities.next"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-muted-foreground hover:text-foreground"
-        >
-          Source
-        </a>
       </div>
-    </div>
-  </footer>
-)
+    </footer>
+  )
+}

--- a/app/(timeline)/PublicFooter.tsx
+++ b/app/(timeline)/PublicFooter.tsx
@@ -10,7 +10,7 @@ export const PublicFooter: FC = () => {
   // Absolute URL on the configured host (ACTIVITIES_HOST) so the logo resolves
   // against the canonical origin even when served behind a CDN on an alias
   // domain, where a root-relative `/logo-nav.png` may be redirected away.
-  const logoSrc = `${getBaseURL()}/logo-nav.png`
+  const logoSrc = new URL('/logo-nav.png', getBaseURL()).toString()
   return (
     <footer className="mx-auto w-full max-w-[680px] px-4 py-8">
       <div className="rounded-xl border bg-background/70 px-5 py-4">

--- a/app/(timeline)/PublicTopBar.tsx
+++ b/app/(timeline)/PublicTopBar.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 
 import { Logo } from '@/lib/components/layout/logo'
 import { Button } from '@/lib/components/ui/button'
-import { getConfig } from '@/lib/config'
+import { getBaseURL, getConfig } from '@/lib/config'
 
 // Public top bar shown to logged-out visitors in place of the app nav sidebar:
 // a slim sticky bar with the brand logo and Sign in / Create account links to
@@ -11,10 +11,13 @@ import { getConfig } from '@/lib/config'
 // CTA is hidden when the server has closed registration.
 export const PublicTopBar: FC = () => {
   const { registrationOpen } = getConfig()
+  // Absolute logo URL on the canonical origin (ACTIVITIES_HOST) so it resolves
+  // even when this page is served on a CDN alias domain, matching PublicFooter.
+  const logoSrc = new URL('/logo-nav.png', getBaseURL()).toString()
   return (
     <header className="sticky top-0 z-30 border-b bg-background/90 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-[680px] items-center gap-3 px-4">
-        <Logo size="md" />
+        <Logo size="md" src={logoSrc} />
         <div className="ml-auto flex items-center gap-2">
           <Button asChild variant="outline" size="sm">
             <Link href="/auth/signin">Sign in</Link>

--- a/app/(timeline)/landing/LandingHero.tsx
+++ b/app/(timeline)/landing/LandingHero.tsx
@@ -2,6 +2,8 @@ import { Activity, Globe, Shield } from 'lucide-react'
 import Image from 'next/image'
 import { FC } from 'react'
 
+import { getBaseURL } from '@/lib/config'
+
 interface LandingHeroProps {
   serviceName: string
 }
@@ -11,61 +13,66 @@ interface LandingHeroProps {
  * preview: a copy-light brand hero on the Activity-orange ground with the
  * signature dual-tint orange gradient and a watermark sparrow mark.
  */
-export const LandingHero: FC<LandingHeroProps> = ({ serviceName }) => (
-  <div
-    className="relative flex h-full min-h-[60vh] flex-col justify-between overflow-hidden px-7 py-10 text-white sm:px-14 sm:py-14"
-    style={{
-      backgroundColor: 'var(--primary)',
-      backgroundImage:
-        'radial-gradient(700px 420px at 18% 8%, hsl(24 95% 56%), transparent 60%),' +
-        'radial-gradient(680px 520px at 100% 100%, hsl(24 95% 38%), transparent 55%)'
-    }}
-  >
-    {/* Oversized faint mark, watermark style. */}
-    <Image
-      src="/logo.png"
-      alt=""
-      aria-hidden="true"
-      width={540}
-      height={540}
-      className="pointer-events-none absolute -bottom-32 -right-32 h-auto w-[360px] select-none opacity-[0.12] sm:w-[540px]"
-    />
-
-    <div className="relative flex items-center gap-3">
+export const LandingHero: FC<LandingHeroProps> = ({ serviceName }) => {
+  // Absolute URL on the canonical origin (ACTIVITIES_HOST) so the logo resolves
+  // even when this landing page is served on a CDN alias domain.
+  const logoSrc = new URL('/logo.png', getBaseURL()).toString()
+  return (
+    <div
+      className="relative flex h-full min-h-[60vh] flex-col justify-between overflow-hidden px-7 py-10 text-white sm:px-14 sm:py-14"
+      style={{
+        backgroundColor: 'var(--primary)',
+        backgroundImage:
+          'radial-gradient(700px 420px at 18% 8%, hsl(24 95% 56%), transparent 60%),' +
+          'radial-gradient(680px 520px at 100% 100%, hsl(24 95% 38%), transparent 55%)'
+      }}
+    >
+      {/* Oversized faint mark, watermark style. */}
       <Image
-        src="/logo.png"
+        src={logoSrc}
         alt=""
         aria-hidden="true"
-        width={44}
-        height={44}
-        className="h-11 w-11 rounded-full object-contain ring-2 ring-white/70"
+        width={540}
+        height={540}
+        className="pointer-events-none absolute -bottom-32 -right-32 h-auto w-[360px] select-none opacity-[0.12] sm:w-[540px]"
       />
-      <span className="text-xl font-semibold tracking-tight">
-        {serviceName}
-      </span>
-    </div>
 
-    <div className="relative mt-10">
-      <h1 className="text-[34px] font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[52px]">
-        See what&apos;s
-        <br />
-        happening next.
-      </h1>
-      <p className="mt-4 max-w-sm text-[15px] leading-[1.5] text-white/90 sm:text-[17px]">
-        Posts and fitness activity, on a server you own.
-      </p>
-    </div>
+      <div className="relative flex items-center gap-3">
+        <Image
+          src={logoSrc}
+          alt=""
+          aria-hidden="true"
+          width={44}
+          height={44}
+          className="h-11 w-11 rounded-full object-contain ring-2 ring-white/70"
+        />
+        <span className="text-xl font-semibold tracking-tight">
+          {serviceName}
+        </span>
+      </div>
 
-    <div className="relative mt-10 flex items-center gap-5 text-[13px] text-white/90">
-      <span className="inline-flex items-center gap-1.5">
-        <Globe className="size-[15px]" /> Fediverse
-      </span>
-      <span className="inline-flex items-center gap-1.5">
-        <Shield className="size-[15px]" /> Self-hosted
-      </span>
-      <span className="inline-flex items-center gap-1.5">
-        <Activity className="size-[15px]" /> Fitness
-      </span>
+      <div className="relative mt-10">
+        <h1 className="text-[34px] font-semibold leading-[1.05] tracking-[-0.02em] sm:text-[52px]">
+          See what&apos;s
+          <br />
+          happening next.
+        </h1>
+        <p className="mt-4 max-w-sm text-[15px] leading-[1.5] text-white/90 sm:text-[17px]">
+          Posts and fitness activity, on a server you own.
+        </p>
+      </div>
+
+      <div className="relative mt-10 flex items-center gap-5 text-[13px] text-white/90">
+        <span className="inline-flex items-center gap-1.5">
+          <Globe className="size-[15px]" /> Fediverse
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <Shield className="size-[15px]" /> Self-hosted
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <Activity className="size-[15px]" /> Fitness
+        </span>
+      </div>
     </div>
-  </div>
-)
+  )
+}

--- a/app/(timeline)/landing/LandingPublicFeed.tsx
+++ b/app/(timeline)/landing/LandingPublicFeed.tsx
@@ -26,7 +26,7 @@ export const LandingPublicFeed: FC<LandingPublicFeedProps> = ({
   // Absolute URL on the configured host (ACTIVITIES_HOST) so the logo resolves
   // against the canonical origin even when served behind a CDN on an alias
   // domain, where a root-relative `/logo-nav.png` may be redirected away.
-  const logoSrc = `${getBaseURL()}/logo-nav.png`
+  const logoSrc = new URL('/logo-nav.png', getBaseURL()).toString()
   return (
     <div className="flex h-full flex-col">
       <div className="sticky top-0 z-10 flex items-center gap-2.5 border-b bg-background/70 px-5 py-3.5 backdrop-blur">

--- a/app/(timeline)/landing/LandingPublicFeed.tsx
+++ b/app/(timeline)/landing/LandingPublicFeed.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import { FC } from 'react'
 
 import { Posts } from '@/lib/components/posts/posts'
+import { getBaseURL } from '@/lib/config'
 import { Status } from '@/lib/types/domain/status'
 
 interface LandingPublicFeedProps {
@@ -21,36 +22,45 @@ export const LandingPublicFeed: FC<LandingPublicFeedProps> = ({
   host,
   currentTime,
   statuses
-}) => (
-  <div className="flex h-full flex-col">
-    <div className="sticky top-0 z-10 flex items-center gap-2.5 border-b bg-background/70 px-5 py-3.5 backdrop-blur">
-      <Image
-        src="/logo-nav.png"
-        alt=""
-        aria-hidden="true"
-        width={28}
-        height={28}
-        className="h-7 w-7 shrink-0 object-contain"
-      />
-      <div className="min-w-0">
-        <h1 className="truncate text-sm font-semibold leading-tight">{host}</h1>
-        <div className="text-xs text-muted-foreground">
-          Recent posts on this server
+}) => {
+  // Absolute URL on the configured host (ACTIVITIES_HOST) so the logo resolves
+  // against the canonical origin even when served behind a CDN on an alias
+  // domain, where a root-relative `/logo-nav.png` may be redirected away.
+  const logoSrc = `${getBaseURL()}/logo-nav.png`
+  return (
+    <div className="flex h-full flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-2.5 border-b bg-background/70 px-5 py-3.5 backdrop-blur">
+        <Image
+          src={logoSrc}
+          alt=""
+          aria-hidden="true"
+          width={28}
+          height={28}
+          className="h-7 w-7 shrink-0 object-contain"
+        />
+        <div className="min-w-0">
+          <h1 className="truncate text-sm font-semibold leading-tight">
+            {host}
+          </h1>
+          <div className="text-xs text-muted-foreground">
+            Recent posts on this server
+          </div>
         </div>
       </div>
-    </div>
 
-    <Posts
-      framed={false}
-      host={host}
-      currentTime={currentTime}
-      statuses={statuses}
-      showActions={false}
-      showReadOnlyStats
-    />
+      <Posts
+        framed={false}
+        host={host}
+        currentTime={currentTime}
+        statuses={statuses}
+        showActions={false}
+        showReadOnlyStats
+      />
 
-    <div className="px-5 py-4 text-center text-xs text-muted-foreground">
-      Sign in to see the full timeline, reply, and follow across the Fediverse.
+      <div className="px-5 py-4 text-center text-xs text-muted-foreground">
+        Sign in to see the full timeline, reply, and follow across the
+        Fediverse.
+      </div>
     </div>
-  </div>
-)
+  )
+}

--- a/app/api/v1/accounts/[id]/endorsements/route.test.ts
+++ b/app/api/v1/accounts/[id]/endorsements/route.test.ts
@@ -86,4 +86,21 @@ describe('GET /api/v1/accounts/:id/endorsements', () => {
     })
     expect(response.status).toBe(404)
   })
+
+  it.each([
+    ['limit=100', '?limit=100', 80],
+    ['limit=0', '?limit=0', 1]
+  ])(
+    'clamps out-of-range %s instead of rejecting it',
+    async (_label, query, expectedLimit) => {
+      const getEndorsements = vi.spyOn(database, 'getEndorsements')
+      const response = await GET(createRequest(ACTOR3_ID, query), {
+        params: Promise.resolve({ id: urlToId(ACTOR3_ID) })
+      })
+      expect(response.status).toBe(200)
+      expect(getEndorsements).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expectedLimit })
+      )
+    }
+  )
 })

--- a/app/api/v1/accounts/[id]/endorsements/route.ts
+++ b/app/api/v1/accounts/[id]/endorsements/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -28,7 +29,7 @@ const EndorsementsQueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(80).default(40)
+  limit: clampedLimit(80, 40)
 })
 
 // GET /api/v1/accounts/:id/endorsements — accounts the given account features.

--- a/app/api/v1/accounts/[id]/followers/route.test.ts
+++ b/app/api/v1/accounts/[id]/followers/route.test.ts
@@ -113,6 +113,27 @@ describe('GET /api/v1/accounts/:id/followers', () => {
     expect(link).toContain('rel="prev"')
   })
 
+  it.each([
+    { query: '?limit=100', expectedLimit: 80 },
+    { query: '?limit=0', expectedLimit: 1 }
+  ])(
+    'clamps an out-of-range $query to 200 (limit $expectedLimit) instead of 400',
+    async ({ query, expectedLimit }) => {
+      const getFollowersSpy = vi.spyOn(database, 'getFollowers')
+
+      const response = await GET(createRequest(ACTOR2_ID, query), {
+        params: Promise.resolve({ id: urlToId(ACTOR2_ID) })
+      })
+
+      expect(response.status).toBe(200)
+      expect(getFollowersSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expectedLimit })
+      )
+
+      getFollowersSpy.mockRestore()
+    }
+  )
+
   it('returns 404 for an unknown account', async () => {
     const unknown = 'https://llun.test/users/nope'
     const response = await GET(createRequest(unknown), {

--- a/app/api/v1/accounts/[id]/followers/route.test.ts
+++ b/app/api/v1/accounts/[id]/followers/route.test.ts
@@ -117,7 +117,7 @@ describe('GET /api/v1/accounts/:id/followers', () => {
     { query: '?limit=100', expectedLimit: 80 },
     { query: '?limit=0', expectedLimit: 1 }
   ])(
-    'clamps an out-of-range $query to 200 (limit $expectedLimit) instead of 400',
+    'clamps an out-of-range $query to limit $expectedLimit instead of rejecting it',
     async ({ query, expectedLimit }) => {
       const getFollowersSpy = vi.spyOn(database, 'getFollowers')
 

--- a/app/api/v1/accounts/[id]/followers/route.ts
+++ b/app/api/v1/accounts/[id]/followers/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
 import {
@@ -29,7 +30,7 @@ const FollowersQueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(80).default(40)
+  limit: clampedLimit(80, 40)
 })
 
 // GET /api/v1/accounts/:id/followers — accounts which follow the given account.

--- a/app/api/v1/accounts/[id]/following/route.test.ts
+++ b/app/api/v1/accounts/[id]/following/route.test.ts
@@ -94,4 +94,22 @@ describe('GET /api/v1/accounts/:id/following', () => {
     })
     expect(response.status).toBe(404)
   })
+
+  it.each([
+    { limit: '100', expected: 80 },
+    { limit: '0', expected: 1 }
+  ])(
+    'clamps an out-of-range limit=$limit to $expected instead of returning 400',
+    async ({ limit, expected }) => {
+      const getFollowingSpy = vi.spyOn(database, 'getFollowing')
+      const response = await GET(createRequest(ACTOR3_ID, `?limit=${limit}`), {
+        params: Promise.resolve({ id: urlToId(ACTOR3_ID) })
+      })
+
+      expect(response.status).toBe(200)
+      expect(getFollowingSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expected })
+      )
+    }
+  )
 })

--- a/app/api/v1/accounts/[id]/following/route.ts
+++ b/app/api/v1/accounts/[id]/following/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
 import {
@@ -29,7 +30,7 @@ const FollowingQueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(80).default(40)
+  limit: clampedLimit(80, 40)
 })
 
 // GET /api/v1/accounts/:id/following — accounts the given account follows.

--- a/app/api/v1/accounts/[id]/media/route.test.ts
+++ b/app/api/v1/accounts/[id]/media/route.test.ts
@@ -19,7 +19,8 @@ describe('GET /api/v1/accounts/:id/media', () => {
     })
   })
 
-  it('returns 422 when media query parameters fail schema validation', async () => {
+  it('clamps an out-of-range limit instead of rejecting the request', async () => {
+    mockDatabase.getAttachmentsForActor.mockResolvedValue([])
     const request = new NextRequest(
       'https://llun.test/api/v1/accounts/llun.test:users:llun/media?limit=0',
       { method: 'GET' }
@@ -28,10 +29,10 @@ describe('GET /api/v1/accounts/:id/media', () => {
     const response = await GET(request, {
       params: Promise.resolve({ id: 'llun.test:users:llun' })
     })
-    const data = await response.json()
 
-    expect(response.status).toBe(422)
-    expect(data.status).toBe('Unprocessable entity')
-    expect(mockDatabase.getAttachmentsForActor).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getAttachmentsForActor).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 1 })
+    )
   })
 })

--- a/app/api/v1/accounts/[id]/media/route.ts
+++ b/app/api/v1/accounts/[id]/media/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { AppRouterParams } from '@/lib/services/guards/types'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -26,7 +27,7 @@ interface Params {
 
 const MediaQueryParams = z.object({
   max_created_at: z.coerce.number().optional(),
-  limit: z.coerce.number().min(1).max(50).default(25).optional()
+  limit: clampedLimit(50, 25)
 })
 
 export const GET = traceApiRoute(

--- a/app/api/v1/accounts/[id]/media/route.ts
+++ b/app/api/v1/accounts/[id]/media/route.ts
@@ -76,7 +76,7 @@ export const GET = traceApiRoute(
       })
     }
 
-    const { limit = 25, max_created_at: maxCreatedAt } = parsedParams.data
+    const { limit, max_created_at: maxCreatedAt } = parsedParams.data
 
     const attachments = await database.getAttachmentsForActor({
       actorId: id,

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -343,19 +343,21 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
   })
 
   it('returns bad request for invalid query params', async () => {
-    const response = await GET(createRequest('?limit=0'), {
+    const response = await GET(createRequest('?only_media=maybe'), {
       params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
     })
 
     expect(response.status).toBe(400)
   })
 
-  it('rejects limits above the Mastodon account statuses cap', async () => {
-    const response = await GET(createRequest('?limit=41'), {
-      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
-    })
+  it('clamps out-of-range limits instead of rejecting them', async () => {
+    for (const query of ['?limit=0', '?limit=41', '?limit=100&pinned=true']) {
+      const response = await GET(createRequest(query), {
+        params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+      })
 
-    expect(response.status).toBe(400)
+      expect(response.status).toBe(200)
+    }
   })
 
   it('allows OAuth tokens with read:statuses to read private owner statuses', async () => {

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -357,15 +357,20 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
     ['?limit=100&pinned=true', 40]
   ])(
     'clamps out-of-range %s instead of rejecting it',
-    async (query, maxLength) => {
+    async (query, expectedLimit) => {
+      const getActorStatusesSpy = vi.spyOn(database, 'getActorStatuses')
+
       const response = await GET(createRequest(query), {
         params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
       })
 
       expect(response.status).toBe(200)
-      const data = (await response.json()) as unknown[]
-      // The clamped limit caps how many statuses can come back.
-      expect(data.length).toBeLessThanOrEqual(maxLength)
+      // The clamped limit is what reaches the DB layer.
+      expect(getActorStatusesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expectedLimit })
+      )
+
+      getActorStatusesSpy.mockRestore()
     }
   )
 

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -350,15 +350,24 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
     expect(response.status).toBe(400)
   })
 
-  it('clamps out-of-range limits instead of rejecting them', async () => {
-    for (const query of ['?limit=0', '?limit=41', '?limit=100&pinned=true']) {
+  it.each([
+    // limit=0 clamps up to the minimum (1); the rest clamp down to the cap (40).
+    ['?limit=0', 1],
+    ['?limit=41', 40],
+    ['?limit=100&pinned=true', 40]
+  ])(
+    'clamps out-of-range %s instead of rejecting it',
+    async (query, maxLength) => {
       const response = await GET(createRequest(query), {
         params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
       })
 
       expect(response.status).toBe(200)
+      const data = (await response.json()) as unknown[]
+      // The clamped limit caps how many statuses can come back.
+      expect(data.length).toBeLessThanOrEqual(maxLength)
     }
-  })
+  )
 
   it('allows OAuth tokens with read:statuses to read private owner statuses', async () => {
     mockStoredToken.mockResolvedValue({

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -81,7 +81,7 @@ export const GET = traceApiRoute(
       const parsedParams = parsed.data
 
       const {
-        limit = 20,
+        limit,
         max_id: maxId,
         min_id: minId,
         since_id: sinceId

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -10,6 +10,7 @@ import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { type Status, StatusType } from '@/lib/types/domain/status'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -33,7 +34,7 @@ const StatusQueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce.number().min(1).max(40).default(20),
+  limit: clampedLimit(40, 20),
   only_media: z
     .enum(['true', 'false', '1', '0'])
     .transform((val) => val === 'true' || val === '1')

--- a/app/api/v1/accounts/search/route.test.ts
+++ b/app/api/v1/accounts/search/route.test.ts
@@ -206,7 +206,7 @@ describe('GET /api/v1/accounts/search', () => {
     })
   })
 
-  it('rejects deep search offsets', async () => {
+  it('clamps deep search offsets to the maximum', async () => {
     const response = await GET(
       new NextRequest(
         'https://llun.test/api/v1/accounts/search?q=runner&offset=10001',
@@ -215,8 +215,14 @@ describe('GET /api/v1/accounts/search', () => {
       context
     )
 
-    expect(response.status).toBe(400)
-    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'runner',
+      limit: 40,
+      offset: 10000,
+      localDomain: 'llun.test',
+      exactActorIds: []
+    })
   })
 
   it('does not webfinger when indexed search finds a mixed-case handle locally', async () => {

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -56,8 +56,8 @@ export const GET = traceApiRoute(
 
       const {
         q,
-        limit = 40,
-        offset = 0,
+        limit,
+        offset,
         resolve = false,
         following = false
       } = parsedParams.data

--- a/app/api/v1/accounts/search/route.ts
+++ b/app/api/v1/accounts/search/route.ts
@@ -8,6 +8,7 @@ import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { parseAccountHandle } from '@/lib/utils/accountHandle'
+import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -18,8 +19,8 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const SearchParams = z.object({
   q: z.string(),
-  limit: z.coerce.number().int().min(1).max(80).default(40).optional(),
-  offset: z.coerce.number().int().min(0).max(10000).default(0).optional(),
+  limit: clampedLimit(80, 40),
+  offset: clampedOffset(10000),
   resolve: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')

--- a/app/api/v1/directory/route.test.ts
+++ b/app/api/v1/directory/route.test.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getLocalMastodonActors: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me'
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'local.test' })
+}))
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OptionalOAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor
+      })
+}))
+
+describe('GET /api/v1/directory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getLocalMastodonActors.mockResolvedValue([])
+  })
+
+  it.each([
+    {
+      description: 'clamps a limit above the cap of 80 down to 80',
+      query: '?limit=100',
+      expectedLimit: 80
+    },
+    {
+      description: 'clamps a limit of 0 up to the minimum of 1',
+      query: '?limit=0',
+      expectedLimit: 1
+    }
+  ])('$description', async ({ query, expectedLimit }) => {
+    const response = await GET(
+      new NextRequest(`https://local.test/api/v1/directory${query}`),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getLocalMastodonActors).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: expectedLimit })
+    )
+  })
+})

--- a/app/api/v1/directory/route.ts
+++ b/app/api/v1/directory/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { getConfig } from '@/lib/config'
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -12,8 +13,8 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const DirectoryParams = z.object({
-  offset: z.coerce.number().int().min(0).default(0),
-  limit: z.coerce.number().int().min(1).max(80).default(40),
+  offset: clampedOffset(),
+  limit: clampedLimit(80, 40),
   order: z.enum(['active', 'new']).default('active'),
   local: z
     .enum(['true', 'false'])

--- a/app/api/v1/endorsements/route.test.ts
+++ b/app/api/v1/endorsements/route.test.ts
@@ -97,4 +97,22 @@ describe('GET /api/v1/endorsements', () => {
     const response = await GET(createRequest(), { params: Promise.resolve({}) })
     expect(response.status).toBe(401)
   })
+
+  it.each([
+    { query: '?limit=100', expected: 80 },
+    { query: '?limit=0', expected: 1 }
+  ])(
+    'clamps out-of-range limit $query to $expected instead of rejecting',
+    async ({ query, expected }) => {
+      const getEndorsements = vi.spyOn(database, 'getEndorsements')
+      const response = await GET(createRequest(query), {
+        params: Promise.resolve({})
+      })
+      expect(response.status).toBe(200)
+      expect(getEndorsements).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: expected })
+      )
+      getEndorsements.mockRestore()
+    }
+  )
 })

--- a/app/api/v1/endorsements/route.ts
+++ b/app/api/v1/endorsements/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -18,7 +19,7 @@ const EndorsementsQueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(80).default(40)
+  limit: clampedLimit(80, 40)
 })
 
 // GET /api/v1/endorsements — accounts the current user has featured.

--- a/app/api/v1/instance/domain_blocks/route.test.ts
+++ b/app/api/v1/instance/domain_blocks/route.test.ts
@@ -73,11 +73,15 @@ describe('GET /api/v1/instance/domain_blocks', () => {
     ])
   })
 
-  it('rejects invalid pagination parameters', async () => {
-    const getDomainBlocks = vi.fn()
+  it('clamps an out-of-range limit instead of rejecting it', async () => {
+    const getDomainBlocks = vi.fn().mockResolvedValue([])
     mockGetDatabase.mockReturnValue({
       getDomainBlocks,
-      getDomainFederationRuleStats: vi.fn()
+      getDomainFederationRuleStats: vi.fn().mockResolvedValue({
+        blocks: 0,
+        suspendBlocks: 0,
+        allows: 0
+      })
     })
 
     const response = await GET(
@@ -87,7 +91,11 @@ describe('GET /api/v1/instance/domain_blocks', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(400)
-    expect(getDomainBlocks).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(getDomainBlocks).toHaveBeenCalledWith({
+      limit: 1000,
+      offset: 0,
+      severity: 'suspend'
+    })
   })
 })

--- a/app/api/v1/instance/domain_blocks/route.ts
+++ b/app/api/v1/instance/domain_blocks/route.ts
@@ -3,14 +3,15 @@ import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
 import { toPublicDomainBlock } from '@/lib/services/federation/domainRules'
+import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, HTTP_STATUS, apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.GET]
 const DomainBlockListQueryParams = z.object({
-  limit: z.coerce.number().int().min(1).max(1000).default(100),
-  offset: z.coerce.number().int().min(0).default(0)
+  limit: clampedLimit(1000, 100),
+  offset: clampedOffset()
 })
 
 export const GET = traceApiRoute(

--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -41,18 +41,36 @@ describe('GET /api/v1/notifications', () => {
     vi.clearAllMocks()
   })
 
-  it('returns 422 when notification query parameters fail schema validation', async () => {
+  it('clamps an out-of-range limit up to the minimum instead of rejecting it', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
     const request = new NextRequest(
       'https://llun.test/api/v1/notifications?limit=0',
       { method: 'GET' }
     )
 
     const response = await GET(request, { params: Promise.resolve({}) })
-    const data = await response.json()
 
-    expect(response.status).toBe(422)
-    expect(data.status).toBe('Unprocessable entity')
-    expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 1 })
+    )
+  })
+
+  it('clamps an above-max limit down to the maximum instead of rejecting it', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v1/notifications?limit=100',
+      { method: 'GET' }
+    )
+
+    const response = await GET(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 80 })
+    )
   })
 
   it('normalizes a single types[] query parameter to an array', async () => {

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -102,7 +102,7 @@ export const GET = traceApiRoute(
     }
 
     const {
-      limit = DEFAULT_LIMIT,
+      limit,
       max_id: maxId,
       min_id: minId,
       since_id: sinceId,

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -8,6 +8,7 @@ import { getMastodonNotification } from '@/lib/services/notifications/getMastodo
 import { groupNotifications } from '@/lib/services/notifications/groupNotifications'
 import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -33,13 +34,7 @@ const NotificationQueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .max(MAX_LIMIT)
-    .default(DEFAULT_LIMIT)
-    .optional(),
+  limit: clampedLimit(MAX_LIMIT, DEFAULT_LIMIT),
   types: z.array(z.string()).optional(),
   exclude_types: z.array(z.string()).optional(),
   account_id: z.string().optional(),

--- a/app/api/v1/notifications/unread_count/route.test.ts
+++ b/app/api/v1/notifications/unread_count/route.test.ts
@@ -63,16 +63,22 @@ describe('GET /api/v1/notifications/unread_count', () => {
     )
   })
 
-  it('returns 422 when limit exceeds the maximum', async () => {
+  it('clamps a limit above the maximum down to the maximum', async () => {
+    mockDatabase.getNotificationsCount.mockResolvedValueOnce(7)
+
     const request = new NextRequest(
       'https://llun.test/api/v1/notifications/unread_count?limit=1001',
       { method: 'GET' }
     )
 
     const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
 
-    expect(response.status).toBe(422)
-    expect(mockDatabase.getNotificationsCount).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ count: 7 })
+    expect(mockDatabase.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 1000 })
+    )
   })
 
   it('maps and forwards type filters to the count query', async () => {
@@ -108,16 +114,22 @@ describe('GET /api/v1/notifications/unread_count', () => {
     )
   })
 
-  it('returns 422 when limit is a float', async () => {
+  it('truncates a fractional limit to an integer', async () => {
+    mockDatabase.getNotificationsCount.mockResolvedValueOnce(1)
+
     const request = new NextRequest(
       'https://llun.test/api/v1/notifications/unread_count?limit=1.5',
       { method: 'GET' }
     )
 
     const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
 
-    expect(response.status).toBe(422)
-    expect(mockDatabase.getNotificationsCount).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ count: 1 })
+    expect(mockDatabase.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 1 })
+    )
   })
 
   it('caps account_id match count at the requested limit', async () => {

--- a/app/api/v1/notifications/unread_count/route.ts
+++ b/app/api/v1/notifications/unread_count/route.ts
@@ -77,7 +77,7 @@ export const GET = traceApiRoute(
     }
 
     const {
-      limit = DEFAULT_LIMIT,
+      limit,
       types,
       exclude_types: excludeTypes,
       account_id: accountId

--- a/app/api/v1/notifications/unread_count/route.ts
+++ b/app/api/v1/notifications/unread_count/route.ts
@@ -4,6 +4,7 @@ import { getDatabase } from '@/lib/database'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { mastodonTypesToInternal } from '@/lib/services/notifications/notificationTypeMapping'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -22,13 +23,7 @@ const ARRAY_QUERY_PARAMS = new Set(['types', 'exclude_types'])
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const UnreadCountQueryParams = z.object({
-  limit: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .max(MAX_LIMIT)
-    .default(DEFAULT_LIMIT)
-    .optional(),
+  limit: clampedLimit(MAX_LIMIT, DEFAULT_LIMIT),
   types: z.array(z.string()).optional(),
   exclude_types: z.array(z.string()).optional(),
   account_id: z.string().optional()

--- a/app/api/v1/statuses/[id]/favourited_by/route.ts
+++ b/app/api/v1/statuses/[id]/favourited_by/route.ts
@@ -5,6 +5,7 @@ import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { buildAccountCursorLinkHeader } from '@/lib/services/mastodon/accountCursorLinkHeader'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -24,7 +25,7 @@ interface Params {
 }
 
 const FavouritedByQueryParams = z.object({
-  limit: z.coerce.number().int().min(1).max(80).default(40),
+  limit: clampedLimit(80, 40),
   max_id: z.string().min(1).optional(),
   min_id: z.string().min(1).optional(),
   since_id: z.string().min(1).optional()

--- a/app/api/v1/statuses/[id]/reblogged_by/route.ts
+++ b/app/api/v1/statuses/[id]/reblogged_by/route.ts
@@ -4,6 +4,7 @@ import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { buildAccountCursorLinkHeader } from '@/lib/services/mastodon/accountCursorLinkHeader'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_400,
@@ -23,7 +24,7 @@ interface Params {
 }
 
 const RebloggedByQueryParams = z.object({
-  limit: z.coerce.number().int().min(1).max(80).default(40),
+  limit: clampedLimit(80, 40),
   max_id: z.string().min(1).optional(),
   min_id: z.string().min(1).optional(),
   since_id: z.string().min(1).optional()

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2765,10 +2765,17 @@ describe('GET /api/v1/statuses/[id]', () => {
       ])
     })
 
-    it.each(['0', '81', 'abc'])(
+    it.each([
+      // The route requests limit + 1 to detect a next page, so the clamped
+      // limit (1 / 80 / fallback 40) reaches the DB as 2 / 81 / 41.
+      ['0', 2],
+      ['81', 81],
+      ['abc', 41]
+    ])(
       'clamps out-of-range limit=%s instead of rejecting it',
-      async (limit) => {
+      async (limit, expectedDbLimit) => {
         mockGetServerSession.mockResolvedValue(null)
+        const getRebloggedBySpy = vi.spyOn(database, 'getRebloggedBy')
 
         const statusId = `${ACTOR1_ID}/statuses/post-1`
         const response = await getStatusRebloggedBy(
@@ -2781,6 +2788,11 @@ describe('GET /api/v1/statuses/[id]', () => {
         )
 
         expect(response.status).toBe(200)
+        expect(getRebloggedBySpy).toHaveBeenCalledWith(
+          expect.objectContaining({ limit: expectedDbLimit })
+        )
+
+        getRebloggedBySpy.mockRestore()
       }
     )
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2766,7 +2766,7 @@ describe('GET /api/v1/statuses/[id]', () => {
     })
 
     it.each(['0', '81', 'abc'])(
-      'returns bad request for invalid limit=%s',
+      'clamps out-of-range limit=%s instead of rejecting it',
       async (limit) => {
         mockGetServerSession.mockResolvedValue(null)
 
@@ -2780,7 +2780,7 @@ describe('GET /api/v1/statuses/[id]', () => {
           { params: Promise.resolve({ id: urlToId(statusId) }) }
         )
 
-        expect(response.status).toBe(400)
+        expect(response.status).toBe(200)
       }
     )
 

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -3344,6 +3344,37 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(linkHeader).toContain('max_id=')
       expect(linkHeader).not.toContain('rel="prev"')
     })
+
+    it.each([
+      // The route requests limit + 1 to detect a next page, so the clamped
+      // limit (1 / 80 / fallback 40) reaches the DB as 2 / 81 / 41.
+      ['0', 2],
+      ['81', 81],
+      ['abc', 41]
+    ])(
+      'clamps out-of-range limit=%s instead of rejecting it',
+      async (limit, expectedDbLimit) => {
+        mockGetServerSession.mockResolvedValue(null)
+        const getFavouritedBySpy = vi.spyOn(database, 'getFavouritedBy')
+
+        const statusId = `${ACTOR1_ID}/statuses/post-1`
+        const response = await getStatusFavouritedBy(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(
+              statusId
+            )}/favourited_by?limit=${limit}`
+          ),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+
+        expect(response.status).toBe(200)
+        expect(getFavouritedBySpy).toHaveBeenCalledWith(
+          expect.objectContaining({ limit: expectedDbLimit })
+        )
+
+        getFavouritedBySpy.mockRestore()
+      }
+    )
   })
 
   describe('edit sensitive/language', () => {

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -109,18 +109,28 @@ describe('GET /api/v2/notifications', () => {
     )
   })
 
-  it('clamps an out-of-range limit instead of rejecting it', async () => {
-    mockDatabase.getNotifications.mockResolvedValueOnce([])
+  it.each([
+    ['below the minimum', '0', 1],
+    ['above the maximum', '100', 80]
+  ])(
+    'clamps an out-of-range limit (%s) instead of rejecting it',
+    async (_label, limit, clamped) => {
+      mockDatabase.getNotifications.mockResolvedValueOnce([])
 
-    const request = new NextRequest(
-      'https://llun.test/api/v2/notifications?limit=0',
-      { method: 'GET' }
-    )
-    const response = await GET(request, { params: Promise.resolve({}) })
+      const request = new NextRequest(
+        `https://llun.test/api/v2/notifications?limit=${limit}`,
+        { method: 'GET' }
+      )
+      const response = await GET(request, { params: Promise.resolve({}) })
 
-    expect(response.status).toBe(200)
-    expect(mockDatabase.getNotifications).toHaveBeenCalled()
-  })
+      expect(response.status).toBe(200)
+      // The route over-fetches GROUP_OVERSCAN (5) rows per requested group, so
+      // the clamped limit reaches getNotifications as limit = clampedLimit * 5.
+      expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: clamped * 5 })
+      )
+    }
+  )
 
   it('anchors the next (max_id) Link on the last returned group most-recent id', async () => {
     mockDatabase.getNotifications.mockResolvedValueOnce([

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -109,15 +109,17 @@ describe('GET /api/v2/notifications', () => {
     )
   })
 
-  it('returns 422 for an invalid limit', async () => {
+  it('clamps an out-of-range limit instead of rejecting it', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
     const request = new NextRequest(
       'https://llun.test/api/v2/notifications?limit=0',
       { method: 'GET' }
     )
     const response = await GET(request, { params: Promise.resolve({}) })
 
-    expect(response.status).toBe(422)
-    expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getNotifications).toHaveBeenCalled()
   })
 
   it('anchors the next (max_id) Link on the last returned group most-recent id', async () => {

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -14,6 +14,7 @@ import {
   mastodonTypesToInternal
 } from '@/lib/services/notifications/notificationTypeMapping'
 import { NotificationType, Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -42,13 +43,7 @@ const QueryParams = z.object({
   max_id: z.string().optional(),
   since_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .max(MAX_LIMIT)
-    .default(DEFAULT_LIMIT)
-    .optional(),
+  limit: clampedLimit(MAX_LIMIT, DEFAULT_LIMIT),
   types: z.array(z.string()).optional(),
   exclude_types: z.array(z.string()).optional(),
   grouped_types: z.array(z.string()).optional(),

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -103,7 +103,7 @@ export const GET = traceApiRoute(
     }
 
     const {
-      limit = DEFAULT_LIMIT,
+      limit,
       max_id: maxId,
       min_id: minId,
       since_id: sinceId,

--- a/app/api/v2/notifications/unread_count/route.test.ts
+++ b/app/api/v2/notifications/unread_count/route.test.ts
@@ -109,6 +109,40 @@ describe('GET /api/v2/notifications/unread_count', () => {
   })
 
   it('clamps an out-of-range limit instead of rejecting it', async () => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'n1',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      },
+      {
+        id: 'n2',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/bob',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 1000,
+        updatedAt: 1000
+      },
+      {
+        id: 'n3',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/carol',
+        isRead: false,
+        filtered: false,
+        createdAt: 3000,
+        updatedAt: 3000
+      }
+    ])
+
     const request = new NextRequest(
       'https://llun.test/api/v2/notifications/unread_count?limit=0',
       { method: 'GET' }
@@ -117,7 +151,8 @@ describe('GET /api/v2/notifications/unread_count', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
-    expect(data.count).toBe(0)
+    // 2 surviving groups, but limit=0 clamps up to min 1 → count = min(2, 1) = 1
+    expect(data.count).toBe(1)
     expect(mockDatabase.getNotifications).toHaveBeenCalled()
   })
 

--- a/app/api/v2/notifications/unread_count/route.test.ts
+++ b/app/api/v2/notifications/unread_count/route.test.ts
@@ -108,15 +108,17 @@ describe('GET /api/v2/notifications/unread_count', () => {
     )
   })
 
-  it('returns 422 for invalid limit', async () => {
+  it('clamps an out-of-range limit instead of rejecting it', async () => {
     const request = new NextRequest(
       'https://llun.test/api/v2/notifications/unread_count?limit=0',
       { method: 'GET' }
     )
     const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
 
-    expect(response.status).toBe(422)
-    expect(mockDatabase.getNotifications).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(data.count).toBe(0)
+    expect(mockDatabase.getNotifications).toHaveBeenCalled()
   })
 
   it('filters by account_id', async () => {

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -10,6 +10,7 @@ import {
   mastodonTypesToInternal
 } from '@/lib/services/notifications/notificationTypeMapping'
 import { NotificationType, Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_422,
@@ -30,13 +31,7 @@ const ARRAY_QUERY_PARAMS = new Set(['types', 'exclude_types', 'grouped_types'])
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const QueryParams = z.object({
-  limit: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .max(MAX_LIMIT)
-    .default(DEFAULT_LIMIT)
-    .optional(),
+  limit: clampedLimit(MAX_LIMIT, DEFAULT_LIMIT),
   types: z.array(z.string()).optional(),
   exclude_types: z.array(z.string()).optional(),
   grouped_types: z.array(z.string()).optional(),

--- a/app/api/v2/notifications/unread_count/route.ts
+++ b/app/api/v2/notifications/unread_count/route.ts
@@ -84,7 +84,7 @@ export const GET = traceApiRoute(
     }
 
     const {
-      limit = DEFAULT_LIMIT,
+      limit,
       types,
       exclude_types: excludeTypes,
       grouped_types: groupedTypesMastodon,

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -1064,4 +1064,16 @@ describe('GET /api/v2/search', () => {
       excludeUnreviewed: false
     })
   })
+
+  it('rejects an invalid search type with a bad request', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/search?q=trail&type=bogus'),
+      context
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockSearchAccountIds).not.toHaveBeenCalled()
+    expect(mockSearchHashtags).not.toHaveBeenCalled()
+    expect(mockSearchStatusIds).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -1045,13 +1045,23 @@ describe('GET /api/v2/search', () => {
     )
   })
 
-  it('rejects invalid search parameters', async () => {
+  it('clamps an over-range limit to the maximum instead of rejecting', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v2/search?q=trail&limit=100'),
       context
     )
 
-    expect(response.status).toBe(400)
-    expect(await response.json()).toEqual({ status: 'Bad Request' })
+    expect(response.status).toBe(200)
+    expect(mockSearchAccountIds).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 40,
+      offset: 0
+    })
+    expect(mockSearchHashtags).toHaveBeenCalledWith({
+      q: 'trail',
+      limit: 40,
+      offset: 0,
+      excludeUnreviewed: false
+    })
   })
 })

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -22,6 +22,7 @@ import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import { Tag } from '@/lib/types/mastodon/tag'
 import { parseAccountHandle } from '@/lib/utils/accountHandle'
 import { normalizeActorId } from '@/lib/utils/activitypub'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import {
@@ -77,7 +78,7 @@ const SearchParams = z.object({
   account_id: z.string().optional(),
   max_id: z.string().optional(),
   min_id: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(40).optional(),
+  limit: clampedLimit(40, 20),
   offset: z.coerce.number().int().min(0).optional()
 })
 

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -79,6 +79,9 @@ const SearchParams = z.object({
   max_id: z.string().optional(),
   min_id: z.string().optional(),
   limit: clampedLimit(40, 20),
+  // offset deliberately stays a plain optional schema (not clampedOffset): this
+  // route distinguishes `offset === undefined` from `0` to gate which results
+  // require auth, and clampedOffset's default(0) would erase that distinction.
   offset: z.coerce.number().int().min(0).optional()
 })
 
@@ -534,7 +537,7 @@ export const GET = traceApiRoute(
       const { database, currentActor } = context
       const params = parsedParams.data
       const query = params.q.trim()
-      const limit = params.limit ?? 20
+      const limit = params.limit
       // Mastodon ignores offset unless an explicit search type is provided.
       const offset = params.type ? (params.offset ?? 0) : 0
 

--- a/lib/components/layout/logo.tsx
+++ b/lib/components/layout/logo.tsx
@@ -5,6 +5,10 @@ interface LogoProps {
   showText?: boolean
   size?: 'sm' | 'md' | 'lg'
   className?: string
+  // Server callers can pass an absolute URL (e.g. built from ACTIVITIES_HOST) so
+  // the logo resolves against the canonical origin behind a CDN alias. Client
+  // callers omit it and use the root-relative default.
+  src?: string
 }
 
 const sizes = {
@@ -16,7 +20,8 @@ const sizes = {
 export function Logo({
   showText = true,
   size = 'md',
-  className = ''
+  className = '',
+  src = '/logo-nav.png'
 }: LogoProps) {
   return (
     <Link
@@ -25,7 +30,7 @@ export function Logo({
       className={`inline-flex items-center gap-2 font-semibold tracking-tight ${sizes[size]} ${className}`}
     >
       <Image
-        src="/logo-nav.png"
+        src={src}
         alt=""
         aria-hidden="true"
         width={32}

--- a/lib/utils/clampedLimit.test.ts
+++ b/lib/utils/clampedLimit.test.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+import { clampedLimit, clampedOffset } from './clampedLimit'
+
+describe('clampedLimit', () => {
+  const schema = clampedLimit(40, 20)
+
+  it.each([
+    ['absent (undefined)', undefined, 20],
+    ['empty string', '', 20],
+    ['non-numeric', 'abc', 20],
+    ['within range', '30', 30],
+    ['at the max', '40', 40],
+    ['above the max clamps down', '41', 40],
+    ['far above the max clamps down', '100', 40],
+    ['below the min clamps up', '0', 1],
+    ['negative clamps up', '-5', 1],
+    ['fractional truncates', '40.9', 40]
+  ])('clamps %s to %d', (_label, input, expected) => {
+    expect(schema.parse(input)).toBe(expected)
+  })
+
+  it('never fails parsing for a well-formed but out-of-range value', () => {
+    const result = schema.safeParse('100')
+    expect(result.success).toBe(true)
+    expect(result.data).toBe(40)
+  })
+
+  it('works inside an object schema without failing the whole parse', () => {
+    const object = z.object({ limit: clampedLimit(40, 20) })
+    const parsed = object.safeParse({ limit: '100' })
+    expect(parsed.success).toBe(true)
+    expect(parsed.data?.limit).toBe(40)
+  })
+
+  it('respects a custom minimum', () => {
+    const minTwo = clampedLimit(80, 40, 2)
+    expect(minTwo.parse('1')).toBe(2)
+  })
+})
+
+describe('clampedOffset', () => {
+  const schema = clampedOffset(10000)
+
+  it.each([
+    ['absent (undefined)', undefined, 0],
+    ['non-numeric', 'abc', 0],
+    ['within range', '40', 40],
+    ['at the max', '10000', 10000],
+    ['above the max clamps down', '10001', 10000],
+    ['negative clamps up', '-1', 0]
+  ])('clamps %s to %d', (_label, input, expected) => {
+    expect(schema.parse(input)).toBe(expected)
+  })
+
+  it('defaults to no maximum when none is given', () => {
+    const unbounded = clampedOffset()
+    expect(unbounded.parse('999999')).toBe(999999)
+  })
+})

--- a/lib/utils/clampedLimit.test.ts
+++ b/lib/utils/clampedLimit.test.ts
@@ -8,6 +8,7 @@ describe('clampedLimit', () => {
   it.each([
     ['absent (undefined)', undefined, 20],
     ['empty string', '', 20],
+    ['whitespace only', '   ', 20],
     ['non-numeric', 'abc', 20],
     ['within range', '30', 30],
     ['at the max', '40', 40],
@@ -15,7 +16,11 @@ describe('clampedLimit', () => {
     ['far above the max clamps down', '100', 40],
     ['below the min clamps up', '0', 1],
     ['negative clamps up', '-5', 1],
-    ['fractional truncates', '40.9', 40]
+    ['fractional truncates', '40.9', 40],
+    ['infinity falls back', 'Infinity', 20],
+    ['negative infinity falls back', '-Infinity', 20],
+    ['overflow to infinity falls back', '1e500', 20],
+    ['NaN string falls back', 'NaN', 20]
   ])('clamps %s to %d', (_label, input, expected) => {
     expect(schema.parse(input)).toBe(expected)
   })
@@ -44,11 +49,15 @@ describe('clampedOffset', () => {
 
   it.each([
     ['absent (undefined)', undefined, 0],
+    ['empty string', '', 0],
+    ['whitespace only', '   ', 0],
     ['non-numeric', 'abc', 0],
     ['within range', '40', 40],
     ['at the max', '10000', 10000],
     ['above the max clamps down', '10001', 10000],
-    ['negative clamps up', '-1', 0]
+    ['negative clamps up', '-1', 0],
+    ['infinity falls back', 'Infinity', 0],
+    ['NaN string falls back', 'NaN', 0]
   ])('clamps %s to %d', (_label, input, expected) => {
     expect(schema.parse(input)).toBe(expected)
   })

--- a/lib/utils/clampedLimit.test.ts
+++ b/lib/utils/clampedLimit.test.ts
@@ -7,6 +7,7 @@ describe('clampedLimit', () => {
 
   it.each([
     ['absent (undefined)', undefined, 20],
+    ['null', null, 20],
     ['empty string', '', 20],
     ['whitespace only', '   ', 20],
     ['non-numeric', 'abc', 20],
@@ -56,6 +57,7 @@ describe('clampedOffset', () => {
 
   it.each([
     ['absent (undefined)', undefined, 0],
+    ['null', null, 0],
     ['empty string', '', 0],
     ['whitespace only', '   ', 0],
     ['non-numeric', 'abc', 0],

--- a/lib/utils/clampedLimit.test.ts
+++ b/lib/utils/clampedLimit.test.ts
@@ -42,6 +42,13 @@ describe('clampedLimit', () => {
     const minTwo = clampedLimit(80, 40, 2)
     expect(minTwo.parse('1')).toBe(2)
   })
+
+  it('clamps an out-of-range fallback into [min, max]', () => {
+    // The absent-value path returns the (clamped) fallback even if a caller
+    // passes one outside [min, max].
+    expect(clampedLimit(40, 1000).parse(undefined)).toBe(40)
+    expect(clampedLimit(40, 0).parse(undefined)).toBe(1)
+  })
 })
 
 describe('clampedOffset', () => {
@@ -56,6 +63,7 @@ describe('clampedOffset', () => {
     ['at the max', '10000', 10000],
     ['above the max clamps down', '10001', 10000],
     ['negative clamps up', '-1', 0],
+    ['fractional truncates', '40.9', 40],
     ['infinity falls back', 'Infinity', 0],
     ['NaN string falls back', 'NaN', 0]
   ])('clamps %s to %d', (_label, input, expected) => {
@@ -65,5 +73,9 @@ describe('clampedOffset', () => {
   it('defaults to no maximum when none is given', () => {
     const unbounded = clampedOffset()
     expect(unbounded.parse('999999')).toBe(999999)
+  })
+
+  it('clamps an out-of-range fallback into [0, max]', () => {
+    expect(clampedOffset(100, 500).parse(undefined)).toBe(100)
   })
 })

--- a/lib/utils/clampedLimit.ts
+++ b/lib/utils/clampedLimit.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+
+// Treat an absent or blank query value as "not provided" so it resolves to the
+// fallback rather than coercing an empty string to `0`.
+const blankToUndefined = (value: unknown) =>
+  typeof value === 'string' && value.trim() === '' ? undefined : value
+
+/**
+ * Zod schema for a Mastodon-style `limit` query parameter that CLAMPS
+ * out-of-range values into `[min, max]` (and falls back to `fallback` for
+ * absent or non-numeric input) instead of rejecting them.
+ *
+ * Mastodon clamps pagination limits rather than returning an error, and so do
+ * this app's timeline routes (see `normalizeTimelineLimit`). Validating with a
+ * hard `.max()` instead makes the entire `schema.safeParse(query)` fail, so a
+ * single out-of-range `limit` 400s/422s the whole request — which breaks real
+ * clients that ask for more rows than the cap (e.g. iOS apps sending
+ * `limit=100` to `/api/v1/accounts/:id/statuses`, whose cap is 40).
+ *
+ * @param max The maximum number of rows the endpoint allows.
+ * @param fallback The default used when `limit` is absent or non-numeric.
+ * @param min The minimum allowed value (Mastodon clamps up to 1).
+ */
+export const clampedLimit = (max: number, fallback: number, min = 1) =>
+  z
+    .preprocess(blankToUndefined, z.coerce.number())
+    .transform((value) =>
+      Number.isFinite(value)
+        ? Math.min(Math.max(Math.trunc(value), min), max)
+        : fallback
+    )
+    .catch(fallback)
+    .default(fallback)
+
+/**
+ * Zod schema for a Mastodon-style `offset` query parameter that CLAMPS into
+ * `[0, max]` (falling back to `fallback` for absent or non-numeric input)
+ * instead of rejecting out-of-range values, for the same reason as
+ * {@link clampedLimit}.
+ *
+ * @param max The maximum offset the endpoint allows.
+ * @param fallback The default used when `offset` is absent or non-numeric.
+ */
+export const clampedOffset = (max = Number.MAX_SAFE_INTEGER, fallback = 0) =>
+  z
+    .preprocess(blankToUndefined, z.coerce.number())
+    .transform((value) =>
+      Number.isFinite(value)
+        ? Math.min(Math.max(Math.trunc(value), 0), max)
+        : fallback
+    )
+    .catch(fallback)
+    .default(fallback)

--- a/lib/utils/clampedLimit.ts
+++ b/lib/utils/clampedLimit.ts
@@ -27,12 +27,13 @@ export const clampedLimit = (max: number, fallback: number, min = 1) => {
   const clamp = (value: number) =>
     Math.min(Math.max(Math.trunc(value), min), max)
   // Clamp the fallback once so it is in range even if a caller violates the
-  // precondition. `.catch` covers non-numeric/blank/non-finite input (NaN,
-  // Infinity, 'abc' — `z.coerce.number()` rejects those) and `.default` covers
-  // an absent value, so the transform only ever receives a finite number.
+  // precondition. `.finite()` makes the non-finite rejection explicit (NaN,
+  // Infinity, 1e500); `.catch` then maps those and non-numeric/blank input to
+  // the fallback, and `.default` covers an absent value — so the transform only
+  // ever receives a finite number.
   const safeFallback = clamp(fallback)
   return z
-    .preprocess(blankToUndefined, z.coerce.number())
+    .preprocess(blankToUndefined, z.coerce.number().finite())
     .transform((value) => clamp(value))
     .catch(safeFallback)
     .default(safeFallback)
@@ -51,11 +52,11 @@ export const clampedLimit = (max: number, fallback: number, min = 1) => {
  */
 export const clampedOffset = (max = Number.MAX_SAFE_INTEGER, fallback = 0) => {
   const clamp = (value: number) => Math.min(Math.max(Math.trunc(value), 0), max)
-  // See clampedLimit: `.catch`/`.default` handle non-finite/absent input, so the
-  // transform only receives a finite number.
+  // See clampedLimit: `.finite()` + `.catch`/`.default` handle non-finite/absent
+  // input, so the transform only receives a finite number.
   const safeFallback = clamp(fallback)
   return z
-    .preprocess(blankToUndefined, z.coerce.number())
+    .preprocess(blankToUndefined, z.coerce.number().finite())
     .transform((value) => clamp(value))
     .catch(safeFallback)
     .default(safeFallback)

--- a/lib/utils/clampedLimit.ts
+++ b/lib/utils/clampedLimit.ts
@@ -26,13 +26,16 @@ const blankToUndefined = (value: unknown) =>
 export const clampedLimit = (max: number, fallback: number, min = 1) => {
   const clamp = (value: number) =>
     Math.min(Math.max(Math.trunc(value), min), max)
+  // Clamp the fallback once so every branch (transform else, catch, default)
+  // yields an in-range value even if a caller violates the precondition.
+  const safeFallback = clamp(fallback)
   return z
     .preprocess(blankToUndefined, z.coerce.number())
     .transform((value) =>
-      Number.isFinite(value) ? clamp(value) : clamp(fallback)
+      Number.isFinite(value) ? clamp(value) : safeFallback
     )
-    .catch(fallback)
-    .default(fallback)
+    .catch(safeFallback)
+    .default(safeFallback)
 }
 
 /**
@@ -48,11 +51,12 @@ export const clampedLimit = (max: number, fallback: number, min = 1) => {
  */
 export const clampedOffset = (max = Number.MAX_SAFE_INTEGER, fallback = 0) => {
   const clamp = (value: number) => Math.min(Math.max(Math.trunc(value), 0), max)
+  const safeFallback = clamp(fallback)
   return z
     .preprocess(blankToUndefined, z.coerce.number())
     .transform((value) =>
-      Number.isFinite(value) ? clamp(value) : clamp(fallback)
+      Number.isFinite(value) ? clamp(value) : safeFallback
     )
-    .catch(fallback)
-    .default(fallback)
+    .catch(safeFallback)
+    .default(safeFallback)
 }

--- a/lib/utils/clampedLimit.ts
+++ b/lib/utils/clampedLimit.ts
@@ -17,20 +17,23 @@ const blankToUndefined = (value: unknown) =>
  * clients that ask for more rows than the cap (e.g. iOS apps sending
  * `limit=100` to `/api/v1/accounts/:id/statuses`, whose cap is 40).
  *
+ * Callers must pass `min <= max` and `min <= fallback <= max`.
+ *
  * @param max The maximum number of rows the endpoint allows.
  * @param fallback The default used when `limit` is absent or non-numeric.
  * @param min The minimum allowed value (Mastodon clamps up to 1).
  */
-export const clampedLimit = (max: number, fallback: number, min = 1) =>
-  z
+export const clampedLimit = (max: number, fallback: number, min = 1) => {
+  const clamp = (value: number) =>
+    Math.min(Math.max(Math.trunc(value), min), max)
+  return z
     .preprocess(blankToUndefined, z.coerce.number())
     .transform((value) =>
-      Number.isFinite(value)
-        ? Math.min(Math.max(Math.trunc(value), min), max)
-        : fallback
+      Number.isFinite(value) ? clamp(value) : clamp(fallback)
     )
     .catch(fallback)
     .default(fallback)
+}
 
 /**
  * Zod schema for a Mastodon-style `offset` query parameter that CLAMPS into
@@ -38,16 +41,18 @@ export const clampedLimit = (max: number, fallback: number, min = 1) =>
  * instead of rejecting out-of-range values, for the same reason as
  * {@link clampedLimit}.
  *
+ * Callers must pass `0 <= fallback <= max`.
+ *
  * @param max The maximum offset the endpoint allows.
  * @param fallback The default used when `offset` is absent or non-numeric.
  */
-export const clampedOffset = (max = Number.MAX_SAFE_INTEGER, fallback = 0) =>
-  z
+export const clampedOffset = (max = Number.MAX_SAFE_INTEGER, fallback = 0) => {
+  const clamp = (value: number) => Math.min(Math.max(Math.trunc(value), 0), max)
+  return z
     .preprocess(blankToUndefined, z.coerce.number())
     .transform((value) =>
-      Number.isFinite(value)
-        ? Math.min(Math.max(Math.trunc(value), 0), max)
-        : fallback
+      Number.isFinite(value) ? clamp(value) : clamp(fallback)
     )
     .catch(fallback)
     .default(fallback)
+}

--- a/lib/utils/clampedLimit.ts
+++ b/lib/utils/clampedLimit.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod'
 
-// Treat an absent or blank query value as "not provided" so it resolves to the
-// fallback rather than coercing an empty string to `0`.
+// Treat an absent (undefined/null) or blank query value as "not provided" so it
+// resolves to the fallback rather than coercing `null`/`''` to `0`. `null` is the
+// idiomatic absent value from `URLSearchParams.get()`.
 const blankToUndefined = (value: unknown) =>
-  typeof value === 'string' && value.trim() === '' ? undefined : value
+  value === null || (typeof value === 'string' && value.trim() === '')
+    ? undefined
+    : value
 
 /**
  * Zod schema for a Mastodon-style `limit` query parameter that CLAMPS

--- a/lib/utils/clampedLimit.ts
+++ b/lib/utils/clampedLimit.ts
@@ -26,14 +26,14 @@ const blankToUndefined = (value: unknown) =>
 export const clampedLimit = (max: number, fallback: number, min = 1) => {
   const clamp = (value: number) =>
     Math.min(Math.max(Math.trunc(value), min), max)
-  // Clamp the fallback once so every branch (transform else, catch, default)
-  // yields an in-range value even if a caller violates the precondition.
+  // Clamp the fallback once so it is in range even if a caller violates the
+  // precondition. `.catch` covers non-numeric/blank/non-finite input (NaN,
+  // Infinity, 'abc' — `z.coerce.number()` rejects those) and `.default` covers
+  // an absent value, so the transform only ever receives a finite number.
   const safeFallback = clamp(fallback)
   return z
     .preprocess(blankToUndefined, z.coerce.number())
-    .transform((value) =>
-      Number.isFinite(value) ? clamp(value) : safeFallback
-    )
+    .transform((value) => clamp(value))
     .catch(safeFallback)
     .default(safeFallback)
 }
@@ -51,12 +51,12 @@ export const clampedLimit = (max: number, fallback: number, min = 1) => {
  */
 export const clampedOffset = (max = Number.MAX_SAFE_INTEGER, fallback = 0) => {
   const clamp = (value: number) => Math.min(Math.max(Math.trunc(value), 0), max)
+  // See clampedLimit: `.catch`/`.default` handle non-finite/absent input, so the
+  // transform only receives a finite number.
   const safeFallback = clamp(fallback)
   return z
     .preprocess(blankToUndefined, z.coerce.number())
-    .transform((value) =>
-      Number.isFinite(value) ? clamp(value) : safeFallback
-    )
+    .transform((value) => clamp(value))
     .catch(safeFallback)
     .default(safeFallback)
 }

--- a/lib/utils/http-headers/csp.test.ts
+++ b/lib/utils/http-headers/csp.test.ts
@@ -1,0 +1,52 @@
+import { resetHostConfigCacheForTests } from '@/lib/config/host'
+
+import {
+  getContentSecurityPolicy,
+  resetContentSecurityPolicyCacheForTests
+} from './csp'
+
+// getContentSecurityPolicy and getProxyHostConfig each memoize, so a test that
+// changes ACTIVITIES_HOST must clear BOTH caches to observe the effect.
+const getImageSources = () =>
+  getContentSecurityPolicy()
+    .split(';')
+    .map((directive) => directive.trim())
+    .find((directive) => directive.startsWith('img-src '))
+    ?.split(/\s+/)
+    .slice(1) ?? []
+
+describe('getContentSecurityPolicy img-src app origin', () => {
+  const originalHost = process.env.ACTIVITIES_HOST
+
+  beforeEach(() => {
+    resetHostConfigCacheForTests()
+    resetContentSecurityPolicyCacheForTests()
+  })
+
+  afterEach(() => {
+    if (originalHost === undefined) delete process.env.ACTIVITIES_HOST
+    else process.env.ACTIVITIES_HOST = originalHost
+    resetHostConfigCacheForTests()
+    resetContentSecurityPolicyCacheForTests()
+  })
+
+  it('allows the canonical app origin (https-normalized) for the absolute logo URL', () => {
+    process.env.ACTIVITIES_HOST = 'app.example.com'
+    resetHostConfigCacheForTests()
+    resetContentSecurityPolicyCacheForTests()
+
+    expect(getImageSources()).toContain('https://app.example.com')
+  })
+
+  it('omits the app origin when ACTIVITIES_HOST is unset', () => {
+    delete process.env.ACTIVITIES_HOST
+    resetHostConfigCacheForTests()
+    resetContentSecurityPolicyCacheForTests()
+
+    const imageSources = getImageSources()
+    expect(imageSources).toContain("'self'")
+    // The empty host yields no app-origin source (getCspSource('') === null), so
+    // the host that the first test injects must not appear here.
+    expect(imageSources).not.toContain('https://app.example.com')
+  })
+})

--- a/lib/utils/http-headers/csp.ts
+++ b/lib/utils/http-headers/csp.ts
@@ -1,4 +1,4 @@
-import { getProxyHostConfig } from '@/lib/config/host'
+import { getBaseURL } from '@/lib/config'
 import { getSecurityHeaderConfig } from '@/lib/config/securityHeaders'
 
 import { type SecurityHeader, getStaticSecurityHeaders } from './static'
@@ -131,11 +131,12 @@ export const getContentSecurityPolicy = () => {
   const allowMapboxSources = hasPublicMapboxAccessToken(fitnessStorage)
   const serviceMediaSources = getConfiguredCspSources(allowMediaDomains)
   const remoteMediaSources = getRemoteMediaCspSources(allowRemoteMediaDomains)
-  // The canonical app origin (ACTIVITIES_HOST). Server-rendered pages load the
-  // logo from this absolute origin so it resolves even when the page is served
-  // on a CDN alias domain; allow it explicitly so an operator with a strict
-  // ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS allowlist doesn't block the logo.
-  const appOriginSource = getCspSource(getProxyHostConfig().host)
+  // The canonical app origin. Server-rendered pages load the logo from this
+  // absolute origin (built from the same getBaseURL()) so it resolves even when
+  // the page is served on a CDN alias domain; allow it explicitly so an operator
+  // with a strict ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS allowlist doesn't block
+  // the logo. Deriving it from getBaseURL() keeps the scheme in lockstep.
+  const appOriginSource = getCspSource(getBaseURL())
   const connectSources = Array.from(
     new Set([
       "'self'",

--- a/lib/utils/http-headers/csp.ts
+++ b/lib/utils/http-headers/csp.ts
@@ -136,7 +136,10 @@ export const getContentSecurityPolicy = () => {
   // on a CDN alias domain; allow it explicitly so an operator with a strict
   // ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS allowlist doesn't block the logo.
   // Read via the sub-path host config (not the @/lib/config barrel) to keep the
-  // proxy's static import graph free of filesystem modules.
+  // proxy's static import graph free of filesystem modules. getCspSource
+  // normalizes a bare host to https, matching getBaseURL()'s default scheme; the
+  // two only diverge under ACTIVITIES_INSECURE_AUTH=true, which is local-dev-only
+  // (served over http from 'self') and must not be paired with a CDN-fronted host.
   const appOriginSource = getCspSource(getProxyHostConfig().host)
   const connectSources = Array.from(
     new Set([

--- a/lib/utils/http-headers/csp.ts
+++ b/lib/utils/http-headers/csp.ts
@@ -1,3 +1,4 @@
+import { getProxyHostConfig } from '@/lib/config/host'
 import { getSecurityHeaderConfig } from '@/lib/config/securityHeaders'
 
 import { type SecurityHeader, getStaticSecurityHeaders } from './static'
@@ -130,6 +131,11 @@ export const getContentSecurityPolicy = () => {
   const allowMapboxSources = hasPublicMapboxAccessToken(fitnessStorage)
   const serviceMediaSources = getConfiguredCspSources(allowMediaDomains)
   const remoteMediaSources = getRemoteMediaCspSources(allowRemoteMediaDomains)
+  // The canonical app origin (ACTIVITIES_HOST). Server-rendered pages load the
+  // logo from this absolute origin so it resolves even when the page is served
+  // on a CDN alias domain; allow it explicitly so an operator with a strict
+  // ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS allowlist doesn't block the logo.
+  const appOriginSource = getCspSource(getProxyHostConfig().host)
   const connectSources = Array.from(
     new Set([
       "'self'",
@@ -148,6 +154,7 @@ export const getContentSecurityPolicy = () => {
       "'self'",
       'data:',
       'blob:',
+      ...(appOriginSource ? [appOriginSource] : []),
       ...remoteMediaSources,
       ...serviceMediaSources,
       ...(mediaStorageSource ? [mediaStorageSource] : [])

--- a/lib/utils/http-headers/csp.ts
+++ b/lib/utils/http-headers/csp.ts
@@ -1,4 +1,4 @@
-import { getBaseURL } from '@/lib/config'
+import { getProxyHostConfig } from '@/lib/config/host'
 import { getSecurityHeaderConfig } from '@/lib/config/securityHeaders'
 
 import { type SecurityHeader, getStaticSecurityHeaders } from './static'
@@ -131,12 +131,13 @@ export const getContentSecurityPolicy = () => {
   const allowMapboxSources = hasPublicMapboxAccessToken(fitnessStorage)
   const serviceMediaSources = getConfiguredCspSources(allowMediaDomains)
   const remoteMediaSources = getRemoteMediaCspSources(allowRemoteMediaDomains)
-  // The canonical app origin. Server-rendered pages load the logo from this
-  // absolute origin (built from the same getBaseURL()) so it resolves even when
-  // the page is served on a CDN alias domain; allow it explicitly so an operator
-  // with a strict ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS allowlist doesn't block
-  // the logo. Deriving it from getBaseURL() keeps the scheme in lockstep.
-  const appOriginSource = getCspSource(getBaseURL())
+  // The canonical app origin (ACTIVITIES_HOST). Server-rendered pages load the
+  // logo from this absolute origin so it resolves even when the page is served
+  // on a CDN alias domain; allow it explicitly so an operator with a strict
+  // ACTIVITIES_ALLOW_REMOTE_MEDIA_DOMAINS allowlist doesn't block the logo.
+  // Read via the sub-path host config (not the @/lib/config barrel) to keep the
+  // proxy's static import graph free of filesystem modules.
+  const appOriginSource = getCspSource(getProxyHostConfig().host)
   const connectSources = Array.from(
     new Set([
       "'self'",


### PR DESCRIPTION
## Background

Reported against the `llun.dev` (CloudFront-fronted) deployment:

1. **Passkey sign-in fails with "Auth cancelled"** on `llun.dev`.
2. **The sign-in logo doesn't load.**
3. **`GET /api/v1/accounts/:id/statuses?...&limit=100&pinned=true` returns `400 Bad Request`** even after a successful email/password login.

All three were root-caused with live evidence.

---

## What this PR fixes

### 1. The `400` on paginated endpoints (root cause + systemic fix)

`/api/v1/accounts/:id/statuses` validated its `limit` with `z.coerce.number().min(1).max(40)`. A well-formed but out-of-range value (`limit=100`) fails `safeParse`, which rejects the **whole** query object → `400`. Verified live: `limit=40` → `200`, `limit=41` → `400`, `limit=100` → `400`.

Real Mastodon **clamps** pagination limits instead of erroring, and this app already does that for timelines (`normalizeTimelineLimit`). An audit found the same reject-instead-of-clamp anti-pattern across **~15 client-facing routes** (a client sending `limit=100` would 400 on statuses, followers, following, search, endorsements, reblogged_by/favourited_by, directory, notifications, v2/search, …).

**Fix:** new `lib/utils/clampedLimit.ts` exporting `clampedLimit(max, fallback, min?)` and `clampedOffset(max?, fallback?)` Zod helpers that clamp into range and fall back to the default for absent/blank/non-numeric input, applied across the affected routes. Existing tests that asserted the old `400`/`422` behaviour were updated to assert clamping (e.g. notifications: `limit=100` now calls the DB with `limit: 80`).

### 2. The logo not loading

On `llun.dev`, CloudFront's default behaviour 302-redirects non-app paths (incl. `/logo-nav.png`) to the **`www.llun.me` S3 bucket**, which 404s (`NoSuchKey`); only `/api/*` and `/auth/*` reach the app origin. The canonical host **does** serve the asset (`https://llun.social/logo-nav.png` → `200 image/png`).

**Fix:** build the logo `src` from `getBaseURL()` (`ACTIVITIES_HOST`) so it loads from the canonical origin regardless of which alias domain the page is served on. Applied to the **Server-Component** surfaces: sign-in page, public footer, landing public-feed header. The shared nav `Logo` is rendered inside a Client Component (`sidebar.tsx`) and can't read the server-only config, so it's intentionally left relative (follow-up would thread the URL down as a prop).

### 3. Misleading passkey error message

The better-auth passkey client **hardcodes** `message: "Auth cancelled"` for *every* failure and only varies `code`. On `llun.dev` the WebAuthn ceremony aborts with `ERROR_INVALID_RP_ID` (see below), but the user just saw "Auth cancelled". `PasskeySigninButton` now maps real WebAuthn error codes to actionable text and stays silent only for genuine user cancellation.

---

## Diagnosed but NOT changed here

### Passkey actually working on `llun.dev` (multi-domain WebAuthn)
The passkey options endpoint on `llun.dev` returns **`"rpId":"llun.social"`** (derived from `getBaseURL()` → `ACTIVITIES_HOST`). WebAuthn requires the rpID to be a registrable suffix of the page origin; `llun.social` is not one for `llun.dev`, so the browser throws `SecurityError` → ceremony aborts. Credential sign-in works because `trustedOrigins` already includes `llun.dev`, but the passkey rpID is a single static host.

A passkey is cryptographically bound to one rpID, so no single rpID serves both `llun.dev` and `llun.social`. Follow-up options:
- Make the passkey rpID/origin **request-host-aware** (the app can already resolve the public host via `selectHeaderHost`). Requires per-host auth instances and users registering a passkey **per domain**.
- Or **standardise on one canonical auth host** for sign-in.

Not bundled here because it touches production auth and can't be browser-verified in CI. Today passkey works if sign-in happens on `https://llun.social`.

---

## Testing
- `yarn run prettier --write .`, `yarn lint` (0 errors), `yarn build` (0 type errors), `yarn test` (full suite green).
- New `lib/utils/clampedLimit.test.ts` covers clamp/floor/ceiling/blank/non-numeric/object-embedding.
- Updated route tests now assert clamping rather than rejection.
- Verified live: `https://llun.social/logo-nav.png` → `200 image/png`; `https://llun.dev/logo-nav.png` → `302` to the dead `www.llun.me`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)