### PR TITLE
Bump version to v1.103.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.103.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.102.0`
- Base main SHA: `c2680ae2e33b3950a7b1e77354b59f5ad5c5e517`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
