### PR TITLE
minor: redesign profile tabs and enable post actions to match design

### DIFF
--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -20,12 +20,14 @@ vi.mock('@/lib/components/posts/posts', () => ({
     statuses,
     currentTime,
     showActions,
-    showReadOnlyStats
+    showReadOnlyStats,
+    onReplyCreated
   }: {
     statuses: Status[]
     currentTime: number
     showActions?: boolean
     showReadOnlyStats?: boolean
+    onReplyCreated?: (status: Status, attachments: never[]) => void
   }) => (
     <div>
       <div data-testid="posts-current-time">{currentTime}</div>
@@ -33,6 +35,19 @@ vi.mock('@/lib/components/posts/posts', () => ({
       <div data-testid="posts-read-only-stats">
         {String(Boolean(showReadOnlyStats))}
       </div>
+      {onReplyCreated && (
+        <button
+          data-testid="trigger-reply-created"
+          onClick={() =>
+            onReplyCreated(
+              createReplyStatus('https://local.example/statuses/new-reply'),
+              []
+            )
+          }
+        >
+          trigger reply created
+        </button>
+      )}
       {statuses.map((status) => (
         <div key={status.id}>{status.id}</div>
       ))}
@@ -452,5 +467,51 @@ describe('ActorTimelines', () => {
     expect(
       screen.getAllByText('https://remote.example/statuses/run')
     ).toHaveLength(2)
+  })
+
+  it('surfaces a newly created reply on the viewer’s own profile', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://local.example/users/me"
+        statuses={[createStatus('https://local.example/statuses/post')]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={currentActorProfile}
+        isCurrentUser
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    expect(
+      screen.queryByText('https://local.example/statuses/new-reply')
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByTestId('trigger-reply-created')[0])
+
+    // The new reply is a reply, so it lands under the Replies tab feed.
+    expect(
+      screen.getByText('https://local.example/statuses/new-reply')
+    ).toBeInTheDocument()
+  })
+
+  it('does not inject a reply into another actor’s profile feed', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/post')]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={currentActorProfile}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    fireEvent.click(screen.getAllByTestId('trigger-reply-created')[0])
+
+    expect(
+      screen.queryByText('https://local.example/statuses/new-reply')
+    ).not.toBeInTheDocument()
   })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ReactNode } from 'react'
 
 import { getActorStatuses } from '@/lib/client'
+import { ActorProfile } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 
 import { ActorTimelines } from './ActorTimelines'
@@ -17,13 +18,21 @@ vi.mock('@/lib/client', () => ({
 vi.mock('@/lib/components/posts/posts', () => ({
   Posts: ({
     statuses,
-    currentTime
+    currentTime,
+    showActions,
+    showReadOnlyStats
   }: {
     statuses: Status[]
     currentTime: number
+    showActions?: boolean
+    showReadOnlyStats?: boolean
   }) => (
     <div>
       <div data-testid="posts-current-time">{currentTime}</div>
+      <div data-testid="posts-show-actions">{String(Boolean(showActions))}</div>
+      <div data-testid="posts-read-only-stats">
+        {String(Boolean(showReadOnlyStats))}
+      </div>
       {statuses.map((status) => (
         <div key={status.id}>{status.id}</div>
       ))}
@@ -60,7 +69,7 @@ vi.mock('@/lib/components/ui/button', () => ({
   )
 }))
 
-const createStatus = (id: string): Status => {
+const createStatus = (id: string, overrides: Partial<Status> = {}): Status => {
   const now = new Date('2026-04-30T10:00:00.000Z').getTime()
   return {
     id,
@@ -82,9 +91,29 @@ const createStatus = (id: string): Status => {
     isActorLiked: false,
     totalLikes: 0,
     attachments: [],
-    tags: []
-  }
+    tags: [],
+    ...overrides
+  } as Status
 }
+
+const createReplyStatus = (id: string): Status =>
+  createStatus(id, { reply: 'https://remote.example/statuses/parent' })
+
+const createFitnessStatus = (id: string): Status =>
+  createStatus(id, {
+    fitness: {
+      id: `${id}-fit`,
+      fileName: 'morning-run.fit',
+      fileType: 'fit',
+      mimeType: 'application/octet-stream',
+      bytes: 1024,
+      url: `${id}/morning-run.fit`
+    }
+  } as Partial<Status>)
+
+const currentActorProfile = {
+  id: 'https://local.example/users/me'
+} as ActorProfile
 
 const FIXED_CURRENT_TIME = new Date('2026-04-30T10:05:00.000Z').getTime()
 
@@ -128,7 +157,7 @@ describe('ActorTimelines', () => {
     })
     expect(
       screen.getAllByText('https://remote.example/statuses/older')
-    ).toHaveLength(2)
+    ).toHaveLength(1)
     expect(
       screen.queryByRole('button', { name: 'Load more' })
     ).not.toBeInTheDocument()
@@ -181,7 +210,7 @@ describe('ActorTimelines', () => {
     })
     expect(
       screen.getAllByText('https://remote.example/statuses/oldest')
-    ).toHaveLength(2)
+    ).toHaveLength(1)
   })
 
   it('shows load more when the initial actor page has no renderable statuses', async () => {
@@ -217,7 +246,7 @@ describe('ActorTimelines', () => {
     })
     expect(
       screen.getAllByText('https://remote.example/statuses/first-post')
-    ).toHaveLength(2)
+    ).toHaveLength(1)
   })
 
   it('shows a retryable error when loading older statuses fails', async () => {
@@ -316,5 +345,112 @@ describe('ActorTimelines', () => {
     } finally {
       dateNowSpy.mockRestore()
     }
+  })
+
+  it('enables interactive post actions when a current actor is provided', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/post')]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={currentActorProfile}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    for (const node of screen.getAllByTestId('posts-show-actions')) {
+      expect(node).toHaveTextContent('true')
+    }
+    for (const node of screen.getAllByTestId('posts-read-only-stats')) {
+      expect(node).toHaveTextContent('false')
+    }
+  })
+
+  it('renders read-only engagement stats for logged-out viewers', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/post')]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    for (const node of screen.getAllByTestId('posts-show-actions')) {
+      expect(node).toHaveTextContent('false')
+    }
+    for (const node of screen.getAllByTestId('posts-read-only-stats')) {
+      expect(node).toHaveTextContent('true')
+    }
+  })
+
+  it('separates replies from posts across the Posts and Replies tabs', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[
+          createStatus('https://remote.example/statuses/post'),
+          createReplyStatus('https://remote.example/statuses/reply')
+        ]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    // The Tabs primitive is mocked to render every tab panel, so a post shows
+    // up only under Posts and a reply only under Replies (one occurrence each).
+    expect(
+      screen.getAllByText('https://remote.example/statuses/post')
+    ).toHaveLength(1)
+    expect(
+      screen.getAllByText('https://remote.example/statuses/reply')
+    ).toHaveLength(1)
+  })
+
+  it('omits the Fitness tab when the actor has no fitness data', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus('https://remote.example/statuses/post')]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Fitness' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows fitness posts under the Fitness tab when the actor has fitness data', () => {
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[
+          createStatus('https://remote.example/statuses/post'),
+          createFitnessStatus('https://remote.example/statuses/run')
+        ]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        hasFitnessData
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Fitness' })).toBeInTheDocument()
+    // The fitness status appears under both Posts (it is a non-reply note) and
+    // the Fitness tab, so it renders twice with the all-panels Tabs mock.
+    expect(
+      screen.getAllByText('https://remote.example/statuses/run')
+    ).toHaveLength(2)
   })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.test.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.test.tsx
@@ -21,13 +21,19 @@ vi.mock('@/lib/components/posts/posts', () => ({
     currentTime,
     showActions,
     showReadOnlyStats,
-    onReplyCreated
+    onReplyCreated,
+    onPostDeleted,
+    onLikeChanged,
+    onBookmarkChanged
   }: {
     statuses: Status[]
     currentTime: number
     showActions?: boolean
     showReadOnlyStats?: boolean
     onReplyCreated?: (status: Status, attachments: never[]) => void
+    onPostDeleted?: (status: Status) => void
+    onLikeChanged?: (status: Status, isLiked: boolean) => void
+    onBookmarkChanged?: (status: Status, isBookmarked: boolean) => void
   }) => (
     <div>
       <div data-testid="posts-current-time">{currentTime}</div>
@@ -48,9 +54,45 @@ vi.mock('@/lib/components/posts/posts', () => ({
           trigger reply created
         </button>
       )}
-      {statuses.map((status) => (
-        <div key={status.id}>{status.id}</div>
-      ))}
+      {statuses.map((status) => {
+        // For a boost, the action callbacks fire with the unwrapped original
+        // status (mirroring the real Posts/Actions wiring).
+        const target =
+          status.type === StatusType.enum.Announce
+            ? status.originalStatus
+            : status
+        return (
+          <div key={status.id}>
+            <span>{status.id}</span>
+            <span data-testid={`like-flag-${target.id}`}>
+              {String(target.isActorLiked)}:{target.totalLikes}
+            </span>
+            <span data-testid={`bookmark-flag-${target.id}`}>
+              {String(target.isActorBookmarked)}
+            </span>
+            <button
+              data-testid={`trigger-delete-${target.id}`}
+              onClick={() => onPostDeleted?.(target)}
+            >
+              delete
+            </button>
+            <button
+              data-testid={`trigger-like-${target.id}`}
+              onClick={() => onLikeChanged?.(target, !target.isActorLiked)}
+            >
+              like
+            </button>
+            <button
+              data-testid={`trigger-bookmark-${target.id}`}
+              onClick={() =>
+                onBookmarkChanged?.(target, !target.isActorBookmarked)
+              }
+            >
+              bookmark
+            </button>
+          </div>
+        )
+      })}
     </div>
   )
 }))
@@ -104,6 +146,7 @@ const createStatus = (id: string, overrides: Partial<Status> = {}): Status => {
     replies: [],
     actorAnnounceStatusId: null,
     isActorLiked: false,
+    isActorBookmarked: false,
     totalLikes: 0,
     attachments: [],
     tags: [],
@@ -113,6 +156,13 @@ const createStatus = (id: string, overrides: Partial<Status> = {}): Status => {
 
 const createReplyStatus = (id: string): Status =>
   createStatus(id, { reply: 'https://remote.example/statuses/parent' })
+
+const createAnnounceStatus = (id: string, original: Status): Status =>
+  ({
+    ...createStatus(id),
+    type: StatusType.enum.Announce,
+    originalStatus: original
+  }) as Status
 
 const createFitnessStatus = (id: string): Status =>
   createStatus(id, {
@@ -513,5 +563,81 @@ describe('ActorTimelines', () => {
     expect(
       screen.queryByText('https://local.example/statuses/new-reply')
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps like state in sync across the feed when a post is liked', () => {
+    const postId = 'https://remote.example/statuses/likeable'
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus(postId)]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={currentActorProfile}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    expect(screen.getByTestId(`like-flag-${postId}`)).toHaveTextContent(
+      'false:0'
+    )
+
+    fireEvent.click(screen.getByTestId(`trigger-like-${postId}`))
+
+    expect(screen.getByTestId(`like-flag-${postId}`)).toHaveTextContent(
+      'true:1'
+    )
+  })
+
+  it('keeps bookmark state in sync across the feed when a post is bookmarked', () => {
+    const postId = 'https://remote.example/statuses/bookmarkable'
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://remote.example/users/actor"
+        statuses={[createStatus(postId)]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={currentActorProfile}
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    expect(screen.getByTestId(`bookmark-flag-${postId}`)).toHaveTextContent(
+      'false'
+    )
+
+    fireEvent.click(screen.getByTestId(`trigger-bookmark-${postId}`))
+
+    expect(screen.getByTestId(`bookmark-flag-${postId}`)).toHaveTextContent(
+      'true'
+    )
+  })
+
+  it('removes a boost of a post when that post is deleted', () => {
+    const originalId = 'https://local.example/statuses/original'
+    const boostId = 'https://local.example/statuses/boost'
+    const original = createStatus(originalId)
+    render(
+      <ActorTimelines
+        host="localhost:3000"
+        actorId="https://local.example/users/me"
+        statuses={[createAnnounceStatus(boostId, original), original]}
+        attachments={[]}
+        currentTime={FIXED_CURRENT_TIME}
+        currentActor={currentActorProfile}
+        isCurrentUser
+        statusPagination={{ nextPageUrl: null, prevPageUrl: null }}
+      />
+    )
+
+    expect(screen.getByText(boostId)).toBeInTheDocument()
+    expect(screen.getByText(originalId)).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByTestId(`trigger-delete-${originalId}`)[0])
+
+    expect(screen.queryByText(boostId)).not.toBeInTheDocument()
+    expect(screen.queryByText(originalId)).not.toBeInTheDocument()
   })
 })

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -331,10 +331,20 @@ export const ActorTimelines: FC<Props> = ({
         className="w-full gap-4"
       >
         <TabsList className="w-full sm:w-fit" aria-label="Profile sections">
-          <TabsTrigger value="posts">Posts</TabsTrigger>
-          <TabsTrigger value="replies">Replies</TabsTrigger>
-          <TabsTrigger value="media">Media</TabsTrigger>
-          {showFitnessTab && <TabsTrigger value="fitness">Fitness</TabsTrigger>}
+          <TabsTrigger value="posts" className="flex-1 sm:flex-none">
+            Posts
+          </TabsTrigger>
+          <TabsTrigger value="replies" className="flex-1 sm:flex-none">
+            Replies
+          </TabsTrigger>
+          <TabsTrigger value="media" className="flex-1 sm:flex-none">
+            Media
+          </TabsTrigger>
+          {showFitnessTab && (
+            <TabsTrigger value="fitness" className="flex-1 sm:flex-none">
+              Fitness
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="posts" className="mt-0">

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -16,7 +16,12 @@ import {
 import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  Status,
+  StatusNote,
+  StatusPoll,
+  StatusType
+} from '@/lib/types/domain/status'
 
 import { ActorMediaGallery } from './ActorMediaGallery'
 
@@ -66,6 +71,30 @@ const isReply = (status: Status) => {
 
 const hasFitnessFile = (status: Status) =>
   status.type === StatusType.enum.Note && Boolean(status.fitness)
+
+// Apply an interactive-state patch (like/bookmark toggle) to the status with
+// the given id, reaching inside a boost to patch its original status too, so
+// every rendered copy (Posts/Replies/Fitness tabs share `currentStatuses`)
+// stays consistent across tab switches and remounts.
+const updateMatchingStatus = (
+  statuses: Status[],
+  targetId: string,
+  patch: (target: StatusNote | StatusPoll) => StatusNote | StatusPoll
+): Status[] =>
+  statuses.map((item) => {
+    if (item.type === StatusType.enum.Announce) {
+      const original = item.originalStatus
+      // Boosts wrap a Note/Poll; nested boosts aren't an interactive target.
+      if (
+        original.type !== StatusType.enum.Announce &&
+        original.id === targetId
+      ) {
+        return { ...item, originalStatus: patch(original) }
+      }
+      return item
+    }
+    return item.id === targetId ? patch(item) : item
+  })
 
 const appendUniqueStatuses = (
   previousStatuses: Status[],
@@ -151,9 +180,43 @@ export const ActorTimelines: FC<Props> = ({
 
   const handlePostDeleted = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
-      previousStatuses.filter((item) => item.id !== status.id)
+      previousStatuses.filter(
+        (item) =>
+          item.id !== status.id &&
+          !(
+            item.type === StatusType.enum.Announce &&
+            item.originalStatus.id === status.id
+          )
+      )
     )
   }, [])
+
+  const handleLikeChanged = useCallback(
+    (status: StatusNote | StatusPoll, isLiked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorLiked: isLiked,
+          totalLikes: isLiked
+            ? target.totalLikes + 1
+            : Math.max(0, target.totalLikes - 1)
+        }))
+      )
+    },
+    []
+  )
+
+  const handleBookmarkChanged = useCallback(
+    (status: StatusNote | StatusPoll, isBookmarked: boolean) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          isActorBookmarked: isBookmarked
+        }))
+      )
+    },
+    []
+  )
 
   const loadMoreStatuses = useCallback(async () => {
     const nextPageUrl = currentStatusPagination.nextPageUrl
@@ -253,6 +316,8 @@ export const ActorTimelines: FC<Props> = ({
         postLineLimit={postLineLimit}
         onReplyCreated={handleReplyCreated}
         onPostDeleted={handlePostDeleted}
+        onLikeChanged={handleLikeChanged}
+        onBookmarkChanged={handleBookmarkChanged}
       />
     ) : (
       <EmptyState>{emptyMessage}</EmptyState>

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -374,7 +374,7 @@ export const ActorTimelines: FC<Props> = ({
               <div className="flex justify-end">
                 <Button variant="outline" asChild>
                   <Link href="/fitness">
-                    <Activity className="size-4" />
+                    <Activity className="size-4" aria-hidden="true" />
                     Fitness dashboard
                   </Link>
                 </Button>

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { Activity } from 'lucide-react'
+import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { getActorStatuses } from '@/lib/client'
@@ -12,6 +14,7 @@ import {
   TabsTrigger
 } from '@/lib/components/ui/tabs'
 import { PostLineLimit } from '@/lib/types/database/rows'
+import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusType } from '@/lib/types/domain/status'
 
@@ -28,10 +31,26 @@ interface Props {
     prevPageUrl: string | null
   }
   postLineLimit?: PostLineLimit
+  /**
+   * The signed-in viewer's profile. When present the feed renders interactive
+   * post actions (reply/boost/like/bookmark); when absent (logged-out) it
+   * falls back to read-only engagement counts.
+   */
+  currentActor?: ActorProfile
+  /** True when the signed-in viewer is looking at their own profile. */
+  isCurrentUser?: boolean
+  /**
+   * Whether this actor has any fitness activities. Drives whether the Fitness
+   * tab is offered at all (it lists the actor's public fitness posts).
+   */
+  hasFitnessData?: boolean
+  isMediaUploadEnabled?: boolean
 }
 
 const LOAD_MORE_PAGE_LIMIT = 5
 const LOAD_MORE_ERROR_MESSAGE = 'Failed to load more posts. Please try again.'
+
+type ProfileTab = 'posts' | 'replies' | 'media' | 'fitness'
 
 const isReply = (status: Status) => {
   switch (status.type) {
@@ -44,6 +63,9 @@ const isReply = (status: Status) => {
       return false
   }
 }
+
+const hasFitnessFile = (status: Status) =>
+  status.type === StatusType.enum.Note && Boolean(status.fitness)
 
 const appendUniqueStatuses = (
   previousStatuses: Status[],
@@ -60,6 +82,10 @@ const appendUniqueStatuses = (
   ]
 }
 
+const EmptyState: FC<{ children: string }> = ({ children }) => (
+  <p className="py-10 text-center text-sm text-muted-foreground">{children}</p>
+)
+
 export const ActorTimelines: FC<Props> = ({
   host,
   actorId,
@@ -67,8 +93,13 @@ export const ActorTimelines: FC<Props> = ({
   statuses,
   attachments,
   statusPagination,
-  postLineLimit
+  postLineLimit,
+  currentActor,
+  isCurrentUser = false,
+  hasFitnessData = false,
+  isMediaUploadEnabled
 }) => {
+  const [activeTab, setActiveTab] = useState<ProfileTab>('posts')
   const [currentStatuses, setCurrentStatuses] = useState<Status[]>(statuses)
   const [currentStatusPagination, setCurrentStatusPagination] = useState({
     nextPageUrl: statusPagination?.nextPageUrl ?? null,
@@ -80,10 +111,39 @@ export const ActorTimelines: FC<Props> = ({
   const loadMoreRef = useRef<HTMLDivElement>(null)
   const isLoadingRef = useRef<boolean>(false)
 
+  const showActions = Boolean(currentActor)
+  const showFitnessTab = Boolean(hasFitnessData)
+
   const postStatuses = useMemo(
     () => currentStatuses.filter((status) => !isReply(status)),
     [currentStatuses]
   )
+  const replyStatuses = useMemo(
+    () => currentStatuses.filter((status) => isReply(status)),
+    [currentStatuses]
+  )
+  const fitnessStatuses = useMemo(
+    () => currentStatuses.filter((status) => hasFitnessFile(status)),
+    [currentStatuses]
+  )
+
+  // The outbox cursor only feeds the post/reply feeds, so the standalone load
+  // more control is hidden on the media and fitness tabs.
+  const canLoadMore =
+    Boolean(currentStatusPagination.nextPageUrl) &&
+    (activeTab === 'posts' || activeTab === 'replies')
+
+  const handleReplyCreated = useCallback(() => {
+    // A reply created from this profile's inline composer is the viewer's own
+    // status; it doesn't belong in the viewed actor's feed, so nothing is
+    // inserted here. The composer closes itself after posting.
+  }, [])
+
+  const handlePostDeleted = useCallback((status: Status) => {
+    setCurrentStatuses((previousStatuses) =>
+      previousStatuses.filter((item) => item.id !== status.id)
+    )
+  }, [])
 
   const loadMoreStatuses = useCallback(async () => {
     const nextPageUrl = currentStatusPagination.nextPageUrl
@@ -168,78 +228,80 @@ export const ActorTimelines: FC<Props> = ({
     return () => {
       observer.disconnect()
     }
-  }, [loadMoreStatuses])
+  }, [loadMoreStatuses, canLoadMore])
+
+  const renderFeed = (feedStatuses: Status[], emptyMessage: string) =>
+    feedStatuses.length > 0 ? (
+      <Posts
+        host={host}
+        currentTime={currentTime}
+        statuses={feedStatuses}
+        currentActor={currentActor}
+        showActions={showActions}
+        showReadOnlyStats={!showActions}
+        isMediaUploadEnabled={isMediaUploadEnabled}
+        postLineLimit={postLineLimit}
+        onReplyCreated={handleReplyCreated}
+        onPostDeleted={handlePostDeleted}
+      />
+    ) : (
+      <EmptyState>{emptyMessage}</EmptyState>
+    )
 
   return (
-    <Tabs defaultValue="posts" className="w-full">
-      <TabsList className="grid w-full grid-cols-3 rounded-none border-b bg-muted/40 p-1">
-        <TabsTrigger
-          value="posts"
-          className="rounded-md data-[state=active]:bg-background data-[state=active]:shadow-sm"
-        >
-          Posts
-        </TabsTrigger>
-        <TabsTrigger
-          value="replies"
-          className="rounded-md data-[state=active]:bg-background data-[state=active]:shadow-sm"
-        >
-          Posts & Replies
-        </TabsTrigger>
-        <TabsTrigger
-          value="media"
-          className="rounded-md data-[state=active]:bg-background data-[state=active]:shadow-sm"
-        >
-          Media
-        </TabsTrigger>
-      </TabsList>
+    <div className="space-y-4">
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as ProfileTab)}
+        className="w-full gap-4"
+      >
+        <TabsList className="w-full sm:w-fit">
+          <TabsTrigger value="posts">Posts</TabsTrigger>
+          <TabsTrigger value="replies">Replies</TabsTrigger>
+          <TabsTrigger value="media">Media</TabsTrigger>
+          {showFitnessTab && <TabsTrigger value="fitness">Fitness</TabsTrigger>}
+        </TabsList>
 
-      {/*
-        framed={false} on the feeds below is intentional: this whole tabbed
-        component is already wrapped in the bordered card in
-        app/(timeline)/[actor]/page.tsx (the `border-b` tab strip is its
-        header). A framed Posts box here would nest a bordered card inside that
-        card and produce a concentric double border. Do not change to framed.
-      */}
-      <TabsContent value="posts" className="mt-0">
-        {postStatuses.length > 0 ? (
-          <Posts
-            host={host}
-            framed={false}
-            currentTime={currentTime}
-            statuses={postStatuses}
-            postLineLimit={postLineLimit}
-          />
-        ) : (
-          <p className="p-8 text-center text-muted-foreground">No posts yet</p>
+        <TabsContent value="posts" className="mt-0">
+          {renderFeed(postStatuses, 'No posts yet')}
+        </TabsContent>
+
+        <TabsContent value="replies" className="mt-0">
+          {renderFeed(replyStatuses, 'No replies yet')}
+        </TabsContent>
+
+        <TabsContent value="media" className="mt-0">
+          {attachments.length > 0 ? (
+            <div className="rounded-xl border bg-card p-2 shadow-sm sm:p-4">
+              <ActorMediaGallery
+                actorId={actorId}
+                initialAttachments={attachments}
+              />
+            </div>
+          ) : (
+            <EmptyState>No media yet</EmptyState>
+          )}
+        </TabsContent>
+
+        {showFitnessTab && (
+          <TabsContent value="fitness" className="mt-0 space-y-4">
+            {isCurrentUser && (
+              <div className="flex justify-end">
+                <Button variant="outline" asChild>
+                  <Link href="/fitness">
+                    <Activity className="size-4" />
+                    Fitness dashboard
+                  </Link>
+                </Button>
+              </div>
+            )}
+            {renderFeed(fitnessStatuses, 'No fitness activities yet')}
+          </TabsContent>
         )}
-      </TabsContent>
+      </Tabs>
 
-      <TabsContent value="replies" className="mt-0">
-        <Posts
-          host={host}
-          framed={false}
-          currentTime={currentTime}
-          statuses={currentStatuses}
-          postLineLimit={postLineLimit}
-        />
-      </TabsContent>
-
-      <TabsContent value="media" className="mt-0">
-        {attachments.length > 0 ? (
-          <div className="p-2 sm:p-4">
-            <ActorMediaGallery
-              actorId={actorId}
-              initialAttachments={attachments}
-            />
-          </div>
-        ) : (
-          <p className="p-8 text-center text-muted-foreground">
-            No media posts yet
-          </p>
-        )}
-      </TabsContent>
-      {currentStatusPagination.nextPageUrl && (
-        <div ref={loadMoreRef} className="border-t p-4 text-center">
+      {canLoadMore && (
+        <div ref={loadMoreRef} className="text-center">
           {loadMoreError && (
             <p className="mb-3 text-sm text-destructive" role="alert">
               {loadMoreError}
@@ -254,6 +316,6 @@ export const ActorTimelines: FC<Props> = ({
           </Button>
         </div>
       )}
-    </Tabs>
+    </div>
   )
 }

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -127,17 +127,27 @@ export const ActorTimelines: FC<Props> = ({
     [currentStatuses]
   )
 
-  // The outbox cursor only feeds the post/reply feeds, so the standalone load
-  // more control is hidden on the media and fitness tabs.
+  // The outbox cursor feeds the post/reply/fitness feeds (all derived from the
+  // loaded status list), so the standalone load more control is offered on
+  // those tabs. The media tab paginates separately via its own gallery loader.
   const canLoadMore =
     Boolean(currentStatusPagination.nextPageUrl) &&
-    (activeTab === 'posts' || activeTab === 'replies')
+    (activeTab === 'posts' ||
+      activeTab === 'replies' ||
+      activeTab === 'fitness')
 
-  const handleReplyCreated = useCallback(() => {
-    // A reply created from this profile's inline composer is the viewer's own
-    // status; it doesn't belong in the viewed actor's feed, so nothing is
-    // inserted here. The composer closes itself after posting.
-  }, [])
+  const handleReplyCreated = useCallback(
+    (status: Status) => {
+      // A reply to another actor's post is the viewer's own status and does not
+      // belong in that actor's feed. On the viewer's own profile, though, the
+      // new reply is theirs — surface it right away (it lands under the Replies
+      // tab) instead of waiting for a reload.
+      if (isCurrentUser) {
+        setCurrentStatuses((previousStatuses) => [status, ...previousStatuses])
+      }
+    },
+    [isCurrentUser]
+  )
 
   const handlePostDeleted = useCallback((status: Status) => {
     setCurrentStatuses((previousStatuses) =>
@@ -255,7 +265,7 @@ export const ActorTimelines: FC<Props> = ({
         onValueChange={(value) => setActiveTab(value as ProfileTab)}
         className="w-full gap-4"
       >
-        <TabsList className="w-full sm:w-fit">
+        <TabsList className="w-full sm:w-fit" aria-label="Profile sections">
           <TabsTrigger value="posts">Posts</TabsTrigger>
           <TabsTrigger value="replies">Replies</TabsTrigger>
           <TabsTrigger value="media">Media</TabsTrigger>

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -12,6 +12,7 @@ import { getDatabase } from '@/lib/database'
 import { getRelationship } from '@/lib/services/accounts/relationship'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
+import { getActorProfile } from '@/lib/types/domain/actor'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { ActorTimelines } from './ActorTimelines'
@@ -43,7 +44,7 @@ export const generateMetadata = async ({
 }
 
 const Page: FC<Props> = async ({ params }) => {
-  const { host } = getConfig()
+  const { host, mediaStorage } = getConfig()
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
 
@@ -80,7 +81,8 @@ const Page: FC<Props> = async ({ params }) => {
     statusesCount,
     statusPagination,
     followingCount,
-    followersCount
+    followersCount,
+    hasFitnessData
   } = actorProfile
 
   const isCurrentUser = currentActor?.id === person.id
@@ -199,18 +201,20 @@ const Page: FC<Props> = async ({ params }) => {
         </div>
       </section>
 
-      <section className="overflow-hidden rounded-2xl border bg-background/80 shadow-sm">
-        <ActorTimelines
-          key={person.id}
-          host={host}
-          actorId={person.id}
-          currentTime={Date.now()}
-          statuses={statuses}
-          attachments={attachments}
-          statusPagination={statusPagination}
-          postLineLimit={actorSettings?.postLineLimit}
-        />
-      </section>
+      <ActorTimelines
+        key={person.id}
+        host={host}
+        actorId={person.id}
+        currentTime={Date.now()}
+        statuses={statuses}
+        attachments={attachments}
+        statusPagination={statusPagination}
+        postLineLimit={actorSettings?.postLineLimit}
+        currentActor={currentActor ? getActorProfile(currentActor) : undefined}
+        isCurrentUser={isCurrentUser}
+        hasFitnessData={hasFitnessData}
+        isMediaUploadEnabled={Boolean(mediaStorage)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The logged-in user profile page (`/@user@domain`) had drifted from the web UI kit design (`ui_kits/web` in the Activities.next Design System). This brings it back in line with the design when you click through to a user handle.

Three gaps were called out and addressed:

1. **Tabs looked different.** The old tab strip was a full-width 3-column `border-b` bar fused to the top of the feed card (`Posts` / `Posts & Replies` / `Media`). The design uses a **standalone segmented control** sitting above the feed. Now: shadcn `TabsList` styling — full-width on mobile, `w-fit` on desktop — with the feed rendered as its own framed card below it.
2. **Timeline looked different & had no actions.** The profile feed rendered posts via `<Posts framed={false}>` without `currentActor`/`showActions`, so there were no reply/boost/like/bookmark controls. Now the signed-in `currentActor` is plumbed through `ActorTimelines → Posts` with `showActions`, matching the main timeline. Logged-out visitors fall back to read-only engagement counts (`showReadOnlyStats`). `onPostDeleted`, `onLikeChanged`, `onBookmarkChanged`, and the inline reply composer are wired in.
3. **Tab set.** Renamed `Posts & Replies` → **Replies** (now replies-only; `Posts` stays non-replies) and added the design's 4th **Fitness** tab, each with an empty state.

## Screenshots

New logged-in profile — standalone segmented tabs (Posts · Replies · Media · Fitness) above a framed feed, with the full action row (reply / boost / like / bookmark / more) on every post:

![New profile page — segmented tabs and per-post action row](https://raw.githubusercontent.com/llun/activities.next/assets/pr-1109-screenshots/profile-new-design-full.png)

<details>
<summary>Header + tabs close-up</summary>

![Profile header and segmented tab control](https://raw.githubusercontent.com/llun/activities.next/assets/pr-1109-screenshots/profile-header-tabs.png)

</details>

> Captured locally against a SQLite mock user. The Fitness tab is correctly hidden here because this actor has no fitness data, and Like is disabled on your own posts (existing behavior). Screenshots are hosted on the separate `assets/pr-1109-screenshots` branch so they stay out of the PR diff and `main`.

## Fitness tab decision

The design's Fitness tab shows a heatmap. In the real app a route heatmap is **private** — only the owner sees `/fitness`, and sharing is opt-in via a token at `/u/heatmaps/[token]` — so embedding another actor's heatmap on a public profile would leak private data. Instead the Fitness tab lists the actor's **public fitness posts** (statuses with a fitness file) using the existing `Posts` feed, and the owner additionally gets a link to their `/fitness` dashboard. The tab is gated on the previously-computed-but-unused `hasFitnessData` flag from `getProfileData`.

## Other

- **Cross-tab state consistency.** Because the feed is tabbed (and a fitness post renders under both Posts and Fitness), like/bookmark toggles are written back to the shared status list via a shared, boost-aware `updateMatchingStatus` helper so they survive tab switches/remounts. Deleting a post also removes any boost of it from the feed.
- The standalone **"Load more"** control is offered on the Posts / Replies / Fitness tabs (all derived from the status cursor); Media paginates via its own gallery loader.

## Testing

- `yarn lint` — clean (0 errors)
- `yarn build` — passes
- `yarn test` — 4991 passed; `ActorTimelines.test.tsx` extended (actions wiring, read-only stats, replies/posts split, Fitness-tab gating & filtering, own-profile reply surfacing, like/bookmark sync, boost-removal-on-delete)
- Browser-verified locally (SQLite + mock user): segmented tabs, post action row, Replies "No replies yet", Fitness tab correctly omitted for an actor with no fitness data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
