### PR TITLE
minor: redesign heatmap share & embed and add a public shared page

### DIFF
--- a/app/u/heatmaps/[token]/CopyLinkButton.tsx
+++ b/app/u/heatmaps/[token]/CopyLinkButton.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { Check, Link as LinkIcon } from 'lucide-react'
-import { FC, useState } from 'react'
+import { FC } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
+import { useCopyToClipboard } from '@/lib/hooks/useCopyToClipboard'
 
 interface CopyLinkButtonProps {
   url: string
@@ -13,23 +14,10 @@ interface CopyLinkButtonProps {
  * The only interactive affordance on the public shared page: copy its own URL.
  */
 export const CopyLinkButton: FC<CopyLinkButtonProps> = ({ url }) => {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async () => {
-    // navigator.clipboard is undefined in insecure (http) contexts and older
-    // browsers; the button simply no-ops there (the link is also visible above).
-    if (!navigator.clipboard) return
-    try {
-      await navigator.clipboard.writeText(url)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1600)
-    } catch {
-      // Clipboard access can be denied; nothing else to do.
-    }
-  }
+  const { copied, copy } = useCopyToClipboard()
 
   return (
-    <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+    <Button type="button" variant="outline" size="sm" onClick={() => copy(url)}>
       {copied ? (
         <Check className="size-4 text-green-600 dark:text-green-500" />
       ) : (

--- a/app/u/heatmaps/[token]/CopyLinkButton.tsx
+++ b/app/u/heatmaps/[token]/CopyLinkButton.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Check, Link as LinkIcon } from 'lucide-react'
+import { FC, useState } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+
+interface CopyLinkButtonProps {
+  url: string
+}
+
+/**
+ * The only interactive affordance on the public shared page: copy its own URL.
+ */
+export const CopyLinkButton: FC<CopyLinkButtonProps> = ({ url }) => {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    // navigator.clipboard is undefined in insecure (http) contexts and older
+    // browsers; the button simply no-ops there (the link is also visible above).
+    if (!navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1600)
+    } catch {
+      // Clipboard access can be denied; nothing else to do.
+    }
+  }
+
+  return (
+    <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+      {copied ? (
+        <Check className="size-4 text-green-600 dark:text-green-500" />
+      ) : (
+        <LinkIcon className="size-4" />
+      )}
+      {copied ? 'Link copied' : 'Copy link'}
+    </Button>
+  )
+}

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { SharedHeatmapPage } from './SharedHeatmapPage'
+import { SharedHeatmapView } from './sharedHeatmapView'
+
+// The route map mounts a GL map; stub it so the test stays focused on chrome.
+vi.mock('@/lib/components/fitness/RouteHeatmapMap', () => ({
+  RouteHeatmapMap: () => <div data-testid="route-map" />
+}))
+
+const baseView: SharedHeatmapView = {
+  title: 'Veluwe',
+  isWorld: false,
+  bboxLabel: 'TL 52.60°N 5.60°E → BR 52.00°N 6.20°E',
+  owner: { name: 'Alice Rider', handle: '@alice@llun.test', initials: 'AR' },
+  generatedLabel: 'June 24, 2026',
+  publicUrl: 'https://llun.test/u/heatmaps/tok123',
+  heatmap: {
+    id: 'hm-1',
+    periodType: 'all_time',
+    periodKey: 'all',
+    region: 'rect:52.60,5.60,52.00,6.20',
+    status: 'completed',
+    bounds: null,
+    segments: [],
+    activityCount: 0,
+    pointCount: 0,
+    totalCount: 0,
+    cursorOffset: 0,
+    isPartial: false,
+    createdAt: 1,
+    updatedAt: 2
+  },
+  stats: { routes: '342', activity: 'Trail Run', period: 'All time' }
+}
+
+const defaultProps = {
+  view: baseView,
+  signupOpen: true,
+  signinUrl: '/auth/signin',
+  signupUrl: '/auth/signup'
+}
+
+describe('SharedHeatmapPage', () => {
+  it('renders the heatmap title, owner, date and read-only stats', () => {
+    render(<SharedHeatmapPage {...defaultProps} />)
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Veluwe' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('@alice@llun.test')).toBeInTheDocument()
+    expect(screen.getByText('Generated June 24, 2026')).toBeInTheDocument()
+    expect(
+      screen.getByText('TL 52.60°N 5.60°E → BR 52.00°N 6.20°E')
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('Routes')).toBeInTheDocument()
+    expect(screen.getByText('342')).toBeInTheDocument()
+    expect(screen.getByText('Trail Run')).toBeInTheDocument()
+    expect(screen.getByTestId('route-map')).toBeInTheDocument()
+  })
+
+  it('offers a copy-link control pointing at the public URL', () => {
+    render(<SharedHeatmapPage {...defaultProps} />)
+    expect(
+      screen.getByRole('button', { name: /Copy link/i })
+    ).toBeInTheDocument()
+  })
+
+  it('shows Create account links only when sign-up is open', () => {
+    const { rerender } = render(<SharedHeatmapPage {...defaultProps} />)
+    expect(
+      screen.getAllByRole('link', { name: /Create account/i }).length
+    ).toBeGreaterThan(0)
+
+    rerender(<SharedHeatmapPage {...defaultProps} signupOpen={false} />)
+    expect(
+      screen.queryByRole('link', { name: /Create account/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a globe heading for the whole-world heatmap', () => {
+    render(
+      <SharedHeatmapPage
+        {...defaultProps}
+        view={{
+          ...baseView,
+          isWorld: true,
+          title: 'Whole world',
+          bboxLabel: undefined
+        }}
+      />
+    )
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Whole world' })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/TL 52\.60°N/)).not.toBeInTheDocument()
+  })
+})

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
@@ -1,0 +1,201 @@
+import {
+  Activity,
+  Calendar,
+  ChevronRight,
+  Eye,
+  Flame,
+  Globe,
+  Maximize,
+  Route
+} from 'lucide-react'
+import Link from 'next/link'
+import { FC } from 'react'
+
+import { RouteHeatmapMap } from '@/lib/components/fitness/RouteHeatmapMap'
+import { Logo } from '@/lib/components/layout/logo'
+import { Button } from '@/lib/components/ui/button'
+
+import { CopyLinkButton } from './CopyLinkButton'
+import { SharedHeatmapView } from './sharedHeatmapView'
+
+export interface SharedHeatmapPageProps {
+  view: SharedHeatmapView
+  mapboxAccessToken?: string
+  /** Whether the instance accepts new sign-ups (gates the Create-account CTAs). */
+  signupOpen: boolean
+  signinUrl: string
+  signupUrl: string
+}
+
+interface StatTileProps {
+  icon: FC<{ className?: string }>
+  label: string
+  value: string
+}
+
+const StatTile: FC<StatTileProps> = ({ icon: Icon, label, value }) => (
+  <div className="rounded-xl border bg-card/80 px-4 py-3 shadow-sm">
+    <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+      <Icon className="size-3.5" />
+      {label}
+    </div>
+    <div className="mt-1 truncate text-lg font-semibold leading-tight tracking-tight tabular-nums">
+      {value}
+    </div>
+  </div>
+)
+
+/**
+ * The public, read-only destination for a shared route heatmap (at
+ * `/u/heatmaps/<token>`). No account required: logged-out chrome, the live heat
+ * map, a read-only stats strip, an owner line, and a join CTA. There are no
+ * edit / generate / share-panel controls — those live in the in-app region page.
+ */
+export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
+  view,
+  mapboxAccessToken,
+  signupOpen,
+  signinUrl,
+  signupUrl
+}) => {
+  const { title, isWorld, bboxLabel, owner, generatedLabel, publicUrl, stats } =
+    view
+
+  return (
+    <div
+      className="min-h-dvh"
+      style={{
+        backgroundImage:
+          'radial-gradient(1200px 600px at 10% -10%, hsl(24 95% 95% / 0.9), transparent 60%),' +
+          'radial-gradient(900px 600px at 90% -10%, hsl(200 80% 94% / 0.8), transparent 55%)',
+        backgroundRepeat: 'no-repeat',
+        backgroundAttachment: 'fixed'
+      }}
+    >
+      {/* public top bar */}
+      <header className="sticky top-0 z-30 border-b bg-background/90 backdrop-blur">
+        <div className="mx-auto flex h-14 max-w-[840px] items-center gap-3 px-4 sm:px-6">
+          <Logo size="md" />
+          <div className="ml-auto flex items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link href={signinUrl}>Sign in</Link>
+            </Button>
+            {signupOpen && (
+              <Button asChild size="sm">
+                <Link href={signupUrl}>Create account</Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-[840px] px-4 py-6 sm:px-6 sm:py-8">
+        {/* public, read-only context pill */}
+        <div className="mb-4 inline-flex items-center gap-1.5 rounded-full border bg-background/70 px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
+          <Eye className="size-3" /> Public heatmap · anyone with the link can
+          view
+        </div>
+
+        {/* header */}
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
+              {isWorld ? (
+                <Globe className="size-6" />
+              ) : (
+                <Maximize className="size-6" />
+              )}
+            </span>
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="flex size-5 items-center justify-center rounded-full bg-muted-foreground text-[10px] font-semibold text-background">
+                    {owner.initials}
+                  </span>
+                  <span className="font-medium text-foreground">
+                    {owner.handle}
+                  </span>
+                </span>
+                <span className="text-muted-foreground/60">·</span>
+                <span>Generated {generatedLabel}</span>
+              </div>
+              {bboxLabel && (
+                <div className="mt-1 font-mono text-[11px] text-muted-foreground/80">
+                  {bboxLabel}
+                </div>
+              )}
+            </div>
+          </div>
+          <CopyLinkButton url={publicUrl} />
+        </div>
+
+        {/* the heat map */}
+        <div className="mt-5">
+          <div className="overflow-hidden rounded-xl border">
+            <RouteHeatmapMap
+              heatmap={view.heatmap}
+              mapboxAccessToken={mapboxAccessToken}
+              heightClassName="h-[440px]"
+            />
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            A live, pannable density map — brighter areas are ridden or run more
+            often. Drag to explore.
+          </p>
+        </div>
+
+        {/* read-only stats */}
+        <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <StatTile icon={Route} label="Routes" value={stats.routes} />
+          <StatTile icon={Activity} label="Activity" value={stats.activity} />
+          <StatTile icon={Calendar} label="Period" value={stats.period} />
+        </div>
+
+        {/* join CTA */}
+        <div className="mt-6 overflow-hidden rounded-2xl border shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-4 bg-primary/5 p-5">
+            <div className="flex items-start gap-3">
+              <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Flame className="size-5" />
+              </span>
+              <div>
+                <div className="text-sm font-semibold">
+                  Make a heatmap from your own routes
+                </div>
+                <p className="mt-0.5 max-w-md text-[13px] leading-relaxed text-muted-foreground">
+                  Upload your activities to Activities and aggregate years of
+                  rides and runs into a density map like this one.
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {signupOpen && (
+                <Button asChild size="sm">
+                  <Link href={signupUrl}>Create account</Link>
+                </Button>
+              )}
+              <Button asChild variant="outline" size="sm">
+                <Link href={signinUrl}>
+                  Sign in <ChevronRight className="size-4" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {/* footer */}
+      <footer className="mx-auto max-w-[840px] px-4 pb-10 sm:px-6">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-6 text-sm text-muted-foreground">
+          <span>
+            <strong className="font-semibold text-foreground">
+              Activities
+            </strong>{' '}
+            — a self-hosted social + fitness server on the Fediverse.
+          </span>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
@@ -62,16 +62,20 @@ export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
     view
 
   return (
-    <div
-      className="min-h-dvh"
-      style={{
-        backgroundImage:
-          'radial-gradient(1200px 600px at 10% -10%, hsl(24 95% 95% / 0.9), transparent 60%),' +
-          'radial-gradient(900px 600px at 90% -10%, hsl(200 80% 94% / 0.8), transparent 55%)',
-        backgroundRepeat: 'no-repeat',
-        backgroundAttachment: 'fixed'
-      }}
-    >
+    <div className="relative min-h-dvh">
+      {/* Branded backdrop. A fixed, behind-content layer rather than
+          `background-attachment: fixed` (which janks/mis-renders on iOS Safari);
+          dimmed in dark mode so the light gradient doesn't glare. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 -z-10 bg-no-repeat dark:opacity-25"
+        style={{
+          backgroundImage:
+            'radial-gradient(1200px 600px at 10% -10%, hsl(24 95% 95% / 0.9), transparent 60%),' +
+            'radial-gradient(900px 600px at 90% -10%, hsl(200 80% 94% / 0.8), transparent 55%)'
+        }}
+      />
+
       {/* public top bar */}
       <header className="sticky top-0 z-30 border-b bg-background/90 backdrop-blur">
         <div className="mx-auto flex h-14 max-w-[840px] items-center gap-3 px-4 sm:px-6">

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
@@ -114,7 +114,10 @@ export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
               <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
               <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
                 <span className="inline-flex items-center gap-1.5">
-                  <span className="flex size-5 items-center justify-center rounded-full bg-muted-foreground text-[10px] font-semibold text-background">
+                  <span
+                    aria-hidden="true"
+                    className="flex size-5 items-center justify-center rounded-full bg-muted-foreground text-[10px] font-semibold text-background"
+                  >
                     {owner.initials}
                   </span>
                   <span className="font-medium text-foreground">

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
@@ -164,9 +164,9 @@ export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
                 <Flame className="size-5" />
               </span>
               <div>
-                <div className="text-sm font-semibold">
+                <h2 className="text-sm font-semibold">
                   Make a heatmap from your own routes
-                </div>
+                </h2>
                 <p className="mt-0.5 max-w-md text-[13px] leading-relaxed text-muted-foreground">
                   Upload your activities to Activities and aggregate years of
                   rides and runs into a density map like this one.

--- a/app/u/heatmaps/[token]/page.tsx
+++ b/app/u/heatmaps/[token]/page.tsx
@@ -53,7 +53,7 @@ const Page: FC<PageProps> = async ({ params }) => {
     const regionNames = await database.getFitnessRouteHeatmapRegionNames({
       actorId: heatmap.actorId
     })
-    regionName = regionNames.find(
+    regionName = regionNames?.find(
       (entry) => entry.region === heatmap.region
     )?.name
   } catch {

--- a/app/u/heatmaps/[token]/page.tsx
+++ b/app/u/heatmaps/[token]/page.tsx
@@ -1,0 +1,98 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { FC } from 'react'
+
+import { getBaseURL, getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { toPublicHeatmap } from '@/lib/services/fitness-files/publicHeatmap'
+import { getPublicMapboxAccessToken } from '@/lib/utils/mapbox'
+
+import { SharedHeatmapPage } from './SharedHeatmapPage'
+import { buildSharedHeatmapView } from './sharedHeatmapView'
+
+export const dynamic = 'force-dynamic'
+
+// A capability URL (the token is the secret), so keep it out of search indexes.
+export const metadata: Metadata = {
+  title: 'Route heatmap',
+  robots: { index: false, follow: false }
+}
+
+interface PageProps {
+  params: Promise<{ token: string }>
+}
+
+const Page: FC<PageProps> = async ({ params }) => {
+  const { token } = await params
+
+  const database = getDatabase()
+  if (!database) notFound()
+
+  const heatmap = await database.getFitnessRouteHeatmapByShareToken({
+    shareToken: token
+  })
+  // Only render a completed heatmap. A shared heatmap re-queued for generation
+  // keeps its token but transitions back to pending/generating; 404 during that
+  // window rather than publish a partial/in-progress page.
+  if (!heatmap || heatmap.status !== 'completed') notFound()
+
+  // Flatten the privacy distinction so the public page shows no hole and no
+  // highlight around private locations (see toPublicHeatmap).
+  const publicHeatmap = toPublicHeatmap(heatmap)
+
+  // Owner display fields (name/handle/initials). Non-critical chrome, so a
+  // lookup failure degrades to an actor-id-derived handle rather than 404ing.
+  const owner = await database
+    .getActorFromId({ id: heatmap.actorId })
+    .catch(() => null)
+
+  // The owner-assigned region label (e.g. "Netherlands"), shown as the title for
+  // drawn areas. Best-effort: a lookup failure degrades to the generic label.
+  let regionName: string | undefined
+  try {
+    const regionNames = await database.getFitnessRouteHeatmapRegionNames({
+      actorId: heatmap.actorId
+    })
+    regionName = regionNames.find(
+      (entry) => entry.region === heatmap.region
+    )?.name
+  } catch {
+    regionName = undefined
+  }
+
+  // Build the public URL against the actor's own canonical domain (matches the
+  // in-app share snippet), falling back to the instance base URL.
+  let origin: string
+  try {
+    origin = new URL(heatmap.actorId).origin
+  } catch {
+    origin = getBaseURL()
+  }
+
+  const view = buildSharedHeatmapView({
+    heatmap: publicHeatmap,
+    owner: owner
+      ? { name: owner.name, username: owner.username, domain: owner.domain }
+      : null,
+    regionName,
+    origin,
+    token
+  })
+
+  const config = getConfig()
+  const mapboxAccessToken = getPublicMapboxAccessToken(
+    config.fitnessStorage?.mapboxAccessToken
+  )
+
+  return (
+    <SharedHeatmapPage
+      view={view}
+      mapboxAccessToken={mapboxAccessToken}
+      signupOpen={config.registrationOpen}
+      signinUrl="/auth/signin"
+      signupUrl="/auth/signup"
+    />
+  )
+}
+
+export default Page

--- a/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
@@ -1,0 +1,176 @@
+import { serializeRegion } from '@/lib/fitness/regions'
+import { FitnessRouteHeatmap } from '@/lib/types/database/fitnessRouteHeatmap'
+
+import {
+  buildSharedHeatmapView,
+  computeInitials,
+  formatActivityLabel,
+  formatGeneratedDate,
+  formatPeriodLabel
+} from './sharedHeatmapView'
+
+const baseHeatmap: FitnessRouteHeatmap = {
+  id: 'hm-1',
+  actorId: 'https://llun.test/users/alice',
+  activityType: undefined,
+  periodType: 'all_time',
+  periodKey: 'all',
+  region: '',
+  segments: [{ points: [{ lat: 52, lng: 5.6 }] }],
+  bounds: { minLat: 52, maxLat: 52.6, minLng: 5.6, maxLng: 6.2 },
+  status: 'completed',
+  activityCount: 342,
+  pointCount: 9001,
+  totalCount: 9001,
+  cursorOffset: 9001,
+  isPartial: false,
+  createdAt: 1000,
+  updatedAt: Date.UTC(2026, 5, 24, 12)
+}
+
+const owner = { name: 'Alice Rider', username: 'alice', domain: 'llun.test' }
+
+describe('formatActivityLabel', () => {
+  it.each([
+    {
+      description: 'undefined → All activities',
+      input: undefined,
+      expected: 'All activities'
+    },
+    {
+      description: 'null → All activities',
+      input: null,
+      expected: 'All activities'
+    },
+    {
+      description: 'humanises trail_run',
+      input: 'trail_run',
+      expected: 'Trail Run'
+    }
+  ])('$description', ({ input, expected }) => {
+    expect(formatActivityLabel(input)).toBe(expected)
+  })
+})
+
+describe('formatPeriodLabel', () => {
+  it('returns All time for the all-time period', () => {
+    expect(formatPeriodLabel('all_time', 'all')).toBe('All time')
+  })
+  it('returns the raw period key otherwise', () => {
+    expect(formatPeriodLabel('yearly', '2025')).toBe('2025')
+    expect(formatPeriodLabel('monthly', '2025-06')).toBe('2025-06')
+  })
+})
+
+describe('computeInitials', () => {
+  it.each([
+    { description: 'two words', input: 'Alice Rider', expected: 'AR' },
+    { description: 'single word', input: 'alice', expected: 'A' },
+    { description: 'caps the first two words', input: 'a b c', expected: 'AB' },
+    { description: 'blank falls back to ?', input: '   ', expected: '?' }
+  ])('$description', ({ input, expected }) => {
+    expect(computeInitials(input)).toBe(expected)
+  })
+})
+
+describe('formatGeneratedDate', () => {
+  it('formats an absolute long date', () => {
+    const formatted = formatGeneratedDate(Date.UTC(2026, 5, 24, 12))
+    expect(formatted).toMatch(/2026/)
+    expect(formatted).toMatch(/June/)
+  })
+})
+
+describe('buildSharedHeatmapView', () => {
+  it('builds the world view with read-only stats and a zeroed map heatmap', () => {
+    const view = buildSharedHeatmapView({
+      heatmap: baseHeatmap,
+      owner,
+      origin: 'https://llun.test',
+      token: 'tok123'
+    })
+
+    expect(view.title).toBe('Whole world')
+    expect(view.isWorld).toBe(true)
+    expect(view.bboxLabel).toBeUndefined()
+    expect(view.owner).toEqual({
+      name: 'Alice Rider',
+      handle: '@alice@llun.test',
+      initials: 'AR'
+    })
+    expect(view.publicUrl).toBe('https://llun.test/u/heatmaps/tok123')
+    expect(view.stats).toEqual({
+      routes: '342',
+      activity: 'All activities',
+      period: 'All time'
+    })
+    // Internal counters are zeroed in the map payload (no public leak), but the
+    // real segments/bounds are kept so the map still renders.
+    expect(view.heatmap.activityCount).toBe(0)
+    expect(view.heatmap.pointCount).toBe(0)
+    expect(view.heatmap.totalCount).toBe(0)
+    expect(view.heatmap.segments).toEqual(baseHeatmap.segments)
+    expect(view.heatmap.bounds).toEqual(baseHeatmap.bounds)
+  })
+
+  it('uses the owner-assigned region name and a bbox caption for a single rect', () => {
+    const region = serializeRegion({
+      type: 'rect',
+      nw: { lat: 52.6, lng: 5.6 },
+      se: { lat: 52, lng: 6.2 }
+    })
+    const view = buildSharedHeatmapView({
+      heatmap: { ...baseHeatmap, region },
+      owner,
+      regionName: 'Veluwe',
+      origin: 'https://llun.test',
+      token: 'tok123'
+    })
+
+    expect(view.isWorld).toBe(false)
+    expect(view.title).toBe('Veluwe')
+    expect(view.bboxLabel).toBe('TL 52.60°N 5.60°E → BR 52.00°N 6.20°E')
+  })
+
+  it('falls back to Map area when a rect has no saved name', () => {
+    const region = serializeRegion({
+      type: 'rect',
+      nw: { lat: 52.6, lng: 5.6 },
+      se: { lat: 52, lng: 6.2 }
+    })
+    const view = buildSharedHeatmapView({
+      heatmap: { ...baseHeatmap, region },
+      owner,
+      origin: 'https://llun.test',
+      token: 'tok123'
+    })
+    expect(view.title).toBe('Map area')
+  })
+
+  it('humanises a filtered activity and yearly period in the stats', () => {
+    const view = buildSharedHeatmapView({
+      heatmap: {
+        ...baseHeatmap,
+        activityType: 'trail_run',
+        periodType: 'yearly',
+        periodKey: '2025'
+      },
+      owner,
+      origin: 'https://llun.test',
+      token: 'tok123'
+    })
+    expect(view.stats.activity).toBe('Trail Run')
+    expect(view.stats.period).toBe('2025')
+  })
+
+  it('derives the handle from the actor id when the owner is missing', () => {
+    const view = buildSharedHeatmapView({
+      heatmap: baseHeatmap,
+      owner: null,
+      origin: 'https://llun.test',
+      token: 'tok123'
+    })
+    expect(view.owner.handle).toBe('@alice@llun.test')
+    expect(view.owner.name).toBe('Athlete')
+  })
+})

--- a/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
@@ -163,6 +163,16 @@ describe('buildSharedHeatmapView', () => {
     expect(view.stats.period).toBe('2025')
   })
 
+  it('does not double the slash when the origin has a trailing slash', () => {
+    const view = buildSharedHeatmapView({
+      heatmap: baseHeatmap,
+      owner,
+      origin: 'https://llun.test/',
+      token: 'tok123'
+    })
+    expect(view.publicUrl).toBe('https://llun.test/u/heatmaps/tok123')
+  })
+
   it('derives the handle from the actor id when the owner is missing', () => {
     const view = buildSharedHeatmapView({
       heatmap: baseHeatmap,

--- a/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
@@ -67,17 +67,25 @@ describe('computeInitials', () => {
     { description: 'two words', input: 'Alice Rider', expected: 'AR' },
     { description: 'single word', input: 'alice', expected: 'A' },
     { description: 'caps the first two words', input: 'a b c', expected: 'AB' },
-    { description: 'blank falls back to ?', input: '   ', expected: '?' }
+    { description: 'blank falls back to ?', input: '   ', expected: '?' },
+    {
+      description: 'keeps a non-BMP leading char intact (no broken surrogate)',
+      input: '𝒜lice',
+      expected: '𝒜'
+    }
   ])('$description', ({ input, expected }) => {
     expect(computeInitials(input)).toBe(expected)
   })
 })
 
 describe('formatGeneratedDate', () => {
-  it('formats an absolute long date', () => {
-    const formatted = formatGeneratedDate(Date.UTC(2026, 5, 24, 12))
-    expect(formatted).toMatch(/2026/)
-    expect(formatted).toMatch(/June/)
+  it('formats an absolute long date in UTC', () => {
+    expect(formatGeneratedDate(Date.UTC(2026, 5, 24, 12))).toBe('June 24, 2026')
+  })
+
+  it('does not shift a UTC-midnight instant across the date boundary', () => {
+    // Without timeZone: 'UTC' this would render Dec 31, 2025 west of UTC.
+    expect(formatGeneratedDate(Date.UTC(2026, 0, 1, 0))).toBe('January 1, 2026')
   })
 })
 

--- a/app/u/heatmaps/[token]/sharedHeatmapView.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.ts
@@ -1,0 +1,143 @@
+import { FitnessRouteHeatmapData } from '@/lib/client'
+import { deserializeRegions, formatRectRegion } from '@/lib/fitness/regions'
+import { FitnessRouteHeatmap } from '@/lib/types/database/fitnessRouteHeatmap'
+import { getMentionFromActorID } from '@/lib/types/domain/actor'
+
+const numberFormatter = new Intl.NumberFormat()
+
+/** "All activities" or a humanised activity type (e.g. "Trail Run"). */
+export const formatActivityLabel = (type?: string | null): string =>
+  type
+    ? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+    : 'All activities'
+
+/** "All time" for the all-time period, otherwise the raw period key. */
+export const formatPeriodLabel = (
+  periodType: string,
+  periodKey: string
+): string => (periodType === 'all_time' ? 'All time' : periodKey)
+
+/** Up to two uppercase initials from a display name (falls back to "?"). */
+export const computeInitials = (name: string): string => {
+  const initials = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+  return initials || '?'
+}
+
+/** Absolute "June 24, 2026"-style date for the public "Generated …" line. */
+export const formatGeneratedDate = (ms: number): string =>
+  new Date(ms).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric'
+  })
+
+export interface SharedHeatmapOwner {
+  name: string
+  handle: string
+  initials: string
+}
+
+export interface SharedHeatmapStats {
+  routes: string
+  activity: string
+  period: string
+}
+
+export interface SharedHeatmapView {
+  title: string
+  isWorld: boolean
+  /** Single-rect bounding-box caption, omitted for world or multi-rect scopes. */
+  bboxLabel?: string
+  owner: SharedHeatmapOwner
+  generatedLabel: string
+  publicUrl: string
+  /**
+   * Map-ready heatmap with the internal generation counters zeroed: as Client
+   * Component props they would otherwise be serialised into the public RSC
+   * payload on this unauthenticated surface (mirrors the embed page). Only the
+   * route count is surfaced — and only as a pre-formatted stat string below.
+   */
+  heatmap: FitnessRouteHeatmapData
+  stats: SharedHeatmapStats
+}
+
+interface BuildSharedHeatmapViewParams {
+  /** Privacy-flattened heatmap (see toPublicHeatmap). Real counters intact. */
+  heatmap: FitnessRouteHeatmap
+  /** Owner display fields; null when the actor could not be resolved. */
+  owner: { name?: string; username: string; domain: string } | null
+  /** Owner-assigned region label (e.g. "Netherlands"); world is never named. */
+  regionName?: string
+  /** Canonical origin for the public URL (the actor's own domain). */
+  origin: string
+  token: string
+}
+
+/**
+ * Builds the read-only view model for the public shared heatmap page from a
+ * completed, privacy-flattened heatmap and its owner. Pure so it can be unit
+ * tested without rendering the async server page.
+ */
+export const buildSharedHeatmapView = ({
+  heatmap,
+  owner,
+  regionName,
+  origin,
+  token
+}: BuildSharedHeatmapViewParams): SharedHeatmapView => {
+  const isWorld = heatmap.region === ''
+  const title = isWorld ? 'Whole world' : regionName?.trim() || 'Map area'
+
+  const regions = isWorld ? [] : deserializeRegions(heatmap.region)
+  const bboxLabel =
+    regions.length === 1 && regions[0].type === 'rect'
+      ? formatRectRegion(regions[0])
+      : undefined
+
+  const ownerName = owner?.name?.trim() || owner?.username?.trim() || 'Athlete'
+  const handle = owner
+    ? `@${owner.username}@${owner.domain}`
+    : getMentionFromActorID(heatmap.actorId, true)
+
+  return {
+    title,
+    isWorld,
+    bboxLabel,
+    owner: {
+      name: ownerName,
+      handle,
+      initials: computeInitials(ownerName)
+    },
+    generatedLabel: formatGeneratedDate(heatmap.updatedAt),
+    publicUrl: `${origin}/u/heatmaps/${token}`,
+    heatmap: {
+      id: heatmap.id,
+      activityType: heatmap.activityType,
+      periodType: heatmap.periodType,
+      periodKey: heatmap.periodKey,
+      region: heatmap.region,
+      status: heatmap.status,
+      bounds: heatmap.bounds ?? null,
+      segments: heatmap.segments,
+      activityCount: 0,
+      pointCount: 0,
+      totalCount: 0,
+      cursorOffset: 0,
+      isPartial: false,
+      createdAt: heatmap.createdAt,
+      updatedAt: heatmap.updatedAt
+    },
+    stats: {
+      routes: numberFormatter.format(Math.max(0, heatmap.activityCount)),
+      activity: formatActivityLabel(heatmap.activityType),
+      period: formatPeriodLabel(heatmap.periodType, heatmap.periodKey)
+    }
+  }
+}

--- a/app/u/heatmaps/[token]/sharedHeatmapView.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.ts
@@ -116,7 +116,8 @@ export const buildSharedHeatmapView = ({
       initials: computeInitials(ownerName)
     },
     generatedLabel: formatGeneratedDate(heatmap.updatedAt),
-    publicUrl: `${origin}/u/heatmaps/${token}`,
+    // Drop any trailing slash so a base like `https://host/` can't yield `//`.
+    publicUrl: `${origin.replace(/\/+$/, '')}/u/heatmaps/${token}`,
     heatmap: {
       id: heatmap.id,
       activityType: heatmap.activityType,

--- a/app/u/heatmaps/[token]/sharedHeatmapView.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.ts
@@ -23,19 +23,26 @@ export const computeInitials = (name: string): string => {
     .trim()
     .split(/\s+/)
     .filter(Boolean)
-    .map((word) => word[0])
+    // Spread to the first full unicode code point so an emoji / non-BMP leading
+    // character isn't sliced into a broken surrogate half.
+    .map((word) => [...word][0])
     .slice(0, 2)
     .join('')
     .toUpperCase()
   return initials || '?'
 }
 
-/** Absolute "June 24, 2026"-style date for the public "Generated …" line. */
+/**
+ * Absolute "June 24, 2026"-style date for the public "Generated …" line. Pinned
+ * to UTC so the rendered date is deterministic regardless of the server's
+ * timezone (consistent with the rest of the fitness dashboard).
+ */
 export const formatGeneratedDate = (ms: number): string =>
   new Date(ms).toLocaleDateString('en-US', {
     month: 'long',
     day: 'numeric',
-    year: 'numeric'
+    year: 'numeric',
+    timeZone: 'UTC'
   })
 
 export interface SharedHeatmapOwner {

--- a/lib/components/fitness/HeatmapShareEmbed.test.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.test.tsx
@@ -113,9 +113,10 @@ describe('HeatmapShareEmbed', () => {
     )
 
     fireEvent.click(screen.getByRole('tab', { name: /Image/i }))
+    // The `&` between query params is entity-escaped inside the HTML attribute.
     expect(
       textboxValues().some((value) =>
-        value.includes('/embed/heatmap/tok123/image?w=600&h=420')
+        value.includes('/embed/heatmap/tok123/image?w=600&amp;h=420')
       )
     ).toBe(true)
   })
@@ -146,6 +147,22 @@ describe('HeatmapShareEmbed', () => {
       textboxValues().some(
         (value) =>
           value.includes('width="800"') && value.includes('height="560"')
+      )
+    ).toBe(true)
+  })
+
+  it('escapes a quote in the origin so the copyable snippet stays well-formed', () => {
+    render(
+      <HeatmapShareEmbed
+        {...defaultProps}
+        embedOrigin={'https://llun.test"x'}
+        shareToken="tok123"
+        defaultOpen
+      />
+    )
+    expect(
+      textboxValues().some((value) =>
+        value.includes('src="https://llun.test&quot;x/embed/heatmap/tok123"')
       )
     ).toBe(true)
   })

--- a/lib/components/fitness/HeatmapShareEmbed.test.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.test.tsx
@@ -88,6 +88,14 @@ describe('HeatmapShareEmbed', () => {
     expect(screen.getByRole('tab', { name: /Image/i })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /Link/i })).toBeInTheDocument()
 
+    // The active tab is wired to its panel for screen readers.
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveAttribute('aria-labelledby', 'share-tab-embed')
+    expect(screen.getByRole('tab', { name: /Embed/i })).toHaveAttribute(
+      'aria-controls',
+      'share-panel-embed'
+    )
+
     // Default (Embed) tab shows the iframe snippet pointing at the embed route.
     expect(
       textboxValues().some((value) =>

--- a/lib/components/fitness/HeatmapShareEmbed.test.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import type { FitnessRouteHeatmapData } from '@/lib/client'
+
+import { HeatmapShareEmbed } from './HeatmapShareEmbed'
+
+// The live preview mounts a GL map; stub it so these tests stay focused on the
+// panel chrome (tabs, sizes, snippets).
+vi.mock('@/lib/components/fitness/RouteHeatmapMap', () => ({
+  RouteHeatmapMap: () => <div data-testid="route-map" />
+}))
+
+const heatmap: FitnessRouteHeatmapData = {
+  id: 'hm-1',
+  region: '',
+  periodType: 'all_time',
+  periodKey: 'all',
+  status: 'completed',
+  bounds: { minLat: 52, maxLat: 52.6, minLng: 5.6, maxLng: 6.2 },
+  segments: [{ points: [{ lat: 52, lng: 5.6 }] }],
+  activityCount: 12,
+  pointCount: 340,
+  totalCount: 20,
+  cursorOffset: 20,
+  isPartial: false,
+  error: null,
+  createdAt: 1,
+  updatedAt: 2
+}
+
+const defaultProps = {
+  shareToken: undefined as string | null | undefined,
+  embedOrigin: 'https://llun.test',
+  regionLabel: undefined as string | undefined,
+  isWorld: true,
+  heatmap,
+  isSharing: false,
+  onShare: vi.fn(),
+  onUnshare: vi.fn()
+}
+
+const textboxValues = (): string[] =>
+  screen
+    .getAllByRole('textbox')
+    .map((node) => (node as HTMLInputElement | HTMLTextAreaElement).value)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('HeatmapShareEmbed', () => {
+  it('renders collapsed to a single Share & embed button by default', () => {
+    render(<HeatmapShareEmbed {...defaultProps} />)
+    const trigger = screen.getByRole('button', { name: /Share & embed/i })
+    expect(trigger).toBeInTheDocument()
+    // No tabs or snippets until the panel is opened.
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+  })
+
+  it('offers Create public link when opened on an unshared heatmap', () => {
+    const onShare = vi.fn()
+    render(<HeatmapShareEmbed {...defaultProps} onShare={onShare} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Share & embed/i }))
+    // Still no copyable snippets while unshared.
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Create public link/i }))
+    expect(onShare).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the three share tabs and a stop-sharing action once shared', () => {
+    const onUnshare = vi.fn()
+    render(
+      <HeatmapShareEmbed
+        {...defaultProps}
+        shareToken="tok123"
+        defaultOpen
+        onUnshare={onUnshare}
+      />
+    )
+
+    expect(screen.getByRole('tab', { name: /Embed/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Image/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Link/i })).toBeInTheDocument()
+
+    // Default (Embed) tab shows the iframe snippet pointing at the embed route.
+    expect(
+      textboxValues().some((value) =>
+        value.includes('https://llun.test/embed/heatmap/tok123"')
+      )
+    ).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: /Stop sharing/i }))
+    expect(onUnshare).toHaveBeenCalledTimes(1)
+  })
+
+  it('switches to the image snippet on the Image tab', () => {
+    render(
+      <HeatmapShareEmbed {...defaultProps} shareToken="tok123" defaultOpen />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: /Image/i }))
+    expect(
+      textboxValues().some((value) =>
+        value.includes('/embed/heatmap/tok123/image?w=600&h=420')
+      )
+    ).toBe(true)
+  })
+
+  it('points the Link tab at the public /u/heatmaps page', () => {
+    render(
+      <HeatmapShareEmbed {...defaultProps} shareToken="tok123" defaultOpen />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: /Link/i }))
+    expect(
+      textboxValues().some(
+        (value) => value === 'https://llun.test/u/heatmaps/tok123'
+      )
+    ).toBe(true)
+    expect(
+      screen.getByRole('link', { name: /Open the public page/i })
+    ).toHaveAttribute('href', 'https://llun.test/u/heatmaps/tok123')
+  })
+
+  it('updates snippet dimensions when a different size is chosen', () => {
+    render(
+      <HeatmapShareEmbed {...defaultProps} shareToken="tok123" defaultOpen />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Large' }))
+    expect(
+      textboxValues().some(
+        (value) =>
+          value.includes('width="800"') && value.includes('height="560"')
+      )
+    ).toBe(true)
+  })
+
+  it('labels and HTML-escapes the region name in snippets', () => {
+    render(
+      <HeatmapShareEmbed
+        {...defaultProps}
+        isWorld={false}
+        regionLabel={'Tom & "Jerry" <loop>'}
+        shareToken="tok123"
+        defaultOpen
+      />
+    )
+
+    const values = textboxValues()
+    expect(
+      values.some((value) =>
+        value.includes(
+          'title="Route heatmap — Tom &amp; &quot;Jerry&quot; &lt;loop&gt;"'
+        )
+      )
+    ).toBe(true)
+  })
+})

--- a/lib/components/fitness/HeatmapShareEmbed.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.tsx
@@ -226,7 +226,7 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
             <Share2 className="size-4" />
           </span>
           <div>
-            <div className="text-sm font-semibold">Share &amp; embed</div>
+            <h3 className="text-sm font-semibold">Share &amp; embed</h3>
             <div className="text-[11px] text-muted-foreground">
               Drop this heatmap into any other website — live embed, image, or a
               link.
@@ -323,7 +323,7 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
                 copyLabel="Copy embed code"
               />
               <div
-                className="overflow-hidden rounded-lg border"
+                className="w-full overflow-hidden rounded-lg border"
                 style={{ maxWidth: size.width }}
               >
                 <RouteHeatmapMap

--- a/lib/components/fitness/HeatmapShareEmbed.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.tsx
@@ -1,0 +1,403 @@
+'use client'
+
+import {
+  Check,
+  Code,
+  Copy,
+  ExternalLink,
+  Image as ImageIcon,
+  Link as LinkIcon,
+  Loader2,
+  Share2,
+  X
+} from 'lucide-react'
+import { FC, useState } from 'react'
+
+import { FitnessRouteHeatmapData } from '@/lib/client'
+import { RouteHeatmapMap } from '@/lib/components/fitness/RouteHeatmapMap'
+import { Button } from '@/lib/components/ui/button'
+import { cn } from '@/lib/utils'
+
+/** Embed/image sizes offered to the owner (mirrors the design kit). */
+interface EmbedSize {
+  id: 'sm' | 'md' | 'lg'
+  label: string
+  width: number
+  height: number
+}
+
+const EMBED_SIZES: readonly EmbedSize[] = [
+  { id: 'sm', label: 'Small', width: 400, height: 300 },
+  { id: 'md', label: 'Medium', width: 600, height: 420 },
+  { id: 'lg', label: 'Large', width: 800, height: 560 }
+]
+
+type ShareTab = 'embed' | 'image' | 'link'
+
+const TABS: readonly { id: ShareTab; label: string; icon: typeof Code }[] = [
+  { id: 'embed', label: 'Embed', icon: Code },
+  { id: 'image', label: 'Image', icon: ImageIcon },
+  { id: 'link', label: 'Link', icon: LinkIcon }
+]
+
+/**
+ * Fully escapes a label for use inside an HTML attribute in a copyable snippet
+ * (& first so an already-escaped entity isn't double-encoded), so a region name
+ * containing &, <, >, or " copies into a valid snippet.
+ */
+const escapeAttr = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+interface CopyFieldProps {
+  value: string
+  /** Render as a multi-line monospace snippet (code) rather than a single line. */
+  mono?: boolean
+  /** Accessible label for the copy button (e.g. "Copy embed code"). */
+  copyLabel: string
+}
+
+/**
+ * A read-only, selectable value with a copy-to-clipboard button. Used for the
+ * iframe/img snippets and the public link.
+ */
+const CopyField: FC<CopyFieldProps> = ({ value, mono, copyLabel }) => {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    // navigator.clipboard is undefined in insecure (http) contexts and older
+    // browsers; the field stays selectable so the user can copy manually.
+    if (!navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1600)
+    } catch {
+      // Clipboard access can be denied; selection fallback still works.
+    }
+  }
+
+  return (
+    <div className="flex items-stretch gap-2">
+      {mono ? (
+        <textarea
+          readOnly
+          rows={3}
+          value={value}
+          onFocus={(event) => event.currentTarget.select()}
+          className="min-w-0 flex-1 resize-none rounded-md border bg-muted/40 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      ) : (
+        <input
+          readOnly
+          type="text"
+          value={value}
+          onFocus={(event) => event.currentTarget.select()}
+          className="min-w-0 flex-1 rounded-md border bg-muted/40 px-2.5 py-1.5 text-[12px] leading-relaxed text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      )}
+      <Button
+        type="button"
+        size="sm"
+        className="h-auto shrink-0 self-stretch px-3"
+        onClick={handleCopy}
+        aria-label={copyLabel}
+      >
+        {copied ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    </div>
+  )
+}
+
+interface ShareEnableCalloutProps {
+  isSharing: boolean
+  onShare: () => void
+}
+
+/** The not-yet-shared state: an opt-in to publish a public, read-only embed. */
+const ShareEnableCallout: FC<ShareEnableCalloutProps> = ({
+  isSharing,
+  onShare
+}) => (
+  <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed bg-muted/30 px-4 py-5 text-sm sm:flex-row sm:items-center sm:justify-between">
+    <p className="text-muted-foreground">
+      Publish a public, read-only page and embeds of this heatmap. Anyone with
+      the link can view it — you can stop sharing at any time.
+    </p>
+    <Button
+      type="button"
+      size="sm"
+      className="shrink-0"
+      disabled={isSharing}
+      onClick={onShare}
+    >
+      {isSharing ? (
+        <Loader2 className="size-4 animate-spin" />
+      ) : (
+        <Share2 className="size-4" />
+      )}
+      Create public link
+    </Button>
+  </div>
+)
+
+export interface HeatmapShareEmbedProps {
+  shareToken: string | null | undefined
+  /** Origin used to build public/embed URLs (the actor's own domain). */
+  embedOrigin: string
+  /** Region label for the snippet title/alt; omit for the whole-world region. */
+  regionLabel?: string
+  isWorld: boolean
+  /** Completed heatmap data, used for the in-panel live preview. */
+  heatmap: FitnessRouteHeatmapData
+  mapboxAccessToken?: string
+  /** A share/unshare request is in flight for this region. */
+  isSharing: boolean
+  onShare: () => void
+  onUnshare: () => void
+  /** Open the panel by default (used in tests / deep links). */
+  defaultOpen?: boolean
+}
+
+/**
+ * Share & embed panel for a generated region heatmap. Collapsed by default to a
+ * single button; opening it offers, once the heatmap is shared, three ways to
+ * drop it into any other website — a live iframe embed, a static image, or a
+ * link to its public page — each a copy-to-clipboard one-liner with a live
+ * preview and a size selector.
+ *
+ * Unlike the design kit (which assumes every generated heatmap has a stable
+ * public id), sharing here is an explicit, revocable opt-in: the public surface
+ * is reachable only through an unguessable share token, so the panel gates the
+ * tabs behind a "Create public link" action and offers "Stop sharing".
+ */
+export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
+  shareToken,
+  embedOrigin,
+  regionLabel,
+  isWorld,
+  heatmap,
+  mapboxAccessToken,
+  isSharing,
+  onShare,
+  onUnshare,
+  defaultOpen = false
+}) => {
+  const [open, setOpen] = useState(defaultOpen)
+  const [tab, setTab] = useState<ShareTab>('embed')
+  const [sizeId, setSizeId] = useState<EmbedSize['id']>('md')
+  const size =
+    EMBED_SIZES.find((entry) => entry.id === sizeId) ?? EMBED_SIZES[1]
+
+  const isShared = Boolean(shareToken)
+  const title = isWorld ? 'Whole world' : regionLabel?.trim() || 'Map area'
+  const altText = `Route heatmap — ${title}`
+  const altAttr = escapeAttr(altText)
+
+  const linkUrl = shareToken ? `${embedOrigin}/u/heatmaps/${shareToken}` : ''
+  const embedSrc = shareToken
+    ? `${embedOrigin}/embed/heatmap/${shareToken}`
+    : ''
+  const imageUrl = shareToken
+    ? `${embedOrigin}/embed/heatmap/${shareToken}/image?w=${size.width}&h=${size.height}`
+    : ''
+
+  const iframeSnippet = `<iframe src="${embedSrc}" width="${size.width}" height="${size.height}"\n  loading="lazy" style="border:0;border-radius:12px"\n  title="${altAttr}"></iframe>`
+  const imageSnippet = `<a href="${linkUrl}">\n  <img src="${imageUrl}" width="${size.width}" height="${size.height}" alt="${altAttr}" />\n</a>`
+
+  if (!open) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-4"
+        onClick={() => setOpen(true)}
+      >
+        <Share2 className="size-4" />
+        Share &amp; embed
+      </Button>
+    )
+  }
+
+  return (
+    <section className="mt-4 rounded-xl border bg-card p-4 shadow-sm">
+      {/* header */}
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 flex size-7 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <Share2 className="size-4" />
+          </span>
+          <div>
+            <div className="text-sm font-semibold">Share &amp; embed</div>
+            <div className="text-[11px] text-muted-foreground">
+              Drop this heatmap into any other website — live embed, image, or a
+              link.
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          aria-label="Close share & embed"
+          className="flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      {!isShared ? (
+        <ShareEnableCallout isSharing={isSharing} onShare={onShare} />
+      ) : (
+        <div className="space-y-3">
+          {/* tabs */}
+          <div
+            role="tablist"
+            aria-label="Share format"
+            className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+          >
+            {TABS.map((entry) => {
+              const active = tab === entry.id
+              const Icon = entry.icon
+              return (
+                <button
+                  key={entry.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setTab(entry.id)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                    active
+                      ? 'bg-primary text-primary-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <Icon className="size-3.5" />
+                  {entry.label}
+                </button>
+              )
+            })}
+          </div>
+
+          {/* size selector — only relevant to embed/image */}
+          {tab !== 'link' && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Size
+              </span>
+              <div className="inline-flex items-center rounded-md border p-0.5">
+                {EMBED_SIZES.map((entry) => (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    aria-pressed={sizeId === entry.id}
+                    onClick={() => setSizeId(entry.id)}
+                    className={cn(
+                      'rounded px-2.5 py-1 text-[11px] font-medium transition-colors',
+                      sizeId === entry.id
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {entry.label}
+                  </button>
+                ))}
+                <span className="self-center px-2 text-[11px] text-muted-foreground/80 tabular-nums">
+                  {size.width}×{size.height}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* body */}
+          {tab === 'embed' && (
+            <div className="space-y-2">
+              <CopyField
+                value={iframeSnippet}
+                mono
+                copyLabel="Copy embed code"
+              />
+              <div
+                className="overflow-hidden rounded-lg border"
+                style={{ maxWidth: size.width }}
+              >
+                <RouteHeatmapMap
+                  heatmap={heatmap}
+                  mapboxAccessToken={mapboxAccessToken}
+                  heightClassName="h-[280px]"
+                />
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                A live, pannable map — it stays in sync with the latest
+                generated version.
+              </p>
+            </div>
+          )}
+
+          {tab === 'image' && (
+            <div className="space-y-2">
+              <CopyField
+                value={imageSnippet}
+                mono
+                copyLabel="Copy image code"
+              />
+              <p className="text-[11px] text-muted-foreground">
+                A static <code className="font-mono">.png</code> snapshot — best
+                for emails, READMEs, and places that block iframes.
+              </p>
+            </div>
+          )}
+
+          {tab === 'link' && (
+            <div className="space-y-2">
+              <CopyField value={linkUrl} copyLabel="Copy public link" />
+              <a
+                href={linkUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+              >
+                <ExternalLink className="size-3.5" /> Open the public page
+              </a>
+              <p className="text-[11px] text-muted-foreground">
+                Anyone with the link can view this heatmap on its own public
+                page.
+              </p>
+            </div>
+          )}
+
+          {/* stop sharing */}
+          <div className="flex items-center justify-between border-t pt-3">
+            <span className="text-[11px] text-muted-foreground">
+              This heatmap is public.
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 px-2.5 text-xs"
+              disabled={isSharing}
+              onClick={onUnshare}
+            >
+              {isSharing ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <X className="size-3.5" />
+              )}
+              Stop sharing
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/lib/components/fitness/HeatmapShareEmbed.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.tsx
@@ -75,6 +75,7 @@ const CopyField: FC<CopyFieldProps> = ({ value, mono, copyLabel }) => {
           readOnly
           rows={3}
           value={value}
+          aria-label={copyLabel}
           onFocus={(event) => event.currentTarget.select()}
           className="min-w-0 flex-1 resize-none rounded-md border bg-muted/40 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
@@ -83,6 +84,7 @@ const CopyField: FC<CopyFieldProps> = ({ value, mono, copyLabel }) => {
           readOnly
           type="text"
           value={value}
+          aria-label={copyLabel}
           onFocus={(event) => event.currentTarget.select()}
           className="min-w-0 flex-1 rounded-md border bg-muted/40 px-2.5 py-1.5 text-[12px] leading-relaxed text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
@@ -199,8 +201,11 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
     ? `${base}/embed/heatmap/${shareToken}/image?w=${size.width}&h=${size.height}`
     : ''
 
-  const iframeSnippet = `<iframe src="${embedSrc}" width="${size.width}" height="${size.height}"\n  loading="lazy" style="border:0;border-radius:12px"\n  title="${altAttr}"></iframe>`
-  const imageSnippet = `<a href="${linkUrl}">\n  <img src="${imageUrl}" width="${size.width}" height="${size.height}" alt="${altAttr}" />\n</a>`
+  // The token (base64url) and origin (a URL.origin) can't contain attribute
+  // delimiters today, but escape the URLs anyway so the copyable HTML stays
+  // well-formed if either ever does — defence in depth.
+  const iframeSnippet = `<iframe src="${escapeAttr(embedSrc)}" width="${size.width}" height="${size.height}"\n  loading="lazy" style="border:0;border-radius:12px"\n  title="${altAttr}"></iframe>`
+  const imageSnippet = `<a href="${escapeAttr(linkUrl)}">\n  <img src="${escapeAttr(imageUrl)}" width="${size.width}" height="${size.height}" alt="${altAttr}" />\n</a>`
 
   if (!open) {
     return (

--- a/lib/components/fitness/HeatmapShareEmbed.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.tsx
@@ -272,7 +272,9 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
                   key={entry.id}
                   type="button"
                   role="tab"
+                  id={`share-tab-${entry.id}`}
                   aria-selected={active}
+                  aria-controls={`share-panel-${entry.id}`}
                   onClick={() => setTab(entry.id)}
                   className={cn(
                     'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
@@ -320,7 +322,12 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
 
           {/* body */}
           {tab === 'embed' && (
-            <div className="space-y-2">
+            <div
+              role="tabpanel"
+              id="share-panel-embed"
+              aria-labelledby="share-tab-embed"
+              className="space-y-2"
+            >
               <CopyField
                 value={iframeSnippet}
                 mono
@@ -344,7 +351,12 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
           )}
 
           {tab === 'image' && (
-            <div className="space-y-2">
+            <div
+              role="tabpanel"
+              id="share-panel-image"
+              aria-labelledby="share-tab-image"
+              className="space-y-2"
+            >
               <CopyField
                 value={imageSnippet}
                 mono
@@ -358,7 +370,12 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
           )}
 
           {tab === 'link' && (
-            <div className="space-y-2">
+            <div
+              role="tabpanel"
+              id="share-panel-link"
+              aria-labelledby="share-tab-link"
+              className="space-y-2"
+            >
               <CopyField value={linkUrl} copyLabel="Copy public link" />
               <a
                 href={linkUrl}

--- a/lib/components/fitness/HeatmapShareEmbed.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.tsx
@@ -190,12 +190,13 @@ export const HeatmapShareEmbed: FC<HeatmapShareEmbedProps> = ({
   const altText = `Route heatmap — ${title}`
   const altAttr = escapeAttr(altText)
 
-  const linkUrl = shareToken ? `${embedOrigin}/u/heatmaps/${shareToken}` : ''
-  const embedSrc = shareToken
-    ? `${embedOrigin}/embed/heatmap/${shareToken}`
-    : ''
+  // Normalise away any trailing slash so a base like `https://host/` can't
+  // produce a double slash in the path.
+  const base = embedOrigin.replace(/\/+$/, '')
+  const linkUrl = shareToken ? `${base}/u/heatmaps/${shareToken}` : ''
+  const embedSrc = shareToken ? `${base}/embed/heatmap/${shareToken}` : ''
   const imageUrl = shareToken
-    ? `${embedOrigin}/embed/heatmap/${shareToken}/image?w=${size.width}&h=${size.height}`
+    ? `${base}/embed/heatmap/${shareToken}/image?w=${size.width}&h=${size.height}`
     : ''
 
   const iframeSnippet = `<iframe src="${embedSrc}" width="${size.width}" height="${size.height}"\n  loading="lazy" style="border:0;border-radius:12px"\n  title="${altAttr}"></iframe>`

--- a/lib/components/fitness/HeatmapShareEmbed.tsx
+++ b/lib/components/fitness/HeatmapShareEmbed.tsx
@@ -16,6 +16,7 @@ import { FC, useState } from 'react'
 import { FitnessRouteHeatmapData } from '@/lib/client'
 import { RouteHeatmapMap } from '@/lib/components/fitness/RouteHeatmapMap'
 import { Button } from '@/lib/components/ui/button'
+import { useCopyToClipboard } from '@/lib/hooks/useCopyToClipboard'
 import { cn } from '@/lib/utils'
 
 /** Embed/image sizes offered to the owner (mirrors the design kit). */
@@ -65,20 +66,7 @@ interface CopyFieldProps {
  * iframe/img snippets and the public link.
  */
 const CopyField: FC<CopyFieldProps> = ({ value, mono, copyLabel }) => {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async () => {
-    // navigator.clipboard is undefined in insecure (http) contexts and older
-    // browsers; the field stays selectable so the user can copy manually.
-    if (!navigator.clipboard) return
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1600)
-    } catch {
-      // Clipboard access can be denied; selection fallback still works.
-    }
-  }
+  const { copied, copy } = useCopyToClipboard()
 
   return (
     <div className="flex items-stretch gap-2">
@@ -103,7 +91,7 @@ const CopyField: FC<CopyFieldProps> = ({ value, mono, copyLabel }) => {
         type="button"
         size="sm"
         className="h-auto shrink-0 self-stretch px-3"
-        onClick={handleCopy}
+        onClick={() => copy(value)}
         aria-label={copyLabel}
       >
         {copied ? (

--- a/lib/components/fitness/RegionHeatmapDetail.test.tsx
+++ b/lib/components/fitness/RegionHeatmapDetail.test.tsx
@@ -241,7 +241,7 @@ describe('RegionHeatmapDetail', () => {
     )
   })
 
-  it('offers a Create embed link action for a completed, unshared heatmap', () => {
+  it('opens the share panel and offers Create public link when unshared', () => {
     const onShare = vi.fn()
     render(
       <RegionHeatmapDetail
@@ -251,15 +251,18 @@ describe('RegionHeatmapDetail', () => {
       />
     )
 
-    expect(screen.getByText('Share & embed')).toBeInTheDocument()
-    // No snippets are shown until the heatmap is shared.
-    expect(screen.queryByText('Embed (iframe)')).not.toBeInTheDocument()
+    // Collapsed by default to a single button.
+    const trigger = screen.getByRole('button', { name: /Share & embed/i })
+    expect(trigger).toBeInTheDocument()
+    // No share tabs until the panel is opened.
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Create embed link/i }))
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByRole('button', { name: /Create public link/i }))
     expect(onShare).toHaveBeenCalledTimes(1)
   })
 
-  it('shows embed snippets and a stop-sharing action once shared', () => {
+  it('shows the embed snippet and a stop-sharing action once shared', () => {
     const onUnshare = vi.fn()
     render(
       <RegionHeatmapDetail
@@ -269,6 +272,8 @@ describe('RegionHeatmapDetail', () => {
       />
     )
 
+    fireEvent.click(screen.getByRole('button', { name: /Share & embed/i }))
+
     const snippets = screen
       .getAllByRole('textbox')
       .map((node) => (node as HTMLTextAreaElement).value)
@@ -277,53 +282,9 @@ describe('RegionHeatmapDetail', () => {
         value.includes('https://llun.test/embed/heatmap/tok123"')
       )
     ).toBe(true)
-    expect(
-      snippets.some((value) =>
-        value.includes('https://llun.test/embed/heatmap/tok123/image"')
-      )
-    ).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: /Stop sharing/i }))
     expect(onUnshare).toHaveBeenCalledTimes(1)
-  })
-
-  it('labels the embed snippets with the region name', () => {
-    render(
-      <RegionHeatmapDetail
-        {...defaultProps}
-        region={rectRegion}
-        heatmap={{ ...completedHeatmap, shareToken: 'tok123' }}
-      />
-    )
-
-    const snippets = screen
-      .getAllByRole('textbox')
-      .map((node) => (node as HTMLTextAreaElement).value)
-    expect(
-      snippets.some((value) => value.includes('title="Veluwe loop"'))
-    ).toBe(true)
-    expect(snippets.some((value) => value.includes('alt="Veluwe loop"'))).toBe(
-      true
-    )
-  })
-
-  it('HTML-escapes special characters in the region label for the snippet', () => {
-    render(
-      <RegionHeatmapDetail
-        {...defaultProps}
-        region={{ ...rectRegion, name: 'Tom & "Jerry" <loop>' }}
-        heatmap={{ ...completedHeatmap, shareToken: 'tok123' }}
-      />
-    )
-
-    const snippets = screen
-      .getAllByRole('textbox')
-      .map((node) => (node as HTMLTextAreaElement).value)
-    expect(
-      snippets.some((value) =>
-        value.includes('title="Tom &amp; &quot;Jerry&quot; &lt;loop&gt;"')
-      )
-    ).toBe(true)
   })
 
   it('invokes onBack from the breadcrumb', () => {

--- a/lib/components/fitness/RegionHeatmapDetail.tsx
+++ b/lib/components/fitness/RegionHeatmapDetail.tsx
@@ -7,19 +7,18 @@ import {
   Calendar,
   Check,
   Clock,
-  Copy,
   Flame,
   Globe,
   Loader2,
   Maximize,
   Pencil,
-  RefreshCw,
-  Share2
+  RefreshCw
 } from 'lucide-react'
 import { FC, ReactNode, useEffect, useRef, useState } from 'react'
 
 import { FitnessRouteHeatmapData } from '@/lib/client'
 import { PickerRegion } from '@/lib/components/fitness/HeatmapRegionPicker'
+import { HeatmapShareEmbed } from '@/lib/components/fitness/HeatmapShareEmbed'
 import { RouteHeatmapMap } from '@/lib/components/fitness/RouteHeatmapMap'
 import { Button } from '@/lib/components/ui/button'
 import { formatRectRegion } from '@/lib/fitness/regions'
@@ -189,136 +188,6 @@ const GenerationTaskRow: FC<GenerationTaskRowProps> = ({
         </Button>
       )}
     </div>
-  )
-}
-
-interface CopyableSnippetProps {
-  label: string
-  value: string
-}
-
-const CopyableSnippet: FC<CopyableSnippetProps> = ({ label, value }) => {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async () => {
-    // navigator.clipboard is undefined in insecure (http) contexts and older
-    // browsers; fall back to the manually-selectable textarea in that case.
-    if (!navigator.clipboard) return
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Clipboard access can be denied; the textarea remains selectable so the
-      // user can still copy manually.
-    }
-  }
-
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-muted-foreground">
-          {label}
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-7 px-2.5 text-xs"
-          onClick={handleCopy}
-        >
-          {copied ? (
-            <Check className="size-3 text-green-600 dark:text-green-500" />
-          ) : (
-            <Copy className="size-3" />
-          )}
-          {copied ? 'Copied' : 'Copy'}
-        </Button>
-      </div>
-      <textarea
-        readOnly
-        rows={2}
-        value={value}
-        onFocus={(event) => event.currentTarget.select()}
-        className="w-full resize-none rounded-md border bg-muted/40 px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      />
-    </div>
-  )
-}
-
-interface EmbedShareSectionProps {
-  shareToken: string | null | undefined
-  embedOrigin: string
-  /** Region label used for the snippet title/alt text (falls back to a generic). */
-  regionLabel?: string
-  isSharing: boolean
-  onShare: () => void
-  onUnshare: () => void
-}
-
-const EmbedShareSection: FC<EmbedShareSectionProps> = ({
-  shareToken,
-  embedOrigin,
-  regionLabel,
-  isSharing,
-  onShare,
-  onUnshare
-}) => {
-  const isShared = Boolean(shareToken)
-  const embedUrl = shareToken
-    ? `${embedOrigin}/embed/heatmap/${shareToken}`
-    : ''
-  const label = regionLabel?.trim() || 'Route heatmap'
-  // Fully escape the label for the snippet's HTML attributes (& first so an
-  // already-escaped entity isn't double-encoded) so a region name containing
-  // &, <, >, or " copies into a valid snippet.
-  const labelAttr = label
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-  const iframeSnippet = `<iframe src="${embedUrl}" width="600" height="420" style="border:0;border-radius:12px" loading="lazy" title="${labelAttr}"></iframe>`
-  const imageSnippet = `<img src="${embedUrl}/image" width="600" height="400" alt="${labelAttr}" />`
-
-  return (
-    <section className="mt-4 rounded-xl border bg-card p-4 shadow-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex items-start gap-2">
-          <span className="mt-0.5 flex size-7 items-center justify-center rounded-md bg-primary/10 text-primary">
-            <Share2 className="size-4" />
-          </span>
-          <div>
-            <div className="text-sm font-semibold">Share &amp; embed</div>
-            <div className="text-[11px] text-muted-foreground">
-              {isShared
-                ? 'Anyone with the link can view this heatmap. Paste a snippet into your site.'
-                : 'Publish a public, read-only embed of this heatmap for your website.'}
-            </div>
-          </div>
-        </div>
-        <Button
-          type="button"
-          variant={isShared ? 'outline' : 'default'}
-          size="sm"
-          disabled={isSharing}
-          onClick={isShared ? onUnshare : onShare}
-        >
-          {isSharing ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <Share2 className="size-4" />
-          )}
-          {isShared ? 'Stop sharing' : 'Create embed link'}
-        </Button>
-      </div>
-
-      {isShared && (
-        <div className="mt-3 space-y-3">
-          <CopyableSnippet label="Embed (iframe)" value={iframeSnippet} />
-          <CopyableSnippet label="Image (img)" value={imageSnippet} />
-        </div>
-      )}
-    </section>
   )
 }
 
@@ -639,10 +508,13 @@ export const RegionHeatmapDetail: FC<RegionHeatmapDetailProps> = ({
               </span>
             )}
           </div>
-          <EmbedShareSection
+          <HeatmapShareEmbed
             shareToken={heatmap.shareToken}
             embedOrigin={embedOrigin}
-            regionLabel={isWorld ? undefined : region.name}
+            regionLabel={region.type === 'rect' ? region.name : undefined}
+            isWorld={isWorld}
+            heatmap={heatmap}
+            mapboxAccessToken={mapboxAccessToken}
             isSharing={isSharing}
             onShare={onShare}
             onUnshare={onUnshare}

--- a/lib/hooks/useCopyToClipboard.test.ts
+++ b/lib/hooks/useCopyToClipboard.test.ts
@@ -12,6 +12,12 @@ const setClipboard = (writeText: ReturnType<typeof vi.fn> | undefined) => {
   })
 }
 
+beforeEach(() => {
+  // Default the legacy fallback to "unavailable" so tests that exercise the
+  // Clipboard API path don't accidentally succeed via execCommand.
+  document.execCommand = vi.fn(() => false)
+})
+
 afterEach(() => {
   vi.useRealTimers()
   setClipboard(undefined)
@@ -38,8 +44,22 @@ describe('useCopyToClipboard', () => {
     expect(result.current.copied).toBe(false)
   })
 
-  it('no-ops without throwing when navigator.clipboard is unavailable', async () => {
+  it('falls back to execCommand when navigator.clipboard is unavailable', async () => {
     setClipboard(undefined)
+    const execCommand = vi.fn(() => true)
+    document.execCommand = execCommand
+
+    const { result } = renderHook(() => useCopyToClipboard())
+    await act(async () => {
+      await result.current.copy('hello')
+    })
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(result.current.copied).toBe(true)
+  })
+
+  it('stays uncopied when neither clipboard API nor execCommand works', async () => {
+    setClipboard(undefined)
+    document.execCommand = vi.fn(() => false)
     const { result } = renderHook(() => useCopyToClipboard())
     await act(async () => {
       await result.current.copy('hello')
@@ -87,9 +107,10 @@ describe('useCopyToClipboard', () => {
     expect(result.current.copied).toBe(false)
   })
 
-  it('stays uncopied when the clipboard write rejects', async () => {
+  it('stays uncopied when the clipboard write rejects and execCommand fails', async () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'))
     setClipboard(writeText)
+    document.execCommand = vi.fn(() => false)
     const { result } = renderHook(() => useCopyToClipboard())
     await act(async () => {
       await result.current.copy('hello')

--- a/lib/hooks/useCopyToClipboard.test.ts
+++ b/lib/hooks/useCopyToClipboard.test.ts
@@ -62,6 +62,31 @@ describe('useCopyToClipboard', () => {
     expect(clearSpy).toHaveBeenCalled()
   })
 
+  it('does not flip copied when it unmounts while the write is in flight', async () => {
+    let resolveWrite: (() => void) | undefined
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve
+        })
+    )
+    setClipboard(writeText)
+
+    const { result, unmount } = renderHook(() => useCopyToClipboard())
+    let copyPromise: Promise<void> | undefined
+    act(() => {
+      copyPromise = result.current.copy('hello')
+    })
+    // Unmount before the clipboard write resolves, then let it resolve.
+    unmount()
+    await act(async () => {
+      resolveWrite?.()
+      await copyPromise
+    })
+    // The guard skips setCopied after unmount — no act warning, no late update.
+    expect(result.current.copied).toBe(false)
+  })
+
   it('stays uncopied when the clipboard write rejects', async () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'))
     setClipboard(writeText)

--- a/lib/hooks/useCopyToClipboard.test.ts
+++ b/lib/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import { useCopyToClipboard } from './useCopyToClipboard'
+
+const setClipboard = (writeText: ReturnType<typeof vi.fn> | undefined) => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: writeText ? { writeText } : undefined
+  })
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  setClipboard(undefined)
+})
+
+describe('useCopyToClipboard', () => {
+  it('writes the text and flips copied true → false after the reset delay', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard(writeText)
+
+    const { result } = renderHook(() => useCopyToClipboard(1000))
+    expect(result.current.copied).toBe(false)
+
+    await act(async () => {
+      await result.current.copy('hello')
+    })
+    expect(writeText).toHaveBeenCalledWith('hello')
+    expect(result.current.copied).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('no-ops without throwing when navigator.clipboard is unavailable', async () => {
+    setClipboard(undefined)
+    const { result } = renderHook(() => useCopyToClipboard())
+    await act(async () => {
+      await result.current.copy('hello')
+    })
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('clears the pending reset timer on unmount', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard(writeText)
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+    const { result, unmount } = renderHook(() => useCopyToClipboard())
+    await act(async () => {
+      await result.current.copy('hello')
+    })
+    unmount()
+    // The unmount cleanup clears the outstanding reset timer.
+    expect(clearSpy).toHaveBeenCalled()
+  })
+
+  it('stays uncopied when the clipboard write rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    setClipboard(writeText)
+    const { result } = renderHook(() => useCopyToClipboard())
+    await act(async () => {
+      await result.current.copy('hello')
+    })
+    await waitFor(() => expect(result.current.copied).toBe(false))
+  })
+})

--- a/lib/hooks/useCopyToClipboard.test.ts
+++ b/lib/hooks/useCopyToClipboard.test.ts
@@ -107,6 +107,20 @@ describe('useCopyToClipboard', () => {
     expect(result.current.copied).toBe(false)
   })
 
+  it('removes the temp textarea even if execCommand throws', async () => {
+    setClipboard(undefined)
+    document.execCommand = vi.fn(() => {
+      throw new Error('boom')
+    })
+    const { result } = renderHook(() => useCopyToClipboard())
+    await act(async () => {
+      await result.current.copy('hello')
+    })
+    expect(result.current.copied).toBe(false)
+    // The finally block must have removed the temporary node from the DOM.
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
   it('stays uncopied when the clipboard write rejects and execCommand fails', async () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'))
     setClipboard(writeText)

--- a/lib/hooks/useCopyToClipboard.ts
+++ b/lib/hooks/useCopyToClipboard.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseCopyToClipboard {
+  /** True for `resetMs` after a successful copy, for transient UI feedback. */
+  copied: boolean
+  /** Copies `text`, then flips `copied` true → false after `resetMs`. */
+  copy: (text: string) => Promise<void>
+}
+
+/**
+ * Copy-to-clipboard with transient "Copied" feedback.
+ *
+ * The pending reset timer is tracked in a ref and cleared on unmount (and before
+ * each new copy), so it can never call `setState` after the component has
+ * unmounted. No-ops where `navigator.clipboard` is unavailable (insecure `http`
+ * contexts and older browsers); callers should keep a manual-selection fallback.
+ */
+export const useCopyToClipboard = (resetMs = 1600): UseCopyToClipboard => {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), [])
+
+  const copy = useCallback(
+    async (text: string) => {
+      if (!navigator.clipboard) return
+      try {
+        await navigator.clipboard.writeText(text)
+        setCopied(true)
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = setTimeout(() => setCopied(false), resetMs)
+      } catch {
+        // Clipboard access can be denied; the caller's selectable field remains.
+      }
+    },
+    [resetMs]
+  )
+
+  return { copied, copy }
+}

--- a/lib/hooks/useCopyToClipboard.ts
+++ b/lib/hooks/useCopyToClipboard.ts
@@ -26,19 +26,25 @@ const writeToClipboard = async (text: string): Promise<boolean> => {
     }
   }
 
+  // Restore focus to wherever the user was (e.g. the Copy button) after the
+  // hidden textarea steals it.
+  const previouslyFocused = document.activeElement
+  const textArea = document.createElement('textarea')
   try {
-    const textArea = document.createElement('textarea')
     textArea.value = text
     textArea.setAttribute('readonly', '')
     textArea.style.position = 'fixed'
     textArea.style.opacity = '0'
     document.body.appendChild(textArea)
     textArea.select()
-    const ok = document.execCommand('copy')
-    document.body.removeChild(textArea)
-    return ok
+    return document.execCommand('copy')
   } catch {
     return false
+  } finally {
+    // A `finally` guarantees the temporary node is removed even if execCommand
+    // throws, so it can never leak into the DOM.
+    textArea.remove()
+    if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus()
   }
 }
 

--- a/lib/hooks/useCopyToClipboard.ts
+++ b/lib/hooks/useCopyToClipboard.ts
@@ -8,12 +8,46 @@ interface UseCopyToClipboard {
 }
 
 /**
+ * Copies `text` to the clipboard, returning whether it succeeded.
+ *
+ * Prefers the async Clipboard API, but `navigator.clipboard` is unavailable in
+ * insecure (`http`) contexts — which this project supports for self-hosted /
+ * local deployments — so it falls back to a hidden-textarea + the legacy
+ * `document.execCommand('copy')`. The same fallback also covers a denied
+ * Clipboard API write.
+ */
+const writeToClipboard = async (text: string): Promise<boolean> => {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall through to the legacy fallback below.
+    }
+  }
+
+  try {
+    const textArea = document.createElement('textarea')
+    textArea.value = text
+    textArea.setAttribute('readonly', '')
+    textArea.style.position = 'fixed'
+    textArea.style.opacity = '0'
+    document.body.appendChild(textArea)
+    textArea.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textArea)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+/**
  * Copy-to-clipboard with transient "Copied" feedback.
  *
  * The pending reset timer is tracked in a ref and cleared on unmount (and before
  * each new copy), so it can never call `setState` after the component has
- * unmounted. No-ops where `navigator.clipboard` is unavailable (insecure `http`
- * contexts and older browsers); callers should keep a manual-selection fallback.
+ * unmounted. Works over both HTTPS and insecure HTTP (see writeToClipboard).
  */
 export const useCopyToClipboard = (resetMs = 1600): UseCopyToClipboard => {
   const [copied, setCopied] = useState(false)
@@ -32,18 +66,13 @@ export const useCopyToClipboard = (resetMs = 1600): UseCopyToClipboard => {
 
   const copy = useCallback(
     async (text: string) => {
-      if (!navigator.clipboard) return
-      try {
-        await navigator.clipboard.writeText(text)
-        // The write is async, so the component may have unmounted while it was
-        // in flight — skip the state update / timer in that case.
-        if (!mountedRef.current) return
-        setCopied(true)
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = setTimeout(() => setCopied(false), resetMs)
-      } catch {
-        // Clipboard access can be denied; the caller's selectable field remains.
-      }
+      const ok = await writeToClipboard(text)
+      // The write may be async, so the component can unmount while it is in
+      // flight — skip the state update / timer if it did, or if it failed.
+      if (!ok || !mountedRef.current) return
+      setCopied(true)
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), resetMs)
     },
     [resetMs]
   )

--- a/lib/hooks/useCopyToClipboard.ts
+++ b/lib/hooks/useCopyToClipboard.ts
@@ -20,14 +20,24 @@ export const useCopyToClipboard = (resetMs = 1600): UseCopyToClipboard => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   )
+  const mountedRef = useRef(true)
 
-  useEffect(() => () => clearTimeout(timeoutRef.current), [])
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearTimeout(timeoutRef.current)
+    }
+  }, [])
 
   const copy = useCallback(
     async (text: string) => {
       if (!navigator.clipboard) return
       try {
         await navigator.clipboard.writeText(text)
+        // The write is async, so the component may have unmounted while it was
+        // in flight — skip the state update / timer in that case.
+        if (!mountedRef.current) return
         setCopied(true)
         clearTimeout(timeoutRef.current)
         timeoutRef.current = setTimeout(() => setCopied(false), resetMs)


### PR DESCRIPTION
## Summary

Aligns the route-heatmap **Share & embed** panel with the design kit (`ui_kits/web/heatmaps.html` → `HeatmapEmbed.jsx` + `SharedHeatmapPage.jsx`) and adds a standalone **public shared page** for a heatmap.

### Share & embed panel (`HeatmapShareEmbed`)
- Replaces the old single-button + two stacked snippets with a **collapsible** panel:
  - Collapsed to one **Share & embed** button.
  - Opening an **unshared** heatmap offers an explicit **Create public link** opt-in.
  - Once shared: three tabs — **Embed** (iframe), **Image** (img), **Link** (public page) — a **Small / Medium / Large** size selector, a copy-to-clipboard field, a **live preview**, and a revocable **Stop sharing** control.
- Keeps the privacy-preserving capability model: the public surface is reachable only through the existing **unguessable share token**, not the design kit's raw `region.id`.

### Public shared page (`/u/heatmaps/[token]`)
- New read-only page resolving the heatmap by its share token (completed only; **404s** when revoked/re-queued, exactly like the embed).
- Public chrome: top bar (Sign in / Create account), an "anyone with the link can view" pill, owner line (handle + initials), copy-link, the live map, **Routes / Activity / Period** stats, a join CTA, and a footer.
- `noindex` (capability URL). Privacy-flattened segments via `toPublicHeatmap`; internal scan counters are zeroed in the map payload so they don't leak into the public RSC payload (only the owner-opted-in route count is surfaced as a stat).

### API
- **Reuses the existing share API** (`POST/DELETE …/fitness-route-heatmap/share`) and the existing embed/image routes (`/embed/heatmap/[token]`, `…/image?w=&h=`). **No new endpoints, no migration.**

## Testing
- `yarn lint`, `yarn build`, `yarn test` (4936 tests) all green.
- New unit/component tests: `HeatmapShareEmbed` (collapse, tabs, sizes, snippets, link, escaping, stop-sharing), `sharedHeatmapView` (view-model), `SharedHeatmapPage` (chrome, stats, sign-up gating, world variant). Updated `RegionHeatmapDetail` tests for the collapsed-first panel.
- Browser-verified locally against SQLite + mock data: the public page renders the live map + stats; the in-app panel shows the Embed/Image/Link tabs, size selector, live preview, and the Link tab's public URL + "Open the public page".

🤖 Generated with [Claude Code](https://claude.com/claude-code)