### PR TITLE
Bump version to v1.101.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.5",
+  "version": "1.101.6",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.6.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.5`
- Base main SHA: `3e975ec2a2604d4380cf35f1c4d1c02fdd3f04ee`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
