### PR TITLE
Bump version to v1.95.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.1",
+  "version": "1.95.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.1`
- Base main SHA: `1ff8c8dce907c4b5a2f4eb9ad33ce994f128df2d`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
