### PR TITLE
fix: align desktop navigation order with design system

### DIFF
--- a/lib/components/layout/mobile-nav.test.tsx
+++ b/lib/components/layout/mobile-nav.test.tsx
@@ -98,14 +98,14 @@ describe('MobileNav', () => {
 
     const items = await screen.findAllByRole('menuitem')
     const names = items.map((item) => item.textContent?.trim())
-    // Design-system overflow order: Explore, Bookmarks, Lists, Favorites,
+    // Design-system overflow order: Explore, Favorites, Bookmarks, Lists,
     // Fitness, Profile, Admin, Settings. (Search is a direct bottom-bar item,
     // so its neighbour Explore leads the overflow.)
     expect(names).toEqual([
       'Explore',
+      'Favorites',
       'Bookmarks',
       'Lists',
-      'Favorites',
       'Fitness',
       'Profile',
       'Admin',
@@ -123,9 +123,9 @@ describe('MobileNav', () => {
     const items = await screen.findAllByRole('menuitem')
     expect(items.map((item) => item.textContent?.trim())).toEqual([
       'Explore',
+      'Favorites',
       'Bookmarks',
       'Lists',
-      'Favorites',
       'Profile',
       'Admin',
       'Settings'
@@ -143,9 +143,9 @@ describe('MobileNav', () => {
     // No Admin entry, so Profile anchors directly before Settings.
     expect(items.map((item) => item.textContent?.trim())).toEqual([
       'Explore',
+      'Favorites',
       'Bookmarks',
       'Lists',
-      'Favorites',
       'Profile',
       'Settings'
     ])

--- a/lib/components/layout/nav-items.test.ts
+++ b/lib/components/layout/nav-items.test.ts
@@ -4,15 +4,15 @@ const itemHrefs = (params: Parameters<typeof buildNavItems>[0]) =>
   buildNavItems(params).map((item) => item.href)
 
 describe('buildNavItems', () => {
-  it('places bookmarks before notifications in the base navigation', () => {
+  it('places favorites before bookmarks in the base navigation', () => {
     expect(itemHrefs({})).toEqual([
       '/',
       '/search',
       '/explore',
       '/messages',
+      '/favorites',
       '/bookmarks',
       '/lists',
-      '/favorites',
       '/notifications',
       '/settings'
     ])
@@ -24,9 +24,9 @@ describe('buildNavItems', () => {
       '/search',
       '/explore',
       '/messages',
+      '/favorites',
       '/bookmarks',
       '/lists',
-      '/favorites',
       '/@llun@llun.test/fitness',
       '/notifications',
       '/settings'
@@ -39,9 +39,9 @@ describe('buildNavItems', () => {
       '/search',
       '/explore',
       '/messages',
+      '/favorites',
       '/bookmarks',
       '/lists',
-      '/favorites',
       '/notifications',
       '/admin',
       '/settings'
@@ -56,9 +56,9 @@ describe('buildNavItems', () => {
       '/search',
       '/explore',
       '/messages',
+      '/favorites',
       '/bookmarks',
       '/lists',
-      '/favorites',
       '/@llun@llun.test/fitness',
       '/notifications',
       '/admin',

--- a/lib/components/layout/nav-items.ts
+++ b/lib/components/layout/nav-items.ts
@@ -27,9 +27,9 @@ const baseNavItems: NavItem[] = [
   { href: '/search', label: 'Search', icon: Search },
   { href: '/explore', label: 'Explore', icon: Compass },
   { href: '/messages', label: 'Messages', icon: Mail },
+  { href: '/favorites', label: 'Favorites', icon: Heart },
   { href: '/bookmarks', label: 'Bookmarks', icon: Bookmark },
   { href: '/lists', label: 'Lists', icon: List },
-  { href: '/favorites', label: 'Favorites', icon: Heart },
   {
     href: '/notifications',
     label: 'Notifications',


### PR DESCRIPTION
## Summary

Updates the desktop navigation order to match the design system's `ui_kits/web/Sidebar.jsx` spec (imported via the Claude Design project [`a61009c5`](https://claude.ai/design/p/a61009c5-7207-4e18-8d2b-a0cace8d672b?file=ui_kits%2Fweb%2Findex.html)).

**Favorites** now sits directly after **Messages** (before Bookmarks and Lists), instead of after Lists. Because the desktop sidebar, tablet rail, and mobile overflow all derive their order from the shared `baseNavItems` array in `lib/components/layout/nav-items.ts`, this one reorder brings every surface into line with the design.

### Order — before → after

| | Before | After (design) |
|--|--|--|
| | Timeline | Timeline |
| | Search | Search |
| | Explore | Explore |
| | Messages | Messages |
| | Bookmarks | **Favorites** |
| | Lists | Bookmarks |
| | **Favorites** | Lists |
| | Fitness | Fitness |
| | Notifications | Notifications |
| | Admin | Admin |
| | Settings | Settings |

(Fitness is inserted before Notifications and Admin before Settings by `buildNavItems`, unchanged.)

## Changes

- `lib/components/layout/nav-items.ts` — move `Favorites` ahead of `Bookmarks` in `baseNavItems`.
- `lib/components/layout/nav-items.test.ts` — update the 4 expected-order assertions.
- `lib/components/layout/mobile-nav.test.tsx` — update the 3 overflow-order assertions and the design-system order comment.

## Testing

- `yarn run prettier --write .` — clean
- `yarn lint` — 0 errors
- `yarn build` — success
- `yarn test` — 564 files / 4981 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)