### PR TITLE
Bump version to v1.92.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.92.5",
+  "version": "1.92.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.92.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.92.5`
- Base main SHA: `f0fb6fef151f6b2db0a5d6b39bd1c894a46f9f94`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
