### PR TITLE
fix: accept form-encoded and multipart bodies on lists/reports/featured_tags

### DIFF
--- a/app/api/v1/featured_tags/route.test.ts
+++ b/app/api/v1/featured_tags/route.test.ts
@@ -52,6 +52,17 @@ const postRequest = (body: unknown) =>
     body: JSON.stringify(body)
   })
 
+const postFormRequest = (params: Record<string, string>) =>
+  new NextRequest('https://llun.test/api/v1/featured_tags', {
+    method: 'POST',
+    headers: {
+      host: 'llun.test',
+      origin: 'https://llun.test',
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: new URLSearchParams(params).toString()
+  })
+
 describe('featured_tags collection endpoints', () => {
   const database = getTestSQLDatabase()
 
@@ -96,6 +107,21 @@ describe('featured_tags collection endpoints', () => {
     const stored = await database.getFeaturedTagByName({
       actorId: ACTOR1_ID,
       name: 'coffee'
+    })
+    expect(stored).not.toBeNull()
+  })
+
+  it('features a tag from a urlencoded form body (native clients)', async () => {
+    const response = await POST(postFormRequest({ name: '#Tea' }), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+    const created = await response.json()
+    expect(created.name).toBe('Tea')
+
+    const stored = await database.getFeaturedTagByName({
+      actorId: ACTOR1_ID,
+      name: 'tea'
     })
     expect(stored).not.toBeNull()
   })

--- a/app/api/v1/featured_tags/route.ts
+++ b/app/api/v1/featured_tags/route.ts
@@ -7,6 +7,7 @@ import {
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonFeaturedTag } from '@/lib/services/mastodon/getMastodonFeaturedTag'
 import { Scope } from '@/lib/types/database/operations'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -70,12 +71,7 @@ export const POST = traceApiRoute(
     async (req, context) => {
       const { database, currentActor } = context
 
-      let json: unknown
-      try {
-        json = await req.json()
-      } catch {
-        json = {}
-      }
+      const json = await getRequestBody(req).catch(() => ({}))
       const parsed = CreateFeaturedTagRequest.safeParse(json)
       if (!parsed.success) {
         return apiResponse({

--- a/app/api/v1/lists/[id]/accounts/route.test.ts
+++ b/app/api/v1/lists/[id]/accounts/route.test.ts
@@ -1,0 +1,188 @@
+import { NextRequest } from 'next/server'
+
+import { idToUrl } from '@/lib/utils/urlToId'
+
+import { DELETE, POST } from './route'
+
+const mockDatabase = {
+  getList: vi.fn(),
+  addListAccounts: vi.fn(),
+  removeListAccounts: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me',
+  domain: 'local.test'
+}
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => {
+  const bypass =
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+  return {
+    OAuthGuard: bypass,
+    OAuthGuardAnyScope: bypass
+  }
+})
+
+const LIST_ID = 'list-1'
+const URL_BASE = `https://local.test/api/v1/lists/${LIST_ID}/accounts`
+
+const params = () => ({ params: Promise.resolve({ id: LIST_ID }) })
+
+describe('POST /api/v1/lists/:id/accounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getList.mockResolvedValue({ id: LIST_ID, title: 'Friends' })
+    mockDatabase.addListAccounts.mockResolvedValue(undefined)
+    mockDatabase.removeListAccounts.mockResolvedValue(undefined)
+  })
+
+  it('adds accounts from a urlencoded bracket-array body', async () => {
+    const request = new NextRequest(URL_BASE, {
+      method: 'POST',
+      body: 'account_ids[]=acc1&account_ids[]=acc2',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+    })
+
+    const response = await POST(request, params())
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.addListAccounts).toHaveBeenCalledWith({
+      listId: LIST_ID,
+      actorId: mockCurrentActor.id,
+      targetActorIds: [idToUrl('acc1'), idToUrl('acc2')]
+    })
+  })
+
+  it('adds accounts from a multipart bracket-array body', async () => {
+    const form = new FormData()
+    form.append('account_ids[]', 'acc1')
+    form.append('account_ids[]', 'acc2')
+    const request = new NextRequest(URL_BASE, {
+      method: 'POST',
+      headers: { 'content-type': 'multipart/form-data; boundary=test-boundary' }
+    })
+    Object.defineProperty(request, 'formData', {
+      value: vi.fn().mockResolvedValue(form)
+    })
+
+    const response = await POST(request, params())
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.addListAccounts).toHaveBeenCalledWith({
+      listId: LIST_ID,
+      actorId: mockCurrentActor.id,
+      targetActorIds: [idToUrl('acc1'), idToUrl('acc2')]
+    })
+  })
+
+  it('adds accounts from a JSON body', async () => {
+    const request = new NextRequest(URL_BASE, {
+      method: 'POST',
+      body: JSON.stringify({ account_ids: ['acc1', 'acc2'] }),
+      headers: { 'content-type': 'application/json' }
+    })
+
+    const response = await POST(request, params())
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.addListAccounts).toHaveBeenCalledWith({
+      listId: LIST_ID,
+      actorId: mockCurrentActor.id,
+      targetActorIds: [idToUrl('acc1'), idToUrl('acc2')]
+    })
+  })
+
+  it('returns 404 when the list does not exist', async () => {
+    mockDatabase.getList.mockResolvedValue(null)
+    const request = new NextRequest(URL_BASE, {
+      method: 'POST',
+      body: 'account_ids[]=acc1',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+    })
+
+    const response = await POST(request, params())
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.addListAccounts).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 when no account ids are supplied', async () => {
+    const request = new NextRequest(URL_BASE, {
+      method: 'POST',
+      body: '',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+    })
+
+    const response = await POST(request, params())
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.addListAccounts).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/v1/lists/:id/accounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getList.mockResolvedValue({ id: LIST_ID, title: 'Friends' })
+    mockDatabase.addListAccounts.mockResolvedValue(undefined)
+    mockDatabase.removeListAccounts.mockResolvedValue(undefined)
+  })
+
+  it('removes accounts read from the query string only (masto.js DELETE)', async () => {
+    const request = new NextRequest(
+      `${URL_BASE}?account_ids[]=acc1&account_ids[]=acc2`,
+      { method: 'DELETE' }
+    )
+
+    const response = await DELETE(request, params())
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.removeListAccounts).toHaveBeenCalledWith({
+      listId: LIST_ID,
+      actorId: mockCurrentActor.id,
+      targetActorIds: [idToUrl('acc1'), idToUrl('acc2')]
+    })
+  })
+
+  it('removes accounts from a urlencoded body', async () => {
+    const request = new NextRequest(URL_BASE, {
+      method: 'DELETE',
+      body: 'account_ids[]=acc1&account_ids[]=acc2',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+    })
+
+    const response = await DELETE(request, params())
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.removeListAccounts).toHaveBeenCalledWith({
+      listId: LIST_ID,
+      actorId: mockCurrentActor.id,
+      targetActorIds: [idToUrl('acc1'), idToUrl('acc2')]
+    })
+  })
+
+  it('returns 422 when no account ids are supplied', async () => {
+    const request = new NextRequest(URL_BASE, { method: 'DELETE' })
+
+    const response = await DELETE(request, params())
+
+    expect(response.status).toBe(422)
+    expect(mockDatabase.removeListAccounts).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/lists/[id]/accounts/route.ts
+++ b/app/api/v1/lists/[id]/accounts/route.ts
@@ -105,11 +105,43 @@ const AccountIdsBody = z.object({
   account_ids: z.array(z.string().min(1)).min(1)
 })
 
+// Collect account_ids from a repeated-param source, preferring the bracket
+// form (account_ids[]=…) that native clients send, falling back to a bare
+// account_ids key. `getAll` returns string[] (URLSearchParams) or
+// FormDataEntryValue[] (FormData); non-string entries are dropped.
+const collectAccountIds = (getAll: (name: string) => unknown[]): string[] => {
+  const bracket = getAll('account_ids[]')
+  const values = bracket.length > 0 ? bracket : getAll('account_ids')
+  return values.filter(
+    (value): value is string => typeof value === 'string' && value.length > 0
+  )
+}
+
+// Accepts account_ids as a JSON array, a form/multipart bracket array
+// (account_ids[]=…), or — for DELETE, which masto.js serialises into the query
+// string rather than the request body — repeated query params.
 const parseAccountIds = async (req: Request): Promise<string[] | null> => {
-  const json = await req.json().catch(() => null)
-  const parsed = AccountIdsBody.safeParse(json)
-  if (!parsed.success) return null
-  return parsed.data.account_ids
+  const contentType = req.headers.get('content-type')?.toLowerCase() ?? ''
+  let accountIds: string[] = []
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const params = new URLSearchParams(await req.text())
+    accountIds = collectAccountIds((name) => params.getAll(name))
+  } else if (contentType.includes('multipart/form-data')) {
+    const form = await req.formData()
+    accountIds = collectAccountIds((name) => form.getAll(name))
+  } else {
+    const json = await req.json().catch(() => null)
+    const parsed = AccountIdsBody.safeParse(json)
+    if (parsed.success) accountIds = parsed.data.account_ids
+  }
+
+  if (accountIds.length === 0) {
+    const query = new URL(req.url).searchParams
+    accountIds = collectAccountIds((name) => query.getAll(name))
+  }
+
+  return accountIds.length > 0 ? accountIds : null
 }
 
 // https://docs.joinmastodon.org/methods/lists/#accounts-add

--- a/app/api/v1/lists/[id]/route.test.ts
+++ b/app/api/v1/lists/[id]/route.test.ts
@@ -58,6 +58,13 @@ const createFormRequest = (body: string) =>
     headers: { 'content-type': 'application/x-www-form-urlencoded' }
   })
 
+const createJsonRequest = (body: unknown) =>
+  new NextRequest(`https://local.test/api/v1/lists/${LIST_ID}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' }
+  })
+
 const createMultipartRequest = (form: FormData) => {
   const request = new NextRequest(
     `https://local.test/api/v1/lists/${LIST_ID}`,
@@ -130,6 +137,18 @@ describe('PUT /api/v1/lists/:id', () => {
     expect(response.status).toBe(200)
     expect(mockDatabase.updateList).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Renamed', exclusive: false })
+    )
+  })
+
+  it('updates the list from a JSON body (regression)', async () => {
+    const response = await PUT(
+      createJsonRequest({ title: 'Renamed', exclusive: true }),
+      { params: Promise.resolve({ id: LIST_ID }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateList).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Renamed', exclusive: true })
     )
   })
 })

--- a/app/api/v1/lists/[id]/route.test.ts
+++ b/app/api/v1/lists/[id]/route.test.ts
@@ -1,0 +1,135 @@
+import { NextRequest } from 'next/server'
+
+import { PUT } from './route'
+
+const mockDatabase = {
+  updateList: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me',
+  domain: 'local.test'
+}
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      }),
+  OAuthGuardAnyScope:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ id: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+const LIST_ID = 'list-123'
+
+const createFormRequest = (body: string) =>
+  new NextRequest(`https://local.test/api/v1/lists/${LIST_ID}`, {
+    method: 'PUT',
+    body,
+    headers: { 'content-type': 'application/x-www-form-urlencoded' }
+  })
+
+const createMultipartRequest = (form: FormData) => {
+  const request = new NextRequest(
+    `https://local.test/api/v1/lists/${LIST_ID}`,
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'multipart/form-data; boundary=----test' }
+    }
+  )
+  // Synthetic NextRequest bodies don't parse multipart, so stub formData().
+  Object.defineProperty(request, 'formData', {
+    value: vi.fn().mockResolvedValue(form)
+  })
+  return request
+}
+
+describe('PUT /api/v1/lists/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.updateList.mockImplementation(async (input) => ({
+      id: input.id,
+      title: input.title ?? 'Existing',
+      repliesPolicy: input.repliesPolicy ?? 'list',
+      exclusive: input.exclusive ?? false
+    }))
+  })
+
+  it('updates the list from a urlencoded body with exclusive=false', async () => {
+    const response = await PUT(
+      createFormRequest('title=Renamed&exclusive=false'),
+      {
+        params: Promise.resolve({ id: LIST_ID })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: LIST_ID,
+        actorId: mockCurrentActor.id,
+        title: 'Renamed',
+        exclusive: false
+      })
+    )
+  })
+
+  it.each([
+    ['1', true],
+    ['true', true],
+    ['0', false],
+    ['false', false]
+  ])('coerces a urlencoded exclusive=%s to %s', async (value, expected) => {
+    await PUT(createFormRequest(`title=Renamed&exclusive=${value}`), {
+      params: Promise.resolve({ id: LIST_ID })
+    })
+
+    expect(mockDatabase.updateList).toHaveBeenCalledWith(
+      expect.objectContaining({ exclusive: expected })
+    )
+  })
+
+  it('updates the list from a multipart body with exclusive=false', async () => {
+    const form = new FormData()
+    form.append('title', 'Renamed')
+    form.append('exclusive', 'false')
+
+    const response = await PUT(createMultipartRequest(form), {
+      params: Promise.resolve({ id: LIST_ID })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.updateList).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Renamed', exclusive: false })
+    )
+  })
+})

--- a/app/api/v1/lists/[id]/route.ts
+++ b/app/api/v1/lists/[id]/route.ts
@@ -7,6 +7,7 @@ import {
 import { getMastodonList } from '@/lib/services/mastodon/getMastodonList'
 import { Scope } from '@/lib/types/database/operations'
 import { ListRepliesPolicy } from '@/lib/types/domain/list'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import {
   ERROR_404,
@@ -15,6 +16,7 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
@@ -57,7 +59,7 @@ export const GET = traceApiRoute(
 const UpdateListBody = z.object({
   title: z.string().trim().min(1).max(255).optional(),
   replies_policy: ListRepliesPolicy.optional(),
-  exclusive: z.coerce.boolean().optional()
+  exclusive: Booleanish.optional()
 })
 
 // https://docs.joinmastodon.org/methods/lists/#update
@@ -67,7 +69,7 @@ export const PUT = traceApiRoute(
     [Scope.enum['write:lists']],
     async (req, { database, currentActor, params }) => {
       const { id } = await params
-      const json = await req.json().catch(() => null)
+      const json = await getRequestBody(req).catch(() => null)
       const parsed = UpdateListBody.safeParse(json)
       if (!parsed.success) {
         return apiResponse({

--- a/app/api/v1/lists/route.test.ts
+++ b/app/api/v1/lists/route.test.ts
@@ -1,0 +1,130 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  createList: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me',
+  domain: 'local.test'
+}
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => {
+  const bypass =
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<Record<string, string>>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<Record<string, string>> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+  return {
+    OAuthGuard: bypass,
+    OAuthGuardAnyScope: bypass
+  }
+})
+
+const createJsonRequest = (body: Record<string, unknown>) =>
+  new NextRequest('https://local.test/api/v1/lists', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' }
+  })
+
+const createFormRequest = (body: string) =>
+  new NextRequest('https://local.test/api/v1/lists', {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/x-www-form-urlencoded' }
+  })
+
+const invoke = (req: NextRequest) => POST(req, { params: Promise.resolve({}) })
+
+describe('POST /api/v1/lists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.createList.mockImplementation(
+      ({
+        title,
+        repliesPolicy,
+        exclusive
+      }: {
+        title: string
+        repliesPolicy?: string
+        exclusive?: boolean
+      }) => ({
+        id: 'list-1',
+        title,
+        repliesPolicy: repliesPolicy ?? 'list',
+        exclusive: exclusive ?? false
+      })
+    )
+  })
+
+  it('creates a list with exclusive false from a urlencoded exclusive=false', async () => {
+    const response = await invoke(
+      createFormRequest('title=My+List&exclusive=false')
+    )
+
+    expect(response.status).toBe(200)
+    // "false" must coerce to boolean false, not be treated as truthy.
+    expect(mockDatabase.createList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        title: 'My List',
+        exclusive: false
+      })
+    )
+    const body = await response.json()
+    expect(body.exclusive).toBe(false)
+  })
+
+  it.each([
+    ['1', true],
+    ['true', true],
+    ['on', true],
+    ['yes', true],
+    ['0', false],
+    ['false', false],
+    ['off', false],
+    ['no', false]
+  ])('coerces a urlencoded exclusive=%s to %s', async (value, expected) => {
+    const response = await invoke(
+      createFormRequest(`title=My+List&exclusive=${value}`)
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.createList).toHaveBeenCalledWith(
+      expect.objectContaining({ exclusive: expected })
+    )
+  })
+
+  it('creates a list from a JSON body (regression)', async () => {
+    const response = await invoke(
+      createJsonRequest({ title: 'JSON List', exclusive: true })
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.createList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        title: 'JSON List',
+        exclusive: true
+      })
+    )
+    const body = await response.json()
+    expect(body.title).toBe('JSON List')
+    expect(body.exclusive).toBe(true)
+  })
+})

--- a/app/api/v1/lists/route.ts
+++ b/app/api/v1/lists/route.ts
@@ -7,9 +7,11 @@ import {
 import { getMastodonList } from '@/lib/services/mastodon/getMastodonList'
 import { Scope } from '@/lib/types/database/operations'
 import { ListRepliesPolicy } from '@/lib/types/domain/list'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_422, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 const CORS_HEADERS = [
   HttpMethod.enum.OPTIONS,
@@ -38,7 +40,7 @@ export const GET = traceApiRoute(
 const CreateListBody = z.object({
   title: z.string().trim().min(1).max(255),
   replies_policy: ListRepliesPolicy.optional(),
-  exclusive: z.coerce.boolean().optional()
+  exclusive: Booleanish.optional()
 })
 
 // https://docs.joinmastodon.org/methods/lists/#create
@@ -47,7 +49,7 @@ export const POST = traceApiRoute(
   OAuthGuard(
     [Scope.enum['write:lists']],
     async (req, { database, currentActor }) => {
-      const json = await req.json().catch(() => null)
+      const json = await getRequestBody(req).catch(() => null)
       const parsed = CreateListBody.safeParse(json)
       if (!parsed.success) {
         return apiResponse({

--- a/app/api/v1/reports/route.test.ts
+++ b/app/api/v1/reports/route.test.ts
@@ -1,0 +1,160 @@
+import { NextRequest } from 'next/server'
+
+import { idToUrl } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  getMastodonActorFromId: vi.fn(),
+  createReport: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me',
+  domain: 'local.test'
+}
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<unknown>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<unknown> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      })
+}))
+
+const createFormRequest = (body: string) =>
+  new NextRequest('https://local.test/api/v1/reports', {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/x-www-form-urlencoded' }
+  })
+
+describe('POST /api/v1/reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getMastodonActorFromId.mockResolvedValue({
+      id: 'acc1',
+      username: 'target'
+    })
+    mockDatabase.createReport.mockImplementation(async (input) => ({
+      id: 'report-1',
+      actionTaken: false,
+      category: input.category ?? null,
+      comment: input.comment ?? '',
+      forward: input.forward,
+      createdAt: Date.now(),
+      statusIds: input.statusIds,
+      ruleIds: input.ruleIds
+    }))
+  })
+
+  it('creates a report with forward=false from a urlencoded body', async () => {
+    const response = await POST(
+      createFormRequest('account_id=acc1&forward=false'),
+      {
+        params: Promise.resolve({})
+      }
+    )
+
+    expect(response.status).toBe(200)
+    // The string "false" must coerce to boolean false, not be truthy-coerced to true.
+    expect(mockDatabase.createReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: mockCurrentActor.id,
+        targetActorId: idToUrl('acc1'),
+        forward: false
+      })
+    )
+  })
+
+  it.each([
+    ['true', true],
+    ['1', true],
+    ['on', true],
+    ['yes', true],
+    ['false', false],
+    ['0', false],
+    ['off', false]
+  ])('coerces a urlencoded forward=%s to %s', async (value, expected) => {
+    const response = await POST(
+      createFormRequest(`account_id=acc1&forward=${value}`),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.createReport).toHaveBeenCalledWith(
+      expect.objectContaining({ forward: expected })
+    )
+  })
+
+  it('defaults forward to false when omitted', async () => {
+    const response = await POST(createFormRequest('account_id=acc1'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.createReport).toHaveBeenCalledWith(
+      expect.objectContaining({ forward: false })
+    )
+  })
+
+  it('parses repeated status_ids[] as an array of two, not dropped', async () => {
+    const response = await POST(
+      createFormRequest('account_id=acc1&status_ids[]=s1&status_ids[]=s2'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const call = mockDatabase.createReport.mock.calls[0][0]
+    // Both ids survive parsing, each mapped from short form to URL form.
+    expect(call.statusIds).toEqual([idToUrl('s1'), idToUrl('s2')])
+  })
+
+  it('parses multipart status_ids[] as an array of two', async () => {
+    const form = new FormData()
+    form.set('account_id', 'acc1')
+    form.append('status_ids[]', 's1')
+    form.append('status_ids[]', 's2')
+    form.set('forward', 'true')
+
+    const request = new NextRequest('https://local.test/api/v1/reports', {
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=test-boundary'
+      }
+    })
+    Object.defineProperty(request, 'formData', {
+      value: vi.fn().mockResolvedValue(form)
+    })
+
+    const response = await POST(request, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    const call = mockDatabase.createReport.mock.calls[0][0]
+    expect(call.statusIds).toEqual([idToUrl('s1'), idToUrl('s2')])
+    expect(call.forward).toBe(true)
+  })
+
+  it('returns 404 when the target account does not exist', async () => {
+    mockDatabase.getMastodonActorFromId.mockResolvedValue(null)
+
+    const response = await POST(createFormRequest('account_id=acc1'), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(404)
+    expect(mockDatabase.createReport).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/reports/route.test.ts
+++ b/app/api/v1/reports/route.test.ts
@@ -41,6 +41,13 @@ const createFormRequest = (body: string) =>
     headers: { 'content-type': 'application/x-www-form-urlencoded' }
   })
 
+const createJsonRequest = (body: unknown) =>
+  new NextRequest('https://local.test/api/v1/reports', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' }
+  })
+
 describe('POST /api/v1/reports', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -145,6 +152,35 @@ describe('POST /api/v1/reports', () => {
     const call = mockDatabase.createReport.mock.calls[0][0]
     expect(call.statusIds).toEqual([idToUrl('s1'), idToUrl('s2')])
     expect(call.forward).toBe(true)
+  })
+
+  it('parses a JSON body with a real boolean forward and a status_ids array', async () => {
+    // Exercises parseReportBody's default (req.json) branch, Booleanish's
+    // z.boolean() arm (only reached by real JSON booleans), and the JSON
+    // status_ids array-union arm — none of which the form paths cover.
+    const response = await POST(
+      createJsonRequest({
+        account_id: 'acc1',
+        forward: true,
+        status_ids: ['s1', 's2']
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const call = mockDatabase.createReport.mock.calls[0][0]
+    expect(call.forward).toBe(true)
+    expect(call.statusIds).toEqual([idToUrl('s1'), idToUrl('s2')])
+  })
+
+  it('reads a real JSON boolean forward=false', async () => {
+    await POST(createJsonRequest({ account_id: 'acc1', forward: false }), {
+      params: Promise.resolve({})
+    })
+
+    expect(mockDatabase.createReport).toHaveBeenCalledWith(
+      expect.objectContaining({ forward: false })
+    )
   })
 
   it('returns 404 when the target account does not exist', async () => {

--- a/app/api/v1/reports/route.ts
+++ b/app/api/v1/reports/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
@@ -23,7 +24,7 @@ const CreateReportBody = z.object({
     .union([z.array(z.string().min(1)), z.string().min(1)])
     .optional(),
   comment: z.string().max(1000).optional(),
-  forward: z.coerce.boolean().optional(),
+  forward: Booleanish.optional(),
   category: ReportCategory.optional(),
   rule_ids: z.union([z.array(z.string().min(1)), z.string().min(1)]).optional()
 })
@@ -33,13 +34,61 @@ const toArray = (value: string[] | string | undefined): string[] => {
   return Array.isArray(value) ? value : [value]
 }
 
+const collectStrings = (values: unknown[]): string[] =>
+  values.filter(
+    (value): value is string => typeof value === 'string' && value.length > 0
+  )
+
+// Build the report object from a form/multipart source. status_ids and rule_ids
+// arrive as bracket arrays (status_ids[]=…); everything else is scalar. The Zod
+// schema then coerces (forward via Booleanish, category via the enum).
+const buildFormReport = (
+  get: (name: string) => unknown,
+  getAll: (name: string) => unknown[]
+) => {
+  const scalar = (name: string) => {
+    const value = get(name)
+    return typeof value === 'string' ? value : undefined
+  }
+  const statusIds = collectStrings(getAll('status_ids[]'))
+  const ruleIds = collectStrings(getAll('rule_ids[]'))
+  return {
+    account_id: scalar('account_id'),
+    status_ids: statusIds.length > 0 ? statusIds : scalar('status_ids'),
+    comment: scalar('comment'),
+    forward: scalar('forward'),
+    category: scalar('category'),
+    rule_ids: ruleIds.length > 0 ? ruleIds : scalar('rule_ids')
+  }
+}
+
+// Accepts JSON, urlencoded, and multipart report bodies.
+const parseReportBody = async (req: Request): Promise<unknown> => {
+  const contentType = req.headers.get('content-type')?.toLowerCase() ?? ''
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const params = new URLSearchParams(await req.text())
+    return buildFormReport(
+      (name) => params.get(name),
+      (name) => params.getAll(name)
+    )
+  }
+  if (contentType.includes('multipart/form-data')) {
+    const form = await req.formData()
+    return buildFormReport(
+      (name) => form.get(name),
+      (name) => form.getAll(name)
+    )
+  }
+  return req.json()
+}
+
 // https://docs.joinmastodon.org/methods/reports/#post
 export const POST = traceApiRoute(
   'createReport',
   OAuthGuard(
     [Scope.enum['write:reports']],
     async (req, { database, currentActor }) => {
-      const json = await req.json().catch(() => null)
+      const json = await parseReportBody(req).catch(() => null)
       const parsed = CreateReportBody.safeParse(json)
       if (!parsed.success) {
         return apiResponse({


### PR DESCRIPTION
## Summary

Phase 1.2 of the Mastodon API remediation plan. Native Mastodon clients send
`application/x-www-form-urlencoded` and `multipart/form-data` bodies (and
serialise `DELETE` params into the query string). These routes only read
`req.json()`, so form/multipart requests failed. Route bodies now go through the
shared form-aware parsers.

**Stacked on #1171** (granular OAuth scopes) — base is `claude/phase1-oauth-scopes`.

## Changes

- **lists (POST) & lists/[id] (PUT):** read the body via `getRequestBody`, and
  switch `exclusive` from `z.coerce.boolean()` (which makes the string `"false"`
  truthy) to the `Booleanish` schema so `"false"` is `false`.
- **lists/[id]/accounts (POST + DELETE):** parse `account_ids` from a JSON array,
  a form/multipart bracket array (`account_ids[]=…`), or — for `DELETE`, which
  masto.js serialises into the query string — repeated query params.
  `getRequestBody` alone can't do this: it collapses bracket keys last-write-wins.
- **featured_tags (POST):** read via `getRequestBody`.
- **reports (POST):** parse JSON/urlencoded/multipart, collecting `status_ids[]`
  / `rule_ids[]` bracket arrays, and switch `forward` to `Booleanish`.

## Tests

- New form-body tests for `lists`, `lists/[id]`, `lists/[id]/accounts`, and
  `reports` — urlencoded + multipart + DELETE-query + boolean-coercion matrices,
  asserting the parsed values reach the DB calls.
- Extend the existing `featured_tags` integration test with a urlencoded case
  (kept the original real-DB GET/POST coverage).
- `yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test` — all green.

## Version bump

`fix:` — patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yDNzak914a5pGcFGTu18v)_