### PR TITLE
fix: resize heatmap embed preview map when the size changes

### DIFF
--- a/lib/components/fitness/RouteHeatmapMap.test.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import type { FitnessRouteHeatmapData } from '@/lib/client'
+import { loadMapboxModule } from '@/lib/utils/mapbox'
+
+import { RouteHeatmapMap } from './RouteHeatmapMap'
+
+// Drive the map through a fake GL module so the test never touches a real CDN /
+// Mapbox script (none load in jsdom). MapLibre is stubbed to a never-resolving
+// loader because these tests always supply a Mapbox token.
+vi.mock('@/lib/utils/mapbox', () => ({
+  getPublicMapboxAccessToken: (token: string) => token,
+  loadMapboxModule: vi.fn()
+}))
+vi.mock('@/lib/utils/maplibre', () => ({
+  loadMaplibreModule: vi.fn(() => new Promise(() => {})),
+  OPENFREEMAP_HEATMAP_STYLE_URL: 'https://tiles.openfreemap.org/styles/positron'
+}))
+
+type Handlers = Record<string, () => void>
+
+// A fake Mapbox/MapLibre GL map: it fires its async 'load' once the component
+// has subscribed (mirroring RegionMap.test's fake), so the load handler runs.
+const createFakeGl = () => {
+  const handlers: Handlers = {}
+  const source = { setData: vi.fn() }
+  const map = {
+    on: vi.fn((event: string, callback: () => void) => {
+      handlers[event] = callback
+    }),
+    remove: vi.fn(),
+    resize: vi.fn(),
+    addSource: vi.fn(),
+    addLayer: vi.fn(),
+    getSource: vi.fn(() => source),
+    fitBounds: vi.fn()
+  }
+  const Map = vi.fn(function MapCtor() {
+    Promise.resolve().then(() => handlers.load?.())
+    return map
+  })
+  return { gl: { Map }, map, handlers }
+}
+
+// Local stand-in for the lib.dom ResizeObserverCallback type — eslint's
+// no-undef doesn't recognise that type name in this config (the ResizeObserver
+// value global is fine).
+type ResizeObserverCallbackFn = (entries: unknown[], observer: unknown) => void
+
+// jsdom ships no ResizeObserver; record instances so a test can fire a
+// container-size change and assert the map re-fits its canvas.
+interface FakeResizeObserver {
+  callback: ResizeObserverCallbackFn
+  observe: ReturnType<typeof vi.fn>
+  unobserve: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+}
+let resizeObservers: FakeResizeObserver[] = []
+
+const mockLoadMapboxModule = loadMapboxModule as jest.MockedFunction<
+  typeof loadMapboxModule
+>
+
+const heatmap: FitnessRouteHeatmapData = {
+  id: 'hm-1',
+  region: '',
+  periodType: 'all_time',
+  periodKey: 'all',
+  status: 'completed',
+  bounds: { minLat: 52, maxLat: 52.6, minLng: 5.6, maxLng: 6.2 },
+  segments: [
+    {
+      points: [
+        { lat: 52, lng: 5.6 },
+        { lat: 52.6, lng: 6.2 }
+      ]
+    }
+  ],
+  activityCount: 12,
+  pointCount: 340,
+  totalCount: 20,
+  cursorOffset: 20,
+  isPartial: false,
+  error: null,
+  createdAt: 1,
+  updatedAt: 2
+}
+
+beforeEach(() => {
+  resizeObservers = []
+  class MockResizeObserver {
+    callback: ResizeObserverCallbackFn
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+    constructor(callback: ResizeObserverCallbackFn) {
+      this.callback = callback
+      resizeObservers.push(this)
+    }
+  }
+  globalThis.ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  // @ts-expect-error reset the polyfill between tests
+  delete globalThis.ResizeObserver
+})
+
+describe('RouteHeatmapMap', () => {
+  it('resizes the GL canvas when its container changes size', async () => {
+    const { gl, map } = createFakeGl()
+    mockLoadMapboxModule.mockResolvedValue(gl as never)
+
+    render(<RouteHeatmapMap heatmap={heatmap} mapboxAccessToken="pk.test" />)
+
+    // The provider badge only renders once the map fires 'load'.
+    await screen.findByText('Mapbox')
+    // The load handler resizes once; the container is now observed.
+    expect(map.resize).toHaveBeenCalledTimes(1)
+    expect(resizeObservers).toHaveLength(1)
+    expect(resizeObservers[0].observe).toHaveBeenCalledTimes(1)
+
+    // Simulate the embed preview swapping width (Small → Large): the observer
+    // fires and the map must resize so the canvas refills the new container.
+    resizeObservers[0].callback(
+      [],
+      resizeObservers[0] as unknown as ResizeObserver
+    )
+    expect(map.resize).toHaveBeenCalledTimes(2)
+  })
+
+  it('disconnects the resize observer when unmounted', async () => {
+    const { gl } = createFakeGl()
+    mockLoadMapboxModule.mockResolvedValue(gl as never)
+
+    const { unmount } = render(
+      <RouteHeatmapMap heatmap={heatmap} mapboxAccessToken="pk.test" />
+    )
+
+    await screen.findByText('Mapbox')
+    expect(resizeObservers[0].disconnect).not.toHaveBeenCalled()
+
+    unmount()
+    expect(resizeObservers[0].disconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/components/fitness/RouteHeatmapMap.test.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.test.tsx
@@ -108,8 +108,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks()
-  // @ts-expect-error reset the polyfill between tests
-  delete globalThis.ResizeObserver
+  // Restore the absent global between tests (jsdom ships no ResizeObserver).
+  Reflect.deleteProperty(globalThis, 'ResizeObserver')
 })
 
 describe('RouteHeatmapMap', () => {

--- a/lib/components/fitness/RouteHeatmapMap.test.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.test.tsx
@@ -149,4 +149,19 @@ describe('RouteHeatmapMap', () => {
     unmount()
     expect(resizeObservers[0].disconnect).toHaveBeenCalledTimes(1)
   })
+
+  it('mounts without observing when the environment has no ResizeObserver', async () => {
+    // SSR / older environments expose no ResizeObserver; the feature-detect
+    // guard must skip observing rather than throw, and the map must still load.
+    Reflect.deleteProperty(globalThis, 'ResizeObserver')
+    const { gl, map } = createFakeGl()
+    mockLoadMapboxModule.mockResolvedValue(gl as never)
+
+    render(<RouteHeatmapMap heatmap={heatmap} mapboxAccessToken="pk.test" />)
+
+    // The map loaded (resizing once on 'load') without constructing an observer.
+    await screen.findByText('Mapbox')
+    expect(map.resize).toHaveBeenCalledTimes(1)
+    expect(resizeObservers).toHaveLength(0)
+  })
 })

--- a/lib/components/fitness/RouteHeatmapMap.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.tsx
@@ -407,6 +407,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
 
     let cancelled = false
     let loadWatchdog: ReturnType<typeof setTimeout> | undefined
+    let resizeObserver: ResizeObserver | undefined
     setIsMapLoaded(false)
 
     provider
@@ -420,6 +421,24 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
           ...provider.mapOptions
         })
         mapRef.current = map
+
+        // Mapbox/MapLibre GL size their canvas from the container at
+        // construction and only recompute it when map.resize() is called; the
+        // libraries' built-in trackResize listens for *window* resizes only.
+        // When the container itself changes width while the window holds steady
+        // — e.g. the Share & embed preview swapping size as the owner picks
+        // Small/Medium/Large, or a collapsing sidebar — the canvas would keep
+        // its old width and leave blank space beside the map. Observe the
+        // container and resize on every box change so the map always fills it.
+        // (ResizeObserver throttles to animation frames, so resizing directly
+        // in the callback is already frame-batched; it never grows the observed
+        // box, so there is no resize loop.)
+        if (typeof ResizeObserver !== 'undefined') {
+          resizeObserver = new ResizeObserver(() => {
+            mapRef.current?.resize()
+          })
+          resizeObserver.observe(containerRef.current)
+        }
 
         // The module promise resolving only means the JS bundle loaded; if the
         // style/tiles never fetch, 'load' never fires and neither does .catch.
@@ -488,6 +507,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     return () => {
       cancelled = true
       if (loadWatchdog) clearTimeout(loadWatchdog)
+      resizeObserver?.disconnect()
       mapRef.current?.remove()
       mapRef.current = null
     }

--- a/lib/components/fitness/RouteHeatmapMap.tsx
+++ b/lib/components/fitness/RouteHeatmapMap.tsx
@@ -413,10 +413,14 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
     provider
       .loadModule()
       .then((gl) => {
-        if (cancelled || !containerRef.current) return
+        // Capture the element once: a ref's `.current` is not narrowed across
+        // the calls below, so a local keeps both the map and the observer
+        // strictly non-null.
+        const container = containerRef.current
+        if (cancelled || !container) return
 
         const map = new gl.Map({
-          container: containerRef.current,
+          container,
           attributionControl: true,
           ...provider.mapOptions
         })
@@ -437,7 +441,7 @@ export const RouteHeatmapMap: FC<RouteHeatmapMapProps> = ({
           resizeObserver = new ResizeObserver(() => {
             mapRef.current?.resize()
           })
-          resizeObserver.observe(containerRef.current)
+          resizeObserver.observe(container)
         }
 
         // The module promise resolving only means the JS bundle loaded; if the


### PR DESCRIPTION
## Problem

In the heatmap **Share & embed** panel, picking a different **Size** (Small / Medium / Large) left empty grey space beside the live map preview — the map no longer filled the preview box:

![empty space on the right when Large is selected](https://github.com/user-attachments/assets/placeholder)

The preview container's `maxWidth` is driven by the chosen size (`lib/components/fitness/HeatmapShareEmbed.tsx`), so the container grows when you switch from Medium (600px) to Large (800px). But Mapbox/MapLibre GL size their `<canvas>` from the container **only at construction and on `map.resize()`** — their built-in `trackResize` listens for **window** resizes, not container-only resizes. So the canvas stayed at its old width and the extra container width rendered as blank space.

## Fix

`RouteHeatmapMap` now attaches a `ResizeObserver` to the map container and calls `map.resize()` whenever its box changes, so the canvas always refills the container. This is the general fix for the class of bug — it also covers other container-driven resizes (e.g. a collapsing sidebar), not just the embed size selector.

- `ResizeObserver` is feature-detected (`typeof ResizeObserver !== 'undefined'`) and disconnected in the effect cleanup alongside the existing `map.remove()`.
- Resizing directly in the callback is fine: `ResizeObserver` already throttles to animation frames, and `map.resize()` never grows the observed box, so there's no resize loop.

## Tests

Added `lib/components/fitness/RouteHeatmapMap.test.tsx`:
- **resizes the GL canvas when its container changes size** — after load, firing the observer callback calls `map.resize()` again.
- **disconnects the resize observer when unmounted**.

## Verification

- `yarn run prettier --write .`
- `yarn lint` — 0 errors
- `yarn build` — succeeds
- `yarn test` — 558 files / 4949 tests pass

No migrations, no config changes.