### PR TITLE
Bump version to v1.105.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.105.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.104.0`
- Base main SHA: `dd94123a6b48e006177d7931ea11a4baddf9b984`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
