### PR TITLE
none: refresh reference docs for features shipped since v1.80

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ yarn lint
 - Use **absolute imports** (`@/lib/...`) for anything outside the current directory
 - **Relative imports** (`./helper`) are only allowed for files in the same directory
 - **Never** use `../` relative imports
-- Apply the same rules to `jest.mock(...)` paths
+- Apply the same rules to `vi.mock(...)` paths
 
 ### File Organization
 
@@ -251,7 +251,7 @@ if (!parsed.success) {
 yarn test
 ```
 
-All tests run in parallel using isolated SQLite in-memory databases for fast execution.
+The suite runs on [Vitest](https://vitest.dev/) (native ESM; use the `vi.*` API, e.g. `vi.fn()` / `vi.mock()` / `vi.importMock()` — there is no `jest` global). All tests run in parallel using isolated SQLite in-memory databases for fast execution.
 
 ### Writing Tests
 
@@ -368,7 +368,7 @@ activities.next/
 - `tsconfig.json` — TypeScript configuration
 - `eslint.config.mjs` — ESLint rules
 - `.prettierrc.yml` — Code formatting rules
-- `jest.config.mjs` — Test configuration
+- `vitest.config.ts` — Test configuration
 - `next.config.ts` — Next.js configuration
 - `knexfile.js` — Database migration configuration
 - `Dockerfile` — Docker container build
@@ -410,7 +410,7 @@ There are **two** committed reference schema dumps, one per supported backend:
 
 - **`migrations/schema.sql`** — the **PostgreSQL** schema (`pg_dump`).
 - **`migrations/schema.sqlite.sql`** — the **SQLite** schema (`sqlite3 .schema`).
-  SQLite is what local dev and the Jest test suite use.
+  SQLite is what local dev and the Vitest test suite use.
 
 Read the file that matches the backend you care about — the two SQL dialects
 differ (e.g. `character varying` / `jsonb` / `timestamp with time zone` vs
@@ -566,7 +566,7 @@ commit, use the `none:` prefix since these files ship nothing.
 - [Next.js Documentation](https://nextjs.org/docs)
 - [ActivityPub Specification](https://www.w3.org/TR/activitypub/)
 - [TypeScript Handbook](https://www.typescriptlang.org/docs/)
-- [Jest Documentation](https://jestjs.io/docs/getting-started)
+- [Vitest Documentation](https://vitest.dev/guide/)
 - [better-auth Documentation](https://www.better-auth.com/)
 - [Knex.js Documentation](https://knexjs.org/)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ Application boundary: Next.js App Router (app/)
         │
         ▼
 Domain and service boundary: Core library (lib/)
-  ├─ Services: auth, guards, media, fitness, email, queue, federation, translation
+  ├─ Services: auth, guards, media, fitness, collections, email, queue, federation, translation
   ├─ ActivityPub: create, follow, like, announce, update, delete, undo
   ├─ Jobs: delivery, imports, fitness processing, map and heatmap generation
   └─ Shared UI: post box, posts, settings, profile, timeline, UI primitives
@@ -181,11 +181,13 @@ Media files (images and video) and fitness files (.fit, .gpx, .tcx) support mult
          └──────────┘ └────────┘ └────────────┘ └───────┘ └──────────┘
 
 Other tables: sessions, notifications, medias, fitness_files,
-              fitness_route_heatmaps, blocks, mutes, filters, reports,
-              markers, endorsements, lists, featured_tags, customEmojis,
-              translation_cache, domain federation rules, recipients,
-              counters, poll_choices, applications, oauth_access_tokens,
-              oauth_authorization_codes
+              fitness_settings, strava_archive_imports,
+              fitness_route_heatmaps, fitness_route_heatmap_region_names,
+              collections, collection_members, collection_timeline,
+              blocks, mutes, filters, reports, markers, endorsements,
+              lists, featured_tags, customEmojis, translation_cache,
+              domain federation rules, recipients, counters, poll_choices,
+              applications, oauth_access_tokens, oauth_authorization_codes
 ```
 
 ## Technology Stack
@@ -201,7 +203,7 @@ Other tables: sessions, notifications, medias, fitness_files,
 | **Database**         | Knex.js (SQLite / PostgreSQL; MySQL-compatible config paths) |
 | **Authentication**   | better-auth                                                  |
 | **Logging**          | Pino                                                         |
-| **Testing**          | Jest (with SWC transforms)                                   |
+| **Testing**          | Vitest (native ESM)                                          |
 | **Code Quality**     | ESLint + Prettier                                            |
 | **Package Manager**  | Yarn 4.15.0                                                  |
 | **Containerization** | Docker (Alpine-based)                                        |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -195,11 +195,12 @@ For asynchronous processing of ActivityPub delivery, file processing, etc.
 
 ## Request Configuration
 
-| Variable                         | Description                                                            |
-| -------------------------------- | ---------------------------------------------------------------------- |
-| `ACTIVITIES_REQUEST_TIMEOUT`     | HTTP request timeout in milliseconds for outgoing federation requests. |
-| `ACTIVITIES_REQUEST_RETRY`       | Number of retries for failed outgoing requests.                        |
-| `ACTIVITIES_REQUEST_RETRY_NOISE` | Random delay noise added between retries (in milliseconds).            |
+| Variable                                     | Description                                                                                                              |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `ACTIVITIES_REQUEST_TIMEOUT`                 | HTTP request timeout in milliseconds for outgoing federation requests.                                                   |
+| `ACTIVITIES_REQUEST_RETRY`                   | Number of retries for failed outgoing requests.                                                                          |
+| `ACTIVITIES_REQUEST_RETRY_NOISE`             | Random delay noise added between retries (in milliseconds).                                                              |
+| `ACTIVITIES_REQUEST_MAX_RESPONSE_SIZE_BYTES` | Maximum size of an outgoing federation request's response body, in bytes (default: 2 MB). Larger responses are rejected. |
 
 ## Observability
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@ This document tracks the implemented and planned features for Activity.next.
 
 - ✅ **ActivityPub federation** — Send and receive activities with other Fediverse servers
 - ✅ **Notes** — Create, receive, edit, and delete posts
-- ✅ **Replies** — Threaded conversation support
+- ✅ **Replies** — Threaded conversation support, including on-demand fetching of full remote reply threads when viewing a remote status
 - ✅ **Image attachments** — Upload and display images in posts
 - ✅ **Boost / Repost** — Share other users' posts (with undo)
 - ✅ **Like / Favorite** — React to posts (with undo)
@@ -37,7 +37,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Main timeline** — Home feed with posts from followed accounts
 - ✅ **Favorites page** — Browse posts you've favorited
 - ✅ **List timelines** — Per-list timelines honoring replies policy, exclusive lists, and block/mute/keyword filtering
-- ✅ **Notifications** — Like, follow, mention, reblog, and follow request notifications
+- ✅ **Notifications** — Like, follow, mention, reblog, follow request, and collection (added-to-collection / collection-update) notifications
 - ✅ **Notification grouping** — Group similar notifications together
 - ✅ **Email notifications** — Configurable email alerts for each notification type
 - ✅ **Push notifications** — Web Push subscriptions with VAPID configuration
@@ -52,8 +52,9 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Fitness file storage** — Upload .fit, .gpx, and .tcx activity files
 - ✅ **Fitness activity processing** — Parse GPS tracks and metrics from uploaded .fit, .gpx, and .tcx files
 - ✅ **Fitness activity display** — Show route maps, activity statistics, analysis graphs, and device info in posts
-- ✅ **Fitness route heatmaps** — Generate route heatmap caches by actor, activity type, period, and region
+- ✅ **Fitness route heatmaps** — Per-region master/detail heatmaps by actor, activity type, period, and region, rendered on an interactive map (Mapbox when a token is configured, otherwise keyless MapLibre / OpenFreeMap), with live generation progress, per-heatmap retry/remove, inline region renaming, and shareable/embeddable views (iframe + image)
 - ✅ **Strava import** — Import activities through Strava OAuth/webhooks and uploaded Strava archive ZIP files
+- ✅ **Fitness import resilience** — Recover stuck/orphaned imports, resumable Strava archive retries, same-ride upload merging, and per-file retry from the UI; repair scripts cover legacy imports
 - ✅ **Fitness privacy locations** — Hide configured location radii from route maps and heatmaps
 - ✅ **Storage quotas** — Per-account file size and storage limits
 
@@ -64,7 +65,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Granular OAuth scopes** — Fine-grained scope enforcement and client-credentials app tokens
 - ✅ **Search** — Search accounts, hashtags, and statuses via `/api/v2/search` (status search backed by a full-text index)
 - ✅ **Lists** — Create and manage timeline lists, their members, replies policy, and exclusive flag
-- ✅ **Collections** — Mastodon 4.6-compatible curated account collections via `/api/v1/collections` (create/update/delete, members, per-member approve/revoke consent, `in_collections`), plus an activities.next shareable **public feed** of each collection (owner-private and public projections, the public one limited to approved members and public-visibility posts) with a per-collection capped materialized feed
+- ✅ **Collections** — Mastodon 4.6-compatible curated account collections via `/api/v1/collections` (create/update/delete, members, per-member approve/revoke consent, `in_collections`), plus an activities.next shareable **public feed** of each collection (owner-private and public projections, the public one limited to approved members and public-visibility posts) with a per-collection capped materialized feed. Collections federate outbound as **FEP-7aa9 `FeaturedCollection`** objects, auto-follow and backfill remote members' existing posts when they are added, and emit added-to-collection / collection-update notifications
 - ✅ **Filters** — Keyword/status filters via `/api/v2/filters` with notification filtering
 - ✅ **Reports** — Submit reports against accounts and statuses via `/api/v1/reports`
 - ✅ **Markers** — Save and restore per-timeline read positions
@@ -90,7 +91,7 @@ This document tracks the implemented and planned features for Activity.next.
 
 ## In Progress
 
-- 🚧 **Fitness import hardening** — Repair and resume scripts cover interrupted or legacy Strava imports while the importer continues to mature
+- 🚧 **Inbound collection federation** — Outbound `FeaturedCollection` federation has shipped; consuming remote `FeaturedCollection` objects is still maturing
 
 ## Planned Features
 

--- a/docs/fitness-file-storage.md
+++ b/docs/fitness-file-storage.md
@@ -48,7 +48,7 @@ Important columns include:
 - `deviceManufacturer`, `deviceName`
 - `createdAt`, `updatedAt`, `deletedAt`
 
-Route heatmap caches are stored in `fitness_route_heatmaps`. They are keyed by actor, activity type, period, and region and store serialized route segments rather than generated PNG files.
+Route heatmap caches are stored in `fitness_route_heatmaps`. They are keyed by actor, activity type, period, and region and store serialized route segments rather than generated PNG files. A nullable `shareToken` column backs the shareable/embeddable heatmap views (iframe + image). User-assigned names for heatmap regions are persisted separately in `fitness_route_heatmap_region_names` (keyed by actor and region) so they survive reloads.
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary

Updates the project's human-facing documentation to match the codebase after a run of feature work (Collections federation, fitness heatmap redesign, fitness import resilience, remote reply threads) and the ESM/Vitest migration. No code or behavior changes — docs only, so this ships nothing (`none:`).

## What changed

- **`docs/features.md`**
  - **Collections** — note outbound **FEP-7aa9 `FeaturedCollection`** federation, auto-follow + backfill of remote members' posts, and added-to-collection / collection-update notifications (#1052, #1056, #1059).
  - **Fitness route heatmaps** — per-region master/detail, interactive Mapbox / keyless MapLibre·OpenFreeMap maps, live generation progress, per-heatmap retry/remove, inline region renaming, and shareable/embeddable views (#1045, #1050, #1051, #1055, #1067, #1070, #1074, #1077).
  - **Replies** — on-demand fetching of full remote reply threads (#1043).
  - Added **Fitness import resilience** (#1060, #1066) and refreshed **Notifications**.
  - **In Progress** — the fitness import hardening item shipped; replaced with inbound collection federation (outbound has shipped, inbound consumption is still maturing — verified no inbound `FeaturedCollection` parsing exists yet).
- **`docs/architecture.md`** — Testing is **Vitest (native ESM)**, not Jest (#991); added `collections` to the services list and the new `collection_*` / `fitness_route_heatmap_region_names` tables to the schema overview.
- **`CONTRIBUTING.md`** — replaced the four stale **Jest** references with Vitest (`vi.mock(...)`, `vitest.config.ts`, the test-suite line, the docs link) and named the test runner in the Testing section.
- **`docs/environment-variables.md`** — documented `ACTIVITIES_REQUEST_MAX_RESPONSE_SIZE_BYTES` (default 2 MB).
- **`docs/fitness-file-storage.md`** — noted the `shareToken` column and the `fitness_route_heatmap_region_names` table.

## Verification

- All edited facts were grep-verified against `lib/`, `app/`, `lib/config/`, and the reference schema dump.
- `yarn run prettier --write` applied to the changed files (re-aligned the env-vars table for the new row).
- Docs-only change: ESLint, `next build`, and Vitest don't process Markdown, so they're no-ops here. Consistent with prior doc-refresh PRs (#932, #842).

🤖 Generated with [Claude Code](https://claude.com/claude-code)