### PR TITLE
fix: diagnose fitness processing failures and merge orphaned same-ride imports

### DIFF
--- a/app/api/v1/statuses/[id]/retry-fitness/route.test.ts
+++ b/app/api/v1/statuses/[id]/retry-fitness/route.test.ts
@@ -154,6 +154,27 @@ describe('POST /api/v1/statuses/[id]/retry-fitness', () => {
     expect(refreshed?.processingStatus).toBe('processing')
   })
 
+  it('keeps the failure reason when the retry cannot be queued', async () => {
+    const { status, file } = await seedFitnessStatus(database, 'rollback')
+    await database.updateFitnessFileProcessingStatus(
+      file.id,
+      'failed',
+      'Invalid TCX file structure'
+    )
+    ;(getQueue().publish as jest.Mock).mockRejectedValueOnce(
+      new Error('queue unavailable')
+    )
+
+    const response = await callRetry(status.id)
+    expect(response.status).toBe(500)
+
+    // Resetting to `pending` clears importError; the rollback must put it back,
+    // or the reason is destroyed exactly when the retry could not even be sent.
+    const refreshed = await database.getFitnessFile({ id: file.id })
+    expect(refreshed?.processingStatus).toBe('failed')
+    expect(refreshed?.importError).toBe('Invalid TCX file structure')
+  })
+
   it('still retries a failed file', async () => {
     const { status, file } = await seedFitnessStatus(database, 'failed')
     await database.updateFitnessFileProcessingStatus(file.id, 'failed')

--- a/app/api/v1/statuses/[id]/retry-fitness/route.ts
+++ b/app/api/v1/statuses/[id]/retry-fitness/route.ts
@@ -94,7 +94,14 @@ export const POST = traceApiRoute(
 
       for (const file of unpublishedFiles) {
         try {
-          await database.updateFitnessFileProcessingStatus(file.id, 'failed')
+          // Restore the reason the reset to `pending` cleared. Without it the
+          // file rolls back to `failed` with no explanation — losing the
+          // diagnostic exactly when the retry could not even be queued.
+          await database.updateFitnessFileProcessingStatus(
+            file.id,
+            'failed',
+            file.importError ?? undefined
+          )
         } catch (rollbackError) {
           logger.error({
             message: 'Failed to roll back fitness file status',

--- a/lib/database/sql/fitnessFile.test.ts
+++ b/lib/database/sql/fitnessFile.test.ts
@@ -392,6 +392,31 @@ describe('FitnessFileDatabase', () => {
           MAX_FITNESS_IMPORT_ERROR_LENGTH
         )
       })
+
+      it('truncates an oversized reason written through the import status too', async () => {
+        const created = await database.createFitnessFile({
+          actorId: actors.primary.id,
+          path: 'fitness/verbose-import.tcx',
+          fileName: 'verbose-import.tcx',
+          fileType: 'tcx',
+          mimeType: 'application/vnd.garmin.tcx+xml',
+          bytes: 2048
+        })
+
+        // Both stages write importError on the same row. If only one capped, a
+        // long reason would be stored in full or truncated depending on which
+        // write landed last.
+        await database.updateFitnessFileImportStatus(
+          created!.id,
+          'failed',
+          'e'.repeat(5_000)
+        )
+
+        const fetched = await database.getFitnessFile({ id: created!.id })
+        expect(fetched?.importError).toHaveLength(
+          MAX_FITNESS_IMPORT_ERROR_LENGTH
+        )
+      })
     })
 
     describe('import fields', () => {

--- a/lib/database/sql/fitnessFile.test.ts
+++ b/lib/database/sql/fitnessFile.test.ts
@@ -1,3 +1,4 @@
+import { MAX_FITNESS_IMPORT_ERROR_LENGTH } from '@/lib/database/sql/fitnessFile'
 import {
   databaseBeforeAll,
   getTestDatabaseTable
@@ -341,6 +342,55 @@ describe('FitnessFileDatabase', () => {
           mapImagePath: 'medias/route-map.png'
         })
         expect(fetched?.activityStartTime).toBeDefined()
+      })
+
+      it('records the failure reason and clears it once the file processes again', async () => {
+        const created = await database.createFitnessFile({
+          actorId: actors.primary.id,
+          path: 'fitness/broken.tcx',
+          fileName: 'broken.tcx',
+          fileType: 'tcx',
+          mimeType: 'application/vnd.garmin.tcx+xml',
+          bytes: 2048
+        })
+
+        await database.updateFitnessFileProcessingStatus(
+          created!.id,
+          'failed',
+          'Invalid TCX file structure'
+        )
+        const failed = await database.getFitnessFile({ id: created!.id })
+        expect(failed).toMatchObject({
+          processingStatus: 'failed',
+          importError: 'Invalid TCX file structure'
+        })
+
+        await database.updateFitnessFileProcessingStatus(created!.id, 'pending')
+        const retried = await database.getFitnessFile({ id: created!.id })
+        expect(retried?.processingStatus).toBe('pending')
+        expect(retried?.importError).toBeUndefined()
+      })
+
+      it('truncates an oversized failure reason', async () => {
+        const created = await database.createFitnessFile({
+          actorId: actors.primary.id,
+          path: 'fitness/verbose.tcx',
+          fileName: 'verbose.tcx',
+          fileType: 'tcx',
+          mimeType: 'application/vnd.garmin.tcx+xml',
+          bytes: 2048
+        })
+
+        await database.updateFitnessFileProcessingStatus(
+          created!.id,
+          'failed',
+          'e'.repeat(5_000)
+        )
+
+        const fetched = await database.getFitnessFile({ id: created!.id })
+        expect(fetched?.importError).toHaveLength(
+          MAX_FITNESS_IMPORT_ERROR_LENGTH
+        )
       })
     })
 

--- a/lib/database/sql/fitnessFile.ts
+++ b/lib/database/sql/fitnessFile.ts
@@ -188,6 +188,7 @@ export interface FitnessFileDatabase {
   updateFitnessFilesProcessingStatus(params: {
     fitnessFileIds: string[]
     processingStatus: FitnessProcessingStatus
+    processingError?: string
   }): Promise<number>
   updateFitnessFileImportStatus(
     fitnessFileId: string,
@@ -225,6 +226,45 @@ export interface FitnessFileDatabase {
 // what a job may write to it so a stack trace or a remote error body cannot
 // bloat the row.
 export const MAX_FITNESS_IMPORT_ERROR_LENGTH = 1000
+
+/**
+ * Builds the row update for a processing-status write, keeping `importError` in
+ * step so the two can never disagree:
+ *
+ * - `failed` WITH a reason records it (truncated).
+ * - `failed` WITHOUT one leaves the column alone. `markImportFileFailed` writes
+ *   the reason through `updateFitnessFileImportStatus` concurrently with this
+ *   call, so clearing here would race it and wipe the reason.
+ * - `completed`/`pending` clear it, so a stale message cannot outlive a retry.
+ *
+ * Callers that set `failed` should always pass a reason; `pending` callers that
+ * may need to roll back must capture `importError` first and pass it back.
+ */
+const buildProcessingStatusUpdate = (
+  processingStatus: FitnessProcessingStatus,
+  processingError?: string
+): Record<string, unknown> => {
+  const updateData: Record<string, unknown> = {
+    processingStatus,
+    updatedAt: new Date()
+  }
+
+  if (processingStatus === 'failed') {
+    if (processingError) {
+      updateData.importError = processingError.slice(
+        0,
+        MAX_FITNESS_IMPORT_ERROR_LENGTH
+      )
+    }
+    return updateData
+  }
+
+  if (processingStatus === 'completed' || processingStatus === 'pending') {
+    updateData.importError = null
+  }
+
+  return updateData
+}
 
 // Helper function to normalize bytes from database which can be number, string, or bigint
 const normalizeBytes = (bytes: number | string | bigint): number => {
@@ -624,38 +664,21 @@ export const FitnessFileSQLDatabaseMixin = (
     processingStatus: FitnessProcessingStatus,
     processingError?: string
   ) {
-    const updateData: Record<string, unknown> = {
-      processingStatus,
-      updatedAt: new Date()
-    }
-
-    if (processingStatus === 'failed') {
-      if (processingError) {
-        updateData.importError = processingError.slice(
-          0,
-          MAX_FITNESS_IMPORT_ERROR_LENGTH
-        )
-      }
-    } else if (
-      processingStatus === 'completed' ||
-      processingStatus === 'pending'
-    ) {
-      updateData.importError = null
-    }
-
     const result = await database('fitness_files')
       .where('id', fitnessFileId)
-      .update(updateData)
+      .update(buildProcessingStatusUpdate(processingStatus, processingError))
 
     return result > 0
   },
 
   async updateFitnessFilesProcessingStatus({
     fitnessFileIds,
-    processingStatus
+    processingStatus,
+    processingError
   }: {
     fitnessFileIds: string[]
     processingStatus: FitnessProcessingStatus
+    processingError?: string
   }) {
     if (fitnessFileIds.length === 0) {
       return 0
@@ -664,10 +687,7 @@ export const FitnessFileSQLDatabaseMixin = (
     return database('fitness_files')
       .whereIn('id', fitnessFileIds)
       .whereNull('deletedAt')
-      .update({
-        processingStatus,
-        updatedAt: new Date()
-      })
+      .update(buildProcessingStatusUpdate(processingStatus, processingError))
   },
 
   async updateFitnessFileImportStatus(

--- a/lib/database/sql/fitnessFile.ts
+++ b/lib/database/sql/fitnessFile.ts
@@ -228,6 +228,15 @@ export interface FitnessFileDatabase {
 export const MAX_FITNESS_IMPORT_ERROR_LENGTH = 1000
 
 /**
+ * Every write to `importError` goes through this, so the cap cannot be bypassed
+ * by whichever setter happens to land last: the import and processing stages
+ * both write the column, and a reason longer than the cap would otherwise be
+ * stored truncated by one and in full by the other.
+ */
+const truncateImportError = (importError: string) =>
+  importError.slice(0, MAX_FITNESS_IMPORT_ERROR_LENGTH)
+
+/**
  * Builds the row update for a processing-status write, keeping `importError` in
  * step so the two can never disagree:
  *
@@ -251,10 +260,7 @@ const buildProcessingStatusUpdate = (
 
   if (processingStatus === 'failed') {
     if (processingError) {
-      updateData.importError = processingError.slice(
-        0,
-        MAX_FITNESS_IMPORT_ERROR_LENGTH
-      )
+      updateData.importError = truncateImportError(processingError)
     }
     return updateData
   }
@@ -699,7 +705,7 @@ export const FitnessFileSQLDatabaseMixin = (
       .where('id', fitnessFileId)
       .update({
         importStatus,
-        importError: importError ?? null,
+        importError: importError ? truncateImportError(importError) : null,
         updatedAt: new Date()
       })
 
@@ -724,7 +730,7 @@ export const FitnessFileSQLDatabaseMixin = (
       .whereNull('deletedAt')
       .update({
         importStatus,
-        importError: importError ?? null,
+        importError: importError ? truncateImportError(importError) : null,
         updatedAt: new Date()
       })
   },

--- a/lib/database/sql/fitnessFile.ts
+++ b/lib/database/sql/fitnessFile.ts
@@ -175,9 +175,15 @@ export interface FitnessFileDatabase {
     fitnessFileId: string,
     statusId: string
   ): Promise<boolean>
+  /**
+   * Sets the processing state, and on `failed` records why in `importError` so
+   * the reason survives the job (the settings UI renders it). `completed` and
+   * `pending` clear it, so a stale message cannot outlive a successful retry.
+   */
   updateFitnessFileProcessingStatus(
     fitnessFileId: string,
-    processingStatus: FitnessProcessingStatus
+    processingStatus: FitnessProcessingStatus,
+    processingError?: string
   ): Promise<boolean>
   updateFitnessFilesProcessingStatus(params: {
     fitnessFileIds: string[]
@@ -214,6 +220,11 @@ export interface FitnessFileDatabase {
     params: GetFitnessActivityCalendarDataParams
   ): Promise<FitnessCalendarDay[]>
 }
+
+// `importError` is a text column shared by the import and processing stages. Cap
+// what a job may write to it so a stack trace or a remote error body cannot
+// bloat the row.
+export const MAX_FITNESS_IMPORT_ERROR_LENGTH = 1000
 
 // Helper function to normalize bytes from database which can be number, string, or bigint
 const normalizeBytes = (bytes: number | string | bigint): number => {
@@ -610,14 +621,31 @@ export const FitnessFileSQLDatabaseMixin = (
 
   async updateFitnessFileProcessingStatus(
     fitnessFileId: string,
-    processingStatus: FitnessProcessingStatus
+    processingStatus: FitnessProcessingStatus,
+    processingError?: string
   ) {
+    const updateData: Record<string, unknown> = {
+      processingStatus,
+      updatedAt: new Date()
+    }
+
+    if (processingStatus === 'failed') {
+      if (processingError) {
+        updateData.importError = processingError.slice(
+          0,
+          MAX_FITNESS_IMPORT_ERROR_LENGTH
+        )
+      }
+    } else if (
+      processingStatus === 'completed' ||
+      processingStatus === 'pending'
+    ) {
+      updateData.importError = null
+    }
+
     const result = await database('fitness_files')
       .where('id', fitnessFileId)
-      .update({
-        processingStatus,
-        updatedAt: new Date()
-      })
+      .update(updateData)
 
     return result > 0
   },

--- a/lib/jobs/fitnessImportOverlap.test.ts
+++ b/lib/jobs/fitnessImportOverlap.test.ts
@@ -1,5 +1,8 @@
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+
 import {
   FitnessOverlapActivity,
+  getOverlapContextFitnessFileIds,
   groupFitnessActivitiesByOverlap
 } from './fitnessImportOverlap'
 
@@ -70,5 +73,62 @@ describe('groupFitnessActivitiesByOverlap', () => {
       ['a', 'b', 'c'],
       ['d']
     ])
+  })
+})
+
+describe('getOverlapContextFitnessFileIds', () => {
+  const baseStart = Date.parse('2026-07-13T05:07:54.000Z')
+  const durationSeconds = 5818
+
+  const buildFile = (
+    overrides: Partial<FitnessFile> & { id: string }
+  ): Pick<
+    FitnessFile,
+    'id' | 'actorId' | 'statusId' | 'activityStartTime' | 'totalDurationSeconds'
+  > => ({
+    actorId: 'actor1',
+    statusId: 'https://llun.test/users/test1/statuses/good-ride',
+    activityStartTime: baseStart,
+    totalDurationSeconds: durationSeconds,
+    ...overrides
+  })
+
+  it('returns the sibling that already owns a status near the activity start', () => {
+    expect(
+      getOverlapContextFitnessFileIds({
+        actorId: 'actor1',
+        fitnessFileId: 'orphan',
+        activityStartTime: baseStart,
+        activityDurationSeconds: durationSeconds,
+        files: [buildFile({ id: 'sibling' })]
+      })
+    ).toEqual(['sibling'])
+  })
+
+  it.each([
+    ['the file itself', { id: 'orphan' }],
+    ['another actor', { id: 'other-actor', actorId: 'actor2' }],
+    ['a file without a status', { id: 'orphan-sibling', statusId: null }],
+    [
+      'a file with no positive duration',
+      { id: 'zero-duration', totalDurationSeconds: 0 }
+    ],
+    [
+      'a file far from the activity start',
+      {
+        id: 'far-away',
+        activityStartTime: baseStart + 30 * 24 * 60 * 60 * 1000
+      }
+    ]
+  ])('excludes %s', (_description, overrides) => {
+    expect(
+      getOverlapContextFitnessFileIds({
+        actorId: 'actor1',
+        fitnessFileId: 'orphan',
+        activityStartTime: baseStart,
+        activityDurationSeconds: durationSeconds,
+        files: [buildFile(overrides as Partial<FitnessFile> & { id: string })]
+      })
+    ).toEqual([])
   })
 })

--- a/lib/jobs/fitnessImportOverlap.ts
+++ b/lib/jobs/fitnessImportOverlap.ts
@@ -1,7 +1,81 @@
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+
 export interface FitnessOverlapActivity {
   id: string
   startTimeMs: number
   durationSeconds: number
+}
+
+/**
+ * Recent-file window scanned for a same-ride sibling. One ride recorded on two
+ * devices arrives as two activities moments apart, so the sibling is always
+ * among the actor's most recent files.
+ */
+export const OVERLAP_CONTEXT_SCAN_LIMIT = 200
+
+type OverlapContextFile = Pick<
+  FitnessFile,
+  'id' | 'actorId' | 'statusId' | 'activityStartTime' | 'totalDurationSeconds'
+>
+
+/**
+ * Picks the actor's other fitness files that ALREADY own a status and sit near
+ * this activity in time — the same-ride candidates. This only narrows the field;
+ * the >=80% overlap decision belongs to `groupFitnessActivitiesByOverlap` via
+ * importFitnessFilesJob, which uses these as `overlapFitnessFileIds` to merge a
+ * file into an existing post instead of creating a duplicate one.
+ */
+export const getOverlapContextFitnessFileIds = ({
+  actorId,
+  fitnessFileId,
+  activityStartTime,
+  activityDurationSeconds,
+  files
+}: {
+  actorId: string
+  fitnessFileId: string
+  activityStartTime?: number
+  activityDurationSeconds: number
+  files: OverlapContextFile[]
+}) => {
+  const sameActorFiles = files.filter(
+    (
+      file
+    ): file is OverlapContextFile & {
+      statusId: string
+      activityStartTime: number
+      totalDurationSeconds: number
+    } =>
+      file.actorId === actorId &&
+      file.id !== fitnessFileId &&
+      typeof file.statusId === 'string' &&
+      typeof file.activityStartTime === 'number' &&
+      typeof file.totalDurationSeconds === 'number' &&
+      file.totalDurationSeconds > 0
+  )
+
+  if (
+    typeof activityStartTime !== 'number' ||
+    !Number.isFinite(activityStartTime) ||
+    activityDurationSeconds <= 0
+  ) {
+    return sameActorFiles.map((file) => file.id)
+  }
+
+  // Keep overlap candidates close to the new activity's start time.
+  const shortPeriodWindowMs = Math.max(
+    activityDurationSeconds * 1000 * 2,
+    60 * 60 * 1000
+  )
+
+  return sameActorFiles
+    .filter((file) => {
+      const existingStartTime = file.activityStartTime
+      return (
+        Math.abs(existingStartTime - activityStartTime) <= shortPeriodWindowMs
+      )
+    })
+    .map((file) => file.id)
 }
 
 const getOverlapRatio = (

--- a/lib/jobs/importFitnessFilesJob.test.ts
+++ b/lib/jobs/importFitnessFilesJob.test.ts
@@ -463,7 +463,13 @@ describe('importFitnessFilesJob', () => {
       'failed',
       'Fitness file missing during import'
     )
-    expect(processingStatusSpy).toHaveBeenCalledWith(missingFileId, 'failed')
+    // Both writes touch importError on the same row, so they must carry the same
+    // reason — otherwise whichever lands last decides what the file says.
+    expect(processingStatusSpy).toHaveBeenCalledWith(
+      missingFileId,
+      'failed',
+      'Fitness file missing during import'
+    )
 
     const updated = await database.getFitnessFile({ id: file!.id })
     expect(updated?.importStatus).toBe('completed')

--- a/lib/jobs/importFitnessFilesJob.test.ts
+++ b/lib/jobs/importFitnessFilesJob.test.ts
@@ -64,6 +64,46 @@ describe('importFitnessFilesJob', () => {
     )
   })
 
+  it('records a reason when status creation rejects with a non-Error', async () => {
+    const file = await database.createFitnessFile({
+      actorId: actor.id,
+      path: 'fitness/non-error-throw.fit',
+      fileName: 'non-error-throw.fit',
+      fileType: 'fit',
+      mimeType: 'application/vnd.ant.fit',
+      bytes: 1_024,
+      importBatchId: 'batch-non-error-throw'
+    })
+
+    mockParseFitnessFile.mockResolvedValueOnce({
+      coordinates: [],
+      trackPoints: [],
+      totalDistanceMeters: 1_000,
+      totalDurationSeconds: 600,
+      startTime: new Date('2026-01-09T00:00:00.000Z')
+    })
+
+    // The queue SDK can reject with a non-Error. `(error as Error).message` is
+    // undefined for it, which writes importError as NULL and leaves the file
+    // failed with no explanation.
+    ;(getQueue().publish as jest.Mock).mockRejectedValueOnce('queue exploded')
+
+    await importFitnessFilesJob(database, {
+      id: 'import-job-non-error-throw',
+      name: IMPORT_FITNESS_FILES_JOB_NAME,
+      data: {
+        actorId: actor.id,
+        batchId: 'batch-non-error-throw',
+        fitnessFileIds: [file!.id],
+        visibility: 'public'
+      }
+    })
+
+    const updated = await database.getFitnessFile({ id: file!.id })
+    expect(updated?.importStatus).toBe('failed')
+    expect(updated?.importError).toBe('queue exploded')
+  })
+
   it('creates local-only merged status, marks primary, and queues processing', async () => {
     const firstFile = await database.createFitnessFile({
       actorId: actor.id,

--- a/lib/jobs/importFitnessFilesJob.test.ts
+++ b/lib/jobs/importFitnessFilesJob.test.ts
@@ -4,7 +4,7 @@ import {
   IMPORT_FITNESS_FILES_JOB_NAME,
   PROCESS_FITNESS_FILE_JOB_NAME
 } from '@/lib/jobs/names'
-import { getFitnessFile } from '@/lib/services/fitness-files'
+import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
 import type { FitnessActivityData } from '@/lib/services/fitness-files/parseFitnessFile'
 import { parseFitnessFile } from '@/lib/services/fitness-files/parseFitnessFile'
 import { getQueue } from '@/lib/services/queue'
@@ -23,7 +23,7 @@ vi.mock('@/lib/services/fitness-files', async () => {
   const actual = await vi.importActual('@/lib/services/fitness-files')
   return {
     ...actual,
-    getFitnessFile: vi.fn()
+    getFitnessFileBuffer: vi.fn()
   }
 })
 
@@ -32,8 +32,8 @@ vi.mock('@/lib/services/fitness-files/parseFitnessFile', async () => ({
   isParseableFitnessFileType: vi.fn().mockReturnValue(true)
 }))
 
-const mockGetFitnessFile = getFitnessFile as jest.MockedFunction<
-  typeof getFitnessFile
+const mockGetFitnessFileBuffer = getFitnessFileBuffer as jest.MockedFunction<
+  typeof getFitnessFileBuffer
 >
 const mockParseFitnessFile = parseFitnessFile as jest.MockedFunction<
   typeof parseFitnessFile
@@ -59,11 +59,9 @@ describe('importFitnessFilesJob', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockGetFitnessFile.mockResolvedValue({
-      type: 'buffer',
-      buffer: Buffer.from('fitness-file-bytes'),
-      contentType: 'application/vnd.ant.fit'
-    })
+    mockGetFitnessFileBuffer.mockResolvedValue(
+      Buffer.from('fitness-file-bytes')
+    )
   })
 
   it('creates local-only merged status, marks primary, and queues processing', async () => {

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -157,6 +157,16 @@ const groupFilesByOverlap = (
   })
 }
 
+/**
+ * Anything can be thrown, not just an Error. `(error as Error).message` is
+ * `undefined` for a thrown string or SDK object, and an undefined reason is
+ * written to `importError` as NULL — so the file ends up `failed` with no
+ * explanation, which is exactly what recording the reason is meant to prevent.
+ */
+export const toImportErrorMessage = (error: unknown) =>
+  (error instanceof Error ? error.message : String(error)) ||
+  'Unknown fitness import error'
+
 const markImportFileFailed = async (
   database: Database,
   fitnessFileId: string,
@@ -347,9 +357,7 @@ export const importFitnessFilesJob = createJobHandle(
             : null)
         })
       } catch (error) {
-        const errorMessage =
-          (error instanceof Error ? error.message : String(error)) ||
-          'Unknown fitness import error'
+        const errorMessage = toImportErrorMessage(error)
 
         logger.warn({
           message: 'Failed to parse fitness file during import',
@@ -445,22 +453,23 @@ export const importFitnessFilesJob = createJobHandle(
           })
         }
       } catch (error) {
-        const nodeError = error as Error
+        // Must not be `(error as Error).message`: this block covers the queue
+        // publish, and a non-Error rejection would make the reason `undefined`,
+        // which updateFitnessFileImportStatus writes as NULL — wiping any prior
+        // reason and leaving the file `failed` with no explanation.
+        const errorMessage = toImportErrorMessage(error)
+
         logger.error({
           message: 'Failed to create local status for imported fitness files',
           actorId,
           batchId,
           fitnessFileIds: targetFitnessFileIds,
-          error: nodeError.message
+          error: errorMessage
         })
 
         await Promise.all(
           orderedTargetGroup.map((item) =>
-            markImportFileFailed(
-              database,
-              item.fitnessFile.id,
-              nodeError.message
-            )
+            markImportFileFailed(database, item.fitnessFile.id, errorMessage)
           )
         )
 

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -8,7 +8,7 @@ import {
 import { Database } from '@/lib/database/types'
 import { groupFitnessActivitiesByOverlap } from '@/lib/jobs/fitnessImportOverlap'
 import { PROCESS_FITNESS_FILE_JOB_NAME } from '@/lib/jobs/names'
-import { getFitnessFile } from '@/lib/services/fitness-files'
+import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
 import {
   isParseableFitnessFileType,
   parseFitnessFile
@@ -46,29 +46,6 @@ interface ParsedImportFile {
   startTimeMs?: number
   source: ParsedImportFileSource
   hasCoordinates?: boolean
-}
-
-const getFitnessFileBuffer = async (
-  database: Database,
-  fitnessFile: FitnessFile
-): Promise<Buffer> => {
-  const data = await getFitnessFile(database, fitnessFile.id, fitnessFile)
-  if (!data) {
-    throw new Error('Fitness file not found in storage')
-  }
-
-  if (data.type === 'buffer') {
-    return data.buffer
-  }
-
-  const response = await fetch(data.redirectUrl)
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download fitness file from redirect URL (${response.status})`
-    )
-  }
-
-  return Buffer.from(await response.arrayBuffer())
 }
 
 const sortFilesByActivityStart = (files: ParsedImportFile[]) => {
@@ -323,7 +300,11 @@ export const importFitnessFilesJob = createJobHandle(
       }
 
       try {
-        const buffer = await getFitnessFileBuffer(database, fitnessFile)
+        const buffer = await getFitnessFileBuffer(
+          database,
+          fitnessFile.id,
+          fitnessFile
+        )
         if (!isParseableFitnessFileType(fitnessFile.fileType)) {
           throw new Error(
             `Unsupported fitness file type for activity parsing: ${fitnessFile.fileType}`

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -9,6 +9,7 @@ import { Database } from '@/lib/database/types'
 import { groupFitnessActivitiesByOverlap } from '@/lib/jobs/fitnessImportOverlap'
 import { PROCESS_FITNESS_FILE_JOB_NAME } from '@/lib/jobs/names'
 import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
+import { toImportErrorMessage } from '@/lib/services/fitness-files/importError'
 import {
   isParseableFitnessFileType,
   parseFitnessFile
@@ -156,16 +157,6 @@ const groupFilesByOverlap = (
     return firstStart - secondStart
   })
 }
-
-/**
- * Anything can be thrown, not just an Error. `(error as Error).message` is
- * `undefined` for a thrown string or SDK object, and an undefined reason is
- * written to `importError` as NULL — so the file ends up `failed` with no
- * explanation, which is exactly what recording the reason is meant to prevent.
- */
-export const toImportErrorMessage = (error: unknown) =>
-  (error instanceof Error ? error.message : String(error)) ||
-  'Unknown fitness import error'
 
 const markImportFileFailed = async (
   database: Database,

--- a/lib/jobs/importFitnessFilesJob.ts
+++ b/lib/jobs/importFitnessFilesJob.ts
@@ -162,13 +162,19 @@ const markImportFileFailed = async (
   fitnessFileId: string,
   importError: string
 ) => {
+  // Both writes target `importError` on the same row, so they must agree on the
+  // value — otherwise whichever lands last decides the reason.
   await Promise.all([
     database.updateFitnessFileImportStatus(
       fitnessFileId,
       'failed',
       importError
     ),
-    database.updateFitnessFileProcessingStatus(fitnessFileId, 'failed')
+    database.updateFitnessFileProcessingStatus(
+      fitnessFileId,
+      'failed',
+      importError
+    )
   ])
 }
 
@@ -341,16 +347,19 @@ export const importFitnessFilesJob = createJobHandle(
             : null)
         })
       } catch (error) {
-        const nodeError = error as Error
+        const errorMessage =
+          (error instanceof Error ? error.message : String(error)) ||
+          'Unknown fitness import error'
+
         logger.warn({
           message: 'Failed to parse fitness file during import',
           fitnessFileId,
           actorId,
           batchId,
-          error: nodeError.message
+          error: errorMessage
         })
 
-        await markImportFileFailed(database, fitnessFile.id, nodeError.message)
+        await markImportFileFailed(database, fitnessFile.id, errorMessage)
       }
     }
 

--- a/lib/jobs/importStravaActivityJob.merge.test.ts
+++ b/lib/jobs/importStravaActivityJob.merge.test.ts
@@ -177,11 +177,7 @@ describe('importStravaActivityJob same-ride merge', () => {
       } as never
     })
 
-    mockGetFitnessFileBuffer.mockResolvedValue({
-      type: 'buffer',
-      buffer: Buffer.from('gpx-bytes'),
-      contentType: 'application/gpx+xml'
-    } as never)
+    mockGetFitnessFileBuffer.mockResolvedValue(Buffer.from('gpx-bytes'))
 
     // Same ride => identical parsed start time + duration => overlap merge.
     mockParseFitnessFile.mockResolvedValue({

--- a/lib/jobs/importStravaActivityJob.merge.test.ts
+++ b/lib/jobs/importStravaActivityJob.merge.test.ts
@@ -1,7 +1,10 @@
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { importStravaActivityJob } from '@/lib/jobs/importStravaActivityJob'
 import { IMPORT_STRAVA_ACTIVITY_JOB_NAME } from '@/lib/jobs/names'
-import { getFitnessFile, saveFitnessFile } from '@/lib/services/fitness-files'
+import {
+  getFitnessFileBuffer,
+  saveFitnessFile
+} from '@/lib/services/fitness-files'
 import { generateMapImage } from '@/lib/services/fitness-files/generateMapImage'
 import { parseFitnessFile } from '@/lib/services/fitness-files/parseFitnessFile'
 import { saveMedia } from '@/lib/services/medias'
@@ -38,7 +41,11 @@ vi.mock('@/lib/services/queue', () => ({
 
 vi.mock('@/lib/services/fitness-files', async () => {
   const actual = await vi.importActual('@/lib/services/fitness-files')
-  return { ...actual, saveFitnessFile: vi.fn(), getFitnessFile: vi.fn() }
+  return {
+    ...actual,
+    saveFitnessFile: vi.fn(),
+    getFitnessFileBuffer: vi.fn()
+  }
 })
 
 vi.mock('@/lib/services/fitness-files/parseFitnessFile', async () => {
@@ -73,8 +80,8 @@ vi.mock('@/lib/services/strava/activity', async () => {
 const mockSaveFitnessFile = saveFitnessFile as jest.MockedFunction<
   typeof saveFitnessFile
 >
-const mockGetFitnessFile = getFitnessFile as jest.MockedFunction<
-  typeof getFitnessFile
+const mockGetFitnessFileBuffer = getFitnessFileBuffer as jest.MockedFunction<
+  typeof getFitnessFileBuffer
 >
 const mockParseFitnessFile = parseFitnessFile as jest.MockedFunction<
   typeof parseFitnessFile
@@ -170,7 +177,7 @@ describe('importStravaActivityJob same-ride merge', () => {
       } as never
     })
 
-    mockGetFitnessFile.mockResolvedValue({
+    mockGetFitnessFileBuffer.mockResolvedValue({
       type: 'buffer',
       buffer: Buffer.from('gpx-bytes'),
       contentType: 'application/gpx+xml'

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -8,6 +8,10 @@ import {
 } from '@/lib/actions/createNote'
 import { UpdateFitnessFileActivityData } from '@/lib/database/sql/fitnessFile'
 import { Database } from '@/lib/database/types'
+import {
+  OVERLAP_CONTEXT_SCAN_LIMIT,
+  getOverlapContextFitnessFileIds
+} from '@/lib/jobs/fitnessImportOverlap'
 import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
 import {
   IMPORT_FITNESS_FILES_JOB_NAME,
@@ -67,7 +71,6 @@ const JobData = z.object({
   visibility: Visibility.optional()
 })
 
-const OVERLAP_CONTEXT_SCAN_LIMIT = 200
 const MAX_STRAVA_PHOTOS_TO_ATTACH = 4
 const STRAVA_PHOTO_ADDRESS_BLOCK_LIST = new BlockList()
 
@@ -110,75 +113,6 @@ const getStravaFallbackPostId = ({
   stravaActivityId: string
 }) => {
   return getHashFromString(`${actorId}:strava-note:${stravaActivityId}`)
-}
-
-const getOverlapContextFitnessFileIds = ({
-  actorId,
-  fitnessFileId,
-  activityStartTime,
-  activityDurationSeconds,
-  files
-}: {
-  actorId: string
-  fitnessFileId: string
-  activityStartTime?: number
-  activityDurationSeconds: number
-  files: Array<
-    Pick<
-      FitnessFile,
-      | 'id'
-      | 'actorId'
-      | 'statusId'
-      | 'activityStartTime'
-      | 'totalDurationSeconds'
-    >
-  >
-}) => {
-  const sameActorFiles = files.filter(
-    (
-      file
-    ): file is Pick<
-      FitnessFile,
-      | 'id'
-      | 'actorId'
-      | 'statusId'
-      | 'activityStartTime'
-      | 'totalDurationSeconds'
-    > & {
-      statusId: string
-      activityStartTime: number
-      totalDurationSeconds: number
-    } =>
-      file.actorId === actorId &&
-      file.id !== fitnessFileId &&
-      typeof file.statusId === 'string' &&
-      typeof file.activityStartTime === 'number' &&
-      typeof file.totalDurationSeconds === 'number' &&
-      file.totalDurationSeconds > 0
-  )
-
-  if (
-    typeof activityStartTime !== 'number' ||
-    !Number.isFinite(activityStartTime) ||
-    activityDurationSeconds <= 0
-  ) {
-    return sameActorFiles.map((file) => file.id)
-  }
-
-  // Keep overlap candidates close to the new activity's start time.
-  const shortPeriodWindowMs = Math.max(
-    activityDurationSeconds * 1000 * 2,
-    60 * 60 * 1000
-  )
-
-  return sameActorFiles
-    .filter((file) => {
-      const existingStartTime = file.activityStartTime
-      return (
-        Math.abs(existingStartTime - activityStartTime) <= shortPeriodWindowMs
-      )
-    })
-    .map((file) => file.id)
 }
 
 const getAttachmentName = (photoId: string | undefined, index: number) => {

--- a/lib/jobs/importStravaActivityJob.ts
+++ b/lib/jobs/importStravaActivityJob.ts
@@ -42,7 +42,6 @@ import {
 } from '@/lib/services/strava/activity'
 import { getStravaActivityBatchId } from '@/lib/services/strava/activityBatch'
 import { addStatusToTimelines } from '@/lib/services/timelines'
-import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { Actor, getMention } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { Visibility } from '@/lib/types/mastodon/visibility'

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -16,6 +16,7 @@ import {
   getEffectiveFitnessStorageConfig,
   saveFitnessFile
 } from '@/lib/services/fitness-files'
+import { toImportErrorMessage } from '@/lib/services/fitness-files/importError'
 import { assertFitnessStoragePath } from '@/lib/services/fitness-files/path'
 import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
 import { saveMedia } from '@/lib/services/medias/index'
@@ -1171,14 +1172,18 @@ export const importStravaArchiveJob = createJobHandle(
         finalImportLastError = null
       }
     } catch (error) {
-      const nodeError = error as Error
+      // This block covers the queue publish, which can reject with a non-Error.
+      // `(error as Error).message` would be undefined, and both writes below put
+      // it in a column (importError / lastError) as NULL — losing the reason.
+      const archiveErrorMessage = toImportErrorMessage(error)
+
       logger.error({
         message: 'Failed to process Strava archive import job',
         importId,
         actorId,
         archiveId,
         archiveFitnessFileId,
-        error: nodeError.message
+        error: archiveErrorMessage
       })
 
       shouldDeleteArchiveSource = false
@@ -1208,7 +1213,7 @@ export const importStravaArchiveJob = createJobHandle(
           importId,
           checkpoint,
           status: 'failed',
-          lastError: nodeError.message,
+          lastError: archiveErrorMessage,
           resolvedAt: null
         })
 
@@ -1216,7 +1221,7 @@ export const importStravaArchiveJob = createJobHandle(
           database.updateFitnessFileImportStatus(
             archiveFitnessFile.id,
             'failed',
-            nodeError.message
+            archiveErrorMessage
           ),
           database.updateFitnessFileProcessingStatus(
             archiveFitnessFile.id,

--- a/lib/jobs/importStravaArchiveJob.ts
+++ b/lib/jobs/importStravaArchiveJob.ts
@@ -1145,19 +1145,21 @@ export const importStravaArchiveJob = createJobHandle(
           : null)
       })
 
-      await Promise.all([
-        database.updateFitnessFileImportStatus(
-          archiveFitnessFile.id,
-          hasFailures ? 'failed' : 'completed',
-          hasFailures
-            ? `${summary}${importFailureMessage ? `: ${importFailureMessage}` : ''}`
-            : summary
-        ),
-        database.updateFitnessFileProcessingStatus(
-          archiveFitnessFile.id,
-          hasFailures ? 'failed' : 'completed'
-        )
-      ])
+      // Sequential, not Promise.all: both writes touch `importError` on the same
+      // row. A `completed` processing status clears it, so racing them can null
+      // the summary the import status is writing. Set the processing status
+      // first and let the summary land last.
+      await database.updateFitnessFileProcessingStatus(
+        archiveFitnessFile.id,
+        hasFailures ? 'failed' : 'completed'
+      )
+      await database.updateFitnessFileImportStatus(
+        archiveFitnessFile.id,
+        hasFailures ? 'failed' : 'completed',
+        hasFailures
+          ? `${summary}${importFailureMessage ? `: ${importFailureMessage}` : ''}`
+          : summary
+      )
 
       if (shouldKeepImportFailed) {
         // Keep fully failed imports active so users can retry/cancel.

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -389,6 +389,29 @@ describe('processFitnessFileJob', () => {
     expect(failedFitnessFile?.importError).toBe('Invalid TCX file structure')
   })
 
+  it('records a reason even when the thrown value is not an Error', async () => {
+    const { statusId, fitnessFileId } = await createStatusWithFitnessFile({
+      text: 'Will reject with a non-Error'
+    })
+
+    // A thrown string/SDK object has no `.message`; without a guard the reason
+    // is written as undefined, leaving the row `failed` with no explanation (or
+    // a stale one from an earlier failure).
+    mockParseFitnessFile.mockRejectedValue('socket hang up')
+
+    await processFitnessFileJob(database, {
+      id: 'job-id-non-error',
+      name: PROCESS_FITNESS_FILE_JOB_NAME,
+      data: { actorId: actor.id, statusId, fitnessFileId }
+    })
+
+    const failedFitnessFile = await database.getFitnessFile({
+      id: fitnessFileId
+    })
+    expect(failedFitnessFile?.processingStatus).toBe('failed')
+    expect(failedFitnessFile?.importError).toBe('socket hang up')
+  })
+
   it('clears a previous failure reason when processing succeeds on retry', async () => {
     const { statusId, fitnessFileId } = await createStatusWithFitnessFile({
       text: 'Will fail then succeed'

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -5,7 +5,7 @@ import {
   SEND_NOTE_JOB_NAME
 } from '@/lib/jobs/names'
 import { processFitnessFileJob } from '@/lib/jobs/processFitnessFileJob'
-import { getFitnessFile } from '@/lib/services/fitness-files'
+import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
 import { generateMapImage } from '@/lib/services/fitness-files/generateMapImage'
 import type { FitnessActivityData } from '@/lib/services/fitness-files/parseFitnessFile'
 import { parseFitnessFile } from '@/lib/services/fitness-files/parseFitnessFile'
@@ -28,7 +28,7 @@ vi.mock('@/lib/services/fitness-files', async () => {
   const actual = await vi.importActual('@/lib/services/fitness-files')
   return {
     ...actual,
-    getFitnessFile: vi.fn()
+    getFitnessFileBuffer: vi.fn()
   }
 })
 
@@ -45,8 +45,8 @@ vi.mock('@/lib/services/medias', async () => ({
   saveMedia: vi.fn()
 }))
 
-const mockGetFitnessFile = getFitnessFile as jest.MockedFunction<
-  typeof getFitnessFile
+const mockGetFitnessFileBuffer = getFitnessFileBuffer as jest.MockedFunction<
+  typeof getFitnessFileBuffer
 >
 const mockParseFitnessFile = parseFitnessFile as jest.MockedFunction<
   typeof parseFitnessFile
@@ -133,11 +133,9 @@ describe('processFitnessFileJob', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockGetFitnessFile.mockResolvedValue({
-      type: 'buffer',
-      buffer: Buffer.from('fitness-file-bytes'),
-      contentType: 'application/vnd.ant.fit'
-    })
+    mockGetFitnessFileBuffer.mockResolvedValue(
+      Buffer.from('fitness-file-bytes')
+    )
 
     mockParseFitnessFile.mockResolvedValue(defaultActivityData)
     mockGenerateMapImage.mockResolvedValue(Buffer.from('png-map-image'))

--- a/lib/jobs/processFitnessFileJob.test.ts
+++ b/lib/jobs/processFitnessFileJob.test.ts
@@ -60,6 +60,22 @@ describe('processFitnessFileJob', () => {
   const database = getTestSQLDatabase()
   let actor: Actor
 
+  const defaultActivityData: FitnessActivityData = {
+    coordinates: [
+      { lat: 37.78, lng: -122.42 },
+      { lat: 37.79, lng: -122.41 }
+    ],
+    trackPoints: [
+      { lat: 37.78, lng: -122.42 },
+      { lat: 37.79, lng: -122.41 }
+    ],
+    totalDistanceMeters: 5_200,
+    totalDurationSeconds: 1_695,
+    elevationGainMeters: 130,
+    activityType: 'running',
+    startTime: new Date('2026-01-05T06:00:00.000Z')
+  }
+
   const createStatusWithFitnessFile = async ({
     text,
     fileType = 'fit'
@@ -122,22 +138,6 @@ describe('processFitnessFileJob', () => {
       buffer: Buffer.from('fitness-file-bytes'),
       contentType: 'application/vnd.ant.fit'
     })
-
-    const defaultActivityData: FitnessActivityData = {
-      coordinates: [
-        { lat: 37.78, lng: -122.42 },
-        { lat: 37.79, lng: -122.41 }
-      ],
-      trackPoints: [
-        { lat: 37.78, lng: -122.42 },
-        { lat: 37.79, lng: -122.41 }
-      ],
-      totalDistanceMeters: 5_200,
-      totalDurationSeconds: 1_695,
-      elevationGainMeters: 130,
-      activityType: 'running',
-      startTime: new Date('2026-01-05T06:00:00.000Z')
-    }
 
     mockParseFitnessFile.mockResolvedValue(defaultActivityData)
     mockGenerateMapImage.mockResolvedValue(Buffer.from('png-map-image'))
@@ -368,6 +368,56 @@ describe('processFitnessFileJob', () => {
     })
     expect(updatedFitnessFile?.processingStatus).toBe('failed')
     expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('records the failure reason on the fitness file when processing fails', async () => {
+    const { statusId, fitnessFileId } = await createStatusWithFitnessFile({
+      text: 'Will fail'
+    })
+
+    mockParseFitnessFile.mockRejectedValue(
+      new Error('Invalid TCX file structure')
+    )
+
+    await processFitnessFileJob(database, {
+      id: 'job-id-failure-reason',
+      name: PROCESS_FITNESS_FILE_JOB_NAME,
+      data: { actorId: actor.id, statusId, fitnessFileId }
+    })
+
+    const failedFitnessFile = await database.getFitnessFile({
+      id: fitnessFileId
+    })
+    expect(failedFitnessFile?.importError).toBe('Invalid TCX file structure')
+  })
+
+  it('clears a previous failure reason when processing succeeds on retry', async () => {
+    const { statusId, fitnessFileId } = await createStatusWithFitnessFile({
+      text: 'Will fail then succeed'
+    })
+
+    mockParseFitnessFile.mockRejectedValue(new Error('transient storage error'))
+    await processFitnessFileJob(database, {
+      id: 'job-id-retry-failure',
+      name: PROCESS_FITNESS_FILE_JOB_NAME,
+      data: { actorId: actor.id, statusId, fitnessFileId }
+    })
+    expect(
+      (await database.getFitnessFile({ id: fitnessFileId }))?.importError
+    ).toBe('transient storage error')
+
+    mockParseFitnessFile.mockResolvedValue(defaultActivityData)
+    await processFitnessFileJob(database, {
+      id: 'job-id-retry-success',
+      name: PROCESS_FITNESS_FILE_JOB_NAME,
+      data: { actorId: actor.id, statusId, fitnessFileId }
+    })
+
+    const retriedFitnessFile = await database.getFitnessFile({
+      id: fitnessFileId
+    })
+    expect(retriedFitnessFile?.processingStatus).toBe('completed')
+    expect(retriedFitnessFile?.importError).toBeUndefined()
   })
 
   it('skips federation publish when publishSendNote is false', async () => {

--- a/lib/jobs/processFitnessFileJob.ts
+++ b/lib/jobs/processFitnessFileJob.ts
@@ -269,19 +269,25 @@ export const processFitnessFileJob = createJobHandle(
       // fitness-route-heatmap route), so it can never pile onto the import /
       // Strava-webhook path and exhaust the worker's heap.
     } catch (error) {
-      const nodeError = error as Error
+      // Anything can be thrown, not just an Error. `(error as Error).message`
+      // would be undefined for a thrown string or SDK object, which records no
+      // reason at all and leaves a stale one from an earlier failure in place.
+      const errorMessage =
+        (error instanceof Error ? error.message : String(error)) ||
+        'Unknown fitness processing error'
+
       logger.error({
         message: 'Failed to process fitness file',
         actorId,
         statusId,
         fitnessFileId,
-        error: nodeError.message
+        error: errorMessage
       })
 
       await database.updateFitnessFileProcessingStatus(
         fitnessFileId,
         'failed',
-        nodeError.message
+        errorMessage
       )
     }
   }

--- a/lib/jobs/processFitnessFileJob.ts
+++ b/lib/jobs/processFitnessFileJob.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod'
 
-import { Database } from '@/lib/database/types'
 import { SEND_NOTE_JOB_NAME } from '@/lib/jobs/names'
-import { getFitnessFile } from '@/lib/services/fitness-files'
+import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
 import { generateMapImage } from '@/lib/services/fitness-files/generateMapImage'
 import type { FitnessActivityData } from '@/lib/services/fitness-files/parseFitnessFile'
 import {
@@ -104,29 +103,6 @@ const buildActivitySummary = (data: FitnessActivityData): string => {
   }
 
   return base
-}
-
-const getFitnessFileBuffer = async (
-  database: Database,
-  fitnessFileId: string
-): Promise<Buffer> => {
-  const data = await getFitnessFile(database, fitnessFileId)
-  if (!data) {
-    throw new Error('Fitness file not found in storage')
-  }
-
-  if (data.type === 'buffer') {
-    return data.buffer
-  }
-
-  const response = await fetch(data.redirectUrl)
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download fitness file from redirect URL (${response.status})`
-    )
-  }
-
-  return Buffer.from(await response.arrayBuffer())
 }
 
 export const processFitnessFileJob = createJobHandle(

--- a/lib/jobs/processFitnessFileJob.ts
+++ b/lib/jobs/processFitnessFileJob.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { SEND_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
 import { generateMapImage } from '@/lib/services/fitness-files/generateMapImage'
+import { toImportErrorMessage } from '@/lib/services/fitness-files/importError'
 import type { FitnessActivityData } from '@/lib/services/fitness-files/parseFitnessFile'
 import {
   isParseableFitnessFileType,
@@ -269,12 +270,10 @@ export const processFitnessFileJob = createJobHandle(
       // fitness-route-heatmap route), so it can never pile onto the import /
       // Strava-webhook path and exhaust the worker's heap.
     } catch (error) {
-      // Anything can be thrown, not just an Error. `(error as Error).message`
-      // would be undefined for a thrown string or SDK object, which records no
-      // reason at all and leaves a stale one from an earlier failure in place.
-      const errorMessage =
-        (error instanceof Error ? error.message : String(error)) ||
+      const errorMessage = toImportErrorMessage(
+        error,
         'Unknown fitness processing error'
+      )
 
       logger.error({
         message: 'Failed to process fitness file',

--- a/lib/jobs/processFitnessFileJob.ts
+++ b/lib/jobs/processFitnessFileJob.ts
@@ -302,7 +302,11 @@ export const processFitnessFileJob = createJobHandle(
         error: nodeError.message
       })
 
-      await database.updateFitnessFileProcessingStatus(fitnessFileId, 'failed')
+      await database.updateFitnessFileProcessingStatus(
+        fitnessFileId,
+        'failed',
+        nodeError.message
+      )
     }
   }
 )

--- a/lib/jobs/regenerateFitnessMapsJob.ts
+++ b/lib/jobs/regenerateFitnessMapsJob.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/jobs/names'
 import { getFitnessFile } from '@/lib/services/fitness-files'
 import { generateMapImage } from '@/lib/services/fitness-files/generateMapImage'
+import { toImportErrorMessage } from '@/lib/services/fitness-files/importError'
 import {
   isParseableFitnessFileType,
   parseFitnessFile
@@ -295,17 +296,21 @@ export const regenerateFitnessMapsJob = createJobHandle(
           statusesNeedingUpdate.add(statusId)
         }
       } catch (error) {
-        const nodeError = error as Error
+        const errorMessage = toImportErrorMessage(
+          error,
+          'Unknown fitness map regeneration error'
+        )
         logger.error({
           message: 'Failed to regenerate fitness map for old status',
           actorId,
           fitnessFileId,
-          error: nodeError.message
+          error: errorMessage
         })
 
         await database.updateFitnessFileProcessingStatus(
           fitnessFileId,
-          'failed'
+          'failed',
+          errorMessage
         )
       }
     }

--- a/lib/services/fitness-files/importError.ts
+++ b/lib/services/fitness-files/importError.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalizes a thrown value into the reason stored on `fitness_files.importError`.
+ *
+ * Anything can be thrown, not just an Error — a queue SDK can reject with a
+ * plain object or string. `(error as Error).message` is `undefined` for those,
+ * and an undefined reason is written to the column as NULL: it wipes any reason
+ * already there and leaves the file `failed` with no explanation, which is the
+ * exact failure recording the reason exists to prevent.
+ */
+export const toImportErrorMessage = (
+  error: unknown,
+  fallback = 'Unknown fitness import error'
+) => (error instanceof Error ? error.message : String(error)) || fallback

--- a/lib/services/fitness-files/index.ts
+++ b/lib/services/fitness-files/index.ts
@@ -109,6 +109,14 @@ export const getFitnessFileBuffer = async (
   fileId: string,
   fileMetadata?: FitnessFile
 ): Promise<Buffer> => {
+  // getFitnessFile returns null both when the object is absent AND when no
+  // fitness storage is configured. Separate them: running a recovery script
+  // against the wrong env otherwise reports every file as missing from storage,
+  // which reads as "the data is gone" when nothing is actually wrong with it.
+  if (!getEffectiveFitnessStorageConfig()) {
+    throw new Error('Fitness storage is not configured')
+  }
+
   const data = await getFitnessFile(database, fileId, fileMetadata)
   if (!data) {
     throw new Error('Fitness file not found in storage')

--- a/lib/services/fitness-files/index.ts
+++ b/lib/services/fitness-files/index.ts
@@ -100,6 +100,34 @@ export const getFitnessFile = async (
   }
 }
 
+/**
+ * Reads a stored fitness file's bytes, following the storage redirect when the
+ * backend serves one (S3). Throws when the file is missing from storage.
+ */
+export const getFitnessFileBuffer = async (
+  database: Database,
+  fileId: string,
+  fileMetadata?: FitnessFile
+): Promise<Buffer> => {
+  const data = await getFitnessFile(database, fileId, fileMetadata)
+  if (!data) {
+    throw new Error('Fitness file not found in storage')
+  }
+
+  if (data.type === 'buffer') {
+    return data.buffer
+  }
+
+  const response = await fetch(data.redirectUrl)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download fitness file from redirect URL (${response.status})`
+    )
+  }
+
+  return Buffer.from(await response.arrayBuffer())
+}
+
 export const deleteFitnessFile = async (
   database: Database,
   fileId: string,

--- a/scripts/fitness/importStoredFitnessFile.ts
+++ b/scripts/fitness/importStoredFitnessFile.ts
@@ -12,8 +12,14 @@
  * files are given at once they are grouped by same-ride overlap (>=80% on
  * start+duration), so one ride recorded as two Strava activities merges into ONE
  * post (one primary carries the map, the rest are attached) instead of creating
- * duplicates. Files that already have a status are skipped, so delete the old
- * duplicate posts first (deleting a status detaches its files back to orphans).
+ * duplicates.
+ *
+ * An orphan whose same-ride sibling ALREADY has a post is merged INTO that post
+ * rather than getting one of its own: the sibling stays primary and keeps its
+ * route map, and the orphan is attached to it (processingStatus='completed', no
+ * second map). So recovering a half-failed same-ride pair — one Strava activity
+ * imported, its twin failed — no longer means deleting the good post first.
+ * Run with --dry-run to see MERGE vs NEW per post before anything is written.
  *
  * Run it with the PRODUCTION env (see diagnoseFitnessImport.ts — move `.env.local`
  * aside so `.env.production` wins, or this hits your local SQLite).
@@ -29,10 +35,7 @@ import { loadEnvConfig } from '@next/env'
 import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
-import {
-  FitnessOverlapActivity,
-  groupFitnessActivitiesByOverlap
-} from '@/lib/jobs/fitnessImportOverlap'
+import { OVERLAP_CONTEXT_SCAN_LIMIT } from '@/lib/jobs/fitnessImportOverlap'
 import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
 import { IMPORT_FITNESS_FILES_JOB_NAME } from '@/lib/jobs/names'
 import { getStravaActivityBatchId } from '@/lib/services/strava/activityBatch'
@@ -40,6 +43,7 @@ import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 import { printDatabaseBanner } from './describeConnection'
+import { buildStoredImportPlan } from './storedImportPlan'
 
 const projectDir = process.cwd()
 loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
@@ -161,6 +165,18 @@ async function main() {
   const targetIds = targets.map((f) => f.id)
   const batchId = targets[0].importBatchId ?? `manual-recover:${targets[0].id}`
 
+  // Same-ride siblings that ALREADY have a post. Handing these to the job as
+  // overlap context makes it reuse the sibling's status for an overlapping
+  // target instead of creating a second post for the same ride.
+  const contextFiles = await database.getFitnessFilesByActor({
+    actorId: input.actorId,
+    limit: OVERLAP_CONTEXT_SCAN_LIMIT
+  })
+  const { overlapFitnessFileIds, groups } = buildStoredImportPlan({
+    targets,
+    contextFiles
+  })
+
   console.log(
     `Recreating posts for ${targets.length} orphaned file(s) in one overlap-aware import` +
       (input.dryRun ? ' (dry run)' : '') +
@@ -169,44 +185,15 @@ async function main() {
   console.log(`  files: ${targets.map((f) => f.fileName).join(', ')}\n`)
 
   if (input.dryRun) {
-    // Predict the post grouping WITHOUT touching the database: files that overlap
-    // >=80% on start+duration merge into one post, while files missing a start
-    // time or a positive duration can't be grouped and each become their own post.
-    const fileNameById = new Map(targets.map((f) => [f.id, f.fileName]))
-    const groupable: FitnessOverlapActivity[] = []
-    const ungroupable: FitnessFile[] = []
-    for (const file of targets) {
-      if (
-        typeof file.activityStartTime === 'number' &&
-        typeof file.totalDurationSeconds === 'number' &&
-        file.totalDurationSeconds > 0
-      ) {
-        groupable.push({
-          id: file.id,
-          startTimeMs: file.activityStartTime,
-          durationSeconds: file.totalDurationSeconds
-        })
-      } else {
-        ungroupable.push(file)
-      }
-    }
-
-    const groups = groupFitnessActivitiesByOverlap(groupable, 0.8)
-    const postCount = groups.length + ungroupable.length
     console.log(
-      `  would create ${postCount} post(s) (dry run — no Strava, no database writes):`
+      `  would write ${groups.length} post(s) (dry run — no Strava, no database writes):`
     )
     groups.forEach((group, index) => {
-      const names = group.map((a) => fileNameById.get(a.id) ?? a.id)
+      const names = group.targetFileNames.join(' + ')
       console.log(
-        `    post ${index + 1}: ${names.join(' + ')}` +
-          (names.length > 1 ? ' (merged — same-ride >=80% overlap)' : '')
-      )
-    })
-    ungroupable.forEach((file, index) => {
-      console.log(
-        `    post ${groups.length + index + 1}: ${file.fileName}` +
-          ' (own post — no start time / positive duration, cannot group)'
+        group.mergeStatusId
+          ? `    post ${index + 1}: ${names} → MERGE into existing post ${group.mergeStatusId}`
+          : `    post ${index + 1}: ${names} → NEW post`
       )
     })
     return 0
@@ -222,7 +209,7 @@ async function main() {
         actorId: input.actorId,
         batchId,
         fitnessFileIds: targetIds,
-        overlapFitnessFileIds: [],
+        overlapFitnessFileIds,
         visibility: input.visibility
       }
     })

--- a/scripts/fitness/importStoredFitnessFile.ts
+++ b/scripts/fitness/importStoredFitnessFile.ts
@@ -35,11 +35,13 @@ import { loadEnvConfig } from '@next/env'
 import { z } from 'zod'
 
 import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
 import { OVERLAP_CONTEXT_SCAN_LIMIT } from '@/lib/jobs/fitnessImportOverlap'
 import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
 import { IMPORT_FITNESS_FILES_JOB_NAME } from '@/lib/jobs/names'
 import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
 import {
+  ParseableFitnessFileType,
   isParseableFitnessFileType,
   parseFitnessFile
 } from '@/lib/services/fitness-files/parseFitnessFile'
@@ -97,6 +99,59 @@ const parseArgs = (args: string[]) => {
     visibility: Visibility.parse(visibility),
     dryRun
   }
+}
+
+const toErrorMessage = (error: unknown) =>
+  (error instanceof Error ? error.message : String(error)) || 'Unknown error'
+
+/**
+ * Loads the candidate same-ride siblings for the targets: files whose ACTIVITY
+ * time sits in the window around each target's ride, plus (as a backstop for
+ * targets that could not be parsed, which therefore have no window) the actor's
+ * most recent files.
+ */
+const getSiblingContextFiles = async (
+  database: Database,
+  actorId: string,
+  targets: StoredImportTarget[]
+): Promise<FitnessFile[]> => {
+  const byId = new Map<string, FitnessFile>()
+
+  for (const target of targets) {
+    if (
+      typeof target.startTimeMs !== 'number' ||
+      typeof target.durationSeconds !== 'number' ||
+      target.durationSeconds <= 0
+    ) {
+      continue
+    }
+
+    // Same window getOverlapContextFitnessFileIds applies when it narrows.
+    const windowMs = Math.max(target.durationSeconds * 1000 * 2, 60 * 60 * 1000)
+    const files = await database.getFitnessFilesByActor({
+      actorId,
+      limit: OVERLAP_CONTEXT_SCAN_LIMIT,
+      startDate: new Date(target.startTimeMs - windowMs),
+      endDate: new Date(target.startTimeMs + windowMs)
+    })
+    files.forEach((file) => byId.set(file.id, file))
+  }
+
+  const hasUnwindowedTarget = targets.some(
+    (target) =>
+      typeof target.startTimeMs !== 'number' ||
+      typeof target.durationSeconds !== 'number' ||
+      target.durationSeconds <= 0
+  )
+  if (hasUnwindowedTarget) {
+    const recent = await database.getFitnessFilesByActor({
+      actorId,
+      limit: OVERLAP_CONTEXT_SCAN_LIMIT
+    })
+    recent.forEach((file) => byId.set(file.id, file))
+  }
+
+  return [...byId.values()]
 }
 
 async function main() {
@@ -175,13 +230,24 @@ async function main() {
   // call it ungroupable and predict a NEW post where the job actually merges.
   const plannedTargets: StoredImportTarget[] = await Promise.all(
     targets.map(async (file) => {
+      let buffer: Buffer
       try {
         if (!isParseableFitnessFileType(file.fileType)) {
           throw new Error(`Unsupported fitness file type: ${file.fileType}`)
         }
-        const buffer = await getFitnessFileBuffer(database, file.id, file)
+        buffer = await getFitnessFileBuffer(database, file.id, file)
+      } catch (error) {
+        // Separate from a parse failure: a storage error is usually transient or
+        // an env mistake ("run it again"), a parse failure is the file itself.
+        return {
+          file,
+          parseError: `could not read from storage: ${toErrorMessage(error)}`
+        }
+      }
+
+      try {
         const activityData = await parseFitnessFile({
-          fileType: file.fileType,
+          fileType: file.fileType as ParseableFitnessFileType,
           buffer
         })
         return {
@@ -192,18 +258,24 @@ async function main() {
             : null)
         }
       } catch (error) {
-        return { file, parseError: (error as Error).message }
+        return { file, parseError: toErrorMessage(error) }
       }
     })
   )
 
-  // Same-ride siblings that ALREADY have a post. Handing these to the job as
-  // overlap context makes it reuse the sibling's status for an overlapping
-  // target instead of creating a second post for the same ride.
-  const contextFiles = await database.getFitnessFilesByActor({
-    actorId: input.actorId,
-    limit: OVERLAP_CONTEXT_SCAN_LIMIT
-  })
+  // Same-ride siblings that ALREADY have a post, so the job reuses their status
+  // instead of creating a second post for the ride.
+  //
+  // Scope this by the ride's ACTIVITY time, not by recency. The Strava importer
+  // can scan "the actor's N most recent files" because it runs seconds after the
+  // sibling was uploaded — but this script exists to recover OLD orphans, and by
+  // now the actor may have uploaded hundreds of files since. A recency window
+  // would drop the sibling and silently create the duplicate post.
+  const contextFiles = await getSiblingContextFiles(
+    database,
+    input.actorId,
+    plannedTargets
+  )
   const { overlapFitnessFileIds, groups, unparseable } = buildStoredImportPlan({
     targets: plannedTargets,
     contextFiles
@@ -216,22 +288,39 @@ async function main() {
   )
   console.log(`  files: ${targets.map((f) => f.fileName).join(', ')}\n`)
 
-  if (input.dryRun) {
+  console.log(
+    `  ${input.dryRun ? 'would write' : 'writing'} ${groups.length} post(s)${
+      input.dryRun ? ' (dry run — no Strava, no database writes)' : ''
+    }:`
+  )
+  groups.forEach((group, index) => {
+    const names = group.targetFileNames.join(' + ')
     console.log(
-      `  would write ${groups.length} post(s) (dry run — no Strava, no database writes):`
+      group.mergeStatusId
+        ? `    post ${index + 1}: ${names} → MERGE into existing post ${group.mergeStatusId}`
+        : `    post ${index + 1}: ${names} → NEW post`
     )
-    groups.forEach((group, index) => {
-      const names = group.targetFileNames.join(' + ')
-      console.log(
-        group.mergeStatusId
-          ? `    post ${index + 1}: ${names} → MERGE into existing post ${group.mergeStatusId}`
-          : `    post ${index + 1}: ${names} → NEW post`
-      )
-    })
-    unparseable.forEach((file) => {
-      console.log(`    ✗ ${file.fileName} → would FAIL to parse: ${file.error}`)
-    })
-    return 0
+  })
+  // Print on the real run too: these files were already parsed, so the script
+  // knows they will fail. Staying quiet until the summary hides it.
+  unparseable.forEach((file) => {
+    console.log(`    ✗ ${file.fileName} → will FAIL, no post: ${file.error}`)
+  })
+  console.log('')
+
+  if (input.dryRun) return 0
+
+  // One bad file among several should not block recovering the rest — the job
+  // marks it failed (with the reason) and imports the others. But when EVERY
+  // target fails, the files are almost certainly fine and the environment is
+  // not (wrong env => no storage config, see the banner above), so importing
+  // would only mark them all failed for a problem that is not theirs.
+  if (unparseable.length === targets.length) {
+    console.error(
+      `Refusing to import: all ${targets.length} file(s) failed to read/parse (see above).\n` +
+        '  This usually means the wrong environment or storage config, not bad files.'
+    )
+    return 1
   }
 
   try {
@@ -249,19 +338,22 @@ async function main() {
       }
     })
   } catch (error) {
-    console.error(
-      `  ✗ importFitnessFilesJob failed: ${(error as Error).message}`
-    )
+    console.error(`  ✗ importFitnessFilesJob failed: ${toErrorMessage(error)}`)
     return 1
   }
 
   // Report the result grouped by the status each file now points to.
   const byStatus = new Map<string, { file: string; primary: boolean }[]>()
-  let unlinked = 0
+  const unlinked: { fileName: string; reason: string }[] = []
   for (const file of targets) {
     const refreshed = await database.getFitnessFile({ id: file.id })
     if (!refreshed?.statusId) {
-      unlinked += 1
+      // The job records why it gave up in importError — surface it instead of
+      // just counting the file, which leaves the operator with nowhere to go.
+      unlinked.push({
+        fileName: file.fileName,
+        reason: refreshed?.importError ?? 'no reason recorded'
+      })
       continue
     }
     const group = byStatus.get(refreshed.statusId) ?? []
@@ -269,7 +361,9 @@ async function main() {
     byStatus.set(refreshed.statusId, group)
   }
 
-  console.log(`Created ${byStatus.size} post(s):`)
+  console.log(
+    `Linked ${targets.length - unlinked.length} file(s) across ${byStatus.size} post(s):`
+  )
   for (const [statusId, files] of byStatus) {
     console.log(`  ✓ ${statusId}`)
     for (const f of files) {
@@ -278,11 +372,11 @@ async function main() {
       )
     }
   }
-  if (unlinked > 0) {
-    console.log(`  ✗ ${unlinked} file(s) did not get linked to a status`)
+  for (const file of unlinked) {
+    console.log(`  ✗ ${file.fileName} — not linked to a status: ${file.reason}`)
   }
 
-  return unlinked > 0 ? 1 : 0
+  return unlinked.length > 0 ? 1 : 0
 }
 
 if (require.main === module) {

--- a/scripts/fitness/importStoredFitnessFile.ts
+++ b/scripts/fitness/importStoredFitnessFile.ts
@@ -38,12 +38,17 @@ import { getDatabase } from '@/lib/database'
 import { OVERLAP_CONTEXT_SCAN_LIMIT } from '@/lib/jobs/fitnessImportOverlap'
 import { importFitnessFilesJob } from '@/lib/jobs/importFitnessFilesJob'
 import { IMPORT_FITNESS_FILES_JOB_NAME } from '@/lib/jobs/names'
+import { getFitnessFileBuffer } from '@/lib/services/fitness-files'
+import {
+  isParseableFitnessFileType,
+  parseFitnessFile
+} from '@/lib/services/fitness-files/parseFitnessFile'
 import { getStravaActivityBatchId } from '@/lib/services/strava/activityBatch'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
 
 import { printDatabaseBanner } from './describeConnection'
-import { buildStoredImportPlan } from './storedImportPlan'
+import { StoredImportTarget, buildStoredImportPlan } from './storedImportPlan'
 
 const projectDir = process.cwd()
 loadEnvConfig(projectDir, process.env.NODE_ENV === 'development')
@@ -165,6 +170,33 @@ async function main() {
   const targetIds = targets.map((f) => f.id)
   const batchId = targets[0].importBatchId ?? `manual-recover:${targets[0].id}`
 
+  // Parse each target the way importFitnessFilesJob will. A file that failed to
+  // import has no stored activity data, so planning from the row would wrongly
+  // call it ungroupable and predict a NEW post where the job actually merges.
+  const plannedTargets: StoredImportTarget[] = await Promise.all(
+    targets.map(async (file) => {
+      try {
+        if (!isParseableFitnessFileType(file.fileType)) {
+          throw new Error(`Unsupported fitness file type: ${file.fileType}`)
+        }
+        const buffer = await getFitnessFileBuffer(database, file.id, file)
+        const activityData = await parseFitnessFile({
+          fileType: file.fileType,
+          buffer
+        })
+        return {
+          file,
+          durationSeconds: activityData.totalDurationSeconds,
+          ...(activityData.startTime
+            ? { startTimeMs: activityData.startTime.getTime() }
+            : null)
+        }
+      } catch (error) {
+        return { file, parseError: (error as Error).message }
+      }
+    })
+  )
+
   // Same-ride siblings that ALREADY have a post. Handing these to the job as
   // overlap context makes it reuse the sibling's status for an overlapping
   // target instead of creating a second post for the same ride.
@@ -172,8 +204,8 @@ async function main() {
     actorId: input.actorId,
     limit: OVERLAP_CONTEXT_SCAN_LIMIT
   })
-  const { overlapFitnessFileIds, groups } = buildStoredImportPlan({
-    targets,
+  const { overlapFitnessFileIds, groups, unparseable } = buildStoredImportPlan({
+    targets: plannedTargets,
     contextFiles
   })
 
@@ -195,6 +227,9 @@ async function main() {
           ? `    post ${index + 1}: ${names} → MERGE into existing post ${group.mergeStatusId}`
           : `    post ${index + 1}: ${names} → NEW post`
       )
+    })
+    unparseable.forEach((file) => {
+      console.log(`    ✗ ${file.fileName} → would FAIL to parse: ${file.error}`)
     })
     return 0
   }

--- a/scripts/fitness/repairFailedFitnessImports.ts
+++ b/scripts/fitness/repairFailedFitnessImports.ts
@@ -45,6 +45,7 @@ import {
   IMPORT_FITNESS_FILES_JOB_NAME,
   IMPORT_STRAVA_ACTIVITY_JOB_NAME
 } from '@/lib/jobs/names'
+import { toImportErrorMessage } from '@/lib/services/fitness-files/importError'
 import { isFitnessImportStuck } from '@/lib/services/fitness-files/processingState'
 import { getStravaActivityIdFromBatchId } from '@/lib/services/strava/activityBatch'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
@@ -252,8 +253,10 @@ const repairBatch = async ({
     )
     return 'repaired'
   } catch (error) {
-    const nodeError = error as Error
-    console.error(`  [${batchId}] failed: ${nodeError.message}`)
+    // Non-Error throws (queue SDK rejections) would make the reason undefined,
+    // which updateFitnessFileImportStatus writes as NULL — wiping the reason.
+    const errorMessage = toImportErrorMessage(error)
+    console.error(`  [${batchId}] failed: ${errorMessage}`)
 
     // The job threw after we reset the files to 'pending'. Restore them to
     // 'failed' (with the error) so they are not left stuck mid-retry and remain
@@ -263,7 +266,7 @@ const repairBatch = async ({
         await database.updateFitnessFileImportStatus(
           fileId,
           'failed',
-          nodeError.message
+          errorMessage
         )
         await database.updateFitnessFileProcessingStatus(fileId, 'failed')
       }

--- a/scripts/fitness/storedImportPlan.test.ts
+++ b/scripts/fitness/storedImportPlan.test.ts
@@ -4,6 +4,7 @@ import { buildStoredImportPlan } from './storedImportPlan'
 
 describe('buildStoredImportPlan', () => {
   const baseStart = Date.parse('2026-07-13T05:07:54.000Z')
+  const rideSeconds = 5818
   const statusId = 'https://llun.test/users/test1/statuses/good-ride'
 
   const buildFile = (overrides: Partial<FitnessFile> & { id: string }) =>
@@ -11,16 +12,24 @@ describe('buildStoredImportPlan', () => {
       actorId: 'actor1',
       statusId: null,
       fileName: `${overrides.id}.tcx`,
-      activityStartTime: baseStart,
-      totalDurationSeconds: 5818,
       ...overrides
     }) as FitnessFile
 
-  const orphan = buildFile({ id: 'orphan', fileName: 'strava-2.tcx' })
+  // The failed twin. A file that never imported has NO stored activity data —
+  // the job parses it, so the plan is built from the parsed values.
+  const orphanFile = buildFile({ id: 'orphan', fileName: 'strava-failed.tcx' })
+  const orphan = {
+    file: orphanFile,
+    startTimeMs: baseStart,
+    durationSeconds: rideSeconds
+  }
+
+  // The successful twin: already owns the post, so it carries stored data.
   const sibling = buildFile({
     id: 'sibling',
-    fileName: 'strava-1.tcx',
+    fileName: 'strava-good.tcx',
     statusId,
+    activityStartTime: baseStart,
     totalDurationSeconds: 5800
   })
 
@@ -32,8 +41,22 @@ describe('buildStoredImportPlan', () => {
 
     expect(plan.overlapFitnessFileIds).toEqual(['sibling'])
     expect(plan.groups).toEqual([
-      { targetFileNames: ['strava-2.tcx'], mergeStatusId: statusId }
+      { targetFileNames: ['strava-failed.tcx'], mergeStatusId: statusId }
     ])
+  })
+
+  it('merges even though the orphan row itself has no stored activity data', () => {
+    // Regression: predicting from the row's empty activityStartTime made the dry
+    // run report NEW post while the real import merged.
+    expect(orphanFile.activityStartTime).toBeUndefined()
+    expect(orphanFile.totalDurationSeconds).toBeUndefined()
+
+    const plan = buildStoredImportPlan({
+      targets: [orphan],
+      contextFiles: [sibling]
+    })
+
+    expect(plan.groups[0].mergeStatusId).toBe(statusId)
   })
 
   it('creates a new post when the only sibling is a different ride', () => {
@@ -50,20 +73,13 @@ describe('buildStoredImportPlan', () => {
     })
 
     expect(plan.groups).toEqual([
-      { targetFileNames: ['strava-2.tcx'], mergeStatusId: null }
+      { targetFileNames: ['strava-failed.tcx'], mergeStatusId: null }
     ])
   })
 
-  it('gives a target with no usable start time or duration its own post', () => {
-    const unparsed = buildFile({
-      id: 'unparsed',
-      fileName: 'unparsed.tcx',
-      activityStartTime: undefined,
-      totalDurationSeconds: undefined
-    })
-
+  it('gives a target with no parsed start time or duration its own post', () => {
     const plan = buildStoredImportPlan({
-      targets: [unparsed],
+      targets: [{ file: buildFile({ id: 'unparsed' }) }],
       contextFiles: [sibling]
     })
 
@@ -72,12 +88,26 @@ describe('buildStoredImportPlan', () => {
     ])
   })
 
-  it('merges two orphans of one ride into a single new post', () => {
-    const secondOrphan = buildFile({
-      id: 'orphan2',
-      fileName: 'strava-3.tcx',
-      totalDurationSeconds: 5790
+  it('reports an unparseable target instead of planning a post for it', () => {
+    const plan = buildStoredImportPlan({
+      targets: [
+        { file: buildFile({ id: 'broken' }), parseError: 'Invalid TCX file' }
+      ],
+      contextFiles: [sibling]
     })
+
+    expect(plan.groups).toEqual([])
+    expect(plan.unparseable).toEqual([
+      { fileName: 'broken.tcx', error: 'Invalid TCX file' }
+    ])
+  })
+
+  it('merges two orphans of one ride into a single new post', () => {
+    const secondOrphan = {
+      file: buildFile({ id: 'orphan2', fileName: 'strava-3.tcx' }),
+      startTimeMs: baseStart,
+      durationSeconds: 5790
+    }
 
     const plan = buildStoredImportPlan({
       targets: [orphan, secondOrphan],
@@ -87,7 +117,7 @@ describe('buildStoredImportPlan', () => {
     expect(plan.overlapFitnessFileIds).toEqual([])
     expect(plan.groups).toEqual([
       {
-        targetFileNames: ['strava-2.tcx', 'strava-3.tcx'],
+        targetFileNames: ['strava-failed.tcx', 'strava-3.tcx'],
         mergeStatusId: null
       }
     ])

--- a/scripts/fitness/storedImportPlan.test.ts
+++ b/scripts/fitness/storedImportPlan.test.ts
@@ -1,0 +1,95 @@
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+
+import { buildStoredImportPlan } from './storedImportPlan'
+
+describe('buildStoredImportPlan', () => {
+  const baseStart = Date.parse('2026-07-13T05:07:54.000Z')
+  const statusId = 'https://llun.test/users/test1/statuses/good-ride'
+
+  const buildFile = (overrides: Partial<FitnessFile> & { id: string }) =>
+    ({
+      actorId: 'actor1',
+      statusId: null,
+      fileName: `${overrides.id}.tcx`,
+      activityStartTime: baseStart,
+      totalDurationSeconds: 5818,
+      ...overrides
+    }) as FitnessFile
+
+  const orphan = buildFile({ id: 'orphan', fileName: 'strava-2.tcx' })
+  const sibling = buildFile({
+    id: 'sibling',
+    fileName: 'strava-1.tcx',
+    statusId,
+    totalDurationSeconds: 5800
+  })
+
+  it('merges an orphan into the existing post of its same-ride sibling', () => {
+    const plan = buildStoredImportPlan({
+      targets: [orphan],
+      contextFiles: [sibling]
+    })
+
+    expect(plan.overlapFitnessFileIds).toEqual(['sibling'])
+    expect(plan.groups).toEqual([
+      { targetFileNames: ['strava-2.tcx'], mergeStatusId: statusId }
+    ])
+  })
+
+  it('creates a new post when the only sibling is a different ride', () => {
+    const differentRide = buildFile({
+      id: 'different',
+      statusId,
+      activityStartTime: baseStart + 3 * 60 * 60 * 1000,
+      totalDurationSeconds: 1200
+    })
+
+    const plan = buildStoredImportPlan({
+      targets: [orphan],
+      contextFiles: [differentRide]
+    })
+
+    expect(plan.groups).toEqual([
+      { targetFileNames: ['strava-2.tcx'], mergeStatusId: null }
+    ])
+  })
+
+  it('gives a target with no usable start time or duration its own post', () => {
+    const unparsed = buildFile({
+      id: 'unparsed',
+      fileName: 'unparsed.tcx',
+      activityStartTime: undefined,
+      totalDurationSeconds: undefined
+    })
+
+    const plan = buildStoredImportPlan({
+      targets: [unparsed],
+      contextFiles: [sibling]
+    })
+
+    expect(plan.groups).toEqual([
+      { targetFileNames: ['unparsed.tcx'], mergeStatusId: null }
+    ])
+  })
+
+  it('merges two orphans of one ride into a single new post', () => {
+    const secondOrphan = buildFile({
+      id: 'orphan2',
+      fileName: 'strava-3.tcx',
+      totalDurationSeconds: 5790
+    })
+
+    const plan = buildStoredImportPlan({
+      targets: [orphan, secondOrphan],
+      contextFiles: []
+    })
+
+    expect(plan.overlapFitnessFileIds).toEqual([])
+    expect(plan.groups).toEqual([
+      {
+        targetFileNames: ['strava-2.tcx', 'strava-3.tcx'],
+        mergeStatusId: null
+      }
+    ])
+  })
+})

--- a/scripts/fitness/storedImportPlan.ts
+++ b/scripts/fitness/storedImportPlan.ts
@@ -1,0 +1,110 @@
+import {
+  FitnessOverlapActivity,
+  getOverlapContextFitnessFileIds,
+  groupFitnessActivitiesByOverlap
+} from '@/lib/jobs/fitnessImportOverlap'
+import { FitnessFile } from '@/lib/types/database/fitnessFile'
+
+export interface StoredImportGroup {
+  targetFileNames: string[]
+  // The post these targets join. Null means importFitnessFilesJob creates one.
+  mergeStatusId: string | null
+}
+
+export interface StoredImportPlan {
+  overlapFitnessFileIds: string[]
+  groups: StoredImportGroup[]
+}
+
+const toOverlapActivity = (
+  file: FitnessFile
+): FitnessOverlapActivity | null => {
+  if (
+    typeof file.activityStartTime !== 'number' ||
+    typeof file.totalDurationSeconds !== 'number' ||
+    file.totalDurationSeconds <= 0
+  ) {
+    return null
+  }
+
+  return {
+    id: file.id,
+    startTimeMs: file.activityStartTime,
+    durationSeconds: file.totalDurationSeconds
+  }
+}
+
+/**
+ * Works out — without touching the database — which orphaned targets join an
+ * existing post and which need a new one, mirroring how importFitnessFilesJob
+ * groups them.
+ *
+ * `overlapFitnessFileIds` is the sibling context handed to that job: files that
+ * ALREADY own a status. When a target overlaps one of them by >=80% on start +
+ * duration, the job reuses the sibling's status (the sibling stays primary and
+ * keeps its route map) instead of creating a duplicate post for the same ride.
+ */
+export const buildStoredImportPlan = ({
+  targets,
+  contextFiles
+}: {
+  targets: FitnessFile[]
+  contextFiles: FitnessFile[]
+}): StoredImportPlan => {
+  const overlapFitnessFileIds = [
+    ...new Set(
+      targets.flatMap((target) =>
+        getOverlapContextFitnessFileIds({
+          actorId: target.actorId,
+          fitnessFileId: target.id,
+          activityDurationSeconds: target.totalDurationSeconds ?? 0,
+          files: contextFiles,
+          ...(typeof target.activityStartTime === 'number'
+            ? { activityStartTime: target.activityStartTime }
+            : null)
+        })
+      )
+    )
+  ]
+
+  const targetById = new Map(targets.map((file) => [file.id, file]))
+  const siblingById = new Map(
+    contextFiles
+      .filter((file) => overlapFitnessFileIds.includes(file.id))
+      .map((file) => [file.id, file])
+  )
+
+  const activities = [...targets, ...siblingById.values()]
+    .map(toOverlapActivity)
+    .filter((activity): activity is FitnessOverlapActivity => activity !== null)
+
+  const groups: StoredImportGroup[] = []
+  for (const group of groupFitnessActivitiesByOverlap(activities, 0.8)) {
+    const groupTargets = group
+      .map((activity) => targetById.get(activity.id))
+      .filter((file): file is FitnessFile => Boolean(file))
+
+    // A group of siblings only, with no target in it, is an existing post that
+    // this run does not touch.
+    if (groupTargets.length === 0) continue
+
+    const mergeStatusId =
+      group
+        .map((activity) => siblingById.get(activity.id))
+        .find((file) => file?.statusId)?.statusId ?? null
+
+    groups.push({
+      targetFileNames: groupTargets.map((file) => file.fileName),
+      mergeStatusId
+    })
+  }
+
+  // A target the import could not parse a start time or duration for cannot be
+  // grouped at all, so it always becomes its own post.
+  for (const target of targets) {
+    if (toOverlapActivity(target)) continue
+    groups.push({ targetFileNames: [target.fileName], mergeStatusId: null })
+  }
+
+  return { overlapFitnessFileIds, groups }
+}

--- a/scripts/fitness/storedImportPlan.ts
+++ b/scripts/fitness/storedImportPlan.ts
@@ -127,10 +127,23 @@ export const buildStoredImportPlan = ({
     // run does not touch.
     if (groupTargets.length === 0) continue
 
+    // The job picks the status from `orderedGroup`, which sortFilesByActivityStart
+    // orders by start time then createdAt then id. Mirror that ordering, or a
+    // group holding two siblings with DIFFERENT statuses (the duplicate-post case
+    // this script repairs) would predict one post and merge into the other.
     const mergeStatusId =
       group
         .map((activity) => siblingById.get(activity.id))
-        .find((file) => file?.statusId)?.statusId ?? null
+        .filter((file): file is FitnessFile => Boolean(file?.statusId))
+        .sort((first, second) => {
+          const firstStart = first.activityStartTime ?? Number.MAX_SAFE_INTEGER
+          const secondStart =
+            second.activityStartTime ?? Number.MAX_SAFE_INTEGER
+          if (firstStart !== secondStart) return firstStart - secondStart
+          if (first.createdAt !== second.createdAt)
+            return first.createdAt - second.createdAt
+          return first.id.localeCompare(second.id)
+        })[0]?.statusId ?? null
 
     groups.push({
       targetFileNames: groupTargets.map((file) => file.fileName),

--- a/scripts/fitness/storedImportPlan.ts
+++ b/scripts/fitness/storedImportPlan.ts
@@ -5,6 +5,22 @@ import {
 } from '@/lib/jobs/fitnessImportOverlap'
 import { FitnessFile } from '@/lib/types/database/fitnessFile'
 
+/**
+ * A file to recover, with the activity data importFitnessFilesJob will see.
+ *
+ * The job PARSES each target before grouping it, so the plan must be built from
+ * the parsed values, not the row's stored ones: a file that failed to import
+ * never got activity data written, so its stored start time and duration are
+ * empty and would make it look ungroupable. `parseError` marks a target the job
+ * will reject outright.
+ */
+export interface StoredImportTarget {
+  file: FitnessFile
+  startTimeMs?: number
+  durationSeconds?: number
+  parseError?: string
+}
+
 export interface StoredImportGroup {
   targetFileNames: string[]
   // The post these targets join. Null means importFitnessFilesJob creates one.
@@ -14,30 +30,30 @@ export interface StoredImportGroup {
 export interface StoredImportPlan {
   overlapFitnessFileIds: string[]
   groups: StoredImportGroup[]
+  unparseable: { fileName: string; error: string }[]
 }
 
 const toOverlapActivity = (
-  file: FitnessFile
+  target: StoredImportTarget
 ): FitnessOverlapActivity | null => {
   if (
-    typeof file.activityStartTime !== 'number' ||
-    typeof file.totalDurationSeconds !== 'number' ||
-    file.totalDurationSeconds <= 0
+    typeof target.startTimeMs !== 'number' ||
+    typeof target.durationSeconds !== 'number' ||
+    target.durationSeconds <= 0
   ) {
     return null
   }
 
   return {
-    id: file.id,
-    startTimeMs: file.activityStartTime,
-    durationSeconds: file.totalDurationSeconds
+    id: target.file.id,
+    startTimeMs: target.startTimeMs,
+    durationSeconds: target.durationSeconds
   }
 }
 
 /**
- * Works out — without touching the database — which orphaned targets join an
- * existing post and which need a new one, mirroring how importFitnessFilesJob
- * groups them.
+ * Works out — without writing anything — which targets join an existing post and
+ * which need a new one, mirroring how importFitnessFilesJob groups them.
  *
  * `overlapFitnessFileIds` is the sibling context handed to that job: files that
  * ALREADY own a status. When a target overlaps one of them by >=80% on start +
@@ -48,35 +64,58 @@ export const buildStoredImportPlan = ({
   targets,
   contextFiles
 }: {
-  targets: FitnessFile[]
+  targets: StoredImportTarget[]
   contextFiles: FitnessFile[]
 }): StoredImportPlan => {
+  const importable = targets.filter((target) => !target.parseError)
+
   const overlapFitnessFileIds = [
     ...new Set(
-      targets.flatMap((target) =>
+      importable.flatMap((target) =>
         getOverlapContextFitnessFileIds({
-          actorId: target.actorId,
-          fitnessFileId: target.id,
-          activityDurationSeconds: target.totalDurationSeconds ?? 0,
+          actorId: target.file.actorId,
+          fitnessFileId: target.file.id,
+          activityDurationSeconds: target.durationSeconds ?? 0,
           files: contextFiles,
-          ...(typeof target.activityStartTime === 'number'
-            ? { activityStartTime: target.activityStartTime }
+          ...(typeof target.startTimeMs === 'number'
+            ? { activityStartTime: target.startTimeMs }
             : null)
         })
       )
     )
   ]
 
-  const targetById = new Map(targets.map((file) => [file.id, file]))
+  const targetById = new Map(
+    importable.map((target) => [target.file.id, target.file])
+  )
   const siblingById = new Map(
     contextFiles
       .filter((file) => overlapFitnessFileIds.includes(file.id))
       .map((file) => [file.id, file])
   )
 
-  const activities = [...targets, ...siblingById.values()]
-    .map(toOverlapActivity)
+  const siblingActivities = [...siblingById.values()]
+    .map((file) =>
+      toOverlapActivity({
+        file,
+        ...(typeof file.activityStartTime === 'number'
+          ? { startTimeMs: file.activityStartTime }
+          : null),
+        ...(typeof file.totalDurationSeconds === 'number'
+          ? { durationSeconds: file.totalDurationSeconds }
+          : null)
+      })
+    )
     .filter((activity): activity is FitnessOverlapActivity => activity !== null)
+
+  const activities = [
+    ...importable
+      .map(toOverlapActivity)
+      .filter(
+        (activity): activity is FitnessOverlapActivity => activity !== null
+      ),
+    ...siblingActivities
+  ]
 
   const groups: StoredImportGroup[] = []
   for (const group of groupFitnessActivitiesByOverlap(activities, 0.8)) {
@@ -84,8 +123,8 @@ export const buildStoredImportPlan = ({
       .map((activity) => targetById.get(activity.id))
       .filter((file): file is FitnessFile => Boolean(file))
 
-    // A group of siblings only, with no target in it, is an existing post that
-    // this run does not touch.
+    // A group of siblings only, with no target in it, is an existing post this
+    // run does not touch.
     if (groupTargets.length === 0) continue
 
     const mergeStatusId =
@@ -99,12 +138,24 @@ export const buildStoredImportPlan = ({
     })
   }
 
-  // A target the import could not parse a start time or duration for cannot be
-  // grouped at all, so it always becomes its own post.
-  for (const target of targets) {
+  // A target the parse found no start time or duration for cannot be grouped at
+  // all, so the job always gives it its own post.
+  for (const target of importable) {
     if (toOverlapActivity(target)) continue
-    groups.push({ targetFileNames: [target.fileName], mergeStatusId: null })
+    groups.push({
+      targetFileNames: [target.file.fileName],
+      mergeStatusId: null
+    })
   }
 
-  return { overlapFitnessFileIds, groups }
+  return {
+    overlapFitnessFileIds,
+    groups,
+    unparseable: targets
+      .filter((target) => target.parseError)
+      .map((target) => ({
+        fileName: target.file.fileName,
+        error: target.parseError as string
+      }))
+  }
 }


### PR DESCRIPTION
## Context

A Strava TCX import failed to process and never made it into a status, while its **same-ride twin** (the other Strava activity for the same ride) imported fine. Investigating the reported file showed the file itself was healthy: it parses to 5564 trackpoints / 38.1 km / 1:36:58 / `Ride`, and the full pipeline (parse → privacy → `generateMapImage`) runs clean on it. It is also a file *we* generated, via `buildTcxFromStravaStreams`.

Two real gaps came out of that:

1. **The failure reason was unrecoverable.** `processFitnessFileJob` logged the error and then wrote only `processingStatus = 'failed'` — so once the worker logs were gone, nothing said *why*.
2. **A half-failed same-ride pair could not be recovered without data loss.** `importStoredFitnessFile.ts` passed `overlapFitnessFileIds: []` and skipped any file that already had a status, so the only documented way to bundle the orphan into its twin's post was to **delete the good post first**.

## Changes

**Persist the failure reason.** `updateFitnessFileProcessingStatus` takes an optional error and records it in the existing `importError` column (capped at 1000 chars), clearing it on `completed`/`pending` so a stale message can't outlive a retry. No migration — the column already exists, and the settings UI already renders it, so the next failure explains itself in the app.

This covers *thrown* errors. A hard-killed worker (OOM/SIGABRT) still writes nothing and is left to the existing stuck-file detector.

**Merge an orphan into its same-ride post.** `getOverlapContextFitnessFileIds` moves to `lib/jobs/fitnessImportOverlap.ts` (exported, no behavior change) so the recovery script can find siblings that already own a post and hand them to `importFitnessFilesJob` as overlap context. The job then reuses that status instead of creating a duplicate: the sibling stays primary and keeps its route map, and the orphan is attached as non-primary (`completed`, error cleared, no second map). The good post's row is never written to.

`--dry-run` now reports `MERGE into existing post <id>` vs `NEW post` per post, so the 80%-overlap threshold can't surprise you after the fact.

## Notes

- The dry run initially predicted `NEW post` while the real import merged — it planned from the target row's *stored* activity data, which is empty precisely because the file failed before parsing. It now parses each target the way the job does.
- `getFitnessFileBuffer` was duplicated in both jobs; extracted to `lib/services/fitness-files` and reused.

## Verification

Full suite green (6146 tests), lint 0 errors, build compiles.

Driven end-to-end against a throwaway local SQLite with the **real reported TCX**, seeded as a successful twin owning a post plus its orphaned failed twin:

- dry run → `MERGE into existing post .../statuses/good-ride`
- real run → orphan gets `statusId=good-ride`, `isPrimary=0`, `processingStatus=completed`, `importError=NULL`, parsed to 38117 m / 5818 s
- good file keeps `isPrimary=1` + its map
- exactly **1** status and **1** route-map attachment (no duplicate post, no second map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)