### PR TITLE
Bump version to v1.95.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.5",
+  "version": "1.95.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.5`
- Base main SHA: `8a6b9faaceba1ef5aa572cff891ba301691f010c`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
