### PR TITLE
Bump version to v1.93.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.93.0",
+  "version": "1.93.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.93.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.93.0`
- Base main SHA: `ad3dfc1807950bd19dd14321c7be7ea6a8a54e39`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
