### PR TITLE
Bump version to v1.101.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.3",
+  "version": "1.101.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.3`
- Base main SHA: `252bbd231e636301e4604a6315836f3551ddf3ed`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
