### PR TITLE
fix: grouped notifications crash the Mastodon iOS app (most_recent_notification_id must be a number)

### DIFF
--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -226,6 +226,55 @@ describe('GET /api/v2/notifications', () => {
     expect(typeof likeGroup.most_recent_notification_id).toBe('number')
   })
 
+  it('keeps groups distinct by group_key when their most_recent_notification_id collides', async () => {
+    // The numeric id is derived from createdAt (epoch ms), so two groups whose
+    // most-recent members share a millisecond collide on the number. That is
+    // benign: clients key the list on the unique group_key, not the number.
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'like-1',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      },
+      {
+        id: 'follow-1',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/bob',
+        groupKey: 'follow:1',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      }
+    ])
+
+    const request = new NextRequest('https://llun.test/api/v2/notifications', {
+      method: 'GET'
+    })
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.notification_groups).toHaveLength(2)
+    const ids = data.notification_groups.map(
+      (g: { most_recent_notification_id: number }) =>
+        g.most_recent_notification_id
+    )
+    // Same millisecond -> same numeric id...
+    expect(ids).toEqual([2000, 2000])
+    // ...but the group_keys stay unique.
+    const keys = data.notification_groups.map(
+      (g: { group_key: string }) => g.group_key
+    )
+    expect(new Set(keys).size).toBe(2)
+  })
+
   it('splits accounts into full and partial with expand_accounts=partial_avatars', async () => {
     mockDatabase.getMastodonActorsFromIds.mockImplementation(
       ({ ids }: { ids: string[] }) =>

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -203,15 +203,27 @@ describe('GET /api/v2/notifications', () => {
       { method: 'GET' }
     )
     const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
 
     expect(response.status).toBe(200)
     const link = response.headers.get('Link') ?? ''
-    // next/max_id anchors on the LAST returned group (the follow group).
+    // next/max_id anchors on the LAST returned group (the follow group). The
+    // cursor is the notification UUID (page_max_id), NOT the numeric
+    // most_recent_notification_id — the server can only resolve UUID cursors.
     expect(link).toContain('max_id=follow-old')
     expect(link).toContain('rel="next"')
     // prev/min_id anchors on the FIRST returned group (the like group).
     expect(link).toContain('min_id=like-new')
     expect(link).toContain('rel="prev"')
+    // The numeric surrogate must NOT leak into the cursor.
+    expect(link).not.toContain('max_id=1000')
+    expect(link).not.toContain('min_id=3000')
+    // most_recent_notification_id is a JSON number (the createdAt epoch ms), so
+    // the Mastodon iOS Int decoder does not crash.
+    const [likeGroup, followGroup] = data.notification_groups
+    expect(likeGroup.most_recent_notification_id).toBe(3000)
+    expect(followGroup.most_recent_notification_id).toBe(1000)
+    expect(typeof likeGroup.most_recent_notification_id).toBe('number')
   })
 
   it('splits accounts into full and partial with expand_accounts=partial_avatars', async () => {

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -247,9 +247,11 @@ export const GET = traceApiRoute(
         const nextCursor = lastGroup.page_max_id
         const prevCursor = firstGroup.page_max_id
         links = [
-          ...(nextCursor ? [buildLink('max_id', nextCursor)] : []),
-          ...(prevCursor ? [buildLink('min_id', prevCursor)] : [])
-        ].join(', ')
+          nextCursor && buildLink('max_id', nextCursor),
+          prevCursor && buildLink('min_id', prevCursor)
+        ]
+          .filter((link): link is string => Boolean(link))
+          .join(', ')
       } else if (!exhausted && lastScannedId) {
         // No visible groups on this page but the source isn't exhausted (e.g. the
         // iteration cap was hit, or account_id filtered out the whole window): emit

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -224,6 +224,11 @@ export const GET = traceApiRoute(
       // were hidden by envelope suppression. When suppression empties the page but
       // the source isn't exhausted, fall back to the oldest collected row so the
       // client keeps paging toward the visible groups further down the timeline.
+      //
+      // The cursor MUST be a resolvable notification id (a UUID this server can
+      // look up), so anchor on page_max_id — the group's most-recent notification
+      // UUID — NOT most_recent_notification_id, which is a numeric surrogate for
+      // clients' Int decoders and is not a resolvable cursor.
       const host = headerHost(req.headers)
       const pathBase = '/api/v2/notifications'
       const buildLink = (cursorParam: string, cursorValue: string) => {
@@ -239,9 +244,11 @@ export const GET = traceApiRoute(
       if (survivingGroups.length > 0) {
         const lastGroup = survivingGroups[survivingGroups.length - 1]
         const firstGroup = survivingGroups[0]
+        const nextCursor = lastGroup.page_max_id
+        const prevCursor = firstGroup.page_max_id
         links = [
-          buildLink('max_id', lastGroup.most_recent_notification_id),
-          buildLink('min_id', firstGroup.most_recent_notification_id)
+          ...(nextCursor ? [buildLink('max_id', nextCursor)] : []),
+          ...(prevCursor ? [buildLink('min_id', prevCursor)] : [])
         ].join(', ')
       } else if (!exhausted && lastScannedId) {
         // No visible groups on this page but the source isn't exhausted (e.g. the

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -109,6 +109,19 @@ product or security decision, not a gap to be closed.
   `Link` pagination headers (remote ids cannot cursor the local store), and
   the fetched statuses are display-only — they are not persisted.
 
+- **Grouped notifications' `most_recent_notification_id` is a synthesized
+  integer, not a resolvable id.** In the `GET /api/v2/notifications` response
+  (and the single-group `/:group_key` variant), Mastodon serializes
+  `most_recent_notification_id` as the numeric notification id, and clients
+  decode it as an integer (the official Mastodon iOS app types it `Int` and
+  crashes on a string). Activity.next uses UUID notification ids, which can't be
+  numbers, so it emits a deterministic integer derived from the group's
+  most-recent notification `createdAt` (epoch ms). This value is display-only —
+  clients never send it back as a cursor. Pagination uses the `Link` header and
+  the string `page_min_id` / `page_max_id`, which stay real UUID cursors the
+  server can resolve. Do **not** "fix" `most_recent_notification_id` back to the
+  UUID string: that re-crashes the Mastodon iOS decoder.
+
 ## Not planned
 
 These endpoints are not implemented and are not currently on the roadmap. They

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -120,7 +120,11 @@ product or security decision, not a gap to be closed.
   clients never send it back as a cursor. Pagination uses the `Link` header and
   the string `page_min_id` / `page_max_id`, which stay real UUID cursors the
   server can resolve. Do **not** "fix" `most_recent_notification_id` back to the
-  UUID string: that re-crashes the Mastodon iOS decoder.
+  UUID string: that re-crashes the Mastodon iOS decoder. Unlike Mastodon's
+  globally-unique integer notification ids, this timestamp-derived value is not
+  guaranteed unique — two groups whose most-recent members were created in the
+  same millisecond share it — which is harmless because clients key the list on
+  the (unique) `group_key`, not on this field.
 
 ## Not planned
 

--- a/lib/services/notifications/getNotificationGroup.test.ts
+++ b/lib/services/notifications/getNotificationGroup.test.ts
@@ -30,11 +30,18 @@ describe('getNotificationGroup', () => {
       group_key: 'like:https://other.test/statuses/1',
       notifications_count: 2,
       type: 'favourite',
-      most_recent_notification_id: 'n1',
+      // A JSON *number* derived from the most-recent member's createdAt (1000ms
+      // epoch) — Mastodon clients decode most_recent_notification_id as an Int
+      // and crash on a string. page_max_id keeps the real UUID cursor.
+      most_recent_notification_id: 1000,
+      page_max_id: 'n1',
       // ISO-8601 of the group's most-recent notification createdAt (1000ms epoch).
       latest_page_notification_at: '1970-01-01T00:00:01.000Z',
       status_id: urlToId('https://other.test/statuses/1')
     })
+    // Guard the wire type: a regression back to the UUID string re-crashes the
+    // Mastodon iOS app (typeMismatch, expected Int).
+    expect(typeof group.most_recent_notification_id).toBe('number')
     expect(group.sample_account_ids).toEqual([
       urlToId('https://other.test/users/alice'),
       urlToId('https://other.test/users/bob')

--- a/lib/services/notifications/getNotificationGroup.ts
+++ b/lib/services/notifications/getNotificationGroup.ts
@@ -15,7 +15,16 @@ export interface MastodonNotificationGroup {
   group_key: string
   notifications_count: number
   type: MastodonNotificationType
-  most_recent_notification_id: string
+  // Mastodon serializes most_recent_notification_id as a JSON *number* (the
+  // numeric notification id), and clients decode it as an integer — the official
+  // Mastodon iOS app types it `Int` and crashes on a string. This service uses
+  // UUID notification ids, which can't be numbers, so we emit a deterministic
+  // integer derived from the group's most-recent notification timestamp. Clients
+  // only use this value for display/deep-links (never as a pagination cursor:
+  // that's the Link header + the string page_min_id/page_max_id below), so the
+  // synthesized number is safe. Keep page_min_id/page_max_id as the real UUID
+  // cursors the server can resolve.
+  most_recent_notification_id: number
   page_min_id?: string
   page_max_id?: string
   // ISO-8601 timestamp of the group's most recent notification, so clients can
@@ -59,8 +68,11 @@ export const getNotificationGroup = (
       group_key: notificationGroupKey(notification),
       notifications_count: notification.groupedCount ?? 1,
       type: internalTypeToMastodon(notification.type),
-      // groupNotifications keeps the most recent notification as the base.
-      most_recent_notification_id: notification.id,
+      // groupNotifications keeps the most recent notification as the base. Its
+      // UUID id can't be a JSON number, so derive a stable integer from the
+      // most-recent member's createdAt (epoch ms, well within a signed 64-bit
+      // int). page_max_id/page_min_id below still carry the real UUID cursors.
+      most_recent_notification_id: Math.trunc(notification.createdAt),
       page_max_id: notification.id,
       // groupedIds[last] is the oldest notification in the group (DB returns most-recent-first).
       page_min_id: notification.groupedIds


### PR DESCRIPTION
## Summary

The official **Mastodon iOS app** crashes when loading notifications against this instance. The `GET /api/v2/notifications` (grouped) response is fetched successfully, but decoding fatally fails:

```
DecodingError.typeMismatch: expected value of type Int.
Path: notification_groups[0].most_recent_notification_id.
Expected to decode Int but found a string instead.
MastodonSDK/Mastodon+API.swift:255: Fatal error
```

**Root cause:** Mastodon serializes `most_recent_notification_id` as the *numeric* notification id, and the Mastodon iOS SDK decodes it into a non-optional Swift `Int` (`NotificationGroup.mostRecentNotificationID: Int` in `Mastodon+Entity+Notification.swift`). This service emitted its **UUID** notification id as a JSON *string*, so the app crashed. Every other id field in the response (`page_min_id`, `page_max_id`, `status_id`, account ids, `sample_account_ids`) decodes as `String`, which is why only this one field crashed.

**Why a synthesized number is safe** (verified against the mastodon-ios `develop` source):
- The app paginates grouped notifications by following the **`Link` header** URLs verbatim — it never builds a cursor from `mostRecentNotificationID`.
- Unread tracking uses the string `page_min_id`/`page_max_id` and the marker `last_read_id` (`String`), compared as strings.
- The only other use of the `Int` is building a web deep-link for `severed_relationships` / `moderation_warning` rows — notification types **this service never generates**.

So the field is effectively display-only for us, and a stable integer satisfies the decoder without affecting paging or unread.

## Fix

- `getNotificationGroup`: `most_recent_notification_id` is now a **number**, derived deterministically from the group's most-recent notification `createdAt` (epoch ms — well within a signed 64-bit int). UUID ids can't be JSON numbers, so a timestamp-based surrogate is the closest stable, monotonic value.
- `page_min_id` / `page_max_id` stay **UUID strings** — the real, resolvable pagination cursors.
- `GET /api/v2/notifications` **`Link` header**: anchor `max_id`/`min_id` on `page_max_id` (the UUID) instead of the now-numeric `most_recent_notification_id`, so the cursors the client sends back still resolve on the server. The single-group `/:group_key` endpoint inherits the change via `getNotificationGroup`.
- Regression tests pin that `most_recent_notification_id` is a JSON number and that the `Link` header uses the UUID, not the surrogate.
- Documented as an intentional divergence in `docs/mastodon-api-compatibility.md` (do not "fix" it back to the UUID — that re-crashes the app).

## Note on the other log lines

The `{"status":"Unauthorized"}` decode errors on `verify_credentials`, `timelines/home`, `filters`, etc. are `401` responses the app logs during early startup (before the token is attached) — the same session's authenticated `/api/v2/notifications` call succeeded with real data, so auth works and those recover. They are non-fatal (no crash) and out of scope here; happy to align the `401` body to Mastodon's `{"error": …}` shape separately if they prove noisy.

## Tests

- `lib/services/notifications/getNotificationGroup.test.ts`: asserts `most_recent_notification_id` is the numeric createdAt and `typeof === 'number'`; `page_max_id` keeps the UUID.
- `app/api/v2/notifications/route.test.ts`: asserts the response's `most_recent_notification_id` values are numbers and the `Link` header cursors are the UUIDs (not the numeric surrogate).
- Full local gate green: `yarn run prettier --write .`, `yarn lint`, `yarn build`, `yarn test` (662 files / 6242 tests).

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: `docs/mastodon-api-compatibility.md` documents the divergence
- [x] No migrations changed
- [x] `version` in `package.json` is untouched
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015F8uCxogFaSyzrghMh4RHF)_