### PR TITLE
fix: real min_id pagination semantics for notifications and list timeline

### DIFF
--- a/app/api/v1/notifications/route.test.ts
+++ b/app/api/v1/notifications/route.test.ts
@@ -145,6 +145,32 @@ describe('GET /api/v1/notifications', () => {
     )
   })
 
+  // min_id and since_id must reach the DB in their own slots — since_id must not
+  // be collapsed into minNotificationId (which would give it adjacent-page
+  // instead of newest-slice semantics).
+  it.each([
+    [
+      'min_id=cursor-a',
+      { minNotificationId: 'cursor-a', sinceNotificationId: undefined }
+    ],
+    [
+      'since_id=cursor-b',
+      { sinceNotificationId: 'cursor-b', minNotificationId: undefined }
+    ]
+  ])('routes %s to its own cursor param', async (query, expected) => {
+    mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+    const request = new NextRequest(
+      `https://llun.test/api/v1/notifications?${query}`,
+      { method: 'GET' }
+    )
+    await GET(request, { params: Promise.resolve({}) })
+
+    expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+      expect.objectContaining(expected)
+    )
+  })
+
   it.each([
     ['1', true],
     ['on', true],

--- a/app/api/v1/notifications/route.ts
+++ b/app/api/v1/notifications/route.ts
@@ -124,7 +124,8 @@ export const GET = traceApiRoute(
         actorId: currentActor.id,
         limit,
         maxNotificationId: maxId,
-        minNotificationId: minId || sinceId,
+        minNotificationId: minId,
+        sinceNotificationId: sinceId,
         types: internalTypes,
         excludeTypes: internalExcludeTypes,
         includeFiltered

--- a/app/api/v1/timelines/[timeline]/route.test.ts
+++ b/app/api/v1/timelines/[timeline]/route.test.ts
@@ -580,8 +580,11 @@ describe('GET /api/v1/timelines/[timeline]', () => {
         { params: Promise.resolve({ timeline: 'main' }) }
       )
 
+      // The home/direct feed backfills DESC, so its lower bound reaches
+      // getTimeline as sinceStatusId (newest-first). since_id still wins the
+      // collapse over min_id.
       expect(spy).toHaveBeenCalledWith(
-        expect.objectContaining({ minStatusId: sinceUrl })
+        expect.objectContaining({ sinceStatusId: sinceUrl })
       )
       spy.mockRestore()
     })

--- a/app/api/v1/timelines/list/[list_id]/route.test.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.test.ts
@@ -144,7 +144,7 @@ describe('GET /api/v1/timelines/list/[list_id]', () => {
     }
   )
 
-  it('uses min_id over since_id for the lower-bound cursor', async () => {
+  it('passes min_id and since_id through as separate cursors', async () => {
     const minUrl = 'https://llun.test/users/test1/statuses/min-cursor'
     const sinceUrl = 'https://llun.test/users/test1/statuses/since-cursor'
     const spy = vi.spyOn(database, 'getListTimeline').mockResolvedValue([])
@@ -154,9 +154,29 @@ describe('GET /api/v1/timelines/list/[list_id]', () => {
       { params: Promise.resolve({ list_id: listId }) }
     )
 
+    // Not collapsed — both reach getListTimeline in their own slots so min_id
+    // gets adjacent-page and since_id gets newest-slice semantics.
     expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ minStatusId: minUrl })
+      expect.objectContaining({ minStatusId: minUrl, sinceStatusId: sinceUrl })
     )
+  })
+
+  it.each([
+    { field: 'min_id' as const, slot: 'minStatusId', other: 'sinceStatusId' },
+    { field: 'since_id' as const, slot: 'sinceStatusId', other: 'minStatusId' }
+  ])('routes $field alone to $slot', async ({ field, slot, other }) => {
+    const url = 'https://llun.test/users/test1/statuses/cursor'
+    const spy = vi.spyOn(database, 'getListTimeline').mockResolvedValue([])
+
+    await GET(request({ [field]: urlToId(url) }), {
+      params: Promise.resolve({ list_id: listId })
+    })
+
+    const call = spy.mock.calls[0][0] as Record<string, unknown>
+    expect(call[slot]).toBe(url)
+    // The absent cursor is passed as null (parseTimelineQuery's default), not
+    // collapsed into the other slot.
+    expect(call[other]).toBeNull()
   })
 
   it('returns 200 with the bad row skipped when one status is un-hydratable', async () => {

--- a/app/api/v1/timelines/list/[list_id]/route.ts
+++ b/app/api/v1/timelines/list/[list_id]/route.ts
@@ -71,19 +71,16 @@ export const GET = traceApiRoute(
         }
         const limit = parsedQuery.query.limit
         const maxStatusId = parsedQuery.query.maxStatusId
-        // `min_id` and `since_id` both express a lower-bound cursor; the list
-        // timeline query takes a single min cursor, so collapse them preserving
-        // this route's existing `min_id`-wins precedence. (min/since ordering
-        // semantics are unchanged by this PR — see PR notes.)
-        const minStatusId =
-          parsedQuery.query.minStatusId ?? parsedQuery.query.sinceStatusId
-
+        // Pass min_id and since_id through separately: min_id returns the page
+        // immediately adjacent to the cursor (ascending seek then reversed),
+        // since_id the newest slice above it.
         const statuses = await database.getListTimeline({
           listId,
           actorId: currentActor.id,
           limit,
           maxStatusId,
-          minStatusId
+          minStatusId: parsedQuery.query.minStatusId,
+          sinceStatusId: parsedQuery.query.sinceStatusId
         })
 
         // The list timeline query returns domain statuses newest-first, so the

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -145,6 +145,34 @@ describe('GET /api/v2/notifications', () => {
     }
   )
 
+  it.each([
+    ['min_id', 'min_id'],
+    ['since_id', 'since_id']
+  ])(
+    'collapses %s to since-semantics for the grouped (DESC) scan',
+    async (_label, param) => {
+      mockDatabase.getNotifications.mockResolvedValueOnce([])
+
+      const request = new NextRequest(
+        `https://llun.test/api/v2/notifications?${param}=cursor-1`,
+        { method: 'GET' }
+      )
+      const response = await GET(request, { params: Promise.resolve({}) })
+
+      expect(response.status).toBe(200)
+      // The grouped v2 path always scans DESC (collectNotificationGroups advances
+      // max_id by the oldest row), so both min_id and since_id must reach
+      // getNotifications as the since-semantics lower bound — never as
+      // minNotificationId, which would flip getNotifications to ascending and
+      // break the batching.
+      expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
+        expect.objectContaining({ sinceNotificationId: 'cursor-1' })
+      )
+      const callArg = mockDatabase.getNotifications.mock.calls[0][0]
+      expect(callArg.minNotificationId).toBeUndefined()
+    }
+  )
+
   it('anchors the next (max_id) Link on the last returned group most-recent id', async () => {
     mockDatabase.getNotifications.mockResolvedValueOnce([
       {

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -135,7 +135,12 @@ export const GET = traceApiRoute(
         database,
         baseQuery: {
           actorId: currentActor.id,
-          minNotificationId: minId || sinceId,
+          // The grouped v2 path fetches in DESC batches (collectNotificationGroups
+          // advances max_id by the oldest row), so its lower bound stays
+          // since-semantics — driving it as min_id would flip getNotifications to
+          // ascending and break the batching. Adjacent-page min_id for grouped
+          // notifications is a separate change.
+          sinceNotificationId: minId || sinceId,
           types: mastodonTypesToInternal(types),
           excludeTypes: mastodonTypesToInternal(excludeTypes),
           includeFiltered

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -1154,6 +1154,68 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('distinguishes min_id (adjacent page) from since_id (newest slice)', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      await createLocalAccount(database, 'member')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      const member = await database.getActorFromUsername({
+        username: 'member',
+        domain: TEST_DOMAIN
+      })
+      if (!owner || !member) throw new Error('actors not created')
+
+      // Five posts, oldest → newest by createdAt.
+      const ids: string[] = []
+      for (let i = 1; i <= 5; i++) {
+        const id = `${member.id}/statuses/${i}`
+        await database.createNote({
+          id,
+          url: id,
+          actorId: member.id,
+          text: `post ${i}`,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          createdAt: 1000 * i
+        })
+        ids.push(id)
+      }
+      const [oldest, second, middle, fourth, newest] = ids
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Cursor list'
+      })
+      await database.addListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        targetActorIds: [member.id]
+      })
+
+      // since_id: the two NEWEST statuses above the cursor.
+      const sincePage = await database.getListTimeline({
+        listId: list.id,
+        actorId: owner.id,
+        sinceStatusId: oldest,
+        limit: 2
+      })
+      expect(sincePage.map((status) => status.id)).toEqual([newest, fourth])
+
+      // min_id: the two OLDEST statuses above the cursor (the adjacent page),
+      // returned newest-first — a different slice than since_id.
+      const minPage = await database.getListTimeline({
+        listId: list.id,
+        actorId: owner.id,
+        minStatusId: oldest,
+        limit: 2
+      })
+      expect(minPage.map((status) => status.id)).toEqual([middle, second])
+    })
+  })
+
   it('paginates from a cursor that exists but is not in the list partition', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -349,7 +349,8 @@ export const ListSQLDatabaseMixin = (
     actorId,
     limit = PER_PAGE_LIMIT,
     maxStatusId,
-    minStatusId
+    minStatusId,
+    sinceStatusId
   }: GetListTimelineParams) {
     // The list's replies_policy governs which replies appear. Default to 'list'
     // (Mastodon's default) when the row is missing so behaviour is well-defined.
@@ -408,9 +409,13 @@ export const ListSQLDatabaseMixin = (
     // feed uses), rather than sorting the whole filtered partition. timelines.
     // createdAt mirrors statuses.createdAt (both written as new Date(status.
     // createdAt) on every write path) and timelines.id is a monotonic tie-breaker.
+    // min_id ascends from the cursor (the oldest rows just newer than it) then
+    // reverses to newest-first, returning the page adjacent to the cursor.
+    // since_id / max_id / no cursor keep DESC.
+    const ascending = Boolean(minStatusId)
     query
-      .orderBy('timelines.createdAt', 'desc')
-      .orderBy('timelines.id', 'desc')
+      .orderBy('timelines.createdAt', ascending ? 'asc' : 'desc')
+      .orderBy('timelines.id', ascending ? 'asc' : 'desc')
       .limit(limit)
       .select('statuses.id')
 
@@ -463,10 +468,13 @@ export const ListSQLDatabaseMixin = (
       return true
     }
 
+    const lowerBoundStatusId = minStatusId || sinceStatusId
     if (maxStatusId && !(await applyCursor(maxStatusId, 'older'))) return []
-    if (minStatusId && !(await applyCursor(minStatusId, 'newer'))) return []
+    if (lowerBoundStatusId && !(await applyCursor(lowerBoundStatusId, 'newer')))
+      return []
 
     const rows = await query
+    if (ascending) rows.reverse()
     const statusIds = rows.map((row) => row.id as string)
     if (statusIds.length === 0) return []
     // getStatusesByIds preserves the input order (it re-maps results over the

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -148,26 +148,49 @@ describe('Notification Database', () => {
         )
       })
 
-      it('should return notifications with since_id cursor (same as min_id)', async () => {
-        const allNotifications = await database.getNotifications({
+      it('distinguishes min_id (adjacent page) from since_id (newest slice)', async () => {
+        // beforeEach seeds 3; add 2 more so the window above the cursor exceeds
+        // the page limit and the two cursor kinds diverge.
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        await database.createNotification({
           actorId: actor1Id,
-          limit: 10
+          type: NotificationType.enum.like,
+          sourceActorId: actor2Id,
+          statusId,
+          groupKey: 'like:2'
+        })
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        await database.createNotification({
+          actorId: actor1Id,
+          type: NotificationType.enum.reblog,
+          sourceActorId: actor2Id,
+          statusId,
+          groupKey: 'reblog:2'
         })
 
-        const withMinId = await database.getNotifications({
+        const all = await database.getNotifications({
           actorId: actor1Id,
-          minNotificationId: allNotifications[2].id,
           limit: 10
         })
+        expect(all).toHaveLength(5)
+        const oldestId = all[4].id
 
         const withSinceId = await database.getNotifications({
           actorId: actor1Id,
-          sinceNotificationId: allNotifications[2].id,
-          limit: 10
+          sinceNotificationId: oldestId,
+          limit: 2
+        })
+        const withMinId = await database.getNotifications({
+          actorId: actor1Id,
+          minNotificationId: oldestId,
+          limit: 2
         })
 
-        expect(withMinId).toHaveLength(withSinceId.length)
-        expect(withMinId.map((n) => n.id)).toEqual(withSinceId.map((n) => n.id))
+        // since_id returns the two NEWEST notifications above the cursor.
+        expect(withSinceId.map((n) => n.id)).toEqual([all[0].id, all[1].id])
+        // min_id returns the two OLDEST above the cursor (the adjacent page),
+        // still newest-first — NOT the same slice as since_id.
+        expect(withMinId.map((n) => n.id)).toEqual([all[2].id, all[3].id])
       })
 
       it('should handle non-existent cursor ID gracefully', async () => {

--- a/lib/database/sql/notification.test.ts
+++ b/lib/database/sql/notification.test.ts
@@ -193,6 +193,17 @@ describe('Notification Database', () => {
         expect(withMinId.map((n) => n.id)).toEqual([all[2].id, all[3].id])
       })
 
+      it('returns an empty page for an unresolvable min_id cursor', async () => {
+        // A min_id whose row was dismissed/cleared (or a foreign id) must
+        // terminate pagination, not drop the filter and return the oldest page.
+        const result = await database.getNotifications({
+          actorId: actor1Id,
+          minNotificationId: 'does-not-exist',
+          limit: 10
+        })
+        expect(result).toEqual([])
+      })
+
       it('should handle non-existent cursor ID gracefully', async () => {
         const notifications = await database.getNotifications({
           actorId: actor1Id,

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -86,11 +86,7 @@ export const NotificationSQLDatabaseMixin = (
     sinceNotificationId,
     includeFiltered
   }: GetNotificationsParams) {
-    let query = database('notifications')
-      .where('actorId', actorId)
-      .orderBy('createdAt', 'desc')
-      .orderBy('id', 'desc') // Secondary sort for deterministic ordering
-      .limit(limit)
+    let query = database('notifications').where('actorId', actorId).limit(limit)
 
     // By default hide policy-filtered notifications (they live in the requests
     // queue). Mastodon's `include_filtered` opts back into seeing them.
@@ -165,8 +161,18 @@ export const NotificationSQLDatabaseMixin = (
       query = query.whereIn('id', ids)
     }
 
+    // min_id ascends from the cursor — the OLDEST notifications just newer than
+    // it — then reverses to the newest-first response shape, so it returns the
+    // page adjacent to the cursor. since_id (and max_id / no cursor) keep the
+    // newest-first DESC ordering (the newest slice above the cursor).
+    const ascending = Boolean(minNotificationId)
+    query = query
+      .orderBy('createdAt', ascending ? 'asc' : 'desc')
+      .orderBy('id', ascending ? 'asc' : 'desc')
+
     const results = await query
-    return results.map(fixNotificationDataDate)
+    const ordered = ascending ? results.reverse() : results
+    return ordered.map(fixNotificationDataDate)
   },
 
   async getNotificationsCount({

--- a/lib/database/sql/notification.ts
+++ b/lib/database/sql/notification.ts
@@ -124,20 +124,24 @@ export const NotificationSQLDatabaseMixin = (
         .where('id', minId)
         .andWhere('actorId', actorId)
         .first()
-      if (minNotification) {
-        // Get notifications newer than cursor: (createdAt > cursor) OR (createdAt = cursor AND id > cursor)
-        query = query.where(function () {
-          this.where('createdAt', '>', minNotification.createdAt).orWhere(
-            function () {
-              this.where('createdAt', '=', minNotification.createdAt).andWhere(
-                'id',
-                '>',
-                minNotification.id
-              )
-            }
-          )
-        })
-      }
+      // An unresolvable lower-bound cursor (dismissed/cleared/foreign id)
+      // terminates pagination with an empty page — matching getListTimeline —
+      // rather than dropping the filter and returning the wrong end of the
+      // timeline (which, with the ascending min_id order below, would surface
+      // the OLDEST notifications instead of an adjacent/empty page).
+      if (!minNotification) return []
+      // Get notifications newer than cursor: (createdAt > cursor) OR (createdAt = cursor AND id > cursor)
+      query = query.where(function () {
+        this.where('createdAt', '>', minNotification.createdAt).orWhere(
+          function () {
+            this.where('createdAt', '=', minNotification.createdAt).andWhere(
+              'id',
+              '>',
+              minNotification.id
+            )
+          }
+        )
+      })
     }
 
     // Support offset-based pagination for backward compatibility

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -20,6 +20,7 @@ export const TimelineSQLDatabaseMixin = (
     timeline,
     actorId,
     minStatusId,
+    sinceStatusId,
     maxStatusId,
     limit = PER_PAGE_LIMIT
   }: GetTimelineParams) {
@@ -176,13 +177,16 @@ export const TimelineSQLDatabaseMixin = (
           return statusRow ? { id: null, createdAt: statusRow.createdAt } : null
         }
 
+        // min_id and since_id are both lower-bound cursors (rows newer than it);
+        // they differ only in ordering, handled below.
+        const lowerBoundStatusId = minStatusId || sinceStatusId
         const [maxRow, minRow] = await Promise.all([
           maxStatusId ? lookupTimelineCursor(maxStatusId) : null,
-          minStatusId ? lookupTimelineCursor(minStatusId) : null
+          lowerBoundStatusId ? lookupTimelineCursor(lowerBoundStatusId) : null
         ])
 
         if (maxStatusId && !maxRow) return []
-        if (minStatusId && !minRow) return []
+        if (lowerBoundStatusId && !minRow) return []
 
         let query = database('timelines')
           .where('actorId', actorId)
@@ -219,6 +223,12 @@ export const TimelineSQLDatabaseMixin = (
           })
         }
 
+        // The home/direct feed is consumed through getFilteredStatusPage, which
+        // backfills by paging max_id DESC, so this query stays newest-first for
+        // both lower-bound cursors. min_id therefore behaves like since_id here
+        // (adjacent-page min_id for the filtered feed is a separate change);
+        // the notification and list-timeline layers, consumed directly, do
+        // implement true min_id.
         const statusesId = await query
           .select('statusId')
           .orderBy([

--- a/lib/services/timelines/getFilteredTimelinePage.ts
+++ b/lib/services/timelines/getFilteredTimelinePage.ts
@@ -151,7 +151,11 @@ export const getFilteredTimelinePage = async ({
       database.getTimeline({
         timeline,
         actorId,
-        minStatusId,
+        // getFilteredStatusPage backfills by paging max_id DESC, so the lower
+        // bound must keep newest-first (since) ordering here — driving it as
+        // min_id would flip getTimeline to ascending and break the backfill.
+        // Adjacent-page min_id for filtered timelines is a separate change.
+        sinceStatusId: minStatusId,
         maxStatusId: cursor,
         limit: batchLimit
       })

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1338,6 +1338,7 @@ export type GetListTimelineParams = {
   limit?: number
   maxStatusId?: string | null
   minStatusId?: string | null
+  sinceStatusId?: string | null
 }
 export type AddStatusToListTimelinesParams = {
   status: Status
@@ -3005,6 +3006,7 @@ export type GetTimelineParams = {
   timeline: Timeline
   actorId?: string
   minStatusId?: string | null
+  sinceStatusId?: string | null
   maxStatusId?: string | null
   limit?: number
 }


### PR DESCRIPTION
## Summary

Phase 1.3 of the Mastodon API remediation plan. `min_id` was treated identically
to `since_id`: both were collapsed into one lower-bound cursor applied to a
`DESC LIMIT n` query, so `min_id` returned the **newest** n rows above the cursor
instead of the page **immediately adjacent** to it. Mastodon's `min_id` is an
ascending keyset seek from the cursor — take n, then reverse to newest-first.

**Stacked on #1173.**

## Fixed (true `min_id` where the query layer is consumed directly)

- **`getNotifications`** (`lib/database/sql/notification.ts`): when
  `minNotificationId` is set, order ascending and reverse; `since`/`max`/no-cursor
  keep DESC. `GET /api/v1/notifications` now passes `min_id` and `since_id`
  through separately.
- **`getListTimeline`** (`lib/database/sql/list.ts`): same ascending-seek +
  reverse for `min_id`; `GET /api/v1/timelines/list/:id` passes them separately.
- Added `sinceStatusId` to `GetTimelineParams` / `GetListTimelineParams`.
- Adjacency tests for both layers proving `min_id` returns the oldest-n above the
  cursor (reversed to newest-first) while `since_id` returns the newest-n.
  Replaced the old `notification.test.ts` case that asserted `min_id === since_id`
  (which only held because its window was smaller than the page limit).

## Intentionally deferred (kept as `since` semantics, documented in-code)

Three paths reach the query layer through a **DESC-only backfill/grouping loop**
that pages by `max_id` and would break if the underlying query flipped to
ascending. They keep their current (since-like) `min_id` behavior; making them
truly adjacent-page is a separate change to those loops:

- **Home / direct timelines** — via `getFilteredStatusPage` (keyword/block/mute
  backfill). `getFilteredTimelinePage` now routes its lower bound through
  `sinceStatusId` so this fix can't accidentally flip it to ascending.
- **`GET /api/v2/notifications`** (grouped) — via `collectNotificationGroups`.
- **Public / tag timelines** — still `max_id`-only (unchanged).

This boundary is called out at each site in code comments.

## Testing

`yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test` — all green
(601 files / 5395 tests).

## Version bump

`fix:` — patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yDNzak914a5pGcFGTu18v)_