### PR TITLE
Bump version to v1.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.80.0",
+  "version": "1.81.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.81.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.80.0`
- Base main SHA: `c470fcbb07b13df2e523f68c01db0bc5d448371d`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
