### PR TITLE
fix: hide passkey sign-in button where passkeys aren't usable

### DIFF
--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.test.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.test.tsx
@@ -31,14 +31,19 @@ const clearWebAuthn = (): void => {
 
 // Render inside act(async) so the mount effect's support-detection promise and
 // the resulting state update flush before we assert.
-const renderButton = async (): Promise<void> => {
+const renderButton = async (
+  props: { credentialEnabled?: boolean } = {}
+): Promise<void> => {
   await act(async () => {
-    render(<PasskeySigninButton />)
+    render(<PasskeySigninButton {...props} />)
   })
 }
 
 const passkeyButton = () =>
   screen.queryByRole('button', { name: /sign in with passkey/i })
+
+const unavailableNotice = () =>
+  screen.queryByText(/passkeys aren't available in this browser/i)
 
 describe('PasskeySigninButton', () => {
   afterEach(() => {
@@ -67,6 +72,41 @@ describe('PasskeySigninButton', () => {
   it('hides the button when the availability check rejects', async () => {
     setPlatformAuthenticator(() => Promise.reject(new Error('nope')))
     await renderButton()
+    expect(passkeyButton()).not.toBeInTheDocument()
+  })
+
+  it('shows an "unavailable" notice when passkeys are unsupported and credential sign-in is disabled', async () => {
+    setPlatformAuthenticator(() => Promise.resolve(false))
+    await renderButton({ credentialEnabled: false })
+    expect(unavailableNotice()).toBeInTheDocument()
+    expect(passkeyButton()).not.toBeInTheDocument()
+  })
+
+  it('shows the notice when the WebAuthn API is absent and credential sign-in is disabled', async () => {
+    clearWebAuthn()
+    await renderButton({ credentialEnabled: false })
+    expect(unavailableNotice()).toBeInTheDocument()
+  })
+
+  it('does not show the notice when credential sign-in is enabled (button just hides)', async () => {
+    setPlatformAuthenticator(() => Promise.resolve(false))
+    await renderButton({ credentialEnabled: true })
+    expect(unavailableNotice()).not.toBeInTheDocument()
+    expect(passkeyButton()).not.toBeInTheDocument()
+  })
+
+  it('shows the button, not the notice, when passkeys are supported even if credential sign-in is disabled', async () => {
+    setPlatformAuthenticator(() => Promise.resolve(true))
+    await renderButton({ credentialEnabled: false })
+    expect(passkeyButton()).toBeInTheDocument()
+    expect(unavailableNotice()).not.toBeInTheDocument()
+  })
+
+  it('does not flash the notice while support is still being detected', async () => {
+    // A detection promise that never resolves keeps `supported` unknown.
+    setPlatformAuthenticator(() => new Promise<boolean>(() => {}))
+    await renderButton({ credentialEnabled: false })
+    expect(unavailableNotice()).not.toBeInTheDocument()
     expect(passkeyButton()).not.toBeInTheDocument()
   })
 })

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.test.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { act, render, screen } from '@testing-library/react'
+
+import { PasskeySigninButton } from './PasskeySigninButton'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('')
+}))
+
+vi.mock('@/lib/services/auth/auth-client', () => ({
+  authClient: { signIn: { passkey: vi.fn() } }
+}))
+
+type WindowWithPasskey = {
+  PublicKeyCredential?: unknown
+}
+
+const setPlatformAuthenticator = (resolver: () => Promise<boolean>): void => {
+  ;(window as unknown as WindowWithPasskey).PublicKeyCredential = {
+    isUserVerifyingPlatformAuthenticatorAvailable: resolver
+  }
+}
+
+const clearWebAuthn = (): void => {
+  delete (window as unknown as WindowWithPasskey).PublicKeyCredential
+}
+
+// Render inside act(async) so the mount effect's support-detection promise and
+// the resulting state update flush before we assert.
+const renderButton = async (): Promise<void> => {
+  await act(async () => {
+    render(<PasskeySigninButton />)
+  })
+}
+
+const passkeyButton = () =>
+  screen.queryByRole('button', { name: /sign in with passkey/i })
+
+describe('PasskeySigninButton', () => {
+  afterEach(() => {
+    clearWebAuthn()
+    vi.clearAllMocks()
+  })
+
+  it('renders the button when a platform authenticator is available', async () => {
+    setPlatformAuthenticator(() => Promise.resolve(true))
+    await renderButton()
+    expect(passkeyButton()).toBeInTheDocument()
+  })
+
+  it('hides the button when the WebAuthn API is absent (in-app browser)', async () => {
+    clearWebAuthn()
+    await renderButton()
+    expect(passkeyButton()).not.toBeInTheDocument()
+  })
+
+  it('hides the button when no platform authenticator is available', async () => {
+    setPlatformAuthenticator(() => Promise.resolve(false))
+    await renderButton()
+    expect(passkeyButton()).not.toBeInTheDocument()
+  })
+
+  it('hides the button when the availability check rejects', async () => {
+    setPlatformAuthenticator(() => Promise.reject(new Error('nope')))
+    await renderButton()
+    expect(passkeyButton()).not.toBeInTheDocument()
+  })
+})

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.test.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.test.tsx
@@ -88,6 +88,16 @@ describe('PasskeySigninButton', () => {
     expect(unavailableNotice()).toBeInTheDocument()
   })
 
+  it('exposes the notice as a status live region so screen readers announce it when it appears', async () => {
+    setPlatformAuthenticator(() => Promise.resolve(false))
+    await renderButton({ credentialEnabled: false })
+    // The notice is injected after client detection, so it must be a live
+    // region to be announced (WCAG 2.1 SC 4.1.3 Status Messages).
+    expect(screen.getByRole('status')).toHaveTextContent(
+      /passkeys aren't available in this browser/i
+    )
+  })
+
   it('does not show the notice when credential sign-in is enabled (button just hides)', async () => {
     setPlatformAuthenticator(() => Promise.resolve(false))
     await renderButton({ credentialEnabled: true })

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -77,7 +77,14 @@ export const PasskeySigninButton: FC<PasskeySigninButtonProps> = ({
   if (!supported) {
     if (credentialEnabled) return null
     return (
-      <div className="flex items-start gap-3 rounded-lg border bg-muted/40 p-3.5">
+      // The notice is injected after client-side detection, so mark it as a
+      // polite live region — otherwise assistive tech never announces the only
+      // content telling the visitor they can't sign in here (WCAG 2.1 SC 4.1.3).
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-start gap-3 rounded-lg border bg-muted/40 p-3.5"
+      >
         <span className="mt-px flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
           <Fingerprint className="size-[15px]" />
         </span>

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Fingerprint } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { FC, useEffect, useState } from 'react'
 
@@ -10,15 +11,29 @@ import { passkeyErrorMessage } from './passkeyErrorMessage'
 import { isPlatformPasskeyAvailable } from './passkeySupport'
 import { resolveSignInRedirect } from './resolveSignInRedirect'
 
-export const PasskeySigninButton: FC = () => {
+interface PasskeySigninButtonProps {
+  /**
+   * Whether credential (email/password) sign-in is available on this instance.
+   * When it is, an environment that can't use passkeys simply hides the button
+   * (the visitor signs in with credentials instead). When it is NOT, passkeys
+   * are the only way in, so an unsupported environment shows a short
+   * "unavailable" notice rather than a blank sign-in card. Defaults to true.
+   */
+  credentialEnabled?: boolean
+}
+
+export const PasskeySigninButton: FC<PasskeySigninButtonProps> = ({
+  credentialEnabled = true
+}) => {
   const [error, setError] = useState<string>()
   const [loading, setLoading] = useState(false)
-  // Start hidden and reveal only once we've confirmed the client can complete a
-  // platform passkey ceremony. Both SSR and the first client render produce the
-  // same `null`, so there's no hydration mismatch, and in-app browsers that
-  // can't use passkeys (iOS WKWebView, the Schrift login dialog, …) never show
-  // the button at all.
-  const [supported, setSupported] = useState(false)
+  // `null` while we're still feature-detecting; `true`/`false` once resolved.
+  // Starting at `null` keeps SSR and the first client render identical (both
+  // render nothing), so there's no hydration mismatch — and no flash of the
+  // "unavailable" notice on browsers that do support passkeys. In-app browsers
+  // that can't use passkeys (iOS WKWebView, the Schrift login dialog, …) resolve
+  // to `false`.
+  const [supported, setSupported] = useState<boolean | null>(null)
   const searchParams = useSearchParams()
   const router = useRouter()
 
@@ -53,7 +68,30 @@ export const PasskeySigninButton: FC = () => {
     }
   }
 
-  if (!supported) return null
+  // Still feature-detecting — render nothing yet.
+  if (supported === null) return null
+
+  // Passkeys can't be used in this browser. If credential sign-in is available
+  // the visitor still has a way in, so just hide the button; otherwise passkeys
+  // were the only method, so explain the situation instead of a blank card.
+  if (!supported) {
+    if (credentialEnabled) return null
+    return (
+      <div className="flex items-start gap-3 rounded-lg border bg-muted/40 p-3.5">
+        <span className="mt-px flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <Fingerprint className="size-[15px]" />
+        </span>
+        <div>
+          <p className="text-sm font-medium">
+            Passkeys aren&apos;t available in this browser
+          </p>
+          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+            Signing in isn&apos;t available here.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-1">

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -1,19 +1,36 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
 import { authClient } from '@/lib/services/auth/auth-client'
 
 import { passkeyErrorMessage } from './passkeyErrorMessage'
+import { isPlatformPasskeyAvailable } from './passkeySupport'
 import { resolveSignInRedirect } from './resolveSignInRedirect'
 
 export const PasskeySigninButton: FC = () => {
   const [error, setError] = useState<string>()
   const [loading, setLoading] = useState(false)
+  // Start hidden and reveal only once we've confirmed the client can complete a
+  // platform passkey ceremony. Both SSR and the first client render produce the
+  // same `null`, so there's no hydration mismatch, and in-app browsers that
+  // can't use passkeys (iOS WKWebView, the Schrift login dialog, …) never show
+  // the button at all.
+  const [supported, setSupported] = useState(false)
   const searchParams = useSearchParams()
   const router = useRouter()
+
+  useEffect(() => {
+    let active = true
+    isPlatformPasskeyAvailable().then((available) => {
+      if (active) setSupported(available)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
 
   const handlePasskeySignin = async () => {
     setError(undefined)
@@ -35,6 +52,8 @@ export const PasskeySigninButton: FC = () => {
       setLoading(false)
     }
   }
+
+  if (!supported) return null
 
   return (
     <div className="space-y-1">

--- a/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
+++ b/app/(nosidebar)/auth/signin/PasskeySigninButton.tsx
@@ -92,7 +92,10 @@ export const PasskeySigninButton: FC<PasskeySigninButtonProps> = ({
           <p className="text-sm font-medium">
             Passkeys aren&apos;t available in this browser
           </p>
-          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+          {/* text-foreground/80 (not text-muted-foreground) so this — the only
+              actionable line in the dead-end state — clears WCAG AA contrast
+              (4.5:1) on the muted panel with margin. */}
+          <p className="mt-0.5 text-xs leading-relaxed text-foreground/80">
             Signing in isn&apos;t available here.
           </p>
         </div>

--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -97,7 +97,7 @@ const Page: FC<Props> = async ({ searchParams }) => {
           <CredentialForm providerName={serviceName ?? 'credentials'} />
         )}
 
-        <PasskeySigninButton />
+        <PasskeySigninButton credentialEnabled={credentialEnabled} />
       </CardContent>
       {registrationOpen && (
         <CardFooter className="justify-center">

--- a/app/(nosidebar)/auth/signin/passkeySupport.test.ts
+++ b/app/(nosidebar)/auth/signin/passkeySupport.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { isPlatformPasskeyAvailable } from './passkeySupport'
+
+type WindowWithPasskey = {
+  PublicKeyCredential?: unknown
+}
+
+const setPublicKeyCredential = (value: unknown): void => {
+  ;(window as unknown as WindowWithPasskey).PublicKeyCredential = value
+}
+
+describe('isPlatformPasskeyAvailable', () => {
+  afterEach(() => {
+    delete (window as unknown as WindowWithPasskey).PublicKeyCredential
+  })
+
+  it('returns false when the WebAuthn API is unavailable (e.g. an in-app WKWebView)', async () => {
+    // No window.PublicKeyCredential is defined.
+    expect(await isPlatformPasskeyAvailable()).toBe(false)
+  })
+
+  it('returns false when isUserVerifyingPlatformAuthenticatorAvailable is not a function', async () => {
+    setPublicKeyCredential({})
+    expect(await isPlatformPasskeyAvailable()).toBe(false)
+  })
+
+  it('returns true when a user-verifying platform authenticator is available', async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () => Promise.resolve(true)
+    })
+    expect(await isPlatformPasskeyAvailable()).toBe(true)
+  })
+
+  it('returns false when no user-verifying platform authenticator is available', async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () =>
+        Promise.resolve(false)
+    })
+    expect(await isPlatformPasskeyAvailable()).toBe(false)
+  })
+
+  it('returns false when the availability check rejects', async () => {
+    setPublicKeyCredential({
+      isUserVerifyingPlatformAuthenticatorAvailable: () =>
+        Promise.reject(new Error('blocked'))
+    })
+    expect(await isPlatformPasskeyAvailable()).toBe(false)
+  })
+})

--- a/app/(nosidebar)/auth/signin/passkeySupport.ts
+++ b/app/(nosidebar)/auth/signin/passkeySupport.ts
@@ -1,0 +1,28 @@
+/**
+ * Feature-detect whether the current client can complete a platform passkey
+ * (WebAuthn) sign-in ceremony.
+ *
+ * Returns `false` in environments that lack the WebAuthn API or expose no
+ * user-verifying platform authenticator — notably in-app browsers such as an
+ * iOS `WKWebView`, the Schrift app's OAuth login dialog, and similar embedded
+ * webviews, where the passkey sign-in button would only ever fail. The sign-in
+ * button is gated on this so it never appears where passkeys can't be used.
+ */
+export const isPlatformPasskeyAvailable = async (): Promise<boolean> => {
+  if (typeof window === 'undefined') return false
+
+  const publicKeyCredential = window.PublicKeyCredential
+  if (
+    !publicKeyCredential ||
+    typeof publicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable !==
+      'function'
+  ) {
+    return false
+  }
+
+  try {
+    return await publicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

The **"Sign in with Passkey"** button on `/auth/signin` was always rendered — including inside in-app browsers that can't complete a WebAuthn ceremony, such as an **iOS `WKWebView`**, the **Schrift app's OAuth login dialog**, and similar embedded webviews. In those contexts the button either does nothing or fails with an error, which is confusing.

This change gates the button on **client-side WebAuthn feature detection** so it only appears where a passkey sign-in can actually work. When passkeys are the *only* sign-in method (an instance with credential sign-in disabled) and they aren't usable, it shows a short **"unavailable" notice** instead of a blank card.

## Behavior

Support is feature-detected on the client (`window.PublicKeyCredential` + `isUserVerifyingPlatformAuthenticatorAvailable()`), tri-state (`null` while detecting):

| Passkeys usable? | Credential sign-in | Result |
|---|---|---|
| Yes | either | Passkey button shown |
| No | **enabled** | Button hidden; visitor uses the credential form |
| No | **disabled** | Notice: *"Passkeys aren't available in this browser"* (no button) |
| detecting… | either | Nothing yet (no flash) |

The button/notice **starts hidden and reveals only after detection resolves**, so SSR and the first client render produce identical output → **no hydration mismatch**, and unsupported in-app browsers never show a broken button.

## What changed

- **`app/(nosidebar)/auth/signin/passkeySupport.ts`** (new) — `isPlatformPasskeyAvailable()`: `false` unless the WebAuthn API exists and a user-verifying platform authenticator is available; degrades to `false` on missing API / error.
- **`app/(nosidebar)/auth/signin/PasskeySigninButton.tsx`** — feature-detects in a mount effect; renders the button, the unavailable notice, or nothing per the table above. Takes a `credentialEnabled` prop (defaults `true`).
- **`app/(nosidebar)/auth/signin/page.tsx`** — passes `credentialEnabled` (from `ACTIVITIES_AUTH`) to the button.
- Tests: `passkeySupport.test.ts` (5) and `PasskeySigninButton.test.tsx` (10).

## Why feature detection (not user-agent sniffing)

`isUserVerifyingPlatformAuthenticatorAvailable()` reports `false` in in-app WKWebViews, so the button hides generically — no app/UA allow-lists to maintain.

**Trade-off:** a desktop with *only* a roaming USB security key and no platform authenticator (Touch ID / Windows Hello) would also hide the button. Acceptable — that audience is tiny and, when credential sign-in is enabled, the credential form stays available.

## Scope

Limited to the functional sign-in button (the surface embedded in app login dialogs). The landing page's "Continue with a passkey" links and the account-settings passkey manager are out of scope.

## Testing

- `yarn run prettier` / `yarn lint` (0 errors) / `yarn build` / `yarn test` (5312 passed) — all green.
- Browser verification against a local SQLite instance on `/auth/signin`:
  - Supported browser (`UVPAA=true`) → passkey button shown, console clean.
  - In-app browser simulated (`UVPAA` forced `false`), credential enabled → button hidden, credential form still shown.
  - **Passkey-only instance (`enableCredential:false`) + in-app browser → "Passkeys aren't available in this browser" notice shown, no button, console clean.**
  - SSR HTML never emits the button/notice markup → hydration-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)