### PR TITLE
fix: public + tag timeline params

### DIFF
--- a/app/api/v1/featured_tags/route.ts
+++ b/app/api/v1/featured_tags/route.ts
@@ -10,6 +10,7 @@ import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
+import { isMastodonHashtagName } from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [
@@ -27,14 +28,13 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 // Mastodon hashtag names are word characters only. Strip a single leading `#`
 // and any surrounding whitespace before validating the bare name.
-const FeaturedTagNameRegex = /^[\p{L}\p{N}_]+$/u
 const CreateFeaturedTagRequest = z.object({
   name: z
     .string()
     .trim()
     .max(255)
     .transform((value) => value.replace(/^#+/, ''))
-    .refine((value) => FeaturedTagNameRegex.test(value), {
+    .refine((value) => isMastodonHashtagName(value), {
       message: 'Invalid hashtag name'
     })
 })

--- a/app/api/v1/timelines/public/route.test.ts
+++ b/app/api/v1/timelines/public/route.test.ts
@@ -90,6 +90,37 @@ describe('GET /api/v1/timelines/public', () => {
     ])
   })
 
+  it('applies instance-wide server hide filters for anonymous viewers', async () => {
+    await database.createServerFilter({
+      title: 'Server hidden',
+      context: ['public'],
+      filterAction: 'hide',
+      expiresAt: null,
+      keywords: [{ keyword: 'serverhidden', wholeWord: false }]
+    })
+    const hiddenStatus = await database.createNote({
+      id: `${ACTOR1_ID}/statuses/public-server-hidden`,
+      url: `${ACTOR1_ID}/statuses/public-server-hidden`,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'serverhidden content'
+    })
+    vi.spyOn(database, 'getTimeline').mockResolvedValue([
+      hiddenStatus,
+      publicStatus
+    ])
+
+    const response = await GET(request(), { params: Promise.resolve({}) })
+
+    expect(response.status).toBe(200)
+    const ids = (await response.json()).map((s: { id: string }) => s.id)
+    // The server-wide hide filter drops the matching status even for a
+    // signed-out (anonymous) viewer; the non-matching status survives.
+    expect(ids).not.toContain(urlToId(hiddenStatus.id))
+    expect(ids).toContain(urlToId(publicStatus.id))
+  })
+
   it.each([
     { description: 'junk opaque id', value: 'apurl_@@@@' },
     { description: 'percent signs', value: '%%%' },

--- a/app/api/v1/timelines/public/route.test.ts
+++ b/app/api/v1/timelines/public/route.test.ts
@@ -174,6 +174,72 @@ describe('GET /api/v1/timelines/public', () => {
     })
   })
 
+  describe('min_id/since_id wiring and prev Link', () => {
+    it.each([
+      { description: 'min_id', param: 'min_id' },
+      { description: 'since_id', param: 'since_id' }
+    ])(
+      'passes the decoded $description cursor to the timeline queries',
+      async ({ param }) => {
+        const spy = vi.spyOn(database, 'getTimeline').mockResolvedValue([])
+        const response = await GET(
+          request({ [param]: urlToId(publicStatus.id) }),
+          { params: Promise.resolve({}) }
+        )
+        expect(response.status).toBe(200)
+        expect(spy).toHaveBeenCalledWith(
+          expect.objectContaining({ minStatusId: publicStatus.id })
+        )
+      }
+    )
+
+    it('prefers min_id over since_id when both are provided', async () => {
+      const spy = vi.spyOn(database, 'getTimeline').mockResolvedValue([])
+      await GET(
+        request({
+          min_id: urlToId(publicStatus.id),
+          since_id: urlToId(`${ACTOR1_ID}/statuses/public-other`)
+        }),
+        { params: Promise.resolve({}) }
+      )
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ minStatusId: publicStatus.id })
+      )
+    })
+
+    it('emits a rel="prev" Link with a min_id cursor for a non-empty page', async () => {
+      vi.spyOn(database, 'getTimeline').mockResolvedValue([publicStatus])
+      const response = await GET(request(), { params: Promise.resolve({}) })
+      const link = response.headers.get('Link')
+      expect(link).toContain('rel="prev"')
+      const prevPart = link!
+        .split(', ')
+        .find((part) => part.includes('rel="prev"'))
+      const prevUrl = new URL(prevPart!.match(/<([^>]+)>/)![1])
+      expect(prevUrl.searchParams.get('min_id')).toBe(urlToId(publicStatus.id))
+    })
+  })
+
+  describe('only_media', () => {
+    it('passes onlyMedia=true to the timeline queries', async () => {
+      const spy = vi.spyOn(database, 'getTimeline').mockResolvedValue([])
+      await GET(request({ only_media: 'true' }), {
+        params: Promise.resolve({})
+      })
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ onlyMedia: true })
+      )
+    })
+
+    it('carries only_media into the pagination Links', async () => {
+      vi.spyOn(database, 'getTimeline').mockResolvedValue([publicStatus])
+      const response = await GET(request({ only_media: 'true' }), {
+        params: Promise.resolve({})
+      })
+      expect(response.headers.get('Link')).toContain('only_media=true')
+    })
+  })
+
   describe('merged default scope and Link scope', () => {
     const REMOTE_ACTOR = 'https://somewhere.test/users/bob'
 

--- a/app/api/v1/timelines/public/route.ts
+++ b/app/api/v1/timelines/public/route.ts
@@ -62,64 +62,55 @@ export const GET = traceApiRoute(
         })
       }
       const pageLimit = parsedQuery.query.limit
-      const { local, remote } = parsedQuery.query
+      const { local, remote, onlyMedia, maxStatusId } = parsedQuery.query
+      // `min_id` and `since_id` both express a lower-bound cursor; the timeline
+      // query takes a single min cursor, so collapse them with `min_id`-wins
+      // precedence (matching the list/collection timelines). Both return the
+      // newest page above the bound, like every other timeline route here.
+      const minStatusId =
+        parsedQuery.query.minStatusId ?? parsedQuery.query.sinceStatusId
+
+      const queryTimeline =
+        (timeline: Timeline) =>
+        ({
+          maxStatusId: cursor,
+          limit
+        }: {
+          maxStatusId: string | null
+          limit: number
+        }) =>
+          database.getTimeline({
+            timeline,
+            maxStatusId: cursor,
+            minStatusId,
+            onlyMedia,
+            limit
+          })
 
       // Mastodon scope: local=true → local only, remote=true → federated only,
       // neither (default) → the federated view (local + relay-sourced remote).
       const fetchBatch =
         local && !remote
-          ? ({
-              maxStatusId,
-              limit
-            }: {
-              maxStatusId: string | null
-              limit: number
-            }) =>
-              database.getTimeline({
-                timeline: Timeline.LOCAL_PUBLIC,
-                maxStatusId,
-                limit
-              })
+          ? queryTimeline(Timeline.LOCAL_PUBLIC)
           : remote && !local
-            ? ({
-                maxStatusId,
-                limit
-              }: {
-                maxStatusId: string | null
-                limit: number
-              }) =>
-                database.getTimeline({
-                  timeline: Timeline.FEDERATED_PUBLIC,
-                  maxStatusId,
-                  limit
-                })
-            : async ({
-                maxStatusId,
-                limit
-              }: {
-                maxStatusId: string | null
-                limit: number
-              }) => {
+            ? queryTimeline(Timeline.FEDERATED_PUBLIC)
+            : async (batch: { maxStatusId: string | null; limit: number }) => {
                 const [localStatuses, remoteStatuses] = await Promise.all([
-                  database.getTimeline({
-                    timeline: Timeline.LOCAL_PUBLIC,
-                    maxStatusId,
-                    limit
-                  }),
-                  database.getTimeline({
-                    timeline: Timeline.FEDERATED_PUBLIC,
-                    maxStatusId,
-                    limit
-                  })
+                  queryTimeline(Timeline.LOCAL_PUBLIC)(batch),
+                  queryTimeline(Timeline.FEDERATED_PUBLIC)(batch)
                 ])
-                return mergePublicStatuses(localStatuses, remoteStatuses, limit)
+                return mergePublicStatuses(
+                  localStatuses,
+                  remoteStatuses,
+                  batch.limit
+                )
               }
 
-      const { statuses, nextMaxStatusId, filterRecords } =
+      const { statuses, nextMaxStatusId, prevMinStatusId, filterRecords } =
         await getFilteredStatusPage({
           database,
           actorId: currentActor?.id,
-          maxStatusId: parsedQuery.query.maxStatusId,
+          maxStatusId,
           limit: pageLimit,
           filterContext: currentActor ? 'public' : undefined,
           fetchBatch
@@ -135,15 +126,27 @@ export const GET = traceApiRoute(
         filterRecords ?? []
       )
       const host = headerHost(req.headers)
-      // Only `next` (older) is emitted: the public timeline query pages forward
-      // by `max_id` only and has no lower-bound cursor, so a `prev`/`min_id`
-      // link would not actually page to newer statuses.
-      const scopeParam = local && !remote ? '&local=true' : ''
-      const remoteScopeParam = remote && !local ? '&remote=true' : ''
+      const linkBaseParams = new URLSearchParams()
+      linkBaseParams.set('limit', `${pageLimit}`)
+      if (local && !remote) linkBaseParams.set('local', 'true')
+      if (remote && !local) linkBaseParams.set('remote', 'true')
+      if (onlyMedia) linkBaseParams.set('only_media', 'true')
+      const buildLink = (
+        cursorName: 'max_id' | 'min_id',
+        cursorValue: string
+      ) => {
+        const linkParams = new URLSearchParams(linkBaseParams)
+        linkParams.set(cursorName, urlToId(cursorValue))
+        const rel = cursorName === 'max_id' ? 'next' : 'prev'
+        return `<https://${host}/api/v1/timelines/public?${linkParams.toString()}>; rel="${rel}"`
+      }
       const nextLink = nextMaxStatusId
-        ? `<https://${host}/api/v1/timelines/public?limit=${pageLimit}&max_id=${urlToId(nextMaxStatusId)}${scopeParam}${remoteScopeParam}>; rel="next"`
+        ? buildLink('max_id', nextMaxStatusId)
         : null
-      const links = [nextLink].filter(Boolean).join(', ')
+      const prevLink = prevMinStatusId
+        ? buildLink('min_id', prevMinStatusId)
+        : null
+      const links = [nextLink, prevLink].filter(Boolean).join(', ')
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/timelines/public/route.ts
+++ b/app/api/v1/timelines/public/route.ts
@@ -112,7 +112,11 @@ export const GET = traceApiRoute(
           actorId: currentActor?.id,
           maxStatusId,
           limit: pageLimit,
-          filterContext: currentActor ? 'public' : undefined,
+          // Applied unconditionally so instance-wide server filters reach
+          // signed-out viewers too (getActiveFilters returns only server
+          // filters when actorId is undefined), per REVIEW.md's cross-view
+          // filtering invariant — matching the anon status detail/context views.
+          filterContext: 'public',
           fetchBatch
         })
       const mastodonStatuses = await getMastodonStatuses(

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -16,6 +16,9 @@ const mockDatabase = {
 const mockCurrentActor = {
   id: 'https://local.test/users/me'
 }
+// Overridable per test so the anonymous (signed-out) path can be exercised.
+let currentActorForRequest: typeof mockCurrentActor | undefined =
+  mockCurrentActor
 
 vi.mock('@/lib/services/guards/OAuthGuard', () => ({
   OptionalOAuthGuard:
@@ -33,7 +36,7 @@ vi.mock('@/lib/services/guards/OAuthGuard', () => ({
     (req: NextRequest, context: { params: Promise<{ hashtag: string }> }) =>
       handle(req, {
         database: mockDatabase,
-        currentActor: mockCurrentActor,
+        currentActor: currentActorForRequest,
         params: context.params
       }),
   corsErrorResponse: vi.fn()
@@ -53,6 +56,7 @@ const status = {
 describe('GET /api/v1/timelines/tag/:hashtag', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    currentActorForRequest = mockCurrentActor
     mockDatabase.getBlockRelations.mockResolvedValue([])
     mockDatabase.getMuteRelations.mockResolvedValue([])
     mockDatabase.getStatusesByHashtag.mockResolvedValue([status])
@@ -207,12 +211,15 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       )
     })
 
-    it('passes the decoded min_id cursor to the hashtag query', async () => {
-      await requestWithQuery({ min_id: urlToId(status.id) })
-      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
-        expect.objectContaining({ minStatusId: status.id })
-      )
-    })
+    it.each([{ param: 'min_id' }, { param: 'since_id' }])(
+      'passes the decoded $param cursor as minStatusId to the hashtag query',
+      async ({ param }) => {
+        await requestWithQuery({ [param]: urlToId(status.id) })
+        expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+          expect.objectContaining({ minStatusId: status.id })
+        )
+      }
+    )
   })
 
   describe('keyword filters and prev Link', () => {
@@ -225,6 +232,158 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
         actorId: mockCurrentActor.id,
         context: 'public'
       })
+    })
+
+    it('drops a status matched by a hide keyword filter before serializing', async () => {
+      const spoilerStatus = {
+        id: 'https://local.test/users/alice/statuses/spoiler',
+        actorId: 'https://local.test/users/alice',
+        type: StatusType.enum.Note,
+        text: 'major blockword spoiler',
+        summary: null
+      } as unknown as Status
+      mockDatabase.getStatusesByHashtag.mockResolvedValue([spoilerStatus])
+      mockDatabase.getActiveFiltersForActor.mockResolvedValue([
+        {
+          filter: {
+            id: 'f-hide',
+            actorId: mockCurrentActor.id,
+            title: 'Spoilers',
+            context: ['public'],
+            filterAction: 'hide',
+            expiresAt: null,
+            createdAt: 0,
+            updatedAt: 0
+          },
+          keywords: [
+            {
+              id: 'f-hide:kw',
+              filterId: 'f-hide',
+              keyword: 'blockword',
+              wholeWord: false,
+              createdAt: 0,
+              updatedAt: 0
+            }
+          ],
+          statuses: []
+        }
+      ])
+
+      await GET(
+        new NextRequest('https://local.test/api/v1/timelines/tag/running'),
+        { params: Promise.resolve({ hashtag: 'running' }) }
+      )
+
+      // getFilteredStatusPage drops the hide match before serialization, so the
+      // Mastodon serializer receives an empty list (not the leaked statuses).
+      expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+        mockDatabase,
+        [],
+        mockCurrentActor.id
+      )
+    })
+
+    it('applies instance-wide server hide filters for signed-out viewers', async () => {
+      currentActorForRequest = undefined
+      const serverBlocked = {
+        id: 'https://local.test/users/alice/statuses/server-blocked',
+        actorId: 'https://local.test/users/alice',
+        type: StatusType.enum.Note,
+        text: 'serverblock content',
+        summary: null
+      } as unknown as Status
+      mockDatabase.getStatusesByHashtag.mockResolvedValue([serverBlocked])
+      mockDatabase.getActiveServerFilters.mockResolvedValue([
+        {
+          filter: {
+            id: 'sf-hide',
+            title: 'Server hide',
+            context: ['public'],
+            filterAction: 'hide',
+            expiresAt: null,
+            createdAt: 0,
+            updatedAt: 0
+          },
+          keywords: [
+            {
+              id: 'sf-hide:kw',
+              filterId: 'sf-hide',
+              keyword: 'serverblock',
+              wholeWord: false,
+              createdAt: 0,
+              updatedAt: 0
+            }
+          ]
+        }
+      ])
+
+      await GET(
+        new NextRequest('https://local.test/api/v1/timelines/tag/running'),
+        { params: Promise.resolve({ hashtag: 'running' }) }
+      )
+
+      // Anonymous: per-actor filters are skipped (no actor), but instance-wide
+      // server filters still load and drop the matching status.
+      expect(mockDatabase.getActiveFiltersForActor).not.toHaveBeenCalled()
+      expect(mockDatabase.getActiveServerFilters).toHaveBeenCalledWith({
+        context: 'public'
+      })
+      expect(mockGetMastodonStatuses).toHaveBeenCalledWith(
+        mockDatabase,
+        [],
+        undefined
+      )
+    })
+
+    it('annotates a warn-filtered status via the response filtered field', async () => {
+      const warnStatus = {
+        id: 'https://local.test/users/alice/statuses/warn',
+        actorId: 'https://local.test/users/alice',
+        type: StatusType.enum.Note,
+        text: 'contains warnword here',
+        summary: null
+      } as unknown as Status
+      mockDatabase.getStatusesByHashtag.mockResolvedValue([warnStatus])
+      // annotateMastodonStatusesWithFilters pairs by status id, so the mock
+      // Mastodon status must carry the domain status's id.
+      mockGetMastodonStatuses.mockResolvedValue([
+        { id: urlToId(warnStatus.id) }
+      ])
+      mockDatabase.getActiveFiltersForActor.mockResolvedValue([
+        {
+          filter: {
+            id: 'f-warn',
+            actorId: mockCurrentActor.id,
+            title: 'Warn',
+            context: ['public'],
+            filterAction: 'warn',
+            expiresAt: null,
+            createdAt: 0,
+            updatedAt: 0
+          },
+          keywords: [
+            {
+              id: 'f-warn:kw',
+              filterId: 'f-warn',
+              keyword: 'warnword',
+              wholeWord: false,
+              createdAt: 0,
+              updatedAt: 0
+            }
+          ],
+          statuses: []
+        }
+      ])
+
+      const response = await GET(
+        new NextRequest('https://local.test/api/v1/timelines/tag/running'),
+        { params: Promise.resolve({ hashtag: 'running' }) }
+      )
+      const data = await response.json()
+      // Warn matches are kept but annotated: the response uses
+      // annotateMastodonStatusesWithFilters, not the raw serialized statuses.
+      expect(data).toHaveLength(1)
+      expect(data[0].filtered?.length ?? 0).toBeGreaterThan(0)
     })
 
     it('emits a rel="prev" Link carrying the tag filters', async () => {

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { Status, StatusType } from '@/lib/types/domain/status'
+import { urlToId } from '@/lib/utils/urlToId'
 
 import { GET } from './route'
 
@@ -8,7 +9,9 @@ const mockGetMastodonStatuses = vi.fn()
 const mockDatabase = {
   getBlockRelations: vi.fn(),
   getMuteRelations: vi.fn(),
-  getStatusesByHashtag: vi.fn()
+  getStatusesByHashtag: vi.fn(),
+  getActiveFiltersForActor: vi.fn(),
+  getActiveServerFilters: vi.fn()
 }
 const mockCurrentActor = {
   id: 'https://local.test/users/me'
@@ -54,6 +57,8 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
     mockDatabase.getMuteRelations.mockResolvedValue([])
     mockDatabase.getStatusesByHashtag.mockResolvedValue([status])
     mockGetMastodonStatuses.mockResolvedValue([{ id: '1' }])
+    mockDatabase.getActiveFiltersForActor.mockResolvedValue([])
+    mockDatabase.getActiveServerFilters.mockResolvedValue([])
   })
 
   it('passes the current actor id when batch serializing authenticated Mastodon hashtag statuses', async () => {
@@ -100,5 +105,142 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual([])
     expect(response.headers.get('Link')).toBeNull()
+  })
+
+  describe('hashtag name validation', () => {
+    it.each([
+      { description: 'a decoded Unicode hashtag', param: '日本語' },
+      {
+        description: 'a percent-encoded Unicode hashtag',
+        param: encodeURIComponent('日本語')
+      }
+    ])(
+      'accepts $description and queries the decoded name',
+      async ({ param }) => {
+        const response = await GET(
+          new NextRequest(
+            `https://local.test/api/v1/timelines/tag/${encodeURIComponent('日本語')}`
+          ),
+          { params: Promise.resolve({ hashtag: param }) }
+        )
+        expect(response.status).toBe(200)
+        expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+          expect.objectContaining({ hashtag: '日本語' })
+        )
+      }
+    )
+
+    it.each([
+      { description: 'a dash', param: 'foo-bar' },
+      { description: 'an encoded space', param: 'foo%20bar' },
+      { description: 'an encoded emoji', param: 'fun%F0%9F%8E%89' }
+    ])('returns 400 for a name containing $description', async ({ param }) => {
+      const response = await GET(
+        new NextRequest(`https://local.test/api/v1/timelines/tag/${param}`),
+        { params: Promise.resolve({ hashtag: param }) }
+      )
+      expect(response.status).toBe(400)
+      expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('tag filters and scope params', () => {
+    const requestWithQuery = (query: Record<string, string | string[]>) => {
+      const url = new URL('https://local.test/api/v1/timelines/tag/running')
+      for (const [key, value] of Object.entries(query)) {
+        for (const item of Array.isArray(value) ? value : [value]) {
+          url.searchParams.append(key, item)
+        }
+      }
+      return GET(new NextRequest(url.toString()), {
+        params: Promise.resolve({ hashtag: 'running' })
+      })
+    }
+
+    it('forwards any[]/all[]/none[] tags to the hashtag query', async () => {
+      const response = await requestWithQuery({
+        'any[]': ['cycling'],
+        'all[]': ['fitness'],
+        'none[]': ['walking']
+      })
+      expect(response.status).toBe(200)
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({
+          anyTags: ['cycling'],
+          allTags: ['fitness'],
+          noneTags: ['walking']
+        })
+      )
+    })
+
+    it('caps each tag mode at four tags like Mastodon', async () => {
+      await requestWithQuery({ 'any[]': ['a1', 'a2', 'a3', 'a4', 'a5'] })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ anyTags: ['a1', 'a2', 'a3', 'a4'] })
+      )
+    })
+
+    it('returns 400 for an invalid additional tag name', async () => {
+      const response = await requestWithQuery({ 'any[]': ['bad tag'] })
+      expect(response.status).toBe(400)
+      expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
+    })
+
+    it('forwards the local scope to the hashtag query', async () => {
+      await requestWithQuery({ local: 'true' })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ local: true, remote: false })
+      )
+    })
+
+    it('forwards the remote scope to the hashtag query', async () => {
+      await requestWithQuery({ remote: 'true' })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ local: false, remote: true })
+      )
+    })
+
+    it('forwards only_media to the hashtag query', async () => {
+      await requestWithQuery({ only_media: 'true' })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ onlyMedia: true })
+      )
+    })
+
+    it('passes the decoded min_id cursor to the hashtag query', async () => {
+      await requestWithQuery({ min_id: urlToId(status.id) })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ minStatusId: status.id })
+      )
+    })
+  })
+
+  describe('keyword filters and prev Link', () => {
+    it('loads keyword filters with the public context for a signed-in viewer', async () => {
+      await GET(
+        new NextRequest('https://local.test/api/v1/timelines/tag/running'),
+        { params: Promise.resolve({ hashtag: 'running' }) }
+      )
+      expect(mockDatabase.getActiveFiltersForActor).toHaveBeenCalledWith({
+        actorId: mockCurrentActor.id,
+        context: 'public'
+      })
+    })
+
+    it('emits a rel="prev" Link carrying the tag filters', async () => {
+      const url = new URL('https://local.test/api/v1/timelines/tag/running')
+      url.searchParams.append('any[]', 'cycling')
+      const response = await GET(new NextRequest(url.toString()), {
+        params: Promise.resolve({ hashtag: 'running' })
+      })
+      const link = response.headers.get('Link')
+      expect(link).toContain('rel="prev"')
+      const prevPart = link!
+        .split(', ')
+        .find((part) => part.includes('rel="prev"'))
+      const prevUrl = new URL(prevPart!.match(/<([^>]+)>/)![1])
+      expect(prevUrl.searchParams.get('min_id')).toBe(urlToId(status.id))
+      expect(prevUrl.searchParams.getAll('any[]')).toEqual(['cycling'])
+    })
   })
 })

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -211,6 +211,12 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       )
     })
 
+    it('rejects an over-length additional tag name with 400', async () => {
+      const response = await requestWithQuery({ 'any[]': 'a'.repeat(256) })
+      expect(response.status).toBe(400)
+      expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
+    })
+
     it('forwards only_media to the hashtag query', async () => {
       await requestWithQuery({ only_media: 'true' })
       expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -177,10 +177,35 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       )
     })
 
-    it('caps each tag mode at four tags like Mastodon', async () => {
+    it('caps all[]/none[] at four tags like Mastodon', async () => {
+      await requestWithQuery({
+        'all[]': ['a1', 'a2', 'a3', 'a4', 'a5'],
+        'none[]': ['n1', 'n2', 'n3', 'n4', 'n5']
+      })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allTags: ['a1', 'a2', 'a3', 'a4'],
+          noneTags: ['n1', 'n2', 'n3', 'n4']
+        })
+      )
+    })
+
+    it('counts the primary hashtag toward the any[] cap (three extra max)', async () => {
+      // Mastodon unions the primary tag into the any[] OR-set before capping
+      // at four (tags_for(Array(tag.name) | Array(params[:any]))), so the
+      // primary counts toward the limit and only three additional names pass.
       await requestWithQuery({ 'any[]': ['a1', 'a2', 'a3', 'a4', 'a5'] })
       expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
-        expect.objectContaining({ anyTags: ['a1', 'a2', 'a3', 'a4'] })
+        expect.objectContaining({ anyTags: ['a1', 'a2', 'a3'] })
+      )
+    })
+
+    it('drops the primary hashtag from any[] to avoid double-counting', async () => {
+      // any[]=running on tag `running` is redundant with the primary term, so
+      // the OR-set stays {running, a1, a2, a3} rather than spending a slot on it.
+      await requestWithQuery({ 'any[]': ['running', 'a1', 'a2', 'a3'] })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ anyTags: ['a1', 'a2', 'a3'] })
       )
     })
 
@@ -399,9 +424,16 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       expect(data[0].filtered?.length ?? 0).toBeGreaterThan(0)
     })
 
-    it('emits a rel="prev" Link carrying the tag filters', async () => {
+    // buildLink shares one linkBaseParams between the prev and next Links, so
+    // asserting the prev Link's base params covers the shared param-building
+    // path (the any/all/none loop plus the local/remote/only_media setters).
+    it('emits a rel="prev" Link carrying every tag filter and scope param', async () => {
       const url = new URL('https://local.test/api/v1/timelines/tag/running')
       url.searchParams.append('any[]', 'cycling')
+      url.searchParams.append('all[]', 'fitness')
+      url.searchParams.append('none[]', 'walking')
+      url.searchParams.set('only_media', 'true')
+      url.searchParams.set('local', 'true')
       const response = await GET(new NextRequest(url.toString()), {
         params: Promise.resolve({ hashtag: 'running' })
       })
@@ -413,6 +445,25 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       const prevUrl = new URL(prevPart!.match(/<([^>]+)>/)![1])
       expect(prevUrl.searchParams.get('min_id')).toBe(urlToId(status.id))
       expect(prevUrl.searchParams.getAll('any[]')).toEqual(['cycling'])
+      expect(prevUrl.searchParams.getAll('all[]')).toEqual(['fitness'])
+      expect(prevUrl.searchParams.getAll('none[]')).toEqual(['walking'])
+      expect(prevUrl.searchParams.get('only_media')).toBe('true')
+      expect(prevUrl.searchParams.get('local')).toBe('true')
+    })
+
+    it('carries the remote scope (not local) into the prev Link', async () => {
+      const url = new URL('https://local.test/api/v1/timelines/tag/running')
+      url.searchParams.set('remote', 'true')
+      const response = await GET(new NextRequest(url.toString()), {
+        params: Promise.resolve({ hashtag: 'running' })
+      })
+      const prevPart = response.headers
+        .get('Link')!
+        .split(', ')
+        .find((part) => part.includes('rel="prev"'))
+      const prevUrl = new URL(prevPart!.match(/<([^>]+)>/)![1])
+      expect(prevUrl.searchParams.get('remote')).toBe('true')
+      expect(prevUrl.searchParams.has('local')).toBe(false)
     })
   })
 })

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -146,6 +146,19 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       expect(response.status).toBe(400)
       expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
     })
+
+    it('returns 400 for an over-length primary hashtag', async () => {
+      // Params caps the primary at .max(255); it is the only length guard on
+      // this path (the Unicode validator has no upper bound), so an unbounded
+      // name must never reach getStatusesByHashtag.
+      const param = 'a'.repeat(256)
+      const response = await GET(
+        new NextRequest(`https://local.test/api/v1/timelines/tag/${param}`),
+        { params: Promise.resolve({ hashtag: param }) }
+      )
+      expect(response.status).toBe(400)
+      expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
+    })
   })
 
   describe('tag filters and scope params', () => {

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -204,6 +204,13 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       )
     })
 
+    it('deduplicates repeated tags before querying', async () => {
+      await requestWithQuery({ 'all[]': ['cycling', 'cycling', 'running'] })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ allTags: ['cycling', 'running'] })
+      )
+    })
+
     it('forwards only_media to the hashtag query', async () => {
       await requestWithQuery({ only_media: 'true' })
       expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -260,6 +260,16 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
     })
 
+    it('ignores a blank additional tag value instead of 400ing', async () => {
+      // An empty filter slot (`?any[]=`) is not a malformed tag — serve the
+      // timeline with that mode empty rather than rejecting the whole request.
+      const response = await requestWithQuery({ 'any[]': '' })
+      expect(response.status).toBe(200)
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ anyTags: [] })
+      )
+    })
+
     it('forwards only_media to the hashtag query', async () => {
       await requestWithQuery({ only_media: 'true' })
       expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
@@ -276,6 +286,19 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
         )
       }
     )
+
+    it('prefers min_id over since_id when both are provided', async () => {
+      // The route collapses both lower-bound cursors with min_id-wins
+      // precedence (matching the public timeline). Pin it so a swapped operand
+      // order can't regress silently.
+      await requestWithQuery({
+        min_id: urlToId(status.id),
+        since_id: urlToId('https://local.test/users/alice/statuses/other')
+      })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ minStatusId: status.id })
+      )
+    })
   })
 
   describe('keyword filters and prev Link', () => {

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -177,6 +177,24 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       )
     })
 
+    it('strips a leading # from an additional tag before querying', async () => {
+      // isMastodonHashtagName rejects '#', so parseAdditionalTags must strip the
+      // leading hash; otherwise a `#cycling` additional tag would 400 the request.
+      await requestWithQuery({ 'any[]': ['#cycling'] })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ anyTags: ['cycling'] })
+      )
+    })
+
+    it('accepts the bare-key (no []) additional tag form', async () => {
+      // Mastodon reads Array(params[:any]), so `any=cycling` without the []
+      // suffix must widen the OR-set the same as `any[]=cycling`.
+      await requestWithQuery({ any: 'cycling' })
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ anyTags: ['cycling'] })
+      )
+    })
+
     it('caps all[]/none[] at four tags like Mastodon', async () => {
       await requestWithQuery({
         'all[]': ['a1', 'a2', 'a3', 'a4', 'a5'],

--- a/app/api/v1/timelines/tag/[hashtag]/route.test.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.test.ts
@@ -147,10 +147,9 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
     })
 
-    it('returns 400 for an over-length primary hashtag', async () => {
-      // Params caps the primary at .max(255); it is the only length guard on
-      // this path (the Unicode validator has no upper bound), so an unbounded
-      // name must never reach getStatusesByHashtag.
+    it('returns 400 for an over-length primary hashtag (decoded > 255)', async () => {
+      // The 255-char cap is enforced on the decoded name, the only length guard
+      // on this path, so an unbounded name never reaches getStatusesByHashtag.
       const param = 'a'.repeat(256)
       const response = await GET(
         new NextRequest(`https://local.test/api/v1/timelines/tag/${param}`),
@@ -158,6 +157,23 @@ describe('GET /api/v1/timelines/tag/:hashtag', () => {
       )
       expect(response.status).toBe(400)
       expect(mockDatabase.getStatusesByHashtag).not.toHaveBeenCalled()
+    })
+
+    it('accepts a Unicode hashtag whose percent-encoded length exceeds 255', async () => {
+      // Each Japanese char percent-encodes to 9 chars, so a 30-char name is 270
+      // encoded — over the decoded 255 limit but a valid short name. The raw
+      // param cap must not reject it before decoding.
+      const name = 'あ'.repeat(30)
+      const encoded = encodeURIComponent(name)
+      expect(encoded.length).toBeGreaterThan(255)
+      const response = await GET(
+        new NextRequest(`https://local.test/api/v1/timelines/tag/${encoded}`),
+        { params: Promise.resolve({ hashtag: encoded }) }
+      )
+      expect(response.status).toBe(200)
+      expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+        expect.objectContaining({ hashtag: name })
+      )
     })
   })
 

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -55,6 +55,11 @@ const parseAdditionalTags = (
   const tags = new Set<string>()
   for (const value of values) {
     const name = value.replace(/^#+/, '')
+    // A blank value (e.g. `?any[]=` or a bare `#`) is an empty filter slot, not
+    // a malformed tag — skip it rather than 400 the whole request, matching
+    // parseTimelineQuery's blank-cursor coercion and Mastodon's lookup-not-reject
+    // behavior (a missing tag simply matches nothing).
+    if (!name) continue
     // Bound the length like the primary hashtag (max 255) so an unbounded tag
     // name can't reach the DB query; then validate the Unicode alphabet.
     if (name.length > 255 || !isMastodonHashtagName(name)) return null

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -107,9 +107,12 @@ export const GET = traceApiRoute(
           actorId: currentActor?.id,
           maxStatusId,
           limit: effectiveLimit,
-          // Hashtag pages use the public keyword-filter context, mirroring the
-          // public timeline: hide-filters drop rows, warn-filters annotate.
-          filterContext: currentActor ? 'public' : undefined,
+          // Hashtag pages use the public keyword-filter context: hide-filters
+          // drop rows, warn-filters annotate. Applied unconditionally so
+          // instance-wide server filters reach signed-out viewers too
+          // (getActiveFilters returns only server filters when actorId is
+          // undefined), per REVIEW.md's cross-view filtering invariant.
+          filterContext: 'public',
           fetchBatch: ({ maxStatusId: cursor, limit }) =>
             database.getStatusesByHashtag({
               hashtag,

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -54,7 +54,9 @@ const parseAdditionalTags = (
   const tags = new Set<string>()
   for (const value of values) {
     const name = value.replace(/^#+/, '')
-    if (!isMastodonHashtagName(name)) return null
+    // Bound the length like the primary hashtag (max 255) so an unbounded tag
+    // name can't reach the DB query; then validate the Unicode alphabet.
+    if (name.length > 255 || !isMastodonHashtagName(name)) return null
     // Dedupe so duplicate tags don't append redundant (esp. `all[]`) subqueries.
     tags.add(name)
   }

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -51,13 +51,14 @@ const parseAdditionalTags = (
     ...searchParams.getAll(`${key}[]`),
     ...searchParams.getAll(key)
   ]
-  const tags: string[] = []
+  const tags = new Set<string>()
   for (const value of values) {
     const name = value.replace(/^#+/, '')
     if (!isMastodonHashtagName(name)) return null
-    tags.push(name)
+    // Dedupe so duplicate tags don't append redundant (esp. `all[]`) subqueries.
+    tags.add(name)
   }
-  return tags.slice(0, TAGS_PER_MODE_LIMIT)
+  return Array.from(tags).slice(0, TAGS_PER_MODE_LIMIT)
 }
 
 // https://docs.joinmastodon.org/methods/timelines/#tag

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -36,8 +36,9 @@ interface RouteParams {
   hashtag: string
 }
 
-// Mastodon caps each of any[]/all[]/none[] at 4 additional tags
-// (HashtagQueryService LIMIT_PER_MODE).
+// Mastodon's HashtagQueryService caps each mode at LIMIT_PER_MODE tags. For
+// all[]/none[] the cap applies to the array on its own; for any[] the primary
+// hashtag is unioned in first (see effectiveAnyTags below), so it counts too.
 const TAGS_PER_MODE_LIMIT = 4
 
 // Collect the repeated `key[]` (and bare `key`) query params as bare hashtag
@@ -97,6 +98,17 @@ export const GET = traceApiRoute(
         return badRequest()
       }
 
+      // `any[]` is special-cased in Mastodon's HashtagQueryService: the primary
+      // hashtag is unioned into the OR-set *before* the LIMIT_PER_MODE cap
+      // (`tags_for(Array(tag.name) | Array(params[:any]))`), so the primary
+      // counts toward the four. Drop the primary and any duplicates, then keep
+      // at most three additional names, so the combined OR-set
+      // `[hashtag, ...effectiveAnyTags]` built by getStatusesByHashtag never
+      // exceeds four. (all[]/none[] stay capped on their own arrays.)
+      const effectiveAnyTags = Array.from(new Set([hashtag, ...anyTags]))
+        .slice(0, TAGS_PER_MODE_LIMIT)
+        .filter((name) => name !== hashtag)
+
       const effectiveLimit = parsedQuery.query.limit
       const { local, remote, onlyMedia, maxStatusId } = parsedQuery.query
       // `min_id` and `since_id` both express a lower-bound cursor; collapse
@@ -125,7 +137,7 @@ export const GET = traceApiRoute(
               onlyMedia,
               local: local && !remote,
               remote: remote && !local,
-              anyTags,
+              anyTags: effectiveAnyTags,
               allTags,
               noneTags
             })
@@ -136,7 +148,7 @@ export const GET = traceApiRoute(
       const linkBaseParams = new URLSearchParams()
       linkBaseParams.set('limit', `${effectiveLimit}`)
       for (const [mode, tags] of [
-        ['any', anyTags],
+        ['any', effectiveAnyTags],
         ['all', allTags],
         ['none', noneTags]
       ] as const) {

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { annotateMastodonStatusesWithFilters } from '@/lib/services/filters/applyFilters'
 import {
   OptionalOAuthGuard,
   corsErrorResponse
@@ -14,6 +15,10 @@ import {
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import {
+  isMastodonHashtagName,
+  normalizeHashtagParam
+} from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -24,11 +29,35 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  hashtag: z.string().regex(/^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/)
+  hashtag: z.string().min(1).max(255)
 })
 
 interface RouteParams {
   hashtag: string
+}
+
+// Mastodon caps each of any[]/all[]/none[] at 4 additional tags
+// (HashtagQueryService LIMIT_PER_MODE).
+const TAGS_PER_MODE_LIMIT = 4
+
+// Collect the repeated `key[]` (and bare `key`) query params as bare hashtag
+// names. Returns null when any provided value is not a valid hashtag name so
+// the caller can 400.
+const parseAdditionalTags = (
+  searchParams: URLSearchParams,
+  key: 'any' | 'all' | 'none'
+): string[] | null => {
+  const values = [
+    ...searchParams.getAll(`${key}[]`),
+    ...searchParams.getAll(key)
+  ]
+  const tags: string[] = []
+  for (const value of values) {
+    const name = value.replace(/^#+/, '')
+    if (!isMastodonHashtagName(name)) return null
+    tags.push(name)
+  }
+  return tags.slice(0, TAGS_PER_MODE_LIMIT)
 }
 
 // https://docs.joinmastodon.org/methods/timelines/#tag
@@ -38,61 +67,109 @@ export const GET = traceApiRoute(
     [Scope.enum.read],
     timelineErrorBoundary(CORS_HEADERS, async (req, context) => {
       const { database, currentActor, params: routeParams } = context
-      const parseResult = Params.safeParse(await routeParams)
-      if (!parseResult.success) {
-        return apiResponse({
+      const badRequest = () =>
+        apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
           data: ERROR_400,
           responseStatusCode: 400
         })
-      }
 
-      const { hashtag } = parseResult.data
+      const parseResult = Params.safeParse(await routeParams)
+      if (!parseResult.success) return badRequest()
+
+      // The App Router hands path params over percent-encoded; decode and
+      // validate against the Unicode hashtag alphabet (letters/numbers/_).
+      const hashtag = normalizeHashtagParam(parseResult.data.hashtag)
+      if (!hashtag) return badRequest()
+
       const url = new URL(req.url)
       const parsedQuery = parseTimelineQuery(url.searchParams)
-      if (!parsedQuery.ok) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
-        })
-      }
-      const effectiveLimit = parsedQuery.query.limit
+      if (!parsedQuery.ok) return badRequest()
 
-      const { statuses, nextMaxStatusId } = await getFilteredStatusPage({
-        database,
-        actorId: currentActor?.id,
-        maxStatusId: parsedQuery.query.maxStatusId,
-        limit: effectiveLimit,
-        fetchBatch: ({ maxStatusId, limit }) =>
-          database.getStatusesByHashtag({
-            hashtag,
-            limit,
-            maxStatusId: maxStatusId ?? undefined
-          })
-      })
+      const anyTags = parseAdditionalTags(url.searchParams, 'any')
+      const allTags = parseAdditionalTags(url.searchParams, 'all')
+      const noneTags = parseAdditionalTags(url.searchParams, 'none')
+      if (anyTags === null || allTags === null || noneTags === null) {
+        return badRequest()
+      }
+
+      const effectiveLimit = parsedQuery.query.limit
+      const { local, remote, onlyMedia, maxStatusId } = parsedQuery.query
+      // `min_id` and `since_id` both express a lower-bound cursor; collapse
+      // them with `min_id`-wins precedence, matching the public timeline.
+      const minStatusId =
+        parsedQuery.query.minStatusId ?? parsedQuery.query.sinceStatusId
+
+      const { statuses, nextMaxStatusId, prevMinStatusId, filterRecords } =
+        await getFilteredStatusPage({
+          database,
+          actorId: currentActor?.id,
+          maxStatusId,
+          limit: effectiveLimit,
+          // Hashtag pages use the public keyword-filter context, mirroring the
+          // public timeline: hide-filters drop rows, warn-filters annotate.
+          filterContext: currentActor ? 'public' : undefined,
+          fetchBatch: ({ maxStatusId: cursor, limit }) =>
+            database.getStatusesByHashtag({
+              hashtag,
+              limit,
+              maxStatusId: cursor ?? undefined,
+              minStatusId: minStatusId ?? undefined,
+              onlyMedia,
+              local: local && !remote,
+              remote: remote && !local,
+              anyTags,
+              allTags,
+              noneTags
+            })
+        })
 
       const host = headerHost(req.headers)
       const encodedTag = encodeURIComponent(hashtag)
-      // Only `next` (older) is emitted: the hashtag query pages forward by
-      // `max_id` only and has no lower-bound cursor, so a `prev`/`min_id` link
-      // would not actually page to newer statuses.
+      const linkBaseParams = new URLSearchParams()
+      linkBaseParams.set('limit', `${effectiveLimit}`)
+      for (const [mode, tags] of [
+        ['any', anyTags],
+        ['all', allTags],
+        ['none', noneTags]
+      ] as const) {
+        for (const tag of tags) linkBaseParams.append(`${mode}[]`, tag)
+      }
+      if (local && !remote) linkBaseParams.set('local', 'true')
+      if (remote && !local) linkBaseParams.set('remote', 'true')
+      if (onlyMedia) linkBaseParams.set('only_media', 'true')
+      const buildLink = (
+        cursorName: 'max_id' | 'min_id',
+        cursorValue: string
+      ) => {
+        const linkParams = new URLSearchParams(linkBaseParams)
+        linkParams.set(cursorName, urlToId(cursorValue))
+        const rel = cursorName === 'max_id' ? 'next' : 'prev'
+        return `<https://${host}/api/v1/timelines/tag/${encodedTag}?${linkParams.toString()}>; rel="${rel}"`
+      }
       const nextLink = nextMaxStatusId
-        ? `<https://${host}/api/v1/timelines/tag/${encodedTag}?limit=${effectiveLimit}&max_id=${urlToId(nextMaxStatusId)}>; rel="next"`
+        ? buildLink('max_id', nextMaxStatusId)
         : null
-      const links = [nextLink].filter(Boolean).join(', ')
+      const prevLink = prevMinStatusId
+        ? buildLink('min_id', prevMinStatusId)
+        : null
+      const links = [nextLink, prevLink].filter(Boolean).join(', ')
       const mastodonStatuses = await getMastodonStatuses(
         database,
         statuses,
         currentActor?.id
       )
+      const annotatedStatuses = annotateMastodonStatusesWithFilters(
+        mastodonStatuses,
+        statuses,
+        filterRecords ?? []
+      )
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: mastodonStatuses,
+        data: annotatedStatuses,
         additionalHeaders: [
           ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
         ]

--- a/app/api/v1/timelines/tag/[hashtag]/route.ts
+++ b/app/api/v1/timelines/tag/[hashtag]/route.ts
@@ -16,6 +16,7 @@ import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import {
+  MAX_ENCODED_HASHTAG_PARAM_LENGTH,
   isMastodonHashtagName,
   normalizeHashtagParam
 } from '@/lib/utils/text/mastodonHashtag'
@@ -29,7 +30,9 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  hashtag: z.string().min(1).max(255)
+  // Bound the raw (percent-encoded) param; the 255-char limit applies to the
+  // decoded name inside normalizeHashtagParam so Unicode tags aren't rejected.
+  hashtag: z.string().min(1).max(MAX_ENCODED_HASHTAG_PARAM_LENGTH)
 })
 
 interface RouteParams {

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -29,6 +29,7 @@ import {
   ACTIVITY_STREAM_PUBLIC_COMPACT
 } from '@/lib/utils/activitystream'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { waitFor } from '@/lib/utils/waitFor'
 
 import { buildPubliclyReadableStatusIdsQuery } from './status'
 
@@ -2888,6 +2889,141 @@ describe('StatusDatabase', () => {
           hashtag: 'nonexistent_tag_xyz'
         })
         expect(results).toHaveLength(0)
+      })
+
+      const createTaggedNote = async ({
+        statusId,
+        tags,
+        actorId = primaryActorId
+      }: {
+        statusId: string
+        tags: string[]
+        actorId?: string
+      }) => {
+        await database.createNote({
+          id: statusId,
+          url: statusId,
+          actorId,
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          text: tags.map((name) => `#${name}`).join(' ')
+        })
+        for (const name of tags) {
+          await database.createTag({
+            statusId,
+            name: `#${name}`,
+            value: `https://${actors.primary.domain}/tags/${name}`,
+            type: 'hashtag'
+          })
+        }
+      }
+
+      it('filters to statuses with attachments when onlyMedia is set', async () => {
+        const suffix = Date.now()
+        const tag = `mediaonly${suffix}`
+        const mediaStatusId = `${primaryActorId}/statuses/hashtag-media-${suffix}`
+        const textStatusId = `${primaryActorId}/statuses/hashtag-text-${suffix}`
+        await createTaggedNote({ statusId: mediaStatusId, tags: [tag] })
+        await createTaggedNote({ statusId: textStatusId, tags: [tag] })
+        await database.createAttachment({
+          actorId: primaryActorId,
+          statusId: mediaStatusId,
+          mediaType: 'image/png',
+          url: `${mediaStatusId}/image.png`
+        })
+
+        const results = await database.getStatusesByHashtag({
+          hashtag: tag,
+          onlyMedia: true
+        })
+        expect(results.map((status) => status.id)).toEqual([mediaStatusId])
+      })
+
+      it('widens the match to statuses carrying any additional tag', async () => {
+        const suffix = Date.now()
+        const primaryTag = `anybase${suffix}`
+        const extraTag = `anyextra${suffix}`
+        const baseStatusId = `${primaryActorId}/statuses/hashtag-any-base-${suffix}`
+        const extraStatusId = `${primaryActorId}/statuses/hashtag-any-extra-${suffix}`
+        await createTaggedNote({ statusId: baseStatusId, tags: [primaryTag] })
+        await createTaggedNote({ statusId: extraStatusId, tags: [extraTag] })
+
+        const results = await database.getStatusesByHashtag({
+          hashtag: primaryTag,
+          anyTags: [extraTag]
+        })
+        expect(results.map((status) => status.id).sort()).toEqual(
+          [baseStatusId, extraStatusId].sort()
+        )
+      })
+
+      it('applies all[] and none[] tag constraints', async () => {
+        const suffix = Date.now()
+        const baseTag = `constraint${suffix}`
+        const extraTag = `extra${suffix}`
+        const bothStatusId = `${primaryActorId}/statuses/hashtag-both-${suffix}`
+        const baseOnlyStatusId = `${primaryActorId}/statuses/hashtag-base-${suffix}`
+        await createTaggedNote({
+          statusId: bothStatusId,
+          tags: [baseTag, extraTag]
+        })
+        await createTaggedNote({ statusId: baseOnlyStatusId, tags: [baseTag] })
+
+        const withAll = await database.getStatusesByHashtag({
+          hashtag: baseTag,
+          allTags: [extraTag]
+        })
+        expect(withAll.map((status) => status.id)).toEqual([bothStatusId])
+
+        const withNone = await database.getStatusesByHashtag({
+          hashtag: baseTag,
+          noneTags: [extraTag]
+        })
+        expect(withNone.map((status) => status.id)).toEqual([baseOnlyStatusId])
+      })
+
+      it('scopes results to local or remote authors', async () => {
+        const suffix = Date.now()
+        const tag = `scope${suffix}`
+        const localStatusId = `${primaryActorId}/statuses/hashtag-local-${suffix}`
+        const remoteActorId = DatabaseSeed.externalActors.primary.id
+        const remoteStatusId = `${remoteActorId}/statuses/hashtag-remote-${suffix}`
+        await createTaggedNote({ statusId: localStatusId, tags: [tag] })
+        await createTaggedNote({
+          statusId: remoteStatusId,
+          tags: [tag],
+          actorId: remoteActorId
+        })
+
+        const localOnly = await database.getStatusesByHashtag({
+          hashtag: tag,
+          local: true
+        })
+        expect(localOnly.map((status) => status.id)).toEqual([localStatusId])
+
+        const remoteOnly = await database.getStatusesByHashtag({
+          hashtag: tag,
+          remote: true
+        })
+        expect(remoteOnly.map((status) => status.id)).toEqual([remoteStatusId])
+      })
+
+      it('returns only statuses newer than minStatusId', async () => {
+        const suffix = Date.now()
+        const tag = `mincursor${suffix}`
+        const ids: string[] = []
+        for (let n = 1; n <= 3; n++) {
+          const statusId = `${primaryActorId}/statuses/hashtag-min-${suffix}-${n}`
+          await createTaggedNote({ statusId, tags: [tag] })
+          ids.push(statusId)
+          await waitFor(5)
+        }
+
+        const results = await database.getStatusesByHashtag({
+          hashtag: tag,
+          minStatusId: ids[0]
+        })
+        expect(results.map((status) => status.id)).toEqual([ids[2], ids[1]])
       })
     })
 

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -2860,6 +2860,35 @@ describe('StatusDatabase', () => {
         expect(ids).toContain(statusId)
       })
 
+      it.each([{ cursor: 'maxStatusId' }, { cursor: 'minStatusId' }])(
+        'returns [] when the $cursor cursor status does not exist',
+        async ({ cursor }) => {
+          const statusId = `${primaryActorId}/statuses/hashtag-cursor-${cursor}-${Date.now()}`
+          await database.createNote({
+            id: statusId,
+            url: statusId,
+            actorId: primaryActorId,
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            text: 'Hello #cursortag'
+          })
+          await database.createTag({
+            statusId,
+            name: '#cursortag',
+            value: `https://${actors.primary.domain}/tags/cursortag`,
+            type: 'hashtag'
+          })
+
+          // An unresolvable cursor yields no page (repo keyset convention),
+          // rather than silently falling back to the first page.
+          const results = await database.getStatusesByHashtag({
+            hashtag: 'cursortag',
+            [cursor]: `${primaryActorId}/statuses/does-not-exist`
+          })
+          expect(results).toEqual([])
+        }
+      )
+
       it('returns compact public statuses with a given hashtag', async () => {
         const statusId = `${primaryActorId}/statuses/compact-hashtag-test-${Date.now()}`
         await database.createNote({

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -3011,6 +3011,32 @@ describe('StatusDatabase', () => {
         expect(withNone.map((status) => status.id)).toEqual([baseOnlyStatusId])
       })
 
+      it('requires every all[] tag to be present (AND across multiple tags)', async () => {
+        const suffix = Date.now()
+        const baseTag = `allbase${suffix}`
+        const tagA = `alla${suffix}`
+        const tagB = `allb${suffix}`
+        const bothStatusId = `${primaryActorId}/statuses/hashtag-all-both-${suffix}`
+        const partialStatusId = `${primaryActorId}/statuses/hashtag-all-partial-${suffix}`
+        await createTaggedNote({
+          statusId: bothStatusId,
+          tags: [baseTag, tagA, tagB]
+        })
+        // Has the base tag and tagA but NOT tagB, so it must be excluded — a
+        // regression collapsing the per-tag AND loop into an OR (whereIn) would
+        // wrongly include it.
+        await createTaggedNote({
+          statusId: partialStatusId,
+          tags: [baseTag, tagA]
+        })
+
+        const results = await database.getStatusesByHashtag({
+          hashtag: baseTag,
+          allTags: [tagA, tagB]
+        })
+        expect(results.map((status) => status.id)).toEqual([bothStatusId])
+      })
+
       it('scopes results to local or remote authors', async () => {
         const suffix = Date.now()
         const tag = `scope${suffix}`

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -2324,9 +2324,18 @@ export const StatusSQLDatabaseMixin = (
   async function getStatusesByHashtag({
     hashtag,
     limit = PER_PAGE_LIMIT,
-    maxStatusId
+    minStatusId,
+    maxStatusId,
+    onlyMedia = false,
+    local = false,
+    remote = false,
+    anyTags = [],
+    allTags = [],
+    noneTags = []
   }: GetStatusesByHashtagParams): Promise<Status[]> {
-    const normalizedNames = getHashtagLookupNames(hashtag)
+    // `any[]` widens the primary tag match: a status qualifies when it carries
+    // the main hashtag OR any of the additional tags (Mastodon semantics).
+    const normalizedNames = [hashtag, ...anyTags].flatMap(getHashtagLookupNames)
     let query = database('tags')
       .innerJoin('statuses', 'tags.statusId', 'statuses.id')
       .innerJoin('recipients', 'statuses.id', 'recipients.statusId')
@@ -2340,6 +2349,62 @@ export const StatusSQLDatabaseMixin = (
       .orderBy('statuses.id', 'desc')
       .limit(limit)
 
+    // `all[]`: every additional tag must also be present on the status.
+    for (const tag of allTags) {
+      const lookupNames = getHashtagLookupNames(tag)
+      if (lookupNames.length === 0) {
+        query = query.whereRaw('1 = 0')
+        continue
+      }
+      query = query.whereExists(function () {
+        this.select(database.raw('1'))
+          .from('tags as all_tags')
+          .whereRaw('?? = ??', ['all_tags.statusId', 'statuses.id'])
+          .where('all_tags.type', 'hashtag')
+          .whereIn('all_tags.nameNormalized', lookupNames)
+      })
+    }
+
+    // `none[]`: statuses carrying any of these tags are excluded.
+    const noneLookupNames = noneTags.flatMap(getHashtagLookupNames)
+    if (noneLookupNames.length > 0) {
+      query = query.whereNotExists(function () {
+        this.select(database.raw('1'))
+          .from('tags as none_tags')
+          .whereRaw('?? = ??', ['none_tags.statusId', 'statuses.id'])
+          .where('none_tags.type', 'hashtag')
+          .whereIn('none_tags.nameNormalized', noneLookupNames)
+      })
+    }
+
+    if (onlyMedia) {
+      query = query.whereExists(function () {
+        this.select(database.raw('1'))
+          .from('attachments')
+          .whereRaw('?? = ??', ['attachments.statusId', 'statuses.id'])
+      })
+    }
+
+    // Mastodon `local`/`remote` scope. A status is local when its author is an
+    // actor this server hosts (privateKey set), mirroring the LOCAL_PUBLIC
+    // timeline selection; remote is the complement (including statuses whose
+    // author has no actors row at all).
+    if (local && !remote) {
+      query = query.whereExists(function () {
+        this.select(database.raw('1'))
+          .from('actors')
+          .whereRaw('?? = ??', ['actors.id', 'statuses.actorId'])
+          .whereNotNull('actors.privateKey')
+      })
+    } else if (remote && !local) {
+      query = query.whereNotExists(function () {
+        this.select(database.raw('1'))
+          .from('actors')
+          .whereRaw('?? = ??', ['actors.id', 'statuses.actorId'])
+          .whereNotNull('actors.privateKey')
+      })
+    }
+
     if (maxStatusId) {
       const cursor = await database('statuses')
         .where('id', maxStatusId)
@@ -2352,6 +2417,24 @@ export const StatusSQLDatabaseMixin = (
               wb2
                 .where('statuses.createdAt', '=', cursor.createdAt)
                 .where('statuses.id', '<', maxStatusId)
+            }
+          )
+        })
+      }
+    }
+
+    if (minStatusId) {
+      const cursor = await database('statuses')
+        .where('id', minStatusId)
+        .select('createdAt')
+        .first<{ createdAt: Date }>()
+      if (cursor) {
+        query = query.where((wb) => {
+          wb.where('statuses.createdAt', '>', cursor.createdAt).orWhere(
+            (wb2) => {
+              wb2
+                .where('statuses.createdAt', '=', cursor.createdAt)
+                .where('statuses.id', '>', minStatusId)
             }
           )
         })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -2410,17 +2410,17 @@ export const StatusSQLDatabaseMixin = (
         .where('id', maxStatusId)
         .select('createdAt')
         .first<{ createdAt: Date }>()
-      if (cursor) {
-        query = query.where((wb) => {
-          wb.where('statuses.createdAt', '<', cursor.createdAt).orWhere(
-            (wb2) => {
-              wb2
-                .where('statuses.createdAt', '=', cursor.createdAt)
-                .where('statuses.id', '<', maxStatusId)
-            }
-          )
+      // An unresolvable cursor yields no page, matching the repo-wide keyset
+      // convention (bookmark/block/follow/mute/scheduledStatus) rather than
+      // silently falling back to the first page.
+      if (!cursor) return []
+      query = query.where((wb) => {
+        wb.where('statuses.createdAt', '<', cursor.createdAt).orWhere((wb2) => {
+          wb2
+            .where('statuses.createdAt', '=', cursor.createdAt)
+            .where('statuses.id', '<', maxStatusId)
         })
-      }
+      })
     }
 
     if (minStatusId) {
@@ -2428,17 +2428,14 @@ export const StatusSQLDatabaseMixin = (
         .where('id', minStatusId)
         .select('createdAt')
         .first<{ createdAt: Date }>()
-      if (cursor) {
-        query = query.where((wb) => {
-          wb.where('statuses.createdAt', '>', cursor.createdAt).orWhere(
-            (wb2) => {
-              wb2
-                .where('statuses.createdAt', '=', cursor.createdAt)
-                .where('statuses.id', '>', minStatusId)
-            }
-          )
+      if (!cursor) return []
+      query = query.where((wb) => {
+        wb.where('statuses.createdAt', '>', cursor.createdAt).orWhere((wb2) => {
+          wb2
+            .where('statuses.createdAt', '=', cursor.createdAt)
+            .where('statuses.id', '>', minStatusId)
         })
-      }
+      })
     }
 
     const rows = await query

--- a/lib/database/sql/timeline.federated.test.ts
+++ b/lib/database/sql/timeline.federated.test.ts
@@ -142,4 +142,27 @@ describe('Timeline.FEDERATED_PUBLIC', () => {
       ).toEqual([])
     })
   })
+
+  it('returns only statuses with attachments when onlyMedia is set', async () => {
+    await withFreshDatabase(async (database) => {
+      const textStatus = await seedFederatedStatus(database, 1)
+      await waitFor(5)
+      const mediaStatus = await seedFederatedStatus(database, 2)
+      await database.createAttachment({
+        actorId: REMOTE,
+        statusId: mediaStatus.id,
+        mediaType: 'image/png',
+        url: `${mediaStatus.id}/image.png`
+      })
+
+      const statuses = await database.getTimeline({
+        timeline: Timeline.FEDERATED_PUBLIC,
+        onlyMedia: true
+      })
+
+      const ids = statuses.map((status) => status.id)
+      expect(ids).toEqual([mediaStatus.id])
+      expect(ids).not.toContain(textStatus.id)
+    })
+  })
 })

--- a/lib/database/sql/timeline.test.ts
+++ b/lib/database/sql/timeline.test.ts
@@ -363,6 +363,35 @@ describe('TimelineDatabase', () => {
           }
         }, 10000)
 
+        it('returns only statuses with attachments when onlyMedia is set', async () => {
+          const mediaStatusId = `${TEST_ID_PUBLIC}/statuses/public-media-1`
+          await database.createNote({
+            actorId: TEST_ID_PUBLIC,
+            cc: [],
+            to: [ACTIVITY_STREAM_PUBLIC],
+            id: mediaStatusId,
+            text: 'This is a public status with media',
+            url: mediaStatusId,
+            reply: '',
+            createdAt: Date.now()
+          })
+          await database.createAttachment({
+            actorId: TEST_ID_PUBLIC,
+            statusId: mediaStatusId,
+            mediaType: 'image/png',
+            url: `${mediaStatusId}/image.png`
+          })
+
+          const statuses = await database.getTimeline({
+            timeline: Timeline.LOCAL_PUBLIC,
+            onlyMedia: true
+          })
+
+          const ids = statuses.map((status) => status.id)
+          expect(ids).toContain(mediaStatusId)
+          expect(ids).not.toContain(`${TEST_ID_PUBLIC}/statuses/public-1`)
+        })
+
         it('continues paginating when a public cursor recipient row is gone', async () => {
           const olderStatusId = `${TEST_ID_PUBLIC}/statuses/public-cursor-older`
           const cursorStatusId = `${TEST_ID_PUBLIC}/statuses/public-cursor`

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -22,7 +22,8 @@ export const TimelineSQLDatabaseMixin = (
     minStatusId,
     sinceStatusId,
     maxStatusId,
-    limit = PER_PAGE_LIMIT
+    limit = PER_PAGE_LIMIT,
+    onlyMedia = false
   }: GetTimelineParams) {
     switch (timeline) {
       case Timeline.LOCAL_PUBLIC: {
@@ -53,6 +54,14 @@ export const TimelineSQLDatabaseMixin = (
           .whereNotNull('actors.privateKey')
           .where('statuses.reply', '')
           .limit(limit)
+
+        if (onlyMedia) {
+          query = query.whereExists(function () {
+            this.select(database.raw('1'))
+              .from('attachments')
+              .whereRaw('?? = ??', ['attachments.statusId', 'statuses.id'])
+          })
+        }
 
         if (maxRow) {
           query = query.where((wb) => {
@@ -115,6 +124,14 @@ export const TimelineSQLDatabaseMixin = (
           // timeline semantics (replies are excluded).
           .where('statuses.reply', '')
           .limit(limit)
+
+        if (onlyMedia) {
+          query = query.whereExists(function () {
+            this.select(database.raw('1'))
+              .from('attachments')
+              .whereRaw('?? = ??', ['attachments.statusId', 'statuses.id'])
+          })
+        }
 
         if (maxRow) {
           query = query.where((wb) => {

--- a/lib/services/timelines/request.test.ts
+++ b/lib/services/timelines/request.test.ts
@@ -23,7 +23,8 @@ describe('parseTimelineQuery', () => {
         minStatusId: null,
         sinceStatusId: null,
         local: false,
-        remote: false
+        remote: false,
+        onlyMedia: false
       }
     })
   })
@@ -44,7 +45,8 @@ describe('parseTimelineQuery', () => {
         minStatusId: realStatusUrl,
         sinceStatusId: realStatusUrl,
         local: false,
-        remote: false
+        remote: false,
+        onlyMedia: false
       }
     })
   })
@@ -61,9 +63,29 @@ describe('parseTimelineQuery', () => {
         minStatusId: null,
         sinceStatusId: null,
         local: false,
-        remote: false
+        remote: false,
+        onlyMedia: false
       }
     })
+  })
+
+  it.each([
+    { description: 'only_media=true sets the media-only flag', value: 'true' },
+    { description: 'only_media=1 sets the media-only flag', value: '1' }
+  ])('$description', ({ value }) => {
+    const result = parseTimelineQuery(params({ only_media: value }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.query.onlyMedia).toBe(true)
+    }
+  })
+
+  it('treats a non-truthy only_media value as false', () => {
+    const result = parseTimelineQuery(params({ only_media: 'false' }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.query.onlyMedia).toBe(false)
+    }
   })
 
   it.each([

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -21,7 +21,10 @@ const TimelineQuerySchema = z.object({
   // Mastodon's public-timeline scope filters. Only the public timeline reads
   // them; other endpoints ignore them.
   local: z.string().optional(),
-  remote: z.string().optional()
+  remote: z.string().optional(),
+  // Media-only filter for the public and hashtag timelines. Other endpoints
+  // ignore it.
+  only_media: z.string().optional()
 })
 
 export interface ParsedTimelineQuery {
@@ -35,6 +38,8 @@ export interface ParsedTimelineQuery {
   // string forms Mastodon accepts (`true`/`1`).
   local: boolean
   remote: boolean
+  // Public/hashtag timeline media filter (Mastodon `only_media`).
+  onlyMedia: boolean
 }
 
 const isTruthyParam = (value: string | undefined): boolean =>
@@ -64,7 +69,8 @@ export const parseTimelineQuery = (
     min_id: searchParams.get('min_id') || undefined,
     since_id: searchParams.get('since_id') || undefined,
     local: searchParams.get('local') || undefined,
-    remote: searchParams.get('remote') || undefined
+    remote: searchParams.get('remote') || undefined,
+    only_media: searchParams.get('only_media') || undefined
   })
   if (!parsed.success) return { ok: false }
 
@@ -95,7 +101,8 @@ export const parseTimelineQuery = (
       minStatusId: minStatusId ?? null,
       sinceStatusId: sinceStatusId ?? null,
       local: isTruthyParam(parsed.data.local),
-      remote: isTruthyParam(parsed.data.remote)
+      remote: isTruthyParam(parsed.data.remote),
+      onlyMedia: isTruthyParam(parsed.data.only_media)
     }
   }
 }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -3009,6 +3009,9 @@ export type GetTimelineParams = {
   sinceStatusId?: string | null
   maxStatusId?: string | null
   limit?: number
+  // Attachments-only filter (Mastodon `only_media`). Honored by the
+  // LOCAL_PUBLIC and FEDERATED_PUBLIC timelines; other timelines ignore it.
+  onlyMedia?: boolean
 }
 export type CreateTimelineStatusParams = {
   timeline: Timeline

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -632,7 +632,19 @@ export type DeleteStatusTagsByTypeParams = {
 export type GetStatusesByHashtagParams = {
   hashtag: string
   limit?: number
+  minStatusId?: string
   maxStatusId?: string
+  // Attachments-only filter (Mastodon `only_media`).
+  onlyMedia?: boolean
+  // Author-locality scope (Mastodon `local`/`remote`): local means the author
+  // has an actors row with a privateKey (this server hosts it).
+  local?: boolean
+  remote?: boolean
+  // Mastodon tag-timeline modes: `anyTags` widen the primary match, `allTags`
+  // must all be present, `noneTags` must all be absent. Bare names, no `#`.
+  anyTags?: string[]
+  allTags?: string[]
+  noneTags?: string[]
 }
 export type GetHashtagStatusesPageParams = {
   hashtag: string

--- a/lib/utils/text/mastodonHashtag.test.ts
+++ b/lib/utils/text/mastodonHashtag.test.ts
@@ -1,7 +1,4 @@
-import {
-  isMastodonHashtagName,
-  normalizeHashtagParam
-} from './mastodonHashtag'
+import { isMastodonHashtagName, normalizeHashtagParam } from './mastodonHashtag'
 
 describe('isMastodonHashtagName', () => {
   it.each([
@@ -23,8 +20,16 @@ describe('isMastodonHashtagName', () => {
 
 describe('normalizeHashtagParam', () => {
   it.each([
-    { description: 'a plain ascii name', param: 'running', expected: 'running' },
-    { description: 'a decoded unicode name', param: '日本語', expected: '日本語' },
+    {
+      description: 'a plain ascii name',
+      param: 'running',
+      expected: 'running'
+    },
+    {
+      description: 'a decoded unicode name',
+      param: '日本語',
+      expected: '日本語'
+    },
     {
       description: 'a percent-encoded unicode name',
       param: '%E6%97%A5%E6%9C%AC%E8%AA%9E',

--- a/lib/utils/text/mastodonHashtag.test.ts
+++ b/lib/utils/text/mastodonHashtag.test.ts
@@ -1,0 +1,48 @@
+import {
+  isMastodonHashtagName,
+  normalizeHashtagParam
+} from './mastodonHashtag'
+
+describe('isMastodonHashtagName', () => {
+  it.each([
+    { description: 'an ascii word tag', name: 'running', expected: true },
+    { description: 'an underscore tag', name: 'trail_running', expected: true },
+    { description: 'japanese letters', name: '日本語', expected: true },
+    { description: 'thai letters', name: 'ไทย', expected: true },
+    { description: 'accented letters', name: 'café', expected: true },
+    { description: 'digits only', name: '2024', expected: true },
+    { description: 'an empty string', name: '', expected: false },
+    { description: 'a space', name: 'two words', expected: false },
+    { description: 'a dash', name: 'foo-bar', expected: false },
+    { description: 'a leading hash', name: '#running', expected: false },
+    { description: 'an emoji', name: 'fun🎉', expected: false }
+  ])('returns $expected for $description', ({ name, expected }) => {
+    expect(isMastodonHashtagName(name)).toBe(expected)
+  })
+})
+
+describe('normalizeHashtagParam', () => {
+  it.each([
+    { description: 'a plain ascii name', param: 'running', expected: 'running' },
+    { description: 'a decoded unicode name', param: '日本語', expected: '日本語' },
+    {
+      description: 'a percent-encoded unicode name',
+      param: '%E6%97%A5%E6%9C%AC%E8%AA%9E',
+      expected: '日本語'
+    },
+    {
+      description: 'an encoded leading hash',
+      param: '%23running',
+      expected: 'running'
+    },
+    { description: 'invalid characters', param: 'foo-bar', expected: null },
+    {
+      description: 'an undecodable percent sequence',
+      param: '100%zz',
+      expected: null
+    },
+    { description: 'an empty string', param: '', expected: null }
+  ])('returns $expected for $description', ({ param, expected }) => {
+    expect(normalizeHashtagParam(param)).toBe(expected)
+  })
+})

--- a/lib/utils/text/mastodonHashtag.test.ts
+++ b/lib/utils/text/mastodonHashtag.test.ts
@@ -46,7 +46,22 @@ describe('normalizeHashtagParam', () => {
       param: '100%zz',
       expected: null
     },
-    { description: 'an empty string', param: '', expected: null }
+    { description: 'an empty string', param: '', expected: null },
+    {
+      description: 'a decoded name at the 255 limit',
+      param: 'a'.repeat(255),
+      expected: 'a'.repeat(255)
+    },
+    {
+      description: 'a decoded name over the 255 limit',
+      param: 'a'.repeat(256),
+      expected: null
+    },
+    {
+      description: 'a short unicode name whose encoded length exceeds 255',
+      param: encodeURIComponent('あ'.repeat(30)),
+      expected: 'あ'.repeat(30)
+    }
   ])('returns $expected for $description', ({ param, expected }) => {
     expect(normalizeHashtagParam(param)).toBe(expected)
   })

--- a/lib/utils/text/mastodonHashtag.ts
+++ b/lib/utils/text/mastodonHashtag.ts
@@ -1,0 +1,27 @@
+// The Mastodon hashtag alphabet: Unicode letters, numbers and underscore.
+// Extracted from the featured-tags endpoint (which already accepted Unicode
+// names) so the tag timeline — and, in a follow-up PR, /api/v1/tags/:tag plus
+// its follow/unfollow routes — validates the same names. The previous
+// ASCII-only route regexes 400'd valid Unicode tags like #日本語.
+export const MASTODON_HASHTAG_NAME_REGEX = /^[\p{L}\p{N}_]+$/u
+
+export const isMastodonHashtagName = (name: string): boolean =>
+  MASTODON_HASHTAG_NAME_REGEX.test(name)
+
+/**
+ * Normalize a dynamic route param into a bare, validated hashtag name. The App
+ * Router hands path segments over percent-encoded (the same reason other
+ * routes call decodeURIComponent on their params), so decode first, then strip
+ * a leading `#`. Returns null when the value cannot be decoded or is not a
+ * valid Mastodon hashtag name.
+ */
+export const normalizeHashtagParam = (param: string): string | null => {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(param)
+  } catch {
+    return null
+  }
+  const name = decoded.replace(/^#+/, '')
+  return isMastodonHashtagName(name) ? name : null
+}

--- a/lib/utils/text/mastodonHashtag.ts
+++ b/lib/utils/text/mastodonHashtag.ts
@@ -5,6 +5,20 @@
 // ASCII-only route regexes 400'd valid Unicode tags like #日本語.
 export const MASTODON_HASHTAG_NAME_REGEX = /^[\p{L}\p{N}_]+$/u
 
+// The real hashtag-name limit, matching the `followed_tags.name varchar(255)`
+// column. Enforced on the *decoded* name (see normalizeHashtagParam).
+export const MAX_HASHTAG_NAME_LENGTH = 255
+
+// Upper bound for the *raw* (still percent-encoded) path param before decoding.
+// A single Unicode codepoint in the hashtag alphabet is up to 4 UTF-8 bytes,
+// and each byte percent-encodes to 3 chars, so a valid 255-codepoint name can
+// be up to 255 * 4 * 3 = 3060 encoded chars; 4096 leaves margin for a leading
+// `#`. Capping the raw param on 255 (as the decoded limit) would prematurely
+// 400 valid Unicode tags like #日本語 (9 encoded chars per character); the
+// decoded name is what must obey MAX_HASHTAG_NAME_LENGTH. Still bounded so an
+// unbounded param can't reach decodeURIComponent.
+export const MAX_ENCODED_HASHTAG_PARAM_LENGTH = 4096
+
 export const isMastodonHashtagName = (name: string): boolean =>
   MASTODON_HASHTAG_NAME_REGEX.test(name)
 
@@ -12,8 +26,8 @@ export const isMastodonHashtagName = (name: string): boolean =>
  * Normalize a dynamic route param into a bare, validated hashtag name. The App
  * Router hands path segments over percent-encoded (the same reason other
  * routes call decodeURIComponent on their params), so decode first, then strip
- * a leading `#`. Returns null when the value cannot be decoded or is not a
- * valid Mastodon hashtag name.
+ * a leading `#`. Returns null when the value cannot be decoded, exceeds the
+ * decoded length limit, or is not a valid Mastodon hashtag name.
  */
 export const normalizeHashtagParam = (param: string): string | null => {
   let decoded: string
@@ -23,5 +37,7 @@ export const normalizeHashtagParam = (param: string): string | null => {
     return null
   }
   const name = decoded.replace(/^#+/, '')
-  return isMastodonHashtagName(name) ? name : null
+  return name.length <= MAX_HASHTAG_NAME_LENGTH && isMastodonHashtagName(name)
+    ? name
+    : null
 }


### PR DESCRIPTION
## What

- **Public timeline** (`/api/v1/timelines/public`): `only_media` is now parsed and applied as an attachments-EXISTS filter in both the local-public and federated queries; `min_id`/`since_id` (min_id wins) are wired through to the DB keyset query; a `rel="prev"` Link is emitted alongside `rel="next"`, and both links carry `limit`, `local`/`remote`, and `only_media`.
- **Tag timeline** (`/api/v1/timelines/tag/:hashtag`): Unicode hashtags (e.g. `#日本語`) no longer 400 — the ASCII regex is replaced by a shared `\p{L}\p{N}_` validator that also percent-decodes the route param; `any[]`/`all[]`/`none[]` tag filters implemented with Mastodon semantics (any widens, all intersects, none excludes; capped at 4 per mode); `local`/`remote` scope statuses by author locality; `only_media`, `min_id`/`since_id`, and a `rel="prev"` Link as on the public route; the route now runs under the `public` keyword-filter context so hide-filters drop rows and warn-filters annotate (mirroring the public timeline).
- **DB layer**: `getTimeline` gains `onlyMedia` for the two public timelines; `getStatusesByHashtag` gains `minStatusId`, `onlyMedia`, `local`/`remote`, `anyTags`/`allTags`/`noneTags` (all optional; existing callers unaffected).
- Shared helper `lib/utils/text/mastodonHashtag.ts` extracted from the featured-tags validator; `app/api/v1/featured_tags` now consumes it (no behavior change). `/api/v1/tags/:tag` + follow/unfollow still use the old ASCII regex — switched to this helper in PR 2.8.

## Notes

- `min_id`/`since_id` are both treated as a lower bound on the newest-first query, consistent with every other timeline route in this codebase; true `min_id` adjacency ordering remains unimplemented repo-wide (pre-existing, unchanged).
- No migrations; schema dumps untouched.
- Part of Phase 2 (Entity & Parameter Gaps), PR 2.7. **PR 2.8 (discovery polish) stacks on this branch** for the shared hashtag validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)