### PR TITLE
fix: Instance entity completion

### DIFF
--- a/app/api/v1/instance/route.test.ts
+++ b/app/api/v1/instance/route.test.ts
@@ -1,21 +1,66 @@
 import { NextRequest } from 'next/server'
 
+import type { Config } from '@/lib/config'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+
 import { GET } from './route'
 
-vi.mock('@/lib/config', () => ({
-  getConfig: vi.fn().mockReturnValue({
-    host: 'llun.test',
-    trustedHosts: ['alias.llun.test'],
-    serviceName: undefined,
-    serviceDescription: undefined,
-    languages: ['en'],
-    mediaStorage: undefined
-  })
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase,
+  getKnex: () => null
 }))
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(),
+  buildBaseURL: (host: string) => `https://${host}`
+}))
+
+const baseConfig = {
+  host: 'llun.test',
+  trustedHosts: ['alias.llun.test'],
+  serviceName: undefined,
+  serviceDescription: undefined,
+  languages: ['en'],
+  mediaStorage: undefined,
+  registrationOpen: true,
+  push: {
+    vapidPublicKey: 'test-vapid-public-key',
+    vapidPrivateKey: 'test-vapid-private-key',
+    vapidEmail: 'mailto:push@llun.test'
+  },
+  email: { type: 'smtp', serviceFromAddress: 'admin@llun.test' }
+}
 
 const params = { params: Promise.resolve({}) }
 
 describe('GET /api/v1/instance', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await database.createAccount({
+      email: 'user@llun.test',
+      username: 'user',
+      passwordHash: 'hashed-password',
+      domain: 'llun.test',
+      privateKey: 'private-key',
+      publicKey: 'public-key'
+    })
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(async () => {
+    const config =
+      await vi.importMock<typeof import('@/lib/config')>('@/lib/config')
+    vi.mocked(config.getConfig).mockReturnValue(baseConfig as unknown as Config)
+  })
+
   it('reports the configured host by default', async () => {
     const response = await GET(
       new NextRequest('https://llun.test/api/v1/instance'),
@@ -44,5 +89,68 @@ describe('GET /api/v1/instance', () => {
       params
     )
     await expect(response.json()).resolves.toMatchObject({ uri: 'llun.test' })
+  })
+
+  it('serves the configured contact email instead of the placeholder', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.email).toBe('admin@llun.test')
+  })
+
+  it('reports instance stats as integers', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.stats).toEqual({
+      user_count: 1,
+      status_count: 0,
+      domain_count: 0
+    })
+  })
+
+  it('serves urls, thumbnail, registrations, rules and contact_account', async () => {
+    const rule = await database.createInstanceRule({
+      text: 'No spam',
+      hint: '',
+      position: 1
+    })
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.urls).toEqual({ streaming_api: '' })
+    expect(body.thumbnail).toBe('https://llun.test/logo.png')
+    expect(body.registrations).toBe(true)
+    expect(body.rules).toEqual([{ id: rule.id, text: 'No spam', hint: '' }])
+    expect(body.contact_account).toBeNull()
+  })
+
+  it('keeps serving the static payload when the database is unavailable', async () => {
+    mockDatabase = null
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v1/instance'),
+        params
+      )
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.uri).toBe('llun.test')
+      expect(body.stats).toEqual({
+        user_count: 0,
+        status_count: 0,
+        domain_count: 0
+      })
+      expect(body.rules).toEqual([])
+      expect(body.contact_account).toBeNull()
+    } finally {
+      mockDatabase = database
+    }
   })
 })

--- a/app/api/v1/instance/route.test.ts
+++ b/app/api/v1/instance/route.test.ts
@@ -153,4 +153,25 @@ describe('GET /api/v1/instance', () => {
       mockDatabase = database
     }
   })
+
+  it('degrades to an empty rules list when getInstanceRules rejects but the database is present (still 200)', async () => {
+    // The DB-unavailable test above sets mockDatabase = null, which short-circuits
+    // the `if (database)` guard before the rules try/catch. This exercises the
+    // catch itself: a present database whose getInstanceRules() rejects must still
+    // return 200 with rules: [], not a 500 on the public endpoint.
+    const rulesSpy = vi
+      .spyOn(database, 'getInstanceRules')
+      .mockRejectedValue(new Error('rules query failed'))
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v1/instance'),
+        params
+      )
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.rules).toEqual([])
+    } finally {
+      rulesSpy.mockRestore()
+    }
+  })
 })

--- a/app/api/v1/instance/route.ts
+++ b/app/api/v1/instance/route.ts
@@ -1,16 +1,25 @@
 import { NextRequest } from 'next/server'
 
-import { getConfig } from '@/lib/config'
+import { buildBaseURL, getConfig } from '@/lib/config'
+import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MAX_PINNED_STATUSES,
   MAX_STATUS_MEDIA_ATTACHMENTS
 } from '@/lib/services/mastodon/constants'
 import {
+  getInstanceContactAccount,
+  getInstanceContactEmail,
+  getInstanceStats
+} from '@/lib/services/mastodon/instance'
+import {
   ACCEPTED_FILE_TYPES,
   MAX_FILE_SIZE
 } from '@/lib/services/medias/constants'
+import { InstanceRuleData } from '@/lib/types/database/operations'
+import { Rule } from '@/lib/types/mastodon/rule'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { VERSION } from '@/lib/utils/version'
@@ -19,20 +28,54 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
+// Public per Mastodon: GET /api/v1/instance is served unauthenticated. The
+// payload must stay robust — database failures degrade to zeroed stats, an
+// empty rules list and a null contact account instead of a 500.
 export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
   const config = getConfig()
+  const database = getDatabase()
+  const domain = headerHost(req.headers)
+  const baseUrl = buildBaseURL(domain)
+
+  let rules: InstanceRuleData[] = []
+  if (database) {
+    try {
+      rules = await database.getInstanceRules()
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to load instance rules for /api/v1/instance',
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  const [stats, contactAccount] = await Promise.all([
+    getInstanceStats(database, config.host),
+    getInstanceContactAccount(database)
+  ])
+
   const data = {
-    uri: headerHost(req.headers),
+    uri: domain,
     title: config.serviceName ?? 'Activities.next',
     short_description:
       config.serviceDescription ?? 'Personal activity pub server with Next.js',
     description:
       config.serviceDescription ?? 'Personal activity pub server with Next.js',
-    email: '-',
+    email: getInstanceContactEmail(config),
     version: VERSION,
-    thumbnail: '',
+    // No streaming API: the documented key is present but empty so clients
+    // treat streaming as unavailable and fall back to polling.
+    urls: { streaming_api: '' },
+    // Integers per the V1::Instance entity — only /api/v1/instance/activity
+    // stringifies its numbers.
+    stats: {
+      user_count: stats.userCount,
+      status_count: stats.statusCount,
+      domain_count: stats.domainCount
+    },
+    thumbnail: `${baseUrl}/logo.png`,
     languages: config.languages,
-    registrations: false,
+    registrations: config.registrationOpen,
     approval_required: false,
     invites_enabled: false,
     configuration: {
@@ -58,7 +101,13 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
         min_expiration: 300,
         max_expiration: 2629746
       }
-    }
+    },
+    contact_account: contactAccount,
+    rules: rules.map((rule): Rule => ({
+      id: rule.id,
+      text: rule.text,
+      hint: rule.hint
+    }))
   }
   return apiResponse({ req, allowedMethods: CORS_HEADERS, data })
 })

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 
+import type { Config } from '@/lib/config'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 
 import { GET } from './route'
@@ -11,15 +12,25 @@ vi.mock('@/lib/database', () => ({
 }))
 
 vi.mock('@/lib/config', () => ({
-  getConfig: vi.fn().mockReturnValue({
-    host: 'llun.test',
-    trustedHosts: ['alias.llun.test'],
-    serviceName: undefined,
-    serviceDescription: undefined,
-    languages: ['en'],
-    mediaStorage: undefined
-  })
+  getConfig: vi.fn(),
+  buildBaseURL: (host: string) => `https://${host}`
 }))
+
+const baseConfig = {
+  host: 'llun.test',
+  trustedHosts: ['alias.llun.test'],
+  serviceName: undefined,
+  serviceDescription: undefined,
+  languages: ['en'],
+  mediaStorage: undefined,
+  registrationOpen: true,
+  push: {
+    vapidPublicKey: 'test-vapid-public-key',
+    vapidPrivateKey: 'test-vapid-private-key',
+    vapidEmail: 'mailto:push@llun.test'
+  },
+  email: { type: 'smtp', serviceFromAddress: 'admin@llun.test' }
+}
 
 const params = { params: Promise.resolve({}) }
 
@@ -34,6 +45,14 @@ describe('GET /api/v2/instance', () => {
   afterAll(async () => {
     mockDatabase = null
     await database.destroy()
+  })
+
+  beforeEach(async () => {
+    const config =
+      await vi.importMock<typeof import('@/lib/config')>('@/lib/config')
+    vi.mocked(config.getConfig).mockReturnValue(
+      baseConfig as unknown as Config
+    )
   })
 
   it('serves the instance payload for an unauthenticated request', async () => {
@@ -112,6 +131,78 @@ describe('GET /api/v2/instance', () => {
     ])
   })
 
+  it('completes the v2 entity with usage, thumbnail, icon and api versions', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.usage).toEqual({ users: { active_month: 0 } })
+    expect(body.thumbnail).toEqual({
+      url: 'https://llun.test/logo.png',
+      versions: {
+        '@1x': 'https://llun.test/logo.png',
+        '@2x': 'https://llun.test/logo.png'
+      }
+    })
+    expect(body.icon).toEqual([
+      { src: 'https://llun.test/icon-192.png', size: '192x192' },
+      { src: 'https://llun.test/icon-512.png', size: '512x512' }
+    ])
+    expect(body.api_versions).toEqual({ mastodon: 2 })
+  })
+
+  it('serves streaming and vapid configuration', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.configuration.urls).toEqual({ streaming: '' })
+    expect(body.configuration.vapid).toEqual({
+      public_key: 'test-vapid-public-key'
+    })
+  })
+
+  it('serves the contact email with a null account when no admin exists', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.contact).toEqual({ email: 'admin@llun.test', account: null })
+  })
+
+  it.each([
+    {
+      description: 'reports registrations enabled when registration is open',
+      registrationOpen: true
+    },
+    {
+      description: 'reports registrations closed when registration is closed',
+      registrationOpen: false
+    }
+  ])('$description', async ({ registrationOpen }) => {
+    const config =
+      await vi.importMock<typeof import('@/lib/config')>('@/lib/config')
+    vi.mocked(config.getConfig).mockReturnValue({
+      ...baseConfig,
+      registrationOpen
+    } as unknown as Config)
+
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.registrations).toEqual({
+      enabled: registrationOpen,
+      approval_required: false,
+      message: null,
+      url: null
+    })
+  })
+
   it('returns empty rules instead of failing when the database is unavailable', async () => {
     mockDatabase = null
     try {
@@ -123,6 +214,11 @@ describe('GET /api/v2/instance', () => {
       const body = await response.json()
       expect(body.domain).toBe('llun.test')
       expect(body.rules).toEqual([])
+      expect(body.usage).toEqual({ users: { active_month: 0 } })
+      expect(body.contact).toEqual({
+        email: 'admin@llun.test',
+        account: null
+      })
     } finally {
       mockDatabase = database
     }

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -221,4 +221,31 @@ describe('GET /api/v2/instance', () => {
       mockDatabase = database
     }
   })
+
+  it('maps usage.users.active_month from the active-month stat, not another counter', async () => {
+    // Distinct counters so a wrong-field mapping (e.g. active_month = userCount)
+    // is caught; with the empty test DB all four are 0 and indistinguishable.
+    const nodeInfoSpy = vi
+      .spyOn(database, 'getNodeInfoStats')
+      .mockResolvedValue({
+        totalUsers: 9,
+        activeMonth: 6,
+        activeHalfyear: 8,
+        localPosts: 15
+      })
+    const peersSpy = vi
+      .spyOn(database, 'getInstancePeers')
+      .mockResolvedValue(['a.test', 'b.test', 'c.test', 'd.test'])
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v2/instance'),
+        params
+      )
+      const body = await response.json()
+      expect(body.usage.users.active_month).toBe(6)
+    } finally {
+      nodeInfoSpy.mockRestore()
+      peersSpy.mockRestore()
+    }
+  })
 })

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -50,9 +50,7 @@ describe('GET /api/v2/instance', () => {
   beforeEach(async () => {
     const config =
       await vi.importMock<typeof import('@/lib/config')>('@/lib/config')
-    vi.mocked(config.getConfig).mockReturnValue(
-      baseConfig as unknown as Config
-    )
+    vi.mocked(config.getConfig).mockReturnValue(baseConfig as unknown as Config)
   })
 
   it('serves the instance payload for an unauthenticated request', async () => {

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest } from 'next/server'
 
-import { getConfig } from '@/lib/config'
+import { buildBaseURL, getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
+  MASTODON_INSTANCE_API_VERSION,
   MAX_PINNED_STATUSES,
   MAX_STATUS_MEDIA_ATTACHMENTS
 } from '@/lib/services/mastodon/constants'
+import {
+  getInstanceContactAccount,
+  getInstanceContactEmail,
+  getInstanceStats
+} from '@/lib/services/mastodon/instance'
 import {
   ACCEPTED_FILE_TYPES,
   MAX_FILE_SIZE
@@ -27,8 +33,11 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 // Public per Mastodon: GET /api/v2/instance is served unauthenticated.
 export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
   const config = getConfig()
+  const domain = headerHost(req.headers)
+  const baseUrl = buildBaseURL(domain)
   // The instance payload must stay robust: when the database is unavailable,
-  // serve the static configuration with an empty rules list instead of failing.
+  // serve the static configuration with an empty rules list, zeroed usage and
+  // a null contact account instead of failing.
   const database = getDatabase()
   let rules: InstanceRuleData[] = []
   if (database) {
@@ -43,19 +52,51 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
       })
     }
   }
+  const [stats, contactAccount] = await Promise.all([
+    getInstanceStats(database, config.host),
+    getInstanceContactAccount(database)
+  ])
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
     data: {
-      domain: headerHost(req.headers),
+      domain,
       title: config.serviceName ?? 'Activities.next',
       version: VERSION,
       source_url: 'https://github.com/llun/activities.next',
       description:
         config.serviceDescription ??
         'Personal activity pub server with Next.js',
+      usage: {
+        users: {
+          active_month: stats.activeMonth
+        }
+      },
+      thumbnail: {
+        url: `${baseUrl}/logo.png`,
+        versions: {
+          '@1x': `${baseUrl}/logo.png`,
+          '@2x': `${baseUrl}/logo.png`
+        }
+      },
+      icon: [
+        { src: `${baseUrl}/icon-192.png`, size: '192x192' },
+        { src: `${baseUrl}/icon-512.png`, size: '512x512' }
+      ],
       languages: config.languages,
+      api_versions: {
+        mastodon: MASTODON_INSTANCE_API_VERSION
+      },
       configuration: {
+        // No streaming API yet: keep the documented key present but empty so
+        // JS clients treat it as falsy and fall back to REST polling instead
+        // of opening a WebSocket that would fail.
+        urls: {
+          streaming: ''
+        },
+        vapid: {
+          public_key: config.push?.vapidPublicKey ?? ''
+        },
         accounts: {
           max_featured_tags: 10,
           max_pinned_statuses: MAX_PINNED_STATUSES
@@ -84,16 +125,18 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
         }
       },
       registrations: {
-        enabled: false,
+        enabled: config.registrationOpen,
         approval_required: false,
         message: null,
         url: null
       },
-      rules: rules.map((rule): Rule => ({
-        id: rule.id,
-        text: rule.text,
-        hint: rule.hint
-      }))
+      contact: {
+        email: getInstanceContactEmail(config),
+        account: contactAccount
+      },
+      rules: rules.map(
+        (rule): Rule => ({ id: rule.id, text: rule.text, hint: rule.hint })
+      )
     }
   })
 })

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -134,9 +134,11 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
         email: getInstanceContactEmail(config),
         account: contactAccount
       },
-      rules: rules.map(
-        (rule): Rule => ({ id: rule.id, text: rule.text, hint: rule.hint })
-      )
+      rules: rules.map((rule): Rule => ({
+        id: rule.id,
+        text: rule.text,
+        hint: rule.hint
+      }))
     }
   })
 })

--- a/lib/database/sql/instanceActivity.test.ts
+++ b/lib/database/sql/instanceActivity.test.ts
@@ -2,6 +2,7 @@ import knex, { Knex } from 'knex'
 
 import {
   getInstanceActivityFromCounters,
+  getInstanceAdminActorIdFromAccounts,
   recordWeeklyLogin,
   recordWeeklyLoginSafely
 } from '@/lib/database/sql/instanceActivity'
@@ -281,5 +282,99 @@ describe('instance activity counters', () => {
     } finally {
       loggerErrorSpy.mockRestore()
     }
+  })
+})
+
+describe('getInstanceAdminActorIdFromAccounts', () => {
+  let database: Knex
+
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: { filename: ':memory:' }
+    })
+
+    await database.schema.createTable('accounts', (table) => {
+      table.string('id').primary()
+      table.string('role').nullable()
+    })
+    await database.schema.createTable('actors', (table) => {
+      table.string('id').primary()
+      table.string('accountId').nullable()
+      table.string('deletionStatus').nullable()
+      table.timestamp('createdAt', { useTz: true })
+    })
+  })
+
+  afterEach(async () => {
+    await database.destroy()
+  })
+
+  it('returns null when no account has the admin role', async () => {
+    await database('accounts').insert({ id: 'account-1', role: null })
+    await database('actors').insert({
+      id: 'https://llun.test/users/user1',
+      accountId: 'account-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z')
+    })
+
+    await expect(
+      getInstanceAdminActorIdFromAccounts(database)
+    ).resolves.toBeNull()
+  })
+
+  it('returns the earliest-created actor owned by an admin account', async () => {
+    await database('accounts').insert([
+      { id: 'account-user', role: null },
+      { id: 'account-admin', role: 'admin' }
+    ])
+    await database('actors').insert([
+      {
+        id: 'https://llun.test/users/user1',
+        accountId: 'account-user',
+        createdAt: new Date('2026-01-01T00:00:00.000Z')
+      },
+      {
+        id: 'https://remote.test/users/remote',
+        accountId: null,
+        createdAt: new Date('2026-01-02T00:00:00.000Z')
+      },
+      {
+        id: 'https://llun.test/users/admin-alias',
+        accountId: 'account-admin',
+        createdAt: new Date('2026-03-01T00:00:00.000Z')
+      },
+      {
+        id: 'https://llun.test/users/admin',
+        accountId: 'account-admin',
+        createdAt: new Date('2026-02-01T00:00:00.000Z')
+      }
+    ])
+
+    await expect(getInstanceAdminActorIdFromAccounts(database)).resolves.toBe(
+      'https://llun.test/users/admin'
+    )
+  })
+
+  it('skips admin actors that are scheduled for deletion', async () => {
+    await database('accounts').insert({ id: 'account-admin', role: 'admin' })
+    await database('actors').insert([
+      {
+        id: 'https://llun.test/users/deleted-admin',
+        accountId: 'account-admin',
+        deletionStatus: 'scheduled',
+        createdAt: new Date('2026-01-01T00:00:00.000Z')
+      },
+      {
+        id: 'https://llun.test/users/admin',
+        accountId: 'account-admin',
+        createdAt: new Date('2026-02-01T00:00:00.000Z')
+      }
+    ])
+
+    await expect(getInstanceAdminActorIdFromAccounts(database)).resolves.toBe(
+      'https://llun.test/users/admin'
+    )
   })
 })

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -230,6 +230,22 @@ export const getInstancePeersFromActors = async (
   return rows.filter((domain): domain is string => Boolean(domain))
 }
 
+export const getInstanceAdminActorIdFromAccounts = async (
+  database: Knex
+): Promise<string | null> => {
+  // Remote actors have a null accountId, so the inner join naturally limits
+  // the lookup to local actors. Earliest-created wins so the contact account
+  // is stable across requests.
+  const row = await database('actors')
+    .join('accounts', 'actors.accountId', 'accounts.id')
+    .where('accounts.role', 'admin')
+    .whereNull('actors.deletionStatus')
+    .orderBy('actors.createdAt', 'asc')
+    .first<{ id: string } | undefined>('actors.id as id')
+
+  return row?.id ?? null
+}
+
 export const InstanceActivitySQLDatabaseMixin = (
   database: Knex
 ): InstanceActivityDatabase => ({
@@ -240,5 +256,8 @@ export const InstanceActivitySQLDatabaseMixin = (
     return getInstancePeersFromActors(database, {
       localDomain: params?.localDomain ?? ''
     })
+  },
+  getInstanceAdminActorId() {
+    return getInstanceAdminActorIdFromAccounts(database)
   }
 })

--- a/lib/database/sql/instanceActivity.ts
+++ b/lib/database/sql/instanceActivity.ts
@@ -241,7 +241,7 @@ export const getInstanceAdminActorIdFromAccounts = async (
     .where('accounts.role', 'admin')
     .whereNull('actors.deletionStatus')
     .orderBy('actors.createdAt', 'asc')
-    .first<{ id: string } | undefined>('actors.id as id')
+    .first<{ id: string }>('actors.id as id')
 
   return row?.id ?? null
 }

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -14,3 +14,8 @@ export const MAX_POLL_EXPIRATION_SECONDS = 60 * 60 * 24 * 31
 export const MIN_SCHEDULED_STATUS_AHEAD_MS = 5 * 60 * 1000
 export const SCHEDULED_AT_TOO_SOON_ERROR =
   'Validation failed: Scheduled at must be at least 5 minutes in the future'
+
+// Advertised in the v2 instance entity (api_versions.mastodon). Mastodon 4.3
+// introduced the field with value 2; this server implements the 4.3-era API
+// surface, so advertise 2 and bump only alongside newer API features.
+export const MASTODON_INSTANCE_API_VERSION = 2

--- a/lib/services/mastodon/instance.test.ts
+++ b/lib/services/mastodon/instance.test.ts
@@ -1,0 +1,150 @@
+import type { Config } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+
+import {
+  EMPTY_INSTANCE_STATS,
+  getInstanceContactAccount,
+  getInstanceContactEmail,
+  getInstanceStats
+} from './instance'
+
+describe('getInstanceContactEmail', () => {
+  it.each([
+    {
+      description:
+        'returns the outbound sender address when email is configured',
+      config: {
+        email: { type: 'smtp', serviceFromAddress: 'admin@llun.test' }
+      },
+      expected: 'admin@llun.test'
+    },
+    {
+      description: 'unwraps a Name <address> sender format',
+      config: {
+        email: { type: 'smtp', serviceFromAddress: 'Admin <admin@llun.test>' }
+      },
+      expected: 'admin@llun.test'
+    },
+    {
+      description: 'falls back to the vapid contact and strips the mailto prefix',
+      config: {
+        push: {
+          vapidPublicKey: 'pub',
+          vapidPrivateKey: 'priv',
+          vapidEmail: 'mailto:push@llun.test'
+        }
+      },
+      expected: 'push@llun.test'
+    },
+    {
+      description: 'prefers the email sender over the vapid contact',
+      config: {
+        email: { type: 'smtp', serviceFromAddress: 'admin@llun.test' },
+        push: {
+          vapidPublicKey: 'pub',
+          vapidPrivateKey: 'priv',
+          vapidEmail: 'mailto:push@llun.test'
+        }
+      },
+      expected: 'admin@llun.test'
+    },
+    {
+      description: 'returns an empty string when nothing is configured',
+      config: {},
+      expected: ''
+    }
+  ])('$description', ({ config, expected }) => {
+    expect(
+      getInstanceContactEmail(config as Pick<Config, 'email' | 'push'>)
+    ).toBe(expected)
+  })
+})
+
+describe('getInstanceStats', () => {
+  it('maps nodeinfo counters and the peers list onto instance stats', async () => {
+    const database = {
+      getNodeInfoStats: vi.fn().mockResolvedValue({
+        totalUsers: 3,
+        activeMonth: 2,
+        activeHalfyear: 3,
+        localPosts: 42
+      }),
+      getInstancePeers: vi
+        .fn()
+        .mockResolvedValue(['mastodon.social', 'pixelfed.social'])
+    } as unknown as Database
+
+    await expect(getInstanceStats(database, 'llun.test')).resolves.toEqual({
+      userCount: 3,
+      statusCount: 42,
+      domainCount: 2,
+      activeMonth: 2
+    })
+    expect(database.getInstancePeers).toHaveBeenCalledWith({
+      localDomain: 'llun.test'
+    })
+  })
+
+  it('returns zeroed stats when the database is unavailable', async () => {
+    await expect(getInstanceStats(null, 'llun.test')).resolves.toEqual(
+      EMPTY_INSTANCE_STATS
+    )
+  })
+
+  it('returns zeroed stats when a stats query fails', async () => {
+    const database = {
+      getNodeInfoStats: vi.fn().mockRejectedValue(new Error('boom')),
+      getInstancePeers: vi.fn().mockResolvedValue([])
+    } as unknown as Database
+
+    await expect(getInstanceStats(database, 'llun.test')).resolves.toEqual(
+      EMPTY_INSTANCE_STATS
+    )
+  })
+})
+
+describe('getInstanceContactAccount', () => {
+  const adminAccount = {
+    id: 'https://llun.test/users/admin',
+    username: 'admin'
+  }
+
+  it('returns the mastodon account for the instance admin actor', async () => {
+    const database = {
+      getInstanceAdminActorId: vi
+        .fn()
+        .mockResolvedValue('https://llun.test/users/admin'),
+      getMastodonActorFromId: vi.fn().mockResolvedValue(adminAccount)
+    } as unknown as Database
+
+    await expect(getInstanceContactAccount(database)).resolves.toEqual(
+      adminAccount
+    )
+    expect(database.getMastodonActorFromId).toHaveBeenCalledWith({
+      id: 'https://llun.test/users/admin'
+    })
+  })
+
+  it('returns null when the instance has no admin account', async () => {
+    const database = {
+      getInstanceAdminActorId: vi.fn().mockResolvedValue(null),
+      getMastodonActorFromId: vi.fn()
+    } as unknown as Database
+
+    await expect(getInstanceContactAccount(database)).resolves.toBeNull()
+    expect(database.getMastodonActorFromId).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the database is unavailable', async () => {
+    await expect(getInstanceContactAccount(null)).resolves.toBeNull()
+  })
+
+  it('returns null when the admin lookup fails', async () => {
+    const database = {
+      getInstanceAdminActorId: vi.fn().mockRejectedValue(new Error('boom')),
+      getMastodonActorFromId: vi.fn()
+    } as unknown as Database
+
+    await expect(getInstanceContactAccount(database)).resolves.toBeNull()
+  })
+})

--- a/lib/services/mastodon/instance.test.ts
+++ b/lib/services/mastodon/instance.test.ts
@@ -26,7 +26,8 @@ describe('getInstanceContactEmail', () => {
       expected: 'admin@llun.test'
     },
     {
-      description: 'falls back to the vapid contact and strips the mailto prefix',
+      description:
+        'falls back to the vapid contact and strips the mailto prefix',
       config: {
         push: {
           vapidPublicKey: 'pub',

--- a/lib/services/mastodon/instance.ts
+++ b/lib/services/mastodon/instance.ts
@@ -10,12 +10,15 @@ export interface InstanceStats {
   activeMonth: number
 }
 
-export const EMPTY_INSTANCE_STATS: InstanceStats = {
+// Frozen: getInstanceStats returns this shared constant by reference on the
+// no-database / query-failure paths, so a caller mutating the result must not
+// be able to corrupt the singleton.
+export const EMPTY_INSTANCE_STATS: Readonly<InstanceStats> = Object.freeze({
   userCount: 0,
   statusCount: 0,
   domainCount: 0,
   activeMonth: 0
-}
+})
 
 // Normalizes VAPID-style `mailto:` prefixes and `Name <address>` sender
 // formats down to the bare address.

--- a/lib/services/mastodon/instance.ts
+++ b/lib/services/mastodon/instance.ts
@@ -1,0 +1,89 @@
+import type { Config } from '@/lib/config'
+import { Database } from '@/lib/database/types'
+import { Mastodon } from '@/lib/types/activitypub'
+import { logger } from '@/lib/utils/logger'
+
+export interface InstanceStats {
+  userCount: number
+  statusCount: number
+  domainCount: number
+  activeMonth: number
+}
+
+export const EMPTY_INSTANCE_STATS: InstanceStats = {
+  userCount: 0,
+  statusCount: 0,
+  domainCount: 0,
+  activeMonth: 0
+}
+
+// Normalizes VAPID-style `mailto:` prefixes and `Name <address>` sender
+// formats down to the bare address.
+const extractEmailAddress = (value: string): string => {
+  const withoutMailto = value.startsWith('mailto:')
+    ? value.slice('mailto:'.length)
+    : value
+  const bracketed = withoutMailto.match(/<([^<>\s]+@[^<>\s]+)>/)
+  return (bracketed ? bracketed[1] : withoutMailto).trim()
+}
+
+// There is no dedicated instance-contact setting in the config, so fall back
+// through the configured outbound sender address, then the Web Push VAPID
+// contact. An empty string means no contact is configured.
+export const getInstanceContactEmail = (
+  config: Pick<Config, 'email' | 'push'>
+): string => {
+  const candidate =
+    config.email?.serviceFromAddress || config.push?.vapidEmail || ''
+  return extractEmailAddress(candidate)
+}
+
+// Instance stats for the v1 entity and the v2 usage block. All sources are
+// cheap: user/status totals come from the maintained nodeinfo counters,
+// active_month reuses the hourly-cached nodeinfo computation (distinct local
+// actors with a status in the last 30 days) and domain count is the length
+// of the peers list. Failures degrade to zeros because the public instance
+// endpoints must never 500 over a stats query.
+export const getInstanceStats = async (
+  database: Database | null,
+  localDomain: string
+): Promise<InstanceStats> => {
+  if (!database) return EMPTY_INSTANCE_STATS
+  try {
+    const [nodeInfoStats, peers] = await Promise.all([
+      database.getNodeInfoStats(),
+      database.getInstancePeers({ localDomain })
+    ])
+    return {
+      userCount: nodeInfoStats.totalUsers,
+      statusCount: nodeInfoStats.localPosts,
+      domainCount: peers.length,
+      activeMonth: nodeInfoStats.activeMonth
+    }
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to load instance stats',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return EMPTY_INSTANCE_STATS
+  }
+}
+
+// The instance contact account is the earliest-created local actor owned by
+// an account with the admin role, or null when the instance has no admin.
+export const getInstanceContactAccount = async (
+  database: Database | null
+): Promise<Mastodon.Account | null> => {
+  if (!database) return null
+  try {
+    const actorId = await database.getInstanceAdminActorId()
+    if (!actorId) return null
+    return await database.getMastodonActorFromId({ id: actorId })
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to load instance contact account',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -3262,6 +3262,10 @@ export interface InstanceActivityDatabase {
     params?: GetInstanceActivityParams
   ): Promise<InstanceActivityWeek[]>
   getInstancePeers(params?: GetInstancePeersParams): Promise<string[]>
+  // Earliest-created local actor owned by an account with the admin role,
+  // used as the Mastodon instance contact account; null when the instance
+  // has no admin.
+  getInstanceAdminActorId(): Promise<string | null>
 }
 
 export type GetInstancePeersParams = {


### PR DESCRIPTION
## Summary

- Complete the v2 Instance entity (`GET /api/v2/instance`): `usage.users.active_month` (reuses the cached nodeinfo active-month query — distinct local actors with a status in the last 30 days), `thumbnail`/`icon` backed by the bundled `public/logo.png` + `icon-192/512.png`, `api_versions: { mastodon: 2 }`, `contact { email, account }`, `configuration.urls.streaming`, `configuration.vapid.public_key` from the push config, and `registrations.enabled` now reflects `config.registrationOpen` instead of being hardcoded `false`.
- Complete the v1 Instance entity (`GET /api/v1/instance`): `stats { user_count, status_count, domain_count }` as integers (per the V1::Instance entity; only `instance/activity` stringifies), `urls.streaming_api`, `contact_account`, `rules` (same source as `/api/v1/instance/rules`), a real contact email instead of the `'-'` placeholder, plus consistency alignment of `registrations` and `thumbnail` with v2.
- New `getInstanceAdminActorId()` database lookup (earliest-created local actor of an `accounts.role = 'admin'` account) feeding the contact account through the existing `getMastodonActorFromId` serializer.
- New shared helpers in `lib/services/mastodon/instance.ts` (`getInstanceContactEmail`, `getInstanceStats`, `getInstanceContactAccount`); all are throw-free so the public instance endpoints degrade to zeros/null instead of 500ing when the database is down.

## Decisions

- Streaming keys are emitted present-but-empty (`''`): no streaming API exists, empty strings are falsy so JS clients fall back to REST polling, and advertising `wss://<domain>` would cause clients to hammer a nonexistent endpoint.
- Contact email is derived (no new env var): `ACTIVITIES_EMAIL_FROM` sender → VAPID contact (`mailto:` stripped) → `''`.
- `api_versions.mastodon = 2` via `MASTODON_INSTANCE_API_VERSION` (the value Mastodon 4.3 introduced the field with; single-constant bump later).

## Notes

- No migrations — the reference schema dumps are unchanged.
- Part of Phase 2 (Entity & Parameter Gaps), PR 2.4. Independent of the other Phase 2 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)