### PR TITLE
Bump version to v1.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.86.1",
+  "version": "1.87.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.87.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.86.1`
- Base main SHA: `d0182e394d23466164a60be1e4382e43e931cd27`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
