### PR TITLE
Bump version to v1.96.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.95.7",
+  "version": "1.96.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.95.7`
- Base main SHA: `ae24b0e4d35068b905dc2f182b53bfac356950ee`
- Included commits: `7`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
