### PR TITLE
chore: bump undici to 7.28.0 to resolve Dependabot security alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12366,9 +12366,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.25.0":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves all **6 open Dependabot security alerts**, every one of which targets the transitive **`undici`** dependency (`>= 7.0.0, < 7.28.0`, dev scope, pulled in by `jsdom`). The fix re-resolves `undici` to **7.28.0**, the first patched release.

| Alert | Severity | Summary |
|-------|----------|---------|
| [#171](https://github.com/llun/activities.next/security/dependabot/171) | High | TLS certificate validation bypass via dropped `requestTls` in SOCKS5 `ProxyAgent` |
| [#174](https://github.com/llun/activities.next/security/dependabot/174) | High | Cross-origin request routing via SOCKS5 proxy pool reuse |
| [#170](https://github.com/llun/activities.next/security/dependabot/170) | Medium | Cross-user information disclosure via shared cache whitespace bypass |
| [#178](https://github.com/llun/activities.next/security/dependabot/178) | Medium | HTTP header injection via `Set-Cookie` percent-decoding |
| [#173](https://github.com/llun/activities.next/security/dependabot/173) | Low | HTTP response queue poisoning via keep-alive socket reuse |
| [#180](https://github.com/llun/activities.next/security/dependabot/180) | Low | `Set-Cookie` SameSite attribute downgrade via permissive substring matching |

> **Note:** A 7th undici advisory (`GHSA-vxpw-j846-p89q`, alert #176, High, same `< 7.28.0` range) is already in `auto_dismissed` state, so it is not in the open set — but `7.28.0` covers it too. The "6 open" count is exact; this is noted only so the GitHub advisory total reconciles cleanly.

## How it was fixed

- Removed **only** the stale `undici@npm:^7.25.0` entry from `yarn.lock` and ran `yarn install`, letting Yarn re-resolve the existing `^7.25.0` range to the latest matching version (**7.28.0**). No new `resolutions` override was added.
- The diff is intentionally minimal — **3 lines in `yarn.lock`**.

```
$ yarn why undici
├─ @digitalbazaar/http-client@npm:4.3.0
│  └─ undici@npm:6.27.0 (via npm:^6.23.0)   ← not affected (alerts are >= 7.0.0)
└─ jsdom@npm:29.1.1
   └─ undici@npm:7.28.0 (via npm:^7.25.0)   ← patched
```

`undici@latest` is now `8.5.0`, but `jsdom@29.1.1` pins the range `^7.25.0`, so the highest stable 7.x (`7.28.0`) is the correct, minimal in-major bump. No advisory affects `7.28.0`, so forcing an 8.x resolution would be unnecessary risk.

## On the `resolutions` cleanup request

The only entry in `resolutions` is `"postcss": "8.5.15"`. It is **intentionally kept** — it is not a stale pin-down, and removing it would be an active regression:

- `8.5.15` is the **current npm latest** for postcss — it is not a "pin-down to an old version".
- It is **load-bearing for dedup**: `next@16.2.6` (and even `next@16.2.9`, the latest on the 16 line) hard-pins postcss to an **exact** `8.4.31` — an exact version cannot float upward on its own, so only a `resolutions` override lifts it. The override collapses next's `8.4.31`, the direct devDep `^8.5.15`, `@tailwindcss/postcss`'s `^8.5.10`, and others onto a single `postcss@8.5.15`. Removing it would re-materialize a separate `postcss@8.4.31` for next (a downgrade + duplicate copy).
- It is **load-bearing for security**: postcss advisory `GHSA-7fh5-64p2-3v2j` (alert #144, vulnerable `< 8.5.10`, already fixed) covers `8.4.31`. So removing the resolution would **reopen the previously-fixed alert #144**, not just add churn. (8.4.31 only patches the older `< 8.4.31` advisory, alert #27.)

No new resolution was introduced for the undici fix, in keeping with the request to avoid stale pin-downs.

## Verification

- `yarn run prettier --write .` — clean (only `yarn.lock` changed)
- `yarn lint` — 0 errors (31 pre-existing `any` warnings in `vitest.d.ts`)
- `yarn build` — success
- `yarn test` — **538 files / 4712 tests pass**. (One unhandled async error from a `@radix-ui/react-focus-scope` timer in `mobile-nav.test.tsx` is a pre-existing jsdom parallel-teardown race — it does not reproduce when the file runs in isolation and is unrelated to the undici HTTP-client bump.)
- `yarn install --immutable` / `--check-cache` — lockfile is idempotent and the new `7.28.0` checksum validates against the registry.
- CI on the PR: Lint/Prettier, Build, All Tests, CodeQL all green.

## Review

Reviewed across two rounds by independent review agents (correctness, completeness, lockfile integrity, repo-policy/version-bump, and an adversarial devil's-advocate on the postcss pin) plus the Gemini bot — all **APPROVE**, no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
