### PR TITLE
fix: discovery polish (tags, followed_tags, directory, trends, instance domain_blocks)

### DIFF
--- a/app/api/v1/directory/route.test.ts
+++ b/app/api/v1/directory/route.test.ts
@@ -60,4 +60,45 @@ describe('GET /api/v1/directory', () => {
       expect.objectContaining({ limit: expectedLimit })
     )
   })
+
+  it.each([
+    {
+      description: 'includes remote actors by default (local=false)',
+      query: '',
+      expectedLocal: false
+    },
+    {
+      description: 'restricts to local actors when local=true',
+      query: '?local=true',
+      expectedLocal: true
+    },
+    {
+      description:
+        'coerces a garbage local value to false instead of rejecting',
+      query: '?local=banana',
+      expectedLocal: false
+    }
+  ])('$description', async ({ query, expectedLocal }) => {
+    const response = await GET(
+      new NextRequest(`https://local.test/api/v1/directory${query}`),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getLocalMastodonActors).toHaveBeenCalledWith(
+      expect.objectContaining({ local: expectedLocal })
+    )
+  })
+
+  it('forwards the order parameter', async () => {
+    const response = await GET(
+      new NextRequest('https://local.test/api/v1/directory?order=new'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getLocalMastodonActors).toHaveBeenCalledWith(
+      expect.objectContaining({ order: 'new' })
+    )
+  })
 })

--- a/app/api/v1/directory/route.ts
+++ b/app/api/v1/directory/route.ts
@@ -7,6 +7,7 @@ import { clampedLimit, clampedOffset } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { Booleanish } from '@/lib/utils/zodBooleanish'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
@@ -16,16 +17,15 @@ const DirectoryParams = z.object({
   offset: clampedOffset(),
   limit: clampedLimit(80, 40),
   order: z.enum(['active', 'new']).default('active'),
-  local: z
-    .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .optional()
+  // Mastodon semantics: local=true restricts the listing to this server's
+  // accounts; the default directory includes known remote actors. Booleanish
+  // coerces the string param and treats garbage as false instead of 400ing.
+  local: Booleanish.default(false)
 })
 
 // https://docs.joinmastodon.org/methods/directory/
-// Lists the local profiles hosted on this server. Remote-only directories are
-// not maintained, so the `local` parameter is accepted but the listing is always
-// the local actors.
+// Lists known profiles: every actor this server has seen by default, or only
+// this server's own accounts when local=true.
 export const GET = traceApiRoute(
   'getDirectory',
   OptionalOAuthGuard([Scope.enum.read], async (req, { database }) => {
@@ -42,12 +42,13 @@ export const GET = traceApiRoute(
       })
     }
 
-    const { offset, limit, order } = parsed.data
+    const { offset, limit, order, local } = parsed.data
     const actors = await database.getLocalMastodonActors({
       localDomain: getConfig().host,
       limit,
       offset,
-      order
+      order,
+      local
     })
 
     return apiResponse({ req, allowedMethods: CORS_HEADERS, data: actors })

--- a/app/api/v1/followed_tags/route.test.ts
+++ b/app/api/v1/followed_tags/route.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+const mockDatabase = {
+  getFollowedTags: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me'
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'local.test' })
+}))
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuardAnyScope:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor
+      })
+}))
+
+describe('GET /api/v1/followed_tags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards min_id and emits next and prev Link headers on a full page', async () => {
+    mockDatabase.getFollowedTags.mockResolvedValue([
+      {
+        id: 'tag-2',
+        actorId: mockCurrentActor.id,
+        name: 'running',
+        createdAt: 2000
+      },
+      {
+        id: 'tag-1',
+        actorId: mockCurrentActor.id,
+        name: 'cycling',
+        createdAt: 1000
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest(
+        'https://local.test/api/v1/followed_tags?limit=2&min_id=tag-0'
+      ),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockDatabase.getFollowedTags).toHaveBeenCalledWith({
+      actorId: mockCurrentActor.id,
+      limit: 2,
+      maxId: null,
+      minId: 'tag-0',
+      sinceId: null
+    })
+    const link = response.headers.get('Link')
+    expect(link).toContain(
+      '<https://local.test/api/v1/followed_tags?limit=2&max_id=tag-1>; rel="next"'
+    )
+    expect(link).toContain(
+      '<https://local.test/api/v1/followed_tags?limit=2&min_id=tag-2>; rel="prev"'
+    )
+  })
+
+  it('emits only the prev link on a short page', async () => {
+    mockDatabase.getFollowedTags.mockResolvedValue([
+      {
+        id: 'tag-1',
+        actorId: mockCurrentActor.id,
+        name: 'cycling',
+        createdAt: 1000
+      }
+    ])
+
+    const response = await GET(
+      new NextRequest('https://local.test/api/v1/followed_tags?limit=2'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const link = response.headers.get('Link')
+    expect(link).not.toContain('rel="next"')
+    expect(link).toContain('min_id=tag-1>; rel="prev"')
+  })
+
+  it('emits no Link header when the actor follows no tags', async () => {
+    mockDatabase.getFollowedTags.mockResolvedValue([])
+
+    const response = await GET(
+      new NextRequest('https://local.test/api/v1/followed_tags'),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Link')).toBeNull()
+  })
+})

--- a/app/api/v1/followed_tags/route.ts
+++ b/app/api/v1/followed_tags/route.ts
@@ -3,6 +3,7 @@ import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonTag } from '@/lib/services/mastodon/getMastodonTag'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { buildPaginationLinkHeader } from '@/lib/utils/paginationLinkHeader'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
@@ -28,30 +29,31 @@ export const GET = traceApiRoute(
           ? Math.min(parsedLimit, MAX_LIMIT)
           : DEFAULT_LIMIT
 
-      const maxId = url.searchParams.get('max_id')
-      const sinceId = url.searchParams.get('since_id')
       const followedTags = await database.getFollowedTags({
         actorId: currentActor.id,
         limit,
-        maxId,
-        sinceId
+        maxId: url.searchParams.get('max_id'),
+        minId: url.searchParams.get('min_id'),
+        sinceId: url.searchParams.get('since_id')
       })
 
-      const host = headerHost(req.headers)
-      const last = followedTags[followedTags.length - 1]
-      const nextLink =
-        followedTags.length === limit && last
-          ? `<https://${host}/api/v1/followed_tags?limit=${limit}&max_id=${last.id}>; rel="next"`
-          : null
-      const links = [nextLink].filter(Boolean).join(', ')
+      // Cursor conventions shared with the other paginated Mastodon routes:
+      // `next` when the page is full (there may be older rows), `prev`
+      // whenever the page has rows (newer rows may have appeared since).
+      const lastTag = followedTags[followedTags.length - 1]
+      const additionalHeaders = buildPaginationLinkHeader({
+        host: headerHost(req.headers),
+        path: '/api/v1/followed_tags',
+        limit,
+        nextMaxId: followedTags.length === limit && lastTag ? lastTag.id : null,
+        prevMinId: followedTags.length > 0 ? followedTags[0].id : null
+      })
 
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
         data: followedTags.map((tag) => getMastodonTag(tag.name, true)),
-        additionalHeaders: [
-          ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
-        ]
+        additionalHeaders
       })
     }
   )

--- a/app/api/v1/instance/domain_blocks/route.test.ts
+++ b/app/api/v1/instance/domain_blocks/route.test.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 
+import { domainDigest } from '@/lib/services/federation/domainRules'
+
 import { GET } from './route'
 
 const mockGetDatabase = vi.fn()
@@ -31,11 +33,26 @@ describe('GET /api/v1/instance/domain_blocks', () => {
         source: null,
         createdAt: 0,
         updatedAt: 0
+      },
+      {
+        id: '2',
+        type: 'block',
+        domain: 'silenced.test',
+        severity: 'silence',
+        rejectMedia: false,
+        rejectReports: false,
+        privateComment: null,
+        publicComment: 'limited',
+        obfuscate: true,
+        source: null,
+        createdAt: 0,
+        updatedAt: 0
       }
     ])
     const getDomainFederationRuleStats = vi.fn().mockResolvedValue({
       blocks: 42,
       suspendBlocks: 7,
+      silenceBlocks: 3,
       allows: 0
     })
 
@@ -56,19 +73,25 @@ describe('GET /api/v1/instance/domain_blocks', () => {
     expect(getDomainBlocks).toHaveBeenCalledWith({
       limit: 25,
       offset: 5,
-      severity: 'suspend'
+      severities: ['silence', 'suspend']
     })
     expect(getDomainFederationRuleStats).toHaveBeenCalledTimes(1)
-    expect(response.headers.get('X-Total-Count')).toBe('7')
+    expect(response.headers.get('X-Total-Count')).toBe('10')
     expect(response.headers.get('X-Offset')).toBe('5')
     expect(response.headers.get('X-Limit')).toBe('25')
     expect(data).toEqual([
       {
         domain: 'blocked.test',
-        digest:
-          'cc5ac927c0bbef58bde4777f9afc52f3ed6c8d0652af02e650d33035030398f2',
+        digest: domainDigest('blocked.test'),
         severity: 'suspend',
         comment: 'spam'
+      },
+      {
+        // Mastodon quarter-visible obfuscation, not the raw digest.
+        domain: 'sile****.*est',
+        digest: domainDigest('silenced.test'),
+        severity: 'silence',
+        comment: 'limited'
       }
     ])
   })
@@ -80,6 +103,7 @@ describe('GET /api/v1/instance/domain_blocks', () => {
       getDomainFederationRuleStats: vi.fn().mockResolvedValue({
         blocks: 0,
         suspendBlocks: 0,
+        silenceBlocks: 0,
         allows: 0
       })
     })
@@ -95,7 +119,7 @@ describe('GET /api/v1/instance/domain_blocks', () => {
     expect(getDomainBlocks).toHaveBeenCalledWith({
       limit: 1000,
       offset: 0,
-      severity: 'suspend'
+      severities: ['silence', 'suspend']
     })
   })
 })

--- a/app/api/v1/instance/domain_blocks/route.ts
+++ b/app/api/v1/instance/domain_blocks/route.ts
@@ -40,7 +40,13 @@ export const GET = traceApiRoute(
 
     const { limit, offset } = parsedParams.data
     const [blocks, stats] = await Promise.all([
-      database.getDomainBlocks({ limit, offset, severity: 'suspend' }),
+      // Mastodon lists every block with user-facing impact: silenced
+      // (limited) domains as well as suspended ones. noop rows stay private.
+      database.getDomainBlocks({
+        limit,
+        offset,
+        severities: ['silence', 'suspend']
+      }),
       database.getDomainFederationRuleStats()
     ])
 
@@ -49,7 +55,7 @@ export const GET = traceApiRoute(
       allowedMethods: CORS_HEADERS,
       data: blocks.map(toPublicDomainBlock),
       additionalHeaders: [
-        ['X-Total-Count', `${stats.suspendBlocks}`],
+        ['X-Total-Count', `${stats.suspendBlocks + stats.silenceBlocks}`],
         ['X-Offset', `${offset}`],
         ['X-Limit', `${limit}`]
       ]

--- a/app/api/v1/tags/[tag]/follow/route.test.ts
+++ b/app/api/v1/tags/[tag]/follow/route.test.ts
@@ -99,5 +99,9 @@ describe('POST /api/v1/tags/:tag/follow', () => {
       { params: Promise.resolve({ tag }) }
     )
     expect(response.status).toBe(expectedStatus)
+    if (expectedStatus === 400) {
+      // A rejected tag must not persist a follow row (guard runs before the write).
+      expect(mockDatabase.followTag).not.toHaveBeenCalled()
+    }
   })
 })

--- a/app/api/v1/tags/[tag]/follow/route.test.ts
+++ b/app/api/v1/tags/[tag]/follow/route.test.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  followTag: vi.fn(),
+  getTagDailyHistory: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me'
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'local.test' })
+}))
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ tag: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ tag: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      }),
+  corsErrorResponse: vi.fn()
+}))
+
+describe('POST /api/v1/tags/:tag/follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.followTag.mockResolvedValue({
+      id: 'followed-tag-1',
+      actorId: mockCurrentActor.id,
+      name: 'running',
+      createdAt: 1000
+    })
+    mockDatabase.getTagDailyHistory.mockResolvedValue(new Map())
+  })
+
+  it('returns the followed Tag entity with its seven-day history', async () => {
+    const DAY_MS = 86_400_000
+    const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+    mockDatabase.getTagDailyHistory.mockResolvedValue(
+      new Map([
+        ['running', [{ dayBucketMs: todayBucketMs, uses: 2, accounts: 1 }]]
+      ])
+    )
+
+    const response = await POST(
+      new NextRequest('https://local.test/api/v1/tags/running/follow', {
+        method: 'POST'
+      }),
+      { params: Promise.resolve({ tag: 'running' }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.following).toBe(true)
+    expect(body.history).toHaveLength(7)
+    expect(body.history[0]).toEqual({
+      day: String(todayBucketMs / 1000),
+      uses: '2',
+      accounts: '1'
+    })
+    expect(mockDatabase.followTag).toHaveBeenCalledWith({
+      actorId: mockCurrentActor.id,
+      name: 'running'
+    })
+  })
+
+  it.each([
+    {
+      description: 'accepts a unicode hashtag name',
+      tag: '日本語',
+      expectedStatus: 200
+    },
+    {
+      description: 'rejects a name containing spaces',
+      tag: 'not a tag',
+      expectedStatus: 400
+    }
+  ])('$description', async ({ tag, expectedStatus }) => {
+    const response = await POST(
+      new NextRequest(
+        `https://local.test/api/v1/tags/${encodeURIComponent(tag)}/follow`,
+        { method: 'POST' }
+      ),
+      { params: Promise.resolve({ tag }) }
+    )
+    expect(response.status).toBe(expectedStatus)
+  })
+})

--- a/app/api/v1/tags/[tag]/follow/route.ts
+++ b/app/api/v1/tags/[tag]/follow/route.ts
@@ -6,7 +6,10 @@ import { getTagHistory } from '@/lib/services/trends/tagHistory'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
-import { normalizeHashtagParam } from '@/lib/utils/text/mastodonHashtag'
+import {
+  MAX_ENCODED_HASHTAG_PARAM_LENGTH,
+  normalizeHashtagParam
+} from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
@@ -14,7 +17,9 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  tag: z.string().max(255)
+  // Cap the raw (percent-encoded) param; normalizeHashtagParam enforces the
+  // 255-char limit on the decoded name so Unicode tags aren't rejected early.
+  tag: z.string().max(MAX_ENCODED_HASHTAG_PARAM_LENGTH)
 })
 
 interface RouteParams {

--- a/app/api/v1/tags/[tag]/follow/route.ts
+++ b/app/api/v1/tags/[tag]/follow/route.ts
@@ -2,9 +2,11 @@ import { z } from 'zod'
 
 import { OAuthGuard, corsErrorResponse } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonTag } from '@/lib/services/mastodon/getMastodonTag'
+import { getTagHistory } from '@/lib/services/trends/tagHistory'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { normalizeHashtagParam } from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
@@ -12,7 +14,7 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  tag: z.string().regex(/^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/)
+  tag: z.string().max(255)
 })
 
 interface RouteParams {
@@ -35,12 +37,22 @@ export const POST = traceApiRoute(
         })
       }
 
-      const { tag } = parsed.data
+      const tag = normalizeHashtagParam(parsed.data.tag)
+      if (!tag) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+
       await database.followTag({ actorId: currentActor.id, name: tag })
+      const history = await getTagHistory(database, tag)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: getMastodonTag(tag, true)
+        data: getMastodonTag(tag, true, history)
       })
     },
     { errorResponse: corsErrorResponse(CORS_HEADERS) }

--- a/app/api/v1/tags/[tag]/route.test.ts
+++ b/app/api/v1/tags/[tag]/route.test.ts
@@ -141,4 +141,20 @@ describe('GET /api/v1/tags/:tag', () => {
     )
     expect(response.status).toBe(expectedStatus)
   })
+
+  it('accepts a unicode tag whose percent-encoded length exceeds 255', async () => {
+    // 30 Japanese chars → 270 percent-encoded chars: over the decoded 255 limit
+    // but a valid short name. The raw param cap must not reject it before
+    // normalizeHashtagParam decodes it.
+    const name = 'あ'.repeat(30)
+    const encoded = encodeURIComponent(name)
+    expect(encoded.length).toBeGreaterThan(255)
+    const response = await GET(
+      new NextRequest(`https://local.test/api/v1/tags/${encoded}`),
+      { params: Promise.resolve({ tag: encoded }) }
+    )
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.name).toBe(name)
+  })
 })

--- a/app/api/v1/tags/[tag]/route.test.ts
+++ b/app/api/v1/tags/[tag]/route.test.ts
@@ -8,6 +8,7 @@ const mockDatabase = {
   getBlockRelations: vi.fn(),
   getMuteRelations: vi.fn(),
   getStatusesByHashtag: vi.fn(),
+  getTagDailyHistory: vi.fn(),
   isFollowingTag: vi.fn()
 }
 const mockCurrentActor = {
@@ -52,6 +53,7 @@ describe('GET /api/v1/tags/:tag', () => {
     mockDatabase.getBlockRelations.mockResolvedValue([])
     mockDatabase.getMuteRelations.mockResolvedValue([])
     mockDatabase.getStatusesByHashtag.mockResolvedValue([status])
+    mockDatabase.getTagDailyHistory.mockResolvedValue(new Map())
     mockDatabase.isFollowingTag.mockResolvedValue(true)
   })
 
@@ -83,5 +85,60 @@ describe('GET /api/v1/tags/:tag', () => {
     const body = await response.json()
     expect(Array.isArray(body.statuses)).toBe(true)
     expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalled()
+  })
+
+  it('includes the seven-day usage history in the Tag entity', async () => {
+    const DAY_MS = 86_400_000
+    const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+    mockDatabase.getTagDailyHistory.mockResolvedValue(
+      new Map([
+        ['running', [{ dayBucketMs: todayBucketMs, uses: 3, accounts: 2 }]]
+      ])
+    )
+
+    const response = await GET(
+      new NextRequest('https://local.test/api/v1/tags/running'),
+      { params: Promise.resolve({ tag: 'running' }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.history).toHaveLength(7)
+    expect(body.history[0]).toEqual({
+      day: String(todayBucketMs / 1000),
+      uses: '3',
+      accounts: '2'
+    })
+    expect(body.history[1]).toEqual({
+      day: String((todayBucketMs - DAY_MS) / 1000),
+      uses: '0',
+      accounts: '0'
+    })
+  })
+
+  it.each([
+    {
+      description: 'accepts a unicode hashtag name',
+      tag: 'こんにちは',
+      expectedStatus: 200
+    },
+    {
+      description: 'accepts an all-numeric hashtag name',
+      tag: '2026',
+      expectedStatus: 200
+    },
+    {
+      description: 'rejects a name containing spaces',
+      tag: 'not a tag',
+      expectedStatus: 400
+    }
+  ])('$description', async ({ tag, expectedStatus }) => {
+    const response = await GET(
+      new NextRequest(
+        `https://local.test/api/v1/tags/${encodeURIComponent(tag)}`
+      ),
+      { params: Promise.resolve({ tag }) }
+    )
+    expect(response.status).toBe(expectedStatus)
   })
 })

--- a/app/api/v1/tags/[tag]/route.ts
+++ b/app/api/v1/tags/[tag]/route.ts
@@ -16,7 +16,10 @@ import { Scope } from '@/lib/types/database/operations'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
-import { normalizeHashtagParam } from '@/lib/utils/text/mastodonHashtag'
+import {
+  MAX_ENCODED_HASHTAG_PARAM_LENGTH,
+  normalizeHashtagParam
+} from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
@@ -25,7 +28,9 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  tag: z.string().max(255)
+  // Cap the raw (percent-encoded) param; normalizeHashtagParam enforces the
+  // 255-char limit on the decoded name so Unicode tags aren't rejected early.
+  tag: z.string().max(MAX_ENCODED_HASHTAG_PARAM_LENGTH)
 })
 
 interface RouteParams {

--- a/app/api/v1/tags/[tag]/route.ts
+++ b/app/api/v1/tags/[tag]/route.ts
@@ -11,10 +11,12 @@ import {
   getFilteredStatusPage,
   normalizeTimelineLimit
 } from '@/lib/services/timelines/getFilteredTimelinePage'
+import { getTagHistory } from '@/lib/services/trends/tagHistory'
 import { Scope } from '@/lib/types/database/operations'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { normalizeHashtagParam } from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
 
@@ -23,7 +25,7 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  tag: z.string().regex(/^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/)
+  tag: z.string().max(255)
 })
 
 interface RouteParams {
@@ -46,7 +48,15 @@ export const GET = traceApiRoute(
           responseStatusCode: 400
         })
 
-      const { tag } = parseResult.data
+      const tag = normalizeHashtagParam(parseResult.data.tag)
+      if (!tag)
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+
       const url = new URL(req.url)
       const format = url.searchParams.get('format')
 
@@ -54,16 +64,19 @@ export const GET = traceApiRoute(
       // including whether the current actor follows it.
       // https://docs.joinmastodon.org/methods/tags/#get
       if (format !== TimelineFormat.enum.activities_next) {
-        const following = currentActor
-          ? await database.isFollowingTag({
-              actorId: currentActor.id,
-              name: tag
-            })
-          : false
+        const [following, history] = await Promise.all([
+          currentActor
+            ? database.isFollowingTag({
+                actorId: currentActor.id,
+                name: tag
+              })
+            : Promise.resolve(false),
+          getTagHistory(database, tag)
+        ])
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: getMastodonTag(tag, following)
+          data: getMastodonTag(tag, following, history)
         })
       }
 

--- a/app/api/v1/tags/[tag]/unfollow/route.test.ts
+++ b/app/api/v1/tags/[tag]/unfollow/route.test.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from 'next/server'
+
+import { POST } from './route'
+
+const mockDatabase = {
+  getTagDailyHistory: vi.fn(),
+  unfollowTag: vi.fn()
+}
+const mockCurrentActor = {
+  id: 'https://local.test/users/me'
+}
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => ({ host: 'local.test' })
+}))
+
+vi.mock('@/lib/services/guards/OAuthGuard', () => ({
+  OAuthGuard:
+    (
+      _scopes: unknown,
+      handle: (
+        req: NextRequest,
+        context: {
+          database: typeof mockDatabase
+          currentActor: typeof mockCurrentActor
+          params: Promise<{ tag: string }>
+        }
+      ) => Promise<Response> | Response
+    ) =>
+    (req: NextRequest, context: { params: Promise<{ tag: string }> }) =>
+      handle(req, {
+        database: mockDatabase,
+        currentActor: mockCurrentActor,
+        params: context.params
+      }),
+  corsErrorResponse: vi.fn()
+}))
+
+describe('POST /api/v1/tags/:tag/unfollow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDatabase.unfollowTag.mockResolvedValue(null)
+    mockDatabase.getTagDailyHistory.mockResolvedValue(new Map())
+  })
+
+  it('returns the unfollowed Tag entity with its seven-day history', async () => {
+    const DAY_MS = 86_400_000
+    const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+    mockDatabase.getTagDailyHistory.mockResolvedValue(
+      new Map([
+        ['running', [{ dayBucketMs: todayBucketMs, uses: 2, accounts: 1 }]]
+      ])
+    )
+
+    const response = await POST(
+      new NextRequest('https://local.test/api/v1/tags/running/unfollow', {
+        method: 'POST'
+      }),
+      { params: Promise.resolve({ tag: 'running' }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.following).toBe(false)
+    expect(body.history).toHaveLength(7)
+    expect(body.history[0]).toEqual({
+      day: String(todayBucketMs / 1000),
+      uses: '2',
+      accounts: '1'
+    })
+    expect(mockDatabase.unfollowTag).toHaveBeenCalledWith({
+      actorId: mockCurrentActor.id,
+      name: 'running'
+    })
+  })
+
+  it.each([
+    {
+      description: 'accepts a unicode hashtag name',
+      tag: '日本語',
+      expectedStatus: 200
+    },
+    {
+      description: 'rejects a name containing spaces',
+      tag: 'not a tag',
+      expectedStatus: 400
+    }
+  ])('$description', async ({ tag, expectedStatus }) => {
+    const response = await POST(
+      new NextRequest(
+        `https://local.test/api/v1/tags/${encodeURIComponent(tag)}/unfollow`,
+        { method: 'POST' }
+      ),
+      { params: Promise.resolve({ tag }) }
+    )
+    expect(response.status).toBe(expectedStatus)
+  })
+})

--- a/app/api/v1/tags/[tag]/unfollow/route.test.ts
+++ b/app/api/v1/tags/[tag]/unfollow/route.test.ts
@@ -94,5 +94,9 @@ describe('POST /api/v1/tags/:tag/unfollow', () => {
       { params: Promise.resolve({ tag }) }
     )
     expect(response.status).toBe(expectedStatus)
+    if (expectedStatus === 400) {
+      // A rejected tag must not trigger an unfollow write (guard runs first).
+      expect(mockDatabase.unfollowTag).not.toHaveBeenCalled()
+    }
   })
 })

--- a/app/api/v1/tags/[tag]/unfollow/route.ts
+++ b/app/api/v1/tags/[tag]/unfollow/route.ts
@@ -6,7 +6,10 @@ import { getTagHistory } from '@/lib/services/trends/tagHistory'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
-import { normalizeHashtagParam } from '@/lib/utils/text/mastodonHashtag'
+import {
+  MAX_ENCODED_HASHTAG_PARAM_LENGTH,
+  normalizeHashtagParam
+} from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
@@ -14,7 +17,9 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  tag: z.string().max(255)
+  // Cap the raw (percent-encoded) param; normalizeHashtagParam enforces the
+  // 255-char limit on the decoded name so Unicode tags aren't rejected early.
+  tag: z.string().max(MAX_ENCODED_HASHTAG_PARAM_LENGTH)
 })
 
 interface RouteParams {

--- a/app/api/v1/tags/[tag]/unfollow/route.ts
+++ b/app/api/v1/tags/[tag]/unfollow/route.ts
@@ -2,9 +2,11 @@ import { z } from 'zod'
 
 import { OAuthGuard, corsErrorResponse } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonTag } from '@/lib/services/mastodon/getMastodonTag'
+import { getTagHistory } from '@/lib/services/trends/tagHistory'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { ERROR_400, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { normalizeHashtagParam } from '@/lib/utils/text/mastodonHashtag'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
@@ -12,7 +14,7 @@ const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
 export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const Params = z.object({
-  tag: z.string().regex(/^[a-zA-Z0-9_]*[a-zA-Z_][a-zA-Z0-9_]*$/)
+  tag: z.string().max(255)
 })
 
 interface RouteParams {
@@ -35,12 +37,22 @@ export const POST = traceApiRoute(
         })
       }
 
-      const { tag } = parsed.data
+      const tag = normalizeHashtagParam(parsed.data.tag)
+      if (!tag) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
+
       await database.unfollowTag({ actorId: currentActor.id, name: tag })
+      const history = await getTagHistory(database, tag)
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: getMastodonTag(tag, false)
+        data: getMastodonTag(tag, false, history)
       })
     },
     { errorResponse: corsErrorResponse(CORS_HEADERS) }

--- a/app/api/v1/trends/statuses/route.test.ts
+++ b/app/api/v1/trends/statuses/route.test.ts
@@ -206,3 +206,84 @@ describe('GET /api/v1/trends/statuses', () => {
     )
   })
 })
+
+describe('GET /api/v1/trends/statuses limit clamping', () => {
+  const database = getTestSQLDatabase()
+  const AUTHOR_ID = 'https://llun.test/users/author'
+  const LIKER_ID = 'https://llun.test/users/liker'
+  const SEEDED_STATUS_COUNT = 22
+
+  const createActor = (id: string, username: string) =>
+    database.createActor({
+      actorId: id,
+      username,
+      domain: 'llun.test',
+      inboxUrl: `${id}/inbox`,
+      sharedInboxUrl: 'https://llun.test/inbox',
+      followersUrl: `${id}/followers`,
+      publicKey: 'public-key',
+      privateKey: 'private-key',
+      createdAt: 1
+    })
+
+  beforeAll(async () => {
+    await database.migrate()
+    await createActor(AUTHOR_ID, 'author')
+    await createActor(LIKER_ID, 'liker')
+
+    // 22 public notes, each with one like so every candidate has score > 0.
+    // 22 > the old cap of 20 and > the new default of 20, which makes the
+    // default and the cap independently observable below.
+    const now = Date.now()
+    for (let index = 0; index < SEEDED_STATUS_COUNT; index++) {
+      const statusId = `${AUTHOR_ID}/statuses/bulk-${index}`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: AUTHOR_ID,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: `Trending candidate ${index}`,
+        createdAt: now - index * 1000
+      })
+      await database.createLike({ actorId: LIKER_ID, statusId })
+    }
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+  })
+
+  const request = (query = '') =>
+    new NextRequest(`https://llun.test/api/v1/trends/statuses${query}`)
+
+  it.each([
+    {
+      description: 'defaults to 20 statuses (not the tags default of 10)',
+      query: '',
+      expectedCount: 20
+    },
+    {
+      description: 'serves limits above the old tags cap of 20',
+      query: '?limit=25',
+      expectedCount: 22
+    },
+    {
+      description: 'falls back to the default of 20 for garbage limits',
+      query: '?limit=garbage',
+      expectedCount: 20
+    }
+  ])('$description', async ({ query, expectedCount }) => {
+    const response = await GET(request(query), { params: Promise.resolve({}) })
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data).toHaveLength(expectedCount)
+  })
+})

--- a/app/api/v1/trends/statuses/route.ts
+++ b/app/api/v1/trends/statuses/route.ts
@@ -1,8 +1,8 @@
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
 import {
-  normalizeTrendsLimit,
-  normalizeTrendsOffset
+  normalizeTrendsOffset,
+  normalizeTrendsStatusesLimit
 } from '@/lib/services/trends/request'
 import { getTrendingStatuses } from '@/lib/services/trends/trendingStatuses'
 import { Scope } from '@/lib/types/database/operations'
@@ -23,7 +23,7 @@ export const GET = traceApiRoute(
     [Scope.enum.read],
     async (req, { database, currentActor }) => {
       const searchParams = new URL(req.url).searchParams
-      const limit = normalizeTrendsLimit(searchParams.get('limit'))
+      const limit = normalizeTrendsStatusesLimit(searchParams.get('limit'))
       const offset = normalizeTrendsOffset(searchParams.get('offset'))
 
       const statuses = await getTrendingStatuses({ database, limit, offset })

--- a/app/api/v1/trends/tags/route.ts
+++ b/app/api/v1/trends/tags/route.ts
@@ -5,8 +5,12 @@ import {
   normalizeTrendsLimit,
   normalizeTrendsOffset
 } from '@/lib/services/trends/request'
-import { Scope, TagDailyHistoryPoint } from '@/lib/types/database/operations'
-import { Tag, TagHistory } from '@/lib/types/mastodon/tag'
+import {
+  getCurrentDayBucketMs,
+  getSevenDayHistory
+} from '@/lib/services/trends/tagHistory'
+import { Scope } from '@/lib/types/database/operations'
+import { Tag } from '@/lib/types/mastodon/tag'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
@@ -14,27 +18,6 @@ import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
 export const OPTIONS = defaultOptions(CORS_HEADERS)
-
-const DAY_MS = 86_400_000
-
-// Seven UTC-day buckets newest first, zero-filled for days without uses.
-// `day` is the unix-second start of the UTC day; all values are strings per
-// the Mastodon Tag history shape.
-const getSevenDayHistory = (
-  todayBucketMs: number,
-  points: TagDailyHistoryPoint[]
-): TagHistory[] => {
-  const pointsByDay = new Map(points.map((point) => [point.dayBucketMs, point]))
-  return Array.from({ length: TRENDS_DAYS }, (_, index) => {
-    const dayBucketMs = todayBucketMs - index * DAY_MS
-    const point = pointsByDay.get(dayBucketMs)
-    return {
-      day: String(dayBucketMs / 1000),
-      uses: String(point?.uses ?? 0),
-      accounts: String(point?.accounts ?? 0)
-    }
-  })
-}
 
 // https://docs.joinmastodon.org/methods/trends/#tags
 // Local trends computed live from public hashtag usage on this instance over
@@ -58,7 +41,7 @@ export const GET = traceApiRoute(
         days: TRENDS_DAYS
       })
 
-      const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+      const todayBucketMs = getCurrentDayBucketMs()
       const tags = await Promise.all(
         trendingTags.map(async (trendingTag): Promise<Tag> => {
           const following = currentActor

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -763,7 +763,9 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
   async getLocalMastodonActors({
     localDomain,
     limit = 40,
-    offset = 0
+    offset = 0,
+    order = 'active',
+    local = true
   }: GetLocalActorsParams) {
     // Actors store the bare host in `domain`, but callers may pass a configured
     // host that includes a scheme (e.g. `https://example.com`). Normalize so the
@@ -771,18 +773,42 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     const normalizedDomain = localDomain.includes('://')
       ? new URL(localDomain).host
       : localDomain
-    // `lastStatusAt` is not persisted on actors (see updateActorLastStatusAt),
-    // so the directory is ordered by account creation time for both the
-    // `active` and `new` Mastodon orderings.
-    const rows = await database<SQLActor>('actors')
-      .where('domain', normalizedDomain)
-      .whereNotNull('accountId')
-      .orderBy('createdAt', 'desc')
-      .limit(limit)
-      .offset(offset)
-      .pluck('id')
+    const query = database<SQLActor>('actors').limit(limit).offset(offset)
 
-    return this.getMastodonActors(rows)
+    // local=false lists every known profile (Mastodon's default directory);
+    // local=true keeps only this server's account-backed actors.
+    if (local) {
+      query
+        .where('actors.domain', normalizedDomain)
+        .whereNotNull('actors.accountId')
+    }
+
+    if (order === 'active') {
+      // `active` sorts by the actor's most recent status — the same
+      // MAX(statuses.createdAt) the serializer exposes as last_status_at
+      // (Mastodon orders by account_stats.last_status_at, which likewise
+      // counts non-public statuses). The grouped subquery walks the
+      // (actorId, createdAt, ...) statuses index; actors with no statuses
+      // sort last, newest account first among them. The boolean `is null`
+      // pre-sort is the portable NULLS LAST pattern the search document
+      // queries use for non-Postgres dialects (documents.ts) and is valid on
+      // Postgres too.
+      const lastStatuses = database('statuses')
+        .select('actorId')
+        .max({ lastStatusAt: 'createdAt' })
+        .groupBy('actorId')
+        .as('last_statuses')
+      query
+        .leftJoin(lastStatuses, 'actors.id', 'last_statuses.actorId')
+        .orderByRaw('?? is null', ['last_statuses.lastStatusAt'])
+        .orderBy('last_statuses.lastStatusAt', 'desc')
+        .orderBy('actors.createdAt', 'desc')
+    } else {
+      query.orderBy('actors.createdAt', 'desc')
+    }
+
+    const rows = await query.select<{ id: string }[]>({ id: 'actors.id' })
+    return this.getMastodonActors(rows.map((row) => row.id))
   },
 
   async getMastodonActors(actorIds: string[]) {

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -781,6 +781,16 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       query
         .where('actors.domain', normalizedDomain)
         .whereNotNull('actors.accountId')
+    } else {
+      // Even the all-profiles view must not expose internal system actors —
+      // the headless federation signer and any other local actor with no
+      // backing account (accountId null on the local domain). Remote actors
+      // (foreign domain) and local account-backed actors are still listed.
+      query.whereNot(function () {
+        this.where('actors.domain', normalizedDomain).whereNull(
+          'actors.accountId'
+        )
+      })
     }
 
     if (order === 'active') {

--- a/lib/database/sql/admin.test.ts
+++ b/lib/database/sql/admin.test.ts
@@ -294,10 +294,11 @@ describe('AdminDatabase', () => {
         const after = await database.getDomainFederationRuleStats()
         expect(after.blocks).toBe(before.blocks + 3)
         expect(after.suspendBlocks).toBe(before.suspendBlocks + 1)
+        expect(after.silenceBlocks).toBe(before.silenceBlocks + 1)
 
         const suspendBlocks = await database.getDomainBlocks({
           limit: 1000,
-          severity: 'suspend'
+          severities: ['suspend']
         })
         const suspendDomains = new Set(
           suspendBlocks.map((block) => block.domain)
@@ -305,6 +306,16 @@ describe('AdminDatabase', () => {
         expect(suspendDomains.has(suspendDomain)).toBe(true)
         expect(suspendDomains.has(silenceDomain)).toBe(false)
         expect(suspendDomains.has(noopDomain)).toBe(false)
+
+        // The public instance endpoint lists both user-facing severities.
+        const publicBlocks = await database.getDomainBlocks({
+          limit: 1000,
+          severities: ['silence', 'suspend']
+        })
+        const publicDomains = new Set(publicBlocks.map((block) => block.domain))
+        expect(publicDomains.has(suspendDomain)).toBe(true)
+        expect(publicDomains.has(silenceDomain)).toBe(true)
+        expect(publicDomains.has(noopDomain)).toBe(false)
       })
 
       it('matches exact domains before wildcard rules in SQL', async () => {

--- a/lib/database/sql/admin.ts
+++ b/lib/database/sql/admin.ts
@@ -421,15 +421,17 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     }
   },
 
-  async getDomainBlocks({ limit = 100, offset = 0, severity } = {}) {
+  async getDomainBlocks({ limit = 100, offset = 0, severities } = {}) {
     const query = database<SQLDomainFederationRule>('domain_federation_rules')
       .where('type', 'block')
       .orderBy('domain', 'asc')
       .limit(limit)
       .offset(offset)
 
-    if (severity) {
-      query.where('severity', severity)
+    // Block rows always persist a severity (only allow rows store null), so a
+    // whereIn filter cannot drop legacy rows.
+    if (severities && severities.length > 0) {
+      query.whereIn('severity', severities)
     }
 
     const rows = await query
@@ -532,30 +534,42 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
   },
 
   async getDomainFederationRuleStats() {
-    const [blockCount, suspendBlockCount, allowCount, sourceRows] =
-      await Promise.all([
-        database('domain_federation_rules')
-          .where('type', 'block')
-          .count<{ count: string | number }>('id as count')
-          .first(),
-        database('domain_federation_rules')
-          .where({
-            type: 'block',
-            severity: DEFAULT_DOMAIN_BLOCK_SEVERITY
-          })
-          .count<{ count: string | number }>('id as count')
-          .first(),
-        database('domain_federation_rules')
-          .where('type', 'allow')
-          .count<{ count: string | number }>('id as count')
-          .first(),
-        database('domain_federation_rules')
-          .select('source')
-          .where('type', 'block')
-          .whereNotNull('source')
-          .groupBy('source')
-          .count<{ source: string; count: string | number }>('id as count')
-      ])
+    const [
+      blockCount,
+      suspendBlockCount,
+      silenceBlockCount,
+      allowCount,
+      sourceRows
+    ] = await Promise.all([
+      database('domain_federation_rules')
+        .where('type', 'block')
+        .count<{ count: string | number }>('id as count')
+        .first(),
+      database('domain_federation_rules')
+        .where({
+          type: 'block',
+          severity: DEFAULT_DOMAIN_BLOCK_SEVERITY
+        })
+        .count<{ count: string | number }>('id as count')
+        .first(),
+      database('domain_federation_rules')
+        .where({
+          type: 'block',
+          severity: 'silence'
+        })
+        .count<{ count: string | number }>('id as count')
+        .first(),
+      database('domain_federation_rules')
+        .where('type', 'allow')
+        .count<{ count: string | number }>('id as count')
+        .first(),
+      database('domain_federation_rules')
+        .select('source')
+        .where('type', 'block')
+        .whereNotNull('source')
+        .groupBy('source')
+        .count<{ source: string; count: string | number }>('id as count')
+    ])
     const sourceCounts = Object.fromEntries(
       (
         sourceRows as unknown as {
@@ -572,6 +586,7 @@ export const AdminSQLDatabaseMixin = (database: Knex): AdminDatabase => ({
     return {
       blocks: Number(blockCount?.count ?? 0),
       suspendBlocks: Number(suspendBlockCount?.count ?? 0),
+      silenceBlocks: Number(silenceBlockCount?.count ?? 0),
       allows: Number(allowCount?.count ?? 0),
       sourceBlocks,
       sourceCounts

--- a/lib/database/sql/directory.test.ts
+++ b/lib/database/sql/directory.test.ts
@@ -139,6 +139,35 @@ describe('directory and peers', () => {
         expect(usernames).toEqual(['actor_id', 'alice'])
       })
     })
+
+    it('excludes internal local system actors (no account) when local is false', async () => {
+      await withFreshDatabase(async (database) => {
+        await createLocalAccount(database, 'alice')
+        // A local-domain actor with no backing account stands in for an
+        // internal system actor such as the headless federation signer
+        // (accountId null on the local domain). It must never surface in the
+        // public directory, even in the all-profiles (local=false) view.
+        const systemActorId = testUserId('__system__')
+        await database.createActor({
+          actorId: systemActorId,
+          username: '__system__',
+          domain: TEST_DOMAIN,
+          followersUrl: `${systemActorId}/followers`,
+          inboxUrl: `${systemActorId}/inbox`,
+          sharedInboxUrl: `https://${TEST_DOMAIN}/inbox`,
+          publicKey: 'system-public-key',
+          createdAt: Date.now()
+        })
+
+        const actors = await database.getLocalMastodonActors({
+          localDomain: TEST_DOMAIN,
+          local: false
+        })
+        const usernames = actors.map((actor) => actor.username)
+        expect(usernames).toContain('alice')
+        expect(usernames).not.toContain('__system__')
+      })
+    })
   })
 
   describe('getInstancePeers', () => {

--- a/lib/database/sql/directory.test.ts
+++ b/lib/database/sql/directory.test.ts
@@ -4,7 +4,8 @@ import {
   getTestSQLDatabase
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
-import { EXTERNAL_ACTORS, TEST_DOMAIN } from '@/lib/stub/const'
+import { EXTERNAL_ACTORS, TEST_DOMAIN, testUserId } from '@/lib/stub/const'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 const withFreshDatabase = async (
   test: (database: Database) => Promise<void>
@@ -80,6 +81,62 @@ describe('directory and peers', () => {
           offset: 2
         })
         expect(secondPage).toHaveLength(1)
+      })
+    })
+
+    it('orders by the most recent status when order is active', async () => {
+      await withFreshDatabase(async (database) => {
+        await createLocalAccount(database, 'alice')
+        await createLocalAccount(database, 'bob')
+        await createLocalAccount(database, 'carol')
+
+        const now = Date.now()
+        const createNote = (username: string, createdAt: number) =>
+          database.createNote({
+            id: `${testUserId(username)}/statuses/1`,
+            url: `${testUserId(username)}/statuses/1`,
+            actorId: testUserId(username),
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [],
+            text: `post by ${username}`,
+            createdAt
+          })
+        // bob posted most recently, alice earlier, carol never.
+        await createNote('alice', now - 60_000)
+        await createNote('bob', now - 1000)
+
+        const actors = await database.getLocalMastodonActors({
+          localDomain: TEST_DOMAIN,
+          order: 'active'
+        })
+        expect(actors.map((actor) => actor.username)).toEqual([
+          'bob',
+          'alice',
+          'carol'
+        ])
+      })
+    })
+
+    it('includes known remote actors when local is false', async () => {
+      await withFreshDatabase(async (database) => {
+        await createLocalAccount(database, 'alice')
+        await database.createActor({
+          actorId: EXTERNAL_ACTORS[0].id,
+          username: EXTERNAL_ACTORS[0].username,
+          domain: EXTERNAL_ACTORS[0].domain,
+          followersUrl: EXTERNAL_ACTORS[0].followers_url,
+          inboxUrl: EXTERNAL_ACTORS[0].inbox_url,
+          sharedInboxUrl: EXTERNAL_ACTORS[0].inbox_url,
+          publicKey: 'remote-public-key',
+          createdAt: Date.now()
+        })
+
+        const actors = await database.getLocalMastodonActors({
+          localDomain: TEST_DOMAIN,
+          local: false
+        })
+        const usernames = actors.map((actor) => actor.username).sort()
+        expect(usernames).toEqual(['actor_id', 'alice'])
       })
     })
   })

--- a/lib/database/sql/followedTag.test.ts
+++ b/lib/database/sql/followedTag.test.ts
@@ -66,4 +66,27 @@ describe('FollowedTagDatabase', () => {
       ).toBeNull()
     })
   })
+
+  it('pages the window immediately newer than min_id, newest first', async () => {
+    await withFreshDatabase(async (database) => {
+      for (const name of ['first', 'second', 'third', 'fourth']) {
+        await database.followTag({ actorId: ACTOR_ID, name })
+      }
+
+      // Newest-first baseline; index 3 is the oldest row.
+      const all = await database.getFollowedTags({ actorId: ACTOR_ID })
+      expect(all).toHaveLength(4)
+
+      const page = await database.getFollowedTags({
+        actorId: ACTOR_ID,
+        minId: all[3].id,
+        limit: 2
+      })
+
+      // min_id pages upward from the cursor: the two rows immediately newer
+      // than the oldest one, still returned newest-first. since_id semantics
+      // would instead return the two newest rows (all[0], all[1]).
+      expect(page.map((tag) => tag.id)).toEqual([all[1].id, all[2].id])
+    })
+  })
 })

--- a/lib/database/sql/followedTag.ts
+++ b/lib/database/sql/followedTag.ts
@@ -88,13 +88,21 @@ export const FollowedTagSQLDatabaseMixin = (
     actorId,
     limit = PER_PAGE_LIMIT,
     maxId,
+    minId,
     sinceId
   }: GetFollowedTagsParams) {
     const query = database<SQLFollowedTag>('followed_tags')
       .where('actorId', actorId)
-      .orderBy('createdAt', 'desc')
-      .orderBy('id', 'desc')
       .limit(limit)
+
+    // min_id pages the window immediately newer than the cursor (ascending
+    // scan, reversed back to newest-first below); since_id keeps the newest
+    // rows (plain descending scan). Mirrors getBookmarks.
+    if (minId) {
+      query.orderBy('createdAt', 'asc').orderBy('id', 'asc')
+    } else {
+      query.orderBy('createdAt', 'desc').orderBy('id', 'desc')
+    }
 
     // Ids are random UUIDs, so they cannot drive chronological pagination.
     // Resolve the cursor row's createdAt and paginate on that, using id as a
@@ -121,10 +129,11 @@ export const FollowedTagSQLDatabaseMixin = (
     }
 
     if (maxId) await applyCursor(maxId, 'older')
-    if (sinceId) await applyCursor(sinceId, 'newer')
+    const newerCursorId = minId || sinceId
+    if (newerCursorId) await applyCursor(newerCursorId, 'newer')
 
     const rows = await query
-    return rows.map(fixFollowedTag)
+    return (minId ? rows.reverse() : rows).map(fixFollowedTag)
   },
 
   async isFollowingTag({ actorId, name }: IsFollowingTagParams) {

--- a/lib/services/federation/domainRules.test.ts
+++ b/lib/services/federation/domainRules.test.ts
@@ -1,3 +1,5 @@
+import { DomainBlock } from '@/lib/types/database/operations'
+
 import {
   domainDigest,
   domainMatchesRule,
@@ -41,27 +43,50 @@ describe('domainRules', () => {
     expect(match?.id).toBe('2')
   })
 
-  it('obfuscates public domain blocks with the digest', () => {
-    const publicBlock = toPublicDomainBlock({
-      id: '1',
-      type: 'block',
-      domain: 'blocked.test',
-      severity: 'suspend',
-      rejectMedia: false,
-      rejectReports: false,
-      privateComment: null,
-      publicComment: 'spam',
-      obfuscate: true,
-      source: null,
-      createdAt: 0,
-      updatedAt: 0
-    })
+  const block = (overrides: Partial<DomainBlock>): DomainBlock => ({
+    id: '1',
+    type: 'block',
+    domain: 'blocked.test',
+    severity: 'suspend',
+    rejectMedia: false,
+    rejectReports: false,
+    privateComment: null,
+    publicComment: 'spam',
+    obfuscate: false,
+    source: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  })
 
-    expect(publicBlock).toEqual({
-      domain: domainDigest('blocked.test'),
+  it('passes non-obfuscated domains through with their digest', () => {
+    expect(toPublicDomainBlock(block({}))).toEqual({
+      domain: 'blocked.test',
       digest: domainDigest('blocked.test'),
       severity: 'suspend',
       comment: 'spam'
     })
+  })
+
+  it.each([
+    {
+      description: 'stars the middle of a two-label domain',
+      domain: 'example.com',
+      expected: 'exa****.*om'
+    },
+    {
+      description: 'keeps dots visible while starring around them',
+      domain: 'blocked.test',
+      expected: 'bloc***.*est'
+    },
+    {
+      description: 'keeps the edges of a short domain',
+      domain: 'ab.cd',
+      expected: 'ab.*d'
+    }
+  ])('$description', ({ domain, expected }) => {
+    const publicBlock = toPublicDomainBlock(block({ domain, obfuscate: true }))
+    expect(publicBlock.domain).toBe(expected)
+    expect(publicBlock.digest).toBe(domainDigest(domain))
   })
 })

--- a/lib/services/federation/domainRules.test.ts
+++ b/lib/services/federation/domainRules.test.ts
@@ -83,6 +83,14 @@ describe('domainRules', () => {
       description: 'keeps the edges of a short domain',
       domain: 'ab.cd',
       expected: 'ab.*d'
+    },
+    {
+      // Astral code points count as two UTF-16 units each; the obfuscation must
+      // measure/index by code point (9 here, not 13) so an IDN domain is starred
+      // correctly rather than off by the surrogate-pair count.
+      description: 'stars an IDN domain by code point, not UTF-16 unit',
+      domain: '𝔞𝔟𝔠𝔡.test',
+      expected: '𝔞𝔟𝔠*.**st'
     }
   ])('$description', ({ domain, expected }) => {
     const publicBlock = toPublicDomainBlock(block({ domain, obfuscate: true }))

--- a/lib/services/federation/domainRules.ts
+++ b/lib/services/federation/domainRules.ts
@@ -82,9 +82,13 @@ export const shouldSuspendDomainBlock = (block: DomainBlock): boolean =>
 // 'exa****.*om'. Clients expect this partially-starred form; the full SHA-256
 // stays available in `digest`.
 const obfuscateDomain = (domain: string): string => {
-  const length = domain.length
+  // Count in code points, not UTF-16 units, so the length/index math lines up
+  // with the code-point array we map over (matters for IDN domains with astral
+  // characters) and matches Mastodon's code-point-based public_domain rule.
+  const chars = [...domain]
+  const length = chars.length
   const visibleRatio = Math.floor(length / 4)
-  return [...domain]
+  return chars
     .map((char, index) =>
       index > visibleRatio && index < length - visibleRatio && char !== '.'
         ? '*'

--- a/lib/services/federation/domainRules.ts
+++ b/lib/services/federation/domainRules.ts
@@ -76,8 +76,25 @@ export const findMatchingDomainRule = <
 export const shouldSuspendDomainBlock = (block: DomainBlock): boolean =>
   block.severity === 'suspend'
 
+// Mastodon's DomainBlock#public_domain rule (app/models/domain_block.rb):
+// keep the first floor(length / 4) + 1 characters, the last floor(length / 4)
+// characters, and every '.', starring the rest — e.g. 'example.com' →
+// 'exa****.*om'. Clients expect this partially-starred form; the full SHA-256
+// stays available in `digest`.
+const obfuscateDomain = (domain: string): string => {
+  const length = domain.length
+  const visibleRatio = Math.floor(length / 4)
+  return [...domain]
+    .map((char, index) =>
+      index > visibleRatio && index < length - visibleRatio && char !== '.'
+        ? '*'
+        : char
+    )
+    .join('')
+}
+
 export const toPublicDomainBlock = (block: DomainBlock) => ({
-  domain: block.obfuscate ? domainDigest(block.domain) : block.domain,
+  domain: block.obfuscate ? obfuscateDomain(block.domain) : block.domain,
   digest: domainDigest(block.domain),
   severity: block.severity,
   comment: block.publicComment

--- a/lib/services/mastodon/getMastodonTag.ts
+++ b/lib/services/mastodon/getMastodonTag.ts
@@ -1,5 +1,5 @@
 import { getConfig } from '@/lib/config'
-import { Tag } from '@/lib/types/mastodon/tag'
+import { Tag, TagHistory } from '@/lib/types/mastodon/tag'
 
 const getTagUrl = (name: string): string => {
   const host = getConfig().host
@@ -8,11 +8,16 @@ const getTagUrl = (name: string): string => {
 }
 
 // Builds a Mastodon Tag entity. https://docs.joinmastodon.org/entities/Tag/
-// Trend history is not indexed yet, so `history` is always empty.
-export const getMastodonTag = (name: string, following: boolean): Tag =>
+// `history` defaults to empty for callers that do not compute the seven-day
+// usage window (see lib/services/trends/tagHistory.ts getTagHistory).
+export const getMastodonTag = (
+  name: string,
+  following: boolean,
+  history: TagHistory[] = []
+): Tag =>
   Tag.parse({
     name: name.replace(/^#+/, ''),
     url: getTagUrl(name.replace(/^#+/, '')),
-    history: [],
+    history,
     following
   })

--- a/lib/services/trends/request.test.ts
+++ b/lib/services/trends/request.test.ts
@@ -1,8 +1,11 @@
 import {
   TRENDS_DEFAULT_LIMIT,
   TRENDS_MAX_LIMIT,
+  TRENDS_STATUSES_DEFAULT_LIMIT,
+  TRENDS_STATUSES_MAX_LIMIT,
   normalizeTrendsLimit,
-  normalizeTrendsOffset
+  normalizeTrendsOffset,
+  normalizeTrendsStatusesLimit
 } from './request'
 
 describe('normalizeTrendsLimit', () => {
@@ -87,5 +90,47 @@ describe('normalizeTrendsOffset', () => {
     }
   ])('$description', ({ value, expected }) => {
     expect(normalizeTrendsOffset(value)).toBe(expected)
+  })
+})
+
+describe('normalizeTrendsStatusesLimit', () => {
+  it.each([
+    {
+      description: 'valid in-range limit above the tags cap passes through',
+      value: '25',
+      expected: 25
+    },
+    {
+      description: 'limit above the max clamps to the max',
+      value: '41',
+      expected: TRENDS_STATUSES_MAX_LIMIT
+    },
+    {
+      description: 'limit at the max stays at the max',
+      value: '40',
+      expected: TRENDS_STATUSES_MAX_LIMIT
+    },
+    {
+      description: 'zero limit falls back to the default',
+      value: '0',
+      expected: TRENDS_STATUSES_DEFAULT_LIMIT
+    },
+    {
+      description: 'negative limit falls back to the default',
+      value: '-5',
+      expected: TRENDS_STATUSES_DEFAULT_LIMIT
+    },
+    {
+      description: 'non-numeric limit falls back to the default',
+      value: 'garbage',
+      expected: TRENDS_STATUSES_DEFAULT_LIMIT
+    },
+    {
+      description: 'absent limit falls back to the default',
+      value: null,
+      expected: TRENDS_STATUSES_DEFAULT_LIMIT
+    }
+  ])('$description', ({ value, expected }) => {
+    expect(normalizeTrendsStatusesLimit(value)).toBe(expected)
   })
 })

--- a/lib/services/trends/request.ts
+++ b/lib/services/trends/request.ts
@@ -1,15 +1,35 @@
 export const TRENDS_DAYS = 7
 export const TRENDS_DEFAULT_LIMIT = 10
 export const TRENDS_MAX_LIMIT = 20
+// GET /api/v1/trends/statuses has its own, larger window per
+// https://docs.joinmastodon.org/methods/trends/#statuses ("Defaults to 20
+// statuses. Max 40 statuses."), unlike tags/links (default 10, max 20).
+export const TRENDS_STATUSES_DEFAULT_LIMIT = 20
+export const TRENDS_STATUSES_MAX_LIMIT = 40
 
 // Garbage or absent input falls back to the default; valid input is clamped
-// to the Mastodon maximum of 20. Mirrors normalizeSuggestionsLimit.
-export const normalizeTrendsLimit = (rawLimit: string | null): number => {
+// to the endpoint's Mastodon maximum. Mirrors normalizeSuggestionsLimit.
+const normalizeLimit = (
+  rawLimit: string | null,
+  { fallback, max }: { fallback: number; max: number }
+): number => {
   const limit = rawLimit !== null ? Number(rawLimit) : null
   return Number.isSafeInteger(limit) && limit && limit > 0
-    ? Math.min(limit, TRENDS_MAX_LIMIT)
-    : TRENDS_DEFAULT_LIMIT
+    ? Math.min(limit, max)
+    : fallback
 }
+
+export const normalizeTrendsLimit = (rawLimit: string | null): number =>
+  normalizeLimit(rawLimit, {
+    fallback: TRENDS_DEFAULT_LIMIT,
+    max: TRENDS_MAX_LIMIT
+  })
+
+export const normalizeTrendsStatusesLimit = (rawLimit: string | null): number =>
+  normalizeLimit(rawLimit, {
+    fallback: TRENDS_STATUSES_DEFAULT_LIMIT,
+    max: TRENDS_STATUSES_MAX_LIMIT
+  })
 
 export const normalizeTrendsOffset = (rawOffset: string | null): number => {
   const offset = rawOffset !== null ? Number(rawOffset) : null

--- a/lib/services/trends/tagHistory.test.ts
+++ b/lib/services/trends/tagHistory.test.ts
@@ -1,0 +1,77 @@
+import { Database } from '@/lib/database/types'
+
+import { getSevenDayHistory, getTagHistory } from './tagHistory'
+
+const DAY_MS = 86_400_000
+
+describe('getSevenDayHistory', () => {
+  it('zero-fills seven newest-first UTC day buckets around the provided points', () => {
+    // 1_700_006_400_000 is an exact UTC day start (divisible by DAY_MS).
+    const todayBucketMs = 1_700_006_400_000
+    const history = getSevenDayHistory(todayBucketMs, [
+      { dayBucketMs: todayBucketMs, uses: 3, accounts: 2 },
+      { dayBucketMs: todayBucketMs - 2 * DAY_MS, uses: 1, accounts: 1 }
+    ])
+
+    expect(history).toHaveLength(7)
+    expect(history[0]).toEqual({
+      day: String(todayBucketMs / 1000),
+      uses: '3',
+      accounts: '2'
+    })
+    expect(history[1]).toEqual({
+      day: String((todayBucketMs - DAY_MS) / 1000),
+      uses: '0',
+      accounts: '0'
+    })
+    expect(history[2]).toEqual({
+      day: String((todayBucketMs - 2 * DAY_MS) / 1000),
+      uses: '1',
+      accounts: '1'
+    })
+    expect(
+      history
+        .slice(3)
+        .every((bucket) => bucket.uses === '0' && bucket.accounts === '0')
+    ).toBe(true)
+  })
+})
+
+describe('getTagHistory', () => {
+  it('normalizes the requested name before reading the daily-history map', async () => {
+    const todayBucketMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+    const getTagDailyHistory = vi
+      .fn()
+      .mockResolvedValue(
+        new Map([
+          ['running', [{ dayBucketMs: todayBucketMs, uses: 5, accounts: 4 }]]
+        ])
+      )
+    const database = { getTagDailyHistory } as unknown as Database
+
+    const history = await getTagHistory(database, '#Running')
+
+    expect(getTagDailyHistory).toHaveBeenCalledWith({
+      names: ['#Running'],
+      days: 7
+    })
+    expect(history[0]).toEqual({
+      day: String(todayBucketMs / 1000),
+      uses: '5',
+      accounts: '4'
+    })
+  })
+
+  it('returns a zero-filled week for a tag with no usage', async () => {
+    const database = {
+      getTagDailyHistory: vi.fn().mockResolvedValue(new Map())
+    } as unknown as Database
+
+    const history = await getTagHistory(database, 'quiet')
+
+    expect(history).toHaveLength(7)
+    expect(
+      history.every((bucket) => bucket.uses === '0' && bucket.accounts === '0')
+    ).toBe(true)
+  })
+})

--- a/lib/services/trends/tagHistory.ts
+++ b/lib/services/trends/tagHistory.ts
@@ -1,0 +1,51 @@
+import { normalizeHashtagSearchName } from '@/lib/database/sql/search/hashtag'
+import { Database } from '@/lib/database/types'
+import { TagDailyHistoryPoint } from '@/lib/types/database/operations'
+import { TagHistory } from '@/lib/types/mastodon/tag'
+
+import { TRENDS_DAYS } from './request'
+
+const DAY_MS = 86_400_000
+
+// Start of the current UTC day in epoch milliseconds — the newest bucket of
+// the trends window.
+export const getCurrentDayBucketMs = (): number =>
+  Math.floor(Date.now() / DAY_MS) * DAY_MS
+
+// Seven UTC-day buckets newest first, zero-filled for days without uses.
+// `day` is the unix-second start of the UTC day; all values are strings per
+// the Mastodon Tag history shape. (Moved from app/api/v1/trends/tags/route.ts
+// so single-tag lookups render exactly the window trends renders.)
+export const getSevenDayHistory = (
+  todayBucketMs: number,
+  points: TagDailyHistoryPoint[]
+): TagHistory[] => {
+  const pointsByDay = new Map(points.map((point) => [point.dayBucketMs, point]))
+  return Array.from({ length: TRENDS_DAYS }, (_, index) => {
+    const dayBucketMs = todayBucketMs - index * DAY_MS
+    const point = pointsByDay.get(dayBucketMs)
+    return {
+      day: String(dayBucketMs / 1000),
+      uses: String(point?.uses ?? 0),
+      accounts: String(point?.accounts ?? 0)
+    }
+  })
+}
+
+// The zero-filled seven-day usage history for a single tag — the same window
+// /api/v1/trends/tags computes, scoped to one name. getTagDailyHistory keys
+// its result by the bare normalized name, so normalize the caller's input the
+// same way before the lookup.
+export const getTagHistory = async (
+  database: Database,
+  name: string
+): Promise<TagHistory[]> => {
+  const history = await database.getTagDailyHistory({
+    names: [name],
+    days: TRENDS_DAYS
+  })
+  return getSevenDayHistory(
+    getCurrentDayBucketMs(),
+    history.get(normalizeHashtagSearchName(name)) ?? []
+  )
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -75,6 +75,10 @@ export type GetLocalActorsParams = {
   limit?: number
   offset?: number
   order?: 'active' | 'new'
+  // false lists every known profile (Mastodon's default directory); true
+  // keeps only this server's account-backed actors. Defaults to true at the
+  // database layer to preserve the method's historical behavior.
+  local?: boolean
 }
 export type IsCurrentActorFollowingParams = {
   currentActorId: string
@@ -1577,6 +1581,7 @@ export type GetFollowedTagsParams = {
   actorId: string
   limit?: number
   maxId?: string | null
+  minId?: string | null
   sinceId?: string | null
 }
 export type IsFollowingTagParams = { actorId: string; name: string }
@@ -3245,6 +3250,7 @@ export type ImportDomainBlockParams = CreateDomainBlockParams
 export type DomainFederationRuleStats = {
   blocks: number
   suspendBlocks: number
+  silenceBlocks: number
   allows: number
   sourceBlocks: number
   sourceCounts: Record<string, number>
@@ -3263,7 +3269,7 @@ export interface AdminDatabase {
   getDomainBlocks(params?: {
     limit?: number
     offset?: number
-    severity?: DomainBlockSeverity
+    severities?: DomainBlockSeverity[]
   }): Promise<DomainBlock[]>
   getDomainAllows(params?: {
     limit?: number


### PR DESCRIPTION
## Phase 2.8 — Discovery polish

Closes five Mastodon-API conformance gaps in the discovery surface (tags, followed_tags, directory, trends, instance domain_blocks). **No migration** — the reference schema dumps are untouched.

> **Stacked on #1194** (PR 2.7). This PR's base is `fix-public-tag-timeline-params`; it reuses the shared unicode hashtag validator (`lib/utils/text/mastodonHashtag.ts`) introduced there. GitHub will auto-retarget this PR to `main` once #1194 merges. Review/merge #1194 first.

### What changed
1. **Trends statuses limit** — `GET /api/v1/trends/statuses` now uses its own clamp (default **20**, max **40**) per the Mastodon docs, instead of sharing the tags/links clamp (10/20). Tags/links keep their clamp. New `normalizeTrendsStatusesLimit`.
2. **Tag entity history** — `GET /api/v1/tags/:id` and the follow/unfollow actions returned an empty `history`. They now return the real zero-filled seven-day bucket window (the same one `/api/v1/trends/tags` computes), via a shared `lib/services/trends/tagHistory.ts`. The three tag routes also switch from the ASCII-only param regex to the shared unicode hashtag validator (accepts unicode + all-numeric names Mastodon accepts) with a `.max(255)` guard.
3. **followed_tags** — now honors `min_id` (ascending window then reverse, mirroring `getBookmarks`) and emits the `rel="prev"` Link header it previously omitted.
4. **directory** — now honors `order=active` (orders by `MAX(statuses.createdAt)` via a grouped left-join with a portable NULLS-LAST pre-sort — **no migration, no persisted column**) and `local` (route defaults to `false`, listing all known profiles like Mastodon; DB default stays `true`). Garbage `local` values coerce via the shared `Booleanish` helper rather than 400ing.
5. **instance/domain_blocks** — now includes `silence`-severity blocks (not just `suspend`) and renders obfuscated domains in Mastodon's partially-starred form (`example.com` → `exa****.*om`, matching `DomainBlock#public_domain`) instead of a full SHA-256 hex digest. The digest stays available in the `digest` field. `X-Total-Count` counts suspend + silence.

### Testing
- Full gate green locally: `prettier:check` clean, `yarn lint` 0 errors, `yarn build` pass, `yarn test` **621 files / 5650 tests pass**.
- New/extended tests cover: the statuses limit table, the seven-day zero-fill + name normalization, tag-route unicode/all-numeric acceptance + history, followed_tags `min_id` + prev Link, directory `order=active` ordering + `local` scope, and domain-block obfuscation (`exa****.*om`, `bloc***.*est`, `ab.*d`) + silence inclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
