### PR TITLE
Bump version to v1.96.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.2",
+  "version": "1.96.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.96.2`
- Base main SHA: `aaa0b474b5a034366943cb21646d559296781583`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
