### PR TITLE
Bump version to v1.98.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.97.1",
+  "version": "1.98.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.98.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.97.1`
- Base main SHA: `e31922363734b1cfe3b7a109c1e1e8d5d02fca70`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
