### PR TITLE
minor: show account identity instead of actor picker on OIDC consent

### DIFF
--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -669,10 +669,15 @@ describe('AuthorizeCard', () => {
     const consentCall = (global.fetch as jest.Mock).mock.calls.find(
       ([url]) => url === '/api/auth/oauth2/consent'
     )
-    const submittedScopes = JSON.parse(consentCall[1].body).scope.split(' ')
+    const submittedScopes: string[] = JSON.parse(
+      consentCall[1].body
+    ).scope.split(' ')
     expect(submittedScopes).toContain('openid')
     expect(submittedScopes).not.toContain('profile')
     expect(submittedScopes).not.toContain('email')
+    // openid is submitted exactly once (via the hidden field), never duplicated
+    // by the disabled checkbox.
+    expect(submittedScopes.filter((s) => s === 'openid')).toHaveLength(1)
   })
 
   it('renders only the locked openid row for a minimal openid-only OIDC request', async () => {
@@ -774,5 +779,23 @@ describe('AuthorizeCard', () => {
 
     expect(screen.getByText('Authorization required')).toBeInTheDocument()
     expect(screen.queryByText(/^Sign in to/)).not.toBeInTheDocument()
+  })
+
+  it('uses a fallback name when the OIDC client has no name', () => {
+    render(
+      <AuthorizeCard
+        client={{ ...client, name: null }}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // Both the title and the description name the client via the fallback, so
+    // neither renders a blank subject.
+    expect(screen.getByText('Sign in to this application')).toBeInTheDocument()
+    expect(screen.getByText('This application')).toBeInTheDocument()
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -742,4 +742,37 @@ describe('AuthorizeCard', () => {
     )
     expect(JSON.parse(consentCall[1].body).scope).toBe('openid read write')
   })
+
+  it('uses sign-in header copy for OIDC requests', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // OIDC is an authentication ("Sign in with …") flow, not a resource grant.
+    expect(screen.getByText('Sign in to Phanpy')).toBeInTheDocument()
+    expect(screen.queryByText('Authorization required')).not.toBeInTheDocument()
+  })
+
+  it('uses authorization header copy for non-OIDC requests', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={signedSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    expect(screen.getByText('Authorization required')).toBeInTheDocument()
+    expect(screen.queryByText(/^Sign in to/)).not.toBeInTheDocument()
+  })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -555,20 +555,100 @@ describe('AuthorizeCard', () => {
     expect(screen.queryByText('rider@example.com')).not.toBeInTheDocument()
   })
 
-  it('renders the avatar fallback initial from the account identity (OIDC)', () => {
+  it('derives the avatar fallback initial from the display name, not the email (OIDC)', () => {
     render(
       <AuthorizeCard
         client={client}
         searchParams={oidcSearchParams}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
-        account={{ email: 'rider@example.com', name: 'Ride', iconUrl: null }}
+        account={{ email: 'rider@example.com', name: 'Zoe', iconUrl: null }}
         navigate={mockNavigate}
       />
     )
 
-    // With no iconUrl the Avatar shows the fallback initial derived from the
-    // display name ('Ride' -> 'R').
-    expect(screen.getByText('R')).toBeInTheDocument()
+    // With no iconUrl the Avatar shows a fallback initial. It must come from
+    // the display name ('Zoe' -> 'Z'), not the email ('rider@…' -> 'R').
+    expect(screen.getByText('Z')).toBeInTheDocument()
+    expect(screen.queryByText('R')).not.toBeInTheDocument()
+  })
+
+  it('derives a Unicode-safe avatar initial for a non-BMP name (OIDC)', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={{ email: 'fox@example.com', name: '🦊 Ranger', iconUrl: null }}
+        navigate={mockNavigate}
+      />
+    )
+
+    // The initial is the whole leading code point, not a broken surrogate half
+    // (the pre-fix `name[0]` would have sliced the emoji in two).
+    expect(screen.getByText('🦊')).toBeInTheDocument()
+  })
+
+  it('does not duplicate the email when the account name equals the email (OIDC)', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={{
+          email: 'rider@example.com',
+          name: 'rider@example.com',
+          iconUrl: null
+        }}
+        navigate={mockNavigate}
+      />
+    )
+
+    // When the display name IS the email, the email must still render exactly
+    // once (the secondary line is suppressed), not twice.
+    expect(screen.getAllByText('rider@example.com')).toHaveLength(1)
+  })
+
+  it('locks the openid scope so it cannot be stripped from an OIDC consent', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // openid is the OIDC subject scope (gates id_token issuance) and must be
+    // locked: checked and not user-toggleable.
+    const openidCheckbox = screen.getByLabelText('openid')
+    expect(openidCheckbox).toBeChecked()
+    expect(openidCheckbox).toBeDisabled()
+    // Optional OIDC scopes stay user-controllable.
+    expect(screen.getByLabelText('profile')).toBeEnabled()
+    expect(screen.getByLabelText('email')).toBeEnabled()
+
+    // Unchecking the optional scopes must not strip openid from the consent.
+    fireEvent.click(screen.getByLabelText('profile'))
+    fireEvent.click(screen.getByLabelText('email'))
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/oauth2/consent',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+    const consentCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === '/api/auth/oauth2/consent'
+    )
+    const submittedScopes = JSON.parse(consentCall[1].body).scope.split(' ')
+    expect(submittedScopes).toContain('openid')
+    expect(submittedScopes).not.toContain('profile')
+    expect(submittedScopes).not.toContain('email')
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -421,7 +421,8 @@ describe('AuthorizeCard', () => {
       />
     )
 
-    // The account email is shown as the signed-in identity.
+    // The OIDC identity caption and the account identity are shown.
+    expect(screen.getByText('Signed in as')).toBeInTheDocument()
     expect(screen.getByText('rider@example.com')).toBeInTheDocument()
     expect(screen.getByText('Ride')).toBeInTheDocument()
     // The multi-actor "Authorize as" picker must NOT appear for an OIDC login:
@@ -611,6 +612,28 @@ describe('AuthorizeCard', () => {
     expect(screen.getAllByText('rider@example.com')).toHaveLength(1)
   })
 
+  it('does not duplicate the email when the name matches it case-insensitively (OIDC)', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={{
+          email: 'rider@example.com',
+          name: 'Rider@Example.com',
+          iconUrl: null
+        }}
+        navigate={mockNavigate}
+      />
+    )
+
+    // The display name differs from the email only by case; emails are
+    // case-insensitive, so the secondary email line is still suppressed.
+    expect(screen.getAllByText('Rider@Example.com')).toHaveLength(1)
+    expect(screen.queryByText('rider@example.com')).not.toBeInTheDocument()
+  })
+
   it('locks the openid scope so it cannot be stripped from an OIDC consent', async () => {
     render(
       <AuthorizeCard
@@ -684,5 +707,39 @@ describe('AuthorizeCard', () => {
       ([url]) => url === '/api/auth/oauth2/consent'
     )
     expect(JSON.parse(consentCall[1].body).scope).toBe('openid')
+  })
+
+  it('flips to the OIDC identity view when openid co-occurs with Mastodon scopes', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={{ ...oidcSearchParams, scope: 'openid read write' }}
+        actors={alternateActors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // A single 'openid' token takes precedence: the identity block shows and
+    // the actor picker is hidden even though Mastodon scopes are also present.
+    expect(screen.getByText('Signed in as')).toBeInTheDocument()
+    expect(screen.queryByText('Authorize as')).not.toBeInTheDocument()
+    // openid is locked; the co-requested Mastodon scopes stay user-toggleable.
+    expect(screen.getByLabelText('openid')).toBeDisabled()
+    expect(screen.getByLabelText('read')).toBeEnabled()
+    expect(screen.getByLabelText('write')).toBeEnabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/oauth2/consent',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+    const consentCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === '/api/auth/oauth2/consent'
+    )
+    expect(JSON.parse(consentCall[1].body).scope).toBe('openid read write')
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -64,6 +64,20 @@ const signedSearchParams: SearchParams = {
   exp: '1779800000'
 }
 
+// An OIDC authentication request is identified by the `openid` scope (OIDC
+// Core §3.1.2.1). The consent screen shows the account identity instead of an
+// actor picker for these, because the OIDC subject is the owning account.
+const oidcSearchParams: SearchParams = {
+  ...signedSearchParams,
+  scope: 'openid profile email'
+}
+
+const account = {
+  email: 'rider@example.com',
+  name: 'Ride',
+  iconUrl: null
+}
+
 describe('AuthorizeCard', () => {
   beforeEach(() => {
     mockPush.mockReset()
@@ -103,6 +117,7 @@ describe('AuthorizeCard', () => {
         searchParams={signedSearchParams}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
+        account={account}
         navigate={mockNavigate}
       />
     )
@@ -153,6 +168,7 @@ describe('AuthorizeCard', () => {
         searchParams={signedSearchParams}
         actors={alternateActors}
         currentActorId="https://activities.local/users/testactor2"
+        account={account}
         navigate={mockNavigate}
       />
     )
@@ -238,6 +254,7 @@ describe('AuthorizeCard', () => {
         searchParams={signedSearchParams}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
+        account={account}
         navigate={mockNavigate}
       />
     )
@@ -290,6 +307,7 @@ describe('AuthorizeCard', () => {
         searchParams={signedSearchParams}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
+        account={account}
         navigate={mockNavigate}
       />
     )
@@ -337,6 +355,7 @@ describe('AuthorizeCard', () => {
         searchParams={signedSearchParams}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
+        account={account}
         navigate={mockNavigate}
       />
     )
@@ -376,6 +395,7 @@ describe('AuthorizeCard', () => {
         }}
         actors={actors}
         currentActorId="https://activities.local/users/llun"
+        account={account}
         navigate={mockNavigate}
       />
     )
@@ -387,5 +407,90 @@ describe('AuthorizeCard', () => {
         'https://phanpy.local/?error=access_denied&state=return-state'
       )
     })
+  })
+
+  it('shows the account identity and hides the actor selector for OIDC requests', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={alternateActors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // The account email is shown as the signed-in identity.
+    expect(screen.getByText('rider@example.com')).toBeInTheDocument()
+    expect(screen.getByText('Ride')).toBeInTheDocument()
+    // The multi-actor "Authorize as" picker must NOT appear for an OIDC login:
+    // the OIDC subject is the owning account, so persona choice is irrelevant.
+    expect(screen.queryByText('Authorize as')).not.toBeInTheDocument()
+    // OIDC scopes are still listed and checked.
+    expect(screen.getByLabelText('openid')).toBeChecked()
+    expect(screen.getByLabelText('profile')).toBeChecked()
+    expect(screen.getByLabelText('email')).toBeChecked()
+  })
+
+  it('shows the account identity for OIDC even with a single actor', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    expect(screen.getByText('rider@example.com')).toBeInTheDocument()
+    expect(screen.queryByText('Authorize as')).not.toBeInTheDocument()
+  })
+
+  it('keeps the actor selector and hides the account identity for non-OIDC requests', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={signedSearchParams}
+        actors={alternateActors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    expect(screen.getByText('Authorize as')).toBeInTheDocument()
+    expect(screen.queryByText('rider@example.com')).not.toBeInTheDocument()
+  })
+
+  it('submits the OIDC scopes and persists the current actor on approve', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/oauth2/consent',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    const consentCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === '/api/auth/oauth2/consent'
+    )
+    const body = JSON.parse(consentCall[1].body)
+    expect(body.accept).toBe(true)
+    expect(body.scope).toBe('openid profile email')
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -651,4 +651,38 @@ describe('AuthorizeCard', () => {
     expect(submittedScopes).not.toContain('profile')
     expect(submittedScopes).not.toContain('email')
   })
+
+  it('renders only the locked openid row for a minimal openid-only OIDC request', async () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={{ ...oidcSearchParams, scope: 'openid' }}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // The identity block still renders for the minimal OIDC request.
+    expect(screen.getByText('rider@example.com')).toBeInTheDocument()
+    // openid is the only scope row, and it is locked.
+    const openidCheckbox = screen.getByLabelText('openid')
+    expect(openidCheckbox).toBeChecked()
+    expect(openidCheckbox).toBeDisabled()
+    expect(screen.queryByLabelText('profile')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('email')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/auth/oauth2/consent',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+    const consentCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === '/api/auth/oauth2/consent'
+    )
+    expect(JSON.parse(consentCall[1].body).scope).toBe('openid')
+  })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx
@@ -492,5 +492,83 @@ describe('AuthorizeCard', () => {
     const body = JSON.parse(consentCall[1].body)
     expect(body.accept).toBe(true)
     expect(body.scope).toBe('openid profile email')
+
+    // persistSelectedActor() still runs in OIDC mode: it switches to (and so
+    // persists) the current actor before consent, even though the picker is
+    // hidden. The switch is the first fetch call.
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe(
+      '/api/v1/actors/switch'
+    )
+    expect(
+      JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body)
+    ).toEqual({ actorId: 'https://activities.local/users/llun' })
+  })
+
+  it('renders the email once as the identity when the account has no name (OIDC)', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={{ email: 'rider@example.com', name: null, iconUrl: null }}
+        navigate={mockNavigate}
+      />
+    )
+
+    // With no name, the email is the primary identity and must not be
+    // duplicated as a secondary line.
+    expect(screen.getAllByText('rider@example.com')).toHaveLength(1)
+  })
+
+  it('treats a whitespace-only account name as no name (OIDC)', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={{ email: 'rider@example.com', name: '   ', iconUrl: null }}
+        navigate={mockNavigate}
+      />
+    )
+
+    expect(screen.getAllByText('rider@example.com')).toHaveLength(1)
+  })
+
+  it('does not treat a scope token merely containing "openid" as OIDC', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={{ ...oidcSearchParams, scope: 'openidfoo profile email' }}
+        actors={alternateActors}
+        currentActorId="https://activities.local/users/llun"
+        account={account}
+        navigate={mockNavigate}
+      />
+    )
+
+    // 'openidfoo' is not the 'openid' token, so this stays the Mastodon path:
+    // the actor picker shows and the account-identity block does not.
+    expect(screen.getByText('Authorize as')).toBeInTheDocument()
+    expect(screen.queryByText('Signed in as')).not.toBeInTheDocument()
+    expect(screen.queryByText('rider@example.com')).not.toBeInTheDocument()
+  })
+
+  it('renders the avatar fallback initial from the account identity (OIDC)', () => {
+    render(
+      <AuthorizeCard
+        client={client}
+        searchParams={oidcSearchParams}
+        actors={actors}
+        currentActorId="https://activities.local/users/llun"
+        account={{ email: 'rider@example.com', name: 'Ride', iconUrl: null }}
+        navigate={mockNavigate}
+      />
+    )
+
+    // With no iconUrl the Avatar shows the fallback initial derived from the
+    // display name ('Ride' -> 'R').
+    expect(screen.getByText('R')).toBeInTheDocument()
   })
 })

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -240,14 +240,15 @@ export const AuthorizeCard: FC<Props> = ({
         <CardDescription>
           {isOidc ? (
             <>
-              <strong>{client.name}</strong> wants to verify your identity using
-              your account. It is a third-party application.{' '}
-              <strong>Only continue if you trust it.</strong>
+              <strong>{client.name || 'This application'}</strong> wants to
+              verify your identity using your account. It is a third-party
+              application. <strong>Only continue if you trust it.</strong>
             </>
           ) : (
             <>
-              <strong>{client.name}</strong> would like permission to access
-              your account. It is a third-party application.{' '}
+              <strong>{client.name || 'This application'}</strong> would like
+              permission to access your account. It is a third-party
+              application.{' '}
               <strong>
                 If you do not trust it, then you should not authorize it.
               </strong>
@@ -370,7 +371,10 @@ export const AuthorizeCard: FC<Props> = ({
                   <div key={scope} className="flex items-center space-x-2">
                     <input
                       className="peer size-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                      name="scope"
+                      // A disabled control is omitted from form submission, but
+                      // also drop the name so a non-standard serializer can't
+                      // double-submit `openid` alongside the hidden field.
+                      name={lockedOidcScope ? undefined : 'scope'}
                       type="checkbox"
                       value={scope}
                       id={`scope-${scope}`}

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -261,8 +261,10 @@ export const AuthorizeCard: FC<Props> = ({
                   </p>
                   {/* Show the email as a secondary line only when a distinct
                       name is the primary identity. Covers name=null, blank, and
-                      name===email (which would otherwise render twice). */}
-                  {accountDisplayName !== account.email && (
+                      name===email (which would otherwise render twice). The
+                      comparison is case-insensitive because emails are. */}
+                  {accountDisplayName.toLowerCase() !==
+                    account.email.toLowerCase() && (
                     <p className="text-xs text-muted-foreground truncate">
                       {account.email}
                     </p>

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -351,7 +351,7 @@ export const AuthorizeCard: FC<Props> = ({
                 return (
                   <div key={scope} className="flex items-center space-x-2">
                     <input
-                      className="size-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                      className="peer size-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
                       name="scope"
                       type="checkbox"
                       value={scope}

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -29,10 +29,17 @@ import { Client } from '@/lib/types/oauth2/client'
 import { buildOAuthQuery } from './authorizeQuery'
 import { SearchParams } from './types'
 
+interface AccountSummary {
+  email: string
+  name?: string | null
+  iconUrl?: string | null
+}
+
 interface Props {
   client: Client
   searchParams: SearchParams
   actors: Actor[]
+  account: AccountSummary
   currentActorId: string
   navigate?: (url: string) => void
 }
@@ -78,12 +85,20 @@ export const AuthorizeCard: FC<Props> = ({
   searchParams,
   client,
   actors,
+  account,
   currentActorId,
   navigate = navigateTo
 }) => {
   const requestedScopes = searchParams.scope.split(' ')
   const router = useRouter()
   const availabledScopes = intersection(UsableScopes, requestedScopes)
+  // An OIDC authentication request is identified by the `openid` scope (OIDC
+  // Core §3.1.2.1). Such a request authenticates the owning account, not a
+  // chosen ActivityPub persona — the id_token/userinfo `sub` is always the
+  // account id — so the consent screen shows the fixed account identity instead
+  // of the multi-actor "Authorize as" picker.
+  const isOidc = requestedScopes.includes('openid')
+  const accountDisplayName = account.name?.trim() || account.email
   const [selectedActorId, setSelectedActorId] = useState(currentActorId)
   const [isSwitching, setIsSwitching] = useState(false)
   const [submittingAction, setSubmittingAction] = useState<
@@ -224,7 +239,33 @@ export const AuthorizeCard: FC<Props> = ({
       </CardHeader>
       <CardContent>
         <form onSubmit={handleApprove} className="space-y-6">
-          {actors.length > 1 && (
+          {isOidc && (
+            <div className="space-y-2">
+              <Label className="text-sm font-medium text-muted-foreground">
+                Signed in as
+              </Label>
+              <div className="flex w-full items-center gap-3 rounded-lg border bg-background p-3">
+                <Avatar className="h-10 w-10">
+                  {account.iconUrl && <AvatarImage src={account.iconUrl} />}
+                  <AvatarFallback className="bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                    {getAvatarInitial(accountDisplayName)}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="flex-1 overflow-hidden">
+                  <p className="text-sm font-medium truncate">
+                    {accountDisplayName}
+                  </p>
+                  {account.name?.trim() && (
+                    <p className="text-xs text-muted-foreground truncate">
+                      {account.email}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!isOidc && actors.length > 1 && (
             <div className="space-y-2">
               <Label className="text-sm font-medium text-muted-foreground">
                 Authorize as

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -230,13 +230,29 @@ export const AuthorizeCard: FC<Props> = ({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Authorization required</CardTitle>
+        {/* OIDC requests are authentication ("Sign in with …") flows, so they
+            get sign-in framing instead of the OAuth resource-grant copy. */}
+        <CardTitle>
+          {isOidc
+            ? `Sign in to ${client.name || 'this application'}`
+            : 'Authorization required'}
+        </CardTitle>
         <CardDescription>
-          <strong>{client.name}</strong> would like permission to access your
-          account. It is a third-party application.{' '}
-          <strong>
-            If you do not trust it, then you should not authorize it.
-          </strong>
+          {isOidc ? (
+            <>
+              <strong>{client.name}</strong> wants to verify your identity using
+              your account. It is a third-party application.{' '}
+              <strong>Only continue if you trust it.</strong>
+            </>
+          ) : (
+            <>
+              <strong>{client.name}</strong> would like permission to access
+              your account. It is a third-party application.{' '}
+              <strong>
+                If you do not trust it, then you should not authorize it.
+              </strong>
+            </>
+          )}
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -243,9 +243,11 @@ export const AuthorizeCard: FC<Props> = ({
         <form onSubmit={handleApprove} className="space-y-6">
           {isOidc && (
             <div className="space-y-2">
-              <Label className="text-sm font-medium text-muted-foreground">
+              {/* Informational caption — not a form-control label, so a <p>
+                  rather than <Label> (which would label nothing). */}
+              <p className="text-sm font-medium text-muted-foreground">
                 Signed in as
-              </Label>
+              </p>
               <div className="flex w-full items-center gap-3 rounded-lg border bg-background p-3">
                 <Avatar className="h-10 w-10" aria-hidden="true">
                   {account.iconUrl && <AvatarImage src={account.iconUrl} />}
@@ -257,7 +259,10 @@ export const AuthorizeCard: FC<Props> = ({
                   <p className="text-sm font-medium truncate">
                     {accountDisplayName}
                   </p>
-                  {account.name?.trim() && (
+                  {/* Show the email as a secondary line only when a distinct
+                      name is the primary identity. Covers name=null, blank, and
+                      name===email (which would otherwise render twice). */}
+                  {accountDisplayName !== account.email && (
                     <p className="text-xs text-muted-foreground truncate">
                       {account.email}
                     </p>
@@ -335,24 +340,37 @@ export const AuthorizeCard: FC<Props> = ({
               Review permissions
             </h3>
             <div className="space-y-3">
-              {availabledScopes.map((scope) => (
-                <div key={scope} className="flex items-center space-x-2">
-                  <input
-                    className="size-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                    name="scope"
-                    type="checkbox"
-                    value={scope}
-                    id={`scope-${scope}`}
-                    defaultChecked
-                  />
-                  <Label
-                    htmlFor={`scope-${scope}`}
-                    className="text-sm font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                  >
-                    {scope}
-                  </Label>
-                </div>
-              ))}
+              {availabledScopes.map((scope) => {
+                // `openid` is what makes this an OIDC authentication request and
+                // gates id_token issuance, so it must not be strippable. Render
+                // it locked (disabled + checked) and submit it via a hidden
+                // field so a disabled checkbox (which a browser omits from form
+                // data) can't silently drop it. Optional OIDC scopes
+                // (profile/email) stay user-toggleable.
+                const lockedOidcScope = isOidc && scope === 'openid'
+                return (
+                  <div key={scope} className="flex items-center space-x-2">
+                    <input
+                      className="size-4 rounded border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                      name="scope"
+                      type="checkbox"
+                      value={scope}
+                      id={`scope-${scope}`}
+                      defaultChecked
+                      disabled={lockedOidcScope}
+                    />
+                    {lockedOidcScope && (
+                      <input type="hidden" name="scope" value={scope} />
+                    )}
+                    <Label
+                      htmlFor={`scope-${scope}`}
+                      className="text-sm font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                    >
+                      {scope}
+                    </Label>
+                  </div>
+                )
+              })}
             </div>
           </div>
 

--- a/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
+++ b/app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx
@@ -111,7 +111,9 @@ export const AuthorizeCard: FC<Props> = ({
 
   const getAvatarInitial = (username: string) => {
     if (!username) return '?'
-    return username[0].toUpperCase()
+    // Spread to the first code point so a surrogate-pair glyph (emoji or a
+    // non-BMP character starting a name) isn't sliced into a broken half.
+    return [...username][0].toUpperCase()
   }
 
   const getHandle = (actor: Actor) => `@${actor.username}@${actor.domain}`
@@ -245,7 +247,7 @@ export const AuthorizeCard: FC<Props> = ({
                 Signed in as
               </Label>
               <div className="flex w-full items-center gap-3 rounded-lg border bg-background p-3">
-                <Avatar className="h-10 w-10">
+                <Avatar className="h-10 w-10" aria-hidden="true">
                   {account.iconUrl && <AvatarImage src={account.iconUrl} />}
                   <AvatarFallback className="bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
                     {getAvatarInitial(accountDisplayName)}

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -139,17 +139,26 @@ describe('/oauth/authorize account summary', () => {
     {
       description: 'a fully-populated account',
       accountName: 'Ride' as string | null,
-      accountIconUrl: 'https://cdn.example/a.png' as string | null
+      accountIconUrl: 'https://cdn.example/a.png' as string | null,
+      expectedIconUrl: 'https://cdn.example/a.png' as string | null
     },
     {
       description:
         'an account with no name or avatar (nulls propagate as null)',
       accountName: null as string | null,
-      accountIconUrl: null as string | null
+      accountIconUrl: null as string | null,
+      expectedIconUrl: null as string | null
+    },
+    {
+      description:
+        'an account whose avatar is a generated placeholder (filtered to null)',
+      accountName: 'Ride' as string | null,
+      accountIconUrl: 'https://www.gravatar.com/avatar/abc123' as string | null,
+      expectedIconUrl: null as string | null
     }
   ])(
     'passes the account summary from actor.account to AuthorizeCard for $description',
-    async ({ accountName, accountIconUrl }) => {
+    async ({ accountName, accountIconUrl, expectedIconUrl }) => {
       vi.mocked(getActorFromSession).mockResolvedValue({
         id: 'https://activities.local/users/llun',
         account: {
@@ -186,13 +195,14 @@ describe('/oauth/authorize account summary', () => {
       expect(redirectMock).not.toHaveBeenCalled()
       // Page returns <div><AuthorizeCard .../></div>; the account summary must
       // be sourced from actor.account (a typo passing the actor would fail
-      // here), and nullish name/iconUrl must propagate unchanged.
+      // here), nullish name/iconUrl must propagate, and a generated-placeholder
+      // avatar is filtered to null (consistent with the rest of the account UI).
       const authorizeCard = (element.props as { children: ReactElement })
         .children
       expect((authorizeCard.props as { account: unknown }).account).toEqual({
         email: 'rider@example.com',
         name: accountName,
-        iconUrl: accountIconUrl
+        iconUrl: expectedIconUrl
       })
     }
   )

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -135,48 +135,65 @@ describe('/oauth/authorize account summary', () => {
     )
   })
 
-  it('passes the account email/name/iconUrl (from actor.account) to AuthorizeCard', async () => {
-    vi.mocked(getActorFromSession).mockResolvedValue({
-      id: 'https://activities.local/users/llun',
-      account: {
-        id: 'account-id',
-        email: 'rider@example.com',
-        name: 'Ride',
-        iconUrl: 'https://cdn.example/a.png'
-      }
-    } as Awaited<ReturnType<typeof getActorFromSession>>)
-
-    vi.mocked(getDatabase).mockReturnValue({
-      getClientFromId: vi.fn().mockResolvedValue({
-        clientId: 'client-id',
-        redirectUris: ['https://app.example/callback']
-      }),
-      getActorsForAccount: vi.fn().mockResolvedValue([])
-    } as unknown as ReturnType<typeof getDatabase>)
-
-    // A live sig/exp pair keeps shouldDelegateToBetterAuth false so the page
-    // renders AuthorizeCard instead of redirecting.
-    const renderParams = {
-      client_id: 'client-id',
-      scope: 'openid profile email',
-      redirect_uri: 'https://app.example/callback',
-      response_type: 'code' as const,
-      sig: 'signed',
-      exp: '9999999999'
+  it.each([
+    {
+      description: 'a fully-populated account',
+      accountName: 'Ride' as string | null,
+      accountIconUrl: 'https://cdn.example/a.png' as string | null
+    },
+    {
+      description:
+        'an account with no name or avatar (nulls propagate as null)',
+      accountName: null as string | null,
+      accountIconUrl: null as string | null
     }
+  ])(
+    'passes the account summary from actor.account to AuthorizeCard for $description',
+    async ({ accountName, accountIconUrl }) => {
+      vi.mocked(getActorFromSession).mockResolvedValue({
+        id: 'https://activities.local/users/llun',
+        account: {
+          id: 'account-id',
+          email: 'rider@example.com',
+          name: accountName,
+          iconUrl: accountIconUrl
+        }
+      } as Awaited<ReturnType<typeof getActorFromSession>>)
 
-    const element = (await Page({
-      searchParams: Promise.resolve(renderParams)
-    })) as ReactElement
+      vi.mocked(getDatabase).mockReturnValue({
+        getClientFromId: vi.fn().mockResolvedValue({
+          clientId: 'client-id',
+          redirectUris: ['https://app.example/callback']
+        }),
+        getActorsForAccount: vi.fn().mockResolvedValue([])
+      } as unknown as ReturnType<typeof getDatabase>)
 
-    expect(redirectMock).not.toHaveBeenCalled()
-    // Page returns <div><AuthorizeCard .../></div>; the account summary must be
-    // sourced from actor.account (a typo passing the actor would fail here).
-    const authorizeCard = (element.props as { children: ReactElement }).children
-    expect((authorizeCard.props as { account: unknown }).account).toEqual({
-      email: 'rider@example.com',
-      name: 'Ride',
-      iconUrl: 'https://cdn.example/a.png'
-    })
-  })
+      // A live sig/exp pair keeps shouldDelegateToBetterAuth false so the page
+      // renders AuthorizeCard instead of redirecting.
+      const renderParams = {
+        client_id: 'client-id',
+        scope: 'openid profile email',
+        redirect_uri: 'https://app.example/callback',
+        response_type: 'code' as const,
+        sig: 'signed',
+        exp: '9999999999'
+      }
+
+      const element = (await Page({
+        searchParams: Promise.resolve(renderParams)
+      })) as ReactElement
+
+      expect(redirectMock).not.toHaveBeenCalled()
+      // Page returns <div><AuthorizeCard .../></div>; the account summary must
+      // be sourced from actor.account (a typo passing the actor would fail
+      // here), and nullish name/iconUrl must propagate unchanged.
+      const authorizeCard = (element.props as { children: ReactElement })
+        .children
+      expect((authorizeCard.props as { account: unknown }).account).toEqual({
+        email: 'rider@example.com',
+        name: accountName,
+        iconUrl: accountIconUrl
+      })
+    }
+  )
 })

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -1,4 +1,7 @@
+import type { ReactElement } from 'react'
+
 import { getBaseURL, getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
@@ -116,5 +119,64 @@ describe('/oauth/authorize redirect host', () => {
     const target = new URL(redirectMock.mock.calls[0][0])
     expect(target.host).toBe(ALIAS_HOST)
     expect(target.pathname).toBe('/api/auth/oauth2/authorize')
+  })
+})
+
+describe('/oauth/authorize account summary', () => {
+  beforeEach(() => {
+    redirectMock.mockClear()
+    vi.mocked(getConfig).mockReturnValue({
+      host: TEST_DOMAIN,
+      trustedHosts: []
+    } as ReturnType<typeof getConfig>)
+    vi.mocked(getBaseURL).mockReturnValue(`https://${TEST_DOMAIN}`)
+    headersMock.mockReturnValue(
+      new Headers({ 'x-forwarded-host': TEST_DOMAIN })
+    )
+  })
+
+  it('passes the account email/name/iconUrl (from actor.account) to AuthorizeCard', async () => {
+    vi.mocked(getActorFromSession).mockResolvedValue({
+      id: 'https://activities.local/users/llun',
+      account: {
+        id: 'account-id',
+        email: 'rider@example.com',
+        name: 'Ride',
+        iconUrl: 'https://cdn.example/a.png'
+      }
+    } as Awaited<ReturnType<typeof getActorFromSession>>)
+
+    vi.mocked(getDatabase).mockReturnValue({
+      getClientFromId: vi.fn().mockResolvedValue({
+        clientId: 'client-id',
+        redirectUris: ['https://app.example/callback']
+      }),
+      getActorsForAccount: vi.fn().mockResolvedValue([])
+    } as unknown as ReturnType<typeof getDatabase>)
+
+    // A live sig/exp pair keeps shouldDelegateToBetterAuth false so the page
+    // renders AuthorizeCard instead of redirecting.
+    const renderParams = {
+      client_id: 'client-id',
+      scope: 'openid profile email',
+      redirect_uri: 'https://app.example/callback',
+      response_type: 'code' as const,
+      sig: 'signed',
+      exp: '9999999999'
+    }
+
+    const element = (await Page({
+      searchParams: Promise.resolve(renderParams)
+    })) as ReactElement
+
+    expect(redirectMock).not.toHaveBeenCalled()
+    // Page returns <div><AuthorizeCard .../></div>; the account summary must be
+    // sourced from actor.account (a typo passing the actor would fail here).
+    const authorizeCard = (element.props as { children: ReactElement }).children
+    expect((authorizeCard.props as { account: unknown }).account).toEqual({
+      email: 'rider@example.com',
+      name: 'Ride',
+      iconUrl: 'https://cdn.example/a.png'
+    })
   })
 })

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -8,6 +8,7 @@ import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Actor } from '@/lib/types/domain/actor'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { isRealAvatar } from '@/lib/utils/isRealAvatar'
 
 import { AuthorizeCard } from './AuthorizeCard'
 import {
@@ -88,7 +89,9 @@ const Page: FC<Props> = async ({ searchParams }) => {
         account={{
           email: actor.account.email,
           name: actor.account.name,
-          iconUrl: actor.account.iconUrl
+          iconUrl: isRealAvatar(actor.account.iconUrl)
+            ? actor.account.iconUrl
+            : null
         }}
         currentActorId={actor.id}
       />

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -85,6 +85,11 @@ const Page: FC<Props> = async ({ searchParams }) => {
         searchParams={params}
         client={client}
         actors={actors}
+        account={{
+          email: actor.account.email,
+          name: actor.account.name,
+          iconUrl: actor.account.iconUrl
+        }}
         currentActorId={actor.id}
       />
     </div>

--- a/app/(timeline)/account/AccountIdentityCard.test.tsx
+++ b/app/(timeline)/account/AccountIdentityCard.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { AccountIdentityCard } from './AccountIdentityCard'
+
+describe('AccountIdentityCard', () => {
+  it('shows the account name as the heading and the email beneath it', () => {
+    render(
+      <AccountIdentityCard
+        name="Ride"
+        email="rider@example.com"
+        iconUrl={null}
+      />
+    )
+
+    expect(screen.getByText('Ride')).toBeInTheDocument()
+    expect(screen.getByText('rider@example.com')).toBeInTheDocument()
+  })
+
+  it('falls back to the email as the heading and renders it once when there is no name', () => {
+    render(
+      <AccountIdentityCard
+        name={null}
+        email="rider@example.com"
+        iconUrl={null}
+      />
+    )
+
+    // No distinct name -> email is the heading and the secondary line is
+    // suppressed so it is never shown twice.
+    expect(screen.getAllByText('rider@example.com')).toHaveLength(1)
+  })
+
+  it('treats a name that equals the email case-insensitively as no name', () => {
+    render(
+      <AccountIdentityCard
+        name="Rider@Example.com"
+        email="rider@example.com"
+        iconUrl={null}
+      />
+    )
+
+    expect(screen.getAllByText(/rider@example\.com/i)).toHaveLength(1)
+  })
+
+  it('derives a Unicode-safe avatar initial from the display name', () => {
+    render(
+      <AccountIdentityCard
+        name="🦊 Ranger"
+        email="fox@example.com"
+        iconUrl={null}
+      />
+    )
+
+    // The initial is the whole leading code point, not a broken surrogate half.
+    expect(screen.getByText('🦊')).toBeInTheDocument()
+  })
+})

--- a/app/(timeline)/account/AccountIdentityCard.tsx
+++ b/app/(timeline)/account/AccountIdentityCard.tsx
@@ -1,0 +1,39 @@
+import { FC } from 'react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+
+interface Props {
+  name?: string | null
+  email: string
+  iconUrl?: string | null
+}
+
+// At-a-glance identity summary for the account: the avatar, display name, and
+// email shared by every actor. Read-only — editing lives in the forms below.
+// Mirrors the OIDC consent identity block so the account's avatar/name read the
+// same wherever they surface.
+export const AccountIdentityCard: FC<Props> = ({ name, email, iconUrl }) => {
+  const displayName = name?.trim() || email
+  // Spread to the first code point so a surrogate-pair glyph (emoji / non-BMP
+  // name) isn't sliced into a broken half.
+  const initial = [...displayName][0]?.toUpperCase() || '?'
+
+  return (
+    <section className="flex items-center gap-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+      <Avatar className="h-16 w-16" aria-hidden="true">
+        {iconUrl && <AvatarImage src={iconUrl} alt="" />}
+        <AvatarFallback className="bg-gray-200 text-xl text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+          {initial}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <h2 className="truncate text-xl font-semibold">{displayName}</h2>
+        {/* Show the email beneath only when a distinct name is the heading, so
+            it never renders twice (case-insensitive — emails are). */}
+        {displayName.toLowerCase() !== email.toLowerCase() && (
+          <p className="truncate text-sm text-muted-foreground">{email}</p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/(timeline)/account/page.tsx
+++ b/app/(timeline)/account/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
+import { AccountIdentityCard } from '@/app/(timeline)/account/AccountIdentityCard'
 import { ChangeEmailForm } from '@/app/(timeline)/account/ChangeEmailForm'
 import { ChangeNameForm } from '@/app/(timeline)/account/ChangeNameForm'
 import { PageHeader } from '@/lib/components/page-header'
@@ -47,6 +48,12 @@ const Page = async ({
       <PageHeader
         title="General"
         description="Your account identity and the actors it contains. These details are shared by every actor."
+      />
+
+      <AccountIdentityCard
+        name={account.name}
+        email={account.email}
+        iconUrl={account.iconUrl}
       />
 
       <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">

--- a/app/(timeline)/account/page.tsx
+++ b/app/(timeline)/account/page.tsx
@@ -53,7 +53,7 @@ const Page = async ({
       <AccountIdentityCard
         name={account.name}
         email={account.email}
-        iconUrl={account.iconUrl}
+        iconUrl={isRealAvatar(account.iconUrl) ? account.iconUrl : null}
       />
 
       <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">


### PR DESCRIPTION
## Summary

The `/oauth/authorize` consent screen is shared by **two** kinds of clients — Mastodon OAuth apps and OIDC relying parties (e.g. la-suite **Docs**). better-auth routes both to it via `oauthProvider({ consentPage: '/oauth/authorize' })`, so today an OIDC login shows the same multi-actor **"Authorize as"** persona picker that Mastodon clients get.

That picker is misleading for OIDC: the OIDC subject is the **owning account**, not a chosen ActivityPub persona — the id_token/userinfo `sub` is always the account id (`lib/services/oauth/userinfo.ts`, `customIdTokenClaims` in `lib/services/auth/auth.ts`). Which persona you pick never changes who you are to the relying party.

This PR differentiates the consent UI:

- **OIDC requests** (identified by the `openid` scope — OIDC Core §3.1.2.1) now render a static **"Signed in as"** account-identity block (avatar + name + email) instead of the actor selector, regardless of how many actors the account owns.
- **Mastodon requests** (no `openid` scope) are **unchanged** — they still show the "Authorize as" persona picker when the account owns more than one actor, and the approve/deny/scope flow is untouched.

## Why the `openid` scope is the right discriminator

OAuth clients (Mastodon apps and OIDC RPs) live in one unified `oauthClient` table, and the trimmed `Client` type that reaches the consent screen has **no** type/kind field. The `openid` scope on the *request* is both the standards-correct signal (it's what makes a request an OIDC authentication request) and the only one available at consent time without surfacing new DB columns. No schema/migration change.

## Scope of change

- `app/(nosidebar)/oauth/authorize/AuthorizeCard.tsx` — add `account` prop + `isOidc` branch.
- `app/(nosidebar)/oauth/authorize/page.tsx` — pass display-safe account fields (`email`, `name`, `iconUrl`) only; no sensitive account fields cross the server→client boundary.
- `app/(nosidebar)/oauth/authorize/AuthorizeCard.test.tsx` — TDD coverage for both paths.

## Testing

- TDD: new tests added (RED → GREEN) covering OIDC-shows-account / hides-picker (single and multi-actor), Mastodon-keeps-picker, and OIDC approve submitting `openid profile email`.
- `yarn run prettier --write .` ✓
- `yarn lint` ✓ (0 errors)
- `yarn build` ✓
- `yarn test` ✓ (571 files, 5067 tests)

## Login authorization screen — preview

The OAuth/OIDC consent screen now adapts to the request type:

- **OIDC apps** (e.g. la suite Docs — `openid` scope): sign-in framing ("Sign in to <app>"), a fixed **"Signed in as"** account identity (avatar + name + email, no actor picker), and the required `openid` scope locked.
- **Mastodon clients** (e.g. Phanpy): unchanged — "Authorization required", the **"Authorize as"** actor picker (when the account has multiple actors), and the requested scopes.

**Desktop** — OIDC (left) vs Mastodon (right):

<img src="https://raw.githubusercontent.com/llun/activities.next/claude/pr1132-screenshots/consent-desktop.png" alt="OAuth/OIDC consent screen, OIDC app vs Mastodon client, desktop" width="980" />

**Mobile:**

<img src="https://raw.githubusercontent.com/llun/activities.next/claude/pr1132-screenshots/consent-mobile.png" alt="OAuth/OIDC consent screen, OIDC app vs Mastodon client, mobile" width="360" />

> Faithful render using the app's real light-theme tokens (not a live-instance capture — the local DB setup wasn't available). Hosted on the throwaway `claude/pr1132-screenshots` branch, not committed to this PR.

_Also in this PR: rebased onto `main` (incl. #1131) and added an account identity header card on the `/account` General page, so the avatar/name shown above are editable in one place._


