### PR TITLE
Bump version to v1.86.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.85.0",
+  "version": "1.86.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.86.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.85.0`
- Base main SHA: `cadfe0a5c77b2ec64dadf5c15a32ff26bb8c9752`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
