### PR TITLE
none: run scripts via CommonJS bootstrap so they load under ESM project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,9 +298,12 @@ These exact steps are verified to work; the gotchas below are load-bearing.
    # The mock scripts run via swc-node, which does NOT auto-load .env.local.
    # Export the vars into the shell first, then run them:
    set -a; . ./.env.local; set +a
-   # The project is ESM-only, so load swc-node's ESM register hook via --import.
-   node --import @swc-node/register/esm-register scripts/createMockUser.ts      # testuser / test@example.com / testpassword123
-   node --import @swc-node/register/esm-register scripts/createMockStatuses.ts  # seeds Home/No-Announce timeline posts
+   # The project is ESM-only. Run scripts through the scripts/run.cjs bootstrap
+   # (also wired into each script's shebang) so @swc-node/register loads them in
+   # CommonJS mode — this resolves the app's extensionless and CommonJS-named
+   # imports, which Node's strict ESM loader rejects.
+   node scripts/run.cjs scripts/createMockUser.ts      # testuser / test@example.com / testpassword123
+   node scripts/run.cjs scripts/createMockStatuses.ts  # seeds Home/No-Announce timeline posts
    ```
 
    The mock user is created already email-verified, so credential sign-in works.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest",
     "prettier": "prettier --write app migrations lib",
     "prettier:check": "prettier --check app migrations lib",
-    "search:reindex": "node --import @swc-node/register/esm-register scripts/rebuildSearchIndex.ts",
+    "search:reindex": "node scripts/run.cjs scripts/rebuildSearchIndex.ts",
     "migrate": "knex migrate:latest",
     "migrate:make": "knex migrate:make --stub migration.stub",
     "prepare": "husky"

--- a/scripts/cleanupLegacyFitnessHeatmaps.ts
+++ b/scripts/cleanupLegacyFitnessHeatmaps.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Deletes legacy PNG heatmap media captured during the route-heatmap migration.
  *

--- a/scripts/cleanupLegacyHeatmapRegions.ts
+++ b/scripts/cleanupLegacyHeatmapRegions.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Soft-deletes route-heatmap cache rows left in the legacy named-region format
  * (e.g. `region = "netherlands,singapore"`) after the move to the world/rectangle

--- a/scripts/cleanupMediaStorage.ts
+++ b/scripts/cleanupMediaStorage.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to clean up media files that are not referenced in the database
  * Usage: scripts/cleanupMediaStorage [--dry-run] [--yes]

--- a/scripts/createMockFitnessData.ts
+++ b/scripts/createMockFitnessData.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Seeds completed, primary fitness files (with activity metadata) and a few
  * linked fitness posts for the local mock user, so the `/fitness` Overview,
@@ -6,7 +6,7 @@
  *
  * Usage (local SQLite only — never a remote DB):
  *   set -a; . ./.env.local; set +a
- *   node -r @swc-node/register scripts/createMockFitnessData.ts [username]
+ *   node scripts/run.cjs scripts/createMockFitnessData.ts [username]
  *
  * Run after createMockUser.ts.
  */

--- a/scripts/createMockStatuses.ts
+++ b/scripts/createMockStatuses.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { Timeline } from '@/lib/services/timelines/types'

--- a/scripts/createMockUser.ts
+++ b/scripts/createMockUser.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to create a test user for development/testing
  * Usage: scripts/createMockUser [username] [email] [password]

--- a/scripts/downloadProductionArchive.ts
+++ b/scripts/downloadProductionArchive.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Downloads a read-only production snapshot into a local archive.
  *

--- a/scripts/fixAttachmentUrls.ts
+++ b/scripts/fixAttachmentUrls.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Fixes attachment URLs that were saved with the wrong host (e.g. localhost:3000)
  * by replacing the host portion with the correct production host from config.

--- a/scripts/fixStuckFitnessProcessing.ts
+++ b/scripts/fixStuckFitnessProcessing.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to fix fitness files stuck in 'processing' status, typically caused
  * by the Cloud Run instance being killed (e.g. OOM) mid-job before the final

--- a/scripts/importStravaArchive.ts
+++ b/scripts/importStravaArchive.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Imports a Strava archive ZIP locally without a queue worker.
  * Run with --help to see usage.

--- a/scripts/listStravaWebhooks.ts
+++ b/scripts/listStravaWebhooks.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to list Strava webhooks for a given actor
  * Usage: NODE_ENV=production scripts/listStravaWebhooks [@username@domain]

--- a/scripts/manageAdminRole.ts
+++ b/scripts/manageAdminRole.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to add or remove admin role for an account by email
  * Usage:

--- a/scripts/rebuildSearchIndex.ts
+++ b/scripts/rebuildSearchIndex.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 import { loadEnvConfig } from '@next/env'
 
 import { getDatabase } from '@/lib/database'

--- a/scripts/recreateFitnessRouteHeatmaps.ts
+++ b/scripts/recreateFitnessRouteHeatmaps.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Recreates every discoverable route heatmap cache variant for one actor.
  *

--- a/scripts/repairStravaActivityFiles.ts
+++ b/scripts/repairStravaActivityFiles.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Repair script to backfill old Strava activity files with full stream data.
  *

--- a/scripts/restoreProductionArchive.ts
+++ b/scripts/restoreProductionArchive.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Restores a production archive into the configured local database and local
  * filesystem storage.

--- a/scripts/resumeStravaProcessing.ts
+++ b/scripts/resumeStravaProcessing.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Resumes Phase 3 (processFitnessFileJob) for fitness files that were left
  * in 'pending' or 'processing' state after an interrupted importStravaArchive run.

--- a/scripts/retrigerStravaActivities.ts
+++ b/scripts/retrigerStravaActivities.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to re-trigger Strava import for activities that were stored as plain
  * notes instead of fitness activities (e.g. indoor rides with no GPS data that

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -1,0 +1,29 @@
+// CommonJS bootstrap for the TypeScript scripts under `scripts/`.
+//
+// The project is ESM-only (`"type": "module"`), which forces Node to load a
+// `.ts` entry through the ESM loader. `@swc-node/register` then compiles every
+// module to ESNext, so the whole import graph is evaluated as ESM and Node's
+// strict ESM resolver rejects the bundler-style imports the app relies on:
+// extensionless `node_modules` subpaths (e.g. `lodash/memoize`) and named
+// imports from CommonJS packages whose exports aren't statically detectable
+// (e.g. `loadEnvConfig` from `@next/env`).
+//
+// Loading the script from this `.cjs` file instead runs `@swc-node/register` in
+// CommonJS mode: the target `.ts` and its graph are compiled to CommonJS and
+// pulled in via `require()`, whose resolver handles extensionless subpaths and
+// whose interop exposes CommonJS named exports — so the scripts run unchanged.
+//
+// Each script's shebang invokes this bootstrap and `env -S` appends the script
+// path as the final argument:
+//   #!/usr/bin/env -S node scripts/run.cjs
+require('@swc-node/register')
+
+const { resolve } = require('node:path')
+
+const target = process.argv[2]
+if (!target) {
+  console.error('Usage: node scripts/run.cjs <script.ts>')
+  process.exit(1)
+}
+
+require(resolve(target))

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -13,17 +13,30 @@
 // pulled in via `require()`, whose resolver handles extensionless subpaths and
 // whose interop exposes CommonJS named exports — so the scripts run unchanged.
 //
+// The target is loaded as the *main* module so scripts guarded by
+// `require.main === module` still execute, and `process.argv` is reshaped to
+// drop this bootstrap so each script sees its own path and arguments exactly as
+// it would when run directly.
+//
 // Each script's shebang invokes this bootstrap and `env -S` appends the script
 // path as the final argument:
 //   #!/usr/bin/env -S node scripts/run.cjs
 require('@swc-node/register')
 
+const Module = require('node:module')
 const { resolve } = require('node:path')
 
 const target = process.argv[2]
 if (!target) {
-  console.error('Usage: node scripts/run.cjs <script.ts>')
+  console.error('Usage: node scripts/run.cjs <script.ts> [args...]')
   process.exit(1)
 }
 
-require(resolve(target))
+const targetPath = resolve(target)
+
+// Reshape argv to [node, <script>, ...scriptArgs] so positional argument
+// indexes match a direct invocation of the script.
+process.argv = [process.argv[0], targetPath, ...process.argv.slice(3)]
+
+// Load the target as the main module so `require.main === module` holds.
+Module._load(targetPath, null, true)

--- a/scripts/runImportStravaActivity.ts
+++ b/scripts/runImportStravaActivity.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r @swc-node/register
+#!/usr/bin/env -S node scripts/run.cjs
 /**
  * Script to run importStravaActivityJob with CLI-provided Strava credentials.
  * Usage:


### PR DESCRIPTION
## Problem

Running the documented heatmap cleanup command failed:

```
$ NODE_ENV=production scripts/cleanupLegacyHeatmapRegions.ts
Error: Cannot find package '@/lib' imported from .../scripts/cleanupLegacyHeatmapRegions.ts
```

This affects **every** script under `scripts/` — they all share the same shebang.

### Root cause

The project is ESM-only (`"type": "module"`), so Node loads a `.ts` entry through the **ESM** loader. The shebang used `node -r @swc-node/register`, whose CommonJS `require` hook cannot intercept ESM resolution, so the `@/…` path aliases never resolve.

The workaround documented in `AGENTS.md` (`node --import @swc-node/register/esm-register`) gets further but then breaks too. `@swc-node/register` 1.11.1 compiles to ESNext, so the whole graph is evaluated as ESM and Node's strict resolver rejects the bundler-style imports the app relies on:
- extensionless `node_modules` subpaths (e.g. `lodash/memoize`, `next/dist/shared/lib/constants`)
- named imports from CommonJS packages whose exports aren't statically detectable by `cjs-module-lexer` (e.g. `loadEnvConfig` from `@next/env`)

(`@swc-node/register`'s own CommonJS fallback is also broken — it bases `createRequire` on `process.cwd()` with no trailing slash, so it resolves against the *parent* directory, which has no `node_modules`.)

## Fix

Add `scripts/run.cjs`, a CommonJS bootstrap that runs `@swc-node/register` in **CommonJS mode** and `require()`s the target script. The graph is then compiled to CommonJS and resolved/interop'd by the CJS loader — which handles extensionless subpaths and CommonJS named-export interop natively. No app source changes needed.

Every script's shebang (plus the `search:reindex` package script and the `AGENTS.md` quickstart) now points at the bootstrap:

```
#!/usr/bin/env -S node scripts/run.cjs
```

## Verification

Both target commands now run:

```
$ NODE_ENV=production scripts/cleanupLegacyHeatmapRegions.ts
No legacy named-region route heatmaps to clean up.
$ NODE_ENV=production scripts/cleanupLegacyHeatmapRegions.ts --apply
No legacy named-region route heatmaps to clean up.
```

(The configured DB currently has **0** legacy named-region rows, so `--apply` is a no-op.)

- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors (pre-existing warnings only)
- `yarn build` — succeeds
- `yarn test` — 528 files / 4607 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)