### PR TITLE
Bump version to v1.87.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.87.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.87.0`
- Base main SHA: `c464f27c821206d2ca8e10e10a6bc392d030fabf`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
