### PR TITLE
minor: store more media per status than the Mastodon federation cap

### DIFF
--- a/app/api/v1/instance/route.test.ts
+++ b/app/api/v1/instance/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import type { Config } from '@/lib/config'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { MAX_STORED_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 
 import { GET } from './route'
 
@@ -130,6 +131,17 @@ describe('GET /api/v1/instance', () => {
     expect(body.registrations).toBe(true)
     expect(body.rules).toEqual([{ id: rule.id, text: 'No spam', hint: '' }])
     expect(body.contact_account).toBeNull()
+  })
+
+  it('advertises the stored media ceiling as max_media_attachments', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v1/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.configuration.statuses.max_media_attachments).toBe(
+      MAX_STORED_MEDIA_ATTACHMENTS
+    )
   })
 
   it('keeps serving the static payload when the database is unavailable', async () => {

--- a/app/api/v1/instance/route.ts
+++ b/app/api/v1/instance/route.ts
@@ -5,7 +5,7 @@ import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MAX_PINNED_STATUSES,
-  MAX_STATUS_MEDIA_ATTACHMENTS
+  MAX_STORED_MEDIA_ATTACHMENTS
 } from '@/lib/services/mastodon/constants'
 import {
   getInstanceContactAccount,
@@ -81,7 +81,7 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
     configuration: {
       statuses: {
         max_characters: 500,
-        max_media_attachments: MAX_STATUS_MEDIA_ATTACHMENTS,
+        max_media_attachments: MAX_STORED_MEDIA_ATTACHMENTS,
         characters_reserved_per_url: 23
       },
       accounts: {

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1811,6 +1811,59 @@ describe('GET /api/v1/statuses/[id]', () => {
       expect(response.status).toBe(422)
     })
 
+    it('rejects more media_attributes than the stored ceiling with 422', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-attributes-over-ceiling`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Over the stored ceiling with attributes',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      // Every attribute references an owned, resolvable media, so without the
+      // ceiling each one would trigger a database.updateMedia write — the
+      // unbounded fan-out this guards against.
+      const mediaAttributes = []
+      for (
+        let index = 0;
+        index < MAX_STORED_MEDIA_ATTACHMENTS + 1;
+        index += 1
+      ) {
+        const media = await database.createMedia({
+          actorId: ACTOR1_ID,
+          original: {
+            path: `medias/attr-ceiling-${index}.webp`,
+            bytes: 1024,
+            mimeType: 'image/jpeg',
+            metaData: { width: 100, height: 100 },
+            fileName: `attr-ceiling-${index}.jpg`
+          }
+        })
+        expect(media).not.toBeNull()
+        mediaAttributes.push({ id: media!.id, description: `Photo ${index}` })
+      }
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({ media_attributes: mediaAttributes }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(422)
+    })
+
     it('clears media attachments with an empty media id list', async () => {
       const statusId = `${ACTOR1_ID}/statuses/api-edit-clear-media`
       await database.createNote({

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -4,7 +4,11 @@ import { NextRequest } from 'next/server'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { encodeFavouritedByCursor } from '@/lib/database/sql/utils/favouritedByCursor'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
-import { MAX_PINNED_STATUSES } from '@/lib/services/mastodon/constants'
+import {
+  MAX_FEDERATION_MEDIA_ATTACHMENTS,
+  MAX_PINNED_STATUSES,
+  MAX_STORED_MEDIA_ATTACHMENTS
+} from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { deleteMediaFile } from '@/lib/services/medias'
 import { getQueue } from '@/lib/services/queue'
@@ -1605,6 +1609,206 @@ describe('GET /api/v1/statuses/[id]', () => {
         })
       ])
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
+    it('stores more media than the federation cap and federates only the first few', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-many-media`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Fitness ride with a full photo set',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const storedCount = MAX_FEDERATION_MEDIA_ATTACHMENTS + 1
+      const mediaIds: string[] = []
+      for (let index = 0; index < storedCount; index += 1) {
+        const media = await database.createMedia({
+          actorId: ACTOR1_ID,
+          original: {
+            path: `medias/api-edit-many-${index}.webp`,
+            bytes: 1024,
+            mimeType: 'image/jpeg',
+            metaData: { width: 320, height: 240 },
+            fileName: `api-edit-many-${index}.jpg`
+          },
+          description: `Ride photo ${index}`
+        })
+        expect(media).not.toBeNull()
+        mediaIds.push(media!.id)
+      }
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({ media_ids: mediaIds }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+
+      // The local Mastodon API returns every stored attachment...
+      const data = await response.json()
+      expect(data.media_attachments).toHaveLength(storedCount)
+
+      const attachments = await database.getAttachmentsWithMedia({ statusId })
+      expect(attachments).toHaveLength(storedCount)
+
+      // ...while the outbound ActivityPub note is trimmed to the federation cap.
+      const updatedStatus = (await database.getStatus({
+        statusId,
+        withReplies: false
+      })) as Status
+      const activityPubNote = getNoteFromStatus(updatedStatus)
+      const federatedAttachments = Array.isArray(activityPubNote?.attachment)
+        ? activityPubNote.attachment
+        : []
+      expect(federatedAttachments).toHaveLength(
+        MAX_FEDERATION_MEDIA_ATTACHMENTS
+      )
+    })
+
+    it('attaches a full photo set to a fitness ride and keeps the route map', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-fitness-photos`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Morning ride',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+      // The route map is a media-manager image upload, mirroring the fitness
+      // import job (processFitnessFileJob stores it via saveMedia).
+      const mapMedia = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: 'medias/ride-route-map.webp',
+          bytes: 2048,
+          mimeType: 'image/png',
+          metaData: { width: 640, height: 480 },
+          fileName: 'ride-route-map.png'
+        },
+        description: 'Activity route map'
+      })
+      expect(mapMedia).not.toBeNull()
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: 'image/png',
+        url: 'https://llun.test/api/v1/files/medias/ride-route-map.webp',
+        width: 640,
+        height: 480,
+        name: 'Activity route map',
+        mediaId: mapMedia!.id
+      })
+
+      const photoCount = MAX_FEDERATION_MEDIA_ATTACHMENTS
+      const photoMediaIds: string[] = []
+      for (let index = 0; index < photoCount; index += 1) {
+        const media = await database.createMedia({
+          actorId: ACTOR1_ID,
+          original: {
+            path: `medias/ride-photo-${index}.webp`,
+            bytes: 1024,
+            mimeType: 'image/jpeg',
+            metaData: { width: 320, height: 240 },
+            fileName: `ride-photo-${index}.jpg`
+          },
+          description: `Ride photo ${index}`
+        })
+        expect(media).not.toBeNull()
+        photoMediaIds.push(media!.id)
+      }
+
+      // A correct client re-sends the existing map alongside the new photos, so
+      // the edited set (map + photos) is larger than the federation cap.
+      const mediaIds = [mapMedia!.id, ...photoMediaIds]
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({ media_ids: mediaIds }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(200)
+
+      // Every photo plus the route map remain on the status.
+      const updatedStatus = (await database.getStatus({
+        statusId,
+        withReplies: false
+      })) as Status
+      expect(updatedStatus.attachments).toHaveLength(mediaIds.length)
+      expect(
+        updatedStatus.attachments.some(
+          (attachment) => attachment.name === 'Activity route map'
+        )
+      ).toBe(true)
+
+      // The federated note is still trimmed to the Mastodon cap.
+      const activityPubNote = getNoteFromStatus(updatedStatus)
+      const federatedAttachments = Array.isArray(activityPubNote?.attachment)
+        ? activityPubNote.attachment
+        : []
+      expect(federatedAttachments).toHaveLength(
+        MAX_FEDERATION_MEDIA_ATTACHMENTS
+      )
+    })
+
+    it('rejects more media_ids than the stored ceiling with 422', async () => {
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-over-ceiling`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Over the stored ceiling',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [`${ACTOR1_ID}/followers`]
+      })
+
+      const mediaIds = Array.from(
+        { length: MAX_STORED_MEDIA_ATTACHMENTS + 1 },
+        (_, index) => `over-ceiling-media-${index}`
+      )
+
+      const response = await PUT(
+        new NextRequest(
+          `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+          {
+            method: 'PUT',
+            body: JSON.stringify({ media_ids: mediaIds }),
+            headers: {
+              'Content-Type': 'application/json',
+              Origin: 'https://llun.test'
+            }
+          }
+        ),
+        { params: Promise.resolve({ id: urlToId(statusId) }) }
+      )
+
+      expect(response.status).toBe(422)
     })
 
     it('clears media attachments with an empty media id list', async () => {

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -16,7 +16,7 @@ import {
   MAX_POLL_EXPIRATION_SECONDS,
   MAX_POLL_OPTIONS,
   MAX_POLL_OPTION_CHARS,
-  MAX_STATUS_MEDIA_ATTACHMENTS,
+  MAX_STORED_MEDIA_ATTACHMENTS,
   MIN_POLL_EXPIRATION_SECONDS,
   MIN_POLL_OPTIONS
 } from '@/lib/services/mastodon/constants'
@@ -199,7 +199,7 @@ export const PUT = traceApiRoute(
             : [...new Set(changes.media_ids)]
         if (
           mediaIds !== undefined &&
-          mediaIds.length > MAX_STATUS_MEDIA_ATTACHMENTS
+          mediaIds.length > MAX_STORED_MEDIA_ATTACHMENTS
         ) {
           return apiResponse({
             req,

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -208,6 +208,20 @@ export const PUT = traceApiRoute(
             responseStatusCode: 422
           })
         }
+        // Bound media_attributes the same way as media_ids: each entry drives a
+        // database.updateMedia write below, so an unbounded array would fan out
+        // an unbounded number of writes.
+        if (
+          mediaAttributes !== undefined &&
+          mediaAttributes.length > MAX_STORED_MEDIA_ATTACHMENTS
+        ) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_422,
+            responseStatusCode: 422
+          })
+        }
 
         let updatedNote
 

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -5,7 +5,11 @@ import { getSQLDatabase } from '@/lib/database/sql'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { PUBLISH_SCHEDULED_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import { hashToken } from '@/lib/services/guards/OAuthGuard'
-import { SCHEDULED_AT_TOO_SOON_ERROR } from '@/lib/services/mastodon/constants'
+import {
+  MAX_FEDERATION_MEDIA_ATTACHMENTS,
+  MAX_STORED_MEDIA_ATTACHMENTS,
+  SCHEDULED_AT_TOO_SOON_ERROR
+} from '@/lib/services/mastodon/constants'
 import { getQueue } from '@/lib/services/queue'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
@@ -321,22 +325,11 @@ describe('POST /api/v1/statuses', () => {
     expect(response.status).toBe(422)
   })
 
-  it('rejects more media_ids than the instance advertises', async () => {
-    const mediaIds: string[] = []
-    for (let index = 0; index < 5; index += 1) {
-      const media = await database.createMedia({
-        actorId: ACTOR1_ID,
-        original: {
-          path: `medias/too-many-attachments-${index}.webp`,
-          bytes: 1024,
-          mimeType: 'image/jpeg',
-          metaData: { width: 100, height: 100 },
-          fileName: `too-many-attachments-${index}.jpg`
-        }
-      })
-      expect(media).not.toBeNull()
-      mediaIds.push(media!.id)
-    }
+  it('rejects more media_ids than the stored ceiling advertises', async () => {
+    const mediaIds = Array.from(
+      { length: MAX_STORED_MEDIA_ATTACHMENTS + 1 },
+      (_, index) => `too-many-attachments-${index}`
+    )
 
     const response = await POST(
       new NextRequest('https://llun.test/api/v1/statuses', {
@@ -355,6 +348,44 @@ describe('POST /api/v1/statuses', () => {
 
     expect(response.status).toBe(422)
     expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('accepts more media_ids than the federation cap and stores them all', async () => {
+    const storedCount = MAX_FEDERATION_MEDIA_ATTACHMENTS + 1
+    const mediaIds: string[] = []
+    for (let index = 0; index < storedCount; index += 1) {
+      const media = await database.createMedia({
+        actorId: ACTOR1_ID,
+        original: {
+          path: `medias/many-attachments-${index}.webp`,
+          bytes: 1024,
+          mimeType: 'image/jpeg',
+          metaData: { width: 100, height: 100 },
+          fileName: `many-attachments-${index}.jpg`
+        }
+      })
+      expect(media).not.toBeNull()
+      mediaIds.push(media!.id)
+    }
+
+    const response = await POST(
+      new NextRequest('https://llun.test/api/v1/statuses', {
+        method: 'POST',
+        body: JSON.stringify({
+          status: 'A ride with more photos than Mastodon renders',
+          media_ids: mediaIds
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.media_attachments).toHaveLength(storedCount)
   })
 
   it('honors sensitive and language on a JSON create', async () => {

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -13,7 +13,7 @@ import {
   MAX_POLL_EXPIRATION_SECONDS,
   MAX_POLL_OPTIONS,
   MAX_POLL_OPTION_CHARS,
-  MAX_STATUS_MEDIA_ATTACHMENTS,
+  MAX_STORED_MEDIA_ATTACHMENTS,
   MIN_POLL_EXPIRATION_SECONDS,
   MIN_POLL_OPTIONS,
   MIN_SCHEDULED_STATUS_AHEAD_MS,
@@ -94,17 +94,19 @@ const NoteSchema = z
       (note.poll?.options.length ?? 0) > 0
   )
 
-// Dedupe, enforce the attachment cap, and resolve media ids to attachments.
-// Returns null when the set exceeds the cap or any id can't be resolved for the
-// actor — both the scheduled and immediate POST paths treat that as a 422.
-// Shared so the two paths can't drift apart.
+// Dedupe, enforce the stored-media ceiling, and resolve media ids to
+// attachments. Returns null when the set exceeds the ceiling or any id can't be
+// resolved for the actor — both the scheduled and immediate POST paths treat
+// that as a 422. Shared so the two paths can't drift apart. The ceiling only
+// bounds how much a single status stores; the federation cap that trims the
+// outbound note lives in getNoteFromStatus.
 const resolveStatusMedia = async (
   database: Database,
   currentActor: Actor,
   mediaIds: string[]
 ): Promise<PostBoxAttachment[] | null> => {
   const uniqueIds = [...new Set(mediaIds)]
-  if (uniqueIds.length > MAX_STATUS_MEDIA_ATTACHMENTS) return null
+  if (uniqueIds.length > MAX_STORED_MEDIA_ATTACHMENTS) return null
   return getAttachmentsFromMediaIds(database, currentActor, uniqueIds)
 }
 

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import type { Config } from '@/lib/config'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { MAX_STORED_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 
 import { GET } from './route'
 
@@ -160,6 +161,17 @@ describe('GET /api/v2/instance', () => {
     expect(body.configuration.vapid).toEqual({
       public_key: 'test-vapid-public-key'
     })
+  })
+
+  it('advertises the stored media ceiling as max_media_attachments', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    const body = await response.json()
+    expect(body.configuration.statuses.max_media_attachments).toBe(
+      MAX_STORED_MEDIA_ATTACHMENTS
+    )
   })
 
   it('serves the contact email with a null account when no admin exists', async () => {

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -6,7 +6,7 @@ import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MASTODON_INSTANCE_API_VERSION,
   MAX_PINNED_STATUSES,
-  MAX_STATUS_MEDIA_ATTACHMENTS
+  MAX_STORED_MEDIA_ATTACHMENTS
 } from '@/lib/services/mastodon/constants'
 import {
   getInstanceContactAccount,
@@ -103,7 +103,7 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
         },
         statuses: {
           max_characters: 500,
-          max_media_attachments: MAX_STATUS_MEDIA_ATTACHMENTS,
+          max_media_attachments: MAX_STORED_MEDIA_ATTACHMENTS,
           characters_reserved_per_url: 23
         },
         media_attachments: {

--- a/lib/actions/createNote.test.ts
+++ b/lib/actions/createNote.test.ts
@@ -3,6 +3,7 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { SEND_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { getQueue } from '@/lib/services/queue'
 import * as timelinesService from '@/lib/services/timelines'
@@ -639,6 +640,39 @@ How are you?
         mediaType: 'image/png',
         url: 'https://example.com/media/image.png'
       })
+    })
+
+    it('federates only the first MAX_FEDERATION_MEDIA_ATTACHMENTS media even when the status stores more', async () => {
+      const storedCount = MAX_FEDERATION_MEDIA_ATTACHMENTS + 1
+      const status = (await createNoteFromUserInput({
+        text: 'Post with more photos than Mastodon renders',
+        currentActor: actor1,
+        attachments: Array.from({ length: storedCount }, (_, index) => ({
+          type: 'upload' as const,
+          id: `overflow-image-${index}`,
+          mediaType: 'image/png',
+          url: `https://example.com/media/overflow-${index}.png`,
+          width: 640,
+          height: 480,
+          name: `overflow-${index}.png`
+        })),
+        database
+      })) as StatusNote
+
+      // The status keeps every attachment locally...
+      expect(status.attachments).toHaveLength(storedCount)
+
+      // ...but the outbound ActivityPub note only carries the federation cap,
+      // keeping the first N of the stored attachments in their stored order.
+      const note = getNoteFromStatus(status) as Note
+      const attachments = Array.isArray(note.attachment) ? note.attachment : []
+      expect(attachments).toHaveLength(MAX_FEDERATION_MEDIA_ATTACHMENTS)
+      const expectedUrls = status.attachments
+        .slice(0, MAX_FEDERATION_MEDIA_ATTACHMENTS)
+        .map((attachment) => attachment.url)
+      expect(attachments.map((attachment) => attachment.url)).toEqual(
+        expectedUrls
+      )
     })
 
     describe('visibility support', () => {

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -1,4 +1,15 @@
-export const MAX_STATUS_MEDIA_ATTACHMENTS = 4
+// The number of media attachments Mastodon (and the wider fediverse) render on
+// a status. We may store more than this locally, but the outbound ActivityPub
+// note only carries the first MAX_FEDERATION_MEDIA_ATTACHMENTS so remote servers
+// receive a Mastodon-compatible payload.
+export const MAX_FEDERATION_MEDIA_ATTACHMENTS = 4
+
+// Upper bound on how many media a single status may store / accept through the
+// create and edit APIs. Purely a safety ceiling so one status can't fan out an
+// unbounded number of media lookups; the fediverse still only ever sees the
+// first MAX_FEDERATION_MEDIA_ATTACHMENTS of them.
+export const MAX_STORED_MEDIA_ATTACHMENTS = 20
+
 export const MAX_PINNED_STATUSES = 5
 
 // Poll limits, matching Mastodon's defaults

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -784,6 +784,37 @@ describe('getMastodonStatus', () => {
     })
   })
 
+  it('returns every attachment without applying the federation cap', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/many-media-attachments`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'Ride with a large photo set',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const attachmentCount = 5
+    for (let index = 0; index < attachmentCount; index += 1) {
+      await database.createAttachment({
+        actorId: ACTOR1_ID,
+        statusId,
+        mediaType: 'image/png',
+        url: `https://${TEST_DOMAIN}/api/v1/files/medias/many-media-${index}.png`,
+        width: 150,
+        height: 150,
+        name: `many-media-${index}.png`
+      })
+    }
+
+    const status = (await database.getStatus({
+      statusId,
+      withReplies: false
+    })) as Status
+    const mastodonStatus = await getMastodonStatus(database, status)
+    expect(mastodonStatus?.media_attachments).toHaveLength(attachmentCount)
+  })
+
   it('returns mastodon announce status', async () => {
     const status = (await database.getStatus({
       statusId: `${ACTOR2_ID}/statuses/post-3`

--- a/lib/types/domain/status.test.ts
+++ b/lib/types/domain/status.test.ts
@@ -1,6 +1,7 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { MockMastodonActivityPubNote } from '@/lib/stub/note'
@@ -357,6 +358,43 @@ describe('Status', () => {
             mediaType: 'image/png',
             url: 'https://example.com/files/image.png'
           })
+        )
+      })
+
+      it('caps Note attachments at the federation limit when the status stores more', async () => {
+        const statusId = `${actor1?.id}/statuses/post-1`
+        const status = (await database.getStatus({
+          statusId
+        })) as StatusNote
+
+        const createdAt = Date.now()
+        const storedCount = MAX_FEDERATION_MEDIA_ATTACHMENTS + 2
+        const note = toActivityPubObject({
+          ...status,
+          attachments: Array.from({ length: storedCount }, (_, index) => ({
+            id: `image-attachment-${index}`,
+            actorId: status.actorId,
+            statusId: status.id,
+            type: 'Document' as const,
+            mediaType: 'image/png',
+            url: `https://example.com/files/image-${index}.png`,
+            width: 100,
+            height: 80,
+            name: `image-${index}.png`,
+            createdAt,
+            updatedAt: createdAt
+          }))
+        })
+
+        const attachments = Array.isArray(note.attachment)
+          ? note.attachment
+          : []
+        expect(attachments).toHaveLength(MAX_FEDERATION_MEDIA_ATTACHMENTS)
+        expect(attachments.map((attachment) => attachment.url)).toEqual(
+          Array.from(
+            { length: MAX_FEDERATION_MEDIA_ATTACHMENTS },
+            (_, index) => `https://example.com/files/image-${index}.png`
+          )
         )
       })
     })

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -8,6 +8,7 @@ import {
   getReply,
   getSummary
 } from '@/lib/activities/note'
+import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import type { Announce as ActivityPubAnnounce } from '@/lib/types/activitypub/activities'
 import { Document } from '@/lib/types/activitypub/objects'
 import {
@@ -392,8 +393,12 @@ export const toActivityPubObject = (status: Status): Note | Question => {
     cc: originalStatus.cc,
     inReplyTo: originalStatus.reply || null,
     content: originalStatus.text,
+    // Only the first MAX_FEDERATION_MEDIA_ATTACHMENTS federate (outbox and the
+    // AP note/replies endpoints); a status may store more, but remote servers
+    // receive a Mastodon-compatible payload. Mirrors getNoteFromStatus.
     attachment: originalStatus.attachments
       .filter((attachment) => !isFitnessAttachment(attachment))
+      .slice(0, MAX_FEDERATION_MEDIA_ATTACHMENTS)
       .map((attachment) => getDocumentFromAttachment(attachment)),
     tag: originalStatus.tags
       .map((tag) => getMentionFromTag(tag) ?? getEmojiFromTag(tag))

--- a/lib/utils/getNoteFromStatus.ts
+++ b/lib/utils/getNoteFromStatus.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@/lib/config'
+import { MAX_FEDERATION_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
 import { Note } from '@/lib/types/activitypub'
 import {
   getDocumentFromAttachment,
@@ -37,8 +38,12 @@ export const getNoteFromStatus = (
     cc: actualStatus.cc,
     inReplyTo: actualStatus.reply || null,
     content: convertMarkdownText(getConfig().host)(actualStatus.text),
+    // A status may store more media than Mastodon renders; only the first
+    // MAX_FEDERATION_MEDIA_ATTACHMENTS federate so remote servers receive a
+    // Mastodon-compatible payload. The extras stay visible on local surfaces.
     attachment: actualStatus.attachments
       .filter((attachment) => !isFitnessAttachment(attachment))
+      .slice(0, MAX_FEDERATION_MEDIA_ATTACHMENTS)
       .map((attachment) => getDocumentFromAttachment(attachment)),
     tag: actualStatus.tags
       .map((tag) => getMentionFromTag(tag) ?? getEmojiFromTag(tag))


### PR DESCRIPTION
## Problem

Editing a status with more than four `media_ids` — e.g. attaching a full photo set to a fitness ride via `PUT /api/v1/statuses/:id` — failed with `422 { "status": "Unprocessable entity" }`.

**Root cause:** `MAX_STATUS_MEDIA_ATTACHMENTS = 4` (the Mastodon *rendering* limit) was enforced as a hard reject at the API entry points (`PUT /api/v1/statuses/:id` and the `POST` create path). It conflated "how many media a status may store" with "how many federate to Mastodon."

## Approach

The 4-attachment limit should only constrain what is **sent to Mastodon**, not how much the service stores. Split the one overloaded constant into two roles (`lib/services/mastodon/constants.ts`):

- **`MAX_FEDERATION_MEDIA_ATTACHMENTS = 4`** — applied *only* when serializing the outbound ActivityPub note, via `.slice(0, 4)` after the existing `isFitnessAttachment` filter, in **both** outbound serializers:
  - `getNoteFromStatus` — push delivery (Create/Update jobs)
  - `toActivityPubObject` — pull (outbox + `/api/users/[username]/statuses/[statusId]` and `/replies`)
- **`MAX_STORED_MEDIA_ATTACHMENTS = 20`** — the entry-point ceiling for create/edit, and the value advertised as `max_media_attachments` by the v1/v2 `instance` endpoints. Purely a safety bound on per-status media fan-out (each id is one DB lookup).

Applies to **all** statuses (not just fitness). The cap re-applies at **outbound federation only** — the local Mastodon API stays uncapped.

## What is intentionally unchanged

Local read surfaces return **every** stored attachment, so clients still see all photos:
- `getMastodonStatus` maps all `status.attachments` → your web/Mastodon clients see everything.
- `FitnessStatusDetail` reads `status.attachments` server-side directly → the Photos tab shows all.

Only the fediverse-facing payload is trimmed to the first four (Mastodon ignores extras anyway).

## Tests (TDD)

- `getNoteFromStatus` / `toActivityPubObject`: cap federated attachments at 4, keeping the first N in stored order.
- `PUT`/`POST /api/v1/statuses`: accept > 4 media (store all, return all), reject > 20 with 422.
- v1/v2 `instance`: advertise `max_media_attachments = 20`.
- `getMastodonStatus`: returns all attachments (no federation cap on the local API).
- Fitness-ride integration test: attach a full photo set + route map, all stored, federation still capped at 4.

Verification gate: `prettier` clean · `lint` 0 errors · `build` clean · **6117 tests pass**. No migrations touched.

## Caveat (behavior surfaced, not introduced)

The generated **route map** is stored as a normal `image/png` media upload (has a `mediaId`, URL under `/api/v1/files/`), so it is *not* an `isFitnessAttachment` and is a **replaceable** media attachment. Editing via `media_ids` that omit the map's id will remove it (existing `updateNote` semantics). Previously the 422 hid this; now the edit succeeds. A correct client should re-send the map's media id alongside new photos (covered by the integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)