### PR TITLE
Bump version to v1.101.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.1",
+  "version": "1.101.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.1`
- Base main SHA: `6ca0029582680c7122033d7a94f77bb061fc1f09`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
