### PR TITLE
chore: use claude-sonnet-5 with low effort for OLTP sync workflow

### DIFF
--- a/.github/workflows/sync-main-to-oltp.yml
+++ b/.github/workflows/sync-main-to-oltp.yml
@@ -124,7 +124,8 @@ jobs:
               unmerged files so the workflow can create the final merge commit.
             - If you cannot reach that state, stop and fail.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
+            --effort low
             --dangerously-skip-permissions
             --max-turns 40
 


### PR DESCRIPTION
## Summary

Update the **Sync Main to OLTP** workflow (`.github/workflows/sync-main-to-oltp.yml`) so its `anthropics/claude-code-action@v1` step runs on [`claude-sonnet-5`](https://www.anthropic.com/news/claude-sonnet-5) at **low** reasoning effort, replacing `claude-sonnet-4-6`.

```diff
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
+            --effort low
             --dangerously-skip-permissions
             --max-turns 40
```

## Why

- `claude-sonnet-5` is the current Sonnet-tier model and supports the `--effort` parameter across all levels.
- The merge-conflict resolution this workflow performs is a well-scoped, mechanical task, so `low` effort keeps it fast and cost-efficient (Sonnet 5 still escalates thinking on genuinely hard merges).

## Notes

- `.github/`-only change → no version bump.
- `--effort low` is the supported Claude Code CLI flag for reasoning effort, passed through `claude_args`.
- No untrusted input is added to any `run:` step; the model/effort change is the only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)