### PR TITLE
Bump version to v1.92.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.92.1",
+  "version": "1.92.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.92.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.92.1`
- Base main SHA: `d00e8511c96e6d850e9d583c2040359b0f575081`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
