### PR TITLE
Bump version to v1.89.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.89.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.88.0`
- Base main SHA: `de42567a1a4ee1c1c2798e9fb5d52d173deef956`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
