### PR TITLE
Bump version to v1.84.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.83.0",
+  "version": "1.84.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.84.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.83.0`
- Base main SHA: `32c4316f1fce405c0ed1c65f02e52960b4bcd69a`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
