### PR TITLE
minor: fix orphaned fitness imports and make Strava retries resumable

### DIFF
--- a/app/(timeline)/fitness/files/page.tsx
+++ b/app/(timeline)/fitness/files/page.tsx
@@ -84,7 +84,10 @@ const Page = async ({
           description: fitnessFile.description,
           createdAt: fitnessFile.createdAt,
           url: `/api/v1/fitness-files/${fitnessFile.id}`,
-          statusId: fitnessFile.statusId ?? undefined
+          statusId: fitnessFile.statusId ?? undefined,
+          importStatus: fitnessFile.importStatus ?? undefined,
+          importError: fitnessFile.importError ?? null,
+          importBatchId: fitnessFile.importBatchId ?? undefined
         }))}
         currentPage={page}
         itemsPerPage={itemsPerPage}

--- a/app/api/v1/fitness/import/[batchId]/route.test.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.test.ts
@@ -1,4 +1,7 @@
-import { IMPORT_FITNESS_FILES_JOB_NAME } from '@/lib/jobs/names'
+import {
+  IMPORT_FITNESS_FILES_JOB_NAME,
+  IMPORT_STRAVA_ACTIVITY_JOB_NAME
+} from '@/lib/jobs/names'
 import { getQueue } from '@/lib/services/queue'
 
 import { GET, POST } from './route'
@@ -561,6 +564,57 @@ describe('fitness import batch route', () => {
         visibility: 'private'
       }
     })
+  })
+
+  it('re-runs the full Strava activity import for strava-activity batches', async () => {
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      {
+        id: 'file-1',
+        actorId: 'https://llun.test/users/llun',
+        fileName: 'strava-19007245213.tcx',
+        fileType: 'tcx',
+        path: 'fitness/strava-19007245213.tcx',
+        mimeType: 'application/vnd.garmin.tcx+xml',
+        bytes: 1024,
+        importBatchId: 'strava-activity:19007245213',
+        importStatus: 'failed',
+        processingStatus: 'failed',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    const request = {
+      headers: new Headers(),
+      json: async () => ({ visibility: 'public' })
+    } as unknown as Parameters<typeof POST>[0]
+
+    const response = await POST(request, {
+      params: Promise.resolve({ batchId: 'strava-activity:19007245213' })
+    })
+    const json = (await response.json()) as { retried: number }
+
+    expect(response.status).toBe(200)
+    expect(json.retried).toBe(1)
+    // Failed files are still reset so the UI reflects the in-progress retry.
+    expect(db.updateFitnessFilesImportStatus).toHaveBeenCalledWith({
+      fitnessFileIds: ['file-1'],
+      importStatus: 'pending'
+    })
+    // The full Strava importer runs (caption/photos/visibility), not just the
+    // file importer. Visibility is intentionally omitted so the job re-derives
+    // the activity's real Strava visibility.
+    expect(getQueue().publish).toHaveBeenCalledWith({
+      id: expect.any(String),
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'https://llun.test/users/llun',
+        stravaActivityId: '19007245213'
+      }
+    })
+    expect(getQueue().publish).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: IMPORT_FITNESS_FILES_JOB_NAME })
+    )
   })
 
   it('includes completed files as overlap context during retry', async () => {

--- a/app/api/v1/fitness/import/[batchId]/route.test.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.test.ts
@@ -744,10 +744,9 @@ describe('fitness import batch route', () => {
 
     expect(response.status).toBe(200)
     expect(json.retried).toBe(1)
-    expect(db.updateFitnessFilesImportStatus).toHaveBeenCalledWith({
-      fitnessFileIds: ['file-1'],
-      importStatus: 'pending'
-    })
+    // The import already succeeded; only its processing failed, so its
+    // importStatus must NOT be reset (a re-import would leave it stuck 'pending').
+    expect(db.updateFitnessFilesImportStatus).not.toHaveBeenCalled()
     expect(db.updateFitnessFilesProcessingStatus).toHaveBeenCalledWith({
       fitnessFileIds: ['file-1'],
       processingStatus: 'pending'
@@ -761,6 +760,52 @@ describe('fitness import batch route', () => {
         fitnessFileIds: ['file-1'],
         overlapFitnessFileIds: [],
         visibility: 'private'
+      }
+    })
+  })
+
+  it('does not reset import status for an already-imported file whose processing failed on a strava-activity retry', async () => {
+    db.getFitnessFilesByBatchId.mockResolvedValue([
+      {
+        id: 'file-1',
+        actorId: 'https://llun.test/users/llun',
+        fileName: 'strava-99.tcx',
+        fileType: 'tcx',
+        path: 'fitness/strava-99.tcx',
+        mimeType: 'application/vnd.garmin.tcx+xml',
+        bytes: 1024,
+        importBatchId: 'strava-activity:99',
+        importStatus: 'completed',
+        processingStatus: 'failed',
+        statusId: 'https://llun.test/users/llun/statuses/existing',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    const request = {
+      headers: new Headers(),
+      json: async () => ({ visibility: 'public' })
+    } as unknown as Parameters<typeof POST>[0]
+
+    const response = await POST(request, {
+      params: Promise.resolve({ batchId: 'strava-activity:99' })
+    })
+    const json = (await response.json()) as { retried: number }
+
+    expect(response.status).toBe(200)
+    expect(json.retried).toBe(1)
+    expect(db.updateFitnessFilesImportStatus).not.toHaveBeenCalled()
+    expect(db.updateFitnessFilesProcessingStatus).toHaveBeenCalledWith({
+      fitnessFileIds: ['file-1'],
+      processingStatus: 'pending'
+    })
+    expect(getQueue().publish).toHaveBeenCalledWith({
+      id: expect.any(String),
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'https://llun.test/users/llun',
+        stravaActivityId: '99'
       }
     })
   })
@@ -843,10 +888,8 @@ describe('fitness import batch route', () => {
     })
 
     expect(response.status).toBe(500)
-    expect(db.updateFitnessFilesImportStatus).toHaveBeenCalledWith({
-      fitnessFileIds: ['file-1'],
-      importStatus: 'pending'
-    })
+    // importStatus was 'completed', so it was never reset to 'pending'.
+    expect(db.updateFitnessFilesImportStatus).not.toHaveBeenCalled()
     expect(db.updateFitnessFilesProcessingStatus).toHaveBeenCalledWith({
       fitnessFileIds: ['file-1'],
       processingStatus: 'pending'

--- a/app/api/v1/fitness/import/[batchId]/route.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.ts
@@ -470,16 +470,31 @@ export const POST = traceApiRoute(
       )
       .map((item) => item.id)
 
-    await Promise.all([
-      database.updateFitnessFilesImportStatus({
-        fitnessFileIds: retriableFileIds,
+    // Reset each status column only for the files that actually failed on that
+    // column. A file whose import already succeeded (importStatus 'completed',
+    // statusId set) but whose later map processing failed must keep its
+    // 'completed' import status: the Strava retry re-runs importStravaActivityJob
+    // which short-circuits past the importer when a statusId exists, so resetting
+    // its importStatus to 'pending' here would leave it stuck 'pending' forever.
+    const importResetFileIds = retriableFiles
+      .filter(({ importStatus }) => importStatus === 'failed')
+      .map(({ file }) => file.id)
+    const processingResetFileIds = retriableFiles
+      .filter(({ processingStatus }) => processingStatus === 'failed')
+      .map(({ file }) => file.id)
+
+    if (importResetFileIds.length > 0) {
+      await database.updateFitnessFilesImportStatus({
+        fitnessFileIds: importResetFileIds,
         importStatus: 'pending'
-      }),
-      database.updateFitnessFilesProcessingStatus({
-        fitnessFileIds: retriableFileIds,
+      })
+    }
+    if (processingResetFileIds.length > 0) {
+      await database.updateFitnessFilesProcessingStatus({
+        fitnessFileIds: processingResetFileIds,
         processingStatus: 'pending'
       })
-    ])
+    }
 
     // A `strava-activity:<id>` batch came from a single Strava activity, so the
     // faithful retry re-runs the full Strava importer (re-fetches the activity

--- a/app/api/v1/fitness/import/[batchId]/route.ts
+++ b/app/api/v1/fitness/import/[batchId]/route.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod'
 
-import { IMPORT_FITNESS_FILES_JOB_NAME } from '@/lib/jobs/names'
+import {
+  IMPORT_FITNESS_FILES_JOB_NAME,
+  IMPORT_STRAVA_ACTIVITY_JOB_NAME
+} from '@/lib/jobs/names'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { getQueue } from '@/lib/services/queue'
+import { getStravaActivityIdFromBatchId } from '@/lib/services/strava/activityBatch'
 import { getStravaArchiveSourceBatchId } from '@/lib/services/strava/archiveImport'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { StravaArchiveImport } from '@/lib/types/database/stravaArchiveImport'
@@ -477,20 +481,39 @@ export const POST = traceApiRoute(
       })
     ])
 
-    try {
-      await getQueue().publish({
-        id: getHashFromString(
-          `${batchActorId}:fitness-import-retry:${batchId}`
-        ),
-        name: IMPORT_FITNESS_FILES_JOB_NAME,
-        data: {
-          actorId: batchActorId,
-          batchId,
-          fitnessFileIds: retriableFileIds,
-          overlapFitnessFileIds,
-          visibility: visibilityParsed.data
+    // A `strava-activity:<id>` batch came from a single Strava activity, so the
+    // faithful retry re-runs the full Strava importer (re-fetches the activity
+    // for its caption, photos and real visibility) rather than only the file
+    // importer (which would recreate the post with an empty caption). Visibility
+    // is omitted so the job re-derives the activity's actual Strava visibility.
+    const stravaActivityId = getStravaActivityIdFromBatchId(batchId)
+    const retryJob = stravaActivityId
+      ? {
+          id: getHashFromString(
+            `${batchActorId}:strava-activity-retry:${batchId}`
+          ),
+          name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+          data: {
+            actorId: batchActorId,
+            stravaActivityId
+          }
         }
-      })
+      : {
+          id: getHashFromString(
+            `${batchActorId}:fitness-import-retry:${batchId}`
+          ),
+          name: IMPORT_FITNESS_FILES_JOB_NAME,
+          data: {
+            actorId: batchActorId,
+            batchId,
+            fitnessFileIds: retriableFileIds,
+            overlapFitnessFileIds,
+            visibility: visibilityParsed.data
+          }
+        }
+
+    try {
+      await getQueue().publish(retryJob)
     } catch (error) {
       const nodeError = error as Error
 

--- a/lib/components/settings/FitnessFileManagement.test.tsx
+++ b/lib/components/settings/FitnessFileManagement.test.tsx
@@ -8,7 +8,8 @@ import { FitnessFileManagement } from './FitnessFileManagement'
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
-    push: vi.fn()
+    push: vi.fn(),
+    refresh: vi.fn()
   }))
 }))
 
@@ -109,6 +110,94 @@ describe('FitnessFileManagement', () => {
         'href',
         '/@alice@example.com/https%3A%2F%2Fexample.com%2Fusers%2Falice%2Fstatuses%2F123'
       )
+    })
+  })
+
+  describe('failed import retry', () => {
+    it('surfaces the import error and retries the batch', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          batchId: 'strava-activity:19007245213',
+          retried: 1
+        })
+      } as Response)
+
+      const files = [
+        {
+          id: 'fitness-failed',
+          actorId: 'https://example.com/users/alice',
+          fileName: 'strava-19007245213.tcx',
+          fileType: 'tcx' as const,
+          mimeType: 'application/vnd.garmin.tcx+xml',
+          bytes: 1024,
+          createdAt: Date.now(),
+          url: '/api/v1/fitness-files/fitness-failed',
+          importStatus: 'failed' as const,
+          importError: 'relation "collection_members" does not exist',
+          importBatchId: 'strava-activity:19007245213'
+        }
+      ]
+
+      render(
+        <FitnessFileManagement
+          used={1024}
+          limit={10485760}
+          fitnessFiles={files}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={1}
+        />
+      )
+
+      expect(screen.getByText('Import failed')).toBeInTheDocument()
+      expect(screen.getByText(/collection_members/)).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /Retry import/i }))
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          '/api/v1/fitness/import/strava-activity%3A19007245213',
+          expect.objectContaining({ method: 'POST' })
+        )
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Retry queued/i)).toBeInTheDocument()
+      })
+    })
+
+    it('does not offer retry for files without an import batch', () => {
+      const files = [
+        {
+          id: 'fitness-orphan',
+          actorId: 'https://example.com/users/alice',
+          fileName: 'orphan.gpx',
+          fileType: 'gpx' as const,
+          mimeType: 'application/gpx+xml',
+          bytes: 1024,
+          createdAt: Date.now(),
+          url: '/api/v1/fitness-files/fitness-orphan',
+          importStatus: 'failed' as const,
+          importError: 'something went wrong'
+        }
+      ]
+
+      render(
+        <FitnessFileManagement
+          used={1024}
+          limit={10485760}
+          fitnessFiles={files}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={1}
+        />
+      )
+
+      expect(screen.getByText('Import failed')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /Retry import/i })
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/lib/components/settings/FitnessFileManagement.test.tsx
+++ b/lib/components/settings/FitnessFileManagement.test.tsx
@@ -167,6 +167,117 @@ describe('FitnessFileManagement', () => {
       })
     })
 
+    it('shows an error message when the retry request fails', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        text: async () => 'Retry rejected',
+        statusText: 'Bad Request'
+      } as Response)
+
+      const files = [
+        {
+          id: 'fitness-failed',
+          actorId: 'https://example.com/users/alice',
+          fileName: 'a.tcx',
+          fileType: 'tcx' as const,
+          mimeType: 'application/vnd.garmin.tcx+xml',
+          bytes: 1024,
+          createdAt: Date.now(),
+          url: '/api/v1/fitness-files/fitness-failed',
+          importStatus: 'failed' as const,
+          importError: 'boom',
+          importBatchId: 'strava-activity:1'
+        }
+      ]
+
+      render(
+        <FitnessFileManagement
+          used={1024}
+          limit={10485760}
+          fitnessFiles={files}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={1}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /Retry import/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Retry rejected')).toBeInTheDocument()
+      })
+    })
+
+    it('disables every retry button while a retry is in flight', async () => {
+      let resolveFetch: (value: unknown) => void = () => undefined
+      vi.spyOn(global, 'fetch').mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        }) as unknown as Promise<Response>
+      )
+
+      const baseFile = {
+        actorId: 'https://example.com/users/alice',
+        fileType: 'tcx' as const,
+        mimeType: 'application/vnd.garmin.tcx+xml',
+        bytes: 1024,
+        createdAt: Date.now(),
+        importStatus: 'failed' as const,
+        importError: 'boom'
+      }
+      const files = [
+        {
+          ...baseFile,
+          id: 'file-a',
+          fileName: 'a.tcx',
+          url: '/api/v1/fitness-files/file-a',
+          importBatchId: 'strava-activity:A'
+        },
+        {
+          ...baseFile,
+          id: 'file-b',
+          fileName: 'b.tcx',
+          url: '/api/v1/fitness-files/file-b',
+          importBatchId: 'strava-activity:B'
+        }
+      ]
+
+      render(
+        <FitnessFileManagement
+          used={2048}
+          limit={10485760}
+          fitnessFiles={files}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={2}
+        />
+      )
+
+      const retryButtons = screen.getAllByRole('button', {
+        name: 'Retry import'
+      })
+      expect(retryButtons).toHaveLength(2)
+
+      fireEvent.click(retryButtons[0])
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Retrying…' })).toBeDisabled()
+      })
+      // The other batch's button is disabled too, so it cannot be dead-clicked.
+      expect(
+        screen.getByRole('button', { name: 'Retry import' })
+      ).toBeDisabled()
+
+      resolveFetch({
+        ok: true,
+        json: async () => ({ batchId: 'strava-activity:A', retried: 1 })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Retry queued/i)).toBeInTheDocument()
+      })
+    })
+
     it('does not offer retry for files without an import batch', () => {
       const files = [
         {

--- a/lib/components/settings/FitnessFileManagement.test.tsx
+++ b/lib/components/settings/FitnessFileManagement.test.tsx
@@ -278,6 +278,66 @@ describe('FitnessFileManagement', () => {
       })
     })
 
+    it('re-exposes the Retry button when a queued batch is still failing after refresh', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ batchId: 'strava-activity:A', retried: 1 })
+      } as Response)
+
+      const failedFile = {
+        id: 'file-a',
+        actorId: 'https://example.com/users/alice',
+        fileName: 'a.tcx',
+        fileType: 'tcx' as const,
+        mimeType: 'application/vnd.garmin.tcx+xml',
+        bytes: 1024,
+        createdAt: Date.now(),
+        url: '/api/v1/fitness-files/file-a',
+        importStatus: 'failed' as const,
+        importError: 'boom',
+        importBatchId: 'strava-activity:A'
+      }
+
+      const { rerender } = render(
+        <FitnessFileManagement
+          used={1024}
+          limit={10485760}
+          fitnessFiles={[failedFile]}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={1}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Retry import' }))
+      await waitFor(() => {
+        expect(screen.getByText(/Retry queued/i)).toBeInTheDocument()
+      })
+      expect(
+        screen.queryByRole('button', { name: 'Retry import' })
+      ).not.toBeInTheDocument()
+
+      // A refresh delivers the same file still failed (the retry did not clear
+      // it); the Retry button must come back rather than stay on "Retry queued".
+      rerender(
+        <FitnessFileManagement
+          used={1024}
+          limit={10485760}
+          fitnessFiles={[{ ...failedFile }]}
+          currentPage={1}
+          itemsPerPage={25}
+          totalItems={1}
+        />
+      )
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Retry import' })
+        ).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/Retry queued/i)).not.toBeInTheDocument()
+    })
+
     it('does not offer retry for files without an import batch', () => {
       const files = [
         {

--- a/lib/components/settings/FitnessFileManagement.tsx
+++ b/lib/components/settings/FitnessFileManagement.tsx
@@ -115,10 +115,13 @@ export function FitnessFileManagement({
     setRetryingBatchId(batchId)
     setRetryError(null)
     try {
-      // Visibility is only consulted for manual-upload batches; Strava-activity
-      // retries re-derive the activity's real visibility server-side. The import
-      // runs asynchronously on the queue, so refresh to pick up the new status.
-      await retryFitnessImportBatch(batchId, 'public')
+      // Visibility is only consulted for manual-upload batches (Strava-activity
+      // retries re-derive the activity's real visibility server-side). The
+      // original choice is not stored on the file, so retry with the safe,
+      // non-publicizing `private` rather than risk re-publishing an originally
+      // unlisted/private post as public. The import runs asynchronously on the
+      // queue, so refresh to pick up the new status.
+      await retryFitnessImportBatch(batchId, 'private')
       setQueuedBatchIds((prev) => new Set(prev).add(batchId))
       router.refresh()
     } catch (error) {
@@ -270,7 +273,7 @@ export function FitnessFileManagement({
                             variant="outline"
                             size="sm"
                             onClick={() => handleRetryImport(retryBatchId)}
-                            disabled={retryingBatchId === retryBatchId}
+                            disabled={retryingBatchId !== null}
                           >
                             {retryingBatchId === retryBatchId
                               ? 'Retrying…'

--- a/lib/components/settings/FitnessFileManagement.tsx
+++ b/lib/components/settings/FitnessFileManagement.tsx
@@ -76,6 +76,23 @@ export function FitnessFileManagement({
   useEffect(() => {
     setFitnessFiles(initialFitnessFiles)
     setCurrentUsed(used)
+    // Drop the "retry queued" flag for any batch that is still failing in the
+    // refreshed data, so its Retry button reappears instead of being stuck on
+    // "Retry queued" forever when a retry did not clear the failure.
+    setQueuedBatchIds((prev) => {
+      if (prev.size === 0) return prev
+      const stillFailingBatchIds = new Set(
+        initialFitnessFiles
+          .filter(
+            (file) => file.importStatus === 'failed' && file.importBatchId
+          )
+          .map((file) => file.importBatchId as string)
+      )
+      const next = new Set(
+        [...prev].filter((batchId) => !stillFailingBatchIds.has(batchId))
+      )
+      return next.size === prev.size ? prev : next
+    })
   }, [initialFitnessFiles, used])
 
   const handleDeleteClick = (fitnessFile: FitnessFileItem) => {

--- a/lib/components/settings/FitnessFileManagement.tsx
+++ b/lib/components/settings/FitnessFileManagement.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
-import { deleteFitnessFile } from '@/lib/client'
+import { deleteFitnessFile, retryFitnessImportBatch } from '@/lib/client'
 import {
   FileListPagination,
   ItemsPerPageDropdown,
@@ -40,6 +40,9 @@ interface FitnessFileItem {
   createdAt: number
   url: string
   statusId?: string
+  importStatus?: 'pending' | 'completed' | 'failed'
+  importError?: string | null
+  importBatchId?: string
 }
 
 interface Props {
@@ -66,6 +69,9 @@ export function FitnessFileManagement({
   const [fileToDelete, setFileToDelete] = useState<FitnessFileItem | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [retryingBatchId, setRetryingBatchId] = useState<string | null>(null)
+  const [queuedBatchIds, setQueuedBatchIds] = useState<Set<string>>(new Set())
+  const [retryError, setRetryError] = useState<string | null>(null)
 
   useEffect(() => {
     setFitnessFiles(initialFitnessFiles)
@@ -100,6 +106,29 @@ export function FitnessFileManagement({
       setDeleteError(message)
     } finally {
       setDeleting(false)
+    }
+  }
+
+  const handleRetryImport = async (batchId: string) => {
+    if (retryingBatchId) return
+
+    setRetryingBatchId(batchId)
+    setRetryError(null)
+    try {
+      // Visibility is only consulted for manual-upload batches; Strava-activity
+      // retries re-derive the activity's real visibility server-side. The import
+      // runs asynchronously on the queue, so refresh to pick up the new status.
+      await retryFitnessImportBatch(batchId, 'public')
+      setQueuedBatchIds((prev) => new Set(prev).add(batchId))
+      router.refresh()
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to retry import. Please try again.'
+      setRetryError(message)
+    } finally {
+      setRetryingBatchId(null)
     }
   }
 
@@ -169,6 +198,13 @@ export function FitnessFileManagement({
                         fitnessFile.statusId
                       )
                     : null
+                  const importFailed = fitnessFile.importStatus === 'failed'
+                  const retryBatchId = importFailed
+                    ? fitnessFile.importBatchId
+                    : undefined
+                  const retryQueued = Boolean(
+                    retryBatchId && queuedBatchIds.has(retryBatchId)
+                  )
 
                   return (
                     <div
@@ -207,9 +243,40 @@ export function FitnessFileManagement({
                             </Link>
                           </div>
                         )}
+                        {importFailed && (
+                          <div className="space-y-1 pt-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="rounded-md bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                                Import failed
+                              </span>
+                              {retryQueued && (
+                                <span className="text-xs text-muted-foreground">
+                                  Retry queued — refresh to see the result.
+                                </span>
+                              )}
+                            </div>
+                            {fitnessFile.importError && (
+                              <p className="text-xs text-destructive">
+                                {fitnessFile.importError}
+                              </p>
+                            )}
+                          </div>
+                        )}
                       </div>
 
                       <div className="flex gap-2">
+                        {retryBatchId && !retryQueued && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleRetryImport(retryBatchId)}
+                            disabled={retryingBatchId === retryBatchId}
+                          >
+                            {retryingBatchId === retryBatchId
+                              ? 'Retrying…'
+                              : 'Retry import'}
+                          </Button>
+                        )}
                         <Button variant="outline" size="sm" asChild>
                           <a href={fitnessFile.url} download>
                             Download
@@ -227,6 +294,10 @@ export function FitnessFileManagement({
                   )
                 })}
               </div>
+
+              {retryError && (
+                <p className="pt-3 text-sm text-destructive">{retryError}</p>
+              )}
 
               <FileListPagination
                 currentPage={currentPage}

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -35,6 +35,7 @@ import {
   isSupportedStravaPhotoMimeType,
   mapStravaVisibilityToMastodon
 } from '@/lib/services/strava/activity'
+import { getStravaActivityBatchId } from '@/lib/services/strava/activityBatch'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { Actor, getMention } from '@/lib/types/domain/actor'
@@ -99,9 +100,6 @@ const getActivityImportGroupKey = (
     : new Date().toISOString().slice(0, 10)
   return `activity_import:${actorId}:${dateStr}`
 }
-
-const getStravaBatchId = (stravaActivityId: string) =>
-  `strava-activity:${stravaActivityId}`
 
 const getStravaFallbackPostId = ({
   actorId,
@@ -490,7 +488,7 @@ export const importStravaActivityJob = createJobHandle(
     })
     const resolvedVisibility =
       visibility ?? mapStravaVisibilityToMastodon(activity.visibility)
-    const batchId = getStravaBatchId(stravaActivityId)
+    const batchId = getStravaActivityBatchId(stravaActivityId)
 
     const batchFiles = await database.getFitnessFilesByBatchId({ batchId })
     let targetFitnessFile =

--- a/lib/services/strava/activityBatch.test.ts
+++ b/lib/services/strava/activityBatch.test.ts
@@ -1,0 +1,40 @@
+import {
+  STRAVA_ACTIVITY_BATCH_PREFIX,
+  getStravaActivityBatchId,
+  getStravaActivityIdFromBatchId
+} from './activityBatch'
+
+describe('getStravaActivityBatchId', () => {
+  it('builds a batch id from a strava activity id', () => {
+    expect(getStravaActivityBatchId('19007245213')).toBe(
+      'strava-activity:19007245213'
+    )
+  })
+})
+
+describe('getStravaActivityIdFromBatchId', () => {
+  it.each([
+    {
+      description: 'extracts the activity id from a strava-activity batch',
+      batchId: `${STRAVA_ACTIVITY_BATCH_PREFIX}19007245213`,
+      expected: '19007245213'
+    },
+    {
+      description: 'returns null for a manual upload batch',
+      batchId: 'batch-1',
+      expected: null
+    },
+    {
+      description: 'returns null for a strava archive batch',
+      batchId: 'strava-archive:archive-1',
+      expected: null
+    },
+    {
+      description: 'returns null when the activity id is empty',
+      batchId: STRAVA_ACTIVITY_BATCH_PREFIX,
+      expected: null
+    }
+  ])('$description', ({ batchId, expected }) => {
+    expect(getStravaActivityIdFromBatchId(batchId)).toBe(expected)
+  })
+})

--- a/lib/services/strava/activityBatch.ts
+++ b/lib/services/strava/activityBatch.ts
@@ -1,0 +1,19 @@
+// A fitness import triggered by a single Strava activity (webhook or
+// re-trigger) is grouped under the import batch id `strava-activity:<id>`. These
+// helpers are the single source of truth for that format so the importer, the
+// retry endpoint, and ops tooling agree on how to build and parse it.
+export const STRAVA_ACTIVITY_BATCH_PREFIX = 'strava-activity:'
+
+export const getStravaActivityBatchId = (stravaActivityId: string): string =>
+  `${STRAVA_ACTIVITY_BATCH_PREFIX}${stravaActivityId}`
+
+export const getStravaActivityIdFromBatchId = (
+  batchId: string
+): string | null => {
+  if (!batchId.startsWith(STRAVA_ACTIVITY_BATCH_PREFIX)) {
+    return null
+  }
+
+  const stravaActivityId = batchId.slice(STRAVA_ACTIVITY_BATCH_PREFIX.length)
+  return stravaActivityId.length > 0 ? stravaActivityId : null
+}

--- a/lib/services/timelines/index.test.ts
+++ b/lib/services/timelines/index.test.ts
@@ -223,6 +223,68 @@ describe('addStatusToTimelines', () => {
     expect(directTimeline.some((s) => s.id === status.id)).toBe(false)
   })
 
+  test('it still records the main timeline when the collection fan-out fails', async () => {
+    const id = randomBytes(16).toString('hex')
+    const status = await database.createNote({
+      id: `${EXTERNAL_ACTOR1}/statuses/${id}`,
+      url: `${EXTERNAL_ACTOR1}/statuses/${id}`,
+      actorId: EXTERNAL_ACTOR1,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [EXTERNAL_ACTOR1_FOLLOWERS],
+      text: 'message despite collection failure'
+    })
+
+    const collectionSpy = vi
+      .spyOn(database, 'addStatusToCollectionTimelines')
+      .mockRejectedValue(
+        new Error('relation "collection_members" does not exist')
+      )
+
+    // A failure materializing the rebuildable collection feed must not abort
+    // status creation and lose the post.
+    await expect(
+      addStatusToTimelines(database, status)
+    ).resolves.toBeUndefined()
+    expect(collectionSpy).toHaveBeenCalled()
+
+    const mainTimeline = await database.getTimeline({
+      timeline: Timeline.MAIN,
+      actorId: ACTOR1_ID
+    })
+    expect(mainTimeline.some((s) => s.id === status.id)).toBe(true)
+
+    collectionSpy.mockRestore()
+  })
+
+  test('it still records the main timeline when the list fan-out fails', async () => {
+    const id = randomBytes(16).toString('hex')
+    const status = await database.createNote({
+      id: `${EXTERNAL_ACTOR1}/statuses/${id}`,
+      url: `${EXTERNAL_ACTOR1}/statuses/${id}`,
+      actorId: EXTERNAL_ACTOR1,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [EXTERNAL_ACTOR1_FOLLOWERS],
+      text: 'message despite list failure'
+    })
+
+    const listSpy = vi
+      .spyOn(database, 'addStatusToListTimelines')
+      .mockRejectedValue(new Error('relation "list_timeline" does not exist'))
+
+    await expect(
+      addStatusToTimelines(database, status)
+    ).resolves.toBeUndefined()
+    expect(listSpy).toHaveBeenCalled()
+
+    const mainTimeline = await database.getTimeline({
+      timeline: Timeline.MAIN,
+      actorId: ACTOR1_ID
+    })
+    expect(mainTimeline.some((s) => s.id === status.id)).toBe(true)
+
+    listSpy.mockRestore()
+  })
+
   test('it skips timelines when a followed actor announces a blocked author', async () => {
     const id = randomBytes(16).toString('hex')
     const originalStatus = await database.createNote({

--- a/lib/services/timelines/index.ts
+++ b/lib/services/timelines/index.ts
@@ -2,6 +2,7 @@ import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import { isDirectStatus } from '@/lib/utils/directStatus'
+import { logger } from '@/lib/utils/logger'
 import { getTracer } from '@/lib/utils/trace'
 
 import { getBlockedRecipientActorIdsForStatus } from './blockFilter'
@@ -9,6 +10,32 @@ import { mainTimelineRule } from './main'
 import { mentionTimelineRule } from './mention'
 import { noannounceTimelineRule } from './noaanounce'
 import { Timeline } from './types'
+
+// The list and collection feeds are materialized, rebuildable projections of
+// the `statuses` table (the same membership-driven fan-out the live query once
+// scanned; lists even ship a `backfill_list_timelines` migration). The status
+// row and its core home/mention/direct timelines are the source of truth. A
+// failure here — e.g. a database mid-migration where the `collection_*`/`list_*`
+// tables do not exist yet, or a transient DB error — must NOT abort status
+// creation and lose the post itself, which would orphan imported fitness files
+// (no status, no page link). Log and continue; the projection can be rebuilt.
+const materializeAuxiliaryFeed = async (
+  feedName: string,
+  status: Status,
+  populate: () => Promise<void>
+): Promise<void> => {
+  try {
+    await populate()
+  } catch (error) {
+    const nodeError = error as Error
+    logger.error({
+      message: `Failed to materialize ${feedName} for status; continuing`,
+      statusId: status.id,
+      actorId: status.actorId,
+      error: nodeError.message
+    })
+  }
+}
 
 export const addStatusToTimelines = async (
   database: Database,
@@ -57,12 +84,16 @@ export const addStatusToTimelines = async (
       // author (independent of the recipient fan-out below, since list ownership
       // — not delivery — decides list membership). Visibility/replies-policy are
       // enforced at read time, so this materializes the same candidate set the
-      // old live list query scanned.
-      await database.addStatusToListTimelines({ status })
+      // old live list query scanned. Best-effort: see materializeAuxiliaryFeed.
+      await materializeAuxiliaryFeed('list timelines', status, () =>
+        database.addStatusToListTimelines({ status })
+      )
       // Likewise fan the post into the capped feed of every collection whose
       // membership includes its author. The owner/public projections (and the
-      // public-only visibility filter) are applied at read time.
-      await database.addStatusToCollectionTimelines({ status })
+      // public-only visibility filter) are applied at read time. Best-effort.
+      await materializeAuxiliaryFeed('collection timelines', status, () =>
+        database.addStatusToCollectionTimelines({ status })
+      )
 
       const isDirect = isDirectStatus(status)
       if (isDirect) {

--- a/scripts/repairFailedFitnessImports.test.ts
+++ b/scripts/repairFailedFitnessImports.test.ts
@@ -159,6 +159,204 @@ describe('repairFailedFitnessImports', () => {
 
     expect(exitCode).toBe(0)
     expect(mockImportStravaActivityJob).not.toHaveBeenCalled()
+    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
     expect(database?.updateFitnessFilesImportStatus).not.toHaveBeenCalled()
+    expect(database?.updateFitnessFilesProcessingStatus).not.toHaveBeenCalled()
+  })
+
+  it('discovers failed batches for an actor across paginated pages and dedups them', async () => {
+    const SCAN_PAGE_SIZE = 200
+    // Page 1 is full (length === SCAN_PAGE_SIZE) so the scan must request a
+    // second page; two of its files fail under the same batch (dedups to one).
+    const firstPage = Array.from({ length: SCAN_PAGE_SIZE }, (_, index) => ({
+      id: `p1-${index}`,
+      actorId,
+      importBatchId:
+        index < 2 ? 'strava-activity:A' : `strava-activity:done-${index}`,
+      importStatus: index < 2 ? 'failed' : 'completed',
+      processingStatus: index < 2 ? 'failed' : 'completed',
+      statusId: index < 2 ? undefined : `${actorId}/statuses/${index}`,
+      fileName: `p1-${index}.tcx`
+    }))
+    // Page 2 is short (ends the scan) with one more failed batch and one failed
+    // file that has no import batch (an orphan that cannot be auto-retried).
+    const secondPage = [
+      {
+        id: 'p2-0',
+        actorId,
+        importBatchId: 'strava-activity:B',
+        importStatus: 'failed',
+        processingStatus: 'failed',
+        fileName: 'p2-0.tcx'
+      },
+      {
+        id: 'p2-orphan',
+        actorId,
+        importStatus: 'failed',
+        processingStatus: 'failed',
+        fileName: 'p2-orphan.tcx'
+      }
+    ]
+
+    const filesByBatch: Record<string, unknown[]> = {
+      'strava-activity:A': [
+        {
+          id: 'p1-0',
+          actorId,
+          importBatchId: 'strava-activity:A',
+          importStatus: 'failed',
+          processingStatus: 'failed',
+          fileName: 'p1-0.tcx'
+        }
+      ],
+      'strava-activity:B': [secondPage[0]]
+    }
+
+    const getFitnessFilesByActor = vi
+      .fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage)
+
+    const database = {
+      getFitnessFilesByActor,
+      getFitnessFilesByBatchId: vi
+        .fn()
+        .mockImplementation(({ batchId }: { batchId: string }) =>
+          Promise.resolve(filesByBatch[batchId] ?? [])
+        ),
+      updateFitnessFilesImportStatus: vi.fn().mockResolvedValue(1),
+      updateFitnessFilesProcessingStatus: vi.fn().mockResolvedValue(1)
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await repairFailedFitnessImports(['--actor-id', actorId])
+
+    expect(exitCode).toBe(0)
+    // Scanned both pages, advancing the offset.
+    expect(getFitnessFilesByActor).toHaveBeenNthCalledWith(1, {
+      actorId,
+      limit: SCAN_PAGE_SIZE,
+      offset: 0
+    })
+    expect(getFitnessFilesByActor).toHaveBeenNthCalledWith(2, {
+      actorId,
+      limit: SCAN_PAGE_SIZE,
+      offset: SCAN_PAGE_SIZE
+    })
+    // Two distinct failed batches discovered (the duplicate in page 1 deduped).
+    expect(mockImportStravaActivityJob).toHaveBeenCalledTimes(2)
+    expect(mockImportStravaActivityJob).toHaveBeenCalledWith(
+      database,
+      expect.objectContaining({
+        data: { actorId, stravaActivityId: 'A' }
+      })
+    )
+    expect(mockImportStravaActivityJob).toHaveBeenCalledWith(
+      database,
+      expect.objectContaining({
+        data: { actorId, stravaActivityId: 'B' }
+      })
+    )
+  })
+
+  it('reports nothing to repair when an actor has no failed imports', async () => {
+    const database = {
+      getFitnessFilesByActor: vi.fn().mockResolvedValue([
+        {
+          id: 'done-1',
+          actorId,
+          importBatchId: 'strava-activity:1',
+          importStatus: 'completed',
+          processingStatus: 'completed',
+          statusId: `${actorId}/statuses/1`,
+          fileName: 'done-1.tcx'
+        }
+      ]),
+      getFitnessFilesByBatchId: vi.fn(),
+      updateFitnessFilesImportStatus: vi.fn(),
+      updateFitnessFilesProcessingStatus: vi.fn()
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await repairFailedFitnessImports(['--actor-id', actorId])
+
+    expect(exitCode).toBe(0)
+    expect(mockImportStravaActivityJob).not.toHaveBeenCalled()
+    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
+    expect(database?.getFitnessFilesByBatchId).not.toHaveBeenCalled()
+  })
+
+  it('skips a batch that has no failed files', async () => {
+    const database = {
+      getFitnessFilesByBatchId: vi.fn().mockResolvedValue([
+        {
+          id: 'done-1',
+          actorId,
+          importBatchId: 'batch-1',
+          importStatus: 'completed',
+          processingStatus: 'completed',
+          statusId: `${actorId}/statuses/1`,
+          fileName: 'done-1.fit'
+        }
+      ]),
+      updateFitnessFilesImportStatus: vi.fn(),
+      updateFitnessFilesProcessingStatus: vi.fn()
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await repairFailedFitnessImports([
+      '--actor-id',
+      actorId,
+      '--batch-id',
+      'batch-1'
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
+    expect(mockImportStravaActivityJob).not.toHaveBeenCalled()
+    expect(database?.updateFitnessFilesImportStatus).not.toHaveBeenCalled()
+  })
+
+  it('restores files to failed and exits non-zero when the importer throws', async () => {
+    const database = {
+      getFitnessFilesByBatchId: vi.fn().mockResolvedValue([
+        {
+          id: 'file-1',
+          actorId,
+          importBatchId: 'strava-activity:19007245213',
+          importStatus: 'failed',
+          processingStatus: 'failed',
+          fileName: 'a.tcx'
+        }
+      ]),
+      updateFitnessFilesImportStatus: vi.fn().mockResolvedValue(1),
+      updateFitnessFilesProcessingStatus: vi.fn().mockResolvedValue(1),
+      updateFitnessFileImportStatus: vi.fn().mockResolvedValue(true),
+      updateFitnessFileProcessingStatus: vi.fn().mockResolvedValue(true)
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+    mockImportStravaActivityJob.mockRejectedValueOnce(new Error('strava down'))
+
+    const exitCode = await repairFailedFitnessImports([
+      '--actor-id',
+      actorId,
+      '--batch-id',
+      'strava-activity:19007245213'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(database?.updateFitnessFileImportStatus).toHaveBeenCalledWith(
+      'file-1',
+      'failed',
+      'strava down'
+    )
+    expect(database?.updateFitnessFileProcessingStatus).toHaveBeenCalledWith(
+      'file-1',
+      'failed'
+    )
   })
 })

--- a/scripts/repairFailedFitnessImports.test.ts
+++ b/scripts/repairFailedFitnessImports.test.ts
@@ -1,0 +1,164 @@
+import { getDatabase } from '@/lib/database'
+import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
+import { importStravaActivityJob } from '@/lib/jobs/importStravaActivityJob'
+import {
+  IMPORT_FITNESS_FILES_JOB_NAME,
+  IMPORT_STRAVA_ACTIVITY_JOB_NAME
+} from '@/lib/jobs/names'
+
+import { repairFailedFitnessImports } from './repairFailedFitnessImports'
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn()
+}))
+
+vi.mock('@/lib/jobs/importStravaActivityJob', () => ({
+  importStravaActivityJob: vi.fn()
+}))
+
+vi.mock('@/lib/jobs/importFitnessFilesJob', () => ({
+  importFitnessFilesJob: vi.fn()
+}))
+
+const mockGetDatabase = getDatabase as jest.MockedFunction<typeof getDatabase>
+const mockImportStravaActivityJob =
+  importStravaActivityJob as jest.MockedFunction<typeof importStravaActivityJob>
+const mockImportFitnessFilesJob = importFitnessFilesJob as jest.MockedFunction<
+  typeof importFitnessFilesJob
+>
+
+const actorId = 'https://llun.social/users/ride'
+
+describe('repairFailedFitnessImports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('re-runs the full Strava importer for a strava-activity batch', async () => {
+    const database = {
+      getFitnessFilesByBatchId: vi.fn().mockResolvedValue([
+        {
+          id: 'file-1',
+          actorId,
+          importBatchId: 'strava-activity:19007245213',
+          importStatus: 'failed',
+          processingStatus: 'failed',
+          fileName: 'strava-19007245213.tcx'
+        }
+      ]),
+      updateFitnessFilesImportStatus: vi.fn().mockResolvedValue(1),
+      updateFitnessFilesProcessingStatus: vi.fn().mockResolvedValue(1)
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await repairFailedFitnessImports([
+      '--actor-id',
+      actorId,
+      '--batch-id',
+      'strava-activity:19007245213'
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(mockImportStravaActivityJob).toHaveBeenCalledWith(
+      database,
+      expect.objectContaining({
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: { actorId, stravaActivityId: '19007245213' }
+      })
+    )
+    expect(mockImportFitnessFilesJob).not.toHaveBeenCalled()
+    expect(database?.updateFitnessFilesImportStatus).toHaveBeenCalledWith({
+      fitnessFileIds: ['file-1'],
+      importStatus: 'pending'
+    })
+  })
+
+  it('re-runs the file importer for a manual upload batch with overlap context', async () => {
+    const database = {
+      getFitnessFilesByBatchId: vi.fn().mockResolvedValue([
+        {
+          id: 'file-failed',
+          actorId,
+          importBatchId: 'batch-1',
+          importStatus: 'failed',
+          processingStatus: 'failed',
+          fileName: 'a.fit'
+        },
+        {
+          id: 'file-done',
+          actorId,
+          importBatchId: 'batch-1',
+          importStatus: 'completed',
+          processingStatus: 'completed',
+          statusId: `${actorId}/statuses/x`,
+          fileName: 'b.fit'
+        }
+      ]),
+      updateFitnessFilesImportStatus: vi.fn().mockResolvedValue(1),
+      updateFitnessFilesProcessingStatus: vi.fn().mockResolvedValue(1)
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await repairFailedFitnessImports([
+      '--actor-id',
+      actorId,
+      '--batch-id',
+      'batch-1'
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(mockImportFitnessFilesJob).toHaveBeenCalledWith(
+      database,
+      expect.objectContaining({
+        name: IMPORT_FITNESS_FILES_JOB_NAME,
+        data: expect.objectContaining({
+          actorId,
+          batchId: 'batch-1',
+          fitnessFileIds: ['file-failed'],
+          overlapFitnessFileIds: ['file-done'],
+          visibility: 'public'
+        })
+      })
+    )
+    expect(mockImportStravaActivityJob).not.toHaveBeenCalled()
+  })
+
+  it('changes nothing in dry-run mode', async () => {
+    const database = {
+      getFitnessFilesByBatchId: vi.fn().mockResolvedValue([
+        {
+          id: 'file-1',
+          actorId,
+          importBatchId: 'strava-activity:1',
+          importStatus: 'failed',
+          processingStatus: 'failed',
+          fileName: 'a.tcx'
+        }
+      ]),
+      updateFitnessFilesImportStatus: vi.fn().mockResolvedValue(1),
+      updateFitnessFilesProcessingStatus: vi.fn().mockResolvedValue(1)
+    } as unknown as ReturnType<typeof getDatabase>
+
+    mockGetDatabase.mockReturnValue(database)
+
+    const exitCode = await repairFailedFitnessImports([
+      '--actor-id',
+      actorId,
+      '--batch-id',
+      'strava-activity:1',
+      '--dry-run'
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(mockImportStravaActivityJob).not.toHaveBeenCalled()
+    expect(database?.updateFitnessFilesImportStatus).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/repairFailedFitnessImports.ts
+++ b/scripts/repairFailedFitnessImports.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env -S node scripts/run.cjs
+/**
+ * Re-runs failed fitness imports directly from the already-stored fitness files,
+ * without needing Strava to re-send a webhook. Use this to recover activities
+ * that imported the file to storage but failed to create the local status (e.g.
+ * the orphaned-files-with-no-post case caused by a missing collection table on a
+ * database that was mid-migration).
+ *
+ * For each failed file the correct importer is invoked in-process:
+ *   - `strava-activity:<id>` batch → importStravaActivityJob (re-fetches the
+ *     Strava activity, so caption/photos/visibility are restored)
+ *   - any other batch (manual upload) → importFitnessFilesJob (recreates the
+ *     post from the stored file)
+ *
+ * IMPORTANT: run this with the PRODUCTION database/storage/Strava env configured
+ * (the same env Cloud Run uses). `NODE_ENV=production` alone only loads local
+ * `.env*` files, so without the real connection settings it will connect to your
+ * local database and find nothing to repair.
+ *
+ * Usage (all failed imports for an actor):
+ *   NODE_ENV=production scripts/repairFailedFitnessImports.ts \
+ *     --actor-id https://<host>/users/<username>
+ *
+ * Usage (only specific batches):
+ *   NODE_ENV=production scripts/repairFailedFitnessImports.ts \
+ *     --actor-id https://<host>/users/<username> \
+ *     --batch-id strava-activity:19007245213 \
+ *     [--batch-id <batch-id> ...]
+ *
+ * Options:
+ *   --visibility <public|unlisted|private|direct>
+ *       Visibility for recreated posts. Default `public`. Only applies to
+ *       manual-upload batches; Strava-activity retries re-derive the activity's
+ *       own visibility from Strava.
+ *   --dry-run
+ *       List what would be retried without changing anything.
+ */
+import { loadEnvConfig } from '@next/env'
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
+import { importStravaActivityJob } from '@/lib/jobs/importStravaActivityJob'
+import {
+  IMPORT_FITNESS_FILES_JOB_NAME,
+  IMPORT_STRAVA_ACTIVITY_JOB_NAME
+} from '@/lib/jobs/names'
+import { getStravaActivityIdFromBatchId } from '@/lib/services/strava/activityBatch'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+
+const projectDir = process.cwd()
+loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
+
+const Visibility = z.enum(['public', 'unlisted', 'private', 'direct'])
+
+const CliArgs = z.object({
+  actorId: z.string().min(1),
+  batchIds: z.array(z.string().min(1)).default([]),
+  visibility: Visibility.default('public'),
+  dryRun: z.boolean().default(false)
+})
+
+const USAGE = `Usage:
+  Repair all failed imports for an actor:
+    NODE_ENV=production scripts/repairFailedFitnessImports.ts \\
+      --actor-id https://<host>/users/<username>
+
+  Repair specific batches:
+    NODE_ENV=production scripts/repairFailedFitnessImports.ts \\
+      --actor-id https://<host>/users/<username> \\
+      --batch-id strava-activity:<id> [--batch-id <batch-id> ...]
+
+  Options:
+    --visibility <public|unlisted|private|direct>  default public (manual batches only)
+    --dry-run                                      list without changing anything`
+
+const ACTOR_SCAN_PAGE_SIZE = 200
+
+const parseArgs = (args: string[]) => {
+  const batchIds: string[] = []
+  let actorId: string | undefined
+  let visibility: string | undefined
+  let dryRun = false
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (!argument.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${argument}`)
+    }
+
+    const [rawKey, inlineValue] = argument.slice(2).split('=', 2)
+
+    if (rawKey === 'dry-run') {
+      dryRun = true
+      continue
+    }
+
+    const nextValue = inlineValue ?? args[index + 1]
+    if (!nextValue || nextValue.startsWith('--')) {
+      throw new Error(`Missing value for --${rawKey}`)
+    }
+
+    if (inlineValue === undefined) {
+      index += 1
+    }
+
+    if (rawKey === 'actor-id') {
+      actorId = nextValue
+    } else if (rawKey === 'batch-id') {
+      batchIds.push(nextValue)
+    } else if (rawKey === 'visibility') {
+      visibility = nextValue
+    } else {
+      throw new Error(`Unknown argument: --${rawKey}`)
+    }
+  }
+
+  return CliArgs.parse({ actorId, batchIds, visibility, dryRun })
+}
+
+const isFailedImport = (file: FitnessFile): boolean =>
+  file.importStatus === 'failed'
+
+const collectActorFailedBatchIds = async (
+  database: NonNullable<ReturnType<typeof getDatabase>>,
+  actorId: string
+): Promise<{ batchIds: string[]; orphanCount: number }> => {
+  const batchIds = new Set<string>()
+  let orphanCount = 0
+  let offset = 0
+
+  for (;;) {
+    const page = await database.getFitnessFilesByActor({
+      actorId,
+      limit: ACTOR_SCAN_PAGE_SIZE,
+      offset
+    })
+
+    for (const file of page) {
+      if (!isFailedImport(file)) continue
+      if (file.importBatchId) {
+        batchIds.add(file.importBatchId)
+      } else {
+        orphanCount += 1
+      }
+    }
+
+    if (page.length < ACTOR_SCAN_PAGE_SIZE) break
+    offset += ACTOR_SCAN_PAGE_SIZE
+  }
+
+  return { batchIds: [...batchIds], orphanCount }
+}
+
+const repairBatch = async ({
+  database,
+  actorId,
+  batchId,
+  visibility,
+  dryRun
+}: {
+  database: NonNullable<ReturnType<typeof getDatabase>>
+  actorId: string
+  batchId: string
+  visibility: z.infer<typeof Visibility>
+  dryRun: boolean
+}): Promise<'repaired' | 'skipped' | 'error'> => {
+  const files = await database.getFitnessFilesByBatchId({ batchId })
+  const actorFiles = files.filter((file) => file.actorId === actorId)
+  const failedFiles = actorFiles.filter(isFailedImport)
+
+  if (failedFiles.length === 0) {
+    console.log(`  [${batchId}] no failed files, skipping`)
+    return 'skipped'
+  }
+
+  const failedFileIds = failedFiles.map((file) => file.id)
+  const stravaActivityId = getStravaActivityIdFromBatchId(batchId)
+
+  if (dryRun) {
+    console.log(
+      `  [${batchId}] would retry ${failedFileIds.length} file(s) via ` +
+        (stravaActivityId
+          ? `Strava activity import (${stravaActivityId})`
+          : 'file import')
+    )
+    return 'repaired'
+  }
+
+  try {
+    await Promise.all([
+      database.updateFitnessFilesImportStatus({
+        fitnessFileIds: failedFileIds,
+        importStatus: 'pending'
+      }),
+      database.updateFitnessFilesProcessingStatus({
+        fitnessFileIds: failedFileIds,
+        processingStatus: 'pending'
+      })
+    ])
+
+    if (stravaActivityId) {
+      await importStravaActivityJob(database, {
+        id: getHashFromString(
+          `repair:strava-activity:${actorId}:${stravaActivityId}`
+        ),
+        name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+        data: { actorId, stravaActivityId }
+      })
+    } else {
+      const overlapFitnessFileIds = actorFiles
+        .filter(
+          (file) => file.importStatus === 'completed' && Boolean(file.statusId)
+        )
+        .map((file) => file.id)
+
+      await importFitnessFilesJob(database, {
+        id: getHashFromString(`repair:fitness-import:${actorId}:${batchId}`),
+        name: IMPORT_FITNESS_FILES_JOB_NAME,
+        data: {
+          actorId,
+          batchId,
+          fitnessFileIds: failedFileIds,
+          overlapFitnessFileIds,
+          visibility
+        }
+      })
+    }
+
+    console.log(
+      `  [${batchId}] retried ${failedFileIds.length} file(s) via ` +
+        (stravaActivityId
+          ? `Strava activity import (${stravaActivityId})`
+          : 'file import')
+    )
+    return 'repaired'
+  } catch (error) {
+    const nodeError = error as Error
+    console.error(`  [${batchId}] failed: ${nodeError.message}`)
+    return 'error'
+  }
+}
+
+export async function repairFailedFitnessImports(args = process.argv.slice(2)) {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE)
+    return 0
+  }
+
+  let input: z.infer<typeof CliArgs>
+  try {
+    input = parseArgs(args)
+  } catch (error) {
+    const nodeError = error as Error
+    console.error(nodeError.message)
+    console.error(USAGE)
+    return 1
+  }
+
+  const database = getDatabase()
+  if (!database) {
+    console.error('Error: Database is not available')
+    return 1
+  }
+
+  let batchIds = input.batchIds
+  if (batchIds.length === 0) {
+    const { batchIds: discoveredBatchIds, orphanCount } =
+      await collectActorFailedBatchIds(database, input.actorId)
+    batchIds = discoveredBatchIds
+
+    if (orphanCount > 0) {
+      console.log(
+        `Note: ${orphanCount} failed file(s) have no import batch and cannot be retried automatically.`
+      )
+    }
+  }
+
+  if (batchIds.length === 0) {
+    console.log('No failed fitness imports to repair for this actor')
+    return 0
+  }
+
+  console.log(
+    `Repairing ${batchIds.length} failed import batch(es) for actor ${input.actorId}` +
+      (input.dryRun ? ' (dry run)' : '')
+  )
+
+  const counts = { repaired: 0, skipped: 0, error: 0 }
+  for (const batchId of batchIds) {
+    const result = await repairBatch({
+      database,
+      actorId: input.actorId,
+      batchId,
+      visibility: input.visibility,
+      dryRun: input.dryRun
+    })
+    counts[result] += 1
+  }
+
+  console.log(
+    `\nDone: ${counts.repaired} repaired, ${counts.skipped} skipped, ${counts.error} error(s)`
+  )
+
+  return counts.error > 0 ? 1 : 0
+}
+
+if (require.main === module) {
+  repairFailedFitnessImports()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error('Script failed:', error)
+      process.exit(1)
+    })
+}

--- a/scripts/repairFailedFitnessImports.ts
+++ b/scripts/repairFailedFitnessImports.ts
@@ -119,8 +119,14 @@ const parseArgs = (args: string[]) => {
   return CliArgs.parse({ actorId, batchIds, visibility, dryRun })
 }
 
+// A true import failure: the file failed to create its status, so it has no
+// statusId. Files that imported successfully but later failed map processing
+// (statusId set, processingStatus 'failed') are NOT re-importable here — a
+// re-import short-circuits past the importer, so retry would leave importStatus
+// stuck. Those are handled by the processing-retry path (resumeStravaProcessing
+// / retryFitnessProcessing) instead.
 const isFailedImport = (file: FitnessFile): boolean =>
-  file.importStatus === 'failed'
+  file.importStatus === 'failed' && !file.statusId
 
 const collectActorFailedBatchIds = async (
   database: NonNullable<ReturnType<typeof getDatabase>>,
@@ -189,16 +195,15 @@ const repairBatch = async ({
   }
 
   try {
-    await Promise.all([
-      database.updateFitnessFilesImportStatus({
-        fitnessFileIds: failedFileIds,
-        importStatus: 'pending'
-      }),
-      database.updateFitnessFilesProcessingStatus({
-        fitnessFileIds: failedFileIds,
-        processingStatus: 'pending'
-      })
-    ])
+    // Sequential to avoid two concurrent UPDATEs racing on the same rows.
+    await database.updateFitnessFilesImportStatus({
+      fitnessFileIds: failedFileIds,
+      importStatus: 'pending'
+    })
+    await database.updateFitnessFilesProcessingStatus({
+      fitnessFileIds: failedFileIds,
+      processingStatus: 'pending'
+    })
 
     if (stravaActivityId) {
       await importStravaActivityJob(database, {
@@ -238,6 +243,25 @@ const repairBatch = async ({
   } catch (error) {
     const nodeError = error as Error
     console.error(`  [${batchId}] failed: ${nodeError.message}`)
+
+    // The job threw after we reset the files to 'pending'. Restore them to
+    // 'failed' (with the error) so they are not left stuck mid-retry and remain
+    // retriable from the UI / a later run.
+    try {
+      for (const fileId of failedFileIds) {
+        await database.updateFitnessFileImportStatus(
+          fileId,
+          'failed',
+          nodeError.message
+        )
+        await database.updateFitnessFileProcessingStatus(fileId, 'failed')
+      }
+    } catch (resetError) {
+      console.error(
+        `  [${batchId}] failed to restore file status: ${(resetError as Error).message}`
+      )
+    }
+
     return 'error'
   }
 }


### PR DESCRIPTION
## Problem

Strava webhook imports were saving the fitness `.tcx`/`.gpx` to storage but **never creating the post** — fitness files appeared in storage with no page linking to them.

The logs showed the real error buried under `Failed to create local status for imported fitness files`:

```
select "collectionSeq", "seq" from "collection_members" where "targetActorId" = $1
  - relation "collection_members" does not exist
```

### Root cause

[`addStatusToTimelines`](lib/services/timelines/index.ts) unconditionally fans every status into the **list** and **collection** materialized feeds. On a database where the `collection_*` tables didn't exist yet (the migration from #1047 hadn't been applied), that query threw. [`importFitnessFilesJob`](lib/jobs/importFitnessFilesJob.ts) caught it, marked the files `failed`, and **deleted** the just-created status. The outer `importStravaActivityJob` swallowed the failure and returned HTTP 200, so qstash never retried.

## Fix

**Root cause — best-effort feed fan-out.** The list and collection feeds are rebuildable projections of the `statuses` table; the status row + its core home/mention/direct timelines are the source of truth. A failure populating those projections now logs and continues instead of losing the post. This protects every status-creation path (inbox, notes, fitness), not just fitness.

**Resumability / retry:**
- The batch-retry endpoint (`POST /api/v1/fitness/import/[batchId]`) now re-runs the **full** `importStravaActivityJob` for `strava-activity:<id>` batches — restoring caption, photos, and the activity's real Strava visibility — instead of only `importFitnessFilesJob` (which recreated the post with an empty caption).
- The **Fitness Files page** surfaces failed imports (badge + error) with a **Retry** button that re-queues the import server-side — no Strava webhook needed.
- New `scripts/repairFailedFitnessImports.ts` re-runs failed imports directly from the stored files for an actor or specific batches (no Strava dependency for manual batches).
- New shared `lib/services/strava/activityBatch` helpers are the single source of truth for the `strava-activity:<id>` batch-id format.

## Testing

- `yarn lint` — clean (0 errors)
- `yarn build` — passes (no type errors)
- `yarn test` — 536 files / 4690 tests pass
- New/updated tests: best-effort fan-out (collection + list failure), full-fidelity Strava retry routing, `activityBatch` helpers, Fitness Files retry UI, and the repair script.

## Notes

- No migration changes (so no schema dump regeneration needed).
- Visibility on Strava-activity retries is intentionally **omitted** so the job re-derives the activity's real Strava visibility rather than forcing `public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)