### PR TITLE
Bump version to v1.92.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.92.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.91.0`
- Base main SHA: `1e3f676f9bff3c96099198fd6139d7f826e4dc47`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
