### PR TITLE
fix: sign remote-statuses and search federation fetches with the instance actor

### DIFF
--- a/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { StatusType } from '@/lib/types/domain/status'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -11,6 +12,10 @@ const mockDatabase = {}
 const mockCurrentActor = {
   id: 'https://local.example/users/me'
 }
+const mockInstanceActor = {
+  id: 'https://local.example/users/__instance__'
+}
+const mockLoggerWarn = vi.fn()
 
 vi.mock('@/lib/services/guards/OAuthGuard', () => ({
   OAuthGuard:
@@ -25,6 +30,12 @@ vi.mock('@/lib/services/guards/OAuthGuard', () => ({
 
 vi.mock('@/lib/activities/getActorPerson')
 vi.mock('@/lib/activities/getActorPosts')
+vi.mock('@/lib/services/federation/getFederationSigningActor')
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args)
+  }
+}))
 
 const actorId = 'https://remote.example/users/actor'
 const pageUrl = 'https://remote.example/users/actor/outbox?page=true&max_id=1'
@@ -37,6 +48,9 @@ const createRequest = (query = '') =>
 describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+      mockInstanceActor
+    )
     ;(getActorPerson as jest.Mock).mockResolvedValue({
       id: actorId,
       type: 'Person',
@@ -89,16 +103,64 @@ describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
       nextPageUrl: null,
       prevPageUrl: `${actorId}/outbox?page=true`
     })
+    // Federation fetches are signed by the headless instance actor, not the
+    // viewer — secure-mode and multi-domain remotes need a publicly resolvable
+    // signer. mockInstanceActor !== mockCurrentActor, so this fails if the route
+    // regresses to signing as the viewer.
     expect(getActorPerson).toHaveBeenCalledWith({
       actorId,
-      signingActor: mockCurrentActor
+      signingActor: mockInstanceActor
     })
     expect(getActorPosts).toHaveBeenCalledWith({
       database: mockDatabase,
       person: expect.objectContaining({ id: actorId }),
-      signingActor: mockCurrentActor,
+      signingActor: mockInstanceActor,
       pageUrl
     })
+  })
+
+  it('falls back to an unsigned fetch and warns when the signing actor cannot be resolved', async () => {
+    ;(getFederationSigningActor as jest.Mock).mockRejectedValue(
+      new Error('database down')
+    )
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ id: urlToId(actorId) })
+    })
+
+    expect(response.status).toBe(200)
+    // `toHaveBeenCalledWith` treats an omitted key and an explicit `undefined`
+    // as equal, so assert the signer directly to prove the fetch is unsigned.
+    expect((getActorPerson as jest.Mock).mock.calls[0][0].signingActor).toBe(
+      undefined
+    )
+    expect((getActorPosts as jest.Mock).mock.calls[0][0].signingActor).toBe(
+      undefined
+    )
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Failed to resolve federation signing actor'
+        )
+      })
+    )
+  })
+
+  it('issues an unsigned fetch without warning when no signing actor exists', async () => {
+    ;(getFederationSigningActor as jest.Mock).mockResolvedValue(undefined)
+
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ id: urlToId(actorId) })
+    })
+
+    expect(response.status).toBe(200)
+    expect((getActorPerson as jest.Mock).mock.calls[0][0].signingActor).toBe(
+      undefined
+    )
+    expect((getActorPosts as jest.Mock).mock.calls[0][0].signingActor).toBe(
+      undefined
+    )
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
   })
 
   it('returns bad request for invalid page urls', async () => {

--- a/app/api/v1/accounts/[id]/remote-statuses/route.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.ts
@@ -3,10 +3,12 @@ import { z } from 'zod'
 import { isCollectionPageUrl } from '@/lib/activities/getActorCollections'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   apiCorsError,
@@ -31,7 +33,7 @@ const StatusQueryParams = z.object({
 export const GET = traceApiRoute(
   'getRemoteAccountStatuses',
   OAuthGuard<Params>([Scope.enum.read], async (req, context) => {
-    const { database, currentActor, params } = context
+    const { database, params } = context
     const encodedAccountId = (await params).id
     if (!encodedAccountId) return apiCorsError(req, CORS_HEADERS, 400)
 
@@ -49,10 +51,27 @@ export const GET = traceApiRoute(
     }
 
     const actorId = idToUrl(encodedAccountId)
-    const person = await getActorPerson({
-      actorId,
-      signingActor: currentActor
-    })
+
+    // Server-to-server federation fetches must be signed by the dedicated
+    // headless instance actor, never the viewer's user actor. Authorized-fetch
+    // ("secure mode") remotes reject unsigned requests with 401, and on
+    // multi-domain setups the viewer's key may not be publicly resolvable. The
+    // instance actor always exists, always has a private key, and is served at
+    // a publicly resolvable URL so the remote can fetch its key and verify the
+    // signature. Resolution is best-effort: a missing/failed signer degrades to
+    // an unsigned fetch (a clean 404) rather than turning into a 500.
+    const signingActor = await getFederationSigningActor(database).catch(
+      (error) => {
+        logger.warn({
+          message:
+            'Failed to resolve federation signing actor for remote account statuses; falling back to an unsigned request',
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return undefined
+      }
+    )
+
+    const person = await getActorPerson({ actorId, signingActor })
     if (!person) return apiCorsError(req, CORS_HEADERS, 404)
 
     if (
@@ -71,7 +90,7 @@ export const GET = traceApiRoute(
     const result = await getActorPosts({
       database,
       person,
-      signingActor: currentActor,
+      signingActor,
       pageUrl: parsed.data.page_url
     })
 

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -20,7 +20,15 @@ const mockGetWebfingerSelf = vi.fn()
 const mockGetActorPerson = vi.fn()
 const mockRecordActorIfNeeded = vi.fn()
 const mockGetRemoteStatus = vi.fn()
+const mockGetFederationSigningActor = vi.fn()
 const mockLoggerWarn = vi.fn()
+
+// The dedicated headless federation signer. It is intentionally a different
+// actor from `oauthActor` (the requesting viewer) so the signing assertions
+// fail if the route regresses to signing remote fetches as the viewer.
+const mockInstanceActor = {
+  id: 'https://llun.test/users/__instance__'
+}
 
 const oauthActor = {
   id: 'https://llun.test/users/searcher',
@@ -95,6 +103,11 @@ vi.mock('@/lib/actions/utils', () => ({
   recordActorIfNeeded: (...args: unknown[]) => mockRecordActorIfNeeded(...args)
 }))
 
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: (...args: unknown[]) =>
+    mockGetFederationSigningActor(...args)
+}))
+
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
     warn: (...args: unknown[]) => mockLoggerWarn(...args)
@@ -161,6 +174,7 @@ describe('GET /api/v2/search', () => {
     mockGetActorPerson.mockResolvedValue(null)
     mockRecordActorIfNeeded.mockResolvedValue(null)
     mockGetRemoteStatus.mockResolvedValue(null)
+    mockGetFederationSigningActor.mockResolvedValue(mockInstanceActor)
   })
 
   it('allows anonymous account and hashtag search but omits statuses', async () => {
@@ -485,20 +499,84 @@ describe('GET /api/v2/search', () => {
     )
 
     expect(response.status).toBe(200)
+    // Remote status + actor resolution are server-to-server fetches signed by
+    // the instance actor, not the viewer.
     expect(mockGetRemoteStatus).toHaveBeenCalledWith({
       statusId: statusUrl,
-      signingActor: oauthActor
+      signingActor: mockInstanceActor
     })
     expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
       actorId: remoteStatus.actorId,
       database: expect.any(Object),
-      signingActor: oauthActor
+      signingActor: mockInstanceActor
     })
     expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
       expect.any(Object),
       [remoteStatus],
       oauthActor.id
     )
+  })
+
+  it('resolves remote statuses unsigned and warns when the signing actor cannot be resolved', async () => {
+    const statusUrl = 'http://remote.test/users/alice/statuses/remote'
+    const remoteStatus = {
+      id: statusUrl,
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockGetFederationSigningActor.mockRejectedValue(new Error('database down'))
+    mockGetRemoteStatus.mockResolvedValue(remoteStatus)
+    mockRecordActorIfNeeded.mockResolvedValue({ id: remoteStatus.actorId })
+    mockSearchStatusIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=2`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    // `toHaveBeenCalledWith` treats an omitted key and an explicit `undefined`
+    // as equal, so assert the signer directly to prove the fetch is unsigned.
+    expect(mockGetRemoteStatus.mock.calls[0][0].signingActor).toBe(undefined)
+    expect(mockRecordActorIfNeeded.mock.calls[0][0].signingActor).toBe(
+      undefined
+    )
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Failed to resolve federation signing actor'
+        )
+      })
+    )
+  })
+
+  it('resolves remote statuses unsigned without warning when no signing actor exists', async () => {
+    const statusUrl = 'http://remote.test/users/alice/statuses/remote'
+    const remoteStatus = {
+      id: statusUrl,
+      actorId: 'https://remote.test/users/alice'
+    }
+    mockGetFederationSigningActor.mockResolvedValue(undefined)
+    mockGetRemoteStatus.mockResolvedValue(remoteStatus)
+    mockRecordActorIfNeeded.mockResolvedValue({ id: remoteStatus.actorId })
+    mockSearchStatusIds.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest(
+        `https://llun.test/api/v2/search?q=${encodeURIComponent(statusUrl)}&type=statuses&resolve=2`,
+        { headers: { Authorization: 'Bearer read-search-token' } }
+      ),
+      context
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockGetRemoteStatus.mock.calls[0][0].signingActor).toBe(undefined)
+    expect(mockRecordActorIfNeeded.mock.calls[0][0].signingActor).toBe(
+      undefined
+    )
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
   })
 
   it('omits resolved remote statuses when actor recording fails', async () => {
@@ -730,14 +808,16 @@ describe('GET /api/v2/search', () => {
     const data = await response.json()
 
     expect(response.status).toBe(200)
+    // Canonicalizing and recording a remote actor are server-to-server fetches
+    // signed by the instance actor, not the viewer.
     expect(mockGetActorPerson).toHaveBeenCalledWith({
       actorId: accountUrl,
-      signingActor: oauthActor
+      signingActor: mockInstanceActor
     })
     expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
       actorId: canonicalActorId,
       database: expect.any(Object),
-      signingActor: oauthActor
+      signingActor: mockInstanceActor
     })
     expect(data.accounts).toEqual([
       {
@@ -781,7 +861,7 @@ describe('GET /api/v2/search', () => {
     expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
       actorId: canonicalActorId,
       database: expect.any(Object),
-      signingActor: oauthActor
+      signingActor: mockInstanceActor
     })
     expect(data.accounts).toEqual([
       {
@@ -915,7 +995,7 @@ describe('GET /api/v2/search', () => {
     expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
       actorId: 'https://remote.test/users/charlie',
       database: expect.any(Object),
-      signingActor: oauthActor
+      signingActor: mockInstanceActor
     })
     expect(mockGetMastodonActorsFromIds).toHaveBeenCalledWith({
       ids: ['https://remote.test/users/charlie']

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -8,6 +8,7 @@ import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { localizeAccounts } from '@/lib/services/accounts/localizeAccount'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import {
   OptionalOAuthGuard,
   corsErrorResponse
@@ -253,13 +254,15 @@ const resolveAccountId = async ({
   currentActor,
   query,
   resolve,
-  following
+  following,
+  signingActor
 }: {
   database: Database
   currentActor: Actor | null
   query: string
   resolve: boolean
   following: boolean
+  signingActor?: Actor
 }) => {
   if (!resolve) return null
 
@@ -269,7 +272,7 @@ const resolveAccountId = async ({
       ? query
       : await getCanonicalAccountActorId({
           query,
-          signingActor: currentActor ?? undefined
+          signingActor
         })
     const actor =
       existingActor ??
@@ -279,7 +282,7 @@ const resolveAccountId = async ({
       (await recordResolvedActorIfNeeded({
         actorId: canonicalActorId,
         database,
-        signingActor: currentActor ?? undefined
+        signingActor
       }))
     if (
       actor &&
@@ -309,7 +312,7 @@ const resolveAccountId = async ({
       ? await recordResolvedActorIfNeeded({
           actorId,
           database,
-          signingActor: currentActor ?? undefined
+          signingActor
         })
       : null
   }
@@ -333,15 +336,20 @@ const getResolvedStatus = async ({
   database,
   currentActor,
   query,
-  resolve
+  resolve,
+  signingActor
 }: {
   database: Database
   currentActor: Actor
   query: string
   resolve: boolean
+  signingActor?: Actor
 }) => {
   if (!resolve || !isUrl(query)) return null
 
+  // Local lookups stay scoped to the requesting user (visibility filtering),
+  // but the remote fetch + actor recording are server-to-server federation
+  // calls and must be signed by the instance actor, not the viewer.
   const localStatus =
     (await database.getStatus({
       statusId: query,
@@ -352,7 +360,7 @@ const getResolvedStatus = async ({
     localStatus ??
     (await getRemoteStatus({
       statusId: query,
-      signingActor: currentActor
+      signingActor
     }))
 
   if (!status) return null
@@ -361,7 +369,7 @@ const getResolvedStatus = async ({
     const actor = await recordResolvedActorIfNeeded({
       actorId: status.actorId,
       database,
-      signingActor: currentActor
+      signingActor
     })
     if (!actor) return null
   }
@@ -380,7 +388,8 @@ const searchAccounts = async ({
   params,
   query,
   limit,
-  offset
+  offset,
+  signingActor
 }: {
   database: Database
   currentActor: Actor | null
@@ -388,6 +397,7 @@ const searchAccounts = async ({
   query: string
   limit: number
   offset: number
+  signingActor?: Actor
 }) => {
   const [resolvedAccountId, indexedIds] = await Promise.all([
     offset === 0
@@ -396,7 +406,8 @@ const searchAccounts = async ({
           currentActor,
           query,
           resolve: params.resolve ?? false,
-          following: params.following ?? false
+          following: params.following ?? false,
+          signingActor
         })
       : Promise.resolve(null),
     database.searchAccountIds({
@@ -450,7 +461,8 @@ const searchStatuses = async ({
   params,
   query,
   limit,
-  offset
+  offset,
+  signingActor
 }: {
   database: Database
   currentActor: Actor
@@ -458,6 +470,7 @@ const searchStatuses = async ({
   query: string
   limit: number
   offset: number
+  signingActor?: Actor
 }) => {
   const indexedLimit = limit * 2
   const [resolvedStatus, indexedIds] = await Promise.all([
@@ -466,7 +479,8 @@ const searchStatuses = async ({
           database,
           currentActor,
           query,
-          resolve: params.resolve ?? false
+          resolve: params.resolve ?? false,
+          signingActor
         })
       : Promise.resolve(null),
     database.searchStatusIds({
@@ -563,6 +577,27 @@ export const GET = traceApiRoute(
       const includeStatuses =
         Boolean(currentActor) && (!params.type || params.type === 'statuses')
 
+      // Only `resolve=true` (on the first page) dereferences a remote actor or
+      // status, and those server-to-server fetches must be signed by the
+      // dedicated headless instance actor — not the requesting user. Secure-mode
+      // remotes reject unsigned/unverifiable requests, and on multi-domain
+      // setups the viewer's key may not be publicly resolvable, so viewer-signed
+      // resolution silently fails. Index search and visibility checks stay
+      // user-scoped (`currentActor`) and are untouched. Resolution is
+      // best-effort: a missing/failed signer degrades to an unsigned fetch
+      // rather than failing the whole search.
+      const requiresRemoteSigner = params.resolve === true && offset === 0
+      const signingActor = requiresRemoteSigner
+        ? await getFederationSigningActor(database).catch((error) => {
+            logger.warn({
+              message:
+                'Failed to resolve federation signing actor for remote search resolution; falling back to an unsigned request',
+              error: error instanceof Error ? error.message : String(error)
+            })
+            return undefined
+          })
+        : undefined
+
       const [accounts, hashtags, domainStatuses] = await Promise.all([
         includeAccounts
           ? searchAccounts({
@@ -571,7 +606,8 @@ export const GET = traceApiRoute(
               params,
               query,
               limit,
-              offset
+              offset,
+              signingActor
             })
           : [],
         includeHashtags
@@ -590,7 +626,8 @@ export const GET = traceApiRoute(
               params,
               query,
               limit,
-              offset
+              offset,
+              signingActor
             })
           : []
       ])


### PR DESCRIPTION
## What & why

Follow-up to the secure-mode federation-signing fixes ([#1116](https://github.com/llun/activities.next/pull/1116) for profiles, plus the status-detail page). Two API routes still signed their **server-to-server ActivityPub fetches** with the viewer's `currentActor` instead of the dedicated headless instance actor (`getFederationSigningActor`). On authorized-fetch ("secure mode") remotes, and on multi-domain setups where the viewer's key isn't publicly resolvable, those unsigned/unverifiable fetches fail (401 → `null` → 404 / silent drop).

The pattern this codebase has standardized on: **every server-to-server federation fetch must sign with the instance actor, never the viewer** — it always exists, always has a private key, and is served at a publicly resolvable URL so the remote can fetch its key and verify the signature.

## Changes

**`app/api/v1/accounts/[id]/remote-statuses/route.ts`**
- Sign `getActorPerson` and `getActorPosts` with `getFederationSigningActor(database)` (best-effort `.catch` → `logger.warn` → `undefined`) instead of `currentActor`. Dropped `currentActor` from the handler (it was only used as the signer).

**`app/api/v2/search/route.ts`** — reviewed each call site rather than blanket-replacing, since search is partly performed on behalf of the requesting user:
- **Switched to the instance signer** for the genuine server-to-server resolution: `getActorPerson` (canonical actor lookup), `getRemoteStatus` (remote note fetch), and the `recordActorIfNeeded` calls. Threaded via a new optional `signingActor` param, resolved **only** on `resolve=true` first-page requests (`requiresRemoteSigner`) so non-resolving searches skip the extra DB read.
- **Left genuinely user-scoped lookups on `currentActor`**: index search (`searchStatusIds`/`searchAccountIds`), `database.getStatus`, `canActorReadStatus`, and the following filter — these are local visibility/index queries, not federation fetches.

> Note: `getFederationSigningActor` already ignores non-instance candidates and falls back to the DB instance actor, so `recordActorIfNeeded` was effectively already instance-signed; threading the resolved signer through makes the intent explicit and skips its redundant internal lookup. A missing/failed signer degrades to an unsigned fetch rather than a 500.

## Tests

- Updated existing assertions to expect the **instance actor** (intentionally `!=` the viewer, so the tests regression-guard against viewer-signing).
- Added best-effort fallback cases on both routes: signer **rejects** (unsigned fetch + `logger.warn`) and signer **absent** (unsigned fetch, no warn). Signer presence is asserted via direct `mock.calls[0][0].signingActor` since `toHaveBeenCalledWith` treats omitted and explicit-`undefined` keys as equal.

## Verification

- `yarn run prettier --write .` ✅
- `yarn lint` — 0 errors ✅
- `yarn build` ✅
- `yarn test` — **5012 passed (565 files)** ✅

No migrations, no schema changes. Patch-level bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)