### PR TITLE
Bump version to v1.101.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.4",
+  "version": "1.101.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.4`
- Base main SHA: `6e9c1b3dee2bb9f04ebcf18ed356869c9b394e2e`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
