### PR TITLE
Bump version to v1.84.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.84.0",
+  "version": "1.84.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.84.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.84.0`
- Base main SHA: `9de7ebd96227f241f96885fa46692af14e3fc3ca`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
