### PR TITLE
Bump version to v1.97.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.96.9",
+  "version": "1.97.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.97.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.96.9`
- Base main SHA: `268e80a6a2279960e29b291c93663b25f1f13087`
- Included commits: `6`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
