### PR TITLE
fix: advertise the request host in OAuth/OIDC metadata for multi-domain deployments

### DIFF
--- a/app/api/oauth/authorize/route.test.ts
+++ b/app/api/oauth/authorize/route.test.ts
@@ -5,12 +5,10 @@ import { resolveAuthBaseURL } from '@/lib/services/auth/requestOrigin'
 import { GET, POST } from './route'
 
 vi.mock('@/lib/config', () => ({
-  getConfig: vi
-    .fn()
-    .mockReturnValue({
-      host: 'activities.local',
-      trustedHosts: ['alias.local']
-    })
+  getConfig: vi.fn().mockReturnValue({
+    host: 'activities.local',
+    trustedHosts: ['alias.local']
+  })
 }))
 
 vi.mock('@/lib/services/auth/requestOrigin', () => ({

--- a/app/api/oauth/authorize/route.test.ts
+++ b/app/api/oauth/authorize/route.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from 'next/server'
+
+import { resolveAuthBaseURL } from '@/lib/services/auth/requestOrigin'
+
+import { GET, POST } from './route'
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi
+    .fn()
+    .mockReturnValue({
+      host: 'activities.local',
+      trustedHosts: ['alias.local']
+    })
+}))
+
+vi.mock('@/lib/services/auth/requestOrigin', () => ({
+  resolveAuthBaseURL: vi.fn()
+}))
+
+vi.mock('@/lib/services/oauth/logging', () => ({
+  oauthLogger: { info: vi.fn(), error: vi.fn() },
+  sanitizeHeaders: vi.fn(() => ({})),
+  sanitizeParams: vi.fn((params) => params)
+}))
+
+describe('/api/oauth/authorize redirect host', () => {
+  beforeEach(() => {
+    vi.mocked(resolveAuthBaseURL).mockReset()
+  })
+
+  it('GET keeps the redirect on the resolved request host and preserves the query', () => {
+    vi.mocked(resolveAuthBaseURL).mockReturnValue('https://alias.local')
+    const req = new NextRequest(
+      'https://alias.local/api/oauth/authorize?client_id=abc&response_type=code&scope=read'
+    )
+
+    const res = GET(req)
+
+    expect(res.status).toBe(302)
+    const url = new URL(res.headers.get('location') as string)
+    expect(url.host).toBe('alias.local')
+    expect(url.pathname).toBe('/api/auth/oauth2/authorize')
+    expect(url.searchParams.get('client_id')).toBe('abc')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('scope')).toBe('read')
+    expect(vi.mocked(resolveAuthBaseURL)).toHaveBeenCalledWith(
+      req.headers,
+      expect.anything()
+    )
+  })
+
+  it('falls back to the host resolveAuthBaseURL returns for an untrusted request host', () => {
+    // selectHeaderHost (inside resolveAuthBaseURL) falls back to the configured
+    // host for untrusted hosts; the route just uses whatever it returns.
+    vi.mocked(resolveAuthBaseURL).mockReturnValue('https://activities.local')
+    const req = new NextRequest(
+      'https://evil.example/api/oauth/authorize?client_id=abc'
+    )
+
+    const res = GET(req)
+
+    const url = new URL(res.headers.get('location') as string)
+    expect(url.host).toBe('activities.local')
+  })
+
+  it('POST merges form-body params and redirects to the resolved host', async () => {
+    vi.mocked(resolveAuthBaseURL).mockReturnValue('https://alias.local')
+    const req = new NextRequest(
+      'https://alias.local/api/oauth/authorize?client_id=abc',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'scope=read+write&response_type=code'
+      }
+    )
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(302)
+    const url = new URL(res.headers.get('location') as string)
+    expect(url.host).toBe('alias.local')
+    expect(url.pathname).toBe('/api/auth/oauth2/authorize')
+    expect(url.searchParams.get('client_id')).toBe('abc')
+    expect(url.searchParams.get('scope')).toBe('read write')
+    expect(url.searchParams.get('response_type')).toBe('code')
+  })
+})

--- a/app/api/oauth/authorize/route.ts
+++ b/app/api/oauth/authorize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
-import { getBaseURL } from '@/lib/config'
+import { getConfig } from '@/lib/config'
+import { resolveAuthBaseURL } from '@/lib/services/auth/requestOrigin'
 import {
   oauthLogger,
   sanitizeHeaders,
@@ -30,16 +31,24 @@ const logAuthorizeRequest = (
 }
 
 // Redirect to better-auth's OAuth2 authorize endpoint for Mastodon compatibility
-// Mastodon clients may hit /api/oauth/authorize directly
+// Mastodon clients may hit /api/oauth/authorize directly. Keep the redirect on
+// the host the request arrived on (validated against trusted hosts) so a client
+// using a served alias domain isn't bounced to the canonical host mid-flow.
 export const GET = (req: NextRequest) => {
-  const url = new URL('/api/auth/oauth2/authorize', getBaseURL())
+  const url = new URL(
+    '/api/auth/oauth2/authorize',
+    resolveAuthBaseURL(req.headers, getConfig())
+  )
   url.search = req.nextUrl.search
   logAuthorizeRequest(req, url, 'GET')
   return Response.redirect(url.toString(), 302)
 }
 
 export const POST = async (req: NextRequest) => {
-  const url = new URL('/api/auth/oauth2/authorize', getBaseURL())
+  const url = new URL(
+    '/api/auth/oauth2/authorize',
+    resolveAuthBaseURL(req.headers, getConfig())
+  )
   // Merge query string params
   req.nextUrl.searchParams.forEach((value, key) =>
     url.searchParams.set(key, value)

--- a/app/api/well-known/oauth-authorization-server/route.ts
+++ b/app/api/well-known/oauth-authorization-server/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
+import { resolveAuthBaseURL } from '@/lib/services/auth/requestOrigin'
 import { getOAuthAuthorizationServerMetadata } from '@/lib/services/wellknown'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -14,10 +16,14 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 export const GET = traceApiRoute(
   'oauthAuthorizationServer',
   async (req: NextRequest) => {
+    // Advertise the host the request arrived on (validated against trusted
+    // hosts) so a client discovering metadata on a served alias domain isn't
+    // bounced to the canonical host. Matches better-auth's per-request baseURL.
+    const baseURL = resolveAuthBaseURL(req.headers, getConfig())
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: getOAuthAuthorizationServerMetadata()
+      data: getOAuthAuthorizationServerMetadata(baseURL)
     })
   }
 )

--- a/app/api/well-known/openid-configuration/route.ts
+++ b/app/api/well-known/openid-configuration/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
+import { resolveAuthBaseURL } from '@/lib/services/auth/requestOrigin'
 import { getOpenIDConfiguration } from '@/lib/services/wellknown'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
@@ -14,10 +16,15 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 export const GET = traceApiRoute(
   'openidConfiguration',
   async (req: NextRequest) => {
+    // Advertise the issuer/endpoints for the host the request arrived on
+    // (validated against trusted hosts) so a discovery-based relying party on a
+    // served alias domain gets an `issuer` matching the id_token `iss`
+    // better-auth signs for that same host.
+    const baseURL = resolveAuthBaseURL(req.headers, getConfig())
     return apiResponse({
       req,
       allowedMethods: CORS_HEADERS,
-      data: getOpenIDConfiguration()
+      data: getOpenIDConfiguration(baseURL)
     })
   }
 )

--- a/lib/services/wellknown/index.test.ts
+++ b/lib/services/wellknown/index.test.ts
@@ -59,6 +59,30 @@ describe('wellknown services', () => {
       expect(metadata.scopes_supported).toContain('follow')
       expect(metadata.scopes_supported).toContain('push')
     })
+
+    it('advertises a provided baseURL host instead of the configured host (multi-domain alias)', () => {
+      const metadata = getOAuthAuthorizationServerMetadata(
+        'https://alias.example.com'
+      )
+
+      expect(metadata.issuer).toBe('https://alias.example.com')
+      expect(metadata.authorization_endpoint).toBe(
+        'https://alias.example.com/api/auth/oauth2/authorize'
+      )
+      expect(metadata.token_endpoint).toBe(
+        'https://alias.example.com/oauth/token'
+      )
+      expect(metadata.revocation_endpoint).toBe(
+        'https://alias.example.com/oauth/revoke'
+      )
+      expect(metadata.userinfo_endpoint).toBe(
+        'https://alias.example.com/oauth/userinfo'
+      )
+      expect(metadata.jwks_uri).toBe('https://alias.example.com/api/auth/jwks')
+      expect(metadata.app_registration_endpoint).toBe(
+        'https://alias.example.com/api/v1/apps'
+      )
+    })
   })
 
   describe('getOpenIDConfiguration', () => {
@@ -150,6 +174,27 @@ describe('wellknown services', () => {
       expect(config.claims_supported).toContain('email')
       expect(config.claims_supported).toContain('email_verified')
       expect(config.claims_supported).toContain('preferred_username')
+    })
+
+    it('advertises a provided baseURL host (issuer + endpoints) for a served alias domain', () => {
+      const config = getOpenIDConfiguration('https://alias.example.com')
+
+      // The issuer must track the per-request host so the id_token `iss`
+      // better-auth signs for that host matches what the RP discovered.
+      expect(config.issuer).toBe('https://alias.example.com/api/auth')
+      expect(config.authorization_endpoint).toBe(
+        'https://alias.example.com/api/auth/oauth2/authorize'
+      )
+      expect(config.token_endpoint).toBe(
+        'https://alias.example.com/oauth/token'
+      )
+      expect(config.userinfo_endpoint).toBe(
+        'https://alias.example.com/oauth/userinfo'
+      )
+      expect(config.jwks_uri).toBe('https://alias.example.com/api/auth/jwks')
+      expect(config.end_session_endpoint).toBe(
+        'https://alias.example.com/api/auth/oauth2/end-session'
+      )
     })
   })
 

--- a/lib/services/wellknown/oauthAuthorizationServer.ts
+++ b/lib/services/wellknown/oauthAuthorizationServer.ts
@@ -18,30 +18,36 @@ export interface OAuthAuthorizationServerMetadata {
   app_registration_endpoint: string
 }
 
-export const getOAuthAuthorizationServerMetadata =
-  (): OAuthAuthorizationServerMetadata => {
-    const baseURL = getBaseURL()
-    return {
-      issuer: baseURL,
-      authorization_endpoint: `${baseURL}/api/auth/oauth2/authorize`,
-      token_endpoint: `${baseURL}/oauth/token`,
-      revocation_endpoint: `${baseURL}/oauth/revoke`,
-      userinfo_endpoint: `${baseURL}/oauth/userinfo`,
-      jwks_uri: `${baseURL}/api/auth/jwks`,
-      scopes_supported: UsableScopes,
-      response_types_supported: ['code'],
-      response_modes_supported: ['query'],
-      grant_types_supported: [
-        'authorization_code',
-        'client_credentials',
-        'refresh_token'
-      ],
-      token_endpoint_auth_methods_supported: [
-        'client_secret_basic',
-        'client_secret_post'
-      ],
-      code_challenge_methods_supported: ['S256'],
-      service_documentation: 'https://github.com/llun/activities.next',
-      app_registration_endpoint: `${baseURL}/api/v1/apps`
-    }
+// `baseURL` defaults to the configured host but callers serving a request
+// SHOULD pass the validated per-request origin (`resolveAuthBaseURL`) so a
+// client discovering this metadata on a trusted alias/served domain is pointed
+// at that same domain — better-auth resolves its baseURL per request the same
+// way, so the advertised endpoints match where the flow actually runs. Falling
+// back to the configured host keeps non-request callers and existing tests working.
+export const getOAuthAuthorizationServerMetadata = (
+  baseURL: string = getBaseURL()
+): OAuthAuthorizationServerMetadata => {
+  return {
+    issuer: baseURL,
+    authorization_endpoint: `${baseURL}/api/auth/oauth2/authorize`,
+    token_endpoint: `${baseURL}/oauth/token`,
+    revocation_endpoint: `${baseURL}/oauth/revoke`,
+    userinfo_endpoint: `${baseURL}/oauth/userinfo`,
+    jwks_uri: `${baseURL}/api/auth/jwks`,
+    scopes_supported: UsableScopes,
+    response_types_supported: ['code'],
+    response_modes_supported: ['query'],
+    grant_types_supported: [
+      'authorization_code',
+      'client_credentials',
+      'refresh_token'
+    ],
+    token_endpoint_auth_methods_supported: [
+      'client_secret_basic',
+      'client_secret_post'
+    ],
+    code_challenge_methods_supported: ['S256'],
+    service_documentation: 'https://github.com/llun/activities.next',
+    app_registration_endpoint: `${baseURL}/api/v1/apps`
   }
+}

--- a/lib/services/wellknown/openidConfiguration.ts
+++ b/lib/services/wellknown/openidConfiguration.ts
@@ -21,8 +21,17 @@ export interface OpenIDConfiguration {
   code_challenge_methods_supported: string[]
 }
 
-export const getOpenIDConfiguration = (): OpenIDConfiguration => {
-  const baseURL = getBaseURL()
+// `baseURL` defaults to the configured host; a request handler SHOULD pass the
+// validated per-request origin (`resolveAuthBaseURL`) so the advertised `issuer`
+// and endpoints match the domain the request arrived on. This is REQUIRED for
+// correctness on a multi-domain deployment: better-auth signs id_tokens with
+// `iss = <its per-request baseURL> + AUTH_BASE_PATH` (the catch-all auth route
+// resolves that baseURL from the request host too), so advertising the canonical
+// host here would make a relying party on a served alias domain reject the
+// id_token for an `iss` mismatch.
+export const getOpenIDConfiguration = (
+  baseURL: string = getBaseURL()
+): OpenIDConfiguration => {
   return {
     // Better Auth signs id_tokens with `iss = baseURL + basePath`, so the
     // discovery `issuer` MUST match that value — a strict OIDC relying party


### PR DESCRIPTION
## Summary

On a multi-domain deployment (`ACTIVITIES_HOST` + `ACTIVITIES_TRUSTED_HOSTS`), the OAuth/OIDC discovery documents and the `/api/oauth/authorize` redirect were built from `getBaseURL()` — the **canonical** host — so a client discovering metadata on a **trusted alias/served domain** was advertised, and bounced to, the canonical host mid-flow.

Fetched from a served domain (`alias.local`), before this PR:

```
/.well-known/oauth-authorization-server  → issuer/authorization_endpoint/token_endpoint = https://activities.local/…
/.well-known/openid-configuration        → issuer = https://activities.local/api/auth
/api/oauth/authorize                     → 302 → https://activities.local/api/auth/oauth2/authorize
```

…even though `/api/v1/instance` on that host reports `uri: alias.local`.

## Why it's a bug

The rest of the auth stack is already per-request host-aware: the better-auth catch-all route (`app/api/auth/[...all]/route.ts`) resolves its `baseURL` via `resolveAuthBaseURL(req.headers, config)` (validated against trusted hosts), so it **signs id_tokens and issues codes with `iss` = the request host**. The static metadata advertising the *canonical* host is therefore inconsistent with the tokens actually issued — a discovery-based OIDC relying party on a served domain can reject the id_token for an `iss` mismatch, and Mastodon-style clients get silently moved to the canonical host. This was surfaced while reproducing the Phanpy login issue in [#1139](https://github.com/llun/activities.next/pull/1139).

## Fix

- `getOAuthAuthorizationServerMetadata(baseURL?)` and `getOpenIDConfiguration(baseURL?)` now accept a `baseURL` that defaults to `getBaseURL()` (so non-request callers and existing tests are unchanged).
- The three route handlers (`oauth-authorization-server`, `openid-configuration`, `oauth/authorize`) pass `resolveAuthBaseURL(req.headers, getConfig())` — the **same** validated per-request origin better-auth uses. `selectHeaderHost` still falls back to the configured host for untrusted Host headers, so the advertised host can't be steered via header injection.

## Testing

- `lib/services/wellknown/index.test.ts`: both builders advertise a provided alias `baseURL` across issuer + all endpoints, while the default (configured host) behavior is unchanged.
- `app/api/oauth/authorize/route.test.ts` (new): GET/POST keep the redirect on the resolved request host and preserve query/form params; untrusted host falls back to the configured host.
- `yarn run prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (5191)
- **End-to-end on the `activities.local` + `alias.local` stack:** the alias host now advertises **itself** across both discovery docs (`issuer`/`authorization_endpoint`/`token_endpoint`/`app_registration_endpoint`), and the canonical host is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
