### PR TITLE
fix: media alt-text limit + nullability

### DIFF
--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -224,7 +224,7 @@ describe('/api/v1/media/[id]', () => {
 
     expect(response.status).toBe(200)
     const data = await response.json()
-    expect(data.description).toBe('')
+    expect(data.description).toBeNull()
   })
 
   it('PUT leaves the description untouched when not provided', async () => {

--- a/app/api/v1/media/[id]/route.test.ts
+++ b/app/api/v1/media/[id]/route.test.ts
@@ -239,6 +239,41 @@ describe('/api/v1/media/[id]', () => {
     expect(data.description).toBe('before')
   })
 
+  it("PUT accepts alt text up to Mastodon's 1500-character limit", async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-long-description')
+    const longDescription = 'a'.repeat(1500)
+
+    const response = await PUT(
+      putRequest(id, { description: longDescription }),
+      {
+        params: Promise.resolve({ id })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.description).toBe(longDescription)
+
+    const stored = await database.getMediaByIdForAccount({
+      mediaId: id,
+      accountId: (await database.getActorFromId({ id: ACTOR1_ID }))!.account!.id
+    })
+    expect(stored?.description).toBe(longDescription)
+  })
+
+  it('PUT returns 422 when alt text exceeds 1500 characters', async () => {
+    const id = await createMediaFor(ACTOR1_ID, 'put-description-too-long')
+
+    const response = await PUT(
+      putRequest(id, { description: 'a'.repeat(1501) }),
+      {
+        params: Promise.resolve({ id })
+      }
+    )
+
+    expect(response.status).toBe(422)
+  })
+
   it('PUT returns 404 for media owned by another account', async () => {
     const id = await createMediaFor(ACTOR2_ID, 'put-foreign')
 

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -8,6 +8,7 @@ import {
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { AuthenticatedApiHandle } from '@/lib/services/guards/types'
 import { deleteMediaFile, saveMediaThumbnail } from '@/lib/services/medias'
+import { MAX_MEDIA_DESCRIPTION_LENGTH } from '@/lib/services/medias/constants'
 import { MediaValidationError } from '@/lib/services/medias/errors'
 import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
 import { FileSchema, FocusSchema } from '@/lib/services/medias/types'
@@ -41,9 +42,10 @@ interface Params {
   id: string
 }
 
-// `description` is stored in a varchar(255) column; cap it to avoid a runtime
-// DB error. Empty/whitespace-only (and explicit null) descriptions are
-// normalised to null so clients can clear alt text by sending "" or null.
+// `description` is capped at Mastodon's 1500-character alt-text limit (the
+// column is `text`, so the cap is API compatibility, not a storage limit).
+// Empty/whitespace-only (and explicit null) descriptions are normalised to
+// null so clients can clear alt text by sending "" or null.
 // `focus` is "x,y" (each axis in [-1.0, 1.0]); a malformed value fails parsing
 // and yields a 422. Both fields are optional; field-level presence is detected
 // from the raw payload so a partial update never clears the field the client
@@ -51,7 +53,7 @@ interface Params {
 const UpdateMediaRequest = z.object({
   description: z
     .string()
-    .max(255)
+    .max(MAX_MEDIA_DESCRIPTION_LENGTH)
     .nullable()
     .optional()
     .transform((value) => (value && value.trim() ? value : null)),

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest } from 'next/server'
-import { z } from 'zod'
 
 import {
   OAuthGuardAnyScope,
@@ -8,10 +7,9 @@ import {
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { AuthenticatedApiHandle } from '@/lib/services/guards/types'
 import { deleteMediaFile, saveMediaThumbnail } from '@/lib/services/medias'
-import { MAX_MEDIA_DESCRIPTION_LENGTH } from '@/lib/services/medias/constants'
 import { MediaValidationError } from '@/lib/services/medias/errors'
 import { getMediaAttachment } from '@/lib/services/medias/getMediaAttachment'
-import { FileSchema, FocusSchema } from '@/lib/services/medias/types'
+import { FileSchema, MediaSchema } from '@/lib/services/medias/types'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
@@ -42,22 +40,15 @@ interface Params {
   id: string
 }
 
-// `description` is capped at Mastodon's 1500-character alt-text limit (the
-// column is `text`, so the cap is API compatibility, not a storage limit).
-// Empty/whitespace-only (and explicit null) descriptions are normalised to
-// null so clients can clear alt text by sending "" or null.
-// `focus` is "x,y" (each axis in [-1.0, 1.0]); a malformed value fails parsing
-// and yields a 422. Both fields are optional; field-level presence is detected
-// from the raw payload so a partial update never clears the field the client
+// Reuse MediaSchema's `description` + `focus` validation so the update path can
+// never drift from the upload path (same 1500-char cap, same empty/whitespace/
+// null -> null normalization, same focus "x,y" parsing that yields a 422 on
+// malformed input). Both fields are optional; field-level presence is detected
+// from the raw payload so a partial update never clears a field the client
 // omitted.
-const UpdateMediaRequest = z.object({
-  description: z
-    .string()
-    .max(MAX_MEDIA_DESCRIPTION_LENGTH)
-    .nullable()
-    .transform((value) => (value && value.trim() ? value : null))
-    .optional(),
-  focus: FocusSchema.optional()
+const UpdateMediaRequest = MediaSchema.pick({
+  description: true,
+  focus: true
 })
 
 const readPayload = async (

--- a/app/api/v1/media/[id]/route.ts
+++ b/app/api/v1/media/[id]/route.ts
@@ -55,8 +55,8 @@ const UpdateMediaRequest = z.object({
     .string()
     .max(MAX_MEDIA_DESCRIPTION_LENGTH)
     .nullable()
-    .optional()
-    .transform((value) => (value && value.trim() ? value : null)),
+    .transform((value) => (value && value.trim() ? value : null))
+    .optional(),
   focus: FocusSchema.optional()
 })
 

--- a/app/api/v1/media/route.test.ts
+++ b/app/api/v1/media/route.test.ts
@@ -133,4 +133,50 @@ describe('POST /api/v1/media', () => {
     expect(data).toMatchObject({ id: '7', type: 'image', blurhash: null })
     expect(mockSaveMedia).toHaveBeenCalledTimes(1)
   })
+
+  it('accepts a 1500-character description and forwards it to saveMedia', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+    const longDescription = 'a'.repeat(1500)
+    const form = buildForm()
+    form.set('description', longDescription)
+    const req = new NextRequest('https://llun.test/api/v1/media', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer write-media-token' }
+    })
+    Object.defineProperty(req, 'formData', {
+      value: vi.fn().mockResolvedValue(form)
+    })
+
+    const response = await POST(req, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    const media = mockSaveMedia.mock.calls[0][2]
+    expect(media.description).toBe(longDescription)
+  })
+
+  it('returns 422 when the description exceeds 1500 characters', async () => {
+    mockStoredToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      referenceId: ACTOR1_ID,
+      scopes: 'write:media'
+    })
+    const form = buildForm()
+    form.set('description', 'a'.repeat(1501))
+    const req = new NextRequest('https://llun.test/api/v1/media', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer write-media-token' }
+    })
+    Object.defineProperty(req, 'formData', {
+      value: vi.fn().mockResolvedValue(form)
+    })
+
+    const response = await POST(req, { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(422)
+    expect(mockSaveMedia).not.toHaveBeenCalled()
+  })
 })

--- a/docs/features.md
+++ b/docs/features.md
@@ -101,6 +101,7 @@ This document tracks the implemented and planned features for Activity.next.
 - [ ] Streaming API for real-time updates
 - [ ] Moderation review dashboard for submitted reports
 - [ ] Bookmark collections
+- [ ] Media attachment `blurhash` computation and animated-GIF `gifv` detection (Mastodon `MediaAttachment` parity — currently always `blurhash: null`, and GIFs are served as `type: "image"`)
 
 ## Feature Requests
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1465,7 +1465,7 @@ const completeUploadPresignedUrlRequest = async ({
       posterUrl: result.media.preview_url ?? undefined,
       width: result.media.meta.original.width,
       height: result.media.meta.original.height,
-      name: result.media.description
+      name: result.media.description ?? undefined
     }
   }
 }

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -269,7 +269,7 @@ export class S3FileStorage implements MediaStorage {
             aspect: presignedMedia.width / presignedMedia.height
           }
         },
-        description: '',
+        description: null,
         blurhash: null
       },
       headers: {

--- a/lib/services/medias/constants.ts
+++ b/lib/services/medias/constants.ts
@@ -15,3 +15,7 @@ export const ACCEPTED_FILE_TYPES = [
   'video/webm',
   'audio/mp4'
 ]
+
+// Mastodon caps media descriptions (alt text) at 1,500 characters.
+// https://docs.joinmastodon.org/user/posting/#media
+export const MAX_MEDIA_DESCRIPTION_LENGTH = 1500

--- a/lib/services/medias/getMediaAttachment.test.ts
+++ b/lib/services/medias/getMediaAttachment.test.ts
@@ -74,10 +74,18 @@ describe('getMediaAttachment', () => {
     )
   })
 
-  it('falls back to an empty description when none is stored', () => {
+  it('emits a null description when none is stored', () => {
     const { description: _description, ...withoutDescription } = baseMedia
     const attachment = getMediaAttachment(withoutDescription, 'llun.test')
-    expect(attachment.description).toBe('')
+    expect(attachment.description).toBeNull()
+  })
+
+  it('normalises an empty stored description to null', () => {
+    const attachment = getMediaAttachment(
+      { ...baseMedia, description: '' },
+      'llun.test'
+    )
+    expect(attachment.description).toBeNull()
   })
 
   it.each([

--- a/lib/services/medias/getMediaAttachment.test.ts
+++ b/lib/services/medias/getMediaAttachment.test.ts
@@ -88,6 +88,22 @@ describe('getMediaAttachment', () => {
     expect(attachment.description).toBeNull()
   })
 
+  it('normalises a whitespace-only stored description to null', () => {
+    const attachment = getMediaAttachment(
+      { ...baseMedia, description: '   ' },
+      'llun.test'
+    )
+    expect(attachment.description).toBeNull()
+  })
+
+  it('returns a real description verbatim, without trimming', () => {
+    const attachment = getMediaAttachment(
+      { ...baseMedia, description: '  a cat  ' },
+      'llun.test'
+    )
+    expect(attachment.description).toBe('  a cat  ')
+  })
+
   it.each([
     {
       description: 'image/png maps to image',

--- a/lib/services/medias/getMediaAttachment.ts
+++ b/lib/services/medias/getMediaAttachment.ts
@@ -64,9 +64,10 @@ export const getMediaAttachment = (
         : {}),
       ...(media.focus ? { focus: media.focus } : {})
     },
-    // Mastodon emits null (not '') when no alt text is set; '' from legacy rows
-    // is normalised to null too.
-    description: media.description || null,
+    // Mastodon emits null (not '') when no alt text is set. Empty and
+    // whitespace-only legacy rows normalise to null too; a real description is
+    // returned verbatim (not trimmed) to match the write-path transform.
+    description: media.description?.trim() ? media.description : null,
     blurhash: null
   })
 }

--- a/lib/services/medias/getMediaAttachment.ts
+++ b/lib/services/medias/getMediaAttachment.ts
@@ -64,7 +64,9 @@ export const getMediaAttachment = (
         : {}),
       ...(media.focus ? { focus: media.focus } : {})
     },
-    description: media.description ?? '',
+    // Mastodon emits null (not '') when no alt text is set; '' from legacy rows
+    // is normalised to null too.
+    description: media.description || null,
     blurhash: null
   })
 }

--- a/lib/services/medias/types.test.ts
+++ b/lib/services/medias/types.test.ts
@@ -18,19 +18,30 @@ describe('PresigedMediaInput', () => {
 describe('MediaSchema', () => {
   const descriptionOnly = MediaSchema.pick({ description: true })
 
+  it('rejects alt text longer than 1500 characters', () => {
+    const result = descriptionOnly.safeParse({ description: 'a'.repeat(1501) })
+    expect(result.success).toBe(false)
+  })
+
   it.each([
     {
-      description: 'accepts alt text at the 1500-character Mastodon limit',
+      description: 'keeps alt text at the 1500-character Mastodon limit',
       value: 'a'.repeat(1500),
-      success: true
+      expected: 'a'.repeat(1500)
     },
     {
-      description: 'rejects alt text longer than 1500 characters',
-      value: 'a'.repeat(1501),
-      success: false
+      description: 'normalises an empty description to null',
+      value: '',
+      expected: null
+    },
+    {
+      description: 'normalises a whitespace-only description to null',
+      value: '   ',
+      expected: null
     }
-  ])('$description', ({ value, success }) => {
+  ])('$description', ({ value, expected }) => {
     const result = descriptionOnly.safeParse({ description: value })
-    expect(result.success).toBe(success)
+    expect(result.success).toBe(true)
+    expect(result.success && result.data.description).toBe(expected)
   })
 })

--- a/lib/services/medias/types.test.ts
+++ b/lib/services/medias/types.test.ts
@@ -1,4 +1,4 @@
-import { PresigedMediaInput } from './types'
+import { MediaSchema, PresigedMediaInput } from './types'
 
 describe('PresigedMediaInput', () => {
   it('normalizes checksum input to lowercase', () => {
@@ -12,5 +12,25 @@ describe('PresigedMediaInput', () => {
     })
 
     expect(parsed.checksum).toBe('a9993e364706816aba3e25717850c26c9cd0d89d')
+  })
+})
+
+describe('MediaSchema', () => {
+  const descriptionOnly = MediaSchema.pick({ description: true })
+
+  it.each([
+    {
+      description: 'accepts alt text at the 1500-character Mastodon limit',
+      value: 'a'.repeat(1500),
+      success: true
+    },
+    {
+      description: 'rejects alt text longer than 1500 characters',
+      value: 'a'.repeat(1501),
+      success: false
+    }
+  ])('$description', ({ value, success }) => {
+    const result = descriptionOnly.safeParse({ description: value })
+    expect(result.success).toBe(success)
   })
 })

--- a/lib/services/medias/types.test.ts
+++ b/lib/services/medias/types.test.ts
@@ -38,6 +38,11 @@ describe('MediaSchema', () => {
       description: 'normalises a whitespace-only description to null',
       value: '   ',
       expected: null
+    },
+    {
+      description: 'accepts an explicit null description as null',
+      value: null,
+      expected: null
     }
   ])('$description', ({ value, expected }) => {
     const result = descriptionOnly.safeParse({ description: value })

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -88,7 +88,8 @@ export const MediaStorageSaveFileOutput = z.object({
     small: MediaMeta.optional(),
     focus: z.object({ x: z.number(), y: z.number() }).optional()
   }),
-  description: z.string(),
+  // Alt text. Mastodon serialises "no description" as null, never ''.
+  description: z.string().nullable(),
   // BlurHash for blurred placeholders. We do not compute it yet, so it is always
   // null, but the field is always present to match Mastodon's serializer.
   blurhash: z.string().nullable()

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -53,8 +53,16 @@ export const MediaSchema = z.object({
   file: FileSchema,
   thumbnail: FileSchema.optional(),
   // Mastodon's alt-text limit. The column is `text`, so this cap is API
-  // compatibility, not a storage constraint.
-  description: z.string().max(MAX_MEDIA_DESCRIPTION_LENGTH).optional(),
+  // compatibility, not a storage constraint. Empty/whitespace-only alt text is
+  // normalised to null so the upload path clears the description the same way
+  // the update path (UpdateMediaRequest) does. `.optional()` stays OUTERMOST so
+  // an omitted field remains an optional key (callers construct MediaSchema
+  // values without a description); a present-but-blank value becomes null.
+  description: z
+    .string()
+    .max(MAX_MEDIA_DESCRIPTION_LENGTH)
+    .transform((value) => (value && value.trim() ? value : null))
+    .optional(),
   focus: FocusSchema.optional()
 })
 export type MediaSchema = z.infer<typeof MediaSchema>

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -61,6 +61,7 @@ export const MediaSchema = z.object({
   description: z
     .string()
     .max(MAX_MEDIA_DESCRIPTION_LENGTH)
+    .nullable()
     .transform((value) => (value && value.trim() ? value : null))
     .optional(),
   focus: FocusSchema.optional()

--- a/lib/services/medias/types.ts
+++ b/lib/services/medias/types.ts
@@ -3,7 +3,11 @@ import { z } from 'zod'
 import { getConfig } from '@/lib/config'
 import { Actor } from '@/lib/types/domain/actor'
 
-import { ACCEPTED_FILE_TYPES, MAX_FILE_SIZE } from './constants'
+import {
+  ACCEPTED_FILE_TYPES,
+  MAX_FILE_SIZE,
+  MAX_MEDIA_DESCRIPTION_LENGTH
+} from './constants'
 
 const FILE_TYPE_ERROR_MESSAGE = `Only ${ACCEPTED_FILE_TYPES.join(',')} are accepted`
 const FILE_SIZE_ERROR_MESSAGE = 'File is larger than the limit.'
@@ -48,7 +52,9 @@ export type FocusSchema = z.infer<typeof FocusSchema>
 export const MediaSchema = z.object({
   file: FileSchema,
   thumbnail: FileSchema.optional(),
-  description: z.string().optional(),
+  // Mastodon's alt-text limit. The column is `text`, so this cap is API
+  // compatibility, not a storage constraint.
+  description: z.string().max(MAX_MEDIA_DESCRIPTION_LENGTH).optional(),
   focus: FocusSchema.optional()
 })
 export type MediaSchema = z.infer<typeof MediaSchema>

--- a/migrations/20260709053955_alter_medias_description_text.js
+++ b/migrations/20260709053955_alter_medias_description_text.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async function (knex) {
+  // Mastodon allows media descriptions (alt text) up to 1,500 characters;
+  // the original varchar(255) column made PostgreSQL reject anything longer.
+  await knex.schema.alterTable('medias', function (table) {
+    table.text('description').nullable().alter()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async function (knex) {
+  // Best-effort rollback: PostgreSQL will refuse the narrowing if any stored
+  // description is longer than 255 characters.
+  await knex.schema.alterTable('medias', function (table) {
+    table.string('description').nullable().alter()
+  })
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -587,7 +587,7 @@ CREATE TABLE public.medias (
     "actorId" character varying(255),
     original character varying(255),
     thumbnail character varying(255),
-    description character varying(255),
+    description text,
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     "accountId" character varying(255),

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -17,7 +17,6 @@ CREATE TABLE `poll_answers` (`answerId` integer not null primary key autoincreme
 CREATE TABLE IF NOT EXISTS "account_providers" (`id` varchar(255), `accountId` varchar(255), `provider` varchar(255), `providerId` varchar(255), `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, `password` text null, `accessToken` text null, `refreshToken` text null, `idToken` text null, `accessTokenExpiresAt` datetime null, `refreshTokenExpiresAt` datetime null, `scope` text null, primary key (`id`));
 CREATE TABLE `sessions` (`id` varchar(255), `accountId` varchar(255), `token` varchar(255), `expireAt` datetime, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, `actorId` varchar(255) null, `ipAddress` text null, `userAgent` text null, primary key (`id`));
 CREATE TABLE `status_history` (`id` integer not null primary key autoincrement, `statusId` varchar(255), `data` json, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP);
-CREATE TABLE `medias` (`id` integer not null primary key autoincrement, `actorId` varchar(255), `original` varchar(255), `thumbnail` varchar(255) null, `description` varchar(255) null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, `accountId` varchar(255), "originalMimeType" varchar(255), "originalBytes" bigint, `thumbnailBytes` bigint null, `thumbnailMimeType` varchar(255) null, `originalMetaData` json, `thumbnailMetaData` json null, `originalFileName` varchar(255) null, `focusX` float null, `focusY` float null);
 CREATE UNIQUE INDEX `timelines_actorId_timeline_statusId_unique` on `timelines` (`actorId`, `timeline`, `statusId`);
 CREATE INDEX `account_providers_accountId_provider_providerId_idx` on `account_providers` (`accountId`, `provider`, `providerId`);
 CREATE INDEX `recipiences_statusId_type_idx` on `recipients` (`statusId`, `type`, `createdAt`, `updatedAt`);
@@ -25,8 +24,6 @@ CREATE INDEX `sessions_accountId_token_idx` on `sessions` (`accountId`, `token`)
 CREATE INDEX `status_history_statusId_idx` on `status_history` (`statusId`, `createdAt`, `updatedAt`);
 CREATE INDEX `statuses_actorId_idx` on `statuses` (`actorId`, `createdAt`, `updatedAt`);
 CREATE INDEX `tags_statusId_type_idx` on `tags` (`statusId`, `type`, `createdAt`, `updatedAt`);
-CREATE INDEX `medias_accountId_originalMimeType_idx` on `medias` (`accountId`, `originalMimeType`);
-CREATE INDEX `medias_actorId_originalMimeType_idx` on `medias` (`actorId`, `originalMimeType`);
 CREATE INDEX `verificationCodeIndex` on `accounts` (`verificationCode`);
 CREATE INDEX `attachments_actorId_idx` on `attachments` (`actorId`);
 CREATE TABLE IF NOT EXISTS "clients" (`id` varchar(255), "name" varchar(255), `secret` varchar(255), `redirectUris` text, `scopes` text, `website` varchar(255), `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
@@ -56,7 +53,6 @@ CREATE TABLE IF NOT EXISTS "counters" (`id` text, `value` bigint not null defaul
 CREATE INDEX `countersIndex` on `counters` (`id`, `createdAt`, `updatedAt`);
 CREATE INDEX `statusesUrlHashIndex` on `statuses` (`urlHash`);
 CREATE INDEX `actors_accountId_idx` on `actors` (`accountId`);
-CREATE INDEX `medias_actorId_createdAt_idx` on `medias` (`actorId`, `createdAt`);
 CREATE INDEX `attachments_mediaId_idx` on `attachments` (`mediaId`);
 CREATE INDEX `recipients_type_actor_created_status_idx` on `recipients` (`type`, `actorId`, `createdAt`, `statusId`);
 CREATE INDEX `passwordResetCodeIndex` on `accounts` (`passwordResetCode`);
@@ -235,3 +231,7 @@ CREATE UNIQUE INDEX `fitness_route_heatmaps_sharetoken_unique` on `fitness_route
 CREATE TABLE `fitness_import_locks` (`lockKey` varchar(255), `token` varchar(255) not null, `expiresAt` bigint not null, `createdAt` datetime default CURRENT_TIMESTAMP, primary key (`lockKey`));
 CREATE INDEX `fitness_import_locks_expiresat_index` on `fitness_import_locks` (`expiresAt`);
 CREATE TABLE `status_detected_languages` (`statusId` varchar(255) not null, `language` varchar(16) not null, `confidence` float, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`statusId`));
+CREATE TABLE IF NOT EXISTS "medias" (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `actorId` varchar(255), `original` varchar(255), `thumbnail` varchar(255) NULL, `description` text NULL, `createdAt` datetime DEFAULT CURRENT_TIMESTAMP, `updatedAt` datetime DEFAULT CURRENT_TIMESTAMP, `accountId` varchar(255), `originalMimeType` varchar(255), `originalBytes` bigint, `thumbnailBytes` bigint NULL, `thumbnailMimeType` varchar(255) NULL, `originalMetaData` json, `thumbnailMetaData` json NULL, `originalFileName` varchar(255) NULL, `focusX` float NULL, `focusY` float NULL);
+CREATE INDEX `medias_accountId_originalMimeType_idx` on `medias` (`accountId`, `originalMimeType`);
+CREATE INDEX `medias_actorId_originalMimeType_idx` on `medias` (`actorId`, `originalMimeType`);
+CREATE INDEX `medias_actorId_createdAt_idx` on `medias` (`actorId`, `createdAt`);


### PR DESCRIPTION
## What

- Mastodon allows 1,500-character media descriptions (alt text); we stored them in a `varchar(255)` column, so >255-char alt text 500'd on PostgreSQL at upload (`MediaSchema` had no length cap) and was rejected with 422 on `PUT /api/v1/media/:id` (`.max(255)`).
- New migration widens `medias.description` to `text`; **both** reference schema dumps (`migrations/schema.sql`, `migrations/schema.sqlite.sql`) regenerated canonically per AGENTS.md.
- Upload (`POST /api/v1/media`, `POST /api/v2/media`) and update (`PUT`/`PATCH /api/v1/media/:id`) now share one `MAX_MEDIA_DESCRIPTION_LENGTH = 1500` cap; >1500 returns 422 like Mastodon.
- MediaAttachment serialization now emits `description: null` when no alt text is set (previously `''`), matching Mastodon's serializer; the S3 presigned-upload output and the web client's presigned-completion path were updated to match.
- `docs/features.md` gains one Planned Features checkbox for the remaining MediaAttachment gaps: `blurhash` computation and `gifv` detection.

## Tests

- Schema-level `it.each` limit tests (1500 vs 1501), upload-route 200/422 boundary tests, update-route boundary tests, and null-description serializer tests; existing `''`-expectation tests updated to `null`.

## Notes

- Migration + both schema dumps regenerated against fresh local DBs (SQLite `.schema`, throwaway local PostgreSQL 17 `pg_dump`). SQLite dump: `medias` table rebuilt with `description text` (all 3 indexes preserved). PostgreSQL dump: single-line `varchar(255)` → `text`.
- Part of Phase 2 (Entity & Parameter Gaps), PR 2.2. Independent of the other Phase 2 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)