### PR TITLE
fix: render heatmap routes on a real interactive map (Mapbox / free MapLibre) instead of a blank SVG

### DIFF
--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -24,11 +24,21 @@ import type {
   FitnessRouteHeatmapSummaryData
 } from '@/lib/client'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
+import { loadMaplibreModule } from '@/lib/utils/maplibre'
 
-import { FitnessHeatmapView, RouteHeatmapMap } from './FitnessHeatmapView'
+import {
+  FitnessHeatmapView,
+  RouteHeatmapMap,
+  downsampleSegments
+} from './FitnessHeatmapView'
 
 vi.mock('@/lib/utils/mapbox', () => ({
   loadMapboxModule: vi.fn()
+}))
+
+vi.mock('@/lib/utils/maplibre', () => ({
+  OPENFREEMAP_STYLE_URL: 'https://tiles.openfreemap.org/styles/bright',
+  loadMaplibreModule: vi.fn()
 }))
 
 vi.mock('@/lib/client', () => ({
@@ -42,6 +52,9 @@ vi.mock('@/lib/client', () => ({
 
 const mockLoadMapboxModule = loadMapboxModule as jest.MockedFunction<
   typeof loadMapboxModule
+>
+const mockLoadMaplibreModule = loadMaplibreModule as jest.MockedFunction<
+  typeof loadMaplibreModule
 >
 const mockClearFitnessRouteHeatmaps =
   clearFitnessRouteHeatmaps as jest.MockedFunction<
@@ -73,6 +86,24 @@ const createDeferred = <T,>() => {
   })
   return { promise, resolve, reject }
 }
+
+// A minimal GL map double whose `load` handler fires synchronously, so the map
+// reaches its ready state within the test. `onAddSource` lets a test capture the
+// GeoJSON handed to the route layer (or throw to exercise the render fallback).
+const createGlMapConstructor = (
+  onAddSource: (id: string, source: unknown) => void = () => {}
+) =>
+  vi.fn().mockImplementation(function () {
+    return {
+      on: (_event: string, callback: () => void) => callback(),
+      remove: vi.fn(),
+      resize: vi.fn(),
+      addSource: vi.fn(onAddSource),
+      addLayer: vi.fn(),
+      getSource: vi.fn(),
+      fitBounds: vi.fn()
+    }
+  })
 
 const completedHeatmap: FitnessRouteHeatmapData = {
   id: 'route-heatmap-1',
@@ -180,6 +211,8 @@ describe('FitnessHeatmapView', () => {
     mockClearFitnessRouteHeatmaps.mockResolvedValue(0)
     mockDeleteFitnessRouteHeatmap.mockResolvedValue(true)
     mockTriggerFitnessRouteHeatmap.mockResolvedValue(true)
+    // No Mapbox token in these tests, so the view uses the keyless MapLibre map.
+    mockLoadMaplibreModule.mockResolvedValue({ Map: createGlMapConstructor() })
   })
 
   afterEach(() => {
@@ -260,7 +293,7 @@ describe('FitnessHeatmapView', () => {
     rerender(<FitnessHeatmapView actorId="https://llun.test/users/second" />)
 
     await waitFor(() => {
-      expect(screen.getByText('Routes')).toBeInTheDocument()
+      expect(screen.getByText('OpenFreeMap')).toBeInTheDocument()
     })
 
     await act(async () => {
@@ -269,14 +302,14 @@ describe('FitnessHeatmapView', () => {
     })
 
     expect(mockTriggerFitnessRouteHeatmap).not.toHaveBeenCalled()
-    expect(screen.getByText('Routes')).toBeInTheDocument()
+    expect(screen.getByText('OpenFreeMap')).toBeInTheDocument()
   })
 
   it('keeps completed refreshes on the normal deduplicated enqueue path', async () => {
     render(<FitnessHeatmapView actorId="https://llun.test/users/llun" />)
 
     await waitFor(() => {
-      expect(screen.getByText('Routes')).toBeInTheDocument()
+      expect(screen.getByText('OpenFreeMap')).toBeInTheDocument()
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Generate heatmap/i }))
@@ -585,14 +618,24 @@ describe('RouteHeatmapMap', () => {
     vi.clearAllMocks()
   })
 
-  it('renders the SVG route fallback when Mapbox is not configured', () => {
+  it('renders the keyless OpenFreeMap map when Mapbox is not configured', async () => {
+    const mapConstructor = createGlMapConstructor()
+    mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
+
     const { container } = render(<RouteHeatmapMap heatmap={completedHeatmap} />)
 
-    expect(screen.getByText('Routes')).toBeInTheDocument()
-    expect(container.querySelector('polyline')).toBeInTheDocument()
+    await waitFor(() => expect(mapConstructor).toHaveBeenCalled())
+    expect(await screen.findByText('OpenFreeMap')).toBeInTheDocument()
+    // No static SVG image is generated — the routes render on a real GL map.
+    expect(container.querySelector('svg')).not.toBeInTheDocument()
+    expect(mockLoadMapboxModule).not.toHaveBeenCalled()
+    expect(mapConstructor.mock.calls[0][0]).toMatchObject({
+      style: 'https://tiles.openfreemap.org/styles/bright',
+      attributionControl: true
+    })
   })
 
-  it('renders an empty route state', () => {
+  it('renders an empty route state without loading any map provider', () => {
     render(
       <RouteHeatmapMap
         heatmap={{
@@ -607,33 +650,25 @@ describe('RouteHeatmapMap', () => {
     expect(
       screen.getByText('No route data for this selection')
     ).toBeInTheDocument()
+    expect(mockLoadMaplibreModule).not.toHaveBeenCalled()
+    expect(mockLoadMapboxModule).not.toHaveBeenCalled()
   })
 
   it('uses Mapbox when a token is configured', async () => {
-    const mapConstructor = vi.fn().mockImplementation(function () {
-      return {
-        on: (_event: string, callback: () => void) => callback(),
-        remove: vi.fn(),
-        resize: vi.fn(),
-        addSource: vi.fn(),
-        addLayer: vi.fn(),
-        getSource: vi.fn(),
-        fitBounds: vi.fn()
-      }
-    })
-    mockLoadMapboxModule.mockResolvedValue({
-      Map: mapConstructor
-    })
+    const mapConstructor = createGlMapConstructor()
+    mockLoadMapboxModule.mockResolvedValue({ Map: mapConstructor })
 
-    render(
+    const { container } = render(
       <RouteHeatmapMap
         heatmap={completedHeatmap}
         mapboxAccessToken="mapbox-token"
       />
     )
 
-    expect(screen.getByText('Mapbox')).toBeInTheDocument()
     await waitFor(() => expect(mapConstructor).toHaveBeenCalled())
+    expect(await screen.findByText('Mapbox')).toBeInTheDocument()
+    expect(container.querySelector('svg')).not.toBeInTheDocument()
+    expect(mockLoadMaplibreModule).not.toHaveBeenCalled()
     expect(mapConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
         accessToken: 'mapbox-token',
@@ -642,112 +677,62 @@ describe('RouteHeatmapMap', () => {
     )
   })
 
-  it('falls back with a diagnostic reason when Mapbox setup fails', async () => {
-    const mapConstructor = vi.fn().mockImplementation(function () {
-      return {
-        on: (_event: string, callback: () => void) => callback(),
-        remove: vi.fn(),
-        resize: vi.fn(),
-        addSource: vi.fn(() => {
-          throw new Error('source unavailable')
-        }),
-        addLayer: vi.fn(),
-        getSource: vi.fn(),
-        fitBounds: vi.fn()
-      }
+  it('shows a non-SVG fallback message when the map fails to render', async () => {
+    const mapConstructor = createGlMapConstructor(() => {
+      throw new Error('source unavailable')
     })
-    mockLoadMapboxModule.mockResolvedValue({
-      Map: mapConstructor
-    })
+    mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
 
-    const { container } = render(
-      <RouteHeatmapMap
-        heatmap={completedHeatmap}
-        mapboxAccessToken="mapbox-token"
-      />
-    )
+    const { container } = render(<RouteHeatmapMap heatmap={completedHeatmap} />)
 
-    await waitFor(() => expect(screen.getByText('Routes')).toBeInTheDocument())
-    expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
     expect(
-      container.querySelector('[data-mapbox-fallback-reason="render-failed"]')
+      await screen.findByText('Map unavailable. Try regenerating this heatmap.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('OpenFreeMap')).not.toBeInTheDocument()
+    expect(container.querySelector('svg')).not.toBeInTheDocument()
+    expect(
+      container.querySelector('[data-map-fallback-reason="render-failed"]')
     ).toBeInTheDocument()
     expect(
-      container.querySelector(
-        '[data-mapbox-fallback-error="source unavailable"]'
-      )
+      container.querySelector('[data-map-fallback-error="source unavailable"]')
     ).toBeInTheDocument()
   })
 
-  it('falls back with a diagnostic reason when Mapbox fails to load', async () => {
-    mockLoadMapboxModule.mockRejectedValue(new Error('module unavailable'))
+  it('shows a non-SVG fallback message when the map module fails to load', async () => {
+    mockLoadMaplibreModule.mockRejectedValue(new Error('module unavailable'))
 
-    const { container } = render(
-      <RouteHeatmapMap
-        heatmap={completedHeatmap}
-        mapboxAccessToken="mapbox-token"
-      />
-    )
+    const { container } = render(<RouteHeatmapMap heatmap={completedHeatmap} />)
 
-    await waitFor(() => expect(screen.getByText('Routes')).toBeInTheDocument())
-    expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
     expect(
-      container.querySelector(
-        '[data-mapbox-fallback-reason="module-load-failed"]'
-      )
+      await screen.findByText('Map unavailable. Try regenerating this heatmap.')
+    ).toBeInTheDocument()
+    expect(container.querySelector('svg')).not.toBeInTheDocument()
+    expect(
+      container.querySelector('[data-map-fallback-reason="module-load-failed"]')
     ).toBeInTheDocument()
     expect(
-      container.querySelector(
-        '[data-mapbox-fallback-error="module unavailable"]'
-      )
+      container.querySelector('[data-map-fallback-error="module unavailable"]')
     ).toBeInTheDocument()
   })
 
-  it('retries Mapbox when the same route cache is regenerated', async () => {
-    const failingMapConstructor = vi.fn().mockImplementation(function () {
-      return {
-        on: (_event: string, callback: () => void) => callback(),
-        remove: vi.fn(),
-        resize: vi.fn(),
-        addSource: vi.fn(() => {
-          throw new Error('source unavailable')
-        }),
-        addLayer: vi.fn(),
-        getSource: vi.fn(),
-        fitBounds: vi.fn()
-      }
+  it('retries the map when the same route cache is regenerated', async () => {
+    const failingMapConstructor = createGlMapConstructor(() => {
+      throw new Error('source unavailable')
     })
-    mockLoadMapboxModule.mockResolvedValue({
-      Map: failingMapConstructor
-    })
+    mockLoadMaplibreModule.mockResolvedValue({ Map: failingMapConstructor })
 
     const { container, rerender } = render(
-      <RouteHeatmapMap
-        heatmap={completedHeatmap}
-        mapboxAccessToken="mapbox-token"
-      />
+      <RouteHeatmapMap heatmap={completedHeatmap} />
     )
 
     await waitFor(() =>
       expect(
-        container.querySelector('[data-mapbox-fallback-reason="render-failed"]')
+        container.querySelector('[data-map-fallback-reason="render-failed"]')
       ).toBeInTheDocument()
     )
 
-    const workingMapConstructor = vi.fn().mockImplementation(function () {
-      return {
-        on: (_event: string, callback: () => void) => callback(),
-        remove: vi.fn(),
-        resize: vi.fn(),
-        addSource: vi.fn(),
-        addLayer: vi.fn(),
-        getSource: vi.fn(),
-        fitBounds: vi.fn()
-      }
-    })
-    mockLoadMapboxModule.mockResolvedValue({
-      Map: workingMapConstructor
-    })
+    const workingMapConstructor = createGlMapConstructor()
+    mockLoadMaplibreModule.mockResolvedValue({ Map: workingMapConstructor })
 
     rerender(
       <RouteHeatmapMap
@@ -755,49 +740,76 @@ describe('RouteHeatmapMap', () => {
           ...completedHeatmap,
           updatedAt: completedHeatmap.updatedAt + 1
         }}
-        mapboxAccessToken="mapbox-token"
       />
     )
 
-    await waitFor(() => expect(screen.getByText('Mapbox')).toBeInTheDocument())
     await waitFor(() => expect(workingMapConstructor).toHaveBeenCalled())
+    expect(await screen.findByText('OpenFreeMap')).toBeInTheDocument()
     expect(
-      container.querySelector('[data-mapbox-fallback-reason]')
+      container.querySelector('[data-map-fallback-reason]')
     ).not.toBeInTheDocument()
   })
 
-  it('uses the SVG route fallback for large route caches', () => {
+  it('downsamples large route caches yet still renders an interactive map', async () => {
     const largeHeatmap = buildLargeHeatmap()
+    let renderedFeatureCount = 0
+    const mapConstructor = createGlMapConstructor((_id, source) => {
+      const data = (source as { data?: { features?: unknown[] } }).data
+      renderedFeatureCount = data?.features?.length ?? 0
+    })
+    mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
 
-    const { container } = render(
-      <RouteHeatmapMap
-        heatmap={largeHeatmap}
-        mapboxAccessToken="mapbox-token"
-      />
+    const { container } = render(<RouteHeatmapMap heatmap={largeHeatmap} />)
+
+    await waitFor(() => expect(mapConstructor).toHaveBeenCalled())
+    expect(await screen.findByText('OpenFreeMap')).toBeInTheDocument()
+    // Large caches still render on a real GL map (no static SVG, no fallback).
+    expect(container.querySelector('svg')).not.toBeInTheDocument()
+    expect(
+      container.querySelector('[data-map-fallback-reason]')
+    ).not.toBeInTheDocument()
+    expect(renderedFeatureCount).toBe(largeHeatmap.segments.length)
+  })
+
+  it('thins oversized geometry while preserving each segment’s endpoints', () => {
+    const longSegment = {
+      points: Array.from({ length: 12 }, (_, index) => ({
+        lat: index,
+        lng: index
+      }))
+    }
+    const shortSegment = {
+      points: [
+        { lat: 0, lng: 0 },
+        { lat: 1, lng: 1 }
+      ]
+    }
+
+    const [thinned, untouched] = downsampleSegments(
+      [longSegment, shortSegment],
+      6
     )
 
-    expect(screen.getByText('Routes')).toBeInTheDocument()
-    expect(
-      screen.getByText('Interactive map unavailable. Showing routes.')
-    ).toBeInTheDocument()
-    expect(screen.queryByText('Mapbox')).not.toBeInTheDocument()
-    const polylines = Array.from(container.querySelectorAll('polyline'))
-    expect(polylines).toHaveLength(largeHeatmap.segments.length)
-    expect(
-      polylines.map(
-        (polyline) =>
-          polyline.getAttribute('points')?.trim().split(/\s+/).filter(Boolean)
-            .length ?? 0
-      )
-    ).toEqual(largeHeatmap.segments.map((segment) => segment.points.length))
-    expect(
-      container.querySelector(
-        '[data-mapbox-fallback-reason="route-cache-too-large"]'
-      )
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector('[data-mapbox-fallback-error]')
-    ).not.toBeInTheDocument()
-    expect(mockLoadMapboxModule).not.toHaveBeenCalled()
+    expect(thinned.points.length).toBeLessThan(longSegment.points.length)
+    expect(thinned.points[0]).toEqual(longSegment.points[0])
+    expect(thinned.points[thinned.points.length - 1]).toEqual(
+      longSegment.points[longSegment.points.length - 1]
+    )
+    // Segments with two or fewer points are left exactly as-is.
+    expect(untouched).toBe(shortSegment)
+  })
+
+  it('returns the original segments unchanged when under the budget', () => {
+    const segments = [
+      {
+        points: [
+          { lat: 0, lng: 0 },
+          { lat: 1, lng: 1 },
+          { lat: 2, lng: 2 }
+        ]
+      }
+    ]
+
+    expect(downsampleSegments(segments, 100)).toBe(segments)
   })
 })

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -824,6 +824,41 @@ describe('RouteHeatmapMap', () => {
     }
   })
 
+  it('keeps a successfully loaded map past the watchdog window', async () => {
+    vi.useFakeTimers()
+    try {
+      // This GL double fires 'load' synchronously, so the watchdog is cleared.
+      const mapConstructor = createGlMapConstructor()
+      mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
+
+      const { container } = render(
+        <RouteHeatmapMap heatmap={completedHeatmap} />
+      )
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(screen.getByText('OpenFreeMap')).toBeInTheDocument()
+
+      // Advancing past the 20s watchdog must NOT flip a loaded map to the
+      // fallback — the success path clears the timer.
+      await act(async () => {
+        vi.advanceTimersByTime(20_000)
+      })
+
+      expect(screen.getByText('OpenFreeMap')).toBeInTheDocument()
+      expect(
+        screen.queryByText('Map unavailable. Try regenerating this heatmap.')
+      ).not.toBeInTheDocument()
+      expect(
+        container.querySelector('[data-map-fallback-reason]')
+      ).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('retries the map when the same route cache is regenerated', async () => {
     const failingMapConstructor = createGlMapConstructor(() => {
       throw new Error('source unavailable')

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -779,6 +779,51 @@ describe('RouteHeatmapMap', () => {
     ).toBeInTheDocument()
   })
 
+  it('falls back when the map never reaches its load event', async () => {
+    vi.useFakeTimers()
+    try {
+      // A map double whose 'load' event never fires (e.g. the style never
+      // fetches), so only the load watchdog can resolve the loading state.
+      const mapConstructor = vi.fn().mockImplementation(function () {
+        return {
+          on: vi.fn(),
+          remove: vi.fn(),
+          resize: vi.fn(),
+          addSource: vi.fn(),
+          addLayer: vi.fn(),
+          getSource: vi.fn(),
+          fitBounds: vi.fn()
+        }
+      })
+      mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
+
+      const { container } = render(
+        <RouteHeatmapMap heatmap={completedHeatmap} />
+      )
+
+      // Flush the module-load promise so the map is created and the watchdog armed.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(mapConstructor).toHaveBeenCalled()
+      expect(screen.getByText('Loading map…')).toBeInTheDocument()
+
+      await act(async () => {
+        vi.advanceTimersByTime(20_000)
+      })
+
+      expect(
+        screen.getByText('Map unavailable. Try regenerating this heatmap.')
+      ).toBeInTheDocument()
+      expect(
+        container.querySelector('[data-map-fallback-reason="load-timeout"]')
+      ).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('retries the map when the same route cache is regenerated', async () => {
     const failingMapConstructor = createGlMapConstructor(() => {
       throw new Error('source unavailable')
@@ -817,9 +862,19 @@ describe('RouteHeatmapMap', () => {
   it('downsamples large route caches yet still renders an interactive map', async () => {
     const largeHeatmap = buildLargeHeatmap()
     let renderedFeatureCount = 0
+    let renderedVertexCount = 0
     const mapConstructor = createGlMapConstructor((_id, source) => {
-      const data = (source as { data?: { features?: unknown[] } }).data
-      renderedFeatureCount = data?.features?.length ?? 0
+      const features =
+        (
+          source as {
+            data?: { features?: { geometry: { coordinates: unknown[] } }[] }
+          }
+        ).data?.features ?? []
+      renderedFeatureCount = features.length
+      renderedVertexCount = features.reduce(
+        (sum, feature) => sum + feature.geometry.coordinates.length,
+        0
+      )
     })
     mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
 
@@ -832,7 +887,12 @@ describe('RouteHeatmapMap', () => {
     expect(
       container.querySelector('[data-map-fallback-reason]')
     ).not.toBeInTheDocument()
+    // Every route still renders, but the geometry handed to the GL layer is
+    // actually thinned — far below the raw point count and near the budget.
     expect(renderedFeatureCount).toBe(largeHeatmap.segments.length)
+    expect(renderedVertexCount).toBeGreaterThan(0)
+    expect(renderedVertexCount).toBeLessThan(largeHeatmap.pointCount)
+    expect(renderedVertexCount).toBeLessThanOrEqual(50_000)
   })
 
   it('thins oversized geometry while preserving each segment’s endpoints', () => {

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -628,11 +628,75 @@ describe('RouteHeatmapMap', () => {
     expect(await screen.findByText('OpenFreeMap')).toBeInTheDocument()
     // No static SVG image is generated — the routes render on a real GL map.
     expect(container.querySelector('svg')).not.toBeInTheDocument()
+    // The GL container keeps an accessible name (the removed SVG used to carry it).
+    expect(
+      screen.getByRole('img', { name: 'Fitness route heatmap' })
+    ).toBeInTheDocument()
     expect(mockLoadMapboxModule).not.toHaveBeenCalled()
     expect(mapConstructor.mock.calls[0][0]).toMatchObject({
       style: 'https://tiles.openfreemap.org/styles/bright',
       attributionControl: true
     })
+  })
+
+  it('shows a loading indicator until the map finishes initializing', async () => {
+    const deferred = createDeferred<{ Map: ReturnType<typeof vi.fn> }>()
+    mockLoadMaplibreModule.mockReturnValue(deferred.promise)
+
+    render(<RouteHeatmapMap heatmap={completedHeatmap} />)
+
+    // The module hasn't resolved yet, so the map is still initializing.
+    expect(await screen.findByText('Loading map…')).toBeInTheDocument()
+    expect(screen.queryByText('OpenFreeMap')).not.toBeInTheDocument()
+
+    await act(async () => {
+      deferred.resolve({ Map: createGlMapConstructor() })
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText('OpenFreeMap')).toBeInTheDocument()
+    expect(screen.queryByText('Loading map…')).not.toBeInTheDocument()
+  })
+
+  it('pushes updated geometry to the existing source when the cache changes', async () => {
+    const setData = vi.fn()
+    const mapConstructor = createGlMapConstructor()
+    mapConstructor.mockImplementation(function () {
+      return {
+        on: (_event: string, callback: () => void) => callback(),
+        remove: vi.fn(),
+        resize: vi.fn(),
+        addSource: vi.fn(),
+        addLayer: vi.fn(),
+        getSource: vi.fn(() => ({ setData })),
+        fitBounds: vi.fn()
+      }
+    })
+    mockLoadMaplibreModule.mockResolvedValue({ Map: mapConstructor })
+
+    const { rerender } = render(<RouteHeatmapMap heatmap={completedHeatmap} />)
+    await screen.findByText('OpenFreeMap')
+    setData.mockClear()
+
+    rerender(
+      <RouteHeatmapMap
+        heatmap={{
+          ...completedHeatmap,
+          updatedAt: completedHeatmap.updatedAt + 1,
+          segments: [
+            {
+              points: [
+                { lat: 52.36, lng: 4.88 },
+                { lat: 52.37, lng: 4.89 },
+                { lat: 52.39, lng: 4.91 }
+              ]
+            }
+          ]
+        }}
+      />
+    )
+
+    await waitFor(() => expect(setData).toHaveBeenCalledTimes(1))
   })
 
   it('renders an empty route state without loading any map provider', () => {
@@ -785,11 +849,11 @@ describe('RouteHeatmapMap', () => {
       ]
     }
 
-    const [thinned, untouched] = downsampleSegments(
-      [longSegment, shortSegment],
-      6
-    )
+    const result = downsampleSegments([longSegment, shortSegment], 6)
+    const [thinned, untouched] = result
 
+    // No segment is dropped — the route count is preserved.
+    expect(result).toHaveLength(2)
     expect(thinned.points.length).toBeLessThan(longSegment.points.length)
     expect(thinned.points[0]).toEqual(longSegment.points[0])
     expect(thinned.points[thinned.points.length - 1]).toEqual(

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -85,11 +85,11 @@ const ROUTE_HEATMAP_POLLING_INTERVAL_MS = 5000
 const STALLED_POLLING_LIMIT = 30
 // Keep recent background jobs live while ignoring restored/stuck rows that are days old.
 const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
-// Cap on route vertices handed to the GL line layer. A whole-world, all-time
+// Target vertex count handed to the GL line layer. A whole-world, all-time
 // cache can aggregate hundreds of thousands of points and staging reproduced
-// blank GL canvases past ~80k, so the geometry is uniformly downsampled to stay
-// well under that. This keeps the map fully interactive (pan/zoom) instead of
-// dropping to a static, non-interactive fallback.
+// blank GL canvases past ~80k, so the geometry is uniformly downsampled toward
+// this budget (see downsampleSegments). This keeps the map fully interactive
+// (pan/zoom) instead of dropping to a static, non-interactive fallback.
 const ROUTE_RENDER_POINT_BUDGET = 40_000
 const ROUTE_HEATMAP_MAP_HEIGHT_CLASS = 'h-[420px]'
 
@@ -234,9 +234,14 @@ const buildRouteGeoJson = (segments: FitnessRouteHeatmapSegment[]) => ({
     }))
 })
 
-// Uniformly thin route geometry so the GL line layer never receives more than
-// `maxPoints` vertices (a whole-world cache can aggregate far more). Each
-// segment keeps its first and last vertex so routes still span their extent.
+// Thin route geometry toward `maxPoints` vertices so the GL line layer stays
+// performant on large caches (a whole-world cache can aggregate far more). The
+// stride is derived from the global vertex total, so it bounds the dominant cost
+// — long routes — proportionally; each segment still keeps its first and last
+// vertex, so routes span their full extent. This is a best-effort target, not a
+// hard ceiling: the per-segment endpoint floor (~2 vertices per segment) keeps a
+// realistic many-route cache well under budget, but pathological inputs (tens of
+// thousands of tiny segments) could still exceed it.
 export const downsampleSegments = (
   segments: FitnessRouteHeatmapSegment[],
   maxPoints: number
@@ -456,7 +461,20 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
         ROUTE_HEATMAP_MAP_HEIGHT_CLASS
       )}
     >
-      <div ref={containerRef} className="h-full w-full" />
+      <div
+        ref={containerRef}
+        role="img"
+        aria-label="Fitness route heatmap"
+        className="h-full w-full"
+      />
+      {!isMapLoaded && (
+        <div
+          role="status"
+          className="absolute inset-0 flex items-center justify-center gap-2 bg-muted/60 text-sm text-muted-foreground"
+        >
+          <Loader2 className="size-4 animate-spin" /> Loading map…
+        </div>
+      )}
       {isMapLoaded && (
         <div className="pointer-events-none absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
           {provider.label}

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -73,7 +73,7 @@ type RouteGlModule = {
   Map: new (options: Record<string, unknown>) => RouteGlMap
 }
 
-type MapFallbackReason = 'module-load-failed' | 'render-failed'
+type MapFallbackReason = 'module-load-failed' | 'render-failed' | 'load-timeout'
 
 interface MapFallbackError {
   message: string
@@ -91,6 +91,10 @@ const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
 // this budget (see downsampleSegments). This keeps the map fully interactive
 // (pan/zoom) instead of dropping to a static, non-interactive fallback.
 const ROUTE_RENDER_POINT_BUDGET = 40_000
+// Fall back to the "Map unavailable" message if the GL map never reaches its
+// 'load' event (e.g. the style/tiles fail to fetch after the JS bundle loaded),
+// instead of spinning the "Loading map…" overlay forever. Mirrors RegionMap.
+const MAP_LOAD_TIMEOUT_MS = 20_000
 const ROUTE_HEATMAP_MAP_HEIGHT_CLASS = 'h-[420px]'
 
 const ROUTE_LINE_STYLES = {
@@ -352,6 +356,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     }
 
     let cancelled = false
+    let loadWatchdog: ReturnType<typeof setTimeout> | undefined
     const mapBounds: [[number, number], [number, number]] = [
       [bounds.minLng, bounds.minLat],
       [bounds.maxLng, bounds.maxLat]
@@ -370,8 +375,21 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
         })
         mapRef.current = map
 
+        // The module promise resolving only means the JS bundle loaded; if the
+        // style/tiles never fetch, 'load' never fires and neither does .catch.
+        // Without this the "Loading map…" overlay would spin forever.
+        loadWatchdog = setTimeout(() => {
+          if (!cancelled) {
+            setMapFallbackError({
+              message: 'Map timed out before the style finished loading'
+            })
+            setMapFallbackReason('load-timeout')
+          }
+        }, MAP_LOAD_TIMEOUT_MS)
+
         map.on('load', () => {
           if (cancelled) return
+          if (loadWatchdog) clearTimeout(loadWatchdog)
           try {
             map.resize()
             map.addSource('route-heatmap', {
@@ -407,6 +425,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
     return () => {
       cancelled = true
+      if (loadWatchdog) clearTimeout(loadWatchdog)
       mapRef.current?.remove()
       mapRef.current = null
     }

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -45,10 +45,7 @@ import {
 } from '@/lib/fitness/regions'
 import { cn } from '@/lib/utils'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
-import {
-  getZoomLevelForBounds,
-  projectWebMercator
-} from '@/lib/utils/webMercator'
+import { OPENFREEMAP_STYLE_URL, loadMaplibreModule } from '@/lib/utils/maplibre'
 
 type PeriodType = 'all_time' | 'yearly' | 'monthly'
 
@@ -57,7 +54,9 @@ interface Props {
   mapboxAccessToken?: string
 }
 
-type MapboxMap = {
+// The Mapbox GL / MapLibre GL surface — only the members this component drives.
+// Both libraries share this subset, so one component can drive either provider.
+type RouteGlMap = {
   on: (event: string, callback: () => void) => void
   remove: () => void
   resize: () => void
@@ -70,31 +69,28 @@ type MapboxMap = {
   ) => void
 }
 
-type MapboxGL = {
-  Map: new (options: Record<string, unknown>) => MapboxMap
+type RouteGlModule = {
+  Map: new (options: Record<string, unknown>) => RouteGlMap
 }
 
-type MapboxFallbackReason =
-  | 'module-load-failed'
-  | 'render-failed'
-  | 'route-cache-too-large'
+type MapFallbackReason = 'module-load-failed' | 'render-failed'
 
-interface MapboxFallbackError {
+interface MapFallbackError {
   message: string
   stack?: string
 }
 
-const MAP_WIDTH = 960
-const MAP_HEIGHT = 560
-const MAP_PADDING = 52
 const currentYear = new Date().getUTCFullYear()
 const ROUTE_HEATMAP_POLLING_INTERVAL_MS = 5000
 const STALLED_POLLING_LIMIT = 30
 // Keep recent background jobs live while ignoring restored/stuck rows that are days old.
 const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
-// Conservative cap: staging reproduced blank Mapbox canvases around 80k route points.
-// Keep a 4x safety margin until this path has browser/device benchmarks.
-const MAPBOX_MAX_ROUTE_POINTS = 20_000
+// Cap on route vertices handed to the GL line layer. A whole-world, all-time
+// cache can aggregate hundreds of thousands of points and staging reproduced
+// blank GL canvases past ~80k, so the geometry is uniformly downsampled to stay
+// well under that. This keeps the map fully interactive (pan/zoom) instead of
+// dropping to a static, non-interactive fallback.
+const ROUTE_RENDER_POINT_BUDGET = 40_000
 const ROUTE_HEATMAP_MAP_HEIGHT_CLASS = 'h-[420px]'
 
 const ROUTE_LINE_STYLES = {
@@ -109,7 +105,7 @@ const ROUTE_LINE_STYLES = {
     opacity: 0.14
   }
 } as const
-const MAPBOX_ROUTE_LINE_PAINT = {
+const ROUTE_LINE_PAINT = {
   'line-color': [
     'case',
     ['boolean', ['get', 'isHiddenByPrivacy'], false],
@@ -131,10 +127,7 @@ const MAPBOX_ROUTE_LINE_PAINT = {
   'line-blur': 0.8
 } as const
 
-const getRouteLineStyle = (isHiddenByPrivacy: boolean) =>
-  isHiddenByPrivacy ? ROUTE_LINE_STYLES.hidden : ROUTE_LINE_STYLES.visible
-
-const getMapboxFallbackError = (error: unknown): MapboxFallbackError => {
+const getMapFallbackError = (error: unknown): MapFallbackError => {
   if (error instanceof Error) {
     return {
       message: error.message,
@@ -241,52 +234,34 @@ const buildRouteGeoJson = (segments: FitnessRouteHeatmapSegment[]) => ({
     }))
 })
 
-const buildSvgMap = (heatmap: FitnessRouteHeatmapData) => {
-  if (!heatmap.bounds || heatmap.segments.length === 0) {
-    return null
+// Uniformly thin route geometry so the GL line layer never receives more than
+// `maxPoints` vertices (a whole-world cache can aggregate far more). Each
+// segment keeps its first and last vertex so routes still span their extent.
+export const downsampleSegments = (
+  segments: FitnessRouteHeatmapSegment[],
+  maxPoints: number
+): FitnessRouteHeatmapSegment[] => {
+  const totalPoints = segments.reduce(
+    (sum, segment) => sum + segment.points.length,
+    0
+  )
+  if (totalPoints <= maxPoints) {
+    return segments
   }
 
-  const zoom = Math.min(
-    15,
-    getZoomLevelForBounds({
-      bounds: heatmap.bounds,
-      width: MAP_WIDTH,
-      height: MAP_HEIGHT,
-      padding: MAP_PADDING
-    })
-  )
-  const southWest = projectWebMercator(
-    { lat: heatmap.bounds.minLat, lng: heatmap.bounds.minLng },
-    zoom
-  )
-  const northEast = projectWebMercator(
-    { lat: heatmap.bounds.maxLat, lng: heatmap.bounds.maxLng },
-    zoom
-  )
-  const centerX = (southWest.x + northEast.x) / 2
-  const centerY = (southWest.y + northEast.y) / 2
-  const topLeftX = centerX - MAP_WIDTH / 2
-  const topLeftY = centerY - MAP_HEIGHT / 2
+  const stride = Math.ceil(totalPoints / maxPoints)
+  return segments.map((segment) => {
+    if (segment.points.length <= 2) {
+      return segment
+    }
 
-  const lines = heatmap.segments
-    .filter((segment) => segment.points.length >= 2)
-    .map((segment, index) => {
-      const isHiddenByPrivacy = Boolean(segment.isHiddenByPrivacy)
-      return {
-        key: `${heatmap.id}-${index}`,
-        style: getRouteLineStyle(isHiddenByPrivacy),
-        points: segment.points
-          .map((point) => {
-            const projected = projectWebMercator(point, zoom)
-            return `${(projected.x - topLeftX).toFixed(1)},${(
-              projected.y - topLeftY
-            ).toFixed(1)}`
-          })
-          .join(' ')
-      }
-    })
-
-  return { lines }
+    const points = segment.points.filter((_, index) => index % stride === 0)
+    const lastPoint = segment.points[segment.points.length - 1]
+    if (points[points.length - 1] !== lastPoint) {
+      points.push(lastPoint)
+    }
+    return { ...segment, points }
+  })
 }
 
 interface RouteHeatmapMapProps {
@@ -294,45 +269,64 @@ interface RouteHeatmapMapProps {
   mapboxAccessToken?: string
 }
 
+interface RouteMapProvider {
+  loadModule: () => Promise<RouteGlModule>
+  mapOptions: Record<string, unknown>
+  label: string
+}
+
 export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   heatmap,
   mapboxAccessToken
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const mapRef = useRef<MapboxMap | null>(null)
+  const mapRef = useRef<RouteGlMap | null>(null)
   const routeGeoJsonRef = useRef(buildRouteGeoJson([]))
-  const [runtimeMapboxFallbackReason, setRuntimeMapboxFallbackReason] =
-    useState<Exclude<MapboxFallbackReason, 'route-cache-too-large'> | null>(
-      null
-    )
-  const [mapboxFallbackError, setMapboxFallbackError] =
-    useState<MapboxFallbackError | null>(null)
+  const [mapFallbackReason, setMapFallbackReason] =
+    useState<MapFallbackReason | null>(null)
+  const [mapFallbackError, setMapFallbackError] =
+    useState<MapFallbackError | null>(null)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
 
   const hasRoutes =
     heatmap?.status === 'completed' &&
     heatmap.segments.some((segment) => segment.points.length >= 2)
   const bounds = heatmap?.bounds
-  const isWithinMapboxBudget =
-    heatmap !== null && heatmap.pointCount <= MAPBOX_MAX_ROUTE_POINTS
-  const budgetMapboxFallbackReason: MapboxFallbackReason | null =
-    mapboxAccessToken && hasRoutes && !isWithinMapboxBudget
-      ? 'route-cache-too-large'
-      : null
-  const mapboxFallbackReason =
-    runtimeMapboxFallbackReason ?? budgetMapboxFallbackReason
-  const mapboxFallbackErrorMessage =
+
+  // Mapbox when a public token is configured; otherwise the keyless MapLibre +
+  // OpenFreeMap provider, so the heatmap always renders on a real, interactive
+  // map without an API key (instead of a static, non-interactive image).
+  const provider = useMemo<RouteMapProvider>(
+    () =>
+      mapboxAccessToken
+        ? {
+            loadModule: () => loadMapboxModule<RouteGlModule>(),
+            mapOptions: {
+              style: 'mapbox://styles/mapbox/outdoors-v12',
+              accessToken: mapboxAccessToken
+            },
+            label: 'Mapbox'
+          }
+        : {
+            loadModule: () => loadMaplibreModule<RouteGlModule>(),
+            mapOptions: { style: OPENFREEMAP_STYLE_URL },
+            label: 'OpenFreeMap'
+          },
+    [mapboxAccessToken]
+  )
+
+  const mapFallbackErrorMessage =
     process.env.NODE_ENV !== 'production'
-      ? mapboxFallbackError?.message
+      ? mapFallbackError?.message
       : undefined
-  const shouldUseMapbox =
-    Boolean(mapboxAccessToken) &&
-    hasRoutes &&
-    Boolean(bounds) &&
-    isWithinMapboxBudget &&
-    !runtimeMapboxFallbackReason
+  const shouldRenderMap = hasRoutes && Boolean(bounds) && !mapFallbackReason
   const routeGeoJson = useMemo(
-    () => buildRouteGeoJson(hasRoutes && heatmap ? heatmap.segments : []),
+    () =>
+      buildRouteGeoJson(
+        hasRoutes && heatmap
+          ? downsampleSegments(heatmap.segments, ROUTE_RENDER_POINT_BUDGET)
+          : []
+      ),
     [hasRoutes, heatmap?.id, heatmap?.updatedAt]
   )
 
@@ -340,13 +334,15 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     routeGeoJsonRef.current = routeGeoJson
   }, [routeGeoJson])
 
+  // Clear the fallback whenever the cache or provider changes so a recovered
+  // map gets a fresh attempt.
   useEffect(() => {
-    setRuntimeMapboxFallbackReason(null)
-    setMapboxFallbackError(null)
-  }, [heatmap?.id, heatmap?.updatedAt, mapboxAccessToken])
+    setMapFallbackReason(null)
+    setMapFallbackError(null)
+  }, [heatmap?.id, heatmap?.updatedAt, provider])
 
   useEffect(() => {
-    if (!shouldUseMapbox || !containerRef.current || !bounds) {
+    if (!shouldRenderMap || !containerRef.current || !bounds) {
       return
     }
 
@@ -357,22 +353,20 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     ]
     setIsMapLoaded(false)
 
-    loadMapboxModule<MapboxGL>()
-      .then((mapboxgl) => {
+    provider
+      .loadModule()
+      .then((gl) => {
         if (cancelled || !containerRef.current) return
 
-        const map = new mapboxgl.Map({
+        const map = new gl.Map({
           container: containerRef.current,
-          style: 'mapbox://styles/mapbox/outdoors-v12',
-          accessToken: mapboxAccessToken,
           attributionControl: true,
-          bounds: mapBounds,
-          fitBoundsOptions: { padding: 56 }
+          ...provider.mapOptions
         })
         mapRef.current = map
 
         map.on('load', () => {
-          if (!map || cancelled) return
+          if (cancelled) return
           try {
             map.resize()
             map.addSource('route-heatmap', {
@@ -387,22 +381,22 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
                 'line-cap': 'round',
                 'line-join': 'round'
               },
-              paint: MAPBOX_ROUTE_LINE_PAINT
+              paint: ROUTE_LINE_PAINT
             })
             map.fitBounds(mapBounds, { padding: 56, duration: 0 })
             setIsMapLoaded(true)
           } catch (error) {
             if (!cancelled) {
-              setMapboxFallbackError(getMapboxFallbackError(error))
-              setRuntimeMapboxFallbackReason('render-failed')
+              setMapFallbackError(getMapFallbackError(error))
+              setMapFallbackReason('render-failed')
             }
           }
         })
       })
       .catch((error) => {
         if (!cancelled) {
-          setMapboxFallbackError(getMapboxFallbackError(error))
-          setRuntimeMapboxFallbackReason('module-load-failed')
+          setMapFallbackError(getMapFallbackError(error))
+          setMapFallbackReason('module-load-failed')
         }
       })
 
@@ -417,19 +411,14 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     bounds?.minLat,
     bounds?.minLng,
     heatmap?.id,
-    mapboxAccessToken,
-    shouldUseMapbox
+    provider,
+    shouldRenderMap
   ])
 
   useEffect(() => {
-    if (!shouldUseMapbox || !isMapLoaded) return
+    if (!shouldRenderMap || !isMapLoaded) return
     mapRef.current?.getSource('route-heatmap')?.setData(routeGeoJson)
-  }, [isMapLoaded, routeGeoJson, shouldUseMapbox])
-
-  const svgMap = useMemo(
-    () => (hasRoutes && heatmap ? buildSvgMap(heatmap) : null),
-    [hasRoutes, heatmap?.id, heatmap?.updatedAt]
-  )
+  }, [isMapLoaded, routeGeoJson, shouldRenderMap])
 
   if (!hasRoutes || !heatmap) {
     return (
@@ -444,31 +433,18 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     )
   }
 
-  if (shouldUseMapbox) {
+  if (mapFallbackReason) {
     return (
       <div
+        role="status"
         className={cn(
-          'relative overflow-hidden bg-muted',
+          'flex flex-col items-center justify-center gap-1 bg-muted/40 px-4 text-center text-sm text-muted-foreground',
           ROUTE_HEATMAP_MAP_HEIGHT_CLASS
         )}
+        data-map-fallback-reason={mapFallbackReason}
+        data-map-fallback-error={mapFallbackErrorMessage}
       >
-        <div ref={containerRef} className="h-full w-full" />
-        <div className="absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
-          Mapbox
-        </div>
-      </div>
-    )
-  }
-
-  if (!svgMap) {
-    return (
-      <div
-        className={cn(
-          'flex items-center justify-center bg-muted/40 text-sm text-muted-foreground',
-          ROUTE_HEATMAP_MAP_HEIGHT_CLASS
-        )}
-      >
-        No route data for this selection
+        Map unavailable. Try regenerating this heatmap.
       </div>
     )
   }
@@ -476,41 +452,16 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   return (
     <div
       className={cn(
-        'relative overflow-hidden bg-slate-100 dark:bg-slate-950',
+        'relative overflow-hidden bg-muted',
         ROUTE_HEATMAP_MAP_HEIGHT_CLASS
       )}
-      data-mapbox-fallback-reason={mapboxFallbackReason ?? undefined}
-      data-mapbox-fallback-error={mapboxFallbackErrorMessage}
     >
-      <svg
-        viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
-        className="h-full w-full"
-        role="img"
-        aria-label="Fitness route heatmap"
-        preserveAspectRatio="xMidYMid slice"
-      >
-        <rect width={MAP_WIDTH} height={MAP_HEIGHT} fill="#f8fafc" />
-        <g>
-          {svgMap.lines.map((line) => (
-            <polyline
-              key={line.key}
-              points={line.points}
-              fill="none"
-              stroke={line.style.color}
-              strokeWidth={line.style.width}
-              strokeOpacity={line.style.opacity}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          ))}
-        </g>
-      </svg>
-      <div className="absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
-        Routes
-      </div>
-      {mapboxFallbackReason ? (
-        <p className="sr-only">Interactive map unavailable. Showing routes.</p>
-      ) : null}
+      <div ref={containerRef} className="h-full w-full" />
+      {isMapLoaded && (
+        <div className="pointer-events-none absolute left-3 top-3 rounded bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
+          {provider.label}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

On the fitness **Heatmaps** page (`/fitness/heatmap`), the route-density result map showed a **blank white background** with red route dots and **could not be panned or zoomed**.

The result map (`RouteHeatmapMap`) only rendered a real interactive map when a public Mapbox `pk.` token was configured. Without a token — the common case — it fell back to a **static SVG** drawn on a blank `#f8fafc` rectangle: route polylines, but no map tiles underneath and no pan/zoom. Large route caches (over a point budget) also dropped to that same SVG.

## Fix

Mirror the heatmap **region picker** (PR #1050): always render a real GL map.

- **Mapbox GL** when a public token is configured; otherwise the **keyless MapLibre GL + OpenFreeMap** provider — so the map always renders a real, pannable/zoomable surface without an API key.
- **Removed the static SVG entirely** (`buildSvgMap`, the `<svg>`/`<polyline>` rendering, and the `webMercator` projection imports), per the request: *don't generate an SVG for the map*.
- **Oversized geometry is uniformly downsampled** to a GL vertex budget (keeping each segment's first/last point) so a whole-world, all-time cache stays interactive instead of dropping to a non-interactive image.
- If the map module fails to load or render, a plain **"Map unavailable"** message is shown — still no SVG.

The instance **CSP already allows** the jsDelivr (MapLibre script/style) and OpenFreeMap (tiles) origins when no Mapbox token is configured (added in #1050), so no CSP change is needed.

## Files

- `app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx` — provider-generic `RouteHeatmapMap`, `downsampleSegments`, SVG removal.
- `app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx` — rewritten map tests (OpenFreeMap render, Mapbox render, no-SVG assertions, load/render fallback, retry, downsampling) + `downsampleSegments` unit tests.

## Verification

- `yarn run prettier --write .`, `yarn lint` (0 errors), `yarn build`, `yarn test` (4657 tests, all pass).
- Reuses the same MapLibre + OpenFreeMap loader/CSP path already verified in-browser in #1050.
- Note: a fully end-to-end live render needs seeded GPS tracks (storage + background processing), which isn't practical to stand up locally; coverage is via the component/integration tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)