### PR TITLE
Bump version to v1.87.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.87.4",
+  "version": "1.87.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.87.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.87.4`
- Base main SHA: `858cad8acab0cee0c5c95e295f7abe6e4e42cbb0`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
