### PR TITLE
fix: hide Approve/Reject on already-handled follow-request notifications

### DIFF
--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -316,6 +316,50 @@ describe('NotificationItem', () => {
     ).not.toBeInTheDocument()
   })
 
+  // Regression: when a request is handled elsewhere and the page soft-refreshes
+  // (e.g. the mark-as-read refresh), the row must re-seed from the new
+  // server-resolved status rather than keep its mount-time 'pending' state. The
+  // follow-request body is keyed by the resolved status so it remounts on change.
+  it('re-seeds the follow-request row when the resolved status changes on refresh', () => {
+    const followRequest = {
+      id: 'notification-follow-request-reseed',
+      actorId: 'https://llun.social/users/llun',
+      type: 'follow_request' as const,
+      sourceActorId: account.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account
+    }
+
+    const { rerender } = render(
+      <NotificationItem
+        notification={{ ...followRequest, followRequestStatus: 'pending' }}
+        host="llun.social"
+        isRead
+        currentTime={currentTime}
+        observeElement={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+
+    rerender(
+      <NotificationItem
+        notification={{ ...followRequest, followRequestStatus: 'accepted' }}
+        host="llun.social"
+        isRead
+        currentTime={currentTime}
+        observeElement={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders activity import notifications with the fitness card and a view link', () => {
     const { container } = renderNotificationItem({
       id: 'notification-activity-import',

--- a/app/(timeline)/notifications/NotificationItem.test.tsx
+++ b/app/(timeline)/notifications/NotificationItem.test.tsx
@@ -268,6 +268,54 @@ describe('NotificationItem', () => {
     expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
   })
 
+  // Regression: once a request is approved (the viewer follows back) the row must
+  // stop offering Approve / Reject and read as already handled. The page resolves
+  // the live follow status and forwards it as followRequestStatus.
+  it('renders an already-approved follow request without actions', () => {
+    renderNotificationItem({
+      id: 'notification-follow-request-accepted',
+      actorId: 'https://llun.social/users/llun',
+      type: 'follow_request',
+      sourceActorId: account.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      followRequestStatus: 'accepted'
+    })
+
+    expect(screen.getByText(/requested to follow you/)).toBeInTheDocument()
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reject' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a resolved follow request without actions', () => {
+    renderNotificationItem({
+      id: 'notification-follow-request-resolved',
+      actorId: 'https://llun.social/users/llun',
+      type: 'follow_request',
+      sourceActorId: account.id,
+      isRead: true,
+      createdAt: currentTime,
+      updatedAt: currentTime,
+      account,
+      followRequestStatus: 'resolved'
+    })
+
+    expect(screen.getByText('No longer pending')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reject' })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders activity import notifications with the fitness card and a view link', () => {
     const { container } = renderNotificationItem({
       id: 'notification-activity-import',

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -6,6 +6,7 @@ import { ReactNode, useEffect, useRef } from 'react'
 
 import { getNotificationStatusPath } from '@/app/(timeline)/notifications/getNotificationStatusPath'
 import {
+  type FollowRequestInitialStatus,
   type NotificationWithAccount,
   hasStatusActor
 } from '@/app/(timeline)/notifications/types'
@@ -33,6 +34,9 @@ interface Props {
     // The collection a collection-typed notification refers to (resolved from
     // its groupKey), or null when it has been deleted.
     collection?: { id: string; title: string } | null
+    // For follow_request rows: the server-resolved state of the request, so an
+    // already-handled request never renders stale Approve / Reject actions.
+    followRequestStatus?: FollowRequestInitialStatus
   }
   host: string
   isRead: boolean
@@ -128,7 +132,12 @@ export const NotificationItem = ({
       if (notification.type === 'follow') {
         body = <FollowNotification account={acc} />
       } else if (notification.type === 'follow_request') {
-        body = <FollowRequestNotification account={acc} />
+        body = (
+          <FollowRequestNotification
+            account={acc}
+            initialStatus={notification.followRequestStatus}
+          />
+        )
       } else if (notification.type === 'added_to_collection') {
         // The consent gate: let the member choose whether to appear on the
         // collection's public link. Needs the collection (from the groupKey)

--- a/app/(timeline)/notifications/NotificationItem.tsx
+++ b/app/(timeline)/notifications/NotificationItem.tsx
@@ -134,6 +134,12 @@ export const NotificationItem = ({
       } else if (notification.type === 'follow_request') {
         body = (
           <FollowRequestNotification
+            // Re-key on the server-resolved status so a request handled
+            // elsewhere (and surfaced on a soft refresh) re-seeds the row
+            // instead of keeping the mount-time state. This NotificationItem is
+            // already keyed by notification.id upstream, so keying by id here
+            // would never reset; the resolved status is what must reset it.
+            key={notification.followRequestStatus ?? 'pending'}
             account={acc}
             initialStatus={notification.followRequestStatus}
           />

--- a/app/(timeline)/notifications/NotificationsList.tsx
+++ b/app/(timeline)/notifications/NotificationsList.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import type { FollowRequestInitialStatus } from '@/app/(timeline)/notifications/types'
 import { markNotificationsRead } from '@/lib/client'
 import type { GroupedNotification } from '@/lib/services/notifications/groupNotifications'
 import type { Mastodon } from '@/lib/types/activitypub'
@@ -14,6 +15,7 @@ interface NotificationWithData extends GroupedNotification {
   account: Mastodon.Account | null
   status?: Status | null
   collection?: { id: string; title: string } | null
+  followRequestStatus?: FollowRequestInitialStatus
 }
 
 interface Props {

--- a/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
@@ -145,6 +145,23 @@ describe('FollowRequestNotification', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('does not start a second action while one is already in flight', async () => {
+    // Accept never resolves, so the first action stays in flight.
+    ;(acceptFollowRequest as jest.Mock).mockReturnValue(new Promise(() => {}))
+    render(<FollowRequestNotification account={account} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => expect(acceptFollowRequest).toHaveBeenCalledTimes(1))
+    // Both actions are mutually exclusive while one is pending.
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    expect(rejectFollowRequest).not.toHaveBeenCalled()
+    expect(acceptFollowRequest).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeDisabled()
+  })
+
   it('keeps the actions and shows an inline error when the request fails', async () => {
     ;(acceptFollowRequest as jest.Mock).mockResolvedValue(false)
     render(<FollowRequestNotification account={account} />)

--- a/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
@@ -2,14 +2,21 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import { acceptFollowRequest, rejectFollowRequest } from '@/lib/client'
 import type { Mastodon } from '@/lib/types/activitypub'
 
 import { FollowRequestNotification } from './FollowRequestNotification'
 
+vi.mock('@/lib/client', () => ({
+  acceptFollowRequest: vi.fn(),
+  rejectFollowRequest: vi.fn()
+}))
+
+const mockRefresh = vi.fn()
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() })
+  useRouter: () => ({ refresh: mockRefresh, push: vi.fn() })
 }))
 
 const account: Mastodon.Account = {
@@ -45,6 +52,12 @@ const account: Mastodon.Account = {
 }
 
 describe('FollowRequestNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(acceptFollowRequest as jest.Mock).mockResolvedValue(true)
+    ;(rejectFollowRequest as jest.Mock).mockResolvedValue(true)
+  })
+
   it('shows Approve and Reject actions for a pending request', () => {
     render(<FollowRequestNotification account={account} />)
 
@@ -75,6 +88,20 @@ describe('FollowRequestNotification', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('shows a rejected label and no actions when the request was already rejected', () => {
+    render(
+      <FollowRequestNotification account={account} initialStatus="rejected" />
+    )
+
+    expect(screen.getByText('Rejected')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reject' })
+    ).not.toBeInTheDocument()
+  })
+
   it('shows a resolved label and no actions when the request is no longer pending', () => {
     render(
       <FollowRequestNotification account={account} initialStatus="resolved" />
@@ -87,5 +114,48 @@ describe('FollowRequestNotification', () => {
     expect(
       screen.queryByRole('button', { name: 'Reject' })
     ).not.toBeInTheDocument()
+  })
+
+  it('approves a pending request and swaps the actions for an approved label', async () => {
+    render(<FollowRequestNotification account={account} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() =>
+      expect(acceptFollowRequest).toHaveBeenCalledWith({ id: account.url })
+    )
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+    expect(mockRefresh).toHaveBeenCalled()
+  })
+
+  it('rejects a pending request and swaps the actions for a rejected label', async () => {
+    render(<FollowRequestNotification account={account} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+
+    await waitFor(() =>
+      expect(rejectFollowRequest).toHaveBeenCalledWith({ id: account.url })
+    )
+    expect(await screen.findByText('Rejected')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reject' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps the actions and shows an inline error when the request fails', async () => {
+    ;(acceptFollowRequest as jest.Mock).mockResolvedValue(false)
+    render(<FollowRequestNotification account={account} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to accept follow request. Please try again.'
+    )
+    // A failed request must leave the row actionable (no optimistic state).
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+    expect(screen.queryByText('Approved')).not.toBeInTheDocument()
   })
 })

--- a/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import type { Mastodon } from '@/lib/types/activitypub'
+
+import { FollowRequestNotification } from './FollowRequestNotification'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() })
+}))
+
+const account: Mastodon.Account = {
+  id: 'https://llun.social/users/ride',
+  username: 'ride',
+  acct: 'ride@llun.social',
+  url: 'https://llun.social/@ride',
+  display_name: 'Ride',
+  note: '',
+  avatar: '',
+  avatar_static: '',
+  header: '',
+  header_static: '',
+  locked: false,
+  source: {
+    note: '',
+    fields: [],
+    privacy: 'public',
+    sensitive: false,
+    language: 'en',
+    follow_requests_count: 0
+  },
+  fields: [],
+  emojis: [],
+  bot: false,
+  group: false,
+  discoverable: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  last_status_at: '2026-05-10',
+  statuses_count: 1,
+  followers_count: 0,
+  following_count: 0
+}
+
+describe('FollowRequestNotification', () => {
+  it('shows Approve and Reject actions for a pending request', () => {
+    render(<FollowRequestNotification account={account} />)
+
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
+  })
+
+  it('shows Approve and Reject actions when initialStatus is pending', () => {
+    render(
+      <FollowRequestNotification account={account} initialStatus="pending" />
+    )
+
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
+  })
+
+  it('shows an approved label and no actions when the request was already accepted', () => {
+    render(
+      <FollowRequestNotification account={account} initialStatus="accepted" />
+    )
+
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reject' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a resolved label and no actions when the request is no longer pending', () => {
+    render(
+      <FollowRequestNotification account={account} initialStatus="resolved" />
+    )
+
+    expect(screen.getByText('No longer pending')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reject' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
@@ -188,4 +188,24 @@ describe('FollowRequestNotification', () => {
     expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
     expect(screen.queryByText('Approved')).not.toBeInTheDocument()
   })
+
+  it('re-enables the action after a failure so it can be retried', async () => {
+    ;(acceptFollowRequest as jest.Mock).mockResolvedValueOnce(false)
+    render(<FollowRequestNotification account={account} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    // The finally block must release both isLoading and the pendingRef lock, so
+    // the button is enabled again and a retry actually dispatches.
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Approve' })).not.toBeDisabled()
+    )
+
+    // The retry succeeds (default mock returns true) and swaps to the label.
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+    expect(acceptFollowRequest).toHaveBeenCalledTimes(2)
+  })
 })

--- a/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { acceptFollowRequest, rejectFollowRequest } from '@/lib/client'
 import type { Mastodon } from '@/lib/types/activitypub'
@@ -145,20 +145,33 @@ describe('FollowRequestNotification', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('does not start a second action while one is already in flight', async () => {
-    // Accept never resolves, so the first action stays in flight.
+  it('rejects a same-tick re-click before the disabled state applies', async () => {
+    // The first request never resolves, so the action stays in flight.
+    ;(acceptFollowRequest as jest.Mock).mockReturnValue(new Promise(() => {}))
+    render(<FollowRequestNotification account={account} />)
+    const approve = screen.getByRole('button', { name: 'Approve' })
+
+    // Both clicks are dispatched in one batch, before React flushes the
+    // disabled={isLoading} state — so only the synchronous pendingRef lock can
+    // stop the second click from starting a concurrent request. (Without the
+    // lock, acceptFollowRequest would be called twice.)
+    await act(async () => {
+      approve.click()
+      approve.click()
+    })
+
+    expect(acceptFollowRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables both actions once one is in flight', async () => {
     ;(acceptFollowRequest as jest.Mock).mockReturnValue(new Promise(() => {}))
     render(<FollowRequestNotification account={account} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
 
-    await waitFor(() => expect(acceptFollowRequest).toHaveBeenCalledTimes(1))
-    // Both actions are mutually exclusive while one is pending.
-    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
-    expect(rejectFollowRequest).not.toHaveBeenCalled()
-    expect(acceptFollowRequest).toHaveBeenCalledTimes(1)
-    expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled()
+    )
     expect(screen.getByRole('button', { name: 'Reject' })).toBeDisabled()
   })
 

--- a/app/(timeline)/notifications/components/FollowRequestNotification.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { FC, useState } from 'react'
+import { FC, useRef, useState } from 'react'
 
 import type { FollowRequestInitialStatus } from '@/app/(timeline)/notifications/types'
 import { acceptFollowRequest, rejectFollowRequest } from '@/lib/client'
@@ -41,8 +41,16 @@ export const FollowRequestNotification: FC<Props> = ({
     useState<FollowRequestInitialStatus>(initialStatus)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Synchronous re-entrancy lock. Accept and Reject are mutually exclusive, and
+  // `disabled={isLoading}` already blocks the buttons once React re-renders;
+  // this ref additionally rejects a second call dispatched in the same tick
+  // (before the disabled state applies), since the isLoading closure is stale
+  // there. It is not React state because it must update synchronously.
+  const pendingRef = useRef(false)
 
   const respond = async (action: 'accept' | 'reject') => {
+    if (pendingRef.current) return
+    pendingRef.current = true
     setIsLoading(true)
     setError(null)
     try {
@@ -57,6 +65,7 @@ export const FollowRequestNotification: FC<Props> = ({
       setError(`Failed to ${action} follow request. Please try again.`)
     } finally {
       setIsLoading(false)
+      pendingRef.current = false
     }
   }
 

--- a/app/(timeline)/notifications/components/FollowRequestNotification.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.tsx
@@ -12,16 +12,15 @@ import { cn } from '@/lib/utils'
 interface Props {
   account: Mastodon.Account
   // The server-resolved state of the request. Defaults to 'pending' so a row
-  // with no resolved status still offers the actions. 'rejected' is only ever
-  // reached from this component's own Reject action, so it is not part of the
-  // server-supplied initial status.
+  // with no resolved status still offers the actions.
   initialStatus?: FollowRequestInitialStatus
 }
 
-type FollowRequestStatus = FollowRequestInitialStatus | 'rejected'
-
 // Labels for the non-pending states (pending renders the action buttons).
-const STATUS_LABEL: Record<Exclude<FollowRequestStatus, 'pending'>, string> = {
+const STATUS_LABEL: Record<
+  Exclude<FollowRequestInitialStatus, 'pending'>,
+  string
+> = {
   accepted: 'Approved',
   rejected: 'Rejected',
   resolved: 'No longer pending'
@@ -38,7 +37,8 @@ export const FollowRequestNotification: FC<Props> = ({
   initialStatus = 'pending'
 }) => {
   const router = useRouter()
-  const [status, setStatus] = useState<FollowRequestStatus>(initialStatus)
+  const [status, setStatus] =
+    useState<FollowRequestInitialStatus>(initialStatus)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/app/(timeline)/notifications/components/FollowRequestNotification.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { FC, useState } from 'react'
 
+import type { FollowRequestInitialStatus } from '@/app/(timeline)/notifications/types'
 import { acceptFollowRequest, rejectFollowRequest } from '@/lib/client'
 import { Button } from '@/lib/components/ui/button'
 import type { Mastodon } from '@/lib/types/activitypub'
@@ -10,17 +11,34 @@ import { cn } from '@/lib/utils'
 
 interface Props {
   account: Mastodon.Account
+  // The server-resolved state of the request. Defaults to 'pending' so a row
+  // with no resolved status still offers the actions. 'rejected' is only ever
+  // reached from this component's own Reject action, so it is not part of the
+  // server-supplied initial status.
+  initialStatus?: FollowRequestInitialStatus
+}
+
+type FollowRequestStatus = FollowRequestInitialStatus | 'rejected'
+
+// Labels for the non-pending states (pending renders the action buttons).
+const STATUS_LABEL: Record<Exclude<FollowRequestStatus, 'pending'>, string> = {
+  accepted: 'Approved',
+  rejected: 'Rejected',
+  resolved: 'No longer pending'
 }
 
 // The body of a follow-request notification: the actor handle plus Approve /
 // Reject actions. The "<name> requested to follow you" headline lives in
 // NotificationItem, so the row always reads as a follow request even before the
-// actions.
-export const FollowRequestNotification: FC<Props> = ({ account }) => {
+// actions. When the request is no longer pending (already accepted, rejected,
+// or withdrawn) the actions are replaced by a status label so the row never
+// invites an action that would just 404.
+export const FollowRequestNotification: FC<Props> = ({
+  account,
+  initialStatus = 'pending'
+}) => {
   const router = useRouter()
-  const [status, setStatus] = useState<'pending' | 'accepted' | 'rejected'>(
-    'pending'
-  )
+  const [status, setStatus] = useState<FollowRequestStatus>(initialStatus)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -75,7 +93,7 @@ export const FollowRequestNotification: FC<Props> = ({ account }) => {
                 : 'text-muted-foreground'
             )}
           >
-            {status === 'accepted' ? 'Approved' : 'Rejected'}
+            {STATUS_LABEL[status]}
           </span>
         )}
       </div>

--- a/app/(timeline)/notifications/followRequestStatus.test.ts
+++ b/app/(timeline)/notifications/followRequestStatus.test.ts
@@ -1,6 +1,10 @@
+import type { Notification } from '@/lib/types/database/operations'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
 
-import { followRequestStatusFromFollow } from './followRequestStatus'
+import {
+  followRequestStatusFromFollow,
+  resolveFollowRequestStatus
+} from './followRequestStatus'
 
 const baseFollow: Follow = {
   id: 'follow-1',
@@ -18,6 +22,16 @@ const baseFollow: Follow = {
   updatedAt: 1000
 }
 
+const followRequestNotification: Pick<
+  Notification,
+  'followId' | 'sourceActorId'
+> = {
+  followId: 'follow-1',
+  sourceActorId: 'https://remote.example/users/alice'
+}
+
+const viewerActorId = 'https://llun.social/users/llun'
+
 describe('followRequestStatusFromFollow', () => {
   it('returns resolved when there is no follow record', () => {
     expect(followRequestStatusFromFollow(null)).toBe('resolved')
@@ -26,11 +40,86 @@ describe('followRequestStatusFromFollow', () => {
   it.each([
     [FollowStatus.enum.Requested, 'pending'],
     [FollowStatus.enum.Accepted, 'accepted'],
-    [FollowStatus.enum.Rejected, 'resolved'],
+    [FollowStatus.enum.Rejected, 'rejected'],
     [FollowStatus.enum.Undo, 'resolved']
   ] as const)('maps a %s follow to %s', (status, expected) => {
     expect(followRequestStatusFromFollow({ ...baseFollow, status })).toBe(
       expected
     )
+  })
+})
+
+describe('resolveFollowRequestStatus', () => {
+  it('resolves the exact follow recorded on the notification by id', async () => {
+    const getFollowFromId = vi.fn().mockResolvedValue({
+      ...baseFollow,
+      status: FollowStatus.enum.Accepted
+    })
+    const getAcceptedOrRequestedFollow = vi.fn()
+    const database = { getFollowFromId, getAcceptedOrRequestedFollow }
+
+    const result = await resolveFollowRequestStatus(
+      database,
+      followRequestNotification,
+      viewerActorId
+    )
+
+    expect(getFollowFromId).toHaveBeenCalledWith({ followId: 'follow-1' })
+    // The exact-id lookup is authoritative, so the requester/viewer pair lookup
+    // must not run.
+    expect(getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+    expect(result).toBe('accepted')
+  })
+
+  it('maps a rejected follow referenced by id to rejected', async () => {
+    const getFollowFromId = vi.fn().mockResolvedValue({
+      ...baseFollow,
+      status: FollowStatus.enum.Rejected
+    })
+    const database = { getFollowFromId, getAcceptedOrRequestedFollow: vi.fn() }
+
+    const result = await resolveFollowRequestStatus(
+      database,
+      followRequestNotification,
+      viewerActorId
+    )
+
+    expect(result).toBe('rejected')
+  })
+
+  it('falls back to the requester/viewer pair when the notification has no followId', async () => {
+    const getFollowFromId = vi.fn()
+    const getAcceptedOrRequestedFollow = vi
+      .fn()
+      .mockResolvedValue({ ...baseFollow, status: FollowStatus.enum.Requested })
+    const database = { getFollowFromId, getAcceptedOrRequestedFollow }
+
+    const result = await resolveFollowRequestStatus(
+      database,
+      { followId: undefined, sourceActorId: baseFollow.actorId },
+      viewerActorId
+    )
+
+    expect(getFollowFromId).not.toHaveBeenCalled()
+    expect(getAcceptedOrRequestedFollow).toHaveBeenCalledWith({
+      actorId: baseFollow.actorId,
+      targetActorId: viewerActorId
+    })
+    expect(result).toBe('pending')
+  })
+
+  it('returns resolved when the referenced follow no longer exists', async () => {
+    const database = {
+      getFollowFromId: vi.fn().mockResolvedValue(null),
+      getAcceptedOrRequestedFollow: vi.fn()
+    }
+
+    const result = await resolveFollowRequestStatus(
+      database,
+      followRequestNotification,
+      viewerActorId
+    )
+
+    expect(result).toBe('resolved')
   })
 })

--- a/app/(timeline)/notifications/followRequestStatus.test.ts
+++ b/app/(timeline)/notifications/followRequestStatus.test.ts
@@ -1,0 +1,36 @@
+import { Follow, FollowStatus } from '@/lib/types/domain/follow'
+
+import { followRequestStatusFromFollow } from './followRequestStatus'
+
+const baseFollow: Follow = {
+  id: 'follow-1',
+  actorId: 'https://remote.example/users/alice',
+  actorHost: 'remote.example',
+  targetActorId: 'https://llun.social/users/llun',
+  targetActorHost: 'llun.social',
+  status: FollowStatus.enum.Requested,
+  inbox: 'https://remote.example/users/alice/inbox',
+  sharedInbox: 'https://remote.example/inbox',
+  reblogs: true,
+  notify: false,
+  languages: null,
+  createdAt: 1000,
+  updatedAt: 1000
+}
+
+describe('followRequestStatusFromFollow', () => {
+  it('returns resolved when there is no follow record', () => {
+    expect(followRequestStatusFromFollow(null)).toBe('resolved')
+  })
+
+  it.each([
+    [FollowStatus.enum.Requested, 'pending'],
+    [FollowStatus.enum.Accepted, 'accepted'],
+    [FollowStatus.enum.Rejected, 'resolved'],
+    [FollowStatus.enum.Undo, 'resolved']
+  ] as const)('maps a %s follow to %s', (status, expected) => {
+    expect(followRequestStatusFromFollow({ ...baseFollow, status })).toBe(
+      expected
+    )
+  })
+})

--- a/app/(timeline)/notifications/followRequestStatus.test.ts
+++ b/app/(timeline)/notifications/followRequestStatus.test.ts
@@ -1,10 +1,15 @@
 import type { Notification } from '@/lib/types/database/operations'
 import { Follow, FollowStatus } from '@/lib/types/domain/follow'
+import { logger } from '@/lib/utils/logger'
 
 import {
   followRequestStatusFromFollow,
   resolveFollowRequestStatus
 } from './followRequestStatus'
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() }
+}))
 
 const baseFollow: Follow = {
   id: 'follow-1',
@@ -121,5 +126,25 @@ describe('resolveFollowRequestStatus', () => {
     )
 
     expect(result).toBe('resolved')
+  })
+
+  it('falls back to resolved and logs when the follow lookup fails', async () => {
+    const error = new Error('database unavailable')
+    const database = {
+      getFollowFromId: vi.fn().mockRejectedValue(error),
+      getAcceptedOrRequestedFollow: vi.fn()
+    }
+
+    const result = await resolveFollowRequestStatus(
+      database,
+      followRequestNotification,
+      viewerActorId
+    )
+
+    // A transient lookup failure must not crash the page, and must not fall
+    // back to 'pending' (that would re-show stale Approve/Reject); 'resolved'
+    // hides the actions safely.
+    expect(result).toBe('resolved')
+    expect(logger.warn).toHaveBeenCalled()
   })
 })

--- a/app/(timeline)/notifications/followRequestStatus.ts
+++ b/app/(timeline)/notifications/followRequestStatus.ts
@@ -1,11 +1,12 @@
 import type { FollowRequestInitialStatus } from '@/app/(timeline)/notifications/types'
+import type { Notification } from '@/lib/types/database/operations'
 import { type Follow, FollowStatus } from '@/lib/types/domain/follow'
 
-// Map the current Follow record between a requester and the viewer to the UI
-// state of its follow-request notification row. A still-Requested follow is
-// actionable; an Accepted one reads as already approved; everything else
-// (Rejected, Undo, or no record at all) is resolved and offers no actions, so a
-// handled request never shows stale Approve / Reject buttons.
+// Map a Follow record to the UI state of its follow-request notification row. A
+// still-Requested follow is actionable; an Accepted one reads as approved; a
+// Rejected one as rejected; everything else (Undo, or no record at all) is
+// resolved and offers no actions, so a handled request never shows stale
+// Approve / Reject buttons.
 export const followRequestStatusFromFollow = (
   follow: Follow | null
 ): FollowRequestInitialStatus => {
@@ -15,7 +16,37 @@ export const followRequestStatusFromFollow = (
       return 'pending'
     case FollowStatus.enum.Accepted:
       return 'accepted'
+    case FollowStatus.enum.Rejected:
+      return 'rejected'
     default:
       return 'resolved'
   }
+}
+
+// The narrow database surface needed to resolve a follow-request row's state.
+interface FollowLookupDatabase {
+  getFollowFromId(params: { followId: string }): Promise<Follow | null>
+  getAcceptedOrRequestedFollow(params: {
+    actorId: string
+    targetActorId: string
+  }): Promise<Follow | null>
+}
+
+// Resolve the live state of a follow-request notification. Prefer the exact
+// follow recorded on the notification (`followId`) so a re-request after a
+// rejection resolves independently of the older, rejected row for the same
+// pair. Fall back to the active follow between the requester (source actor) and
+// the viewer (target) only when no `followId` was recorded.
+export const resolveFollowRequestStatus = async (
+  database: FollowLookupDatabase,
+  notification: Pick<Notification, 'followId' | 'sourceActorId'>,
+  viewerActorId: string
+): Promise<FollowRequestInitialStatus> => {
+  const follow = notification.followId
+    ? await database.getFollowFromId({ followId: notification.followId })
+    : await database.getAcceptedOrRequestedFollow({
+        actorId: notification.sourceActorId,
+        targetActorId: viewerActorId
+      })
+  return followRequestStatusFromFollow(follow)
 }

--- a/app/(timeline)/notifications/followRequestStatus.ts
+++ b/app/(timeline)/notifications/followRequestStatus.ts
@@ -1,6 +1,7 @@
 import type { FollowRequestInitialStatus } from '@/app/(timeline)/notifications/types'
 import type { Notification } from '@/lib/types/database/operations'
 import { type Follow, FollowStatus } from '@/lib/types/domain/follow'
+import { logger } from '@/lib/utils/logger'
 
 // Map a Follow record to the UI state of its follow-request notification row. A
 // still-Requested follow is actionable; an Accepted one reads as approved; a
@@ -42,11 +43,23 @@ export const resolveFollowRequestStatus = async (
   notification: Pick<Notification, 'followId' | 'sourceActorId'>,
   viewerActorId: string
 ): Promise<FollowRequestInitialStatus> => {
-  const follow = notification.followId
-    ? await database.getFollowFromId({ followId: notification.followId })
-    : await database.getAcceptedOrRequestedFollow({
-        actorId: notification.sourceActorId,
-        targetActorId: viewerActorId
-      })
-  return followRequestStatusFromFollow(follow)
+  try {
+    const follow = notification.followId
+      ? await database.getFollowFromId({ followId: notification.followId })
+      : await database.getAcceptedOrRequestedFollow({
+          actorId: notification.sourceActorId,
+          targetActorId: viewerActorId
+        })
+    return followRequestStatusFromFollow(follow)
+  } catch (error) {
+    // A transient lookup failure must not crash the whole notifications page.
+    // Degrade to 'resolved' (hide the actions) rather than 'pending', so a
+    // failed lookup never re-shows Approve / Reject for an already-handled
+    // request — the row self-heals on the next load.
+    logger.warn(
+      { err: error, followId: notification.followId },
+      'Failed to resolve follow request status; defaulting to resolved'
+    )
+    return 'resolved'
+  }
 }

--- a/app/(timeline)/notifications/followRequestStatus.ts
+++ b/app/(timeline)/notifications/followRequestStatus.ts
@@ -1,0 +1,21 @@
+import type { FollowRequestInitialStatus } from '@/app/(timeline)/notifications/types'
+import { type Follow, FollowStatus } from '@/lib/types/domain/follow'
+
+// Map the current Follow record between a requester and the viewer to the UI
+// state of its follow-request notification row. A still-Requested follow is
+// actionable; an Accepted one reads as already approved; everything else
+// (Rejected, Undo, or no record at all) is resolved and offers no actions, so a
+// handled request never shows stale Approve / Reject buttons.
+export const followRequestStatusFromFollow = (
+  follow: Follow | null
+): FollowRequestInitialStatus => {
+  if (!follow) return 'resolved'
+  switch (follow.status) {
+    case FollowStatus.enum.Requested:
+      return 'pending'
+    case FollowStatus.enum.Accepted:
+      return 'accepted'
+    default:
+      return 'resolved'
+  }
+}

--- a/app/(timeline)/notifications/page.test.tsx
+++ b/app/(timeline)/notifications/page.test.tsx
@@ -1,7 +1,30 @@
+import { type ReactNode, isValidElement } from 'react'
+
 import type { Notification } from '@/lib/types/database/operations'
 import { type Follow, FollowStatus } from '@/lib/types/domain/follow'
 
+import { NotificationsList } from './NotificationsList'
 import Page from './page'
+
+// Walk the (unrendered) element tree the Server Component returns and find the
+// first element of a given component type, so a test can read the props the
+// page forwards to a child without rendering the whole client tree.
+const findElementByType = (
+  node: ReactNode,
+  type: unknown
+): { props: Record<string, unknown> } | null => {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findElementByType(child, type)
+      if (found) return found
+    }
+    return null
+  }
+  if (!isValidElement(node)) return null
+  if (node.type === type) return node as { props: Record<string, unknown> }
+  const props = node.props as { children?: ReactNode }
+  return findElementByType(props?.children, type)
+}
 
 const mockGetConfig = vi.fn()
 const mockGetDatabase = vi.fn()
@@ -94,7 +117,7 @@ describe('notifications page', () => {
     ])
     mockGetDatabase.mockReturnValue(database)
 
-    await Page({ searchParams: Promise.resolve({}) })
+    const element = await Page({ searchParams: Promise.resolve({}) })
 
     // The exact follow recorded on the notification is looked up; the
     // requester/viewer pair fallback is not used when a followId exists.
@@ -103,6 +126,22 @@ describe('notifications page', () => {
       followId: 'follow-1'
     })
     expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+
+    // The resolved status must actually reach the list, not just be computed:
+    // assert the follow_request row is forwarded with followRequestStatus and
+    // that other rows carry none.
+    const list = findElementByType(element, NotificationsList)
+    const forwarded = (
+      list?.props.notifications as Array<{
+        id: string
+        followRequestStatus?: string
+      }>
+    ).reduce<Record<string, string | undefined>>((map, notification) => {
+      map[notification.id] = notification.followRequestStatus
+      return map
+    }, {})
+    expect(forwarded[followRequestNotification.id]).toBe('accepted')
+    expect(forwarded[likeNotification.id]).toBeUndefined()
   })
 
   it('does not resolve follow state for non follow_request rows', async () => {

--- a/app/(timeline)/notifications/page.test.tsx
+++ b/app/(timeline)/notifications/page.test.tsx
@@ -1,0 +1,117 @@
+import type { Notification } from '@/lib/types/database/operations'
+import { type Follow, FollowStatus } from '@/lib/types/domain/follow'
+
+import Page from './page'
+
+const mockGetConfig = vi.fn()
+const mockGetDatabase = vi.fn()
+const mockGetServerAuthSession = vi.fn()
+const mockGetActorFromSession = vi.fn()
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => mockGetConfig()
+}))
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockGetDatabase()
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerAuthSession()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: (...args: unknown[]) => mockGetActorFromSession(...args)
+}))
+
+const currentTime = new Date('2026-05-17T12:00:00.000Z').getTime()
+const viewerActorId = 'https://llun.social/users/llun'
+const requesterActorId = 'https://remote.example/users/alice'
+
+const followRequestNotification: Notification = {
+  id: 'notification-follow-request',
+  actorId: viewerActorId,
+  type: 'follow_request',
+  sourceActorId: requesterActorId,
+  followId: 'follow-1',
+  isRead: false,
+  filtered: false,
+  groupKey: 'ungrouped-notification-follow-request',
+  createdAt: currentTime,
+  updatedAt: currentTime
+}
+
+const likeNotification: Notification = {
+  id: 'notification-like',
+  actorId: viewerActorId,
+  type: 'like',
+  sourceActorId: 'https://remote.example/users/bob',
+  isRead: true,
+  filtered: false,
+  groupKey: 'ungrouped-notification-like',
+  createdAt: currentTime - 1,
+  updatedAt: currentTime - 1
+}
+
+const acceptedFollow: Follow = {
+  id: 'follow-1',
+  actorId: requesterActorId,
+  actorHost: 'remote.example',
+  targetActorId: viewerActorId,
+  targetActorHost: 'llun.social',
+  status: FollowStatus.enum.Accepted,
+  inbox: 'https://remote.example/users/alice/inbox',
+  sharedInbox: 'https://remote.example/inbox',
+  reblogs: true,
+  notify: false,
+  languages: null,
+  createdAt: currentTime,
+  updatedAt: currentTime
+}
+
+const buildDatabase = (notifications: Notification[]) => ({
+  getNotifications: vi.fn().mockResolvedValue(notifications),
+  getNotificationsCount: vi.fn().mockResolvedValue(notifications.length),
+  getMastodonActorFromId: vi.fn().mockResolvedValue(null),
+  getStatus: vi.fn().mockResolvedValue(null),
+  getCollectionById: vi.fn().mockResolvedValue(null),
+  getFollowFromId: vi.fn().mockResolvedValue(acceptedFollow),
+  getAcceptedOrRequestedFollow: vi.fn().mockResolvedValue(null)
+})
+
+describe('notifications page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetConfig.mockReturnValue({ host: 'llun.social' })
+    mockGetServerAuthSession.mockResolvedValue({ user: { id: 'account-1' } })
+    mockGetActorFromSession.mockResolvedValue({ id: viewerActorId })
+  })
+
+  it('resolves the follow state by the notification followId for follow_request rows', async () => {
+    const database = buildDatabase([
+      followRequestNotification,
+      likeNotification
+    ])
+    mockGetDatabase.mockReturnValue(database)
+
+    await Page({ searchParams: Promise.resolve({}) })
+
+    // The exact follow recorded on the notification is looked up; the
+    // requester/viewer pair fallback is not used when a followId exists.
+    expect(database.getFollowFromId).toHaveBeenCalledTimes(1)
+    expect(database.getFollowFromId).toHaveBeenCalledWith({
+      followId: 'follow-1'
+    })
+    expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
+
+  it('does not resolve follow state for non follow_request rows', async () => {
+    const database = buildDatabase([likeNotification])
+    mockGetDatabase.mockReturnValue(database)
+
+    await Page({ searchParams: Promise.resolve({}) })
+
+    expect(database.getFollowFromId).not.toHaveBeenCalled()
+    expect(database.getAcceptedOrRequestedFollow).not.toHaveBeenCalled()
+  })
+})

--- a/app/(timeline)/notifications/page.tsx
+++ b/app/(timeline)/notifications/page.tsx
@@ -18,7 +18,7 @@ import {
   NotificationFilterTabs,
   type NotificationTab
 } from './components/NotificationFilterTabs'
-import { followRequestStatusFromFollow } from './followRequestStatus'
+import { resolveFollowRequestStatus } from './followRequestStatus'
 
 export const dynamic = 'force-dynamic'
 
@@ -129,16 +129,10 @@ const Page = async ({ searchParams }: Props) => {
 
       // For follow_request rows, resolve the live follow state so an already
       // handled request (accepted, rejected, or withdrawn) never offers stale
-      // Approve / Reject actions. The follower is the source actor; the viewer
-      // is the target.
+      // Approve / Reject actions.
       const followRequestStatus =
         notification.type === 'follow_request'
-          ? followRequestStatusFromFollow(
-              await database.getAcceptedOrRequestedFollow({
-                actorId: notification.sourceActorId,
-                targetActorId: actor.id
-              })
-            )
+          ? await resolveFollowRequestStatus(database, notification, actor.id)
           : undefined
 
       return {

--- a/app/(timeline)/notifications/page.tsx
+++ b/app/(timeline)/notifications/page.tsx
@@ -18,6 +18,7 @@ import {
   NotificationFilterTabs,
   type NotificationTab
 } from './components/NotificationFilterTabs'
+import { followRequestStatusFromFollow } from './followRequestStatus'
 
 export const dynamic = 'force-dynamic'
 
@@ -126,11 +127,26 @@ const Page = async ({ searchParams }: Props) => {
           ? { id: collectionId, title: collectionTitles.get(collectionId)! }
           : null
 
+      // For follow_request rows, resolve the live follow state so an already
+      // handled request (accepted, rejected, or withdrawn) never offers stale
+      // Approve / Reject actions. The follower is the source actor; the viewer
+      // is the target.
+      const followRequestStatus =
+        notification.type === 'follow_request'
+          ? followRequestStatusFromFollow(
+              await database.getAcceptedOrRequestedFollow({
+                actorId: notification.sourceActorId,
+                targetActorId: actor.id
+              })
+            )
+          : undefined
+
       return {
         ...notification,
         account,
         status,
-        collection
+        collection,
+        followRequestStatus
       }
     })
   )

--- a/app/(timeline)/notifications/types.ts
+++ b/app/(timeline)/notifications/types.ts
@@ -2,15 +2,20 @@ import type { GroupedNotification } from '@/lib/services/notifications/groupNoti
 import type { Mastodon } from '@/lib/types/activitypub'
 import type { Status } from '@/lib/types/domain/status'
 
-// The server-resolved state of a follow request, derived from the current
-// `Follow` record between the requester and the viewer. It seeds the initial
-// UI of FollowRequestNotification so an already-handled request never renders
-// stale Approve / Reject actions on load:
+// The server-resolved state of a follow request, derived from the `Follow`
+// record the notification references. It seeds the initial UI of
+// FollowRequestNotification so an already-handled request never renders stale
+// Approve / Reject actions on load:
 //   - 'pending'  → the follow is still Requested; show the actions.
 //   - 'accepted' → the follow was already approved; show an approved label.
-//   - 'resolved' → no Accepted/Requested follow exists (rejected, withdrawn,
-//                  or gone); show a neutral, non-actionable label.
-export type FollowRequestInitialStatus = 'pending' | 'accepted' | 'resolved'
+//   - 'rejected' → the follow was rejected; show a rejected label.
+//   - 'resolved' → the follow was withdrawn or is gone; show a neutral label.
+// The component also reuses these states for its own optimistic Approve/Reject.
+export type FollowRequestInitialStatus =
+  | 'pending'
+  | 'accepted'
+  | 'rejected'
+  | 'resolved'
 
 export interface NotificationWithAccount extends GroupedNotification {
   account: Mastodon.Account

--- a/app/(timeline)/notifications/types.ts
+++ b/app/(timeline)/notifications/types.ts
@@ -2,6 +2,16 @@ import type { GroupedNotification } from '@/lib/services/notifications/groupNoti
 import type { Mastodon } from '@/lib/types/activitypub'
 import type { Status } from '@/lib/types/domain/status'
 
+// The server-resolved state of a follow request, derived from the current
+// `Follow` record between the requester and the viewer. It seeds the initial
+// UI of FollowRequestNotification so an already-handled request never renders
+// stale Approve / Reject actions on load:
+//   - 'pending'  → the follow is still Requested; show the actions.
+//   - 'accepted' → the follow was already approved; show an approved label.
+//   - 'resolved' → no Accepted/Requested follow exists (rejected, withdrawn,
+//                  or gone); show a neutral, non-actionable label.
+export type FollowRequestInitialStatus = 'pending' | 'accepted' | 'resolved'
+
 export interface NotificationWithAccount extends GroupedNotification {
   account: Mastodon.Account
   status: Status | null


### PR DESCRIPTION
## Problem

On the Notifications page, a **follow request** row kept showing **Approve / Reject** actions even after the request was already handled — e.g. the viewer had approved it and the requester now follows them (see the reported screenshot, `@null@llun.dev` still showing Approve/Reject). Clicking the actions on a non-pending request just results in a `404` from the follow-request API, so the buttons were misleading.

### Root cause

`FollowRequestNotification` always initialised its local state to `'pending'`, so it rendered the action buttons unconditionally, independent of the real `Follow` record state on the server.

## Fix

The notifications Server Component now resolves the live follow state for each `follow_request` row and forwards it as `followRequestStatus`:

| Live `Follow` status | Resolved state | Row renders |
| --- | --- | --- |
| `Requested` | `pending` | Approve / Reject actions |
| `Accepted` | `accepted` | "Approved" label, no actions |
| Rejected / Undo / no record | `resolved` | "No longer pending" label, no actions |

- The follower is the notification's **source actor**; the viewer is the **target**. The lookup reuses the existing, well-tested `getAcceptedOrRequestedFollow`.
- `FollowRequestNotification` seeds its initial state from `initialStatus` (defaulting to `'pending'` so a row without a resolved status still offers the actions), and keeps the in-session `'rejected'` state produced by its own Reject action.
- The status→UI mapping is extracted into a pure `followRequestStatusFromFollow` helper. The `default` branch maps any non-`Requested`/`Accepted` follow to `resolved`, so a stale/unexpected status can never resurface the buttons.

## Tests

- `followRequestStatus.test.ts` — pure mapper: `null`/`Requested`/`Accepted`/`Rejected`/`Undo` → expected UI state.
- `FollowRequestNotification.test.tsx` — renders actions for `pending`, "Approved" + no actions for `accepted`, "No longer pending" + no actions for `resolved`.
- `NotificationItem.test.tsx` — threading: an `accepted` / `resolved` row renders the label and no Approve/Reject buttons.

## Verification

- `yarn run prettier --write .` ✓
- `yarn lint` ✓ (0 errors)
- `yarn build` ✓
- `yarn test` ✓ (570 files, 5048 tests)

No migrations changed, so the reference schema dumps are untouched.