### PR TITLE
fix: modern Application entity + authorize params

### DIFF
--- a/app/(nosidebar)/auth/signin/page.test.tsx
+++ b/app/(nosidebar)/auth/signin/page.test.tsx
@@ -108,6 +108,20 @@ describe('/auth/signin already-authenticated resume', () => {
     expect(redirectMock.mock.calls[0][0]).toBe('/')
   })
 
+  it('renders the sign-in form for an authenticated user when force_login is true', async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    const element = await Page({
+      searchParams: Promise.resolve({
+        redirectBack: '/oauth/authorize?client_id=phanpy&scope=read',
+        force_login: 'true'
+      })
+    })
+
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(element).toBeTruthy()
+  })
+
   it('renders the sign-in form for a logged-out visitor (no redirect)', async () => {
     vi.mocked(getServerAuthSession).mockResolvedValue(null)
 

--- a/app/(nosidebar)/auth/signin/page.test.tsx
+++ b/app/(nosidebar)/auth/signin/page.test.tsx
@@ -122,6 +122,24 @@ describe('/auth/signin already-authenticated resume', () => {
     expect(element).toBeTruthy()
   })
 
+  it('still resumes an authenticated user when force_login is the falsy value "false"', async () => {
+    // force_login='false' is a legitimate Mastodon value meaning "do NOT force
+    // re-login": Booleanish parses it as success:true/data:false, so the page
+    // must still auto-resume. Pins that the gate reads `.data`, not just
+    // `.success` (which absent-param and 'true' cases can't distinguish).
+    vi.mocked(getServerAuthSession).mockResolvedValue(aSession)
+
+    await Page({
+      searchParams: Promise.resolve({
+        redirectBack: '/fitness',
+        force_login: 'false'
+      })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    expect(redirectMock.mock.calls[0][0]).toBe('/fitness')
+  })
+
   it('renders the sign-in form for a logged-out visitor (no redirect)', async () => {
     vi.mocked(getServerAuthSession).mockResolvedValue(null)
 

--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -16,6 +16,7 @@ import { getBaseURL, getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 import { CredentialForm } from './CredentialForm'
 import { PasskeySigninButton } from './PasskeySigninButton'
@@ -55,8 +56,16 @@ const Page: FC<Props> = async ({ searchParams }) => {
   const session = await getServerAuthSession()
 
   if (!database) throw new Error('Database is not available')
-  if (session && session.user) {
-    const target = resolveSignInRedirect(toSearchParams(await searchParams))
+  const params = toSearchParams(await searchParams)
+  // Mastodon `force_login`: /oauth/authorize forwards force_login=true when
+  // the client demands a fresh interactive login. Skip the
+  // already-authenticated auto-resume so the form renders; the eventual
+  // sign-in resumes via the accompanying redirectBack (which omits
+  // force_login). safeParse fails on a missing param, which reads as false.
+  const forceLoginParam = Booleanish.safeParse(params.get('force_login'))
+  const forceLogin = forceLoginParam.success && forceLoginParam.data
+  if (session && session.user && !forceLogin) {
+    const target = resolveSignInRedirect(params)
     // Only forward to the consent page when the session has a usable actor —
     // /oauth/authorize bounces an actor-less session straight back here, so
     // resuming without one would loop. Plain logins (target '/') skip the lookup.

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.test.ts
@@ -27,6 +27,20 @@ describe('resolveSignInRedirect', () => {
     expect(query.has('ba_param')).toBe(false)
   })
 
+  it('drops force_login when resuming an OIDC request after a fresh login', () => {
+    const params = new URLSearchParams(
+      'response_type=code&client_id=app&redirect_uri=https%3A%2F%2Fapp.local%2Fcb' +
+        '&scope=read&force_login=true'
+    )
+
+    const result = resolveSignInRedirect(params)
+
+    expect(result.startsWith('/oauth/authorize?')).toBe(true)
+    const query = new URLSearchParams(result.split('?')[1])
+    expect(query.has('force_login')).toBe(false)
+    expect(query.get('client_id')).toBe('app')
+  })
+
   it('prefers a safe redirectBack over OIDC params', () => {
     const params = new URLSearchParams(
       'redirectBack=%2Ffitness&response_type=code&client_id=docs'

--- a/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
+++ b/app/(nosidebar)/auth/signin/resolveSignInRedirect.ts
@@ -9,10 +9,15 @@ import { isSafeInternalPath } from '@/lib/utils/isSafeInternalPath'
 // request: response_type, client_id, redirect_uri, scope, state, PKCE, nonce,
 // prompt, and any other standard param like response_mode/login_hint/max_age)
 // is preserved.
+// `force_login` is not part of the better-auth envelope, but it is consumed
+// here for the same reason prompt=login is stripped below: the interactive
+// login it demanded has just happened, so forwarding it would bounce the
+// now-authenticated user back to the sign-in form in a loop.
 const isBetterAuthEnvelopeKey = (key: string): boolean =>
   key === 'redirectBack' ||
   key === 'sig' ||
   key === 'exp' ||
+  key === 'force_login' ||
   key.startsWith('ba_')
 
 /**

--- a/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
+++ b/app/(nosidebar)/oauth/authorize/authorizeQuery.ts
@@ -33,7 +33,11 @@ const shouldIncludeOAuthParam = (
 
 export const buildOAuthQuery = (params: SearchParams): string => {
   const oauthQuery = new URLSearchParams()
-  const values = params as Record<string, string | null | undefined>
+  // SearchParams carries non-string members (e.g. the coerced `force_login`
+  // boolean); the page strips those before building any query, so treat the
+  // input as the string record this helper actually forwards. The `unknown`
+  // bridge is required because `boolean` no longer overlaps the string record.
+  const values = params as unknown as Record<string, string | null | undefined>
   for (const key of BetterAuthAuthorizationParamOrder) {
     const value = values[key]
     if (shouldIncludeOAuthParam(key, value)) oauthQuery.set(key, value)

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -122,6 +122,75 @@ describe('/oauth/authorize redirect host', () => {
   })
 })
 
+describe('/oauth/authorize Mastodon authorize params', () => {
+  beforeEach(() => {
+    redirectMock.mockClear()
+    vi.mocked(getConfig).mockReturnValue({
+      host: TEST_DOMAIN,
+      trustedHosts: []
+    } as ReturnType<typeof getConfig>)
+    vi.mocked(getBaseURL).mockReturnValue(`https://${TEST_DOMAIN}`)
+    vi.mocked(getActorFromSession).mockResolvedValue(null)
+    headersMock.mockReturnValue(
+      new Headers({ 'x-forwarded-host': TEST_DOMAIN })
+    )
+  })
+
+  it('defaults a missing scope to read instead of returning 404', async () => {
+    await Page({
+      searchParams: Promise.resolve({
+        client_id: 'client-id',
+        redirect_uri: 'https://app.example/callback',
+        response_type: 'code'
+      })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.pathname).toBe('/auth/signin')
+    const redirectBack = new URLSearchParams(
+      (target.searchParams.get('redirectBack') as string).split('?')[1]
+    )
+    expect(redirectBack.get('scope')).toBe('read')
+  })
+
+  it('delegates with the defaulted read scope for an authenticated session', async () => {
+    vi.mocked(getActorFromSession).mockResolvedValue({
+      id: 'actor-id',
+      account: { id: 'account-id' }
+    } as Awaited<ReturnType<typeof getActorFromSession>>)
+
+    await Page({
+      searchParams: Promise.resolve({
+        client_id: 'client-id',
+        redirect_uri: 'https://app.example/callback',
+        response_type: 'code'
+      })
+    })
+
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.pathname).toBe('/api/auth/oauth2/authorize')
+    expect(target.searchParams.get('scope')).toBe('read')
+  })
+
+  it('accepts the Mastodon lang param and never forwards it', async () => {
+    // Regression pin: before this change lang was silently stripped by Zod;
+    // now it is an explicit schema member that must still not leak into
+    // forwarded queries.
+    await Page({
+      searchParams: Promise.resolve({ ...searchParams, lang: 'fr' })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.pathname).toBe('/auth/signin')
+    const redirectBack = new URLSearchParams(
+      (target.searchParams.get('redirectBack') as string).split('?')[1]
+    )
+    expect(redirectBack.has('lang')).toBe(false)
+  })
+})
+
 describe('/oauth/authorize account summary', () => {
   beforeEach(() => {
     redirectMock.mockClear()

--- a/app/(nosidebar)/oauth/authorize/page.test.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.test.tsx
@@ -189,6 +189,46 @@ describe('/oauth/authorize Mastodon authorize params', () => {
     )
     expect(redirectBack.has('lang')).toBe(false)
   })
+
+  it('redirects an authenticated session to sign-in when force_login is true', async () => {
+    vi.mocked(getActorFromSession).mockResolvedValue({
+      id: 'actor-id',
+      account: { id: 'account-id' }
+    } as Awaited<ReturnType<typeof getActorFromSession>>)
+
+    await Page({
+      searchParams: Promise.resolve({ ...searchParams, force_login: 'true' })
+    })
+
+    expect(redirectMock).toHaveBeenCalledTimes(1)
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.pathname).toBe('/auth/signin')
+    expect(target.searchParams.get('force_login')).toBe('true')
+    // redirectBack must NOT carry force_login or the resumed request would
+    // bounce straight back to sign-in forever.
+    const redirectBack = new URLSearchParams(
+      (target.searchParams.get('redirectBack') as string).split('?')[1]
+    )
+    expect(redirectBack.has('force_login')).toBe(false)
+    expect(redirectBack.get('client_id')).toBe('client-id')
+  })
+
+  it('proceeds with the active session when force_login is false', async () => {
+    // Regression pin: a falsy force_login must not force re-authentication
+    // and must not leak into the delegated better-auth query.
+    vi.mocked(getActorFromSession).mockResolvedValue({
+      id: 'actor-id',
+      account: { id: 'account-id' }
+    } as Awaited<ReturnType<typeof getActorFromSession>>)
+
+    await Page({
+      searchParams: Promise.resolve({ ...searchParams, force_login: 'false' })
+    })
+
+    const target = new URL(redirectMock.mock.calls[0][0])
+    expect(target.pathname).toBe('/api/auth/oauth2/authorize')
+    expect(target.searchParams.has('force_login')).toBe(false)
+  })
 })
 
 describe('/oauth/authorize account summary', () => {

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -39,9 +39,10 @@ const Page: FC<Props> = async ({ searchParams }) => {
     return notFound()
   }
   // `lang` is accepted for Mastodon compatibility but intentionally unused
-  // (the consent UI is not localized); destructure it away so it is never
-  // forwarded to better-auth or into sign-in redirectBack URLs.
-  const { lang: _lang, ...params } = parsedResult.data
+  // (the consent UI is not localized); destructure it — and force_login,
+  // which is consumed right below — away so neither is ever forwarded to
+  // better-auth or into sign-in redirectBack URLs.
+  const { force_login: forceLogin, lang: _lang, ...params } = parsedResult.data
 
   const actor = await getActorFromSession(database, session)
 
@@ -54,9 +55,16 @@ const Page: FC<Props> = async ({ searchParams }) => {
   const { protocol } = new URL(getBaseURL())
   const requestBaseURL = `${protocol}//${requestHost}`
 
-  if (!actor || !actor.account) {
+  // Mastodon `force_login=true` forces re-authentication even when a session
+  // exists. redirectBack deliberately omits force_login: once the fresh login
+  // happens the requirement is satisfied, and keeping it would bounce the
+  // resumed request back to sign-in forever. The extra force_login param on
+  // the sign-in URL tells that page to skip its already-authenticated
+  // auto-resume so the form actually renders.
+  if (!actor || !actor.account || forceLogin) {
     const url = new URL('/auth/signin', requestBaseURL)
     url.searchParams.append('redirectBack', buildOAuthAuthorizePath(params))
+    if (forceLogin) url.searchParams.append('force_login', 'true')
     return redirect(url.toString())
   }
 

--- a/app/(nosidebar)/oauth/authorize/page.tsx
+++ b/app/(nosidebar)/oauth/authorize/page.tsx
@@ -21,7 +21,9 @@ import { SearchParams } from './types'
 export const dynamic = 'force-dynamic'
 
 interface Props {
-  searchParams: Promise<SearchParams>
+  // Raw query params as Next.js provides them; SearchParams.safeParse below
+  // produces the typed/coerced form.
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 const Page: FC<Props> = async ({ searchParams }) => {
@@ -36,7 +38,10 @@ const Page: FC<Props> = async ({ searchParams }) => {
   if (!parsedResult.success) {
     return notFound()
   }
-  const params = parsedResult.data
+  // `lang` is accepted for Mastodon compatibility but intentionally unused
+  // (the consent UI is not localized); destructure it away so it is never
+  // forwarded to better-auth or into sign-in redirectBack URLs.
+  const { lang: _lang, ...params } = parsedResult.data
 
   const actor = await getActorFromSession(database, session)
 

--- a/app/(nosidebar)/oauth/authorize/types.ts
+++ b/app/(nosidebar)/oauth/authorize/types.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 
 export const SearchParams = z.object({
   client_id: z.string(),
-  scope: z.string(),
+  // Mastodon defaults a missing scope to `read`
+  // (https://docs.joinmastodon.org/methods/oauth/#authorize). Output stays a
+  // plain string so consumers can keep calling scope.split(' ').
+  scope: z.string().default('read'),
   redirect_uri: z.string(),
   response_type: z.literal('code'),
   // Signed params from better-auth oauth-provider
@@ -14,6 +17,10 @@ export const SearchParams = z.object({
   code_challenge: z.string().optional(),
   code_challenge_method: z.string().optional(),
   nonce: z.string().optional(),
-  prompt: z.string().optional()
+  prompt: z.string().optional(),
+  // Mastodon `lang`: locale hint for the authorization screen. Accepted for
+  // compatibility and intentionally ignored — this consent UI is not
+  // localized — and stripped by the page before any query is forwarded.
+  lang: z.string().optional()
 })
 export type SearchParams = z.infer<typeof SearchParams>

--- a/app/(nosidebar)/oauth/authorize/types.ts
+++ b/app/(nosidebar)/oauth/authorize/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { Booleanish } from '@/lib/utils/zodBooleanish'
+
 export const SearchParams = z.object({
   client_id: z.string(),
   // Mastodon defaults a missing scope to `read`
@@ -18,6 +20,10 @@ export const SearchParams = z.object({
   code_challenge_method: z.string().optional(),
   nonce: z.string().optional(),
   prompt: z.string().optional(),
+  // Mastodon `force_login`: force the login form even with an active session
+  // (needed to authorize a second account from the same browser). Coerced to a
+  // boolean; the page strips it before forwarding the OAuth query.
+  force_login: Booleanish.optional(),
   // Mastodon `lang`: locale hint for the authorization screen. Accepted for
   // compatibility and intentionally ignored — this consent UI is not
   // localized — and stripped by the page before any query is forwarded.

--- a/app/api/oauth/userinfo/route.test.ts
+++ b/app/api/oauth/userinfo/route.test.ts
@@ -27,6 +27,17 @@ vi.mock('@/lib/services/guards/OAuthGuard', () => ({
       })
 }))
 
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'example.com', trustedHosts: [] })
+}))
+
+// Host resolution is unit-tested in lib/services/auth/requestOrigin.test.ts;
+// here it only has to be deterministic so
+// iss = 'https://example.com' + AUTH_BASE_PATH.
+vi.mock('@/lib/services/auth/requestOrigin', () => ({
+  resolveAuthBaseURL: () => 'https://example.com'
+}))
+
 const { GET } = await import('./route')
 
 const makeAccount = (overrides: Partial<Account> = {}): Account => {
@@ -91,12 +102,14 @@ describe('GET /oauth/userinfo', () => {
     expect(response.status).toBe(200)
     // OIDC §5.3.2: the userinfo sub is the account id (matches the id_token sub).
     expect(body.sub).toBe('account-sub-xyz')
+    // Same value the discovery document advertises as `issuer`.
+    expect(body.iss).toBe('https://example.com/api/auth')
     expect(body.preferred_username).toBe('testuser')
     expect(body.email).toBe('test@example.com')
     expect(body.email_verified).toBe(true)
   })
 
-  it('returns only sub for openid-only scope', async () => {
+  it('returns only iss and sub for openid-only scope', async () => {
     const account = makeAccount({ id: 'account-openid-only' })
     guardState.currentActor = makeActor(account)
     guardState.grantedScopes = ['openid']
@@ -106,6 +119,7 @@ describe('GET /oauth/userinfo', () => {
 
     expect(response.status).toBe(200)
     expect(body.sub).toBe('account-openid-only')
+    expect(body.iss).toBe('https://example.com/api/auth')
     expect(body).not.toHaveProperty('preferred_username')
     expect(body).not.toHaveProperty('email')
   })

--- a/app/api/oauth/userinfo/route.ts
+++ b/app/api/oauth/userinfo/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest } from 'next/server'
 
+import { getConfig } from '@/lib/config'
+import { AUTH_BASE_PATH } from '@/lib/services/auth/constants'
+import { resolveAuthBaseURL } from '@/lib/services/auth/requestOrigin'
 import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
 import { getUserInfo } from '@/lib/services/oauth/userinfo'
 import { Scope } from '@/lib/types/database/operations'
@@ -38,6 +41,10 @@ const respondWithUserInfo = OAuthGuardAnyScope(
     const userInfo = getUserInfo({
       actor: currentActor,
       account,
+      // Same issuer the discovery document advertises (and better-auth stamps
+      // into id_tokens): the validated per-request origin + auth basePath, so
+      // a relying party can match userinfo `iss` against the id_token `iss`.
+      issuer: `${resolveAuthBaseURL(req.headers, getConfig())}${AUTH_BASE_PATH}`,
       scopes: grantedScopes
     })
 

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -316,6 +316,18 @@ describe('createApplication', () => {
     expect(response.website).toBeNull()
   })
 
+  test('it returns website null when the registration passes a blank website', async () => {
+    const response = (await createApplication({
+      client_name: 'blankWebsiteClient',
+      redirect_uris: 'https://blank-website.llun.dev/callback',
+      scopes: 'read',
+      website: ''
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+    expect(response.website).toBeNull()
+  })
+
   test('it accepts redirect_uris as an array of URIs (Mastodon 4.3 form)', async () => {
     const response = (await createApplication({
       client_name: 'arrayRedirectClient',

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -61,9 +61,12 @@ describe('createApplication', () => {
       id: expect.toBeString(),
       client_id: expect.toBeString(),
       client_secret: expect.toBeString(),
+      client_secret_expires_at: 0,
       name: 'client1',
       website: 'https://test.llun.dev',
-      redirect_uri: 'https://test.llun.dev/apps/redirect'
+      scopes: ['read', 'write'],
+      redirect_uri: 'https://test.llun.dev/apps/redirect',
+      redirect_uris: ['https://test.llun.dev/apps/redirect']
     })
     expect(response.id).not.toEqual(response.client_id)
     expect(response.id).toMatch(
@@ -86,9 +89,12 @@ describe('createApplication', () => {
       id: expect.toBeString(),
       client_id: expect.toBeString(),
       client_secret: expect.toBeString(),
+      client_secret_expires_at: 0,
       name: 'existsClient',
       website: 'https://test.llun.dev',
-      redirect_uri: 'https://test.llun.dev/apps/redirect'
+      scopes: ['read', 'write'],
+      redirect_uri: 'https://test.llun.dev/apps/redirect',
+      redirect_uris: ['https://test.llun.dev/apps/redirect']
     })
   })
 
@@ -288,7 +294,26 @@ describe('createApplication', () => {
       { registrationKey: 'multi-redirect-source' }
     )) as SuccessResponse
     expect(response.type).toEqual('success')
-    expect(response.redirect_uri).toEqual('https://test.llun.dev/callback')
+    // Deprecated field: 4.3 semantics are the newline-join of ALL URIs, no
+    // longer just the first one.
+    expect(response.redirect_uri).toEqual(
+      'https://test.llun.dev/callback\nhttps://test.llun.dev/alt-callback'
+    )
+    expect(response.redirect_uris).toEqual([
+      'https://test.llun.dev/callback',
+      'https://test.llun.dev/alt-callback'
+    ])
+  })
+
+  test('it returns website null when the registration omits website', async () => {
+    const response = (await createApplication({
+      client_name: 'noWebsiteClient',
+      redirect_uris: 'https://no-website.llun.dev/callback',
+      scopes: 'read'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+    expect(response.website).toBeNull()
   })
 
   test('it accepts redirect_uris as an array of URIs (Mastodon 4.3 form)', async () => {

--- a/app/api/v1/apps/createApplication.test.ts
+++ b/app/api/v1/apps/createApplication.test.ts
@@ -291,6 +291,42 @@ describe('createApplication', () => {
     expect(response.redirect_uri).toEqual('https://test.llun.dev/callback')
   })
 
+  test('it accepts redirect_uris as an array of URIs (Mastodon 4.3 form)', async () => {
+    const response = (await createApplication({
+      client_name: 'arrayRedirectClient',
+      redirect_uris: [
+        'https://array.llun.dev/callback',
+        'https://array.llun.dev/alt-callback'
+      ],
+      scopes: 'read',
+      website: 'https://array.llun.dev'
+    })) as SuccessResponse
+
+    expect(response.type).toBe('success')
+
+    const dbClient = await knexDatabase('oauthClient')
+      .where({ id: response.id })
+      .first()
+    expect(JSON.parse(dbClient.redirectUris)).toEqual([
+      'https://array.llun.dev/callback',
+      'https://array.llun.dev/alt-callback'
+    ])
+  })
+
+  test('it errors when redirect_uris is an empty array', async () => {
+    const response = await createApplication({
+      client_name: 'emptyArrayRedirectClient',
+      redirect_uris: [],
+      scopes: 'read',
+      website: 'https://empty-array.llun.dev'
+    })
+
+    expect(response).toEqual({
+      type: 'error',
+      error: 'Failed to validate request'
+    })
+  })
+
   test('it enables end-session and stores post_logout_redirect_uris as a JSON-array string when provided', async () => {
     const response = (await createApplication({
       client_name: 'logoutClient',

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -313,7 +313,10 @@ export const createApplication = async (
           // Mastodon 4.3+: 0 means the client secret never expires.
           client_secret_expires_at: 0,
           name: request.client_name,
-          website: request.website ?? null,
+          // Match the persisted value (line uses `|| null`): a present-but-blank
+          // website is stored as null and read back as null by verify_credentials,
+          // so the create response must report null too, not "".
+          website: request.website || null,
           scopes: parsedScopes,
           redirect_uris: redirectUris,
           // Deprecated in Mastodon 4.3 but still returned: the newline-joined

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -310,9 +310,15 @@ export const createApplication = async (
           id: dbId,
           client_id: clientId,
           client_secret: clientSecret,
+          // Mastodon 4.3+: 0 means the client secret never expires.
+          client_secret_expires_at: 0,
           name: request.client_name,
-          website: request.website,
-          redirect_uri: redirectUris[0]
+          website: request.website ?? null,
+          scopes: parsedScopes,
+          redirect_uris: redirectUris,
+          // Deprecated in Mastodon 4.3 but still returned: the newline-joined
+          // form of ALL registered URIs (previously only the first).
+          redirect_uri: redirectUris.join('\n')
         }
         return response
       } catch (error) {

--- a/app/api/v1/apps/createApplication.ts
+++ b/app/api/v1/apps/createApplication.ts
@@ -229,9 +229,13 @@ export const createApplication = async (
           }
           parsedScopes.push(parsed.data)
         }
-        // Mastodon API: multiple redirect URIs are newline-separated
-        const redirectUris = request.redirect_uris
-          .split('\n')
+        // Mastodon API: multiple redirect URIs arrive as a JSON array (4.3+)
+        // or as a single newline-separated string (deprecated pre-4.3 form).
+        const redirectUris = (
+          Array.isArray(request.redirect_uris)
+            ? request.redirect_uris
+            : request.redirect_uris.split('\n')
+        )
           .map((uri) => uri.trim())
           .filter(Boolean)
         if (redirectUris.length === 0) {

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -3,9 +3,13 @@ import { NextRequest } from 'next/server'
 
 import { POST, resetAppRegistrationWarningStateForTests } from './route'
 
-const mockGetConfig = vi.fn(() => ({
-  secretPhase: 'registration-pepper-secret'
-}))
+type MockConfig = {
+  secretPhase: string
+  push?: { vapidPublicKey: string }
+}
+const mockGetConfig = vi.fn(
+  (): MockConfig => ({ secretPhase: 'registration-pepper-secret' })
+)
 const mockGetTrustProxyIpHeadersConfig = vi.fn(() => false)
 
 const hashIpRegistrationKey = (ip: string) =>
@@ -63,9 +67,12 @@ describe('apps route', () => {
       id: 'app-id',
       client_id: 'client-id',
       client_secret: 'client-secret',
+      client_secret_expires_at: 0,
       name: 'client',
       website: null,
-      redirect_uri: 'https://client.llun.dev/callback'
+      scopes: ['read'],
+      redirect_uri: 'https://client.llun.dev/callback',
+      redirect_uris: ['https://client.llun.dev/callback']
     })
   })
 
@@ -195,6 +202,54 @@ describe('apps route', () => {
       }),
       { registrationKey: undefined }
     )
+  })
+
+  test('includes the configured vapid_key in the registration response', async () => {
+    mockGetConfig.mockReturnValue({
+      secretPhase: 'registration-pepper-secret',
+      push: { vapidPublicKey: 'vapid-public-key' }
+    })
+    const req = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        client_name: 'client',
+        redirect_uris: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      id: 'app-id',
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      client_secret_expires_at: 0,
+      name: 'client',
+      website: null,
+      scopes: ['read'],
+      redirect_uri: 'https://client.llun.dev/callback',
+      redirect_uris: ['https://client.llun.dev/callback'],
+      vapid_key: 'vapid-public-key'
+    })
+  })
+
+  test('returns vapid_key null when web push is not configured', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        client_name: 'client',
+        redirect_uris: 'https://client.llun.dev/callback'
+      })
+    })
+
+    const response = await POST(req)
+    const body = await response.json()
+
+    expect(body.vapid_key).toBeNull()
   })
 
   test('returns too many requests when app registration is throttled', async () => {

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -7,9 +7,9 @@ type MockConfig = {
   secretPhase: string
   push?: { vapidPublicKey: string }
 }
-const mockGetConfig = vi.fn(
-  (): MockConfig => ({ secretPhase: 'registration-pepper-secret' })
-)
+const mockGetConfig = vi.fn((): MockConfig => ({
+  secretPhase: 'registration-pepper-secret'
+}))
 const mockGetTrustProxyIpHeadersConfig = vi.fn(() => false)
 
 const hashIpRegistrationKey = (ip: string) =>

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -170,6 +170,33 @@ describe('apps route', () => {
     expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
   })
 
+  test('accepts the Mastodon 4.3 array form of redirect_uris', async () => {
+    const req = new NextRequest('https://llun.test/api/v1/apps', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        client_name: 'array-client',
+        redirect_uris: [
+          'https://client.llun.dev/callback',
+          'https://client.llun.dev/alt-callback'
+        ]
+      })
+    })
+
+    const response = await POST(req)
+
+    expect(response.status).toBe(200)
+    expect(mockCreateApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirect_uris: [
+          'https://client.llun.dev/callback',
+          'https://client.llun.dev/alt-callback'
+        ]
+      }),
+      { registrationKey: undefined }
+    )
+  })
+
   test('returns too many requests when app registration is throttled', async () => {
     mockCreateApplication.mockResolvedValue({
       type: 'error',

--- a/app/api/v1/apps/route.ts
+++ b/app/api/v1/apps/route.ts
@@ -138,6 +138,16 @@ export const POST = traceApiRoute('createApp', async (req: NextRequest) => {
     })
   }
 
-  const { type: _type, ...data } = response
-  return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
+  const { type: _type, ...application } = response
+  return apiResponse({
+    req,
+    allowedMethods: CORS_HEADERS,
+    data: {
+      ...application,
+      // Same source as GET /api/v1/apps/verify_credentials: the Web Push VAPID
+      // public key, or null when push is not configured. Deprecated in
+      // Mastodon 4.3 but still part of the CredentialApplication entity.
+      vapid_key: getConfig().push?.vapidPublicKey ?? null
+    }
+  })
 })

--- a/app/api/v1/apps/types.ts
+++ b/app/api/v1/apps/types.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 
 export const PostRequest = z.object({
   client_name: z.string(),
-  redirect_uris: z.string(),
+  // Mastodon ≤4.2 sends a single (possibly newline-separated) string; 4.3+
+  // clients may send a JSON array of URIs. Accept both; createApplication
+  // normalizes to an array.
+  redirect_uris: z.union([z.string(), z.string().array()]),
   // Optional OpenID Connect RP-Initiated Logout callbacks. Like `redirect_uris`
   // these are newline-separated. When present (and at least one valid URI is
   // given) the created client gets `enableEndSession = true` so it can drive

--- a/app/api/v1/apps/types.ts
+++ b/app/api/v1/apps/types.ts
@@ -21,10 +21,15 @@ export const SuccessResponse = z.object({
   type: z.literal('success'),
   id: z.string(),
   name: z.string(),
-  website: z.string().optional(),
+  website: z.string().nullable(),
+  scopes: z.string().array(),
+  // Deprecated in Mastodon 4.3 but still returned: newline-join of all URIs.
   redirect_uri: z.string(),
+  redirect_uris: z.string().array(),
   client_id: z.string(),
-  client_secret: z.string()
+  client_secret: z.string(),
+  // 0 means the client secret never expires (Mastodon 4.3+).
+  client_secret_expires_at: z.literal(0)
 })
 export type SuccessResponse = z.infer<typeof SuccessResponse>
 

--- a/app/api/v1/apps/verify_credentials/route.test.ts
+++ b/app/api/v1/apps/verify_credentials/route.test.ts
@@ -103,8 +103,12 @@ describe('GET /api/v1/apps/verify_credentials', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual({
+      id: 'client-row-1',
       name: 'Test App',
       website: 'https://app.example.com',
+      scopes: ['read'],
+      redirect_uris: ['https://app.example.com/callback'],
+      redirect_uri: 'https://app.example.com/callback',
       vapid_key: 'vapid-public-key'
     })
     // App tokens have no actor; the route never resolves one.
@@ -132,8 +136,43 @@ describe('GET /api/v1/apps/verify_credentials', () => {
     expect(data).toEqual({
       name: 'Web',
       website: null,
+      scopes: [],
+      redirect_uris: [],
+      redirect_uri: '',
       vapid_key: 'vapid-public-key'
     })
+  })
+
+  test('joins multiple registered redirect URIs with newlines in redirect_uri', async () => {
+    mockStoredTokens.set(hashToken('multi-token'), {
+      token: hashToken('multi-token'),
+      referenceId: null,
+      clientId: 'client-app-1',
+      expiresAt: new Date(Date.now() + 3600000),
+      scopes: JSON.stringify(['read'])
+    })
+    mockClients.set(
+      'client-app-1',
+      buildClient({
+        redirectUris: [
+          'https://app.example.com/callback',
+          'https://app.example.com/alt-callback'
+        ]
+      })
+    )
+
+    const response = await GET(createRequest('multi-token'), {
+      params: Promise.resolve({})
+    })
+    const data = await response.json()
+
+    expect(data.redirect_uris).toEqual([
+      'https://app.example.com/callback',
+      'https://app.example.com/alt-callback'
+    ])
+    expect(data.redirect_uri).toBe(
+      'https://app.example.com/callback\nhttps://app.example.com/alt-callback'
+    )
   })
 
   test('returns 200 for a user token', async () => {

--- a/app/api/v1/apps/verify_credentials/route.ts
+++ b/app/api/v1/apps/verify_credentials/route.ts
@@ -14,19 +14,28 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 // required), so authenticate against the full usable-scope set rather than
 // requiring `read`. App (client_credentials) tokens have no associated actor,
 // so OAuthAppGuard validates the token without requiring one and provides the
-// owning client whose public-facing details we echo back.
+// owning client, echoed back as a full Application entity. When the owning
+// client row was deleted the route keeps answering 200 with generic fallbacks
+// (and no id — there is no application row left to identify).
 export const GET = traceApiRoute(
   'verifyAppCredentials',
   OAuthAppGuard(
     [...UsableScopes],
     async (req, { client }) => {
       const config = getConfig()
+      const redirectUris = client?.redirectUris ?? []
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: {
+          ...(client ? { id: client.id } : {}),
           name: client?.name ?? 'Web',
           website: client?.website ?? null,
+          scopes: client?.scopes ?? [],
+          redirect_uris: redirectUris,
+          // Deprecated in Mastodon 4.3 but still returned: the newline-joined
+          // form of all registered redirect URIs.
+          redirect_uri: redirectUris.join('\n'),
           vapid_key: config.push?.vapidPublicKey ?? null
         }
       })

--- a/lib/services/oauth/userinfo.test.ts
+++ b/lib/services/oauth/userinfo.test.ts
@@ -36,10 +36,29 @@ const makeAccount = (overrides: Partial<Account> = {}): Account => {
   }
 }
 
+// The same `${baseURL}${AUTH_BASE_PATH}` value the discovery document
+// advertises; the route passes it in per request.
+const ISSUER = 'https://example.com/api/auth'
+
 describe('getUserInfo', () => {
+  it('includes iss matching the discovery issuer', () => {
+    const userInfo = getUserInfo({
+      actor: makeActor(),
+      account: makeAccount(),
+      issuer: ISSUER,
+      scopes: ['openid']
+    })
+
+    expect(userInfo.iss).toBe(ISSUER)
+  })
+
   it('uses the account id as the sub claim, not the actor id', () => {
     const account = makeAccount({ id: 'account-sub-123' })
-    const userInfo = getUserInfo({ actor: makeActor(), account })
+    const userInfo = getUserInfo({
+      actor: makeActor(),
+      account,
+      issuer: ISSUER
+    })
 
     // OIDC §5.3.2: the userinfo sub MUST match the id_token sub. Better Auth
     // signs the id_token with the account (user) id, so the canonical subject
@@ -60,6 +79,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor(),
       account,
+      issuer: ISSUER,
       scopes: ['openid']
     })
 
@@ -68,7 +88,11 @@ describe('getUserInfo', () => {
 
   it('returns sub, profile and email claims when no scopes are specified (legacy/session)', () => {
     const account = makeAccount({ id: 'account-1' })
-    const userInfo = getUserInfo({ actor: makeActor(), account })
+    const userInfo = getUserInfo({
+      actor: makeActor(),
+      account,
+      issuer: ISSUER
+    })
 
     expect(userInfo.sub).toBe('account-1')
     expect(userInfo.name).toBe('Test User')
@@ -79,19 +103,16 @@ describe('getUserInfo', () => {
     expect(userInfo.email_verified).toBe(true)
   })
 
-  it('returns only sub for openid-only scope', () => {
+  it('returns only iss and sub for openid-only scope', () => {
     const account = makeAccount({ id: 'account-1' })
     const userInfo = getUserInfo({
       actor: makeActor(),
       account,
+      issuer: ISSUER,
       scopes: ['openid']
     })
 
-    expect(userInfo.sub).toBe('account-1')
-    expect(userInfo).not.toHaveProperty('name')
-    expect(userInfo).not.toHaveProperty('preferred_username')
-    expect(userInfo).not.toHaveProperty('email')
-    expect(userInfo).not.toHaveProperty('email_verified')
+    expect(userInfo).toEqual({ iss: ISSUER, sub: 'account-1' })
   })
 
   it('includes profile claims when profile scope is granted', () => {
@@ -99,6 +120,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor(),
       account,
+      issuer: ISSUER,
       scopes: ['openid', 'profile']
     })
 
@@ -114,6 +136,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor(),
       account: makeAccount(),
+      issuer: ISSUER,
       scopes: ['read']
     })
 
@@ -121,16 +144,19 @@ describe('getUserInfo', () => {
     expect(userInfo.preferred_username).toBe('testuser')
   })
 
-  it('omits name and picture when actor has null values', () => {
+  it('returns empty-string name and picture when the actor has none', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ name: null, iconUrl: null }),
       account: makeAccount(),
+      issuer: ISSUER,
       scopes: ['openid', 'profile']
     })
 
-    expect(userInfo).not.toHaveProperty('name')
+    // Mastodon always returns these claims from /oauth/userinfo; empty
+    // string, not omission.
+    expect(userInfo.name).toBe('')
+    expect(userInfo.picture).toBe('')
     expect(userInfo.preferred_username).toBe('testuser')
-    expect(userInfo).not.toHaveProperty('picture')
     expect(userInfo.profile).toBe('https://example.com/users/testuser')
   })
 
@@ -144,6 +170,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
       account,
+      issuer: ISSUER,
       scopes: ['openid', 'email']
     })
 
@@ -162,6 +189,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
       account,
+      issuer: ISSUER,
       scopes: ['openid', 'profile']
     })
 
@@ -180,6 +208,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
       account,
+      issuer: ISSUER,
       scopes: ['openid', 'email']
     })
 
@@ -198,6 +227,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
       account,
+      issuer: ISSUER,
       scopes: ['openid', 'email']
     })
 
@@ -215,6 +245,7 @@ describe('getUserInfo', () => {
     const userInfo = getUserInfo({
       actor: makeActor({ account }),
       account,
+      issuer: ISSUER,
       scopes: ['openid', 'email']
     })
 

--- a/lib/services/oauth/userinfo.ts
+++ b/lib/services/oauth/userinfo.ts
@@ -2,6 +2,7 @@ import { Account } from '@/lib/types/domain/account'
 import { Actor } from '@/lib/types/domain/actor'
 
 export interface UserInfoBase {
+  iss: string
   sub: string
 }
 
@@ -24,12 +25,14 @@ export type UserInfo = UserInfoBase &
 interface GetUserInfoOptions {
   actor: Actor
   account: Account
+  issuer: string
   scopes?: string[]
 }
 
 export const getUserInfo = ({
   actor,
   account,
+  issuer,
   scopes
 }: GetUserInfoOptions): UserInfo => {
   const includeProfile =
@@ -38,16 +41,27 @@ export const getUserInfo = ({
   const email = account.email
 
   return {
+    // The issuer this response was produced by — the same
+    // `${baseURL}${AUTH_BASE_PATH}` the OpenID discovery document advertises
+    // and better-auth stamps as the id_token `iss`. Mastodon 4.3+ also
+    // returns `iss` from /oauth/userinfo.
+    iss: issuer,
     // OIDC §5.3.2 requires the userinfo `sub` to equal the id_token `sub`. Better
     // Auth signs the id_token with `sub = account id` (the user record id), so the
     // canonical subject here is the owning account id — one OIDC subject per human,
-    // regardless of how many ActivityPub actors that account owns. Profile fields
-    // below stay actor-sourced (the actor selected for this session/token).
+    // regardless of how many ActivityPub actors that account owns. This is an
+    // intentional divergence from Mastodon (which returns the account URL as
+    // `sub`): changing it would break every relying party that stored the
+    // id_token `sub`. Profile fields below stay actor-sourced (the actor
+    // selected for this session/token).
     sub: account.id,
     ...(includeProfile && {
-      ...(actor.name != null ? { name: actor.name } : {}),
+      // Mastodon always returns name/picture from /oauth/userinfo; fall back
+      // to empty strings instead of omitting the claims when the actor has
+      // none.
+      name: actor.name ?? '',
       preferred_username: actor.username,
-      ...(actor.iconUrl != null ? { picture: actor.iconUrl } : {}),
+      picture: actor.iconUrl ?? '',
       profile: actor.id
     }),
     ...(includeEmail && email != null


### PR DESCRIPTION
## What

- `POST /api/v1/apps` now accepts `redirect_uris` as a newline-separated string (pre-4.3 form) **or** a JSON array (Mastodon 4.3+ form); previously the array form failed validation with 422.
- `POST /api/v1/apps` returns the modern CredentialApplication entity: `scopes[]`, `redirect_uris[]`, `client_secret_expires_at: 0`, `vapid_key` (from push config, `null` when push is unconfigured), `website: null` when absent, and the deprecated `redirect_uri` is now the newline-join of ALL registered URIs (was: first URI only).
- `GET /api/v1/apps/verify_credentials` returns the full Application entity (`id`, `name`, `website`, `scopes[]`, `redirect_uris[]`, newline-joined `redirect_uri`, `vapid_key`) instead of the pre-4.3 `{name, website, vapid_key}`; a token whose client row was deleted still answers 200 with generic fallbacks and no `id`.
- `GET /oauth/authorize` no longer 404s when `scope` is missing — it defaults to `read` per the Mastodon docs; `lang` is now an explicit accepted-and-ignored schema param (stripped before any forwarded query).
- `GET /oauth/authorize` honors `force_login=true`: an authenticated session is sent to the sign-in form (the sign-in page skips its already-authenticated auto-resume when `force_login` is set), and `force_login` is consumed after the fresh login so the resumed request can never loop.
- `GET/POST /oauth/userinfo` now returns `iss` (identical to the discovery document's `issuer` for the request host) and always includes `name`/`picture` (empty string when the actor has none) whenever profile claims are granted.
- Intentional divergence (documented in code): userinfo `sub` stays the better-auth account id, not Mastodon's account URL — OIDC requires userinfo `sub` to equal the id_token `sub`, and changing it would break existing relying parties.

## Notes

- No DB migrations; reference schema dumps unchanged. Tests: new/updated Vitest coverage in `app/api/v1/apps/*`, `app/api/v1/apps/verify_credentials/*`, `app/(nosidebar)/oauth/authorize/page.test.tsx`, `app/(nosidebar)/auth/signin/*`, `lib/services/oauth/userinfo.test.ts`, `app/api/oauth/userinfo/route.test.ts`.
- Part of Phase 2 (Entity & Parameter Gaps), PR 2.3. Independent of the other Phase 2 PRs.

## Out of scope, found while reading

- The signin page's already-authenticated auto-resume also defeats better-auth's own `prompt=login` for OIDC relying parties (`resolveSignInRedirect` strips `login` tokens and resumes without an interactive login when a session exists). Same family as `force_login` but for the discovery-based RP flow — needs its own fix.
- `POST /api/v1/apps` validation failures return `{ status: 'Unprocessable entity' }` (the shared `ERROR_422` body), not Mastodon's `{ error: "..." }` error shape.
- Form-encoded `redirect_uris[]=a&redirect_uris[]=b` bodies collapse to the last value in `getRequestBody`; only JSON bodies benefit from the new array form (Mastodon's array form is JSON, so this is acceptable).
- `PostRequest.website` is `z.string().optional()` with no URL validation; Mastodon validates it as a URL.
- An explicitly empty `scope=` query param on `/oauth/authorize` stays `''` (Zod `.default` only fills missing keys), yielding an empty permissions list rather than the `read` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)