### PR TITLE
fix: show remote actor profile data and posts in the Mastodon API

### DIFF
--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -1,22 +1,19 @@
-import { getActorFollowers } from '@/lib/activities/getActorFollowers'
-import { getActorFollowing } from '@/lib/activities/getActorFollowing'
+import { getActorCollectionCounts } from '@/lib/activities/getActorCollectionCounts'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
-import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
-import { logger } from '@/lib/utils/logger'
 
 import { getProfileData } from './getProfileData'
 
 // Mock dependencies via Jest module name mapper aliases
-vi.mock('@/lib/activities/getActorFollowers')
-vi.mock('@/lib/activities/getActorFollowing')
+vi.mock('@/lib/activities/getActorCollectionCounts')
 vi.mock('@/lib/activities/getActorPerson')
 vi.mock('@/lib/activities/getActorPosts')
 vi.mock('@/lib/activities/getWebfingerSelf')
@@ -195,13 +192,12 @@ describe('getProfileData', () => {
         statuses: mockStatuses,
         statusesCount: 0
       })
-      ;(getActorFollowing as jest.Mock).mockResolvedValue({
-        followingCount: 10
+      ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
+        followersCount: 20,
+        followingCount: 10,
+        statusesCount: 0
       })
-      ;(getActorFollowers as jest.Mock).mockResolvedValue({
-        followerCount: 20
-      })
-      ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+      ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(
         mockFederationSigningActor
       )
     })
@@ -237,7 +233,10 @@ describe('getProfileData', () => {
       // 404ing. See getFederationSigningActor.
       await getProfileData(mockDatabase, '@remoteuser@remote.com', true)
 
-      expect(getFederationSigningActor).toHaveBeenCalledWith(mockDatabase)
+      expect(getFederationSigningActorSafe).toHaveBeenCalledWith(
+        mockDatabase,
+        expect.any(String)
+      )
       expect(getActorPerson).toHaveBeenCalledWith({
         actorId: 'https://remote.com/users/remoteuser',
         signingActor: mockFederationSigningActor
@@ -248,13 +247,45 @@ describe('getProfileData', () => {
         pageUrl: undefined,
         signingActor: mockFederationSigningActor
       })
-      expect(getActorFollowing).toHaveBeenCalledWith({
+      expect(getActorCollectionCounts).toHaveBeenCalledWith({
         person: mockPerson,
         signingActor: mockFederationSigningActor
       })
-      expect(getActorFollowers).toHaveBeenCalledWith({
-        person: mockPerson,
-        signingActor: mockFederationSigningActor
+    })
+
+    it('persists the fetched profile snapshot and collection counts for known actors', async () => {
+      ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
+        followersCount: 5370,
+        followingCount: 519,
+        statusesCount: null
+      })
+
+      const result = await getProfileData(
+        mockDatabase,
+        '@remoteuser@remote.com',
+        true
+      )
+
+      expect(result).toMatchObject({
+        followersCount: 5370,
+        followingCount: 519
+      })
+      // Same field set recordActorIfNeeded persists (getPersistableProfile),
+      // so both refresh paths write consistent snapshots.
+      expect(mockDatabase.updateActor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: mockPerson.id,
+          name: 'Remote User',
+          summary: 'A remote user',
+          manuallyApprovesFollowers: false,
+          fields: []
+        })
+      )
+      expect(mockDatabase.setActorCounters).toHaveBeenCalledWith({
+        actorId: mockPerson.id,
+        followersCount: 5370,
+        followingCount: 519,
+        statusCount: null
       })
     })
 
@@ -299,41 +330,18 @@ describe('getProfileData', () => {
       // Should NOT call expensive remote APIs — including the signer, so an
       // anonymous page view never resolves or provisions the instance actor.
       expect(getWebfingerSelf).not.toHaveBeenCalled()
-      expect(getFederationSigningActor).not.toHaveBeenCalled()
+      expect(getFederationSigningActorSafe).not.toHaveBeenCalled()
       expect(getActorPerson).not.toHaveBeenCalled()
       expect(getActorPosts).not.toHaveBeenCalled()
-      expect(getActorFollowing).not.toHaveBeenCalled()
-      expect(getActorFollowers).not.toHaveBeenCalled()
-    })
-
-    it('falls back to an unsigned fetch when the signer resolution fails', async () => {
-      // A transient instance-actor failure (DB/keypair error) must not crash
-      // the render: getProfileData resolves the signer best-effort, so a
-      // rejection degrades to an unsigned fetch instead of a 500.
-      ;(getFederationSigningActor as jest.Mock).mockRejectedValue(
-        new Error('signer unavailable')
-      )
-
-      const result = await getProfileData(
-        mockDatabase,
-        '@remoteuser@remote.com',
-        true
-      )
-
-      expect(result).not.toBeNull()
-      const personCall = (getActorPerson as jest.Mock).mock.calls[0][0]
-      expect('signingActor' in personCall).toBe(false)
-      // The failure is surfaced (not silently swallowed) so a persistently
-      // broken signer stays diagnosable.
-      expect(logger.warn).toHaveBeenCalled()
+      expect(getActorCollectionCounts).not.toHaveBeenCalled()
     })
 
     it('omits the signing actor entirely when no instance actor is available', async () => {
-      // getFederationSigningActor returns undefined when the instance actor
-      // could not be resolved/provisioned. The fetch must then fall back to an
-      // unsigned request (no `signingActor` key at all) rather than passing
-      // `signingActor: undefined` downstream. This locks in the `: {}` branch.
-      ;(getFederationSigningActor as jest.Mock).mockResolvedValue(undefined)
+      // getFederationSigningActorSafe owns the warn-and-degrade handling and
+      // returns undefined when the instance actor could not be resolved. The
+      // fetch must then fall back to an unsigned request (no `signingActor`
+      // key at all) rather than passing `signingActor: undefined` downstream.
+      ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(undefined)
 
       const result = await getProfileData(
         mockDatabase,
@@ -397,13 +405,12 @@ describe('getProfileData', () => {
         statuses: mockStatuses,
         statusesCount: 0
       })
-      ;(getActorFollowing as jest.Mock).mockResolvedValue({
-        followingCount: 10
+      ;(getActorCollectionCounts as jest.Mock).mockResolvedValue({
+        followersCount: 20,
+        followingCount: 10,
+        statusesCount: 0
       })
-      ;(getActorFollowers as jest.Mock).mockResolvedValue({
-        followerCount: 20
-      })
-      ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+      ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(
         mockFederationSigningActor
       )
 

--- a/app/(timeline)/[actor]/getProfileData.test.ts
+++ b/app/(timeline)/[actor]/getProfileData.test.ts
@@ -39,6 +39,7 @@ describe('getProfileData', () => {
     getActorFollowingCount: vi.fn(),
     getActorFollowersCount: vi.fn(),
     getActorHasFitnessData: vi.fn(),
+    setActorCounters: vi.fn(),
     updateActor: vi.fn()
   } as unknown as Database
 
@@ -105,6 +106,7 @@ describe('getProfileData', () => {
     ;(mockDatabase.getActorFollowingCount as jest.Mock).mockResolvedValue(10)
     ;(mockDatabase.getActorFollowersCount as jest.Mock).mockResolvedValue(20)
     ;(mockDatabase.getActorHasFitnessData as jest.Mock).mockResolvedValue(false)
+    ;(mockDatabase.setActorCounters as jest.Mock).mockResolvedValue(undefined)
     ;(getPersonFromActor as jest.Mock).mockReturnValue(mockPerson)
   })
 

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -147,6 +147,29 @@ export const getProfileData = async (
     getActorFollowers({ person, ...signingParams })
   ])
 
+  // Persist the freshly-fetched collection sizes for known actors so the
+  // Mastodon API (which reads the counter rows) serves the same counts this
+  // page displays. The collection helpers report 0 for both "empty" and
+  // "fetch failed", so only positive values are trusted here — null preserves
+  // the stored counter. Best-effort — the page renders from the live values
+  // either way.
+  if (persistedActor) {
+    await database
+      .setActorCounters({
+        actorId: person.id,
+        followersCount: actorFollowersResponse.followerCount || null,
+        followingCount: actorFollowingResponse.followingCount || null,
+        statusCount: actorPostsResponse.statusesCount || null
+      })
+      .catch((error) => {
+        logger.warn({
+          message: 'Failed to persist remote actor collection counts',
+          actorId: person.id,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+  }
+
   return {
     ...actorPostsResponse,
     person,

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -1,14 +1,13 @@
-import { getActorFollowers } from '@/lib/activities/getActorFollowers'
-import { getActorFollowing } from '@/lib/activities/getActorFollowing'
+import { getPersistableProfile } from '@/lib/actions/utils'
+import { getActorCollectionCounts } from '@/lib/activities/getActorCollectionCounts'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { getWebfingerSelf } from '@/lib/activities/getWebfingerSelf'
 import { Database } from '@/lib/database/types'
-import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { Actor } from '@/lib/types/activitypub'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status } from '@/lib/types/domain/status'
-import { getActorImageUrl } from '@/lib/utils/activitypubActor'
 import { getPersonFromActor } from '@/lib/utils/getPersonFromActor'
 import { logger } from '@/lib/utils/logger'
 
@@ -88,27 +87,14 @@ export const getProfileData = async (
   // resolvable). The instance actor always exists, always has a private key,
   // and is served at a publicly resolvable URL so the remote can fetch its key
   // and verify the signature. This is the same headless signer used by the
-  // federation jobs and relay/follow flows (getFederationSigningActor); without
-  // it, secure-mode remote profiles 404.
+  // federation jobs and relay/follow flows; without it, secure-mode remote
+  // profiles 404. Resolution is best-effort and degrades to an unsigned fetch.
   //
   // WebFinger discovery and signer resolution are independent, so resolve them
   // concurrently to avoid stacking their latencies on the profile render.
-  // Signer resolution is best-effort: a missing/failed instance actor must not
-  // turn a clean 404 (unknown actor) into a 500, so a failure degrades to an
-  // unsigned fetch via the `signingActor`-less branch below.
   const [actorId, signingActor] = await Promise.all([
     getWebfingerSelf({ account: actorHandle.slice(1) }),
-    getFederationSigningActor(database).catch((error) => {
-      // Degrade to an unsigned fetch, but surface the failure so a persistently
-      // broken signer (which would silently 404 every secure-mode profile)
-      // remains diagnosable rather than vanishing.
-      logger.warn({
-        message:
-          'Failed to resolve federation signing actor for remote profile fetch; falling back to an unsigned request',
-        error: error instanceof Error ? error.message : String(error)
-      })
-      return undefined
-    })
+    getFederationSigningActorSafe(database, 'for remote profile fetch')
   ])
   if (!actorId) return null
 
@@ -117,48 +103,40 @@ export const getProfileData = async (
   if (!person) return null
 
   if (persistedActor) {
+    // Same field set recordActorIfNeeded persists, so the web profile page
+    // and the Mastodon API refresh paths write consistent snapshots (including
+    // metadata fields and the locked state).
     await database.updateActor({
       actorId: person.id,
-      name: person.name,
-      summary: person.summary || '',
-      iconUrl: getActorImageUrl(person.icon),
-      headerImageUrl: getActorImageUrl(person.image),
-      publicKey: person.publicKey.publicKeyPem,
-      followersUrl: person.followers,
-      inboxUrl: person.inbox,
-      sharedInboxUrl: person.endpoints?.sharedInbox || ''
+      ...getPersistableProfile(person)
     })
   }
 
-  const [
-    actorPostsResponse,
-    attachments,
-    actorFollowingResponse,
-    actorFollowersResponse
-  ] = await Promise.all([
-    getActorPosts({
-      database,
-      person,
-      pageUrl: options.statusPageUrl,
-      ...signingParams
-    }),
-    database.getAttachmentsForActor({ actorId: person.id }),
-    getActorFollowing({ person, ...signingParams }),
-    getActorFollowers({ person, ...signingParams })
-  ])
+  const [actorPostsResponse, attachments, collectionCounts] = await Promise.all(
+    [
+      getActorPosts({
+        database,
+        person,
+        pageUrl: options.statusPageUrl,
+        ...signingParams
+      }),
+      database.getAttachmentsForActor({ actorId: person.id }),
+      getActorCollectionCounts({ person, ...signingParams })
+    ]
+  )
 
   // Persist the freshly-fetched collection sizes for known actors so the
   // Mastodon API (which reads the counter rows) serves the same counts this
-  // page displays. The collection helpers report 0 for both "empty" and
-  // "fetch failed", so only positive values are trusted here — null preserves
-  // the stored counter. Best-effort — the page renders from the live values
-  // either way.
+  // page displays. getActorCollectionCounts distinguishes a fetch failure
+  // (null, preserves the stored counter) from a real zero. getActorPosts
+  // reports 0 for both, so only positive status counts are trusted here.
+  // Best-effort — the page renders from the live values either way.
   if (persistedActor) {
     await database
       .setActorCounters({
         actorId: person.id,
-        followersCount: actorFollowersResponse.followerCount || null,
-        followingCount: actorFollowingResponse.followingCount || null,
+        followersCount: collectionCounts.followersCount,
+        followingCount: collectionCounts.followingCount,
         statusCount: actorPostsResponse.statusesCount || null
       })
       .catch((error) => {
@@ -178,8 +156,8 @@ export const getProfileData = async (
       prevPageUrl: actorPostsResponse.prevPageUrl ?? null
     },
     attachments,
-    followingCount: actorFollowingResponse.followingCount,
-    followersCount: actorFollowersResponse.followerCount,
+    followingCount: collectionCounts.followingCount ?? 0,
+    followersCount: collectionCounts.followersCount ?? 0,
     isInternalAccount: false,
     hasFitnessData: false
   }

--- a/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.test.ts
@@ -2,7 +2,8 @@ import { NextRequest } from 'next/server'
 
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
-import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { StatusType } from '@/lib/types/domain/status'
 import { urlToId } from '@/lib/utils/urlToId'
 
@@ -30,6 +31,7 @@ vi.mock('@/lib/services/guards/OAuthGuard', () => ({
 
 vi.mock('@/lib/activities/getActorPerson')
 vi.mock('@/lib/activities/getActorPosts')
+vi.mock('@/lib/services/federation/domainPolicy')
 vi.mock('@/lib/services/federation/getFederationSigningActor')
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
@@ -48,7 +50,8 @@ const createRequest = (query = '') =>
 describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+    ;(canFederateWithDomain as jest.Mock).mockResolvedValue(true)
+    ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(
       mockInstanceActor
     )
     ;(getActorPerson as jest.Mock).mockResolvedValue({
@@ -119,10 +122,10 @@ describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
     })
   })
 
-  it('falls back to an unsigned fetch and warns when the signing actor cannot be resolved', async () => {
-    ;(getFederationSigningActor as jest.Mock).mockRejectedValue(
-      new Error('database down')
-    )
+  it('issues an unsigned fetch when no signing actor can be resolved', async () => {
+    // getFederationSigningActorSafe owns the warn-and-degrade behavior; the
+    // route only needs to tolerate the undefined signer it returns.
+    ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(undefined)
 
     const response = await GET(createRequest(), {
       params: Promise.resolve({ id: urlToId(actorId) })
@@ -137,30 +140,18 @@ describe('GET /api/v1/accounts/[id]/remote-statuses', () => {
     expect((getActorPosts as jest.Mock).mock.calls[0][0].signingActor).toBe(
       undefined
     )
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining(
-          'Failed to resolve federation signing actor'
-        )
-      })
-    )
   })
 
-  it('issues an unsigned fetch without warning when no signing actor exists', async () => {
-    ;(getFederationSigningActor as jest.Mock).mockResolvedValue(undefined)
+  it('returns 404 for actors on blocked federation domains without fetching', async () => {
+    ;(canFederateWithDomain as jest.Mock).mockResolvedValue(false)
 
     const response = await GET(createRequest(), {
       params: Promise.resolve({ id: urlToId(actorId) })
     })
 
-    expect(response.status).toBe(200)
-    expect((getActorPerson as jest.Mock).mock.calls[0][0].signingActor).toBe(
-      undefined
-    )
-    expect((getActorPosts as jest.Mock).mock.calls[0][0].signingActor).toBe(
-      undefined
-    )
-    expect(mockLoggerWarn).not.toHaveBeenCalled()
+    expect(response.status).toBe(404)
+    expect(getActorPerson).not.toHaveBeenCalled()
+    expect(getActorPosts).not.toHaveBeenCalled()
   })
 
   it('returns bad request for invalid page urls', async () => {

--- a/app/api/v1/accounts/[id]/remote-statuses/route.ts
+++ b/app/api/v1/accounts/[id]/remote-statuses/route.ts
@@ -3,12 +3,12 @@ import { z } from 'zod'
 import { isCollectionPageUrl } from '@/lib/activities/getActorCollections'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
-import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { OAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { Scope } from '@/lib/types/database/operations'
 import { cleanJson } from '@/lib/utils/cleanJson'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { logger } from '@/lib/utils/logger'
 import {
   ERROR_400,
   apiCorsError,
@@ -59,17 +59,14 @@ export const GET = traceApiRoute(
     // instance actor always exists, always has a private key, and is served at
     // a publicly resolvable URL so the remote can fetch its key and verify the
     // signature. Resolution is best-effort: a missing/failed signer degrades to
-    // an unsigned fetch (a clean 404) rather than turning into a 500.
-    const signingActor = await getFederationSigningActor(database).catch(
-      (error) => {
-        logger.warn({
-          message:
-            'Failed to resolve federation signing actor for remote account statuses; falling back to an unsigned request',
-          error: error instanceof Error ? error.message : String(error)
-        })
-        return undefined
-      }
-    )
+    // an unsigned fetch (a clean 404) rather than turning into a 500. Domain
+    // policy applies to every live-outbox surface: blocked domains are not
+    // fetchable here either.
+    const [canFederate, signingActor] = await Promise.all([
+      canFederateWithDomain(database, actorId),
+      getFederationSigningActorSafe(database, 'for remote account statuses')
+    ])
+    if (!canFederate) return apiCorsError(req, CORS_HEADERS, 404)
 
     const person = await getActorPerson({ actorId, signingActor })
     if (!person) return apiCorsError(req, CORS_HEADERS, 404)

--- a/app/api/v1/accounts/[id]/remove_from_followers/route.ts
+++ b/app/api/v1/accounts/[id]/remove_from_followers/route.ts
@@ -45,14 +45,15 @@ export const POST = traceApiRoute(
       })
 
       if (follow && follow.status === FollowStatus.enum.Accepted) {
+        // updateFollowStatus decrements both actors' follow counters inside
+        // its transaction. Do NOT recount them from the local follows table
+        // here: for a remote target that recount would overwrite the
+        // remote-advertised totalFollowing synced from their server with a
+        // local-only value.
         await database.updateFollowStatus({
           followId: follow.id,
           status: FollowStatus.enum.Undo
         })
-        await Promise.all([
-          database.updateActorFollowersCount(currentActor.id),
-          database.updateActorFollowingCount(targetActorId)
-        ])
 
         // Federate the removal to remote followers so they learn they were
         // removed (Mastodon sends a Reject for the original Follow).

--- a/app/api/v1/accounts/[id]/route.test.ts
+++ b/app/api/v1/accounts/[id]/route.test.ts
@@ -2,7 +2,8 @@ import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { seedDatabase } from '@/lib/stub/database'
-import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { urlToId } from '@/lib/utils/urlToId'
 
 import { GET } from './route'
@@ -10,6 +11,12 @@ import { GET } from './route'
 const mockGetServerSession = vi.fn()
 vi.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: () => mockGetServerSession()
+}))
+
+const mockRecordActorIfNeeded = vi.fn()
+vi.mock('@/lib/actions/utils', () => ({
+  recordActorIfNeeded: (...params: unknown[]) =>
+    mockRecordActorIfNeeded(...params)
 }))
 
 let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
@@ -58,6 +65,7 @@ describe('GET /api/v1/accounts/:id', () => {
     vi.clearAllMocks()
     // Public endpoint: no session.
     mockGetServerSession.mockResolvedValue(null)
+    mockRecordActorIfNeeded.mockResolvedValue(undefined)
   })
 
   it('returns the public account without authentication', async () => {
@@ -90,5 +98,58 @@ describe('GET /api/v1/accounts/:id', () => {
       params: Promise.resolve({ id: urlToId(unknown) })
     })
     expect(response.status).toBe(404)
+  })
+
+  it('refreshes known remote actors for authenticated viewers', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockRecordActorIfNeeded).toHaveBeenCalledWith({
+      actorId: EXTERNAL_ACTOR1,
+      database
+    })
+  })
+
+  it('does not refresh local actors for authenticated viewers', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+
+    const response = await GET(createRequest(ACTOR1_ID), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockRecordActorIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger remote fetches for anonymous viewers', async () => {
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockRecordActorIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('serves the stored account when the remote refresh fails', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+    mockRecordActorIfNeeded.mockRejectedValue(new Error('remote down'))
+
+    const response = await GET(createRequest(EXTERNAL_ACTOR1), {
+      params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.id).toBe(urlToId(EXTERNAL_ACTOR1))
   })
 })

--- a/app/api/v1/accounts/[id]/route.ts
+++ b/app/api/v1/accounts/[id]/route.ts
@@ -1,3 +1,4 @@
+import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { localizeAccount } from '@/lib/services/accounts/localizeAccount'
 import {
   OptionalOAuthGuard,
@@ -6,6 +7,7 @@ import {
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
+import { logger } from '@/lib/utils/logger'
 import { apiCorsError, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 import { idToUrl } from '@/lib/utils/urlToId'
@@ -29,10 +31,33 @@ export const GET = traceApiRoute(
   OptionalOAuthGuard<Params>(
     [Scope.enum.read, Scope.enum['read:accounts']],
     async (req, context) => {
-      const { database, params } = context
+      const { database, currentActor, params } = context
       const encodedAccountId = (await params).id
       if (!encodedAccountId) return apiCorsError(req, CORS_HEADERS, 400)
       const id = idToUrl(encodedAccountId)
+
+      // Opening a profile is the moment a client needs current remote data
+      // (display name, bio, lock state, follower/following/status counts), so
+      // refresh known remote actors here. recordActorIfNeeded is a no-op for
+      // recently-synced actors, only refreshing stale ones, and any failure
+      // falls back to the stored profile. Gated on an authenticated viewer and
+      // an already-known actor so anonymous requests never trigger remote
+      // fetches for arbitrary ids.
+      if (currentActor) {
+        const persistedActor = await database.getActorFromId({ id })
+        if (persistedActor && !persistedActor.privateKey) {
+          await recordActorIfNeeded({ actorId: id, database }).catch(
+            (error) => {
+              logger.warn({
+                message: 'Failed to refresh remote actor for account view',
+                actorId: id,
+                error: error instanceof Error ? error.message : String(error)
+              })
+            }
+          )
+        }
+      }
+
       const actor = await database.getMastodonActorFromId({ id })
       if (!actor) return apiCorsError(req, CORS_HEADERS, 404)
       return apiResponse({

--- a/app/api/v1/accounts/[id]/route.ts
+++ b/app/api/v1/accounts/[id]/route.ts
@@ -44,8 +44,11 @@ export const GET = traceApiRoute(
       // an already-known actor so anonymous requests never trigger remote
       // fetches for arbitrary ids.
       if (currentActor) {
-        const persistedActor = await database.getActorFromId({ id })
-        if (persistedActor && !persistedActor.privateKey) {
+        const [persistedActor, isInternalActor] = await Promise.all([
+          database.getActorFromId({ id }),
+          database.isInternalActor({ actorId: id })
+        ])
+        if (persistedActor && !isInternalActor) {
           await recordActorIfNeeded({ actorId: id, database }).catch(
             (error) => {
               logger.warn({

--- a/app/api/v1/accounts/[id]/route.ts
+++ b/app/api/v1/accounts/[id]/route.ts
@@ -44,11 +44,15 @@ export const GET = traceApiRoute(
       // an already-known actor so anonymous requests never trigger remote
       // fetches for arbitrary ids.
       if (currentActor) {
-        const [persistedActor, isInternalActor] = await Promise.all([
-          database.getActorFromId({ id }),
-          database.isInternalActor({ actorId: id })
-        ])
-        if (persistedActor && !isInternalActor) {
+        const persistedActor = await database.getActorFromId({ id })
+        // Internal actors (account-backed users and the headless signer, which
+        // always carries a private key) are never refreshed from the network.
+        // The loaded row already answers this, so no isInternalActor query.
+        if (
+          persistedActor &&
+          !persistedActor.account &&
+          !persistedActor.privateKey
+        ) {
           await recordActorIfNeeded({ actorId: id, database }).catch(
             (error) => {
               logger.warn({

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -7,6 +7,7 @@ import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
 import { seedActor3 } from '@/lib/stub/seed/actor3'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { type Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
@@ -18,6 +19,12 @@ const mockGetServerSession = vi.fn()
 const mockStoredToken = vi.fn()
 vi.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: () => mockGetServerSession()
+}))
+
+const mockGetRemoteActorStatuses = vi.fn()
+vi.mock('@/lib/services/mastodon/getRemoteActorStatuses', () => ({
+  getRemoteActorStatuses: (...params: unknown[]) =>
+    mockGetRemoteActorStatuses(...params)
 }))
 
 let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
@@ -76,6 +83,7 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
     vi.clearAllMocks()
     mockGetServerSession.mockResolvedValue(null)
     mockStoredToken.mockResolvedValue(null)
+    mockGetRemoteActorStatuses.mockResolvedValue([])
   })
 
   it('allows anonymous reads but only returns public and unlisted statuses', async () => {
@@ -719,6 +727,129 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
     expect(returnedStatus).not.toHaveProperty('pinned')
   })
 
+  describe('remote actor live outbox fallback', () => {
+    const buildRemoteStatus = (statusId: string): Status =>
+      ({
+        id: statusId,
+        url: statusId,
+        actorId: EXTERNAL_ACTOR1,
+        actor: null,
+        type: StatusType.enum.Note,
+        text: 'Live remote status',
+        summary: null,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        edits: [],
+        reply: '',
+        replies: [],
+        actorAnnounceStatusId: null,
+        isActorLiked: false,
+        isLocalActor: false,
+        totalLikes: 0,
+        attachments: [],
+        tags: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      }) as Status
+
+    const createRemoteRequest = (query = '') =>
+      new NextRequest(
+        `https://llun.test/api/v1/accounts/${urlToId(EXTERNAL_ACTOR1)}/statuses${query}`
+      )
+
+    it('serves live outbox statuses without pagination links when the local store is empty', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const liveStatusId = `${EXTERNAL_ACTOR1}/statuses/live-1`
+      mockGetRemoteActorStatuses.mockResolvedValue([
+        buildRemoteStatus(liveStatusId)
+      ])
+
+      const response = await GET(createRemoteRequest('?exclude_replies=true'), {
+        params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+      })
+
+      expect(response.status).toBe(200)
+      const data = (await response.json()) as Array<{ uri: string }>
+      expect(data.map((status) => status.uri)).toEqual([liveStatusId])
+      // Remote ids can't page the local store, so a live page must not
+      // advertise cursors.
+      expect(response.headers.get('Link')).toBeNull()
+      expect(mockGetRemoteActorStatuses).toHaveBeenCalledWith({
+        database,
+        actorId: EXTERNAL_ACTOR1,
+        limit: 20,
+        excludeReplies: true,
+        excludeReblogs: false,
+        onlyMedia: false
+      })
+    })
+
+    it('falls back to locally-stored statuses when the live fetch returns nothing', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const localStatusId = `${EXTERNAL_ACTOR1}/statuses/local-fallback`
+      await database.createNote({
+        id: localStatusId,
+        url: localStatusId,
+        actorId: EXTERNAL_ACTOR1,
+        text: 'Local remote-actor status',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+
+      const response = await GET(createRemoteRequest(), {
+        params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+      })
+
+      expect(response.status).toBe(200)
+      const data = (await response.json()) as Array<{ uri: string }>
+      expect(data.map((status) => status.uri)).toContain(localStatusId)
+      expect(mockGetRemoteActorStatuses).toHaveBeenCalled()
+    })
+
+    it('does not fetch remote statuses for anonymous viewers', async () => {
+      const response = await GET(createRemoteRequest(), {
+        params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+      })
+
+      expect(response.status).toBe(200)
+      expect(mockGetRemoteActorStatuses).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      { description: 'pagination requests', query: '?max_id=some-id' },
+      { description: 'pinned requests', query: '?pinned=true' },
+      { description: 'tagged requests', query: '?tagged=running' }
+    ])('does not fetch remote statuses for $description', async ({ query }) => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const response = await GET(createRemoteRequest(query), {
+        params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+      })
+
+      expect(response.status).toBe(200)
+      expect(mockGetRemoteActorStatuses).not.toHaveBeenCalled()
+    })
+
+    it('does not fetch remote statuses for local actors', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const response = await GET(createRequest(), {
+        params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+      })
+
+      expect(response.status).toBe(200)
+      expect(mockGetRemoteActorStatuses).not.toHaveBeenCalled()
+    })
+  })
+
   it('preserves compatible filter params in pagination links', async () => {
     const now = Date.now() + 80_000
     const olderStatusId = `${ACTOR1_ID}/statuses/account-link-older`
@@ -766,5 +897,42 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
     expect(link).toContain('tagged=linktag')
     expect(link).toContain('max_id=')
     expect(link).toContain('min_id=')
+  })
+
+  it('pages past an encoded max_id cursor instead of repeating the first page', async () => {
+    const now = Date.now() + 90_000
+    const olderStatusId = `${ACTOR1_ID}/statuses/account-cursor-older`
+    const newerStatusId = `${ACTOR1_ID}/statuses/account-cursor-newer`
+
+    for (const [statusId, createdAt] of [
+      [olderStatusId, now],
+      [newerStatusId, now + 1]
+    ] as const) {
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Account cursor paging',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        createdAt
+      })
+    }
+
+    const firstPage = await GET(createRequest('?limit=1'), {
+      params: Promise.resolve({ id: urlToId(ACTOR1_ID) })
+    })
+    expect(firstPage.status).toBe(200)
+    const firstData = (await firstPage.json()) as Array<{ uri: string }>
+    expect(firstData.map((status) => status.uri)).toEqual([newerStatusId])
+
+    // Clients echo the opaque encoded id from the response/Link header.
+    const secondPage = await GET(
+      createRequest(`?limit=1&max_id=${urlToId(newerStatusId)}`),
+      { params: Promise.resolve({ id: urlToId(ACTOR1_ID) }) }
+    )
+    expect(secondPage.status).toBe(200)
+    const secondData = (await secondPage.json()) as Array<{ uri: string }>
+    expect(secondData.map((status) => status.uri)).toEqual([olderStatusId])
   })
 })

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -786,6 +786,71 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
       })
     })
 
+    it('merges live statuses with locally-stored ones, preferring the local copy on id collisions', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const now = Date.now() + 100_000
+      const localOnlyStatusId = `${EXTERNAL_ACTOR1}/statuses/merge-local-only`
+      const sharedStatusId = `${EXTERNAL_ACTOR1}/statuses/merge-shared`
+      const liveOnlyStatusId = `${EXTERNAL_ACTOR1}/statuses/merge-live-only`
+
+      // A followers-only post that only exists locally must survive the live
+      // page (the remote outbox never exposes it). seedDatabase already made
+      // actor1 an accepted follower of EXTERNAL_ACTOR1, so it is readable.
+      await database.createNote({
+        id: localOnlyStatusId,
+        url: localOnlyStatusId,
+        actorId: EXTERNAL_ACTOR1,
+        text: 'Followers-only local post',
+        to: [`${EXTERNAL_ACTOR1}/followers`],
+        cc: [],
+        createdAt: now
+      })
+      await database.createNote({
+        id: sharedStatusId,
+        url: sharedStatusId,
+        actorId: EXTERNAL_ACTOR1,
+        text: 'Shared post (local copy)',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        createdAt: now + 1
+      })
+
+      mockGetRemoteActorStatuses.mockResolvedValue([
+        {
+          ...buildRemoteStatus(sharedStatusId),
+          text: 'Shared post (live copy)',
+          createdAt: now + 1,
+          updatedAt: now + 1
+        },
+        {
+          ...buildRemoteStatus(liveOnlyStatusId),
+          createdAt: now + 2,
+          updatedAt: now + 2
+        }
+      ] as Status[])
+
+      const response = await GET(createRemoteRequest(), {
+        params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+      })
+
+      expect(response.status).toBe(200)
+      const data = (await response.json()) as Array<{
+        uri: string
+        text: string | null
+      }>
+      const uris = data.map((status) => status.uri)
+      expect(uris).toContain(liveOnlyStatusId)
+      expect(uris).toContain(sharedStatusId)
+      expect(uris).toContain(localOnlyStatusId)
+      // No duplicate for the shared id, and the local copy wins.
+      expect(uris.filter((uri) => uri === sharedStatusId)).toHaveLength(1)
+      expect(
+        data.find((status) => status.uri === sharedStatusId)?.text
+      ).toContain('local copy')
+    })
+
     it('falls back to locally-stored statuses when the live fetch returns nothing', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor1.email }

--- a/app/api/v1/accounts/[id]/statuses/route.test.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.test.ts
@@ -851,6 +851,76 @@ describe('GET /api/v1/accounts/[id]/statuses', () => {
       ).toContain('local copy')
     })
 
+    it('keeps every local status on a live page instead of slicing it away', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const remoteActorId = 'https://llun.dev/users/topup'
+      await database.createActor({
+        actorId: remoteActorId,
+        username: 'topup',
+        domain: 'llun.dev',
+        followersUrl: `${remoteActorId}/followers`,
+        inboxUrl: `${remoteActorId}/inbox`,
+        sharedInboxUrl: `${remoteActorId}/inbox`,
+        publicKey: 'publicKey',
+        createdAt: Date.now()
+      })
+      const now = Date.now() + 110_000
+      const oldLocalStatusId = `${remoteActorId}/statuses/topup-local-old`
+      await database.createNote({
+        id: oldLocalStatusId,
+        url: oldLocalStatusId,
+        actorId: remoteActorId,
+        text: 'Old local post',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        createdAt: now - 10_000
+      })
+      // Two live posts newer than the local one: with limit=2 a plain
+      // sort+slice would push the local post off the (link-less) page.
+      mockGetRemoteActorStatuses.mockResolvedValue([
+        {
+          ...buildRemoteStatus(`${remoteActorId}/statuses/live-new-1`),
+          actorId: remoteActorId,
+          createdAt: now + 2,
+          updatedAt: now + 2
+        },
+        {
+          ...buildRemoteStatus(`${remoteActorId}/statuses/live-new-2`),
+          actorId: remoteActorId,
+          createdAt: now + 1,
+          updatedAt: now + 1
+        }
+      ] as Status[])
+
+      const response = await GET(
+        new NextRequest(
+          `https://llun.test/api/v1/accounts/${urlToId(remoteActorId)}/statuses?limit=2`
+        ),
+        { params: Promise.resolve({ id: urlToId(remoteActorId) }) }
+      )
+
+      expect(response.status).toBe(200)
+      const data = (await response.json()) as Array<{ uri: string }>
+      const uris = data.map((status) => status.uri)
+      expect(uris).toHaveLength(2)
+      expect(uris).toContain(oldLocalStatusId)
+      expect(uris).toContain(`${remoteActorId}/statuses/live-new-1`)
+    })
+
+    it('treats an empty cursor param as no cursor instead of rejecting it', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+
+      const response = await GET(createRemoteRequest('?max_id=&limit=1'), {
+        params: Promise.resolve({ id: urlToId(EXTERNAL_ACTOR1) })
+      })
+
+      expect(response.status).toBe(200)
+    })
+
     it('falls back to locally-stored statuses when the live fetch returns nothing', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor1.email }

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -94,10 +94,10 @@ export const GET = traceApiRoute(
       // stores raw status URLs and silently ignores an unknown cursor, which
       // would serve the same first page over and over. An undecodable cursor
       // is a deliberate 400, using the same decodeCursor rule as the timeline
-      // endpoints.
-      const maxId = decodeCursor(encodedMaxId)
-      const minId = decodeCursor(encodedMinId)
-      const sinceId = decodeCursor(encodedSinceId)
+      // endpoints; an empty cursor param means "no cursor" there too.
+      const maxId = decodeCursor(encodedMaxId || undefined)
+      const minId = decodeCursor(encodedMinId || undefined)
+      const sinceId = decodeCursor(encodedSinceId || undefined)
       if (maxId === null || minId === null || sinceId === null) {
         return apiResponse({
           req,
@@ -238,19 +238,21 @@ export const GET = traceApiRoute(
       // them — the outbox only exposes public/unlisted posts, so a follower's
       // locally-federated followers-only statuses must survive. On id
       // collisions keep the local copy: it carries viewer interaction state
-      // (favourited/bookmarked/own reblog).
+      // (favourited/bookmarked/own reblog). Every readable local status is
+      // kept (the live-fetch gate guarantees there are fewer than `limit` of
+      // them) and the newest live statuses top up the remaining slots — a
+      // live page carries no pagination links, so a follower-only local post
+      // pushed off the page would otherwise become unreachable.
       const localStatusIds = new Set(
         readableStatuses.map((status) => status.id)
       )
       const visibleStatuses = servedLiveStatuses
         ? [
             ...readableStatuses,
-            ...liveRemoteStatuses.filter(
-              (status) => !localStatusIds.has(status.id)
-            )
-          ]
-            .sort((a, b) => b.createdAt - a.createdAt)
-            .slice(0, limit)
+            ...liveRemoteStatuses
+              .filter((status) => !localStatusIds.has(status.id))
+              .slice(0, Math.max(0, limit - readableStatuses.length))
+          ].sort((a, b) => b.createdAt - a.createdAt)
         : readableStatuses.slice(0, limit)
       const visibleStatusIds = visibleStatuses.map((status) => status.id)
       const pinnedStatusIds =

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -8,6 +8,7 @@ import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
 import { getRemoteActorStatuses } from '@/lib/services/mastodon/getRemoteActorStatuses'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
+import { decodeCursor } from '@/lib/services/timelines/request'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
 import { type Status, StatusType } from '@/lib/types/domain/status'
@@ -20,7 +21,7 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl, safeIdToUrl } from '@/lib/utils/urlToId'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const MAX_STATUS_SCAN_BATCHES = 10
@@ -92,10 +93,11 @@ export const GET = traceApiRoute(
       // status URLs), so decode the cursors before querying — the database
       // stores raw status URLs and silently ignores an unknown cursor, which
       // would serve the same first page over and over. An undecodable cursor
-      // is a deliberate 400, matching the timeline endpoints.
-      const maxId = encodedMaxId ? safeIdToUrl(encodedMaxId) : undefined
-      const minId = encodedMinId ? safeIdToUrl(encodedMinId) : undefined
-      const sinceId = encodedSinceId ? safeIdToUrl(encodedSinceId) : undefined
+      // is a deliberate 400, using the same decodeCursor rule as the timeline
+      // endpoints.
+      const maxId = decodeCursor(encodedMaxId)
+      const minId = decodeCursor(encodedMinId)
+      const sinceId = decodeCursor(encodedSinceId)
       if (maxId === null || minId === null || sinceId === null) {
         return apiResponse({
           req,
@@ -216,10 +218,10 @@ export const GET = traceApiRoute(
       if (
         currentActor &&
         isFirstPage &&
-        !actor.privateKey &&
         readableStatuses.length < limit &&
         parsedParams.pinned !== true &&
-        !parsedParams.tagged
+        !parsedParams.tagged &&
+        !(await database.isInternalActor({ actorId: id }))
       ) {
         liveRemoteStatuses = await getRemoteActorStatuses({
           database,
@@ -232,8 +234,23 @@ export const GET = traceApiRoute(
       }
       const servedLiveStatuses = liveRemoteStatuses.length > 0
 
+      // Merge live statuses with the locally-stored ones instead of replacing
+      // them — the outbox only exposes public/unlisted posts, so a follower's
+      // locally-federated followers-only statuses must survive. On id
+      // collisions keep the local copy: it carries viewer interaction state
+      // (favourited/bookmarked/own reblog).
+      const localStatusIds = new Set(
+        readableStatuses.map((status) => status.id)
+      )
       const visibleStatuses = servedLiveStatuses
-        ? liveRemoteStatuses
+        ? [
+            ...readableStatuses,
+            ...liveRemoteStatuses.filter(
+              (status) => !localStatusIds.has(status.id)
+            )
+          ]
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .slice(0, limit)
         : readableStatuses.slice(0, limit)
       const visibleStatusIds = visibleStatuses.map((status) => status.id)
       const pinnedStatusIds =
@@ -276,19 +293,17 @@ export const GET = traceApiRoute(
       // Live-fetched statuses carry remote ids the local store can't use as
       // cursors (getActorStatuses ignores unknown max_id/min_id, which would
       // make clients loop over the same page), so a live page is served
-      // without pagination links.
-      const nextLink =
+      // without pagination links. The local scan was exhausted before the
+      // live fetch ran, so no stored statuses hide behind the missing links.
+      const includePaginationLinks =
         !servedLiveStatuses && mastodonStatuses.length > 0
-          ? buildLink(
-              'max_id',
-              mastodonStatuses[mastodonStatuses.length - 1].id
-            )
-          : null
+      const nextLink = includePaginationLinks
+        ? buildLink('max_id', mastodonStatuses[mastodonStatuses.length - 1].id)
+        : null
 
-      const prevLink =
-        !servedLiveStatuses && mastodonStatuses.length > 0
-          ? buildLink('min_id', mastodonStatuses[0].id)
-          : null
+      const prevLink = includePaginationLinks
+        ? buildLink('min_id', mastodonStatuses[0].id)
+        : null
 
       const links = [nextLink, prevLink].filter(Boolean).join(', ')
 

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -215,13 +215,18 @@ export const GET = traceApiRoute(
       // locally-stored statuses.
       let liveRemoteStatuses: Status[] = []
       const isFirstPage = !maxId && !minId && !sinceId
+      // Internal actors (account-backed users and the headless signer, which
+      // always carries a private key) never live-fetch their own outbox; the
+      // actor row loaded above already answers this without an
+      // isInternalActor query.
       if (
         currentActor &&
         isFirstPage &&
         readableStatuses.length < limit &&
         parsedParams.pinned !== true &&
         !parsedParams.tagged &&
-        !(await database.isInternalActor({ actorId: id }))
+        !actor.account &&
+        !actor.privateKey
       ) {
         liveRemoteStatuses = await getRemoteActorStatuses({
           database,

--- a/app/api/v1/accounts/[id]/statuses/route.ts
+++ b/app/api/v1/accounts/[id]/statuses/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/services/guards/OAuthGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { getRemoteActorStatuses } from '@/lib/services/mastodon/getRemoteActorStatuses'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { FollowStatus } from '@/lib/types/domain/follow'
@@ -19,7 +20,7 @@ import {
   defaultOptions
 } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl } from '@/lib/utils/urlToId'
+import { idToUrl, safeIdToUrl } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 const MAX_STATUS_SCAN_BATCHES = 10
@@ -82,10 +83,27 @@ export const GET = traceApiRoute(
 
       const {
         limit,
-        max_id: maxId,
-        min_id: minId,
-        since_id: sinceId
+        max_id: encodedMaxId,
+        min_id: encodedMinId,
+        since_id: encodedSinceId
       } = parsedParams
+
+      // Clients echo back the opaque ids this endpoint emits (urlToId-encoded
+      // status URLs), so decode the cursors before querying — the database
+      // stores raw status URLs and silently ignores an unknown cursor, which
+      // would serve the same first page over and over. An undecodable cursor
+      // is a deliberate 400, matching the timeline endpoints.
+      const maxId = encodedMaxId ? safeIdToUrl(encodedMaxId) : undefined
+      const minId = encodedMinId ? safeIdToUrl(encodedMinId) : undefined
+      const sinceId = encodedSinceId ? safeIdToUrl(encodedSinceId) : undefined
+      if (maxId === null || minId === null || sinceId === null) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_400,
+          responseStatusCode: 400
+        })
+      }
 
       const follow =
         currentActor && currentActor.id !== id
@@ -187,7 +205,36 @@ export const GET = traceApiRoute(
         nextMaxId = statuses[statuses.length - 1].id
       }
 
-      const visibleStatuses = readableStatuses.slice(0, limit)
+      // A remote actor's posts only exist locally once they federate here, so
+      // the local store usually can't fill a profile's first page. Fetch the
+      // actor's recent public posts live from their outbox instead — display
+      // only, nothing is persisted. Gated on an authenticated viewer (like
+      // remote lookups) and a first-page request; failures fall back to the
+      // locally-stored statuses.
+      let liveRemoteStatuses: Status[] = []
+      const isFirstPage = !maxId && !minId && !sinceId
+      if (
+        currentActor &&
+        isFirstPage &&
+        !actor.privateKey &&
+        readableStatuses.length < limit &&
+        parsedParams.pinned !== true &&
+        !parsedParams.tagged
+      ) {
+        liveRemoteStatuses = await getRemoteActorStatuses({
+          database,
+          actorId: id,
+          limit,
+          excludeReplies: parsedParams.exclude_replies === true,
+          excludeReblogs: parsedParams.exclude_reblogs === true,
+          onlyMedia: parsedParams.only_media === true
+        })
+      }
+      const servedLiveStatuses = liveRemoteStatuses.length > 0
+
+      const visibleStatuses = servedLiveStatuses
+        ? liveRemoteStatuses
+        : readableStatuses.slice(0, limit)
       const visibleStatusIds = visibleStatuses.map((status) => status.id)
       const pinnedStatusIds =
         currentActor?.id === id && parsedParams.pinned === true
@@ -226,8 +273,12 @@ export const GET = traceApiRoute(
         return `<https://${host}${pathBase}?${linkParams.toString()}>; rel="${cursorName === 'max_id' ? 'next' : 'prev'}"`
       }
 
+      // Live-fetched statuses carry remote ids the local store can't use as
+      // cursors (getActorStatuses ignores unknown max_id/min_id, which would
+      // make clients loop over the same page), so a live page is served
+      // without pagination links.
       const nextLink =
-        mastodonStatuses.length > 0
+        !servedLiveStatuses && mastodonStatuses.length > 0
           ? buildLink(
               'max_id',
               mastodonStatuses[mastodonStatuses.length - 1].id
@@ -235,7 +286,7 @@ export const GET = traceApiRoute(
           : null
 
       const prevLink =
-        mastodonStatuses.length > 0
+        !servedLiveStatuses && mastodonStatuses.length > 0
           ? buildLink('min_id', mastodonStatuses[0].id)
           : null
 

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -84,6 +84,19 @@ product or security decision, not a gap to be closed.
   `featuring` flag (Mastodon 4.4.0) also appears on the `POST /api/v1/tags/:name/feature`
   and `POST /api/v1/tags/:name/unfeature` responses.
 
+- **Remote profiles are fetched live instead of served from local history
+  only.** Mastodon renders a remote account from whatever has already federated
+  to the instance, so a small instance shows an empty profile with zeroed
+  counts. Activity.next stores the remote-advertised follower/following/status
+  collection totals when it records or refreshes a remote actor (opening a
+  profile via `GET /api/v1/accounts/:id` refreshes a stale one for
+  authenticated viewers), and `GET /api/v1/accounts/:id/statuses` falls back to
+  fetching the actor's recent public posts live from their outbox when the
+  local store cannot fill the first page for an authenticated viewer. A
+  live-served page carries no `Link` pagination headers (remote ids cannot
+  cursor the local store), and the fetched statuses are display-only — they are
+  not persisted.
+
 ## Not planned
 
 These endpoints are not implemented and are not currently on the roadmap. They

--- a/lib/actions/utils.test.ts
+++ b/lib/actions/utils.test.ts
@@ -34,7 +34,7 @@ const mockPerson = (
     publicKeyPem: 'public-key'
   },
   endpoints: {
-    sharedInbox: `https://${new URL(actorId).hostname}/inbox`
+    sharedInbox: `${new URL(actorId).origin}/inbox`
   },
   ...overrides
 })

--- a/lib/actions/utils.test.ts
+++ b/lib/actions/utils.test.ts
@@ -202,6 +202,14 @@ describe('recordActorIfNeeded', () => {
     const actor = await recordActorIfNeeded({ actorId, database })
 
     expect(actor?.id).toBe(actorId)
+
+    // The failed sync stamps the marker, so the next call must not re-attempt
+    // the remote fetch until the actor goes stale.
+    mockGetActorPerson.mockClear()
+    await expect(
+      recordActorIfNeeded({ actorId, database })
+    ).resolves.toMatchObject({ id: actorId })
+    expect(mockGetActorPerson).not.toHaveBeenCalled()
   })
 
   it('refreshes the persisted actor type for stale remote actors', async () => {

--- a/lib/actions/utils.test.ts
+++ b/lib/actions/utils.test.ts
@@ -6,10 +6,38 @@ import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { BlockedFederationDomainError, recordActorIfNeeded } from './utils'
 
 const mockGetActorPerson = vi.fn()
+const mockGetActorCollectionCounts = vi.fn()
 
 vi.mock('@/lib/activities/getActorPerson', () => ({
   getActorPerson: (...params: unknown[]) => mockGetActorPerson(...params)
 }))
+
+vi.mock('@/lib/activities/getActorCollectionCounts', () => ({
+  getActorCollectionCounts: (...params: unknown[]) =>
+    mockGetActorCollectionCounts(...params)
+}))
+
+const mockPerson = (
+  actorId: string,
+  overrides: Record<string, unknown> = {}
+) => ({
+  id: actorId,
+  type: 'Person',
+  preferredUsername: actorId.split('/').pop(),
+  followers: `${actorId}/followers`,
+  following: `${actorId}/following`,
+  inbox: `${actorId}/inbox`,
+  outbox: `${actorId}/outbox`,
+  publicKey: {
+    id: `${actorId}#main-key`,
+    owner: actorId,
+    publicKeyPem: 'public-key'
+  },
+  endpoints: {
+    sharedInbox: `https://${new URL(actorId).hostname}/inbox`
+  },
+  ...overrides
+})
 
 describe('recordActorIfNeeded', () => {
   const database = getTestSQLDatabase()
@@ -24,6 +52,11 @@ describe('recordActorIfNeeded', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockGetActorCollectionCounts.mockResolvedValue({
+      followersCount: null,
+      followingCount: null,
+      statusesCount: null
+    })
   })
 
   it('rejects actors from blocked domains before fetching them', async () => {
@@ -38,6 +71,137 @@ describe('recordActorIfNeeded', () => {
         database
       })
     ).rejects.toThrow(BlockedFederationDomainError)
+  })
+
+  it('persists remote profile data and collection counts when recording a new actor', async () => {
+    const actorId = 'https://remote-profile.test/users/matteo'
+    mockGetActorPerson.mockResolvedValue(
+      mockPerson(actorId, {
+        name: 'Matteo',
+        summary: '<p>I make apps.</p>',
+        manuallyApprovesFollowers: false,
+        published: '2018-08-10T00:00:00Z',
+        icon: { type: 'Image', url: 'https://remote-profile.test/avatar.png' },
+        image: { type: 'Image', url: 'https://remote-profile.test/header.png' },
+        attachment: [
+          {
+            type: 'PropertyValue',
+            name: 'Website',
+            value: 'https://example.com'
+          },
+          { type: 'SomethingElse', name: 'ignored' }
+        ]
+      })
+    )
+    mockGetActorCollectionCounts.mockResolvedValue({
+      followersCount: 5370,
+      followingCount: 519,
+      statusesCount: 641
+    })
+
+    const actor = await recordActorIfNeeded({ actorId, database })
+
+    expect(actor).toMatchObject({
+      id: actorId,
+      name: 'Matteo',
+      summary: '<p>I make apps.</p>',
+      iconUrl: 'https://remote-profile.test/avatar.png',
+      headerImageUrl: 'https://remote-profile.test/header.png'
+    })
+
+    const account = await database.getMastodonActorFromId({ id: actorId })
+    expect(account).toMatchObject({
+      display_name: 'Matteo',
+      locked: false,
+      followers_count: 5370,
+      following_count: 519,
+      statuses_count: 641,
+      fields: [
+        { name: 'Website', value: 'https://example.com', verified_at: null }
+      ]
+    })
+  })
+
+  it('skips remote fetches when the stored actor is fresh and counters are synced', async () => {
+    const actorId = 'https://remote-fresh.test/users/synced'
+    mockGetActorPerson.mockResolvedValue(mockPerson(actorId))
+    mockGetActorCollectionCounts.mockResolvedValue({
+      followersCount: 10,
+      followingCount: 20,
+      statusesCount: 30
+    })
+
+    await recordActorIfNeeded({ actorId, database })
+    mockGetActorPerson.mockClear()
+    mockGetActorCollectionCounts.mockClear()
+
+    const actor = await recordActorIfNeeded({ actorId, database })
+
+    expect(actor?.id).toBe(actorId)
+    expect(mockGetActorPerson).not.toHaveBeenCalled()
+    expect(mockGetActorCollectionCounts).not.toHaveBeenCalled()
+  })
+
+  it('syncs profile and counters for a fresh actor whose counters were never synced', async () => {
+    const actorId = 'https://remote-unsynced.test/users/legacy'
+    // A remote actor recorded before collection counts were persisted: fresh
+    // updatedAt but no counter rows.
+    await database.createActor({
+      actorId,
+      type: 'Person',
+      username: 'legacy',
+      domain: 'remote-unsynced.test',
+      followersUrl: `${actorId}/followers`,
+      inboxUrl: `${actorId}/inbox`,
+      sharedInboxUrl: 'https://remote-unsynced.test/inbox',
+      publicKey: 'legacy-public-key',
+      createdAt: Date.now()
+    })
+
+    mockGetActorPerson.mockResolvedValue(
+      mockPerson(actorId, {
+        name: 'Legacy Actor',
+        manuallyApprovesFollowers: false
+      })
+    )
+    mockGetActorCollectionCounts.mockResolvedValue({
+      followersCount: 12,
+      followingCount: 34,
+      statusesCount: 56
+    })
+
+    const actor = await recordActorIfNeeded({ actorId, database })
+
+    expect(actor).toMatchObject({ id: actorId, name: 'Legacy Actor' })
+    await expect(
+      database.getMastodonActorFromId({ id: actorId })
+    ).resolves.toMatchObject({
+      display_name: 'Legacy Actor',
+      locked: false,
+      followers_count: 12,
+      following_count: 34,
+      statuses_count: 56
+    })
+  })
+
+  it('returns the stored actor when a counter-only sync cannot fetch the person', async () => {
+    const actorId = 'https://remote-unreachable.test/users/offline'
+    await database.createActor({
+      actorId,
+      type: 'Person',
+      username: 'offline',
+      domain: 'remote-unreachable.test',
+      followersUrl: `${actorId}/followers`,
+      inboxUrl: `${actorId}/inbox`,
+      sharedInboxUrl: 'https://remote-unreachable.test/inbox',
+      publicKey: 'offline-public-key',
+      createdAt: Date.now()
+    })
+    mockGetActorPerson.mockResolvedValue(null)
+
+    const actor = await recordActorIfNeeded({ actorId, database })
+
+    expect(actor?.id).toBe(actorId)
   })
 
   it('refreshes the persisted actor type for stale remote actors', async () => {
@@ -93,6 +257,43 @@ describe('recordActorIfNeeded', () => {
         type: 'Service',
         publicKey: 'new-public-key'
       })
+    } finally {
+      await database.destroy()
+    }
+  })
+
+  it('returns undefined when a stale refresh cannot fetch the person', async () => {
+    const sql = knex({
+      client: 'better-sqlite3',
+      useNullAsDefault: true,
+      connection: {
+        filename: ':memory:'
+      }
+    })
+    const database = getSQLDatabase(sql)
+    await database.migrate()
+
+    try {
+      const actorId = 'https://remote-stale.test/users/gone'
+      const oldTime = new Date(Date.now() - 4 * 86_400_000)
+      await database.createActor({
+        actorId,
+        type: 'Person',
+        username: 'gone',
+        domain: 'remote-stale.test',
+        followersUrl: `${actorId}/followers`,
+        inboxUrl: `${actorId}/inbox`,
+        sharedInboxUrl: 'https://remote-stale.test/inbox',
+        publicKey: 'stale-public-key',
+        createdAt: oldTime.getTime()
+      })
+      await sql('actors').where('id', actorId).update({ updatedAt: oldTime })
+
+      mockGetActorPerson.mockResolvedValue(null)
+
+      await expect(
+        recordActorIfNeeded({ actorId, database })
+      ).resolves.toBeUndefined()
     } finally {
       await database.destroy()
     }

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -1,9 +1,14 @@
+import { getActorCollectionCounts } from '@/lib/activities/getActorCollectionCounts'
 import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { Actor as ActivityPubActor } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
-import { getActorImageUrl } from '@/lib/utils/activitypubActor'
+import {
+  getActorImageUrl,
+  getActorProfileFields
+} from '@/lib/utils/activitypubActor'
 import { logger } from '@/lib/utils/logger'
 
 interface RecordActorIfNeededParams {
@@ -11,6 +16,8 @@ interface RecordActorIfNeededParams {
   database: Database
   signingActor?: Actor
 }
+
+const REMOTE_ACTOR_REFRESH_INTERVAL_MS = 3 * 86_400_000
 
 export class BlockedFederationDomainError extends Error {
   constructor(actorId: string) {
@@ -25,6 +32,55 @@ export const assertActorCanFederate = async ({
 }: RecordActorIfNeededParams): Promise<void> => {
   if (!(await canFederateWithDomain(database, actorId))) {
     throw new BlockedFederationDomainError(actorId)
+  }
+}
+
+// Sync the collection sizes the remote server advertises (followers/following/
+// outbox totalItems) into the actor's local counter rows — the values the
+// Mastodon account serializer reads. Without this, remote actors show zero
+// followers/following and a local-only status count in Mastodon clients.
+// Best-effort: a failed sync leaves the existing counters untouched.
+const syncActorCollectionCounts = async (
+  database: Database,
+  person: ActivityPubActor,
+  signingActor?: Actor
+): Promise<void> => {
+  try {
+    const counts = await getActorCollectionCounts({ person, signingActor })
+    await database.setActorCounters({
+      actorId: person.id,
+      followersCount: counts.followersCount,
+      followingCount: counts.followingCount,
+      statusCount: counts.statusesCount
+    })
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to sync remote actor collection counts',
+      actorId: person.id,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+// The remote profile data persisted on both the create and refresh paths, so
+// Mastodon clients see the actor's real display name, bio, images, metadata
+// fields and follow-approval (locked) state instead of local defaults.
+const getPersistableProfile = (person: ActivityPubActor) => {
+  const iconUrl = getActorImageUrl(person.icon)
+  const headerImageUrl = getActorImageUrl(person.image)
+  return {
+    type: person.type,
+    ...(person.name ? { name: person.name } : {}),
+    ...(person.summary ? { summary: person.summary } : {}),
+    ...(iconUrl ? { iconUrl } : {}),
+    ...(headerImageUrl ? { headerImageUrl } : {}),
+    // ActivityStreams treats an absent flag as "does not require approval".
+    manuallyApprovesFollowers: person.manuallyApprovesFollowers ?? false,
+    fields: getActorProfileFields(person),
+    followersUrl: person.followers ?? '',
+    inboxUrl: person.inbox,
+    sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
+    publicKey: person.publicKey.publicKeyPem || ''
   }
 }
 
@@ -58,46 +114,48 @@ export const recordActorIfNeeded = async ({
   }
 
   if (!existingActor) {
+    const resolvedSigningActor = await getResolvedSigningActor()
     const person = await getActorPerson({
       actorId,
-      signingActor: await getResolvedSigningActor()
+      signingActor: resolvedSigningActor
     })
     if (!person) return
-    const iconUrl = getActorImageUrl(person.icon)
     const actor = await database.createActor({
       actorId,
-      type: person.type,
       username: person.preferredUsername,
       domain: new URL(person.id).hostname,
-      followersUrl: person.followers ?? '',
-      inboxUrl: person.inbox,
-      sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
-      ...(iconUrl ? { iconUrl } : {}),
-      publicKey: person.publicKey.publicKeyPem || '',
+      ...getPersistableProfile(person),
       createdAt: new Date(person.published ?? Date.now()).getTime()
     })
+    await syncActorCollectionCounts(database, person, resolvedSigningActor)
     return actor ?? undefined
   }
 
   const currentTime = Date.now()
   // Update actor if it's older than 3 day
-  if (currentTime - existingActor.updatedAt > 3 * 86_400_000) {
-    const person = await getActorPerson({
-      actorId,
-      signingActor: await getResolvedSigningActor()
-    })
-    if (!person) return undefined
-    const iconUrl = getActorImageUrl(person.icon)
-    const actor = await database.updateActor({
-      actorId,
-      type: person.type,
-      followersUrl: person.followers ?? '',
-      inboxUrl: person.inbox,
-      sharedInboxUrl: person.endpoints?.sharedInbox ?? person.inbox,
-      ...(iconUrl ? { iconUrl } : {}),
-      publicKey: person.publicKey.publicKeyPem || ''
-    })
-    return actor ?? undefined
+  const isStale =
+    currentTime - existingActor.updatedAt > REMOTE_ACTOR_REFRESH_INTERVAL_MS
+  // Also refresh when the actor's collection counters were never synced —
+  // remote actors recorded before counter syncing existed would otherwise
+  // keep showing zero followers/following until the next stale refresh.
+  const needsCounterSync =
+    !isStale && !(await database.hasActorCounters({ actorId }))
+  if (!isStale && !needsCounterSync) {
+    return existingActor
   }
-  return existingActor
+
+  const resolvedSigningActor = await getResolvedSigningActor()
+  const person = await getActorPerson({
+    actorId,
+    signingActor: resolvedSigningActor
+  })
+  // A counter-only sync must not degrade the previous behavior of returning
+  // the stored actor when the remote fetch fails.
+  if (!person) return isStale ? undefined : existingActor
+  const actor = await database.updateActor({
+    actorId,
+    ...getPersistableProfile(person)
+  })
+  await syncActorCollectionCounts(database, person, resolvedSigningActor)
+  return actor ?? undefined
 }

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -62,10 +62,11 @@ const syncActorCollectionCounts = async (
   }
 }
 
-// The remote profile data persisted on both the create and refresh paths, so
+// The remote profile data persisted whenever a remote actor is recorded or
+// refreshed (recordActorIfNeeded here, plus the web profile page), so
 // Mastodon clients see the actor's real display name, bio, images, metadata
 // fields and follow-approval (locked) state instead of local defaults.
-const getPersistableProfile = (person: ActivityPubActor) => {
+export const getPersistableProfile = (person: ActivityPubActor) => {
   const iconUrl = getActorImageUrl(person.icon)
   const headerImageUrl = getActorImageUrl(person.image)
   return {
@@ -123,7 +124,9 @@ export const recordActorIfNeeded = async ({
     const actor = await database.createActor({
       actorId,
       username: person.preferredUsername,
-      domain: new URL(person.id).hostname,
+      // host (not hostname) so instances on non-standard ports keep the port
+      // in the stored domain, matching getActorDomain and handle lookups.
+      domain: new URL(person.id).host,
       ...getPersistableProfile(person),
       createdAt: new Date(person.published ?? Date.now()).getTime()
     })
@@ -132,15 +135,13 @@ export const recordActorIfNeeded = async ({
   }
 
   const currentTime = Date.now()
-  // Update actor if it's older than 3 day
+  // Update actor if it's older than 3 day. Also refresh a fresh actor whose
+  // collection counters were never synced — remote actors recorded before
+  // counter syncing existed would otherwise keep showing zero
+  // followers/following until the next stale refresh.
   const isStale =
     currentTime - existingActor.updatedAt > REMOTE_ACTOR_REFRESH_INTERVAL_MS
-  // Also refresh when the actor's collection counters were never synced —
-  // remote actors recorded before counter syncing existed would otherwise
-  // keep showing zero followers/following until the next stale refresh.
-  const needsCounterSync =
-    !isStale && !(await database.hasActorCounters({ actorId }))
-  if (!isStale && !needsCounterSync) {
+  if (!isStale && (await database.hasActorCounters({ actorId }))) {
     return existingActor
   }
 
@@ -149,9 +150,16 @@ export const recordActorIfNeeded = async ({
     actorId,
     signingActor: resolvedSigningActor
   })
-  // A counter-only sync must not degrade the previous behavior of returning
-  // the stored actor when the remote fetch fails.
-  if (!person) return isStale ? undefined : existingActor
+  if (!person) {
+    if (isStale) return undefined
+    // A counter-only sync must not degrade the previous behavior of returning
+    // the stored actor when the remote fetch fails. Mark the counters synced
+    // (rows created, values preserved) so an unreachable actor doesn't
+    // re-trigger a blocking remote fetch on every subsequent call — the
+    // 3-day stale refresh remains the retry path.
+    await database.setActorCounters({ actorId })
+    return existingActor
+  }
   const actor = await database.updateActor({
     actorId,
     ...getPersistableProfile(person)

--- a/lib/actions/utils.ts
+++ b/lib/actions/utils.ts
@@ -153,11 +153,19 @@ export const recordActorIfNeeded = async ({
   if (!person) {
     if (isStale) return undefined
     // A counter-only sync must not degrade the previous behavior of returning
-    // the stored actor when the remote fetch fails. Mark the counters synced
-    // (rows created, values preserved) so an unreachable actor doesn't
+    // the stored actor when the remote fetch fails (so the marker write is
+    // best-effort too). Stamp the sync marker so an unreachable actor doesn't
     // re-trigger a blocking remote fetch on every subsequent call — the
     // 3-day stale refresh remains the retry path.
-    await database.setActorCounters({ actorId })
+    try {
+      await database.setActorCounters({ actorId })
+    } catch (error) {
+      logger.warn({
+        message: 'Failed to mark remote actor counter sync as attempted',
+        actorId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
     return existingActor
   }
   const actor = await database.updateActor({

--- a/lib/activities/getActorCollectionCounts.test.ts
+++ b/lib/activities/getActorCollectionCounts.test.ts
@@ -1,0 +1,92 @@
+import { enableFetchMocks } from 'jest-fetch-mock'
+
+import { mockRequests } from '@/lib/stub/activities'
+import { MockActivityPubPerson } from '@/lib/stub/person'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { Actor } from '@/lib/types/activitypub'
+
+import { getActorCollectionCounts } from './getActorCollectionCounts'
+import { getActorPerson } from './getActorPerson'
+
+enableFetchMocks()
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+  mockRequests(fetchMock)
+})
+
+describe('getActorCollectionCounts', () => {
+  it('returns the totalItems advertised by each collection', async () => {
+    const person = (await getActorPerson({ actorId: ACTOR1_ID })) as Actor
+
+    await expect(getActorCollectionCounts({ person })).resolves.toEqual({
+      followersCount: 8,
+      followingCount: 8,
+      statusesCount: 10
+    })
+  })
+
+  it('returns null for collections that fail to load', async () => {
+    const remoteActorId = 'https://remote.test/users/unavailable'
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      const url = new URL(req.url)
+      if (url.pathname === '/users/unavailable') {
+        return {
+          status: 200,
+          body: JSON.stringify(MockActivityPubPerson({ id: remoteActorId }))
+        }
+      }
+      if (url.pathname === '/users/unavailable/outbox') {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: `${remoteActorId}/outbox`,
+            type: 'OrderedCollection',
+            totalItems: 42
+          })
+        }
+      }
+      return { status: 404 }
+    })
+
+    const person = (await getActorPerson({ actorId: remoteActorId })) as Actor
+
+    await expect(getActorCollectionCounts({ person })).resolves.toEqual({
+      followersCount: null,
+      followingCount: null,
+      statusesCount: 42
+    })
+  })
+
+  it('returns null when a collection has no numeric totalItems', async () => {
+    const remoteActorId = 'https://remote.test/users/hidden'
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(async (req) => {
+      const url = new URL(req.url)
+      if (url.pathname === '/users/hidden') {
+        return {
+          status: 200,
+          body: JSON.stringify(MockActivityPubPerson({ id: remoteActorId }))
+        }
+      }
+      return {
+        status: 200,
+        body: JSON.stringify({
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: req.url,
+          type: 'OrderedCollection'
+        })
+      }
+    })
+
+    const person = (await getActorPerson({ actorId: remoteActorId })) as Actor
+
+    await expect(getActorCollectionCounts({ person })).resolves.toEqual({
+      followersCount: null,
+      followingCount: null,
+      statusesCount: null
+    })
+  })
+})

--- a/lib/activities/getActorCollectionCounts.ts
+++ b/lib/activities/getActorCollectionCounts.ts
@@ -1,9 +1,7 @@
-import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
-import { OrderedCollection } from '@/lib/activities/orderedCollection'
+import { fetchCollectionRoot } from '@/lib/activities/getActorCollections'
 import { Actor } from '@/lib/types/activitypub'
 import { Actor as DomainActor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
-import { request } from '@/lib/utils/request'
 
 type CollectionField = 'followers' | 'following' | 'outbox'
 
@@ -31,14 +29,8 @@ const getCollectionTotalItems = async (
   if (!url) return null
 
   try {
-    const response = await request({
-      url,
-      headers: activityPubRequestHeaders({ url, signingActor })
-    })
-    if (response.statusCode !== 200) return null
-
-    const collection = JSON.parse(response.body) as OrderedCollection
-    const totalItems = collection.totalItems
+    const { collection } = await fetchCollectionRoot({ url, signingActor })
+    const totalItems = collection?.totalItems
     if (
       typeof totalItems !== 'number' ||
       !Number.isFinite(totalItems) ||

--- a/lib/activities/getActorCollectionCounts.ts
+++ b/lib/activities/getActorCollectionCounts.ts
@@ -1,0 +1,75 @@
+import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
+import { OrderedCollection } from '@/lib/activities/orderedCollection'
+import { Actor } from '@/lib/types/activitypub'
+import { Actor as DomainActor } from '@/lib/types/domain/actor'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+
+type CollectionField = 'followers' | 'following' | 'outbox'
+
+export interface ActorCollectionCounts {
+  followersCount: number | null
+  followingCount: number | null
+  statusesCount: number | null
+}
+
+interface Params {
+  person: Actor
+  signingActor?: DomainActor
+}
+
+// Fetch a single collection root and read its advertised totalItems. Unlike
+// getActorCollections this never follows the first page — callers here only
+// need the collection size. Best-effort: any failure yields null so callers
+// can keep the locally-known value instead of overwriting it with a zero.
+const getCollectionTotalItems = async (
+  person: Actor,
+  field: CollectionField,
+  signingActor?: DomainActor
+): Promise<number | null> => {
+  const url = person[field]
+  if (!url) return null
+
+  try {
+    const response = await request({
+      url,
+      headers: activityPubRequestHeaders({ url, signingActor })
+    })
+    if (response.statusCode !== 200) return null
+
+    const collection = JSON.parse(response.body) as OrderedCollection
+    const totalItems = collection.totalItems
+    if (
+      typeof totalItems !== 'number' ||
+      !Number.isFinite(totalItems) ||
+      totalItems < 0
+    ) {
+      return null
+    }
+    return Math.floor(totalItems)
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to fetch actor collection total items',
+      actorId: person.id,
+      field,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}
+
+// The follower/following/status counts a remote actor advertises on its
+// followers/following/outbox collections. These are the numbers Mastodon
+// clients expect on an Account entity; the local database only knows about
+// relationships and statuses that involve this instance.
+export const getActorCollectionCounts = async ({
+  person,
+  signingActor
+}: Params): Promise<ActorCollectionCounts> => {
+  const [followersCount, followingCount, statusesCount] = await Promise.all([
+    getCollectionTotalItems(person, 'followers', signingActor),
+    getCollectionTotalItems(person, 'following', signingActor),
+    getCollectionTotalItems(person, 'outbox', signingActor)
+  ])
+  return { followersCount, followingCount, statusesCount }
+}

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -35,6 +35,31 @@ export const isCollectionPageUrl = (pageUrl: string, collectionUrl: string) => {
   }
 }
 
+// Fetch an ActivityPub collection root document (no page follow). Shared by
+// the full collection fetch below and the counts-only helper
+// (getActorCollectionCounts) so the fetch semantics stay in one place. A
+// non-200 response yields a null collection; network errors propagate for the
+// caller to handle.
+export const fetchCollectionRoot = async ({
+  url,
+  signingActor
+}: {
+  url: string
+  signingActor?: DomainActor
+}): Promise<{ statusCode: number; collection: OrderedCollection | null }> => {
+  const response = await request({
+    url,
+    headers: activityPubRequestHeaders({ url, signingActor })
+  })
+  if (response.statusCode !== 200) {
+    return { statusCode: response.statusCode, collection: null }
+  }
+  return {
+    statusCode: response.statusCode,
+    collection: JSON.parse(response.body) as OrderedCollection
+  }
+}
+
 export const getActorCollections = async ({
   person,
   field,
@@ -53,14 +78,11 @@ export const getActorCollections = async ({
         return null
       }
 
-      const fieldResponse = await request({
+      const fieldResponse = await fetchCollectionRoot({
         url: person[field],
-        headers: activityPubRequestHeaders({
-          url: person[field],
-          signingActor
-        })
+        signingActor
       })
-      if (fieldResponse.statusCode !== 200) {
+      if (!fieldResponse.collection) {
         span.setAttributes({
           url: person[field],
           status: fieldResponse.statusCode
@@ -72,7 +94,7 @@ export const getActorCollections = async ({
         return null
       }
 
-      const collection = JSON.parse(fieldResponse.body) as OrderedCollection
+      const collection = fieldResponse.collection
       const firstPageUrl = getOrderCollectionFirstPage(collection)
       const collectionPageUrl =
         pageUrl && isCollectionPageUrl(pageUrl, person[field])

--- a/lib/activities/getActorCollections.ts
+++ b/lib/activities/getActorCollections.ts
@@ -54,9 +54,15 @@ export const fetchCollectionRoot = async ({
   if (response.statusCode !== 200) {
     return { statusCode: response.statusCode, collection: null }
   }
-  return {
-    statusCode: response.statusCode,
-    collection: JSON.parse(response.body) as OrderedCollection
+  try {
+    return {
+      statusCode: response.statusCode,
+      collection: JSON.parse(response.body) as OrderedCollection
+    }
+  } catch {
+    // A 200 with an empty or non-JSON body is an unavailable collection, not
+    // a crash for the caller.
+    return { statusCode: response.statusCode, collection: null }
   }
 }
 

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -127,6 +127,87 @@ describe('ActorDatabase', () => {
       })
     })
 
+    describe('setActorCounters and hasActorCounters', () => {
+      it('reports unsynced counters for a freshly-created actor', async () => {
+        const actorId = `https://${TEST_DOMAIN}/users/counters-unsynced`
+        await database.createActor({
+          actorId,
+          username: 'counters-unsynced',
+          domain: TEST_DOMAIN,
+          followersUrl: `${actorId}/followers`,
+          inboxUrl: `${actorId}/inbox`,
+          sharedInboxUrl: `${actorId}/inbox`,
+          publicKey: 'publicKey',
+          createdAt: Date.now()
+        })
+
+        await expect(
+          database.hasActorCounters({ actorId })
+        ).resolves.toBeFalse()
+      })
+
+      it('stores provided counts and serves them on the Mastodon account', async () => {
+        const actorId = `https://${TEST_DOMAIN}/users/counters-set`
+        await database.createActor({
+          actorId,
+          username: 'counters-set',
+          domain: 'counters.example',
+          followersUrl: `${actorId}/followers`,
+          inboxUrl: `${actorId}/inbox`,
+          sharedInboxUrl: `${actorId}/inbox`,
+          publicKey: 'publicKey',
+          createdAt: Date.now()
+        })
+
+        await database.setActorCounters({
+          actorId,
+          followersCount: 5370,
+          followingCount: 519,
+          statusCount: 641
+        })
+
+        await expect(database.hasActorCounters({ actorId })).resolves.toBeTrue()
+        await expect(
+          database.getMastodonActorFromId({ id: actorId })
+        ).resolves.toMatchObject({
+          followers_count: 5370,
+          following_count: 519,
+          statuses_count: 641
+        })
+      })
+
+      it('preserves existing counter values for null counts while marking them synced', async () => {
+        const actorId = `https://${TEST_DOMAIN}/users/counters-partial`
+        await database.createActor({
+          actorId,
+          username: 'counters-partial',
+          domain: 'counters.example',
+          followersUrl: `${actorId}/followers`,
+          inboxUrl: `${actorId}/inbox`,
+          sharedInboxUrl: `${actorId}/inbox`,
+          publicKey: 'publicKey',
+          createdAt: Date.now()
+        })
+        await database.increaseActorStatusCount(actorId, 3)
+
+        await database.setActorCounters({
+          actorId,
+          followersCount: 12,
+          followingCount: null,
+          statusCount: null
+        })
+
+        await expect(database.hasActorCounters({ actorId })).resolves.toBeTrue()
+        await expect(
+          database.getMastodonActorFromId({ id: actorId })
+        ).resolves.toMatchObject({
+          followers_count: 12,
+          following_count: 0,
+          statuses_count: 3
+        })
+      })
+    })
+
     describe('deprecated actor', () => {
       it('returns actor from id', async () => {
         const id = `https://${TEST_DOMAIN}/users/${TEST_USERNAME3}`

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -13,7 +13,6 @@ import {
   decreaseCounterValue,
   deleteCounterValue,
   deleteCounterValues,
-  ensureCounterRow,
   getCounterValue,
   getCounterValues,
   increaseCounterValue,
@@ -1006,9 +1005,10 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
 
   // Overwrite the actor's counter rows with the collection sizes a remote
   // server advertises (followers/following/outbox totalItems). A null or
-  // undefined value keeps the locally-accumulated counter but still creates
-  // the row, so hasActorCounters reports the actor as synced even when the
-  // remote hides a collection's total.
+  // undefined value keeps the locally-accumulated counter. Every call also
+  // stamps the remote-counts-synced marker row, so hasActorCounters reports
+  // the sync as done even when the remote hides (or fails to serve) a
+  // collection's total.
   async setActorCounters({
     actorId,
     followersCount,
@@ -1021,26 +1021,32 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       [CounterKey.totalFollowing(actorId), followingCount],
       [CounterKey.totalStatus(actorId), statusCount]
     ]
-    for (const [key, value] of counters) {
-      if (typeof value === 'number') {
-        await setCounterValue(database, key, value, currentTime)
-      } else {
-        await ensureCounterRow(database, key, currentTime)
-      }
-    }
+    await Promise.all([
+      ...counters
+        .filter(
+          (counter): counter is [string, number] =>
+            typeof counter[1] === 'number'
+        )
+        .map(([key, value]) =>
+          setCounterValue(database, key, value, currentTime)
+        ),
+      setCounterValue(
+        database,
+        CounterKey.remoteCountsSyncedAt(actorId),
+        Math.floor(currentTime.getTime() / 1000),
+        currentTime
+      )
+    ])
   },
 
-  // Whether the actor's follower/following/status counter rows all exist.
-  // Missing rows mean the actor's remote collection counts were never synced
-  // (rows are created on sync even when a value is unavailable).
+  // Whether the actor's remote collection counts were ever synced (the
+  // remote-counts-synced marker row exists). The follower/following/status
+  // rows themselves can't carry this signal: local accumulation (follows,
+  // federated statuses) creates them too.
   async hasActorCounters({ actorId }: HasActorCountersParams) {
-    const keys = [
-      CounterKey.totalFollowers(actorId),
-      CounterKey.totalFollowing(actorId),
-      CounterKey.totalStatus(actorId)
-    ]
-    const counters = await getCounterValues(database, keys)
-    return keys.every((key) => key in counters)
+    const key = CounterKey.remoteCountsSyncedAt(actorId)
+    const counters = await getCounterValues(database, [key])
+    return key in counters
   },
 
   async increaseActorStatusCount(actorId: string, amount: number = 1) {
@@ -1748,6 +1754,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       await deleteCounterValue(trx, CounterKey.totalFollowing(actorId))
       await deleteCounterValue(trx, CounterKey.totalBlocking(actorId))
       await deleteCounterValue(trx, CounterKey.totalBlockedBy(actorId))
+      await deleteCounterValue(trx, CounterKey.remoteCountsSyncedAt(actorId))
 
       if (persistedActor?.accountId) {
         await decreaseCounterValue(

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -13,6 +13,7 @@ import {
   decreaseCounterValue,
   deleteCounterValue,
   deleteCounterValues,
+  ensureCounterRow,
   getCounterValue,
   getCounterValues,
   increaseCounterValue,
@@ -54,10 +55,12 @@ import {
   GetActorsFromIdsParams,
   GetActorsScheduledForDeletionParams,
   GetLocalActorsParams,
+  HasActorCountersParams,
   IsCurrentActorFollowingParams,
   IsInternalActorParams,
   NotificationPolicy,
   ScheduleActorDeletionParams,
+  SetActorCountersParams,
   StartActorDeletionParams,
   UpdateActorParams,
   UpdateNotificationPolicyParams
@@ -116,6 +119,8 @@ const insertActorWithSearchIndex = async (
     summary,
     iconUrl,
     headerImageUrl,
+    manuallyApprovesFollowers,
+    fields,
     followersUrl,
     inboxUrl,
     sharedInboxUrl,
@@ -130,7 +135,11 @@ const insertActorWithSearchIndex = async (
     headerImageUrl,
     followersUrl,
     inboxUrl,
-    sharedInboxUrl
+    sharedInboxUrl,
+    ...(manuallyApprovesFollowers !== undefined
+      ? { manuallyApprovesFollowers }
+      : null),
+    ...(fields !== undefined ? { fields } : null)
   }
   const actor = {
     id: actorId,
@@ -993,6 +1002,45 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       CounterKey.totalFollowing(actorId),
       parseInt(result?.count ?? '0', 10)
     )
+  },
+
+  // Overwrite the actor's counter rows with the collection sizes a remote
+  // server advertises (followers/following/outbox totalItems). A null or
+  // undefined value keeps the locally-accumulated counter but still creates
+  // the row, so hasActorCounters reports the actor as synced even when the
+  // remote hides a collection's total.
+  async setActorCounters({
+    actorId,
+    followersCount,
+    followingCount,
+    statusCount
+  }: SetActorCountersParams) {
+    const currentTime = new Date()
+    const counters: [string, number | null | undefined][] = [
+      [CounterKey.totalFollowers(actorId), followersCount],
+      [CounterKey.totalFollowing(actorId), followingCount],
+      [CounterKey.totalStatus(actorId), statusCount]
+    ]
+    for (const [key, value] of counters) {
+      if (typeof value === 'number') {
+        await setCounterValue(database, key, value, currentTime)
+      } else {
+        await ensureCounterRow(database, key, currentTime)
+      }
+    }
+  },
+
+  // Whether the actor's follower/following/status counter rows all exist.
+  // Missing rows mean the actor's remote collection counts were never synced
+  // (rows are created on sync even when a value is unavailable).
+  async hasActorCounters({ actorId }: HasActorCountersParams) {
+    const keys = [
+      CounterKey.totalFollowers(actorId),
+      CounterKey.totalFollowing(actorId),
+      CounterKey.totalStatus(actorId)
+    ]
+    const counters = await getCounterValues(database, keys)
+    return keys.every((key) => key in counters)
   },
 
   async increaseActorStatusCount(actorId: string, amount: number = 1) {

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -977,32 +977,6 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     })
   },
 
-  async updateActorFollowersCount(actorId: string) {
-    const result = await database('follows')
-      .where('targetActorId', actorId)
-      .andWhere('status', 'Accepted')
-      .count<{ count: string }>('* as count')
-      .first()
-    await setCounterValue(
-      database,
-      CounterKey.totalFollowers(actorId),
-      parseInt(result?.count ?? '0', 10)
-    )
-  },
-
-  async updateActorFollowingCount(actorId: string) {
-    const result = await database('follows')
-      .where('actorId', actorId)
-      .andWhere('status', 'Accepted')
-      .count<{ count: string }>('* as count')
-      .first()
-    await setCounterValue(
-      database,
-      CounterKey.totalFollowing(actorId),
-      parseInt(result?.count ?? '0', 10)
-    )
-  },
-
   // Overwrite the actor's counter rows with the collection sizes a remote
   // server advertises (followers/following/outbox totalItems). A null or
   // undefined value keeps the locally-accumulated counter. Every call also

--- a/lib/database/sql/utils/counter.ts
+++ b/lib/database/sql/utils/counter.ts
@@ -56,7 +56,7 @@ export const CounterKey = {
 
 type SQLDatabase = Knex | Knex.Transaction
 
-const ensureCounterRow = async (
+export const ensureCounterRow = async (
   database: SQLDatabase,
   id: string,
   currentTime: Date

--- a/lib/database/sql/utils/counter.ts
+++ b/lib/database/sql/utils/counter.ts
@@ -32,6 +32,12 @@ export const CounterKey = {
   totalStatus: (actorId: string) => `total-status:${actorId}`,
   totalFollowers: (actorId: string) => `total-followers:${actorId}`,
   totalFollowing: (actorId: string) => `total-following:${actorId}`,
+  // Marker row (value = epoch seconds) recording that the actor's
+  // remote-advertised collection totals were synced at least once. Row
+  // existence is the signal; the follower/following/status rows above can't
+  // carry it because local accumulation (follows, federated statuses) also
+  // creates them.
+  remoteCountsSyncedAt: (actorId: string) => `remote-counts-synced:${actorId}`,
   totalBlocking: (actorId: string) => `total-blocking:${actorId}`,
   totalBlockedBy: (actorId: string) => `total-blocked-by:${actorId}`,
   totalLike: (statusId: string) => `total-like:${statusId}`,
@@ -56,7 +62,7 @@ export const CounterKey = {
 
 type SQLDatabase = Knex | Knex.Transaction
 
-export const ensureCounterRow = async (
+const ensureCounterRow = async (
   database: SQLDatabase,
   id: string,
   currentTime: Date

--- a/lib/services/federation/getFederationSigningActor.test.ts
+++ b/lib/services/federation/getFederationSigningActor.test.ts
@@ -4,8 +4,18 @@ import {
   FEDERATION_SIGNING_ACTOR_USERNAME
 } from '@/lib/services/federation/instanceActor'
 import { Actor } from '@/lib/types/domain/actor'
+import { logger } from '@/lib/utils/logger'
 
-import { getFederationSigningActor } from './getFederationSigningActor'
+import {
+  getFederationSigningActor,
+  getFederationSigningActorSafe
+} from './getFederationSigningActor'
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn()
+  }
+}))
 
 const serviceActor = {
   id: 'https://example.com/users/__instance__',
@@ -44,5 +54,38 @@ describe('getFederationSigningActor', () => {
       serviceActor
     )
     expect(database.getFederationSigningActor).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getFederationSigningActorSafe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the resolved signer without logging', async () => {
+    const database = {
+      getFederationSigningActor: vi.fn().mockResolvedValue(serviceActor)
+    } as unknown as Database
+
+    await expect(
+      getFederationSigningActorSafe(database, 'for a test fetch')
+    ).resolves.toBe(serviceActor)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('degrades to undefined and warns with the caller context on failure', async () => {
+    const database = {
+      getFederationSigningActor: vi.fn().mockRejectedValue(new Error('down'))
+    } as unknown as Database
+
+    await expect(
+      getFederationSigningActorSafe(database, 'for a test fetch')
+    ).resolves.toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('for a test fetch'),
+        error: 'down'
+      })
+    )
   })
 })

--- a/lib/services/federation/getFederationSigningActor.ts
+++ b/lib/services/federation/getFederationSigningActor.ts
@@ -1,6 +1,7 @@
 import { Database } from '@/lib/database/types'
 import { isFederationSigningActor } from '@/lib/services/federation/instanceActor'
 import { Actor } from '@/lib/types/domain/actor'
+import { logger } from '@/lib/utils/logger'
 
 /**
  * Returns the dedicated headless federation signer.
@@ -17,3 +18,20 @@ export const getFederationSigningActor = async (
 
   return (await database.getFederationSigningActor()) ?? undefined
 }
+
+/**
+ * Best-effort variant of getFederationSigningActor for fetch paths that must
+ * degrade to an unsigned request instead of failing: a resolution error is
+ * logged (with the caller-provided context appended) and yields undefined.
+ */
+export const getFederationSigningActorSafe = async (
+  database: Database,
+  context: string
+): Promise<Actor | undefined> =>
+  getFederationSigningActor(database).catch((error) => {
+    logger.warn({
+      message: `Failed to resolve federation signing actor ${context}; falling back to an unsigned request`,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return undefined
+  })

--- a/lib/services/mastodon/getRemoteActorStatuses.test.ts
+++ b/lib/services/mastodon/getRemoteActorStatuses.test.ts
@@ -1,0 +1,223 @@
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import { getRemoteActorStatuses } from './getRemoteActorStatuses'
+
+vi.mock('@/lib/activities/getActorPerson')
+vi.mock('@/lib/activities/getActorPosts')
+vi.mock('@/lib/services/federation/domainPolicy')
+vi.mock('@/lib/services/federation/getFederationSigningActor')
+
+const actorId = 'https://remote.example/users/actor'
+const knownAuthorId = 'https://remote.example/users/known'
+const unknownAuthorId = 'https://remote.example/users/unknown'
+
+const mockGetActorsFromIds = vi.fn()
+const mockDatabase = {
+  getActorsFromIds: (...params: unknown[]) => mockGetActorsFromIds(...params)
+} as unknown as Database
+
+const mockInstanceActor = {
+  id: 'https://local.example/users/__instance__'
+}
+
+const buildNote = (id: string, overrides: Partial<Status> = {}): Status =>
+  ({
+    id,
+    url: id,
+    actorId,
+    actor: null,
+    type: StatusType.enum.Note,
+    text: 'Remote note',
+    summary: null,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    reply: '',
+    replies: [],
+    actorAnnounceStatusId: null,
+    isActorLiked: false,
+    isLocalActor: false,
+    totalLikes: 0,
+    attachments: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }) as Status
+
+const buildAnnounce = (id: string, originalAuthorId: string): Status =>
+  ({
+    id,
+    actorId,
+    actor: null,
+    type: StatusType.enum.Announce,
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    isLocalActor: false,
+    createdAt: 1,
+    updatedAt: 1,
+    originalStatus: buildNote(`${originalAuthorId}/statuses/original`, {
+      actorId: originalAuthorId
+    } as Partial<Status>)
+  }) as Status
+
+describe('getRemoteActorStatuses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(canFederateWithDomain as jest.Mock).mockResolvedValue(true)
+    ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+      mockInstanceActor
+    )
+    ;(getActorPerson as jest.Mock).mockResolvedValue({
+      id: actorId,
+      type: 'Person',
+      preferredUsername: 'actor',
+      outbox: `${actorId}/outbox`
+    })
+    mockGetActorsFromIds.mockResolvedValue([])
+  })
+
+  it('returns the actor recent public posts signed by the instance actor', async () => {
+    ;(getActorPosts as jest.Mock).mockResolvedValue({
+      statuses: [buildNote(`${actorId}/statuses/1`)],
+      statusesCount: 1,
+      nextPageUrl: null,
+      prevPageUrl: null
+    })
+
+    const statuses = await getRemoteActorStatuses({
+      database: mockDatabase,
+      actorId,
+      limit: 20
+    })
+
+    expect(statuses.map((status) => status.id)).toEqual([
+      `${actorId}/statuses/1`
+    ])
+    expect(getActorPerson).toHaveBeenCalledWith({
+      actorId,
+      signingActor: mockInstanceActor
+    })
+    expect(getActorPosts).toHaveBeenCalledWith({
+      database: mockDatabase,
+      person: expect.objectContaining({ id: actorId }),
+      signingActor: mockInstanceActor
+    })
+  })
+
+  it.each([
+    {
+      description: 'drops non-public statuses',
+      status: buildNote(`${actorId}/statuses/private`, {
+        to: [`${actorId}/followers`],
+        cc: []
+      }),
+      options: {}
+    },
+    {
+      description: 'drops replies when excludeReplies is set',
+      status: buildNote(`${actorId}/statuses/reply`, {
+        reply: `${actorId}/statuses/parent`
+      }),
+      options: { excludeReplies: true }
+    },
+    {
+      description: 'drops posts without media when onlyMedia is set',
+      status: buildNote(`${actorId}/statuses/no-media`),
+      options: { onlyMedia: true }
+    },
+    {
+      description: 'drops reblogs when excludeReblogs is set',
+      status: buildAnnounce(`${actorId}/statuses/announce`, knownAuthorId),
+      options: { excludeReblogs: true }
+    },
+    {
+      description: 'drops reblogs whose original author is unknown locally',
+      status: buildAnnounce(
+        `${actorId}/statuses/unknown-announce`,
+        unknownAuthorId
+      ),
+      options: {}
+    }
+  ])('$description', async ({ status, options }) => {
+    ;(getActorPosts as jest.Mock).mockResolvedValue({
+      statuses: [status],
+      statusesCount: 1,
+      nextPageUrl: null,
+      prevPageUrl: null
+    })
+
+    await expect(
+      getRemoteActorStatuses({
+        database: mockDatabase,
+        actorId,
+        limit: 20,
+        ...options
+      })
+    ).resolves.toEqual([])
+  })
+
+  it('keeps reblogs whose original author is known locally', async () => {
+    mockGetActorsFromIds.mockResolvedValue([{ id: knownAuthorId }])
+    ;(getActorPosts as jest.Mock).mockResolvedValue({
+      statuses: [buildAnnounce(`${actorId}/statuses/announce`, knownAuthorId)],
+      statusesCount: 1,
+      nextPageUrl: null,
+      prevPageUrl: null
+    })
+
+    const statuses = await getRemoteActorStatuses({
+      database: mockDatabase,
+      actorId,
+      limit: 20
+    })
+
+    expect(statuses.map((status) => status.id)).toEqual([
+      `${actorId}/statuses/announce`
+    ])
+    expect(mockGetActorsFromIds).toHaveBeenCalledWith({
+      ids: [knownAuthorId]
+    })
+  })
+
+  it('caps the returned statuses at the requested limit', async () => {
+    ;(getActorPosts as jest.Mock).mockResolvedValue({
+      statuses: [
+        buildNote(`${actorId}/statuses/1`),
+        buildNote(`${actorId}/statuses/2`),
+        buildNote(`${actorId}/statuses/3`)
+      ],
+      statusesCount: 3,
+      nextPageUrl: null,
+      prevPageUrl: null
+    })
+
+    await expect(
+      getRemoteActorStatuses({ database: mockDatabase, actorId, limit: 2 })
+    ).resolves.toHaveLength(2)
+  })
+
+  it('returns an empty list for blocked federation domains without fetching', async () => {
+    ;(canFederateWithDomain as jest.Mock).mockResolvedValue(false)
+
+    await expect(
+      getRemoteActorStatuses({ database: mockDatabase, actorId, limit: 20 })
+    ).resolves.toEqual([])
+    expect(getActorPerson).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty list when the remote fetch fails', async () => {
+    ;(getActorPosts as jest.Mock).mockRejectedValue(new Error('network down'))
+
+    await expect(
+      getRemoteActorStatuses({ database: mockDatabase, actorId, limit: 20 })
+    ).resolves.toEqual([])
+  })
+})

--- a/lib/services/mastodon/getRemoteActorStatuses.test.ts
+++ b/lib/services/mastodon/getRemoteActorStatuses.test.ts
@@ -2,7 +2,7 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
-import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
@@ -72,7 +72,7 @@ describe('getRemoteActorStatuses', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(canFederateWithDomain as jest.Mock).mockResolvedValue(true)
-    ;(getFederationSigningActor as jest.Mock).mockResolvedValue(
+    ;(getFederationSigningActorSafe as jest.Mock).mockResolvedValue(
       mockInstanceActor
     )
     ;(getActorPerson as jest.Mock).mockResolvedValue({
@@ -144,6 +144,22 @@ describe('getRemoteActorStatuses', () => {
         `${actorId}/statuses/unknown-announce`,
         unknownAuthorId
       ),
+      options: {}
+    },
+    {
+      description: 'drops reblogs on media-only pages',
+      status: buildAnnounce(
+        `${actorId}/statuses/media-announce`,
+        knownAuthorId
+      ),
+      options: { onlyMedia: true }
+    },
+    {
+      description: 'drops malformed reblogs with a missing original status',
+      status: {
+        ...buildAnnounce(`${actorId}/statuses/broken-announce`, knownAuthorId),
+        originalStatus: null
+      } as unknown as Status,
       options: {}
     }
   ])('$description', async ({ status, options }) => {

--- a/lib/services/mastodon/getRemoteActorStatuses.ts
+++ b/lib/services/mastodon/getRemoteActorStatuses.ts
@@ -2,7 +2,7 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
-import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
 import { Status, StatusType } from '@/lib/types/domain/status'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { logger } from '@/lib/utils/logger'
@@ -33,21 +33,15 @@ export const getRemoteActorStatuses = async ({
   onlyMedia = false
 }: GetRemoteActorStatusesParams): Promise<Status[]> => {
   try {
-    if (!(await canFederateWithDomain(database, actorId))) return []
-
     // Server-to-server fetches are signed by the headless instance actor so
     // authorized-fetch ("secure mode") remotes accept them; a missing signer
-    // degrades to an unsigned fetch.
-    const signingActor = await getFederationSigningActor(database).catch(
-      (error) => {
-        logger.warn({
-          message:
-            'Failed to resolve federation signing actor for remote statuses; falling back to an unsigned request',
-          error: error instanceof Error ? error.message : String(error)
-        })
-        return undefined
-      }
-    )
+    // degrades to an unsigned fetch. Independent of the federation policy
+    // check, so resolve both concurrently.
+    const [canFederate, signingActor] = await Promise.all([
+      canFederateWithDomain(database, actorId),
+      getFederationSigningActorSafe(database, 'for remote statuses')
+    ])
+    if (!canFederate) return []
     const signingParams = signingActor ? { signingActor } : {}
 
     const person = await getActorPerson({ actorId, ...signingParams })
@@ -62,13 +56,24 @@ export const getRemoteActorStatuses = async ({
     // The Mastodon serializer resolves a reblog's author from the database, so
     // an Announce whose original author is unknown locally can't be rendered.
     // Keep only announces with locally-known original authors.
-    const announceAuthorIds = [
-      ...new Set(
-        statuses
-          .filter((status) => status.type === StatusType.enum.Announce)
-          .map((status) => status.originalStatus.actorId)
-      )
-    ]
+    // Remote data can be malformed: tolerate an Announce with a missing
+    // original (or author) instead of letting one bad status abort the whole
+    // fetch via the outer catch. Skipped entirely when the filter below drops
+    // every Announce anyway (reblogs excluded, or media-only pages).
+    const announceAuthorIds =
+      excludeReblogs || onlyMedia
+        ? []
+        : [
+            ...new Set(
+              statuses
+                .filter(
+                  (status) =>
+                    status.type === StatusType.enum.Announce &&
+                    status.originalStatus?.actorId
+                )
+                .map((status) => status.originalStatus.actorId)
+            )
+          ]
     const knownAuthorIds = new Set(
       announceAuthorIds.length > 0
         ? (await database.getActorsFromIds({ ids: announceAuthorIds })).map(
@@ -86,8 +91,13 @@ export const getRemoteActorStatuses = async ({
         if (visibility !== 'public' && visibility !== 'unlisted') return false
 
         if (status.type === StatusType.enum.Announce) {
-          if (excludeReblogs) return false
-          return knownAuthorIds.has(status.originalStatus.actorId)
+          // The media tab shows the actor's own media posts, never boosts —
+          // matching getActorStatuses' only_media handling on the local path.
+          if (excludeReblogs || onlyMedia) return false
+          return Boolean(
+            status.originalStatus?.actorId &&
+            knownAuthorIds.has(status.originalStatus.actorId)
+          )
         }
         if (excludeReplies && status.reply) return false
         if (onlyMedia && status.attachments.length === 0) return false

--- a/lib/services/mastodon/getRemoteActorStatuses.ts
+++ b/lib/services/mastodon/getRemoteActorStatuses.ts
@@ -1,0 +1,105 @@
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { getActorPosts } from '@/lib/activities/getActorPosts'
+import { Database } from '@/lib/database/types'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { Status, StatusType } from '@/lib/types/domain/status'
+import { getVisibility } from '@/lib/utils/getVisibility'
+import { logger } from '@/lib/utils/logger'
+
+interface GetRemoteActorStatusesParams {
+  database: Database
+  actorId: string
+  limit: number
+  excludeReplies?: boolean
+  excludeReblogs?: boolean
+  onlyMedia?: boolean
+}
+
+// Live-fetch a remote actor's most recent posts from their outbox for the
+// Mastodon statuses API. A remote actor's posts only exist locally once they
+// federate here (e.g. after someone follows them), so a profile opened in a
+// Mastodon client would otherwise show an empty timeline. The statuses are
+// ephemeral — served for display, not persisted.
+//
+// Best-effort by design: any failure returns an empty list and the caller
+// falls back to the locally-stored statuses.
+export const getRemoteActorStatuses = async ({
+  database,
+  actorId,
+  limit,
+  excludeReplies = false,
+  excludeReblogs = false,
+  onlyMedia = false
+}: GetRemoteActorStatusesParams): Promise<Status[]> => {
+  try {
+    if (!(await canFederateWithDomain(database, actorId))) return []
+
+    // Server-to-server fetches are signed by the headless instance actor so
+    // authorized-fetch ("secure mode") remotes accept them; a missing signer
+    // degrades to an unsigned fetch.
+    const signingActor = await getFederationSigningActor(database).catch(
+      (error) => {
+        logger.warn({
+          message:
+            'Failed to resolve federation signing actor for remote statuses; falling back to an unsigned request',
+          error: error instanceof Error ? error.message : String(error)
+        })
+        return undefined
+      }
+    )
+    const signingParams = signingActor ? { signingActor } : {}
+
+    const person = await getActorPerson({ actorId, ...signingParams })
+    if (!person) return []
+
+    const { statuses } = await getActorPosts({
+      database,
+      person,
+      ...signingParams
+    })
+
+    // The Mastodon serializer resolves a reblog's author from the database, so
+    // an Announce whose original author is unknown locally can't be rendered.
+    // Keep only announces with locally-known original authors.
+    const announceAuthorIds = [
+      ...new Set(
+        statuses
+          .filter((status) => status.type === StatusType.enum.Announce)
+          .map((status) => status.originalStatus.actorId)
+      )
+    ]
+    const knownAuthorIds = new Set(
+      announceAuthorIds.length > 0
+        ? (await database.getActorsFromIds({ ids: announceAuthorIds })).map(
+            (actor) => actor.id
+          )
+        : []
+    )
+
+    return statuses
+      .filter((status) => {
+        // The outbox should only expose public/unlisted posts; enforce that
+        // here so a misbehaving remote can't slip restricted posts into the
+        // response.
+        const visibility = getVisibility(status.to, status.cc)
+        if (visibility !== 'public' && visibility !== 'unlisted') return false
+
+        if (status.type === StatusType.enum.Announce) {
+          if (excludeReblogs) return false
+          return knownAuthorIds.has(status.originalStatus.actorId)
+        }
+        if (excludeReplies && status.reply) return false
+        if (onlyMedia && status.attachments.length === 0) return false
+        return true
+      })
+      .slice(0, limit)
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to fetch remote actor statuses from outbox',
+      actorId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return []
+  }
+}

--- a/lib/services/mastodon/getRemoteActorStatuses.ts
+++ b/lib/services/mastodon/getRemoteActorStatuses.ts
@@ -3,7 +3,7 @@ import { getActorPosts } from '@/lib/activities/getActorPosts'
 import { Database } from '@/lib/database/types'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActorSafe } from '@/lib/services/federation/getFederationSigningActor'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { Status, StatusAnnounce, StatusType } from '@/lib/types/domain/status'
 import { getVisibility } from '@/lib/utils/getVisibility'
 import { logger } from '@/lib/utils/logger'
 
@@ -67,9 +67,9 @@ export const getRemoteActorStatuses = async ({
             ...new Set(
               statuses
                 .filter(
-                  (status) =>
+                  (status): status is StatusAnnounce =>
                     status.type === StatusType.enum.Announce &&
-                    status.originalStatus?.actorId
+                    Boolean(status.originalStatus?.actorId)
                 )
                 .map((status) => status.originalStatus.actorId)
             )

--- a/lib/services/timelines/request.ts
+++ b/lib/services/timelines/request.ts
@@ -49,7 +49,12 @@ export type ParseTimelineQueryResult =
   { ok: true; query: ParsedTimelineQuery } | { ok: false }
 
 // undefined → cursor not provided; null → provided but undecodable (→ 400).
-const decodeCursor = (raw: string | undefined): string | null | undefined =>
+// Shared by the timeline endpoints (via parseTimelineQuery) and other
+// Mastodon list endpoints (e.g. account statuses) so every cursor is decoded
+// with the same rule.
+export const decodeCursor = (
+  raw: string | undefined
+): string | null | undefined =>
   raw === undefined ? undefined : safeIdToUrl(raw)
 
 /**

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -57,6 +57,9 @@ export type CreateActorParams = {
   summary?: string
   iconUrl?: string
   headerImageUrl?: string
+  manuallyApprovesFollowers?: boolean
+  // Mastodon profile metadata fields (name/value pairs).
+  fields?: { name: string; value: string }[]
 
   inboxUrl: string
   sharedInboxUrl: string
@@ -81,6 +84,16 @@ export type GetLocalActorsParams = {
   // database layer to preserve the method's historical behavior.
   local?: boolean
 }
+export type SetActorCountersParams = {
+  actorId: string
+  // null/undefined preserves the locally-accumulated value for that counter
+  // while still creating the row, so hasActorCounters treats the actor as
+  // synced (e.g. remotes that hide a collection's totalItems).
+  followersCount?: number | null
+  followingCount?: number | null
+  statusCount?: number | null
+}
+export type HasActorCountersParams = { actorId: string }
 export type IsCurrentActorFollowingParams = {
   currentActorId: string
   followingActorId: string
@@ -209,6 +222,8 @@ export interface ActorDatabase {
   deleteActor(params: DeleteActorParams): Promise<void>
   updateActorFollowersCount(actorId: string): Promise<void>
   updateActorFollowingCount(actorId: string): Promise<void>
+  setActorCounters(params: SetActorCountersParams): Promise<void>
+  hasActorCounters(params: HasActorCountersParams): Promise<boolean>
   increaseActorStatusCount(actorId: string, amount?: number): Promise<void>
   decreaseActorStatusCount(actorId: string, amount?: number): Promise<void>
   updateActorLastStatusAt(actorId: string, time: number): Promise<void>

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -87,8 +87,11 @@ export type GetLocalActorsParams = {
 export type SetActorCountersParams = {
   actorId: string
   // null/undefined preserves the locally-accumulated value for that counter
-  // while still creating the row, so hasActorCounters treats the actor as
-  // synced (e.g. remotes that hide a collection's totalItems).
+  // (e.g. remotes that hide a collection's totalItems). Every call stamps the
+  // remote-counts-synced marker row regardless, which is what
+  // hasActorCounters reports — counter-row existence can't carry the sync
+  // signal because local accumulation (follows, federated statuses) also
+  // creates those rows.
   followersCount?: number | null
   followingCount?: number | null
   statusCount?: number | null
@@ -220,8 +223,6 @@ export interface ActorDatabase {
   ): Promise<Mastodon.Account[]>
   updateActor(params: UpdateActorParams): Promise<Actor | null>
   deleteActor(params: DeleteActorParams): Promise<void>
-  updateActorFollowersCount(actorId: string): Promise<void>
-  updateActorFollowingCount(actorId: string): Promise<void>
   setActorCounters(params: SetActorCountersParams): Promise<void>
   hasActorCounters(params: HasActorCountersParams): Promise<boolean>
   increaseActorStatusCount(actorId: string, amount?: number): Promise<void>

--- a/lib/utils/activitypubActor.ts
+++ b/lib/utils/activitypubActor.ts
@@ -1,4 +1,7 @@
-import { Actor as ActivityPubActor } from '@/lib/types/activitypub'
+import {
+  Actor as ActivityPubActor,
+  PropertyValue
+} from '@/lib/types/activitypub'
 import { ActorProfile } from '@/lib/types/domain/actor'
 
 const UUID_USERNAME_PATTERN =
@@ -29,6 +32,25 @@ export const getActorImageUrl = (image: ActivityPubActor['icon']) => {
   if (!image) return undefined
   if (Array.isArray(image)) return image.find((item) => item.url)?.url
   return image.url
+}
+
+// Mastodon profile metadata fields arrive as PropertyValue attachments on the
+// actor document. Unknown attachment shapes are tolerated by the schema (the
+// loose-object fallback), so narrow back to valid PropertyValues here.
+export const getActorProfileFields = (
+  person: ActivityPubActor
+): { name: string; value: string }[] => {
+  const attachments = Array.isArray(person.attachment)
+    ? person.attachment
+    : person.attachment
+      ? [person.attachment]
+      : []
+  return attachments.flatMap((item) => {
+    const parsed = PropertyValue.safeParse(item)
+    return parsed.success
+      ? [{ name: parsed.data.name, value: parsed.data.value }]
+      : []
+  })
 }
 
 const getActorCreatedAt = (published: string | null | undefined) => {

--- a/lib/utils/urlToId.test.ts
+++ b/lib/utils/urlToId.test.ts
@@ -173,6 +173,13 @@ describe('safeIdToUrl', () => {
     expect(safeIdToUrl(opaque)).toEqual('https://llun.test:8443/users/test1')
   })
 
+  it('passes a raw status URL through unchanged', () => {
+    // Raw URLs are already the stored id form; idToUrl would mangle the
+    // double slash after the scheme, silently breaking the cursor.
+    const url = 'https://mastodon.social/users/test1/statuses/123'
+    expect(safeIdToUrl(url)).toEqual(url)
+  })
+
   // A numeric Mastodon id (or other well-formed-but-unknown value) decodes to a
   // valid URL: it is accepted and the DB simply finds no matching row (empty
   // page), matching Mastodon — it must NOT 400.

--- a/lib/utils/urlToId.ts
+++ b/lib/utils/urlToId.ts
@@ -129,6 +129,18 @@ export const idToUrl = (id: string) => {
 export const safeIdToUrl = (value: string): string | null => {
   if (!value) return null
 
+  // A raw status URL is already the stored id — pass it through instead of
+  // letting idToUrl mangle the double slash after the scheme (encoded ids
+  // never start with a scheme, so there is no ambiguity).
+  if (/^https?:\/\//.test(value)) {
+    try {
+      const { protocol } = new URL(value)
+      return protocol === 'http:' || protocol === 'https:' ? value : null
+    } catch {
+      return null
+    }
+  }
+
   let decoded: string
   try {
     decoded = idToUrl(value)


### PR DESCRIPTION
## Summary

Opening a remote user's profile (e.g. `@mttvll@mastodon.social`) in a Mastodon client (official iOS app, Ivory, etc.) showed **0 followers, 0 following, a wrong post count, the bare username instead of the display name, no bio, a wrong "Request to follow" (locked) button, and an empty Activity tab** — while the same profile looked fine on mastodon.social (5,370 followers / 519 following / 641 posts for this user).

Root causes:

1. **Account counts came only from local counters.** `getMastodonActors` builds `followers_count` / `following_count` / `statuses_count` from the `counters` table, which for a remote actor only tracks relationships/statuses this instance has seen — nothing ever fetched the totals the remote server advertises on its `followers` / `following` / `outbox` collections. (The web UI profile page fetches these live per view, but never persisted them, and the Mastodon API never fetched them at all.)
2. **`recordActorIfNeeded` dropped most profile data.** It persisted neither `name`, `summary`, header image, profile metadata fields, nor `manuallyApprovesFollowers` — so `locked` fell back to `true` ("Request to follow" for every remote account, even unlocked ones) and the display name fell back to the username.
3. **`GET /api/v1/accounts/:id/statuses` served only locally-stored statuses**, which is empty for a remote actor nobody on the instance follows.
4. Existing actors were never refreshed by the client-visible flows: lookup/search only *record missing* actors, so stale rows stayed stale.

### Changes

- **`recordActorIfNeeded`** now persists the full remote profile (name, bio, avatar, header, `manuallyApprovesFollowers`, `PropertyValue` metadata fields) on both the create and 3-day-refresh paths, and syncs the remote-advertised collection totals into the actor's counter rows via the new `getActorCollectionCounts` helper (3 parallel collection-root fetches, best-effort). It also refreshes a *fresh* actor whose counters were never synced, so actors recorded before this fix heal on the next view instead of waiting out the refresh interval.
- **`GET /api/v1/accounts/:id`** refreshes a known, stale remote actor before serialization (authenticated viewers only, existing actors only — anonymous requests can't trigger remote fetches for arbitrary ids). Failures fall back to the stored profile.
- **`GET /api/v1/accounts/:id/statuses`** falls back to fetching the actor's recent public posts live from their outbox (new `getRemoteActorStatuses` service) when the local store can't fill the first page for an authenticated viewer. Statuses are display-only (not persisted), filtered to public/unlisted, respect `exclude_replies` / `exclude_reblogs` / `only_media`, and drop reblogs whose original author is unknown locally (the serializer can't render those). A live page carries no `Link` pagination headers since remote ids can't cursor the local store.
- **Cursor decoding fix:** the statuses endpoint passed the client-echoed `max_id`/`min_id`/`since_id` (urlToId-encoded) straight to the database, which silently ignores unknown ids — so page 2 of a profile repeated page 1. Cursors are now decoded with `safeIdToUrl` (undecodable → 400), matching the timeline endpoints.
- **`getProfileData`** (web UI remote profile) persists the counts it already fetches, so the web view and the Mastodon API stay consistent.
- **DB:** new `setActorCounters` / `hasActorCounters` on the actor mixin; `CreateActorParams` gains `manuallyApprovesFollowers` and `fields`. No migrations — the `counters` table already exists, so both schema dumps are untouched.
- **Docs:** documented the live-fetch divergence from stock Mastodon in `docs/mastodon-api-compatibility.md`.

### Verification

Ran locally with SQLite + mock user (`scripts/mock/createMockUser.ts`) against the real fediverse:

`GET /api/v1/accounts/lookup?acct=mttvll@mastodon.social&resolve=true` (before → after):

| field | before | after |
| --- | --- | --- |
| `display_name` | `""` (client falls back to `mttvll`) | `Matteo` |
| `note` | `""` | real bio |
| `locked` | `true` ("Request to follow") | `false` |
| `followers_count` | 0 | 5370 |
| `following_count` | 0 | 519 |
| `statuses_count` | local-only count | 641 |
| `fields` | `[]` | 2 profile metadata fields |

`GET /api/v1/accounts/:id/statuses?exclude_replies=true` returned the user's actual recent public posts (including media attachments and a reblog) instead of `[]`, with no `Link` header on the live page. The web profile page (`/@mttvll@mastodon.social`) was verified in a real browser and shows the same counts and posts.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: I grepped `*.md` and `docs/` for every command, env var, route, script, or convention this PR renames, removes, or reshapes (AGENTS.md → Documentation Maintenance)
- [x] If migrations changed: BOTH `migrations/schema.sql` and `migrations/schema.sqlite.sql` are regenerated in this PR (no migrations changed)
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description (schema changes live in `migrations/` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NQyx4bZjX2GFGRRw5Kaht

---
_Generated by [Claude Code](https://claude.ai/code/session_011NQyx4bZjX2GFGRRw5Kaht)_