### PR TITLE
fix: don't 500 every authenticated page when session resolution throws

### DIFF
--- a/lib/services/auth/getSession.test.ts
+++ b/lib/services/auth/getSession.test.ts
@@ -64,4 +64,19 @@ describe('getServerAuthSession', () => {
       })
     )
   })
+
+  it('lets a headers() dynamic-rendering bailout propagate instead of swallowing it', async () => {
+    // headers() throws an internal control-flow signal during static generation
+    // to bail the route out to dynamic rendering; it is resolved outside the
+    // try/catch so it must propagate (not be turned into a null session, which
+    // would let Next.js statically cache the page as unauthenticated).
+    const dynamicBailout = new Error('Dynamic server usage')
+    headersMock.mockRejectedValueOnce(dynamicBailout)
+
+    const { getServerAuthSession } = await import('./getSession')
+
+    await expect(getServerAuthSession()).rejects.toThrow(dynamicBailout)
+    expect(getSessionMock).not.toHaveBeenCalled()
+    expect(loggerErrorMock).not.toHaveBeenCalled()
+  })
 })

--- a/lib/services/auth/getSession.test.ts
+++ b/lib/services/auth/getSession.test.ts
@@ -7,13 +7,9 @@ const headersMock = vi.fn(async () => new Headers())
 vi.mock('next/headers', () => ({ headers: () => headersMock() }))
 
 const loggerErrorMock = vi.fn()
+// getServerAuthSession only calls logger.error, so only that method is mocked.
 vi.mock('@/lib/utils/logger', () => ({
-  logger: {
-    error: (...args: unknown[]) => loggerErrorMock(...args),
-    warn: vi.fn(),
-    info: vi.fn(),
-    debug: vi.fn()
-  }
+  logger: { error: (...args: unknown[]) => loggerErrorMock(...args) }
 }))
 
 describe('getServerAuthSession', () => {

--- a/lib/services/auth/getSession.test.ts
+++ b/lib/services/auth/getSession.test.ts
@@ -55,8 +55,13 @@ describe('getServerAuthSession', () => {
 
     expect(await getServerAuthSession()).toBeNull()
     expect(loggerErrorMock).toHaveBeenCalledTimes(1)
+    // The error must travel under `err` so the logger's GCP formatter extracts
+    // its stack trace into `stack_trace`.
     expect(loggerErrorMock).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Failed to resolve auth session' })
+      expect.objectContaining({
+        message: 'Failed to resolve auth session',
+        err: expect.any(Error)
+      })
     )
   })
 })

--- a/lib/services/auth/getSession.test.ts
+++ b/lib/services/auth/getSession.test.ts
@@ -1,0 +1,62 @@
+const getSessionMock = vi.fn()
+vi.mock('./auth', () => ({
+  getAuth: () => ({ api: { getSession: getSessionMock } })
+}))
+
+const headersMock = vi.fn(async () => new Headers())
+vi.mock('next/headers', () => ({ headers: () => headersMock() }))
+
+const loggerErrorMock = vi.fn()
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: (...args: unknown[]) => loggerErrorMock(...args),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+describe('getServerAuthSession', () => {
+  beforeEach(() => {
+    // Fresh module each test so React's cache() does not memoize across cases.
+    vi.resetModules()
+    getSessionMock.mockReset()
+    loggerErrorMock.mockReset()
+    headersMock.mockClear()
+  })
+
+  it('returns the session better-auth resolves', async () => {
+    const session = { user: { email: 'rider@example.com' } }
+    getSessionMock.mockResolvedValue(session)
+
+    const { getServerAuthSession } = await import('./getSession')
+
+    expect(await getServerAuthSession()).toEqual(session)
+    expect(loggerErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null when there is no session', async () => {
+    getSessionMock.mockResolvedValue(null)
+
+    const { getServerAuthSession } = await import('./getSession')
+
+    expect(await getServerAuthSession()).toBeNull()
+    expect(loggerErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed (logs + returns null) when session resolution throws, e.g. a JWKS signing error', async () => {
+    // Mirrors the jwt plugin's /get-session after-hook failing to sign the
+    // set-auth-jwt header with an incompatible JWKS key.
+    getSessionMock.mockRejectedValue(
+      new Error('Invalid or unsupported JWK "alg" (Algorithm) Parameter value')
+    )
+
+    const { getServerAuthSession } = await import('./getSession')
+
+    expect(await getServerAuthSession()).toBeNull()
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1)
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Failed to resolve auth session' })
+    )
+  })
+})

--- a/lib/services/auth/getSession.ts
+++ b/lib/services/auth/getSession.ts
@@ -1,6 +1,8 @@
 import { headers } from 'next/headers'
 import { cache } from 'react'
 
+import { logger } from '@/lib/utils/logger'
+
 import { getAuth } from './auth'
 
 // Wrapped in React `cache()` so the better-auth session lookup is deduplicated
@@ -9,8 +11,26 @@ import { getAuth } from './auth'
 // session independently.
 export const getServerAuthSession = cache(async () => {
   const auth = getAuth()
-  const session = await auth.api.getSession({
-    headers: await headers()
-  })
-  return session
+  try {
+    return await auth.api.getSession({
+      headers: await headers()
+    })
+  } catch (error) {
+    // better-auth resolves the session and THEN, via the jwt plugin's
+    // `/get-session` after-hook, signs a short-lived JWT for the `set-auth-jwt`
+    // response header (which this app does not consume). If that signing throws
+    // — e.g. a `jwks` key whose alg doesn't match the configured RS256 (a
+    // pre-#1040 Ed25519 key left behind on the rollout) raises
+    // `ERR_JOSE_NOT_SUPPORTED` — the whole getSession call rejects. Left
+    // unhandled that 500s every authenticated page, notably the
+    // `/oauth/authorize` consent page, breaking Mastodon/OAuth login while OIDC
+    // relying parties (which hit better-auth's authorize endpoint, not
+    // `/get-session`) keep working — an asymmetry that's hard to diagnose.
+    //
+    // Fail closed: log it (this is a deploy-config issue — clear stale `jwks`
+    // rows on the RS256 rollout) and treat the request as unauthenticated so
+    // public and sign-in paths still render instead of the whole app erroring.
+    logger.error({ message: 'Failed to resolve auth session', error })
+    return null
+  }
 })

--- a/lib/services/auth/getSession.ts
+++ b/lib/services/auth/getSession.ts
@@ -11,10 +11,14 @@ import { getAuth } from './auth'
 // session independently.
 export const getServerAuthSession = cache(async () => {
   const auth = getAuth()
+  // Resolve headers OUTSIDE the try: `headers()` is a dynamic API that, during
+  // static generation/prerender, throws an internal control-flow signal (e.g.
+  // DynamicServerError) to bail the route out to dynamic rendering. That signal
+  // must propagate — catching it would let Next.js statically cache the page as
+  // unauthenticated. Only better-auth's session lookup is guarded below.
+  const requestHeaders = await headers()
   try {
-    return await auth.api.getSession({
-      headers: await headers()
-    })
+    return await auth.api.getSession({ headers: requestHeaders })
   } catch (error) {
     // better-auth resolves the session and THEN, via the jwt plugin's
     // `/get-session` after-hook, signs a short-lived JWT for the `set-auth-jwt`

--- a/lib/services/auth/getSession.ts
+++ b/lib/services/auth/getSession.ts
@@ -30,7 +30,9 @@ export const getServerAuthSession = cache(async () => {
     // Fail closed: log it (this is a deploy-config issue — clear stale `jwks`
     // rows on the RS256 rollout) and treat the request as unauthenticated so
     // public and sign-in paths still render instead of the whole app erroring.
-    logger.error({ message: 'Failed to resolve auth session', error })
+    // Pass the error under `err` so the logger's GCP formatter extracts its
+    // stack trace into `stack_trace` for Error Reporting (see lib/utils/logger).
+    logger.error({ message: 'Failed to resolve auth session', err: error })
     return null
   }
 })


### PR DESCRIPTION
## Summary

`getServerAuthSession()` could 500 **every authenticated page** when better-auth's session lookup throws. better-auth resolves the session and then — via the jwt plugin's `/get-session` `after` hook — signs a short-lived JWT for the `set-auth-jwt` response header (which this app does not consume). When that signing throws, the whole `getSession()` call rejects and propagates as a 500.

The concrete trigger I hit while reproducing the Phanpy login issue ([#1139](https://github.com/llun/activities.next/pull/1139)) was a `jwks` key whose alg doesn't match the configured RS256 — a pre-[#1040](https://github.com/llun/activities.next/pull/1040) Ed25519 key left behind on the RS256 rollout raises `ERR_JOSE_NOT_SUPPORTED`:

```
⨯ JOSENotSupported: Invalid or unsupported JWK "alg" (Algorithm) Parameter value
    at async (lib/services/auth/getSession.ts:12) → auth.api.getSession(...)
    at async Page (app/(nosidebar)/oauth/authorize/page.tsx)
  → 500
```

## Why it presents as "OIDC works, Mastodon/Phanpy doesn't"

OIDC relying parties hit better-auth's `/oauth2/authorize` endpoint directly, which never runs the `/get-session` after-hook, so they keep working. Mastodon/OAuth login goes through the custom `/oauth/authorize` consent **page**, which calls `getServerAuthSession` — so it 500s. That asymmetry is hard to diagnose.

## Fix

Fail closed, matching the existing catch-and-degrade pattern already in this module (`getActorIdFromCookie`): **log the error and return `null`** (treat the request as unauthenticated) so public and sign-in paths still render instead of the whole app erroring.

- Returning `null` on an auth-resolution failure **denies** access (safe direction) — it never grants it.
- The underlying signing failure remains a deploy-config issue (clear stale `jwks` rows on the RS256 rollout, as documented in `auth.ts`); this change only stops a single auth-layer hiccup — transient or persistent — from taking the whole app (and OAuth login) down with an unhandled 500.

## Testing

- `lib/services/auth/getSession.test.ts` (new): returns the resolved session; returns `null` for no session; and **fails closed (logs + returns `null`) when resolution throws** (simulating the JWKS signing error). Uses `vi.resetModules()` per case so React's `cache()` doesn't memoize across tests.
- `yarn run prettier --write .` ✓ · `yarn lint` ✓ (0 errors) · `yarn build` ✓ · `yarn test` ✓ (5189)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
