### PR TITLE
Bump version to v1.101.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.7",
+  "version": "1.101.8",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.101.8.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.101.7`
- Base main SHA: `df8b4bcfadc1a9b0036c7d0f83edd21eec251d1e`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
