### PR TITLE
fix: resume OIDC login after sign-in instead of dropping the request

### DIFF
--- a/app/(nosidebar)/auth/signin/CredentialForm.tsx
+++ b/app/(nosidebar)/auth/signin/CredentialForm.tsx
@@ -10,6 +10,8 @@ import { Label } from '@/lib/components/ui/label'
 import { authClient } from '@/lib/services/auth/auth-client'
 import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
+import { resolveSignInRedirect } from './resolveSignInRedirect'
+
 interface Props {
   providerName: string
 }
@@ -49,9 +51,7 @@ export const CredentialForm: FC<Props> = ({ providerName }) => {
       return
     }
 
-    const raw = searchParams.get('redirectBack') || '/'
-    const redirectBack =
-      raw.startsWith('/') && !raw.startsWith('//') ? raw : '/'
+    const redirectBack = resolveSignInRedirect(searchParams)
 
     try {
       const result = await authClient.signIn.email({

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/lib/components/ui/button'
 import { authClient } from '@/lib/services/auth/auth-client'
 
 import { passkeyErrorMessage } from './passkeyErrorMessage'
+import { resolveSignInRedirect } from './resolveSignInRedirect'
 
 export const PasskeySigninButton: FC = () => {
   const [error, setError] = useState<string>()
@@ -17,9 +18,7 @@ export const PasskeySigninButton: FC = () => {
   const handlePasskeySignin = async () => {
     setError(undefined)
     setLoading(true)
-    const raw = searchParams.get('redirectBack') || '/'
-    const redirectBack =
-      raw.startsWith('/') && !raw.startsWith('//') ? raw : '/'
+    const redirectBack = resolveSignInRedirect(searchParams)
     try {
       const result = await authClient.signIn.passkey({ autoFill: false })
       if (!result || result.error) {

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -1,0 +1,93 @@
+import { resolveSignInRedirect } from './resolveSignInRedirect'
+
+describe('resolveSignInRedirect', () => {
+  it('resumes an OIDC login redirect to the consent page without the login signature', () => {
+    // Shape better-auth's loginPage redirect produces: the OAuth request plus
+    // its signed envelope (exp/ba_iat/ba_param/sig) and NO redirectBack.
+    const params = new URLSearchParams(
+      'response_type=code&client_id=docs&redirect_uri=https%3A%2F%2Fdocs.llun.social%2Fcb' +
+        '&scope=openid+profile&state=xyz' +
+        '&exp=1700000600&ba_iat=1700000000000&ba_param=client_id&sig=ABC'
+    )
+
+    const result = resolveSignInRedirect(params)
+
+    expect(result.startsWith('/oauth/authorize?')).toBe(true)
+    const query = new URLSearchParams(result.split('?')[1])
+    expect(query.get('response_type')).toBe('code')
+    expect(query.get('client_id')).toBe('docs')
+    expect(query.get('redirect_uri')).toBe('https://docs.llun.social/cb')
+    expect(query.get('scope')).toBe('openid profile')
+    expect(query.get('state')).toBe('xyz')
+    // The login signature/envelope is dropped so the consent page re-delegates
+    // to better-auth for a fresh consent signature.
+    expect(query.has('sig')).toBe(false)
+    expect(query.has('exp')).toBe(false)
+    expect(query.has('ba_iat')).toBe(false)
+    expect(query.has('ba_param')).toBe(false)
+  })
+
+  it('prefers a safe redirectBack over OIDC params', () => {
+    const params = new URLSearchParams(
+      'redirectBack=%2Ffitness&response_type=code&client_id=docs'
+    )
+    expect(resolveSignInRedirect(params)).toBe('/fitness')
+  })
+
+  it('preserves an existing /oauth/authorize redirectBack verbatim', () => {
+    const back =
+      '/oauth/authorize?client_id=docs&scope=openid&redirect_uri=https://x/cb&response_type=code'
+    const params = new URLSearchParams()
+    params.set('redirectBack', back)
+    expect(resolveSignInRedirect(params)).toBe(back)
+  })
+
+  it.each([
+    {
+      description: 'a protocol-relative redirectBack',
+      redirectBack: '//evil.com'
+    },
+    {
+      description: 'an absolute redirectBack',
+      redirectBack: 'https://evil.com'
+    },
+    { description: 'an empty redirectBack', redirectBack: '' }
+  ])(
+    'falls back to / for $description when there is no OIDC request',
+    ({ redirectBack }) => {
+      const params = new URLSearchParams()
+      params.set('redirectBack', redirectBack)
+      expect(resolveSignInRedirect(params)).toBe('/')
+    }
+  )
+
+  it('falls back to / for a plain sign-in with no params', () => {
+    expect(resolveSignInRedirect(new URLSearchParams())).toBe('/')
+  })
+
+  it('does not treat a non-code response_type as an OIDC request', () => {
+    const params = new URLSearchParams('response_type=token&client_id=docs')
+    expect(resolveSignInRedirect(params)).toBe('/')
+  })
+
+  it('does not resume when client_id is missing', () => {
+    const params = new URLSearchParams('response_type=code')
+    expect(resolveSignInRedirect(params)).toBe('/')
+  })
+
+  it('carries PKCE, nonce and prompt through the resume', () => {
+    const params = new URLSearchParams(
+      'response_type=code&client_id=docs&redirect_uri=https%3A%2F%2Fx%2Fcb&scope=openid' +
+        '&code_challenge=abc&code_challenge_method=S256&nonce=n1&prompt=consent&sig=S&exp=1'
+    )
+
+    const query = new URLSearchParams(
+      resolveSignInRedirect(params).split('?')[1]
+    )
+    expect(query.get('code_challenge')).toBe('abc')
+    expect(query.get('code_challenge_method')).toBe('S256')
+    expect(query.get('nonce')).toBe('n1')
+    expect(query.get('prompt')).toBe('consent')
+    expect(query.has('sig')).toBe(false)
+  })
+})

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -51,7 +51,15 @@ describe('resolveSignInRedirect', () => {
       description: 'an absolute redirectBack',
       redirectBack: 'https://evil.com'
     },
-    { description: 'an empty redirectBack', redirectBack: '' }
+    { description: 'an empty redirectBack', redirectBack: '' },
+    {
+      description: 'a backslash-prefixed redirectBack (resolves off-origin)',
+      redirectBack: '/\\evil.com'
+    },
+    {
+      description: 'a tab-then-slash redirectBack (resolves off-origin)',
+      redirectBack: '/\t/evil.com'
+    }
   ])(
     'falls back to / for $description when there is no OIDC request',
     ({ redirectBack }) => {
@@ -89,5 +97,39 @@ describe('resolveSignInRedirect', () => {
     expect(query.get('nonce')).toBe('n1')
     expect(query.get('prompt')).toBe('consent')
     expect(query.has('sig')).toBe(false)
+  })
+
+  it('ignores an unsafe redirectBack and resumes the OIDC request instead', () => {
+    // redirectBack=/\evil.com is an open-redirect attempt; it must be dropped,
+    // and the genuine OIDC request resumed rather than falling back to '/'.
+    const params = new URLSearchParams(
+      'redirectBack=%2F%5Cevil.com&response_type=code&client_id=docs' +
+        '&redirect_uri=https%3A%2F%2Fx%2Fcb&scope=openid'
+    )
+
+    const result = resolveSignInRedirect(params)
+    expect(result.startsWith('/oauth/authorize?')).toBe(true)
+    expect(new URLSearchParams(result.split('?')[1]).get('client_id')).toBe(
+      'docs'
+    )
+  })
+
+  it('does not resume when client_id is an empty string', () => {
+    const params = new URLSearchParams('response_type=code&client_id=')
+    expect(resolveSignInRedirect(params)).toBe('/')
+  })
+
+  it('carries request_uri (PAR) through the resume', () => {
+    const params = new URLSearchParams(
+      'response_type=code&client_id=docs' +
+        '&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Aabc'
+    )
+
+    const query = new URLSearchParams(
+      resolveSignInRedirect(params).split('?')[1]
+    )
+    expect(query.get('request_uri')).toBe(
+      'urn:ietf:params:oauth:request_uri:abc'
+    )
   })
 })

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -160,26 +160,64 @@ describe('resolveSignInRedirect', () => {
     expect(query.has('ba_pl')).toBe(false)
   })
 
-  it('strips the login/create prompt tokens on resume but keeps consent', () => {
-    // better-auth's GET authorize re-redirects prompt=login/create to the
-    // login page; forwarding them verbatim would bounce the now-authenticated
-    // user back to /auth/signin -> '/'.
-    const loginOnly = new URLSearchParams(
-      'response_type=code&client_id=docs&prompt=login'
-    )
-    expect(
-      new URLSearchParams(resolveSignInRedirect(loginOnly).split('?')[1]).has(
-        'prompt'
-      )
-    ).toBe(false)
+  // better-auth's GET authorize re-redirects prompt=login/create to the login
+  // page, so those tokens must be stripped on resume (the interactive login just
+  // happened) while every other prompt value — notably `none` (silent auth) —
+  // is preserved. `expected: null` means the prompt param is removed entirely.
+  it.each([
+    {
+      description: 'strips a lone login prompt',
+      prompt: 'login',
+      expected: null
+    },
+    {
+      description: 'strips a lone create prompt',
+      prompt: 'create',
+      expected: null
+    },
+    {
+      description: 'strips both login and create, removing the param',
+      prompt: 'login create',
+      expected: null
+    },
+    {
+      description: 'keeps consent while stripping login',
+      prompt: 'login consent',
+      expected: 'consent'
+    },
+    {
+      description: 'keeps consent while stripping create',
+      prompt: 'create consent',
+      expected: 'consent'
+    },
+    {
+      description: 'preserves a lone consent prompt',
+      prompt: 'consent',
+      expected: 'consent'
+    },
+    {
+      description: 'preserves prompt=none (silent authentication)',
+      prompt: 'none',
+      expected: 'none'
+    },
+    {
+      description: 'preserves consent and none together',
+      prompt: 'consent none',
+      expected: 'consent none'
+    }
+  ])('$description on OIDC resume', ({ prompt, expected }) => {
+    const params = new URLSearchParams()
+    params.set('response_type', 'code')
+    params.set('client_id', 'docs')
+    params.set('prompt', prompt)
 
-    const loginAndConsent = new URLSearchParams(
-      'response_type=code&client_id=docs&prompt=login+consent'
+    const query = new URLSearchParams(
+      resolveSignInRedirect(params).split('?')[1]
     )
-    expect(
-      new URLSearchParams(
-        resolveSignInRedirect(loginAndConsent).split('?')[1]
-      ).get('prompt')
-    ).toBe('consent')
+    if (expected === null) {
+      expect(query.has('prompt')).toBe(false)
+    } else {
+      expect(query.get('prompt')).toBe(expected)
+    }
   })
 })

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -100,6 +100,25 @@ describe('resolveSignInRedirect', () => {
     expect(query.has('sig')).toBe(false)
   })
 
+  it('resumes a Mastodon (non-openid) OAuth request the same way', () => {
+    // The resume is OAuth-generic, not OIDC-specific: a Mastodon client that
+    // reaches better-auth's authorize endpoint logged out (its RFC 8414
+    // authorization_endpoint is also /api/auth/oauth2/authorize) is resumed to
+    // the consent page too — which renders the Mastodon actor picker because
+    // the scope has no `openid`.
+    const params = new URLSearchParams(
+      'response_type=code&client_id=phanpy&redirect_uri=https%3A%2F%2Fphanpy.app%2Fcb' +
+        '&scope=read+write+follow+push&sig=S&exp=1'
+    )
+
+    const result = resolveSignInRedirect(params)
+    const query = new URLSearchParams(result.split('?')[1])
+    expect(result.startsWith('/oauth/authorize?')).toBe(true)
+    expect(query.get('client_id')).toBe('phanpy')
+    expect(query.get('scope')).toBe('read write follow push')
+    expect(query.has('sig')).toBe(false)
+  })
+
   it('ignores an unsafe redirectBack and resumes the OIDC request instead', () => {
     // redirectBack=/\evil.com is an open-redirect attempt; it must be dropped,
     // and the genuine OIDC request resumed rather than falling back to '/'.

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -69,18 +69,19 @@ describe('resolveSignInRedirect', () => {
     }
   )
 
-  it('falls back to / for a plain sign-in with no params', () => {
-    expect(resolveSignInRedirect(new URLSearchParams())).toBe('/')
-  })
-
-  it('does not treat a non-code response_type as an OIDC request', () => {
-    const params = new URLSearchParams('response_type=token&client_id=docs')
-    expect(resolveSignInRedirect(params)).toBe('/')
-  })
-
-  it('does not resume when client_id is missing', () => {
-    const params = new URLSearchParams('response_type=code')
-    expect(resolveSignInRedirect(params)).toBe('/')
+  it.each([
+    { description: 'there are no params', query: '' },
+    {
+      description: 'response_type is not code',
+      query: 'response_type=token&client_id=docs'
+    },
+    { description: 'client_id is missing', query: 'response_type=code' },
+    {
+      description: 'client_id is an empty string',
+      query: 'response_type=code&client_id='
+    }
+  ])('falls back to / when $description', ({ query }) => {
+    expect(resolveSignInRedirect(new URLSearchParams(query))).toBe('/')
   })
 
   it('carries PKCE, nonce and prompt through the resume', () => {
@@ -114,11 +115,6 @@ describe('resolveSignInRedirect', () => {
     )
   })
 
-  it('does not resume when client_id is an empty string', () => {
-    const params = new URLSearchParams('response_type=code&client_id=')
-    expect(resolveSignInRedirect(params)).toBe('/')
-  })
-
   it('carries request_uri (PAR) through the resume', () => {
     const params = new URLSearchParams(
       'response_type=code&client_id=docs' +
@@ -131,5 +127,59 @@ describe('resolveSignInRedirect', () => {
     expect(query.get('request_uri')).toBe(
       'urn:ietf:params:oauth:request_uri:abc'
     )
+  })
+
+  it('forwards other standard OIDC params (response_mode, login_hint, max_age) through the resume', () => {
+    const params = new URLSearchParams(
+      'response_type=code&client_id=docs&response_mode=query' +
+        '&login_hint=user%40example.com&max_age=300&ui_locales=en'
+    )
+
+    const query = new URLSearchParams(
+      resolveSignInRedirect(params).split('?')[1]
+    )
+    expect(query.get('response_mode')).toBe('query')
+    expect(query.get('login_hint')).toBe('user@example.com')
+    expect(query.get('max_age')).toBe('300')
+    expect(query.get('ui_locales')).toBe('en')
+  })
+
+  it('drops the better-auth signature envelope (sig/exp/ba_*) on resume', () => {
+    const params = new URLSearchParams(
+      'response_type=code&client_id=docs' +
+        '&sig=S&exp=1&ba_iat=2&ba_param=client_id&ba_pl=x'
+    )
+
+    const query = new URLSearchParams(
+      resolveSignInRedirect(params).split('?')[1]
+    )
+    expect(query.has('sig')).toBe(false)
+    expect(query.has('exp')).toBe(false)
+    expect(query.has('ba_iat')).toBe(false)
+    expect(query.has('ba_param')).toBe(false)
+    expect(query.has('ba_pl')).toBe(false)
+  })
+
+  it('strips the login/create prompt tokens on resume but keeps consent', () => {
+    // better-auth's GET authorize re-redirects prompt=login/create to the
+    // login page; forwarding them verbatim would bounce the now-authenticated
+    // user back to /auth/signin -> '/'.
+    const loginOnly = new URLSearchParams(
+      'response_type=code&client_id=docs&prompt=login'
+    )
+    expect(
+      new URLSearchParams(resolveSignInRedirect(loginOnly).split('?')[1]).has(
+        'prompt'
+      )
+    ).toBe(false)
+
+    const loginAndConsent = new URLSearchParams(
+      'response_type=code&client_id=docs&prompt=login+consent'
+    )
+    expect(
+      new URLSearchParams(
+        resolveSignInRedirect(loginAndConsent).split('?')[1]
+      ).get('prompt')
+    ).toBe('consent')
   })
 })

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -109,10 +109,11 @@ describe('resolveSignInRedirect', () => {
     )
 
     const result = resolveSignInRedirect(params)
+    const query = new URLSearchParams(result.split('?')[1])
     expect(result.startsWith('/oauth/authorize?')).toBe(true)
-    expect(new URLSearchParams(result.split('?')[1]).get('client_id')).toBe(
-      'docs'
-    )
+    expect(query.get('client_id')).toBe('docs')
+    // The unsafe redirectBack must not be echoed into the resumed query.
+    expect(query.has('redirectBack')).toBe(false)
   })
 
   it('carries request_uri (PAR) through the resume', () => {

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
@@ -1,5 +1,6 @@
 import { buildOAuthAuthorizePath } from '@/app/(nosidebar)/oauth/authorize/authorizeQuery'
 import type { SearchParams } from '@/app/(nosidebar)/oauth/authorize/types'
+import { isSafeInternalPath } from '@/lib/utils/isSafeInternalPath'
 
 // The OAuth/OIDC authorization-request params better-auth forwards in its
 // loginPage redirect. Deliberately excludes the signed envelope (sig/exp and
@@ -16,9 +17,6 @@ const OIDC_REQUEST_PARAM_KEYS = [
   'nonce',
   'prompt'
 ] as const
-
-const isSafeInternalPath = (value: string): boolean =>
-  value.startsWith('/') && !value.startsWith('//')
 
 /**
  * Decides where the sign-in forms navigate after a successful login.
@@ -55,6 +53,10 @@ export const resolveSignInRedirect = (
     searchParams.get('response_type') === 'code' &&
     searchParams.get('client_id')
   ) {
+    // Built by loop so only params actually present are forwarded (an explicit
+    // object would emit empty `state=`/`nonce=` keys). buildOAuthQuery treats
+    // its input as a string record; the cast is needed only because SearchParams
+    // types `response_type` as the literal 'code'.
     const oidcRequest: Record<string, string> = {}
     for (const key of OIDC_REQUEST_PARAM_KEYS) {
       const value = searchParams.get(key)

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
@@ -43,7 +43,7 @@ export const resolveSignInRedirect = (
   searchParams: Pick<URLSearchParams, 'get' | 'forEach'>
 ): string => {
   const redirectBack = searchParams.get('redirectBack')
-  if (redirectBack && isSafeInternalPath(redirectBack)) {
+  if (isSafeInternalPath(redirectBack)) {
     return redirectBack
   }
 

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
@@ -2,21 +2,18 @@ import { buildOAuthAuthorizePath } from '@/app/(nosidebar)/oauth/authorize/autho
 import type { SearchParams } from '@/app/(nosidebar)/oauth/authorize/types'
 import { isSafeInternalPath } from '@/lib/utils/isSafeInternalPath'
 
-// The OAuth/OIDC authorization-request params better-auth forwards in its
-// loginPage redirect. Deliberately excludes the signed envelope (sig/exp and
-// better-auth's internal ba_iat/ba_param) so it is dropped on resume — see below.
-const OIDC_REQUEST_PARAM_KEYS = [
-  'response_type',
-  'client_id',
-  'redirect_uri',
-  'scope',
-  'state',
-  'request_uri',
-  'code_challenge',
-  'code_challenge_method',
-  'nonce',
-  'prompt'
-] as const
+// better-auth's loginPage redirect wraps the OAuth query in a signed envelope:
+// `sig`/`exp` (the signature and its expiry) plus `ba_*` internals (ba_iat,
+// ba_param, ba_pl). Those — and our own `redirectBack` — must NOT be forwarded
+// when resuming the request; everything else (the relying party's full OIDC
+// request: response_type, client_id, redirect_uri, scope, state, PKCE, nonce,
+// prompt, and any other standard param like response_mode/login_hint/max_age)
+// is preserved.
+const isBetterAuthEnvelopeKey = (key: string): boolean =>
+  key === 'redirectBack' ||
+  key === 'sig' ||
+  key === 'exp' ||
+  key.startsWith('ba_')
 
 /**
  * Decides where the sign-in forms navigate after a successful login.
@@ -30,19 +27,20 @@ const OIDC_REQUEST_PARAM_KEYS = [
  *
  *   1. honour a safe `redirectBack` (e.g. the custom consent page's own handoff),
  *   2. else, if the URL carries an OIDC authorization request, resume it by
- *      returning the consent page path with the bare OAuth params — `sig`/`exp`
- *      are dropped on purpose so the consent page's `shouldDelegateToBetterAuth`
- *      returns true and re-delegates to better-auth (now authenticated) for a
- *      fresh consent signature; this is robust to a slow login whose 10-minute
- *      login signature has expired,
+ *      returning the consent page path with the request's params (minus the
+ *      better-auth envelope) — `sig`/`exp` are dropped on purpose so the consent
+ *      page's `shouldDelegateToBetterAuth` returns true and re-delegates to
+ *      better-auth (now authenticated) for a fresh consent signature; this is
+ *      robust to a slow login whose 10-minute login signature has expired,
  *   3. else fall back to `/`.
  *
- * Only ever returns an internal path. `redirect_uri` is carried as an opaque
- * query value and is validated downstream by the consent page (against the
- * client's registered URIs) and better-auth — it is never the navigation target.
+ * Only ever returns an internal path (see `isSafeInternalPath`). `redirect_uri`
+ * is carried as an opaque query value and validated downstream by the consent
+ * page (against the client's registered URIs) and better-auth — never the
+ * navigation target.
  */
 export const resolveSignInRedirect = (
-  searchParams: Pick<URLSearchParams, 'get'>
+  searchParams: Pick<URLSearchParams, 'get' | 'forEach'>
 ): string => {
   const redirectBack = searchParams.get('redirectBack')
   if (redirectBack && isSafeInternalPath(redirectBack)) {
@@ -53,15 +51,26 @@ export const resolveSignInRedirect = (
     searchParams.get('response_type') === 'code' &&
     searchParams.get('client_id')
   ) {
-    // Built by loop so only params actually present are forwarded (an explicit
-    // object would emit empty `state=`/`nonce=` keys). buildOAuthQuery treats
-    // its input as a string record; the cast is needed only because SearchParams
-    // types `response_type` as the literal 'code'.
     const oidcRequest: Record<string, string> = {}
-    for (const key of OIDC_REQUEST_PARAM_KEYS) {
-      const value = searchParams.get(key)
-      if (value != null) oidcRequest[key] = value
+    searchParams.forEach((value, key) => {
+      if (!isBetterAuthEnvelopeKey(key)) oidcRequest[key] = value
+    })
+
+    // The interactive login better-auth's `prompt=login`/`create` demanded has
+    // just happened, so strip those tokens — leaving them would make
+    // better-auth's GET authorize bounce the now-authenticated user back to
+    // /auth/signin -> '/', re-dropping the request. `consent` (and any other
+    // tokens) are preserved; the param is removed entirely if nothing is left.
+    if (oidcRequest.prompt) {
+      const prompts = oidcRequest.prompt
+        .split(' ')
+        .filter((token) => token && token !== 'login' && token !== 'create')
+      if (prompts.length > 0) oidcRequest.prompt = prompts.join(' ')
+      else delete oidcRequest.prompt
     }
+
+    // buildOAuthQuery treats its input as a string record; the cast is needed
+    // only because SearchParams types `response_type` as the literal 'code'.
     return buildOAuthAuthorizePath(oidcRequest as unknown as SearchParams)
   }
 

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
@@ -1,0 +1,67 @@
+import { buildOAuthAuthorizePath } from '@/app/(nosidebar)/oauth/authorize/authorizeQuery'
+import type { SearchParams } from '@/app/(nosidebar)/oauth/authorize/types'
+
+// The OAuth/OIDC authorization-request params better-auth forwards in its
+// loginPage redirect. Deliberately excludes the signed envelope (sig/exp and
+// better-auth's internal ba_iat/ba_param) so it is dropped on resume — see below.
+const OIDC_REQUEST_PARAM_KEYS = [
+  'response_type',
+  'client_id',
+  'redirect_uri',
+  'scope',
+  'state',
+  'request_uri',
+  'code_challenge',
+  'code_challenge_method',
+  'nonce',
+  'prompt'
+] as const
+
+const isSafeInternalPath = (value: string): boolean =>
+  value.startsWith('/') && !value.startsWith('//')
+
+/**
+ * Decides where the sign-in forms navigate after a successful login.
+ *
+ * better-auth advertises its own `/api/auth/oauth2/authorize` as the OIDC
+ * `authorization_endpoint`, so a relying party (e.g. la-suite Docs) sends a
+ * logged-out user straight there — bypassing the custom `/oauth/authorize` page,
+ * the only place that sets a `redirectBack`. better-auth then redirects here
+ * with the signed OAuth query but NO `redirectBack`. Without resuming, the forms
+ * would push to `/` and silently drop the OIDC request. So:
+ *
+ *   1. honour a safe `redirectBack` (e.g. the custom consent page's own handoff),
+ *   2. else, if the URL carries an OIDC authorization request, resume it by
+ *      returning the consent page path with the bare OAuth params — `sig`/`exp`
+ *      are dropped on purpose so the consent page's `shouldDelegateToBetterAuth`
+ *      returns true and re-delegates to better-auth (now authenticated) for a
+ *      fresh consent signature; this is robust to a slow login whose 10-minute
+ *      login signature has expired,
+ *   3. else fall back to `/`.
+ *
+ * Only ever returns an internal path. `redirect_uri` is carried as an opaque
+ * query value and is validated downstream by the consent page (against the
+ * client's registered URIs) and better-auth — it is never the navigation target.
+ */
+export const resolveSignInRedirect = (
+  searchParams: Pick<URLSearchParams, 'get'>
+): string => {
+  const redirectBack = searchParams.get('redirectBack')
+  if (redirectBack && isSafeInternalPath(redirectBack)) {
+    return redirectBack
+  }
+
+  if (
+    searchParams.get('response_type') === 'code' &&
+    searchParams.get('client_id')
+  ) {
+    const oidcRequest: Record<string, string> = {}
+    for (const key of OIDC_REQUEST_PARAM_KEYS) {
+      const value = searchParams.get(key)
+      if (value != null) oidcRequest[key] = value
+    }
+    return buildOAuthAuthorizePath(oidcRequest as unknown as SearchParams)
+  }
+
+  return '/'
+}

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
@@ -51,7 +51,9 @@ export const resolveSignInRedirect = (
     searchParams.get('response_type') === 'code' &&
     searchParams.get('client_id')
   ) {
-    const oidcRequest: Record<string, string> = {}
+    // Null-proto so a query key that collides with an Object.prototype member
+    // (e.g. `__proto__`, `constructor`) can't pollute the forwarded request.
+    const oidcRequest: Record<string, string> = Object.create(null)
     searchParams.forEach((value, key) => {
       if (!isBetterAuthEnvelopeKey(key)) oidcRequest[key] = value
     })

--- a/app/(nosidebar)/auth/two-factor/page.tsx
+++ b/app/(nosidebar)/auth/two-factor/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 
 const getRedirectBack = (value: string | string[] | undefined): string => {
   const raw = Array.isArray(value) ? value[0] : value
-  return raw && isSafeInternalPath(raw) ? raw : '/'
+  return isSafeInternalPath(raw) ? raw : '/'
 }
 
 const Page: FC<{

--- a/app/(nosidebar)/auth/two-factor/page.tsx
+++ b/app/(nosidebar)/auth/two-factor/page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle
 } from '@/lib/components/ui/card'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { isSafeInternalPath } from '@/lib/utils/isSafeInternalPath'
 
 import { TwoFactorForm } from './TwoFactorForm'
 
@@ -20,7 +21,7 @@ export const metadata: Metadata = {
 
 const getRedirectBack = (value: string | string[] | undefined): string => {
   const raw = Array.isArray(value) ? value[0] : value
-  return raw && raw.startsWith('/') && !raw.startsWith('//') ? raw : '/'
+  return raw && isSafeInternalPath(raw) ? raw : '/'
 }
 
 const Page: FC<{

--- a/lib/utils/isSafeInternalPath.test.ts
+++ b/lib/utils/isSafeInternalPath.test.ts
@@ -39,4 +39,22 @@ describe('isSafeInternalPath', () => {
   ])('rejects $description', ({ value }) => {
     expect(isSafeInternalPath(value)).toBe(false)
   })
+
+  it.each([
+    { description: 'a percent-encoded double slash', value: '/%2f%2fevil.com' },
+    { description: 'a percent-encoded backslash', value: '/%5cevil.com' },
+    {
+      description: 'a literal percent that is not an escape',
+      value: '/100%done'
+    }
+  ])(
+    'accepts $description as a same-origin path (percent-encoding is not decoded during navigation)',
+    ({ value }) => {
+      // router.push / server redirect keep these encoded in the path, so they
+      // resolve same-origin (NOT off-origin). Decoding the pathname to "reject"
+      // them would over-reject valid paths like /100%done and throw on malformed
+      // escapes, so they are intentionally treated as safe internal paths.
+      expect(isSafeInternalPath(value)).toBe(true)
+    }
+  )
 })

--- a/lib/utils/isSafeInternalPath.test.ts
+++ b/lib/utils/isSafeInternalPath.test.ts
@@ -24,6 +24,7 @@ describe('isSafeInternalPath', () => {
     { description: 'a protocol-relative path', value: '//evil.com' },
     { description: 'a triple-slash path', value: '///evil.com' },
     { description: 'a backslash-prefixed path', value: '/\\evil.com' },
+    { description: 'a path with a backslash anywhere', value: '/foo\\bar' },
     { description: 'a tab-then-slash path', value: '/\t/evil.com' },
     { description: 'a newline-then-slash path', value: '/\n/evil.com' },
     { description: 'an absolute http URL', value: 'https://evil.com' },

--- a/lib/utils/isSafeInternalPath.test.ts
+++ b/lib/utils/isSafeInternalPath.test.ts
@@ -1,0 +1,40 @@
+import { isSafeInternalPath } from './isSafeInternalPath'
+
+describe('isSafeInternalPath', () => {
+  it.each([
+    { description: 'the root path', value: '/' },
+    { description: 'a normal internal path', value: '/fitness' },
+    {
+      description: 'an internal path whose query contains a URL',
+      value: '/oauth/authorize?redirect_uri=https://x/cb&scope=openid'
+    },
+    {
+      description: 'an internal path with a slash inside a query value',
+      value: '/path?a=//b'
+    },
+    {
+      description: 'a path that normalizes to a same-origin path',
+      value: '/\nfoo'
+    }
+  ])('accepts $description', ({ value }) => {
+    expect(isSafeInternalPath(value)).toBe(true)
+  })
+
+  it.each([
+    { description: 'a protocol-relative path', value: '//evil.com' },
+    { description: 'a backslash-prefixed path', value: '/\\evil.com' },
+    { description: 'a tab-then-slash path', value: '/\t/evil.com' },
+    { description: 'a newline-then-slash path', value: '/\n/evil.com' },
+    { description: 'an absolute http URL', value: 'https://evil.com' },
+    {
+      description: 'a scheme-relative javascript URL',
+      value: 'javascript:alert(1)'
+    },
+    { description: 'a relative path without a leading slash', value: 'foo' },
+    { description: 'an empty string', value: '' },
+    { description: 'null', value: null },
+    { description: 'undefined', value: undefined }
+  ])('rejects $description', ({ value }) => {
+    expect(isSafeInternalPath(value)).toBe(false)
+  })
+})

--- a/lib/utils/isSafeInternalPath.test.ts
+++ b/lib/utils/isSafeInternalPath.test.ts
@@ -22,6 +22,7 @@ describe('isSafeInternalPath', () => {
 
   it.each([
     { description: 'a protocol-relative path', value: '//evil.com' },
+    { description: 'a triple-slash path', value: '///evil.com' },
     { description: 'a backslash-prefixed path', value: '/\\evil.com' },
     { description: 'a tab-then-slash path', value: '/\t/evil.com' },
     { description: 'a newline-then-slash path', value: '/\n/evil.com' },

--- a/lib/utils/isSafeInternalPath.ts
+++ b/lib/utils/isSafeInternalPath.ts
@@ -17,11 +17,18 @@ const SENTINEL_ORIGIN = 'https://internal.invalid'
 export const isSafeInternalPath = (
   value: string | null | undefined
 ): value is string => {
-  // Reject protocol-relative / multi-slash targets up front as defense in depth
-  // against a parser differential between the URL constructor here and the
-  // browser's own navigation (e.g. `///evil.com`), then confirm the candidate
-  // resolves back to the sentinel origin.
-  if (!value || !value.startsWith('/') || value.startsWith('//')) return false
+  // Reject protocol-relative / multi-slash targets and any backslash up front as
+  // defense in depth against a parser differential between the URL constructor
+  // here and the browser's own navigation (e.g. `///evil.com`, `/\evil.com`),
+  // then confirm the candidate resolves back to the sentinel origin.
+  if (
+    !value ||
+    !value.startsWith('/') ||
+    value.startsWith('//') ||
+    value.includes('\\')
+  ) {
+    return false
+  }
   try {
     return new URL(value, SENTINEL_ORIGIN).origin === SENTINEL_ORIGIN
   } catch {

--- a/lib/utils/isSafeInternalPath.ts
+++ b/lib/utils/isSafeInternalPath.ts
@@ -1,0 +1,26 @@
+// Sentinel origin used only to resolve a candidate redirect target. Its exact
+// value is irrelevant — it just has to be an origin nothing else can match.
+const SENTINEL_ORIGIN = 'https://internal.invalid'
+
+/**
+ * Whether `value` is a safe same-origin redirect target (an absolute internal
+ * path), guarding the post-login / post-2FA redirects against open redirects
+ * (CWE-601).
+ *
+ * It resolves the candidate the way the browser / WHATWG URL parser does, so it
+ * also rejects the bypasses a naive `startsWith('/') && !startsWith('//')` check
+ * misses: backslashes and tab/newline characters get normalized such that e.g.
+ * `/\evil.com` and `/<tab>/evil.com` resolve to an off-origin `https://evil.com/`.
+ * A value is safe only if it starts with `/` and still resolves to the sentinel
+ * origin (i.e. it never escapes to another host).
+ */
+export const isSafeInternalPath = (
+  value: string | null | undefined
+): boolean => {
+  if (!value || !value.startsWith('/')) return false
+  try {
+    return new URL(value, SENTINEL_ORIGIN).origin === SENTINEL_ORIGIN
+  } catch {
+    return false
+  }
+}

--- a/lib/utils/isSafeInternalPath.ts
+++ b/lib/utils/isSafeInternalPath.ts
@@ -17,7 +17,11 @@ const SENTINEL_ORIGIN = 'https://internal.invalid'
 export const isSafeInternalPath = (
   value: string | null | undefined
 ): boolean => {
-  if (!value || !value.startsWith('/')) return false
+  // Reject protocol-relative / multi-slash targets up front as defense in depth
+  // against a parser differential between the URL constructor here and the
+  // browser's own navigation (e.g. `///evil.com`), then confirm the candidate
+  // resolves back to the sentinel origin.
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return false
   try {
     return new URL(value, SENTINEL_ORIGIN).origin === SENTINEL_ORIGIN
   } catch {

--- a/lib/utils/isSafeInternalPath.ts
+++ b/lib/utils/isSafeInternalPath.ts
@@ -16,7 +16,7 @@ const SENTINEL_ORIGIN = 'https://internal.invalid'
  */
 export const isSafeInternalPath = (
   value: string | null | undefined
-): boolean => {
+): value is string => {
   // Reject protocol-relative / multi-slash targets up front as defense in depth
   // against a parser differential between the URL constructor here and the
   // browser's own navigation (e.g. `///evil.com`), then confirm the candidate


### PR DESCRIPTION
## Summary

Logged-out OIDC login was broken: a user signing in from a relying party (e.g. la-suite **Docs**) — with **either** passkey **or** email/password — would sign in successfully but land on the **home timeline** instead of the consent screen, and never get redirected back to the relying party. The OIDC authorization request was silently dropped.

## Root cause (pre-existing — not from #1132)

The OIDC discovery doc advertises better-auth's own endpoint as the `authorization_endpoint` (`/api/auth/oauth2/authorize`), so a relying party sends a logged-out user **straight there**, bypassing the custom `/oauth/authorize` page — the only place that sets a `redirectBack`. For an unauthenticated request, better-auth redirects to `/auth/signin?<signed OAuth query>` with **no `redirectBack`**. The sign-in forms (`CredentialForm`, `PasskeySigninButton`) resumed **only** via `searchParams.get('redirectBack') || '/'` and did not forward `oauth_query` to better-auth's `signIn` call, so:

1. no `redirectBack` → `router.push('/')` → home, and
2. better-auth's own in-band resume hooks never fired (they require `oauth_query` in the sign-in request body; its `oAuthState` is request-scoped `AsyncLocalStorage` that can't bridge the login→authorize navigation).

That's why **both** auth methods failed identically. Every component in this path predates #1132 (authz endpoint since the original OIDC support; the `redirectBack`-only forms since their introduction).

## Fix

A new **pure** helper `resolveSignInRedirect(searchParams)` used by both forms:

1. safe `redirectBack` present → use it (unchanged behavior, incl. the custom consent page's own handoff),
2. else if the URL carries an OIDC request (`response_type=code` + `client_id`) → resume by returning `/oauth/authorize?<bare OAuth params>` **with `sig`/`exp` dropped** — dropping the signature forces the consent page's `shouldDelegateToBetterAuth` to re-delegate to better-auth (now authenticated) for a **fresh** consent signature, which is robust to a slow login whose 10-minute login signature has expired,
3. else → `/`.

Additive and low-risk: no changes to `auth.ts`, the OIDC discovery, `authorizeQuery.ts`, or the consent page. Only ever returns an internal path; `redirect_uri` is carried as an opaque query value and validated downstream.

## Testing

- TDD: `resolveSignInRedirect.test.ts` — pure unit tests (no live instance) covering OIDC resume (sig/exp/ba_* dropped), `redirectBack` precedence, custom-page handoff preserved, open-redirect (`//evil.com`, `https://…`) → `/`, non-`code` / missing `client_id` → `/`, and PKCE/nonce/prompt round-trip.
- `yarn run prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (5137)

## Verification note

The pure helper proves the resume **target** is computed correctly without a live instance. End-to-end confirmation needs a real OIDC client + discovery (a registered RP), so final smoke-testing should be done on a deployed instance: from the RP, sign in logged-out (both passkey and password) and confirm you reach the consent screen then bounce back to the RP. Negative checks: plain `/auth/signin` → `/`; `?redirectBack=/fitness` → `/fitness`; `//evil.com` not followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)