### PR TITLE
fix: bound fitness activity processing to prevent worker OOM crash (SIGABRT)

### DIFF
--- a/lib/services/fitness-files/generateMapImage.test.ts
+++ b/lib/services/fitness-files/generateMapImage.test.ts
@@ -238,4 +238,34 @@ describe('generateMapImage', () => {
       ).toBe(true)
     }
   })
+
+  it('renders a very long OSM route without overflowing the call stack', async () => {
+    mockGetMapProviderConfig.mockReturnValue({ type: 'osm' })
+
+    const tileBuffer = await pngTile()
+    global.fetch = vi.fn().mockImplementation(async () => {
+      return new Response(Buffer.from(tileBuffer), {
+        status: 200,
+        headers: { 'Content-Type': 'image/png' }
+      })
+    }) as unknown as typeof fetch
+
+    // Well past the ~130k point ceiling where Math.min(...)/Math.max(...) spreads
+    // throw a RangeError; the full-resolution SVG polyline would also abort
+    // sharp/libvips. The render path must downsample the geometry first.
+    const longRide = Array.from({ length: 200_000 }, (_value, index) => ({
+      lat: 37.78 + index * 0.00001,
+      lng: -122.42 + index * 0.00001
+    }))
+
+    const result = await generateMapImage({
+      coordinates: longRide,
+      routeSegments: [longRide]
+    })
+
+    expect(result?.length).toBeGreaterThan(0)
+    // Downsampled to a bounded tile window, so only a handful of tiles are
+    // fetched — never one request per raw GPS point.
+    expect((global.fetch as jest.Mock).mock.calls.length).toBeLessThan(100)
+  })
 })

--- a/lib/services/fitness-files/generateMapImage.ts
+++ b/lib/services/fitness-files/generateMapImage.ts
@@ -133,27 +133,50 @@ const buildMapboxUrl = ({
 }
 
 const renderOsmMap = async ({
-  coordinates,
   routeSegments,
   width,
   height
 }: {
-  coordinates: FitnessCoordinate[]
   routeSegments: FitnessCoordinate[][]
   width: number
   height: number
 }): Promise<Buffer> => {
+  // A long activity (a multi-hour ride can carry >100k GPS points) would
+  // otherwise be projected at full resolution, which overflows two ways: the
+  // Math.min(...)/Math.max(...) spreads below throw a RangeError past ~130k
+  // elements, and the per-point SVG polyline handed to sharp/libvips grows large
+  // enough to abort the native process (SIGABRT). An 800x600 map only needs a
+  // few hundred points, so downsample the geometry first — exactly what the
+  // Mapbox path already does — before projecting anything. The metric series
+  // (distance/duration/elevation/HR/power) are derived elsewhere from the
+  // full-resolution trackpoints and are unaffected by this render-only cap.
+  const sampledSegments = downsampleRouteSegments(routeSegments)
+  if (sampledSegments.length === 0) {
+    throw new Error('No route segments remain after downsampling')
+  }
+  const sampledCoordinates = sampledSegments.flat()
+
   const padding = 56
-  const zoom = getZoomLevel({ coordinates, width, height, padding })
-  const projected = coordinates.map((coordinate) => project(coordinate, zoom))
+  const zoom = getZoomLevel({
+    coordinates: sampledCoordinates,
+    width,
+    height,
+    padding
+  })
 
-  const xValues = projected.map((point) => point.x)
-  const yValues = projected.map((point) => point.y)
-
-  const minX = Math.min(...xValues)
-  const maxX = Math.max(...xValues)
-  const minY = Math.min(...yValues)
-  const maxY = Math.max(...yValues)
+  // Single-pass min/max over the projected points (mirrors the reduce loop in
+  // calculateCoordinateBounds) — never spread the array into Math.min/Math.max.
+  let minX = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const coordinate of sampledCoordinates) {
+    const point = project(coordinate, zoom)
+    if (point.x < minX) minX = point.x
+    if (point.x > maxX) maxX = point.x
+    if (point.y < minY) minY = point.y
+    if (point.y > maxY) maxY = point.y
+  }
 
   const centerX = (minX + maxX) / 2
   const centerY = (minY + maxY) / 2
@@ -184,7 +207,7 @@ const renderOsmMap = async ({
     )
   )
 
-  const projectedSegments = routeSegments.map((segment) =>
+  const projectedSegments = sampledSegments.map((segment) =>
     segment.map((coordinate) => {
       const point = project(coordinate, zoom)
       return {
@@ -320,7 +343,6 @@ export const generateMapImage = async ({
   }
 
   return renderOsmMap({
-    coordinates: routeCoordinates,
     routeSegments: normalizedRouteSegments,
     width,
     height

--- a/lib/services/fitness-files/parseFitnessFile.test.ts
+++ b/lib/services/fitness-files/parseFitnessFile.test.ts
@@ -149,6 +149,67 @@ describe('parseFitnessFile', () => {
     expect(parsed.startTime?.toISOString()).toBe('2026-01-03T06:00:00.000Z')
   })
 
+  it('derives FIT distance from a very long record list without overflowing the call stack', async () => {
+    const recordCount = 200_000
+    FitParserMock.mockImplementation(function () {
+      return {
+        parse: (
+          _buffer: Buffer,
+          callback: (error: Error | null, data?: unknown) => void
+        ) =>
+          // No session totals, so the record-distance fallback runs. A
+          // `Math.max(...samples)` spread over this many records would throw a
+          // RangeError; the reduce must handle it.
+          callback(null, {
+            sessions: [],
+            records: Array.from({ length: recordCount }, (_value, index) => ({
+              position_lat: 37.78 + index * 0.00001,
+              position_long: -122.42 + index * 0.00001,
+              distance: index
+            }))
+          })
+      }
+    })
+
+    const parsed = await parseFitnessFile({
+      fileType: 'fit',
+      buffer: Buffer.from('binary-fit-content')
+    })
+
+    expect(parsed.totalDistanceMeters).toBe(recordCount - 1)
+  })
+
+  it('caps the decoded trackpoints for an oversized activity', async () => {
+    const recordCount = 400_000
+    FitParserMock.mockImplementation(function () {
+      return {
+        parse: (
+          _buffer: Buffer,
+          callback: (error: Error | null, data?: unknown) => void
+        ) =>
+          callback(null, {
+            sessions: [{ total_distance: 1000 }],
+            records: Array.from({ length: recordCount }, (_value, index) => ({
+              position_lat: 37.78 + index * 0.00001,
+              position_long: -122.42 + index * 0.00001
+            }))
+          })
+      }
+    })
+
+    const parsed = await parseFitnessFile({
+      fileType: 'fit',
+      buffer: Buffer.from('binary-fit-content')
+    })
+
+    // Every record carries GPS, so without the cap coordinates would equal the
+    // full record count. The cap keeps peak memory bounded so the worker cannot
+    // OOM-abort mid-job on a very large activity.
+    expect(parsed.coordinates.length).toBeGreaterThan(0)
+    expect(parsed.coordinates.length).toBeLessThan(recordCount)
+    expect(parsed.coordinates.length).toBeLessThanOrEqual(100_000)
+  })
+
   it('throws when FIT parser reports an error', async () => {
     FitParserMock.mockImplementation(function () {
       return {

--- a/lib/services/fitness-files/parseFitnessFile.ts
+++ b/lib/services/fitness-files/parseFitnessFile.ts
@@ -3,6 +3,7 @@ import FitParser from 'fit-file-parser'
 import type { FitData } from 'fit-file-parser'
 import { z } from 'zod'
 
+import { downsamplePoints } from '@/lib/services/fitness-files/privacy'
 import { getBrandFromManufacturer } from '@/lib/utils/fitnessDeviceBrands'
 
 export interface FitnessCoordinate {
@@ -56,6 +57,17 @@ const XML_OPTIONS = {
 }
 
 const EARTH_RADIUS_METERS = 6_371_000
+
+// The 50 MB upload cap bounds file BYTES, not decoded point count: a dense FIT
+// or verbose GPX/TCX can decode to millions of trackpoints, and the processing
+// job then holds ~10 full-resolution copies of them (coordinates, track points,
+// four metric series, privacy segments, map projection). On a memory-limited
+// Cloud Run instance that exhausts the V8 heap and aborts the process (SIGABRT),
+// killing the fitness worker mid-job. Capping the decoded trackpoints before any
+// per-point structure is built keeps peak memory bounded. Endpoints are always
+// preserved, so cumulative distance/duration are unaffected; only activities far
+// larger than any real workout (well over a full day at 1 Hz) lose resolution.
+const MAX_FITNESS_TRACK_POINTS = 100_000
 
 const NumberLikeSchema = z.union([z.number(), z.string()])
 const DateLikeSchema = z.union([z.number(), z.string(), z.date()])
@@ -411,7 +423,13 @@ const parseFit = async (buffer: Buffer): Promise<FitnessActivityData> => {
   })
 
   const sessions = asArray(parsed.sessions)
-  const records = asArray(parsed.records)
+  // Bound the decoded record count before building any per-point structure.
+  // Cumulative distance is monotonic and the last sample is always kept, so the
+  // record-distance fallback below is unaffected.
+  const records = downsamplePoints(
+    asArray(parsed.records),
+    MAX_FITNESS_TRACK_POINTS
+  )
   const primarySession = sessions[0]
 
   // Extract device info from device_infos (device_index 0 = primary recording device).
@@ -467,14 +485,18 @@ const parseFit = async (buffer: Buffer): Promise<FitnessActivityData> => {
     })
     .filter((point): point is NonNullable<typeof point> => point !== null)
 
-  const recordDistanceSamples = records
-    .map((record) => toNumber(record.distance))
-    .filter((distance): distance is number => typeof distance === 'number')
-
-  const distanceFromRecords =
-    recordDistanceSamples.length > 0
-      ? Math.max(...recordDistanceSamples)
-      : undefined
+  // Reduce instead of `Math.max(...samples)`: a long ride can hold >100k records
+  // and spreading that many arguments overflows the call stack (RangeError past
+  // ~130k elements). Cumulative distance is monotonic, so the max is the final
+  // sample either way.
+  const distanceFromRecords = records.reduce<number | undefined>(
+    (max, record) => {
+      const distance = toNumber(record.distance)
+      if (typeof distance !== 'number') return max
+      return max === undefined || distance > max ? distance : max
+    },
+    undefined
+  )
 
   const base = toActivityData({
     points,
@@ -511,9 +533,14 @@ const parseGpx = (buffer: Buffer): FitnessActivityData => {
   }
 
   const tracks = asArray(parsedResult.data.gpx?.trk)
-  const points = tracks
-    .flatMap((track) => asArray(track.trkseg))
-    .flatMap((segment) => asArray(segment.trkpt))
+  // Bound the decoded trackpoint count before building any per-point structure.
+  const rawTrackpoints = downsamplePoints(
+    tracks
+      .flatMap((track) => asArray(track.trkseg))
+      .flatMap((segment) => asArray(segment.trkpt)),
+    MAX_FITNESS_TRACK_POINTS
+  )
+  const points = rawTrackpoints
     .map((point) => {
       const lat = normalizeLatitude(point.lat)
       const lng = normalizeLongitude(point.lon)
@@ -559,9 +586,13 @@ const parseTcx = (buffer: Buffer): FitnessActivityData => {
   const activity = activities[0]
   const laps = asArray(activity?.Lap)
 
-  const rawTrackpoints = laps
-    .flatMap((lap) => asArray(lap.Track))
-    .flatMap((track) => asArray(track.Trackpoint))
+  // Bound the decoded trackpoint count before building any per-point structure.
+  const rawTrackpoints = downsamplePoints(
+    laps
+      .flatMap((lap) => asArray(lap.Track))
+      .flatMap((track) => asArray(track.Trackpoint)),
+    MAX_FITNESS_TRACK_POINTS
+  )
 
   // GPS-only points for coordinates and map track (FitnessTrackPoint requires lat/lng)
   const gpsPoints = rawTrackpoints

--- a/lib/services/fitness-files/privacy.ts
+++ b/lib/services/fitness-files/privacy.ts
@@ -304,7 +304,7 @@ export const buildPrivacySegments = <T extends { isHiddenByPrivacy: boolean }>(
   return segments
 }
 
-const downsamplePoints = <T>(points: T[], maxPoints: number): T[] => {
+export const downsamplePoints = <T>(points: T[], maxPoints: number): T[] => {
   if (maxPoints <= 0) {
     return []
   }


### PR DESCRIPTION
## Summary

The QStash fitness worker (`POST /api/v1/queue/qstash` → `processFitnessFileJob`) crashes with **`Uncaught signal: 6` (SIGABRT)** on large activities in production, returning **503** to QStash and leaving the fitness file stranded in `processing` forever. This was diagnosed from Cloud Run logs for `https://llun.social/users/ride` (a cycling account = long GPS tracks).

## Root cause

The signal discriminates the cause:

- **Signal 6 (SIGABRT), not 9 (SIGKILL)** → a process-internal V8 `abort()`, i.e. `FatalProcessOutOfMemory`, not a cgroup RAM-cap kill.
- **`pid=1, tid=1`** → main JS thread (the queue handler awaits the job inline), so it's the JS heap, not a libuv/native thread.
- **HTTP 503 "malformed response", not 400/200** → the process died mid-request; a caught error would be a clean 400 and a self-handled failure a 200.
- **7–10s before the abort** → the classic near-heap-limit GC-thrash-then-abort signature (and well under the 30s QStash timeout).

The only input guard is a **50 MB byte cap**, which does **not** bound decoded point count. A dense FIT / verbose GPX/TCX decodes to millions of trackpoints, and `processFitnessFileJob` then holds **~10 full-resolution copies** of the track (records → points → coordinates → track-point clone → 4 metric series → privacy segments → filtered coordinates → projected → x/y arrays). On a memory-limited instance that exhausts the V8 heap → `abort()` → SIGABRT. Because the abort is native, the job's `try/catch` never runs, so the file is never marked `failed`.

Two catchable *siblings* of the same unbounded-size disease were also confirmed (they mark a file `failed`/`completed` rather than crashing, but fail large activities): `Math.min(...xValues)`/`Math.max(...)` in `renderOsmMap` and `Math.max(...recordDistanceSamples)` in `parseFit` throw `RangeError: Maximum call stack size exceeded` past ~130k elements (empirically confirmed on Node 24).

## Fix

- **Cap decoded trackpoints** (`MAX_FITNESS_TRACK_POINTS = 100_000`, endpoints preserved via the existing uniform downsampler) in all three parsers **before any per-point structure is built**, so one oversized activity can no longer build the ~10 copies that exhaust the heap. Cumulative distance/duration are unaffected (the last cumulative-distance sample is always kept); only activities far larger than any real workout (well over a full day at 1 Hz) lose resolution.
- **Downsample the OSM map route before projecting** (the Mapbox path already did this) and replace the unbounded `Math.min(...)`/`Math.max(...)` spreads over every point with a **single-pass min/max loop**.
- **Replace the `Math.max(...records)` distance-fallback spread** in `parseFit` with a `reduce`.
- Export the existing `downsamplePoints` helper from `privacy.ts` for reuse.

## Recovery of already-stranded files

This change prevents **new** crashes; it does not itself reset files stranded by past crashes. Those are recovered by the existing tooling — `isFitnessProcessingStuck` (15-min staleness) plus the `scripts/fitness/fixStuckFitnessProcessing.ts` maintenance script / retry endpoint — which the operator runs after deploy.

## Tests

Three failing-first tests (verified failing on pre-fix source with `RangeError`/unbounded output, green with the fix):
- `generateMapImage`: renders a 200k-point OSM route without overflowing the call stack, and bounds the tile window.
- `parseFitnessFile`: derives FIT distance from a 200k-record list without overflowing the call stack.
- `parseFitnessFile`: caps decoded trackpoints for an oversized (400k-point) activity.

Gate: `prettier` ✓, `lint` ✓ (0 errors), `build` ✓, `test` ✓ (6116 tests). No migration/schema-dump changes.

## Follow-up (optional)

`MAX_FITNESS_TRACK_POINTS` is a module constant; it could be promoted to an `ACTIVITIES_*` config value for parity with the heatmap's `ACTIVITIES_FITNESS_ROUTE_HEATMAP_FILE_POINT_LIMIT` if operators want to tune it without a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)