### PR TITLE
Bump version to v1.102.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.101.8",
+  "version": "1.102.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.102.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.101.8`
- Base main SHA: `2a1b386467f177451deb09a7f37eff499a8632a2`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
