### PR TITLE
fix: keep poll options an array so single-option remote polls parse

### DIFF
--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -76,33 +76,36 @@ describe('compactActivityPub', () => {
     expect(result.alsoKnownAs).toEqual(['https://old.example/users/alice'])
   })
 
-  it('forces poll options to arrays even for a single option', async () => {
-    // A single-option poll would otherwise compact `oneOf` to a bare object and
-    // fail the Question schema's `QuestionOption[]`. `@container: @set` keeps it
-    // an array.
-    const result = asRecord(
-      await compactActivityPub({
+  // Both poll-option fields are forced to arrays by separate context overrides,
+  // so guard both at the compaction layer (the layer that produces the
+  // bare-object-vs-array shape the bug was about).
+  it.each([{ field: 'oneOf' }, { field: 'anyOf' }])(
+    'forces poll options ($field) to an array even for a single option',
+    async ({ field }) => {
+      const input: Record<string, unknown> = {
         '@context': ACTIVITY_STREAMS_CONTEXT_URL,
         id: 'https://remote.example/polls/1',
         type: 'Question',
         attributedTo: 'https://remote.example/users/alice',
         published: '2026-01-01T00:00:00Z',
-        endTime: '2026-01-02T00:00:00Z',
-        oneOf: [
-          {
-            type: 'Note',
-            name: 'Only choice',
-            replies: { type: 'Collection', totalItems: 0 }
-          }
-        ]
-      })
-    )
+        endTime: '2026-01-02T00:00:00Z'
+      }
+      input[field] = [
+        {
+          type: 'Note',
+          name: 'Only choice',
+          replies: { type: 'Collection', totalItems: 0 }
+        }
+      ]
 
-    const options = result.oneOf as Array<Record<string, unknown>>
-    expect(Array.isArray(options)).toBe(true)
-    expect(options).toHaveLength(1)
-    expect(options[0].name).toBe('Only choice')
-  })
+      const result = asRecord(await compactActivityPub(input))
+
+      const options = result[field] as Array<Record<string, unknown>>
+      expect(Array.isArray(options)).toBe(true)
+      expect(options).toHaveLength(1)
+      expect(options[0].name).toBe('Only choice')
+    }
+  )
 
   it('keeps an embedded object but collapses a bare reference', async () => {
     const create = asRecord(

--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -76,6 +76,34 @@ describe('compactActivityPub', () => {
     expect(result.alsoKnownAs).toEqual(['https://old.example/users/alice'])
   })
 
+  it('forces poll options to arrays even for a single option', async () => {
+    // A single-option poll would otherwise compact `oneOf` to a bare object and
+    // fail the Question schema's `QuestionOption[]`. `@container: @set` keeps it
+    // an array.
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': ACTIVITY_STREAMS_CONTEXT_URL,
+        id: 'https://remote.example/polls/1',
+        type: 'Question',
+        attributedTo: 'https://remote.example/users/alice',
+        published: '2026-01-01T00:00:00Z',
+        endTime: '2026-01-02T00:00:00Z',
+        oneOf: [
+          {
+            type: 'Note',
+            name: 'Only choice',
+            replies: { type: 'Collection', totalItems: 0 }
+          }
+        ]
+      })
+    )
+
+    const options = result.oneOf as Array<Record<string, unknown>>
+    expect(Array.isArray(options)).toBe(true)
+    expect(options).toHaveLength(1)
+    expect(options[0].name).toBe('Only choice')
+  })
+
   it('keeps an embedded object but collapses a bare reference', async () => {
     const create = asRecord(
       await compactActivityPub({

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -129,7 +129,11 @@ const CANONICAL_CONTEXT = {
       to: { '@id': 'as:to', '@type': '@id', '@container': '@set' },
       cc: { '@id': 'as:cc', '@type': '@id', '@container': '@set' },
       tag: { '@id': 'as:tag', '@container': '@set' },
-      attachment: { '@id': 'as:attachment', '@container': '@set' }
+      attachment: { '@id': 'as:attachment', '@container': '@set' },
+      // Poll options are object-valued sets; force arrays so a single-option
+      // poll does not compact to a bare object and fail the Question schema.
+      oneOf: { '@id': 'as:oneOf', '@container': '@set' },
+      anyOf: { '@id': 'as:anyOf', '@container': '@set' }
     }
   ]
 }

--- a/lib/types/activitypub/objects.test.ts
+++ b/lib/types/activitypub/objects.test.ts
@@ -1,0 +1,47 @@
+import { Question } from '@/lib/types/activitypub/objects'
+
+describe('Question', () => {
+  const option = (name: string) => ({
+    type: 'Note' as const,
+    name,
+    replies: { type: 'Collection' as const, totalItems: 0 }
+  })
+
+  const base = {
+    id: 'https://remote.example/polls/1',
+    type: 'Question' as const,
+    attributedTo: 'https://remote.example/users/alice',
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: [],
+    content: 'Single option?',
+    published: '2026-01-01T00:00:00Z',
+    endTime: '2026-01-02T00:00:00Z'
+  }
+
+  // JSON-LD compaction collapses a single-option `oneOf`/`anyOf` array to a bare
+  // object, so the schema must tolerate either shape and normalise to an array.
+  it.each([
+    { field: 'oneOf' as const, description: 'an array', input: [option('A')] },
+    {
+      field: 'oneOf' as const,
+      description: 'a single collapsed object',
+      input: option('A')
+    },
+    { field: 'anyOf' as const, description: 'an array', input: [option('A')] },
+    {
+      field: 'anyOf' as const,
+      description: 'a single collapsed object',
+      input: option('A')
+    }
+  ])(
+    'accepts $field as $description and normalises to an array',
+    ({ field, input }) => {
+      const result = Question.safeParse({ ...base, [field]: input })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data[field]).toEqual([option('A')])
+      }
+    }
+  )
+})

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -177,12 +177,19 @@ export const Question = BaseContent.extend({
     )
     .nullish(),
 
-  // Single-choice poll options (mutually exclusive with anyOf)
-  oneOf: QuestionOption.array()
+  // Single-choice poll options (mutually exclusive with anyOf). A single-option
+  // poll can arrive as a bare object (JSON-LD compaction collapses a one-element
+  // set, and the raw-input fallback preserves whatever the peer sent), so accept
+  // either shape and normalise to an array.
+  oneOf: z
+    .union([QuestionOption, QuestionOption.array()])
+    .transform((value) => (Array.isArray(value) ? value : [value]))
     .describe('Poll options for single-choice polls')
     .optional(),
   // Multiple-choice poll options (mutually exclusive with oneOf)
-  anyOf: QuestionOption.array()
+  anyOf: z
+    .union([QuestionOption, QuestionOption.array()])
+    .transform((value) => (Array.isArray(value) ? value : [value]))
     .describe('Poll options for multiple-choice polls')
     .optional(),
 


### PR DESCRIPTION
## Problem

Same bug class as #1119 (the `alsoKnownAs` profile-404 fix), surfaced by **#1119's own review**: a remote poll with a **single option** silently fails to import.

`Question.oneOf` / `Question.anyOf` are declared `QuestionOption.array()`, but the canonical JSON-LD context did **not** force them to a set (unlike `to`/`cc`/`tag`/`attachment`). So a one-element `oneOf` array compacts to a bare object, and `Question.safeParse` fails:

```
oneOf: Invalid input: expected array, received object
```

`createPollJob` / `updatePollJob` then drop the inbound poll. Mastodon mandates ≥2 options so it's rare across the fediverse, but the AP spec doesn't forbid a single-option poll and other servers/relays can emit one. (Confirmed empirically by compacting a single-option `Question`.)

## Fix

Mirrors #1119's two-pronged approach:

- **`CANONICAL_CONTEXT`:** add `@container: @set` to `oneOf`/`anyOf` (object-valued, so **no** `@type: @id`) → compaction always yields an array, matching `tag`/`attachment`.
- **`Question` schema:** make `oneOf`/`anyOf` liberal — accept a single `QuestionOption` **or** an array and normalise to an array, as defense for the raw-input fallback. Output type stays `QuestionOption[] | undefined`; fields stay optional.

## Changes

- `lib/activities/jsonld/index.ts` — `@container: @set` for `oneOf`/`anyOf`.
- `lib/types/activitypub/objects.ts` — liberal + normalising `oneOf`/`anyOf`.
- `lib/activities/jsonld/index.test.ts` — single-option compaction stays an array.
- `lib/types/activitypub/objects.test.ts` — `Question` parses with `oneOf`/`anyOf` as a single object or array (new file).

## Scope

Independent of #1119 (no overlapping lines beyond different entries in the same context block). `git diff` is exactly these 4 files — no `alsoKnownAs` / actor changes.

## Testing

- `yarn lint` ✅ · `yarn build` ✅ · `yarn test` ✅ (566 files / 5013 tests)
- Existing `createPollJob` / `updatePollJob` suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)