### PR TITLE
Bump version to v1.87.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.87.2",
+  "version": "1.87.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.87.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.87.2`
- Base main SHA: `0322a89f529a1fbeb7d10505330299e85eb7dbc3`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
