### PR TITLE
Bump version to v1.87.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.87.1",
+  "version": "1.87.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.87.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.87.1`
- Base main SHA: `0d475472f52a8a7903afa110d1071ead9ff642bf`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
