### PR TITLE
fix: stop session revoke 500 when the session minted OAuth tokens

### DIFF
--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -528,6 +528,67 @@ describe('AccountDatabase', () => {
     })
 
     describe('account sessions', () => {
+      // SQLite leaves foreign keys OFF by default, so the shared test database
+      // never enforces them — which is exactly why the session ↔ OAuth-token FK
+      // violation only surfaced on PostgreSQL in production. Spin up an isolated
+      // database with enforcement ON so these tests reproduce that constraint.
+      const createForeignKeyEnforcingDatabase = () =>
+        knex({
+          client: 'better-sqlite3',
+          useNullAsDefault: true,
+          connection: { filename: ':memory:' },
+          pool: {
+            afterCreate: (
+              conn: { pragma: (statement: string) => void },
+              done: (error: Error | null, conn: unknown) => void
+            ) => {
+              conn.pragma('foreign_keys = ON')
+              done(null, conn)
+            }
+          }
+        })
+
+      // Mint an OAuth access + refresh token bound to `sessionId`, mirroring the
+      // rows better-auth's OAuth provider writes when an app is authorized. Both
+      // tables carry a `sessionId` FK into `sessions.id`.
+      const seedOAuthTokensForSession = async (
+        knexDatabase: ReturnType<typeof knex>,
+        {
+          accountId,
+          sessionId,
+          suffix
+        }: { accountId: string; sessionId: string; suffix: string }
+      ) => {
+        const clientId = `client-${suffix}`
+        await knexDatabase('oauthClient').insert({
+          id: crypto.randomUUID(),
+          clientId,
+          redirectUris: '[]'
+        })
+        const refreshId = crypto.randomUUID()
+        await knexDatabase('oauthRefreshToken').insert({
+          id: refreshId,
+          token: `refresh-${suffix}`,
+          clientId,
+          userId: accountId,
+          sessionId,
+          expiresAt: new Date(Date.now() + 3_600_000),
+          scopes: 'read'
+        })
+        const accessId = crypto.randomUUID()
+        await knexDatabase('oauthAccessToken').insert({
+          id: accessId,
+          token: `access-${suffix}`,
+          clientId,
+          userId: accountId,
+          sessionId,
+          refreshId,
+          expiresAt: new Date(Date.now() + 3_600_000),
+          scopes: 'read'
+        })
+        return { accessId, refreshId }
+      }
+
       it('creates, updates, and deletes account sessions', async () => {
         const { accountId } = await createTestAccount()
         const token = `token-${crypto.randomUUID()}`
@@ -716,6 +777,131 @@ describe('AccountDatabase', () => {
         } finally {
           await new Promise((resolve) => setImmediate(resolve))
           errorSpy.mockRestore()
+          await knexDatabase.destroy()
+        }
+      })
+
+      it('revokes a session that minted OAuth tokens without violating the foreign key', async () => {
+        const knexDatabase = createForeignKeyEnforcingDatabase()
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        try {
+          await sqlDatabase.migrate()
+
+          const [{ foreign_keys: fkEnabled }] = await knexDatabase.raw(
+            'PRAGMA foreign_keys'
+          )
+          // Guard against a vacuous test: without enforcement the old bare
+          // delete would pass too.
+          expect(fkEnabled).toBe(1)
+
+          const accountId = await sqlDatabase.createAccount({
+            email: `revoke-${crypto.randomUUID()}@${TEST_DOMAIN}`,
+            username: `revoke-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-revoke-key',
+            publicKey: 'public-revoke-key'
+          })
+
+          const token = `revoke-token-${crypto.randomUUID()}`
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token,
+            expireAt: Date.now() + 60_000
+          })
+          const session = await knexDatabase('sessions')
+            .where('token', token)
+            .first<{ id: string }>('id')
+          const { accessId, refreshId } = await seedOAuthTokensForSession(
+            knexDatabase,
+            {
+              accountId,
+              sessionId: session.id,
+              suffix: crypto.randomUUID().slice(0, 8)
+            }
+          )
+
+          // The bug: this threw with PostgreSQL FK error 23503 before the fix.
+          await expect(
+            sqlDatabase.deleteAccountSession({ token })
+          ).resolves.toBeUndefined()
+
+          expect(await sqlDatabase.getAccountSession({ token })).toBeNull()
+          // The tokens survive, detached from the now-deleted session, so the
+          // connected app keeps working.
+          const access = await knexDatabase('oauthAccessToken')
+            .where('id', accessId)
+            .first()
+          const refresh = await knexDatabase('oauthRefreshToken')
+            .where('id', refreshId)
+            .first()
+          expect(access?.sessionId).toBeNull()
+          expect(refresh?.sessionId).toBeNull()
+        } finally {
+          await knexDatabase.destroy()
+        }
+      })
+
+      it('revokes other sessions that minted OAuth tokens and keeps the current one', async () => {
+        const knexDatabase = createForeignKeyEnforcingDatabase()
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        try {
+          await sqlDatabase.migrate()
+
+          const accountId = await sqlDatabase.createAccount({
+            email: `revoke-all-${crypto.randomUUID()}@${TEST_DOMAIN}`,
+            username: `revoke-all-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-revoke-all-key',
+            publicKey: 'public-revoke-all-key'
+          })
+
+          const keepToken = `keep-${crypto.randomUUID()}`
+          const revokeToken = `revoke-${crypto.randomUUID()}`
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token: keepToken,
+            expireAt: Date.now() + 60_000
+          })
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token: revokeToken,
+            expireAt: Date.now() + 60_000
+          })
+          const revoked = await knexDatabase('sessions')
+            .where('token', revokeToken)
+            .first<{ id: string }>('id')
+          const { accessId, refreshId } = await seedOAuthTokensForSession(
+            knexDatabase,
+            {
+              accountId,
+              sessionId: revoked.id,
+              suffix: crypto.randomUUID().slice(0, 8)
+            }
+          )
+
+          const count = await sqlDatabase.deleteOtherAccountSessions({
+            accountId,
+            exceptToken: keepToken
+          })
+          expect(count).toBe(1)
+
+          const remaining = await sqlDatabase.getAccountAllSessions({
+            accountId
+          })
+          expect(remaining.map((item) => item.token)).toEqual([keepToken])
+          const access = await knexDatabase('oauthAccessToken')
+            .where('id', accessId)
+            .first()
+          const refresh = await knexDatabase('oauthRefreshToken')
+            .where('id', refreshId)
+            .first()
+          expect(access?.sessionId).toBeNull()
+          expect(refresh?.sessionId).toBeNull()
+        } finally {
           await knexDatabase.destroy()
         }
       })

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import knex from 'knex'
 
 import { getSQLDatabase } from '@/lib/database/sql'
+import { SESSION_ID_CHUNK_SIZE } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
 import {
   TestDatabaseTable,
   databaseBeforeAll,
@@ -1037,6 +1038,98 @@ describe('AccountDatabase', () => {
                 .first()
             )?.sessionId
           ).toBeNull()
+        } finally {
+          await knexDatabase.destroy()
+        }
+      })
+
+      it('revokes more sessions than the bind-parameter chunk size in one call', async () => {
+        const knexDatabase = createForeignKeyEnforcingDatabase()
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        try {
+          await sqlDatabase.migrate()
+
+          const accountId = await sqlDatabase.createAccount({
+            email: `bulk-${crypto.randomUUID()}@${TEST_DOMAIN}`,
+            username: `bulk-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-bulk-key',
+            publicKey: 'public-bulk-key'
+          })
+
+          const keepToken = `keep-${crypto.randomUUID()}`
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token: keepToken,
+            expireAt: Date.now() + 60_000
+          })
+
+          // Insert more revocable sessions than one chunk holds so the delete
+          // (and the token detach) must span at least two `whereIn` batches.
+          const now = new Date()
+          const revokeCount = SESSION_ID_CHUNK_SIZE + 5
+          const sessionRows = Array.from(
+            { length: revokeCount },
+            (_, index) => ({
+              id: `bulk-sid-${index}`,
+              accountId,
+              token: `bulk-token-${index}`,
+              expireAt: new Date(Date.now() + 60_000),
+              createdAt: now,
+              updatedAt: now
+            })
+          )
+          // Batch the seed insert itself (SQLite caps a compound INSERT at 500
+          // rows) — which is the same class of limit the production chunking
+          // guards against.
+          await knexDatabase.batchInsert('sessions', sessionRows, 100)
+
+          // Put OAuth tokens on sessions in both chunks (first, mid, last) so the
+          // detach has to reach across batches too.
+          const tokenSessionIndexes = [
+            0,
+            SESSION_ID_CHUNK_SIZE,
+            revokeCount - 1
+          ]
+          const seeded = []
+          for (const index of tokenSessionIndexes) {
+            seeded.push(
+              await seedOAuthTokensForSession(knexDatabase, {
+                accountId,
+                sessionId: `bulk-sid-${index}`,
+                suffix: `bulk-${index}`
+              })
+            )
+          }
+
+          const count = await sqlDatabase.deleteOtherAccountSessions({
+            accountId,
+            exceptToken: keepToken
+          })
+          expect(count).toBe(revokeCount)
+
+          const remaining = await sqlDatabase.getAccountAllSessions({
+            accountId
+          })
+          expect(remaining.map((item) => item.token)).toEqual([keepToken])
+          for (const { accessId, refreshId } of seeded) {
+            expect(
+              (
+                await knexDatabase('oauthAccessToken')
+                  .where('id', accessId)
+                  .first()
+              )?.sessionId
+            ).toBeNull()
+            expect(
+              (
+                await knexDatabase('oauthRefreshToken')
+                  .where('id', refreshId)
+                  .first()
+              )?.sessionId
+            ).toBeNull()
+          }
         } finally {
           await knexDatabase.destroy()
         }

--- a/lib/database/sql/account.test.ts
+++ b/lib/database/sql/account.test.ts
@@ -905,6 +905,142 @@ describe('AccountDatabase', () => {
           await knexDatabase.destroy()
         }
       })
+
+      it('changePassword wipes sessions that minted OAuth tokens without violating the foreign key', async () => {
+        const knexDatabase = createForeignKeyEnforcingDatabase()
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        try {
+          await sqlDatabase.migrate()
+          const [{ foreign_keys: fkEnabled }] = await knexDatabase.raw(
+            'PRAGMA foreign_keys'
+          )
+          expect(fkEnabled).toBe(1)
+
+          const accountId = await sqlDatabase.createAccount({
+            email: `change-pw-${crypto.randomUUID()}@${TEST_DOMAIN}`,
+            username: `change-pw-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-change-pw-key',
+            publicKey: 'public-change-pw-key'
+          })
+
+          const token = `change-pw-${crypto.randomUUID()}`
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token,
+            expireAt: Date.now() + 60_000
+          })
+          const session = await knexDatabase('sessions')
+            .where('token', token)
+            .first<{ id: string }>('id')
+          const { accessId, refreshId } = await seedOAuthTokensForSession(
+            knexDatabase,
+            {
+              accountId,
+              sessionId: session.id,
+              suffix: crypto.randomUUID().slice(0, 8)
+            }
+          )
+
+          // Changing a password wipes every session for the account; before the
+          // fix this 500'd on the sessionId FK for accounts with connected apps.
+          await expect(
+            sqlDatabase.changePassword({
+              accountId,
+              newPasswordHash: 'changed_password_hash'
+            })
+          ).resolves.toBeUndefined()
+
+          expect(
+            await sqlDatabase.getAccountAllSessions({ accountId })
+          ).toHaveLength(0)
+          expect(
+            (
+              await knexDatabase('oauthAccessToken')
+                .where('id', accessId)
+                .first()
+            )?.sessionId
+          ).toBeNull()
+          expect(
+            (
+              await knexDatabase('oauthRefreshToken')
+                .where('id', refreshId)
+                .first()
+            )?.sessionId
+          ).toBeNull()
+        } finally {
+          await knexDatabase.destroy()
+        }
+      })
+
+      it('resetPasswordWithCode wipes sessions that minted OAuth tokens without violating the foreign key', async () => {
+        const knexDatabase = createForeignKeyEnforcingDatabase()
+        const sqlDatabase = getSQLDatabase(knexDatabase)
+
+        try {
+          await sqlDatabase.migrate()
+
+          const email = `reset-pw-${crypto.randomUUID()}@${TEST_DOMAIN}`
+          const accountId = await sqlDatabase.createAccount({
+            email,
+            username: `reset-pw-${crypto.randomUUID().slice(0, 8)}`,
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'private-reset-pw-key',
+            publicKey: 'public-reset-pw-key'
+          })
+
+          const token = `reset-pw-${crypto.randomUUID()}`
+          await sqlDatabase.createAccountSession({
+            accountId,
+            token,
+            expireAt: Date.now() + 60_000
+          })
+          const session = await knexDatabase('sessions')
+            .where('token', token)
+            .first<{ id: string }>('id')
+          const { accessId, refreshId } = await seedOAuthTokensForSession(
+            knexDatabase,
+            {
+              accountId,
+              sessionId: session.id,
+              suffix: crypto.randomUUID().slice(0, 8)
+            }
+          )
+
+          const passwordResetCode = `reset-${crypto.randomUUID()}`
+          await sqlDatabase.requestPasswordReset({ email, passwordResetCode })
+
+          await expect(
+            sqlDatabase.resetPasswordWithCode({
+              passwordResetCode,
+              newPasswordHash: 'reset_password_hash'
+            })
+          ).resolves.toMatchObject({ id: accountId })
+
+          expect(
+            await sqlDatabase.getAccountAllSessions({ accountId })
+          ).toHaveLength(0)
+          expect(
+            (
+              await knexDatabase('oauthAccessToken')
+                .where('id', accessId)
+                .first()
+            )?.sessionId
+          ).toBeNull()
+          expect(
+            (
+              await knexDatabase('oauthRefreshToken')
+                .where('id', refreshId)
+                .first()
+            )?.sessionId
+          ).toBeNull()
+        } finally {
+          await knexDatabase.destroy()
+        }
+      })
     })
   })
 })

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -8,7 +8,7 @@ import {
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
 import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
-import { detachOAuthTokensFromSessions } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
+import { deleteSessionsWithTokenDetach } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
@@ -343,36 +343,20 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
   async deleteAccountSession({
     token
   }: DeleteAccountSessionParams): Promise<void> {
-    await database.transaction(async (trx) => {
-      const rows = await trx('sessions')
-        .where('token', token)
-        .select<{ id: string }[]>('id')
-      // Delete by the resolved primary keys rather than re-running the lookup
-      // filter, so the detach and delete act on exactly the same rows (no row
-      // a concurrent insert added between the two statements can slip through
-      // undetached). `filter(Boolean)` guards against a stray empty id.
-      const ids = rows.map((row) => row.id).filter(Boolean)
-      if (ids.length === 0) return
-      await detachOAuthTokensFromSessions(trx, ids)
-      await trx('sessions').whereIn('id', ids).delete()
-    })
+    await database.transaction((trx) =>
+      deleteSessionsWithTokenDetach(trx, (query) => query.where('token', token))
+    )
   },
 
   async deleteOtherAccountSessions({
     accountId,
     exceptToken
   }: DeleteOtherAccountSessionsParams): Promise<number> {
-    return database.transaction(async (trx) => {
-      const rows = await trx('sessions')
-        .where('accountId', accountId)
-        .andWhereNot('token', exceptToken)
-        .select<{ id: string }[]>('id')
-      const ids = rows.map((row) => row.id).filter(Boolean)
-      if (ids.length === 0) return 0
-      await detachOAuthTokensFromSessions(trx, ids)
-      const deletedCount = await trx('sessions').whereIn('id', ids).delete()
-      return deletedCount
-    })
+    return database.transaction((trx) =>
+      deleteSessionsWithTokenDetach(trx, (query) =>
+        query.where('accountId', accountId).andWhereNot('token', exceptToken)
+      )
+    )
   },
 
   async getAccountProviders({ accountId }: GetAccountProvidersParams): Promise<
@@ -720,7 +704,9 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         .onConflict('id')
         .merge({ password: newPasswordHash, updatedAt: now })
 
-      await trx('sessions').where('accountId', targetAccountId).delete()
+      await deleteSessionsWithTokenDetach(trx, (query) =>
+        query.where('accountId', targetAccountId)
+      )
       return targetAccountId
     })
 
@@ -752,7 +738,9 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         })
         .onConflict('id')
         .merge({ password: newPasswordHash, updatedAt: currentTime })
-      await trx('sessions').where('accountId', accountId).delete()
+      await deleteSessionsWithTokenDetach(trx, (query) =>
+        query.where('accountId', accountId)
+      )
     })
   },
 

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -8,6 +8,7 @@ import {
   increaseCounterValue
 } from '@/lib/database/sql/utils/counter'
 import { incrementBucket } from '@/lib/database/sql/utils/counterBucket'
+import { detachOAuthTokensFromSessions } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
 import { getCompatibleJSON } from '@/lib/database/sql/utils/getCompatibleJSON'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
@@ -342,17 +343,37 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
   async deleteAccountSession({
     token
   }: DeleteAccountSessionParams): Promise<void> {
-    await database('sessions').where('token', token).delete()
+    await database.transaction(async (trx) => {
+      const rows = await trx('sessions')
+        .where('token', token)
+        .select<{ id: string }[]>('id')
+      await detachOAuthTokensFromSessions(
+        trx,
+        rows.map((row) => row.id)
+      )
+      await trx('sessions').where('token', token).delete()
+    })
   },
 
   async deleteOtherAccountSessions({
     accountId,
     exceptToken
   }: DeleteOtherAccountSessionsParams): Promise<number> {
-    return database('sessions')
-      .where('accountId', accountId)
-      .andWhereNot('token', exceptToken)
-      .delete()
+    return database.transaction(async (trx) => {
+      const rows = await trx('sessions')
+        .where('accountId', accountId)
+        .andWhereNot('token', exceptToken)
+        .select<{ id: string }[]>('id')
+      await detachOAuthTokensFromSessions(
+        trx,
+        rows.map((row) => row.id)
+      )
+      const deletedCount = await trx('sessions')
+        .where('accountId', accountId)
+        .andWhereNot('token', exceptToken)
+        .delete()
+      return deletedCount
+    })
   },
 
   async getAccountProviders({ accountId }: GetAccountProvidersParams): Promise<

--- a/lib/database/sql/account.ts
+++ b/lib/database/sql/account.ts
@@ -347,11 +347,14 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
       const rows = await trx('sessions')
         .where('token', token)
         .select<{ id: string }[]>('id')
-      await detachOAuthTokensFromSessions(
-        trx,
-        rows.map((row) => row.id)
-      )
-      await trx('sessions').where('token', token).delete()
+      // Delete by the resolved primary keys rather than re-running the lookup
+      // filter, so the detach and delete act on exactly the same rows (no row
+      // a concurrent insert added between the two statements can slip through
+      // undetached). `filter(Boolean)` guards against a stray empty id.
+      const ids = rows.map((row) => row.id).filter(Boolean)
+      if (ids.length === 0) return
+      await detachOAuthTokensFromSessions(trx, ids)
+      await trx('sessions').whereIn('id', ids).delete()
     })
   },
 
@@ -364,14 +367,10 @@ export const AccountSQLDatabaseMixin = (database: Knex): AccountDatabase => ({
         .where('accountId', accountId)
         .andWhereNot('token', exceptToken)
         .select<{ id: string }[]>('id')
-      await detachOAuthTokensFromSessions(
-        trx,
-        rows.map((row) => row.id)
-      )
-      const deletedCount = await trx('sessions')
-        .where('accountId', accountId)
-        .andWhereNot('token', exceptToken)
-        .delete()
+      const ids = rows.map((row) => row.id).filter(Boolean)
+      if (ids.length === 0) return 0
+      await detachOAuthTokensFromSessions(trx, ids)
+      const deletedCount = await trx('sessions').whereIn('id', ids).delete()
       return deletedCount
     })
   },

--- a/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
+++ b/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
@@ -1,5 +1,20 @@
 import { Knex } from 'knex'
 
+// Cap each `whereIn` list well under the smallest backend bind-parameter ceiling
+// (SQLite's historical 999) so a large bulk session cleanup — e.g. expired
+// sessions across every account flowing through the better-auth adapter — can't
+// blow the limit and crash. PostgreSQL's ceiling (65535) is far higher, so one
+// conservative size is safe for every backend.
+export const SESSION_ID_CHUNK_SIZE = 500
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
 /**
  * `oauthAccessToken.sessionId` and `oauthRefreshToken.sessionId` are foreign
  * keys into `sessions.id` with no `ON DELETE` action, so PostgreSQL — which,
@@ -17,13 +32,14 @@ export const detachOAuthTokensFromSessions = async (
   trx: Knex.Transaction,
   sessionIds: string[]
 ): Promise<void> => {
-  if (sessionIds.length === 0) return
-  await trx('oauthAccessToken')
-    .whereIn('sessionId', sessionIds)
-    .update({ sessionId: null })
-  await trx('oauthRefreshToken')
-    .whereIn('sessionId', sessionIds)
-    .update({ sessionId: null })
+  for (const batch of chunk(sessionIds, SESSION_ID_CHUNK_SIZE)) {
+    await trx('oauthAccessToken')
+      .whereIn('sessionId', batch)
+      .update({ sessionId: null })
+    await trx('oauthRefreshToken')
+      .whereIn('sessionId', batch)
+      .update({ sessionId: null })
+  }
 }
 
 /**
@@ -33,7 +49,8 @@ export const detachOAuthTokensFromSessions = async (
  * reintroduce the `sessionId` FK violation — deleting by the resolved ids also
  * means a session a concurrent insert added between the lookup and the delete
  * can't be deleted undetached. Must run inside a transaction; returns the number
- * of sessions deleted. `filter(Boolean)` guards against a stray empty id.
+ * of sessions deleted. `filter(Boolean)` guards against a stray empty id, and
+ * the delete is chunked to stay under backend bind-parameter limits.
  */
 export const deleteSessionsWithTokenDetach = async (
   trx: Knex.Transaction,
@@ -45,6 +62,9 @@ export const deleteSessionsWithTokenDetach = async (
   const ids = rows.map((row) => row.id).filter(Boolean)
   if (ids.length === 0) return 0
   await detachOAuthTokensFromSessions(trx, ids)
-  const deletedCount = await trx('sessions').whereIn('id', ids).delete()
+  let deletedCount = 0
+  for (const batch of chunk(ids, SESSION_ID_CHUNK_SIZE)) {
+    deletedCount += await trx('sessions').whereIn('id', batch).delete()
+  }
   return deletedCount
 }

--- a/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
+++ b/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
@@ -56,6 +56,9 @@ export const deleteSessionsWithTokenDetach = async (
   trx: Knex.Transaction,
   scope: (query: Knex.QueryBuilder) => Knex.QueryBuilder
 ): Promise<number> => {
+  // Knex's `.select<T>()` types the full awaited result, so the array shape
+  // `{ id: string }[]` is intentional here (not a single row); `.select<{ id }>`
+  // would type `rows` as one object and break the `.map` below.
   const rows = await scope(trx('sessions')).select<{ id: string }[]>(
     'sessions.id'
   )

--- a/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
+++ b/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
@@ -25,3 +25,26 @@ export const detachOAuthTokensFromSessions = async (
     .whereIn('sessionId', sessionIds)
     .update({ sessionId: null })
 }
+
+/**
+ * FK-safe session delete. Resolves the session ids matched by `scope`, detaches
+ * their OAuth tokens, then deletes exactly those rows (by primary key). Every
+ * code path that removes `sessions` rows must go through here so none can
+ * reintroduce the `sessionId` FK violation — deleting by the resolved ids also
+ * means a session a concurrent insert added between the lookup and the delete
+ * can't be deleted undetached. Must run inside a transaction; returns the number
+ * of sessions deleted. `filter(Boolean)` guards against a stray empty id.
+ */
+export const deleteSessionsWithTokenDetach = async (
+  trx: Knex.Transaction,
+  scope: (query: Knex.QueryBuilder) => Knex.QueryBuilder
+): Promise<number> => {
+  const rows = await scope(trx('sessions')).select<{ id: string }[]>(
+    'sessions.id'
+  )
+  const ids = rows.map((row) => row.id).filter(Boolean)
+  if (ids.length === 0) return 0
+  await detachOAuthTokensFromSessions(trx, ids)
+  const deletedCount = await trx('sessions').whereIn('id', ids).delete()
+  return deletedCount
+}

--- a/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
+++ b/lib/database/sql/utils/detachOAuthTokensFromSessions.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex'
+
+/**
+ * `oauthAccessToken.sessionId` and `oauthRefreshToken.sessionId` are foreign
+ * keys into `sessions.id` with no `ON DELETE` action, so PostgreSQL — which,
+ * unlike the SQLite backend the test suite runs on, actually enforces foreign
+ * keys — rejects deleting a session that minted OAuth tokens with error 23503.
+ *
+ * Detaching those tokens (clearing the session link) before the session row is
+ * removed lets the session be revoked while the connected app keeps working:
+ * bearer-token validation never reads `sessionId` (see `OAuthGuard`), and the
+ * app is still revoked on its own through `revokeAccountConnectedApp`. Call this
+ * inside the same transaction as the session delete so a partial failure can't
+ * leave tokens detached from a session that still exists.
+ */
+export const detachOAuthTokensFromSessions = async (
+  trx: Knex.Transaction,
+  sessionIds: string[]
+): Promise<void> => {
+  if (sessionIds.length === 0) return
+  await trx('oauthAccessToken')
+    .whereIn('sessionId', sessionIds)
+    .update({ sessionId: null })
+  await trx('oauthRefreshToken')
+    .whereIn('sessionId', sessionIds)
+    .update({ sessionId: null })
+}

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -822,9 +822,11 @@ describe('knexAdapter', () => {
       ).toBeNull()
     })
 
-    it('deleteMany() detaches OAuth tokens and returns the deleted count', async () => {
+    it('deleteMany() detaches a mixed batch and returns the deleted count', async () => {
+      // bulk-a minted OAuth tokens; bulk-b did not. The realistic "revoke all
+      // other sessions" case is a mix, and both must be deleted.
       await seedSessionWithTokens('bulk-a')
-      await seedSessionWithTokens('bulk-b')
+      await fkDb('sessions').insert({ id: 'sid-bulk-b', token: 'bulk-b' })
 
       const count = await fkAdapter.deleteMany({
         model: 'sessions',
@@ -839,12 +841,38 @@ describe('knexAdapter', () => {
 
       expect(count).toBe(2)
       expect(await fkDb('sessions').select()).toHaveLength(0)
+      // bulk-a's tokens must SURVIVE (not be deleted), detached from the
+      // now-deleted session — asserting existence + null sessionId, not just
+      // the absence of non-null links.
+      const access = await fkDb('oauthAccessToken')
+        .where('id', 'at-bulk-a')
+        .first()
+      const refresh = await fkDb('oauthRefreshToken')
+        .where('id', 'rt-bulk-a')
+        .first()
+      expect(access).toBeDefined()
+      expect(access?.sessionId).toBeNull()
+      expect(refresh).toBeDefined()
+      expect(refresh?.sessionId).toBeNull()
+    })
+
+    it('deleteMany() is a no-op returning 0 when no session matches', async () => {
+      await seedSessionWithTokens('survivor')
+
+      const count = await fkAdapter.deleteMany({
+        model: 'sessions',
+        where: [{ field: 'token', value: 'missing', operator: 'eq' as const }]
+      })
+
+      expect(count).toBe(0)
+      // The unrelated session and its (still-attached) tokens are untouched.
       expect(
-        await fkDb('oauthAccessToken').whereNotNull('sessionId')
-      ).toHaveLength(0)
+        await fkDb('sessions').where('token', 'survivor').first()
+      ).toBeDefined()
       expect(
-        await fkDb('oauthRefreshToken').whereNotNull('sessionId')
-      ).toHaveLength(0)
+        (await fkDb('oauthAccessToken').where('id', 'at-survivor').first())
+          ?.sessionId
+      ).toBe('sid-survivor')
     })
   })
 

--- a/lib/services/auth/knexAdapter.test.ts
+++ b/lib/services/auth/knexAdapter.test.ts
@@ -731,6 +731,123 @@ describe('knexAdapter', () => {
     })
   })
 
+  // Deleting a session that minted OAuth tokens trips the
+  // oauthAccessToken/oauthRefreshToken sessionId FKs on PostgreSQL. The adapter
+  // is what better-auth calls for sign-out and session cleanup, so it must
+  // detach those tokens first. SQLite leaves FKs off by default, so this block
+  // uses a dedicated database with enforcement ON to reproduce the constraint.
+  describe('session deletion detaches OAuth tokens', () => {
+    let fkDb: Knex
+    let fkAdapter: ReturnType<ReturnType<typeof knexAdapter>>
+
+    beforeAll(async () => {
+      fkDb = knex({
+        client: 'better-sqlite3',
+        useNullAsDefault: true,
+        connection: { filename: ':memory:' },
+        pool: {
+          afterCreate: (
+            conn: { pragma: (statement: string) => void },
+            done: (error: Error | null, conn: unknown) => void
+          ) => {
+            conn.pragma('foreign_keys = ON')
+            done(null, conn)
+          }
+        }
+      })
+      await fkDb.schema.createTable('sessions', (table) => {
+        table.text('id').primary()
+        table.text('token').unique()
+      })
+      await fkDb.schema.createTable('oauthAccessToken', (table) => {
+        table.text('id').primary()
+        table.text('sessionId').references('id').inTable('sessions')
+      })
+      await fkDb.schema.createTable('oauthRefreshToken', (table) => {
+        table.text('id').primary()
+        table.text('sessionId').references('id').inTable('sessions')
+      })
+      fkAdapter = knexAdapter(fkDb)({} as never)
+    })
+
+    afterAll(async () => {
+      await fkDb.destroy()
+    })
+
+    beforeEach(async () => {
+      await fkDb('oauthAccessToken').delete()
+      await fkDb('oauthRefreshToken').delete()
+      await fkDb('sessions').delete()
+    })
+
+    const seedSessionWithTokens = async (token: string) => {
+      const sessionId = `sid-${token}`
+      await fkDb('sessions').insert({ id: sessionId, token })
+      await fkDb('oauthAccessToken').insert({ id: `at-${token}`, sessionId })
+      await fkDb('oauthRefreshToken').insert({ id: `rt-${token}`, sessionId })
+    }
+
+    it('delete() detaches OAuth tokens before removing the session', async () => {
+      const [{ foreign_keys: fkEnabled }] = await fkDb.raw(
+        'PRAGMA foreign_keys'
+      )
+      // Guard against a vacuous test: without enforcement the naive delete
+      // would pass too.
+      expect(fkEnabled).toBe(1)
+
+      await seedSessionWithTokens('signout-token')
+
+      await expect(
+        fkAdapter.delete({
+          model: 'sessions',
+          where: [
+            { field: 'token', value: 'signout-token', operator: 'eq' as const }
+          ]
+        })
+      ).resolves.toBeUndefined()
+
+      expect(
+        await fkDb('sessions').where('token', 'signout-token').first()
+      ).toBeUndefined()
+      expect(
+        (await fkDb('oauthAccessToken').where('id', 'at-signout-token').first())
+          ?.sessionId
+      ).toBeNull()
+      expect(
+        (
+          await fkDb('oauthRefreshToken')
+            .where('id', 'rt-signout-token')
+            .first()
+        )?.sessionId
+      ).toBeNull()
+    })
+
+    it('deleteMany() detaches OAuth tokens and returns the deleted count', async () => {
+      await seedSessionWithTokens('bulk-a')
+      await seedSessionWithTokens('bulk-b')
+
+      const count = await fkAdapter.deleteMany({
+        model: 'sessions',
+        where: [
+          {
+            field: 'token',
+            value: ['bulk-a', 'bulk-b'],
+            operator: 'in' as const
+          }
+        ]
+      })
+
+      expect(count).toBe(2)
+      expect(await fkDb('sessions').select()).toHaveLength(0)
+      expect(
+        await fkDb('oauthAccessToken').whereNotNull('sessionId')
+      ).toHaveLength(0)
+      expect(
+        await fkDb('oauthRefreshToken').whereNotNull('sessionId')
+      ).toHaveLength(0)
+    })
+  })
+
   describe('count', () => {
     beforeEach(async () => {
       await db('users').insert([

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -2,6 +2,7 @@ import { CleanedWhere, createAdapterFactory } from 'better-auth/adapters'
 import { Knex } from 'knex'
 
 import { recordWeeklyLoginSafely } from '@/lib/database/sql/instanceActivity'
+import { detachOAuthTokensFromSessions } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
@@ -197,6 +198,33 @@ const applyWhere = (
   return query
 }
 
+const SESSIONS_TABLE = 'sessions'
+
+// Deleting a session whose grants minted OAuth tokens fails on PostgreSQL's
+// `oauthAccessToken`/`oauthRefreshToken` `sessionId` foreign keys, so detach
+// those tokens before removing the session (see `detachOAuthTokensFromSessions`).
+// Covers every better-auth session removal — sign-out, "revoke session", and
+// expired-session cleanup — that flows through the adapter's delete methods.
+// Wrapped in a transaction so a failure can't leave tokens detached from a
+// session that still exists. Returns the number of sessions deleted.
+const deleteSessionsDetachingOAuthTokens = (
+  db: Knex,
+  where: CleanedWhere[] | undefined
+): Promise<number> =>
+  db.transaction(async (trx) => {
+    const scoped = () => {
+      const query = trx(SESSIONS_TABLE)
+      return where ? applyWhere(query, SESSIONS_TABLE, where) : query
+    }
+    const rows = await scoped().select<{ id: string }[]>(`${SESSIONS_TABLE}.id`)
+    await detachOAuthTokensFromSessions(
+      trx,
+      rows.map((row) => row.id)
+    )
+    const deletedCount = await scoped().delete()
+    return deletedCount
+  })
+
 type KnexAdapterOptions = {
   // The WebAuthn rpID this auth instance serves. better-auth's passkey plugin
   // does not persist the rpID a credential was created with (its schema can't be
@@ -345,6 +373,10 @@ export const knexAdapter = (db: Knex, options: KnexAdapterOptions = {}) =>
 
         async delete({ model, where }) {
           const tableName = getModelName(model)
+          if (tableName === SESSIONS_TABLE) {
+            await deleteSessionsDetachingOAuthTokens(db, where)
+            return
+          }
           let query = db(tableName)
           if (where) {
             query = applyWhere(query, tableName, where)
@@ -354,6 +386,9 @@ export const knexAdapter = (db: Knex, options: KnexAdapterOptions = {}) =>
 
         async deleteMany({ model, where }) {
           const tableName = getModelName(model)
+          if (tableName === SESSIONS_TABLE) {
+            return deleteSessionsDetachingOAuthTokens(db, where)
+          }
           let query = db(tableName)
           if (where) {
             query = applyWhere(query, tableName, where)

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -212,16 +212,16 @@ const deleteSessionsDetachingOAuthTokens = (
   where: CleanedWhere[] | undefined
 ): Promise<number> =>
   db.transaction(async (trx) => {
-    const scoped = () => {
-      const query = trx(SESSIONS_TABLE)
-      return where ? applyWhere(query, SESSIONS_TABLE, where) : query
-    }
-    const rows = await scoped().select<{ id: string }[]>(`${SESSIONS_TABLE}.id`)
-    await detachOAuthTokensFromSessions(
-      trx,
-      rows.map((row) => row.id)
-    )
-    const deletedCount = await scoped().delete()
+    const lookup = trx(SESSIONS_TABLE)
+    const scoped = where ? applyWhere(lookup, SESSIONS_TABLE, where) : lookup
+    const rows = await scoped.select<{ id: string }[]>(`${SESSIONS_TABLE}.id`)
+    // Delete by the resolved primary keys rather than re-running the (possibly
+    // complex) where filter, so the detach and delete act on exactly the same
+    // rows. `filter(Boolean)` guards against a stray empty id.
+    const ids = rows.map((row) => row.id).filter(Boolean)
+    if (ids.length === 0) return 0
+    await detachOAuthTokensFromSessions(trx, ids)
+    const deletedCount = await trx(SESSIONS_TABLE).whereIn('id', ids).delete()
     return deletedCount
   })
 

--- a/lib/services/auth/knexAdapter.ts
+++ b/lib/services/auth/knexAdapter.ts
@@ -2,7 +2,7 @@ import { CleanedWhere, createAdapterFactory } from 'better-auth/adapters'
 import { Knex } from 'knex'
 
 import { recordWeeklyLoginSafely } from '@/lib/database/sql/instanceActivity'
-import { detachOAuthTokensFromSessions } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
+import { deleteSessionsWithTokenDetach } from '@/lib/database/sql/utils/detachOAuthTokensFromSessions'
 import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
 import { normalizeEmail } from '@/lib/utils/normalizeEmail'
 
@@ -211,19 +211,11 @@ const deleteSessionsDetachingOAuthTokens = (
   db: Knex,
   where: CleanedWhere[] | undefined
 ): Promise<number> =>
-  db.transaction(async (trx) => {
-    const lookup = trx(SESSIONS_TABLE)
-    const scoped = where ? applyWhere(lookup, SESSIONS_TABLE, where) : lookup
-    const rows = await scoped.select<{ id: string }[]>(`${SESSIONS_TABLE}.id`)
-    // Delete by the resolved primary keys rather than re-running the (possibly
-    // complex) where filter, so the detach and delete act on exactly the same
-    // rows. `filter(Boolean)` guards against a stray empty id.
-    const ids = rows.map((row) => row.id).filter(Boolean)
-    if (ids.length === 0) return 0
-    await detachOAuthTokensFromSessions(trx, ids)
-    const deletedCount = await trx(SESSIONS_TABLE).whereIn('id', ids).delete()
-    return deletedCount
-  })
+  db.transaction((trx) =>
+    deleteSessionsWithTokenDetach(trx, (query) =>
+      where ? applyWhere(query, SESSIONS_TABLE, where) : query
+    )
+  )
 
 type KnexAdapterOptions = {
   // The WebAuthn rpID this auth instance serves. better-auth's passkey plugin


### PR DESCRIPTION
## Summary

Revoking a session from **Account → Sessions** — both **Revoke** on a single session and **Revoke all others** — failed with `Failed to revoke that session. Please try again.` Production logs showed the API returning **500**:

```
delete from "sessions" where "token" = $1 - update or delete on table "sessions"
violates foreign key constraint "oauthaccesstoken_sessionid_foreign" on table "oauthAccessToken"
code: '23503'
detail: 'Key (id)=(…) is still referenced from table "oauthAccessToken".'
```

## Root cause

`oauthAccessToken.sessionId` and `oauthRefreshToken.sessionId` are foreign keys into `sessions.id` with **no `ON DELETE` action** ([migration](https://github.com/llun/activities.next/blob/main/migrations/20260320200000_add_oauth_provider_tables.js)). So `DELETE FROM sessions` is rejected by PostgreSQL (error `23503`) whenever the session had authorized an OAuth app. An account with connected apps (the reporter had 44) trips this immediately, on both revoke endpoints.

It slipped through because the Jest/Vitest suite runs on **SQLite, which leaves foreign keys off by default** — the happy-path tests passed while production failed.

## Fix

Detach the OAuth tokens (clear their `sessionId`) inside the **same transaction**, just before deleting the session. Revoking a web session then simply signs the device out:

- bearer-token validation never reads `sessionId` (see `OAuthGuard`), so the connected app keeps working, and
- the app is still revoked on its own through `revokeAccountConnectedApp`.

This is the established pattern in this codebase — `revokeAccountConnectedApp` already manages these cascades in app code because the FKs have no `ON DELETE` (a schema-level `ON DELETE SET NULL` migration was ruled out: SQLite can't `ALTER` a foreign-key constraint without a full table rebuild).

Applied to **both** code paths that delete sessions:

| Path | Used by |
| --- | --- |
| `deleteAccountSession` / `deleteOtherAccountSessions` (`lib/database/sql/account.ts`) | The Sessions-page revoke endpoints (the reported bug) |
| `knexAdapter` `delete` / `deleteMany` (`lib/services/auth/knexAdapter.ts`) | better-auth sign-out, revoke, and expired-session cleanup — same FK, same latent 500 |

Both call a shared `detachOAuthTokensFromSessions` helper.

## Tests

Added regression tests in `account.test.ts` and `knexAdapter.test.ts` that run against an **isolated SQLite database with `PRAGMA foreign_keys = ON`**, reproducing the constraint the shared backend ignores. Each was verified to **fail before the fix** (`SQLITE_CONSTRAINT_FOREIGNKEY`) and pass after, and they assert the tokens survive with a null `sessionId`.

- `yarn lint` — clean
- `yarn build` — clean
- `yarn test` — 579 files / 5177 tests pass

No migration added, so the reference schema dumps are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)