### PR TITLE
Bump version to v1.95.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.4",
+  "version": "1.95.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.4`
- Base main SHA: `f8e3ae2083bd0a7dfa3bcd8fc6cb397791e5072f`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
