### PR TITLE
Bump version to v1.97.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.97.0",
+  "version": "1.97.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.97.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.97.0`
- Base main SHA: `2d68ac229e679c0b3968c14c67892550f4606a0e`
- Included commits: `8`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
