### PR TITLE
Bump version to v1.92.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.92.4",
+  "version": "1.92.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.92.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.92.4`
- Base main SHA: `34e5261720a1034ea51435bb8d67fc9750d5e85b`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
