### PR TITLE
Bump version to v1.77.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.76.1",
+  "version": "1.77.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.77.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.76.1`
- Base main SHA: `8609afc5c8d638790d87162d140c83b5061a041a`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
