### PR TITLE
Bump version to v1.100.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.99.0",
+  "version": "1.100.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.100.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.99.0`
- Base main SHA: `056ae11040364a573f4c8cf72a53526b04e083ef`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
