### PR TITLE
refactor: remove activity & period selection from fitness heatmaps

### DIFF
--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -6,7 +6,6 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import {
   deleteFitnessRouteHeatmap,
-  getDistinctFitnessActivityTypes,
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmapRegionNames,
   getFitnessRouteHeatmaps,
@@ -47,7 +46,6 @@ vi.mock('@/lib/components/fitness/RegionMap', () => ({
 
 vi.mock('@/lib/client', () => ({
   deleteFitnessRouteHeatmap: vi.fn(),
-  getDistinctFitnessActivityTypes: vi.fn(),
   getFitnessRouteHeatmap: vi.fn(),
   getFitnessRouteHeatmapRegionNames: vi.fn(),
   getFitnessRouteHeatmaps: vi.fn(),
@@ -66,10 +64,6 @@ const mockLoadMaplibreModule = loadMaplibreModule as jest.MockedFunction<
 const mockDeleteFitnessRouteHeatmap =
   deleteFitnessRouteHeatmap as jest.MockedFunction<
     typeof deleteFitnessRouteHeatmap
-  >
-const mockGetDistinctFitnessActivityTypes =
-  getDistinctFitnessActivityTypes as jest.MockedFunction<
-    typeof getDistinctFitnessActivityTypes
   >
 const mockGetFitnessRouteHeatmap =
   getFitnessRouteHeatmap as jest.MockedFunction<typeof getFitnessRouteHeatmap>
@@ -262,7 +256,6 @@ const createFitBoundsCapturingModule = () => {
 describe('FitnessHeatmapView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetDistinctFitnessActivityTypes.mockResolvedValue([])
     mockGetFitnessRouteHeatmap.mockResolvedValue(null)
     mockGetFitnessRouteHeatmaps.mockResolvedValue([])
     mockGetFitnessRouteHeatmapRegionNames.mockResolvedValue([])
@@ -277,12 +270,19 @@ describe('FitnessHeatmapView', () => {
     vi.useRealTimers()
   })
 
-  it('renders the source panel and a default whole-world region', async () => {
+  it('renders the region list with a default whole-world region', async () => {
     render(
       <FitnessHeatmapView actorId={ACTOR} embedOrigin="https://test.example" />
     )
 
-    expect(await screen.findByText('Heatmap source')).toBeInTheDocument()
+    // The Activity + Period source selectors were removed from this page.
+    expect(
+      await screen.findByText(/1 region · 0 generated/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Heatmap source')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('combobox', { name: 'Period' })
+    ).not.toBeInTheDocument()
     // The default whole-world region row (its description is unique to the row,
     // unlike the "Whole world" add button).
     expect(
@@ -290,7 +290,6 @@ describe('FitnessHeatmapView', () => {
     ).toBeInTheDocument()
     // The default region has no heatmap under the all-time source.
     expect(screen.getByText('Not generated')).toBeInTheDocument()
-    expect(screen.getByText(/1 region · 0 generated/i)).toBeInTheDocument()
   })
 
   it('seeds a drawn region from an existing heatmap and shows its status', async () => {
@@ -511,7 +510,9 @@ describe('FitnessHeatmapView', () => {
     ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /All regions/i }))
-    expect(await screen.findByText('Heatmap source')).toBeInTheDocument()
+    expect(
+      await screen.findByText(/1 region · 0 generated/i)
+    ).toBeInTheDocument()
   })
 
   it('renames an opened drawn region inline and persists the label', async () => {
@@ -779,30 +780,6 @@ describe('FitnessHeatmapView', () => {
         })
       )
     })
-  })
-
-  it('re-derives region status when the period source changes', async () => {
-    mockGetFitnessRouteHeatmaps.mockResolvedValue([
-      worldSummary({ updatedAt: TEST_NOW })
-    ])
-
-    render(
-      <FitnessHeatmapView actorId={ACTOR} embedOrigin="https://test.example" />
-    )
-
-    // The all-time heatmap matches the default source.
-    expect(await screen.findByText(/^Generated/)).toBeInTheDocument()
-
-    // Switching to a yearly source re-keys the region; the all-time heatmap no
-    // longer matches, so the row flips to "Not generated".
-    fireEvent.change(screen.getByRole('combobox', { name: 'Period' }), {
-      target: { value: 'yearly' }
-    })
-
-    await waitFor(() =>
-      expect(screen.getByText('Not generated')).toBeInTheDocument()
-    )
-    expect(screen.queryByText(/^Generated/)).not.toBeInTheDocument()
   })
 
   it('seeds and dedupes regions from legacy multi-region heatmap keys', async () => {

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -57,6 +57,16 @@ const STALE_IN_FLIGHT_HEATMAP_MS = 15 * 60_000
 
 const WORLD_REGION: PickerRegion = { id: 'world', type: 'world' }
 
+// The Activity + Period source selectors were removed from this page, so the
+// heatmap source is fixed: all activities, all time. These are module constants
+// (not per-render state) so they are evaluated once and stay out of the hook
+// dependency arrays, while the existing source-keyed fetch/poll/share/remove
+// logic — and the detail page's "All activities / All time" meta chips — keep
+// working unchanged.
+const SELECTED_ACTIVITY_TYPE: string | undefined = undefined
+const PERIOD_TYPE: PeriodType = 'all_time'
+const EFFECTIVE_PERIOD_KEY = 'all'
+
 const formatActivityLabel = (type?: string): string =>
   type
     ? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
@@ -216,14 +226,6 @@ export const FitnessHeatmapView: FC<Props> = ({
     }
   }, [actorId])
 
-  // The Activity + Period selectors were removed from this page: every region
-  // heatmap is now aggregated across all activities for all time. These fixed
-  // values keep the existing source-keyed fetch/poll/share/remove logic — and
-  // the detail page's "All activities / All time" meta chips — working unchanged.
-  const selectedActivityType: string | undefined = undefined
-  const periodType: PeriodType = 'all_time'
-  const effectivePeriodKey = 'all'
-
   const openRegion = useMemo(
     () => regions.find((region) => region.id === openRegionId) ?? null,
     [regions, openRegionId]
@@ -233,7 +235,7 @@ export const FitnessHeatmapView: FC<Props> = ({
     : null
 
   const focusKey = openRegion
-    ? `${actorId}:${selectedActivityType ?? ''}:${periodType}:${effectivePeriodKey}:${openRegionKey}`
+    ? `${actorId}:${SELECTED_ACTIVITY_TYPE ?? ''}:${PERIOD_TYPE}:${EFFECTIVE_PERIOD_KEY}:${openRegionKey}`
     : ''
 
   useEffect(() => {
@@ -251,10 +253,10 @@ export const FitnessHeatmapView: FC<Props> = ({
 
   const sourceMatch = useCallback(
     (heatmap: FitnessRouteHeatmapSummaryData): boolean =>
-      (heatmap.activityType ?? '') === (selectedActivityType ?? '') &&
-      heatmap.periodType === periodType &&
-      heatmap.periodKey === effectivePeriodKey,
-    [selectedActivityType, periodType, effectivePeriodKey]
+      (heatmap.activityType ?? '') === (SELECTED_ACTIVITY_TYPE ?? '') &&
+      heatmap.periodType === PERIOD_TYPE &&
+      heatmap.periodKey === EFFECTIVE_PERIOD_KEY,
+    []
   )
 
   const heatmapForRegion = useCallback(
@@ -291,9 +293,9 @@ export const FitnessHeatmapView: FC<Props> = ({
       const [heatmap, allHeatmaps] = await Promise.all([
         getFitnessRouteHeatmap({
           actorId,
-          activityType: selectedActivityType,
-          periodType,
-          periodKey: effectivePeriodKey,
+          activityType: SELECTED_ACTIVITY_TYPE,
+          periodType: PERIOD_TYPE,
+          periodKey: EFFECTIVE_PERIOD_KEY,
           region: openRegionKey || undefined
         }),
         getFitnessRouteHeatmaps({ actorId })
@@ -311,14 +313,7 @@ export const FitnessHeatmapView: FC<Props> = ({
     } finally {
       if (isCurrent()) setIsLoading(false)
     }
-  }, [
-    actorId,
-    selectedActivityType,
-    periodType,
-    effectivePeriodKey,
-    openRegionId,
-    openRegionKey
-  ])
+  }, [actorId, openRegionId, openRegionKey])
 
   useEffect(() => {
     fetchFocused()
@@ -361,9 +356,9 @@ export const FitnessHeatmapView: FC<Props> = ({
       Promise.all([
         getFitnessRouteHeatmap({
           actorId,
-          activityType: selectedActivityType,
-          periodType,
-          periodKey: effectivePeriodKey,
+          activityType: SELECTED_ACTIVITY_TYPE,
+          periodType: PERIOD_TYPE,
+          periodKey: EFFECTIVE_PERIOD_KEY,
           region: openRegionKey || undefined
         }),
         getFitnessRouteHeatmaps({ actorId })
@@ -435,9 +430,6 @@ export const FitnessHeatmapView: FC<Props> = ({
     shouldPollFocused,
     hasAnyListInFlight,
     actorId,
-    selectedActivityType,
-    periodType,
-    effectivePeriodKey,
     openRegionKey,
     focusKey,
     generationPending
@@ -449,9 +441,9 @@ export const FitnessHeatmapView: FC<Props> = ({
       const key = focusKeyRef.current
       const success = await triggerFitnessRouteHeatmap({
         actorId,
-        activityType: selectedActivityType,
-        periodType,
-        periodKey: effectivePeriodKey,
+        activityType: SELECTED_ACTIVITY_TYPE,
+        periodType: PERIOD_TYPE,
+        periodKey: EFFECTIVE_PERIOD_KEY,
         region: openRegionKey || undefined,
         retry
       })
@@ -466,14 +458,7 @@ export const FitnessHeatmapView: FC<Props> = ({
         .then(setHeatmaps)
         .catch(() => {})
     },
-    [
-      actorId,
-      selectedActivityType,
-      periodType,
-      effectivePeriodKey,
-      openRegionId,
-      openRegionKey
-    ]
+    [actorId, openRegionId, openRegionKey]
   )
 
   const runGeneration = useCallback(async () => {
@@ -508,9 +493,9 @@ export const FitnessHeatmapView: FC<Props> = ({
     try {
       const shareToken = await shareFitnessRouteHeatmap({
         actorId,
-        activityType: selectedActivityType,
-        periodType,
-        periodKey: effectivePeriodKey,
+        activityType: SELECTED_ACTIVITY_TYPE,
+        periodType: PERIOD_TYPE,
+        periodKey: EFFECTIVE_PERIOD_KEY,
         region: openRegionKey || undefined
       })
       if (focusKeyRef.current !== key) return
@@ -525,14 +510,7 @@ export const FitnessHeatmapView: FC<Props> = ({
     } finally {
       setIsSharing(false)
     }
-  }, [
-    actorId,
-    selectedActivityType,
-    periodType,
-    effectivePeriodKey,
-    openRegionId,
-    openRegionKey
-  ])
+  }, [actorId, openRegionId, openRegionKey])
 
   const handleUnshare = useCallback(async () => {
     if (!openRegionId || openRegionKey === null) return
@@ -542,9 +520,9 @@ export const FitnessHeatmapView: FC<Props> = ({
     try {
       await unshareFitnessRouteHeatmap({
         actorId,
-        activityType: selectedActivityType,
-        periodType,
-        periodKey: effectivePeriodKey,
+        activityType: SELECTED_ACTIVITY_TYPE,
+        periodType: PERIOD_TYPE,
+        periodKey: EFFECTIVE_PERIOD_KEY,
         region: openRegionKey || undefined
       })
       if (focusKeyRef.current !== key) return
@@ -557,14 +535,7 @@ export const FitnessHeatmapView: FC<Props> = ({
     } finally {
       setIsSharing(false)
     }
-  }, [
-    actorId,
-    selectedActivityType,
-    periodType,
-    effectivePeriodKey,
-    openRegionId,
-    openRegionKey
-  ])
+  }, [actorId, openRegionId, openRegionKey])
 
   const handleRegionRemoved = useCallback(
     async (region: PickerRegion) => {
@@ -582,9 +553,9 @@ export const FitnessHeatmapView: FC<Props> = ({
       try {
         await deleteFitnessRouteHeatmap({
           actorId,
-          activityType: selectedActivityType,
-          periodType,
-          periodKey: effectivePeriodKey,
+          activityType: SELECTED_ACTIVITY_TYPE,
+          periodType: PERIOD_TYPE,
+          periodKey: EFFECTIVE_PERIOD_KEY,
           region: key || undefined
         })
       } catch (err) {
@@ -598,7 +569,7 @@ export const FitnessHeatmapView: FC<Props> = ({
         )
       }
     },
-    [actorId, selectedActivityType, periodType, effectivePeriodKey, sourceMatch]
+    [actorId, sourceMatch]
   )
 
   const handleRegionSaved = useCallback(
@@ -661,8 +632,8 @@ export const FitnessHeatmapView: FC<Props> = ({
       <RegionHeatmapDetail
         region={openRegion}
         meta={{
-          activity: formatActivityLabel(selectedActivityType),
-          period: formatPeriodLabel(periodType, effectivePeriodKey)
+          activity: formatActivityLabel(SELECTED_ACTIVITY_TYPE),
+          period: formatPeriodLabel(PERIOD_TYPE, EFFECTIVE_PERIOD_KEY)
         }}
         heatmap={heatmapData}
         mapboxAccessToken={mapboxAccessToken}

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Flame } from 'lucide-react'
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
@@ -8,7 +7,6 @@ import {
   FitnessRouteHeatmapRegionNameData,
   FitnessRouteHeatmapSummaryData,
   deleteFitnessRouteHeatmap,
-  getDistinctFitnessActivityTypes,
   getFitnessRouteHeatmap,
   getFitnessRouteHeatmapRegionNames,
   getFitnessRouteHeatmaps,
@@ -25,7 +23,6 @@ import {
   withRegionIds
 } from '@/lib/components/fitness/HeatmapRegionPicker'
 import { RegionHeatmapDetail } from '@/lib/components/fitness/RegionHeatmapDetail'
-import { Select } from '@/lib/components/ui/select'
 import {
   HeatmapRegion,
   deserializeRegions,
@@ -53,7 +50,6 @@ interface Props {
   embedOrigin: string
 }
 
-const currentYear = new Date().getUTCFullYear()
 const ROUTE_HEATMAP_POLLING_INTERVAL_MS = 5000
 const STALLED_POLLING_LIMIT = 30
 // Keep recent background jobs live while ignoring restored/stuck rows that are days old.
@@ -84,24 +80,6 @@ const computeProgressPercent = (
 
 const isRouteHeatmapInFlight = (status?: string): boolean =>
   status === 'generating' || status === 'pending'
-
-const generateYearOptions = (): number[] => {
-  const years: number[] = []
-  for (let y = currentYear; y >= currentYear - 10; y--) {
-    years.push(y)
-  }
-  return years
-}
-
-const generateMonthOptions = (year: number): string[] => {
-  const months: string[] = []
-  const now = new Date()
-  const maxMonth = year === now.getUTCFullYear() ? now.getUTCMonth() : 11
-  for (let m = maxMonth; m >= 0; m--) {
-    months.push(`${year}-${String(m + 1).padStart(2, '0')}`)
-  }
-  return months
-}
 
 /** Maps a region's matching heatmap summary into a display status atom. */
 const summaryToStatus = (
@@ -181,11 +159,6 @@ export const FitnessHeatmapView: FC<Props> = ({
   mapboxAccessToken,
   embedOrigin
 }) => {
-  const [activityTypes, setActivityTypes] = useState<string[]>([])
-  const [selectedType, setSelectedType] = useState<string>('')
-  const [periodType, setPeriodType] = useState<PeriodType>('all_time')
-  const [periodKey, setPeriodKey] = useState<string>('all')
-  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
   // Static id for the default so the initial SSR render and client hydration
   // produce identical state (a dynamically generated id would differ).
   const [regions, setRegions] = useState<PickerRegion[]>(() => [WORLD_REGION])
@@ -215,12 +188,6 @@ export const FitnessHeatmapView: FC<Props> = ({
     return () => clearInterval(id)
   }, [])
 
-  useEffect(() => {
-    getDistinctFitnessActivityTypes({ actorId })
-      .then(setActivityTypes)
-      .catch(() => {})
-  }, [actorId])
-
   // Initial load: reset to the default region list for this actor, then pull
   // the actor's heatmaps and seed in any previously generated regions. This
   // effect runs once per actorId, so the merge happens once (and is idempotent
@@ -249,12 +216,13 @@ export const FitnessHeatmapView: FC<Props> = ({
     }
   }, [actorId])
 
-  const selectedActivityType = selectedType || undefined
-  const effectivePeriodKey = useMemo(() => {
-    if (periodType === 'all_time') return 'all'
-    if (periodType === 'yearly') return `${selectedYear}`
-    return periodKey
-  }, [periodType, selectedYear, periodKey])
+  // The Activity + Period selectors were removed from this page: every region
+  // heatmap is now aggregated across all activities for all time. These fixed
+  // values keep the existing source-keyed fetch/poll/share/remove logic — and
+  // the detail page's "All activities / All time" meta chips — working unchanged.
+  const selectedActivityType: string | undefined = undefined
+  const periodType: PeriodType = 'all_time'
+  const effectivePeriodKey = 'all'
 
   const openRegion = useMemo(
     () => regions.find((region) => region.id === openRegionId) ?? null,
@@ -474,38 +442,6 @@ export const FitnessHeatmapView: FC<Props> = ({
     focusKey,
     generationPending
   ])
-
-  const yearOptions = useMemo(() => generateYearOptions(), [])
-  const monthOptions = useMemo(
-    () => generateMonthOptions(selectedYear),
-    [selectedYear]
-  )
-
-  const handlePeriodTypeChange = (newType: PeriodType) => {
-    setPeriodType(newType)
-    if (newType === 'all_time') {
-      setPeriodKey('all')
-    } else if (newType === 'yearly') {
-      setPeriodKey(`${selectedYear}`)
-    } else {
-      const month = String(new Date().getUTCMonth() + 1).padStart(2, '0')
-      setPeriodKey(`${selectedYear}-${month}`)
-    }
-  }
-
-  const handleYearChange = (year: number) => {
-    setSelectedYear(year)
-    if (periodType === 'yearly') {
-      setPeriodKey(`${year}`)
-      return
-    }
-    if (periodType === 'monthly') {
-      const currentMonth = periodKey.split('-')[1] ?? '01'
-      const newKey = `${year}-${currentMonth}`
-      const options = generateMonthOptions(year)
-      setPeriodKey(options.includes(newKey) ? newKey : options[0])
-    }
-  }
 
   const enqueueGeneration = useCallback(
     async (retry: boolean) => {
@@ -765,92 +701,6 @@ export const FitnessHeatmapView: FC<Props> = ({
           {error}
         </div>
       )}
-
-      {/* Heatmap source — applies to every region you generate below. */}
-      <section className="rounded-xl border bg-card p-4 shadow-sm">
-        <div className="mb-3 flex items-center gap-2">
-          <span className="flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground">
-            <Flame className="size-4" />
-          </span>
-          <div>
-            <div className="text-sm font-semibold">Heatmap source</div>
-            <div className="text-[11px] text-muted-foreground">
-              Applies to every region you generate below.
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <label className="space-y-1.5">
-            <span className="block text-xs font-medium text-muted-foreground">
-              Activity
-            </span>
-            <Select
-              value={selectedType}
-              onChange={(e) => setSelectedType(e.target.value)}
-            >
-              <option value="">All activities</option>
-              {activityTypes.map((type) => (
-                <option key={type} value={type}>
-                  {formatActivityLabel(type)}
-                </option>
-              ))}
-            </Select>
-          </label>
-
-          <label className="space-y-1.5">
-            <span className="block text-xs font-medium text-muted-foreground">
-              Period
-            </span>
-            <Select
-              value={periodType}
-              onChange={(e) =>
-                handlePeriodTypeChange(e.target.value as PeriodType)
-              }
-            >
-              <option value="all_time">All time</option>
-              <option value="yearly">Yearly</option>
-              <option value="monthly">Monthly</option>
-            </Select>
-          </label>
-
-          {periodType !== 'all_time' && (
-            <label className="space-y-1.5">
-              <span className="block text-xs font-medium text-muted-foreground">
-                Year
-              </span>
-              <Select
-                value={selectedYear}
-                onChange={(e) => handleYearChange(parseInt(e.target.value, 10))}
-              >
-                {yearOptions.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </Select>
-            </label>
-          )}
-
-          {periodType === 'monthly' && (
-            <label className="space-y-1.5">
-              <span className="block text-xs font-medium text-muted-foreground">
-                Month
-              </span>
-              <Select
-                value={periodKey}
-                onChange={(e) => setPeriodKey(e.target.value)}
-              >
-                {monthOptions.map((month) => (
-                  <option key={month} value={month}>
-                    {month}
-                  </option>
-                ))}
-              </Select>
-            </label>
-          )}
-        </div>
-      </section>
 
       {/* Region list — each opens its own heatmap page. */}
       <section className="rounded-xl border bg-card p-4 shadow-sm">

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.test.tsx
@@ -34,8 +34,7 @@ const baseView: SharedHeatmapView = {
     isPartial: false,
     createdAt: 1,
     updatedAt: 2
-  },
-  stats: { routes: '342', activity: 'Trail Run', period: 'All time' }
+  }
 }
 
 const defaultProps = {
@@ -46,7 +45,7 @@ const defaultProps = {
 }
 
 describe('SharedHeatmapPage', () => {
-  it('renders the heatmap title, owner, date and read-only stats', () => {
+  it('renders the heatmap title, owner, date and the map', () => {
     render(<SharedHeatmapPage {...defaultProps} />)
 
     expect(
@@ -58,10 +57,15 @@ describe('SharedHeatmapPage', () => {
       screen.getByText('TL 52.60°N 5.60°E → BR 52.00°N 6.20°E')
     ).toBeInTheDocument()
 
-    expect(screen.getByText('Routes')).toBeInTheDocument()
-    expect(screen.getByText('342')).toBeInTheDocument()
-    expect(screen.getByText('Trail Run')).toBeInTheDocument()
     expect(screen.getByTestId('route-map')).toBeInTheDocument()
+  })
+
+  it('shows only the map — no read-only stats strip', () => {
+    render(<SharedHeatmapPage {...defaultProps} />)
+
+    expect(screen.queryByText('Routes')).not.toBeInTheDocument()
+    expect(screen.queryByText('Activity')).not.toBeInTheDocument()
+    expect(screen.queryByText('Period')).not.toBeInTheDocument()
   })
 
   it('offers a copy-link control pointing at the public URL', () => {

--- a/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
+++ b/app/u/heatmaps/[token]/SharedHeatmapPage.tsx
@@ -1,13 +1,4 @@
-import {
-  Activity,
-  Calendar,
-  ChevronRight,
-  Eye,
-  Flame,
-  Globe,
-  Maximize,
-  Route
-} from 'lucide-react'
+import { ChevronRight, Eye, Flame, Globe, Maximize } from 'lucide-react'
 import Link from 'next/link'
 import { FC } from 'react'
 
@@ -27,29 +18,12 @@ export interface SharedHeatmapPageProps {
   signupUrl: string
 }
 
-interface StatTileProps {
-  icon: FC<{ className?: string }>
-  label: string
-  value: string
-}
-
-const StatTile: FC<StatTileProps> = ({ icon: Icon, label, value }) => (
-  <div className="rounded-xl border bg-card/80 px-4 py-3 shadow-sm">
-    <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-      <Icon className="size-3.5" />
-      {label}
-    </div>
-    <div className="mt-1 truncate text-lg font-semibold leading-tight tracking-tight tabular-nums">
-      {value}
-    </div>
-  </div>
-)
-
 /**
  * The public, read-only destination for a shared route heatmap (at
  * `/u/heatmaps/<token>`). No account required: logged-out chrome, the live heat
- * map, a read-only stats strip, an owner line, and a join CTA. There are no
- * edit / generate / share-panel controls — those live in the in-app region page.
+ * map as the sole content block, an owner line, and a join CTA. There are no
+ * read-only stats and no edit / generate / share-panel controls — the latter
+ * live in the in-app region page.
  */
 export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
   view,
@@ -58,8 +32,7 @@ export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
   signinUrl,
   signupUrl
 }) => {
-  const { title, isWorld, bboxLabel, owner, generatedLabel, publicUrl, stats } =
-    view
+  const { title, isWorld, bboxLabel, owner, generatedLabel, publicUrl } = view
 
   return (
     <div className="relative min-h-dvh">
@@ -150,13 +123,6 @@ export const SharedHeatmapPage: FC<SharedHeatmapPageProps> = ({
             A live, pannable density map — brighter areas are ridden or run more
             often. Drag to explore.
           </p>
-        </div>
-
-        {/* read-only stats */}
-        <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
-          <StatTile icon={Route} label="Routes" value={stats.routes} />
-          <StatTile icon={Activity} label="Activity" value={stats.activity} />
-          <StatTile icon={Calendar} label="Period" value={stats.period} />
         </div>
 
         {/* join CTA */}

--- a/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
@@ -74,7 +74,7 @@ describe('buildSharedHeatmapView', () => {
     })
     expect(view.publicUrl).toBe('https://llun.test/u/heatmaps/tok123')
     // The public page renders only the map: no read-only stats are exposed.
-    expect('stats' in view).toBe(false)
+    expect(view).not.toHaveProperty('stats')
     // Internal counters are zeroed in the map payload (no public leak), but the
     // real segments/bounds are kept so the map still renders.
     expect(view.heatmap.activityCount).toBe(0)

--- a/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.test.ts
@@ -4,9 +4,7 @@ import { FitnessRouteHeatmap } from '@/lib/types/database/fitnessRouteHeatmap'
 import {
   buildSharedHeatmapView,
   computeInitials,
-  formatActivityLabel,
-  formatGeneratedDate,
-  formatPeriodLabel
+  formatGeneratedDate
 } from './sharedHeatmapView'
 
 const baseHeatmap: FitnessRouteHeatmap = {
@@ -29,38 +27,6 @@ const baseHeatmap: FitnessRouteHeatmap = {
 }
 
 const owner = { name: 'Alice Rider', username: 'alice', domain: 'llun.test' }
-
-describe('formatActivityLabel', () => {
-  it.each([
-    {
-      description: 'undefined → All activities',
-      input: undefined,
-      expected: 'All activities'
-    },
-    {
-      description: 'null → All activities',
-      input: null,
-      expected: 'All activities'
-    },
-    {
-      description: 'humanises trail_run',
-      input: 'trail_run',
-      expected: 'Trail Run'
-    }
-  ])('$description', ({ input, expected }) => {
-    expect(formatActivityLabel(input)).toBe(expected)
-  })
-})
-
-describe('formatPeriodLabel', () => {
-  it('returns All time for the all-time period', () => {
-    expect(formatPeriodLabel('all_time', 'all')).toBe('All time')
-  })
-  it('returns the raw period key otherwise', () => {
-    expect(formatPeriodLabel('yearly', '2025')).toBe('2025')
-    expect(formatPeriodLabel('monthly', '2025-06')).toBe('2025-06')
-  })
-})
 
 describe('computeInitials', () => {
   it.each([
@@ -90,7 +56,7 @@ describe('formatGeneratedDate', () => {
 })
 
 describe('buildSharedHeatmapView', () => {
-  it('builds the world view with read-only stats and a zeroed map heatmap', () => {
+  it('builds the world view with a zeroed map heatmap and no stats', () => {
     const view = buildSharedHeatmapView({
       heatmap: baseHeatmap,
       owner,
@@ -107,11 +73,8 @@ describe('buildSharedHeatmapView', () => {
       initials: 'AR'
     })
     expect(view.publicUrl).toBe('https://llun.test/u/heatmaps/tok123')
-    expect(view.stats).toEqual({
-      routes: '342',
-      activity: 'All activities',
-      period: 'All time'
-    })
+    // The public page renders only the map: no read-only stats are exposed.
+    expect('stats' in view).toBe(false)
     // Internal counters are zeroed in the map payload (no public leak), but the
     // real segments/bounds are kept so the map still renders.
     expect(view.heatmap.activityCount).toBe(0)
@@ -153,22 +116,6 @@ describe('buildSharedHeatmapView', () => {
       token: 'tok123'
     })
     expect(view.title).toBe('Map area')
-  })
-
-  it('humanises a filtered activity and yearly period in the stats', () => {
-    const view = buildSharedHeatmapView({
-      heatmap: {
-        ...baseHeatmap,
-        activityType: 'trail_run',
-        periodType: 'yearly',
-        periodKey: '2025'
-      },
-      owner,
-      origin: 'https://llun.test',
-      token: 'tok123'
-    })
-    expect(view.stats.activity).toBe('Trail Run')
-    expect(view.stats.period).toBe('2025')
   })
 
   it('does not double the slash when the origin has a trailing slash', () => {

--- a/app/u/heatmaps/[token]/sharedHeatmapView.ts
+++ b/app/u/heatmaps/[token]/sharedHeatmapView.ts
@@ -3,20 +3,6 @@ import { deserializeRegions, formatRectRegion } from '@/lib/fitness/regions'
 import { FitnessRouteHeatmap } from '@/lib/types/database/fitnessRouteHeatmap'
 import { getMentionFromActorID } from '@/lib/types/domain/actor'
 
-const numberFormatter = new Intl.NumberFormat()
-
-/** "All activities" or a humanised activity type (e.g. "Trail Run"). */
-export const formatActivityLabel = (type?: string | null): string =>
-  type
-    ? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
-    : 'All activities'
-
-/** "All time" for the all-time period, otherwise the raw period key. */
-export const formatPeriodLabel = (
-  periodType: string,
-  periodKey: string
-): string => (periodType === 'all_time' ? 'All time' : periodKey)
-
 /** Up to two uppercase initials from a display name (falls back to "?"). */
 export const computeInitials = (name: string): string => {
   const initials = name
@@ -51,12 +37,6 @@ export interface SharedHeatmapOwner {
   initials: string
 }
 
-export interface SharedHeatmapStats {
-  routes: string
-  activity: string
-  period: string
-}
-
 export interface SharedHeatmapView {
   title: string
   isWorld: boolean
@@ -68,11 +48,10 @@ export interface SharedHeatmapView {
   /**
    * Map-ready heatmap with the internal generation counters zeroed: as Client
    * Component props they would otherwise be serialised into the public RSC
-   * payload on this unauthenticated surface (mirrors the embed page). Only the
-   * route count is surfaced — and only as a pre-formatted stat string below.
+   * payload on this unauthenticated surface (mirrors the embed page). The public
+   * page renders only the map, so no counter is surfaced.
    */
   heatmap: FitnessRouteHeatmapData
-  stats: SharedHeatmapStats
 }
 
 interface BuildSharedHeatmapViewParams {
@@ -141,11 +120,6 @@ export const buildSharedHeatmapView = ({
       isPartial: false,
       createdAt: heatmap.createdAt,
       updatedAt: heatmap.updatedAt
-    },
-    stats: {
-      routes: numberFormatter.format(Math.max(0, heatmap.activityCount)),
-      activity: formatActivityLabel(heatmap.activityType),
-      period: formatPeriodLabel(heatmap.periodType, heatmap.periodKey)
     }
   }
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -52,7 +52,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Fitness file storage** — Upload .fit, .gpx, and .tcx activity files
 - ✅ **Fitness activity processing** — Parse GPS tracks and metrics from uploaded .fit, .gpx, and .tcx files
 - ✅ **Fitness activity display** — Show route maps, activity statistics, analysis graphs, and device info in posts
-- ✅ **Fitness route heatmaps** — Per-region master/detail heatmaps by actor, activity type, period, and region, rendered on an interactive map (Mapbox when a token is configured, otherwise keyless MapLibre / OpenFreeMap), with live generation progress, per-heatmap retry/remove, inline region renaming, and shareable/embeddable views (iframe + image)
+- ✅ **Fitness route heatmaps** — Per-region master/detail heatmaps by actor and region (aggregated across all activities and all time), rendered on an interactive map (Mapbox when a token is configured, otherwise keyless MapLibre / OpenFreeMap), with live generation progress, per-heatmap retry/remove, inline region renaming, and shareable/embeddable views (iframe + image)
 - ✅ **Strava import** — Import activities through Strava OAuth/webhooks and uploaded Strava archive ZIP files
 - ✅ **Fitness import resilience** — Recover stuck/orphaned imports, resumable Strava archive retries, same-ride upload merging, and per-file retry from the UI; repair scripts cover legacy imports
 - ✅ **Fitness privacy locations** — Hide configured location radii from route maps and heatmaps

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2606,23 +2606,6 @@ export const getFitnessCalendarData = async ({
   return response.json()
 }
 
-export const getDistinctFitnessActivityTypes = async ({
-  actorId
-}: {
-  actorId: string
-}): Promise<string[]> => {
-  const encodedId = urlToId(actorId)
-  const response = await fetch(
-    `/api/v1/accounts/${encodedId}/fitness-activity-types`,
-    {
-      method: 'GET',
-      headers: { Accept: 'application/json' }
-    }
-  )
-  if (!response.ok) return []
-  return response.json()
-}
-
 export type DirectConversationView = DirectConversation & {
   accounts: MastodonAccount[]
 }


### PR DESCRIPTION
## Summary

Aligns the fitness **Heatmaps** experience with the design system (`ui_kits/web/FitnessHeatmaps.jsx`), which no longer exposes the per-source **Activity** and **Period** controls. Heatmaps are now always aggregated across **all activities / all time** — one heatmap per region.

### `/fitness/heatmap` (in-app)
- Removed the **"Heatmap source"** card (Activity + Period selectors) entirely.
- Removed the now-unused state and helpers (`activityTypes`, `selectedType`, `periodType`/`periodKey`/`selectedYear`, the year/month option generators, and the `getDistinctFitnessActivityTypes` fetch).
- The source is now fixed (`all activities` / `all time`) via constants, so all existing source-keyed fetch / poll / share / remove logic — and the region detail page's **"All activities / All time"** meta chips — keep working unchanged.

### `/u/heatmaps/[token]` (public shared page)
- Removed the read-only **Routes / Activity / Period** stats strip so the page **shows only the map**, keeping the owner header and the join CTA.
- Removed the now-dead `stats` field, `SharedHeatmapStats` type, and `formatActivityLabel` / `formatPeriodLabel` helpers from the view model.

## Testing
- `yarn run prettier --write` ✅
- `yarn lint` ✅ (0 errors)
- `yarn build` ✅
- `yarn test` ✅ (558 files, 4944 tests)

## Notes
- No API/schema/config changes — the heatmap endpoints still accept `activityType`/`periodType`/`periodKey`; this PR only removes the UI selectors and fixes the source to all-time/all-activities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)