### PR TITLE
Bump version to v1.95.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.0",
+  "version": "1.95.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.0`
- Base main SHA: `60c9c4293faf5cd37f2cbc1450f7e85605108f85`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
