### PR TITLE
docs: add minimal-effort quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ For a more detailed architecture overview, see [docs/architecture.md](docs/archi
 ### Quick Start
 
 > In a hurry? The [Quickstart](docs/quickstart.md) gets a local instance running
-> with the least possible setup — SQLite and the three required variables.
+> with the least possible setup — SQLite and the three core settings (host,
+> secret phrase, and a database).
 
 1. **Clone the repository:**
 
@@ -136,7 +137,7 @@ For PostgreSQL or advanced Docker setups, see:
 
 | Document                                               | Description                                             |
 | ------------------------------------------------------ | ------------------------------------------------------- |
-| [Quickstart](docs/quickstart.md)                       | Fastest minimal local setup (SQLite, 3 required vars)   |
+| [Quickstart](docs/quickstart.md)                       | Fastest minimal local setup (SQLite, 3 core settings)   |
 | [Setup Guide](docs/setup.md)                           | General configuration and first-time setup              |
 | [Architecture](docs/architecture.md)                   | System architecture, data flow, and design decisions    |
 | [SQLite Setup](docs/sqlite-setup.md)                   | SQLite database configuration and Docker deployment     |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For a more detailed architecture overview, see [docs/architecture.md](docs/archi
 
 ### Quick Start
 
+> In a hurry? The [Quickstart](docs/quickstart.md) gets a local instance running
+> with the least possible setup — SQLite and the three required variables.
+
 1. **Clone the repository:**
 
    ```bash
@@ -133,6 +136,7 @@ For PostgreSQL or advanced Docker setups, see:
 
 | Document                                               | Description                                             |
 | ------------------------------------------------------ | ------------------------------------------------------- |
+| [Quickstart](docs/quickstart.md)                       | Fastest minimal local setup (SQLite, 3 required vars)   |
 | [Setup Guide](docs/setup.md)                           | General configuration and first-time setup              |
 | [Architecture](docs/architecture.md)                   | System architecture, data flow, and design decisions    |
 | [SQLite Setup](docs/sqlite-setup.md)                   | SQLite database configuration and Docker deployment     |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,6 +2,9 @@
 
 This document lists all environment variables supported by Activity.next.
 
+> Only getting started? The [Quickstart](quickstart.md) covers the three
+> variables strictly required to boot a local instance.
+
 Application configuration is provided through environment variables. Root-level `config.json` files are ignored; migrate any previous file settings to the corresponding `ACTIVITIES_*` or `OTEL_EXPORTER_*` variables listed below. Application config is read at runtime, so Docker/standalone builds do not need real `ACTIVITIES_*` or `OTEL_EXPORTER_*` values at build time. Environment variables read outside app config, such as `NODE_ENV`, `BUILD_STANDALONE`, `NEXT_TELEMETRY_DISABLED`, and `LOG_LEVEL`, still apply.
 
 ## Core Configuration

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,8 +2,9 @@
 
 This document lists all environment variables supported by Activity.next.
 
-> Only getting started? The [Quickstart](quickstart.md) covers the three
-> variables strictly required to boot a local instance.
+> Only getting started? The [Quickstart](quickstart.md) covers the three core
+> settings strictly required to boot a local instance (host, secret phrase, and
+> a database).
 
 Application configuration is provided through environment variables. Root-level `config.json` files are ignored; migrate any previous file settings to the corresponding `ACTIVITIES_*` or `OTEL_EXPORTER_*` variables listed below. Application config is read at runtime, so Docker/standalone builds do not need real `ACTIVITIES_*` or `OTEL_EXPORTER_*` values at build time. Environment variables read outside app config, such as `NODE_ENV`, `BUILD_STANDALONE`, `NEXT_TELEMETRY_DISABLED`, and `LOG_LEVEL`, still apply.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart
+
+The fastest way to get a local Activity.next instance running, with the **least
+amount of setup**. This uses SQLite (a single file, no database server) and the
+three environment variables that are strictly required.
+
+For production deployments, federation, media storage, email, and every other
+option, see the [Setup Guide](setup.md) and the
+[Environment Variables Guide](environment-variables.md).
+
+## Prerequisites
+
+- **Node.js 24** or higher
+- **Yarn** (enabled via Corepack)
+
+## 1. Clone and install
+
+```bash
+git clone https://github.com/llun/activities.next.git
+cd activities.next
+corepack enable
+yarn install
+```
+
+## 2. Create a minimal `.env.local`
+
+Only three settings are strictly required to boot the app: the host, a secret
+phrase, and a database. SQLite needs no server, so this is the least-effort
+choice:
+
+```bash
+ACTIVITIES_HOST=localhost:3000
+ACTIVITIES_SECRET_PHASE=local-dev-secret-phrase-change-me
+ACTIVITIES_DATABASE_CLIENT=better-sqlite3
+ACTIVITIES_DATABASE_SQLITE_FILENAME=./dev.sqlite3
+```
+
+> **Local sign-in over `http`:** add `ACTIVITIES_INSECURE_AUTH=true` so the
+> instance accepts `http://localhost` sign-in. Without it, sign-in is forced to
+> `https` and fails with `403 Invalid origin`.
+>
+> **Restrict who can register (optional but recommended):** add
+> `ACTIVITIES_ALLOW_EMAILS='["you@example.com"]'` (single-quoted so the JSON
+> array survives). Only listed emails can sign up.
+
+A practical local `.env.local` therefore looks like:
+
+```bash
+ACTIVITIES_HOST=localhost:3000
+ACTIVITIES_SECRET_PHASE=local-dev-secret-phrase-change-me
+ACTIVITIES_INSECURE_AUTH=true
+ACTIVITIES_ALLOW_EMAILS='["you@example.com"]'
+ACTIVITIES_DATABASE_CLIENT=better-sqlite3
+ACTIVITIES_DATABASE_SQLITE_FILENAME=./dev.sqlite3
+```
+
+> **Generate a real secret** for anything beyond throwaway local use:
+> `openssl rand -base64 32`. In production, `ACTIVITIES_SECRET_PHASE` must be at
+> least 32 characters or the app refuses to start.
+
+## 3. Migrate and run
+
+```bash
+yarn migrate   # creates the SQLite schema in ./dev.sqlite3
+yarn dev       # starts the dev server on http://localhost:3000
+```
+
+## 4. Sign up
+
+Open `http://localhost:3000/auth/signup` and create your account with an email
+that is in `ACTIVITIES_ALLOW_EMAILS` (or any email if you left it unset).
+
+That's it — you now have a running instance.
+
+## What's intentionally left out
+
+To keep this minimal, the steps above skip everything optional. Each is disabled
+or runs in a degraded-but-fine mode until you configure it:
+
+| Feature            | Default without config        | Where to enable                                                             |
+| ------------------ | ----------------------------- | --------------------------------------------------------------------------- |
+| Media uploads      | Disabled                      | [Setup Guide → Media Storage](setup.md#media-storage-optional)              |
+| Email verification | Disabled                      | [Setup Guide → Email](setup.md#email-configuration-optional)                |
+| Background jobs    | Run synchronously             | [Setup Guide → Queue](setup.md#queue-configuration-optional)                |
+| Push notifications | Disabled                      | [Setup Guide → Push Notifications](setup.md#push-notifications-optional)    |
+| Federation         | Needs a public domain + HTTPS | [Setup Guide → Starting the Application](setup.md#starting-the-application) |
+
+## Next steps
+
+- **Production / real deployment:** [Setup Guide](setup.md)
+- **All configuration options:** [Environment Variables Guide](environment-variables.md)
+- **Database choices:** [SQLite Setup](sqlite-setup.md) · [PostgreSQL Setup](postgresql-setup.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,8 @@
 
 The fastest way to get a local Activity.next instance running, with the **least
 amount of setup**. This uses SQLite (a single file, no database server) and the
-three environment variables that are strictly required.
+three core settings that are strictly required: the host, a secret phrase, and a
+database.
 
 For production deployments, federation, media storage, email, and every other
 option, see the [Setup Guide](setup.md) and the
@@ -35,13 +36,20 @@ ACTIVITIES_DATABASE_CLIENT=better-sqlite3
 ACTIVITIES_DATABASE_SQLITE_FILENAME=./dev.sqlite3
 ```
 
+The database is a single setting, but SQLite expresses it as two variables: the
+client (`better-sqlite3`) and the file path. (Alternatively, you can collapse it
+into one `ACTIVITIES_DATABASE` JSON variable — see the
+[Environment Variables Guide](environment-variables.md#database).)
+
 > **Local sign-in over `http`:** add `ACTIVITIES_INSECURE_AUTH=true` so the
 > instance accepts `http://localhost` sign-in. Without it, sign-in is forced to
 > `https` and fails with `403 Invalid origin`.
 >
 > **Restrict who can register (optional but recommended):** add
 > `ACTIVITIES_ALLOW_EMAILS='["you@example.com"]'` (single-quoted so the JSON
-> array survives). Only listed emails can sign up.
+> array survives) so only listed emails can sign up. When it is unset (the
+> default), `ACTIVITIES_ALLOW_EMAILS` falls back to an empty list and
+> registration is open to anyone who can reach the instance.
 
 A practical local `.env.local` therefore looks like:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,8 +3,9 @@
 This guide provides an overview of how to set up Activity.next for development or production.
 
 > **Just want to try it locally?** See the [Quickstart](quickstart.md) for the
-> fastest minimal setup (SQLite and the three required variables). This guide
-> covers the full set of configuration options.
+> fastest minimal setup (SQLite and the three core settings: host, secret
+> phrase, and a database). This guide covers the full set of configuration
+> options.
 
 ## Prerequisites
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,6 +2,10 @@
 
 This guide provides an overview of how to set up Activity.next for development or production.
 
+> **Just want to try it locally?** See the [Quickstart](quickstart.md) for the
+> fastest minimal setup (SQLite and the three required variables). This guide
+> covers the full set of configuration options.
+
 ## Prerequisites
 
 - **Node.js 24** or higher


### PR DESCRIPTION
## Summary

Adds a dedicated **Quickstart** doc describing the fastest way to get a local Activity.next instance running with the least possible setup, and wires it into the existing documentation.

The quickstart focuses on the **three strictly-required environment variables** to boot the app, plus SQLite (no database server needed):

- `ACTIVITIES_HOST`
- `ACTIVITIES_SECRET_PHASE`
- a database (SQLite via `ACTIVITIES_DATABASE_CLIENT` + `ACTIVITIES_DATABASE_SQLITE_FILENAME`)

It also calls out the two practical local-dev extras (`ACTIVITIES_INSECURE_AUTH=true` for `http` sign-in, and `ACTIVITIES_ALLOW_EMAILS` to gate registration), and a table of what is intentionally left out (media, email, queue, push, federation) with links to the full Setup Guide.

## Changes

- **New:** `docs/quickstart.md` — minimal local setup walkthrough (clone → minimal `.env.local` → migrate → run → sign up).
- `README.md` — add Quickstart to the documentation table and a pointer at the top of the Quick Start section.
- `docs/setup.md` — link to the Quickstart at the top.
- `docs/environment-variables.md` — link to the Quickstart at the top.

## Notes

- Docs-only change; no code, config, or migrations touched. Tagged `docs:` (no release impact intended).
- The required-variable claims are derived from the config loader in `lib/config/` (`Config` schema in `lib/config/index.ts`, `getDatabaseConfig`, `getHostConfigFromEnvironment`) and the existing local-testing notes in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015cVbiaCNBJ5ePrLGjs8piD)_