### PR TITLE
minor: fitness import robustness — recover stuck processing + merge same-ride uploads

### DIFF
--- a/app/api/v1/statuses/[id]/retry-fitness/route.test.ts
+++ b/app/api/v1/statuses/[id]/retry-fitness/route.test.ts
@@ -1,0 +1,168 @@
+import knex from 'knex'
+import { NextRequest } from 'next/server'
+
+import { getSQLDatabase } from '@/lib/database/sql'
+import { STUCK_PROCESSING_THRESHOLD_MS } from '@/lib/services/fitness-files/processingState'
+import { getQueue } from '@/lib/services/queue'
+import { seedDatabase } from '@/lib/stub/database'
+import {
+  ACTOR1_FOLLOWER_URL,
+  ACTOR1_ID,
+  seedActor1
+} from '@/lib/stub/seed/actor1'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockGetServerSession = vi.fn()
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+vi.mock('@/lib/config', () => ({
+  getBaseURL: vi.fn().mockReturnValue('https://llun.test'),
+  getConfig: vi.fn().mockReturnValue({
+    host: 'llun.test',
+    allowEmails: [],
+    secretPhase: 'test-secret'
+  })
+}))
+
+let mockDatabase: ReturnType<typeof getSQLDatabase> | null = null
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    get: () => undefined
+  })
+}))
+
+vi.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: vi.fn()
+}))
+
+vi.mock('@/lib/services/queue', () => ({
+  getQueue: vi.fn().mockReturnValue({
+    publish: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+const callRetry = (statusId: string) =>
+  POST(
+    new NextRequest(
+      `https://llun.test/api/v1/statuses/${urlToId(statusId)}/retry-fitness`,
+      { method: 'POST', headers: { Origin: 'https://llun.test' } }
+    ),
+    { params: Promise.resolve({ id: urlToId(statusId) }) }
+  )
+
+const seedFitnessStatus = async (
+  database: ReturnType<typeof getSQLDatabase>,
+  suffix: string
+) => {
+  const status = await database.createNote({
+    id: `${ACTOR1_ID}/statuses/retry-fitness-${suffix}`,
+    url: `${ACTOR1_ID}/statuses/retry-fitness-${suffix}`,
+    actorId: ACTOR1_ID,
+    text: 'Fitness activity',
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [ACTOR1_FOLLOWER_URL]
+  })
+  const file = await database.createFitnessFile({
+    actorId: ACTOR1_ID,
+    statusId: status.id,
+    path: `fitness/retry-${suffix}.tcx`,
+    fileName: `retry-${suffix}.tcx`,
+    fileType: 'tcx',
+    mimeType: 'application/vnd.garmin.tcx+xml',
+    bytes: 1_024
+  })
+  return { status, file: file! }
+}
+
+describe('POST /api/v1/statuses/[id]/retry-fitness', () => {
+  const knexInstance = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+  const database = getSQLDatabase(knexInstance)
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retries a file stranded in processing past the stuck threshold', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'))
+
+    const { status, file } = await seedFitnessStatus(database, 'stuck')
+    await database.updateFitnessFileProcessingStatus(file.id, 'processing')
+
+    // Jump past the threshold so the file looks stranded mid-job.
+    vi.setSystemTime(
+      new Date(Date.now() + STUCK_PROCESSING_THRESHOLD_MS + 60_000)
+    )
+
+    const response = await callRetry(status.id)
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as { retried: number }
+    expect(json.retried).toBe(1)
+    expect(getQueue().publish).toHaveBeenCalledTimes(1)
+
+    const refreshed = await database.getFitnessFile({ id: file.id })
+    expect(refreshed?.processingStatus).toBe('pending')
+  })
+
+  it('does not retry a file that is still actively processing', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2030-02-01T00:00:00.000Z'))
+
+    const { status, file } = await seedFitnessStatus(database, 'in-flight')
+    await database.updateFitnessFileProcessingStatus(file.id, 'processing')
+
+    // Still well within the threshold — a genuinely in-flight job.
+    vi.setSystemTime(new Date(Date.now() + 60_000))
+
+    const response = await callRetry(status.id)
+    expect(response.status).toBe(422)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+
+    const refreshed = await database.getFitnessFile({ id: file.id })
+    expect(refreshed?.processingStatus).toBe('processing')
+  })
+
+  it('still retries a failed file', async () => {
+    const { status, file } = await seedFitnessStatus(database, 'failed')
+    await database.updateFitnessFileProcessingStatus(file.id, 'failed')
+
+    const response = await callRetry(status.id)
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as { retried: number }
+    expect(json.retried).toBe(1)
+
+    const refreshed = await database.getFitnessFile({ id: file.id })
+    expect(refreshed?.processingStatus).toBe('pending')
+  })
+})

--- a/app/api/v1/statuses/[id]/retry-fitness/route.test.ts
+++ b/app/api/v1/statuses/[id]/retry-fitness/route.test.ts
@@ -10,6 +10,7 @@ import {
   ACTOR1_ID,
   seedActor1
 } from '@/lib/stub/seed/actor1'
+import { seedActor2 } from '@/lib/stub/seed/actor2'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -164,5 +165,71 @@ describe('POST /api/v1/statuses/[id]/retry-fitness', () => {
 
     const refreshed = await database.getFitnessFile({ id: file.id })
     expect(refreshed?.processingStatus).toBe('pending')
+  })
+
+  it('rejects a retry from someone who does not own the status and queues nothing', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor2.email }
+    })
+    const { status, file } = await seedFitnessStatus(database, 'owner-only')
+    await database.updateFitnessFileProcessingStatus(file.id, 'failed')
+
+    const response = await callRetry(status.id)
+    expect(response.status).toBe(403)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+
+    const refreshed = await database.getFitnessFile({ id: file.id })
+    expect(refreshed?.processingStatus).toBe('failed')
+  })
+
+  it('retries every failed and stuck-processing file in a status but skips completed ones', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2030-03-01T00:00:00.000Z'))
+
+    const status = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/retry-fitness-multi`,
+      url: `${ACTOR1_ID}/statuses/retry-fitness-multi`,
+      actorId: ACTOR1_ID,
+      text: 'Fitness activity',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [ACTOR1_FOLLOWER_URL]
+    })
+    const makeFile = (suffix: string) =>
+      database.createFitnessFile({
+        actorId: ACTOR1_ID,
+        statusId: status.id,
+        path: `fitness/multi-${suffix}.tcx`,
+        fileName: `multi-${suffix}.tcx`,
+        fileType: 'tcx',
+        mimeType: 'application/vnd.garmin.tcx+xml',
+        bytes: 1_024
+      })
+    const failed = await makeFile('failed')
+    const stuck = await makeFile('stuck')
+    const completed = await makeFile('completed')
+    await database.updateFitnessFileProcessingStatus(failed!.id, 'failed')
+    await database.updateFitnessFileProcessingStatus(stuck!.id, 'processing')
+    await database.updateFitnessFileProcessingStatus(completed!.id, 'completed')
+
+    // Age past the threshold so `stuck` is stranded; `completed` stays done.
+    vi.setSystemTime(
+      new Date(Date.now() + STUCK_PROCESSING_THRESHOLD_MS + 60_000)
+    )
+
+    const response = await callRetry(status.id)
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as { retried: number }
+    expect(json.retried).toBe(2)
+    expect(getQueue().publish).toHaveBeenCalledTimes(2)
+
+    expect(
+      (await database.getFitnessFile({ id: failed!.id }))?.processingStatus
+    ).toBe('pending')
+    expect(
+      (await database.getFitnessFile({ id: stuck!.id }))?.processingStatus
+    ).toBe('pending')
+    expect(
+      (await database.getFitnessFile({ id: completed!.id }))?.processingStatus
+    ).toBe('completed')
   })
 })

--- a/app/api/v1/statuses/[id]/retry-fitness/route.ts
+++ b/app/api/v1/statuses/[id]/retry-fitness/route.ts
@@ -1,4 +1,5 @@
 import { PROCESS_FITNESS_FILE_JOB_NAME } from '@/lib/jobs/names'
+import { isFitnessProcessingStuck } from '@/lib/services/fitness-files/processingState'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getQueue } from '@/lib/services/queue'
 import { Scope } from '@/lib/types/database/operations'
@@ -45,8 +46,16 @@ export const POST = traceApiRoute(
     }
 
     const files = await database.getFitnessFilesByStatus({ statusId })
+    // `failed` files are the explicit failure case. A file still marked
+    // `processing` long after the job started is stranded too: the worker was
+    // killed mid-job (e.g. OOM/deploy) before it could write `completed` or
+    // `failed`, and nothing re-queues it. Treat such stuck files as retriable
+    // while leaving genuinely in-flight jobs (recent `processing`) alone.
+    const now = Date.now()
     const retriableFiles = files.filter(
-      (file) => file.processingStatus === 'failed'
+      (file) =>
+        file.processingStatus === 'failed' ||
+        isFitnessProcessingStuck(file, now)
     )
 
     if (retriableFiles.length === 0) {

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -46,7 +46,8 @@ vi.mock('@/lib/client', () => ({
   unmute: vi.fn(),
   block: vi.fn(),
   unblock: vi.fn(),
-  createReport: vi.fn()
+  createReport: vi.fn(),
+  retryFitnessProcessing: vi.fn()
 }))
 
 const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
@@ -935,6 +936,56 @@ describe('Post', () => {
 
     expect(
       screen.queryByRole('link', { name: /View on Strava|View source/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the processing spinner while a fresh fitness file is still processing', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        currentActor={status.actor!}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            processingStatus: 'processing',
+            processingStuck: false
+          }
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Processing fitness activity/i)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Retry/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('offers the owner a retry instead of an endless spinner once processing is stuck', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        currentActor={status.actor!}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            processingStatus: 'processing',
+            processingStuck: true
+          }
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Processing fitness activity/i)
     ).not.toBeInTheDocument()
   })
 })

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -110,10 +110,16 @@ export const Post: FC<PostProps> = (props) => {
   const fitnessFile =
     actualStatus.type === StatusType.enum.Note ? actualStatus.fitness : null
   const fitnessProcessingStatus = fitnessFile?.processingStatus ?? 'completed'
+  // A file left in `processing` long after its worker died (server computes
+  // `processingStuck`) is surfaced as a retry instead of an endless spinner.
+  const isFitnessStuck = Boolean(fitnessFile?.processingStuck)
   const isFitnessProcessing =
-    fitnessProcessingStatus === 'pending' ||
-    fitnessProcessingStatus === 'processing'
-  const isFitnessFailed = fitnessProcessingStatus === 'failed'
+    !isFitnessStuck &&
+    (fitnessProcessingStatus === 'pending' ||
+      fitnessProcessingStatus === 'processing')
+  const isFitnessFailed = fitnessProcessingStatus === 'failed' || isFitnessStuck
+  const fitnessRetryVariant: 'failed' | 'stuck' =
+    fitnessProcessingStatus === 'failed' ? 'failed' : 'stuck'
   const isFitnessCompleted = fitnessProcessingStatus === 'completed'
   const fitnessDistance = formatFitnessDistance(
     fitnessFile?.totalDistanceMeters
@@ -194,12 +200,16 @@ export const Post: FC<PostProps> = (props) => {
 
           {isFitnessFailed ? (
             isOwner ? (
-              <RetryFitnessButton statusId={actualStatus.id} />
+              <RetryFitnessButton
+                statusId={actualStatus.id}
+                variant={fitnessRetryVariant}
+              />
             ) : (
               <div className="mt-2 flex items-center gap-2 text-destructive">
                 <span>
-                  Processing failed. The original activity file is still
-                  available.
+                  {fitnessRetryVariant === 'stuck'
+                    ? 'Processing is taking longer than expected. The original activity file is still available.'
+                    : 'Processing failed. The original activity file is still available.'}
                 </span>
               </div>
             )

--- a/lib/components/posts/retry-fitness-button.tsx
+++ b/lib/components/posts/retry-fitness-button.tsx
@@ -8,9 +8,22 @@ import { cn } from '@/lib/utils'
 
 interface Props {
   statusId: string
+  // `failed`: the job threw and gave up. `stuck`: the file is still marked
+  // `processing` long after its worker died mid-run. Both are retriable; the
+  // copy differs so the owner sees why.
+  variant?: 'failed' | 'stuck'
 }
 
-export const RetryFitnessButton: FC<Props> = ({ statusId }) => {
+const LEAD_TEXT: Record<NonNullable<Props['variant']>, string> = {
+  failed: 'Processing failed. The original activity file is still available.',
+  stuck:
+    'Processing is taking longer than expected. The original activity file is still available.'
+}
+
+export const RetryFitnessButton: FC<Props> = ({
+  statusId,
+  variant = 'failed'
+}) => {
   const [isRetrying, setIsRetrying] = useState(false)
   const [retryQueued, setRetryQueued] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -26,9 +39,7 @@ export const RetryFitnessButton: FC<Props> = ({ statusId }) => {
 
   return (
     <div className="mt-2 flex items-center gap-2 text-destructive">
-      <span>
-        Processing failed. The original activity file is still available.
-      </span>
+      <span>{LEAD_TEXT[variant]}</span>
       <span className="inline-flex flex-col gap-0.5">
         <button
           className={cn(

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -9,6 +9,7 @@ import {
   getTestDatabaseTable
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
+import { STUCK_PROCESSING_THRESHOLD_MS } from '@/lib/services/fitness-files/processingState'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Timeline } from '@/lib/services/timelines/types'
 import { TEST_DOMAIN, TEST_PASSWORD_HASH } from '@/lib/stub/const'
@@ -477,8 +478,51 @@ describe('StatusDatabase', () => {
           mimeType: 'application/octet-stream',
           bytes: 4096,
           url: `/api/v1/fitness-files/${fitnessFile?.id}`,
-          sourceUrl: 'https://www.strava.com/activities/123'
+          sourceUrl: 'https://www.strava.com/activities/123',
+          processingStuck: false
         })
+      })
+
+      it('flags a fitness file stranded in processing as processingStuck', async () => {
+        vi.useFakeTimers({ toFake: ['Date'] })
+        try {
+          vi.setSystemTime(new Date('2031-01-01T00:00:00.000Z'))
+          const statusId = `${emptyActorId}/statuses/fitness-stuck`
+
+          await database.createNote({
+            id: statusId,
+            url: statusId,
+            actorId: emptyActorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            text: 'This post is stuck processing'
+          })
+
+          const fitnessFile = await database.createFitnessFile({
+            actorId: emptyActorId,
+            statusId,
+            path: `fitness/${Date.now()}-stuck.fit`,
+            fileName: 'stuck.fit',
+            fileType: 'fit',
+            mimeType: 'application/octet-stream',
+            bytes: 4096
+          })
+          await database.updateFitnessFileProcessingStatus(
+            fitnessFile!.id,
+            'processing'
+          )
+
+          // Jump past the stuck threshold without finishing the job.
+          vi.setSystemTime(
+            new Date(Date.now() + STUCK_PROCESSING_THRESHOLD_MS + 60_000)
+          )
+
+          const status = (await database.getStatus({ statusId })) as StatusNote
+          expect(status.fitness?.processingStatus).toBe('processing')
+          expect(status.fitness?.processingStuck).toBe(true)
+        } finally {
+          vi.useRealTimers()
+        }
       })
 
       it('returns announce status', async () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -525,6 +525,45 @@ describe('StatusDatabase', () => {
         }
       })
 
+      it('serializes the primary fitness file when a status has several', async () => {
+        const statusId = `${emptyActorId}/statuses/fitness-multi`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Same ride recorded on two devices'
+        })
+
+        // Insert the secondary file first so an unordered .first() would
+        // wrongly surface it instead of the primary.
+        const secondary = await database.createFitnessFile({
+          actorId: emptyActorId,
+          statusId,
+          path: 'fitness/multi-secondary.fit',
+          fileName: 'secondary.fit',
+          fileType: 'fit',
+          mimeType: 'application/octet-stream',
+          bytes: 1024
+        })
+        const primary = await database.createFitnessFile({
+          actorId: emptyActorId,
+          statusId,
+          path: 'fitness/multi-primary.fit',
+          fileName: 'primary.fit',
+          fileType: 'fit',
+          mimeType: 'application/octet-stream',
+          bytes: 2048
+        })
+        await database.updateFitnessFilePrimary(secondary!.id, false)
+        await database.updateFitnessFilePrimary(primary!.id, true)
+
+        const status = (await database.getStatus({ statusId })) as StatusNote
+        expect(status.fitness?.id).toBe(primary!.id)
+        expect(status.fitness?.fileName).toBe('primary.fit')
+      })
+
       it('returns announce status', async () => {
         const status = await database.getStatus({
           statusId: statuses.replyAuthor.announceOwn

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -28,6 +28,7 @@ import {
   PUBLIC_ACTIVITY_RECIPIENTS,
   applyPotentiallyReadableStatusFilter as applyPotentiallyReadableStatusVisibilityFilter
 } from '@/lib/database/sql/utils/statusVisibility'
+import { isFitnessProcessingStuck } from '@/lib/services/fitness-files/processingState'
 import { SQLFitnessFile } from '@/lib/types/database/fitnessFile'
 import { ActorDatabase } from '@/lib/types/database/operations'
 import { BookmarkDatabase } from '@/lib/types/database/operations'
@@ -2514,6 +2515,17 @@ export const StatusSQLDatabaseMixin = (
               bytes: Number(fitnessFile.bytes),
               url: `/api/v1/fitness-files/${fitnessFile.id}`,
               processingStatus: fitnessFile.processingStatus ?? 'pending',
+              // True when the file has sat in `processing` long enough that the
+              // worker must have died mid-job. Lets clients offer a retry
+              // instead of an endless spinner. Computed server-side so the
+              // client never does time math (avoids hydration drift).
+              processingStuck: isFitnessProcessingStuck(
+                {
+                  processingStatus: fitnessFile.processingStatus,
+                  updatedAt: getCompatibleTime(fitnessFile.updatedAt)
+                },
+                Date.now()
+              ),
               ...(typeof fitnessFile.totalDistanceMeters === 'number'
                 ? { totalDistanceMeters: fitnessFile.totalDistanceMeters }
                 : null),

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -2457,9 +2457,15 @@ export const StatusSQLDatabaseMixin = (
           })
         : null,
       database('status_history').where('statusId', data.id),
+      // A status can carry several fitness files (e.g. the same ride merged
+      // from two devices). Surface the primary one — matching
+      // getFitnessFileByStatus — instead of an arbitrary `.first()`.
       database<SQLFitnessFile>('fitness_files')
         .where('statusId', data.id)
         .whereNull('deletedAt')
+        .orderBy('isPrimary', 'desc')
+        .orderBy('activityStartTime', 'asc')
+        .orderBy('createdAt', 'asc')
         .first()
     ])
 

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -298,6 +298,25 @@ describe('importStravaActivityJob', () => {
     )
   })
 
+  it('seeds activity start time and duration at import so later same-ride imports can merge before processing', async () => {
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-seed',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: {
+        actorId: 'actor-1',
+        stravaActivityId: '123'
+      }
+    })
+
+    expect(database.updateFitnessFileActivityData).toHaveBeenCalledWith(
+      'new-file',
+      expect.objectContaining({
+        activityStartTime: new Date('2026-01-01T00:00:00.000Z'),
+        totalDurationSeconds: 1_500
+      })
+    )
+  })
+
   it('uses CLI-provided Strava auth without loading fitness settings', async () => {
     mockGetValidStravaAccessToken.mockImplementationOnce(
       async ({ fitnessSettings }) => fitnessSettings.accessToken ?? null

--- a/lib/jobs/importStravaActivityJob.test.ts
+++ b/lib/jobs/importStravaActivityJob.test.ts
@@ -317,6 +317,57 @@ describe('importStravaActivityJob', () => {
     )
   })
 
+  it('seeds duration but omits activityStartTime when the activity has no start_date', async () => {
+    mockGetStravaActivity.mockResolvedValue({
+      id: 123,
+      upload_id: 67890,
+      name: 'Morning Run',
+      distance: 5_000,
+      elapsed_time: 1_500,
+      total_elevation_gain: 120,
+      sport_type: 'Run',
+      visibility: 'everyone'
+    })
+
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-no-start',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: { actorId: 'actor-1', stravaActivityId: '123' }
+    })
+
+    const seedCall = database.updateFitnessFileActivityData.mock.calls.find(
+      (call) => call[0] === 'new-file'
+    )
+    expect(seedCall).toBeDefined()
+    expect(seedCall![1]).toMatchObject({ totalDurationSeconds: 1_500 })
+    expect(seedCall![1]).not.toHaveProperty('activityStartTime')
+  })
+
+  it('does not seed activity data at import when start_date, duration, and device are all absent', async () => {
+    mockGetStravaActivity.mockResolvedValue({
+      id: 123,
+      upload_id: 67890,
+      name: 'Morning Run',
+      distance: 5_000,
+      elapsed_time: 0,
+      moving_time: 0,
+      total_elevation_gain: 120,
+      sport_type: 'Run',
+      visibility: 'everyone'
+    })
+
+    await importStravaActivityJob(database as unknown as Database, {
+      id: 'job-empty-seed',
+      name: IMPORT_STRAVA_ACTIVITY_JOB_NAME,
+      data: { actorId: 'actor-1', stravaActivityId: '123' }
+    })
+
+    const seedCall = database.updateFitnessFileActivityData.mock.calls.find(
+      (call) => call[0] === 'new-file'
+    )
+    expect(seedCall).toBeUndefined()
+  })
+
   it('uses CLI-provided Strava auth without loading fitness settings', async () => {
     mockGetValidStravaAccessToken.mockImplementationOnce(
       async ({ fitnessSettings }) => fitnessSettings.accessToken ?? null

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -586,19 +586,36 @@ export const importStravaActivityJob = createJobHandle(
         )
       }
 
+      // Seed the activity's start time and duration straight from the Strava
+      // metadata, before async processing parses the file. The same-ride
+      // overlap merge matches candidates on activityStartTime + duration, so
+      // without this seed a second device's upload of the same ride can't find
+      // its sibling until that sibling finishes processing — which fails
+      // exactly when both imports arrive together (and worse when processing
+      // stalls), leaving duplicate posts. Processing later overwrites these
+      // with the parsed values.
+      const importActivityData: UpdateFitnessFileActivityData = {}
+      const activityStartMs = getStravaActivityStartTimeMs(activity)
+      if (activityStartMs !== undefined) {
+        importActivityData.activityStartTime = new Date(activityStartMs)
+      }
+      const activityDurationSeconds = getStravaActivityDurationSeconds(activity)
+      if (activityDurationSeconds > 0) {
+        importActivityData.totalDurationSeconds = activityDurationSeconds
+      }
       if (activity.device_name) {
         const manufacturerKey = getManufacturerKeyFromDeviceName(
           activity.device_name
         )
-        const deviceData = {
-          deviceName: activity.device_name,
-          ...(manufacturerKey !== undefined
-            ? { deviceManufacturer: manufacturerKey }
-            : {})
+        importActivityData.deviceName = activity.device_name
+        if (manufacturerKey !== undefined) {
+          importActivityData.deviceManufacturer = manufacturerKey
         }
+      }
+      if (Object.keys(importActivityData).length > 0) {
         await database.updateFitnessFileActivityData(
           storedFitnessFile.id,
-          deviceData
+          importActivityData
         )
       }
 

--- a/lib/services/fitness-files/processingState.test.ts
+++ b/lib/services/fitness-files/processingState.test.ts
@@ -1,0 +1,74 @@
+import {
+  STUCK_PROCESSING_THRESHOLD_MS,
+  isFitnessProcessingStuck
+} from './processingState'
+
+describe('isFitnessProcessingStuck', () => {
+  const now = 1_700_000_000_000
+
+  it('returns true when a file has been processing past the threshold', () => {
+    expect(
+      isFitnessProcessingStuck(
+        {
+          processingStatus: 'processing',
+          updatedAt: now - STUCK_PROCESSING_THRESHOLD_MS - 1
+        },
+        now
+      )
+    ).toBe(true)
+  })
+
+  it('returns true at exactly the threshold boundary', () => {
+    expect(
+      isFitnessProcessingStuck(
+        {
+          processingStatus: 'processing',
+          updatedAt: now - STUCK_PROCESSING_THRESHOLD_MS
+        },
+        now
+      )
+    ).toBe(true)
+  })
+
+  it('returns false while a file is still within the threshold', () => {
+    expect(
+      isFitnessProcessingStuck(
+        { processingStatus: 'processing', updatedAt: now - 1_000 },
+        now
+      )
+    ).toBe(false)
+  })
+
+  it.each(['pending', 'completed', 'failed'] as const)(
+    'returns false for %s status no matter how old it is',
+    (processingStatus) => {
+      expect(
+        isFitnessProcessingStuck(
+          {
+            processingStatus,
+            updatedAt: now - STUCK_PROCESSING_THRESHOLD_MS - 1
+          },
+          now
+        )
+      ).toBe(false)
+    }
+  )
+
+  it('returns false when processingStatus is missing', () => {
+    expect(
+      isFitnessProcessingStuck(
+        { updatedAt: now - STUCK_PROCESSING_THRESHOLD_MS - 1 },
+        now
+      )
+    ).toBe(false)
+  })
+
+  it('defaults to the current time when no clock is provided', () => {
+    expect(
+      isFitnessProcessingStuck({
+        processingStatus: 'processing',
+        updatedAt: Date.now() - STUCK_PROCESSING_THRESHOLD_MS - 1_000
+      })
+    ).toBe(true)
+  })
+})

--- a/lib/services/fitness-files/processingState.ts
+++ b/lib/services/fitness-files/processingState.ts
@@ -1,0 +1,26 @@
+import { FitnessProcessingStatus } from '@/lib/types/database/fitnessFile'
+
+// A fitness file is moved to `processing` the moment the job starts and is
+// flipped to `completed`/`failed` only inside the job's try/catch. When the
+// worker is killed mid-job (e.g. OOM, deploy SIGTERM, timeout) the process
+// dies before either write lands — which is NOT a catchable error — so the
+// file is stranded in `processing` forever. Anything still `processing` past
+// this threshold is treated as stuck and eligible for retry. Real processing
+// completes in seconds, so a generous window avoids racing a genuinely
+// in-flight job.
+export const STUCK_PROCESSING_THRESHOLD_MS = 15 * 60 * 1000
+
+interface FitnessProcessingState {
+  processingStatus?: FitnessProcessingStatus | null
+  // Milliseconds since epoch of the last processing-status write. Callers must
+  // normalize raw SQL timestamps (e.g. via getCompatibleTime) before passing.
+  updatedAt: number
+}
+
+export const isFitnessProcessingStuck = (
+  file: FitnessProcessingState,
+  now: number = Date.now()
+): boolean => {
+  if (file.processingStatus !== 'processing') return false
+  return now - file.updatedAt >= STUCK_PROCESSING_THRESHOLD_MS
+}

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -34,6 +34,10 @@ export const StatusFitnessFile = z.object({
   processingStatus: z
     .enum(['pending', 'processing', 'completed', 'failed'])
     .optional(),
+  // True when a `processing` file has been stranded long enough that its worker
+  // must have died mid-job; signals clients to offer a retry. Computed
+  // server-side from the file's `updatedAt`.
+  processingStuck: z.boolean().optional(),
   totalDistanceMeters: z.number().optional(),
   totalDurationSeconds: z.number().optional(),
   elevationGainMeters: z.number().optional(),


### PR DESCRIPTION
Three related fixes from the same stuck-fitness incident on llun.social.

---

## 1. Recover fitness files stranded in `processing`

### Problem
The 4 newest Strava `.tcx` activities were stuck forever on "Processing fitness activity…", in `processingStatus: "processing"` with stats parsed but no map.

`processFitnessFileJob` marks a file `processing` up front and only flips it to `completed`/`failed` inside a `try/catch`. When the Cloud Run worker is **killed mid-job** (OOM, deploy SIGTERM, timeout) the process dies — not a catchable error — so the file is stranded. QStash has **0 retries**, no reaper, and both recovery surfaces (Retry button + `/retry-fitness`) gated strictly on `failed`, so an orphaned-in-`processing` file had zero recovery.

### Fix
- **`isFitnessProcessingStuck()`** — a file still `processing` past a 15-minute threshold (by `updatedAt`) is treated as stranded. No migration.
- **`/retry-fitness`** retries `failed` **or** stuck-`processing`, leaving in-flight jobs alone.
- **`processingStuck`** serialized server-side (no client time math → no hydration drift); the post shows a **Retry** control instead of an endless spinner.

---

## 2. Merge same-ride uploads recorded on two devices

### Problem
Recording one ride on two head units produces two Strava activities that should collapse into **one** post (overlap merge). They didn't — duplicate posts.

The merge matches candidates on `activityStartTime` + `totalDurationSeconds`, but those are only written during **async processing**. Strava fires a webhook **per activity**, so a second device's upload can't find its sibling until that sibling finishes processing — which fails when both arrive together, worse when processing stalls.

### Fix
Seed `activityStartTime` (from `start_date`) + `totalDurationSeconds` (from `elapsed_time`) onto the new fitness file **at import time**; processing later overwrites with parsed values. A later same-ride import can then match an already-imported sibling without waiting for it to finish processing.

Known residual: a truly simultaneous double-import can still race; fully closing it needs per-actor import serialization or a post-processing reconcile (follow-up).

---

## 3. Display the primary fitness file on multi-file posts

### Problem
A status can carry several fitness files (exactly what #2's merge produces). The `toStatus` serializer fetched one with `.first()` and **no ordering**, so a merged post could display an arbitrary — possibly non-primary — recording.

### Fix
Order the serializer's fitness fetch by `isPrimary` (then `activityStartTime`, `createdAt`), matching `getFitnessFileByStatus`, so the primary recording is always the one shown.

---

## Tests
- `processingState.test.ts`, `retry-fitness/route.test.ts`, `status.test.ts`, `post.test.tsx` — stuck detection, retry, serialization, UI.
- `importStravaActivityJob.test.ts` — import seeds `activityStartTime` + `totalDurationSeconds`.
- `status.test.ts` — multi-file status serializes the primary.

prettier / lint / `next build` / full suite (4730 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)