### PR TITLE
fix: flatten + focus the route heatmap map and brighten route lines

### DIFF
--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -1056,7 +1056,11 @@ describe('RouteHeatmapMap', () => {
       [SINGAPORE_CLUSTER_BOUNDS.minLng, SINGAPORE_CLUSTER_BOUNDS.minLat],
       [SINGAPORE_CLUSTER_BOUNDS.maxLng, SINGAPORE_CLUSTER_BOUNDS.maxLat]
     ])
-    expect(fitBounds.mock.calls[0][1]).toMatchObject({ maxZoom: 12 })
+    expect(fitBounds.mock.calls[0][1]).toMatchObject({
+      padding: 56,
+      duration: 0,
+      maxZoom: 12
+    })
   })
 })
 
@@ -1250,15 +1254,18 @@ describe('computeFocusBounds', () => {
     expect(result.bounds).toBe(bounds)
   })
 
-  it('does not merge cells a knight’s-move apart, focusing the densest', () => {
+  it('does not merge cells a knight’s-move apart, focusing the densest cell', () => {
     const bounds = { minLat: 52, maxLat: 55, minLng: 4, maxLng: 13 }
-    // Cells 0:10 and 2:11 are not 8-adjacent (dx=2), so they stay separate — this
-    // pins that it is grid adjacency, not mere proximity, that merges clusters.
+    // Cell 0:10 (two points) is strictly denser than cell 2:11 (one point), and
+    // the two cells are a knight's move apart (dx=2), so they stay separate — this
+    // pins that grid adjacency (not mere proximity) is what merges clusters, and
+    // that the seed is chosen by density rather than Map insertion order.
     const result = computeFocusBounds(
       [
         {
           points: [
             { lat: 52, lng: 4 },
+            { lat: 53, lng: 4 },
             { lat: 55, lng: 13 }
           ]
         }
@@ -1269,9 +1276,44 @@ describe('computeFocusBounds', () => {
     expect(result.focused).toBe(true)
     expect(result.bounds).toEqual({
       minLat: 52,
-      maxLat: 52,
+      maxLat: 53,
       minLng: 4,
       maxLng: 4
+    })
+  })
+
+  it('frames the densest cell even when another cluster has more cells', () => {
+    // Cluster A spans two 8-adjacent cells (0:0 and 0:1) of one point each — the
+    // largest connected cluster by cell count. Cluster B is a single isolated cell
+    // (8:0) holding three points — the densest cell. The focus must frame B (seed
+    // = densest cell, then its cluster), proving the helper does not instead pick
+    // the cluster with the most cells.
+    const bounds = { minLat: 0, maxLat: 7, minLng: 2, maxLng: 40.2 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 2, lng: 2 },
+            { lat: 7, lng: 2 }
+          ]
+        },
+        {
+          points: [
+            { lat: 0, lng: 40 },
+            { lat: 0.1, lng: 40.1 },
+            { lat: 0.2, lng: 40.2 }
+          ]
+        }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(true)
+    expect(result.bounds).toEqual({
+      minLat: 0,
+      maxLat: 0.2,
+      minLng: 40,
+      maxLng: 40.2
     })
   })
 })

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -1228,4 +1228,50 @@ describe('computeFocusBounds', () => {
       maxLng: 179.9
     })
   })
+
+  it('merges cells that touch only diagonally (8-connectivity)', () => {
+    const bounds = { minLat: 52, maxLat: 55, minLng: 4, maxLng: 8 }
+    // The two 5° cells (0:10 and 1:11) are diagonal neighbours — connected only
+    // at a corner. 8-connectivity merges them into one contiguous cluster, so
+    // the full bounds are kept (a 4-connected flood fill would NOT merge these).
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52, lng: 4 },
+            { lat: 55, lng: 8 }
+          ]
+        }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(false)
+    expect(result.bounds).toBe(bounds)
+  })
+
+  it('does not merge cells a knight’s-move apart, focusing the densest', () => {
+    const bounds = { minLat: 52, maxLat: 55, minLng: 4, maxLng: 13 }
+    // Cells 0:10 and 2:11 are not 8-adjacent (dx=2), so they stay separate — this
+    // pins that it is grid adjacency, not mere proximity, that merges clusters.
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52, lng: 4 },
+            { lat: 55, lng: 13 }
+          ]
+        }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(true)
+    expect(result.bounds).toEqual({
+      minLat: 52,
+      maxLat: 52,
+      minLng: 4,
+      maxLng: 4
+    })
+  })
 })

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -1145,11 +1145,87 @@ describe('computeFocusBounds', () => {
     })
   })
 
-  it('returns the full bounds when there are no finite points', () => {
+  it('returns the full bounds for an empty segment list', () => {
     const bounds = { minLat: 0, maxLat: 0, minLng: 0, maxLng: 0 }
     const result = computeFocusBounds([], bounds)
 
     expect(result.focused).toBe(false)
     expect(result.bounds).toBe(bounds)
+  })
+
+  it('skips non-finite vertices so they create no spurious cluster', () => {
+    const bounds = { minLat: 52.36, maxLat: 52.39, minLng: 4.88, maxLng: 4.91 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52.36, lng: 4.88 },
+            { lat: 52.39, lng: 4.91 }
+          ]
+        },
+        // An entirely non-finite segment must contribute no grid cell; otherwise
+        // it would look like a second region and flip the result to focused.
+        {
+          points: [
+            { lat: NaN, lng: NaN },
+            { lat: Infinity, lng: -Infinity }
+          ]
+        }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(false)
+    expect(result.bounds).toBe(bounds)
+  })
+
+  it('ignores non-finite vertices when framing a focused cluster', () => {
+    const bounds = { minLat: 1.3, maxLat: 52.39, minLng: 4.88, maxLng: 103.9 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52.36, lng: 4.88 },
+            { lat: 52.37, lng: 4.89 },
+            { lat: 52.39, lng: 4.91 }
+          ]
+        },
+        // The denser cluster carries a stray non-finite vertex that must not
+        // widen (or NaN-poison) the focused box.
+        { points: [{ lat: NaN, lng: 103.8 }, ...SINGAPORE_CLUSTER_POINTS] }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(true)
+    expect(result.bounds).toEqual(SINGAPORE_CLUSTER_BOUNDS)
+  })
+
+  it('does not merge clusters straddling the antimeridian (documented limitation)', () => {
+    // Two clusters at opposite signs near ±180° lon fall in non-adjacent grid
+    // cells, so the focus frames only the denser one rather than spanning the
+    // shorter way around the globe.
+    const bounds = { minLat: 0, maxLat: 1, minLng: -179.9, maxLng: 179.9 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 0.5, lng: 179.5 },
+            { lat: 0.6, lng: 179.7 },
+            { lat: 0.55, lng: 179.9 }
+          ]
+        },
+        { points: [{ lat: 0.5, lng: -179.9 }] }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(true)
+    expect(result.bounds).toEqual({
+      minLat: 0.5,
+      maxLat: 0.6,
+      minLng: 179.5,
+      maxLng: 179.9
+    })
   })
 })

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -21,6 +21,7 @@ import { loadMaplibreModule } from '@/lib/utils/maplibre'
 import {
   FitnessHeatmapView,
   RouteHeatmapMap,
+  computeFocusBounds,
   downsampleSegments
 } from './FitnessHeatmapView'
 
@@ -30,6 +31,8 @@ vi.mock('@/lib/utils/mapbox', () => ({
 
 vi.mock('@/lib/utils/maplibre', () => ({
   OPENFREEMAP_STYLE_URL: 'https://tiles.openfreemap.org/styles/bright',
+  OPENFREEMAP_HEATMAP_STYLE_URL:
+    'https://tiles.openfreemap.org/styles/positron',
   loadMaplibreModule: vi.fn()
 }))
 
@@ -184,6 +187,61 @@ const buildLargeHeatmap = (): FitnessRouteHeatmapData => {
     pointCount: segmentCount * pointsPerSegment,
     updatedAt: 3
   })
+}
+
+// A denser route cluster ~100° of longitude away from the Amsterdam fixture, so a
+// whole-world cache containing both spans the globe. computeFocusBounds tightens
+// the initial view to this (denser) cluster instead of the global extent.
+const SINGAPORE_CLUSTER_POINTS = [
+  { lat: 1.3, lng: 103.7 },
+  { lat: 1.32, lng: 103.75 },
+  { lat: 1.35, lng: 103.8 },
+  { lat: 1.37, lng: 103.85 },
+  { lat: 1.4, lng: 103.9 },
+  { lat: 1.33, lng: 103.78 }
+]
+const SINGAPORE_CLUSTER_BOUNDS = {
+  minLat: 1.3,
+  maxLat: 1.4,
+  minLng: 103.7,
+  maxLng: 103.9
+}
+
+// Whole-world cache with two disjoint regions: a small Amsterdam cluster (2
+// points) and the denser Singapore cluster above.
+const disjointWorldHeatmap = (
+  overrides: Partial<FitnessRouteHeatmapData> = {}
+): FitnessRouteHeatmapData =>
+  worldHeatmap({
+    bounds: { minLat: 1.3, maxLat: 52.39, minLng: 4.88, maxLng: 103.9 },
+    segments: [
+      {
+        points: [
+          { lat: 52.36, lng: 4.88 },
+          { lat: 52.39, lng: 4.91 }
+        ]
+      },
+      { points: SINGAPORE_CLUSTER_POINTS }
+    ],
+    ...overrides
+  })
+
+// A GL map double that captures the bounds/options handed to fitBounds, so a
+// test can assert the initial framing (full extent vs. focused dense cluster).
+const createFitBoundsCapturingModule = () => {
+  const fitBounds = vi.fn()
+  const Map = vi.fn().mockImplementation(function () {
+    return {
+      on: (_event: string, callback: () => void) => callback(),
+      remove: vi.fn(),
+      resize: vi.fn(),
+      addSource: vi.fn(),
+      addLayer: vi.fn(),
+      getSource: vi.fn(),
+      fitBounds
+    }
+  })
+  return { Map, fitBounds }
 }
 
 describe('FitnessHeatmapView', () => {
@@ -640,8 +698,9 @@ describe('RouteHeatmapMap', () => {
       screen.getByRole('img', { name: 'Fitness route heatmap' })
     ).toBeInTheDocument()
     expect(mockLoadMapboxModule).not.toHaveBeenCalled()
+    // The keyless path uses the light "positron" basemap so the routes stay legible.
     expect(mapConstructor.mock.calls[0][0]).toMatchObject({
-      style: 'https://tiles.openfreemap.org/styles/bright',
+      style: 'https://tiles.openfreemap.org/styles/positron',
       attributionControl: true
     })
   })
@@ -737,7 +796,10 @@ describe('RouteHeatmapMap', () => {
     expect(mapConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
         accessToken: 'mapbox-token',
-        attributionControl: true
+        attributionControl: true,
+        // Light 2D basemap + flat mercator projection (no zoomed-out globe).
+        style: 'mapbox://styles/mapbox/light-v11',
+        projection: 'mercator'
       })
     )
   })
@@ -960,5 +1022,134 @@ describe('RouteHeatmapMap', () => {
     ]
 
     expect(downsampleSegments(segments, 100)).toBe(segments)
+  })
+
+  it('fits the full bounds (no zoom cap) for a single contiguous region', async () => {
+    const { Map, fitBounds } = createFitBoundsCapturingModule()
+    mockLoadMaplibreModule.mockResolvedValue({ Map })
+
+    render(<RouteHeatmapMap heatmap={worldHeatmap()} />)
+
+    await waitFor(() => expect(fitBounds).toHaveBeenCalled())
+    expect(fitBounds.mock.calls[0][0]).toEqual([
+      [4.88, 52.36],
+      [4.91, 52.39]
+    ])
+    // A single region keeps the natural fit — no focus zoom cap is applied.
+    expect(fitBounds.mock.calls[0][1]).not.toHaveProperty('maxZoom')
+    expect(fitBounds.mock.calls[0][1]).toMatchObject({
+      padding: 56,
+      duration: 0
+    })
+  })
+
+  it('opens focused on the densest cluster for a disjoint multi-region cache', async () => {
+    const { Map, fitBounds } = createFitBoundsCapturingModule()
+    mockLoadMaplibreModule.mockResolvedValue({ Map })
+
+    render(<RouteHeatmapMap heatmap={disjointWorldHeatmap()} />)
+
+    await waitFor(() => expect(fitBounds).toHaveBeenCalled())
+    // The initial view tightens to the dense Singapore cluster (not the global
+    // Europe→Singapore extent) and caps the zoom so it opens with pannable context.
+    expect(fitBounds.mock.calls[0][0]).toEqual([
+      [SINGAPORE_CLUSTER_BOUNDS.minLng, SINGAPORE_CLUSTER_BOUNDS.minLat],
+      [SINGAPORE_CLUSTER_BOUNDS.maxLng, SINGAPORE_CLUSTER_BOUNDS.maxLat]
+    ])
+    expect(fitBounds.mock.calls[0][1]).toMatchObject({ maxZoom: 12 })
+  })
+})
+
+describe('computeFocusBounds', () => {
+  it('keeps the full bounds for a single contiguous region', () => {
+    const bounds = { minLat: 52.36, maxLat: 52.39, minLng: 4.88, maxLng: 4.91 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52.36, lng: 4.88 },
+            { lat: 52.39, lng: 4.91 }
+          ]
+        }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(false)
+    expect(result.bounds).toBe(bounds)
+  })
+
+  it('keeps the full bounds for a region spanning several adjacent cells', () => {
+    // Points spread contiguously across ~8° of longitude (several 5° cells that
+    // are 8-connected), so there is a single cluster — show the whole extent.
+    const bounds = { minLat: 50, maxLat: 52, minLng: 4, maxLng: 12 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 50, lng: 4 },
+            { lat: 51, lng: 8 },
+            { lat: 52, lng: 12 }
+          ]
+        }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(false)
+    expect(result.bounds).toBe(bounds)
+  })
+
+  it('tightens to the densest cluster for disjoint regions', () => {
+    const bounds = { minLat: 1.3, maxLat: 52.39, minLng: 4.88, maxLng: 103.9 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52.36, lng: 4.88 },
+            { lat: 52.39, lng: 4.91 }
+          ]
+        },
+        { points: SINGAPORE_CLUSTER_POINTS }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(true)
+    expect(result.bounds).toEqual(SINGAPORE_CLUSTER_BOUNDS)
+  })
+
+  it('ignores a sparse far-away outlier and frames the main cluster', () => {
+    const bounds = { minLat: 52.36, maxLat: 52.39, minLng: 4.88, maxLng: 40 }
+    const result = computeFocusBounds(
+      [
+        {
+          points: [
+            { lat: 52.36, lng: 4.88 },
+            { lat: 52.37, lng: 4.89 },
+            { lat: 52.39, lng: 4.91 }
+          ]
+        },
+        // A single stray point far east in its own, disconnected cell.
+        { points: [{ lat: 52.36, lng: 40 }] }
+      ],
+      bounds
+    )
+
+    expect(result.focused).toBe(true)
+    expect(result.bounds).toEqual({
+      minLat: 52.36,
+      maxLat: 52.39,
+      minLng: 4.88,
+      maxLng: 4.91
+    })
+  })
+
+  it('returns the full bounds when there are no finite points', () => {
+    const bounds = { minLat: 0, maxLat: 0, minLng: 0, maxLng: 0 }
+    const result = computeFocusBounds([], bounds)
+
+    expect(result.focused).toBe(false)
+    expect(result.bounds).toBe(bounds)
   })
 })

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -31,9 +31,13 @@ import { formatRelativeTime } from '@/lib/fitness/relativeTime'
 // Re-exported so existing imports/tests keep resolving the route map from here.
 export {
   RouteHeatmapMap,
+  computeFocusBounds,
   downsampleSegments
 } from '@/lib/components/fitness/RouteHeatmapMap'
-export type { RouteHeatmapMapProps } from '@/lib/components/fitness/RouteHeatmapMap'
+export type {
+  RouteFocusBounds,
+  RouteHeatmapMapProps
+} from '@/lib/components/fitness/RouteHeatmapMap'
 
 type PeriodType = 'all_time' | 'yearly' | 'monthly'
 

--- a/lib/components/fitness/RouteHeatmapMap.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.tsx
@@ -169,6 +169,16 @@ export interface RouteFocusBounds {
 
 const cellKey = (cellX: number, cellY: number) => `${cellX}:${cellY}`
 
+// A grid cell's point count plus the bounding box of the (finite) vertices in it,
+// accumulated in a single pass so the focused extent needs no second scan.
+interface FocusCell {
+  count: number
+  minLat: number
+  maxLat: number
+  minLng: number
+  maxLng: number
+}
+
 // Pick the initial map view for a route cache. A whole-world / multi-region cache
 // has bounds spanning every recorded region (e.g. Europe *and* Singapore), so
 // fitting the full extent renders the routes as a tiny scatter on a flat world
@@ -186,7 +196,10 @@ export const computeFocusBounds = (
   segments: FitnessRouteHeatmapSegment[],
   bounds: FitnessRouteHeatmapBounds
 ): RouteFocusBounds => {
-  const cellCounts = new Map<string, number>()
+  // Single pass: bucket every finite vertex into an absolute grid cell, tracking
+  // each cell's point count and bounding box. Non-finite vertices are skipped so
+  // they never create a spurious cell.
+  const cells = new Map<string, FocusCell>()
   for (const segment of segments) {
     for (const point of segment.points) {
       if (!Number.isFinite(point.lng) || !Number.isFinite(point.lat)) continue
@@ -194,69 +207,77 @@ export const computeFocusBounds = (
         Math.floor(point.lng / FOCUS_CLUSTER_CELL_DEG),
         Math.floor(point.lat / FOCUS_CLUSTER_CELL_DEG)
       )
-      cellCounts.set(key, (cellCounts.get(key) ?? 0) + 1)
+      const cell = cells.get(key)
+      if (!cell) {
+        cells.set(key, {
+          count: 1,
+          minLat: point.lat,
+          maxLat: point.lat,
+          minLng: point.lng,
+          maxLng: point.lng
+        })
+        continue
+      }
+      cell.count += 1
+      if (point.lat < cell.minLat) cell.minLat = point.lat
+      if (point.lat > cell.maxLat) cell.maxLat = point.lat
+      if (point.lng < cell.minLng) cell.minLng = point.lng
+      if (point.lng > cell.maxLng) cell.maxLng = point.lng
     }
   }
 
   // 0 or 1 occupied cell: nothing to disambiguate — show the full bounds.
-  if (cellCounts.size <= 1) {
+  if (cells.size <= 1) {
     return { bounds, focused: false }
   }
 
   let seedKey = ''
   let seedCount = -1
-  for (const [key, count] of cellCounts) {
-    if (count > seedCount) {
-      seedCount = count
+  for (const [key, cell] of cells) {
+    if (cell.count > seedCount) {
+      seedCount = cell.count
       seedKey = key
     }
   }
 
   // 8-connected flood fill over occupied cells starting from the densest one.
-  const cluster = new Set<string>()
+  // Cells are marked visited as they are enqueued, so each is pushed exactly
+  // once and only occupied neighbours enter the stack.
+  const cluster = new Set<string>([seedKey])
   const stack = [seedKey]
   while (stack.length > 0) {
     const key = stack.pop() as string
-    if (cluster.has(key) || !cellCounts.has(key)) continue
-    cluster.add(key)
     const [cellX, cellY] = key.split(':').map(Number)
     for (let dx = -1; dx <= 1; dx += 1) {
       for (let dy = -1; dy <= 1; dy += 1) {
         if (dx === 0 && dy === 0) continue
-        stack.push(cellKey(cellX + dx, cellY + dy))
+        const neighborKey = cellKey(cellX + dx, cellY + dy)
+        if (cells.has(neighborKey) && !cluster.has(neighborKey)) {
+          cluster.add(neighborKey)
+          stack.push(neighborKey)
+        }
       }
     }
   }
 
   // Every occupied cell is in one connected cluster → the data is contiguous, so
   // the full bounds already frame it well.
-  if (cluster.size === cellCounts.size) {
+  if (cluster.size === cells.size) {
     return { bounds, focused: false }
   }
 
+  // Union the densest cluster's per-cell boxes into the focused extent. Each cell
+  // came from at least one finite vertex, so the result is always finite.
   let minLat = Infinity
   let maxLat = -Infinity
   let minLng = Infinity
   let maxLng = -Infinity
-  for (const segment of segments) {
-    for (const point of segment.points) {
-      if (!Number.isFinite(point.lng) || !Number.isFinite(point.lat)) continue
-      const key = cellKey(
-        Math.floor(point.lng / FOCUS_CLUSTER_CELL_DEG),
-        Math.floor(point.lat / FOCUS_CLUSTER_CELL_DEG)
-      )
-      if (!cluster.has(key)) continue
-      if (point.lat < minLat) minLat = point.lat
-      if (point.lat > maxLat) maxLat = point.lat
-      if (point.lng < minLng) minLng = point.lng
-      if (point.lng > maxLng) maxLng = point.lng
-    }
-  }
-
-  // Defensive: no finite point matched the cluster (should not happen) — fall
-  // back to the full bounds rather than an inverted/NaN box.
-  if (!Number.isFinite(minLat)) {
-    return { bounds, focused: false }
+  for (const key of cluster) {
+    const cell = cells.get(key) as FocusCell
+    if (cell.minLat < minLat) minLat = cell.minLat
+    if (cell.maxLat > maxLat) maxLat = cell.maxLat
+    if (cell.minLng < minLng) minLng = cell.minLng
+    if (cell.maxLng > maxLng) maxLng = cell.maxLng
   }
 
   return { bounds: { minLat, maxLat, minLng, maxLng }, focused: true }
@@ -410,8 +431,10 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
               },
               paint: ROUTE_LINE_PAINT
             })
-            // Frame the densest cluster (focused) or the full extent, reading
-            // the latest value from the ref so an updated cache reframes too.
+            // Frame the densest cluster (focused) or the full extent. The focus
+            // is read from a ref so this asynchronous 'load' handler uses the
+            // latest computed value rather than a stale closure; fitBounds runs
+            // once per map mount (not on in-place, same-id cache updates).
             const framing = focusRef.current
             const frameBounds = framing?.bounds ?? bounds
             map.fitBounds(

--- a/lib/components/fitness/RouteHeatmapMap.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.tsx
@@ -4,12 +4,16 @@ import { Loader2 } from 'lucide-react'
 import { FC, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
+  FitnessRouteHeatmapBounds,
   FitnessRouteHeatmapData,
   FitnessRouteHeatmapSegment
 } from '@/lib/client'
 import { cn } from '@/lib/utils'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
-import { OPENFREEMAP_STYLE_URL, loadMaplibreModule } from '@/lib/utils/maplibre'
+import {
+  OPENFREEMAP_HEATMAP_STYLE_URL,
+  loadMaplibreModule
+} from '@/lib/utils/maplibre'
 
 // The Mapbox GL / MapLibre GL surface — only the members this component drives.
 // Both libraries share this subset, so one component can drive either provider.
@@ -22,7 +26,7 @@ type RouteGlMap = {
   getSource: (id: string) => { setData: (data: unknown) => void } | undefined
   fitBounds: (
     bounds: [[number, number], [number, number]],
-    options?: { padding?: number; duration?: number }
+    options?: { padding?: number; duration?: number; maxZoom?: number }
   ) => void
 }
 
@@ -49,16 +53,26 @@ const ROUTE_RENDER_POINT_BUDGET = 40_000
 const MAP_LOAD_TIMEOUT_MS = 20_000
 const ROUTE_HEATMAP_MAP_HEIGHT_CLASS = 'h-[420px]'
 
+// Absolute grid-cell size (degrees) used to cluster route points for the initial
+// view. ~5° ≈ a few hundred km, so activities within a metro area land in the
+// same or an 8-connected neighbouring cell while far-apart regions (e.g. Europe
+// vs Singapore) fall into disjoint, non-adjacent cells. See computeFocusBounds.
+const FOCUS_CLUSTER_CELL_DEG = 5
+// When the cache spans disjoint regions we open focused on the densest cluster;
+// cap the initial zoom so a very compact cluster still opens with surrounding
+// context to pan from, rather than snapping to street level.
+const FOCUS_MAX_ZOOM = 12
+
 const ROUTE_LINE_STYLES = {
   visible: {
     color: '#ef4444',
-    width: 3.2,
-    opacity: 0.2
+    width: 2.8,
+    opacity: 0.55
   },
   hidden: {
     color: '#2563eb',
-    width: 2.4,
-    opacity: 0.14
+    width: 2.2,
+    opacity: 0.4
   }
 } as const
 const ROUTE_LINE_PAINT = {
@@ -80,7 +94,7 @@ const ROUTE_LINE_PAINT = {
     ROUTE_LINE_STYLES.hidden.opacity,
     ROUTE_LINE_STYLES.visible.opacity
   ],
-  'line-blur': 0.8
+  'line-blur': 0.4
 } as const
 
 const getMapFallbackError = (error: unknown): MapFallbackError => {
@@ -147,6 +161,107 @@ export const downsampleSegments = (
   })
 }
 
+export interface RouteFocusBounds {
+  bounds: FitnessRouteHeatmapBounds
+  /** True when the view was tightened to a single dense cluster (disjoint data). */
+  focused: boolean
+}
+
+const cellKey = (cellX: number, cellY: number) => `${cellX}:${cellY}`
+
+// Pick the initial map view for a route cache. A whole-world / multi-region cache
+// has bounds spanning every recorded region (e.g. Europe *and* Singapore), so
+// fitting the full extent renders the routes as a tiny scatter on a flat world
+// map. Instead, bucket the route vertices into an absolute lon/lat grid, flood
+// fill the 8-connected cluster containing the densest cell, and fit to that
+// cluster — so the map opens zoomed in on where most activity is while the user
+// can still pan to the other regions. For a single contiguous region every
+// vertex falls in one connected cluster, so the authoritative full bounds are
+// returned unchanged (focused: false).
+//
+// Note: clusters straddling the antimeridian (±180° lon) land in non-adjacent
+// cells and would not be merged; that is acceptable for this best-effort initial
+// framing (mercator fitBounds has its own antimeridian limitations regardless).
+export const computeFocusBounds = (
+  segments: FitnessRouteHeatmapSegment[],
+  bounds: FitnessRouteHeatmapBounds
+): RouteFocusBounds => {
+  const cellCounts = new Map<string, number>()
+  for (const segment of segments) {
+    for (const point of segment.points) {
+      if (!Number.isFinite(point.lng) || !Number.isFinite(point.lat)) continue
+      const key = cellKey(
+        Math.floor(point.lng / FOCUS_CLUSTER_CELL_DEG),
+        Math.floor(point.lat / FOCUS_CLUSTER_CELL_DEG)
+      )
+      cellCounts.set(key, (cellCounts.get(key) ?? 0) + 1)
+    }
+  }
+
+  // 0 or 1 occupied cell: nothing to disambiguate — show the full bounds.
+  if (cellCounts.size <= 1) {
+    return { bounds, focused: false }
+  }
+
+  let seedKey = ''
+  let seedCount = -1
+  for (const [key, count] of cellCounts) {
+    if (count > seedCount) {
+      seedCount = count
+      seedKey = key
+    }
+  }
+
+  // 8-connected flood fill over occupied cells starting from the densest one.
+  const cluster = new Set<string>()
+  const stack = [seedKey]
+  while (stack.length > 0) {
+    const key = stack.pop() as string
+    if (cluster.has(key) || !cellCounts.has(key)) continue
+    cluster.add(key)
+    const [cellX, cellY] = key.split(':').map(Number)
+    for (let dx = -1; dx <= 1; dx += 1) {
+      for (let dy = -1; dy <= 1; dy += 1) {
+        if (dx === 0 && dy === 0) continue
+        stack.push(cellKey(cellX + dx, cellY + dy))
+      }
+    }
+  }
+
+  // Every occupied cell is in one connected cluster → the data is contiguous, so
+  // the full bounds already frame it well.
+  if (cluster.size === cellCounts.size) {
+    return { bounds, focused: false }
+  }
+
+  let minLat = Infinity
+  let maxLat = -Infinity
+  let minLng = Infinity
+  let maxLng = -Infinity
+  for (const segment of segments) {
+    for (const point of segment.points) {
+      if (!Number.isFinite(point.lng) || !Number.isFinite(point.lat)) continue
+      const key = cellKey(
+        Math.floor(point.lng / FOCUS_CLUSTER_CELL_DEG),
+        Math.floor(point.lat / FOCUS_CLUSTER_CELL_DEG)
+      )
+      if (!cluster.has(key)) continue
+      if (point.lat < minLat) minLat = point.lat
+      if (point.lat > maxLat) maxLat = point.lat
+      if (point.lng < minLng) minLng = point.lng
+      if (point.lng > maxLng) maxLng = point.lng
+    }
+  }
+
+  // Defensive: no finite point matched the cluster (should not happen) — fall
+  // back to the full bounds rather than an inverted/NaN box.
+  if (!Number.isFinite(minLat)) {
+    return { bounds, focused: false }
+  }
+
+  return { bounds: { minLat, maxLat, minLng, maxLng }, focused: true }
+}
+
 export interface RouteHeatmapMapProps {
   heatmap: FitnessRouteHeatmapData | null
   mapboxAccessToken?: string
@@ -165,6 +280,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const mapRef = useRef<RouteGlMap | null>(null)
   const routeGeoJsonRef = useRef(buildRouteGeoJson([]))
+  const focusRef = useRef<RouteFocusBounds | null>(null)
   const [mapFallbackReason, setMapFallbackReason] =
     useState<MapFallbackReason | null>(null)
   const [mapFallbackError, setMapFallbackError] =
@@ -185,14 +301,20 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
         ? {
             loadModule: () => loadMapboxModule<RouteGlModule>(),
             mapOptions: {
-              style: 'mapbox://styles/mapbox/outdoors-v12',
+              // Light 2D basemap so the coloured routes stand out, and an
+              // explicit mercator projection so a wide cache opens as a flat,
+              // pannable map instead of Mapbox GL v3's default zoomed-out globe.
+              style: 'mapbox://styles/mapbox/light-v11',
+              projection: 'mercator',
               accessToken: mapboxAccessToken
             },
             label: 'Mapbox'
           }
         : {
             loadModule: () => loadMaplibreModule<RouteGlModule>(),
-            mapOptions: { style: OPENFREEMAP_STYLE_URL },
+            // MapLibre renders a flat mercator map by default; the light
+            // "positron" style keeps the route overlay legible.
+            mapOptions: { style: OPENFREEMAP_HEATMAP_STYLE_URL },
             label: 'OpenFreeMap'
           },
     [mapboxAccessToken]
@@ -203,19 +325,31 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
       ? mapFallbackError?.message
       : undefined
   const shouldRenderMap = hasRoutes && Boolean(bounds) && !mapFallbackReason
-  const routeGeoJson = useMemo(
+  const downsampledSegments = useMemo(
     () =>
-      buildRouteGeoJson(
-        hasRoutes && heatmap
-          ? downsampleSegments(heatmap.segments, ROUTE_RENDER_POINT_BUDGET)
-          : []
-      ),
+      hasRoutes && heatmap
+        ? downsampleSegments(heatmap.segments, ROUTE_RENDER_POINT_BUDGET)
+        : [],
     [hasRoutes, heatmap?.id, heatmap?.updatedAt]
+  )
+  const routeGeoJson = useMemo(
+    () => buildRouteGeoJson(downsampledSegments),
+    [downsampledSegments]
+  )
+  // The initial framing: tighten a disjoint multi-region cache to its densest
+  // cluster (computeFocusBounds), or keep the full bounds for a single region.
+  const focus = useMemo<RouteFocusBounds | null>(
+    () => (bounds ? computeFocusBounds(downsampledSegments, bounds) : null),
+    [downsampledSegments, bounds]
   )
 
   useEffect(() => {
     routeGeoJsonRef.current = routeGeoJson
   }, [routeGeoJson])
+
+  useEffect(() => {
+    focusRef.current = focus
+  }, [focus])
 
   // Clear the fallback whenever the cache or provider changes so a recovered
   // map gets a fresh attempt.
@@ -231,10 +365,6 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
     let cancelled = false
     let loadWatchdog: ReturnType<typeof setTimeout> | undefined
-    const mapBounds: [[number, number], [number, number]] = [
-      [bounds.minLng, bounds.minLat],
-      [bounds.maxLng, bounds.maxLat]
-    ]
     setIsMapLoaded(false)
 
     provider
@@ -280,7 +410,21 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
               },
               paint: ROUTE_LINE_PAINT
             })
-            map.fitBounds(mapBounds, { padding: 56, duration: 0 })
+            // Frame the densest cluster (focused) or the full extent, reading
+            // the latest value from the ref so an updated cache reframes too.
+            const framing = focusRef.current
+            const frameBounds = framing?.bounds ?? bounds
+            map.fitBounds(
+              [
+                [frameBounds.minLng, frameBounds.minLat],
+                [frameBounds.maxLng, frameBounds.maxLat]
+              ],
+              {
+                padding: 56,
+                duration: 0,
+                ...(framing?.focused ? { maxZoom: FOCUS_MAX_ZOOM } : {})
+              }
+            )
             setIsMapLoaded(true)
           } catch (error) {
             if (!cancelled) {

--- a/lib/utils/maplibre.test.ts
+++ b/lib/utils/maplibre.test.ts
@@ -113,4 +113,14 @@ describe('loadMaplibreModule', () => {
       /^https:\/\/tiles\.openfreemap\.org\//
     )
   })
+
+  it('exposes a light OpenFreeMap style URL for the route heatmap', async () => {
+    const { OPENFREEMAP_HEATMAP_STYLE_URL } =
+      await import('@/lib/utils/maplibre')
+    // Same origin as the bright style (no extra CSP allowance) but the light
+    // "positron" basemap, so coloured routes stay legible.
+    expect(OPENFREEMAP_HEATMAP_STYLE_URL).toBe(
+      'https://tiles.openfreemap.org/styles/positron'
+    )
+  })
 })

--- a/lib/utils/maplibre.ts
+++ b/lib/utils/maplibre.ts
@@ -26,6 +26,16 @@ const MAPLIBRE_LOAD_TIMEOUT_MS = 15000
 export const OPENFREEMAP_STYLE_URL =
   'https://tiles.openfreemap.org/styles/bright'
 
+/**
+ * Keyless OpenFreeMap light style for the route heatmap result map. The light,
+ * low-saturation "positron" basemap keeps the coloured route overlay legible —
+ * the colourful "bright" style used by the region picker washes the lines out.
+ * Served from the same `tiles.openfreemap.org` origin, so it needs no extra CSP
+ * allowance.
+ */
+export const OPENFREEMAP_HEATMAP_STYLE_URL =
+  'https://tiles.openfreemap.org/styles/positron'
+
 let maplibreModulePromise: Promise<unknown> | null = null
 
 export const loadMaplibreModule = async <T>(): Promise<T> => {


### PR DESCRIPTION
## Summary

The fitness route heatmap result map had two usability problems when viewing the **Whole world** cache:

1. **It opened as a zoomed-out globe.** Mapbox GL v3 defaults to the globe projection at low zoom, so a cache spanning disjoint regions (e.g. Europe + Singapore) rendered as a tiny scatter of dots on a 3D sphere.
2. **The routes were hard to see.** The colourful `outdoors-v12` / `bright` basemaps plus a very low route opacity (0.2) washed the lines out.

This PR makes the result map open as a **flat, pannable map focused on the densest activity cluster**, on a **light basemap** that keeps the routes legible.

## Changes

- **Mapbox → `light-v11` + `projection: 'mercator'`.** Light 2D basemap (as requested) and an explicit flat projection, so a wide cache opens as a pannable flat map instead of the default zoomed-out globe.
- **MapLibre (keyless) → OpenFreeMap `positron`.** The colourful `bright` style washed the overlay out; `positron` is light/low-saturation. Served from the same `tiles.openfreemap.org` origin, so **no CSP change**. The region **picker** keeps `bright`.
- **Brighter route paint.** Higher opacity (0.55 visible / 0.4 hidden) and crisper blur (0.4) so a single pass is clearly visible while overlaps still build into a density gradient.
- **`computeFocusBounds` (new, exported + tested).** Buckets route vertices into an absolute 5° lon/lat grid and flood-fills the 8-connected cluster containing the densest cell. Multi-region caches open framed on that cluster (zoom capped so it opens with pannable context); a single contiguous region returns its full bounds unchanged. Far-away outliers no longer blow up the initial view. The map stays fully interactive, so the user can pan to the other regions.

## Behaviour

| Cache | Before | After |
| --- | --- | --- |
| Single region | Flat fit to bounds | Unchanged (flat fit to bounds) |
| Whole world / disjoint | Zoomed-out globe, faint dots | Flat map zoomed into the densest cluster, bold routes, pannable |

## Verification

- `yarn lint` — 0 errors.
- `yarn build` — green.
- `yarn test` — 4746 passed (added unit tests for `computeFocusBounds`, integration tests asserting the focused `fitBounds` + `maxZoom`, Mapbox `light-v11`/`mercator` options, and the `positron` style URL).
- Browser visual check of the keyless MapLibre path confirmed the route lines are far more legible on the light basemap (before/after attached in the PR thread).

## Notes

- Clusters straddling the antimeridian (±180°) land in non-adjacent grid cells and would not be merged; acceptable for this best-effort initial framing (documented in `computeFocusBounds`).
- No migration; no API/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)