### PR TITLE
fix: keep alsoKnownAs an array so single-alias remote actors don't 404

### DIFF
--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -59,6 +59,23 @@ describe('compactActivityPub', () => {
     expect(result.cc).toEqual(['https://remote.example/users/alice/followers'])
   })
 
+  it('forces alsoKnownAs to an array even for a single migration alias', async () => {
+    // Mastodon emits `alsoKnownAs` as a set of ids. With only one alias the
+    // value compacts to a scalar string unless the canonical context marks it
+    // `@container: @set`, which then fails the actor schema's `string[]`.
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': [ACTIVITY_STREAMS_CONTEXT_URL, SECURITY_V1_CONTEXT_URL],
+        id: 'https://remote.example/users/alice',
+        type: 'Person',
+        preferredUsername: 'alice',
+        alsoKnownAs: ['https://old.example/users/alice']
+      })
+    )
+
+    expect(result.alsoKnownAs).toEqual(['https://old.example/users/alice'])
+  })
+
   it('keeps an embedded object but collapses a bare reference', async () => {
     const create = asRecord(
       await compactActivityPub({

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -112,7 +112,13 @@ const CANONICAL_CONTEXT = {
       suspended: 'toot:suspended',
       manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
       movedTo: { '@id': 'as:movedTo', '@type': '@id' },
-      alsoKnownAs: { '@id': 'as:alsoKnownAs', '@type': '@id' },
+      // A set of migration aliases — force an array so a single alias does not
+      // compact to a scalar string and fail the actor schema's `string[]`.
+      alsoKnownAs: {
+        '@id': 'as:alsoKnownAs',
+        '@type': '@id',
+        '@container': '@set'
+      },
       featured: { '@id': 'toot:featured', '@type': '@id' },
       featuredTags: { '@id': 'toot:featuredTags', '@type': '@id' },
       devices: { '@id': 'toot:devices', '@type': '@id' },

--- a/lib/types/activitypub/actor.test.ts
+++ b/lib/types/activitypub/actor.test.ts
@@ -1,0 +1,49 @@
+import { Actor } from '@/lib/types/activitypub/actor'
+
+describe('Actor', () => {
+  const base = {
+    id: 'https://remote.example/users/alice',
+    type: 'Person' as const,
+    preferredUsername: 'alice',
+    inbox: 'https://remote.example/users/alice/inbox',
+    outbox: 'https://remote.example/users/alice/outbox',
+    publicKey: {
+      id: 'https://remote.example/users/alice#main-key',
+      owner: 'https://remote.example/users/alice',
+      publicKeyPem: '-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----'
+    }
+  }
+
+  // A single-element `alsoKnownAs` array collapses to a scalar during JSON-LD
+  // compaction, so the schema must tolerate a bare string and still normalise
+  // to an array. This was the second cause of remote secure-mode profiles
+  // 404ing after the actor fetch itself started succeeding.
+  it.each([
+    {
+      description: 'array of aliases',
+      input: ['https://old.example/users/alice'],
+      expected: ['https://old.example/users/alice']
+    },
+    {
+      description: 'single alias collapsed to a string',
+      input: 'https://old.example/users/alice',
+      expected: ['https://old.example/users/alice']
+    }
+  ])('accepts alsoKnownAs as $description', ({ input, expected }) => {
+    const result = Actor.safeParse({ ...base, alsoKnownAs: input })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.alsoKnownAs).toEqual(expected)
+    }
+  })
+
+  it('parses an actor without alsoKnownAs', () => {
+    const result = Actor.safeParse(base)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.alsoKnownAs).toBeUndefined()
+    }
+  })
+})

--- a/lib/types/activitypub/actor.ts
+++ b/lib/types/activitypub/actor.ts
@@ -39,7 +39,14 @@ export const APActor = z.object({
   memorial: z.boolean().optional(),
   suspended: z.boolean().optional(),
   devices: z.string().url().optional(),
-  alsoKnownAs: z.array(z.string()).optional(),
+  // `alsoKnownAs` is a set of ids, but a single alias can arrive as a bare
+  // string (JSON-LD compaction collapses a one-element set, and the raw-input
+  // fallback preserves whatever the peer sent). Accept either shape and
+  // normalise to an array so consumers see one consistent type.
+  alsoKnownAs: z
+    .union([z.string(), z.array(z.string())])
+    .transform((value) => (Array.isArray(value) ? value : [value]))
+    .optional(),
   movedTo: z.string().optional(),
   publicKey: z.object({
     id: z.string(),


### PR DESCRIPTION
## Problem

After #1116 fixed the signing, a logged-in visit to a secure-mode remote profile (e.g. `https://llun.social/@gemeenteamsterdam@social.amsterdam.nl`) **still returned 404** — but now for a different reason. Production logs showed:

```
[getActorProfile] [
  { "expected": "array", "code": "invalid_type", "path": ["alsoKnownAs"],
    "message": "Invalid input: expected array, received string" }
]
```

The signed actor fetch now succeeds (200), but `Actor.safeParse` rejects the document, so `getActorPerson` returns `null` → `getProfileData` returns `null` → `notFound()`.

## Root cause

Mastodon emits `alsoKnownAs` as a **set** of migration-alias ids. `gemeenteamsterdam` has exactly **one** alias, and JSON-LD compaction collapses a single-element array to a scalar:

- `CANONICAL_CONTEXT` defined `alsoKnownAs` as `{ @id, @type: @id }` — **without** `@container: @set`, unlike `to`/`cc`/`tag`/`attachment`.
- So `alsoKnownAs: ["https://…"]` compacts to `alsoKnownAs: "https://…"` (a string).
- The `Actor` schema required `z.array(z.string())`, so the whole actor failed validation.

This only bit actors with a **single** alias — multi-alias actors stay arrays, which is why most remote profiles worked.

### Reproduced

```
single-element array → compacted "https://…" (string) → parse FAIL: expected array, received string
two-element array    → compacted [...]          (array)  → parse OK
bare string          → compacted "https://…"    (string) → parse FAIL
```

## Fix

- **`CANONICAL_CONTEXT`:** add `@container: @set` to `alsoKnownAs` so compaction always yields an array (matching the other collection-like properties — the documented "always arrays" pattern).
- **`Actor` schema:** make it liberal — accept a bare string **or** an array and normalise to an array, as defense for the raw-input compaction fallback and quirky peers. Output type stays `string[] | undefined`; the field stays optional.

After the fix all three shapes compact to an array and the actor parses.

## Changes

- `lib/activities/jsonld/index.ts` — `@container: @set` for `alsoKnownAs`.
- `lib/types/activitypub/actor.ts` — liberal + normalising `alsoKnownAs`.
- `lib/activities/jsonld/index.test.ts` — single-alias compaction stays an array.
- `lib/types/activitypub/actor.test.ts` — actor parses with `alsoKnownAs` as string or array (new file).

## Testing

- `yarn lint` ✅ · `yarn build` ✅ · `yarn test` ✅ (566 files / 5012 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)