### PR TITLE
Bump version to v1.86.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.86.0",
+  "version": "1.86.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.86.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.86.0`
- Base main SHA: `c175d5181c2e6b76fd5168365dd9d1ee2a6077af`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
