### PR TITLE
Bump version to v1.82.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.81.0",
+  "version": "1.82.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.82.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.81.0`
- Base main SHA: `4d5070f8947c7e18d1560be21ab68eeef5e208e9`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
