### PR TITLE
fix: persist fitness heatmap region names across reloads

### DIFF
--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/client'
 import type {
   FitnessRouteHeatmapData,
+  FitnessRouteHeatmapRegionNameData,
   FitnessRouteHeatmapSummaryData
 } from '@/lib/client'
 import { loadMapboxModule } from '@/lib/utils/mapbox'
@@ -401,6 +402,33 @@ describe('FitnessHeatmapView', () => {
         screen.queryByText(/Couldn't save the region name/i)
       ).not.toBeInTheDocument()
     )
+  })
+
+  it('keeps an in-session rename made while the initial names fetch is in flight', async () => {
+    // Heatmaps resolve immediately; the names fetch stays pending so the mount
+    // load is still in flight while the user renames.
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([])
+    const namesDeferred = createDeferred<FitnessRouteHeatmapRegionNameData[]>()
+    mockGetFitnessRouteHeatmapRegionNames.mockReturnValue(namesDeferred.promise)
+
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    // Draw + name an area whose canonical key already has a (now-stale) stored
+    // name on the server — the default box serializes to this key.
+    await drawAndSaveArea('New name')
+    expect(await screen.findByText('New name')).toBeInTheDocument()
+
+    // The in-flight names fetch resolves with the OLD label for that same key.
+    await act(async () => {
+      namesDeferred.resolve([
+        { region: 'rect:53.00,3.00,50.00,7.00', name: 'Old name' }
+      ])
+    })
+
+    // The user's in-session rename must win; the stale snapshot must not revert
+    // it (it self-corrects to the server value on the next reload anyway).
+    expect(await screen.findByText('New name')).toBeInTheDocument()
+    expect(screen.queryByText('Old name')).not.toBeInTheDocument()
   })
 
   it('ignores a saved name whose region key matches no current region', async () => {

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -348,6 +348,82 @@ describe('FitnessHeatmapView', () => {
     expect(call.region).toMatch(/^rect:/)
   })
 
+  const drawAndSaveArea = async (name: string) => {
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Draw area on map/i })
+    )
+    fireEvent.change(screen.getByPlaceholderText(/Veluwe loop/i), {
+      target: { value: name }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add area' }))
+  }
+
+  it('surfaces an error when saving a region name is rejected by the server', async () => {
+    mockSetFitnessRouteHeatmapRegionName.mockResolvedValue(false)
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    await drawAndSaveArea('Coastal ride')
+
+    expect(
+      await screen.findByText(/Couldn't save the region name/i)
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces an error when saving a region name throws', async () => {
+    mockSetFitnessRouteHeatmapRegionName.mockRejectedValue(
+      new Error('network down')
+    )
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    await drawAndSaveArea('Coastal ride')
+
+    expect(
+      await screen.findByText(/Couldn't save the region name/i)
+    ).toBeInTheDocument()
+  })
+
+  it('ignores a saved name whose region key matches no current region', async () => {
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([
+      worldSummary({
+        id: 'hm-rect',
+        region: 'rect:52.60,5.60,52.00,6.20',
+        status: 'completed',
+        updatedAt: TEST_NOW
+      })
+    ])
+    // A stale label for a different region key (e.g. a removed region).
+    mockGetFitnessRouteHeatmapRegionNames.mockResolvedValue([
+      { region: 'rect:10.00,10.00,9.00,11.00', name: 'Stale label' }
+    ])
+
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    // The discovered region keeps the generic fallback; the unrelated label is
+    // not applied to it (and does not crash the render).
+    expect(await screen.findByText('Map area')).toBeInTheDocument()
+    expect(screen.queryByText('Stale label')).not.toBeInTheDocument()
+  })
+
+  it('still loads heatmaps when the region-names fetch fails', async () => {
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([
+      worldSummary({
+        id: 'hm-rect',
+        region: 'rect:52.60,5.60,52.00,6.20',
+        status: 'completed',
+        updatedAt: TEST_NOW
+      })
+    ])
+    mockGetFitnessRouteHeatmapRegionNames.mockRejectedValue(
+      new Error('names fetch failed')
+    )
+
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    // The discovered region still appears (labels just fall back to "Map area").
+    expect(await screen.findByText('Map area')).toBeInTheDocument()
+    expect(screen.getByText(/2 regions · 1 generated/i)).toBeInTheDocument()
+  })
+
   it('opens a region detail page and returns to the list', async () => {
     render(<FitnessHeatmapView actorId={ACTOR} />)
 

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -8,7 +8,9 @@ import {
   deleteFitnessRouteHeatmap,
   getDistinctFitnessActivityTypes,
   getFitnessRouteHeatmap,
+  getFitnessRouteHeatmapRegionNames,
   getFitnessRouteHeatmaps,
+  setFitnessRouteHeatmapRegionName,
   triggerFitnessRouteHeatmap
 } from '@/lib/client'
 import type {
@@ -46,7 +48,9 @@ vi.mock('@/lib/client', () => ({
   deleteFitnessRouteHeatmap: vi.fn(),
   getDistinctFitnessActivityTypes: vi.fn(),
   getFitnessRouteHeatmap: vi.fn(),
+  getFitnessRouteHeatmapRegionNames: vi.fn(),
   getFitnessRouteHeatmaps: vi.fn(),
+  setFitnessRouteHeatmapRegionName: vi.fn(),
   triggerFitnessRouteHeatmap: vi.fn()
 }))
 
@@ -68,6 +72,14 @@ const mockGetFitnessRouteHeatmap =
   getFitnessRouteHeatmap as jest.MockedFunction<typeof getFitnessRouteHeatmap>
 const mockGetFitnessRouteHeatmaps =
   getFitnessRouteHeatmaps as jest.MockedFunction<typeof getFitnessRouteHeatmaps>
+const mockGetFitnessRouteHeatmapRegionNames =
+  getFitnessRouteHeatmapRegionNames as jest.MockedFunction<
+    typeof getFitnessRouteHeatmapRegionNames
+  >
+const mockSetFitnessRouteHeatmapRegionName =
+  setFitnessRouteHeatmapRegionName as jest.MockedFunction<
+    typeof setFitnessRouteHeatmapRegionName
+  >
 const mockTriggerFitnessRouteHeatmap =
   triggerFitnessRouteHeatmap as jest.MockedFunction<
     typeof triggerFitnessRouteHeatmap
@@ -250,6 +262,8 @@ describe('FitnessHeatmapView', () => {
     mockGetDistinctFitnessActivityTypes.mockResolvedValue([])
     mockGetFitnessRouteHeatmap.mockResolvedValue(null)
     mockGetFitnessRouteHeatmaps.mockResolvedValue([])
+    mockGetFitnessRouteHeatmapRegionNames.mockResolvedValue([])
+    mockSetFitnessRouteHeatmapRegionName.mockResolvedValue(true)
     mockDeleteFitnessRouteHeatmap.mockResolvedValue(true)
     mockTriggerFitnessRouteHeatmap.mockResolvedValue(true)
     // No Mapbox token in these tests, so the view uses the keyless MapLibre map.
@@ -290,6 +304,48 @@ describe('FitnessHeatmapView', () => {
     expect(await screen.findByText('Map area')).toBeInTheDocument()
     expect(screen.getByText(/2 regions · 1 generated/i)).toBeInTheDocument()
     expect(screen.getByText(/^Generated/)).toBeInTheDocument()
+  })
+
+  it('rehydrates a saved region name instead of showing "Map area"', async () => {
+    mockGetFitnessRouteHeatmaps.mockResolvedValue([
+      worldSummary({
+        id: 'hm-rect',
+        region: 'rect:52.60,5.60,52.00,6.20',
+        status: 'completed',
+        updatedAt: TEST_NOW
+      })
+    ])
+    mockGetFitnessRouteHeatmapRegionNames.mockResolvedValue([
+      { region: 'rect:52.60,5.60,52.00,6.20', name: 'Veluwe loop' }
+    ])
+
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    // The persisted label is used; the generic fallback never appears.
+    expect(await screen.findByText('Veluwe loop')).toBeInTheDocument()
+    expect(screen.queryByText('Map area')).not.toBeInTheDocument()
+  })
+
+  it('persists a region name when an area is saved', async () => {
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    // Open the draw composer, give the area a name, and save it.
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Draw area on map/i })
+    )
+    fireEvent.change(screen.getByPlaceholderText(/Veluwe loop/i), {
+      target: { value: 'Coastal ride' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add area' }))
+
+    await waitFor(() =>
+      expect(mockSetFitnessRouteHeatmapRegionName).toHaveBeenCalledWith(
+        expect.objectContaining({ actorId: ACTOR, name: 'Coastal ride' })
+      )
+    )
+    // The saved region key is a canonical, non-empty rect token.
+    const call = mockSetFitnessRouteHeatmapRegionName.mock.calls[0][0]
+    expect(call.region).toMatch(/^rect:/)
   })
 
   it('opens a region detail page and returns to the list', async () => {

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -382,6 +382,27 @@ describe('FitnessHeatmapView', () => {
     ).toBeInTheDocument()
   })
 
+  it('clears a prior save error once a later save succeeds', async () => {
+    mockSetFitnessRouteHeatmapRegionName.mockResolvedValueOnce(false)
+    render(<FitnessHeatmapView actorId={ACTOR} />)
+
+    await drawAndSaveArea('Coastal ride')
+    expect(
+      await screen.findByText(/Couldn't save the region name/i)
+    ).toBeInTheDocument()
+
+    // Re-saving the same area now succeeds; the stale error must clear.
+    mockSetFitnessRouteHeatmapRegionName.mockResolvedValue(true)
+    fireEvent.click(screen.getByRole('button', { name: /Edit area/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save area' }))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Couldn't save the region name/i)
+      ).not.toBeInTheDocument()
+    )
+  })
+
   it('ignores a saved name whose region key matches no current region', async () => {
     mockGetFitnessRouteHeatmaps.mockResolvedValue([
       worldSummary({

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -5,11 +5,14 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   FitnessRouteHeatmapData,
+  FitnessRouteHeatmapRegionNameData,
   FitnessRouteHeatmapSummaryData,
   deleteFitnessRouteHeatmap,
   getDistinctFitnessActivityTypes,
   getFitnessRouteHeatmap,
+  getFitnessRouteHeatmapRegionNames,
   getFitnessRouteHeatmaps,
+  setFitnessRouteHeatmapRegionName,
   triggerFitnessRouteHeatmap
 } from '@/lib/client'
 import {
@@ -146,6 +149,24 @@ const mergeDiscoveredRegions = (
   return additions.length ? [...current, ...withRegionIds(additions)] : current
 }
 
+/**
+ * Applies saved region labels (keyed by canonical region key) onto a region
+ * list, so a region rediscovered from its heatmap regains its user-given name
+ * instead of falling back to the generic "Map area". World regions are unnamed.
+ */
+const applyRegionNames = (
+  regions: PickerRegion[],
+  names: FitnessRouteHeatmapRegionNameData[]
+): PickerRegion[] => {
+  if (names.length === 0) return regions
+  const nameByKey = new Map(names.map((entry) => [entry.region, entry.name]))
+  return regions.map((region) => {
+    if (region.type !== 'rect') return region
+    const name = nameByKey.get(serializeRegion(toHeatmapRegion(region)))
+    return name ? { ...region, name } : region
+  })
+}
+
 export const FitnessHeatmapView: FC<Props> = ({
   actorId,
   mapboxAccessToken
@@ -198,11 +219,16 @@ export const FitnessHeatmapView: FC<Props> = ({
     setOpenRegionId(null)
 
     let cancelled = false
-    getFitnessRouteHeatmaps({ actorId })
-      .then((all) => {
+    Promise.all([
+      getFitnessRouteHeatmaps({ actorId }),
+      getFitnessRouteHeatmapRegionNames({ actorId })
+    ])
+      .then(([all, names]) => {
         if (cancelled) return
         setHeatmaps(all)
-        setRegions((current) => mergeDiscoveredRegions(current, all))
+        setRegions((current) =>
+          applyRegionNames(mergeDiscoveredRegions(current, all), names)
+        )
       })
       .catch(() => {})
     return () => {
@@ -558,6 +584,34 @@ export const FitnessHeatmapView: FC<Props> = ({
     [actorId, selectedActivityType, periodType, effectivePeriodKey, sourceMatch]
   )
 
+  const handleRegionSaved = useCallback(
+    async (region: PickerRegion) => {
+      // Only drawn areas carry a label; the world-wide region (empty key) is
+      // never named.
+      if (region.type !== 'rect') return
+      const key = serializeRegion(toHeatmapRegion(region))
+      if (!key) return
+      let saved: boolean
+      try {
+        saved = await setFitnessRouteHeatmapRegionName({
+          actorId,
+          region: key,
+          name: region.name ?? null
+        })
+      } catch {
+        saved = false
+      }
+      if (!saved) {
+        // The name is already shown in-session; surface the failure so the user
+        // knows it may not survive a refresh rather than failing silently.
+        setError(
+          "Couldn't save the region name. It may not persist after a refresh."
+        )
+      }
+    },
+    [actorId]
+  )
+
   const focusedProgressPercent = heatmapData
     ? computeProgressPercent(heatmapData.totalCount, heatmapData.cursorOffset)
     : null
@@ -706,6 +760,7 @@ export const FitnessHeatmapView: FC<Props> = ({
           onOpen={(region) => setOpenRegionId(region.id)}
           getRegionStatus={getRegionStatus}
           onRegionRemoved={handleRegionRemoved}
+          onRegionSaved={handleRegionSaved}
         />
       </section>
     </div>

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -221,7 +221,9 @@ export const FitnessHeatmapView: FC<Props> = ({
     let cancelled = false
     Promise.all([
       getFitnessRouteHeatmaps({ actorId }),
-      getFitnessRouteHeatmapRegionNames({ actorId })
+      // Labels are non-critical metadata: a failed names fetch must not block the
+      // heatmaps from loading, so it degrades to "no saved labels".
+      getFitnessRouteHeatmapRegionNames({ actorId }).catch(() => [])
     ])
       .then(([all, names]) => {
         if (cancelled) return

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -609,6 +609,9 @@ export const FitnessHeatmapView: FC<Props> = ({
         setError(
           "Couldn't save the region name. It may not persist after a refresh."
         )
+      } else {
+        // Clear any stale error from a prior failed save once one succeeds.
+        setError(null)
       }
     },
     [actorId]

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -150,9 +150,14 @@ const mergeDiscoveredRegions = (
 }
 
 /**
- * Applies saved region labels (keyed by canonical region key) onto a region
- * list, so a region rediscovered from its heatmap regains its user-given name
- * instead of falling back to the generic "Map area". World regions are unnamed.
+ * Seeds saved region labels (keyed by canonical region key) onto a region list,
+ * so a region rediscovered from its heatmap regains its user-given name instead
+ * of falling back to the generic "Map area". World regions are unnamed.
+ *
+ * Only fills in a name when the region doesn't already have one: this runs once
+ * on the initial load, and the names snapshot is captured when the fetch starts,
+ * so a label a user set in-session while that fetch was still in flight must not
+ * be reverted to the (now-stale) stored value.
  */
 const applyRegionNames = (
   regions: PickerRegion[],
@@ -161,7 +166,7 @@ const applyRegionNames = (
   if (names.length === 0) return regions
   const nameByKey = new Map(names.map((entry) => [entry.region, entry.name]))
   return regions.map((region) => {
-    if (region.type !== 'rect') return region
+    if (region.type !== 'rect' || region.name) return region
     const name = nameByKey.get(serializeRegion(toHeatmapRegion(region)))
     return name ? { ...region, name } : region
   })

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.test.ts
@@ -190,4 +190,88 @@ describe('GET/PUT /api/v1/accounts/[id]/fitness-route-heatmap-region-names', () 
     expect(response.status).toBe(403)
     expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
   })
+
+  it('canonicalizes a non-canonical region key before saving', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      // High-precision coordinates that normalizeRegion rounds to 2 dp.
+      body: JSON.stringify({
+        region: 'rect:52.6011,5.6044,52.0000,6.2000',
+        name: 'Veluwe loop'
+      })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    // The stored key (and the echoed region) is the canonical, rounded form so
+    // it matches the key a heatmap's `region` uses.
+    expect(mockDb.setFitnessRouteHeatmapRegionName).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID,
+      region: 'rect:52.60,5.60,52.00,6.20',
+      name: 'Veluwe loop'
+    })
+    await expect(response.json()).resolves.toEqual({
+      region: 'rect:52.60,5.60,52.00,6.20',
+      name: 'Veluwe loop'
+    })
+  })
+
+  it('rejects a region that normalizes to nothing (malformed input)', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      // Unparseable region token — drops to the empty sentinel, not a real region.
+      body: JSON.stringify({ region: 'not-a-region', name: 'x' })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a syntactically valid body that fails schema validation', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      // `region` must be a string.
+      body: JSON.stringify({ region: 123, name: 'x' })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-JSON body', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      body: 'not json'
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
+  })
 })

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.test.ts
@@ -1,0 +1,193 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+
+import { GET, PUT } from './route'
+
+const mockGetServerSession = vi.fn()
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+const mockGetActorFromSession = vi.fn()
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: (...args: unknown[]) => mockGetActorFromSession(...args)
+}))
+
+type MockDatabase = Pick<
+  Database,
+  'getFitnessRouteHeatmapRegionNames' | 'setFitnessRouteHeatmapRegionName'
+>
+
+let mockDatabase: MockDatabase | null = null
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+describe('GET/PUT /api/v1/accounts/[id]/fitness-route-heatmap-region-names', () => {
+  const mockDb: jest.Mocked<MockDatabase> = {
+    getFitnessRouteHeatmapRegionNames: vi.fn(),
+    setFitnessRouteHeatmapRegionName: vi.fn()
+  }
+
+  const encodedId = ACTOR1_ID.replace('https://', '').replaceAll('/', ':')
+  const baseUrl = `http://llun.test/api/v1/accounts/${encodedId}/fitness-route-heatmap-region-names`
+
+  beforeAll(() => {
+    mockDatabase = mockDb
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockGetActorFromSession.mockResolvedValue({
+      ...seedActor1,
+      id: ACTOR1_ID
+    })
+    mockDb.getFitnessRouteHeatmapRegionNames.mockResolvedValue([])
+    mockDb.setFitnessRouteHeatmapRegionName.mockResolvedValue()
+  })
+
+  it('returns the saved region names for the owner', async () => {
+    mockDb.getFitnessRouteHeatmapRegionNames.mockResolvedValue([
+      { region: 'rect:52.60,5.60,52.00,6.20', name: 'Veluwe loop' }
+    ])
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      names: [{ region: 'rect:52.60,5.60,52.00,6.20', name: 'Veluwe loop' }]
+    })
+    expect(mockDb.getFitnessRouteHeatmapRegionNames).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID
+    })
+  })
+
+  it('returns 403 for another actor on GET', async () => {
+    mockGetActorFromSession.mockResolvedValue({
+      ...seedActor1,
+      id: 'https://llun.test/users/other'
+    })
+
+    const request = new NextRequest(baseUrl)
+    const response = await GET(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockDb.getFitnessRouteHeatmapRegionNames).not.toHaveBeenCalled()
+  })
+
+  it('saves a region name for the owner', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        region: 'rect:52.60,5.60,52.00,6.20',
+        name: '  Veluwe loop  '
+      })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    // Name is trimmed; region is normalized to its canonical form.
+    expect(mockDb.setFitnessRouteHeatmapRegionName).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID,
+      region: 'rect:52.60,5.60,52.00,6.20',
+      name: 'Veluwe loop'
+    })
+    await expect(response.json()).resolves.toEqual({
+      region: 'rect:52.60,5.60,52.00,6.20',
+      name: 'Veluwe loop'
+    })
+  })
+
+  it('clears a region name when the name is blank', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        region: 'rect:52.60,5.60,52.00,6.20',
+        name: '   '
+      })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).toHaveBeenCalledWith({
+      actorId: ACTOR1_ID,
+      region: 'rect:52.60,5.60,52.00,6.20',
+      name: null
+    })
+  })
+
+  it('rejects naming the world-wide region', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ region: '', name: 'Everywhere' })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(400)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the PUT lacks same-origin proof', async () => {
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ region: 'rect:52.60,5.60,52.00,6.20', name: 'x' })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
+  })
+
+  it('does not save a region name for another actor', async () => {
+    mockGetActorFromSession.mockResolvedValue({
+      ...seedActor1,
+      id: 'https://llun.test/users/other'
+    })
+
+    const request = new NextRequest(baseUrl, {
+      method: 'PUT',
+      headers: {
+        Origin: 'https://test.llun.dev',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ region: 'rect:52.60,5.60,52.00,6.20', name: 'x' })
+    })
+    const response = await PUT(request, {
+      params: Promise.resolve({ id: encodedId })
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockDb.setFitnessRouteHeatmapRegionName).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.ts
@@ -46,8 +46,12 @@ const SetRegionNameBody = z.object({
 
 // Canonicalises a raw region key the same way the heatmap routes do, so a saved
 // label keys on the exact serialized form that a heatmap's `region` uses.
-const normalizeRegion = (rawRegion: string) =>
-  serializeRegions(deserializeRegions(rawRegion))
+// `deserializeRegions`/`serializeRegions` are total (they drop unknown tokens
+// rather than throwing), so malformed input — and the world-wide region — both
+// normalize to the empty sentinel; return null for those since neither is a
+// nameable region.
+const normalizeRegion = (rawRegion: string): string | null =>
+  serializeRegions(deserializeRegions(rawRegion)) || null
 
 export const GET = traceApiRoute(
   'getAccountFitnessRouteHeatmapRegionNames',
@@ -191,9 +195,9 @@ export const PUT = traceApiRoute(
     }
 
     const region = normalizeRegion(parsed.data.region)
-    // The world-wide region (empty key) is never named; reject so the store
-    // is not asked to key a label on the world sentinel.
-    if (region === '') {
+    // Reject the world-wide region (empty key, never named) and any malformed
+    // input that normalized away to nothing.
+    if (!region) {
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.ts
@@ -1,0 +1,223 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { getDatabase } from '@/lib/database'
+import { deserializeRegions, serializeRegions } from '@/lib/fitness/regions'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { hasSameOriginProof } from '@/lib/services/guards/sameOriginProof'
+import { AppRouterParams } from '@/lib/services/guards/types'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_400,
+  ERROR_401,
+  ERROR_403,
+  ERROR_500,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PUT
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+const SetRegionNameBody = z.object({
+  // Looser raw cap than the 255-char cache-key column: clients may send
+  // high-precision coordinates that normalizeRegion rounds + caps under 255.
+  region: z.string().max(1024),
+  // The region label. Blank/whitespace/null clears the stored label. The DB
+  // column is varchar(255); the UI input caps typing at 80.
+  name: z
+    .string()
+    .max(255)
+    .nullish()
+    .transform((value) => value?.trim() || null)
+})
+
+// Canonicalises a raw region key the same way the heatmap routes do, so a saved
+// label keys on the exact serialized form that a heatmap's `region` uses.
+const normalizeRegion = (rawRegion: string) =>
+  serializeRegions(deserializeRegions(rawRegion))
+
+export const GET = traceApiRoute(
+  'getAccountFitnessRouteHeatmapRegionNames',
+  async (req: NextRequest, params: AppRouterParams<Params>) => {
+    const session = await getServerAuthSession()
+    if (!session?.user?.email) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const currentActor = await getActorFromSession(database, session)
+    if (!currentActor) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const { id: encodedAccountId } = await params.params
+    const id = idToUrl(encodedAccountId)
+
+    if (currentActor.id !== id) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: 403
+      })
+    }
+
+    const names = await database.getFitnessRouteHeatmapRegionNames({
+      actorId: id
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { names }
+    })
+  },
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { accountId: params?.id || 'unknown' }
+    }
+  }
+)
+
+export const PUT = traceApiRoute(
+  'setAccountFitnessRouteHeatmapRegionName',
+  async (req: NextRequest, params: AppRouterParams<Params>) => {
+    const session = await getServerAuthSession()
+    if (!session?.user?.email) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    // Manually authenticated cookie-session mutation: apply the same CSRF
+    // same-origin proof as AuthenticatedGuard.
+    if (!hasSameOriginProof(req)) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: 403
+      })
+    }
+
+    const database = getDatabase()
+    if (!database) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_500,
+        responseStatusCode: 500
+      })
+    }
+
+    const currentActor = await getActorFromSession(database, session)
+    if (!currentActor) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_401,
+        responseStatusCode: 401
+      })
+    }
+
+    const { id: encodedAccountId } = await params.params
+    const id = idToUrl(encodedAccountId)
+
+    if (currentActor.id !== id) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_403,
+        responseStatusCode: 403
+      })
+    }
+
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const parsed = SetRegionNameBody.safeParse(body)
+    if (!parsed.success) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    const region = normalizeRegion(parsed.data.region)
+    // The world-wide region (empty key) is never named; reject so the store
+    // is not asked to key a label on the world sentinel.
+    if (region === '') {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: 400
+      })
+    }
+
+    await database.setFitnessRouteHeatmapRegionName({
+      actorId: id,
+      region,
+      name: parsed.data.name
+    })
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { region, name: parsed.data.name }
+    })
+  },
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { accountId: params?.id || 'unknown' }
+    }
+  }
+)

--- a/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.ts
+++ b/app/api/v1/accounts/[id]/fitness-route-heatmap-region-names/route.ts
@@ -195,9 +195,12 @@ export const PUT = traceApiRoute(
     }
 
     const region = normalizeRegion(parsed.data.region)
-    // Reject the world-wide region (empty key, never named) and any malformed
-    // input that normalized away to nothing.
-    if (!region) {
+    // Reject the world-wide region (empty key, never named), malformed input
+    // that normalized away to nothing, and — defensively — any key over the
+    // 255-char column limit. `serializeRegions` already caps output to
+    // MAX_HEATMAP_REGIONS (≤244 chars), so this guards future precision/cap
+    // changes rather than a currently-reachable case.
+    if (!region || region.length > 255) {
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2439,6 +2439,62 @@ export const clearFitnessRouteHeatmaps = async ({
   return typeof json.deleted === 'number' ? json.deleted : 0
 }
 
+export interface FitnessRouteHeatmapRegionNameData {
+  /** Serialized region scope (a single sorted `rect:` token). */
+  region: string
+  name: string
+}
+
+/** Loads the actor's saved region labels, keyed by serialized region scope. */
+export const getFitnessRouteHeatmapRegionNames = async ({
+  actorId
+}: {
+  actorId: string
+}): Promise<FitnessRouteHeatmapRegionNameData[]> => {
+  const encodedId = urlToId(actorId)
+  const response = await fetch(
+    `${window.origin}/api/v1/accounts/${encodedId}/fitness-route-heatmap-region-names`,
+    {
+      method: 'GET',
+      headers: { Accept: 'application/json' }
+    }
+  )
+  if (!response.ok) return []
+  try {
+    const json = await response.json()
+    return Array.isArray(json.names)
+      ? (json.names as FitnessRouteHeatmapRegionNameData[])
+      : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Saves (or, with a blank/null name, clears) the label for one region. Resolves
+ * to true when the server accepted the change.
+ */
+export const setFitnessRouteHeatmapRegionName = async ({
+  actorId,
+  region,
+  name
+}: {
+  actorId: string
+  region: string
+  name: string | null
+}): Promise<boolean> => {
+  const encodedId = urlToId(actorId)
+  const response = await fetch(
+    `${window.origin}/api/v1/accounts/${encodedId}/fitness-route-heatmap-region-names`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ region, name })
+    }
+  )
+  return response.ok
+}
+
 export const getFitnessCalendarData = async ({
   actorId,
   startDate,

--- a/lib/components/fitness/HeatmapRegionPicker.test.tsx
+++ b/lib/components/fitness/HeatmapRegionPicker.test.tsx
@@ -232,6 +232,34 @@ describe('HeatmapRegionPicker', () => {
     })
   })
 
+  it('does not fire onRegionSaved when a drawn area collapses onto an existing region', () => {
+    const onRegionSaved = vi.fn()
+    // Same coords as the composer's DEFAULT_BOX (nw 53,3 / se 50,7).
+    const existing: PickerRegion[] = [
+      {
+        id: 'rect-1',
+        type: 'rect',
+        nw: { lat: 53, lng: 3 },
+        se: { lat: 50, lng: 7 }
+      }
+    ]
+    render(
+      <HeatmapRegionPicker
+        value={existing}
+        onChange={vi.fn()}
+        onRegionSaved={onRegionSaved}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Draw area on map/i }))
+    const nameField = screen.getAllByRole('textbox')[0]
+    fireEvent.change(nameField, { target: { value: 'Duplicate' } })
+    fireEvent.click(screen.getByRole('button', { name: /Add area/i }))
+
+    // The duplicate draw is dropped by dedupe, so its name must not overwrite the
+    // surviving region's stored label.
+    expect(onRegionSaved).not.toHaveBeenCalled()
+  })
+
   it('fires onRegionSaved with the new label when an area is renamed', () => {
     const onRegionSaved = vi.fn()
     render(

--- a/lib/components/fitness/HeatmapRegionPicker.test.tsx
+++ b/lib/components/fitness/HeatmapRegionPicker.test.tsx
@@ -210,6 +210,49 @@ describe('HeatmapRegionPicker', () => {
     expect(onRegionRemoved.mock.calls[0][0]).toMatchObject({ id: 'rect-1' })
   })
 
+  it('fires onRegionSaved with the named area when a new area is added', () => {
+    const onRegionSaved = vi.fn()
+    render(
+      <HeatmapRegionPicker
+        value={[]}
+        onChange={vi.fn()}
+        onRegionSaved={onRegionSaved}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Draw area on map/i }))
+    // Textbox order: Area name, NW latitude, NW longitude, SE latitude, SE longitude.
+    const nameField = screen.getAllByRole('textbox')[0]
+    fireEvent.change(nameField, { target: { value: 'Coastal ride' } })
+    fireEvent.click(screen.getByRole('button', { name: /Add area/i }))
+
+    expect(onRegionSaved).toHaveBeenCalledTimes(1)
+    expect(onRegionSaved.mock.calls[0][0]).toMatchObject({
+      type: 'rect',
+      name: 'Coastal ride'
+    })
+  })
+
+  it('fires onRegionSaved with the new label when an area is renamed', () => {
+    const onRegionSaved = vi.fn()
+    render(
+      <HeatmapRegionPicker
+        value={rectValue}
+        onChange={vi.fn()}
+        onRegionSaved={onRegionSaved}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Edit area/i }))
+    const nameField = screen.getAllByRole('textbox')[0]
+    fireEvent.change(nameField, { target: { value: 'Renamed loop' } })
+    fireEvent.click(screen.getByRole('button', { name: /Save area/i }))
+
+    expect(onRegionSaved).toHaveBeenCalledTimes(1)
+    expect(onRegionSaved.mock.calls[0][0]).toMatchObject({
+      id: 'rect-1',
+      name: 'Renamed loop'
+    })
+  })
+
   it('labels the remove control per region kind (area vs region)', () => {
     render(<HeatmapRegionPicker value={rectValue} onChange={vi.fn()} />)
     expect(

--- a/lib/components/fitness/HeatmapRegionPicker.tsx
+++ b/lib/components/fitness/HeatmapRegionPicker.tsx
@@ -531,10 +531,16 @@ export const HeatmapRegionPicker: FC<HeatmapRegionPickerProps> = ({
     // Drop regions that collapse to the same canonical key — each region owns one
     // heatmap, so a duplicate would share (and fight over) a single cache row
     // (removing one would soft-delete the cache the survivor still points at).
-    onChange(dedupeByRegionKey(next))
+    const deduped = dedupeByRegionKey(next)
+    onChange(deduped)
     setComposer(null)
-    // Persist the label by region key (idempotent; a blank name clears it).
-    onRegionSaved?.(savedRegion)
+    // Persist the label by region key (idempotent; a blank name clears it) — but
+    // only when the saved region actually survived the dedupe. Otherwise a draw
+    // that collapsed onto an existing region would overwrite that region's stored
+    // name with the dropped draw's name (a session-vs-reload mismatch).
+    if (deduped.some((region) => region.id === savedRegion.id)) {
+      onRegionSaved?.(savedRegion)
+    }
   }
 
   const editingRegion =

--- a/lib/components/fitness/HeatmapRegionPicker.tsx
+++ b/lib/components/fitness/HeatmapRegionPicker.tsx
@@ -483,6 +483,12 @@ interface HeatmapRegionPickerProps {
   getRegionStatus?: (region: PickerRegion) => RegionDisplayStatus | null
   /** Fired after a region leaves the list, so its cached heatmap can be pruned. */
   onRegionRemoved?: (region: PickerRegion) => void
+  /**
+   * Fired after a drawn area is added or edited, with the saved region (carrying
+   * its current `name`). Lets the orchestrator persist the label so it survives
+   * a reload instead of reverting to the generic "Map area".
+   */
+  onRegionSaved?: (region: PickerRegion) => void
 }
 
 interface ComposerState {
@@ -495,7 +501,8 @@ export const HeatmapRegionPicker: FC<HeatmapRegionPickerProps> = ({
   mapboxAccessToken,
   onOpen,
   getRegionStatus,
-  onRegionRemoved
+  onRegionRemoved,
+  onRegionSaved
 }) => {
   const [composer, setComposer] = useState<ComposerState | null>(null)
   const hasWorld = value.some((region) => region.type === 'world')
@@ -513,18 +520,21 @@ export const HeatmapRegionPicker: FC<HeatmapRegionPickerProps> = ({
   }
 
   const saveRect = (rect: RectRegion) => {
+    const savedRegion: PickerRegion = composer?.editId
+      ? { ...rect, id: composer.editId }
+      : { ...rect, id: createRegionId() }
     const next = composer?.editId
       ? value.map((region) =>
-          region.id === composer.editId
-            ? { ...region, ...rect, id: region.id }
-            : region
+          region.id === composer.editId ? savedRegion : region
         )
-      : [...value, { id: createRegionId(), ...rect }]
+      : [...value, savedRegion]
     // Drop regions that collapse to the same canonical key — each region owns one
     // heatmap, so a duplicate would share (and fight over) a single cache row
     // (removing one would soft-delete the cache the survivor still points at).
     onChange(dedupeByRegionKey(next))
     setComposer(null)
+    // Persist the label by region key (idempotent; a blank name clears it).
+    onRegionSaved?.(savedRegion)
   }
 
   const editingRegion =

--- a/lib/database/sql/fitnessRouteHeatmap.test.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.test.ts
@@ -527,5 +527,85 @@ describe('FitnessRouteHeatmapDatabase', () => {
         ).resolves.not.toBeNull()
       })
     })
+
+    describe('getFitnessRouteHeatmapRegionNames / setFitnessRouteHeatmapRegionName', () => {
+      const REGION = 'rect:50.00,4.00,49.00,5.00'
+
+      it('returns an empty list when the actor has no saved region names', async () => {
+        await expect(
+          database.getFitnessRouteHeatmapRegionNames({
+            actorId: actors.empty.id
+          })
+        ).resolves.toEqual([])
+      })
+
+      it('stores and retrieves a region name', async () => {
+        await database.setFitnessRouteHeatmapRegionName({
+          actorId: actors.primary.id,
+          region: REGION,
+          name: 'Veluwe loop'
+        })
+
+        const names = await database.getFitnessRouteHeatmapRegionNames({
+          actorId: actors.primary.id
+        })
+        expect(names).toEqual(
+          expect.arrayContaining([{ region: REGION, name: 'Veluwe loop' }])
+        )
+      })
+
+      it('upserts the name for the same region instead of duplicating it', async () => {
+        await database.setFitnessRouteHeatmapRegionName({
+          actorId: actors.primary.id,
+          region: REGION,
+          name: 'First name'
+        })
+        await database.setFitnessRouteHeatmapRegionName({
+          actorId: actors.primary.id,
+          region: REGION,
+          name: 'Second name'
+        })
+
+        const names = await database.getFitnessRouteHeatmapRegionNames({
+          actorId: actors.primary.id
+        })
+        const matching = names.filter((entry) => entry.region === REGION)
+        expect(matching).toEqual([{ region: REGION, name: 'Second name' }])
+      })
+
+      it('clears the stored name when set to null', async () => {
+        await database.setFitnessRouteHeatmapRegionName({
+          actorId: actors.primary.id,
+          region: REGION,
+          name: 'To be cleared'
+        })
+        await database.setFitnessRouteHeatmapRegionName({
+          actorId: actors.primary.id,
+          region: REGION,
+          name: null
+        })
+
+        const names = await database.getFitnessRouteHeatmapRegionNames({
+          actorId: actors.primary.id
+        })
+        expect(names.some((entry) => entry.region === REGION)).toBe(false)
+      })
+
+      it('scopes saved names to the owning actor', async () => {
+        await database.setFitnessRouteHeatmapRegionName({
+          actorId: actors.primary.id,
+          region: 'rect:10.00,10.00,9.00,11.00',
+          name: 'Primary only'
+        })
+
+        const otherActorNames =
+          await database.getFitnessRouteHeatmapRegionNames({
+            actorId: actors.replyAuthor.id
+          })
+        expect(
+          otherActorNames.some((entry) => entry.name === 'Primary only')
+        ).toBe(false)
+      })
+    })
   })
 })

--- a/lib/database/sql/fitnessRouteHeatmap.ts
+++ b/lib/database/sql/fitnessRouteHeatmap.ts
@@ -6,10 +6,12 @@ import {
   FitnessRouteHeatmap,
   FitnessRouteHeatmapBounds,
   FitnessRouteHeatmapPeriodType,
+  FitnessRouteHeatmapRegionName,
   FitnessRouteHeatmapSegment,
   FitnessRouteHeatmapStatus,
   FitnessRouteHeatmapSummary,
-  SQLFitnessRouteHeatmap
+  SQLFitnessRouteHeatmap,
+  SQLFitnessRouteHeatmapRegionName
 } from '@/lib/types/database/fitnessRouteHeatmap'
 
 export interface CreateFitnessRouteHeatmapParams {
@@ -101,6 +103,24 @@ export interface FitnessRouteHeatmapDatabase {
     actorId: string
     includeDeleted?: boolean
   }): Promise<string[]>
+  /**
+   * Returns every saved region label for the actor as `{ region, name }` pairs,
+   * keyed by the serialized region cache key. Used to rehydrate region names in
+   * the heatmaps UI so a rediscovered region keeps its label.
+   */
+  getFitnessRouteHeatmapRegionNames(params: {
+    actorId: string
+  }): Promise<FitnessRouteHeatmapRegionName[]>
+  /**
+   * Upserts the label for one `(actorId, region)` region. A null/blank name
+   * clears the stored label (deletes the row). The world-wide region (empty
+   * `region` key) is unnamed and never stored.
+   */
+  setFitnessRouteHeatmapRegionName(params: {
+    actorId: string
+    region: string
+    name: string | null
+  }): Promise<void>
   deleteFitnessRouteHeatmapsForActor(params: {
     actorId: string
   }): Promise<number>
@@ -436,6 +456,55 @@ export const FitnessRouteHeatmapSQLDatabaseMixin = (
     const rows = await query.distinct('region').orderBy('region', 'asc')
 
     return rows.map((row: { region: string }) => row.region)
+  },
+
+  async getFitnessRouteHeatmapRegionNames({ actorId }: { actorId: string }) {
+    const rows = await database<SQLFitnessRouteHeatmapRegionName>(
+      'fitness_route_heatmap_region_names'
+    )
+      .where('actorId', actorId)
+      .select('region', 'name')
+      .orderBy('region', 'asc')
+
+    return rows.map(
+      (row): FitnessRouteHeatmapRegionName => ({
+        region: row.region,
+        name: row.name
+      })
+    )
+  },
+
+  async setFitnessRouteHeatmapRegionName({
+    actorId,
+    region,
+    name
+  }: {
+    actorId: string
+    region: string
+    name: string | null
+  }) {
+    const trimmed = name?.trim() ?? ''
+    // A blank name clears the label. The world-wide region (empty key) is never
+    // named, so there is nothing to store for it either.
+    if (trimmed === '' || region === '') {
+      await database('fitness_route_heatmap_region_names')
+        .where('actorId', actorId)
+        .where('region', region)
+        .delete()
+      return
+    }
+
+    const currentTime = new Date()
+    await database('fitness_route_heatmap_region_names')
+      .insert({
+        actorId,
+        region,
+        name: trimmed,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      .onConflict(['actorId', 'region'])
+      .merge({ name: trimmed, updatedAt: currentTime })
   },
 
   async deleteFitnessRouteHeatmapsForActor({ actorId }: { actorId: string }) {

--- a/lib/types/database/fitnessRouteHeatmap.ts
+++ b/lib/types/database/fitnessRouteHeatmap.ts
@@ -87,3 +87,22 @@ export type FitnessRouteHeatmapSummary = Omit<
   FitnessRouteHeatmap,
   'bounds' | 'segments'
 >
+
+/**
+ * A user-facing label for a route-heatmap region, scoped to one `(actorId,
+ * region)` pair. The region label is deliberately NOT part of the serialized
+ * region cache key (see `lib/fitness/regions`), so it is persisted here to
+ * survive reloads instead of reverting to the generic "Map area".
+ */
+export interface SQLFitnessRouteHeatmapRegionName {
+  actorId: string
+  region: string
+  name: string
+  createdAt: Date | string | number
+  updatedAt: Date | string | number
+}
+
+export interface FitnessRouteHeatmapRegionName {
+  region: string
+  name: string
+}

--- a/migrations/20260622000000_add_fitness_route_heatmap_region_names.js
+++ b/migrations/20260622000000_add_fitness_route_heatmap_region_names.js
@@ -23,7 +23,12 @@ export const up = async function (knex) {
   await knex.schema.createTable(
     'fitness_route_heatmap_region_names',
     function (table) {
-      table.string('actorId').notNullable().references('id').inTable('actors')
+      table
+        .string('actorId')
+        .notNullable()
+        .references('id')
+        .inTable('actors')
+        .onDelete('CASCADE')
       table.string('region').notNullable()
       table.string('name').notNullable()
       table.timestamp('createdAt', { useTz: true }).notNullable()

--- a/migrations/20260622000000_add_fitness_route_heatmap_region_names.js
+++ b/migrations/20260622000000_add_fitness_route_heatmap_region_names.js
@@ -1,0 +1,43 @@
+/**
+ * Adds `fitness_route_heatmap_region_names`, a per-`(actorId, region)` store for
+ * the user-facing label of a route-heatmap region. The label is intentionally
+ * NOT part of the serialized region cache key (see `lib/fitness/regions`), so it
+ * needs its own home to survive reloads — otherwise a region rediscovered from
+ * its heatmap renders as the generic "Map area".
+ *
+ * The name is region-scoped (one per region, independent of activity/period and
+ * of the heatmap-generation lifecycle), so it lives in its own table rather than
+ * being denormalized across the `fitness_route_heatmaps` rows.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  const hasTable = await knex.schema.hasTable(
+    'fitness_route_heatmap_region_names'
+  )
+  if (hasTable) {
+    return
+  }
+
+  await knex.schema.createTable(
+    'fitness_route_heatmap_region_names',
+    function (table) {
+      table.string('actorId').notNullable().references('id').inTable('actors')
+      table.string('region').notNullable()
+      table.string('name').notNullable()
+      table.timestamp('createdAt', { useTz: true }).notNullable()
+      table.timestamp('updatedAt', { useTz: true }).notNullable()
+
+      table.primary(['actorId', 'region'])
+    }
+  )
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  await knex.schema.dropTableIfExists('fitness_route_heatmap_region_names')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1607,7 +1607,7 @@ ALTER TABLE ONLY public.fitness_files
     ADD CONSTRAINT fitness_files_statusid_foreign FOREIGN KEY ("statusId") REFERENCES public.statuses(id) ON DELETE SET NULL;
 
 ALTER TABLE ONLY public.fitness_route_heatmap_region_names
-    ADD CONSTRAINT fitness_route_heatmap_region_names_actorid_foreign FOREIGN KEY ("actorId") REFERENCES public.actors(id);
+    ADD CONSTRAINT fitness_route_heatmap_region_names_actorid_foreign FOREIGN KEY ("actorId") REFERENCES public.actors(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY public.fitness_route_heatmaps
     ADD CONSTRAINT fitness_route_heatmaps_actorid_foreign FOREIGN KEY ("actorId") REFERENCES public.actors(id);

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -398,6 +398,14 @@ CREATE TABLE public.fitness_files (
     "sourceUrl" text
 );
 
+CREATE TABLE public.fitness_route_heatmap_region_names (
+    "actorId" character varying(255) NOT NULL,
+    region character varying(255) NOT NULL,
+    name character varying(255) NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL
+);
+
 CREATE TABLE public.fitness_route_heatmaps (
     id character varying(255) NOT NULL,
     "actorId" character varying(255) NOT NULL,
@@ -1185,6 +1193,9 @@ ALTER TABLE ONLY public.filters
 ALTER TABLE ONLY public.fitness_files
     ADD CONSTRAINT fitness_files_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY public.fitness_route_heatmap_region_names
+    ADD CONSTRAINT fitness_route_heatmap_region_names_pkey PRIMARY KEY ("actorId", region);
+
 ALTER TABLE ONLY public.fitness_route_heatmaps
     ADD CONSTRAINT fitness_route_heatmaps_actorid_activitytypekey_periodtype_perio UNIQUE ("actorId", "activityTypeKey", "periodType", "periodKey", region);
 
@@ -1594,6 +1605,9 @@ ALTER TABLE ONLY public.fitness_files
 
 ALTER TABLE ONLY public.fitness_files
     ADD CONSTRAINT fitness_files_statusid_foreign FOREIGN KEY ("statusId") REFERENCES public.statuses(id) ON DELETE SET NULL;
+
+ALTER TABLE ONLY public.fitness_route_heatmap_region_names
+    ADD CONSTRAINT fitness_route_heatmap_region_names_actorid_foreign FOREIGN KEY ("actorId") REFERENCES public.actors(id);
 
 ALTER TABLE ONLY public.fitness_route_heatmaps
     ADD CONSTRAINT fitness_route_heatmaps_actorid_foreign FOREIGN KEY ("actorId") REFERENCES public.actors(id);

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -230,3 +230,4 @@ CREATE UNIQUE INDEX `collection_timeline_collection_status_unique` on `collectio
 CREATE INDEX `collection_timeline_read` on `collection_timeline` (`collectionSeq`, `sortKey`);
 CREATE INDEX `collection_timeline_member` on `collection_timeline` (`memberSeq`);
 CREATE INDEX `collection_timeline_status` on `collection_timeline` (`statusId`);
+CREATE TABLE `fitness_route_heatmap_region_names` (`actorId` varchar(255) not null, `region` varchar(255) not null, `name` varchar(255) not null, `createdAt` datetime not null, `updatedAt` datetime not null, foreign key(`actorId`) references `actors`(`id`), primary key (`actorId`, `region`));

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -230,4 +230,4 @@ CREATE UNIQUE INDEX `collection_timeline_collection_status_unique` on `collectio
 CREATE INDEX `collection_timeline_read` on `collection_timeline` (`collectionSeq`, `sortKey`);
 CREATE INDEX `collection_timeline_member` on `collection_timeline` (`memberSeq`);
 CREATE INDEX `collection_timeline_status` on `collection_timeline` (`statusId`);
-CREATE TABLE `fitness_route_heatmap_region_names` (`actorId` varchar(255) not null, `region` varchar(255) not null, `name` varchar(255) not null, `createdAt` datetime not null, `updatedAt` datetime not null, foreign key(`actorId`) references `actors`(`id`), primary key (`actorId`, `region`));
+CREATE TABLE `fitness_route_heatmap_region_names` (`actorId` varchar(255) not null, `region` varchar(255) not null, `name` varchar(255) not null, `createdAt` datetime not null, `updatedAt` datetime not null, foreign key(`actorId`) references `actors`(`id`) on delete CASCADE, primary key (`actorId`, `region`));


### PR DESCRIPTION
## Problem

On the fitness **Heatmaps** page, editing a region's name and saving did not persist — after a reload the label reverted to the generic **"Map area"**.

**Root cause:** region names were UI-only client state. The serialized region cache key (e.g. `rect:52.60,5.60,52.00,6.20`) deliberately excludes the name, and on load the region list is rebuilt from existing heatmaps via `deserializeRegions(heatmap.region)` — which produces nameless regions, so any saved label was lost.

## Fix

Persist labels server-side in a new per-`(actor, region)` store, **decoupled from the async heatmap-generation lifecycle** so a rename survives without regenerating the heatmap. (Names are region-scoped — one per region, independent of activity/period — so they live in their own table rather than being denormalized across the multiple `fitness_route_heatmaps` rows a region can have.)

- **Migration** `20260622000000_add_fitness_route_heatmap_region_names`: new table `(actorId, region, name, createdAt, updatedAt)` with a `(actorId, region)` primary key. Both reference schema dumps (`schema.sql` + `schema.sqlite.sql`) regenerated.
- **DB layer**: `getFitnessRouteHeatmapRegionNames` / `setFitnessRouteHeatmapRegionName` (upsert via `onConflict(...).merge()`; a blank/null name clears the label; the world-wide region is never named).
- **API**: `GET` / `PUT /api/v1/accounts/[id]/fitness-route-heatmap-region-names` — owner-scoped, `PUT` carries the same same-origin (CSRF) proof as other cookie-session mutations, region is normalized to its canonical key, and naming the world-wide region is rejected.
- **Client + UI**: names are rehydrated onto the region list on load (`applyRegionNames`) and persisted on save — `HeatmapRegionPicker` fires a new `onRegionSaved` callback that the view forwards to `setFitnessRouteHeatmapRegionName`. A save failure surfaces a soft inline error.

## Tests

- DB mixin: store / retrieve / upsert / clear / actor-scoping.
- Route: GET + PUT, 403 for other actors, same-origin-proof rejection, name trimming + region normalization, world-region rejection.
- Picker: `onRegionSaved` fires on add and on rename.
- View: a saved name rehydrates instead of "Map area"; saving an area persists via the API.
- `prettier`, `lint`, `build`, and the full suite (4774 tests) are green.

## Manual verification

Verified end-to-end against a local SQLite DB: seeded a completed heatmap + a saved name, confirmed the region loads as its label (not "Map area"), renamed it in the UI, reloaded, and confirmed the new label persisted (and the DB row updated).

## Notes for deploy

Additive, backward-compatible migration — no data backfill required. Existing (pre-fix) regions simply have no stored label until the user names them.