### PR TITLE
Bump version to v1.95.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.94.0",
+  "version": "1.95.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.94.0`
- Base main SHA: `a7c0adee085fe2f7f56c3277683310d4a9756e38`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
