### PR TITLE
fix: status create/edit/delete/history param gaps

### DIFF
--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2258,6 +2258,183 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(updatedStatus?.cc).toEqual([`${ACTOR1_ID}/followers`])
       expect(getQueue().publish).not.toHaveBeenCalled()
     })
+
+    it('updates attachment description and focus through media_attributes', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-media-attributes`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Media attributes target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-attributes.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-attributes.jpg'
+        },
+        description: 'Old description'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-attributes.webp',
+        width: 320,
+        height: 240,
+        name: 'Old description',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_attributes: [
+                {
+                  id: media!.id,
+                  description: 'New description',
+                  focus: '0.5,-0.5'
+                }
+              ]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.media_attachments).toHaveLength(1)
+      expect(data.media_attachments[0]).toMatchObject({
+        description: 'New description'
+      })
+
+      const actor = await database.getActorFromId({ id: ACTOR1_ID })
+      const updatedMedia = await database.getMediaByIdForAccount({
+        mediaId: media!.id,
+        accountId: actor!.account!.id
+      })
+      expect(updatedMedia?.description).toBe('New description')
+      expect(updatedMedia?.focus).toEqual({ x: 0.5, y: -0.5 })
+    })
+
+    it('keeps the existing description when media_attributes only updates focus', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-media-attributes-focus`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Focus only target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-attributes-focus.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-attributes-focus.jpg'
+        },
+        description: 'Keep description'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-attributes-focus.webp',
+        width: 320,
+        height: 240,
+        name: 'Keep description',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_attributes: [{ id: media!.id, focus: '0,1' }]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const actor = await database.getActorFromId({ id: ACTOR1_ID })
+      const updatedMedia = await database.getMediaByIdForAccount({
+        mediaId: media!.id,
+        accountId: actor!.account!.id
+      })
+      // An omitted description must be left untouched (not cleared to null).
+      expect(updatedMedia?.description).toBe('Keep description')
+      expect(updatedMedia?.focus).toEqual({ x: 0, y: 1 })
+    })
+
+    it('rejects media_attributes for media the actor does not own', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-media-attributes-foreign`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Foreign media attributes target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const foreignMedia = await database.createMedia({
+        actorId: ACTOR2_ID,
+        original: {
+          path: 'medias/api-edit-attributes-foreign.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-attributes-foreign.jpg'
+        }
+      })
+      expect(foreignMedia).not.toBeNull()
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_attributes: [
+                { id: foreignMedia!.id, description: 'Hijacked' }
+              ]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(422)
+    })
   })
 
   describe('status delete', () => {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2392,6 +2392,66 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(updatedMedia?.focus).toEqual({ x: 0, y: 1 })
     })
 
+    it('clears an attachment description when media_attributes sends description null', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-media-attributes-clear`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Clear description target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/api-edit-attributes-clear.webp',
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: 'api-edit-attributes-clear.jpg'
+        },
+        description: 'Alt text to clear'
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: 'https://llun.test/api/v1/files/medias/api-edit-attributes-clear.webp',
+        width: 320,
+        height: 240,
+        name: 'Alt text to clear',
+        mediaId: media!.id
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              media_attributes: [{ id: media!.id, description: null }]
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const actor = await database.getActorFromId({ id: ACTOR1_ID })
+      const updatedMedia = await database.getMediaByIdForAccount({
+        mediaId: media!.id,
+        accountId: actor!.account!.id
+      })
+      // Explicit null clears the stored alt text (blank/null normalise to null).
+      expect(updatedMedia?.description ?? null).toBeNull()
+    })
+
     it('rejects media_attributes for media the actor does not own', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-media-attributes-foreign`
       await database.createNote({
@@ -2487,6 +2547,11 @@ describe('GET /api/v1/statuses/[id]', () => {
       ])
       expect(data.poll.votes_count).toBe(0)
       expect(data.poll.voters_count).toBe(0)
+      // expires_in (7200s) is rebased from now into expires_at (seconds -> ms).
+      const expiresAt = new Date(data.poll.expires_at).getTime()
+      expect(Math.abs(expiresAt - (Date.now() + 7200 * 1000))).toBeLessThan(
+        60_000
+      )
 
       const historyResponse = await getStatusHistory(
         new NextRequest(
@@ -2548,6 +2613,50 @@ describe('GET /api/v1/statuses/[id]', () => {
         { title: 'Yes', votes_count: null },
         { title: 'No', votes_count: null }
       ])
+    })
+
+    it('resets votes and switches to anyOf when a poll edit flips multiple to true', async () => {
+      const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-multiple-flip`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR1_ID,
+        text: 'Single choice poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Red', 'Blue'],
+        endAt: Date.now() + 60_000
+      })
+      await database.recordPollVotes({
+        statusId: pollId,
+        actorId: ACTOR2_ID,
+        choices: [0]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              poll: { options: ['Red', 'Blue'], multiple: true }
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(pollId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      // Same options, but flipping the multiple-choice mode resets votes and
+      // switches the poll to anyOf (Mastodon UpdateStatusService#update_poll!).
+      expect(data.poll.multiple).toBe(true)
+      expect(data.poll.votes_count).toBe(0)
+      expect(data.poll.voters_count).toBe(0)
     })
 
     it.each([

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -6,6 +6,7 @@ import { encodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByC
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { MAX_PINNED_STATUSES } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { deleteMediaFile } from '@/lib/services/medias'
 import { getQueue } from '@/lib/services/queue'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
@@ -27,7 +28,7 @@ import { POST as muteStatus } from './mute/route'
 import { POST as pinStatus } from './pin/route'
 import { POST as reblogStatus } from './reblog/route'
 import { GET as getStatusRebloggedBy } from './reblogged_by/route'
-import { GET, PUT } from './route'
+import { DELETE, GET, PUT } from './route'
 import { GET as getStatusSource } from './source/route'
 import { POST as unbookmarkStatus } from './unbookmark/route'
 import { POST as unfavouriteStatus } from './unfavourite/route'
@@ -63,7 +64,13 @@ vi.mock('@/lib/services/queue', async () => ({
 
 vi.mock('@/lib/activities', async () => ({
   sendLike: vi.fn().mockResolvedValue(undefined),
-  sendUndoLike: vi.fn().mockResolvedValue(undefined)
+  sendUndoLike: vi.fn().mockResolvedValue(undefined),
+  deleteStatus: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/lib/services/medias', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/services/medias')>()),
+  deleteMediaFile: vi.fn().mockResolvedValue(true)
 }))
 
 vi.mock('@/lib/config', async () => ({
@@ -2251,6 +2258,110 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(updatedStatus?.cc).toEqual([`${ACTOR1_ID}/followers`])
       expect(getQueue().publish).not.toHaveBeenCalled()
     })
+  })
+
+  describe('status delete', () => {
+    const createNoteWithMedia = async (suffix: string) => {
+      const statusId = `${ACTOR1_ID}/statuses/api-delete-${suffix}`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Delete target',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: `medias/api-delete-${suffix}.webp`,
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 320, height: 240 },
+          fileName: `api-delete-${suffix}.jpg`
+        },
+        thumbnail: {
+          path: `medias/api-delete-${suffix}-thumb.webp`,
+          bytes: 128,
+          mimeType: 'image/webp',
+          metaData: { width: 32, height: 24 }
+        }
+      })
+      expect(media).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: media!.original.mimeType,
+        url: `https://llun.test/api/v1/files/medias/api-delete-${suffix}.webp`,
+        width: 320,
+        height: 240,
+        name: 'Delete media',
+        mediaId: media!.id
+      })
+      return { statusId, media: media! }
+    }
+
+    const deleteStatusRequest = (statusId: string, query = '') =>
+      DELETE(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}${query}`,
+          { method: 'DELETE', headers: { Origin: 'https://llun.test' } }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+    it('destroys media rows and storage files when delete_media is true', async () => {
+      const { statusId, media } = await createNoteWithMedia('with-media')
+
+      const response = await deleteStatusRequest(statusId, '?delete_media=true')
+
+      expect(response.status).toBe(200)
+      await expect(
+        database.getStatus({ statusId, withReplies: false })
+      ).resolves.toBeNull()
+
+      const actor = await database.getActorFromId({ id: ACTOR1_ID })
+      await expect(
+        database.getMediaByIdForAccount({
+          mediaId: media.id,
+          accountId: actor!.account!.id
+        })
+      ).resolves.toBeNull()
+      expect(deleteMediaFile).toHaveBeenCalledWith(
+        expect.anything(),
+        'medias/api-delete-with-media.webp'
+      )
+      expect(deleteMediaFile).toHaveBeenCalledWith(
+        expect.anything(),
+        'medias/api-delete-with-media-thumb.webp'
+      )
+    })
+
+    it.each([
+      { description: 'omits delete_media', suffix: 'keep-default', query: '' },
+      {
+        description: 'sends delete_media=false',
+        suffix: 'keep-false',
+        query: '?delete_media=false'
+      }
+    ])(
+      'keeps media rows for redrafting when the client $description',
+      async ({ suffix, query }) => {
+        const { statusId, media } = await createNoteWithMedia(suffix)
+
+        const response = await deleteStatusRequest(statusId, query)
+
+        expect(response.status).toBe(200)
+        const actor = await database.getActorFromId({ id: ACTOR1_ID })
+        await expect(
+          database.getMediaByIdForAccount({
+            mediaId: media.id,
+            accountId: actor!.account!.id
+          })
+        ).resolves.not.toBeNull()
+        expect(deleteMediaFile).not.toHaveBeenCalled()
+      }
+    )
   })
 
   describe('status with replies', () => {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2733,6 +2733,42 @@ describe('GET /api/v1/statuses/[id]', () => {
         expect(response.status).toBe(422)
       }
     )
+
+    it('allows a poll edit that carries an empty media_ids array', async () => {
+      const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-empty-media`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR1_ID,
+        text: 'Poll with an empty media edit',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Yes', 'No'],
+        endAt: Date.now() + 60_000
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              // Many clients send an empty media_ids by default; on a poll edit
+              // that must be ignored, not rejected with 422.
+              media_ids: [],
+              poll: { options: ['Yes', 'No'], hide_totals: true }
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(pollId) }) }
+      )
+
+      expect(response.status).toBe(200)
+    })
   })
 
   describe('status delete', () => {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2435,6 +2435,185 @@ describe('GET /api/v1/statuses/[id]', () => {
 
       expect(response.status).toBe(422)
     })
+
+    it('edits poll options with vote reset and snapshots the old options in history', async () => {
+      const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-options`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR1_ID,
+        text: 'Editable poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Old A', 'Old B'],
+        endAt: Date.now() + 60_000
+      })
+      await database.recordPollVotes({
+        statusId: pollId,
+        actorId: ACTOR2_ID,
+        choices: [0]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              status: 'Editable poll v2',
+              poll: {
+                options: ['New A', 'New B'],
+                expires_in: 7200,
+                hide_totals: true
+              }
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(pollId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.content).toContain('Editable poll v2')
+      // Replaced options start from zero and hide_totals nulls the running
+      // tallies per option.
+      expect(data.poll.options).toEqual([
+        { title: 'New A', votes_count: null },
+        { title: 'New B', votes_count: null }
+      ])
+      expect(data.poll.votes_count).toBe(0)
+      expect(data.poll.voters_count).toBe(0)
+
+      const historyResponse = await getStatusHistory(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(pollId)}/history`
+        ),
+        { params: Promise.resolve({ id: urlToId(pollId) }) }
+      )
+      const revisions = await historyResponse.json()
+      expect(revisions).toHaveLength(2)
+      expect(revisions[0].poll).toEqual({
+        options: [{ title: 'Old A' }, { title: 'Old B' }]
+      })
+      expect(revisions[1].poll).toEqual({
+        options: [{ title: 'New A' }, { title: 'New B' }]
+      })
+    })
+
+    it('keeps existing votes when only hide_totals changes on a poll edit', async () => {
+      const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-hide-totals-only`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR1_ID,
+        text: 'Hide totals only poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Yes', 'No'],
+        endAt: Date.now() + 60_000
+      })
+      await database.recordPollVotes({
+        statusId: pollId,
+        actorId: ACTOR2_ID,
+        choices: [0]
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({
+              poll: { options: ['Yes', 'No'], hide_totals: true }
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(pollId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      // Votes survive; hide_totals only masks the per-option numbers.
+      expect(data.poll.votes_count).toBe(1)
+      expect(data.poll.voters_count).toBe(1)
+      expect(data.poll.options).toEqual([
+        { title: 'Yes', votes_count: null },
+        { title: 'No', votes_count: null }
+      ])
+    })
+
+    it.each([
+      {
+        description: 'a poll payload on a note edit',
+        body: { poll: { options: ['A', 'B'] } }
+      }
+    ])('rejects $description with 422', async ({ body }) => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-note-no-poll`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Note cannot gain a poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify(body),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(422)
+    })
+
+    it('rejects media params on a poll edit with 422', async () => {
+      const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-no-media`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR1_ID,
+        text: 'Poll cannot gain media',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['Yes', 'No'],
+        endAt: Date.now() + 60_000
+      })
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({ media_ids: ['1'] }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(pollId) }) }
+      )
+
+      expect(response.status).toBe(422)
+    })
   })
 
   describe('status delete', () => {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -2693,36 +2693,46 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(response.status).toBe(422)
     })
 
-    it('rejects media params on a poll edit with 422', async () => {
-      const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-no-media`
-      await database.createPoll({
-        id: pollId,
-        url: pollId,
-        actorId: ACTOR1_ID,
-        text: 'Poll cannot gain media',
-        to: [ACTIVITY_STREAM_PUBLIC],
-        cc: [],
-        choices: ['Yes', 'No'],
-        endAt: Date.now() + 60_000
-      })
+    it.each([
+      { param: 'media_ids', body: { media_ids: ['1'] } },
+      {
+        param: 'media_attributes',
+        body: { media_attributes: [{ id: '1', description: 'x' }] }
+      },
+      { param: 'visibility', body: { visibility: 'private' } }
+    ])(
+      'rejects a poll edit that also changes $param with 422',
+      async ({ param, body }) => {
+        const pollId = `${ACTOR1_ID}/statuses/api-edit-poll-reject-${param}`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: ACTOR1_ID,
+          text: 'Poll cannot change media or visibility',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          choices: ['Yes', 'No'],
+          endAt: Date.now() + 60_000
+        })
 
-      const response = await PUT(
-        new NextRequest(
-          `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
-          {
-            method: 'PUT',
-            body: JSON.stringify({ media_ids: ['1'] }),
-            headers: {
-              'Content-Type': 'application/json',
-              Origin: 'https://llun.test'
+        const response = await PUT(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(pollId)}`,
+            {
+              method: 'PUT',
+              body: JSON.stringify(body),
+              headers: {
+                'Content-Type': 'application/json',
+                Origin: 'https://llun.test'
+              }
             }
-          }
-        ),
-        { params: Promise.resolve({ id: urlToId(pollId) }) }
-      )
+          ),
+          { params: Promise.resolve({ id: urlToId(pollId) }) }
+        )
 
-      expect(response.status).toBe(422)
-    })
+        expect(response.status).toBe(422)
+      }
+    )
   })
 
   describe('status delete', () => {

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { deleteMediaFile } from '@/lib/services/medias'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
@@ -20,6 +21,7 @@ import { Scope } from '@/lib/types/database/operations'
 import { isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { StatusType } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   ERROR_403,
@@ -350,6 +352,34 @@ export const DELETE = traceApiRoute(
         })
       }
 
+      // Mastodon's delete_media param: when truthy the status's uploaded media
+      // is destroyed immediately instead of being kept for redrafting. An
+      // absent param means false; Booleanish mirrors Mastodon's string
+      // boolean coercion for query/form values.
+      const deleteMediaRaw = new URL(req.url).searchParams.get('delete_media')
+      const deleteMediaParsed = Booleanish.safeParse(deleteMediaRaw ?? 'false')
+      const shouldDeleteMedia =
+        deleteMediaParsed.success && deleteMediaParsed.data
+
+      // Capture the media-manager ids before deletion — the attachment rows
+      // are removed with the status. Fitness attachments are not media-manager
+      // uploads and are never storage-deleted here.
+      const mediaIdsToDelete =
+        shouldDeleteMedia && status.type !== StatusType.enum.Announce
+          ? [
+              ...new Set(
+                status.attachments
+                  .filter(
+                    (attachment) =>
+                      !isFitnessStatusAttachment(attachment) &&
+                      attachment.mediaId !== null &&
+                      attachment.mediaId !== undefined
+                  )
+                  .map((attachment) => String(attachment.mediaId))
+              )
+            ]
+          : []
+
       // Get the status for return before deletion
       const mastodonStatus = await getMastodonStatus(
         database,
@@ -359,6 +389,44 @@ export const DELETE = traceApiRoute(
 
       // Delete the status and send Delete activity
       await deleteStatusFromUserInput({ currentActor, statusId, database })
+
+      // With the status (and its attachment rows) gone, reuse the media-manager
+      // DELETE flow: row + usage counters inside a transaction, then
+      // best-effort storage cleanup. deleteMediaForAccount still reports
+      // 'in-use' when the media is attached to another status, so shared media
+      // is never destroyed from under a surviving status.
+      const account = currentActor.account
+      if (mediaIdsToDelete.length > 0 && account) {
+        for (const mediaId of mediaIdsToDelete) {
+          const result = await database.deleteMediaForAccount({
+            mediaId,
+            accountId: account.id
+          })
+          if (result.status !== 'deleted') {
+            logger.warn({
+              message: 'Skipped media cleanup while deleting status',
+              statusId,
+              mediaId,
+              reason: result.status
+            })
+            continue
+          }
+          const deletions = await Promise.allSettled(
+            result.files.map((filePath) => deleteMediaFile(database, filePath))
+          )
+          deletions.forEach((deletion, index) => {
+            if (deletion.status === 'rejected' || !deletion.value) {
+              logger.warn({
+                message:
+                  'Failed to delete storage file for deleted status media',
+                filePath: result.files[index],
+                statusId,
+                mediaId
+              })
+            }
+          })
+        }
+      }
 
       return apiResponse({
         req,

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { deleteStatusFromUserInput } from '@/lib/actions/deleteStatus'
 import { updateNoteFromUserInput } from '@/lib/actions/updateNote'
 import { updateNoteVisibilityFromUserInput } from '@/lib/actions/updateNoteVisibility'
+import { updatePollFromUserInput } from '@/lib/actions/updatePoll'
 import {
   annotateMastodonStatusesWithFilters,
   getActiveFilters
@@ -11,7 +12,14 @@ import {
   OAuthGuardAnyScope,
   OptionalOAuthGuard
 } from '@/lib/services/guards/OAuthGuard'
-import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
+import {
+  MAX_POLL_EXPIRATION_SECONDS,
+  MAX_POLL_OPTIONS,
+  MAX_POLL_OPTION_CHARS,
+  MAX_STATUS_MEDIA_ATTACHMENTS,
+  MIN_POLL_EXPIRATION_SECONDS,
+  MIN_POLL_OPTIONS
+} from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { deleteMediaFile } from '@/lib/services/medias'
 import { FocusSchema } from '@/lib/services/medias/types'
@@ -120,11 +128,30 @@ const EditMediaAttributeSchema = z.object({
   focus: FocusSchema.optional()
 })
 
+// Same bounds as the POST route's PollSchema; expires_in is optional on edit
+// (omitted keeps the current expiry, provided rebases it from now — Mastodon
+// edit semantics).
+const EditPollSchema = z.object({
+  options: z
+    .array(z.string().trim().min(1).max(MAX_POLL_OPTION_CHARS))
+    .min(MIN_POLL_OPTIONS)
+    .max(MAX_POLL_OPTIONS),
+  expires_in: z.coerce
+    .number()
+    .int()
+    .min(MIN_POLL_EXPIRATION_SECONDS)
+    .max(MAX_POLL_EXPIRATION_SECONDS)
+    .optional(),
+  multiple: Booleanish.optional(),
+  hide_totals: Booleanish.optional()
+})
+
 const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().nullish(),
   media_ids: z.array(z.coerce.string()).optional(),
   media_attributes: z.array(EditMediaAttributeSchema).optional(),
+  poll: EditPollSchema.optional(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional(),
   language: z.string().trim().min(1).optional(),
   sensitive: Booleanish.optional()
@@ -189,6 +216,7 @@ export const PUT = traceApiRoute(
           changes.spoiler_text !== undefined ||
           mediaIds !== undefined ||
           mediaAttributes !== undefined ||
+          changes.poll !== undefined ||
           changes.sensitive !== undefined ||
           changes.language !== undefined
         const visibility = changes.visibility
@@ -205,7 +233,8 @@ export const PUT = traceApiRoute(
         const existingStatus = await database.getStatus({ statusId })
         if (
           !existingStatus ||
-          existingStatus.type !== StatusType.enum.Note ||
+          (existingStatus.type !== StatusType.enum.Note &&
+            existingStatus.type !== StatusType.enum.Poll) ||
           existingStatus.actorId !== currentActor.id
         ) {
           return apiResponse({
@@ -213,6 +242,80 @@ export const PUT = traceApiRoute(
             allowedMethods: CORS_HEADERS,
             data: ERROR_403,
             responseStatusCode: 403
+          })
+        }
+
+        if (existingStatus.type === StatusType.enum.Poll) {
+          // Poll statuses carry no media, and visibility editing is only
+          // implemented for notes (updateNoteVisibility rejects polls).
+          if (
+            mediaIds !== undefined ||
+            mediaAttributes !== undefined ||
+            visibility !== undefined
+          ) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_422,
+              responseStatusCode: 422
+            })
+          }
+          const updatedPoll = await updatePollFromUserInput({
+            statusId,
+            currentActor,
+            text: changes.status,
+            summary: changes.spoiler_text,
+            sensitive: changes.sensitive,
+            language: changes.language,
+            ...(changes.poll
+              ? {
+                  poll: {
+                    options: changes.poll.options,
+                    expiresIn: changes.poll.expires_in,
+                    multiple: changes.poll.multiple,
+                    hideTotals: changes.poll.hide_totals
+                  }
+                }
+              : {}),
+            status: existingStatus,
+            database
+          })
+          if (!updatedPoll) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_403,
+              responseStatusCode: 403
+            })
+          }
+          const mastodonPollStatus = await getMastodonStatus(
+            database,
+            updatedPoll,
+            currentActor.id
+          )
+          if (!mastodonPollStatus) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_500,
+              responseStatusCode: 500
+            })
+          }
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: mastodonPollStatus
+          })
+        }
+
+        // Notes cannot gain a poll after the fact (Mastodon's note→poll
+        // conversion on edit is not supported here).
+        if (changes.poll !== undefined) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_422,
+            responseStatusCode: 422
           })
         }
 

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -247,10 +247,13 @@ export const PUT = traceApiRoute(
 
         if (existingStatus.type === StatusType.enum.Poll) {
           // Poll statuses carry no media, and visibility editing is only
-          // implemented for notes (updateNoteVisibility rejects polls).
+          // implemented for notes (updateNoteVisibility rejects polls). Only a
+          // non-empty media set is a real conflict — many clients send an empty
+          // `media_ids: []`/`media_attributes: []` by default on every edit, and
+          // rejecting those would break ordinary poll edits.
           if (
-            mediaIds !== undefined ||
-            mediaAttributes !== undefined ||
+            (mediaIds !== undefined && mediaIds.length > 0) ||
+            (mediaAttributes !== undefined && mediaAttributes.length > 0) ||
             visibility !== undefined
           ) {
             return apiResponse({

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -14,6 +14,7 @@ import {
 import { MAX_STATUS_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { deleteMediaFile } from '@/lib/services/medias'
+import { FocusSchema } from '@/lib/services/medias/types'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
@@ -103,10 +104,27 @@ export const GET = traceApiRoute(
   )
 )
 
+// Matches PUT /api/v1/media/:id's update rules: description capped at the
+// varchar(255) column with blank/explicit-null normalised to null (clears alt
+// text), focus parsed from Mastodon's "x,y" string form. `.optional()` stays
+// OUTERMOST on description so an omitted field short-circuits to undefined
+// (leave untouched) instead of running the transform and clearing alt text.
+const EditMediaAttributeSchema = z.object({
+  id: z.coerce.string(),
+  description: z
+    .string()
+    .max(255)
+    .nullable()
+    .transform((value) => (value && value.trim() ? value : null))
+    .optional(),
+  focus: FocusSchema.optional()
+})
+
 const EditNoteSchema = z.object({
   status: z.string().optional(),
   spoiler_text: z.string().nullish(),
   media_ids: z.array(z.coerce.string()).optional(),
+  media_attributes: z.array(EditMediaAttributeSchema).optional(),
   visibility: z.enum(['public', 'unlisted', 'private', 'direct']).optional(),
   language: z.string().trim().min(1).optional(),
   sensitive: Booleanish.optional()
@@ -147,6 +165,7 @@ export const PUT = traceApiRoute(
           })
         }
         const changes = parsed.data
+        const mediaAttributes = changes.media_attributes
         const mediaIds =
           changes.media_ids === undefined
             ? undefined
@@ -169,6 +188,7 @@ export const PUT = traceApiRoute(
           changes.status !== undefined ||
           changes.spoiler_text !== undefined ||
           mediaIds !== undefined ||
+          mediaAttributes !== undefined ||
           changes.sensitive !== undefined ||
           changes.language !== undefined
         const visibility = changes.visibility
@@ -196,10 +216,64 @@ export const PUT = traceApiRoute(
           })
         }
 
+        // Apply per-attachment metadata edits (Mastodon media_attributes[])
+        // before resolving attachments so the refreshed description/focus flow
+        // into the status's attachment rows below. Reuses the same updateMedia
+        // path as PUT /api/v1/media/:id, including its owner check.
+        if (mediaAttributes !== undefined && mediaAttributes.length > 0) {
+          const account = currentActor.account
+          if (!account) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data: ERROR_422,
+              responseStatusCode: 422
+            })
+          }
+          for (const attribute of mediaAttributes) {
+            const updatedMedia = await database.updateMedia({
+              mediaId: attribute.id,
+              accountId: account.id,
+              ...(attribute.description !== undefined
+                ? { description: attribute.description }
+                : {}),
+              ...(attribute.focus !== undefined
+                ? { focus: attribute.focus }
+                : {})
+            })
+            if (!updatedMedia) {
+              return apiResponse({
+                req,
+                allowedMethods: CORS_HEADERS,
+                data: ERROR_422,
+                responseStatusCode: 422
+              })
+            }
+          }
+        }
+
+        // media_attributes without media_ids re-resolves the status's current
+        // media set so the updated metadata is copied onto the attachment rows.
+        const attachmentMediaIds =
+          mediaIds ??
+          (mediaAttributes !== undefined && mediaAttributes.length > 0
+            ? existingStatus.attachments
+                .filter(
+                  (attachment) =>
+                    !isFitnessStatusAttachment(attachment) &&
+                    attachment.mediaId !== null &&
+                    attachment.mediaId !== undefined
+                )
+                .map((attachment) => String(attachment.mediaId))
+            : undefined)
         const attachments =
-          mediaIds === undefined
+          attachmentMediaIds === undefined
             ? undefined
-            : await getAttachmentsFromMediaIds(database, currentActor, mediaIds)
+            : await getAttachmentsFromMediaIds(
+                database,
+                currentActor,
+                attachmentMediaIds
+              )
         if (attachments === null) {
           return apiResponse({
             req,
@@ -209,7 +283,7 @@ export const PUT = traceApiRoute(
           })
         }
         const changesTextOrMedia =
-          changes.status !== undefined || mediaIds !== undefined
+          changes.status !== undefined || attachmentMediaIds !== undefined
         if (changesTextOrMedia) {
           const effectiveText =
             changes.status === undefined ? existingStatus.text : changes.status

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -11,7 +11,7 @@ import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
-import { Status } from '@/lib/types/domain/status'
+import { Status, StatusPoll } from '@/lib/types/domain/status'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { getNoteFromStatus } from '@/lib/utils/getNoteFromStatus'
 import { urlToId } from '@/lib/utils/urlToId'
@@ -461,6 +461,31 @@ describe('POST /api/v1/statuses', () => {
       { title: 'Coffee', votes_count: 0 }
     ])
     expect(mastodonStatus.poll.multiple).toBe(false)
+  })
+
+  it('persists poll hide_totals on a JSON poll create', async () => {
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'Secret tally?',
+          poll: { options: ['Yes', 'No'], expires_in: 3600, hide_totals: true }
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const mastodonStatus = await response.json()
+    const status = (await database.getStatus({
+      statusId: mastodonStatus.uri,
+      withReplies: false
+    })) as StatusPoll
+    expect(status.hideTotals).toBe(true)
   })
 
   it('rejects a status that carries both media and a poll with 422', async () => {

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -338,6 +338,7 @@ export const POST = traceApiRoute(
             choices: note.poll.options,
             endAt: Date.now() + note.poll.expires_in * 1000,
             pollType: note.poll.multiple ? 'anyOf' : 'oneOf',
+            hideTotals: note.poll.hide_totals,
             visibility: note.visibility,
             sensitive: note.sensitive,
             language: note.language ?? null,

--- a/lib/actions/createPoll.ts
+++ b/lib/actions/createPoll.ts
@@ -27,6 +27,8 @@ interface CreatePollFromUserInputParams {
   database: Database
   endAt: number
   pollType?: 'oneOf' | 'anyOf'
+  // Mastodon poll[hide_totals]: hide per-option tallies until the poll expires.
+  hideTotals?: boolean
   visibility?: MastodonVisibility
   sensitive?: boolean
   language?: string | null
@@ -43,6 +45,7 @@ export const createPollFromUserInput = async ({
   database,
   endAt,
   pollType,
+  hideTotals = false,
   visibility,
   sensitive = false,
   language = null,
@@ -117,6 +120,7 @@ export const createPollFromUserInput = async ({
     choices,
     endAt,
     pollType,
+    hideTotals,
     sensitive,
     language,
     applicationName: application?.name ?? null,

--- a/lib/actions/updatePoll.ts
+++ b/lib/actions/updatePoll.ts
@@ -1,0 +1,106 @@
+import { persistEmojiTagsForStatus } from '@/lib/actions/createNote'
+import { Database } from '@/lib/database/types'
+import { persistDetectedLanguage } from '@/lib/services/language-detection'
+import { addStatusToTimelines } from '@/lib/services/timelines'
+import { Actor } from '@/lib/types/domain/actor'
+import { StatusPoll, StatusType } from '@/lib/types/domain/status'
+import { getSpan } from '@/lib/utils/trace'
+
+interface UpdatePollFromUserInput {
+  statusId: string
+  currentActor: Actor
+  text?: string
+  summary?: string | null
+  sensitive?: boolean
+  language?: string | null
+  poll?: {
+    options: string[]
+    expiresIn?: number
+    multiple?: boolean
+    hideTotals?: boolean
+  }
+  status?: StatusPoll
+  database: Database
+}
+
+export const updatePollFromUserInput = async ({
+  statusId,
+  currentActor,
+  text,
+  summary,
+  sensitive,
+  language,
+  poll,
+  status: preloadedStatus,
+  database
+}: UpdatePollFromUserInput) => {
+  const span = getSpan('actions', 'updatePollFromUser', { statusId })
+  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
+  if (
+    !status ||
+    status.id !== statusId ||
+    status.type !== StatusType.enum.Poll ||
+    status.actorId !== currentActor.id
+  ) {
+    span.end()
+    return null
+  }
+
+  const existingTitles = status.choices.map((choice) => choice.title)
+  const nextPollType =
+    poll?.multiple === undefined
+      ? status.pollType
+      : poll.multiple
+        ? 'anyOf'
+        : 'oneOf'
+  // Mastodon resets votes only when the option set or the multiple-choice mode
+  // actually changes (UpdateStatusService#update_poll!); expiry and
+  // hide_totals adjust in place without invalidating existing votes.
+  const resetVotes =
+    poll !== undefined &&
+    (poll.options.length !== existingTitles.length ||
+      poll.options.some((option, index) => option !== existingTitles[index]) ||
+      nextPollType !== status.pollType)
+
+  let updatedStatus = await database.updatePoll({
+    statusId,
+    text: text ?? status.text,
+    summary: summary === undefined ? undefined : summary?.trim() || '',
+    choices: resetVotes
+      ? poll!.options.map((title) => ({ title, totalVotes: 0 }))
+      : status.choices.map((choice) => ({
+          title: choice.title,
+          totalVotes: choice.totalVotes
+        })),
+    ...(sensitive !== undefined ? { sensitive } : {}),
+    ...(language !== undefined ? { language } : {}),
+    ...(poll?.expiresIn !== undefined
+      ? { endAt: Date.now() + poll.expiresIn * 1000 }
+      : {}),
+    ...(poll?.multiple !== undefined ? { pollType: nextPollType } : {}),
+    ...(poll?.hideTotals !== undefined ? { hideTotals: poll.hideTotals } : {}),
+    resetVotes
+  })
+  if (!updatedStatus) {
+    span.end()
+    return null
+  }
+
+  // Mirror updateNoteFromUserInput: re-sync emoji tags and re-detect the
+  // content language when the text changes.
+  if (text !== undefined) {
+    await database.deleteStatusTagsByType({ statusId, type: 'emoji' })
+    await persistEmojiTagsForStatus({ database, statusId, text })
+    await persistDetectedLanguage({ database, statusId, text })
+    updatedStatus = (await database.getStatus({ statusId })) ?? updatedStatus
+  }
+
+  await addStatusToTimelines(database, updatedStatus)
+
+  // Outbound federation of poll edits (Update(Question)) is not wired up:
+  // getNoteFromStatus returns null for polls and sendUpdateNoteJob rejects
+  // non-Note statuses, so the edit stays local for now.
+
+  span.end()
+  return updatedStatus
+}

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2731,6 +2731,82 @@ describe('StatusDatabase', () => {
           pollOptions: ['Old A', 'Old B']
         })
       })
+
+      it('replaces poll options and resets votes when resetVotes is true', async () => {
+        const pollId = `${emptyActorId}/statuses/poll-replace-options`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Replace options poll',
+          choices: ['Old A', 'Old B'],
+          endAt: Date.now() + 60_000
+        })
+        await database.recordPollVotes({
+          statusId: pollId,
+          actorId: primaryActorId,
+          choices: [0]
+        })
+
+        const updated = (await database.updatePoll({
+          statusId: pollId,
+          text: 'Replace options poll',
+          choices: [
+            { title: 'New A', totalVotes: 0 },
+            { title: 'New B', totalVotes: 0 },
+            { title: 'New C', totalVotes: 0 }
+          ],
+          endAt: Date.now() + 120_000,
+          hideTotals: true,
+          resetVotes: true
+        })) as StatusPoll
+
+        expect(updated.choices.map((choice) => choice.title)).toEqual([
+          'New A',
+          'New B',
+          'New C'
+        ])
+        expect(updated.choices.every((choice) => choice.totalVotes === 0)).toBe(
+          true
+        )
+        expect(updated.votersCount).toBe(0)
+        expect(updated.hideTotals).toBe(true)
+
+        const revisions = await database.getStatusEditHistory({
+          statusId: pollId
+        })
+        expect(revisions).toHaveLength(1)
+        expect(revisions[0].pollOptions).toEqual(['Old A', 'Old B'])
+      })
+
+      it('does not record an edit revision for a tally-only update', async () => {
+        const pollId = `${emptyActorId}/statuses/poll-tally-only`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Tally poll',
+          choices: ['Yes', 'No'],
+          endAt: Date.now() + 60_000
+        })
+
+        await database.updatePoll({
+          statusId: pollId,
+          text: 'Tally poll',
+          choices: [
+            { title: 'Yes', totalVotes: 5 },
+            { title: 'No', totalVotes: 2 }
+          ]
+        })
+
+        await expect(
+          database.getStatusEditHistory({ statusId: pollId })
+        ).resolves.toEqual([])
+      })
     })
 
     describe('poll votes', () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2731,6 +2731,36 @@ describe('StatusDatabase', () => {
         expect(fetched.edits).toHaveLength(0)
       })
 
+      it('records no spurious revision when a createPoll-default ("") summary is cleared', async () => {
+        const pollId = `${emptyActorId}/statuses/poll-default-summary`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: [],
+          text: 'Default summary poll',
+          // No summary -> createPoll default '' (the action would pass null);
+          // clearing it must still be treated as unchanged vs null.
+          choices: ['Alpha', 'Beta'],
+          endAt: Date.now() + 1000
+        })
+
+        await database.updatePoll({
+          statusId: pollId,
+          summary: '',
+          choices: [
+            { title: 'Alpha', totalVotes: 0 },
+            { title: 'Beta', totalVotes: 0 }
+          ]
+        })
+
+        const fetched = (await database.getStatus({
+          statusId: pollId
+        })) as StatusPoll
+        expect(fetched.edits).toHaveLength(0)
+      })
+
       it('snapshots previous poll options into edit history when poll content changes', async () => {
         const pollId = `${emptyActorId}/statuses/poll-history-snapshot`
         await database.createPoll({

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2434,6 +2434,51 @@ describe('StatusDatabase', () => {
           url: 'https://example.com/new.png'
         })
       })
+
+      it('snapshots sensitive, attachments and poll options into edit history revisions', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-history-snapshot`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Snapshot original',
+          sensitive: true
+        })
+        await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://example.com/snapshot-old.jpg',
+          width: 320,
+          height: 240,
+          name: 'old alt text',
+          mediaId: 'snapshot-old-media'
+        })
+
+        await database.updateNote({
+          statusId,
+          text: 'Snapshot updated',
+          summary: null,
+          sensitive: false,
+          attachments: []
+        })
+
+        const revisions = await database.getStatusEditHistory({ statusId })
+        expect(revisions).toHaveLength(1)
+        expect(revisions[0]).toMatchObject({
+          text: 'Snapshot original',
+          sensitive: true,
+          pollOptions: null
+        })
+        expect(revisions[0].attachments).toHaveLength(1)
+        expect(revisions[0].attachments?.[0]).toMatchObject({
+          url: 'https://example.com/snapshot-old.jpg',
+          name: 'old alt text',
+          mediaId: 'snapshot-old-media'
+        })
+      })
     })
 
     describe('updateNoteVisibility', () => {
@@ -2546,6 +2591,40 @@ describe('StatusDatabase', () => {
           { title: 'Alpha', totalVotes: 2 },
           { title: 'Beta', totalVotes: 1 }
         ])
+      })
+
+      it('snapshots previous poll options into edit history when poll content changes', async () => {
+        const pollId = `${emptyActorId}/statuses/poll-history-snapshot`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Original poll text',
+          choices: ['Old A', 'Old B'],
+          endAt: Date.now() + 60_000
+        })
+
+        await database.updatePoll({
+          statusId: pollId,
+          text: 'Updated poll text',
+          choices: [
+            { title: 'Old A', totalVotes: 0 },
+            { title: 'Old B', totalVotes: 0 }
+          ]
+        })
+
+        const revisions = await database.getStatusEditHistory({
+          statusId: pollId
+        })
+        expect(revisions).toHaveLength(1)
+        expect(revisions[0]).toMatchObject({
+          text: 'Original poll text',
+          sensitive: false,
+          attachments: [],
+          pollOptions: ['Old A', 'Old B']
+        })
       })
     })
 

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2541,6 +2541,49 @@ describe('StatusDatabase', () => {
           mediaId: 'snapshot-old-media'
         })
       })
+
+      it('refreshes the copied name on attachments kept across an edit', async () => {
+        const statusId = `${emptyActorId}/statuses/update-note-refresh-name`
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Refresh name target'
+        })
+        await database.createAttachment({
+          actorId: emptyActorId,
+          statusId,
+          mediaType: 'image/jpeg',
+          url: 'https://example.com/kept.jpg',
+          width: 320,
+          height: 240,
+          name: 'old alt',
+          mediaId: 'kept-media'
+        })
+
+        const updated = await database.updateNote({
+          statusId,
+          text: 'Refresh name target',
+          summary: null,
+          attachments: [
+            {
+              type: 'upload',
+              id: 'kept-media',
+              mediaType: 'image/jpeg',
+              url: 'https://example.com/kept.jpg',
+              width: 320,
+              height: 240,
+              name: 'new alt'
+            }
+          ]
+        })
+
+        expect(updated?.attachments).toEqual([
+          expect.objectContaining({ mediaId: 'kept-media', name: 'new alt' })
+        ])
+      })
     })
 
     describe('updateNoteVisibility', () => {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2128,6 +2128,68 @@ describe('StatusDatabase', () => {
       })
     })
 
+    describe('createPoll', () => {
+      it.each([
+        {
+          description: 'persists hideTotals true when provided',
+          hideTotals: true,
+          expected: true
+        },
+        {
+          description: 'defaults hideTotals to false when omitted',
+          hideTotals: undefined,
+          expected: false
+        }
+      ])('$description', async ({ hideTotals, expected }) => {
+        const pollId = `${emptyActorId}/statuses/poll-hide-totals-${expected}`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Hide totals poll',
+          choices: ['Yes', 'No'],
+          endAt: Date.now() + 60_000,
+          ...(hideTotals === undefined ? {} : { hideTotals })
+        })
+
+        const fetched = (await database.getStatus({
+          statusId: pollId
+        })) as StatusPoll
+        expect(fetched.hideTotals).toBe(expected)
+      })
+
+      it('preserves hideTotals across a poll text update', async () => {
+        const pollId = `${emptyActorId}/statuses/poll-hide-totals-preserved`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: 'Original hidden poll',
+          choices: ['Yes', 'No'],
+          endAt: Date.now() + 60_000,
+          hideTotals: true
+        })
+
+        await database.updatePoll({
+          statusId: pollId,
+          text: 'Edited hidden poll',
+          choices: [
+            { title: 'Yes', totalVotes: 0 },
+            { title: 'No', totalVotes: 0 }
+          ]
+        })
+
+        const fetched = (await database.getStatus({
+          statusId: pollId
+        })) as StatusPoll
+        expect(fetched.hideTotals).toBe(true)
+      })
+    })
+
     describe('updateNote', () => {
       it('updates note content and records edit history', async () => {
         const statusId = `${emptyActorId}/statuses/update-note`

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2698,6 +2698,39 @@ describe('StatusDatabase', () => {
         ])
       })
 
+      it('normalizes an empty summary to null without a spurious edit revision', async () => {
+        const pollId = `${emptyActorId}/statuses/poll-empty-summary`
+        await database.createPoll({
+          id: pollId,
+          url: pollId,
+          actorId: emptyActorId,
+          to: ['https://www.w3.org/ns/activitystreams#Public'],
+          cc: [],
+          text: 'No CW poll',
+          summary: null,
+          choices: ['Alpha', 'Beta'],
+          endAt: Date.now() + 1000
+        })
+
+        // Editing a null-CW poll with the conventional empty spoiler keeps the
+        // summary null (not ''), matching createPoll's `|| null` normalization,
+        // so nothing user-visible changes and no edit revision is recorded.
+        await database.updatePoll({
+          statusId: pollId,
+          summary: '',
+          choices: [
+            { title: 'Alpha', totalVotes: 0 },
+            { title: 'Beta', totalVotes: 0 }
+          ]
+        })
+
+        const fetched = (await database.getStatus({
+          statusId: pollId
+        })) as StatusPoll
+        expect(fetched.summary ?? null).toBeNull()
+        expect(fetched.edits).toHaveLength(0)
+      })
+
       it('snapshots previous poll options into edit history when poll content changes', async () => {
         const pollId = `${emptyActorId}/statuses/poll-history-snapshot`
         await database.createPoll({

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -987,7 +987,12 @@ export const StatusSQLDatabaseMixin = (
     const currentTime = new Date()
     const data = getCompatibleJSON(existingStatus.content)
     const nextText = text ?? data.text
-    const nextSummary = summary ?? data.summary
+    // undefined = keep the existing summary; a provided value (including an
+    // empty/whitespace string) normalizes to null when blank, matching
+    // createPoll's `summary?.trim() || null` so a cleared CW never persists as
+    // '' (which would flip contentChanged and record a spurious edit revision).
+    const nextSummary =
+      summary === undefined ? data.summary : summary?.trim() || null
     const content = {
       url: data.url,
       text: nextText,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -547,7 +547,13 @@ export const StatusSQLDatabaseMixin = (
 
     const previousData = {
       text: status.text,
-      summary: status.summary
+      summary: status.summary,
+      // Snapshot the state each /statuses/:id/history revision needs; rows
+      // without these keys (written before snapshotting) read back as null and
+      // fall back to the status's current values in the serializer.
+      sensitive: status.sensitive ?? false,
+      attachments: status.attachments,
+      pollOptions: null
     }
     const currentTime = new Date()
     const content = {
@@ -964,9 +970,16 @@ export const StatusSQLDatabaseMixin = (
 
     await database.transaction(async (trx) => {
       if (nextText !== data.text || nextSummary !== data.summary) {
+        const previousChoices = await trx('poll_choices')
+          .where('statusId', statusId)
+          .orderBy('choiceId', 'asc')
+          .select<{ title: string }[]>('title')
         const previousData = {
           text: data.text,
-          summary: data.summary
+          summary: data.summary,
+          sensitive: data.sensitive ?? false,
+          attachments: [],
+          pollOptions: previousChoices.map((choice) => choice.title)
         }
         await trx('status_history').insert({
           statusId,
@@ -1059,9 +1072,22 @@ export const StatusSQLDatabaseMixin = (
       .orderBy('id', 'asc')
     return rows.map((row) => {
       const content = getCompatibleJSON(row.data)
+      // Rows written before per-revision snapshots only carry text/summary;
+      // the extended fields parse to null so readers can fall back to the
+      // status's current values.
+      const attachments = Attachment.array().safeParse(content?.attachments)
+      const pollOptions = Array.isArray(content?.pollOptions)
+        ? content.pollOptions.filter(
+            (option: unknown): option is string => typeof option === 'string'
+          )
+        : null
       return {
         text: content?.text ?? '',
         summary: content?.summary ?? null,
+        sensitive:
+          typeof content?.sensitive === 'boolean' ? content.sensitive : null,
+        attachments: attachments.success ? attachments.data : null,
+        pollOptions,
         supersededAt: getCompatibleTime(row.updatedAt)
       }
     })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -805,6 +805,7 @@ export const StatusSQLDatabaseMixin = (
     endAt,
     choices,
     pollType = 'oneOf',
+    hideTotals = false,
     sensitive = false,
     language = null,
     applicationName = null,
@@ -821,7 +822,8 @@ export const StatusSQLDatabaseMixin = (
       sensitive,
       language,
       endAt,
-      pollType
+      pollType,
+      hideTotals
     }
     const statusContent = JSON.stringify(content)
     const searchStatus: SQLStatusSearchRow = {
@@ -930,6 +932,7 @@ export const StatusSQLDatabaseMixin = (
       actorAnnounceStatusId: null,
       endAt,
       pollType,
+      hideTotals,
       isLocalActor: Boolean(actor?.account),
       createdAt: getCompatibleTime(statusCreatedAt),
       updatedAt: getCompatibleTime(statusUpdatedAt)
@@ -957,7 +960,8 @@ export const StatusSQLDatabaseMixin = (
       sensitive: data.sensitive ?? false,
       language: data.language ?? null,
       endAt: data.endAt,
-      pollType: data.pollType
+      pollType: data.pollType,
+      hideTotals: data.hideTotals ?? false
     }
     const statusContent = JSON.stringify(content)
     const searchStatus: SQLStatusSearchRow = {
@@ -2704,6 +2708,7 @@ export const StatusSQLDatabaseMixin = (
         // Date.now() so hydration stays deterministic.
         endAt: coercePollEndAt(content.endAt, base.createdAt),
         pollType: content.pollType ?? 'oneOf',
+        hideTotals: content.hideTotals ?? false,
         votersCount,
         voted,
         ownVotes

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -642,6 +642,35 @@ export const StatusSQLDatabaseMixin = (
             })
           })
         )
+
+        // Attachments kept across the edit refresh their copied metadata (alt
+        // text): the attachment row snapshots media.description at attach
+        // time, so a media_attributes edit must re-copy it or the status keeps
+        // serving the stale description. Only rows whose alt text actually
+        // changed are rewritten, so an edit that leaves the media untouched
+        // preserves the existing row (createdAt/updatedAt) unchanged.
+        const existingNameByMediaId = new Map(
+          existingReplaceableAttachments.map((attachment) => [
+            attachment.mediaId,
+            attachment.name ?? ''
+          ])
+        )
+        const keptAttachments = attachments.filter(
+          (attachment) =>
+            existingMediaIds.has(attachment.id) &&
+            (attachment.name ?? '') !== existingNameByMediaId.get(attachment.id)
+        )
+        await Promise.all(
+          keptAttachments.map((attachment) =>
+            trx('attachments')
+              .where('statusId', status.id)
+              .where('mediaId', attachment.id)
+              .update({
+                name: attachment.name ?? '',
+                updatedAt: currentTime
+              })
+          )
+        )
       }
     })
     await indexStatusSearchDocument(database, { status: searchStatus })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1018,7 +1018,10 @@ export const StatusSQLDatabaseMixin = (
     // (federated vote sync) must not.
     const contentChanged =
       nextText !== data.text ||
-      nextSummary !== data.summary ||
+      // Treat an empty-string summary the same as null: a poll created with the
+      // createPoll default ('') edited with a blank spoiler normalizes to null,
+      // which is not a user-visible change and must not record a revision.
+      (nextSummary || null) !== (data.summary || null) ||
       content.sensitive !== (data.sensitive ?? false) ||
       content.language !== (data.language ?? null) ||
       content.endAt !== data.endAt ||

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -972,7 +972,13 @@ export const StatusSQLDatabaseMixin = (
     statusId,
     text,
     summary,
-    choices
+    choices,
+    sensitive,
+    language,
+    endAt,
+    pollType,
+    hideTotals,
+    resetVotes = false
   }: UpdatePollParams) {
     const existingStatus = await database('statuses')
       .where('id', statusId)
@@ -986,11 +992,13 @@ export const StatusSQLDatabaseMixin = (
       url: data.url,
       text: nextText,
       summary: nextSummary,
-      sensitive: data.sensitive ?? false,
-      language: data.language ?? null,
-      endAt: data.endAt,
-      pollType: data.pollType,
-      hideTotals: data.hideTotals ?? false
+      sensitive:
+        sensitive === undefined ? (data.sensitive ?? false) : sensitive,
+      language: language === undefined ? (data.language ?? null) : language,
+      endAt: endAt ?? data.endAt,
+      pollType: pollType ?? data.pollType,
+      hideTotals:
+        hideTotals === undefined ? (data.hideTotals ?? false) : hideTotals
     }
     const statusContent = JSON.stringify(content)
     const searchStatus: SQLStatusSearchRow = {
@@ -1001,8 +1009,20 @@ export const StatusSQLDatabaseMixin = (
       createdAt: existingStatus.createdAt
     }
 
+    // Any user-visible change records an edit revision; a tally-only refresh
+    // (federated vote sync) must not.
+    const contentChanged =
+      nextText !== data.text ||
+      nextSummary !== data.summary ||
+      content.sensitive !== (data.sensitive ?? false) ||
+      content.language !== (data.language ?? null) ||
+      content.endAt !== data.endAt ||
+      content.pollType !== data.pollType ||
+      content.hideTotals !== (data.hideTotals ?? false) ||
+      resetVotes
+
     await database.transaction(async (trx) => {
-      if (nextText !== data.text || nextSummary !== data.summary) {
+      if (contentChanged) {
         const previousChoices = await trx('poll_choices')
           .where('statusId', statusId)
           .orderBy('choiceId', 'asc')
@@ -1028,6 +1048,24 @@ export const StatusSQLDatabaseMixin = (
             content: statusContent,
             updatedAt: currentTime
           })
+      }
+      if (resetVotes) {
+        // Mastodon resets a poll whose options changed: all recorded votes are
+        // removed and the replacement options start from zero. Sequential
+        // inserts keep choiceId order deterministic for hydration.
+        await trx('poll_answers').where('statusId', statusId).delete()
+        await trx('poll_voters').where('statusId', statusId).delete()
+        await trx('poll_choices').where('statusId', statusId).delete()
+        for (const choice of choices) {
+          await trx('poll_choices').insert({
+            statusId,
+            title: choice.title,
+            totalVotes: 0,
+            createdAt: currentTime,
+            updatedAt: currentTime
+          })
+        }
+        return
       }
       for (const choice of choices) {
         await trx('poll_choices')

--- a/lib/jobs/publishScheduledStatusJob.test.ts
+++ b/lib/jobs/publishScheduledStatusJob.test.ts
@@ -7,6 +7,7 @@ import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { Actor } from '@/lib/types/domain/actor'
+import { StatusPoll } from '@/lib/types/domain/status'
 import { ScheduledStatusParams } from '@/lib/types/mastodon/scheduledStatus'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
@@ -124,6 +125,35 @@ describe('publishScheduledStatusJob', () => {
 
     const row = await database.getScheduledStatusById({ id: scheduled.id })
     expect(row).toBeNull()
+  })
+
+  it('carries poll hide_totals through to the published poll', async () => {
+    const text = `Hidden totals scheduled poll ${Date.now()}`
+    const scheduled = await database.createScheduledStatus({
+      actorId: actor1.id,
+      scheduledAt: Date.now() - 1_000,
+      params: baseParams({
+        text,
+        poll: {
+          options: ['Yes', 'No'],
+          expires_in: 3600,
+          multiple: false,
+          hide_totals: true
+        }
+      })
+    })
+
+    await publishScheduledStatusJob(database, {
+      id: 'job-poll-hide-totals',
+      name: PUBLISH_SCHEDULED_STATUS_JOB_NAME,
+      data: { scheduledStatusId: scheduled.id }
+    })
+
+    const statuses = await database.getActorStatuses({ actorId: actor1.id })
+    const published = statuses.find((status) =>
+      status.text.includes(text)
+    ) as StatusPoll
+    expect(published.hideTotals).toBe(true)
   })
 
   it('drops the scheduled row without re-publishing when the idempotency key already maps to a status', async () => {

--- a/lib/jobs/publishScheduledStatusJob.ts
+++ b/lib/jobs/publishScheduledStatusJob.ts
@@ -122,6 +122,7 @@ export const publishScheduledStatusJob = createJobHandle(
         choices: params.poll.options,
         endAt: Date.now() + params.poll.expires_in * 1000,
         pollType: params.poll.multiple ? 'anyOf' : 'oneOf',
+        hideTotals: params.poll.hide_totals,
         visibility: params.visibility,
         sensitive: params.sensitive ?? false,
         language: params.language ?? null,

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -411,6 +411,69 @@ describe('getMastodonStatus', () => {
       expect(mastodonStatus.poll?.voters_count).toEqual(1)
     })
 
+    it('hides per-option tallies for a running hide_totals poll', async () => {
+      const pollId = `${ACTOR3_ID}/statuses/mastodon-hide-totals-running-${Date.now()}`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR3_ID,
+        text: 'Hidden totals poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['First', 'Second'],
+        pollType: 'oneOf',
+        endAt: Date.now() + 60_000,
+        hideTotals: true
+      })
+      await database.recordPollVotes({
+        statusId: pollId,
+        actorId: ACTOR1_ID,
+        choices: [0]
+      })
+
+      const status = (await database.getStatus({ statusId: pollId })) as Status
+      const mastodonStatus = await getMastodonStatus(database, status, ACTOR3_ID)
+
+      expect(mastodonStatus?.poll?.options).toEqual([
+        { title: 'First', votes_count: null },
+        { title: 'Second', votes_count: null }
+      ])
+      // Mastodon's PollSerializer keeps the top-level counts numeric even while
+      // per-option tallies are hidden.
+      expect(mastodonStatus?.poll?.votes_count).toEqual(1)
+      expect(mastodonStatus?.poll?.voters_count).toEqual(1)
+    })
+
+    it('reveals per-option tallies for a hide_totals poll after expiry', async () => {
+      const pollId = `${ACTOR3_ID}/statuses/mastodon-hide-totals-expired-${Date.now()}`
+      await database.createPoll({
+        id: pollId,
+        url: pollId,
+        actorId: ACTOR3_ID,
+        text: 'Expired hidden totals poll',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        choices: ['First', 'Second'],
+        pollType: 'oneOf',
+        endAt: Date.now() - 60_000,
+        hideTotals: true
+      })
+      await database.recordPollVotes({
+        statusId: pollId,
+        actorId: ACTOR1_ID,
+        choices: [0]
+      })
+
+      const status = (await database.getStatus({ statusId: pollId })) as Status
+      const mastodonStatus = await getMastodonStatus(database, status, ACTOR3_ID)
+
+      expect(mastodonStatus?.poll?.expired).toBe(true)
+      expect(mastodonStatus?.poll?.options).toEqual([
+        { title: 'First', votes_count: 1 },
+        { title: 'Second', votes_count: 0 }
+      ])
+    })
+
     it('keys hydrated account cache by actor id when account url is a profile url', async () => {
       const status = (await database.getStatus({
         statusId: `${ACTOR1_ID}/statuses/post-1`

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -432,7 +432,11 @@ describe('getMastodonStatus', () => {
       })
 
       const status = (await database.getStatus({ statusId: pollId })) as Status
-      const mastodonStatus = await getMastodonStatus(database, status, ACTOR3_ID)
+      const mastodonStatus = await getMastodonStatus(
+        database,
+        status,
+        ACTOR3_ID
+      )
 
       expect(mastodonStatus?.poll?.options).toEqual([
         { title: 'First', votes_count: null },
@@ -465,7 +469,11 @@ describe('getMastodonStatus', () => {
       })
 
       const status = (await database.getStatus({ statusId: pollId })) as Status
-      const mastodonStatus = await getMastodonStatus(database, status, ACTOR3_ID)
+      const mastodonStatus = await getMastodonStatus(
+        database,
+        status,
+        ACTOR3_ID
+      )
 
       expect(mastodonStatus?.poll?.expired).toBe(true)
       expect(mastodonStatus?.poll?.options).toEqual([

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -431,7 +431,8 @@ export const getMastodonStatus = async (
     // Mastodon's Poll#show_totals_now?: a hide_totals poll keeps per-option
     // tallies hidden (null) until it expires; the top-level votes_count and
     // voters_count stay numeric per the Poll entity spec.
-    const showTotals = !(status.hideTotals ?? false) || Date.now() > status.endAt
+    const showTotals =
+      !(status.hideTotals ?? false) || Date.now() > status.endAt
 
     pollData = Mastodon.Poll.parse({
       id: urlToId(status.id),

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -428,6 +428,11 @@ export const getMastodonStatus = async (
       options
     )
 
+    // Mastodon's Poll#show_totals_now?: a hide_totals poll keeps per-option
+    // tallies hidden (null) until it expires; the top-level votes_count and
+    // voters_count stay numeric per the Poll entity spec.
+    const showTotals = !(status.hideTotals ?? false) || Date.now() > status.endAt
+
     pollData = Mastodon.Poll.parse({
       id: urlToId(status.id),
       expires_at: getISOTimeUTC(status.endAt),
@@ -440,7 +445,7 @@ export const getMastodonStatus = async (
       voters_count: status.votersCount ?? 0,
       options: status.choices.map((choice) => ({
         title: choice.title,
-        votes_count: choice.totalVotes
+        votes_count: showTotals ? choice.totalVotes : null
       })),
       emojis: [],
       voted,

--- a/lib/services/mastodon/getMastodonStatusEdits.test.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.test.ts
@@ -1,0 +1,105 @@
+import knex from 'knex'
+
+import { getSQLDatabase } from '@/lib/database/sql'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { StatusNote } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import { getMastodonStatusEdits } from './getMastodonStatusEdits'
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn().mockReturnValue({ host: 'llun.test' })
+}))
+
+describe('getMastodonStatusEdits', () => {
+  const knexInstance = knex({
+    client: 'better-sqlite3',
+    useNullAsDefault: true,
+    connection: { filename: ':memory:' }
+  })
+  const database = getSQLDatabase(knexInstance)
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  it('renders per-revision sensitive flags and media from snapshots', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/edits-snapshot-note`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'First version',
+      sensitive: true
+    })
+    await database.createAttachment({
+      actorId: ACTOR1_ID,
+      statusId,
+      mediaType: 'image/jpeg',
+      url: 'https://llun.test/api/v1/files/medias/edits-old.webp',
+      width: 320,
+      height: 240,
+      name: 'old alt',
+      mediaId: 'edits-old-media'
+    })
+
+    await database.updateNote({
+      statusId,
+      text: 'Second version',
+      summary: null,
+      sensitive: false,
+      attachments: []
+    })
+
+    const status = (await database.getStatus({ statusId })) as StatusNote
+    const edits = await getMastodonStatusEdits(database, status)
+
+    expect(edits).toHaveLength(2)
+    expect(edits[0]).toMatchObject({ sensitive: true })
+    expect(edits[0].content).toContain('First version')
+    expect(edits[0].media_attachments).toHaveLength(1)
+    expect(edits[0].media_attachments[0]).toMatchObject({
+      description: 'old alt',
+      url: 'https://llun.test/api/v1/files/medias/edits-old.webp'
+    })
+    expect(edits[1]).toMatchObject({ sensitive: false })
+    expect(edits[1].content).toContain('Second version')
+    expect(edits[1].media_attachments).toEqual([])
+  })
+
+  it('falls back to current values for legacy revisions without snapshots', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/edits-legacy-note`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'Live version',
+      sensitive: true
+    })
+    // A history row written before snapshots existed: only text/summary.
+    await knexInstance('status_history').insert({
+      statusId,
+      data: JSON.stringify({ text: 'Legacy version', summary: null }),
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
+
+    const status = (await database.getStatus({ statusId })) as StatusNote
+    const edits = await getMastodonStatusEdits(database, status)
+
+    expect(edits).toHaveLength(2)
+    expect(edits[0].content).toContain('Legacy version')
+    expect(edits[0]).toMatchObject({ sensitive: true })
+    expect(edits[0].media_attachments).toEqual(edits[1].media_attachments)
+  })
+})

--- a/lib/services/mastodon/getMastodonStatusEdits.test.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.test.ts
@@ -86,6 +86,19 @@ describe('getMastodonStatusEdits', () => {
       text: 'Live version',
       sensitive: true
     })
+    // Give the live status an attachment so the legacy revision (whose media
+    // snapshot is null) must fall back to the CURRENT, non-empty media list —
+    // a regressed fallback returning [] would fail the length assertion below.
+    await database.createAttachment({
+      actorId: ACTOR1_ID,
+      statusId,
+      mediaType: 'image/jpeg',
+      url: 'https://llun.test/api/v1/files/medias/legacy-fallback.jpg',
+      width: 320,
+      height: 240,
+      name: 'legacy fallback alt',
+      mediaId: 'legacy-fallback-media'
+    })
     // A history row written before snapshots existed: only text/summary.
     await knexInstance('status_history').insert({
       statusId,
@@ -100,6 +113,11 @@ describe('getMastodonStatusEdits', () => {
     expect(edits).toHaveLength(2)
     expect(edits[0].content).toContain('Legacy version')
     expect(edits[0]).toMatchObject({ sensitive: true })
+    // The legacy null-snapshot revision falls back to the current media list.
+    expect(edits[0].media_attachments).toHaveLength(1)
+    expect(edits[0].media_attachments[0]).toMatchObject({
+      url: 'https://llun.test/api/v1/files/medias/legacy-fallback.jpg'
+    })
     expect(edits[0].media_attachments).toEqual(edits[1].media_attachments)
   })
 })

--- a/lib/services/mastodon/getMastodonStatusEdits.ts
+++ b/lib/services/mastodon/getMastodonStatusEdits.ts
@@ -1,6 +1,8 @@
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { Mastodon } from '@/lib/types/activitypub'
+import { StatusEditRevision } from '@/lib/types/database/operations'
+import { getMastodonAttachment } from '@/lib/types/domain/attachment'
 import {
   Status,
   StatusNote,
@@ -35,11 +37,17 @@ export interface MastodonStatusEdit {
  * oldest-first and including the original version, matching
  * `GET /api/v1/statuses/:id/history`.
  *
- * Storage only snapshots the text/summary of each prior version (in
- * `status_history`), so per-revision media, poll options, and emojis are
- * approximated with the status's current values. Only the textual content and
- * timestamps differ between revisions.
+ * Each prior version is a per-revision snapshot in `status_history` carrying
+ * its own text/summary/sensitive/media/poll-options. Rows written before
+ * snapshotting existed carry null in the extended fields; those fall back to
+ * the status's current values. Only `emojis` is still taken from the live
+ * status for every revision.
  */
+type RevisionSnapshot = Pick<
+  StatusEditRevision,
+  'text' | 'summary' | 'sensitive' | 'attachments' | 'pollOptions'
+>
+
 export const getMastodonStatusEdits = async (
   database: Database,
   status: StatusNote | StatusPoll,
@@ -49,61 +57,76 @@ export const getMastodonStatusEdits = async (
   if (!current) return []
 
   const host = getConfig().host
-  const pollOptions =
+  const currentPollOptions =
     status.type === StatusType.enum.Poll
-      ? { options: status.choices.map((choice) => ({ title: choice.title })) }
-      : undefined
+      ? status.choices.map((choice) => choice.title)
+      : null
 
   const buildEdit = (
-    text: string,
-    summary: string | null,
+    revision: RevisionSnapshot,
     createdAtMs: number
-  ): MastodonStatusEdit => ({
-    content: processStatusText(host, { ...status, text, summary } as Status),
-    spoiler_text: summary ?? '',
-    // Mastodon stores a dedicated sensitive flag per revision; storage here only
-    // snapshots text/summary, so use the status's current sensitive flag,
-    // forced true when this revision carries a content warning.
-    sensitive:
-      (status.sensitive ?? false) || Boolean(summary && summary.length > 0),
-    created_at: getISOTimeUTC(createdAtMs),
-    account: current.account,
-    ...(pollOptions ? { poll: pollOptions } : {}),
-    media_attachments: current.media_attachments,
-    emojis: current.emojis
-  })
+  ): MastodonStatusEdit => {
+    // Legacy rows (written before per-revision snapshots) carry null in the
+    // extended fields; fall back to the status's current values for those.
+    const sensitive = revision.sensitive ?? status.sensitive ?? false
+    const pollOptions = revision.pollOptions ?? currentPollOptions
+    return {
+      content: processStatusText(host, {
+        ...status,
+        text: revision.text,
+        summary: revision.summary
+      } as Status),
+      spoiler_text: revision.summary ?? '',
+      // Mastodon forces sensitive=true whenever the revision carries a content
+      // warning, mirroring the live-status serializer.
+      sensitive:
+        sensitive || Boolean(revision.summary && revision.summary.length > 0),
+      created_at: getISOTimeUTC(createdAtMs),
+      account: current.account,
+      ...(pollOptions
+        ? { poll: { options: pollOptions.map((title) => ({ title })) } }
+        : {}),
+      // getMastodonAttachment returns null for attachments it cannot serialize
+      // (non image/video); drop those like the timeline serializer effectively
+      // does rather than emitting null entries.
+      media_attachments: revision.attachments
+        ? (revision.attachments
+            .map((attachment) => getMastodonAttachment(attachment))
+            .filter(
+              (attachment) => attachment !== null
+            ) as Mastodon.Status['media_attachments'])
+        : current.media_attachments,
+      emojis: current.emojis
+    }
+  }
+
+  const currentRevision: RevisionSnapshot = {
+    text: status.text,
+    summary: status.summary ?? null,
+    sensitive: status.sensitive ?? false,
+    attachments: status.attachments,
+    pollOptions: currentPollOptions
+  }
 
   const revisions = await database.getStatusEditHistory({ statusId: status.id })
   if (revisions.length === 0) {
     // Never edited: history is the single original/current version.
-    return [buildEdit(status.text, status.summary ?? null, status.createdAt)]
+    return [buildEdit(currentRevision, status.createdAt)]
   }
 
   const edits: MastodonStatusEdit[] = []
   // The original version's content is the oldest snapshot, created when the
   // status itself was created.
-  edits.push(
-    buildEdit(revisions[0].text, revisions[0].summary, status.createdAt)
-  )
+  edits.push(buildEdit(revisions[0], status.createdAt))
   // Each later prior version was created at the moment the version before it
   // was superseded.
   for (let i = 1; i < revisions.length; i++) {
-    edits.push(
-      buildEdit(
-        revisions[i].text,
-        revisions[i].summary,
-        revisions[i - 1].supersededAt
-      )
-    )
+    edits.push(buildEdit(revisions[i], revisions[i - 1].supersededAt))
   }
   // The current (live) version was created when the last prior version was
   // superseded.
   edits.push(
-    buildEdit(
-      status.text,
-      status.summary ?? null,
-      revisions[revisions.length - 1].supersededAt
-    )
+    buildEdit(currentRevision, revisions[revisions.length - 1].supersededAt)
   )
   return edits
 }

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -156,6 +156,27 @@ describe('parseStatusRequestBody', () => {
     })
   })
 
+  it('applies aligned media_attributes fields independently (description without focus)', async () => {
+    // 2 ids + 2 descriptions (aligned -> apply) but only 1 focus (ambiguous ->
+    // skip): the description and focus alignment checks are independent, so the
+    // aligned descriptions must still apply even though focus does not.
+    const params = new URLSearchParams()
+    params.append('media_attributes[][id]', '10')
+    params.append('media_attributes[][description]', 'alt A')
+    params.append('media_attributes[][focus]', '0,0')
+    params.append('media_attributes[][id]', '11')
+    params.append('media_attributes[][description]', 'alt B')
+    const body = await parseStatusRequestBody(
+      createRequest('application/x-www-form-urlencoded', params.toString())
+    )
+    expect(body).toEqual({
+      media_attributes: [
+        { id: '10', description: 'alt A' },
+        { id: '11', description: 'alt B' }
+      ]
+    })
+  })
+
   it('omits media_attributes when a urlencoded body sends none', async () => {
     const body = await parseStatusRequestBody(
       createRequest(

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -139,6 +139,23 @@ describe('parseStatusRequestBody', () => {
     })
   })
 
+  it('does not zip partial media_attributes fields to avoid mis-assigning them', async () => {
+    // Two ids but only one description: with positional bare-[] fields this is
+    // ambiguous (the description could belong to either id), so it must NOT be
+    // applied to the wrong media — both entries stay id-only. Clients needing
+    // per-item control should use a JSON body.
+    const params = new URLSearchParams()
+    params.append('media_attributes[][id]', '10')
+    params.append('media_attributes[][id]', '11')
+    params.append('media_attributes[][description]', 'only alt')
+    const body = await parseStatusRequestBody(
+      createRequest('application/x-www-form-urlencoded', params.toString())
+    )
+    expect(body).toEqual({
+      media_attributes: [{ id: '10' }, { id: '11' }]
+    })
+  })
+
   it('omits media_attributes when a urlencoded body sends none', async () => {
     const body = await parseStatusRequestBody(
       createRequest(

--- a/lib/services/statuses/parseStatusRequestBody.test.ts
+++ b/lib/services/statuses/parseStatusRequestBody.test.ts
@@ -119,4 +119,33 @@ describe('parseStatusRequestBody', () => {
     expect(body).toEqual({ media_ids: [] })
     expect('media_ids' in body).toBe(true)
   })
+
+  it('reconstructs media_attributes entries from a urlencoded body', async () => {
+    const params = new URLSearchParams()
+    params.append('media_attributes[][id]', '10')
+    params.append('media_attributes[][description]', 'first alt')
+    params.append('media_attributes[][focus]', '0.5,-0.5')
+    params.append('media_attributes[][id]', '11')
+    params.append('media_attributes[][description]', 'second alt')
+    params.append('media_attributes[][focus]', '0,0')
+    const body = await parseStatusRequestBody(
+      createRequest('application/x-www-form-urlencoded', params.toString())
+    )
+    expect(body).toEqual({
+      media_attributes: [
+        { id: '10', description: 'first alt', focus: '0.5,-0.5' },
+        { id: '11', description: 'second alt', focus: '0,0' }
+      ]
+    })
+  })
+
+  it('omits media_attributes when a urlencoded body sends none', async () => {
+    const body = await parseStatusRequestBody(
+      createRequest(
+        'application/x-www-form-urlencoded',
+        new URLSearchParams({ status: 'no media attributes' }).toString()
+      )
+    )
+    expect(body).toEqual({ status: 'no media attributes' })
+  })
 })

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -14,6 +14,9 @@ const STATUS_STRING_FIELDS = [
 
 const MEDIA_ID_FIELDS = ['media_ids', 'media_ids[]'] as const
 const POLL_OPTION_FIELDS = ['poll[options][]', 'poll[options]'] as const
+const MEDIA_ATTRIBUTE_ID_FIELD = 'media_attributes[][id]'
+const MEDIA_ATTRIBUTE_DESCRIPTION_FIELD = 'media_attributes[][description]'
+const MEDIA_ATTRIBUTE_FOCUS_FIELD = 'media_attributes[][focus]'
 
 const collectStatusFields = (
   get: (name: string) => unknown,
@@ -57,6 +60,31 @@ const collectStatusFields = (
     const hideTotals = get('poll[hide_totals]')
     if (typeof hideTotals === 'string') poll.hide_totals = hideTotals
     body.poll = poll
+  }
+
+  // Reconstruct the `media_attributes` array-of-hashes Mastodon form clients
+  // flatten into repeated `media_attributes[][id]` / `[][description]` /
+  // `[][focus]` fields. Fields are zipped by position (the nth occurrence of
+  // each field belongs to the nth entry), which holds for clients that send
+  // the same fields for every entry; JSON bodies carry the nested array
+  // natively and skip this path.
+  const mediaAttributeIds = getAll(MEDIA_ATTRIBUTE_ID_FIELD).filter(
+    (value): value is string => typeof value === 'string'
+  )
+  if (mediaAttributeIds.length > 0) {
+    const descriptions = getAll(MEDIA_ATTRIBUTE_DESCRIPTION_FIELD).filter(
+      (value): value is string => typeof value === 'string'
+    )
+    const focuses = getAll(MEDIA_ATTRIBUTE_FOCUS_FIELD).filter(
+      (value): value is string => typeof value === 'string'
+    )
+    body.media_attributes = mediaAttributeIds.map((id, index) => ({
+      id,
+      ...(index < descriptions.length
+        ? { description: descriptions[index] }
+        : {}),
+      ...(index < focuses.length ? { focus: focuses[index] } : {})
+    }))
   }
 
   return body

--- a/lib/services/statuses/parseStatusRequestBody.ts
+++ b/lib/services/statuses/parseStatusRequestBody.ts
@@ -64,10 +64,13 @@ const collectStatusFields = (
 
   // Reconstruct the `media_attributes` array-of-hashes Mastodon form clients
   // flatten into repeated `media_attributes[][id]` / `[][description]` /
-  // `[][focus]` fields. Fields are zipped by position (the nth occurrence of
-  // each field belongs to the nth entry), which holds for clients that send
-  // the same fields for every entry; JSON bodies carry the nested array
-  // natively and skip this path.
+  // `[][focus]` fields. With bare `[]` fields the description/focus values
+  // associate with ids purely by position, so a partial submission (fewer
+  // description/focus values than ids) is ambiguous: apply a field only when
+  // EVERY id has a corresponding value, otherwise leave it untouched rather
+  // than risk mapping a value to the wrong media. Clients needing per-item
+  // control should send a JSON body — the nested array is unambiguous and
+  // carries these values natively (skipping this path).
   const mediaAttributeIds = getAll(MEDIA_ATTRIBUTE_ID_FIELD).filter(
     (value): value is string => typeof value === 'string'
   )
@@ -78,12 +81,12 @@ const collectStatusFields = (
     const focuses = getAll(MEDIA_ATTRIBUTE_FOCUS_FIELD).filter(
       (value): value is string => typeof value === 'string'
     )
+    const alignedDescriptions = descriptions.length === mediaAttributeIds.length
+    const alignedFocuses = focuses.length === mediaAttributeIds.length
     body.media_attributes = mediaAttributeIds.map((id, index) => ({
       id,
-      ...(index < descriptions.length
-        ? { description: descriptions[index] }
-        : {}),
-      ...(index < focuses.length ? { focus: focuses[index] } : {})
+      ...(alignedDescriptions ? { description: descriptions[index] } : {}),
+      ...(alignedFocuses ? { focus: focuses[index] } : {})
     }))
   }
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -496,6 +496,11 @@ export type GetStatusEditHistoryParams = BaseStatusParams
 export type StatusEditRevision = {
   text: string
   summary: string | null
+  // Per-revision snapshots. Null on rows written before snapshotting existed;
+  // readers fall back to the status's current values for those.
+  sensitive: boolean | null
+  attachments: Attachment[] | null
+  pollOptions: string[] | null
   supersededAt: number
 }
 export type DeleteStatusParams = BaseStatusParams & {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -472,6 +472,8 @@ export type CreatePollParams = BaseCreateStatusParams & {
   choices: string[]
   endAt: number
   pollType?: 'oneOf' | 'anyOf'
+  // Mastodon poll[hide_totals]: hide per-option tallies until the poll expires.
+  hideTotals?: boolean
 }
 export type UpdatePollParams = Pick<CreatePollParams, 'text' | 'summary'> &
   BaseStatusParams & {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -478,6 +478,16 @@ export type CreatePollParams = BaseCreateStatusParams & {
 export type UpdatePollParams = Pick<CreatePollParams, 'text' | 'summary'> &
   BaseStatusParams & {
     choices: { title: string; totalVotes: number }[]
+    // Omit to preserve the existing values; provide to overwrite (user edits).
+    sensitive?: boolean
+    language?: string | null
+    endAt?: number
+    pollType?: 'oneOf' | 'anyOf'
+    hideTotals?: boolean
+    // When true `choices` replaces the option set and all recorded votes are
+    // cleared (Mastodon edit semantics); when false/omitted `choices` only
+    // refreshes tallies for the existing titles (federated poll refresh).
+    resetVotes?: boolean
   }
 
 export type GetStatusParams = BaseStatusParams & {

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -123,6 +123,9 @@ export const StatusPoll = StatusNote.extend({
   choices: PollChoice.array(),
   endAt: z.number(),
   pollType: z.enum(['oneOf', 'anyOf']).default('oneOf'),
+  // Mastodon poll[hide_totals]: per-option tallies stay hidden until the poll
+  // expires. Optional so existing rows/literals default to false.
+  hideTotals: z.boolean().optional(),
   votersCount: z.number().optional(),
   voted: z.boolean().optional(),
   ownVotes: z.array(z.number()).optional()


### PR DESCRIPTION
## What

- `poll[hide_totals]` is now persisted on the poll (JSON content blob — no migration) and honored by the serializer: per-option `votes_count` is `null` while a `hide_totals` poll runs and reappears after expiry; top-level `votes_count`/`voters_count` stay numeric, matching Mastodon's `REST::PollSerializer`. Wired through immediate POST, scheduled publish, and poll edits.
- `DELETE /api/v1/statuses/:id?delete_media=true` destroys the status's media-manager rows (reusing the `DELETE /api/v1/media/:id` flow with its in-use guard and usage-counter decrements) and best-effort deletes the storage objects; without the param, media is kept for redrafting as before.
- `PUT /api/v1/statuses/:id` supports `media_attributes[][id|description|focus]` (JSON and form encodings), reusing the media route's validation and `updateMedia`, and refreshing the copied alt text on the status's attachment rows. Omitted fields are left untouched; explicit `""`/`null` clears alt text.
- `PUT /api/v1/statuses/:id` can now edit polls: text/CW/sensitive/language plus `poll[options]`/`expires_in`/`multiple`/`hide_totals`; option or multiple-mode changes replace the option set and reset all votes (Mastodon semantics), while `hide_totals`/`expires_in`-only changes keep votes. Poll edits are local-only for now (outbound `Update(Question)` federation is not wired up — follow-up).
- `GET /api/v1/statuses/:id/history` now renders per-revision `sensitive`, `media_attachments`, and `poll.options` from snapshots written into `status_history.data` at edit time; rows predating snapshots fall back to current values.

## Notes

- No schema migration: both `status_history.data` and `statuses.content` are JSON columns, so the reference schema dumps are untouched.
- Part of Phase 2 (Entity & Parameter Gaps), PR 2.6. Independent of the other Phase 2 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)