### PR TITLE
fix: resume OAuth login for already-authenticated users at the sign-in page

### DIFF
--- a/app/(nosidebar)/auth/signin/page.test.tsx
+++ b/app/(nosidebar)/auth/signin/page.test.tsx
@@ -1,0 +1,124 @@
+import { getBaseURL, getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Page from './page'
+
+vi.mock('@/lib/config')
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: vi.fn(() => ({}))
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', () => ({
+  getActorFromSession: vi.fn()
+}))
+
+// The sign-in forms are client components that pull in the better-auth client;
+// stub them so importing the server page stays light. The logged-in redirect
+// branch never renders them anyway.
+vi.mock('./CredentialForm', () => ({ CredentialForm: () => null }))
+vi.mock('./PasskeySigninButton', () => ({ PasskeySigninButton: () => null }))
+
+const redirectMock = vi.fn((path: string) => path)
+vi.mock('next/navigation', () => ({
+  redirect: (path: string) => redirectMock(path)
+}))
+
+const aSession = { user: { email: 'rider@example.com' } } as Awaited<
+  ReturnType<typeof getServerAuthSession>
+>
+const anActor = { id: 'actor-id' } as Awaited<
+  ReturnType<typeof getActorFromSession>
+>
+
+describe('/auth/signin already-authenticated resume', () => {
+  beforeEach(() => {
+    redirectMock.mockClear()
+    vi.mocked(getDatabase).mockReturnValue({} as ReturnType<typeof getDatabase>)
+    vi.mocked(getConfig).mockReturnValue({
+      auth: { enableCredential: true },
+      registrationOpen: false
+    } as ReturnType<typeof getConfig>)
+    vi.mocked(getBaseURL).mockReturnValue('https://activities.local')
+    vi.mocked(getActorFromSession).mockResolvedValue(anActor)
+  })
+
+  it('forwards an authenticated user to the resumed OAuth consent page instead of home', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    await Page({
+      searchParams: Promise.resolve({
+        response_type: 'code',
+        client_id: 'phanpy',
+        redirect_uri: 'https://phanpy.local/',
+        scope: 'read write follow push',
+        code_challenge: 'abc',
+        code_challenge_method: 'S256'
+      })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = redirectMock.mock.calls[0][0]
+    expect(target.startsWith('/oauth/authorize?')).toBe(true)
+    const query = new URLSearchParams(target.split('?')[1])
+    expect(query.get('client_id')).toBe('phanpy')
+    expect(query.get('code_challenge')).toBe('abc')
+  })
+
+  it('forwards an authenticated user to a safe redirectBack instead of home', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    await Page({
+      searchParams: Promise.resolve({ redirectBack: '/fitness' })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    expect(redirectMock.mock.calls[0][0]).toBe('/fitness')
+  })
+
+  it('sends an authenticated user with no resume target to home', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    await Page({ searchParams: Promise.resolve({}) })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    expect(redirectMock.mock.calls[0][0]).toBe('/')
+  })
+
+  it('falls back to home when the authenticated session has no usable actor (avoids a /oauth/authorize redirect loop)', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+    vi.mocked(getActorFromSession).mockResolvedValue(null)
+
+    await Page({
+      searchParams: Promise.resolve({
+        response_type: 'code',
+        client_id: 'phanpy',
+        redirect_uri: 'https://phanpy.local/',
+        scope: 'read'
+      })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    expect(redirectMock.mock.calls[0][0]).toBe('/')
+  })
+
+  it('renders the sign-in form for a logged-out visitor (no redirect)', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(null)
+
+    const element = await Page({
+      searchParams: Promise.resolve({
+        response_type: 'code',
+        client_id: 'phanpy'
+      })
+    })
+
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(element).toBeTruthy()
+  })
+})

--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -15,22 +15,54 @@ import {
 import { getBaseURL, getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 
 import { CredentialForm } from './CredentialForm'
 import { PasskeySigninButton } from './PasskeySigninButton'
+import { resolveSignInRedirect } from './resolveSignInRedirect'
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Activities.next: Sign in'
 }
 
-const Page: FC = async () => {
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+// The sign-in forms resume an in-flight OAuth/OIDC request after a fresh login
+// (see resolveSignInRedirect). A relying party that targets better-auth's
+// authorize endpoint (the advertised authorization_endpoint), or a custom
+// /oauth/authorize link, can also land an *already-authenticated* visitor here
+// — better-auth bounces a logged-out authorize to /auth/signin, and the user may
+// have signed in elsewhere in between. Build the same URLSearchParams the forms
+// see so this server entrypoint resumes the request identically instead of
+// dropping it on the home timeline.
+const toSearchParams = (
+  raw: Record<string, string | string[] | undefined>
+): URLSearchParams => {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value))
+      value.forEach((entry) => params.append(key, entry))
+    else if (value != null) params.append(key, value)
+  }
+  return params
+}
+
+const Page: FC<Props> = async ({ searchParams }) => {
   const database = getDatabase()
   const session = await getServerAuthSession()
 
   if (!database) throw new Error('Database is not available')
   if (session && session.user) {
-    return redirect('/')
+    const target = resolveSignInRedirect(toSearchParams(await searchParams))
+    // Only forward to the consent page when the session has a usable actor —
+    // /oauth/authorize bounces an actor-less session straight back here, so
+    // resuming without one would loop. Plain logins (target '/') skip the lookup.
+    if (target === '/') return redirect('/')
+    const actor = await getActorFromSession(database, session)
+    return redirect(actor ? target : '/')
   }
 
   const { auth, serviceName, registrationOpen } = getConfig()


### PR DESCRIPTION
## Summary

Logging in with **Phanpy / web clients while already signed into the instance** dropped the user on the **home timeline** instead of redirecting back to the client. [#1135](https://github.com/llun/activities.next/pull/1135) fixed the same "OAuth request dropped → home" symptom for *fresh* logins by teaching the sign-in **forms** to resume the request (`resolveSignInRedirect`), but it left the matching gap on the sign-in **page** server component: it still did `if (session) redirect('/')`, so an **already-authenticated** visitor who lands on `/auth/signin` mid-flow lost the request.

## Why this hits Phanpy/web clients but not OIDC (docs.llun.dev)

- A logged-in user starting an OAuth login can still be bounced to `/auth/signin` with the authorization request — better-auth redirects a no-session/`prompt` authorize to its `loginPage`, and `/oauth/authorize` redirects an actor-less session there too. The page then sent them **home**, dropping the request.
- OIDC relying parties (e.g. la-suite **Docs**) hit better-auth's `/api/auth/oauth2/authorize` **directly**, bypassing this page, so they were unaffected — matching the report that *docs works but Phanpy doesn't*.

## Fix

`app/(nosidebar)/auth/signin/page.tsx` now forwards an **authenticated** visitor through the **same** `resolveSignInRedirect` the forms use, instead of always going home:

- Handles both sign-in URL shapes — `redirectBack=…` (custom `/oauth/authorize` handoff) and the bare `response_type=code&client_id=…` envelope better-auth's `loginPage` produces.
- Guarded by `getActorFromSession`: a session **without a usable actor** still goes to `/`, because resuming to `/oauth/authorize` without an actor would bounce straight back to `/auth/signin` and loop.
- Plain logins (no resume target) keep the existing `redirect('/')` behavior.

Additive and low-risk: no changes to `auth.ts`, the OIDC discovery, `resolveSignInRedirect`, or the consent page. The page only ever redirects to an internal path; `redirect_uri` is carried as an opaque query value and validated downstream by the consent page and better-auth.

## Testing

- New `app/(nosidebar)/auth/signin/page.test.tsx`: authenticated user → resumes to `/oauth/authorize` (OIDC params preserved incl. PKCE), resumes a safe `redirectBack`, falls back to `/` with no resume target, falls back to `/` (no loop) when the session has no actor, and renders the form for a logged-out visitor.
- `yarn run prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (5186)
- **End-to-end on the real `activities.local` + `phanpy.local` Docker stack** (PostgreSQL, HTTPS via Traefik): with the fix, an already-authenticated user starting a Phanpy login is redirected **back to Phanpy** instead of the home timeline, for both sign-in URL shapes.

## Follow-ups (out of scope, noted while reproducing — not in this PR)

- The OAuth/OIDC server metadata (`getOAuthAuthorizationServerMetadata` / `getOpenIDConfiguration`) and `app/api/oauth/authorize/route.ts` hardcode `getBaseURL()` (the canonical host), so a client on a trusted alias/served domain is advertised the canonical host — they should be request-host-aware like the `/oauth/authorize` page.
- `/oauth/authorize` 500s if `getServerAuthSession()` throws (e.g. a stale pre-#1040 `jwks` key → `ERR_JOSE_NOT_SUPPORTED`), which is asymmetric vs OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
