### PR TITLE
Bump version to v1.95.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.6",
+  "version": "1.95.7",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.95.7.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.95.6`
- Base main SHA: `772b978cde475ff8c988bf10f79ad6cbd63e0ef1`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
