### PR TITLE
Bump version to v1.107.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.107.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.106.0`
- Base main SHA: `b2045935fcef3371e9817fb4624a850192e94cc6`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
