### PR TITLE
Bump version to v1.90.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.89.3",
+  "version": "1.90.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.90.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.89.3`
- Base main SHA: `13fc863d2facd270a579aa776ec980cf96102e99`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
