### PR TITLE
Bump version to v1.101.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.0",
+  "version": "1.101.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.0`
- Base main SHA: `c9504995c3e0571b4072f4284f7d9a07ffe7ee08`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
