### PR TITLE
Bump version to v1.87.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.87.3",
+  "version": "1.87.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.87.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.87.3`
- Base main SHA: `1b42a3811270e02391c617d19149e3939e583974`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
