### PR TITLE
minor: quote data model + inbound quote federation (Epic 4.1a)

### DIFF
--- a/lib/activities/jsonld/index.test.ts
+++ b/lib/activities/jsonld/index.test.ts
@@ -196,6 +196,106 @@ describe('compactActivityPub', () => {
     expect(tags[0].name).toBe('#fediverse')
   })
 
+  it('keeps quote extension terms when the sender defines them with full IRIs', async () => {
+    // Mastodon 4.5 / Fedibird / Misskey each carry the quote target under their
+    // own vocabulary and *define* those terms in the outbound @context. Without
+    // matching aliases in CANONICAL_CONTEXT they compact to CURIEs/full IRIs and
+    // vanish from the parsed note.
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': [
+          ACTIVITY_STREAMS_CONTEXT_URL,
+          {
+            quote: { '@id': 'https://w3id.org/fep/044f#quote', '@type': '@id' },
+            quoteUri: 'http://fedibird.com/ns#quoteUri',
+            _misskey_quote: 'https://misskey-hub.net/ns#_misskey_quote',
+            quoteAuthorization: {
+              '@id': 'https://w3id.org/fep/044f#quoteAuthorization',
+              '@type': '@id'
+            }
+          }
+        ],
+        id: 'https://remote.example/notes/2',
+        type: 'Note',
+        attributedTo: 'https://remote.example/users/alice',
+        published: '2026-01-01T00:00:00Z',
+        quote: 'https://llun.test/users/me/statuses/1',
+        quoteUri: 'https://llun.test/users/me/statuses/1',
+        _misskey_quote: 'https://llun.test/users/me/statuses/1',
+        quoteAuthorization: 'https://llun.test/users/me/quote_authorizations/9'
+      })
+    )
+
+    expect(result.quote).toBe('https://llun.test/users/me/statuses/1')
+    expect(result.quoteUri).toBe('https://llun.test/users/me/statuses/1')
+    expect(result._misskey_quote).toBe('https://llun.test/users/me/statuses/1')
+    expect(result.quoteAuthorization).toBe(
+      'https://llun.test/users/me/quote_authorizations/9'
+    )
+  })
+
+  // The blank-node accident (`_:QuoteRequest`) only recovers a bare term when
+  // the sender does NOT define the type. Mastodon DOES define these terms, so
+  // assert the sender-defined-IRI path survives via a real alias.
+  it.each([
+    { type: 'QuoteRequest', iri: 'https://w3id.org/fep/044f#QuoteRequest' },
+    {
+      type: 'QuoteAuthorization',
+      iri: 'https://w3id.org/fep/044f#QuoteAuthorization'
+    }
+  ])(
+    'keeps a $type type as a bare term when the sender defines it with a full IRI',
+    async ({ type, iri }) => {
+      const result = asRecord(
+        await compactActivityPub({
+          '@context': [ACTIVITY_STREAMS_CONTEXT_URL, { [type]: iri }],
+          id: 'https://remote.example/activities/1',
+          type,
+          actor: 'https://remote.example/users/alice'
+        })
+      )
+
+      expect(result.type).toBe(type)
+    }
+  )
+
+  it('keeps interactionPolicy.canQuote.automaticApproval an array for a single approver', async () => {
+    // #1119-class regression: a single-element approval set must not collapse to
+    // a scalar. `@container: @set` in CANONICAL_CONTEXT keeps it an array.
+    const result = asRecord(
+      await compactActivityPub({
+        '@context': [
+          ACTIVITY_STREAMS_CONTEXT_URL,
+          {
+            gts: 'https://gotosocial.org/ns#',
+            interactionPolicy: 'gts:interactionPolicy',
+            canQuote: 'gts:canQuote',
+            automaticApproval: {
+              '@id': 'gts:automaticApproval',
+              '@type': '@id',
+              '@container': '@set'
+            }
+          }
+        ],
+        id: 'https://remote.example/notes/1',
+        type: 'Note',
+        attributedTo: 'https://remote.example/users/alice',
+        published: '2026-01-01T00:00:00Z',
+        interactionPolicy: {
+          canQuote: {
+            automaticApproval: ['https://remote.example/users/alice/followers']
+          }
+        }
+      })
+    )
+
+    const policy = asRecord(result.interactionPolicy)
+    const canQuote = asRecord(policy.canQuote)
+    expect(canQuote.automaticApproval).toEqual([
+      'https://remote.example/users/alice/followers'
+    ])
+  })
+
   it('injects a default context for documents that omit @context', async () => {
     const result = asRecord(
       await compactActivityPub({

--- a/lib/activities/jsonld/index.ts
+++ b/lib/activities/jsonld/index.ts
@@ -30,6 +30,10 @@ export const SECURITY_V1_CONTEXT_URL = 'https://w3id.org/security/v1'
 
 const MASTODON_NAMESPACE = 'http://joinmastodon.org/ns#'
 const SCHEMA_NAMESPACE = 'http://schema.org#'
+const FEP_044F_NAMESPACE = 'https://w3id.org/fep/044f#'
+const GOTOSOCIAL_NAMESPACE = 'https://gotosocial.org/ns#'
+const FEDIBIRD_NAMESPACE = 'http://fedibird.com/ns#'
+const MISSKEY_NAMESPACE = 'https://misskey-hub.net/ns#'
 
 const BUNDLED_CONTEXTS: Record<string, unknown> = {
   [ACTIVITY_STREAMS_CONTEXT_URL]: activityStreamsContext,
@@ -92,6 +96,10 @@ const CANONICAL_CONTEXT = {
     {
       toot: MASTODON_NAMESPACE,
       schema: SCHEMA_NAMESPACE,
+      fep044f: FEP_044F_NAMESPACE,
+      gts: GOTOSOCIAL_NAMESPACE,
+      fedibird: FEDIBIRD_NAMESPACE,
+      misskey: MISSKEY_NAMESPACE,
 
       // Extension *types* we match on, aliased so they compact to bare terms.
       // These are not defined in the bundled ActivityStreams context, so without
@@ -99,6 +107,11 @@ const CANONICAL_CONTEXT = {
       // and be dropped by the strict `type` validators downstream.
       Emoji: 'toot:Emoji',
       Hashtag: 'as:Hashtag',
+      // Quote-post extension types (FEP-044f). Mastodon 4.5 defines these in its
+      // outbound context, so without aliases they compact to full IRIs and the
+      // strict `type` validators drop them.
+      QuoteRequest: 'fep044f:QuoteRequest',
+      QuoteAuthorization: 'fep044f:QuoteAuthorization',
 
       // Extension terms we read, mapped to their canonical IRIs so they survive
       // compaction as bare property names instead of being dropped.
@@ -124,6 +137,42 @@ const CANONICAL_CONTEXT = {
       devices: { '@id': 'toot:devices', '@type': '@id' },
       PropertyValue: 'schema:PropertyValue',
       value: 'schema:value',
+
+      // Quote target (FEP-044f `quote`) — a by-reference id. `@type: @id` keeps
+      // a bare id as a string while an embedded object still passes through
+      // (same pattern as `movedTo`).
+      quote: { '@id': 'fep044f:quote', '@type': '@id' },
+      // Legacy compat aliases (Mastodon `quoteUrl`, Fedibird `quoteUri`, Misskey
+      // `_misskey_quote`). These servers define the terms *without* `@type: @id`
+      // and emit the target as a plain URL string literal, so keep them plain
+      // here — an `@type: @id` mapping would fail to represent that literal and
+      // drop the value during compaction.
+      quoteUrl: 'as:quoteUrl',
+      quoteUri: 'fedibird:quoteUri',
+      _misskey_quote: 'misskey:_misskey_quote',
+      quoteAuthorization: {
+        '@id': 'fep044f:quoteAuthorization',
+        '@type': '@id'
+      },
+      // FEP-044f QuoteAuthorization stamp fields (GoToSocial ns).
+      interactingObject: { '@id': 'gts:interactingObject', '@type': '@id' },
+      interactionTarget: { '@id': 'gts:interactionTarget', '@type': '@id' },
+
+      // Interaction policy (GoToSocial ns, emitted by Mastodon 4.5). The
+      // approval arrays are `@container: @set` so a single approver does not
+      // collapse to a scalar (the #1119/#1120 array-collapse class).
+      interactionPolicy: 'gts:interactionPolicy',
+      canQuote: 'gts:canQuote',
+      automaticApproval: {
+        '@id': 'gts:automaticApproval',
+        '@type': '@id',
+        '@container': '@set'
+      },
+      manualApproval: {
+        '@id': 'gts:manualApproval',
+        '@type': '@id',
+        '@container': '@set'
+      },
 
       // Collection-like properties: always arrays.
       to: { '@id': 'as:to', '@type': '@id', '@container': '@set' },

--- a/lib/activities/note.test.ts
+++ b/lib/activities/note.test.ts
@@ -115,6 +115,16 @@ describe('note entity utilities', () => {
 
       expect(getQuoteTargetId(note)).toBeNull()
     })
+
+    it('returns null for an embedded quote object without an id', () => {
+      const note = {
+        type: 'Note',
+        id: 'https://example.com/note/1',
+        quote: { type: 'Link', href: 'https://example.com/note/quoted' }
+      } as unknown as BaseNote
+
+      expect(getQuoteTargetId(note)).toBeNull()
+    })
   })
 
   describe('getAttachments', () => {

--- a/lib/activities/note.test.ts
+++ b/lib/activities/note.test.ts
@@ -3,6 +3,7 @@ import {
   getAttachments,
   getContent,
   getLanguage,
+  getQuoteTargetId,
   getReply,
   getSummary,
   getTags,
@@ -62,6 +63,57 @@ describe('note entity utilities', () => {
 
     it('returns undefined for null', () => {
       expect(getReply(null)).toBeUndefined()
+    })
+  })
+
+  describe('getQuoteTargetId', () => {
+    const target = 'https://example.com/note/quoted'
+
+    it.each([
+      { field: 'quote' },
+      { field: 'quoteUrl' },
+      { field: 'quoteUri' },
+      { field: '_misskey_quote' }
+    ])('reads the quote target from $field', ({ field }) => {
+      const note = {
+        type: 'Note',
+        id: 'https://example.com/note/1',
+        [field]: target
+      } as unknown as BaseNote
+
+      expect(getQuoteTargetId(note)).toEqual(target)
+    })
+
+    it('reads the quote target from an embedded quote object', () => {
+      const note = {
+        type: 'Note',
+        id: 'https://example.com/note/1',
+        quote: { id: target, type: 'Note' }
+      } as unknown as BaseNote
+
+      expect(getQuoteTargetId(note)).toEqual(target)
+    })
+
+    it('prefers quote over the compat aliases', () => {
+      const note = {
+        type: 'Note',
+        id: 'https://example.com/note/1',
+        quote: target,
+        quoteUri: 'https://example.com/note/other',
+        _misskey_quote: 'https://example.com/note/other'
+      } as unknown as BaseNote
+
+      expect(getQuoteTargetId(note)).toEqual(target)
+    })
+
+    it('returns null when the note quotes nothing', () => {
+      const note = {
+        type: 'Note',
+        id: 'https://example.com/note/1',
+        content: 'Test'
+      } as unknown as BaseNote
+
+      expect(getQuoteTargetId(note)).toBeNull()
     })
   })
 

--- a/lib/activities/note.ts
+++ b/lib/activities/note.ts
@@ -34,6 +34,21 @@ export const getReply = (reply: ReplyValue): string | undefined => {
   return reply?.id
 }
 
+/**
+ * Resolve the quoted status id from a note's quote fields, following FEP-044f
+ * precedence: `quote` (a bare id string or an embedded `{ id }` object) →
+ * `quoteUrl` (Mastodon) → `quoteUri` (Fedibird) → `_misskey_quote` (Misskey).
+ * Returns null when the note quotes nothing.
+ */
+export const getQuoteTargetId = (object: BaseNote): string | null => {
+  const { quote } = object
+  if (typeof quote === 'string' && quote) return quote
+  if (quote && typeof quote === 'object' && typeof quote.id === 'string') {
+    return quote.id
+  }
+  return object.quoteUrl || object.quoteUri || object._misskey_quote || null
+}
+
 const isDocument = (attachment: Attachment): attachment is Document =>
   Document.safeParse(attachment).success
 

--- a/lib/activities/quoteRequest.ts
+++ b/lib/activities/quoteRequest.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+// FEP-044f quote handshake objects. Both are validated only after the inbound
+// document has been run through `compactActivityPub`, which turns the
+// `@type: @id` extension terms into bare id strings and the extension types into
+// bare terms. Schemas stay liberal (no `.strict()`): we model only the fields we
+// consume and tolerate everything else.
+
+/**
+ * The hosted authorization stamp the quoted author issues. It must stay
+ * dereferenceable while the quote is approved; a receiver treats a quote as
+ * approved only when this stamp's three fields all match.
+ */
+export const QuoteAuthorization = z.object({
+  id: z.string(),
+  type: z.literal('QuoteAuthorization'),
+  // The quoted author who issued the authorization.
+  attributedTo: z.string(),
+  // The quoting object (the note that does the quoting).
+  interactingObject: z.string(),
+  // The quoted object (the status being quoted).
+  interactionTarget: z.string()
+})
+export type QuoteAuthorization = z.infer<typeof QuoteAuthorization>
+
+/**
+ * The request a quoter sends to the quoted author's inbox. `instrument` is the
+ * quoting note (embedded object or a bare id after compaction).
+ */
+export const QuoteRequest = z.object({
+  id: z.string(),
+  type: z.literal('QuoteRequest'),
+  actor: z.string(),
+  // The quoted status id.
+  object: z.string(),
+  // The quoting note (embedded object or a bare id reference).
+  instrument: z.union([z.string(), z.looseObject({ id: z.string() })])
+})
+export type QuoteRequest = z.infer<typeof QuoteRequest>

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -39,6 +39,7 @@ import { ServerFilterSQLDatabaseMixin } from '@/lib/database/sql/serverFilter'
 import { StatusSQLDatabaseMixin } from '@/lib/database/sql/status'
 import { StatusDetectedLanguageSQLDatabaseMixin } from '@/lib/database/sql/statusDetectedLanguage'
 import { StatusMuteSQLDatabaseMixin } from '@/lib/database/sql/statusMute'
+import { StatusQuoteSQLDatabaseMixin } from '@/lib/database/sql/statusQuote'
 import { StravaArchiveImportSQLDatabaseMixin } from '@/lib/database/sql/stravaArchiveImport'
 import { SuggestionSQLDatabaseMixin } from '@/lib/database/sql/suggestion'
 import { TimelineSQLDatabaseMixin } from '@/lib/database/sql/timeline'
@@ -66,6 +67,7 @@ export const getSQLDatabase = (database: Knex): Database => {
   const endorsementDatabase = EndorsementSQLDatabaseMixin(database)
   const featuredTagDatabase = FeaturedTagSQLDatabaseMixin(database)
   const statusMuteDatabase = StatusMuteSQLDatabaseMixin(database)
+  const statusQuoteDatabase = StatusQuoteSQLDatabaseMixin(database)
   const idempotencyDatabase = IdempotencySQLDatabaseMixin(database)
   const translationCacheDatabase = TranslationCacheSQLDatabaseMixin(database)
   const statusDetectedLanguageDatabase =
@@ -150,6 +152,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...endorsementDatabase,
     ...featuredTagDatabase,
     ...statusMuteDatabase,
+    ...statusQuoteDatabase,
     ...idempotencyDatabase,
     ...translationCacheDatabase,
     ...statusDetectedLanguageDatabase,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -80,10 +80,12 @@ import { getActorProfile } from '@/lib/types/domain/actor'
 import { Attachment, isFitnessAttachment } from '@/lib/types/domain/attachment'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
 import {
+  QuoteState,
   Status,
   StatusAnnounce,
   StatusNote,
   StatusPoll,
+  StatusQuote,
   StatusType
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
@@ -138,6 +140,9 @@ type StatusHydrationContext = {
   // independent (unlike the like/bookmark sets above), so callers populate it
   // for any timeline page regardless of whether a viewer is signed in.
   detectedLanguages?: Record<string, string>
+  // Pre-batched quote edges, keyed by the quoting statusId. Viewer-independent;
+  // the viewer-relative downgrades happen later in the Mastodon serializer.
+  quoteEdges?: Map<string, StatusQuote>
 }
 
 export const buildPubliclyReadableStatusIdsQuery = ({
@@ -434,6 +439,7 @@ export const StatusSQLDatabaseMixin = (
     reply = '',
     sensitive = false,
     language = null,
+    quoteApprovalPolicy,
     applicationName = null,
     applicationWebsite = null,
     createdAt
@@ -446,7 +452,10 @@ export const StatusSQLDatabaseMixin = (
       text,
       summary,
       sensitive,
-      language
+      language,
+      // Persisted in the blob (no column). JSON.stringify drops it when
+      // undefined, so non-quotable-policy statuses store nothing extra.
+      ...(quoteApprovalPolicy ? { quoteApprovalPolicy } : {})
     }
     const statusContent = JSON.stringify(content)
     const searchStatus: SQLStatusSearchRow = {
@@ -524,6 +533,7 @@ export const StatusSQLDatabaseMixin = (
       summary,
       sensitive,
       language,
+      ...(quoteApprovalPolicy ? { quoteApprovalPolicy } : {}),
       // Content detection runs after this insert (in the actions/jobs layer
       // that called createNote), so the row this function just wrote has no
       // detected language yet — matches what a hydrated re-fetch would show
@@ -1589,26 +1599,34 @@ export const StatusSQLDatabaseMixin = (
     // per-status query in getStatusWithAttachmentsFromData. Run it in the
     // same Promise.all as the bookmark/like queries below rather than
     // sequentially, so all three independent batched lookups overlap.
-    const [detectedLanguages, bookmarkRows, likeRows] = await Promise.all([
-      hasHydrationStatusIds
-        ? statusDetectedLanguageDatabase.getDetectedLanguages({
-            statusIds: [...hydrationStatusIds]
-          })
-        : Promise.resolve({}),
-      currentActorId && hasHydrationStatusIds
-        ? database('bookmarks')
-            .where('actorId', currentActorId)
-            .whereIn('statusId', [...hydrationStatusIds])
-            .select<{ statusId: string }[]>('statusId')
-        : Promise.resolve([]),
-      currentActorId && hasHydrationStatusIds
-        ? database('likes')
-            .where('actorId', currentActorId)
-            .whereIn('statusId', [...hydrationStatusIds])
-            .select<{ statusId: string }[]>('statusId')
-        : Promise.resolve([])
-    ])
+    const [detectedLanguages, quoteEdges, bookmarkRows, likeRows] =
+      await Promise.all([
+        hasHydrationStatusIds
+          ? statusDetectedLanguageDatabase.getDetectedLanguages({
+              statusIds: [...hydrationStatusIds]
+            })
+          : Promise.resolve({}),
+        // Quote edges are viewer-independent, so batch them for every fetch (as
+        // with detected languages) rather than falling back to a per-status
+        // query in getStatusWithAttachmentsFromData.
+        hasHydrationStatusIds
+          ? getStatusQuoteEdges([...hydrationStatusIds])
+          : Promise.resolve(new Map<string, StatusQuote>()),
+        currentActorId && hasHydrationStatusIds
+          ? database('bookmarks')
+              .where('actorId', currentActorId)
+              .whereIn('statusId', [...hydrationStatusIds])
+              .select<{ statusId: string }[]>('statusId')
+          : Promise.resolve([]),
+        currentActorId && hasHydrationStatusIds
+          ? database('likes')
+              .where('actorId', currentActorId)
+              .whereIn('statusId', [...hydrationStatusIds])
+              .select<{ statusId: string }[]>('statusId')
+          : Promise.resolve([])
+      ])
     hydrationContext.detectedLanguages = detectedLanguages
+    hydrationContext.quoteEdges = quoteEdges
     if (currentActorId) {
       hydrationContext.bookmarkedStatusIds = new Set(
         bookmarkRows.map((row) => row.statusId)
@@ -1677,6 +1695,43 @@ export const StatusSQLDatabaseMixin = (
     }
 
     return statusIds
+  }
+
+  type StatusQuoteEdgeRow = {
+    statusId: string
+    quotedStatusId: string
+    state: string
+    authorizationUri: string | null
+  }
+
+  const toStatusQuoteEdge = (row: StatusQuoteEdgeRow): StatusQuote => ({
+    quotedStatusId: row.quotedStatusId,
+    state: QuoteState.parse(row.state),
+    authorizationUri: row.authorizationUri ?? null
+  })
+
+  // Per-status quote-edge read used when a caller did not pre-batch them into the
+  // hydration context (mirrors the detected-language fallback).
+  const getStatusQuoteEdgeForData = async (
+    statusId: string
+  ): Promise<StatusQuote | null> => {
+    const row = await database<StatusQuoteEdgeRow>('status_quotes')
+      .where('statusId', statusId)
+      .first('statusId', 'quotedStatusId', 'state', 'authorizationUri')
+    return row ? toStatusQuoteEdge(row) : null
+  }
+
+  // Batch quote-edge read for a timeline page (avoids one query per status).
+  const getStatusQuoteEdges = async (
+    statusIds: string[]
+  ): Promise<Map<string, StatusQuote>> => {
+    const edges = new Map<string, StatusQuote>()
+    if (statusIds.length === 0) return edges
+    const rows = await database<StatusQuoteEdgeRow>('status_quotes')
+      .whereIn('statusId', statusIds)
+      .select('statusId', 'quotedStatusId', 'state', 'authorizationUri')
+    for (const row of rows) edges.set(row.statusId, toStatusQuoteEdge(row))
+    return edges
   }
 
   const addCounterAdjustment = (
@@ -2745,7 +2800,8 @@ export const StatusSQLDatabaseMixin = (
       actorAnnounceStatus,
       edits,
       fitnessFile,
-      detectedLanguage
+      detectedLanguage,
+      quoteEdge
     ] = await Promise.all([
       mediaDatabase.getAttachments({ statusId: data.id }),
       getTags({ statusId: data.id }),
@@ -2796,7 +2852,12 @@ export const StatusSQLDatabaseMixin = (
         ? (hydrationContext.detectedLanguages[data.id] ?? null)
         : statusDetectedLanguageDatabase.getDetectedLanguage({
             statusId: data.id
-          })
+          }),
+      // Quote edge: use the pre-batched map when present, otherwise read this
+      // status's edge directly (mirrors the detected-language fallback).
+      hydrationContext?.quoteEdges
+        ? (hydrationContext.quoteEdges.get(data.id) ?? null)
+        : getStatusQuoteEdgeForData(data.id)
     ])
 
     const repliesNote = (
@@ -2834,6 +2895,13 @@ export const StatusSQLDatabaseMixin = (
       applicationWebsite: data.applicationWebsite ?? null,
       reply: data.reply,
       replies: repliesNote,
+      // The quote edge (this status quotes another), when present. Announce rows
+      // return earlier and never carry it.
+      ...(quoteEdge ? { quote: quoteEdge } : {}),
+      // Who may quote THIS status, read back from the content blob.
+      ...(content.quoteApprovalPolicy
+        ? { quoteApprovalPolicy: content.quoteApprovalPolicy }
+        : {}),
       totalLikes,
       totalShares,
       isActorLiked: isActorLikedStatusResult,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1233,16 +1233,22 @@ export const StatusSQLDatabaseMixin = (
     }
 
     const statuses = await query
-    // Batch detected-language hydration so this doesn't N+1 one query per
-    // reply (mirroring getStatusesByIds).
+    // Batch detected-language and quote-edge hydration so this doesn't N+1 one
+    // query per reply (mirroring getStatusesByIds).
     const hydrationStatusIds = await collectHydrationStatusIds(statuses)
+    const [detectedLanguages, quoteEdges] = await Promise.all([
+      hydrationStatusIds.size > 0
+        ? statusDetectedLanguageDatabase.getDetectedLanguages({
+            statusIds: [...hydrationStatusIds]
+          })
+        : Promise.resolve({}),
+      hydrationStatusIds.size > 0
+        ? getStatusQuoteEdges([...hydrationStatusIds])
+        : Promise.resolve(new Map<string, StatusQuote>())
+    ])
     const hydrationContext: StatusHydrationContext = {
-      detectedLanguages:
-        hydrationStatusIds.size > 0
-          ? await statusDetectedLanguageDatabase.getDetectedLanguages({
-              statusIds: [...hydrationStatusIds]
-            })
-          : {}
+      detectedLanguages,
+      quoteEdges
     }
     const statusesWithAttachments = (
       await Promise.all(
@@ -1465,17 +1471,23 @@ export const StatusSQLDatabaseMixin = (
     }
 
     const statuses = await query
-    // Batch detected-language hydration so this doesn't N+1 one query per
-    // status (mirroring getStatusesByIds) — actor status lists back profile
-    // pages and the Mastodon accounts/:id/statuses endpoint.
+    // Batch detected-language and quote-edge hydration so this doesn't N+1 one
+    // query per status (mirroring getStatusesByIds) — actor status lists back
+    // profile pages and the Mastodon accounts/:id/statuses endpoint.
     const hydrationStatusIds = await collectHydrationStatusIds(statuses)
+    const [detectedLanguages, quoteEdges] = await Promise.all([
+      hydrationStatusIds.size > 0
+        ? statusDetectedLanguageDatabase.getDetectedLanguages({
+            statusIds: [...hydrationStatusIds]
+          })
+        : Promise.resolve({}),
+      hydrationStatusIds.size > 0
+        ? getStatusQuoteEdges([...hydrationStatusIds])
+        : Promise.resolve(new Map<string, StatusQuote>())
+    ])
     const hydrationContext: StatusHydrationContext = {
-      detectedLanguages:
-        hydrationStatusIds.size > 0
-          ? await statusDetectedLanguageDatabase.getDetectedLanguages({
-              statusIds: [...hydrationStatusIds]
-            })
-          : {}
+      detectedLanguages,
+      quoteEdges
     }
     const statusesWithAttachments = (
       await Promise.all(

--- a/lib/database/sql/statusQuote.test.ts
+++ b/lib/database/sql/statusQuote.test.ts
@@ -1,0 +1,295 @@
+import { randomUUID } from 'node:crypto'
+
+import {
+  databaseBeforeAll,
+  getTestDatabaseTable
+} from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { QuoteState } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+describe('StatusQuoteDatabase', () => {
+  const table = getTestDatabaseTable()
+
+  beforeAll(async () => {
+    await databaseBeforeAll(table)
+  })
+
+  afterAll(async () => {
+    await Promise.all(table.map((item) => item[1].destroy()))
+  })
+
+  describe.each(table)('%s', (_, database) => {
+    beforeAll(async () => {
+      await seedDatabase(database as Database)
+    })
+
+    const uniqueId = (name: string) =>
+      `${ACTOR1_ID}/statuses/quote-${name}-${randomUUID()}`
+
+    const createStatus = async (name: string, actorId = ACTOR1_ID) => {
+      const statusId = uniqueId(name)
+      return database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId,
+        text: `Quote ${name}`,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+    }
+
+    it('creates a pending edge and reads it back', async () => {
+      const statusId = uniqueId('create')
+      const quotedStatusId = uniqueId('create-target')
+
+      const created = await database.createStatusQuote({
+        statusId,
+        quotedStatusId,
+        quoteRequestId: `${statusId}/quote-request`
+      })
+
+      expect(created.state).toBe('pending')
+      expect(created.quotedStatusId).toBe(quotedStatusId)
+
+      const fetched = await database.getStatusQuote({ statusId })
+      expect(fetched).toMatchObject({
+        statusId,
+        quotedStatusId,
+        state: 'pending',
+        quoteRequestId: `${statusId}/quote-request`,
+        authorizationUri: null
+      })
+    })
+
+    it('returns null for a status with no quote edge', async () => {
+      await expect(
+        database.getStatusQuote({ statusId: uniqueId('missing') })
+      ).resolves.toBeNull()
+    })
+
+    it('upserts on statusId instead of inserting a duplicate', async () => {
+      const statusId = uniqueId('upsert')
+      const firstTarget = uniqueId('upsert-a')
+      const secondTarget = uniqueId('upsert-b')
+
+      await database.createStatusQuote({
+        statusId,
+        quotedStatusId: firstTarget
+      })
+      const updated = await database.createStatusQuote({
+        statusId,
+        quotedStatusId: secondTarget,
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/stamp/1'
+      })
+
+      expect(updated).toMatchObject({
+        statusId,
+        quotedStatusId: secondTarget,
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/stamp/1'
+      })
+      // A single edge exists (getStatusQuote returns the upserted row).
+      const fetched = await database.getStatusQuote({ statusId })
+      expect(fetched?.quotedStatusId).toBe(secondTarget)
+    })
+
+    it('returns null when updating the state of a non-existent edge', async () => {
+      await expect(
+        database.updateStatusQuoteState({
+          statusId: uniqueId('no-edge'),
+          state: 'accepted'
+        })
+      ).resolves.toBeNull()
+    })
+
+    // Full one-way transition matrix. `expected` is the state AFTER the attempt:
+    // legal transitions apply, everything else is a no-op that keeps `from`.
+    it.each([
+      { from: 'pending', to: 'accepted', expected: 'accepted' },
+      { from: 'pending', to: 'rejected', expected: 'rejected' },
+      { from: 'pending', to: 'revoked', expected: 'pending' },
+      { from: 'pending', to: 'deleted', expected: 'pending' },
+      { from: 'pending', to: 'pending', expected: 'pending' },
+      { from: 'accepted', to: 'revoked', expected: 'revoked' },
+      { from: 'accepted', to: 'deleted', expected: 'deleted' },
+      { from: 'accepted', to: 'pending', expected: 'accepted' },
+      { from: 'accepted', to: 'rejected', expected: 'accepted' },
+      { from: 'accepted', to: 'accepted', expected: 'accepted' },
+      { from: 'rejected', to: 'accepted', expected: 'rejected' },
+      { from: 'revoked', to: 'accepted', expected: 'revoked' },
+      { from: 'revoked', to: 'revoked', expected: 'revoked' },
+      { from: 'deleted', to: 'accepted', expected: 'deleted' }
+    ] as { from: QuoteState; to: QuoteState; expected: QuoteState }[])(
+      'transitions $from -> $to result in $expected',
+      async ({ from, to, expected }) => {
+        const statusId = uniqueId(`transition-${from}-${to}`)
+        await database.createStatusQuote({
+          statusId,
+          quotedStatusId: uniqueId('transition-target'),
+          state: from
+        })
+
+        const result = await database.updateStatusQuoteState({
+          statusId,
+          state: to
+        })
+
+        expect(result?.state).toBe(expected)
+        const fetched = await database.getStatusQuote({ statusId })
+        expect(fetched?.state).toBe(expected)
+      }
+    )
+
+    it('stores the authorization uri when accepting', async () => {
+      const statusId = uniqueId('accept-stamp')
+      await database.createStatusQuote({
+        statusId,
+        quotedStatusId: uniqueId('accept-stamp-target')
+      })
+
+      const result = await database.updateStatusQuoteState({
+        statusId,
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/stamp/accept'
+      })
+
+      expect(result).toMatchObject({
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/stamp/accept'
+      })
+    })
+
+    it('lists quoting status ids newest first, filtered by state', async () => {
+      const quotedStatusId = uniqueId('listing-target')
+      const accepted: string[] = []
+      for (let i = 0; i < 3; i += 1) {
+        const statusId = `${ACTOR1_ID}/statuses/listing-${i}-${randomUUID()}`
+        await database.createStatusQuote({
+          statusId,
+          quotedStatusId,
+          state: 'accepted'
+        })
+        accepted.push(statusId)
+      }
+      // A pending edge for the same quoted status is excluded by the filter.
+      await database.createStatusQuote({
+        statusId: uniqueId('listing-pending'),
+        quotedStatusId,
+        state: 'pending'
+      })
+
+      const ids = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted'
+      })
+
+      expect(ids).toHaveLength(3)
+      expect([...ids].sort()).toEqual([...accepted].sort())
+    })
+
+    it('paginates quoting status ids with maxId', async () => {
+      const quotedStatusId = uniqueId('paginate-target')
+      const ids: string[] = []
+      for (let i = 0; i < 3; i += 1) {
+        const statusId = `${ACTOR1_ID}/statuses/paginate-${i}-${randomUUID()}`
+        await database.createStatusQuote({
+          statusId,
+          quotedStatusId,
+          state: 'accepted'
+        })
+        ids.push(statusId)
+      }
+
+      const all = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted'
+      })
+      expect(all).toHaveLength(3)
+
+      // Page after the first returned id: everything strictly older than it.
+      const afterFirst = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted',
+        maxId: all[0]
+      })
+      expect(afterFirst).toEqual(all.slice(1))
+      expect(afterFirst).not.toContain(all[0])
+    })
+
+    it('hydrates the quote edge onto the quoting status', async () => {
+      const quoting = await createStatus('hydrate')
+      const quoted = await createStatus('hydrate-target')
+      await database.createStatusQuote({
+        statusId: quoting.id,
+        quotedStatusId: quoted.id,
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/stamp/hydrate'
+      })
+
+      const status = await database.getStatus({ statusId: quoting.id })
+      expect(status?.type).toBe('Note')
+      if (status?.type !== 'Note') throw new Error('expected a Note status')
+      expect(status.quote).toEqual({
+        quotedStatusId: quoted.id,
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/stamp/hydrate'
+      })
+    })
+
+    it('leaves quote undefined on a status that quotes nothing', async () => {
+      const status = await createStatus('no-quote')
+      const fetched = await database.getStatus({ statusId: status.id })
+      if (fetched?.type !== 'Note') throw new Error('expected a Note status')
+      expect(fetched.quote).toBeUndefined()
+    })
+
+    it('persists and hydrates quoteApprovalPolicy from the content blob', async () => {
+      const statusId = uniqueId('policy')
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'policy',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        quoteApprovalPolicy: 'followers'
+      })
+
+      const status = await database.getStatus({ statusId })
+      if (status?.type !== 'Note') throw new Error('expected a Note status')
+      expect(status.quoteApprovalPolicy).toBe('followers')
+    })
+
+    it('batch-hydrates quote edges via getStatusesByIds', async () => {
+      const quoted = await createStatus('batch-target')
+      const quotingA = await createStatus('batch-a')
+      const quotingB = await createStatus('batch-b')
+      await database.createStatusQuote({
+        statusId: quotingA.id,
+        quotedStatusId: quoted.id,
+        state: 'accepted'
+      })
+      await database.createStatusQuote({
+        statusId: quotingB.id,
+        quotedStatusId: quoted.id,
+        state: 'pending'
+      })
+
+      const statuses = await database.getStatusesByIds({
+        statusIds: [quotingA.id, quotingB.id]
+      })
+      const byId = new Map(statuses.map((status) => [status.id, status]))
+      const a = byId.get(quotingA.id)
+      const b = byId.get(quotingB.id)
+      if (a?.type !== 'Note' || b?.type !== 'Note') {
+        throw new Error('expected Note statuses')
+      }
+      expect(a.quote?.state).toBe('accepted')
+      expect(b.quote?.state).toBe('pending')
+    })
+  })
+})

--- a/lib/database/sql/statusQuote.test.ts
+++ b/lib/database/sql/statusQuote.test.ts
@@ -106,23 +106,36 @@ describe('StatusQuoteDatabase', () => {
       ).resolves.toBeNull()
     })
 
-    // Full one-way transition matrix. `expected` is the state AFTER the attempt:
-    // legal transitions apply, everything else is a no-op that keeps `from`.
+    // Full one-way transition matrix — all 25 (from, to) pairs. `expected` is the
+    // state AFTER the attempt: legal transitions apply, everything else is a
+    // no-op that keeps `from` (terminal states rejected/revoked/deleted have no
+    // legal outgoing transition).
     it.each([
+      { from: 'pending', to: 'pending', expected: 'pending' },
       { from: 'pending', to: 'accepted', expected: 'accepted' },
       { from: 'pending', to: 'rejected', expected: 'rejected' },
       { from: 'pending', to: 'revoked', expected: 'pending' },
       { from: 'pending', to: 'deleted', expected: 'pending' },
-      { from: 'pending', to: 'pending', expected: 'pending' },
+      { from: 'accepted', to: 'pending', expected: 'accepted' },
+      { from: 'accepted', to: 'accepted', expected: 'accepted' },
+      { from: 'accepted', to: 'rejected', expected: 'accepted' },
       { from: 'accepted', to: 'revoked', expected: 'revoked' },
       { from: 'accepted', to: 'deleted', expected: 'deleted' },
-      { from: 'accepted', to: 'pending', expected: 'accepted' },
-      { from: 'accepted', to: 'rejected', expected: 'accepted' },
-      { from: 'accepted', to: 'accepted', expected: 'accepted' },
+      { from: 'rejected', to: 'pending', expected: 'rejected' },
       { from: 'rejected', to: 'accepted', expected: 'rejected' },
+      { from: 'rejected', to: 'rejected', expected: 'rejected' },
+      { from: 'rejected', to: 'revoked', expected: 'rejected' },
+      { from: 'rejected', to: 'deleted', expected: 'rejected' },
+      { from: 'revoked', to: 'pending', expected: 'revoked' },
       { from: 'revoked', to: 'accepted', expected: 'revoked' },
+      { from: 'revoked', to: 'rejected', expected: 'revoked' },
       { from: 'revoked', to: 'revoked', expected: 'revoked' },
-      { from: 'deleted', to: 'accepted', expected: 'deleted' }
+      { from: 'revoked', to: 'deleted', expected: 'revoked' },
+      { from: 'deleted', to: 'pending', expected: 'deleted' },
+      { from: 'deleted', to: 'accepted', expected: 'deleted' },
+      { from: 'deleted', to: 'rejected', expected: 'deleted' },
+      { from: 'deleted', to: 'revoked', expected: 'deleted' },
+      { from: 'deleted', to: 'deleted', expected: 'deleted' }
     ] as { from: QuoteState; to: QuoteState; expected: QuoteState }[])(
       'transitions $from -> $to result in $expected',
       async ({ from, to, expected }) => {
@@ -218,6 +231,52 @@ describe('StatusQuoteDatabase', () => {
       })
       expect(afterFirst).toEqual(all.slice(1))
       expect(afterFirst).not.toContain(all[0])
+
+      // sinceId mirrors maxId in the opposite direction: everything strictly
+      // newer than the last returned id.
+      const beforeLast = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted',
+        sinceId: all[all.length - 1]
+      })
+      expect(beforeLast).toEqual(all.slice(0, all.length - 1))
+      expect(beforeLast).not.toContain(all[all.length - 1])
+    })
+
+    it('returns an empty page when the cursor id does not exist', async () => {
+      const quotedStatusId = uniqueId('cursor-missing-target')
+      await database.createStatusQuote({
+        statusId: uniqueId('cursor-missing-quoting'),
+        quotedStatusId,
+        state: 'accepted'
+      })
+
+      await expect(
+        database.getQuotingStatusIds({
+          quotedStatusId,
+          state: 'accepted',
+          maxId: uniqueId('cursor-nonexistent')
+        })
+      ).resolves.toEqual([])
+    })
+
+    it('lists all edges regardless of state when no state filter is given', async () => {
+      const quotedStatusId = uniqueId('unfiltered-target')
+      const accepted = uniqueId('unfiltered-accepted')
+      const pending = uniqueId('unfiltered-pending')
+      await database.createStatusQuote({
+        statusId: accepted,
+        quotedStatusId,
+        state: 'accepted'
+      })
+      await database.createStatusQuote({
+        statusId: pending,
+        quotedStatusId,
+        state: 'pending'
+      })
+
+      const ids = await database.getQuotingStatusIds({ quotedStatusId })
+      expect([...ids].sort()).toEqual([accepted, pending].sort())
     })
 
     it('hydrates the quote edge onto the quoting status', async () => {

--- a/lib/database/sql/statusQuote.ts
+++ b/lib/database/sql/statusQuote.ts
@@ -1,0 +1,189 @@
+import { Knex } from 'knex'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  CreateStatusQuoteParams,
+  GetQuotingStatusIdsParams,
+  GetStatusQuoteParams,
+  StatusQuoteDatabase,
+  StatusQuoteRecord,
+  UpdateStatusQuoteStateParams
+} from '@/lib/types/database/operations'
+import { QuoteState } from '@/lib/types/domain/status'
+
+type StatusQuoteRow = {
+  statusId: string
+  quotedStatusId: string
+  state: string
+  quoteRequestId: string | null
+  authorizationUri: string | null
+  createdAt: number | Date | string
+  updatedAt: number | Date | string
+}
+
+const fixStatusQuoteRow = (row: StatusQuoteRow): StatusQuoteRecord => ({
+  statusId: row.statusId,
+  quotedStatusId: row.quotedStatusId,
+  state: QuoteState.parse(row.state),
+  quoteRequestId: row.quoteRequestId ?? null,
+  authorizationUri: row.authorizationUri ?? null,
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+// One-way quote-edge state machine (FEP-044f). A transition not listed here is a
+// no-op — this makes late messages idempotent and resolves Accept-vs-Delete
+// races by construction (a revoked/rejected/deleted edge never regresses).
+const ALLOWED_TRANSITIONS: Record<QuoteState, QuoteState[]> = {
+  pending: ['accepted', 'rejected'],
+  accepted: ['revoked', 'deleted'],
+  rejected: [],
+  revoked: [],
+  deleted: []
+}
+
+const canTransition = (from: QuoteState, to: QuoteState): boolean =>
+  ALLOWED_TRANSITIONS[from].includes(to)
+
+const STATUS_QUOTE_CURSOR_COLUMNS = [
+  'statusId',
+  'quotedStatusId',
+  'state',
+  'quoteRequestId',
+  'authorizationUri',
+  'createdAt',
+  'updatedAt'
+] as const
+
+export const StatusQuoteSQLDatabaseMixin = (
+  database: Knex
+): StatusQuoteDatabase => {
+  const getStatusQuoteRow = (
+    db: Knex | Knex.Transaction,
+    statusId: string
+  ): Promise<StatusQuoteRow | undefined> =>
+    db<StatusQuoteRow>('status_quotes')
+      .where('statusId', statusId)
+      .first(...STATUS_QUOTE_CURSOR_COLUMNS)
+
+  return {
+    async createStatusQuote({
+      statusId,
+      quotedStatusId,
+      state = 'pending',
+      quoteRequestId = null,
+      authorizationUri = null
+    }: CreateStatusQuoteParams): Promise<StatusQuoteRecord> {
+      const currentTime = new Date()
+      return database.transaction(async (trx) => {
+        const existing = await getStatusQuoteRow(trx, statusId)
+        if (existing) {
+          await trx('status_quotes').where('statusId', statusId).update({
+            quotedStatusId,
+            state,
+            quoteRequestId,
+            authorizationUri,
+            updatedAt: currentTime
+          })
+        } else {
+          await trx('status_quotes').insert({
+            statusId,
+            quotedStatusId,
+            state,
+            quoteRequestId,
+            authorizationUri,
+            createdAt: currentTime,
+            updatedAt: currentTime
+          })
+        }
+        const row = await getStatusQuoteRow(trx, statusId)
+        // The row was just written in this transaction, so it always exists.
+        return fixStatusQuoteRow(row as StatusQuoteRow)
+      })
+    },
+
+    async getStatusQuote({
+      statusId
+    }: GetStatusQuoteParams): Promise<StatusQuoteRecord | null> {
+      const row = await getStatusQuoteRow(database, statusId)
+      return row ? fixStatusQuoteRow(row) : null
+    },
+
+    async updateStatusQuoteState({
+      statusId,
+      state,
+      authorizationUri
+    }: UpdateStatusQuoteStateParams): Promise<StatusQuoteRecord | null> {
+      return database.transaction(async (trx) => {
+        const existing = await getStatusQuoteRow(trx, statusId)
+        if (!existing) return null
+
+        const currentState = QuoteState.parse(existing.state)
+        if (!canTransition(currentState, state)) {
+          // Illegal (or same-state) transition: leave the row untouched.
+          return fixStatusQuoteRow(existing)
+        }
+
+        await trx('status_quotes')
+          .where('statusId', statusId)
+          .update({
+            state,
+            // Only overwrite the stamp uri when the caller supplies one; a
+            // transition that does not carry a stamp keeps the existing value.
+            ...(authorizationUri !== undefined ? { authorizationUri } : {}),
+            updatedAt: new Date()
+          })
+        const row = await getStatusQuoteRow(trx, statusId)
+        return fixStatusQuoteRow(row as StatusQuoteRow)
+      })
+    },
+
+    async getQuotingStatusIds({
+      quotedStatusId,
+      state,
+      limit = 20,
+      maxId,
+      sinceId
+    }: GetQuotingStatusIdsParams): Promise<string[]> {
+      const query = database<StatusQuoteRow>('status_quotes')
+        .where('quotedStatusId', quotedStatusId)
+        .limit(limit)
+      if (state) query.where('state', state)
+
+      // Keyset pagination over (createdAt, statusId), newest first. The cursor
+      // ids reference the quoting status id (the PK of this table).
+      if (maxId) {
+        const cursor = await database<StatusQuoteRow>('status_quotes')
+          .where('statusId', maxId)
+          .first('createdAt')
+        if (!cursor) return []
+        query.andWhere((builder) => {
+          builder.where('createdAt', '<', cursor.createdAt).orWhere((tie) => {
+            tie
+              .where('createdAt', cursor.createdAt)
+              .andWhere('statusId', '<', maxId)
+          })
+        })
+      }
+      if (sinceId) {
+        const cursor = await database<StatusQuoteRow>('status_quotes')
+          .where('statusId', sinceId)
+          .first('createdAt')
+        if (!cursor) return []
+        query.andWhere((builder) => {
+          builder.where('createdAt', '>', cursor.createdAt).orWhere((tie) => {
+            tie
+              .where('createdAt', cursor.createdAt)
+              .andWhere('statusId', '>', sinceId)
+          })
+        })
+      }
+
+      const rows = await query
+        .orderBy('createdAt', 'desc')
+        .orderBy('statusId', 'desc')
+        .select('statusId')
+      return rows.map((row) => row.statusId)
+    }
+  }
+}

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -40,6 +40,7 @@ import {
   StatusDatabase,
   StatusDetectedLanguageDatabase,
   StatusMuteDatabase,
+  StatusQuoteDatabase,
   SuggestionDatabase,
   TimelineDatabase,
   TranslationCacheDatabase,
@@ -85,6 +86,7 @@ export type Database = AccountDatabase &
   StatusDatabase &
   StatusDetectedLanguageDatabase &
   StatusMuteDatabase &
+  StatusQuoteDatabase &
   SuggestionDatabase &
   TrendsDatabase &
   IdempotencyDatabase &

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -8,8 +8,10 @@ import { seedDatabase } from '@/lib/stub/database'
 import { MockImageDocument } from '@/lib/stub/imageDocument'
 import { MockLitepubNote, MockMastodonActivityPubNote } from '@/lib/stub/note'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 enableFetchMocks()
 
@@ -671,5 +673,135 @@ describe('createNoteJob', () => {
     expect(hashtagTags).toHaveLength(1)
     expect(mentionTags[0].name).toEqual('@someone')
     expect(hashtagTags[0].name).toEqual('#topic')
+  })
+
+  describe('quote ingest', () => {
+    const createLocalQuoted = async (suffix: string, actorId: string) => {
+      const id = `${actorId}/statuses/quoted-${suffix}`
+      await database.createNote({
+        id,
+        url: id,
+        actorId,
+        text: 'quoted status',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      return id
+    }
+
+    it('stores an accepted edge for a self-quote', async () => {
+      const authorId = actor1?.id as string
+      const quotedId = await createLocalQuoted('self', authorId)
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: `${authorId}/statuses/quoting-self`,
+          from: authorId,
+          content: 'self quote'
+        }),
+        quote: quotedId
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-self',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: authorId
+      })
+
+      const edge = await database.getStatusQuote({ statusId: note.id })
+      expect(edge).toMatchObject({
+        quotedStatusId: quotedId,
+        state: 'accepted'
+      })
+    })
+
+    it.each([
+      { label: 'FEP quote', field: 'quote' },
+      { label: 'Fedibird quoteUri', field: 'quoteUri' },
+      { label: 'Misskey _misskey_quote', field: '_misskey_quote' }
+    ])(
+      'stores a pending edge for a $label with no stamp from a different author',
+      async ({ field }) => {
+        const authorId = actor1?.id as string
+        const quotedId = await createLocalQuoted(`pending-${field}`, authorId)
+        const note = {
+          ...MockMastodonActivityPubNote({
+            id: `${ACTOR2_ID}/statuses/quoting-${field}`,
+            from: ACTOR2_ID,
+            content: 'cross-author quote'
+          }),
+          [field]: quotedId
+        }
+
+        await createNoteJob(database, {
+          id: `quote-pending-${field}`,
+          name: CREATE_NOTE_JOB_NAME,
+          data: note,
+          verifiedSenderActorId: ACTOR2_ID
+        })
+
+        const edge = await database.getStatusQuote({ statusId: note.id })
+        expect(edge).toMatchObject({
+          quotedStatusId: quotedId,
+          state: 'pending'
+        })
+      }
+    )
+
+    it('leaves no quote edge for a note that quotes nothing', async () => {
+      const note = MockMastodonActivityPubNote({
+        id: `${actor1?.id}/statuses/no-quote`,
+        from: actor1?.id,
+        content: 'plain note'
+      })
+      await createNoteJob(database, {
+        id: 'quote-none',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: actor1?.id
+      })
+      await expect(
+        database.getStatusQuote({ statusId: note.id })
+      ).resolves.toBeNull()
+    })
+
+    it('does not rewrite the edge for a duplicate Create', async () => {
+      const authorId = actor1?.id as string
+      const quotedId = await createLocalQuoted('dup', authorId)
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: `${authorId}/statuses/quoting-dup`,
+          from: authorId,
+          content: 'dup quote'
+        }),
+        quote: quotedId
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-dup',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: authorId
+      })
+      // Sentinel that a second ingest would clobber (the note carries no stamp).
+      await database.createStatusQuote({
+        statusId: note.id,
+        quotedStatusId: quotedId,
+        state: 'accepted',
+        authorizationUri: 'https://llun.test/sentinel'
+      })
+
+      await createNoteJob(database, {
+        id: 'quote-dup',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: authorId
+      })
+
+      const edge = await database.getStatusQuote({ statusId: note.id })
+      // The duplicate returned early (existing status), so createStatusQuote was
+      // not called again and the sentinel survives.
+      expect(edge?.authorizationUri).toBe('https://llun.test/sentinel')
+    })
   })
 })

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -9,11 +9,13 @@ import {
   getAttachments,
   getContent,
   getLanguage,
+  getQuoteTargetId,
   getReply,
   getSummary,
   getTags
 } from '@/lib/activities/note'
 import { persistDetectedLanguage } from '@/lib/services/language-detection'
+import { verifyRemoteQuote } from '@/lib/services/quotes/verifyRemoteQuote'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import {
   ArticleContent,
@@ -115,6 +117,29 @@ export const createNoteJob = createJobHandle(
       text,
       html: true
     })
+
+    // Record the quote edge (FEP-044f) if this note quotes another status. The
+    // state is derived from the receiver rules; a fetch/verification failure
+    // degrades to `pending` and never drops the note.
+    const quotedStatusId = getQuoteTargetId(note)
+    if (quotedStatusId) {
+      const quotedStatus = await database.getStatus({
+        statusId: quotedStatusId,
+        withReplies: false
+      })
+      const state = await verifyRemoteQuote({
+        database,
+        note,
+        actorId,
+        quotedStatus
+      })
+      await database.createStatusQuote({
+        statusId: note.id,
+        quotedStatusId,
+        state,
+        authorizationUri: note.quoteAuthorization ?? null
+      })
+    }
 
     const tags = getTags(note)
 

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -1682,6 +1682,67 @@ describe('getMastodonStatus', () => {
       expect(innerQuote.quoted_status_id).toBeNull()
     })
 
+    it('downgrades a depth-1 accepted quote to unauthorized when the viewer cannot read the innermost status', async () => {
+      // A (public) -> B (public), accepted; B -> C accepted, but C is
+      // followers-only. An anonymous viewer sees A, embeds B, and the shallow
+      // B->C quote must downgrade to unauthorized with no leaked id.
+      const c = await makeStatus(ACTOR1_ID, {
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+      const b = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: b.id,
+        quotedStatusId: c.id,
+        state: 'accepted'
+      })
+      const a = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: a.id,
+        quotedStatusId: b.id,
+        state: 'accepted'
+      })
+
+      const hydrated = (await database.getStatus({ statusId: a.id })) as Status
+      const result = await getMastodonStatus(database, hydrated)
+      const innerQuote = (
+        result?.quote as {
+          quoted_status: {
+            quote?: { state: string; quoted_status_id: unknown }
+          }
+        }
+      ).quoted_status.quote as { state: string; quoted_status_id: unknown }
+      expect(innerQuote.state).toBe('unauthorized')
+      expect(innerQuote.quoted_status_id).toBeNull()
+    })
+
+    it('downgrades a depth-1 accepted quote to deleted when the innermost status is gone', async () => {
+      const b = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: b.id,
+        quotedStatusId: `${ACTOR1_ID}/statuses/mq-shallow-missing`,
+        state: 'accepted'
+      })
+      const a = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: a.id,
+        quotedStatusId: b.id,
+        state: 'accepted'
+      })
+
+      const hydrated = (await database.getStatus({ statusId: a.id })) as Status
+      const result = await getMastodonStatus(database, hydrated)
+      const innerQuote = (
+        result?.quote as {
+          quoted_status: {
+            quote?: { state: string; quoted_status_id: unknown }
+          }
+        }
+      ).quoted_status.quote as { state: string; quoted_status_id: unknown }
+      expect(innerQuote.state).toBe('deleted')
+      expect(innerQuote.quoted_status_id).toBeNull()
+    })
+
     it.each([
       {
         description: 'public policy, author viewer',

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -1560,6 +1560,28 @@ describe('getMastodonStatus', () => {
       expect(quote.quoted_status).toBeNull()
     })
 
+    it('hydrates the embedded quote viewer action state on the single-status path', async () => {
+      // No batch cache: getQuotedStatus must pass currentActorId so the embedded
+      // quoted_status reflects the viewer's bookmark, not a default false.
+      const quoted = await makeStatus(ACTOR1_ID)
+      await database.createBookmark({ actorId: ACTOR2_ID, statusId: quoted.id })
+      const quoting = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: quoting.id,
+        quotedStatusId: quoted.id,
+        state: 'accepted'
+      })
+      const hydrated = (await database.getStatus({
+        statusId: quoting.id
+      })) as Status
+
+      const result = await getMastodonStatus(database, hydrated, ACTOR2_ID)
+      const quote = result?.quote as {
+        quoted_status: { bookmarked?: boolean } | null
+      }
+      expect(quote.quoted_status?.bookmarked).toBe(true)
+    })
+
     it('embeds an accepted quote for an authenticated non-author viewer of a public status', async () => {
       const quoted = await makeStatus(ACTOR1_ID)
       const result = await serializeQuoting(quoted.id, 'accepted', ACTOR2_ID)

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -1471,4 +1471,210 @@ describe('getMastodonStatus', () => {
       expect(mastodonStatus?.emojis[0].shortcode).toBe('emoji_no_colons')
     })
   })
+
+  describe('quote serialization', () => {
+    let counter = 0
+    const makeStatus = async (
+      actorId: string,
+      { to = [ACTIVITY_STREAM_PUBLIC], cc = [] as string[] } = {}
+    ): Promise<Status> => {
+      counter += 1
+      const id = `${actorId}/statuses/mq-${counter}`
+      await database.createNote({
+        id,
+        url: id,
+        actorId,
+        text: `quote test ${counter}`,
+        to,
+        cc
+      })
+      return (await database.getStatus({ statusId: id })) as Status
+    }
+
+    const serializeQuoting = async (
+      quotedStatusId: string,
+      state: 'pending' | 'accepted' | 'rejected' | 'revoked' | 'deleted',
+      currentActorId?: string
+    ) => {
+      const quoting = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: quoting.id,
+        quotedStatusId,
+        state
+      })
+      const hydrated = (await database.getStatus({
+        statusId: quoting.id
+      })) as Status
+      return getMastodonStatus(database, hydrated, currentActorId)
+    }
+
+    it('embeds the quoted status for an accepted quote', async () => {
+      const quoted = await makeStatus(ACTOR1_ID)
+      const result = await serializeQuoting(quoted.id, 'accepted')
+      const quote = result?.quote as {
+        state: string
+        quoted_status: { id: string } | null
+      }
+      expect(quote.state).toBe('accepted')
+      expect(quote.quoted_status?.id).toBe(urlToId(quoted.id))
+    })
+
+    it.each([
+      { state: 'pending' as const },
+      { state: 'rejected' as const },
+      { state: 'revoked' as const },
+      { state: 'deleted' as const }
+    ])(
+      'serializes a $state quote as a placeholder with no quoted status',
+      async ({ state }) => {
+        const quoted = await makeStatus(ACTOR1_ID)
+        const result = await serializeQuoting(quoted.id, state)
+        const quote = result?.quote as {
+          state: string
+          quoted_status: unknown
+        }
+        expect(quote.state).toBe(state)
+        expect(quote.quoted_status).toBeNull()
+      }
+    )
+
+    it('downgrades an accepted quote to deleted when the quoted status is gone', async () => {
+      const result = await serializeQuoting(
+        `${ACTOR1_ID}/statuses/mq-nonexistent`,
+        'accepted'
+      )
+      const quote = result?.quote as { state: string; quoted_status: unknown }
+      expect(quote.state).toBe('deleted')
+      expect(quote.quoted_status).toBeNull()
+    })
+
+    it('downgrades an accepted quote to unauthorized when the viewer cannot read the quoted status', async () => {
+      // Followers-only quoted status; an anonymous viewer cannot read it.
+      const quoted = await makeStatus(ACTOR1_ID, {
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+      const result = await serializeQuoting(quoted.id, 'accepted')
+      const quote = result?.quote as { state: string; quoted_status: unknown }
+      expect(quote.state).toBe('unauthorized')
+      expect(quote.quoted_status).toBeNull()
+    })
+
+    it('emits a shallow quote at depth 1 and stops recursing', async () => {
+      const c = await makeStatus(ACTOR1_ID)
+      const b = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: b.id,
+        quotedStatusId: c.id,
+        state: 'accepted'
+      })
+      const a = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: a.id,
+        quotedStatusId: b.id,
+        state: 'accepted'
+      })
+
+      const hydrated = (await database.getStatus({ statusId: a.id })) as Status
+      const result = await getMastodonStatus(database, hydrated)
+
+      const outerQuote = result?.quote as {
+        state: string
+        quoted_status: {
+          id: string
+          quote?: { state: string; quoted_status_id?: string }
+        }
+      }
+      expect(outerQuote.quoted_status.id).toBe(urlToId(b.id))
+      // The inner quote (B -> C) is shallow: id only, no embedded status.
+      const innerQuote = outerQuote.quoted_status.quote as {
+        state: string
+        quoted_status_id?: string
+        quoted_status?: unknown
+      }
+      expect(innerQuote.quoted_status_id).toBe(urlToId(c.id))
+      expect(innerQuote.quoted_status).toBeUndefined()
+    })
+
+    it.each([
+      {
+        description: 'public policy, author viewer',
+        policy: undefined,
+        viewer: ACTOR1_ID,
+        expectedAutomatic: ['public'],
+        expectedCurrentUser: 'automatic'
+      },
+      {
+        description: 'public policy, anonymous viewer',
+        policy: 'public' as const,
+        viewer: undefined,
+        expectedAutomatic: ['public'],
+        expectedCurrentUser: 'unknown'
+      },
+      {
+        description: 'nobody policy, non-author viewer',
+        policy: 'nobody' as const,
+        viewer: ACTOR2_ID,
+        expectedAutomatic: [] as string[],
+        expectedCurrentUser: 'denied'
+      },
+      {
+        description: 'followers policy, non-author viewer',
+        policy: 'followers' as const,
+        viewer: ACTOR2_ID,
+        expectedAutomatic: ['followers'],
+        expectedCurrentUser: 'unknown'
+      }
+    ])(
+      'emits quote_approval for $description',
+      async ({ policy, viewer, expectedAutomatic, expectedCurrentUser }) => {
+        counter += 1
+        const id = `${ACTOR1_ID}/statuses/mq-approval-${counter}`
+        await database.createNote({
+          id,
+          url: id,
+          actorId: ACTOR1_ID,
+          text: 'approval',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          ...(policy ? { quoteApprovalPolicy: policy } : {})
+        })
+        const status = (await database.getStatus({ statusId: id })) as Status
+        const result = await getMastodonStatus(database, status, viewer)
+        expect(result?.quote_approval).toEqual({
+          automatic: expectedAutomatic,
+          manual: [],
+          current_user: expectedCurrentUser
+        })
+      }
+    )
+
+    it('batch-prefetches quoted statuses with a single getStatusesByIds call', async () => {
+      const quotingStatuses: Status[] = []
+      for (let i = 0; i < 5; i += 1) {
+        const quoted = await makeStatus(ACTOR1_ID)
+        const quoting = await makeStatus(ACTOR1_ID)
+        await database.createStatusQuote({
+          statusId: quoting.id,
+          quotedStatusId: quoted.id,
+          state: 'accepted'
+        })
+        quotingStatuses.push(
+          (await database.getStatus({
+            statusId: quoting.id
+          })) as Status
+        )
+      }
+
+      const spy = vi.spyOn(database, 'getStatusesByIds')
+      const results = await getMastodonStatuses(database, quotingStatuses)
+
+      expect(results).toHaveLength(5)
+      // One call for the quoted-status prefetch (no replies in these fixtures).
+      expect(spy).toHaveBeenCalledTimes(1)
+      for (const result of results) {
+        expect((result.quote as { state: string }).state).toBe('accepted')
+      }
+    })
+  })
 })

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -1560,6 +1560,64 @@ describe('getMastodonStatus', () => {
       expect(quote.quoted_status).toBeNull()
     })
 
+    it('embeds an accepted quote for an authenticated non-author viewer of a public status', async () => {
+      const quoted = await makeStatus(ACTOR1_ID)
+      const result = await serializeQuoting(quoted.id, 'accepted', ACTOR2_ID)
+      const quote = result?.quote as {
+        state: string
+        quoted_status: { id: string } | null
+      }
+      expect(quote.state).toBe('accepted')
+      expect(quote.quoted_status?.id).toBe(urlToId(quoted.id))
+    })
+
+    it('embeds an accepted quote when the authenticated viewer authored the followers-only quoted status', async () => {
+      // Exercises the authenticated getViewerActor + canActorReadStatus self-read
+      // path: a followers-only quoted status is readable by its own author.
+      const quoted = await makeStatus(ACTOR1_ID, {
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+      const result = await serializeQuoting(quoted.id, 'accepted', ACTOR1_ID)
+      const quote = result?.quote as {
+        state: string
+        quoted_status: { id: string } | null
+      }
+      expect(quote.state).toBe('accepted')
+      expect(quote.quoted_status?.id).toBe(urlToId(quoted.id))
+    })
+
+    it('resolves the viewer once per batch and embeds readable accepted quotes', async () => {
+      // Followers-only quoted status + author viewer, hydrated through the batch
+      // path so the viewer Actor comes from options.viewerActor (not a per-status
+      // fetch).
+      const quoted = await makeStatus(ACTOR1_ID, {
+        to: [`${ACTOR1_ID}/followers`],
+        cc: []
+      })
+      const quoting = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: quoting.id,
+        quotedStatusId: quoted.id,
+        state: 'accepted'
+      })
+      const hydrated = (await database.getStatus({
+        statusId: quoting.id
+      })) as Status
+
+      const [result] = await getMastodonStatuses(
+        database,
+        [hydrated],
+        ACTOR1_ID
+      )
+      const quote = result.quote as {
+        state: string
+        quoted_status: { id: string } | null
+      }
+      expect(quote.state).toBe('accepted')
+      expect(quote.quoted_status?.id).toBe(urlToId(quoted.id))
+    })
+
     it('emits a shallow quote at depth 1 and stops recursing', async () => {
       const c = await makeStatus(ACTOR1_ID)
       const b = await makeStatus(ACTOR1_ID)
@@ -1596,11 +1654,46 @@ describe('getMastodonStatus', () => {
       expect(innerQuote.quoted_status).toBeUndefined()
     })
 
+    it('withholds the quoted id in a shallow quote when the inner edge is not accepted', async () => {
+      const c = await makeStatus(ACTOR1_ID)
+      const b = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: b.id,
+        quotedStatusId: c.id,
+        state: 'pending'
+      })
+      const a = await makeStatus(ACTOR1_ID)
+      await database.createStatusQuote({
+        statusId: a.id,
+        quotedStatusId: b.id,
+        state: 'accepted'
+      })
+
+      const hydrated = (await database.getStatus({ statusId: a.id })) as Status
+      const result = await getMastodonStatus(database, hydrated)
+      const outerQuote = result?.quote as {
+        quoted_status: { quote?: { state: string; quoted_status_id: unknown } }
+      }
+      const innerQuote = outerQuote.quoted_status.quote as {
+        state: string
+        quoted_status_id: unknown
+      }
+      expect(innerQuote.state).toBe('pending')
+      expect(innerQuote.quoted_status_id).toBeNull()
+    })
+
     it.each([
       {
         description: 'public policy, author viewer',
         policy: undefined,
         viewer: ACTOR1_ID,
+        expectedAutomatic: ['public'],
+        expectedCurrentUser: 'automatic'
+      },
+      {
+        description: 'public policy, authenticated non-author viewer',
+        policy: 'public' as const,
+        viewer: ACTOR2_ID,
         expectedAutomatic: ['public'],
         expectedCurrentUser: 'automatic'
       },

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -1,10 +1,14 @@
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { isConversationMutedForActor } from '@/lib/services/mastodon/conversationMute'
+import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Mastodon } from '@/lib/types/activitypub'
+import { Actor } from '@/lib/types/domain/actor'
 import { getMastodonAttachment } from '@/lib/types/domain/attachment'
 import {
+  QuoteApprovalPolicy,
   Status,
+  StatusNote,
   StatusPoll,
   StatusType,
   hasStatusBeenEdited
@@ -38,6 +42,7 @@ interface MastodonTag {
 
 type MastodonAccountCache = Map<string, Promise<Mastodon.Account | null>>
 type ReplyStatusCache = Map<string, Status | null>
+type QuotedStatusCache = Map<string, Status | null>
 type StatusMetricsCache = {
   reblogs: Map<string, number>
   replies: Map<string, number>
@@ -51,8 +56,16 @@ type PollVoteCache = Map<string, PollVoteState>
 interface GetMastodonStatusOptions {
   accountCache?: MastodonAccountCache
   replyStatusCache?: ReplyStatusCache
+  quotedStatusCache?: QuotedStatusCache
   statusMetricsCache?: StatusMetricsCache
   pollVoteCache?: PollVoteCache
+  // Depth of quote nesting: 0 emits a full Quote (embedding the quoted status),
+  // >= 1 emits a ShallowQuote (id only) and does not recurse further.
+  quoteDepth?: number
+  // The signed-in viewer as a domain Actor (or null for anonymous), resolved
+  // once per batch so quote visibility checks don't re-fetch it per status.
+  // `undefined` means "not resolved yet"; a per-status call resolves it lazily.
+  viewerActor?: Actor | null
   pinnedStatusIds?: Set<string>
   // The set of thread-root status ids whose conversations the current actor has
   // muted. An empty set means "no mutes", letting per-status checks short-circuit.
@@ -221,6 +234,74 @@ const getReplyStatus = async (
   const replyStatus = await database.getStatus({ statusId })
   replyStatusCache.set(statusId, replyStatus)
   return replyStatus
+}
+
+// Collect the ids of quoted statuses that will be embedded (only `accepted`
+// edges at depth 0 render the full quoted status), mirroring addStatusReplyIds.
+const addStatusQuoteIds = (status: Status, statusIds: Set<string>) => {
+  if (status.type === StatusType.enum.Announce) {
+    addStatusQuoteIds(status.originalStatus, statusIds)
+    return
+  }
+  if (status.quote?.state === 'accepted' && status.quote.quotedStatusId) {
+    statusIds.add(status.quote.quotedStatusId)
+  }
+}
+
+const getQuotedStatus = async (
+  database: Database,
+  statusId: string,
+  options?: GetMastodonStatusOptions
+) => {
+  const quotedStatusCache = options?.quotedStatusCache
+  if (!quotedStatusCache) return database.getStatus({ statusId })
+
+  if (quotedStatusCache.has(statusId)) {
+    return quotedStatusCache.get(statusId) ?? null
+  }
+
+  const quotedStatus = await database.getStatus({ statusId })
+  quotedStatusCache.set(statusId, quotedStatus)
+  return quotedStatus
+}
+
+// Resolve the viewer as a domain Actor for quote visibility checks. Uses the
+// batch-resolved value when present; otherwise fetches once (single-status path).
+const getViewerActor = async (
+  database: Database,
+  currentActorId?: string,
+  options?: GetMastodonStatusOptions
+): Promise<Actor | null> => {
+  if (!currentActorId) return null
+  if (options && options.viewerActor !== undefined) return options.viewerActor
+  return (await database.getActorFromId({ id: currentActorId })) ?? null
+}
+
+// Approved audiences per policy. Manual approval queues are not modelled in v1,
+// so `manual` is always empty.
+const QUOTE_POLICY_AUTOMATIC_AUDIENCE: Record<QuoteApprovalPolicy, string[]> = {
+  public: ['public'],
+  followers: ['followers'],
+  nobody: []
+}
+
+// Build the `quote_approval` object for a non-Announce status. `current_user`
+// is the viewer's standing; the follower-relationship refinement for the
+// `followers` policy lands with canQuoteStatus in a later PR, so an
+// unauthenticated or follower viewer sees `unknown` there.
+const getQuoteApproval = (
+  status: StatusNote | StatusPoll,
+  currentActorId?: string
+) => {
+  const policy: QuoteApprovalPolicy = status.quoteApprovalPolicy ?? 'public'
+  const automatic = QUOTE_POLICY_AUTOMATIC_AUDIENCE[policy]
+  let currentUser: string
+  if (!currentActorId) currentUser = 'unknown'
+  else if (currentActorId === status.actorId) currentUser = 'automatic'
+  else if (policy === 'public') currentUser = 'automatic'
+  else if (policy === 'nobody') currentUser = 'denied'
+  else currentUser = 'unknown'
+  return { automatic, manual: [] as string[], current_user: currentUser }
 }
 
 const getStatusReblogsCount = async (
@@ -454,9 +535,65 @@ export const getMastodonStatus = async (
     })
   }
 
+  const quoteDepth = options?.quoteDepth ?? 0
+  const quoteApproval = getQuoteApproval(status, currentActorId)
+
+  let quote:
+    | { state: string; quoted_status: Mastodon.Status | null }
+    | { state: string; quoted_status_id: string | null }
+    | undefined
+  const edge = status.quote
+  if (edge) {
+    if (quoteDepth >= 1) {
+      // Depth >= 1: reference by id only and stop recursing (ShallowQuote).
+      quote = {
+        state: edge.state,
+        quoted_status_id: urlToId(edge.quotedStatusId)
+      }
+    } else if (edge.state !== 'accepted') {
+      // Only `accepted` embeds the quoted status; other states show a
+      // placeholder with no quoted status.
+      quote = { state: edge.state, quoted_status: null }
+    } else {
+      const quotedStatus = await getQuotedStatus(
+        database,
+        edge.quotedStatusId,
+        options
+      )
+      if (!quotedStatus) {
+        // The quoted status is gone: downgrade to `deleted`.
+        quote = { state: 'deleted', quoted_status: null }
+      } else {
+        const viewer = await getViewerActor(database, currentActorId, options)
+        const canRead = await canActorReadStatus({
+          database,
+          status: quotedStatus,
+          currentActor: viewer
+        })
+        if (!canRead) {
+          // The viewer cannot read the quoted status: downgrade to
+          // `unauthorized` and withhold the quoted status.
+          quote = { state: 'unauthorized', quoted_status: null }
+        } else {
+          const quotedEntity = await getMastodonStatus(
+            database,
+            quotedStatus,
+            currentActorId,
+            { ...options, quoteDepth: 1 }
+          )
+          quote = quotedEntity
+            ? { state: 'accepted', quoted_status: quotedEntity }
+            : { state: 'deleted', quoted_status: null }
+        }
+      }
+    }
+  }
+
   return Mastodon.Status.parse({
     ...mastodonStatus,
-    poll: pollData
+    poll: pollData,
+    quote_approval: quoteApproval,
+    ...(quote ? { quote } : {})
   })
 }
 
@@ -473,6 +610,7 @@ export const getMastodonStatuses = async (
   const replyStatusIds = new Set<string>()
   const pollStatusIds = new Set<string>()
   const pinnedLookupStatusIds = new Set<string>()
+  const quoteStatusIds = new Set<string>()
 
   // Collect lookup ids per status, dropping any whose shape throws here (for
   // example a reblog whose original was deleted, leaving a null originalStatus).
@@ -486,6 +624,7 @@ export const getMastodonStatuses = async (
       addStatusReplyIds(status, replyStatusIds)
       addStatusPollIds(status, pollStatusIds)
       addStatusPinnedLookupIds(status, pinnedLookupStatusIds, currentActorId)
+      addStatusQuoteIds(status, quoteStatusIds)
       safeStatuses.push(status)
     } catch (error) {
       logger.warn({
@@ -503,6 +642,7 @@ export const getMastodonStatuses = async (
   const requestedActorIds = [...actorIds]
   const requestedMetricStatusIds = [...metricStatusIds]
   const requestedReplyStatusIds = [...replyStatusIds]
+  const requestedQuoteStatusIds = [...quoteStatusIds]
   const requestedPollStatusIds = currentActorId ? [...pollStatusIds] : []
   const requestedPinnedLookupStatusIds =
     currentActorId && !inputOptions.pinnedStatusIds
@@ -513,6 +653,8 @@ export const getMastodonStatuses = async (
     reblogCounts,
     replyCounts,
     replyStatuses,
+    quotedStatuses,
+    viewerActor,
     pollVotes,
     pinnedStatusIds,
     mutedConversationRootIds
@@ -532,6 +674,19 @@ export const getMastodonStatuses = async (
           currentActorId
         })
       : Promise.resolve([]),
+    // Prefetch quoted statuses regardless of visibility (no visibleToActorId):
+    // the per-status downgrade distinguishes "missing" (deleted) from
+    // "present but unreadable" (unauthorized).
+    requestedQuoteStatusIds.length > 0
+      ? database.getStatusesByIds({
+          statusIds: requestedQuoteStatusIds,
+          currentActorId
+        })
+      : Promise.resolve([]),
+    // The viewer as a domain Actor, resolved once for quote visibility checks.
+    currentActorId
+      ? database.getActorFromId({ id: currentActorId })
+      : Promise.resolve(null),
     requestedPollStatusIds.length > 0 && currentActorId
       ? database.getActorPollVotesForStatuses({
           statusIds: requestedPollStatusIds,
@@ -596,6 +751,10 @@ export const getMastodonStatuses = async (
     replyStatusCache: new Map(
       requestedReplyStatusIds.map((statusId) => [statusId, null])
     ),
+    quotedStatusCache: new Map(
+      requestedQuoteStatusIds.map((statusId) => [statusId, null])
+    ),
+    viewerActor: viewerActor ?? null,
     pollVoteCache: new Map(
       requestedPollStatusIds.map((statusId) => {
         const ownVotes = pollVotes[statusId] ?? []
@@ -611,6 +770,9 @@ export const getMastodonStatuses = async (
   }
   for (const replyStatus of replyStatuses) {
     options.replyStatusCache?.set(replyStatus.id, replyStatus)
+  }
+  for (const quotedStatus of quotedStatuses) {
+    options.quotedStatusCache?.set(quotedStatus.id, quotedStatus)
   }
 
   return (

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -251,16 +251,22 @@ const addStatusQuoteIds = (status: Status, statusIds: Set<string>) => {
 const getQuotedStatus = async (
   database: Database,
   statusId: string,
+  currentActorId?: string,
   options?: GetMastodonStatusOptions
 ) => {
   const quotedStatusCache = options?.quotedStatusCache
-  if (!quotedStatusCache) return database.getStatus({ statusId })
+  // The batch cache is populated by getStatusesByIds with the viewer, so cached
+  // quoted statuses already carry the viewer's action state. The uncached
+  // (single-status) path must pass currentActorId itself, otherwise the embedded
+  // quoted_status would report favourited/bookmarked/reblogged as false.
+  if (!quotedStatusCache)
+    return database.getStatus({ statusId, currentActorId })
 
   if (quotedStatusCache.has(statusId)) {
     return quotedStatusCache.get(statusId) ?? null
   }
 
-  const quotedStatus = await database.getStatus({ statusId })
+  const quotedStatus = await database.getStatus({ statusId, currentActorId })
   quotedStatusCache.set(statusId, quotedStatus)
   return quotedStatus
 }
@@ -556,6 +562,7 @@ export const getMastodonStatus = async (
       const quotedStatus = await getQuotedStatus(
         database,
         edge.quotedStatusId,
+        currentActorId,
         options
       )
       if (!quotedStatus) {

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -544,28 +544,22 @@ export const getMastodonStatus = async (
     | undefined
   const edge = status.quote
   if (edge) {
-    if (quoteDepth >= 1) {
-      // Depth >= 1: reference by id only and stop recursing (ShallowQuote). Only
-      // an accepted edge exposes the quoted id, matching the depth-0 contract
-      // where non-accepted states withhold the quoted status.
-      quote = {
-        state: edge.state,
-        quoted_status_id:
-          edge.state === 'accepted' ? urlToId(edge.quotedStatusId) : null
-      }
-    } else if (edge.state !== 'accepted') {
-      // Only `accepted` embeds the quoted status; other states show a
-      // placeholder with no quoted status.
-      quote = { state: edge.state, quoted_status: null }
-    } else {
+    // Resolve the viewer-relative state and the readable quoted status once, then
+    // apply it identically at depth 0 (full Quote) and depth >= 1 (ShallowQuote):
+    // only an `accepted` edge whose target exists and is readable resolves a
+    // quoted status; a missing target downgrades to `deleted`, an unreadable one
+    // to `unauthorized`, and both withhold the target (no embed, no id). This
+    // stops a nested quote from leaking a deleted/unreadable status id.
+    let effectiveState: string = edge.state
+    let readableQuoted: Status | null = null
+    if (edge.state === 'accepted') {
       const quotedStatus = await getQuotedStatus(
         database,
         edge.quotedStatusId,
         options
       )
       if (!quotedStatus) {
-        // The quoted status is gone: downgrade to `deleted`.
-        quote = { state: 'deleted', quoted_status: null }
+        effectiveState = 'deleted'
       } else {
         const viewer = await getViewerActor(database, currentActorId, options)
         const canRead = await canActorReadStatus({
@@ -573,22 +567,32 @@ export const getMastodonStatus = async (
           status: quotedStatus,
           currentActor: viewer
         })
-        if (!canRead) {
-          // The viewer cannot read the quoted status: downgrade to
-          // `unauthorized` and withhold the quoted status.
-          quote = { state: 'unauthorized', quoted_status: null }
-        } else {
-          const quotedEntity = await getMastodonStatus(
-            database,
-            quotedStatus,
-            currentActorId,
-            { ...options, quoteDepth: 1 }
-          )
-          quote = quotedEntity
-            ? { state: 'accepted', quoted_status: quotedEntity }
-            : { state: 'deleted', quoted_status: null }
-        }
+        if (!canRead) effectiveState = 'unauthorized'
+        else readableQuoted = quotedStatus
       }
+    }
+
+    if (quoteDepth >= 1) {
+      // ShallowQuote: reference by id only, and only when the downgraded state is
+      // still accepted (target exists and is readable). Stops recursion.
+      quote = {
+        state: effectiveState,
+        quoted_status_id: readableQuoted ? urlToId(readableQuoted.id) : null
+      }
+    } else if (!readableQuoted) {
+      // Placeholder: no embedded quoted status for non-accepted / deleted /
+      // unauthorized states.
+      quote = { state: effectiveState, quoted_status: null }
+    } else {
+      const quotedEntity = await getMastodonStatus(
+        database,
+        readableQuoted,
+        currentActorId,
+        { ...options, quoteDepth: 1 }
+      )
+      quote = quotedEntity
+        ? { state: 'accepted', quoted_status: quotedEntity }
+        : { state: 'deleted', quoted_status: null }
     }
   }
 

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -545,10 +545,13 @@ export const getMastodonStatus = async (
   const edge = status.quote
   if (edge) {
     if (quoteDepth >= 1) {
-      // Depth >= 1: reference by id only and stop recursing (ShallowQuote).
+      // Depth >= 1: reference by id only and stop recursing (ShallowQuote). Only
+      // an accepted edge exposes the quoted id, matching the depth-0 contract
+      // where non-accepted states withhold the quoted status.
       quote = {
         state: edge.state,
-        quoted_status_id: urlToId(edge.quotedStatusId)
+        quoted_status_id:
+          edge.state === 'accepted' ? urlToId(edge.quotedStatusId) : null
       }
     } else if (edge.state !== 'accepted') {
       // Only `accepted` embeds the quoted status; other states show a

--- a/lib/services/quotes/verifyRemoteQuote.test.ts
+++ b/lib/services/quotes/verifyRemoteQuote.test.ts
@@ -152,4 +152,70 @@ describe('verifyRemoteQuote', () => {
     })
     expect(state).toBe('pending')
   })
+
+  it('is pending when the stamp is hosted on a foreign authority (forgery)', async () => {
+    // The attacker serves a stamp that names the victim in attributedTo and
+    // matches both ids, but hosts it on their own domain. The authority check
+    // must reject it.
+    const { request } = await vi.importMock<
+      typeof import('@/lib/utils/request')
+    >('@/lib/utils/request')
+    const foreignStampUri = 'https://evil.example/quote_authorizations/1'
+    ;(request as ReturnType<typeof vi.fn>).mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({
+        id: foreignStampUri,
+        type: 'QuoteAuthorization',
+        attributedTo: QUOTED_AUTHOR_ID,
+        interactingObject: QUOTING_NOTE_ID,
+        interactionTarget: QUOTED_STATUS_ID
+      })
+    })
+
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quoteAuthorization: foreignStampUri }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('pending')
+  })
+
+  it('is pending when the stamp id is on a foreign authority', async () => {
+    const { request } = await vi.importMock<
+      typeof import('@/lib/utils/request')
+    >('@/lib/utils/request')
+    ;(request as ReturnType<typeof vi.fn>).mockResolvedValue({
+      statusCode: 200,
+      body: validStampBody({
+        id: 'https://evil.example/quote_authorizations/9'
+      })
+    })
+
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quoteAuthorization: STAMP_URI }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('pending')
+  })
+
+  it('is pending when the stamp body is not a valid QuoteAuthorization', async () => {
+    const { request } = await vi.importMock<
+      typeof import('@/lib/utils/request')
+    >('@/lib/utils/request')
+    ;(request as ReturnType<typeof vi.fn>).mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ id: STAMP_URI, type: 'Note' })
+    })
+
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quoteAuthorization: STAMP_URI }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('pending')
+  })
 })

--- a/lib/services/quotes/verifyRemoteQuote.test.ts
+++ b/lib/services/quotes/verifyRemoteQuote.test.ts
@@ -1,0 +1,155 @@
+import type { BaseNote } from '@/lib/activities/note'
+import type { Database } from '@/lib/database/types'
+import { verifyRemoteQuote } from '@/lib/services/quotes/verifyRemoteQuote'
+import type { Status } from '@/lib/types/domain/status'
+
+vi.mock('@/lib/utils/request', () => ({ request: vi.fn() }))
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: vi.fn().mockResolvedValue(undefined)
+}))
+// Compaction is tested separately; keep it identity here so the stamp body we
+// return in tests is validated as-is.
+vi.mock('@/lib/activities/jsonld', () => ({
+  compactActivityPub: vi.fn(async (input: unknown) => input)
+}))
+
+const QUOTING_ACTOR_ID = 'https://remote.example/users/quoter'
+const QUOTED_AUTHOR_ID = 'https://llun.test/users/target'
+const QUOTED_STATUS_ID = 'https://llun.test/users/target/statuses/1'
+const QUOTING_NOTE_ID = 'https://remote.example/users/quoter/statuses/9'
+const STAMP_URI = 'https://llun.test/users/target/quote_authorizations/1'
+
+const database = {} as Database
+
+const makeNote = (extra: Record<string, unknown> = {}): BaseNote =>
+  ({
+    id: QUOTING_NOTE_ID,
+    type: 'Note',
+    attributedTo: QUOTING_ACTOR_ID,
+    quote: QUOTED_STATUS_ID,
+    ...extra
+  }) as unknown as BaseNote
+
+const makeQuotedStatus = (actorId = QUOTED_AUTHOR_ID): Status =>
+  ({ type: 'Note', actorId }) as unknown as Status
+
+const validStampBody = (overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    id: STAMP_URI,
+    type: 'QuoteAuthorization',
+    attributedTo: QUOTED_AUTHOR_ID,
+    interactingObject: QUOTING_NOTE_ID,
+    interactionTarget: QUOTED_STATUS_ID,
+    ...overrides
+  })
+
+describe('verifyRemoteQuote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('accepts a self-quote (same author) without fetching a stamp', async () => {
+    const { request } = await vi.importMock<
+      typeof import('@/lib/utils/request')
+    >('@/lib/utils/request')
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote(),
+      actorId: QUOTED_AUTHOR_ID,
+      quotedStatus: makeQuotedStatus(QUOTED_AUTHOR_ID)
+    })
+    expect(state).toBe('accepted')
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('is pending when there is no authorization stamp', async () => {
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote(),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('pending')
+  })
+
+  it('is pending when the quoted status is unknown locally', async () => {
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quoteAuthorization: STAMP_URI }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: null
+    })
+    expect(state).toBe('pending')
+  })
+
+  it('accepts when the stamp validates all three fields', async () => {
+    const { request } = await vi.importMock<
+      typeof import('@/lib/utils/request')
+    >('@/lib/utils/request')
+    ;(request as ReturnType<typeof vi.fn>).mockResolvedValue({
+      statusCode: 200,
+      body: validStampBody()
+    })
+
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quoteAuthorization: STAMP_URI }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('accepted')
+  })
+
+  it('is pending when the stamp fetch does not return 200', async () => {
+    const { request } = await vi.importMock<
+      typeof import('@/lib/utils/request')
+    >('@/lib/utils/request')
+    ;(request as ReturnType<typeof vi.fn>).mockResolvedValue({
+      statusCode: 404,
+      body: ''
+    })
+
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quoteAuthorization: STAMP_URI }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('pending')
+  })
+
+  it.each([
+    { field: 'attributedTo', value: 'https://evil.example/users/impostor' },
+    { field: 'interactingObject', value: 'https://evil.example/notes/other' },
+    { field: 'interactionTarget', value: 'https://evil.example/notes/other' }
+  ])(
+    'is pending when the stamp $field does not match',
+    async ({ field, value }) => {
+      const { request } = await vi.importMock<
+        typeof import('@/lib/utils/request')
+      >('@/lib/utils/request')
+      ;(request as ReturnType<typeof vi.fn>).mockResolvedValue({
+        statusCode: 200,
+        body: validStampBody({ [field]: value })
+      })
+
+      const state = await verifyRemoteQuote({
+        database,
+        note: makeNote({ quoteAuthorization: STAMP_URI }),
+        actorId: QUOTING_ACTOR_ID,
+        quotedStatus: makeQuotedStatus()
+      })
+      expect(state).toBe('pending')
+    }
+  )
+
+  it('is pending for a Misskey bare quote with no stamp', async () => {
+    const state = await verifyRemoteQuote({
+      database,
+      note: makeNote({ quote: undefined, _misskey_quote: QUOTED_STATUS_ID }),
+      actorId: QUOTING_ACTOR_ID,
+      quotedStatus: makeQuotedStatus()
+    })
+    expect(state).toBe('pending')
+  })
+})

--- a/lib/services/quotes/verifyRemoteQuote.ts
+++ b/lib/services/quotes/verifyRemoteQuote.ts
@@ -1,0 +1,99 @@
+import { activityPubRequestHeaders } from '@/lib/activities/activityPubHeaders'
+import { compactActivityPub } from '@/lib/activities/jsonld'
+import { BaseNote, getQuoteTargetId } from '@/lib/activities/note'
+import { QuoteAuthorization } from '@/lib/activities/quoteRequest'
+import { Database } from '@/lib/database/types'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import {
+  QuoteState,
+  Status,
+  getOriginalStatus
+} from '@/lib/types/domain/status'
+import { logger } from '@/lib/utils/logger'
+import { request } from '@/lib/utils/request'
+
+type VerifyRemoteQuoteParams = {
+  database: Database
+  // The quoting note (already compacted at the inbox boundary).
+  note: BaseNote
+  // The quoting actor id (the note's attributedTo, normalized).
+  actorId: string
+  // The quoted status, if we already have it locally; null otherwise.
+  quotedStatus: Status | null
+}
+
+/**
+ * Fetch and validate the FEP-044f QuoteAuthorization stamp. Signed with the
+ * headless instance actor (every s2s fetch uses the instance signer), compacted,
+ * and safe-parsed. Any failure yields null so the caller degrades to `pending`.
+ */
+const fetchQuoteAuthorization = async (
+  database: Database,
+  stampUri: string
+): Promise<QuoteAuthorization | null> => {
+  try {
+    const signingActor = await getFederationSigningActor(database)
+    const { statusCode, body } = await request({
+      url: stampUri,
+      headers: activityPubRequestHeaders({
+        url: stampUri,
+        signingActor,
+        accept: 'application/activity+json'
+      })
+    })
+    if (statusCode !== 200) return null
+    const compacted = await compactActivityPub(JSON.parse(body))
+    const parsed = QuoteAuthorization.safeParse(compacted)
+    return parsed.success ? parsed.data : null
+  } catch (error) {
+    logger.warn({
+      message: 'Failed to fetch quote authorization stamp',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}
+
+/**
+ * Decide the stored state of an inbound remote quote, applying the FEP-044f
+ * receiver rules:
+ * - quoter == quoted author (self-quote) → `accepted` (same-authority shortcut);
+ * - a `quoteAuthorization` stamp that dereferences to a valid QuoteAuthorization
+ *   whose three fields (attributedTo, interactingObject, interactionTarget) all
+ *   match → `accepted`;
+ * - anything else (no stamp, unknown quoted author, fetch/parse failure, field
+ *   mismatch) → `pending` (rendered as an unapproved placeholder, never dropped).
+ */
+export const verifyRemoteQuote = async ({
+  database,
+  note,
+  actorId,
+  quotedStatus
+}: VerifyRemoteQuoteParams): Promise<QuoteState> => {
+  const quotedStatusId = getQuoteTargetId(note)
+  if (!quotedStatusId) return 'pending'
+
+  const quotedAuthorId = quotedStatus
+    ? getOriginalStatus(quotedStatus).actorId
+    : null
+
+  // Same-authority shortcut: the quoted author is the quoter.
+  if (quotedAuthorId && quotedAuthorId === actorId) return 'accepted'
+
+  const stampUri = note.quoteAuthorization
+  if (!stampUri) return 'pending'
+
+  // We can only verify the stamp's `attributedTo` against a known quoted author.
+  // Without the quoted status locally we cannot confirm the author, so treat the
+  // quote as unapproved rather than trusting a stamp the quoter chose.
+  if (!quotedAuthorId) return 'pending'
+
+  const stamp = await fetchQuoteAuthorization(database, stampUri)
+  if (!stamp) return 'pending'
+
+  const valid =
+    stamp.attributedTo === quotedAuthorId &&
+    stamp.interactingObject === note.id &&
+    stamp.interactionTarget === quotedStatusId
+  return valid ? 'accepted' : 'pending'
+}

--- a/lib/services/quotes/verifyRemoteQuote.ts
+++ b/lib/services/quotes/verifyRemoteQuote.ts
@@ -22,6 +22,19 @@ type VerifyRemoteQuoteParams = {
   quotedStatus: Status | null
 }
 
+// Two ActivityPub ids share authority when they are served from the same host.
+// The stamp is authoritative only if the quoted author's own server hosts it, so
+// a stamp fetched from (or claiming an id on) any other host is not trusted —
+// this is what stops a quoter from serving a forged authorization that merely
+// *names* the quoted author in `attributedTo`.
+const sameAuthority = (a: string, b: string): boolean => {
+  try {
+    return new URL(a).host === new URL(b).host
+  } catch {
+    return false
+  }
+}
+
 /**
  * Fetch and validate the FEP-044f QuoteAuthorization stamp. Signed with the
  * headless instance actor (every s2s fetch uses the instance signer), compacted,
@@ -58,11 +71,13 @@ const fetchQuoteAuthorization = async (
  * Decide the stored state of an inbound remote quote, applying the FEP-044f
  * receiver rules:
  * - quoter == quoted author (self-quote) → `accepted` (same-authority shortcut);
- * - a `quoteAuthorization` stamp that dereferences to a valid QuoteAuthorization
- *   whose three fields (attributedTo, interactingObject, interactionTarget) all
- *   match → `accepted`;
- * - anything else (no stamp, unknown quoted author, fetch/parse failure, field
- *   mismatch) → `pending` (rendered as an unapproved placeholder, never dropped).
+ * - a `quoteAuthorization` stamp that is hosted under the quoted author's own
+ *   authority (both the fetched URL and the stamp's declared id) AND dereferences
+ *   to a valid QuoteAuthorization whose three fields (attributedTo,
+ *   interactingObject, interactionTarget) all match → `accepted`;
+ * - anything else (no stamp, unknown quoted author, foreign-authority stamp,
+ *   fetch/parse failure, field mismatch) → `pending` (rendered as an unapproved
+ *   placeholder, never dropped).
  */
 export const verifyRemoteQuote = async ({
   database,
@@ -92,6 +107,13 @@ export const verifyRemoteQuote = async ({
   if (!stamp) return 'pending'
 
   const valid =
+    // The stamp must actually be hosted under the quoted author's authority —
+    // both the URL we fetched and the id the document claims — otherwise a
+    // quoter could serve a forged stamp naming the author in `attributedTo`.
+    sameAuthority(stampUri, quotedAuthorId) &&
+    sameAuthority(stamp.id, quotedAuthorId) &&
+    // FEP-044f three-field match: issued by the quoted author, for this exact
+    // quoting note, targeting this exact quoted status.
     stamp.attributedTo === quotedAuthorId &&
     stamp.interactingObject === note.id &&
     stamp.interactionTarget === quotedStatusId

--- a/lib/types/activitypub/objects.test.ts
+++ b/lib/types/activitypub/objects.test.ts
@@ -1,4 +1,34 @@
-import { Question } from '@/lib/types/activitypub/objects'
+import { Note, Question } from '@/lib/types/activitypub/objects'
+
+describe('Note quote fields', () => {
+  const base = {
+    id: 'https://remote.example/notes/1',
+    type: 'Note' as const,
+    attributedTo: 'https://remote.example/users/alice',
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    cc: [],
+    content: 'quoting',
+    published: '2026-01-01T00:00:00Z'
+  }
+
+  it('accepts a string quote target', () => {
+    const result = Note.safeParse({
+      ...base,
+      quote: 'https://llun.test/users/me/statuses/1'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts an embedded quote object without an id instead of rejecting the whole note', () => {
+    // Liberal-inbound mandate: an unusual/blank-node quote value must never drop
+    // the entire note.
+    const result = Note.safeParse({
+      ...base,
+      quote: { type: 'Link', href: 'https://llun.test/users/me/statuses/1' }
+    })
+    expect(result.success).toBe(true)
+  })
+})
 
 describe('Question', () => {
   const option = (name: string) => ({

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -132,8 +132,10 @@ export const BaseContent = z.object({
   // Quote-post fields (FEP-044f / Mastodon 4.5). Kept liberal: the target may be
   // a bare id string or an embedded object (`quote`), and legacy servers carry
   // it under compat aliases. `quoteAuthorization` is the hosted stamp id; the
-  // `interactionPolicy` object is tolerated but not validated here.
-  quote: z.union([z.string(), z.looseObject({ id: z.string() })]).nullish(),
+  // `interactionPolicy` object is tolerated but not validated here. The object
+  // form is a loose object (no required `id`) so an unusual/blank-node quote
+  // value never rejects the whole note — getQuoteTargetId reads `.id` defensively.
+  quote: z.union([z.string(), z.looseObject({})]).nullish(),
   quoteUrl: z.string().nullish(),
   quoteUri: z.string().nullish(),
   _misskey_quote: z.string().nullish(),

--- a/lib/types/activitypub/objects.ts
+++ b/lib/types/activitypub/objects.ts
@@ -129,6 +129,17 @@ export const BaseContent = z.object({
   attachment: z.union([Attachment, Attachment.array()]).nullish(),
   tag: z.union([Tag, Tag.array()]).nullish(),
 
+  // Quote-post fields (FEP-044f / Mastodon 4.5). Kept liberal: the target may be
+  // a bare id string or an embedded object (`quote`), and legacy servers carry
+  // it under compat aliases. `quoteAuthorization` is the hosted stamp id; the
+  // `interactionPolicy` object is tolerated but not validated here.
+  quote: z.union([z.string(), z.looseObject({ id: z.string() })]).nullish(),
+  quoteUrl: z.string().nullish(),
+  quoteUri: z.string().nullish(),
+  _misskey_quote: z.string().nullish(),
+  quoteAuthorization: z.string().nullish(),
+  interactionPolicy: z.looseObject({}).nullish(),
+
   published: z.string().describe('Object published datetime'),
   updated: z.string().describe('Object updated datetime').nullish()
 })

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -29,7 +29,12 @@ import { List, ListRepliesPolicy } from '@/lib/types/domain/list'
 import { Mute } from '@/lib/types/domain/mute'
 import { Relay, RelayState } from '@/lib/types/domain/relay'
 import { Session } from '@/lib/types/domain/session'
-import { Status, StatusType } from '@/lib/types/domain/status'
+import {
+  QuoteApprovalPolicy,
+  QuoteState,
+  Status,
+  StatusType
+} from '@/lib/types/domain/status'
 import { Tag, TagType } from '@/lib/types/domain/tag'
 import * as Mastodon from '@/lib/types/mastodon'
 import { Client } from '@/lib/types/oauth2/client'
@@ -465,6 +470,11 @@ interface BaseCreateStatusParams {
   // Mastodon-compatible content flags persisted in the status content blob.
   sensitive?: boolean
   language?: string | null
+
+  // Who may quote this status (FEP-044f / Mastodon 4.5). Persisted in the status
+  // content blob, not a column. Omit to leave it unset (defaults to `public` at
+  // consumption).
+  quoteApprovalPolicy?: QuoteApprovalPolicy
 
   // The registered OAuth client (Mastodon "application") that authored the
   // status. Null when created through the web session.
@@ -2568,6 +2578,60 @@ export interface BookmarkDatabase {
     params: IsActorBookmarkedStatusParams
   ): Promise<boolean>
   getBookmarks(params: GetBookmarksParams): Promise<Bookmark[]>
+}
+
+// ============================================================================
+// Status Quote Database (FEP-044f / Mastodon 4.5 quote edges)
+// ============================================================================
+
+// One quote edge: the quoting status (`statusId`, PK) → the quoted status. Only
+// the five persistent states are stored; viewer-relative states are computed at
+// serialization time. There is intentionally no FK to statuses (the edge can be
+// created before the quoting status row exists, matching likes/recipients).
+export type StatusQuoteRecord = {
+  statusId: string
+  quotedStatusId: string
+  state: QuoteState
+  quoteRequestId: string | null
+  authorizationUri: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+export type CreateStatusQuoteParams = {
+  statusId: string
+  quotedStatusId: string
+  state?: QuoteState
+  quoteRequestId?: string | null
+  authorizationUri?: string | null
+}
+export type GetStatusQuoteParams = { statusId: string }
+export type UpdateStatusQuoteStateParams = {
+  statusId: string
+  state: QuoteState
+  authorizationUri?: string | null
+}
+export type GetQuotingStatusIdsParams = {
+  quotedStatusId: string
+  state?: QuoteState
+  limit?: number
+  maxId?: string | null
+  sinceId?: string | null
+}
+
+export interface StatusQuoteDatabase {
+  // Upsert on `statusId` (the edge may pre-exist from an inbound QuoteRequest).
+  createStatusQuote(params: CreateStatusQuoteParams): Promise<StatusQuoteRecord>
+  getStatusQuote(
+    params: GetStatusQuoteParams
+  ): Promise<StatusQuoteRecord | null>
+  // Enforces the one-way state machine; an illegal transition is a no-op that
+  // returns the row unchanged. Returns null when no edge exists.
+  updateStatusQuoteState(
+    params: UpdateStatusQuoteStateParams
+  ): Promise<StatusQuoteRecord | null>
+  // Ids of statuses quoting `quotedStatusId`, newest first, for GET /:id/quotes.
+  getQuotingStatusIds(params: GetQuotingStatusIdsParams): Promise<string[]>
 }
 
 // ============================================================================

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -66,7 +66,8 @@ export type Edited = z.infer<typeof Edited>
 // The five *persisted* quote-edge states. The viewer-relative states
 // (unauthorized | blocked_account | blocked_domain | muted_account) are never
 // stored — they are computed at serialization time from the viewer's
-// relationship to the quoted status.
+// relationship to the quoted status (the Mastodon serializer currently emits
+// `deleted`/`unauthorized`; the block/mute-relative ones are not yet computed).
 export const QuoteState = z.enum([
   'pending',
   'accepted',

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -63,6 +63,33 @@ export const Edited = z.object({
 
 export type Edited = z.infer<typeof Edited>
 
+// The five *persisted* quote-edge states. The viewer-relative states
+// (unauthorized | blocked_account | blocked_domain | muted_account) are never
+// stored — they are computed at serialization time from the viewer's
+// relationship to the quoted status.
+export const QuoteState = z.enum([
+  'pending',
+  'accepted',
+  'rejected',
+  'revoked',
+  'deleted'
+])
+export type QuoteState = z.infer<typeof QuoteState>
+
+// Who may quote a status (FEP-044f `interactionPolicy.canQuote`). Mastodon's
+// vocabulary is exactly these three; there is no `following` value.
+export const QuoteApprovalPolicy = z.enum(['public', 'followers', 'nobody'])
+export type QuoteApprovalPolicy = z.infer<typeof QuoteApprovalPolicy>
+
+// The quote *edge* on a quoting status — the bare quoted-status id plus the
+// edge state, mirroring how `reply` is a bare id string (no embedded status).
+export const StatusQuote = z.object({
+  quotedStatusId: z.string(),
+  state: QuoteState,
+  authorizationUri: z.string().nullable().optional()
+})
+export type StatusQuote = z.infer<typeof StatusQuote>
+
 const StatusBase = z.object({
   id: z.string(),
   actorId: z.string(),
@@ -115,7 +142,15 @@ export const StatusNote = StatusBase.extend({
 
   attachments: Attachment.array(),
   tags: Tag.array(),
-  fitness: StatusFitnessFile.optional()
+  fitness: StatusFitnessFile.optional(),
+
+  // The quote edge (this status quotes another). Liberal/optional so existing
+  // status literals and non-quoting statuses remain valid; StatusPoll inherits
+  // it, StatusAnnounce (extends StatusBase) correctly does not.
+  quote: StatusQuote.nullable().optional(),
+  // Who may quote THIS status. Stored in the content JSON blob, not a column;
+  // defaults to `public` at consumption when absent.
+  quoteApprovalPolicy: QuoteApprovalPolicy.optional()
 })
 export type StatusNote = z.infer<typeof StatusNote>
 

--- a/lib/types/mastodon/status/base.ts
+++ b/lib/types/mastodon/status/base.ts
@@ -14,8 +14,12 @@ import { Mention } from './mention'
 import { Tag } from './tag'
 
 // Quote lifecycle state (Mastodon 4.5 Quote entity). Nine values: the five
-// persisted states plus four viewer-relative ones the serializer computes.
-// Unknown values are treated as `unauthorized` by clients.
+// persisted states plus four viewer-relative ones. The serializer currently
+// computes `deleted` (target gone) and `unauthorized` (viewer cannot read the
+// target); the block/mute-relative states (`blocked_account`, `blocked_domain`,
+// `muted_account`) are part of the vocabulary — clients may receive them from
+// other servers — but are not yet emitted locally. Unknown values are treated
+// as `unauthorized` by clients.
 export const MastodonQuoteState = z.enum([
   'pending',
   'accepted',

--- a/lib/types/mastodon/status/base.ts
+++ b/lib/types/mastodon/status/base.ts
@@ -13,6 +13,40 @@ import { Application } from './application'
 import { Mention } from './mention'
 import { Tag } from './tag'
 
+// Quote lifecycle state (Mastodon 4.5 Quote entity). Nine values: the five
+// persisted states plus four viewer-relative ones the serializer computes.
+// Unknown values are treated as `unauthorized` by clients.
+export const MastodonQuoteState = z.enum([
+  'pending',
+  'accepted',
+  'rejected',
+  'revoked',
+  'deleted',
+  'unauthorized',
+  'blocked_account',
+  'blocked_domain',
+  'muted_account'
+])
+export type MastodonQuoteState = z.infer<typeof MastodonQuoteState>
+
+// Who may quote a status and where the current viewer stands. `automatic`/
+// `manual` carry the approved policy audiences; `current_user` is one of
+// automatic | manual | denied | unknown.
+export const QuoteApproval = z.object({
+  automatic: z.string().array(),
+  manual: z.string().array(),
+  current_user: z.string()
+})
+export type QuoteApproval = z.infer<typeof QuoteApproval>
+
+// Nested quote reference used at depth >= 1 to stop recursion: the quoted status
+// is referenced by id only.
+export const ShallowQuote = z.object({
+  state: MastodonQuoteState,
+  quoted_status_id: z.string().nullable()
+})
+export type ShallowQuote = z.infer<typeof ShallowQuote>
+
 export const BaseStatus = z.object({
   id: z
     .string()
@@ -133,6 +167,26 @@ export const BaseStatus = z.object({
     .optional()
     .describe(
       'If the current token has an authorized user: The filters and keywords that matched this status'
-    )
+    ),
+
+  // Quote post (FEP-044f / Mastodon 4.5). At depth 0 this is a full Quote whose
+  // `quoted_status` embeds the quoted status (serialized at depth 1); at depth
+  // >= 1 it is a ShallowQuote referencing the quoted status by id only. The
+  // `quoted_status` reference is a lazy self-reference broken with an explicit
+  // return type so the recursive schema still infers.
+  quote: z
+    .union([
+      z.object({
+        state: MastodonQuoteState,
+        quoted_status: z.lazy((): z.ZodType => BaseStatus).nullable()
+      }),
+      ShallowQuote
+    ])
+    .nullable()
+    .optional()
+    .describe('The status this status quotes'),
+  quote_approval: QuoteApproval.optional().describe(
+    'Who may quote this status and where the current viewer stands'
+  )
 })
 export type BaseStatus = z.infer<typeof BaseStatus>

--- a/migrations/20260713000000_add_status_quotes.js
+++ b/migrations/20260713000000_add_status_quotes.js
@@ -1,0 +1,39 @@
+/**
+ * Quote-post edges (FEP-044f / Mastodon 4.5). One row per quoting status
+ * (a status may quote at most one other status — PK on statusId). Rows are
+ * created for remote QuoteRequests BEFORE the quoting status row exists, so
+ * there is intentionally no FK to statuses (matches likes/recipients/bookmarks).
+ *
+ * The stored `state` is only the five persistent states
+ * (pending | accepted | rejected | revoked | deleted). The viewer-relative
+ * states (unauthorized | blocked_account | blocked_domain | muted_account) are
+ * computed at serialization time and never persisted.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = (knex) =>
+  knex.schema.createTable('status_quotes', (table) => {
+    table.string('statusId', 255).primary()
+    table.string('quotedStatusId', 255).notNullable()
+    table.string('state', 255).notNullable().defaultTo('pending')
+    // The QuoteRequest activity id we sent (outbound) or received (inbound);
+    // inbound Accept/Reject responses are matched against it.
+    table.text('quoteRequestId').nullable()
+    // The QuoteAuthorization stamp id once accepted (ours or theirs).
+    table.text('authorizationUri').nullable()
+    table.timestamp('createdAt', { useTz: true }).defaultTo(knex.fn.now())
+    table.timestamp('updatedAt', { useTz: true }).defaultTo(knex.fn.now())
+
+    table.index(
+      ['quotedStatusId', 'state', 'createdAt'],
+      'status_quotes_quoted_state_idx'
+    )
+    table.index(['authorizationUri'], 'status_quotes_authorization_idx')
+  })
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = (knex) => knex.schema.dropTable('status_quotes')

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -934,6 +934,16 @@ CREATE TABLE public.status_pins (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.status_quotes (
+    "statusId" character varying(255) NOT NULL,
+    "quotedStatusId" character varying(255) NOT NULL,
+    state character varying(255) DEFAULT 'pending'::character varying NOT NULL,
+    "quoteRequestId" text,
+    "authorizationUri" text,
+    "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE public.statuses (
     id character varying(255) NOT NULL,
     "actorId" character varying(255),
@@ -1390,6 +1400,9 @@ ALTER TABLE ONLY public.status_mutes
 ALTER TABLE ONLY public.status_pins
     ADD CONSTRAINT status_pins_pkey PRIMARY KEY ("actorId", "statusId");
 
+ALTER TABLE ONLY public.status_quotes
+    ADD CONSTRAINT status_quotes_pkey PRIMARY KEY ("statusId");
+
 ALTER TABLE ONLY public.statuses
     ADD CONSTRAINT statuses_pkey PRIMARY KEY (id);
 
@@ -1609,6 +1622,10 @@ CREATE INDEX status_mutes_status ON public.status_mutes USING btree ("statusId")
 CREATE INDEX status_pins_actor_created_status ON public.status_pins USING btree ("actorId", "createdAt", "statusId");
 
 CREATE INDEX status_pins_status ON public.status_pins USING btree ("statusId");
+
+CREATE INDEX status_quotes_authorization_idx ON public.status_quotes USING btree ("authorizationUri");
+
+CREATE INDEX status_quotes_quoted_state_idx ON public.status_quotes USING btree ("quotedStatusId", state, "createdAt");
 
 CREATE INDEX "statusesReplyHashIndex" ON public.statuses USING btree ("replyHash");
 

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -239,3 +239,6 @@ CREATE INDEX `actors_domain_last_status_at_idx` on `actors` (`domain`, `lastStat
 CREATE TABLE `actor_domain_blocks` (`id` varchar(255), `actorId` varchar(255) not null, `domain` varchar(255) not null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
 CREATE UNIQUE INDEX `actor_domain_blocks_actor_domain_unique` on `actor_domain_blocks` (`actorId`, `domain`);
 CREATE INDEX `actor_domain_blocks_actor_created` on `actor_domain_blocks` (`actorId`, `createdAt`);
+CREATE TABLE `status_quotes` (`statusId` varchar(255), `quotedStatusId` varchar(255) not null, `state` varchar(255) not null default 'pending', `quoteRequestId` text null, `authorizationUri` text null, `createdAt` datetime default CURRENT_TIMESTAMP, `updatedAt` datetime default CURRENT_TIMESTAMP, primary key (`statusId`));
+CREATE INDEX `status_quotes_quoted_state_idx` on `status_quotes` (`quotedStatusId`, `state`, `createdAt`);
+CREATE INDEX `status_quotes_authorization_idx` on `status_quotes` (`authorizationUri`);


### PR DESCRIPTION
## Epic 4.1 — Quote posts (Mastodon 4.5), PR 4.1a of 4

First PR of the quote-posts epic. After this, quotes arriving from Mastodon / Misskey / Fedibird render correctly in every timeline for API clients. **No local quoting yet** — that's 4.1b.

Design is per the Phase 4 plan's binding decisions: `status_quotes` satellite table (5 persisted states; viewer-relative states computed at serialization), `quoteApprovalPolicy` in the per-status content JSON (no column), full FEP-044f vocabulary aliased in `CANONICAL_CONTEXT`.

### What's in this PR
- **Migration + both dumps.** `status_quotes` (PK on `statusId`, no FK — the edge can be created before the quoting status row exists, matching likes/recipients). Regenerated `migrations/schema.sql` (PG) and `migrations/schema.sqlite.sql` (SQLite) from a full migration run of each backend.
- **JSON-LD compaction aliases** (the load-bearing step). `quote`, `quoteUrl`, `quoteUri`, `_misskey_quote`, `quoteAuthorization`, `QuoteRequest`/`QuoteAuthorization` types, and `interactionPolicy.canQuote.{automaticApproval,manualApproval}` — with survives-compaction regression tests, including the single-element array-collapse guard (#1119/#1120 class) and a sender-defined-IRI variant (not the blank-node accident).
- **Liberal AP schema fields** on `BaseContent` + `getQuoteTargetId` (precedence `quote` → `quoteUrl` → `quoteUri` → `_misskey_quote`).
- **Domain model.** `QuoteState`, `QuoteApprovalPolicy`, `StatusQuote`; `quote` edge + `quoteApprovalPolicy` on `StatusNote` (`StatusPoll` inherits; `StatusAnnounce` correctly excluded).
- **DB module** `statusQuote.ts` — `createStatusQuote` (upsert), `getStatusQuote`, `updateStatusQuoteState` (one-way state machine), `getQuotingStatusIds` (keyset pagination). Plus status hydration: batch quote-edge reads in `getStatusesByIds` and `quoteApprovalPolicy` read from the content blob.
- **Inbound ingest.** `verifyRemoteQuote` implements the FEP receiver rules — same-author shortcut, instance-signed stamp fetch + three-field match, degrade to `pending` on any failure — wired into `createNoteJob`.
- **Mastodon entities + serializer.** `Quote` / `ShallowQuote` / `QuoteApproval` on `BaseStatus`; depth-limited serialization (full at depth 0, shallow at depth ≥ 1), viewer-relative `deleted`/`unauthorized` downgrades, and a batched `quotedStatusCache` (no N+1).

### Deviations from the plan (mechanical drift; code at HEAD wins)
- The plan's Decision-3 context block put `@type: @id` on the legacy compat aliases (`quoteUrl`/`quoteUri`/`_misskey_quote`), but its own RED test emits those as plain URL-string literals — inconsistent. Fedibird/Misskey define these terms **without** `@type: @id`, so an `@type: @id` mapping drops the literal during compaction. Reconciled: compat aliases are plain term→IRI; `@type: @id` is kept only on the FEP-044f id references (`quote`, `quoteAuthorization`). Verified by the regression test.
- Migration uses `table.timestamp(col, { useTz: true })` (the current repo convention → `timestamp with time zone` in PG, `datetime` in SQLite) instead of the plan sketch's `table.datetime`, matching the existing satellite tables.
- `quote_approval.current_user` for the `followers` policy returns `unknown` until `canQuoteStatus` lands in 4.1b/4.1c (the plan shares that service for the accurate follower check).

### Test evidence
Local gate green on Node 24: `prettier --write .`, `yarn lint` (0 errors), `yarn build`, `yarn test` (664 files, 6307 tests passing). New coverage: compaction alias regressions, `getQuoteTargetId`, the `statusQuote` module (upsert, full transition matrix, pagination, hydration), `verifyRemoteQuote` (all FEP branches incl. stamp field mismatch), `createNoteJob` quote ingest (self-quote/Misskey/Fedibird/duplicate), and the serializer state × viewer matrix + shallow-recursion + no-N+1 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)