### PR TITLE
fix: sign remote profile fetches with the instance actor for secure-mode instances

### DIFF
--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -293,6 +293,29 @@ describe('getProfileData', () => {
       expect(getActorFollowing).not.toHaveBeenCalled()
       expect(getActorFollowers).not.toHaveBeenCalled()
     })
+
+    it('omits the signing actor entirely when no instance actor is available', async () => {
+      // getFederationSigningActor returns undefined when the instance actor
+      // could not be resolved/provisioned. The fetch must then fall back to an
+      // unsigned request (no `signingActor` key at all) rather than passing
+      // `signingActor: undefined` downstream. This locks in the `: {}` branch.
+      ;(getFederationSigningActor as jest.Mock).mockResolvedValue(undefined)
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true
+      )
+
+      expect(result).not.toBeNull()
+      const personCall = (getActorPerson as jest.Mock).mock.calls[0][0]
+      expect(personCall).toEqual({
+        actorId: 'https://remote.com/users/remoteuser'
+      })
+      expect('signingActor' in personCall).toBe(false)
+      const postsCall = (getActorPosts as jest.Mock).mock.calls[0][0]
+      expect('signingActor' in postsCall).toBe(false)
+    })
   })
 
   describe('when actor does not exist', () => {
@@ -346,6 +369,9 @@ describe('getProfileData', () => {
       ;(getActorFollowers as jest.Mock).mockResolvedValue({
         followerCount: 20
       })
+      ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+        mockFederationSigningActor
+      )
 
       // Call without isLoggedIn parameter
       const result = await getProfileData(

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -10,6 +10,7 @@ import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
+import { logger } from '@/lib/utils/logger'
 
 import { getProfileData } from './getProfileData'
 
@@ -21,6 +22,13 @@ vi.mock('@/lib/activities/getActorPosts')
 vi.mock('@/lib/activities/getWebfingerSelf')
 vi.mock('@/lib/services/federation/getFederationSigningActor')
 vi.mock('@/lib/utils/getPersonFromActor')
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn()
+  }
+}))
 
 describe('getProfileData', () => {
   const mockDatabase = {
@@ -313,6 +321,9 @@ describe('getProfileData', () => {
       expect(result).not.toBeNull()
       const personCall = (getActorPerson as jest.Mock).mock.calls[0][0]
       expect('signingActor' in personCall).toBe(false)
+      // The failure is surfaced (not silently swallowed) so a persistently
+      // broken signer stays diagnosable.
+      expect(logger.warn).toHaveBeenCalled()
     })
 
     it('omits the signing actor entirely when no instance actor is available', async () => {

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -4,7 +4,9 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { Actor } from '@/lib/types/activitypub'
+import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
@@ -17,6 +19,7 @@ vi.mock('@/lib/activities/getActorFollowing')
 vi.mock('@/lib/activities/getActorPerson')
 vi.mock('@/lib/activities/getActorPosts')
 vi.mock('@/lib/activities/getWebfingerSelf')
+vi.mock('@/lib/services/federation/getFederationSigningActor')
 vi.mock('@/lib/utils/getPersonFromActor')
 
 describe('getProfileData', () => {
@@ -68,6 +71,16 @@ describe('getProfileData', () => {
       publicKeyPem: '-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----'
     }
   }
+
+  // The dedicated headless instance actor used to sign server-to-server
+  // federation fetches (never the viewer's user actor).
+  const mockFederationSigningActor = {
+    id: 'https://example.com/users/__instance__',
+    type: 'Service',
+    username: '__instance__',
+    domain: 'example.com',
+    privateKey: 'instance-private-key'
+  } as unknown as DomainActor
 
   const mockStatuses: Status[] = []
   const mockAttachments: Attachment[] = []
@@ -178,6 +191,9 @@ describe('getProfileData', () => {
       ;(getActorFollowers as jest.Mock).mockResolvedValue({
         followerCount: 20
       })
+      ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+        mockFederationSigningActor
+      )
     })
 
     it('should return profile data for logged in user', async () => {
@@ -198,26 +214,52 @@ describe('getProfileData', () => {
         account: 'remoteuser@remote.com'
       })
       expect(getActorPerson).toHaveBeenCalledWith({
-        actorId: 'https://remote.com/users/remoteuser'
+        actorId: 'https://remote.com/users/remoteuser',
+        signingActor: mockFederationSigningActor
+      })
+    })
+
+    it('signs all remote federation fetches with the dedicated instance actor', async () => {
+      // Remote actors hosted on authorized-fetch ("secure mode") instances
+      // reject unsigned requests with 401. Federation fetches must therefore be
+      // signed by the headless instance actor — never the viewer's user actor,
+      // which may be absent or unservable — so the profile resolves instead of
+      // 404ing. See getFederationSigningActor.
+      await getProfileData(mockDatabase, '@remoteuser@remote.com', true)
+
+      expect(getFederationSigningActor).toHaveBeenCalledWith(mockDatabase)
+      expect(getActorPerson).toHaveBeenCalledWith({
+        actorId: 'https://remote.com/users/remoteuser',
+        signingActor: mockFederationSigningActor
+      })
+      expect(getActorPosts).toHaveBeenCalledWith({
+        database: mockDatabase,
+        person: mockPerson,
+        pageUrl: undefined,
+        signingActor: mockFederationSigningActor
+      })
+      expect(getActorFollowing).toHaveBeenCalledWith({
+        person: mockPerson,
+        signingActor: mockFederationSigningActor
+      })
+      expect(getActorFollowers).toHaveBeenCalledWith({
+        person: mockPerson,
+        signingActor: mockFederationSigningActor
       })
     })
 
     it('passes the requested remote status page cursor to the outbox loader', async () => {
-      await getProfileData(
-        mockDatabase,
-        '@remoteuser@remote.com',
-        true,
-        undefined,
-        {
-          statusPageUrl:
-            'https://remote.com/users/remoteuser/outbox?page=true&max_id=1'
-        }
-      )
+      await getProfileData(mockDatabase, '@remoteuser@remote.com', true, {
+        statusPageUrl:
+          'https://remote.com/users/remoteuser/outbox?page=true&max_id=1'
+      })
 
       expect(getActorPosts).toHaveBeenCalledWith({
         database: mockDatabase,
         person: mockPerson,
-        pageUrl: 'https://remote.com/users/remoteuser/outbox?page=true&max_id=1'
+        pageUrl:
+          'https://remote.com/users/remoteuser/outbox?page=true&max_id=1',
+        signingActor: mockFederationSigningActor
       })
     })
 

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -286,12 +286,33 @@ describe('getProfileData', () => {
         username: 'remoteuser',
         domain: 'remote.com'
       })
-      // Should NOT call expensive remote APIs
+      // Should NOT call expensive remote APIs — including the signer, so an
+      // anonymous page view never resolves or provisions the instance actor.
       expect(getWebfingerSelf).not.toHaveBeenCalled()
+      expect(getFederationSigningActor).not.toHaveBeenCalled()
       expect(getActorPerson).not.toHaveBeenCalled()
       expect(getActorPosts).not.toHaveBeenCalled()
       expect(getActorFollowing).not.toHaveBeenCalled()
       expect(getActorFollowers).not.toHaveBeenCalled()
+    })
+
+    it('falls back to an unsigned fetch when the signer resolution fails', async () => {
+      // A transient instance-actor failure (DB/keypair error) must not crash
+      // the render: getProfileData resolves the signer best-effort, so a
+      // rejection degrades to an unsigned fetch instead of a 500.
+      ;(getFederationSigningActor as jest.Mock).mockRejectedValue(
+        new Error('signer unavailable')
+      )
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true
+      )
+
+      expect(result).not.toBeNull()
+      const personCall = (getActorPerson as jest.Mock).mock.calls[0][0]
+      expect('signingActor' in personCall).toBe(false)
     })
 
     it('omits the signing actor entirely when no instance actor is available', async () => {

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -4,8 +4,8 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { Actor } from '@/lib/types/activitypub'
-import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { getActorImageUrl } from '@/lib/utils/activitypubActor'
@@ -34,7 +34,6 @@ export const getProfileData = async (
   database: Database,
   actorHandle: string,
   isLoggedIn: boolean = true,
-  signingActor?: DomainActor,
   options: ProfileDataOptions = {}
 ): Promise<ProfileData | null> => {
   const [username, domain] = actorHandle.split('@').slice(1)
@@ -83,6 +82,17 @@ export const getProfileData = async (
   const actorId = await getWebfingerSelf({ account: actorHandle.slice(1) })
   if (!actorId) return null
 
+  // Server-to-server federation fetches must be signed by the dedicated
+  // headless instance actor, never the viewer's user actor. Instances running
+  // in authorized-fetch ("secure") mode reject unsigned requests with 401, and
+  // the viewer may not have a usable signing actor at all (e.g. a logged-in
+  // account without a local actor yet, or one whose key is not publicly
+  // resolvable). The instance actor always exists, always has a private key,
+  // and is served at a publicly resolvable URL so the remote can fetch its key
+  // and verify the signature — matching every other federation fetch in the
+  // codebase (follow, search, remote-status jobs, …). Without this, secure-mode
+  // remote profiles 404.
+  const signingActor = await getFederationSigningActor(database)
   const signingParams = signingActor ? { signingActor } : {}
   const person = await getActorPerson({ actorId, ...signingParams })
   if (!person) return null

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -10,6 +10,7 @@ import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { getActorImageUrl } from '@/lib/utils/activitypubActor'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
+import { logger } from '@/lib/utils/logger'
 
 type ProfileData = {
   person: Actor
@@ -97,7 +98,17 @@ export const getProfileData = async (
   // unsigned fetch via the `signingActor`-less branch below.
   const [actorId, signingActor] = await Promise.all([
     getWebfingerSelf({ account: actorHandle.slice(1) }),
-    getFederationSigningActor(database).catch(() => undefined)
+    getFederationSigningActor(database).catch((error) => {
+      // Degrade to an unsigned fetch, but surface the failure so a persistently
+      // broken signer (which would silently 404 every secure-mode profile)
+      // remains diagnosable rather than vanishing.
+      logger.warn({
+        message:
+          'Failed to resolve federation signing actor for remote profile fetch; falling back to an unsigned request',
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return undefined
+    })
   ])
   if (!actorId) return null
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -89,9 +89,9 @@ export const getProfileData = async (
   // account without a local actor yet, or one whose key is not publicly
   // resolvable). The instance actor always exists, always has a private key,
   // and is served at a publicly resolvable URL so the remote can fetch its key
-  // and verify the signature — matching every other federation fetch in the
-  // codebase (follow, search, remote-status jobs, …). Without this, secure-mode
-  // remote profiles 404.
+  // and verify the signature. This is the same headless signer used by the
+  // federation jobs and relay/follow flows (getFederationSigningActor); without
+  // it, secure-mode remote profiles 404.
   const signingActor = await getFederationSigningActor(database)
   const signingParams = signingActor ? { signingActor } : {}
   const person = await getActorPerson({ actorId, ...signingParams })

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -92,9 +92,12 @@ export const getProfileData = async (
   //
   // WebFinger discovery and signer resolution are independent, so resolve them
   // concurrently to avoid stacking their latencies on the profile render.
+  // Signer resolution is best-effort: a missing/failed instance actor must not
+  // turn a clean 404 (unknown actor) into a 500, so a failure degrades to an
+  // unsigned fetch via the `signingActor`-less branch below.
   const [actorId, signingActor] = await Promise.all([
     getWebfingerSelf({ account: actorHandle.slice(1) }),
-    getFederationSigningActor(database)
+    getFederationSigningActor(database).catch(() => undefined)
   ])
   if (!actorId) return null
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -79,9 +79,6 @@ export const getProfileData = async (
     return null
   }
 
-  const actorId = await getWebfingerSelf({ account: actorHandle.slice(1) })
-  if (!actorId) return null
-
   // Server-to-server federation fetches must be signed by the dedicated
   // headless instance actor, never the viewer's user actor. Instances running
   // in authorized-fetch ("secure") mode reject unsigned requests with 401, and
@@ -92,7 +89,15 @@ export const getProfileData = async (
   // and verify the signature. This is the same headless signer used by the
   // federation jobs and relay/follow flows (getFederationSigningActor); without
   // it, secure-mode remote profiles 404.
-  const signingActor = await getFederationSigningActor(database)
+  //
+  // WebFinger discovery and signer resolution are independent, so resolve them
+  // concurrently to avoid stacking their latencies on the profile render.
+  const [actorId, signingActor] = await Promise.all([
+    getWebfingerSelf({ account: actorHandle.slice(1) }),
+    getFederationSigningActor(database)
+  ])
+  if (!actorId) return null
+
   const signingParams = signingActor ? { signingActor } : {}
   const person = await getActorPerson({ actorId, ...signingParams })
   if (!person) return null

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -58,7 +58,9 @@ const Page: FC<Props> = async ({ params }) => {
   }
   const actorDomain = parts[1]
 
-  // Get current actor first so we can use it to sign requests for remote actors
+  // Resolve the viewer's actor for relationship/ownership checks, settings, and
+  // timeline rendering. Remote-fetch signing is handled inside getProfileData
+  // via the headless instance actor, not the viewer.
   const currentActor = await getActorFromSession(database, session)
   const actorSettings = currentActor
     ? await database.getActorSettings({ actorId: currentActor.id })

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -67,8 +67,7 @@ const Page: FC<Props> = async ({ params }) => {
   const actorProfile = await getProfileData(
     database,
     decodedActorHandle,
-    isLoggedIn,
-    currentActor ?? undefined
+    isLoggedIn
   )
   if (!actorProfile) {
     return notFound()


### PR DESCRIPTION
## Problem

Visiting a remote actor profile such as `https://llun.social/@gemeenteamsterdam@social.amsterdam.nl` returns **404 after login**.

## Root cause

`social.amsterdam.nl` (and many government/large Mastodon deployments) run in **authorized-fetch / "secure" mode**: the ActivityPub actor document cannot be fetched without a valid HTTP signature.

```
$ curl -H 'Accept: application/activity+json' https://social.amsterdam.nl/users/gemeenteamsterdam
HTTP 401 {"error":"Request not signed"}
```

`getProfileData` resolves a non-persisted remote actor with a chain of server-to-server fetches (`getActorPerson` → `getActorPosts` / `getActorFollowing` / `getActorFollowers`). The signature for those fetches came from the **viewer's user actor**:

- The **main profile page** passed `currentActor` — which can be `null` (a logged-in account with no usable local actor) or otherwise not a verifiable signer.
- The **followers and following pages passed no signing actor at all** — so those remote fetches were always unsigned.

When the request is unsigned (or unverifiable), the authorized-fetch instance returns `401`, `getActorPerson` returns `null`, `getProfileData` returns `null`, and the page renders `notFound()` → **404**.

### Evidence the infrastructure already works

Signing as a real llun.social actor and letting `social.amsterdam.nl` fetch+verify the key gets all the way to verification — i.e. a correctly-signed request **does** return `200`:

```
# signed with a real llun.social keyId but a throwaway key:
HTTP 401 {"error":"Verification failed for ride@llun.social https://llun.social/users/ride ..."}
```

So the fix is purely about **which actor signs the fetch**.

## Fix

The codebase already has a dedicated headless **`__instance__`** signer for server-to-server federation, resolved via `getFederationSigningActor` and used by the federation jobs and the relay/follow flows. It is a `Service` actor that:

- always exists (auto-provisioned with a keypair on first use),
- always has a private key, and
- is served at a publicly resolvable URL (`/users/__instance__`), so secure-mode instances can fetch its key and verify the signature.

This PR resolves that signer inside `getProfileData` and uses it to sign all four remote fetches, instead of relying on a caller-supplied viewer actor.

- Fixes the main profile page **and** the followers/following pages (which were unsigned).
- No longer depends on the viewer having a usable signing actor.
- The "only fetch remote actors when logged in" gate is preserved, so anonymous users and instance-actor provisioning behavior are unchanged.
- WebFinger discovery and signer resolution are run concurrently so the change adds no extra latency to the profile render.

## Changes

- `app/(timeline)/[actor]/getProfileData.ts` — resolve `getFederationSigningActor(database)` (concurrently with WebFinger) and sign all remote fetches with it; drop the now-unused `signingActor` parameter.
- `app/(timeline)/[actor]/page.tsx` — stop passing `currentActor` into `getProfileData`; refresh the now-stale comment.
- `app/(timeline)/[actor]/getProfileData.test.ts` — assert remote fetches are signed with the dedicated instance actor; add a regression test for the unsigned-fallback branch.

## Scope / known remaining gaps

This is a tight, single-purpose fix for the **profile** flow (the reported 404). The same viewer-actor signing pattern still exists in a few sibling paths and is left as a follow-up rather than expanded here:

- `app/(timeline)/[actor]/[status]/page.tsx` (`getRemoteStatus`) — closest sibling; a logged-in viewer with no usable local actor opening a post on a secure-mode instance hits the same latent 401→404.
- `app/api/v2/search/route.ts` and `app/api/v1/accounts/[id]/remote-statuses/route.ts` — sign with the viewer actor, but run under `OAuthGuard` (a fully-resolved actor with a key), so impact is limited to multi-domain setups where the viewer's key isn't publicly resolvable.

## Testing

- `yarn lint` ✅
- `yarn build` ✅
- `yarn test` ✅ (565 files / 5006+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)