### PR TITLE
Bump version to v1.89.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.89.1",
+  "version": "1.89.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.89.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.89.1`
- Base main SHA: `e0c7d0b970abbaba95e6eb93dcf634f184e76064`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
