### PR TITLE
minor: emit added_to_collection and collection_update notifications

### DIFF
--- a/app/(timeline)/notifications/notificationConfig.ts
+++ b/app/(timeline)/notifications/notificationConfig.ts
@@ -2,10 +2,12 @@ import {
   Activity,
   AtSign,
   Heart,
+  Library,
   type LucideIcon,
   Repeat2,
   Reply,
-  UserPlus
+  UserPlus,
+  Users
 } from 'lucide-react'
 
 import type { NotificationType } from '@/lib/types/database/operations'
@@ -85,6 +87,18 @@ export const NOTIFICATION_TYPE_CONFIG: Record<
     badgeClassName: PRIMARY_BADGE,
     verb: 'Your fitness activity is ready',
     kind: 'system'
+  },
+  added_to_collection: {
+    icon: Users,
+    badgeClassName: RELATIONSHIP_BADGE,
+    verb: 'added you to a collection',
+    kind: 'relationship'
+  },
+  collection_update: {
+    icon: Library,
+    badgeClassName: RELATIONSHIP_BADGE,
+    verb: 'updated a collection you’re in',
+    kind: 'relationship'
   }
 }
 

--- a/app/api/v1/collections/[id]/items/route.ts
+++ b/app/api/v1/collections/[id]/items/route.ts
@@ -6,6 +6,7 @@ import {
   OAuthGuardAnyScope
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
+import { notifyAddedToCollection } from '@/lib/services/notifications/collectionNotifications'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
@@ -148,11 +149,18 @@ export const POST = traceApiRoute(
         })
       }
 
-      await database.addCollectionMembers({
+      const addedActorIds = await database.addCollectionMembers({
         id,
         actorId: currentActor.id,
         targetActorIds: accountIds.map((accountId) => idToUrl(accountId))
       })
+      // Notify the newly-added local members (added_to_collection). Best-effort:
+      // a notification failure must not fail the membership change.
+      await notifyAddedToCollection(database, {
+        collectionId: id,
+        ownerActorId: currentActor.id,
+        addedActorIds
+      }).catch(() => {})
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
     }
   )

--- a/app/api/v1/collections/[id]/route.ts
+++ b/app/api/v1/collections/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   OAuthGuardAnyScope
 } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonCollection } from '@/lib/services/mastodon/getMastodonCollection'
+import { notifyCollectionUpdated } from '@/lib/services/notifications/collectionNotifications'
 import { Scope } from '@/lib/types/database/operations'
 import { CollectionVisibility } from '@/lib/types/domain/collection'
 import { CollectionTopicInput } from '@/lib/types/mastodon/collection'
@@ -119,6 +120,28 @@ export const PATCH = traceApiRoute(
           responseStatusCode: 404
         })
       }
+
+      // Notify approved local members when the collection's METADATA changed
+      // (title/description/topic/language/visibility) — not for a feed-only
+      // toggle. Best-effort: notification failures must not fail the update.
+      const metadataChanged =
+        parsed.data.title !== undefined ||
+        parsed.data.description !== undefined ||
+        parsed.data.topic !== undefined ||
+        parsed.data.language !== undefined ||
+        parsed.data.visibility !== undefined
+      if (metadataChanged) {
+        const members = await database.getApprovedCollectionMembers({
+          id,
+          actorId: currentActor.id
+        })
+        await notifyCollectionUpdated(database, {
+          collectionId: id,
+          ownerActorId: currentActor.id,
+          memberActorIds: members.map((member) => member.id)
+        }).catch(() => {})
+      }
+
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,

--- a/lib/database/sql/collection.test.ts
+++ b/lib/database/sql/collection.test.ts
@@ -261,6 +261,48 @@ describe('CollectionDatabase', () => {
       })
     })
 
+    it('returns the newly-added member ids (and nothing on re-add)', async () => {
+      await withFreshDatabase(async (database) => {
+        for (const name of ['owner', 'alice', 'bob']) {
+          await createLocalAccount(database, name)
+        }
+        const owner = await actor(database, 'owner')
+        const alice = await actor(database, 'alice')
+        const bob = await actor(database, 'bob')
+
+        const collection = await database.createCollection({
+          actorId: owner.id,
+          title: 'People'
+        })
+
+        const firstAdd = await database.addCollectionMembers({
+          id: collection.id,
+          actorId: owner.id,
+          targetActorIds: [alice.id, bob.id]
+        })
+        expect([...firstAdd].sort()).toEqual([alice.id, bob.id].sort())
+
+        // Re-adding alice plus a new member carol returns only carol.
+        await createLocalAccount(database, 'carol')
+        const carol = await actor(database, 'carol')
+        const secondAdd = await database.addCollectionMembers({
+          id: collection.id,
+          actorId: owner.id,
+          targetActorIds: [alice.id, carol.id]
+        })
+        expect(secondAdd).toEqual([carol.id])
+
+        // Not owned by another actor → nothing added.
+        expect(
+          await database.addCollectionMembers({
+            id: collection.id,
+            actorId: alice.id,
+            targetActorIds: [bob.id]
+          })
+        ).toEqual([])
+      })
+    })
+
     it('returns only approved members with their actor type (for the AP representation)', async () => {
       await withFreshDatabase(async (database) => {
         for (const name of ['owner', 'alice', 'bob']) {

--- a/lib/database/sql/collection.ts
+++ b/lib/database/sql/collection.ts
@@ -416,9 +416,9 @@ export const CollectionSQLDatabaseMixin = (
     actorId,
     targetActorIds
   }: AddCollectionMembersParams) {
-    if (targetActorIds.length === 0) return
+    if (targetActorIds.length === 0) return []
     const seq = await getOwnedCollectionSeq(database, id, actorId)
-    if (seq === null) return
+    if (seq === null) return []
 
     const currentTime = new Date()
     const rows = targetActorIds.map((targetActorId) => ({
@@ -431,7 +431,26 @@ export const CollectionSQLDatabaseMixin = (
       createdAt: currentTime
     }))
 
+    // Actor ids that were not already members before this call — returned so the
+    // route notifies only newly-added members (a re-add is a no-op, not a
+    // re-notify).
+    let newlyAdded: string[] = []
     await database.transaction(async (trx) => {
+      const existing = new Set<string>()
+      for (const chunk of chunkArray(
+        targetActorIds,
+        getWhereInBatchSize(trx, 1)
+      )) {
+        const existingRows = await trx('collection_members')
+          .where('collectionSeq', seq)
+          .whereIn('targetActorId', chunk)
+          .select('targetActorId')
+        for (const row of existingRows) {
+          existing.add(row.targetActorId as string)
+        }
+      }
+      newlyAdded = targetActorIds.filter((target) => !existing.has(target))
+
       const batchSize = getInsertBatchSize(trx, rows[0])
       for (const chunk of chunkArray(rows, batchSize)) {
         await trx('collection_members')
@@ -466,6 +485,7 @@ export const CollectionSQLDatabaseMixin = (
         memberSeqByActorId
       })
     })
+    return newlyAdded
   },
 
   async removeCollectionMembers({

--- a/lib/services/notifications/collectionNotifications.test.ts
+++ b/lib/services/notifications/collectionNotifications.test.ts
@@ -1,0 +1,88 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import {
+  notifyAddedToCollection,
+  notifyCollectionUpdated
+} from '@/lib/services/notifications/collectionNotifications'
+import { TEST_DOMAIN } from '@/lib/stub/const'
+
+const withFreshDatabase = async (test: (db: Database) => Promise<void>) => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  try {
+    await test(database)
+  } finally {
+    await database.destroy()
+  }
+}
+
+const createLocalAccount = (database: Database, username: string) =>
+  database.createAccount({
+    email: `${username}@${TEST_DOMAIN}`,
+    username,
+    passwordHash: 'hash',
+    domain: TEST_DOMAIN,
+    privateKey: `privateKey-${username}`,
+    publicKey: `publicKey-${username}`
+  })
+
+const actor = async (database: Database, username: string) => {
+  const found = await database.getActorFromUsername({
+    username,
+    domain: TEST_DOMAIN
+  })
+  if (!found) throw new Error(`${username} not created`)
+  return found
+}
+
+const notificationsFor = (database: Database, actorId: string) =>
+  database.getNotifications({ actorId, limit: 40 })
+
+describe('collection notifications', () => {
+  it('notifies newly-added local members, skipping the owner and remotes', async () => {
+    await withFreshDatabase(async (database) => {
+      for (const name of ['owner', 'alice']) {
+        await createLocalAccount(database, name)
+      }
+      const owner = await actor(database, 'owner')
+      const alice = await actor(database, 'alice')
+      const remoteId = 'https://remote.example/users/bob'
+
+      await notifyAddedToCollection(database, {
+        collectionId: 'col-1',
+        ownerActorId: owner.id,
+        addedActorIds: [alice.id, owner.id, remoteId]
+      })
+
+      const aliceNotifications = await notificationsFor(database, alice.id)
+      expect(aliceNotifications).toHaveLength(1)
+      expect(aliceNotifications[0].type).toBe('added_to_collection')
+      expect(aliceNotifications[0].sourceActorId).toBe(owner.id)
+
+      // Owner is never self-notified; the remote member is not notified locally.
+      expect(await notificationsFor(database, owner.id)).toHaveLength(0)
+      expect(await notificationsFor(database, remoteId)).toHaveLength(0)
+    })
+  })
+
+  it('notifies members on a collection_update', async () => {
+    await withFreshDatabase(async (database) => {
+      for (const name of ['owner', 'alice']) {
+        await createLocalAccount(database, name)
+      }
+      const owner = await actor(database, 'owner')
+      const alice = await actor(database, 'alice')
+
+      await notifyCollectionUpdated(database, {
+        collectionId: 'col-1',
+        ownerActorId: owner.id,
+        memberActorIds: [alice.id]
+      })
+
+      const aliceNotifications = await notificationsFor(database, alice.id)
+      expect(aliceNotifications).toHaveLength(1)
+      expect(aliceNotifications[0].type).toBe('collection_update')
+      expect(aliceNotifications[0].sourceActorId).toBe(owner.id)
+    })
+  })
+})

--- a/lib/services/notifications/collectionNotifications.ts
+++ b/lib/services/notifications/collectionNotifications.ts
@@ -1,0 +1,86 @@
+import { Database } from '@/lib/database/types'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
+
+// A collection member is local iff it shares the owner's host. The owner is
+// always a local actor (collections are owner-scoped), so its host is this
+// server's host — no extra lookup needed. Remote members are notified over the
+// wire by the (deferred) FEP-7aa9 FeatureRequest flow, not here.
+const isLocalMember = (
+  memberActorId: string,
+  ownerActorId: string
+): boolean => {
+  try {
+    return new URL(memberActorId).host === new URL(ownerActorId).host
+  } catch {
+    return false
+  }
+}
+
+// Emit a collection notification (added_to_collection / collection_update) to
+// each local member, sourced from the collection owner (the curator). The owner
+// is skipped (a curator adding/curating themselves shouldn't self-notify), and
+// the recipient's notification policy is applied via createNotificationWithPolicy.
+// Notifications are grouped per collection.
+const notifyCollectionMembers = async (
+  database: Database,
+  {
+    collectionId,
+    ownerActorId,
+    memberActorIds,
+    type
+  }: {
+    collectionId: string
+    ownerActorId: string
+    memberActorIds: string[]
+    type: 'added_to_collection' | 'collection_update'
+  }
+): Promise<void> => {
+  const recipients = memberActorIds.filter(
+    (memberId) =>
+      memberId !== ownerActorId && isLocalMember(memberId, ownerActorId)
+  )
+  await Promise.all(
+    recipients.map((recipient) =>
+      createNotificationWithPolicy(database, {
+        actorId: recipient,
+        type,
+        sourceActorId: ownerActorId,
+        groupKey: `${type}:${collectionId}`
+      })
+    )
+  )
+}
+
+// A curator added members to their collection: notify the newly-added local
+// members.
+export const notifyAddedToCollection = (
+  database: Database,
+  params: {
+    collectionId: string
+    ownerActorId: string
+    addedActorIds: string[]
+  }
+): Promise<void> =>
+  notifyCollectionMembers(database, {
+    collectionId: params.collectionId,
+    ownerActorId: params.ownerActorId,
+    memberActorIds: params.addedActorIds,
+    type: 'added_to_collection'
+  })
+
+// A collection's metadata changed: notify its approved local members (the ones
+// publicly "in" the collection).
+export const notifyCollectionUpdated = (
+  database: Database,
+  params: {
+    collectionId: string
+    ownerActorId: string
+    memberActorIds: string[]
+  }
+): Promise<void> =>
+  notifyCollectionMembers(database, {
+    collectionId: params.collectionId,
+    ownerActorId: params.ownerActorId,
+    memberActorIds: params.memberActorIds,
+    type: 'collection_update'
+  })

--- a/lib/services/notifications/collectionNotifications.ts
+++ b/lib/services/notifications/collectionNotifications.ts
@@ -35,11 +35,20 @@ const notifyCollectionMembers = async (
     type: 'added_to_collection' | 'collection_update'
   }
 ): Promise<void> => {
-  const recipients = memberActorIds.filter(
-    (memberId) =>
-      memberId !== ownerActorId && isLocalMember(memberId, ownerActorId)
-  )
-  await Promise.all(
+  // Dedupe recipients — `addedActorIds` derives from the request's account_ids,
+  // which may repeat — so a member is never notified twice for one call.
+  const recipients = [
+    ...new Set(
+      memberActorIds.filter(
+        (memberId) =>
+          memberId !== ownerActorId && isLocalMember(memberId, ownerActorId)
+      )
+    )
+  ]
+  // allSettled (not all): every recipient's notification is awaited to
+  // completion even if one rejects, so a single failure can't drop the others
+  // or let the request return before they're persisted.
+  await Promise.allSettled(
     recipients.map((recipient) =>
       createNotificationWithPolicy(database, {
         actorId: recipient,

--- a/lib/services/notifications/getMastodonNotification.ts
+++ b/lib/services/notifications/getMastodonNotification.ts
@@ -20,6 +20,8 @@ type MastodonNotificationType =
   | 'favourite'
   | 'poll'
   | 'update'
+  | 'added_to_collection'
+  | 'collection_update'
   | 'admin.sign_up'
   | 'admin.report'
 
@@ -55,6 +57,10 @@ const mapNotificationType = (
       return 'mention'
     case 'activity_import':
       return 'status'
+    case 'added_to_collection':
+      return 'added_to_collection'
+    case 'collection_update':
+      return 'collection_update'
     default:
       return 'mention' // Default fallback
   }

--- a/lib/services/notifications/notificationTypeMapping.ts
+++ b/lib/services/notifications/notificationTypeMapping.ts
@@ -58,6 +58,8 @@ export type MastodonNotificationType =
   | 'favourite'
   | 'poll'
   | 'update'
+  | 'added_to_collection'
+  | 'collection_update'
   | 'admin.sign_up'
   | 'admin.report'
 
@@ -83,6 +85,10 @@ export const internalTypeToMastodon = (
       return 'mention'
     case 'activity_import':
       return 'status'
+    case 'added_to_collection':
+      return 'added_to_collection'
+    case 'collection_update':
+      return 'collection_update'
     default:
       return 'mention'
   }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -109,6 +109,8 @@ export type UpdateActorParams = {
     reply?: boolean
     reblog?: boolean
     activity_import?: boolean
+    added_to_collection?: boolean
+    collection_update?: boolean
   }
   pushNotifications?: {
     follow_request?: boolean
@@ -118,6 +120,8 @@ export type UpdateActorParams = {
     reply?: boolean
     reblog?: boolean
     activity_import?: boolean
+    added_to_collection?: boolean
+    collection_update?: boolean
   }
   fitness?: {
     strava?: {
@@ -1440,7 +1444,9 @@ export interface CollectionDatabase {
   getCollectionMemberCounts(
     params: GetCollectionMemberCountsParams
   ): Promise<Record<string, number>>
-  addCollectionMembers(params: AddCollectionMembersParams): Promise<void>
+  // Adds members (idempotently) and returns the actor ids that were NEWLY added
+  // (not already members), so callers can notify only the newly-added members.
+  addCollectionMembers(params: AddCollectionMembersParams): Promise<string[]>
   removeCollectionMembers(params: RemoveCollectionMembersParams): Promise<void>
   setCollectionMemberState(
     params: SetCollectionMemberStateParams
@@ -2524,7 +2530,12 @@ export const NotificationType = z.enum([
   'mention',
   'reply',
   'reblog',
-  'activity_import'
+  'activity_import',
+  // Mastodon 4.6 Collections: a member was added to a collection
+  // (`added_to_collection`) or a collection they're in had its metadata changed
+  // (`collection_update`).
+  'added_to_collection',
+  'collection_update'
 ])
 
 export type NotificationType = z.infer<typeof NotificationType>

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -37,6 +37,8 @@ export interface ActorSettings {
     reply?: boolean
     reblog?: boolean
     activity_import?: boolean
+    added_to_collection?: boolean
+    collection_update?: boolean
   }
   pushNotifications?: {
     follow_request?: boolean
@@ -46,6 +48,8 @@ export interface ActorSettings {
     reply?: boolean
     reblog?: boolean
     activity_import?: boolean
+    added_to_collection?: boolean
+    collection_update?: boolean
   }
   // Mastodon notification policy. Each value is 'accept' | 'filter' | 'drop'.
   // Structurally compatible with NotificationPolicy in database/operations.ts


### PR DESCRIPTION
## Summary

Follow-up #2 of the Collections work: emit the two **Mastodon 4.6 Collections notification types** — `added_to_collection` and `collection_update` — for **local** recipients. (Remote members are intentionally deferred to the FEP-7aa9 `FeatureRequest` consent flow, the next federation PR.)

## What's included

- **New `NotificationType` values** `added_to_collection` / `collection_update`, wired through:
  - the Mastodon entity type mapping (`internalTypeToMastodon` / `mapNotificationType` — they pass through with the same names),
  - the notifications **UI config** (`NOTIFICATION_TYPE_CONFIG`, a `Record` over all types — required), and
  - the email/push **settings shapes** (so the existing per-type toggles type-check; collection alerts default to on like the others).
- **`added_to_collection`** — emitted from `POST /api/v1/collections/:id/items` for the members that were **newly added**. `addCollectionMembers` now returns the newly-added actor ids, so a re-add (or re-POST) is a no-op rather than a re-notify. Sourced from the curator (collection owner).
- **`collection_update`** — emitted from `PATCH /api/v1/collections/:id` to the **approved** members when the collection's **metadata** changes (title/description/topic/language/visibility) — *not* for a feed-only (`feed_enabled`) toggle.
- **Shared `collectionNotifications` service** — filters to **local** members (a member is local iff it shares the owner's host; the owner is always local), **skips the owner** (no self-notify), applies the recipient's notification policy via `createNotificationWithPolicy`, and **groups per collection** (`<type>:<collectionId>`). Emission is best-effort — a notification failure never fails the membership/metadata change.

## Design notes

- **No migration.** Notifications reuse the existing `notifications` table (recipient `actorId`, `sourceActorId`, `type`, `groupKey`). The Mastodon `Notification` entity has no collection field, so a `collectionId` column would be unused — deferred until/if the entity gains one.
- **Local-only** is deliberate: only local actors read our notifications API; remote members are notified over the wire by the deferred consent flow.
- Policy-aware: a collection notification from a non-followed curator is filtered/dropped exactly per the recipient's notification policy (no special-casing).

## Testing

- Full suite green (**4680 tests**), `lint` clean, `build` passes.
- New: `collectionNotifications` service test (local member notified; owner + remote skipped; update path) and a storage test asserting `addCollectionMembers` returns only the newly-added ids (and `[]` on re-add / non-owner).

## Deferred

- Web-push **alerts** for the new types (the `PushAlerts` wire keys) and a Mastodon `NotificationFallback` entity for clients that don't yet support the types — both optional client-compat niceties.
- Over-the-wire notification of **remote** members (FEP-7aa9 `FeatureRequest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9Z9tMHVKToWfbeak9VFya)_