### PR TITLE
fix: meet WCAG AA contrast for muted text on muted surfaces

### DIFF
--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -1112,7 +1112,7 @@ const ActivityMapPanel: FC<{
           />
         </button>
       ) : (
-        <div className="flex h-full items-center justify-center bg-gradient-to-br from-muted to-muted-foreground/20 text-sm text-muted-foreground">
+        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
           Map preview unavailable
         </div>
       )}

--- a/app/globals.contrast.test.ts
+++ b/app/globals.contrast.test.ts
@@ -14,10 +14,13 @@ import { describe, expect, it } from 'vitest'
  * the floor can never silently regress in either theme.
  */
 
+// Strip CSS comments up front so declaration parsing can't be tripped up by
+// colons/semicolons/`--token`-like text inside a comment (the light
+// --muted-foreground now carries a multi-line rationale comment right above it).
 const css = readFileSync(
   fileURLToPath(new URL('./globals.css', import.meta.url)),
   'utf8'
-)
+).replace(/\/\*[\s\S]*?\*\//g, '')
 
 const AA_NORMAL = 4.5
 
@@ -69,14 +72,20 @@ const contrastRatio = (a: Rgb, b: Rgb): number => {
   return (hi + 0.05) / (lo + 0.05)
 }
 
+/** Escape every regex metacharacter (including backslash) in a literal. */
+const escapeRegExp = (literal: string): string =>
+  literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 /** Extract the flat `--token: value;` declarations of a top-level CSS block. */
 const parseBlock = (selector: string): Record<string, string> => {
-  const escaped = selector.replace(/[.]/g, '\\$&')
+  const escaped = escapeRegExp(selector)
   const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
   if (!match) throw new Error(`Could not find CSS block for ${selector}`)
   const tokens: Record<string, string> = {}
   for (const line of match[1].split(';')) {
-    const decl = line.match(/(--[\w-]+)\s*:\s*(.+)/)
+    // Anchor to statement start so only real declarations match, never a
+    // `--token`-like fragment inside a value.
+    const decl = line.match(/^\s*(--[\w-]+)\s*:\s*(.+)/)
     if (decl) tokens[decl[1].trim()] = decl[2].trim()
   }
   return tokens

--- a/app/globals.contrast.test.ts
+++ b/app/globals.contrast.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * WCAG 2.1 AA (SC 1.4.3) guard for muted secondary text.
+ *
+ * `text-muted-foreground` renders on the muted-family surfaces
+ * (`--muted`/`--secondary`/`--accent`, `--card`, `--popover`, `--background`)
+ * all over the app. Historically the light-theme token was `hsl(0 0% 45.1%)`
+ * (#737373), which only reached ~4.35:1 on the lightest muted surface
+ * (`--muted` #f5f5f5) and so failed the 4.5:1 requirement for normal text. This
+ * test recomputes the contrast from the live `app/globals.css` token values so
+ * the floor can never silently regress in either theme.
+ */
+
+const css = readFileSync(
+  fileURLToPath(new URL('./globals.css', import.meta.url)),
+  'utf8'
+)
+
+const AA_NORMAL = 4.5
+
+type Rgb = [number, number, number]
+
+/** Parse a space-separated `hsl(H S% L%)` string into [h, s(0-1), l(0-1)]. */
+const parseHsl = (value: string): [number, number, number] => {
+  const match = value.match(/hsl\(\s*([\d.]+)\s+([\d.]+)%\s+([\d.]+)%\s*\)/)
+  if (!match) throw new Error(`Not a space-separated hsl() value: ${value}`)
+  return [Number(match[1]), Number(match[2]) / 100, Number(match[3]) / 100]
+}
+
+const hslToRgb = (h: number, s: number, l: number): Rgb => {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hp = h / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  const [r, g, b] =
+    hp < 1
+      ? [c, x, 0]
+      : hp < 2
+        ? [x, c, 0]
+        : hp < 3
+          ? [0, c, x]
+          : hp < 4
+            ? [0, x, c]
+            : hp < 5
+              ? [x, 0, c]
+              : [c, 0, x]
+  const m = l - c / 2
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255)
+  ]
+}
+
+const relativeLuminance = ([r, g, b]: Rgb): number => {
+  const [rl, gl, bl] = [r, g, b].map((channel) => {
+    const c = channel / 255
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+  })
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl
+}
+
+const contrastRatio = (a: Rgb, b: Rgb): number => {
+  const la = relativeLuminance(a)
+  const lb = relativeLuminance(b)
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** Extract the flat `--token: value;` declarations of a top-level CSS block. */
+const parseBlock = (selector: string): Record<string, string> => {
+  const escaped = selector.replace(/[.]/g, '\\$&')
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+  if (!match) throw new Error(`Could not find CSS block for ${selector}`)
+  const tokens: Record<string, string> = {}
+  for (const line of match[1].split(';')) {
+    const decl = line.match(/(--[\w-]+)\s*:\s*(.+)/)
+    if (decl) tokens[decl[1].trim()] = decl[2].trim()
+  }
+  return tokens
+}
+
+const rgbOf = (tokens: Record<string, string>, name: string): Rgb =>
+  hslToRgb(...parseHsl(tokens[name]))
+
+const themes = {
+  light: parseBlock(':root'),
+  dark: parseBlock('.dark')
+} as const
+
+// The muted-family surfaces that muted secondary text actually renders on.
+const surfaceTokens = [
+  '--background',
+  '--card',
+  '--popover',
+  '--muted',
+  '--secondary',
+  '--accent'
+]
+
+const cases = (['light', 'dark'] as const).flatMap((theme) =>
+  surfaceTokens.map((surface) => ({ theme, surface }))
+)
+
+describe('muted-foreground contrast (WCAG 2.1 AA SC 1.4.3)', () => {
+  it.each(cases)(
+    '$theme --muted-foreground on $surface meets 4.5:1',
+    ({ theme, surface }) => {
+      const tokens = themes[theme]
+      const fg = rgbOf(tokens, '--muted-foreground')
+      const bg = rgbOf(tokens, surface)
+      const ratio = contrastRatio(fg, bg)
+      expect(
+        ratio,
+        `${theme} muted-foreground ${JSON.stringify(fg)} on ${surface} ${JSON.stringify(bg)} = ${ratio.toFixed(3)}:1`
+      ).toBeGreaterThanOrEqual(AA_NORMAL)
+    }
+  )
+
+  it('keeps muted-foreground visibly muted (lighter than the foreground text)', () => {
+    // Guard against "fixing" contrast by darkening the token to near-black: the
+    // muted color must stay clearly lighter than the primary --foreground.
+    const light = themes.light
+    const mutedLum = relativeLuminance(rgbOf(light, '--muted-foreground'))
+    const foregroundLum = relativeLuminance(rgbOf(light, '--foreground'))
+    expect(mutedLum).toBeGreaterThan(foregroundLum + 0.1)
+  })
+})

--- a/app/globals.css
+++ b/app/globals.css
@@ -74,7 +74,13 @@
   --secondary: hsl(0 0% 96.1%);
   --secondary-foreground: hsl(0 0% 9%);
   --muted: hsl(0 0% 96.1%);
-  --muted-foreground: hsl(0 0% 45.1%);
+  /* Muted secondary text. Darkened from 45.1% (#737373) to 43% (#6e6e6e) so it
+     clears WCAG 2.1 AA (4.5:1) even on the lightest muted-family surface —
+     bg-muted/secondary/accent #f5f5f5 — where #737373 only reached ~4.35:1.
+     #6e6e6e gives 4.68:1 on #f5f5f5, 4.89:1 on the card, 5.10:1 on white; the
+     shift is visually negligible. The dark-theme token below is separate and
+     unchanged. */
+  --muted-foreground: hsl(0 0% 43%);
   --accent: hsl(0 0% 96.1%);
   --accent-foreground: hsl(0 0% 9%);
   --destructive: hsl(0 84.2% 60.2%);


### PR DESCRIPTION
## Summary

`text-muted-foreground` on muted-family backgrounds failed WCAG 2.1 AA SC 1.4.3 (4.5:1 for normal text) in the **light** theme. The light token `--muted-foreground: hsl(0 0% 45.1%)` (#737373) only reached ~4.35:1 on `bg-muted`/`bg-secondary`/`bg-accent` (#f5f5f5) and marginally failed on muted tints (e.g. `bg-muted/40` over the card → ~4.47:1). This was first spotted while reviewing #1167 (which patched only its own one-off notice); this PR is the system-wide fix.

The fix is a **single design-token change** plus one targeted patch:

- **`app/globals.css`** — darken the light `--muted-foreground` from `hsl(0 0% 45.1%)` (#737373) to `hsl(0 0% 43%)` (#6e6e6e). One edit clears every muted-on-muted instance at once. The dark-theme token (`hsl(0 0% 63.9%)`) is a separate declaration and is **untouched**.
- **`app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx`** — the "Map preview unavailable" fallback layered muted text over a `bg-gradient-to-br from-muted to-muted-foreground/20` gradient whose dark end resolves to ~#dbdbdb (darker than #f5f5f5), giving ~3.4:1 — the only case the token darken can't reach. Dropped the decorative gradient so the text sits on the container's solid `bg-muted`.

## How it was audited

Fanned out over all **138 files / 565 usages** of `text-muted-foreground`, resolving the actual background each usage renders on (element, ancestor, or component surface) and computing the contrast for both themes. Result: **119 muted-on-surface co-locations**, of which **118 are cleared by the 43% darken** (every muted-family surface #f5f5f5-or-lighter: `bg-muted`/`secondary`/`accent`, card, popover, background, and all muted tints). Exactly **1** sat on a surface darker than #f5f5f5 — the gradient above — and is fixed directly. No `text-muted-foreground` renders on `bg-border`/`bg-input` or a raw palette gray (those greys are all `AvatarFallback` with `text-gray-600`, out of scope).

## Contrast (measured, before → after)

Light theme, `text-muted-foreground`:

| Surface | #737373 (before) | #6e6e6e (after) |
| --- | --- | --- |
| `bg-muted`/`bg-secondary`/`bg-accent` #f5f5f5 | 4.35 ✗ | **4.68** ✓ |
| `bg-muted/40` over card #f8f8f8 | 4.47 ✗ | **4.80** ✓ |
| `bg-card` #fafafa | 4.54 (marginal) | **4.89** ✓ |
| `bg-background`/`bg-popover` #ffffff | 4.74 ✓ | **5.10** ✓ |

Dark theme is unchanged and still comfortably passes (5.6–7.8:1 on its muted-family surfaces). The visual shift in light mode is negligible (5 grey levels) and muted text still reads as clearly secondary.

## Tests / verification

- **`yarn test`** — 595 files / 5311 tests pass, including a new **`app/globals.contrast.test.ts`** that recomputes contrast from the live `globals.css` token values and asserts the 4.5:1 AA floor for `--muted-foreground` on every muted-family surface in both themes (plus a guard that the token stays visibly muted, not near-black). This locks the token so it can never silently regress.
- **`yarn run prettier --write .`**, **`yarn lint`** (0 errors), **`yarn build`** — all green.
- **Browser (Chromium, both themes)** — read the actual compiled token → `rgb()` the browser paints via `getComputedStyle` on real `bg-muted` + `text-muted-foreground` elements: light `#6e6e6e` gives 4.68:1 on muted, 4.89 on card, 5.10 on white; dark `#a3a3a3` gives 5.6–7.8:1. Spot-checked the sign-in and account/sessions pages (muted-on-muted pills, avatar fallbacks, and group-header strips) in light and dark — legible, no visual degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWLoWKaYgQHBzEjxgimW3o

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWLoWKaYgQHBzEjxgimW3o)_