### PR TITLE
Bump version to v1.98.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.98.0",
+  "version": "1.98.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.98.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.98.0`
- Base main SHA: `5d82d74b1e4a9676187b3e5b23b3290707f29c98`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
