### PR TITLE
Bump version to v1.96.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.8",
+  "version": "1.96.9",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.96.9.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.96.8`
- Base main SHA: `b03bdcd2b856f3219d64af48f2ae80c47d9cdf11`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
