### PR TITLE
Bump version to v1.96.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.1",
+  "version": "1.96.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.96.1`
- Base main SHA: `d448c49dc1316def37b0df2478d8779a4b606c91`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
