### PR TITLE
Bump version to v1.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.84.1",
+  "version": "1.85.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.85.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.84.1`
- Base main SHA: `d79495d2bad975c9330f8db8f66d7a4bc0d479e4`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
