### PR TITLE
Bump version to v1.95.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.2",
+  "version": "1.95.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.2`
- Base main SHA: `2503b748af3c1a1cdd1d5f2c6c1975617a9aa635`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
