### PR TITLE
Bump version to v1.96.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.7",
+  "version": "1.96.8",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.96.7`
- Base main SHA: `64363cba65e4c1afc46122fe52285d61d6d753ba`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
