### PR TITLE
fix: ignore stale non-RSA JWKS keys so RS256 signing self-heals

### DIFF
--- a/lib/services/auth/auth.ts
+++ b/lib/services/auth/auth.ts
@@ -2,7 +2,7 @@ import { oauthProvider } from '@better-auth/oauth-provider'
 import { passkey } from '@better-auth/passkey'
 import bcrypt from 'bcrypt'
 import { betterAuth } from 'better-auth'
-import { jwt, twoFactor } from 'better-auth/plugins'
+import { type Jwk, jwt, twoFactor } from 'better-auth/plugins'
 
 import { getBaseURL, getConfig } from '@/lib/config'
 import { getDatabase, getKnex } from '@/lib/database'
@@ -14,6 +14,23 @@ import { buildTrustedOrigins } from './trustedOrigins'
 
 export const AUTH_COOKIE_PREFIX = 'better-auth'
 export const AUTH_SESSION_COOKIE_NAME = 'session_token'
+
+// The jwt plugin is configured for RS256 below, which can only sign with an RSA
+// key. A deployment that issued tokens before the RS256 switch still has the
+// plugin's old Ed25519/OKP key sitting in the `jwks` table, and because that
+// table has no per-key `alg` column, better-auth resolves the signing algorithm
+// from the config (RS256) and then tries to load that stale key as RS256. jose
+// rejects the mismatch with `Invalid or unsupported JWK "alg" (Algorithm)
+// Parameter value`, which 500s every authenticated request (the `/get-session`
+// hook signs a JWT on each session read). Keep only RSA keys so any stale key is
+// ignored rather than signed.
+const isRsaJwk = (key: Pick<Jwk, 'publicKey'>): boolean => {
+  try {
+    return (JSON.parse(key.publicKey) as { kty?: unknown }).kty === 'RSA'
+  } catch {
+    return false
+  }
+}
 
 const buildAuth = (baseURL: string) => {
   const config = getConfig()
@@ -42,25 +59,30 @@ const buildAuth = (baseURL: string) => {
     disabledPaths: ['/token'], // Disable jwt plugin's /api/auth/token;
     // OAuth tokens are issued via oauthProvider. JWKS stays enabled for OAuthGuard.
     plugins: [
-      // Sign the JWKS key (and therefore the OIDC id_tokens the oauthProvider
-      // signs via this plugin) with RS256 so the published JWKS matches the
-      // `id_token_signing_alg_values_supported: ['RS256']` advertised in the
-      // OpenID discovery document. Without this the plugin defaults to
-      // EdDSA/Ed25519 and a strict RS256 relying party (e.g. mozilla-django-oidc
-      // with OIDC_RP_SIGN_ALGO=RS256) cannot verify the id_token signature.
-      //
-      // Rollout note: this `jwks` table has no per-key `alg` column (and the
-      // plugin's jwks schema declares none), so better-auth resolves the signing
-      // and JWKS `alg` from THIS config, not from each stored key. A fresh
-      // deployment generates an RSA key on the first sign / first /api/auth/jwks
-      // request and is consistent. A deployment that already signed a token (an
-      // Ed25519 key already sits in `jwks`) must have that row cleared once on
-      // rollout so a fresh RSA key is generated — otherwise the plugin loads the
-      // stale Ed25519 key and tries to sign it as RS256, which throws. This does
-      // not affect Mastodon OAuth2 clients: they use opaque access tokens
-      // verified against the database (not the JWKS), and id_tokens are
-      // short-lived, so no long-lived token depends on the retired EdDSA key.
-      jwt({ jwks: { keyPairConfig: { alg: 'RS256', modulusLength: 2048 } } }),
+      jwt({
+        // Sign the JWKS key (and therefore the OIDC id_tokens the oauthProvider
+        // signs via this plugin) with RS256 so the published JWKS matches the
+        // `id_token_signing_alg_values_supported: ['RS256']` advertised in the
+        // OpenID discovery document. Without this the plugin defaults to
+        // EdDSA/Ed25519 and a strict RS256 relying party (e.g. mozilla-django-oidc
+        // with OIDC_RP_SIGN_ALGO=RS256) cannot verify the id_token signature.
+        // Mastodon OAuth2 clients are unaffected — they use opaque access tokens
+        // verified against the database, not the JWKS.
+        jwks: { keyPairConfig: { alg: 'RS256', modulusLength: 2048 } },
+        // Only ever hand better-auth RSA keys (see isRsaJwk). With any stale
+        // pre-RS256 Ed25519 key filtered out, getLatestKey() finds no usable key
+        // and better-auth generates a fresh RSA key, while the JWKS endpoint and
+        // JWT verification only ever see RSA keys. This self-heals an upgraded
+        // database without a manual cleanup or migration — the retired EdDSA key
+        // is harmless since Mastodon clients use opaque tokens and id_tokens are
+        // short-lived.
+        adapter: {
+          getJwks: async (ctx) =>
+            (await ctx.context.adapter.findMany<Jwk>({ model: 'jwks' })).filter(
+              isRsaJwk
+            )
+        }
+      }),
       // rpID/origin are derived from this instance's resolved host so passkey
       // ceremonies run against the domain the request actually arrived on. See
       // `getAuth` and `resolveAuthBaseURL` for how the host is chosen per request.

--- a/lib/services/auth/jwks.test.ts
+++ b/lib/services/auth/jwks.test.ts
@@ -117,6 +117,10 @@ describe('OIDC JWKS with a stale pre-RS256 EdDSA key', () => {
   const BASE_URL = 'https://stale-key.example.com'
 
   beforeAll(async () => {
+    // Reset the module registry so getAuth's per-baseURL instance cache from the
+    // previous describe can't bridge to this block's database; the fresh import
+    // in getStaleKeyAuth then builds an instance bound to the seeded DB below.
+    vi.resetModules()
     holder.knex = await buildInMemoryKnex()
 
     // Seed the exact row the pre-RS256 plugin left behind: an Ed25519/OKP public
@@ -140,7 +144,7 @@ describe('OIDC JWKS with a stale pre-RS256 EdDSA key', () => {
     return getAuth(BASE_URL)
   }
 
-  it('hides the EdDSA key and publishes an RSA key instead of 500ing', async () => {
+  it('publishes only an RSA key and hides the stale EdDSA key', async () => {
     const auth = await getStaleKeyAuth()
     const response = await auth.handler(
       new Request(`${BASE_URL}/api/auth/jwks`, { method: 'GET' })
@@ -151,8 +155,9 @@ describe('OIDC JWKS with a stale pre-RS256 EdDSA key', () => {
       keys: Array<Record<string, unknown>>
     }
 
-    // The OKP key is filtered out; better-auth regenerates an RSA key so the
-    // published set is RSA-only and matches the advertised RS256.
+    // The OKP key is filtered out so it is never published stamped with the
+    // configured RS256 (which no RP could verify); better-auth regenerates an RSA
+    // key, so the published set is RSA-only and matches the advertised RS256.
     expect(jwks.keys.length).toBeGreaterThanOrEqual(1)
     expect(jwks.keys.some((key) => key.kty === 'OKP')).toBe(false)
     expect(jwks.keys.every((key) => key.kty === 'RSA')).toBe(true)

--- a/lib/services/auth/jwks.test.ts
+++ b/lib/services/auth/jwks.test.ts
@@ -1,3 +1,4 @@
+import { decodeProtectedHeader, exportJWK, generateKeyPair } from 'jose'
 import knex, { Knex } from 'knex'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -100,5 +101,75 @@ describe('OIDC JWKS (RS256)', () => {
 
     expect(config.jwks_uri).toBe('https://test.example.com/api/auth/jwks')
     expect(config.id_token_signing_alg_values_supported).toEqual(['RS256'])
+  })
+})
+
+// Reproduces the production 500: a deployment that signed tokens before the
+// RS256 switch still has the jwt plugin's old Ed25519/OKP key in `jwks`. Because
+// the table has no per-key `alg` column, better-auth would load that key and try
+// to sign it as the configured RS256, which jose rejects with
+// `Invalid or unsupported JWK "alg" (Algorithm) Parameter value` — 500ing every
+// authenticated request. The getJwks RSA filter must hide the stale key so the
+// instance self-heals with a fresh RSA key.
+describe('OIDC JWKS with a stale pre-RS256 EdDSA key', () => {
+  // A distinct base URL so getAuth() builds a fresh instance bound to this
+  // describe's database rather than reusing the cached one from above.
+  const BASE_URL = 'https://stale-key.example.com'
+
+  beforeAll(async () => {
+    holder.knex = await buildInMemoryKnex()
+
+    // Seed the exact row the pre-RS256 plugin left behind: an Ed25519/OKP public
+    // key. The private key is never read because the RSA filter drops this row
+    // before anything imports it, so a placeholder is enough.
+    const { publicKey } = await generateKeyPair('EdDSA', { extractable: true })
+    await holder.knex('jwks').insert({
+      id: 'stale-eddsa-key',
+      publicKey: JSON.stringify(await exportJWK(publicKey)),
+      privateKey: JSON.stringify({ placeholder: true }),
+      createdAt: new Date().toISOString()
+    })
+  })
+
+  afterAll(async () => {
+    await holder.knex?.destroy()
+  })
+
+  const getStaleKeyAuth = async () => {
+    const { getAuth } = await import('@/lib/services/auth/auth')
+    return getAuth(BASE_URL)
+  }
+
+  it('hides the EdDSA key and publishes an RSA key instead of 500ing', async () => {
+    const auth = await getStaleKeyAuth()
+    const response = await auth.handler(
+      new Request(`${BASE_URL}/api/auth/jwks`, { method: 'GET' })
+    )
+
+    expect(response.status).toBe(200)
+    const jwks = (await response.json()) as {
+      keys: Array<Record<string, unknown>>
+    }
+
+    // The OKP key is filtered out; better-auth regenerates an RSA key so the
+    // published set is RSA-only and matches the advertised RS256.
+    expect(jwks.keys.length).toBeGreaterThanOrEqual(1)
+    expect(jwks.keys.some((key) => key.kty === 'OKP')).toBe(false)
+    expect(jwks.keys.every((key) => key.kty === 'RSA')).toBe(true)
+    expect(jwks.keys.every((key) => key.alg === 'RS256')).toBe(true)
+  })
+
+  it('signs a JWT with the fresh RSA key rather than throwing on the stale key', async () => {
+    const auth = await getStaleKeyAuth()
+
+    // signJWT drives the same getLatestKey path as the `/get-session` hook that
+    // 500s in production. With the stale key filtered out it must succeed and
+    // sign with RS256, never importing the Ed25519 key as RS256.
+    const result = (await auth.api.signJWT({
+      body: { payload: { sub: 'account-1' } }
+    })) as { token: string }
+
+    expect(typeof result.token).toBe('string')
+    expect(decodeProtectedHeader(result.token).alg).toBe('RS256')
   })
 })


### PR DESCRIPTION
## Summary

Opening the site returns **HTTP 500** for logged-in users. The Cloud Run logs show:

```
⨯ aa: Invalid or unsupported JWK "alg" (Algorithm) Parameter value
  code: 'ERR_JOSE_NOT_SUPPORTED'
```

on `GET https://llun.social/` (the home page SSR render).

## Root cause

The RS256 switch in #1040 set the better-auth `jwt` plugin to sign with RS256:

```ts
jwt({ jwks: { keyPairConfig: { alg: 'RS256', modulusLength: 2048 } } })
```

But the `jwks` table (migration `20260321000000_add_jwks_table.js`) has **no per-key `alg` column**, and better-auth's own jwt schema doesn't declare one either. So when signing, the plugin resolves the algorithm from config, not from the stored key:

```ts
// better-auth/dist/plugins/jwt/sign.mjs
const alg = key.alg ?? options?.jwks?.keyPairConfig?.alg ?? 'EdDSA' // → 'RS256' (key.alg is undefined)
const privateKey = await importJWK(JSON.parse(privateWebKey), alg)  // importJWK(<Ed25519 OKP key>, 'RS256')
```

A deployment that signed tokens **before** the RS256 switch still has the plugin's old **Ed25519/OKP** key in the table. `importJWK` of an `OKP` key under `RS256` hits jose's unsupported branch (`jwk_to_key.js`) and throws. This signing runs on **every** session read — the jwt plugin's `/get-session` `after` hook signs a JWT whenever a session exists — so SSR `auth.api.getSession()` for any logged-in viewer 500s the whole page.

## Fix

Add a `jwks.adapter.getJwks` filter (a public, documented `JwtOptions` extension point) that hands better-auth **only RSA keys**:

```ts
adapter: {
  getJwks: async (ctx) =>
    (await ctx.context.adapter.findMany<Jwk>({ model: 'jwks' })).filter(isRsaJwk)
}
```

Both the signing path (`getLatestKey`) and the publish/verify path (`getAllKeys`) route through this hook. With the stale Ed25519 key hidden:

- `getLatestKey()` finds no usable key → better-auth **generates a fresh RSA key** and signs RS256.
- The `/api/auth/jwks` endpoint and JWT verification only ever see RSA keys (matching the advertised `id_token_signing_alg_values_supported: ['RS256']`).

This **self-heals existing databases on code deploy** — no manual DB cleanup or migration is required (which matters because the Dockerfile only migrates the bundled build-time SQLite, not the external production DB). The retired EdDSA key is harmless: Mastodon clients use opaque DB-verified access tokens, and id_tokens are short-lived.

## Testing

- Added a regression test in `lib/services/auth/jwks.test.ts` that seeds the exact pre-RS256 Ed25519/OKP row, then asserts:
  - `GET /api/auth/jwks` returns 200 with an **RSA-only** key set (no OKP) instead of 500ing.
  - `auth.api.signJWT(...)` (same `getLatestKey` path as the `/get-session` hook) succeeds and signs with **RS256**, never importing the Ed25519 key.
  - This test fails without the fix (it caught a misplaced option during development).
- `yarn lint` — clean (0 errors).
- `yarn build` — succeeds.
- `yarn test` — the full suite passes except 3 pre-existing, unrelated flakes in `lib/utils/request.test.ts` (local `127.0.0.1` HTTP-stream "Premature close"), confirmed failing on the clean base branch too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjsN2dAbdGsmd2B3RoT8yX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjsN2dAbdGsmd2B3RoT8yX)_