### PR TITLE
Bump version to v1.76.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.76.0",
+  "version": "1.76.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.76.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.76.0`
- Base main SHA: `6e904db80209261f739020bb09be8a3ba259109a`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
