### PR TITLE
Bump version to v1.80.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.80.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.79.0`
- Base main SHA: `de47c0cf40ae481de80f880c575a8058794b582d`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
