### PR TITLE
Bump version to v1.96.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.3",
+  "version": "1.96.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.96.3`
- Base main SHA: `cc2e2943bbdcfa2cc52e29fcd42d9c7b5c534284`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
