### PR TITLE
fix: complete real min_id pagination on home timeline, grouped notifications, and list accounts

### DIFF
--- a/app/api/v1/lists/[id]/accounts/route.test.ts
+++ b/app/api/v1/lists/[id]/accounts/route.test.ts
@@ -66,6 +66,27 @@ describe('GET /api/v1/lists/:id/accounts', () => {
     )
   })
 
+  it.each([
+    { field: 'min_id' as const, slot: 'minId', other: 'sinceId' },
+    { field: 'since_id' as const, slot: 'sinceId', other: 'minId' }
+  ])(
+    'routes $field alone to $slot without collapsing into $other',
+    async ({ field, slot, other }) => {
+      const request = new NextRequest(`${URL_BASE}?${field}=cursor-x`)
+      const response = await GET(request, params())
+      expect(response.status).toBe(200)
+      const call = mockDatabase.getListAccounts.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >
+      expect(call[slot]).toBe('cursor-x')
+      // The absent cursor is passed as null (query default), never collapsed
+      // into the other slot — so min_id gets adjacent-page and since_id gets
+      // newest-slice semantics.
+      expect(call[other]).toBeNull()
+    }
+  )
+
   it('returns all members without pagination when limit=0', async () => {
     mockDatabase.getListAccounts.mockResolvedValue({
       accounts: [{ id: 'a1' }, { id: 'a2' }],

--- a/app/api/v1/lists/[id]/accounts/route.ts
+++ b/app/api/v1/lists/[id]/accounts/route.ts
@@ -67,10 +67,12 @@ export const GET = traceApiRoute(
           actorId: currentActor.id,
           limit,
           maxId: url.searchParams.get('max_id'),
-          // The prev link we emit uses min_id, so accept it as well as the
-          // legacy since_id for newer-page pagination.
-          sinceId:
-            url.searchParams.get('since_id') || url.searchParams.get('min_id')
+          // Pass min_id and since_id through separately: min_id returns the page
+          // immediately adjacent to the cursor (ascending seek then reversed),
+          // since_id the newest slice above it. The prev link we emit uses
+          // min_id, so it round-trips into the adjacent-page path.
+          minId: url.searchParams.get('min_id'),
+          sinceId: url.searchParams.get('since_id')
         }
       )
 

--- a/app/api/v1/timelines/[timeline]/route.test.ts
+++ b/app/api/v1/timelines/[timeline]/route.test.ts
@@ -594,7 +594,7 @@ describe('GET /api/v1/timelines/[timeline]', () => {
       }
     )
 
-    test('since_id takes precedence over min_id for the lower-bound cursor', async () => {
+    test('min_id takes precedence over since_id and drives the adjacent-page (ascending) scan', async () => {
       mockGetServerSession.mockResolvedValue({
         user: { email: seedActor1.email }
       })
@@ -610,12 +610,31 @@ describe('GET /api/v1/timelines/[timeline]', () => {
         { params: Promise.resolve({ timeline: 'main' }) }
       )
 
-      // The home/direct feed backfills DESC, so its lower bound reaches
-      // getTimeline as sinceStatusId (newest-first). since_id still wins the
-      // collapse over min_id.
+      // min_id is the adjacent-page cursor, so it wins and reaches getTimeline
+      // as minStatusId (ascending seek then reversed) — never collapsed into the
+      // DESC since path.
       expect(spy).toHaveBeenCalledWith(
-        expect.objectContaining({ sinceStatusId: sinceUrl })
+        expect.objectContaining({ minStatusId: minUrl })
       )
+      spy.mockRestore()
+    })
+
+    test('since_id alone reaches getTimeline as the DESC sinceStatusId lower bound', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const sinceUrl = 'https://llun.test/users/test1/statuses/since-only'
+      const spy = vi.spyOn(database, 'getTimeline').mockResolvedValue([])
+
+      await GET(createRequest({ since_id: urlToId(sinceUrl) }), {
+        params: Promise.resolve({ timeline: 'main' })
+      })
+
+      const call = spy.mock.calls[0][0] as Record<string, unknown>
+      expect(call.sinceStatusId).toBe(sinceUrl)
+      // since_id keeps newest-first ordering, so the DESC backfill never drives
+      // it as min_id.
+      expect(call.minStatusId).toBeUndefined()
       spy.mockRestore()
     })
   })

--- a/app/api/v1/timelines/[timeline]/route.ts
+++ b/app/api/v1/timelines/[timeline]/route.ts
@@ -90,14 +90,13 @@ export const GET = traceApiRoute(
       // Keep /api/v1/timelines/direct for Mastodon client compatibility.
       // The messages UI uses /api/v1/conversations for threaded direct messages.
 
-      // `since_id` and `min_id` both express a lower-bound cursor here; the DB
-      // timeline query takes a single min cursor, so collapse them preserving
-      // this route's existing `since_id`-wins precedence. (min/since ordering
-      // semantics are unchanged by this PR — see PR notes.)
+      // Pass min_id and since_id through separately: min_id returns the page
+      // immediately adjacent to the cursor (ascending seek then reversed),
+      // since_id the newest slice above it. min_id wins when both are present.
       const pageLimit = parsedQuery.query.limit
       const maxStatusId = parsedQuery.query.maxStatusId
-      const minStatusId =
-        parsedQuery.query.sinceStatusId ?? parsedQuery.query.minStatusId
+      const minStatusId = parsedQuery.query.minStatusId
+      const sinceStatusId = parsedQuery.query.sinceStatusId
 
       const { statuses, nextMaxStatusId, prevMinStatusId, filterRecords } =
         await getFilteredTimelinePage({
@@ -105,6 +104,7 @@ export const GET = traceApiRoute(
           timeline,
           actorId: currentActor.id,
           minStatusId,
+          sinceStatusId,
           maxStatusId,
           limit: pageLimit,
           filterContext: getFilterContextForTimeline(timeline)

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -240,6 +240,45 @@ describe('GET /api/v2/notifications', () => {
     expect(link).toContain('rel="prev"')
   })
 
+  it('emits a min_id continuation link when a min_id page has no visible groups but the source is not exhausted', async () => {
+    // Every scanned window is one bursty group whose accounts do not resolve, so
+    // the envelope suppresses it: the collector hits its iteration cap without
+    // exhausting (full batches, <limit groups) and no group survives. On a min_id
+    // (ascending) page this must page UPWARD via a min_id link from the last
+    // scanned row, not a max_id link.
+    mockDatabase.getMastodonActorsFromIds.mockResolvedValue([])
+    // batchSize = limit(2) * GROUP_OVERSCAN(5) = 10 full rows, one group.
+    mockDatabase.getNotifications.mockResolvedValue(
+      Array.from({ length: 10 }, (_, i) => ({
+        id: `burst-${i}`,
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 3000 - i,
+        updatedAt: 3000 - i
+      }))
+    )
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications?limit=2&min_id=floor',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.notification_groups).toHaveLength(0)
+    const link = response.headers.get('Link') ?? ''
+    // Ascending: continue upward with a min_id (prev) link from the newest
+    // scanned row — never a max_id (next) link that would page back down.
+    expect(link).toContain('min_id=burst-0')
+    expect(link).toContain('rel="prev"')
+    expect(link).not.toContain('max_id=')
+  })
+
   it('anchors the next (max_id) Link on the last returned group most-recent id', async () => {
     mockDatabase.getNotifications.mockResolvedValueOnce([
       {

--- a/app/api/v2/notifications/route.test.ts
+++ b/app/api/v2/notifications/route.test.ts
@@ -146,32 +146,99 @@ describe('GET /api/v2/notifications', () => {
   )
 
   it.each([
-    ['min_id', 'min_id'],
-    ['since_id', 'since_id']
+    {
+      field: 'min_id' as const,
+      slot: 'minNotificationId',
+      other: 'sinceNotificationId'
+    },
+    {
+      field: 'since_id' as const,
+      slot: 'sinceNotificationId',
+      other: 'minNotificationId'
+    }
   ])(
-    'collapses %s to since-semantics for the grouped (DESC) scan',
-    async (_label, param) => {
+    'routes $field to its own cursor param for the grouped scan',
+    async ({ field, slot, other }) => {
       mockDatabase.getNotifications.mockResolvedValueOnce([])
 
       const request = new NextRequest(
-        `https://llun.test/api/v2/notifications?${param}=cursor-1`,
+        `https://llun.test/api/v2/notifications?${field}=cursor-1`,
         { method: 'GET' }
       )
       const response = await GET(request, { params: Promise.resolve({}) })
 
       expect(response.status).toBe(200)
-      // The grouped v2 path always scans DESC (collectNotificationGroups advances
-      // max_id by the oldest row), so both min_id and since_id must reach
-      // getNotifications as the since-semantics lower bound — never as
-      // minNotificationId, which would flip getNotifications to ascending and
-      // break the batching.
-      expect(mockDatabase.getNotifications).toHaveBeenCalledWith(
-        expect.objectContaining({ sinceNotificationId: 'cursor-1' })
-      )
-      const callArg = mockDatabase.getNotifications.mock.calls[0][0]
-      expect(callArg.minNotificationId).toBeUndefined()
+      // min_id drives collectNotificationGroups' ascending (adjacent-page) scan
+      // via minNotificationId; since_id keeps the DESC scan via
+      // sinceNotificationId. They must never collapse into one slot.
+      const callArg = mockDatabase.getNotifications.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >
+      expect(callArg[slot]).toBe('cursor-1')
+      expect(callArg[other]).toBeUndefined()
     }
   )
+
+  it('returns the adjacent (oldest) groups above the cursor for min_id, newest-first', async () => {
+    // Three distinct groups above the cursor, newest-first (the ascending seek
+    // in getNotifications returns min_id windows newest-first). With limit=2 the
+    // adjacent page is the two OLDEST of them (reblog, follow) — not the newest
+    // two — returned newest-first.
+    mockDatabase.getNotifications.mockResolvedValueOnce([
+      {
+        id: 'g-new',
+        type: 'like',
+        sourceActorId: 'https://other.test/users/alice',
+        statusId: 'https://other.test/statuses/1',
+        groupKey: 'like:https://other.test/statuses/1',
+        isRead: false,
+        filtered: false,
+        createdAt: 3000,
+        updatedAt: 3000
+      },
+      {
+        id: 'g-mid',
+        type: 'reblog',
+        sourceActorId: 'https://other.test/users/bob',
+        statusId: 'https://other.test/statuses/2',
+        groupKey: 'reblog:https://other.test/statuses/2',
+        isRead: false,
+        filtered: false,
+        createdAt: 2000,
+        updatedAt: 2000
+      },
+      {
+        id: 'g-old',
+        type: 'follow',
+        sourceActorId: 'https://other.test/users/carol',
+        groupKey: 'follow:1',
+        isRead: false,
+        filtered: false,
+        createdAt: 1000,
+        updatedAt: 1000
+      }
+    ])
+
+    const request = new NextRequest(
+      'https://llun.test/api/v2/notifications?limit=2&min_id=floor',
+      { method: 'GET' }
+    )
+    const response = await GET(request, { params: Promise.resolve({}) })
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(
+      data.notification_groups.map((g: { group_key: string }) => g.group_key)
+    ).toEqual(['reblog:https://other.test/statuses/2', 'follow:1'])
+    const link = response.headers.get('Link') ?? ''
+    // next/max_id anchors on the oldest surviving group; prev/min_id on the
+    // newest surviving group.
+    expect(link).toContain('max_id=g-old')
+    expect(link).toContain('rel="next"')
+    expect(link).toContain('min_id=g-mid')
+    expect(link).toContain('rel="prev"')
+  })
 
   it('anchors the next (max_id) Link on the last returned group most-recent id', async () => {
     mockDatabase.getNotifications.mockResolvedValueOnce([

--- a/app/api/v2/notifications/route.ts
+++ b/app/api/v2/notifications/route.ts
@@ -139,12 +139,12 @@ export const GET = traceApiRoute(
         database,
         baseQuery: {
           actorId: currentActor.id,
-          // The grouped v2 path fetches in DESC batches (collectNotificationGroups
-          // advances max_id by the oldest row), so its lower bound stays
-          // since-semantics — driving it as min_id would flip getNotifications to
-          // ascending and break the batching. Adjacent-page min_id for grouped
-          // notifications is a separate change.
-          sinceNotificationId: minId || sinceId,
+          // min_id drives collectNotificationGroups' ascending (adjacent-page)
+          // scan — the oldest groups just newer than the cursor; since_id keeps
+          // the DESC scan (the newest slice above it). They stay in their own
+          // slots so neither semantics collapses into the other.
+          minNotificationId: minId,
+          sinceNotificationId: sinceId,
           types: mastodonTypesToInternal(types),
           excludeTypes: mastodonTypesToInternal(excludeTypes),
           includeFiltered
@@ -178,7 +178,14 @@ export const GET = traceApiRoute(
         currentActor.id,
         filterRecords
       )
-      const survivingGroups = fullEnvelope.notification_groups.slice(0, limit)
+      // min_id scans ascending, so the accumulated envelope (newest-first) holds
+      // the groups just above the cursor: the adjacent page is its OLDEST `limit`
+      // survivors (the tail), still newest-first. Every other cursor kind scans
+      // DESC, so the adjacent/newest page is the leading `limit`.
+      const ascending = Boolean(minId)
+      const survivingGroups = ascending
+        ? fullEnvelope.notification_groups.slice(-limit)
+        : fullEnvelope.notification_groups.slice(0, limit)
       const keptStatusIds = new Set(
         survivingGroups.map((g) => g.status_id).filter(Boolean)
       )
@@ -254,10 +261,13 @@ export const GET = traceApiRoute(
           .join(', ')
       } else if (!exhausted && lastScannedId) {
         // No visible groups on this page but the source isn't exhausted (e.g. the
-        // iteration cap was hit, or account_id filtered out the whole window): emit
-        // only a next link from the last scanned row so the client keeps paging
-        // toward matching/visible groups further down instead of stopping.
-        links = buildLink('max_id', lastScannedId)
+        // iteration cap was hit, or account_id filtered out the whole window):
+        // emit a single link from the last scanned row so the client keeps paging
+        // toward matching/visible groups. min_id pages upward (newer), so hand it
+        // a min_id link; every other scan pages downward with a max_id link.
+        links = ascending
+          ? buildLink('min_id', lastScannedId)
+          : buildLink('max_id', lastScannedId)
       }
 
       return apiResponse({

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -1293,6 +1293,48 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('getListAccounts returns an empty page for an unresolvable min_id cursor', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      if (!owner) throw new Error('owner not created')
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Members list'
+      })
+      for (const username of ['m1', 'm2', 'm3']) {
+        await createLocalAccount(database, username)
+        const member = await database.getActorFromUsername({
+          username,
+          domain: TEST_DOMAIN
+        })
+        if (!member) throw new Error(`${username} not created`)
+        await database.addListAccounts({
+          listId: list.id,
+          actorId: owner.id,
+          targetActorIds: [member.id]
+        })
+      }
+
+      // A min_id whose membership row was removed (or a foreign id) must
+      // terminate pagination with an empty page — matching getListTimeline —
+      // rather than dropping the filter and returning the OLDEST members (the
+      // wrong end of the list under the ascending min_id order).
+      const page = await database.getListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        minId: 'does-not-exist',
+        limit: 2
+      })
+      expect(page.accounts).toEqual([])
+      expect(page.nextMaxId).toBeNull()
+      expect(page.prevMinId).toBeNull()
+    })
+  })
+
   it('paginates from a cursor that exists but is not in the list partition', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.test.ts
+++ b/lib/database/sql/list.test.ts
@@ -1216,6 +1216,83 @@ describe('ListDatabase', () => {
     })
   })
 
+  it('getListAccounts distinguishes min_id (adjacent page) from since_id (newest slice)', async () => {
+    await withFreshDatabase(async (database) => {
+      await createLocalAccount(database, 'owner')
+      const owner = await database.getActorFromUsername({
+        username: 'owner',
+        domain: TEST_DOMAIN
+      })
+      if (!owner) throw new Error('owner not created')
+
+      const list = await database.createList({
+        actorId: owner.id,
+        title: 'Members list'
+      })
+
+      // Five members, oldest → newest by membership createdAt. addListAccounts
+      // stamps one createdAt per call, so add them one per call with a small gap
+      // to give each row a distinct, ordered createdAt (the id tie-break is a
+      // random UUID and can't order them chronologically on its own).
+      const usernames = ['m1', 'm2', 'm3', 'm4', 'm5']
+      for (const username of usernames) {
+        await createLocalAccount(database, username)
+        const member = await database.getActorFromUsername({
+          username,
+          domain: TEST_DOMAIN
+        })
+        if (!member) throw new Error(`${username} not created`)
+        await database.addListAccounts({
+          listId: list.id,
+          actorId: owner.id,
+          targetActorIds: [member.id]
+        })
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+
+      // Full page is newest-first; nextMaxId is the oldest member's (m1)
+      // membership-row id — the cursor both pagination kinds page above.
+      const full = await database.getListAccounts({
+        listId: list.id,
+        actorId: owner.id
+      })
+      expect(full.accounts.map((account) => account.username)).toEqual([
+        'm5',
+        'm4',
+        'm3',
+        'm2',
+        'm1'
+      ])
+      const cursor = full.nextMaxId
+      if (!cursor) throw new Error('expected a cursor for m1')
+
+      // since_id: the two NEWEST members above the cursor.
+      const sincePage = await database.getListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        sinceId: cursor,
+        limit: 2
+      })
+      expect(sincePage.accounts.map((account) => account.username)).toEqual([
+        'm5',
+        'm4'
+      ])
+
+      // min_id: the two OLDEST members above the cursor (the adjacent page),
+      // returned newest-first — a different slice than since_id.
+      const minPage = await database.getListAccounts({
+        listId: list.id,
+        actorId: owner.id,
+        minId: cursor,
+        limit: 2
+      })
+      expect(minPage.accounts.map((account) => account.username)).toEqual([
+        'm3',
+        'm2'
+      ])
+    })
+  })
+
   it('paginates from a cursor that exists but is not in the list partition', async () => {
     await withFreshDatabase(async (database) => {
       await createLocalAccount(database, 'owner')

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -209,12 +209,17 @@ export const ListSQLDatabaseMixin = (
     const applyCursor = async (
       cursorId: string,
       direction: 'older' | 'newer'
-    ) => {
+    ): Promise<boolean> => {
       const cursor = await database('list_accounts')
         .where({ listId, actorId, id: cursorId })
         .select('createdAt')
         .first<{ createdAt: number | Date }>()
-      if (!cursor) return
+      // Returns false when the cursor row is gone (removed member / foreign id),
+      // so the caller ends pagination with an empty page instead of silently
+      // dropping the WHERE — which, under the ascending min_id order, would
+      // return the OLDEST members (the wrong end of the list). Mirrors
+      // getListTimeline's unresolvable-cursor guard.
+      if (!cursor) return false
       const operator = direction === 'older' ? '<' : '>'
       query.andWhere((builder) => {
         builder
@@ -225,13 +230,17 @@ export const ListSQLDatabaseMixin = (
               .andWhere('id', operator, cursorId)
           })
       })
+      return true
     }
 
+    const emptyPage = { accounts: [], nextMaxId: null, prevMinId: null }
     // min_id and since_id are both lower-bound cursors (rows newer than it); they
-    // differ only in ordering, handled by `ascending` above.
+    // differ only in ordering, handled by `ascending` above. An unresolvable
+    // cursor terminates pagination with an empty page.
     const lowerBoundId = minId || sinceId
-    if (maxId) await applyCursor(maxId, 'older')
-    if (lowerBoundId) await applyCursor(lowerBoundId, 'newer')
+    if (maxId && !(await applyCursor(maxId, 'older'))) return emptyPage
+    if (lowerBoundId && !(await applyCursor(lowerBoundId, 'newer')))
+      return emptyPage
 
     const rows = await query.select('id', 'targetActorId')
     // Ascending (min_id) rows come back oldest-first; flip to the newest-first

--- a/lib/database/sql/list.ts
+++ b/lib/database/sql/list.ts
@@ -185,14 +185,20 @@ export const ListSQLDatabaseMixin = (
     actorId,
     limit = PER_PAGE_LIMIT,
     maxId,
+    minId,
     sinceId
   }: GetListAccountsParams) {
+    // min_id ascends from the cursor (the oldest members just newer than it) then
+    // reverses to newest-first, returning the page adjacent to the cursor.
+    // since_id / max_id / no cursor keep DESC (the newest slice above the cursor).
+    const ascending = Boolean(minId)
+
     // Scope to the owner defensively so this never leaks another actor's list
     // members even if a caller forgets the route-level ownership check.
     const query = database('list_accounts')
       .where({ listId, actorId })
-      .orderBy('createdAt', 'desc')
-      .orderBy('id', 'desc')
+      .orderBy('createdAt', ascending ? 'asc' : 'desc')
+      .orderBy('id', ascending ? 'asc' : 'desc')
 
     // Mastodon: limit=0 returns ALL members without pagination.
     if (limit > 0) query.limit(limit)
@@ -221,10 +227,16 @@ export const ListSQLDatabaseMixin = (
       })
     }
 
+    // min_id and since_id are both lower-bound cursors (rows newer than it); they
+    // differ only in ordering, handled by `ascending` above.
+    const lowerBoundId = minId || sinceId
     if (maxId) await applyCursor(maxId, 'older')
-    if (sinceId) await applyCursor(sinceId, 'newer')
+    if (lowerBoundId) await applyCursor(lowerBoundId, 'newer')
 
     const rows = await query.select('id', 'targetActorId')
+    // Ascending (min_id) rows come back oldest-first; flip to the newest-first
+    // response shape used by every other cursor kind.
+    if (ascending) rows.reverse()
     const targetActorIds = rows.map((row) => row.targetActorId as string)
     const accounts = await getMastodonActors(targetActorIds)
     return {

--- a/lib/database/sql/timeline.test.ts
+++ b/lib/database/sql/timeline.test.ts
@@ -151,6 +151,64 @@ describe('TimelineDatabase', () => {
           expect(secondPageIds).not.toContain(statusBId)
           expect(secondPageIds).not.toContain(statusAId)
         }, 15000)
+
+        it('distinguishes min_id (adjacent page) from since_id (newest slice)', async () => {
+          const TEST_ID_CURSOR = `https://${TEST_DOMAIN}/users/timeline-cursor`
+          await database.createAccount({
+            email: `timeline-cursor@${TEST_DOMAIN}`,
+            username: 'timeline-cursor',
+            passwordHash: TEST_PASSWORD_HASH,
+            domain: TEST_DOMAIN,
+            privateKey: 'privateKey-timeline-cursor',
+            publicKey: 'publicKey-timeline-cursor'
+          })
+
+          const sender = 'https://llun.dev/users/timeline-cursor-sender'
+          await database.createFollow({
+            actorId: TEST_ID_CURSOR,
+            targetActorId: sender,
+            status: FollowStatus.enum.Accepted,
+            inbox: `${sender}/inbox`,
+            sharedInbox: `${sender}/inbox`
+          })
+
+          // Five posts, oldest → newest by createdAt.
+          const ids: string[] = []
+          for (let i = 1; i <= 5; i++) {
+            const id = `${sender}/statuses/cursor-${i}`
+            const status = await database.createNote({
+              id,
+              url: id,
+              actorId: sender,
+              text: `cursor post ${i}`,
+              to: [ACTIVITY_STREAM_PUBLIC],
+              cc: [TEST_ID_CURSOR],
+              createdAt: 1000 * i
+            })
+            await addStatusToTimelines(database, status)
+            ids.push(id)
+          }
+          const [oldest, second, middle, fourth, newest] = ids
+
+          // since_id: the two NEWEST statuses above the cursor.
+          const sincePage = await database.getTimeline({
+            timeline: Timeline.MAIN,
+            actorId: TEST_ID_CURSOR,
+            sinceStatusId: oldest,
+            limit: 2
+          })
+          expect(sincePage.map((status) => status.id)).toEqual([newest, fourth])
+
+          // min_id: the two OLDEST statuses above the cursor (the adjacent page),
+          // returned newest-first — a different slice than since_id.
+          const minPage = await database.getTimeline({
+            timeline: Timeline.MAIN,
+            actorId: TEST_ID_CURSOR,
+            minStatusId: oldest,
+            limit: 2
+          })
+          expect(minPage.map((status) => status.id)).toEqual([middle, second])
+        }, 15000)
       })
 
       describe('Timeline.MAIN filters', () => {

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -195,7 +195,11 @@ export const TimelineSQLDatabaseMixin = (
         }
 
         // min_id and since_id are both lower-bound cursors (rows newer than it);
-        // they differ only in ordering, handled below.
+        // they differ only in ordering, handled below. min_id ascends from the
+        // cursor (the oldest rows just newer than it) then reverses to
+        // newest-first, returning the page adjacent to the cursor; since_id /
+        // max_id / no cursor keep DESC (the newest slice above the cursor).
+        const ascending = Boolean(minStatusId)
         const lowerBoundStatusId = minStatusId || sinceStatusId
         const [maxRow, minRow] = await Promise.all([
           maxStatusId ? lookupTimelineCursor(maxStatusId) : null,
@@ -240,19 +244,22 @@ export const TimelineSQLDatabaseMixin = (
           })
         }
 
-        // The home/direct feed is consumed through getFilteredStatusPage, which
-        // backfills by paging max_id DESC, so this query stays newest-first for
-        // both lower-bound cursors. min_id therefore behaves like since_id here
-        // (adjacent-page min_id for the filtered feed is a separate change);
-        // the notification and list-timeline layers, consumed directly, do
-        // implement true min_id.
+        // min_id scans ascending (oldest rows just newer than the cursor) so the
+        // keyset seek + limit lands on the page adjacent to the cursor; the id
+        // list is reversed below to the newest-first response shape. Every other
+        // cursor kind (since_id / max_id / none) stays newest-first DESC. The
+        // filtered home/direct feed (getFilteredStatusPage) mirrors this: it
+        // backfills DESC for since/max and ascends for min_id.
+        const order: 'asc' | 'desc' = ascending ? 'asc' : 'desc'
         const statusesId = await query
           .select('statusId')
           .orderBy([
-            { column: 'createdAt', order: 'desc' },
-            { column: 'id', order: 'desc' }
+            { column: 'createdAt', order },
+            { column: 'id', order }
           ])
           .limit(limit)
+        // Ascending (min_id) rows come back oldest-first; flip to newest-first.
+        if (ascending) statusesId.reverse()
 
         const statuses: Array<Status | null> = []
         for (const { statusId } of statusesId) {

--- a/lib/services/notifications/collectNotificationGroups.test.ts
+++ b/lib/services/notifications/collectNotificationGroups.test.ts
@@ -184,4 +184,68 @@ describe('collectNotificationGroups', () => {
     // lastScannedId is the id of the last raw row scanned, so the caller can page on.
     expect(result.lastScannedId).toBe('bob4')
   })
+
+  it('ascends from min_id, walking up past a bursty group until it has `limit` groups', async () => {
+    // getNotifications returns min_id batches newest-first (the v1 ascending
+    // seek then reverse). First window above the floor is one big like group;
+    // the next window up adds the remaining groups.
+    const batch1 = Array.from({ length: 5 }, (_, i) =>
+      notif({ id: `a${i}`, groupKey: 'like:s1', createdAt: 1000 - i })
+    )
+    const batch2 = [
+      notif({
+        id: 'b0',
+        type: NotificationType.enum.reblog,
+        groupKey: 'reblog:s2',
+        createdAt: 1100
+      }),
+      notif({
+        id: 'b1',
+        type: NotificationType.enum.follow,
+        groupKey: 'follow',
+        createdAt: 1099
+      })
+      // Short batch (< batchSize) → the newer end is exhausted.
+    ]
+    const getNotifications = vi
+      .fn()
+      .mockResolvedValueOnce(batch1)
+      .mockResolvedValueOnce(batch2)
+    const database = { getNotifications } as unknown as Database
+
+    const result = await collectNotificationGroups({
+      database,
+      baseQuery: {
+        actorId: 'https://llun.test/users/me',
+        minNotificationId: 'floor'
+      },
+      limit: 3,
+      batchSize: 5
+    })
+
+    expect(getNotifications).toHaveBeenCalledTimes(2)
+    // Ascending mode drives the lower-bound cursor, never max_id.
+    expect(getNotifications.mock.calls[0][0]).toMatchObject({
+      minNotificationId: 'floor'
+    })
+    expect(getNotifications.mock.calls[0][0].maxNotificationId).toBeUndefined()
+    // The cursor advances UP to the newest raw row of the first window.
+    expect(getNotifications.mock.calls[1][0]).toMatchObject({
+      minNotificationId: 'a0'
+    })
+    expect(result.groups).toHaveLength(3)
+    expect(result.exhausted).toBe(true)
+    expect(result.rawNotifications).toHaveLength(7)
+    // Rows are returned newest-first so grouping keeps most-recent-member
+    // samples and correct page_max_id cursors.
+    expect(result.rawNotifications.map((n) => n.id)).toEqual([
+      'b0',
+      'b1',
+      'a0',
+      'a1',
+      'a2',
+      'a3',
+      'a4'
+    ])
+  })
 })

--- a/lib/services/notifications/collectNotificationGroups.ts
+++ b/lib/services/notifications/collectNotificationGroups.ts
@@ -67,8 +67,13 @@ export const collectNotificationGroups = async ({
   startCursor,
   maxIterations = DEFAULT_MAX_ITERATIONS
 }: CollectParams): Promise<CollectResult> => {
+  // min_id drives an ascending (adjacent-page) scan: getNotifications returns
+  // the oldest rows just newer than the cursor (newest-first), and we walk UP
+  // toward newer rows across batches. Every other lower bound (since_id) keeps
+  // the DESC scan that pages max_id down toward older rows.
+  const ascending = Boolean(baseQuery.minNotificationId)
   const accumulated: Notification[] = []
-  let cursor = startCursor
+  let cursor = ascending ? baseQuery.minNotificationId : startCursor
   let lastScannedId: string | undefined
   let exhausted = false
 
@@ -76,7 +81,9 @@ export const collectNotificationGroups = async ({
     const batch = await database.getNotifications({
       ...baseQuery,
       limit: batchSize,
-      maxNotificationId: cursor
+      ...(ascending
+        ? { minNotificationId: cursor }
+        : { maxNotificationId: cursor })
     })
     if (batch.length === 0) {
       exhausted = true
@@ -88,10 +95,12 @@ export const collectNotificationGroups = async ({
       : batch
     accumulated.push(...filteredBatch)
 
-    // Advance the cursor by the raw batch tail regardless of account filtering so
+    // Advance the cursor by the raw batch edge regardless of account filtering so
     // account_id paging keeps scanning past bursts from other accounts. Track it
-    // even when every row was filtered out, so the caller can keep paging.
-    cursor = batch[batch.length - 1].id
+    // even when every row was filtered out, so the caller can keep paging. DESC
+    // batches are newest→oldest, so the tail (oldest) walks down; ascending
+    // batches are newest-first, so the head (newest) walks up.
+    cursor = ascending ? batch[0].id : batch[batch.length - 1].id
     lastScannedId = cursor
 
     // Fewer rows than requested means the DB has no more matching notifications.
@@ -107,9 +116,19 @@ export const collectNotificationGroups = async ({
     }
   }
 
+  // Ascending batches accumulate in oldest→newest window order; re-sort
+  // newest-first (createdAt desc, id desc) so grouping keeps most-recent-member
+  // samples and correct page_max_id cursors, matching the DESC path.
+  const rawNotifications = ascending
+    ? [...accumulated].sort(
+        (a, b) =>
+          b.createdAt - a.createdAt || (a.id < b.id ? 1 : a.id > b.id ? -1 : 0)
+      )
+    : accumulated
+
   return {
-    rawNotifications: accumulated,
-    groups: prepareGroupedNotifications(accumulated, groupedTypes),
+    rawNotifications,
+    groups: prepareGroupedNotifications(rawNotifications, groupedTypes),
     exhausted,
     lastScannedId
   }

--- a/lib/services/timelines/getFilteredTimelinePage.test.ts
+++ b/lib/services/timelines/getFilteredTimelinePage.test.ts
@@ -250,6 +250,99 @@ describe('getFilteredStatusPage', () => {
     )
   })
 
+  it('ascends from the cursor and returns the adjacent page newest-first for min_id', async () => {
+    const a1 = createStatus('asc-1')
+    const a2 = createStatus('asc-2')
+    const a3 = createStatus('asc-3')
+    const a4 = createStatus('asc-4')
+    const a5 = createStatus('asc-5')
+    // Ascending batches are oldest-first: the wrapper reverses getTimeline's
+    // newest-first output for the backfill loop, and getTimeline(min_id='floor')
+    // returns the oldest window just above the cursor.
+    const batches = new Map<string | null, Status[]>([
+      ['floor', [a1, a2, a3]],
+      [a3.id, [a4, a5]]
+    ])
+    const database = {
+      getBlockRelations: vi.fn(async () => []),
+      getMuteRelations: vi.fn(async () => []),
+      getActorDomainBlocks: vi.fn(async () => [])
+    } as unknown as Database
+    const fetchBatch = vi.fn(({ minStatusId }) =>
+      Promise.resolve(batches.get(minStatusId) ?? [])
+    )
+
+    const page = await getFilteredStatusPage({
+      database,
+      actorId: readerActorId,
+      limit: 3,
+      minStatusId: 'floor',
+      fetchBatch
+    })
+
+    // The three oldest statuses above the cursor, returned newest-first.
+    expect(page.statuses.map((status) => status.id)).toEqual([
+      a3.id,
+      a2.id,
+      a1.id
+    ])
+    // prev (newer) continues above the newest returned; next (older) below the
+    // oldest returned.
+    expect(page.prevMinStatusId).toBe(a3.id)
+    expect(page.nextMaxStatusId).toBe(a1.id)
+    // Only the first ascending window was needed for a full page.
+    expect(fetchBatch).toHaveBeenCalledTimes(1)
+    expect(fetchBatch).toHaveBeenCalledWith(
+      expect.objectContaining({ minStatusId: 'floor', maxStatusId: null })
+    )
+  })
+
+  it('walks up past filtered rows to fill a min_id page', async () => {
+    const a1 = createStatus('asc-a1')
+    const a2 = createStatus('asc-a2')
+    const a3 = createStatus('asc-a3')
+    const blocked = createStatus('asc-blocked', blockedActorId)
+    // floor → [blocked, a1, a2] then a2 → [a3]. The first window under-fills
+    // after the block is dropped, so the loop ascends to a2 (the newest raw row
+    // of the first window) for more.
+    const batches = new Map<string | null, Status[]>([
+      ['floor', [blocked, a1, a2]],
+      [a2.id, [a3]]
+    ])
+    const getBlockRelations = vi.fn(
+      async ({ targetActorIds }: GetBlockRelationsParams) =>
+        targetActorIds.some((targetActorId) => targetActorId === blockedActorId)
+          ? [{ actorId: readerActorId, targetActorId: blockedActorId }]
+          : []
+    )
+    const database = {
+      getBlockRelations,
+      getMuteRelations: vi.fn(async () => []),
+      getActorDomainBlocks: vi.fn(async () => [])
+    } as unknown as Database
+    const fetchBatch = vi.fn(({ minStatusId }) =>
+      Promise.resolve(batches.get(minStatusId) ?? [])
+    )
+
+    const page = await getFilteredStatusPage({
+      database,
+      actorId: readerActorId,
+      limit: 3,
+      minStatusId: 'floor',
+      fetchBatch
+    })
+
+    expect(page.statuses.map((status) => status.id)).toEqual([
+      a3.id,
+      a2.id,
+      a1.id
+    ])
+    expect(fetchBatch.mock.calls.map((call) => call[0].minStatusId)).toEqual([
+      'floor',
+      a2.id
+    ])
+  })
+
   it('omits statuses whose author the reader has muted', async () => {
     const muted = createStatus('muted', mutedActorId)
     const visible1 = createStatus('visible-1')

--- a/lib/services/timelines/getFilteredTimelinePage.test.ts
+++ b/lib/services/timelines/getFilteredTimelinePage.test.ts
@@ -1,11 +1,15 @@
 import { Database } from '@/lib/database/types'
+import { Timeline } from '@/lib/services/timelines/types'
 import {
   GetBlockRelationsParams,
   GetMuteRelationsParams
 } from '@/lib/types/database/operations'
 import { Status, StatusType } from '@/lib/types/domain/status'
 
-import { getFilteredStatusPage } from './getFilteredTimelinePage'
+import {
+  getFilteredStatusPage,
+  getFilteredTimelinePage
+} from './getFilteredTimelinePage'
 
 const readerActorId = 'https://llun.test/users/reader'
 const blockedActorId = 'https://blocked.test/users/blocked'
@@ -343,6 +347,53 @@ describe('getFilteredStatusPage', () => {
     ])
   })
 
+  it('keeps a min_id continuation cursor when a filtered window empties the capped ascending page', async () => {
+    // Every row above the cursor is blocked and each ascending window is full,
+    // so exhausted never trips and the backfill cap (5) is hit with nothing
+    // visible. The page must still hand back a min_id continuation cursor (the
+    // newest scanned id) so the client can page UP past the block, mirroring the
+    // DESC branch's lastScannedStatusId fallback.
+    const blockedBatches = new Map<string | null, Status[]>()
+    let lastScanned = ''
+    let key: string | null = 'floor'
+    for (let window = 0; window < 5; window++) {
+      const lo = createStatus(`cap-${window}-a`, blockedActorId)
+      const hi = createStatus(`cap-${window}-b`, blockedActorId)
+      blockedBatches.set(key, [lo, hi]) // oldest-first window of 2 blocked rows
+      key = hi.id // ascending loop advances to the newest raw row
+      lastScanned = hi.id
+    }
+    const getBlockRelations = vi.fn(
+      async ({ targetActorIds }: GetBlockRelationsParams) =>
+        targetActorIds.some((targetActorId) => targetActorId === blockedActorId)
+          ? [{ actorId: readerActorId, targetActorId: blockedActorId }]
+          : []
+    )
+    const database = {
+      getBlockRelations,
+      getMuteRelations: vi.fn(async () => []),
+      getActorDomainBlocks: vi.fn(async () => [])
+    } as unknown as Database
+    const fetchBatch = vi.fn(({ minStatusId }) =>
+      Promise.resolve(blockedBatches.get(minStatusId) ?? [])
+    )
+
+    const page = await getFilteredStatusPage({
+      database,
+      actorId: readerActorId,
+      limit: 2,
+      minStatusId: 'floor',
+      fetchBatch
+    })
+
+    expect(page.statuses).toEqual([])
+    // Continuation: prev (min_id, newer) advances past the block; there is no
+    // older page to fetch, so next (max_id) stays null.
+    expect(page.prevMinStatusId).toBe(lastScanned)
+    expect(page.nextMaxStatusId).toBeNull()
+    expect(fetchBatch).toHaveBeenCalledTimes(5)
+  })
+
   it('omits statuses whose author the reader has muted', async () => {
     const muted = createStatus('muted', mutedActorId)
     const visible1 = createStatus('visible-1')
@@ -432,5 +483,47 @@ describe('getFilteredStatusPage', () => {
     expect(getActorDomainBlocks).toHaveBeenCalledWith({
       actorId: readerActorId
     })
+  })
+})
+
+describe('getFilteredTimelinePage', () => {
+  it('bridges getTimeline newest-first output through the ascending loop back to newest-first for min_id', async () => {
+    const s1 = createStatus('bridge-1')
+    const s2 = createStatus('bridge-2')
+    const s3 = createStatus('bridge-3')
+    // getTimeline returns min_id windows newest-first (DB reverses internally).
+    const getTimeline = vi.fn(
+      async ({ minStatusId }: { minStatusId?: string | null }) =>
+        minStatusId === 'floor' ? [s3, s2, s1] : []
+    )
+    const database = {
+      getTimeline,
+      getBlockRelations: vi.fn(async () => []),
+      getMuteRelations: vi.fn(async () => []),
+      getActorDomainBlocks: vi.fn(async () => [])
+    } as unknown as Database
+
+    const page = await getFilteredTimelinePage({
+      database,
+      timeline: Timeline.MAIN,
+      actorId: readerActorId,
+      minStatusId: 'floor',
+      limit: 3
+    })
+
+    // The wrapper reverses getTimeline's newest-first batch to oldest-first for
+    // the ascending loop, which reverses the assembled page back to newest-first:
+    // the two flips compose without scrambling the order.
+    expect(page.statuses.map((status) => status.id)).toEqual([
+      s3.id,
+      s2.id,
+      s1.id
+    ])
+    // Ascending mode drives getTimeline via minStatusId with no max ceiling, and
+    // never as sinceStatusId.
+    expect(getTimeline).toHaveBeenCalledWith(
+      expect.objectContaining({ minStatusId: 'floor', maxStatusId: null })
+    )
+    expect(getTimeline.mock.calls[0][0].sinceStatusId).toBeUndefined()
   })
 })

--- a/lib/services/timelines/getFilteredTimelinePage.ts
+++ b/lib/services/timelines/getFilteredTimelinePage.ts
@@ -30,6 +30,9 @@ export const normalizeTimelineLimit = (limit?: number | null) =>
 
 interface FetchFilteredStatusBatchParams {
   maxStatusId: string | null
+  // Set (with maxStatusId null) only in ascending min_id mode; the batch must
+  // then come back oldest-first so the loop can walk up toward newer rows.
+  minStatusId: string | null
   limit: number
 }
 
@@ -37,6 +40,10 @@ interface GetFilteredStatusPageParams {
   database: Database
   actorId?: string
   maxStatusId?: string | null
+  // When set, the page is built ascending from this lower-bound cursor (the
+  // oldest rows just newer than it) and returned newest-first — Mastodon's
+  // adjacent-page min_id. fetchBatch must return oldest-first batches for it.
+  minStatusId?: string | null
   limit?: number
   filterContext?: FilterContext
   fetchBatch: (params: FetchFilteredStatusBatchParams) => Promise<Status[]>
@@ -46,14 +53,19 @@ export const getFilteredStatusPage = async ({
   database,
   actorId,
   maxStatusId = null,
+  minStatusId = null,
   limit = PER_PAGE_LIMIT,
   filterContext,
   fetchBatch
 }: GetFilteredStatusPageParams): Promise<FilteredTimelinePage> => {
   const pageLimit = normalizeTimelineLimit(limit)
+  // min_id ascends from its cursor (oldest-first) then reverses to newest-first,
+  // returning the page adjacent to the cursor; every other cursor kind backfills
+  // DESC (newest-first) from max_id. min_id wins when both are present.
+  const ascending = Boolean(minStatusId)
   const statuses: Status[] = []
   let iterations = 0
-  let cursor = maxStatusId
+  let cursor = ascending ? minStatusId : maxStatusId
   let lastScannedStatusId: string | null = null
   let exhausted = false
 
@@ -75,7 +87,8 @@ export const getFilteredStatusPage = async ({
   while (statuses.length < pageLimit && iterations < MAX_BACKFILL_ITERATIONS) {
     iterations++
     const batch = await fetchBatch({
-      maxStatusId: cursor,
+      maxStatusId: ascending ? null : cursor,
+      minStatusId: ascending ? cursor : null,
       limit: pageLimit
     })
     if (batch.length === 0) {
@@ -112,6 +125,24 @@ export const getFilteredStatusPage = async ({
   }
 
   const visibleStatuses = statuses.slice(0, pageLimit)
+
+  if (ascending) {
+    // Ascending accumulation is oldest-first; the adjacent page is the oldest
+    // `pageLimit` visible statuses, returned newest-first. rel=prev (newer)
+    // continues above the newest returned; rel=next (older) below the oldest.
+    visibleStatuses.reverse()
+    return {
+      statuses: visibleStatuses,
+      nextMaxStatusId:
+        visibleStatuses.length > 0
+          ? visibleStatuses[visibleStatuses.length - 1].id
+          : null,
+      prevMinStatusId:
+        visibleStatuses.length > 0 ? visibleStatuses[0].id : null,
+      filterRecords
+    }
+  }
+
   const lastVisibleStatusId =
     visibleStatuses.length > 0
       ? visibleStatuses[visibleStatuses.length - 1].id
@@ -143,6 +174,7 @@ interface GetFilteredTimelinePageParams {
   timeline: Timeline
   actorId: string
   minStatusId?: string | null
+  sinceStatusId?: string | null
   maxStatusId?: string | null
   limit?: number
   filterContext?: FilterContext
@@ -153,6 +185,7 @@ export const getFilteredTimelinePage = async ({
   timeline,
   actorId,
   minStatusId = null,
+  sinceStatusId = null,
   maxStatusId = null,
   limit = PER_PAGE_LIMIT,
   filterContext
@@ -161,18 +194,35 @@ export const getFilteredTimelinePage = async ({
     database,
     actorId,
     maxStatusId,
+    minStatusId,
     limit,
     filterContext,
-    fetchBatch: ({ maxStatusId: cursor, limit: batchLimit }) =>
-      database.getTimeline({
+    fetchBatch: async ({
+      maxStatusId: descCursor,
+      minStatusId: ascCursor,
+      limit: batchLimit
+    }) => {
+      if (ascCursor !== null) {
+        // min_id (adjacent-page) mode: getTimeline returns the oldest window
+        // above the cursor newest-first; reverse it to oldest-first so the
+        // ascending backfill loop can walk up toward newer rows.
+        const rows = await database.getTimeline({
+          timeline,
+          actorId,
+          minStatusId: ascCursor,
+          maxStatusId: null,
+          limit: batchLimit
+        })
+        return rows.reverse()
+      }
+      // since_id / max_id / no cursor: backfill DESC (newest-first) with
+      // since_id as the lower bound.
+      return database.getTimeline({
         timeline,
         actorId,
-        // getFilteredStatusPage backfills by paging max_id DESC, so the lower
-        // bound must keep newest-first (since) ordering here — driving it as
-        // min_id would flip getTimeline to ascending and break the backfill.
-        // Adjacent-page min_id for filtered timelines is a separate change.
-        sinceStatusId: minStatusId,
-        maxStatusId: cursor,
+        sinceStatusId,
+        maxStatusId: descCursor,
         limit: batchLimit
       })
+    }
   })

--- a/lib/services/timelines/getFilteredTimelinePage.ts
+++ b/lib/services/timelines/getFilteredTimelinePage.ts
@@ -131,14 +131,22 @@ export const getFilteredStatusPage = async ({
     // `pageLimit` visible statuses, returned newest-first. rel=prev (newer)
     // continues above the newest returned; rel=next (older) below the oldest.
     visibleStatuses.reverse()
+    const hasVisible = visibleStatuses.length > 0
     return {
       statuses: visibleStatuses,
-      nextMaxStatusId:
-        visibleStatuses.length > 0
-          ? visibleStatuses[visibleStatuses.length - 1].id
-          : null,
-      prevMinStatusId:
-        visibleStatuses.length > 0 ? visibleStatuses[0].id : null,
+      nextMaxStatusId: hasVisible
+        ? visibleStatuses[visibleStatuses.length - 1].id
+        : null,
+      // When a filtered window empties the page but the source isn't exhausted
+      // (the backfill cap was hit), keep the client paging UP past the block via
+      // the last scanned id — mirroring the DESC branch's lastScannedStatusId
+      // fallback, so an all-filtered stretch above the cursor can't dead-stop
+      // min_id pagination and silently withhold newer posts.
+      prevMinStatusId: hasVisible
+        ? visibleStatuses[0].id
+        : exhausted
+          ? null
+          : lastScannedStatusId,
       filterRecords
     }
   }

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1413,6 +1413,7 @@ export type GetListAccountsParams = {
   actorId: string
   limit?: number
   maxId?: string | null
+  minId?: string | null
   sinceId?: string | null
 }
 export type ListAccountsPage = {


### PR DESCRIPTION
## Summary

PR #1175 shipped true ascending-seek-then-reverse `min_id` for v1 notifications and the list timeline, and **deferred three surfaces** (with explicit `min_id≡since_id` comments): the home timeline, v2 grouped notifications, and `lists/:id/accounts`. This PR completes them using the exact pattern and adjacency regression-test shape #1175 established.

`min_id` returns the page **immediately adjacent** to the cursor — the oldest rows just newer than it, returned newest-first (ascending keyset seek then reverse). `since_id` / `max_id` / no cursor keep newest-first DESC (the newest slice above the cursor). The two cursor kinds now reach each surface in **separate slots** instead of being collapsed.

## Changes per surface

**1. Home timeline** (`/api/v1/timelines/:timeline`)
- `getTimeline` (MAIN/HOME/DIRECT) scans ascending + reverses for `min_id`; every other cursor stays DESC.
- `getFilteredStatusPage` gained an ascending backfill mode that walks **up** past filter-dropped rows (blocks/mutes/domain-blocks/keyword filters) to fill the page, then reverses to newest-first. `getFilteredTimelinePage`'s ascending `fetchBatch` reverses `getTimeline`'s newest-first output to oldest-first for the loop.
- The route passes `min_id` and `since_id` through separately; `min_id` wins when both are present. The home RSC page (no cursor) is unaffected.

**2. v2 grouped notifications** (`/api/v2/notifications`)
- `collectNotificationGroups` gained an ascending (adjacent-page) scan gated on `minNotificationId`: it walks up from the cursor and re-sorts accumulated rows newest-first so grouping keeps most-recent-member samples and correct `page_max_id` cursors. `unread_count` (never sets `minNotificationId`) is unaffected.
- The route routes `min_id → minNotificationId` (reusing the already-correct v1 ascending DB path) and, for `min_id`, slices the **oldest** `limit` surviving groups (the adjacent page, still newest-first); the empty-page fallback emits a `min_id` link.

**3. `lists/:id/accounts`**
- `getListAccounts` gained the ascending branch + reverse (direct analog of `getListTimeline` from #1175); the route passes `min_id`/`since_id` as separate cursors.

## Tests (TDD — RED then GREEN)
- DB-layer adjacency: `getTimeline` (MAIN), `getListAccounts` (seed N, `min_id=<kth>` → adjacent page newest-first, distinct from the `since_id` newest slice).
- Service: `getFilteredStatusPage` ascending backfill returns the adjacent page and walks up past filtered rows; `collectNotificationGroups` ascending walk-up + newest-first re-sort.
- Route: cursor routing (`min_id`/`since_id` never collapse), `min_id` precedence on the home timeline, grouped-notification `min_id` adjacency + `rel=prev`/`rel=next` Link cursors.

## Notes
- `docs/mastodon-api-compatibility.md` carries no `min_id` deviation note, so no doc change was needed.
- No migration; `package.json` version untouched.

## Gate
`yarn run prettier --write .` · `yarn lint` (0 errors) · `yarn build` · `yarn test` (6252 passed) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)