### PR TITLE
Bump version to v1.96.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.4",
+  "version": "1.96.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.96.4`
- Base main SHA: `2d634fc8fd1f7f46c56b4b24b382c92c50e35df4`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
