### PR TITLE
Bump version to v1.88.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.87.6",
+  "version": "1.88.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.88.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.87.6`
- Base main SHA: `9c38a29678591ba8123cc44ba92a9bef3821e843`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
