### PR TITLE
fix: make OIDC provider RS256-compliant for strict relying parties

### DIFF
--- a/app/api/oauth/userinfo/route.test.ts
+++ b/app/api/oauth/userinfo/route.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from 'next/server'
+
+import { Account } from '@/lib/types/domain/account'
+import { Actor } from '@/lib/types/domain/actor'
+
+// Drive the route handler directly with a controlled OAuth context so we can
+// exercise the route-level fail-closed branch (account-less actor -> 401) that
+// the getUserInfo unit tests cannot reach (getUserInfo now requires an account).
+const guardState = vi.hoisted(() => ({
+  currentActor: null as Actor | null,
+  grantedScopes: undefined as string[] | undefined
+}))
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuardAnyScope:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: { currentActor: Actor | null; grantedScopes?: string[] }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest) =>
+      handle(req, {
+        currentActor: guardState.currentActor,
+        grantedScopes: guardState.grantedScopes
+      })
+}))
+
+const { GET } = await import('./route')
+
+const makeAccount = (overrides: Partial<Account> = {}): Account => {
+  const now = Date.now()
+  return {
+    id: 'account-abc-123',
+    email: 'test@example.com',
+    emailVerifiedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
+}
+
+const makeActor = (account: Account | null): Actor => ({
+  id: 'https://example.com/users/testuser',
+  username: 'testuser',
+  domain: 'example.com',
+  name: 'Test User',
+  iconUrl: 'https://example.com/avatar.png',
+  headerImageUrl: null,
+  summary: 'A test user',
+  followersUrl: 'https://example.com/users/testuser/followers',
+  inboxUrl: 'https://example.com/users/testuser/inbox',
+  sharedInboxUrl: 'https://example.com/inbox',
+  publicKey: 'public-key',
+  privateKey: 'private-key',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  ...(account ? { account } : { account: null })
+})
+
+const callGet = () =>
+  GET(new NextRequest('https://example.com/oauth/userinfo'), {
+    params: Promise.resolve({})
+  })
+
+describe('GET /oauth/userinfo', () => {
+  beforeEach(() => {
+    guardState.currentActor = null
+    guardState.grantedScopes = undefined
+  })
+
+  it('fails closed with 401 invalid_token when the actor has no account', async () => {
+    guardState.currentActor = makeActor(null)
+    guardState.grantedScopes = ['openid', 'profile', 'email']
+
+    const response = await callGet()
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_token' })
+  })
+
+  it('returns sub equal to the account id with profile and email claims', async () => {
+    const account = makeAccount({ id: 'account-sub-xyz' })
+    guardState.currentActor = makeActor(account)
+    guardState.grantedScopes = ['openid', 'profile', 'email']
+
+    const response = await callGet()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    // OIDC §5.3.2: the userinfo sub is the account id (matches the id_token sub).
+    expect(body.sub).toBe('account-sub-xyz')
+    expect(body.preferred_username).toBe('testuser')
+    expect(body.email).toBe('test@example.com')
+    expect(body.email_verified).toBe(true)
+  })
+
+  it('returns only sub for openid-only scope', async () => {
+    const account = makeAccount({ id: 'account-openid-only' })
+    guardState.currentActor = makeActor(account)
+    guardState.grantedScopes = ['openid']
+
+    const response = await callGet()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.sub).toBe('account-openid-only')
+    expect(body).not.toHaveProperty('preferred_username')
+    expect(body).not.toHaveProperty('email')
+  })
+})

--- a/app/api/oauth/userinfo/route.ts
+++ b/app/api/oauth/userinfo/route.ts
@@ -4,7 +4,7 @@ import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { getUserInfo } from '@/lib/services/oauth/userinfo'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { HTTP_STATUS, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [
@@ -20,9 +20,24 @@ const respondWithUserInfo = OAuthGuardAnyScope(
   async (req: NextRequest, context) => {
     const { currentActor, grantedScopes } = context
 
+    // The OIDC `sub` is the owning account id, so the actor resolved from the
+    // access token must carry its account. A token issued through the OAuth
+    // consent flow always maps to a local actor with an account; a missing one
+    // is an unexpected state we fail closed on rather than emit a `sub`-less
+    // (spec-invalid) userinfo response.
+    const account = currentActor.account
+    if (!account) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: { error: 'invalid_token' },
+        responseStatusCode: HTTP_STATUS.UNAUTHORIZED
+      })
+    }
+
     const userInfo = getUserInfo({
       actor: currentActor,
-      account: currentActor.account,
+      account,
       scopes: grantedScopes
     })
 

--- a/lib/services/auth/auth.ts
+++ b/lib/services/auth/auth.ts
@@ -42,7 +42,25 @@ const buildAuth = (baseURL: string) => {
     disabledPaths: ['/token'], // Disable jwt plugin's /api/auth/token;
     // OAuth tokens are issued via oauthProvider. JWKS stays enabled for OAuthGuard.
     plugins: [
-      jwt(),
+      // Sign the JWKS key (and therefore the OIDC id_tokens the oauthProvider
+      // signs via this plugin) with RS256 so the published JWKS matches the
+      // `id_token_signing_alg_values_supported: ['RS256']` advertised in the
+      // OpenID discovery document. Without this the plugin defaults to
+      // EdDSA/Ed25519 and a strict RS256 relying party (e.g. mozilla-django-oidc
+      // with OIDC_RP_SIGN_ALGO=RS256) cannot verify the id_token signature.
+      //
+      // Rollout note: this `jwks` table has no per-key `alg` column (and the
+      // plugin's jwks schema declares none), so better-auth resolves the signing
+      // and JWKS `alg` from THIS config, not from each stored key. A fresh
+      // deployment generates an RSA key on the first sign / first /api/auth/jwks
+      // request and is consistent. A deployment that already signed a token (an
+      // Ed25519 key already sits in `jwks`) must have that row cleared once on
+      // rollout so a fresh RSA key is generated — otherwise the plugin loads the
+      // stale Ed25519 key and tries to sign it as RS256, which throws. This does
+      // not affect Mastodon OAuth2 clients: they use opaque access tokens
+      // verified against the database (not the JWKS), and id_tokens are
+      // short-lived, so no long-lived token depends on the retired EdDSA key.
+      jwt({ jwks: { keyPairConfig: { alg: 'RS256', modulusLength: 2048 } } }),
       // rpID/origin are derived from this instance's resolved host so passkey
       // ceremonies run against the domain the request actually arrived on. See
       // `getAuth` and `resolveAuthBaseURL` for how the host is chosen per request.

--- a/lib/services/auth/jwks.test.ts
+++ b/lib/services/auth/jwks.test.ts
@@ -1,0 +1,104 @@
+import knex, { Knex } from 'knex'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { getOpenIDConfiguration } from '@/lib/services/wellknown/openidConfiguration'
+
+// A fresh in-memory SQLite database stands in for the deployment database so the
+// real better-auth instance (and its jwt plugin) provisions a real signing key.
+const holder = vi.hoisted(() => ({ knex: null as Knex | null }))
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({
+    host: 'test.example.com',
+    serviceName: 'Activities.next Test',
+    // Long enough that better-auth does not warn about a weak secret.
+    secretPhase: 'test-secret-phrase-that-is-long-enough-1234567890',
+    trustedHosts: []
+  }),
+  getBaseURL: () => 'https://test.example.com'
+}))
+
+vi.mock('@/lib/database', () => ({
+  // The jwt plugin only needs the Knex handle (via knexAdapter); the higher
+  // level Database is unused on the public /jwks path, so null is sufficient.
+  getKnex: () => holder.knex,
+  getDatabase: () => null
+}))
+
+const SQLITE_SCHEMA_PATH = fileURLToPath(
+  new URL('../../../migrations/schema.sqlite.sql', import.meta.url)
+)
+
+const buildInMemoryKnex = async (): Promise<Knex> => {
+  const instance = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+  const sql = readFileSync(SQLITE_SCHEMA_PATH, 'utf8')
+  const connection = await instance.client.acquireConnection()
+  try {
+    connection.exec(sql)
+  } finally {
+    await instance.client.releaseConnection(connection)
+  }
+  return instance
+}
+
+describe('OIDC JWKS (RS256)', () => {
+  beforeAll(async () => {
+    holder.knex = await buildInMemoryKnex()
+  })
+
+  afterAll(async () => {
+    await holder.knex?.destroy()
+  })
+
+  const fetchJwks = async () => {
+    const { getAuth } = await import('@/lib/services/auth/auth')
+    const auth = getAuth('https://test.example.com')
+    const response = await auth.handler(
+      new Request('https://test.example.com/api/auth/jwks', { method: 'GET' })
+    )
+    expect(response.status).toBe(200)
+    return response.json() as Promise<{
+      keys: Array<Record<string, unknown>>
+    }>
+  }
+
+  it('publishes an RS256/RSA verification key with a kid at /api/auth/jwks', async () => {
+    const jwks = await fetchJwks()
+
+    expect(Array.isArray(jwks.keys)).toBe(true)
+    expect(jwks.keys.length).toBeGreaterThanOrEqual(1)
+
+    const rsaKey = jwks.keys.find((key) => key.kty === 'RSA')
+    expect(rsaKey).toBeDefined()
+    // The discovery document advertises id_token_signing_alg RS256, so the
+    // published verification key MUST be an RSA key with a matching alg/kid.
+    expect(rsaKey).toMatchObject({ kty: 'RSA', alg: 'RS256' })
+    expect(rsaKey?.kid).toBeString()
+    expect(rsaKey?.kid).toBeTruthy()
+    // RSA public material is present; private material is never published.
+    expect(rsaKey?.n).toBeString()
+    expect(rsaKey?.e).toBeString()
+    expect(rsaKey).not.toHaveProperty('d')
+  })
+
+  it('does not publish an EdDSA/OKP key (the pre-RS256 default)', async () => {
+    const jwks = await fetchJwks()
+
+    // A leftover EdDSA key would be served stamped with the configured RS256
+    // alg and could never verify; the published set must be RSA-only.
+    expect(jwks.keys.some((key) => key.kty === 'OKP')).toBe(false)
+    expect(jwks.keys.every((key) => key.alg === 'RS256')).toBe(true)
+  })
+
+  it('advertises the JWKS endpoint that serves this RS256 key in discovery', () => {
+    const config = getOpenIDConfiguration()
+
+    expect(config.jwks_uri).toBe('https://test.example.com/api/auth/jwks')
+    expect(config.id_token_signing_alg_values_supported).toEqual(['RS256'])
+  })
+})

--- a/lib/services/oauth/userinfo.test.ts
+++ b/lib/services/oauth/userinfo.test.ts
@@ -22,27 +22,72 @@ const makeActor = (overrides: Partial<Actor> = {}): Actor => ({
   ...overrides
 })
 
-describe('getUserInfo', () => {
-  it('returns all claims when no scopes specified (legacy/session)', () => {
-    const userInfo = getUserInfo({ actor: makeActor() })
+const makeAccount = (overrides: Partial<Account> = {}): Account => {
+  const now = Date.now()
+  return {
+    // Better Auth account ids are short nanoids, deliberately unlike the
+    // actor's URL id so the `sub = account.id` assertions are meaningful.
+    id: 'lfpCbM75O9OcBmxgq9JI',
+    email: 'test@example.com',
+    emailVerifiedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides
+  }
+}
 
-    expect(userInfo.sub).toBeString()
+describe('getUserInfo', () => {
+  it('uses the account id as the sub claim, not the actor id', () => {
+    const account = makeAccount({ id: 'account-sub-123' })
+    const userInfo = getUserInfo({ actor: makeActor(), account })
+
+    // OIDC §5.3.2: the userinfo sub MUST match the id_token sub. Better Auth
+    // signs the id_token with the account (user) id, so the canonical subject
+    // here is the account id — never the actor URL id.
+    expect(userInfo.sub).toBe('account-sub-123')
+    expect(userInfo.sub).not.toBe(makeActor().id)
+  })
+
+  it('returns a sub equal to the id_token sub (account id) for the same session', () => {
+    const account = makeAccount({ id: 'shared-subject-id' })
+
+    // Better Auth resolves the id_token `sub` via resolveSubjectIdentifier,
+    // which (with subject_types_supported: ['public'], no pairwise secret)
+    // returns user.id — the Better Auth account id. Mirror that here so the
+    // assertion documents the cross-endpoint invariant.
+    const idTokenSub = account.id
+
+    const userInfo = getUserInfo({
+      actor: makeActor(),
+      account,
+      scopes: ['openid']
+    })
+
+    expect(userInfo.sub).toBe(idTokenSub)
+  })
+
+  it('returns sub, profile and email claims when no scopes are specified (legacy/session)', () => {
+    const account = makeAccount({ id: 'account-1' })
+    const userInfo = getUserInfo({ actor: makeActor(), account })
+
+    expect(userInfo.sub).toBe('account-1')
     expect(userInfo.name).toBe('Test User')
     expect(userInfo.preferred_username).toBe('testuser')
     expect(userInfo.picture).toBe('https://example.com/avatar.png')
     expect(userInfo.profile).toBe('https://example.com/users/testuser')
-    // No account provided, so email claims are omitted
-    expect(userInfo).not.toHaveProperty('email')
-    expect(userInfo).not.toHaveProperty('email_verified')
+    expect(userInfo.email).toBe('test@example.com')
+    expect(userInfo.email_verified).toBe(true)
   })
 
   it('returns only sub for openid-only scope', () => {
+    const account = makeAccount({ id: 'account-1' })
     const userInfo = getUserInfo({
       actor: makeActor(),
+      account,
       scopes: ['openid']
     })
 
-    expect(userInfo.sub).toBeTruthy()
+    expect(userInfo.sub).toBe('account-1')
     expect(userInfo).not.toHaveProperty('name')
     expect(userInfo).not.toHaveProperty('preferred_username')
     expect(userInfo).not.toHaveProperty('email')
@@ -50,12 +95,14 @@ describe('getUserInfo', () => {
   })
 
   it('includes profile claims when profile scope is granted', () => {
+    const account = makeAccount()
     const userInfo = getUserInfo({
       actor: makeActor(),
+      account,
       scopes: ['openid', 'profile']
     })
 
-    expect(userInfo.sub).toBeTruthy()
+    expect(userInfo.sub).toBe(account.id)
     expect(userInfo.name).toBe('Test User')
     expect(userInfo.preferred_username).toBe('testuser')
     expect(userInfo.picture).toBe('https://example.com/avatar.png')
@@ -66,6 +113,7 @@ describe('getUserInfo', () => {
   it('includes profile claims when read scope is granted', () => {
     const userInfo = getUserInfo({
       actor: makeActor(),
+      account: makeAccount(),
       scopes: ['read']
     })
 
@@ -76,6 +124,7 @@ describe('getUserInfo', () => {
   it('omits name and picture when actor has null values', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ name: null, iconUrl: null }),
+      account: makeAccount(),
       scopes: ['openid', 'profile']
     })
 
@@ -86,14 +135,11 @@ describe('getUserInfo', () => {
   })
 
   it('includes email claims when email scope is granted', () => {
-    const now = Date.now()
-    const account: Account = {
+    const account = makeAccount({
       id: 'account-1',
       email: 'test@example.com',
-      emailVerifiedAt: now,
-      createdAt: now,
-      updatedAt: now
-    }
+      emailVerifiedAt: Date.now()
+    })
 
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
@@ -107,14 +153,11 @@ describe('getUserInfo', () => {
   })
 
   it('omits email claims when email scope is not granted', () => {
-    const now = Date.now()
-    const account: Account = {
+    const account = makeAccount({
       id: 'account-1',
       email: 'test@example.com',
-      emailVerifiedAt: now,
-      createdAt: now,
-      updatedAt: now
-    }
+      emailVerifiedAt: Date.now()
+    })
 
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
@@ -126,26 +169,13 @@ describe('getUserInfo', () => {
     expect(userInfo).not.toHaveProperty('email_verified')
   })
 
-  it('omits email claims when account has no email', () => {
-    const userInfo = getUserInfo({
-      actor: makeActor(),
-      scopes: ['openid', 'email']
-    })
-
-    expect(userInfo).not.toHaveProperty('email')
-    expect(userInfo).not.toHaveProperty('email_verified')
-  })
-
   it('returns email_verified true when verifiedAt is set', () => {
-    const now = Date.now()
-    const account: Account = {
+    const account = makeAccount({
       id: 'account-3',
       email: 'verified@example.com',
       emailVerifiedAt: null,
-      verifiedAt: now,
-      createdAt: now,
-      updatedAt: now
-    }
+      verifiedAt: Date.now()
+    })
 
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
@@ -157,15 +187,30 @@ describe('getUserInfo', () => {
     expect(userInfo.email_verified).toBe(true)
   })
 
+  it('returns email_verified true when emailVerifiedAt is set', () => {
+    const account = makeAccount({
+      id: 'account-4',
+      email: 'verified@example.com',
+      emailVerifiedAt: Date.now(),
+      verifiedAt: undefined
+    })
+
+    const userInfo = getUserInfo({
+      actor: makeActor({ account }),
+      account,
+      scopes: ['openid', 'email']
+    })
+
+    expect(userInfo.email_verified).toBe(true)
+  })
+
   it('returns email_verified false when neither verifiedAt nor emailVerifiedAt is set', () => {
-    const now = Date.now()
-    const account: Account = {
+    const account = makeAccount({
       id: 'account-2',
       email: 'unverified@example.com',
       emailVerifiedAt: null,
-      createdAt: now,
-      updatedAt: now
-    }
+      verifiedAt: undefined
+    })
 
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
@@ -175,12 +220,5 @@ describe('getUserInfo', () => {
 
     expect(userInfo.email).toBe('unverified@example.com')
     expect(userInfo.email_verified).toBe(false)
-  })
-
-  it('encodes actor ID as sub claim', () => {
-    const userInfo = getUserInfo({ actor: makeActor() })
-
-    expect(userInfo.sub).toBeTruthy()
-    expect(typeof userInfo.sub).toBe('string')
   })
 })

--- a/lib/services/oauth/userinfo.ts
+++ b/lib/services/oauth/userinfo.ts
@@ -1,6 +1,5 @@
 import { Account } from '@/lib/types/domain/account'
 import { Actor } from '@/lib/types/domain/actor'
-import { urlToId } from '@/lib/utils/urlToId'
 
 export interface UserInfoBase {
   sub: string
@@ -24,7 +23,7 @@ export type UserInfo = UserInfoBase &
 
 interface GetUserInfoOptions {
   actor: Actor
-  account?: Account | null
+  account: Account
   scopes?: string[]
 }
 
@@ -36,10 +35,15 @@ export const getUserInfo = ({
   const includeProfile =
     !scopes || scopes.includes('profile') || scopes.includes('read')
   const includeEmail = !scopes || scopes.includes('email')
-  const email = account?.email
+  const email = account.email
 
   return {
-    sub: urlToId(actor.id),
+    // OIDC §5.3.2 requires the userinfo `sub` to equal the id_token `sub`. Better
+    // Auth signs the id_token with `sub = account id` (the user record id), so the
+    // canonical subject here is the owning account id — one OIDC subject per human,
+    // regardless of how many ActivityPub actors that account owns. Profile fields
+    // below stay actor-sourced (the actor selected for this session/token).
+    sub: account.id,
     ...(includeProfile && {
       ...(actor.name != null ? { name: actor.name } : {}),
       preferred_username: actor.username,
@@ -50,7 +54,7 @@ export const getUserInfo = ({
       ? {
           email,
           email_verified:
-            account?.verifiedAt != null || account?.emailVerifiedAt != null
+            account.verifiedAt != null || account.emailVerifiedAt != null
         }
       : {})
   }

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -65,7 +65,9 @@ describe('wellknown services', () => {
       const config = getOpenIDConfiguration()
 
       expect(config).toMatchObject({
-        issuer: 'https://test.example.com',
+        // Better Auth signs id_tokens with iss = baseURL + basePath
+        // (`/api/auth`), so discovery must advertise that same issuer.
+        issuer: 'https://test.example.com/api/auth',
         authorization_endpoint:
           'https://test.example.com/api/auth/oauth2/authorize',
         token_endpoint: 'https://test.example.com/oauth/token',
@@ -81,6 +83,26 @@ describe('wellknown services', () => {
         ],
         code_challenge_methods_supported: ['S256']
       })
+    })
+
+    it('advertises the basePath issuer that Better Auth stamps on id_tokens', () => {
+      const config = getOpenIDConfiguration()
+
+      // The id_token `iss` is baseURL + basePath; discovery must match it
+      // exactly or a strict OIDC relying party rejects the token.
+      expect(config.issuer).toBe('https://test.example.com/api/auth')
+    })
+
+    it('keeps a distinct issuer from the RFC 8414 OAuth metadata (bare origin)', () => {
+      // OAuth2 access tokens carry no `iss`, so the authorization-server
+      // metadata intentionally keeps the bare origin for Mastodon compatibility.
+      // Only the OIDC discovery issuer gains the `/api/auth` basePath.
+      const oidc = getOpenIDConfiguration()
+      const oauth = getOAuthAuthorizationServerMetadata()
+
+      expect(oauth.issuer).toBe('https://test.example.com')
+      expect(oidc.issuer).not.toBe(oauth.issuer)
+      expect(oidc.issuer).toBe(`${oauth.issuer}/api/auth`)
     })
 
     it('includes OIDC scopes and claims', () => {

--- a/lib/services/wellknown/openidConfiguration.ts
+++ b/lib/services/wellknown/openidConfiguration.ts
@@ -22,7 +22,13 @@ export interface OpenIDConfiguration {
 export const getOpenIDConfiguration = (): OpenIDConfiguration => {
   const baseURL = getBaseURL()
   return {
-    issuer: baseURL,
+    // Better Auth signs id_tokens with `iss = baseURL + basePath` (the auth
+    // basePath is `/api/auth`), so the discovery `issuer` MUST match that value
+    // — a strict OIDC relying party rejects an id_token whose `iss` differs from
+    // the issuer it discovered here. The RFC 8414 OAuth metadata
+    // (oauthAuthorizationServer.ts) intentionally keeps the bare origin for
+    // Mastodon compatibility; OAuth2 access tokens carry no `iss` to reconcile.
+    issuer: `${baseURL}/api/auth`,
     authorization_endpoint: `${baseURL}/api/auth/oauth2/authorize`,
     token_endpoint: `${baseURL}/oauth/token`,
     userinfo_endpoint: `${baseURL}/oauth/userinfo`,


### PR DESCRIPTION
## Summary

A live `authorization_code` + PKCE(S256) run against the provider (acting as the IdP for a `lasuite/impress` "Docs" app using `mozilla-django-oidc` with `OIDC_RP_SIGN_ALGO=RS256`) surfaced **three defects** that block a strict RS256 OpenID Connect relying party. This PR fixes all three. Mastodon OAuth2 clients (opaque access tokens + the `/api/v1/*` REST API) are unaffected.

### Fix 1 — id_token must be RS256 (was EdDSA)
`jwt()` was called with no args, so Better Auth defaulted to **EdDSA/Ed25519**, while `openidConfiguration.ts` advertises `id_token_signing_alg_values_supported: ['RS256']`. The live `/api/auth/jwks` therefore served only an EdDSA key and a strict RS256 client failed signature verification.

- Configured the plugin: `jwt({ jwks: { keyPairConfig: { alg: 'RS256', modulusLength: 2048 } } })` (option name verified against `better-auth@1.6.19`'s `JWKOptions`).
- `OAuthGuard` verifies bearer JWTs via `verifyAccessToken` → jose `createLocalJWKSet`/`jwtVerify`, which selects the key by **`kid`** and is **not pinned to an alg** (no `algorithms` in `verifyOptions`), so adding the RSA key is safe for it.

### Fix 2 — issuer inconsistency
Discovery set `issuer: baseURL` (`https://llun.social`), but Better Auth signs id_tokens with `iss = baseURL + basePath` (`https://llun.social/api/auth`). Aligned the **OIDC discovery** issuer to `` `${baseURL}/api/auth` ``. The RFC 8414 OAuth metadata (`oauthAuthorizationServer.ts`) intentionally keeps the **bare origin** for Mastodon compatibility (OAuth2 access tokens carry no `iss`).

### Fix 3 — userinfo `sub` ≠ id_token `sub` (OIDC §5.3.2)
id_token `sub` is the Better Auth **account** id; `getUserInfo` returned `urlToId(actor.id)`. 

- **Canonical subject decision: the account id.** One OIDC subject per human, regardless of how many ActivityPub actors the account owns. `getUserInfo` now returns `sub: account.id`; the `account` argument is **required**. Profile fields (`name`, `preferred_username`, `picture`, `profile`) stay **actor-sourced**.
- The userinfo route fails closed (`401 invalid_token`) if the token's resolved actor has no owning account, rather than emitting a `sub`-less (spec-invalid) response.

## Backward compatibility
- **Mastodon clients unaffected.** Verified live that their access tokens are **opaque** (no `resource`/`audience` ⇒ better-auth issues opaque, DB-verified tokens, not JWKS-verified JWTs). `verify_credentials` still returns the account.
- **userinfo `sub` value changes** (account id instead of actor-url id). A spec-compliant RP could not have worked before this PR anyway, since `id_token.sub` already ≠ `userinfo.sub`; no existing RP could have keyed users on the old value.

## ⚠️ Deployment / rollout note (EdDSA → RS256 key cutover)
This integration's `jwks` table has **no per-key `alg` column** (the plugin's jwks schema declares none), so better-auth resolves the signing/JWKS `alg` from **config**, not from each stored key. Consequences, confirmed empirically with `jose`:

- **Fresh deployment:** an RSA key is generated on the first sign / first `/api/auth/jwks` request and everything is consistent. ✅ (This is what local dev, the tests, and the e2e run below exercise.)
- **Existing deployment that already signed a token** (an Ed25519 key already sits in `jwks`): the plugin would load that stale key and try to sign it as RS256, which **throws** (`importJWK(ed25519Jwk, 'RS256')` → `JOSENotSupported`). The one-time rollout step is therefore to **clear the `jwks` table** so a fresh RSA key is generated.
- Because of the missing per-key `alg`, a retained Ed25519 key would also be **served stamped `alg: RS256`** and could never verify a legacy EdDSA token (`JWKSNoMatchingKey`) — so keeping it has no upside here. Clearing it is safe: Mastodon access tokens are opaque (DB-verified, not JWKS) and id_tokens are short-lived (consumed at login), so no long-lived token depends on the retired key. This is the one place the change deviates from the literal "keep EdDSA keys published" guidance — the deviation is forced by the missing `alg` column and is documented in `lib/services/auth/auth.ts`.

## Tests
- `lib/services/oauth/userinfo.test.ts` — `sub = account.id` (not actor id), `userinfo.sub === id_token.sub` invariant, `account` now required, email/profile scope behavior.
- `lib/services/wellknown/index.test.ts` — discovery `issuer === ${baseURL}/api/auth`, distinct from the bare-origin OAuth metadata issuer.
- `lib/services/auth/jwks.test.ts` (new) — boots a real `getAuth()` against in-memory SQLite and asserts `/api/auth/jwks` publishes an **RS256/RSA** key with a `kid` (and no EdDSA/OKP key).

`prettier`, `lint` (0 errors), `build`, and the full `vitest` suite (525 files / 4560 tests) all pass.

## End-to-end verification (running instance)
Full `authorization_code` + PKCE(S256) flow + Mastodon regression, all green:

```
id_token header  = {"alg":"RS256","kid":"QXOhairIHfIiTTki7K5PqDR8nzvyDeCp"}
id_token claims  = {"iss":"http://localhost:3000/api/auth","sub":"136a089a-…","aud":"<client_id>","email":"test@example.com","email_verified":true}
  ✓ id_token header alg === RS256
  ✓ id_token kid resolves to the RSA JWKS key
  ✓ id_token iss === discovery issuer (signature verified against RS256 JWKS)
  ✓ id_token sub === account id
userinfo         = {"sub":"136a089a-…","name":"Test User","preferred_username":"testuser","profile":"…","email":"…","email_verified":true}
  ✓ userinfo.sub === id_token.sub (OIDC §5.3.2)
Mastodon regression: access_token format = opaque
  ✓ GET /api/v1/accounts/verify_credentials -> 200 (acct = testuser)
```

## Out of scope / observation
better-auth's `userNormalClaims` does `user.name.split(' ')` and throws a 500 when an account has a **null `name`** *and* the `profile` scope is requested. This is pre-existing library behavior, independent of these fixes, and not addressed here (accounts created via signup carry a name). Flagging it for visibility.
