### PR TITLE
refactor: remove redundant Heatmaps button from fitness overview

### DIFF
--- a/app/(timeline)/fitness/page.tsx
+++ b/app/(timeline)/fitness/page.tsx
@@ -1,4 +1,3 @@
-import { Flame } from 'lucide-react'
 import { Metadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
@@ -103,14 +102,6 @@ const Page: FC = async () => {
       <PageHeader
         title="Overview"
         description="Your last 6 months of activity"
-        actions={
-          <Button variant="outline" size="sm" asChild>
-            <Link href="/fitness/heatmap">
-              <Flame className="mr-1.5 h-4 w-4" />
-              Heatmaps
-            </Link>
-          </Button>
-        }
       />
 
       <ActorFitnessDashboard


### PR DESCRIPTION
## Summary

The fitness **Overview** page (`app/(timeline)/fitness/page.tsx`) rendered a "Heatmaps" action button in its `PageHeader` linking to `/fitness/heatmap`. That destination is already reachable from the **Heatmaps** tab in the fitness section sub-navigation dropdown (`app/(timeline)/fitness/layout.tsx`), so the button was redundant.

This PR removes the duplicate button and the now-unused `Flame` import. `Button`/`Link` imports remain — they're still used by the empty-state card.

## Changes

- Remove the `actions={…}` Heatmaps button from the Overview `PageHeader`.
- Drop the unused `Flame` lucide-react import.

## Testing

- `yarn run prettier --write .`
- `yarn lint` — 0 errors (pre-existing `no-explicit-any` warnings only)
- `yarn build` — succeeds
- `yarn test` — 534 files / 4677 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)