### PR TITLE
Bump version to v1.99.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.98.1",
+  "version": "1.99.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.99.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.98.1`
- Base main SHA: `fcc0b0990db219781fad43d94b13bc6fd1ace0b9`
- Included commits: `5`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
