### PR TITLE
Bump version to v1.101.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.100.1",
+  "version": "1.101.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.100.1`
- Base main SHA: `68bff25e016a2e3eff27873572c7be22a8403a30`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
