### PR TITLE
minor: auto-follow and backfill remote collection members

### DIFF
--- a/app/api/v1/collections/[id]/items/route.ts
+++ b/app/api/v1/collections/[id]/items/route.ts
@@ -1,14 +1,18 @@
+import { randomUUID } from 'crypto'
 import { z } from 'zod'
 
 import { PER_PAGE_LIMIT } from '@/lib/database/constants'
+import { INGEST_COLLECTION_MEMBER_JOB_NAME } from '@/lib/jobs/names'
 import {
   OAuthGuard,
   OAuthGuardAnyScope
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { notifyAddedToCollection } from '@/lib/services/notifications/collectionNotifications'
+import { getQueue } from '@/lib/services/queue'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_404,
   ERROR_422,
@@ -161,6 +165,26 @@ export const POST = traceApiRoute(
         ownerActorId: currentActor.id,
         addedActorIds
       }).catch(() => {})
+      // Kick off remote-member ingestion (instance actor follows + backfills
+      // their recent posts) out of band so federation never blocks the
+      // response. The job itself filters out local members and already-followed
+      // actors, so it's safe to enqueue one per newly-added member.
+      for (const memberActorId of addedActorIds) {
+        getQueue()
+          .publish({
+            id: randomUUID(),
+            name: INGEST_COLLECTION_MEMBER_JOB_NAME,
+            data: { memberActorId }
+          })
+          .catch((error) => {
+            logger.warn({
+              message: 'Failed to queue collection member ingestion',
+              collectionId: id,
+              memberActorId,
+              error
+            })
+          })
+      }
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: {} })
     }
   )

--- a/app/api/v1/collections/[id]/items/route.ts
+++ b/app/api/v1/collections/[id]/items/route.ts
@@ -166,10 +166,18 @@ export const POST = traceApiRoute(
         addedActorIds
       }).catch(() => {})
       // Kick off remote-member ingestion (instance actor follows + backfills
-      // their recent posts) out of band so federation never blocks the
-      // response. The job itself filters out local members and already-followed
-      // actors, so it's safe to enqueue one per newly-added member.
-      for (const memberActorId of addedActorIds) {
+      // their recent posts) out of band so federation never blocks the response
+      // (fire-and-forget, mirroring the block/unblock routes). Only remote
+      // members need ingestion — local members' posts already fan into the
+      // collection feed on create — so pre-filter to remote and dedupe before
+      // publishing one job each. The job re-guards remote/already-followed, so
+      // this is purely to avoid enqueuing known no-ops. Member ids are stored
+      // actor URLs (built via idToUrl), so `new URL` is safe without a guard.
+      const ownerHost = new URL(currentActor.id).host
+      const remoteMemberActorIds = [...new Set(addedActorIds)].filter(
+        (memberActorId) => new URL(memberActorId).host !== ownerHost
+      )
+      for (const memberActorId of remoteMemberActorIds) {
         getQueue()
           .publish({
             id: randomUUID(),

--- a/lib/jobs/index.ts
+++ b/lib/jobs/index.ts
@@ -12,6 +12,7 @@ import { generateFitnessRouteHeatmapJob } from './generateFitnessRouteHeatmapJob
 import { importFitnessFilesJob } from './importFitnessFilesJob'
 import { importStravaActivityJob } from './importStravaActivityJob'
 import { importStravaArchiveJob } from './importStravaArchiveJob'
+import { ingestCollectionMemberJob } from './ingestCollectionMemberJob'
 import {
   CREATE_ANNOUNCE_JOB_NAME,
   CREATE_NOTE_JOB_NAME,
@@ -25,6 +26,7 @@ import {
   IMPORT_FITNESS_FILES_JOB_NAME,
   IMPORT_STRAVA_ACTIVITY_JOB_NAME,
   IMPORT_STRAVA_ARCHIVE_JOB_NAME,
+  INGEST_COLLECTION_MEMBER_JOB_NAME,
   PROCESS_FITNESS_FILE_JOB_NAME,
   PUBLISH_SCHEDULED_STATUS_JOB_NAME,
   REGENERATE_FITNESS_MAPS_JOB_NAME,
@@ -80,5 +82,6 @@ export const JOBS: Record<string, JobHandle> = {
   [SEND_UNDO_FOLLOW_JOB_NAME]: sendUndoFollowJob,
   [SEND_UNBLOCK_JOB_NAME]: sendUnblockJob,
   [FETCH_REMOTE_STATUS_JOB_NAME]: fetchRemoteStatusJob,
-  [PUBLISH_SCHEDULED_STATUS_JOB_NAME]: publishScheduledStatusJob
+  [PUBLISH_SCHEDULED_STATUS_JOB_NAME]: publishScheduledStatusJob,
+  [INGEST_COLLECTION_MEMBER_JOB_NAME]: ingestCollectionMemberJob
 }

--- a/lib/jobs/ingestCollectionMemberJob.test.ts
+++ b/lib/jobs/ingestCollectionMemberJob.test.ts
@@ -8,6 +8,7 @@ import { INGEST_COLLECTION_MEMBER_JOB_NAME } from '@/lib/jobs/names'
 import { getFederationSigningActorId } from '@/lib/services/federation/instanceActor'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
 import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { Status, StatusType } from '@/lib/types/domain/status'
@@ -157,6 +158,68 @@ describe('ingestCollectionMemberJob', () => {
       })
 
       expect(mockFollow).not.toHaveBeenCalled()
+    } finally {
+      await freshDatabase.destroy()
+    }
+  })
+
+  it("surfaces a backfilled note in the owner's collection feed", async () => {
+    // Isolated DB so this test's follow/collection state can't collide with the
+    // shared-DB cases above (an existing follow would short-circuit the job).
+    const freshDatabase = getTestSQLDatabase()
+    await freshDatabase.migrate()
+    await seedDatabase(freshDatabase)
+    try {
+      await freshDatabase.getFederationSigningActor()
+      // A distinct remote member at its own host, recorded so createNote can
+      // resolve the author.
+      const memberActorId = 'https://remote.example/users/curated'
+      await freshDatabase.createActor({
+        actorId: memberActorId,
+        username: 'curated',
+        domain: 'remote.example',
+        inboxUrl: `${memberActorId}/inbox`,
+        sharedInboxUrl: 'https://remote.example/inbox',
+        followersUrl: `${memberActorId}/followers`,
+        publicKey: 'publicKey',
+        createdAt: Date.now()
+      })
+      mockGetActorPerson.mockResolvedValue({ id: memberActorId } as never)
+      mockRecordActorIfNeeded.mockResolvedValue({ id: memberActorId } as never)
+
+      const collection = await freshDatabase.createCollection({
+        actorId: ACTOR1_ID,
+        title: 'Curated people',
+        publicFeed: true
+      })
+      await freshDatabase.addCollectionMembers({
+        id: collection.id,
+        actorId: ACTOR1_ID,
+        targetActorIds: [memberActorId]
+      })
+
+      const statusId = 'https://remote.example/users/curated/statuses/1'
+      mockGetActorPosts.mockResolvedValue({
+        statusesCount: 1,
+        statuses: [
+          noteStatus({ id: statusId, url: statusId, actorId: memberActorId })
+        ],
+        nextPageUrl: null,
+        prevPageUrl: null
+      })
+
+      await ingestCollectionMemberJob(freshDatabase, {
+        id: 'ingest-job',
+        name: INGEST_COLLECTION_MEMBER_JOB_NAME,
+        data: { memberActorId }
+      })
+
+      const ownerFeed = await freshDatabase.getCollectionTimeline({
+        id: collection.id,
+        actorId: ACTOR1_ID,
+        projection: 'owner'
+      })
+      expect(ownerFeed.map((status) => status.id)).toContain(statusId)
     } finally {
       await freshDatabase.destroy()
     }

--- a/lib/jobs/ingestCollectionMemberJob.test.ts
+++ b/lib/jobs/ingestCollectionMemberJob.test.ts
@@ -1,0 +1,180 @@
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { follow } from '@/lib/activities'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { ingestCollectionMemberJob } from '@/lib/jobs/ingestCollectionMemberJob'
+import { INGEST_COLLECTION_MEMBER_JOB_NAME } from '@/lib/jobs/names'
+import { getFederationSigningActorId } from '@/lib/services/federation/instanceActor'
+import { TEST_DOMAIN } from '@/lib/stub/const'
+import { seedDatabase } from '@/lib/stub/database'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+vi.mock('@/lib/activities', () => ({
+  follow: vi.fn()
+}))
+vi.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: vi.fn()
+}))
+vi.mock('@/lib/activities/getActorPosts', () => ({
+  getActorPosts: vi.fn()
+}))
+vi.mock('@/lib/actions/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/actions/utils')>()),
+  recordActorIfNeeded: vi.fn()
+}))
+
+const mockFollow = follow as jest.MockedFunction<typeof follow>
+const mockGetActorPerson = getActorPerson as jest.MockedFunction<
+  typeof getActorPerson
+>
+const mockGetActorPosts = getActorPosts as jest.MockedFunction<
+  typeof getActorPosts
+>
+const mockRecordActorIfNeeded = recordActorIfNeeded as jest.MockedFunction<
+  typeof recordActorIfNeeded
+>
+
+// Minimal Note-shaped status the job persists. Only the fields the job reads
+// are meaningful; the rest are filler to satisfy the union type.
+const noteStatus = (overrides: Partial<Status>): Status =>
+  ({
+    type: StatusType.enum.Note,
+    id: `${EXTERNAL_ACTOR1}/statuses/1`,
+    actorId: EXTERNAL_ACTOR1,
+    actor: null,
+    url: `${EXTERNAL_ACTOR1}/statuses/1`,
+    text: 'hello world',
+    summary: null,
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: [],
+    reply: '',
+    edits: [],
+    replies: [],
+    isLocalActor: false,
+    actorAnnounceStatusId: null,
+    isActorLiked: false,
+    isActorBookmarked: false,
+    totalLikes: 0,
+    totalShares: 0,
+    attachments: [],
+    tags: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides
+  }) as Status
+
+describe('ingestCollectionMemberJob', () => {
+  const database = getTestSQLDatabase()
+  let signingActorId: string
+
+  const runJob = (memberActorId: string) =>
+    ingestCollectionMemberJob(database, {
+      id: 'ingest-job',
+      name: INGEST_COLLECTION_MEMBER_JOB_NAME,
+      data: { memberActorId }
+    })
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    // Bootstraps (and persists) the headless instance actor at TEST_DOMAIN.
+    await database.getFederationSigningActor()
+    signingActorId = getFederationSigningActorId(TEST_DOMAIN)
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    mockFollow.mockReset().mockResolvedValue(true)
+    mockGetActorPerson
+      .mockReset()
+      .mockResolvedValue({ id: EXTERNAL_ACTOR1 } as never)
+    mockGetActorPosts.mockReset().mockResolvedValue({
+      statusesCount: 0,
+      statuses: [],
+      nextPageUrl: null,
+      prevPageUrl: null
+    })
+    mockRecordActorIfNeeded
+      .mockReset()
+      .mockResolvedValue({ id: EXTERNAL_ACTOR1 } as never)
+  })
+
+  it('follows a newly-added remote member and backfills their notes', async () => {
+    const statusId = `${EXTERNAL_ACTOR1}/statuses/backfill-1`
+    mockGetActorPosts.mockResolvedValue({
+      statusesCount: 1,
+      statuses: [noteStatus({ id: statusId, url: statusId })],
+      nextPageUrl: null,
+      prevPageUrl: null
+    })
+
+    await runJob(EXTERNAL_ACTOR1)
+
+    expect(mockFollow).toHaveBeenCalledTimes(1)
+    const createdFollow = await database.getAcceptedOrRequestedFollow({
+      actorId: signingActorId,
+      targetActorId: EXTERNAL_ACTOR1
+    })
+    expect(createdFollow).toMatchObject({
+      actorId: signingActorId,
+      targetActorId: EXTERNAL_ACTOR1,
+      status: FollowStatus.enum.Requested
+    })
+
+    const backfilled = await database.getStatus({ statusId })
+    expect(backfilled).toMatchObject({ id: statusId, text: 'hello world' })
+  })
+
+  it('is a no-op for a local member (no follow, no backfill)', async () => {
+    const localMember = `https://${TEST_DOMAIN}/users/localUser`
+
+    await runJob(localMember)
+
+    expect(mockFollow).not.toHaveBeenCalled()
+    expect(mockGetActorPosts).not.toHaveBeenCalled()
+  })
+
+  it('does not follow when there is no federation signing actor', async () => {
+    const freshDatabase = getTestSQLDatabase()
+    await freshDatabase.migrate()
+    await seedDatabase(freshDatabase)
+    try {
+      vi.spyOn(freshDatabase, 'getFederationSigningActor').mockResolvedValue(
+        null
+      )
+
+      await ingestCollectionMemberJob(freshDatabase, {
+        id: 'ingest-job',
+        name: INGEST_COLLECTION_MEMBER_JOB_NAME,
+        data: { memberActorId: EXTERNAL_ACTOR1 }
+      })
+
+      expect(mockFollow).not.toHaveBeenCalled()
+    } finally {
+      await freshDatabase.destroy()
+    }
+  })
+
+  it('skips a member the instance actor already follows', async () => {
+    // Pre-create the follow so the idempotency guard short-circuits.
+    await database.createFollow({
+      actorId: signingActorId,
+      targetActorId: EXTERNAL_ACTOR1,
+      status: FollowStatus.enum.Accepted,
+      inbox: `${signingActorId}/inbox`,
+      sharedInbox: `https://${TEST_DOMAIN}/inbox`
+    })
+
+    await runJob(EXTERNAL_ACTOR1)
+
+    expect(mockFollow).not.toHaveBeenCalled()
+    expect(mockGetActorPosts).not.toHaveBeenCalled()
+  })
+})

--- a/lib/jobs/ingestCollectionMemberJob.ts
+++ b/lib/jobs/ingestCollectionMemberJob.ts
@@ -4,6 +4,7 @@ import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { follow } from '@/lib/activities'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { COLLECTION_BACKFILL_MAX_POSTS } from '@/lib/services/timelines/types'
@@ -140,8 +141,12 @@ export const ingestCollectionMemberJob = createJobHandle(
         // Fan the backfilled note into every collection whose membership
         // includes its author (the read-time projections still apply).
         await database.addStatusToCollectionTimelines({ status: created })
-      } catch {
-        // Ignore: a concurrent ingest may have already stored this note.
+      } catch (error) {
+        // A concurrent ingest racing on the same note id is a harmless
+        // unique-constraint conflict — skip it. Any other DB error (a lock,
+        // timeout, …) propagates so a real queue can retry the job.
+        if (isUniqueConstraintError(error)) continue
+        throw error
       }
     }
   }

--- a/lib/jobs/ingestCollectionMemberJob.ts
+++ b/lib/jobs/ingestCollectionMemberJob.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod'
+
+import { recordActorIfNeeded } from '@/lib/actions/utils'
+import { follow } from '@/lib/activities'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { COLLECTION_BACKFILL_MAX_POSTS } from '@/lib/services/timelines/types'
+import { FollowStatus } from '@/lib/types/domain/follow'
+import { StatusNote, StatusType } from '@/lib/types/domain/status'
+import { logger } from '@/lib/utils/logger'
+
+import { createJobHandle } from './createJobHandle'
+import { INGEST_COLLECTION_MEMBER_JOB_NAME } from './names'
+
+// Two actor ids share a host iff they live on the same instance. The instance
+// actor is always local, so comparing against its host is how we tell a remote
+// member (needs follow + backfill) from a local one (whose posts already fan
+// into the collection feed through the normal create flow).
+const isSameHost = (actorId: string, otherActorId: string): boolean => {
+  try {
+    return new URL(actorId).host === new URL(otherActorId).host
+  } catch {
+    return false
+  }
+}
+
+// A remote actor was added to a collection. The instance/federation actor
+// follows them (so their future posts keep arriving over federation and fan
+// into the collection feed) and backfills their most recent public posts (so
+// the feed shows history immediately instead of starting empty). Both steps are
+// idempotent and best-effort: re-adding a member, or a member already followed
+// for another collection, does no extra work, and a federation failure on one
+// post never aborts the rest.
+export const ingestCollectionMemberJob = createJobHandle(
+  INGEST_COLLECTION_MEMBER_JOB_NAME,
+  async (database, message) => {
+    const { memberActorId } = z
+      .object({ memberActorId: z.string() })
+      .parse(message.data)
+
+    const signingActor = await getFederationSigningActor(database)
+    if (!signingActor) return
+
+    // Local members need neither a follow nor a backfill: their posts already
+    // fan into the collection feed when created, so this job is a no-op for them.
+    if (isSameHost(memberActorId, signingActor.id)) return
+
+    if (!(await canFederateWithDomain(database, memberActorId))) return
+
+    // Idempotency guard: a member can belong to several collections (or be
+    // re-added), but the instance actor only needs to follow + backfill them
+    // once. An existing accepted/requested follow means we've already ingested
+    // them, so skip both steps.
+    const existingFollow = await database.getAcceptedOrRequestedFollow({
+      actorId: signingActor.id,
+      targetActorId: memberActorId
+    })
+    if (existingFollow) return
+
+    // Record the member's actor up front so backfilled notes satisfy the
+    // foreign key and fan-out can resolve the author.
+    const actor = await recordActorIfNeeded({
+      actorId: memberActorId,
+      database,
+      signingActor
+    })
+    if (!actor) return
+
+    const person = await getActorPerson({
+      actorId: memberActorId,
+      signingActor
+    })
+    if (!person) return
+
+    const followItem = await database.createFollow({
+      actorId: signingActor.id,
+      targetActorId: memberActorId,
+      status: FollowStatus.enum.Requested,
+      inbox: `${signingActor.id}/inbox`,
+      sharedInbox: `https://${signingActor.domain}/inbox`
+    })
+    await follow(followItem.id, signingActor, memberActorId, signingActor)
+
+    // Backfill the most recent posts from the member's outbox. Only plain notes
+    // are stored here (announces/polls carry extra structure the simple
+    // createNote path can't persist); the cap bounds federation traffic and the
+    // inline NoQueue latency.
+    let statuses
+    try {
+      ;({ statuses } = await getActorPosts({ database, person, signingActor }))
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to backfill collection member posts',
+        memberActorId,
+        error
+      })
+      return
+    }
+
+    const recentNotes = statuses
+      .filter(
+        (status): status is StatusNote => status.type === StatusType.enum.Note
+      )
+      .slice(0, COLLECTION_BACKFILL_MAX_POSTS)
+
+    for (const note of recentNotes) {
+      const existing = await database.getStatus({ statusId: note.id })
+      if (existing) continue
+      try {
+        const created = await database.createNote({
+          id: note.id,
+          url: note.url,
+          actorId: note.actorId,
+          text: note.text,
+          summary: note.summary ?? '',
+          to: note.to,
+          cc: note.cc,
+          reply: note.reply || '',
+          createdAt: note.createdAt
+        })
+        // Fan the backfilled note into every collection whose membership
+        // includes its author (the read-time projections still apply).
+        await database.addStatusToCollectionTimelines({ status: created })
+      } catch {
+        // Ignore: a concurrent ingest may have already stored this note.
+      }
+    }
+  }
+)

--- a/lib/jobs/ingestCollectionMemberJob.ts
+++ b/lib/jobs/ingestCollectionMemberJob.ts
@@ -28,11 +28,14 @@ const isSameHost = (actorId: string, otherActorId: string): boolean => {
 
 // A remote actor was added to a collection. The instance/federation actor
 // follows them (so their future posts keep arriving over federation and fan
-// into the collection feed) and backfills their most recent public posts (so
-// the feed shows history immediately instead of starting empty). Both steps are
-// idempotent and best-effort: re-adding a member, or a member already followed
-// for another collection, does no extra work, and a federation failure on one
-// post never aborts the rest.
+// into the collection feed) and backfills their most recent public posts so the
+// curator's (owner-projection) feed shows history immediately instead of
+// starting empty. The public projection still gates on the member's featuring
+// consent (members start `pending` and only `approved` members appear publicly),
+// so backfilled rows surface publicly only once that consent lands — by design.
+// Both steps are idempotent and best-effort: re-adding a member, or a member
+// already followed for another collection, does no extra work, and a federation
+// failure on one post never aborts the rest.
 export const ingestCollectionMemberJob = createJobHandle(
   INGEST_COLLECTION_MEMBER_JOB_NAME,
   async (database, message) => {
@@ -74,12 +77,16 @@ export const ingestCollectionMemberJob = createJobHandle(
     })
     if (!person) return
 
+    // Derive the inbox/sharedInbox from the signing actor's own canonical id so
+    // the protocol and port match it (rather than hardcoding https), keeping
+    // local/dev and custom-port deployments correct.
+    const signingActorOrigin = new URL(signingActor.id).origin
     const followItem = await database.createFollow({
       actorId: signingActor.id,
       targetActorId: memberActorId,
       status: FollowStatus.enum.Requested,
       inbox: `${signingActor.id}/inbox`,
-      sharedInbox: `https://${signingActor.domain}/inbox`
+      sharedInbox: `${signingActorOrigin}/inbox`
     })
     await follow(followItem.id, signingActor, memberActorId, signingActor)
 
@@ -104,10 +111,20 @@ export const ingestCollectionMemberJob = createJobHandle(
         (status): status is StatusNote => status.type === StatusType.enum.Note
       )
       .slice(0, COLLECTION_BACKFILL_MAX_POSTS)
+    if (recentNotes.length === 0) return
+
+    // Resolve which notes are already stored in a single round-trip rather than
+    // one getStatus per note, so the existence check is O(1) queries.
+    const existingIds = new Set(
+      (
+        await database.getStatusesByIds({
+          statusIds: recentNotes.map((note) => note.id)
+        })
+      ).map((status) => status.id)
+    )
 
     for (const note of recentNotes) {
-      const existing = await database.getStatus({ statusId: note.id })
-      if (existing) continue
+      if (existingIds.has(note.id)) continue
       try {
         const created = await database.createNote({
           id: note.id,

--- a/lib/jobs/names.ts
+++ b/lib/jobs/names.ts
@@ -24,3 +24,4 @@ export const GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME =
   'GenerateFitnessRouteHeatmapJob'
 export const FETCH_REMOTE_STATUS_JOB_NAME = 'FetchRemoteStatusJob'
 export const PUBLISH_SCHEDULED_STATUS_JOB_NAME = 'PublishScheduledStatusJob'
+export const INGEST_COLLECTION_MEMBER_JOB_NAME = 'IngestCollectionMemberJob'

--- a/lib/services/timelines/types.ts
+++ b/lib/services/timelines/types.ts
@@ -30,6 +30,11 @@ export const COLLECTION_FEED_MAX_ROWS = 1000
 // Trim only once a collection overshoots the cap by this slack, so eviction is
 // batched (one DELETE per overshoot) rather than paid on every single insert.
 export const COLLECTION_FEED_TRIM_SLACK = 100
+// When a remote actor is added to a collection the instance actor follows them
+// and backfills at most this many of their most recent posts, so the feed shows
+// history immediately instead of waiting for new activity to federate in. Bounds
+// the one-off federation traffic (and, under the in-process NoQueue, latency).
+export const COLLECTION_BACKFILL_MAX_POSTS = 40
 
 export interface TimelineRuleParams {
   database: Database


### PR DESCRIPTION
## Summary

Third follow-up to the Collections feature. When a **remote** actor is added to a collection, the instance/federation actor now **follows** them and **backfills** their recent public posts, so the collection feed shows history immediately instead of starting empty and keeps receiving the member's future posts over federation.

This is the "Follow + backfill" scope agreed for this PR; unfollow-on-remove is intentionally deferred to a later follow-up.

## How it works

- A new out-of-band `IngestCollectionMemberJob` (`lib/jobs/ingestCollectionMemberJob.ts`):
  1. Resolves the headless federation signing actor (no-op if absent).
  2. Skips **local** members — their posts already fan into the collection feed through the normal create flow.
  3. Skips members the instance actor **already follows** (idempotent across collections / re-adds).
  4. Records the member actor, creates a `Requested` follow, and sends the `Follow` activity.
  5. Backfills the member's most recent public notes from their outbox (capped at `COLLECTION_BACKFILL_MAX_POSTS = 40`), persisting each and fanning it into every collection whose membership includes the author.
- The items `POST` route publishes one job per newly-added member via a **fire-and-forget** `getQueue().publish(...)`, so federation never blocks the HTTP response. The job's own guards make it safe to enqueue one per added member (local / already-followed members no-op).

## Notes

- No migration — `follows` and `statuses` tables already exist, so neither schema dump changes.
- Best-effort throughout: a federation failure on one post never aborts the rest, and a notification/ingestion failure can't fail the membership change.
- New unit tests cover the happy path (follow created + activity sent + note backfilled), the local-member no-op, the missing-signer no-op, and the already-followed short-circuit.

`prettier` / `lint` / `build` / `test` all green locally (325 related tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9Z9tMHVKToWfbeak9VFya)_