### PR TITLE
fix: make follow_requests authorize/reject usable by API clients

### DIFF
--- a/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.test.tsx
@@ -122,7 +122,7 @@ describe('FollowRequestNotification', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
 
     await waitFor(() =>
-      expect(acceptFollowRequest).toHaveBeenCalledWith({ id: account.url })
+      expect(acceptFollowRequest).toHaveBeenCalledWith({ id: account.id })
     )
     expect(await screen.findByText('Approved')).toBeInTheDocument()
     expect(
@@ -137,7 +137,7 @@ describe('FollowRequestNotification', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
 
     await waitFor(() =>
-      expect(rejectFollowRequest).toHaveBeenCalledWith({ id: account.url })
+      expect(rejectFollowRequest).toHaveBeenCalledWith({ id: account.id })
     )
     expect(await screen.findByText('Rejected')).toBeInTheDocument()
     expect(

--- a/app/(timeline)/notifications/components/FollowRequestNotification.tsx
+++ b/app/(timeline)/notifications/components/FollowRequestNotification.tsx
@@ -54,10 +54,12 @@ export const FollowRequestNotification: FC<Props> = ({
     setIsLoading(true)
     setError(null)
     try {
+      // Send the account id (the urlToId format the API resolves), matching
+      // what a Mastodon client would send; the route still accepts a raw URL.
       const ok =
         action === 'accept'
-          ? await acceptFollowRequest({ id: account.url })
-          : await rejectFollowRequest({ id: account.url })
+          ? await acceptFollowRequest({ id: account.id })
+          : await rejectFollowRequest({ id: account.id })
       if (!ok) throw new Error('request failed')
       setStatus(action === 'accept' ? 'accepted' : 'rejected')
       router.refresh()

--- a/app/api/v1/follow_requests/[id]/authorize/route.test.ts
+++ b/app/api/v1/follow_requests/[id]/authorize/route.test.ts
@@ -84,6 +84,25 @@ describe('POST /api/v1/follow_requests/:id/authorize', () => {
     })
   })
 
+  it('passes a raw http:// actor URL through unchanged (not mangled by idToUrl)', async () => {
+    const httpUrl = 'http://local.test/users/alice'
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue({
+      id: 'follow-1',
+      status: 'Requested',
+      actorId: httpUrl,
+      targetActorId: mockCurrentActor.id
+    })
+    await POST(request(httpUrl), {
+      params: Promise.resolve({ id: httpUrl })
+    })
+    // idToUrl would split the scheme colon and mangle an http:// URL, so the
+    // route must pass it through unchanged like it does an https:// URL.
+    expect(mockDatabase.getAcceptedOrRequestedFollow).toHaveBeenCalledWith({
+      actorId: httpUrl,
+      targetActorId: mockCurrentActor.id
+    })
+  })
+
   it('returns 404 when there is no pending request', async () => {
     mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
     const id = urlToId(followerUrl)

--- a/app/api/v1/follow_requests/[id]/authorize/route.test.ts
+++ b/app/api/v1/follow_requests/[id]/authorize/route.test.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server'
+
+import { idToUrl, urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/me',
+  domain: 'llun.test'
+}
+const mockDatabase = {
+  getAcceptedOrRequestedFollow: vi.fn(),
+  getActorFromId: vi.fn(),
+  updateFollowStatus: vi.fn()
+}
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuardAnyScope:
+    (_scopes: unknown, handle: (req: NextRequest, ctx: unknown) => unknown) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        database: mockDatabase,
+        params: context.params
+      }),
+  corsErrorResponse: () => () => new Response(null)
+}))
+
+const mockRelationship = { id: 'rel', following: false, requested: false }
+vi.mock('@/lib/services/accounts/relationship', () => ({
+  getRelationship: vi.fn(async () => mockRelationship)
+}))
+
+vi.mock('@/lib/activities', () => ({ acceptFollow: vi.fn() }))
+
+const followerUrl = 'https://remote.test/users/alice'
+
+const request = (id: string) =>
+  new NextRequest(
+    `https://llun.test/api/v1/follow_requests/${encodeURIComponent(id)}/authorize`,
+    { method: 'POST' }
+  )
+
+describe('POST /api/v1/follow_requests/:id/authorize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue({
+      id: 'follow-1',
+      status: 'Requested',
+      actorId: followerUrl,
+      targetActorId: mockCurrentActor.id
+    })
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: followerUrl,
+      domain: 'remote.test',
+      inboxUrl: 'https://remote.test/users/alice/inbox'
+    })
+  })
+
+  it('resolves an account id in urlToId format via idToUrl', async () => {
+    const id = urlToId(followerUrl)
+    expect(idToUrl(id)).toBe(followerUrl)
+
+    const response = await POST(request(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    // The Mastodon-format account id is resolved back to the actor URL.
+    expect(mockDatabase.getAcceptedOrRequestedFollow).toHaveBeenCalledWith({
+      actorId: followerUrl,
+      targetActorId: mockCurrentActor.id
+    })
+    expect(await response.json()).toEqual(mockRelationship)
+  })
+
+  it('accepts a raw actor URL id (first-party UI back-compat)', async () => {
+    await POST(request(followerUrl), {
+      params: Promise.resolve({ id: followerUrl })
+    })
+    expect(mockDatabase.getAcceptedOrRequestedFollow).toHaveBeenCalledWith({
+      actorId: followerUrl,
+      targetActorId: mockCurrentActor.id
+    })
+  })
+
+  it('returns 404 when there is no pending request', async () => {
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    const id = urlToId(followerUrl)
+    const response = await POST(request(id), {
+      params: Promise.resolve({ id })
+    })
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v1/follow_requests/[id]/authorize/route.ts
+++ b/app/api/v1/follow_requests/[id]/authorize/route.ts
@@ -1,16 +1,16 @@
 import { acceptFollow } from '@/lib/activities'
 import { FollowRequest } from '@/lib/activities/followAction'
 import { getRelationship } from '@/lib/services/accounts/relationship'
-import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import {
-  ERROR_404,
-  ERROR_500,
-  apiResponse,
-  defaultOptions
-} from '@/lib/utils/response'
+import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
@@ -18,19 +18,15 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const POST = traceApiRoute(
   'authorizeFollowRequest',
-  AuthenticatedGuard<{ id: string }>(
+  OAuthGuardAnyScope<{ id: string }>(
+    [Scope.enum.write, Scope.enum['write:follows']],
     async (req, { currentActor, database, params }) => {
-      if (!database) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_500,
-          responseStatusCode: 500
-        })
-      }
-
       const { id } = await params
-      const accountId = decodeURIComponent(id)
+      // Accept both the urlToId-format id every GET endpoint emits (what
+      // Mastodon clients send) and a raw actor URL (the first-party UI's
+      // historical shape) so the UI migration is non-breaking.
+      const rawId = decodeURIComponent(id)
+      const accountId = rawId.startsWith('https://') ? rawId : idToUrl(rawId)
 
       // Find the follow request from this account to current actor
       const follow = await database.getAcceptedOrRequestedFollow({
@@ -90,6 +86,7 @@ export const POST = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: relationship
       })
-    }
+    },
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/app/api/v1/follow_requests/[id]/authorize/route.ts
+++ b/app/api/v1/follow_requests/[id]/authorize/route.ts
@@ -24,9 +24,11 @@ export const POST = traceApiRoute(
       const { id } = await params
       // Accept both the urlToId-format id every GET endpoint emits (what
       // Mastodon clients send) and a raw actor URL (the first-party UI's
-      // historical shape) so the UI migration is non-breaking.
+      // historical shape) so the UI migration is non-breaking. Match http(s)
+      // so a local/dev http:// actor URL passes through instead of being
+      // mangled by idToUrl (which would split the scheme colon).
       const rawId = decodeURIComponent(id)
-      const accountId = rawId.startsWith('https://') ? rawId : idToUrl(rawId)
+      const accountId = /^https?:\/\//.test(rawId) ? rawId : idToUrl(rawId)
 
       // Find the follow request from this account to current actor
       const follow = await database.getAcceptedOrRequestedFollow({

--- a/app/api/v1/follow_requests/[id]/reject/route.test.ts
+++ b/app/api/v1/follow_requests/[id]/reject/route.test.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server'
+
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockCurrentActor = {
+  id: 'https://llun.test/users/me',
+  domain: 'llun.test'
+}
+const mockDatabase = {
+  getAcceptedOrRequestedFollow: vi.fn(),
+  getActorFromId: vi.fn(),
+  updateFollowStatus: vi.fn()
+}
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuardAnyScope:
+    (_scopes: unknown, handle: (req: NextRequest, ctx: unknown) => unknown) =>
+    (req: NextRequest, context: { params: Promise<{ id: string }> }) =>
+      handle(req, {
+        currentActor: mockCurrentActor,
+        database: mockDatabase,
+        params: context.params
+      }),
+  corsErrorResponse: () => () => new Response(null)
+}))
+
+const getRelationship = vi.fn()
+vi.mock('@/lib/services/accounts/relationship', () => ({
+  getRelationship: (params: unknown) => getRelationship(params)
+}))
+
+vi.mock('@/lib/activities', () => ({ rejectFollow: vi.fn() }))
+
+const followerUrl = 'https://remote.test/users/alice'
+
+const request = (id: string) =>
+  new NextRequest(
+    `https://llun.test/api/v1/follow_requests/${encodeURIComponent(id)}/reject`,
+    { method: 'POST' }
+  )
+
+describe('POST /api/v1/follow_requests/:id/reject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue({
+      id: 'follow-1',
+      status: 'Requested',
+      actorId: followerUrl,
+      targetActorId: mockCurrentActor.id
+    })
+    mockDatabase.getActorFromId.mockResolvedValue({
+      id: followerUrl,
+      domain: 'remote.test',
+      inboxUrl: 'https://remote.test/users/alice/inbox'
+    })
+  })
+
+  it('returns the getRelationship result, not a hardcoded literal', async () => {
+    const relationship = {
+      id: urlToId(followerUrl),
+      following: false,
+      requested: false,
+      languages: null
+    }
+    getRelationship.mockResolvedValue(relationship)
+    const id = urlToId(followerUrl)
+
+    const response = await POST(request(id), {
+      params: Promise.resolve({ id })
+    })
+
+    expect(response.status).toBe(200)
+    // Resolved via idToUrl and handed to getRelationship (not the old all-false
+    // literal); the response is exactly what getRelationship returns.
+    expect(getRelationship).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentActor: mockCurrentActor,
+        targetActorId: followerUrl
+      })
+    )
+    expect(await response.json()).toEqual(relationship)
+  })
+
+  it('returns 404 when there is no pending request', async () => {
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
+    const id = urlToId(followerUrl)
+    const response = await POST(request(id), {
+      params: Promise.resolve({ id })
+    })
+    expect(response.status).toBe(404)
+    expect(getRelationship).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/v1/follow_requests/[id]/reject/route.test.ts
+++ b/app/api/v1/follow_requests/[id]/reject/route.test.ts
@@ -83,6 +83,39 @@ describe('POST /api/v1/follow_requests/:id/reject', () => {
     expect(await response.json()).toEqual(relationship)
   })
 
+  it('accepts a raw actor URL id (first-party UI back-compat)', async () => {
+    getRelationship.mockResolvedValue({ id: urlToId(followerUrl) })
+    await POST(request(followerUrl), {
+      params: Promise.resolve({ id: followerUrl })
+    })
+    // A raw https:// actor URL is passed through unchanged (not run through
+    // idToUrl), matching the authorize route's back-compat behavior.
+    expect(mockDatabase.getAcceptedOrRequestedFollow).toHaveBeenCalledWith({
+      actorId: followerUrl,
+      targetActorId: mockCurrentActor.id
+    })
+  })
+
+  it('passes a raw http:// actor URL through unchanged (not mangled by idToUrl)', async () => {
+    const httpUrl = 'http://local.test/users/alice'
+    mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue({
+      id: 'follow-1',
+      status: 'Requested',
+      actorId: httpUrl,
+      targetActorId: mockCurrentActor.id
+    })
+    getRelationship.mockResolvedValue({ id: urlToId(httpUrl) })
+    await POST(request(httpUrl), {
+      params: Promise.resolve({ id: httpUrl })
+    })
+    // idToUrl would split the scheme colon and mangle an http:// URL, so the
+    // route must pass it through unchanged like it does an https:// URL.
+    expect(mockDatabase.getAcceptedOrRequestedFollow).toHaveBeenCalledWith({
+      actorId: httpUrl,
+      targetActorId: mockCurrentActor.id
+    })
+  })
+
   it('returns 404 when there is no pending request', async () => {
     mockDatabase.getAcceptedOrRequestedFollow.mockResolvedValue(null)
     const id = urlToId(followerUrl)

--- a/app/api/v1/follow_requests/[id]/reject/route.ts
+++ b/app/api/v1/follow_requests/[id]/reject/route.ts
@@ -1,15 +1,16 @@
 import { rejectFollow } from '@/lib/activities'
 import { FollowRequest } from '@/lib/activities/followAction'
-import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { getRelationship } from '@/lib/services/accounts/relationship'
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import {
-  ERROR_404,
-  ERROR_500,
-  apiResponse,
-  defaultOptions
-} from '@/lib/utils/response'
+import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 
@@ -17,19 +18,15 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 export const POST = traceApiRoute(
   'rejectFollowRequest',
-  AuthenticatedGuard<{ id: string }>(
+  OAuthGuardAnyScope<{ id: string }>(
+    [Scope.enum.write, Scope.enum['write:follows']],
     async (req, { currentActor, database, params }) => {
-      if (!database) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_500,
-          responseStatusCode: 500
-        })
-      }
-
       const { id } = await params
-      const accountId = decodeURIComponent(id)
+      // Accept both the urlToId-format id every GET endpoint emits (what
+      // Mastodon clients send) and a raw actor URL (the first-party UI's
+      // historical shape) so the UI migration is non-breaking.
+      const rawId = decodeURIComponent(id)
+      const accountId = rawId.startsWith('https://') ? rawId : idToUrl(rawId)
 
       // Find the follow request from this account to current actor
       const follow = await database.getAcceptedOrRequestedFollow({
@@ -74,31 +71,21 @@ export const POST = traceApiRoute(
       }
       await rejectFollow(currentActor, followerActor.inboxUrl, followRequest)
 
-      // Return relationship
-      const relationship = {
-        id: accountId,
-        following: false,
-        showing_reblogs: true,
-        notifying: false,
-        languages: [],
-        followed_by: false,
-        blocking: false,
-        blocked_by: false,
-        muting: false,
-        muting_notifications: false,
-        muting_expires_at: null,
-        requested: false,
-        requested_by: false,
-        domain_blocking: false,
-        endorsed: false,
-        note: ''
-      }
+      // Return the real relationship (the request is no longer pending) rather
+      // than a hardcoded all-false literal, matching the authorize route and
+      // every other relationship response (id in urlToId format, languages null).
+      const relationship = await getRelationship({
+        database,
+        currentActor,
+        targetActorId: accountId
+      })
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: relationship
       })
-    }
+    },
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/app/api/v1/follow_requests/[id]/reject/route.ts
+++ b/app/api/v1/follow_requests/[id]/reject/route.ts
@@ -24,9 +24,11 @@ export const POST = traceApiRoute(
       const { id } = await params
       // Accept both the urlToId-format id every GET endpoint emits (what
       // Mastodon clients send) and a raw actor URL (the first-party UI's
-      // historical shape) so the UI migration is non-breaking.
+      // historical shape) so the UI migration is non-breaking. Match http(s)
+      // so a local/dev http:// actor URL passes through instead of being
+      // mangled by idToUrl (which would split the scheme colon).
       const rawId = decodeURIComponent(id)
-      const accountId = rawId.startsWith('https://') ? rawId : idToUrl(rawId)
+      const accountId = /^https?:\/\//.test(rawId) ? rawId : idToUrl(rawId)
 
       // Find the follow request from this account to current actor
       const follow = await database.getAcceptedOrRequestedFollow({

--- a/app/api/v1/routeScopeWiring.test.ts
+++ b/app/api/v1/routeScopeWiring.test.ts
@@ -195,6 +195,15 @@ const EXPECTED: Array<{ module: string; scopes: string[] }> = [
   {
     module: '@/app/api/oauth/userinfo/route',
     scopes: ['openid', 'profile', 'read']
+  },
+  // follow_requests authorize/reject
+  {
+    module: '@/app/api/v1/follow_requests/[id]/authorize/route',
+    scopes: ['write', 'write:follows']
+  },
+  {
+    module: '@/app/api/v1/follow_requests/[id]/reject/route',
+    scopes: ['write', 'write:follows']
   }
 ]
 


### PR DESCRIPTION
## Summary

Phase 1.4 of the Mastodon API remediation plan. `POST /api/v1/follow_requests/:id/authorize`
and `.../reject` were guarded by `AuthenticatedGuard` (cookie-session only,
redirects to `/auth/signin` on failure) and resolved `:id` with a raw
`decodeURIComponent`. So a Mastodon client — which sends a **bearer token** and
the account `id` in the `urlToId` format every GET endpoint emits — could not use
them. The reject path also returned a hardcoded all-false Relationship literal.

**Stacked on #1175.**

## Changes

- **Guard:** `AuthenticatedGuard` → `OAuthGuardAnyScope([write, write:follows])`
  (with `corsErrorResponse`). Cookie sessions still work through the guard's
  session path; bearer tokens now work too.
- **Id resolution:** resolve `:account_id` with `idToUrl()` (matching the
  `accounts/[id]/follow` sibling), with a raw-actor-URL fallback so the
  first-party UI's historical shape keeps working during the migration.
- **Reject:** return `getRelationship(...)` instead of the hardcoded literal, so
  the response matches the authorize route and every other Relationship (`id` in
  `urlToId` format, `languages: null`, real fields).
- **UI:** `FollowRequestNotification` now sends `account.id` (the `urlToId`
  format) instead of `account.url`.

## Tests

- New `authorize`/`reject` route tests: an account `id` in `urlToId` format
  resolves via `idToUrl` to the actor URL; a raw actor URL still works
  (back-compat); reject returns the `getRelationship` result (not a literal);
  404 with no pending request.
- Added both routes to `routeScopeWiring.test.ts` so their `[write, write:follows]`
  literals are covered.
- Updated `FollowRequestNotification.test.tsx` to assert `account.id`.
- `yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test` — all green
  (603 files / 5407 tests).

## Version bump

`fix:` — patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yDNzak914a5pGcFGTu18v)_