### PR TITLE
Bump version to v1.101.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.2",
+  "version": "1.101.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.2`
- Base main SHA: `ffced0e33befb8ac31494ee685ca67d1b7eb4e1c`
- Included commits: `6`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
