### PR TITLE
Bump version to v1.94.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.93.1",
+  "version": "1.94.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.94.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.93.1`
- Base main SHA: `a1f0519a5bb5882a71f8938a0ced36840954d4cb`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
