### PR TITLE
Bump version to v1.76.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.75.5",
+  "version": "1.76.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.76.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.75.5`
- Base main SHA: `d71d4c6271b9104e4b61ddcd5e8cf446ab239d25`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
