### PR TITLE
fix: sign remote status fetches with the instance actor for secure-mode instances

### DIFF
--- a/app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.remote-signing.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+
+import { getRemoteStatus } from '@/lib/activities/getRemoteStatus'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { getQueue } from '@/lib/services/queue'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { logger } from '@/lib/utils/logger'
+
+import Page from './page'
+import { resolveStatusFromPath } from './resolveStatusFromPath'
+
+vi.mock('next/navigation', async () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  })
+}))
+
+vi.mock('@/lib/config', async () => ({
+  getConfig: vi.fn(() => ({
+    host: 'activities.local',
+    fitnessStorage: undefined,
+    mediaStorage: undefined,
+    registrationOpen: false
+  }))
+}))
+
+const mockGetStatus = vi.fn()
+const mockGetStatusReplies = vi.fn()
+
+vi.mock('@/lib/database', async () => ({
+  getDatabase: vi.fn(() => ({
+    getStatus: mockGetStatus,
+    getStatusReplies: mockGetStatusReplies
+  }))
+}))
+
+vi.mock('@/lib/activities/getRemoteStatus', async () => ({
+  getRemoteStatus: vi.fn()
+}))
+
+vi.mock('@/lib/services/federation/getFederationSigningActor', async () => ({
+  getFederationSigningActor: vi.fn()
+}))
+
+vi.mock('@/lib/services/auth/getSession', async () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/queue', async () => ({
+  getQueue: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', async () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/mapbox', async () => ({
+  getPublicMapboxAccessToken: vi.fn(() => undefined)
+}))
+
+vi.mock('@/lib/utils/logger', async () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+vi.mock('./resolveStatusFromPath', async () => ({
+  ...(await vi.importActual('./resolveStatusFromPath')),
+  resolveStatusFromPath: vi.fn()
+}))
+
+vi.mock('./Header', async () => ({ Header: () => null }))
+vi.mock('./RemoteStatusLoading', async () => ({
+  RemoteStatusLoading: () => null
+}))
+vi.mock('./SignInCallout', async () => ({ SignInCallout: () => null }))
+vi.mock('./StatusStatStrip', async () => ({ StatusStatStrip: () => null }))
+vi.mock('./StatusBox', async () => ({ StatusBox: () => null }))
+
+const mockResolveStatusFromPath = vi.mocked(resolveStatusFromPath)
+const mockGetRemoteStatus = vi.mocked(getRemoteStatus)
+const mockGetFederationSigningActor = vi.mocked(getFederationSigningActor)
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+const mockGetQueue = vi.mocked(getQueue)
+
+const REMOTE_STATUS_URL =
+  'https://social.amsterdam.nl/users/gemeenteamsterdam/statuses/123'
+
+// The dedicated headless instance actor used to sign server-to-server
+// federation fetches — never the viewer's user actor.
+const instanceActor = {
+  id: 'https://activities.local/users/__instance__',
+  type: 'Service',
+  username: '__instance__',
+  domain: 'activities.local',
+  privateKey: 'instance-private-key'
+} as unknown as Actor
+
+// A logged-in viewer that resolves to a usable local actor. It must NOT be the
+// signer for federation fetches even when present.
+const buildViewer = (): Actor =>
+  ({
+    id: 'https://activities.local/users/viewer',
+    type: 'Person',
+    username: 'viewer',
+    domain: 'activities.local',
+    followersUrl: 'https://activities.local/users/viewer/followers',
+    inboxUrl: 'https://activities.local/users/viewer/inbox',
+    sharedInboxUrl: 'https://activities.local/inbox',
+    publicKey: 'public-key',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1,
+    updatedAt: 1
+  }) as unknown as Actor
+
+const buildRemoteNote = (): Status =>
+  ({
+    id: REMOTE_STATUS_URL,
+    type: 'Note',
+    actorId: 'https://social.amsterdam.nl/users/gemeenteamsterdam',
+    actor: null,
+    url: REMOTE_STATUS_URL,
+    text: 'body',
+    reply: '',
+    replies: [],
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    isLocalActor: false,
+    isActorLiked: false,
+    isActorBookmarked: false,
+    actorAnnounceStatusId: null,
+    totalLikes: 0,
+    totalShares: 0,
+    attachments: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1
+  }) as unknown as Status
+
+const renderRemoteStatusPage = async () => {
+  const element = await Page({
+    params: Promise.resolve({
+      actor: '@gemeenteamsterdam@social.amsterdam.nl',
+      status: '123'
+    })
+  })
+  render(element)
+}
+
+describe('Page remote-status fetch signing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetStatus.mockReset()
+    // A logged-in viewer with a usable local actor is present; the federation
+    // fetch must still be signed by the instance actor, not this viewer.
+    mockGetServerAuthSession.mockResolvedValue({} as never)
+    mockGetActorFromSession.mockResolvedValue(buildViewer())
+    mockGetStatusReplies.mockResolvedValue([])
+    mockGetQueue.mockReturnValue({
+      publish: vi.fn().mockResolvedValue(undefined),
+      runsInline: false
+    } as never)
+    // The status is not in our database, so the page live-fetches it.
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: null,
+      statusId: '',
+      fullStatusId: REMOTE_STATUS_URL,
+      isStatusHash: false
+    })
+    mockGetRemoteStatus.mockResolvedValue(buildRemoteNote())
+  })
+
+  it('signs the remote status fetch with the instance actor, not the viewer', async () => {
+    // Posts hosted on authorized-fetch ("secure mode") instances reject
+    // unsigned/unverifiable fetches, so the live fetch must be signed by the
+    // headless instance actor — never the viewer's user actor, which may be
+    // absent or unservable. Otherwise the post 404s.
+    mockGetFederationSigningActor.mockResolvedValue(instanceActor)
+
+    await renderRemoteStatusPage()
+
+    expect(mockGetFederationSigningActor).toHaveBeenCalledWith(
+      expect.anything()
+    )
+    expect(mockGetRemoteStatus).toHaveBeenCalledWith({
+      statusId: REMOTE_STATUS_URL,
+      signingActor: instanceActor
+    })
+  })
+
+  it('falls back to an unsigned fetch when the signer resolution rejects', async () => {
+    // A transient instance-actor failure must not crash the render: the signer
+    // resolves best-effort, so a rejection degrades to an unsigned fetch
+    // instead of a 500.
+    mockGetFederationSigningActor.mockRejectedValue(
+      new Error('signer unavailable')
+    )
+
+    await renderRemoteStatusPage()
+
+    const call = mockGetRemoteStatus.mock.calls[0][0]
+    expect(call.statusId).toBe(REMOTE_STATUS_URL)
+    expect(call.signingActor).toBeUndefined()
+    // The failure is surfaced (not silently swallowed) so a persistently broken
+    // signer stays diagnosable.
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('falls back to an unsigned fetch when no instance actor is available', async () => {
+    // getFederationSigningActor returns undefined when the instance actor could
+    // not be resolved/provisioned; the fetch then degrades to an unsigned
+    // request rather than signing as the viewer.
+    mockGetFederationSigningActor.mockResolvedValue(undefined)
+
+    await renderRemoteStatusPage()
+
+    const call = mockGetRemoteStatus.mock.calls[0][0]
+    expect(call.statusId).toBe(REMOTE_STATUS_URL)
+    expect(call.signingActor).toBeUndefined()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+})

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -7,6 +7,7 @@ import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { FETCH_REMOTE_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { getQueue } from '@/lib/services/queue'
 import {
   canActorReadStatus,
@@ -71,9 +72,32 @@ const Page: FC<Props> = async ({ params }) => {
   let { status, statusId } = resolvedStatus
 
   if (!status && !isStatusHash && fullStatusId) {
+    // Server-to-server federation fetches must be signed by the dedicated
+    // headless instance actor, never the viewer's user actor. Instances running
+    // in authorized-fetch ("secure") mode reject unsigned/unverifiable requests,
+    // and the viewer may not have a usable signing actor at all (e.g. a
+    // logged-in account without a local actor, or one whose key is not publicly
+    // resolvable on a multi-domain setup). The instance actor always exists, has
+    // a private key, and is served at a publicly resolvable URL so the remote
+    // can verify the signature; without it, posts on secure-mode instances 404.
+    // Resolution is best-effort: a missing/failed instance actor must degrade to
+    // an unsigned fetch rather than turning a clean 404 into a 500. The failure
+    // is surfaced (not swallowed) so a persistently broken signer stays
+    // diagnosable. getRemoteStatus is shared with search, which intentionally
+    // signs as the requesting user, so only this call site is changed.
+    const signingActor = await getFederationSigningActor(database).catch(
+      (error) => {
+        logger.warn({
+          message:
+            'Failed to resolve federation signing actor for remote status fetch; falling back to an unsigned request',
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return undefined
+      }
+    )
     status = await getRemoteStatus({
       statusId: fullStatusId,
-      signingActor: currentActor ?? undefined
+      signingActor
     })
     statusId = status?.id ?? ''
 


### PR DESCRIPTION
Follow-up to #1116 (which fixed remote **profile** pages 404ing on authorized-fetch / "secure mode" Mastodon instances by signing federation fetches with the dedicated headless `__instance__` actor via `getFederationSigningActor`). This applies the same treatment to the **status-detail** page.

## Problem

`app/(timeline)/[actor]/[status]/page.tsx` live-fetched a remote post with:

```ts
status = await getRemoteStatus({
  statusId: fullStatusId,
  signingActor: currentActor ?? undefined
})
```

`currentActor` comes from `getActorFromSession` and is `null` for a logged-in account with no usable local actor. So opening a post hosted on a secure-mode instance (e.g. a status under `@gemeenteamsterdam@social.amsterdam.nl`) made an unsigned/unverifiable AP fetch → `getNote`/`getActorPerson` returned `null` → the page rendered `notFound()` (404). Same root cause as the profile bug, on the immediately adjacent flow (clicking a post from a profile).

## Fix

Inside the live-fetch branch, resolve `getFederationSigningActor(database)` best-effort (`.catch` → `logger.warn` → `undefined`) and pass it as `signingActor`, instead of the viewer's `currentActor`:

- The instance actor always exists, has a private key, and is served at a publicly resolvable URL so the remote can verify the signature.
- Best-effort: a missing/failed instance actor degrades to an unsigned fetch rather than turning a clean 404 into a 500. The failure is surfaced via `logger.warn` so a persistently broken signer stays diagnosable.
- Resolution happens **inside** the `if (!status && !isStatusHash && fullStatusId)` branch, so locally-resolved statuses never provision the instance actor.
- `getRemoteStatus` is **shared** with `app/api/v2/search/route.ts`, which intentionally signs as the requesting user, so **only the status-page call site changed** — the shared function is untouched.

## Tests

New `page.remote-signing.test.tsx` renders the Server Component directly (same approach as `page.visibility.test.tsx`), mirroring `getProfileData.test.ts`:

- Signs the remote fetch with the **instance actor even when a viewer is present** (proves instance ≠ viewer; fails on the old code which passed the viewer).
- Graceful **unsigned fallback when the signer rejects** (+ `logger.warn`).
- **Unsigned fallback when no instance actor is available** (no warn).

Written test-first and watched fail on the pre-change code.

## Verification

`yarn run prettier --write .` · `yarn lint` (0 errors) · `yarn build` ✓ · `yarn test` (5008 passed).

## Out of scope (lower priority)

`app/api/v1/accounts/[id]/remote-statuses/route.ts` and `app/api/v2/search/route.ts` still sign remote fetches with the viewer actor. They run under `OAuthGuard` so the viewer is usually a resolvable signer (failing only on multi-domain setups), and search is partly user-scoped by design — so they need per-call-site review rather than a blanket change. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)