### PR TITLE
fix: return Mastodon { error } shape for all API error responses (fixes Phanpy Settings 404 toast)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ For the most common task shapes, follow the step-by-step **Task Recipes** sectio
 
 - Always use `apiResponse` and `apiErrorResponse` from `@/lib/utils/response` for API route responses.
 - **Do NOT** use `Response.json()` directly in API routes.
+- **Error responses use Mastodon's `{ error: "message" }` shape, never `{ status: ... }`.** `apiErrorResponse`, `apiCorsError`, and the shared `codeMap`/`ERROR_4xx` constants all emit `{ error }` (the HTTP reason phrase for the response `statusText` lives separately in `REASON_PHRASE`), matching the [Mastodon `Error` entity](https://docs.joinmastodon.org/entities/Error/). Mastodon-API clients read the human-readable message from the `error` field — masto.js, for one, leaves an error's `message` empty for any other shape and drops the body into `additionalProperties` — so a `{ status: ... }` error body breaks them (this is what surfaced Phanpy's Settings 404 toast). When you write an inline error body, use `data: { error: '…' }`. Only success acknowledgements (`DEFAULT_200`/`DEFAULT_202`) keep the `{ status: 'OK' }`/`{ status: 'Accepted' }` shape, because they are not errors.
 - On CORS-enabled endpoints (those that export `OPTIONS`), always use `apiResponse` — even for error responses — so CORS headers are included. Reserve `apiErrorResponse` for non-CORS routes or middleware.
 - Example usage:
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -31,6 +31,11 @@ change doesn't touch.
   `@/lib/utils/response` — never `Response.json()`. On CORS-enabled routes (those
   exporting `OPTIONS`), use `apiResponse` even for errors so CORS headers are sent;
   reserve `apiErrorResponse` for non-CORS routes or middleware.
+- Error bodies use Mastodon's `{ error: 'message' }` shape, never `{ status: … }`.
+  The shared `apiErrorResponse` / `apiCorsError` / `codeMap` helpers already emit
+  `{ error }`; an inline error body must too (`data: { error: '…' }`). Mastodon
+  clients read the message from `error`, so a `{ status: … }` body breaks them.
+  Only success acks (`DEFAULT_200`/`DEFAULT_202`) keep `{ status: … }`.
 - Request bodies are validated with Zod **`safeParse`**, never `.parse()` (which
   throws and surfaces as a 500). Invalid input returns a 4xx, not a 500.
 - String fields backed by a sized column (e.g. `varchar(255)`) carry a matching

--- a/app/api/users/[username]/inbox/route.test.ts
+++ b/app/api/users/[username]/inbox/route.test.ts
@@ -52,7 +52,7 @@ vi.mock('@/lib/services/guards/ActivityPubVerifyGuard', () => ({
       context: { params: Promise<{ username: string }> }
     ) => {
       if (!(await mockVerifyAllows(req, context))) {
-        return Response.json({ status: 'Bad Request' }, { status: 400 })
+        return Response.json({ error: 'Bad Request' }, { status: 400 })
       }
 
       const activityBody =

--- a/app/api/v1/accounts/[id]/block/route.test.ts
+++ b/app/api/v1/accounts/[id]/block/route.test.ts
@@ -101,7 +101,7 @@ describe('POST /api/v1/accounts/:id/block', () => {
       params: Promise.resolve({ id: urlToId(targetActorId) })
     })
 
-    await expect(response.json()).resolves.toEqual({ status: 'Forbidden' })
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' })
     expect(response.status).toBe(403)
     expect(recordActorIfNeededMock).toHaveBeenCalledWith({
       actorId: targetActorId,

--- a/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
+++ b/app/api/v1/accounts/[id]/fitness-heatmap/route.test.ts
@@ -61,7 +61,7 @@ describe('/api/v1/accounts/[id]/fitness-heatmap legacy adapter', () => {
     })
 
     expect(response.status).toBe(404)
-    await expect(response.json()).resolves.toEqual({ status: 'Not Found' })
+    await expect(response.json()).resolves.toEqual({ error: 'Not Found' })
   })
 
   it('adapts route cache data to the legacy flat heatmap payload', async () => {

--- a/app/api/v1/accounts/[id]/follow/route.ts
+++ b/app/api/v1/accounts/[id]/follow/route.ts
@@ -86,7 +86,7 @@ export const POST = traceApiRoute(
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: { status: 'Forbidden' },
+          data: { error: 'Forbidden' },
           responseStatusCode: HTTP_STATUS.FORBIDDEN
         })
       }

--- a/app/api/v1/accounts/email/route.test.ts
+++ b/app/api/v1/accounts/email/route.test.ts
@@ -123,7 +123,7 @@ describe('POST /api/v1/accounts/email', () => {
 
     expect(response.status).toBe(500)
     await expect(response.json()).resolves.toEqual({
-      status: 'Internal Server Error'
+      error: 'Internal Server Error'
     })
     expect(mockDb.requestEmailChange).toHaveBeenCalled()
   })

--- a/app/api/v1/accounts/email/verify/route.test.ts
+++ b/app/api/v1/accounts/email/verify/route.test.ts
@@ -118,7 +118,7 @@ describe('POST /api/v1/accounts/email/verify', () => {
 
     expect(response.status).toBe(500)
     await expect(response.json()).resolves.toEqual({
-      status: 'Internal Server Error'
+      error: 'Internal Server Error'
     })
   })
 })

--- a/app/api/v1/accounts/follow/route.ts
+++ b/app/api/v1/accounts/follow/route.ts
@@ -109,7 +109,7 @@ export const POST = traceApiRoute(
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
-        data: { status: 'Forbidden' },
+        data: { error: 'Forbidden' },
         responseStatusCode: HTTP_STATUS.FORBIDDEN
       })
     }

--- a/app/api/v1/accounts/like/route.test.ts
+++ b/app/api/v1/accounts/like/route.test.ts
@@ -56,7 +56,7 @@ describe('POST /api/v1/accounts/like', () => {
     const data = await response.json()
 
     expect(response.status).toBe(422)
-    expect(data.status).toBe('Unprocessable entity')
+    expect(data.error).toBe('Unprocessable entity')
     expect(mockDatabase.getStatus).not.toHaveBeenCalled()
     expect(mockSendLike).not.toHaveBeenCalled()
   })
@@ -72,7 +72,7 @@ describe('POST /api/v1/accounts/like', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data.status).toBe('Bad Request')
+    expect(data.error).toBe('Bad Request')
     expect(mockDatabase.getStatus).not.toHaveBeenCalled()
     expect(mockSendLike).not.toHaveBeenCalled()
   })
@@ -94,7 +94,7 @@ describe('DELETE /api/v1/accounts/like', () => {
     const data = await response.json()
 
     expect(response.status).toBe(422)
-    expect(data.status).toBe('Unprocessable entity')
+    expect(data.error).toBe('Unprocessable entity')
     expect(mockDatabase.getStatus).not.toHaveBeenCalled()
     expect(mockSendUndoLike).not.toHaveBeenCalled()
   })
@@ -110,7 +110,7 @@ describe('DELETE /api/v1/accounts/like', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data.status).toBe('Bad Request')
+    expect(data.error).toBe('Bad Request')
     expect(mockDatabase.getStatus).not.toHaveBeenCalled()
     expect(mockSendUndoLike).not.toHaveBeenCalled()
   })

--- a/app/api/v1/accounts/outbox/route.test.ts
+++ b/app/api/v1/accounts/outbox/route.test.ts
@@ -82,7 +82,7 @@ describe('POST /api/v1/accounts/outbox', () => {
 
     expect(res.status).toBe(422)
     await expect(res.json()).resolves.toEqual({
-      status: 'Unprocessable entity'
+      error: 'Unprocessable entity'
     })
   })
 
@@ -107,7 +107,7 @@ describe('POST /api/v1/accounts/outbox', () => {
 
     expect(res.status).toBe(422)
     await expect(res.json()).resolves.toEqual({
-      status: 'Unprocessable entity'
+      error: 'Unprocessable entity'
     })
   })
 })

--- a/app/api/v1/accounts/password/reset/request/route.test.ts
+++ b/app/api/v1/accounts/password/reset/request/route.test.ts
@@ -130,7 +130,7 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     const data = await response.json()
 
     expect(response.status).toBe(500)
-    expect(data).toEqual({ status: 'Internal Server Error' })
+    expect(data).toEqual({ error: 'Internal Server Error' })
     expect(mockDb.requestPasswordReset).toHaveBeenCalledTimes(2)
   })
 
@@ -147,7 +147,7 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     const data = await response.json()
 
     expect(response.status).toBe(500)
-    expect(data).toEqual({ status: 'Internal Server Error' })
+    expect(data).toEqual({ error: 'Internal Server Error' })
     expect(mockDb.requestPasswordReset).toHaveBeenCalledTimes(2)
   })
 
@@ -158,7 +158,7 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data).toEqual({ status: 'Bad Request' })
+    expect(data).toEqual({ error: 'Bad Request' })
     expect(response.headers.get('access-control-allow-origin')).toBe(
       'https://client.llun.test'
     )
@@ -174,7 +174,7 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data).toEqual({ status: 'Bad Request' })
+    expect(data).toEqual({ error: 'Bad Request' })
     expect(response.headers.get('access-control-allow-origin')).toBe(
       'https://client.llun.test'
     )
@@ -192,7 +192,7 @@ describe('POST /api/v1/accounts/password/reset/request', () => {
     const data = await response.json()
 
     expect(response.status).toBe(500)
-    expect(data).toEqual({ status: 'Internal Server Error' })
+    expect(data).toEqual({ error: 'Internal Server Error' })
     expect(response.headers.get('access-control-allow-origin')).toBe(
       'https://client.llun.test'
     )

--- a/app/api/v1/accounts/password/reset/route.test.ts
+++ b/app/api/v1/accounts/password/reset/route.test.ts
@@ -58,7 +58,7 @@ describe('POST /api/v1/accounts/password/reset', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data).toEqual({ status: 'Bad Request' })
+    expect(data).toEqual({ error: 'Bad Request' })
     expect(response.headers.get('access-control-allow-origin')).toBe(
       'https://client.llun.test'
     )

--- a/app/api/v1/accounts/password/route.test.ts
+++ b/app/api/v1/accounts/password/route.test.ts
@@ -106,7 +106,7 @@ describe('POST /api/v1/accounts/password', () => {
     const response = await POST(request, { params: Promise.resolve({}) })
 
     expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+    await expect(response.json()).resolves.toEqual({ error: 'Bad Request' })
   })
 
   it('returns 422 for body failing schema validation', async () => {
@@ -153,7 +153,7 @@ describe('POST /api/v1/accounts/password', () => {
 
     expect(response.status).toBe(500)
     await expect(response.json()).resolves.toEqual({
-      status: 'Internal Server Error'
+      error: 'Internal Server Error'
     })
     expect(mockDb.changePassword).toHaveBeenCalledWith({
       accountId: account.id,

--- a/app/api/v1/accounts/repost/route.test.ts
+++ b/app/api/v1/accounts/repost/route.test.ts
@@ -58,7 +58,7 @@ describe('POST /api/v1/accounts/repost', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data.status).toBe('Bad Request')
+    expect(data.error).toBe('Bad Request')
     expect(mockUserAnnounce).not.toHaveBeenCalled()
   })
 })
@@ -82,7 +82,7 @@ describe('DELETE /api/v1/accounts/repost', () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data.status).toBe('Bad Request')
+    expect(data.error).toBe('Bad Request')
     expect(mockUserUndoAnnounce).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/apps/route.test.ts
+++ b/app/api/v1/apps/route.test.ts
@@ -271,7 +271,7 @@ describe('apps route', () => {
     const response = await POST(req)
 
     await expect(response.json()).resolves.toEqual({
-      status: 'Too Many Requests'
+      error: 'Too Many Requests'
     })
     expect(response.status).toBe(429)
   })

--- a/app/api/v1/fitness/general/route.test.ts
+++ b/app/api/v1/fitness/general/route.test.ts
@@ -538,7 +538,7 @@ describe('Fitness General Settings API', () => {
       const data = await response.json()
 
       expect(response.status).toBe(422)
-      expect(data.status).toBe('Unprocessable entity')
+      expect(data.error).toBe('Unprocessable entity')
       expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
       expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
     })
@@ -559,7 +559,7 @@ describe('Fitness General Settings API', () => {
       const response = await POST(request, { params: Promise.resolve({}) })
 
       expect(response.status).toBe(400)
-      await expect(response.json()).resolves.toEqual({ status: 'Bad Request' })
+      await expect(response.json()).resolves.toEqual({ error: 'Bad Request' })
       expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
       expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()
     })
@@ -586,7 +586,7 @@ describe('Fitness General Settings API', () => {
 
       expect(response.status).toBe(500)
       await expect(response.json()).resolves.toEqual({
-        status: 'Internal Server Error'
+        error: 'Internal Server Error'
       })
       expect(mockDb.createFitnessSettings).toHaveBeenCalled()
     })

--- a/app/api/v1/fitness/strava/route.test.ts
+++ b/app/api/v1/fitness/strava/route.test.ts
@@ -259,7 +259,7 @@ describe('Strava Settings API', () => {
       const data = await response.json()
 
       expect(response.status).toBe(422)
-      expect(data.status).toBe('Unprocessable entity')
+      expect(data.error).toBe('Unprocessable entity')
     })
 
     it('rejects empty client secret when creating a connection', async () => {
@@ -279,7 +279,7 @@ describe('Strava Settings API', () => {
       const data = await response.json()
 
       expect(response.status).toBe(422)
-      expect(data.status).toBe('Unprocessable entity')
+      expect(data.error).toBe('Unprocessable entity')
     })
 
     it('rejects invalid visibility values', async () => {
@@ -300,7 +300,7 @@ describe('Strava Settings API', () => {
       const data = await response.json()
 
       expect(response.status).toBe(422)
-      expect(data.status).toBe('Unprocessable entity')
+      expect(data.error).toBe('Unprocessable entity')
     })
 
     it('returns a bad request response for malformed JSON bodies', async () => {
@@ -320,7 +320,7 @@ describe('Strava Settings API', () => {
       const data = await response.json()
 
       expect(response.status).toBe(400)
-      expect(data.status).toBe('Bad Request')
+      expect(data.error).toBe('Bad Request')
       expect(mockDb.getFitnessSettings).not.toHaveBeenCalled()
       expect(mockDb.createFitnessSettings).not.toHaveBeenCalled()
       expect(mockDb.updateFitnessSettings).not.toHaveBeenCalled()

--- a/app/api/v1/instance/activity/route.test.ts
+++ b/app/api/v1/instance/activity/route.test.ts
@@ -50,7 +50,7 @@ describe('GET /api/v1/instance/activity', () => {
     )
 
     await expect(response.json()).resolves.toEqual({
-      status: 'Internal Server Error'
+      error: 'Internal Server Error'
     })
     expect(response.status).toBe(500)
   })
@@ -67,7 +67,7 @@ describe('GET /api/v1/instance/activity', () => {
     )
 
     await expect(response.json()).resolves.toEqual({
-      status: 'Internal Server Error'
+      error: 'Internal Server Error'
     })
     expect(response.status).toBe(500)
     expect(getInstanceActivity).toHaveBeenCalledTimes(1)

--- a/app/api/v1/push/subscription/route.test.ts
+++ b/app/api/v1/push/subscription/route.test.ts
@@ -223,11 +223,15 @@ describe('GET /api/v1/push/subscription', () => {
     expect(body.server_key).toBe('test-vapid-public-key')
   })
 
-  it('returns 404 when there is no subscription', async () => {
+  it('returns 404 with the Mastodon "Record not found" body when there is no subscription', async () => {
     mockDatabase!.getPushSubscriptionForActor = vi.fn().mockResolvedValue(null)
     const req = new NextRequest('http://localhost/api/v1/push/subscription')
     const res = await GET(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(404)
+    // Mastodon-API clients (e.g. Phanpy) detect the "no subscription yet" case
+    // by matching the error message; masto.js reads that message from `error`,
+    // so the body must be `{ error: 'Record not found' }`, not `{ status: … }`.
+    expect(await res.json()).toEqual({ error: 'Record not found' })
   })
 
   it('scopes the lookup to the requesting bearer token', async () => {
@@ -312,7 +316,7 @@ describe('PUT /api/v1/push/subscription', () => {
     )
   })
 
-  it('returns 404 when there is no subscription to update', async () => {
+  it('returns 404 with the Mastodon "Record not found" body when there is no subscription to update', async () => {
     mockDatabase!.updatePushSubscription = vi.fn().mockResolvedValue(null)
     const req = new NextRequest('http://localhost/api/v1/push/subscription', {
       method: 'PUT',
@@ -324,6 +328,7 @@ describe('PUT /api/v1/push/subscription', () => {
     })
     const res = await PUT(req, { params: Promise.resolve({}) })
     expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Record not found' })
   })
 })
 
@@ -402,7 +407,11 @@ describe('push subscription when push is not configured', () => {
     expect(mockDatabase!.createPushSubscription).not.toHaveBeenCalled()
 
     const get = new NextRequest('http://localhost/api/v1/push/subscription')
-    expect((await GET(get, { params: Promise.resolve({}) })).status).toBe(404)
+    const getRes = await GET(get, { params: Promise.resolve({}) })
+    expect(getRes.status).toBe(404)
+    // Same Mastodon "Record not found" shape as the no-subscription case, so
+    // clients treat a push-disabled server as simply "no subscription".
+    expect(await getRes.json()).toEqual({ error: 'Record not found' })
 
     const put = new NextRequest('http://localhost/api/v1/push/subscription', {
       method: 'PUT',

--- a/app/api/v1/push/subscription/route.test.ts
+++ b/app/api/v1/push/subscription/route.test.ts
@@ -403,7 +403,9 @@ describe('push subscription when push is not configured', () => {
         Origin: 'http://localhost'
       }
     })
-    expect((await POST(post, { params: Promise.resolve({}) })).status).toBe(404)
+    const postRes = await POST(post, { params: Promise.resolve({}) })
+    expect(postRes.status).toBe(404)
+    expect(await postRes.json()).toEqual({ error: 'Record not found' })
     expect(mockDatabase!.createPushSubscription).not.toHaveBeenCalled()
 
     const get = new NextRequest('http://localhost/api/v1/push/subscription')

--- a/app/api/v1/push/subscription/route.ts
+++ b/app/api/v1/push/subscription/route.ts
@@ -9,7 +9,7 @@ import {
 import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
 import {
@@ -32,6 +32,16 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const guardOptions = { errorResponse: corsErrorResponse(CORS_HEADERS) }
 
+// Mastodon answers a missing push subscription with `{ error: 'Record not
+// found' }` (HTTP 404), not the generic `{ status: 'Not Found' }`. Mastodon-API
+// clients rely on that: Phanpy treats "no subscription yet" as the expected
+// state only when the error *message* matches `/(not found|unknown)/i`. masto.js
+// derives that message from the body's `error` field, so a `{ status: … }` body
+// leaves the message empty, the check misses, and opening Settings surfaces a
+// `{"statusCode":404,"additionalProperties":{"status":"Not Found"}}` toast. Emit
+// the Mastodon shape so the message carries "Record not found".
+const RECORD_NOT_FOUND = { error: 'Record not found' }
+
 // Web Push requires VAPID keys; without `config.push` configured the server has
 // no `server_key` to hand out and `pushNotification` skips delivery entirely,
 // so a stored subscription would silently never receive notifications. Return
@@ -42,7 +52,7 @@ const requirePushConfig = (req: NextRequest): Response | null => {
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
-    data: ERROR_404,
+    data: RECORD_NOT_FOUND,
     responseStatusCode: 404
   })
 }
@@ -128,7 +138,7 @@ export const GET = traceApiRoute(
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_404,
+          data: RECORD_NOT_FOUND,
           responseStatusCode: 404
         })
       }
@@ -179,7 +189,7 @@ export const PUT = traceApiRoute(
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_404,
+          data: RECORD_NOT_FOUND,
           responseStatusCode: 404
         })
       }

--- a/app/api/v1/push/subscription/route.ts
+++ b/app/api/v1/push/subscription/route.ts
@@ -45,7 +45,9 @@ const RECORD_NOT_FOUND = { error: 'Record not found' }
 // Web Push requires VAPID keys; without `config.push` configured the server has
 // no `server_key` to hand out and `pushNotification` skips delivery entirely,
 // so a stored subscription would silently never receive notifications. Return
-// 404 instead, matching `app/api/v1/push/vapid-key/route.ts`.
+// 404 — like `app/api/v1/push/vapid-key/route.ts` does for a missing key —
+// but with the Mastodon `{ error }` body above so clients read it as "no
+// subscription" rather than an error (see the RECORD_NOT_FOUND note).
 const requirePushConfig = (req: NextRequest): Response | null => {
   const config = getConfig()
   if (config.push) return null

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -1324,7 +1324,7 @@ describe('GET /api/v1/statuses/[id]', () => {
       )
 
       expect(response.status).toBe(404)
-      await expect(response.json()).resolves.toEqual({ status: 'Not Found' })
+      await expect(response.json()).resolves.toEqual({ error: 'Not Found' })
       await expect(
         database.isActorBookmarkedStatus({ actorId: ACTOR3_ID, statusId })
       ).resolves.toBe(false)

--- a/app/api/v2/search/route.test.ts
+++ b/app/api/v2/search/route.test.ts
@@ -306,7 +306,7 @@ describe('GET /api/v2/search', () => {
     const data = await response.json()
 
     expect(response.status).toBe(401)
-    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(data).toEqual({ error: 'Unauthorized' })
     expect(mockSearchAccountIds).not.toHaveBeenCalled()
     expect(mockSearchHashtags).not.toHaveBeenCalled()
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
@@ -322,7 +322,7 @@ describe('GET /api/v2/search', () => {
     const data = await response.json()
 
     expect(response.status).toBe(401)
-    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(data).toEqual({ error: 'Unauthorized' })
     expect(mockSearchAccountIds).not.toHaveBeenCalled()
     expect(mockSearchHashtags).not.toHaveBeenCalled()
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
@@ -338,7 +338,7 @@ describe('GET /api/v2/search', () => {
     const data = await response.json()
 
     expect(response.status).toBe(401)
-    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(data).toEqual({ error: 'Unauthorized' })
     expect(mockSearchAccountIds).not.toHaveBeenCalled()
   })
 
@@ -433,7 +433,7 @@ describe('GET /api/v2/search', () => {
     const data = await response.json()
 
     expect(response.status).toBe(401)
-    expect(data).toEqual({ status: 'Unauthorized' })
+    expect(data).toEqual({ error: 'Unauthorized' })
     expect(mockSearchStatusIds).not.toHaveBeenCalled()
   })
 

--- a/lib/client.test.ts
+++ b/lib/client.test.ts
@@ -247,7 +247,7 @@ describe('client createPoll', () => {
   })
 
   it('throws when poll creation is rejected by the server', async () => {
-    fetchMock.mockResponse(JSON.stringify({ status: 'Unprocessable entity' }), {
+    fetchMock.mockResponse(JSON.stringify({ error: 'Unprocessable entity' }), {
       status: 422
     })
 

--- a/lib/components/settings/FitnessFileManagement.test.tsx
+++ b/lib/components/settings/FitnessFileManagement.test.tsx
@@ -499,7 +499,7 @@ describe('FitnessFileManagement', () => {
     it('parses API JSON errors into readable delete messages', async () => {
       vi.spyOn(global, 'fetch').mockResolvedValue({
         ok: false,
-        text: async () => JSON.stringify({ status: 'Not Found' }),
+        text: async () => JSON.stringify({ error: 'Not Found' }),
         statusText: 'Not Found'
       } as Response)
 

--- a/lib/services/timelines/request.test.ts
+++ b/lib/services/timelines/request.test.ts
@@ -209,6 +209,6 @@ describe('timelineErrorBoundary', () => {
     const response = await wrapped(request(), {})
     expect(response.status).toBe(500)
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy()
-    expect(await response.json()).toEqual({ status: 'Internal Server Error' })
+    expect(await response.json()).toEqual({ error: 'Internal Server Error' })
   })
 })

--- a/lib/utils/response.test.ts
+++ b/lib/utils/response.test.ts
@@ -16,16 +16,16 @@ import {
 
 describe('response utilities', () => {
   describe('error constants', () => {
-    it('has correct error status messages', () => {
-      expect(ERROR_400).toEqual({ status: 'Bad Request' })
-      expect(ERROR_401).toEqual({ status: 'Unauthorized' })
-      expect(ERROR_403).toEqual({ status: 'Forbidden' })
-      expect(ERROR_404).toEqual({ status: 'Not Found' })
-      expect(ERROR_422).toEqual({ status: 'Unprocessable entity' })
-      expect(ERROR_500).toEqual({ status: 'Internal Server Error' })
+    it('uses the Mastodon { error } shape', () => {
+      expect(ERROR_400).toEqual({ error: 'Bad Request' })
+      expect(ERROR_401).toEqual({ error: 'Unauthorized' })
+      expect(ERROR_403).toEqual({ error: 'Forbidden' })
+      expect(ERROR_404).toEqual({ error: 'Not Found' })
+      expect(ERROR_422).toEqual({ error: 'Unprocessable entity' })
+      expect(ERROR_500).toEqual({ error: 'Internal Server Error' })
     })
 
-    it('has correct success status messages', () => {
+    it('keeps the { status } shape for success acknowledgements', () => {
       expect(DEFAULT_200).toEqual({ status: 'OK' })
       expect(DEFAULT_202).toEqual({ status: 'Accepted' })
     })

--- a/lib/utils/response.ts
+++ b/lib/utils/response.ts
@@ -5,19 +5,28 @@ import { SERVICE_NAME } from '@/lib/constants'
 
 import { HttpMethod, getCORSHeaders } from './http-headers'
 
-export const ERROR_500 = { status: 'Internal Server Error' }
+// Mastodon serializes every error as `{ "error": "message" }`
+// (https://docs.joinmastodon.org/entities/Error/). Emit that shape for all
+// error responses so Mastodon-API clients (Phanpy, Elk, Tusky, the iOS app, …)
+// can read the message: masto.js, for instance, derives an error's `message`
+// from this `error` field and drops any other key into `additionalProperties`,
+// so the old generic `{ status: … }` body left the message empty. The HTTP
+// reason phrase used for the response `statusText` lives separately in
+// `REASON_PHRASE`, so it stays correct regardless of the body shape.
+export const ERROR_500 = { error: 'Internal Server Error' }
 
-export const ERROR_400 = { status: 'Bad Request' }
-export const ERROR_401 = { status: 'Unauthorized' }
-export const ERROR_403 = { status: 'Forbidden' }
-export const ERROR_404 = { status: 'Not Found' }
-export const ERROR_409 = { status: 'Conflict' }
-export const ERROR_422 = { status: 'Unprocessable entity' }
-export const ERROR_429 = { status: 'Too Many Requests' }
-export const ERROR_413 = { status: 'Payload Too Large' }
-export const ERROR_501 = { status: 'Not Implemented' }
-export const ERROR_503 = { status: 'Service Unavailable' }
+export const ERROR_400 = { error: 'Bad Request' }
+export const ERROR_401 = { error: 'Unauthorized' }
+export const ERROR_403 = { error: 'Forbidden' }
+export const ERROR_404 = { error: 'Not Found' }
+export const ERROR_409 = { error: 'Conflict' }
+export const ERROR_422 = { error: 'Unprocessable entity' }
+export const ERROR_429 = { error: 'Too Many Requests' }
+export const ERROR_413 = { error: 'Payload Too Large' }
+export const ERROR_501 = { error: 'Not Implemented' }
+export const ERROR_503 = { error: 'Service Unavailable' }
 
+// Success acknowledgements are not errors, so they keep the `{ status }` shape.
 export const DEFAULT_200 = { status: 'OK' }
 export const DEFAULT_202 = { status: 'Accepted' }
 
@@ -57,6 +66,25 @@ export const codeMap = {
 
 export type StatusCode = keyof typeof codeMap
 
+// HTTP reason phrases for the response `statusText`, kept independent of the
+// JSON body: error bodies now carry the human-readable message under `error`
+// (not `status`), so `statusText` reads from here instead of the body object.
+export const REASON_PHRASE: Record<StatusCode, string> = {
+  [HTTP_STATUS.OK]: 'OK',
+  [HTTP_STATUS.ACCEPTED]: 'Accepted',
+  [HTTP_STATUS.BAD_REQUEST]: 'Bad Request',
+  [HTTP_STATUS.UNAUTHORIZED]: 'Unauthorized',
+  [HTTP_STATUS.FORBIDDEN]: 'Forbidden',
+  [HTTP_STATUS.NOT_FOUND]: 'Not Found',
+  [HTTP_STATUS.CONFLICT]: 'Conflict',
+  [HTTP_STATUS.PAYLOAD_TOO_LARGE]: 'Payload Too Large',
+  [HTTP_STATUS.UNPROCESSABLE_ENTITY]: 'Unprocessable entity',
+  [HTTP_STATUS.TOO_MANY_REQUESTS]: 'Too Many Requests',
+  [HTTP_STATUS.INTERNAL_SERVER_ERROR]: 'Internal Server Error',
+  [HTTP_STATUS.NOT_IMPLEMENTED]: 'Not Implemented',
+  [HTTP_STATUS.SERVICE_UNAVAILABLE]: 'Service Unavailable'
+}
+
 export const UNFOLLOW_NETWORK_ERROR_CODES = [
   'ENOTFOUND',
   'DEPTH_ZERO_SELF_SIGNED_CERT'
@@ -68,7 +96,9 @@ export const apiErrorResponse = (code: StatusCode) => {
     if (code >= 400) {
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: codeMap[code]?.status || ERROR_500.status
+        message:
+          REASON_PHRASE[code] ||
+          REASON_PHRASE[HTTP_STATUS.INTERNAL_SERVER_ERROR]
       })
     } else {
       span.setStatus({
@@ -80,17 +110,17 @@ export const apiErrorResponse = (code: StatusCode) => {
   if (!codeMap[code]) {
     return Response.json(ERROR_500, {
       status: code,
-      statusText: ERROR_500.status
+      statusText: REASON_PHRASE[HTTP_STATUS.INTERNAL_SERVER_ERROR]
     })
   }
 
   return Response.json(codeMap[code], {
     status: code,
-    statusText: codeMap[code].status
+    statusText: REASON_PHRASE[code]
   })
 }
 
-export const statusText = (code: StatusCode) => codeMap[code].status
+export const statusText = (code: StatusCode) => REASON_PHRASE[code]
 export const defaultStatusOption = (code: StatusCode) => ({
   status: code,
   statusText: statusText(code)


### PR DESCRIPTION
## Summary

Opening **Settings** in Phanpy against an activities.next instance (e.g. `llun.social`) pops an error toast:

```
{"statusCode":404,"additionalProperties":{"status":"Not Found"}}
```

**Root cause.** On the Settings screen Phanpy's `initSubscription()` calls `masto.v1.push.subscription.fetch()` → `GET /api/v1/push/subscription`. When there is no subscription (or push isn't configured), the route returned HTTP 404 with the app's generic body `{ "status": "Not Found" }`. Mastodon returns `{ "error": "…" }`, and Mastodon-API clients depend on that shape: masto.js builds an error's `message` from the body's **`error`** field and drops every other key into **`additionalProperties`**, so a `{ "status": … }` body yields an **empty `message`**. Phanpy only treats "no subscription yet" as expected when `/(not found|unknown)/i.test(err.message)` matches, so with an empty message the harmless 404 escapes as the toast above.

This is not unique to push subscriptions — it's systemic. Across the app, status-style errors (401/403/404/500) — including the auth guards on every protected route — emitted the non-Mastodon `{ status: … }` body.

## Fix

Standardize **every** API error response to Mastodon's `{ error: 'message' }` shape ([Mastodon `Error` entity](https://docs.joinmastodon.org/entities/Error/)):

- **`lib/utils/response.ts`** — the `ERROR_4xx`/`ERROR_5xx` constants (and therefore `codeMap`, `apiErrorResponse`, `apiCorsError`, and the `OAuthGuard`/`ActivityPubVerifyGuard` that build on them) now emit `{ error }`. The HTTP reason phrase for the response `statusText` moved to a dedicated `REASON_PHRASE` map, so `statusText` stays correct independent of the body shape.
- The push-subscription route keeps its precise Mastodon message `{ error: 'Record not found' }` (GET/PUT missing subscription + push-not-configured), and its regression tests.
- Two inline `{ status: 'Forbidden' }` follow-route bodies converted.
- **Success acknowledgements** (`DEFAULT_200`/`DEFAULT_202`) intentionally keep `{ status: 'OK' }`/`{ status: 'Accepted' }` — they are not errors.

The web UI is unaffected: `lib/client.ts`'s error extractors already read `.error` (with a `.status` fallback). `AGENTS.md` and `REVIEW.md` document the convention so `{ status }` error bodies aren't reintroduced.

## Verification

Diagnosed by reading the source on both sides (activities.next route + Phanpy `push-notifications.js` + masto.js error construction), then reproduced end-to-end against a **local SQLite** instance with a real signed better-auth session (Phanpy.social is hosted and can't reach a localhost dev server, so the exact API call was exercised directly):

| | `GET /api/v1/push/subscription` (no subscription) |
| --- | --- |
| **Before** | `404` `{"status":"Not Found"}` → empty masto.js message → Phanpy toast |
| **After** | `404` `{"error":"Record not found"}` → message present → handled silently |

`yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` (662 files, 6243 tests) all pass. Route/unit tests that asserted the old `{ status }` shape were updated to `{ error }`.

## Note on scope

This changes the body of **every** API error response. It aligns with the Mastodon contract clients actually expect (the old `{ status }` shape was never a documented contract), so it's marked `fix:` — but if you consider the broad response-shape change worth a larger version bump, retitle with `minor:`/`major:` before squash-merge.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: `AGENTS.md` (API Response Guidelines) and `REVIEW.md` document the `{ error }` convention
- [x] If migrations changed: N/A (no migrations)
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHVhEkfrftEkyzLYsptoJg