### PR TITLE
Bump version to v1.75.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.75.4",
+  "version": "1.75.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.75.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.75.4`
- Base main SHA: `38536b0918fc3787813795ff7a0e5d9fc5e56712`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
