### PR TITLE
Bump version to v1.95.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.3",
+  "version": "1.95.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.3`
- Base main SHA: `80d79fc1ea7984151739144e0d621a342ad9fde0`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
