### PR TITLE
minor: add admin moderation UI

### DIFF
--- a/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.test.tsx
+++ b/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  adminApproveAccount,
+  adminUnsuspendAccount,
+  getAdminAccount
+} from '@/lib/client'
+import { AdminAccount } from '@/lib/types/mastodon/admin/account'
+
+import { ActorModerationPanel } from './ActorModerationPanel'
+
+vi.mock('@/lib/client', () => ({
+  getAdminAccount: vi.fn(),
+  performAdminAccountAction: vi.fn(),
+  adminUnsuspendAccount: vi.fn(),
+  adminUnsilenceAccount: vi.fn(),
+  adminUnsensitiveAccount: vi.fn(),
+  adminEnableAccount: vi.fn(),
+  adminApproveAccount: vi.fn(),
+  adminRejectAccount: vi.fn(),
+  adminDeleteAccount: vi.fn()
+}))
+
+const mockGetAdminAccount = getAdminAccount as unknown as ReturnType<
+  typeof vi.fn
+>
+const mockUnsuspend = adminUnsuspendAccount as unknown as ReturnType<
+  typeof vi.fn
+>
+const mockApprove = adminApproveAccount as unknown as ReturnType<typeof vi.fn>
+
+const account = (overrides: Partial<AdminAccount>): AdminAccount =>
+  ({
+    id: 'acct-1',
+    username: 'target',
+    domain: null,
+    suspended: false,
+    silenced: false,
+    sensitized: false,
+    disabled: false,
+    approved: true,
+    ...overrides
+  }) as AdminAccount
+
+describe('ActorModerationPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a Suspended badge and unsuspends a suspended remote actor', async () => {
+    mockGetAdminAccount.mockResolvedValue(
+      account({ domain: 'remote.example', suspended: true })
+    )
+    mockUnsuspend.mockResolvedValue(account({ domain: 'remote.example' }))
+
+    render(<ActorModerationPanel actorId="acct-1" username="target" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('Suspended')).toBeInTheDocument()
+    )
+    // Remote actors do not expose login-scoped actions.
+    expect(screen.queryByText('Disable login')).not.toBeInTheDocument()
+    expect(screen.queryByText('Approve')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unsuspend' }))
+    await waitFor(() => expect(mockUnsuspend).toHaveBeenCalledWith('acct-1'))
+  })
+
+  it('offers Approve/Reject for a pending local account', async () => {
+    mockGetAdminAccount.mockResolvedValue(
+      account({ domain: null, approved: false })
+    )
+    mockApprove.mockResolvedValue(account({ approved: true }))
+
+    render(<ActorModerationPanel actorId="acct-1" username="target" />)
+
+    await waitFor(() => expect(screen.getByText('Pending')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    await waitFor(() => expect(mockApprove).toHaveBeenCalledWith('acct-1'))
+  })
+})

--- a/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.test.tsx
+++ b/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.test.tsx
@@ -6,8 +6,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import {
   adminApproveAccount,
+  adminDeleteAccount,
+  adminRejectAccount,
   adminUnsuspendAccount,
-  getAdminAccount
+  getAdminAccount,
+  performAdminAccountAction
 } from '@/lib/client'
 import { AdminAccount } from '@/lib/types/mastodon/admin/account'
 
@@ -32,12 +35,26 @@ const mockUnsuspend = adminUnsuspendAccount as unknown as ReturnType<
   typeof vi.fn
 >
 const mockApprove = adminApproveAccount as unknown as ReturnType<typeof vi.fn>
+const mockReject = adminRejectAccount as unknown as ReturnType<typeof vi.fn>
+const mockDelete = adminDeleteAccount as unknown as ReturnType<typeof vi.fn>
+const mockAction = performAdminAccountAction as unknown as ReturnType<
+  typeof vi.fn
+>
 
+// A non-null role marks a local (account-backed) actor; remote actors pass
+// `role: null`. The panel uses role — not domain — to gate login-scoped actions.
 const account = (overrides: Partial<AdminAccount>): AdminAccount =>
   ({
     id: 'acct-1',
     username: 'target',
     domain: null,
+    role: {
+      id: '-99',
+      name: '',
+      color: '',
+      permissions: '0',
+      highlighted: false
+    },
     suspended: false,
     silenced: false,
     sensitized: false,
@@ -53,21 +70,36 @@ describe('ActorModerationPanel', () => {
 
   it('shows a Suspended badge and unsuspends a suspended remote actor', async () => {
     mockGetAdminAccount.mockResolvedValue(
-      account({ domain: 'remote.example', suspended: true })
+      account({ domain: 'remote.example', role: null, suspended: true })
     )
-    mockUnsuspend.mockResolvedValue(account({ domain: 'remote.example' }))
+    mockUnsuspend.mockResolvedValue(
+      account({ domain: 'remote.example', role: null })
+    )
 
     render(<ActorModerationPanel actorId="acct-1" username="target" />)
 
     await waitFor(() =>
       expect(screen.getByText('Suspended')).toBeInTheDocument()
     )
-    // Remote actors do not expose login-scoped actions.
+    // Remote actors (null role) do not expose login-scoped actions.
     expect(screen.queryByText('Disable login')).not.toBeInTheDocument()
     expect(screen.queryByText('Approve')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Unsuspend' }))
     await waitFor(() => expect(mockUnsuspend).toHaveBeenCalledWith('acct-1'))
+  })
+
+  it('treats a local actor on a secondary domain as local (login actions shown)', async () => {
+    // domain is non-null (secondary served domain) but role is set → local.
+    mockGetAdminAccount.mockResolvedValue(account({ domain: 'second.example' }))
+
+    render(<ActorModerationPanel actorId="acct-1" username="target" />)
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Disable login' })
+      ).toBeInTheDocument()
+    )
   })
 
   it('offers Approve/Reject for a pending local account', async () => {
@@ -81,5 +113,55 @@ describe('ActorModerationPanel', () => {
     await waitFor(() => expect(screen.getByText('Pending')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
     await waitFor(() => expect(mockApprove).toHaveBeenCalledWith('acct-1'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    await waitFor(() => expect(mockReject).toHaveBeenCalledWith('acct-1'))
+  })
+
+  it.each([
+    { label: 'Suspend', type: 'suspend' },
+    { label: 'Silence', type: 'silence' },
+    { label: 'Mark sensitive', type: 'sensitive' },
+    { label: 'Disable login', type: 'disable' }
+  ])(
+    'routes the $label primary action through performAdminAccountAction',
+    async ({ label, type }) => {
+      mockGetAdminAccount.mockResolvedValue(account({ domain: null }))
+      mockAction.mockResolvedValue(undefined)
+
+      render(<ActorModerationPanel actorId="acct-1" username="target" />)
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+      )
+      fireEvent.click(screen.getByRole('button', { name: label }))
+      await waitFor(() =>
+        expect(mockAction).toHaveBeenCalledWith({ id: 'acct-1', type })
+      )
+    }
+  )
+
+  it('confirms before deleting a suspended account', async () => {
+    mockGetAdminAccount.mockResolvedValue(account({ suspended: true }))
+    mockDelete.mockResolvedValue(account({ suspended: true }))
+    const confirmSpy = vi.spyOn(window, 'confirm')
+
+    render(<ActorModerationPanel actorId="acct-1" username="target" />)
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Delete permanently' })
+      ).toBeInTheDocument()
+    )
+
+    // Declining the confirm dialog does not call the API.
+    confirmSpy.mockReturnValueOnce(false)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete permanently' }))
+    expect(mockDelete).not.toHaveBeenCalled()
+
+    // Accepting it does.
+    confirmSpy.mockReturnValueOnce(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete permanently' }))
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('acct-1'))
+    confirmSpy.mockRestore()
   })
 })

--- a/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.tsx
+++ b/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.tsx
@@ -56,6 +56,7 @@ export const ActorModerationPanel = ({ actorId, username }: Props) => {
   const [account, setAccount] = useState<AdminAccount | null>(null)
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
+  const [removed, setRemoved] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
@@ -86,6 +87,28 @@ export const ActorModerationPanel = ({ actorId, username }: Props) => {
     }
   }
 
+  // Reject (and any future removing action) deletes the account synchronously,
+  // so re-fetching it would 404. Mark it removed instead of reloading.
+  const runRemoving = async (fn: () => Promise<unknown>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await fn()
+      setRemoved(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (removed) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Account rejected and removed.
+      </p>
+    )
+  }
   if (loading) {
     return (
       <p className="text-sm text-muted-foreground">Loading moderation state…</p>
@@ -99,10 +122,13 @@ export const ActorModerationPanel = ({ actorId, username }: Props) => {
     )
   }
 
-  // domain === null means the actor is on this instance's configured host, so
-  // login-scoped actions (disable/enable, approve/reject) are available; remote
-  // actors only support suspend/silence/sensitize.
-  const isLocal = account.domain === null
+  // A non-null role means the actor is account-backed on this instance (the
+  // serializer emits null role only for account-less remote actors) — mirroring
+  // the API's `Boolean(account)` local gate. This is correct even for a local
+  // actor served on a secondary domain, whose `domain` is non-null. Login-scoped
+  // actions (disable/enable, approve/reject) apply only to these local actors;
+  // remote actors support suspend/silence/sensitize.
+  const isLocal = account.role !== null
 
   return (
     <div className="space-y-3">
@@ -204,7 +230,7 @@ export const ActorModerationPanel = ({ actorId, username }: Props) => {
               label="Reject"
               disabled={busy}
               destructive
-              onClick={() => run(() => adminRejectAccount(actorId))}
+              onClick={() => runRemoving(() => adminRejectAccount(actorId))}
             />
           </>
         ) : null}

--- a/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.tsx
+++ b/app/(timeline)/admin/accounts/[id]/ActorModerationPanel.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  adminApproveAccount,
+  adminDeleteAccount,
+  adminEnableAccount,
+  adminRejectAccount,
+  adminUnsensitiveAccount,
+  adminUnsilenceAccount,
+  adminUnsuspendAccount,
+  getAdminAccount,
+  performAdminAccountAction
+} from '@/lib/client'
+import { AdminAccount } from '@/lib/types/mastodon/admin/account'
+
+interface Props {
+  // The Mastodon account id (urlToId(actor.id)).
+  actorId: string
+  username: string
+}
+
+const Badge = ({ label }: { label: string }) => (
+  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+    {label}
+  </span>
+)
+
+const ActionButton = ({
+  label,
+  onClick,
+  disabled,
+  destructive
+}: {
+  label: string
+  onClick: () => void
+  disabled: boolean
+  destructive?: boolean
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+      destructive
+        ? 'border-destructive/40 text-destructive hover:bg-destructive/10'
+        : 'hover:bg-muted'
+    }`}
+  >
+    {label}
+  </button>
+)
+
+export const ActorModerationPanel = ({ actorId, username }: Props) => {
+  const [account, setAccount] = useState<AdminAccount | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      setAccount(await getAdminAccount(actorId))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }, [actorId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const run = async (fn: () => Promise<unknown>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await fn()
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <p className="text-sm text-muted-foreground">Loading moderation state…</p>
+    )
+  }
+  if (!account) {
+    return (
+      <p className="text-sm text-destructive">
+        {error ?? 'Moderation state unavailable'}
+      </p>
+    )
+  }
+
+  // domain === null means the actor is on this instance's configured host, so
+  // login-scoped actions (disable/enable, approve/reject) are available; remote
+  // actors only support suspend/silence/sensitize.
+  const isLocal = account.domain === null
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-muted-foreground">
+          @{username} moderation
+        </span>
+        {account.suspended ? <Badge label="Suspended" /> : null}
+        {account.silenced ? <Badge label="Silenced" /> : null}
+        {account.sensitized ? <Badge label="Sensitized" /> : null}
+        {account.disabled ? <Badge label="Disabled" /> : null}
+        {isLocal && !account.approved ? <Badge label="Pending" /> : null}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {account.suspended ? (
+          <ActionButton
+            label="Unsuspend"
+            disabled={busy}
+            onClick={() => run(() => adminUnsuspendAccount(actorId))}
+          />
+        ) : (
+          <ActionButton
+            label="Suspend"
+            disabled={busy}
+            destructive
+            onClick={() =>
+              run(() =>
+                performAdminAccountAction({ id: actorId, type: 'suspend' })
+              )
+            }
+          />
+        )}
+
+        {account.silenced ? (
+          <ActionButton
+            label="Unsilence"
+            disabled={busy}
+            onClick={() => run(() => adminUnsilenceAccount(actorId))}
+          />
+        ) : (
+          <ActionButton
+            label="Silence"
+            disabled={busy}
+            onClick={() =>
+              run(() =>
+                performAdminAccountAction({ id: actorId, type: 'silence' })
+              )
+            }
+          />
+        )}
+
+        {account.sensitized ? (
+          <ActionButton
+            label="Unsensitive"
+            disabled={busy}
+            onClick={() => run(() => adminUnsensitiveAccount(actorId))}
+          />
+        ) : (
+          <ActionButton
+            label="Mark sensitive"
+            disabled={busy}
+            onClick={() =>
+              run(() =>
+                performAdminAccountAction({ id: actorId, type: 'sensitive' })
+              )
+            }
+          />
+        )}
+
+        {isLocal && account.disabled ? (
+          <ActionButton
+            label="Enable login"
+            disabled={busy}
+            onClick={() => run(() => adminEnableAccount(actorId))}
+          />
+        ) : null}
+        {isLocal && !account.disabled ? (
+          <ActionButton
+            label="Disable login"
+            disabled={busy}
+            destructive
+            onClick={() =>
+              run(() =>
+                performAdminAccountAction({ id: actorId, type: 'disable' })
+              )
+            }
+          />
+        ) : null}
+
+        {isLocal && !account.approved ? (
+          <>
+            <ActionButton
+              label="Approve"
+              disabled={busy}
+              onClick={() => run(() => adminApproveAccount(actorId))}
+            />
+            <ActionButton
+              label="Reject"
+              disabled={busy}
+              destructive
+              onClick={() => run(() => adminRejectAccount(actorId))}
+            />
+          </>
+        ) : null}
+
+        {account.suspended ? (
+          <ActionButton
+            label="Delete permanently"
+            disabled={busy}
+            destructive
+            onClick={() => {
+              if (
+                window.confirm(
+                  'Permanently delete this account? This cannot be undone.'
+                )
+              ) {
+                run(() => adminDeleteAccount(actorId))
+              }
+            }}
+          />
+        ) : null}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  )
+}

--- a/app/(timeline)/admin/accounts/[id]/page.tsx
+++ b/app/(timeline)/admin/accounts/[id]/page.tsx
@@ -7,6 +7,9 @@ import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getMention } from '@/lib/types/domain/actor'
 import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { ActorModerationPanel } from './ActorModerationPanel'
 
 export const dynamic = 'force-dynamic'
 
@@ -89,7 +92,7 @@ const Page = async ({ params }: Props) => {
             {actors.map((actor) => (
               <div
                 key={actor.id}
-                className="flex items-center justify-between rounded-xl border p-4"
+                className="flex flex-wrap items-center justify-between rounded-xl border p-4"
               >
                 <div className="min-w-0 flex-1">
                   <p className="font-medium truncate">
@@ -107,6 +110,12 @@ const Page = async ({ params }: Props) => {
                   ) : (
                     new Date(actor.createdAt).toLocaleDateString()
                   )}
+                </div>
+                <div className="mt-4 basis-full border-t pt-4">
+                  <ActorModerationPanel
+                    actorId={urlToId(actor.id)}
+                    username={actor.username}
+                  />
                 </div>
               </div>
             ))}

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -3,6 +3,7 @@
 import {
   BarChart3,
   Filter,
+  Flag,
   Globe,
   Hash,
   Megaphone,
@@ -30,6 +31,7 @@ interface Props {
 const tabs: SectionNavTab[] = [
   { name: 'Overview', url: '/admin', icon: BarChart3 },
   { name: 'Accounts', url: '/admin/accounts', icon: Users },
+  { name: 'Reports', url: '/admin/reports', icon: Flag },
   { name: 'Hashtags', url: '/admin/tags', icon: Hash },
   { name: 'Filters', url: '/admin/filters', icon: Filter },
   { name: 'Rules', url: '/admin/rules', icon: Scale },

--- a/app/(timeline)/admin/reports/AdminReportsList.test.tsx
+++ b/app/(timeline)/admin/reports/AdminReportsList.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { getAdminReports } from '@/lib/client'
+import { AdminReport } from '@/lib/types/mastodon/admin/report'
+
+import { AdminReportsList } from './AdminReportsList'
+
+vi.mock('@/lib/client', () => ({
+  getAdminReports: vi.fn()
+}))
+
+const mockGetAdminReports = getAdminReports as unknown as ReturnType<
+  typeof vi.fn
+>
+
+const report = (overrides: Partial<AdminReport>): AdminReport =>
+  ({
+    id: 'report-1',
+    action_taken: false,
+    category: 'spam',
+    comment: '',
+    account: { username: 'reporter', domain: null },
+    target_account: { username: 'troll', domain: 'evil.example' },
+    statuses: [],
+    rules: [],
+    ...overrides
+  }) as AdminReport
+
+describe('AdminReportsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists open reports and toggles to resolved', async () => {
+    mockGetAdminReports.mockResolvedValue([report({})])
+
+    render(<AdminReportsList />)
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('reporter → troll@evil.example')
+      ).toBeInTheDocument()
+    )
+    expect(mockGetAdminReports).toHaveBeenCalledWith(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolved' }))
+    await waitFor(() => expect(mockGetAdminReports).toHaveBeenCalledWith(true))
+  })
+
+  it('shows an empty state when there are no reports', async () => {
+    mockGetAdminReports.mockResolvedValue([])
+    render(<AdminReportsList />)
+    await waitFor(() =>
+      expect(screen.getByText('No open reports.')).toBeInTheDocument()
+    )
+  })
+})

--- a/app/(timeline)/admin/reports/AdminReportsList.tsx
+++ b/app/(timeline)/admin/reports/AdminReportsList.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+
+import { getAdminReports } from '@/lib/client'
+import { AdminReport } from '@/lib/types/mastodon/admin/report'
+
+const acct = (account: AdminReport['account']) =>
+  account.domain ? `${account.username}@${account.domain}` : account.username
+
+export const AdminReportsList = () => {
+  const [resolved, setResolved] = useState(false)
+  const [reports, setReports] = useState<AdminReport[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setReports(await getAdminReports(resolved))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load reports')
+    } finally {
+      setLoading(false)
+    }
+  }, [resolved])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  return (
+    <div className="space-y-4">
+      <div className="inline-flex rounded-lg border p-0.5 text-sm">
+        <button
+          type="button"
+          onClick={() => setResolved(false)}
+          className={`rounded-md px-3 py-1 font-medium transition-colors ${
+            !resolved ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+          }`}
+        >
+          Unresolved
+        </button>
+        <button
+          type="button"
+          onClick={() => setResolved(true)}
+          className={`rounded-md px-3 py-1 font-medium transition-colors ${
+            resolved ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+          }`}
+        >
+          Resolved
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading reports…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : reports.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-6 text-center text-muted-foreground">
+          No {resolved ? 'resolved' : 'open'} reports.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {reports.map((report) => (
+            <li key={report.id}>
+              <Link
+                href={`/admin/reports/${report.id}`}
+                className="flex items-center justify-between gap-4 rounded-xl border p-4 transition-colors hover:bg-muted"
+              >
+                <div className="min-w-0">
+                  <p className="truncate font-medium">
+                    {acct(report.account)} → {acct(report.target_account)}
+                  </p>
+                  <p className="truncate text-sm text-muted-foreground">
+                    {report.category}
+                    {report.statuses.length > 0
+                      ? ` · ${report.statuses.length} status${
+                          report.statuses.length === 1 ? '' : 'es'
+                        }`
+                      : ''}
+                  </p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                    report.action_taken
+                      ? 'bg-muted text-muted-foreground'
+                      : 'bg-primary/10 text-primary'
+                  }`}
+                >
+                  {report.action_taken ? 'Resolved' : 'Open'}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/app/(timeline)/admin/reports/[id]/AdminReportDetail.test.tsx
+++ b/app/(timeline)/admin/reports/[id]/AdminReportDetail.test.tsx
@@ -7,7 +7,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import {
   assignAdminReportToSelf,
   getAdminReport,
-  resolveAdminReport
+  reopenAdminReport,
+  resolveAdminReport,
+  unassignAdminReport,
+  updateAdminReport
 } from '@/lib/client'
 import { AdminReport } from '@/lib/types/mastodon/admin/report'
 
@@ -27,6 +30,9 @@ const mockAssign = assignAdminReportToSelf as unknown as ReturnType<
   typeof vi.fn
 >
 const mockResolve = resolveAdminReport as unknown as ReturnType<typeof vi.fn>
+const mockReopen = reopenAdminReport as unknown as ReturnType<typeof vi.fn>
+const mockUnassign = unassignAdminReport as unknown as ReturnType<typeof vi.fn>
+const mockUpdate = updateAdminReport as unknown as ReturnType<typeof vi.fn>
 
 const report = (overrides: Partial<AdminReport>): AdminReport =>
   ({
@@ -65,5 +71,47 @@ describe('AdminReportDetail', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Resolve' }))
     await waitFor(() => expect(mockResolve).toHaveBeenCalledWith('report-1'))
+  })
+
+  it('reopens a resolved report and unassigns an assigned one', async () => {
+    mockGetAdminReport.mockResolvedValue(
+      report({
+        action_taken: true,
+        assigned_account: { username: 'mod', domain: null } as never
+      })
+    )
+    mockReopen.mockResolvedValue(report({}))
+    mockUnassign.mockResolvedValue(report({}))
+
+    render(<AdminReportDetail reportId="report-1" />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Reopen' })).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen' }))
+    await waitFor(() => expect(mockReopen).toHaveBeenCalledWith('report-1'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unassign' }))
+    await waitFor(() => expect(mockUnassign).toHaveBeenCalledWith('report-1'))
+  })
+
+  it('updates the category from the select', async () => {
+    mockGetAdminReport.mockResolvedValue(report({}))
+    mockUpdate.mockResolvedValue(report({ category: 'violation' }))
+
+    render(<AdminReportDetail reportId="report-1" />)
+    await waitFor(() =>
+      expect(screen.getByText('troll@evil.example')).toBeInTheDocument()
+    )
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'violation' }
+    })
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith({
+        id: 'report-1',
+        category: 'violation'
+      })
+    )
   })
 })

--- a/app/(timeline)/admin/reports/[id]/AdminReportDetail.test.tsx
+++ b/app/(timeline)/admin/reports/[id]/AdminReportDetail.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  assignAdminReportToSelf,
+  getAdminReport,
+  resolveAdminReport
+} from '@/lib/client'
+import { AdminReport } from '@/lib/types/mastodon/admin/report'
+
+import { AdminReportDetail } from './AdminReportDetail'
+
+vi.mock('@/lib/client', () => ({
+  getAdminReport: vi.fn(),
+  updateAdminReport: vi.fn(),
+  assignAdminReportToSelf: vi.fn(),
+  unassignAdminReport: vi.fn(),
+  resolveAdminReport: vi.fn(),
+  reopenAdminReport: vi.fn()
+}))
+
+const mockGetAdminReport = getAdminReport as unknown as ReturnType<typeof vi.fn>
+const mockAssign = assignAdminReportToSelf as unknown as ReturnType<
+  typeof vi.fn
+>
+const mockResolve = resolveAdminReport as unknown as ReturnType<typeof vi.fn>
+
+const report = (overrides: Partial<AdminReport>): AdminReport =>
+  ({
+    id: 'report-1',
+    action_taken: false,
+    category: 'spam',
+    comment: 'unsolicited ads',
+    account: { username: 'reporter', domain: null },
+    target_account: { username: 'troll', domain: 'evil.example' },
+    assigned_account: null,
+    action_taken_by_account: null,
+    statuses: [],
+    rules: [],
+    ...overrides
+  }) as AdminReport
+
+describe('AdminReportDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the report and drives assign/resolve', async () => {
+    mockGetAdminReport.mockResolvedValue(report({}))
+    mockAssign.mockResolvedValue(report({}))
+    mockResolve.mockResolvedValue(report({ action_taken: true }))
+
+    render(<AdminReportDetail reportId="report-1" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('troll@evil.example')).toBeInTheDocument()
+    )
+    expect(screen.getByText('unsolicited ads')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assign to me' }))
+    await waitFor(() => expect(mockAssign).toHaveBeenCalledWith('report-1'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }))
+    await waitFor(() => expect(mockResolve).toHaveBeenCalledWith('report-1'))
+  })
+})

--- a/app/(timeline)/admin/reports/[id]/AdminReportDetail.tsx
+++ b/app/(timeline)/admin/reports/[id]/AdminReportDetail.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 
 import {
+  type ReportCategory,
   assignAdminReportToSelf,
   getAdminReport,
   reopenAdminReport,
@@ -11,7 +12,6 @@ import {
   unassignAdminReport,
   updateAdminReport
 } from '@/lib/client'
-import { ReportCategory } from '@/lib/client'
 import { AdminReport } from '@/lib/types/mastodon/admin/report'
 
 const CATEGORIES: ReportCategory[] = ['spam', 'legal', 'violation', 'other']

--- a/app/(timeline)/admin/reports/[id]/AdminReportDetail.tsx
+++ b/app/(timeline)/admin/reports/[id]/AdminReportDetail.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  assignAdminReportToSelf,
+  getAdminReport,
+  reopenAdminReport,
+  resolveAdminReport,
+  unassignAdminReport,
+  updateAdminReport
+} from '@/lib/client'
+import { ReportCategory } from '@/lib/client'
+import { AdminReport } from '@/lib/types/mastodon/admin/report'
+
+const CATEGORIES: ReportCategory[] = ['spam', 'legal', 'violation', 'other']
+
+const acct = (account: AdminReport['account']) =>
+  account.domain ? `${account.username}@${account.domain}` : account.username
+
+export const AdminReportDetail = ({ reportId }: { reportId: string }) => {
+  const [report, setReport] = useState<AdminReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      setReport(await getAdminReport(reportId))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load report')
+    } finally {
+      setLoading(false)
+    }
+  }, [reportId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const run = async (fn: () => Promise<unknown>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await fn()
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading report…</p>
+  }
+  if (!report) {
+    return (
+      <p className="text-sm text-destructive">
+        {error ?? 'Report unavailable'}
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border bg-background/80 p-6 shadow-sm">
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <dt className="text-sm text-muted-foreground">Reporter</dt>
+            <dd className="font-medium">{acct(report.account)}</dd>
+          </div>
+          <div>
+            <dt className="text-sm text-muted-foreground">Target</dt>
+            <dd className="font-medium">{acct(report.target_account)}</dd>
+          </div>
+          <div>
+            <dt className="text-sm text-muted-foreground">Category</dt>
+            <dd className="font-medium">{report.category}</dd>
+          </div>
+          <div>
+            <dt className="text-sm text-muted-foreground">Status</dt>
+            <dd className="font-medium">
+              {report.action_taken ? 'Resolved' : 'Open'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-sm text-muted-foreground">Assigned to</dt>
+            <dd className="font-medium">
+              {report.assigned_account
+                ? acct(report.assigned_account)
+                : 'Unassigned'}
+            </dd>
+          </div>
+        </dl>
+        {report.comment ? (
+          <p className="mt-4 whitespace-pre-wrap text-sm">{report.comment}</p>
+        ) : null}
+      </div>
+
+      {report.rules.length > 0 ? (
+        <div className="rounded-2xl border bg-background/80 p-6 shadow-sm">
+          <h2 className="mb-2 text-sm font-semibold">Broken rules</h2>
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {report.rules.map((rule) => (
+              <li key={rule.id}>{rule.text}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {report.statuses.length > 0 ? (
+        <div className="rounded-2xl border bg-background/80 p-6 shadow-sm">
+          <h2 className="mb-2 text-sm font-semibold">
+            Reported statuses ({report.statuses.length})
+          </h2>
+          <ul className="space-y-2 text-sm">
+            {report.statuses.map((status) => (
+              <li key={status.id} className="truncate">
+                <Link
+                  href={status.url ?? '#'}
+                  className="text-primary hover:underline"
+                >
+                  {status.url ?? status.id}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="text-sm text-muted-foreground">Category</label>
+        <select
+          value={report.category}
+          disabled={busy}
+          onChange={(event) =>
+            run(() =>
+              updateAdminReport({
+                id: reportId,
+                category: event.target.value as ReportCategory
+              })
+            )
+          }
+          className="rounded-lg border px-2 py-1.5 text-sm"
+        >
+          {CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {category}
+            </option>
+          ))}
+        </select>
+
+        {report.assigned_account ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => unassignAdminReport(reportId))}
+            className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
+          >
+            Unassign
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => assignAdminReportToSelf(reportId))}
+            className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
+          >
+            Assign to me
+          </button>
+        )}
+
+        {report.action_taken ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => reopenAdminReport(reportId))}
+            className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
+          >
+            Reopen
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => resolveAdminReport(reportId))}
+            className="rounded-lg border border-primary/40 px-3 py-1.5 text-sm font-medium text-primary hover:bg-primary/10 disabled:opacity-50"
+          >
+            Resolve
+          </button>
+        )}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  )
+}

--- a/app/(timeline)/admin/reports/[id]/page.tsx
+++ b/app/(timeline)/admin/reports/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { PageHeader } from '@/lib/components/page-header'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+import { AdminReportDetail } from './AdminReportDetail'
+
+export const dynamic = 'force-dynamic'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+const Page = async ({ params }: Props) => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const { id } = await params
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Link
+          href="/admin/reports"
+          aria-label="Back to reports list"
+          className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <PageHeader className="flex-1" title="Report" />
+      </div>
+      <AdminReportDetail reportId={id} />
+    </div>
+  )
+}
+
+export default Page

--- a/app/(timeline)/admin/reports/page.tsx
+++ b/app/(timeline)/admin/reports/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation'
+
+import { PageHeader } from '@/lib/components/page-header'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+import { AdminReportsList } from './AdminReportsList'
+
+export const dynamic = 'force-dynamic'
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Reports"
+        description="Review and resolve moderation reports."
+      />
+      <AdminReportsList />
+    </div>
+  )
+}
+
+export default Page

--- a/docs/features.md
+++ b/docs/features.md
@@ -71,6 +71,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Collections** — curated account collections aligned with the **final Mastodon 4.6 spec**: dual request vocabulary (`name`/`tag_name`/`discoverable`/`sensitive`/`account_ids` plus the pre-final `title`/`topic`/`visibility` extensions), spec response entities (`WrappedCollection`, `CollectionWithAccounts`, `WrappedCollectionItem` with stable item ids), anonymous reads of discoverable collections, `GET /api/v1/accounts/:id/collections`, cross-owner `in_collections`, and item-id-addressed remove/revoke (account-id addressing kept as an extension). Plus an activities.next shareable **public feed** of each collection (owner-private and public projections, the public one limited to approved members and public-visibility posts) with a per-collection capped materialized feed. Collections federate outbound as **FEP-7aa9 `FeaturedCollection`** objects, auto-follow and backfill remote members' existing posts when they are added, and emit added-to-collection / collection-update notifications
 - ✅ **Filters** — Keyword/status filters via `/api/v2/filters` with notification filtering, plus the deprecated Mastodon v1 `/api/v1/filters` (and `/api/v1/filters/:id`) compatibility shim served as a view over the same v2 filter storage
 - ✅ **Reports** — Submit reports against accounts and statuses via `/api/v1/reports`
+- ✅ **Admin moderation** — Moderate accounts and reports via the Mastodon admin API (`/api/v1/admin/accounts`, `/api/v2/admin/accounts`, `POST /api/v1/admin/accounts/:id/action`, the approve/reject/enable/unsilence/unsuspend/unsensitive state actions, suspended-first `DELETE`, and the reports workflow `GET`/`PUT /api/v1/admin/reports[/:id]` + `assign_to_self`/`unassign`/`resolve`/`reopen`), enforced instance-wide (sign-in, token acceptance, ActivityPub 410, inbound-inbox drops, timeline filtering, forced-sensitive creation), with per-actor moderation controls and a reports queue in the admin area (`/admin/accounts/:id`, `/admin/reports`)
 - ✅ **Markers** — Save and restore per-timeline read positions
 - ✅ **Announcements** — Read active instance announcements via `GET /api/v1/announcements`, dismiss them with `POST /api/v1/announcements/:id/dismiss`, and react with `PUT`/`DELETE /api/v1/announcements/:id/reactions/:name`; unread active announcements surface as a dismissible banner at the top of the home timeline for signed-in users, and admins manage them in the admin area (`/admin/announcements`) backed by `/api/v2/admin/announcements`
 - ✅ **Endorsements** — Feature accounts on your profile
@@ -105,7 +106,6 @@ This document tracks the implemented and planned features for Activity.next.
 ## Planned Features
 
 - [ ] Streaming API for real-time updates
-- [ ] Moderation review dashboard for submitted reports
 - [ ] Bookmark collections
 - [ ] Media attachment `blurhash` computation and animated-GIF `gifv` detection (Mastodon `MediaAttachment` parity — currently always `blurhash: null`, and GIFs are served as `type: "image"`)
 

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -50,6 +50,8 @@ product or security decision, not a gap to be closed.
 
 - **`GET /api/v1/timelines/direct` is retained.** Mastodon removed this endpoint
   in 3.0 in favor of conversations, but Activity.next keeps it for legacy clients.
+  The first-party UI uses `/api/v1/conversations` for threaded direct messages;
+  the `direct` timeline is served by the shared `timelines/[timeline]` handler.
 
 - **Admin account ids are the actor id space, not numeric snowflakes.**
   `Admin::Account.id` (and the `account`/`target_account`/`assigned_account`/
@@ -64,8 +66,6 @@ product or security decision, not a gap to be closed.
   "suspend freezes login" needs both `suspend` and `disable`. Registration
   approval is wired but empty today (`pending` lists return `[]` until an
   approval-required mode exists).
-  The first-party UI uses `/api/v1/conversations` for threaded direct messages;
-  the `direct` timeline is served by the shared `timelines/[timeline]` handler.
 
 - **The legacy `follow` scope is not honored for granular follow actions.**
   Mastodon deprecated the aggregate `follow` scope in 3.5 in favor of

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -50,6 +50,20 @@ product or security decision, not a gap to be closed.
 
 - **`GET /api/v1/timelines/direct` is retained.** Mastodon removed this endpoint
   in 3.0 in favor of conversations, but Activity.next keeps it for legacy clients.
+
+- **Admin account ids are the actor id space, not numeric snowflakes.**
+  `Admin::Account.id` (and the `account`/`target_account`/`assigned_account`/
+  `action_taken_by_account` ids embedded in `Admin::Report`) is
+  `urlToId(actor.id)` — the same base64url/colon-encoded actor id every other
+  account-shaped endpoint uses — never the internal login-account UUID. Admin
+  report ids are the raw report UUIDs. Admin tooling that assumes numeric ids
+  must treat these as opaque strings. Because one login account can own several
+  actors across domains, `suspend`/`silence`/`sensitize` act per actor and apply
+  to remote actors too, while `disable`/`enable`/`approve`/`reject` are
+  local-account-only (a remote target returns `422`); a full Mastodon-style
+  "suspend freezes login" needs both `suspend` and `disable`. Registration
+  approval is wired but empty today (`pending` lists return `[]` until an
+  approval-required mode exists).
   The first-party UI uses `/api/v1/conversations` for threaded direct messages;
   the `direct` timeline is served by the shared `timelines/[timeline]` handler.
 
@@ -172,3 +186,13 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
 - **Admin CRUD extras** — custom emoji, domain allow/deny lists (with import),
   announcements, filters, and rules management under `/api/v1/admin/*` and
   `/api/v2/admin/*`.
+
+The standard Mastodon **admin moderation** cluster is implemented:
+`GET /api/v1/admin/accounts`, `GET /api/v2/admin/accounts`,
+`GET /api/v1/admin/accounts/:id`, `POST /api/v1/admin/accounts/:id/action`, the
+`approve`/`reject`/`enable`/`unsilence`/`unsuspend`/`unsensitive` state actions,
+`DELETE /api/v1/admin/accounts/:id` (suspended-first), and the reports API
+(`GET`/`PUT /api/v1/admin/reports[/:id]`, `assign_to_self`/`unassign`/`resolve`/
+`reopen`). See the admin id-space divergence above. `warning_preset_id` and
+`send_email_notification` on the account action endpoint are accepted and
+ignored (no moderation-mail/presets subsystems).

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -15,6 +15,8 @@ import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
 import { Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
+import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
+import type { AdminReport } from '@/lib/types/mastodon/admin/report'
 import type { Announcement } from '@/lib/types/mastodon/announcement'
 import type { CollectionEntity } from '@/lib/types/mastodon/collection'
 import type { CustomEmoji } from '@/lib/types/mastodon/customEmoji'
@@ -3960,3 +3962,172 @@ export const getPasskeys = async (): Promise<Passkey[]> => {
   const data = await response.json()
   return Array.isArray(data) ? data : []
 }
+
+// ============================================================================
+// Admin moderation — accounts (Admin::Account) and reports (Admin::Report).
+// All calls go through the same-origin cookie session (AdminApiGuard).
+// ============================================================================
+
+export interface AdminAccountFilters {
+  origin?: 'local' | 'remote'
+  status?: 'active' | 'pending' | 'disabled' | 'silenced' | 'suspended'
+  username?: string
+  byDomain?: string
+}
+
+export const getAdminAccounts = async (
+  filters: AdminAccountFilters = {}
+): Promise<AdminAccount[]> => {
+  const params = new URLSearchParams()
+  if (filters.origin) params.set('origin', filters.origin)
+  if (filters.status) params.set('status', filters.status)
+  if (filters.username) params.set('username', filters.username)
+  if (filters.byDomain) params.set('by_domain', filters.byDomain)
+  const query = params.toString()
+  const response = await fetch(
+    `/api/v2/admin/accounts${query ? `?${query}` : ''}`,
+    { headers: { Accept: 'application/json' }, credentials: 'include' }
+  )
+  if (!response.ok) throw new Error('Failed to load admin accounts')
+  return (await response.json()) as AdminAccount[]
+}
+
+export const getAdminAccount = async (id: string): Promise<AdminAccount> => {
+  const response = await fetch(`/api/v1/admin/accounts/${id}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include'
+  })
+  if (!response.ok) throw new Error('Failed to load admin account')
+  return (await response.json()) as AdminAccount
+}
+
+export type AdminAccountActionType =
+  'none' | 'disable' | 'sensitive' | 'silence' | 'suspend'
+
+export const performAdminAccountAction = async ({
+  id,
+  type,
+  reportId,
+  text
+}: {
+  id: string
+  type: AdminAccountActionType
+  reportId?: string
+  text?: string
+}): Promise<void> => {
+  const response = await fetch(`/api/v1/admin/accounts/${id}/action`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      type,
+      ...(reportId ? { report_id: reportId } : {}),
+      ...(text ? { text } : {})
+    })
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to perform account action')
+  }
+}
+
+const adminAccountStateChange =
+  (action: string) =>
+  async (id: string): Promise<AdminAccount> => {
+    const response = await fetch(`/api/v1/admin/accounts/${id}/${action}`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => null)
+      throw new Error(error?.error ?? `Failed to ${action} account`)
+    }
+    return (await response.json()) as AdminAccount
+  }
+
+export const adminEnableAccount = adminAccountStateChange('enable')
+export const adminUnsilenceAccount = adminAccountStateChange('unsilence')
+export const adminUnsuspendAccount = adminAccountStateChange('unsuspend')
+export const adminUnsensitiveAccount = adminAccountStateChange('unsensitive')
+export const adminApproveAccount = adminAccountStateChange('approve')
+export const adminRejectAccount = adminAccountStateChange('reject')
+
+export const adminDeleteAccount = async (id: string): Promise<AdminAccount> => {
+  const response = await fetch(`/api/v1/admin/accounts/${id}`, {
+    method: 'DELETE',
+    credentials: 'include'
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to delete account')
+  }
+  return (await response.json()) as AdminAccount
+}
+
+export const getAdminReports = async (
+  resolved?: boolean
+): Promise<AdminReport[]> => {
+  const params = new URLSearchParams()
+  if (resolved !== undefined)
+    params.set('resolved', resolved ? 'true' : 'false')
+  const query = params.toString()
+  const response = await fetch(
+    `/api/v1/admin/reports${query ? `?${query}` : ''}`,
+    { headers: { Accept: 'application/json' }, credentials: 'include' }
+  )
+  if (!response.ok) throw new Error('Failed to load admin reports')
+  return (await response.json()) as AdminReport[]
+}
+
+export const getAdminReport = async (id: string): Promise<AdminReport> => {
+  const response = await fetch(`/api/v1/admin/reports/${id}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include'
+  })
+  if (!response.ok) throw new Error('Failed to load admin report')
+  return (await response.json()) as AdminReport
+}
+
+export const updateAdminReport = async ({
+  id,
+  category,
+  ruleIds
+}: {
+  id: string
+  category?: ReportCategory
+  ruleIds?: string[]
+}): Promise<AdminReport> => {
+  const response = await fetch(`/api/v1/admin/reports/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      ...(category ? { category } : {}),
+      ...(ruleIds ? { rule_ids: ruleIds } : {})
+    })
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to update report')
+  }
+  return (await response.json()) as AdminReport
+}
+
+const adminReportAction =
+  (action: string) =>
+  async (id: string): Promise<AdminReport> => {
+    const response = await fetch(`/api/v1/admin/reports/${id}/${action}`, {
+      method: 'POST',
+      credentials: 'include'
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => null)
+      throw new Error(error?.error ?? `Failed to ${action} report`)
+    }
+    return (await response.json()) as AdminReport
+  }
+
+export const assignAdminReportToSelf = adminReportAction('assign_to_self')
+export const unassignAdminReport = adminReportAction('unassign')
+export const resolveAdminReport = adminReportAction('resolve')
+export const reopenAdminReport = adminReportAction('reopen')


### PR DESCRIPTION
## Epic 4.2d — Admin moderation UI

Final PR of the Admin moderation epic (Phase 4). UI on top of the 4.2b/4.2c APIs — **UI-only, no new endpoints**.

### Client wrappers (`lib/client.ts`)
No direct `fetch()` in components — every call goes through named `lib/client.ts` exports: `getAdminAccounts`, `getAdminAccount`, `performAdminAccountAction`, `adminEnable/Unsilence/Unsuspend/Unsensitive/Approve/RejectAccount`, `adminDeleteAccount`, `getAdminReports`, `getAdminReport`, `updateAdminReport`, `assign/unassign/resolve/reopenAdminReport`.

### UI (Decision 6 — augment, don't migrate)
- **`/admin/accounts/[id]`** keeps its RSC account/actors loading and gains a per-actor **`ActorModerationPanel`** (client component) that dogfoods the API: state badges (suspended/silenced/sensitized/disabled/pending) + action buttons. Login-scoped (disable/enable) and approval (approve/reject) actions are hidden for remote actors per the Decision 2 matrix; Delete appears only once suspended.
- **`/admin/reports`** — reports queue with an Unresolved/Resolved toggle.
- **`/admin/reports/[id]`** — report detail (reporter/target/category/status/comment, reported statuses, broken rules) with a category editor and assign/unassign + resolve/reopen controls.
- Admin dropdown sub-nav gains a **Reports** entry (no nav rail, no header tabs — per the design system).

### Docs
- `docs/mastodon-api-compatibility.md` documents the implemented admin moderation cluster and the actor id-space divergence (base64url actor ids, per-actor suspend/silence vs login-wide disable, empty-today `pending`).
- `docs/features.md` marks admin moderation ✅ and removes the planned "moderation review dashboard".

### Browser verification (port 3042, mock admin user, local SQLite)
Migrated a throwaway `dev.sqlite3`, created the sanctioned mock user, promoted it to `admin`, and seeded a remote target actor + an open report. Verified in the in-app browser:
1. **Sign-in** as the mock admin → redirected to the timeline.
2. **`/admin/reports`** renders the Reports sub-nav tab, the Unresolved/Resolved toggle, and the report card `testuser → troll@remote.example · spam · Open`.
3. **`/admin/reports/:id`** renders Reporter/Target/Category/Status/Assigned + the comment and the category/assign/resolve controls.
4. **Resolve** (a real end-to-end mutation): Status flipped `Open → Resolved` and the button became `Reopen`.
5. **`/admin/accounts/:id`** renders the `@testuser moderation` panel with `Suspend / Silence / Mark sensitive / Disable login` (login-scoped action shown because it's a local, approved account).

(The admin's own actor was intentionally not suspended, to avoid locking the verification session.)

### Tests / gate
Component tests (jsdom) for `ActorModerationPanel` (badges + suspend/approve actions, remote-hides-login-actions), `AdminReportsList` (list + toggle + empty state), and `AdminReportDetail` (assign/resolve). Full gate green: prettier → lint (0 errors) → build → test (**674 files, 6443 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
