### PR TITLE
minor: enable OIDC RP-initiated (single) logout

### DIFF
--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -401,7 +401,7 @@ describe('createApplication', () => {
     }
   ])(
     'it rejects post_logout_redirect_uris with $description',
-    async ({ uri }) => {
+    async ({ uri }: { uri: string }) => {
       const response = await createApplication({
         client_name: 'unsafeLogoutClient',
         redirect_uris: 'https://unsafe-logout.llun.dev/callback',

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -291,6 +291,103 @@ describe('createApplication', () => {
     expect(response.redirect_uri).toEqual('https://test.llun.dev/callback')
   })
 
+  test('it enables end-session and stores post_logout_redirect_uris as a JSON-array string when provided', async () => {
+    const response = (await createApplication({
+      client_name: 'logoutClient',
+      redirect_uris: 'https://logout.llun.dev/callback',
+      post_logout_redirect_uris: 'https://logout.llun.dev/logout-callback',
+      scopes: 'openid read',
+      website: 'https://logout.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(dbClient.enableEndSession).toBeTruthy()
+    // Same JSON-array-string format as redirectUris so better-auth's adapter
+    // JSON-parses it back into an array for its postLogoutRedirectUris check.
+    expect(dbClient.postLogoutRedirectUris).toBe(
+      '["https://logout.llun.dev/logout-callback"]'
+    )
+    expect(JSON.parse(dbClient.postLogoutRedirectUris)).toEqual([
+      'https://logout.llun.dev/logout-callback'
+    ])
+  })
+
+  test('it supports newline-separated post_logout_redirect_uris', async () => {
+    const response = (await createApplication({
+      client_name: 'multiLogoutClient',
+      redirect_uris: 'https://multi-logout.llun.dev/callback',
+      post_logout_redirect_uris:
+        'https://multi-logout.llun.dev/logout-a\nhttps://multi-logout.llun.dev/logout-b',
+      scopes: 'openid read',
+      website: 'https://multi-logout.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(dbClient.enableEndSession).toBeTruthy()
+    expect(JSON.parse(dbClient.postLogoutRedirectUris)).toEqual([
+      'https://multi-logout.llun.dev/logout-a',
+      'https://multi-logout.llun.dev/logout-b'
+    ])
+  })
+
+  test('it leaves end-session disabled when post_logout_redirect_uris is omitted', async () => {
+    const response = (await createApplication({
+      client_name: 'noLogoutClient',
+      redirect_uris: 'https://no-logout.llun.dev/callback',
+      scopes: 'read',
+      website: 'https://no-logout.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(dbClient.enableEndSession).toBeFalsy()
+    expect(dbClient.postLogoutRedirectUris).toBeNull()
+  })
+
+  test('it ignores whitespace-only post_logout_redirect_uris and keeps end-session disabled', async () => {
+    const response = (await createApplication({
+      client_name: 'blankLogoutClient',
+      redirect_uris: 'https://blank-logout.llun.dev/callback',
+      post_logout_redirect_uris: '   \n\t  ',
+      scopes: 'read',
+      website: 'https://blank-logout.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(dbClient.enableEndSession).toBeFalsy()
+    expect(dbClient.postLogoutRedirectUris).toBeNull()
+  })
+
+  test('it rejects post_logout_redirect_uris with an unsafe scheme', async () => {
+    const response = await createApplication({
+      client_name: 'unsafeLogoutClient',
+      redirect_uris: 'https://unsafe-logout.llun.dev/callback',
+      post_logout_redirect_uris: 'javascript:alert(1)',
+      scopes: 'read',
+      website: 'https://unsafe-logout.llun.dev'
+    })
+
+    expect(response).toEqual({
+      type: 'error',
+      error: 'Failed to validate request'
+    })
+  })
+
   test('it rate limits app registration floods from the same unauthenticated source', async () => {
     const registrationKey = 'flood-source'
     const now = new Date('2026-05-12T12:00:00.000Z')

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -351,6 +351,10 @@ describe('createApplication', () => {
     const dbClient = await knexDatabase('oauthClient')
       .where({ id: response.id })
       .first()
+    // Explicitly disabled, not merely absent: the row carries a written
+    // (non-null) falsy enableEndSession, which the pre-change code (no insert)
+    // could not produce. This keeps the regression guard load-bearing.
+    expect(dbClient.enableEndSession).not.toBeNull()
     expect(dbClient.enableEndSession).toBeFalsy()
     expect(dbClient.postLogoutRedirectUris).toBeNull()
   })
@@ -369,6 +373,7 @@ describe('createApplication', () => {
     const dbClient = await knexDatabase('oauthClient')
       .where({ id: response.id })
       .first()
+    expect(dbClient.enableEndSession).not.toBeNull()
     expect(dbClient.enableEndSession).toBeFalsy()
     expect(dbClient.postLogoutRedirectUris).toBeNull()
   })
@@ -432,6 +437,30 @@ describe('createApplication', () => {
     expect(JSON.parse(dbClient.postLogoutRedirectUris)).toEqual([
       'http://127.0.0.1:3000/logout-callback'
     ])
+  })
+
+  test('it rejects the whole registration when any post_logout_redirect_uri is invalid', async () => {
+    // Validation is all-or-nothing: one bad URI in the list fails the request and
+    // persists nothing — a future refactor that silently filtered out invalid
+    // entries would be a security regression, so pin the behavior.
+    const response = await createApplication({
+      client_name: 'mixedLogoutClient',
+      redirect_uris: 'https://mixed-logout.llun.dev/callback',
+      post_logout_redirect_uris:
+        'https://mixed-logout.llun.dev/logout-callback\njavascript:alert(1)',
+      scopes: 'read',
+      website: 'https://mixed-logout.llun.dev'
+    })
+
+    expect(response).toEqual({
+      type: 'error',
+      error: 'Failed to validate request'
+    })
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ name: 'mixedLogoutClient' })
+      .first()
+    expect(dbClient).toBeUndefined()
   })
 
   test('it rate limits app registration floods from the same unauthenticated source', async () => {

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -373,19 +373,65 @@ describe('createApplication', () => {
     expect(dbClient.postLogoutRedirectUris).toBeNull()
   })
 
-  test('it rejects post_logout_redirect_uris with an unsafe scheme', async () => {
-    const response = await createApplication({
-      client_name: 'unsafeLogoutClient',
-      redirect_uris: 'https://unsafe-logout.llun.dev/callback',
-      post_logout_redirect_uris: 'javascript:alert(1)',
-      scopes: 'read',
-      website: 'https://unsafe-logout.llun.dev'
-    })
+  // The end-session endpoint validates the incoming post_logout_redirect_uri
+  // with SafeUrlSchema (rejects unsafe schemes, fragments, and non-HTTPS except
+  // loopback). Registration mirrors that exactly so a stored URI can't pass
+  // registration yet fail at logout time.
+  test.each([
+    {
+      description: 'an unsafe scheme',
+      uri: 'javascript:alert(1)'
+    },
+    {
+      description: 'a fragment component',
+      uri: 'https://unsafe-logout.llun.dev/logout-callback#frag'
+    },
+    {
+      description: 'a non-HTTPS scheme on a non-loopback host',
+      uri: 'http://unsafe-logout.llun.dev/logout-callback'
+    },
+    {
+      description: 'a value that is not a valid URL',
+      uri: 'not a url'
+    }
+  ])(
+    'it rejects post_logout_redirect_uris with $description',
+    async ({ uri }) => {
+      const response = await createApplication({
+        client_name: 'unsafeLogoutClient',
+        redirect_uris: 'https://unsafe-logout.llun.dev/callback',
+        post_logout_redirect_uris: uri,
+        scopes: 'read',
+        website: 'https://unsafe-logout.llun.dev'
+      })
 
-    expect(response).toEqual({
-      type: 'error',
-      error: 'Failed to validate request'
-    })
+      expect(response).toEqual({
+        type: 'error',
+        error: 'Failed to validate request'
+      })
+    }
+  )
+
+  test('it allows http post_logout_redirect_uris on loopback hosts', async () => {
+    // Parity with the end-session SafeUrlSchema: HTTP is permitted for loopback
+    // (localhost / 127.0.0.1) so local-dev RPs are not over-rejected.
+    const response = (await createApplication({
+      client_name: 'loopbackLogoutClient',
+      redirect_uris: 'https://loopback-logout.llun.dev/callback',
+      post_logout_redirect_uris: 'http://127.0.0.1:3000/logout-callback',
+      scopes: 'read',
+      website: 'https://loopback-logout.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(dbClient.enableEndSession).toBeTruthy()
+    expect(JSON.parse(dbClient.postLogoutRedirectUris)).toEqual([
+      'http://127.0.0.1:3000/logout-callback'
+    ])
   })
 
   test('it rate limits app registration floods from the same unauthenticated source', async () => {

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -1,3 +1,4 @@
+import { SafeUrlSchema } from '@better-auth/core/utils/redirect-uri'
 import crypto from 'crypto'
 import type { Knex } from 'knex'
 
@@ -241,20 +242,19 @@ export const createApplication = async (
           }
         }
         // Optional OpenID Connect RP-Initiated Logout callbacks (newline-
-        // separated, like redirect_uris). Validate the same way and, when at
-        // least one valid URI is supplied, enable end-session for the client so
-        // it can drive single logout. Omitted ⇒ end-session stays disabled.
+        // separated, like redirect_uris). When at least one valid URI is
+        // supplied, end-session is enabled for the client so it can drive single
+        // logout; omitted ⇒ end-session stays disabled. Validate each URI with
+        // the SAME SafeUrlSchema the end-session endpoint enforces on the
+        // incoming post_logout_redirect_uri query param (rejects fragments and
+        // non-HTTPS except loopback) so a stored URI can never pass registration
+        // yet silently fail at logout time.
         const postLogoutRedirectUris = (request.post_logout_redirect_uris ?? '')
           .split('\n')
           .map((uri) => uri.trim())
           .filter(Boolean)
         for (const uri of postLogoutRedirectUris) {
-          try {
-            const parsed = new URL(uri)
-            if (unsafeSchemes.has(parsed.protocol)) {
-              return validationErrorResponse()
-            }
-          } catch {
+          if (!SafeUrlSchema.safeParse(uri).success) {
             return validationErrorResponse()
           }
         }

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -240,6 +240,25 @@ export const createApplication = async (
             return validationErrorResponse()
           }
         }
+        // Optional OpenID Connect RP-Initiated Logout callbacks (newline-
+        // separated, like redirect_uris). Validate the same way and, when at
+        // least one valid URI is supplied, enable end-session for the client so
+        // it can drive single logout. Omitted ⇒ end-session stays disabled.
+        const postLogoutRedirectUris = (request.post_logout_redirect_uris ?? '')
+          .split('\n')
+          .map((uri) => uri.trim())
+          .filter(Boolean)
+        for (const uri of postLogoutRedirectUris) {
+          try {
+            const parsed = new URL(uri)
+            if (unsafeSchemes.has(parsed.protocol)) {
+              return validationErrorResponse()
+            }
+          } catch {
+            return validationErrorResponse()
+          }
+        }
+        const enableEndSession = postLogoutRedirectUris.length > 0
         const dbId = crypto.randomUUID()
         await db('oauthClient').insert({
           id: dbId,
@@ -248,6 +267,12 @@ export const createApplication = async (
           name: request.client_name,
           scopes: JSON.stringify(parsedScopes),
           redirectUris: JSON.stringify(redirectUris),
+          // Stored as a JSON-array string to match `redirectUris`; better-auth's
+          // adapter JSON-parses `string[]` fields back into arrays on read.
+          postLogoutRedirectUris: enableEndSession
+            ? JSON.stringify(postLogoutRedirectUris)
+            : null,
+          enableEndSession,
           uri: request.website || null,
           // Mastodon /api/v1/apps has no PKCE-capability field; PKCE is opt-in
           // at authorize-time via code_challenge. better-auth still enforces it

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -1,3 +1,12 @@
+// SafeUrlSchema is a PUBLIC export of @better-auth/core (its `exports` map
+// declares `./utils/*`, and the schema's own doc-comment sanctions external
+// consumption). @better-auth/core is a direct, exact-pinned (1.6.20) dependency,
+// so this resolves under strict package managers (this repo uses Yarn 4) and
+// can't drift on a minor/patch bump. We deliberately reuse it rather than
+// re-implement the policy: the end-session endpoint validates the incoming
+// `post_logout_redirect_uri` with this exact same schema, so reusing it keeps
+// registration-time and logout-time validation byte-for-byte aligned (a local
+// copy would silently drift on any future better-auth change).
 import { SafeUrlSchema } from '@better-auth/core/utils/redirect-uri'
 import crypto from 'crypto'
 import type { Knex } from 'knex'

--- a/app/api/v1/apps/types.ts
+++ b/app/api/v1/apps/types.ts
@@ -3,6 +3,12 @@ import { z } from 'zod'
 export const PostRequest = z.object({
   client_name: z.string(),
   redirect_uris: z.string(),
+  // Optional OpenID Connect RP-Initiated Logout callbacks. Like `redirect_uris`
+  // these are newline-separated. When present (and at least one valid URI is
+  // given) the created client gets `enableEndSession = true` so it can drive
+  // single logout via `/api/auth/oauth2/end-session`. Omitted ⇒ logout stays
+  // disabled (current behavior).
+  post_logout_redirect_uris: z.string().optional(),
   scopes: z.string().optional(),
   website: z.string().optional()
 })

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,6 +28,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Passkeys** — Register and use passkeys for account authentication
 - ✅ **Two-factor authentication** — TOTP-based second-factor login support
 - ✅ **OAuth 2.0 provider** — App acts as a full OAuth 2.0 / OpenID Connect server
+- ✅ **OIDC RP-Initiated Logout** — `end_session_endpoint` advertised in discovery; OAuth clients registered with `post_logout_redirect_uris` can drive single logout (sign the user out of this instance, not just the relying party)
 - ✅ **OAuth Bearer tokens** — API authentication for third-party clients
 - ✅ **Email verification** — Required for new accounts
 - ✅ **Password reset** — Reset password via email

--- a/lib/services/auth/auth.ts
+++ b/lib/services/auth/auth.ts
@@ -9,6 +9,7 @@ import { getDatabase, getKnex } from '@/lib/database'
 import { UsableScopes } from '@/lib/types/database/operations'
 import { logger } from '@/lib/utils/logger'
 
+import { AUTH_BASE_PATH } from './constants'
 import { knexAdapter } from './knexAdapter'
 import { buildTrustedOrigins } from './trustedOrigins'
 
@@ -37,7 +38,7 @@ const buildAuth = (baseURL: string) => {
       getBaseURL(),
       config.trustedHosts ?? []
     ),
-    basePath: '/api/auth',
+    basePath: AUTH_BASE_PATH,
     database: knexAdapter(db, { passkeyRpID: rpID }),
     disabledPaths: ['/token'], // Disable jwt plugin's /api/auth/token;
     // OAuth tokens are issued via oauthProvider. JWKS stays enabled for OAuthGuard.

--- a/lib/services/auth/constants.ts
+++ b/lib/services/auth/constants.ts
@@ -1,10 +1,14 @@
-// The better-auth mount path. This is the single source of truth for the auth
-// basePath: better-auth joins it onto the configured baseURL to form
-// `ctx.context.baseURL` (e.g. `https://llun.social/api/auth`), which is the
-// value it stamps as the OIDC id_token `iss`, the value the RP-Initiated Logout
-// endpoint enforces (`id_token.iss === jwt.issuer ?? ctx.context.baseURL`), and
-// the prefix every `/api/auth/...` endpoint is served under. The hand-written
-// OpenID discovery document (lib/services/wellknown/openidConfiguration.ts)
-// builds its `issuer`/endpoints from the same constant so the advertised issuer
-// can never drift from the basePath the tokens are actually signed with.
+// The basePath the better-auth instance is mounted at. better-auth joins it onto
+// the configured baseURL to form `ctx.context.baseURL`
+// (e.g. `https://llun.social/api/auth`), which is the value it stamps as the OIDC
+// id_token `iss`, the value the RP-Initiated Logout endpoint enforces
+// (`id_token.iss === jwt.issuer ?? ctx.context.baseURL`), and the prefix every
+// `/api/auth/...` endpoint is served under.
+//
+// This is shared by the two places that must agree on it: `auth.ts` passes it as
+// better-auth's `basePath`, and the hand-written OpenID discovery document
+// (lib/services/wellknown/openidConfiguration.ts) builds its `issuer`/endpoints
+// from it — so the advertised issuer can never drift from the basePath the tokens
+// are actually signed under. (Note: the OAuth proxy routes under `app/api/oauth/*`
+// still spell `/api/auth/...` literally; migrating those is out of scope here.)
 export const AUTH_BASE_PATH = '/api/auth'

--- a/lib/services/auth/constants.ts
+++ b/lib/services/auth/constants.ts
@@ -1,0 +1,10 @@
+// The better-auth mount path. This is the single source of truth for the auth
+// basePath: better-auth joins it onto the configured baseURL to form
+// `ctx.context.baseURL` (e.g. `https://llun.social/api/auth`), which is the
+// value it stamps as the OIDC id_token `iss`, the value the RP-Initiated Logout
+// endpoint enforces (`id_token.iss === jwt.issuer ?? ctx.context.baseURL`), and
+// the prefix every `/api/auth/...` endpoint is served under. The hand-written
+// OpenID discovery document (lib/services/wellknown/openidConfiguration.ts)
+// builds its `issuer`/endpoints from the same constant so the advertised issuer
+// can never drift from the basePath the tokens are actually signed with.
+export const AUTH_BASE_PATH = '/api/auth'

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -1,4 +1,5 @@
 import { Database } from '@/lib/database/types'
+import { AUTH_BASE_PATH } from '@/lib/services/auth/constants'
 
 import {
   getHostMetaXML,
@@ -74,6 +75,8 @@ describe('wellknown services', () => {
         userinfo_endpoint: 'https://test.example.com/oauth/userinfo',
         jwks_uri: 'https://test.example.com/api/auth/jwks',
         revocation_endpoint: 'https://test.example.com/oauth/revoke',
+        end_session_endpoint:
+          'https://test.example.com/api/auth/oauth2/end-session',
         response_types_supported: ['code'],
         subject_types_supported: ['public'],
         id_token_signing_alg_values_supported: ['RS256'],
@@ -91,6 +94,33 @@ describe('wellknown services', () => {
       // The id_token `iss` is baseURL + basePath; discovery must match it
       // exactly or a strict OIDC relying party rejects the token.
       expect(config.issuer).toBe('https://test.example.com/api/auth')
+    })
+
+    it('advertises the RP-initiated logout end_session_endpoint under the issuer', () => {
+      // django-lasuite/mozilla-django-oidc reads `end_session_endpoint` from
+      // discovery to perform single logout against this instance.
+      const config = getOpenIDConfiguration()
+
+      expect(config.end_session_endpoint).toBe(
+        'https://test.example.com/api/auth/oauth2/end-session'
+      )
+    })
+
+    it('builds the issuer and logout endpoint from the same basePath constant the auth instance uses', () => {
+      // The oauth-provider's RP-initiated logout rejects an id_token unless
+      // `id_token.iss === jwt.issuer ?? ctx.context.baseURL`, where
+      // `ctx.context.baseURL` is `${baseURL}${basePath}` — and `basePath` is the
+      // shared `AUTH_BASE_PATH` constant `auth.ts` passes to better-auth. The
+      // id_token `iss`, the discovery `issuer`, and the end-session check all
+      // resolve to that single value, so a future basePath change moves the
+      // discovery issuer with it instead of silently breaking logout with
+      // "invalid issuer".
+      const config = getOpenIDConfiguration()
+
+      expect(config.issuer).toBe(`https://test.example.com${AUTH_BASE_PATH}`)
+      expect(config.end_session_endpoint).toBe(
+        `${config.issuer}/oauth2/end-session`
+      )
     })
 
     it('keeps a distinct issuer from the RFC 8414 OAuth metadata (bare origin)', () => {

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -106,15 +106,15 @@ describe('wellknown services', () => {
       )
     })
 
-    it('builds the issuer and logout endpoint from the same basePath constant the auth instance uses', () => {
-      // The oauth-provider's RP-initiated logout rejects an id_token unless
-      // `id_token.iss === jwt.issuer ?? ctx.context.baseURL`, where
-      // `ctx.context.baseURL` is `${baseURL}${basePath}` — and `basePath` is the
-      // shared `AUTH_BASE_PATH` constant `auth.ts` passes to better-auth. The
-      // id_token `iss`, the discovery `issuer`, and the end-session check all
-      // resolve to that single value, so a future basePath change moves the
-      // discovery issuer with it instead of silently breaking logout with
-      // "invalid issuer".
+    it('builds the issuer and logout endpoint from the shared AUTH_BASE_PATH constant', () => {
+      // `auth.ts` passes `AUTH_BASE_PATH` to better-auth as `basePath`, and the
+      // discovery doc builds its `issuer`/endpoints from the same constant, so
+      // the advertised issuer tracks the basePath the id_token `iss` is signed
+      // under (the value the end-session check enforces). This asserts the
+      // discovery side of that coupling — that the issuer and end_session_endpoint
+      // are derived from AUTH_BASE_PATH, not a divergent hardcoded literal. (It
+      // can't observe `auth.ts`'s `basePath` wiring directly; that side is held
+      // by both consuming this one exported constant.)
       const config = getOpenIDConfiguration()
 
       expect(config.issuer).toBe(`https://test.example.com${AUTH_BASE_PATH}`)

--- a/lib/services/wellknown/openidConfiguration.ts
+++ b/lib/services/wellknown/openidConfiguration.ts
@@ -1,4 +1,5 @@
 import { getBaseURL } from '@/lib/config'
+import { AUTH_BASE_PATH } from '@/lib/services/auth/constants'
 import { UsableScopes } from '@/lib/types/database/operations'
 
 export interface OpenIDConfiguration {
@@ -8,6 +9,7 @@ export interface OpenIDConfiguration {
   userinfo_endpoint: string
   jwks_uri: string
   revocation_endpoint: string
+  end_session_endpoint: string
   scopes_supported: readonly string[]
   response_types_supported: string[]
   response_modes_supported: string[]
@@ -22,18 +24,29 @@ export interface OpenIDConfiguration {
 export const getOpenIDConfiguration = (): OpenIDConfiguration => {
   const baseURL = getBaseURL()
   return {
-    // Better Auth signs id_tokens with `iss = baseURL + basePath` (the auth
-    // basePath is `/api/auth`), so the discovery `issuer` MUST match that value
-    // — a strict OIDC relying party rejects an id_token whose `iss` differs from
-    // the issuer it discovered here. The RFC 8414 OAuth metadata
+    // Better Auth signs id_tokens with `iss = baseURL + basePath`, so the
+    // discovery `issuer` MUST match that value — a strict OIDC relying party
+    // rejects an id_token whose `iss` differs from the issuer it discovered here.
+    // `AUTH_BASE_PATH` is the SAME constant `auth.ts` passes to better-auth as
+    // `basePath`, so the advertised issuer can never drift from the basePath the
+    // tokens are actually signed with. The RFC 8414 OAuth metadata
     // (oauthAuthorizationServer.ts) intentionally keeps the bare origin for
     // Mastodon compatibility; OAuth2 access tokens carry no `iss` to reconcile.
-    issuer: `${baseURL}/api/auth`,
-    authorization_endpoint: `${baseURL}/api/auth/oauth2/authorize`,
+    issuer: `${baseURL}${AUTH_BASE_PATH}`,
+    authorization_endpoint: `${baseURL}${AUTH_BASE_PATH}/oauth2/authorize`,
     token_endpoint: `${baseURL}/oauth/token`,
     userinfo_endpoint: `${baseURL}/oauth/userinfo`,
-    jwks_uri: `${baseURL}/api/auth/jwks`,
+    jwks_uri: `${baseURL}${AUTH_BASE_PATH}/jwks`,
     revocation_endpoint: `${baseURL}/oauth/revoke`,
+    // OpenID Connect RP-Initiated Logout 1.0 endpoint, served by the
+    // @better-auth/oauth-provider plugin under the auth basePath. A
+    // discovery-based relying party (e.g. django-lasuite/mozilla-django-oidc)
+    // reads this to perform single logout. The plugin verifies the supplied
+    // `id_token_hint` and enforces `id_token.iss === jwt.issuer ?? baseURL`,
+    // where its `baseURL` is `${baseURL}${AUTH_BASE_PATH}` — exactly the `issuer`
+    // advertised above and stamped on every id_token, so the issuer check is
+    // satisfied by construction for tokens this instance issues.
+    end_session_endpoint: `${baseURL}${AUTH_BASE_PATH}/oauth2/end-session`,
     scopes_supported: UsableScopes,
     response_types_supported: ['code'],
     response_modes_supported: ['query'],


### PR DESCRIPTION
## Summary

Enables **OpenID Connect RP-Initiated (single) Logout** so a discovery-based relying party — `docs.llun.dev` (La Suite Impress, via `django-lasuite` / `mozilla-django-oidc`) — can fully log a user out of `llun.social`, not just out of Docs locally.

`@better-auth/oauth-provider` already serves the live endpoint `GET /api/auth/oauth2/end-session`. It resolves the client from `id_token_hint.aud`, requires the client's `enableEndSession = true`, verifies the `id_token` against our JWKS, deletes the session named by the token's `sid` claim, and redirects only to a `post_logout_redirect_uri` that exact-matches the client's `postLogoutRedirectUris`. This PR wires the surrounding config around that endpoint.

## What changed

**1. Discovery — advertise `end_session_endpoint`** (`lib/services/wellknown/openidConfiguration.ts`)
- Added `end_session_endpoint: ${baseURL}/api/auth/oauth2/end-session` to the hand-written OIDC `openid-configuration` document (+ interface + tests).
- **Deliberately not** added to the RFC 8414 `oauth-authorization-server` metadata: `end_session_endpoint` is an OIDC parameter (RP-Initiated Logout / Session Management), the OAuth doc keeps a bare-origin `issuer` for Mastodon compatibility, and the library's own metadata producers split it the same way. `mozilla-django-oidc` discovers it from the OIDC document.

**2. Issuer coupling — confirmed, no fix needed, hardened** (`lib/services/auth/constants.ts`, `auth.ts`, `openidConfiguration.ts`)
- End-session enforces `id_token.iss === jwt.issuer ?? ctx.context.baseURL`. Traced through the library: `createIdToken` signs `iss` with the *identical* expression, `signJWT` honors that explicit `iss`, no custom `jwt.issuer` is configured, and `ctx.context.baseURL = ${baseURL}/api/auth`. So the check holds **by construction** for tokens we issue — confirmed, no code fix required.
- To keep it that way, the auth `basePath` is now single-sourced as `AUTH_BASE_PATH` and the discovery `issuer`/endpoints build from the same constant, so a future `basePath` change can't silently desync the advertised issuer from the basePath tokens are signed with. Added a regression test.

**3. Registration — optional `post_logout_redirect_uris`** (`app/api/v1/apps/createApplication.ts`, `types.ts`)
- The Mastodon `/api/v1/apps` flow accepts an optional newline-separated `post_logout_redirect_uris` (validated like `redirect_uris`). When ≥1 valid URI is present, the new client gets `enableEndSession = true` and the URIs stored as a JSON-array string (the format better-auth round-trips `string[]` columns through). Omitted ⇒ current behavior (logout stays disabled). Fully backward compatible.

No migration: `oauthClient.enableEndSession` and `postLogoutRedirectUris` already exist (migration `20260320200000`).

## ⚠️ Production step (run manually — does NOT ship in this PR)

The existing Docs client must be enabled out-of-band via a one-off update to the production database — **not** by re-registering (re-registering mints a new `client_id` and breaks the live Docs env). On the Docs client row (`clientId = 6AAjE6xydMRglbQWtypH9TLxVFOzGzjD`), set `enableEndSession = true` and `postLogoutRedirectUris` to the registered post-logout callback, stored in the same format as the existing `redirectUris` column.

Note: the logout redirect is a **byte-exact** match (no normalization), so the stored post-logout URI must equal what `mozilla-django-oidc` sends character-for-character (mind the trailing slash). The exact statements are handled through the deployment runbook, not this PR description.

## ⚠️ Re-login requirement

The `sid` claim is only embedded in id_tokens issued **while `enableEndSession` was true**. After the DB `UPDATE`, every existing Docs id_token still has no `sid`, so end-session fails with `id token missing session` until the user signs in again once.
- Clients **without** `offline_access` recover on their next interactive login.
- Clients **with** `offline_access` recover on their next `refresh_token` grant (it re-issues a fresh id_token with `sid`), as long as the underlying session still exists. Default id_token lifetime is ~10h.

## Testing

- `yarn lint` ✅ (0 errors) · `yarn build` ✅ · affected suites ✅ (`wellknown`, `apps/createApplication`, `apps/route`, `auth/jwks`, full `auth` + `wellknown` dirs — 96 tests).
- New tests: discovery `end_session_endpoint` + issuer/basePath coupling; `createApplication` enabling end-session, JSON-array-string storage, newline-separated URIs, omitted/whitespace ⇒ disabled, unsafe-scheme rejection.

## Reviewer notes

- The change was independently reviewed across 5 dimensions (issuer-match, production SQL, backward-compat, discovery-metadata, rollout caveats). All verdicts confirmed correct; the production-SQL identifier-quoting and the re-login/`offline_access` nuances above came from that pass.
- Registration validates `post_logout_redirect_uris` with the **same** `SafeUrlSchema` the end-session endpoint enforces at runtime (rejects fragments + non-HTTPS except loopback), so a stored URI can't pass registration yet fail at logout. (`redirect_uris` keeps its native-app-friendly validation.) Addressed gemini's review in `e3416f91`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

