### PR TITLE
Bump version to v1.90.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.90.0",
+  "version": "1.90.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.90.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.90.0`
- Base main SHA: `0bf7af266e60cd3e87f58ab3ca8d143190842977`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
