### PR TITLE
Bump version to v1.104.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.103.0",
+  "version": "1.104.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.104.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.103.0`
- Base main SHA: `f6025a94f900c1f6a8fb2ccb7e75b15eb78d1969`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
