### PR TITLE
Bump version to v1.91.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.90.1",
+  "version": "1.91.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.91.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.90.1`
- Base main SHA: `3003ddeacef1f05831753b01cd0e1c223c44ded4`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
