### PR TITLE
minor: quote management API + quote-policy preferences (Epic 4.1c)

### DIFF
--- a/app/api/v1/accounts/update_credentials/route.test.ts
+++ b/app/api/v1/accounts/update_credentials/route.test.ts
@@ -112,6 +112,27 @@ describe('PATCH /api/v1/accounts/update_credentials', () => {
     updateActor.mockRestore()
   })
 
+  it('persists source[quote_policy] as the default quote policy and echoes it in source', async () => {
+    const updateActor = vi.spyOn(database, 'updateActor')
+    const form = new FormData()
+    form.set('source[quote_policy]', 'followers')
+
+    const response = await PATCH(createRequest(form), {
+      params: Promise.resolve({})
+    })
+
+    expect(response.status).toBe(200)
+    expect(updateActor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: ACTOR1_ID,
+        defaultQuotePolicy: 'followers'
+      })
+    )
+    const data = await response.json()
+    expect(data.source.quote_policy).toBe('followers')
+    updateActor.mockRestore()
+  })
+
   it('accepts a request with no recognized fields without error', async () => {
     const response = await PATCH(createRequest(new FormData()), {
       params: Promise.resolve({})

--- a/app/api/v1/preferences/route.test.ts
+++ b/app/api/v1/preferences/route.test.ts
@@ -111,6 +111,7 @@ describe('/api/v1/preferences', () => {
       'posting:default:visibility': 'public',
       'posting:default:sensitive': false,
       'posting:default:language': null,
+      'posting:default:quote_policy': 'public',
       'reading:expand:media': 'default',
       'reading:expand:spoilers': false,
       'reading:autoplay:gifs': false
@@ -123,6 +124,7 @@ describe('/api/v1/preferences', () => {
       defaultPrivacy: 'private',
       defaultSensitive: true,
       defaultLanguage: 'th',
+      defaultQuotePolicy: 'followers',
       readingExpandMedia: 'show_all',
       readingExpandSpoilers: true,
       readingAutoplayGifs: true
@@ -136,6 +138,7 @@ describe('/api/v1/preferences', () => {
       'posting:default:visibility': 'private',
       'posting:default:sensitive': true,
       'posting:default:language': 'th',
+      'posting:default:quote_policy': 'followers',
       'reading:expand:media': 'show_all',
       'reading:expand:spoilers': true,
       'reading:autoplay:gifs': true

--- a/app/api/v1/preferences/route.ts
+++ b/app/api/v1/preferences/route.ts
@@ -28,6 +28,9 @@ export const GET = traceApiRoute(
           // language. The Account serializer defaults source.language to 'en',
           // so read the raw setting instead of the serialized account.
           'posting:default:language': settings?.defaultLanguage ?? null,
+          // Mastodon 4.5 default quote-approval policy for new statuses.
+          'posting:default:quote_policy':
+            settings?.defaultQuotePolicy ?? 'public',
           'reading:expand:media': currentActor.readingExpandMedia ?? 'default',
           'reading:expand:spoilers':
             currentActor.readingExpandSpoilers ?? false,

--- a/app/api/v1/statuses/[id]/interaction_policy/route.test.ts
+++ b/app/api/v1/statuses/[id]/interaction_policy/route.test.ts
@@ -1,0 +1,148 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { PUT } from './route'
+
+const mockGetServerSession = vi.fn()
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    get: vi.fn().mockReturnValue(undefined)
+  })
+}))
+
+vi.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: vi.fn()
+}))
+
+vi.mock('@/lib/services/queue', () => ({
+  getQueue: vi.fn().mockReturnValue({
+    publish: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/lib/config', () => ({
+  getBaseURL: vi.fn().mockReturnValue('https://llun.test'),
+  getConfig: vi.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const putRequest = (encodedId: string, body: unknown) =>
+  new NextRequest(
+    `https://llun.test/api/v1/statuses/${encodedId}/interaction_policy`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://llun.test'
+      }
+    }
+  )
+
+describe('PUT /api/v1/statuses/[id]/interaction_policy', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  it('sets who may quote the status without recording an edit and re-federates', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/interaction-policy-1`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'my post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const response = await PUT(
+      putRequest(urlToId(statusId), { quote_approval_policy: 'followers' }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+
+    expect(response.status).toBe(200)
+    const status = await response.json()
+    expect(status.quote_approval.automatic).toEqual(['followers'])
+    // Changing the interaction policy is not an edit — edited_at must stay null.
+    expect(status.edited_at).toBeNull()
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({ name: SEND_UPDATE_NOTE_JOB_NAME })
+    )
+  })
+
+  it('returns 403 when the caller is not the status author', async () => {
+    const statusId = `${ACTOR2_ID}/statuses/interaction-policy-not-mine`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR2_ID,
+      text: 'someone elses post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const response = await PUT(
+      putRequest(urlToId(statusId), { quote_approval_policy: 'nobody' }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+
+    expect(response.status).toBe(403)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 for an invalid quote_approval_policy value', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/interaction-policy-invalid`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      text: 'my post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const response = await PUT(
+      putRequest(urlToId(statusId), { quote_approval_policy: 'everyone' }),
+      { params: Promise.resolve({ id: urlToId(statusId) }) }
+    )
+
+    expect(response.status).toBe(422)
+  })
+})

--- a/app/api/v1/statuses/[id]/interaction_policy/route.ts
+++ b/app/api/v1/statuses/[id]/interaction_policy/route.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod'
+
+import { updateStatusInteractionPolicyFromUserInput } from '@/lib/actions/updateStatusInteractionPolicy'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
+import { Scope } from '@/lib/types/database/operations'
+import { QuoteApprovalPolicy } from '@/lib/types/domain/status'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_403,
+  ERROR_422,
+  ERROR_500,
+  apiCorsError,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.PUT]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+const BodySchema = z.object({
+  quote_approval_policy: QuoteApprovalPolicy
+})
+
+// PUT /api/v1/statuses/:id/interaction_policy — the author sets who may quote
+// this status. Rewrites the content-blob policy without recording an edit (so
+// edited_at never flips) and re-federates the note so its advertised
+// interactionPolicy.canQuote refreshes.
+export const PUT = traceApiRoute(
+  'updateStatusInteractionPolicy',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:statuses']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const encodedStatusId = (await params).id
+      if (!encodedStatusId) return apiCorsError(req, CORS_HEADERS, 404)
+      const statusId = idToUrl(encodedStatusId)
+
+      let parsed: z.infer<typeof BodySchema>
+      try {
+        const result = BodySchema.safeParse(await parseStatusRequestBody(req))
+        if (!result.success) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_422,
+            responseStatusCode: 422
+          })
+        }
+        parsed = result.data
+      } catch {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_422,
+          responseStatusCode: 422
+        })
+      }
+
+      const updatedStatus = await updateStatusInteractionPolicyFromUserInput({
+        statusId,
+        currentActor,
+        quoteApprovalPolicy: parsed.quote_approval_policy,
+        database
+      })
+      // null = not found, not owned, or not a Note/Poll — author-only.
+      if (!updatedStatus) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_403,
+          responseStatusCode: 403
+        })
+      }
+
+      const mastodonStatus = await getMastodonStatus(
+        database,
+        updatedStatus,
+        currentActor.id
+      )
+      if (!mastodonStatus) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: mastodonStatus
+      })
+    }
+  ),
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { statusId: params?.id || 'unknown' }
+    }
+  }
+)

--- a/app/api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke/route.test.ts
+++ b/app/api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke/route.test.ts
@@ -1,0 +1,267 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SEND_QUOTE_REVOKE_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { POST } from './route'
+
+const mockGetServerSession = vi.fn()
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    get: vi.fn().mockReturnValue(undefined)
+  })
+}))
+
+vi.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: vi.fn()
+}))
+
+vi.mock('@/lib/services/queue', () => ({
+  getQueue: vi.fn().mockReturnValue({
+    publish: vi.fn().mockResolvedValue(undefined)
+  })
+}))
+
+vi.mock('@/lib/config', () => ({
+  getBaseURL: vi.fn().mockReturnValue('https://llun.test'),
+  getConfig: vi.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+const REMOTE_QUOTER_ID = 'https://remote.example/users/quoter'
+
+const revokeRequest = (encodedQuotedId: string, encodedQuotingId: string) =>
+  new NextRequest(
+    `https://llun.test/api/v1/statuses/${encodedQuotedId}/quotes/${encodedQuotingId}/revoke`,
+    { method: 'POST', headers: { Origin: 'https://llun.test' } }
+  )
+
+describe('POST /api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    await database.createActor({
+      actorId: REMOTE_QUOTER_ID,
+      username: 'quoter',
+      domain: 'remote.example',
+      followersUrl: `${REMOTE_QUOTER_ID}/followers`,
+      inboxUrl: `${REMOTE_QUOTER_ID}/inbox`,
+      sharedInboxUrl: 'https://remote.example/inbox',
+      publicKey: 'public-key',
+      createdAt: Date.now()
+    })
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { email: seedActor1.email }
+    })
+  })
+
+  const seedAcceptedQuote = async (
+    suffix: string,
+    quoterId: string,
+    authorizationUri: string | null
+  ) => {
+    const quotedId = `${ACTOR1_ID}/statuses/revoke-quoted-${suffix}`
+    await database.createNote({
+      id: quotedId,
+      url: quotedId,
+      actorId: ACTOR1_ID,
+      text: 'quote me',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const quotingId = `${quoterId}/statuses/revoke-quoting-${suffix}`
+    await database.createNote({
+      id: quotingId,
+      url: quotingId,
+      actorId: quoterId,
+      text: 'quoting you',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createStatusQuote({
+      statusId: quotingId,
+      quotedStatusId: quotedId,
+      state: 'accepted',
+      authorizationUri
+    })
+    return { quotedId, quotingId }
+  }
+
+  it('revokes an accepted quote and federates a stamp Delete to the quoting author', async () => {
+    const stampUri = `${ACTOR1_ID}/quote_authorizations/revoke-1`
+    const { quotedId, quotingId } = await seedAcceptedQuote(
+      'federated',
+      REMOTE_QUOTER_ID,
+      stampUri
+    )
+
+    const response = await POST(
+      revokeRequest(urlToId(quotedId), urlToId(quotingId)),
+      {
+        params: Promise.resolve({
+          id: urlToId(quotedId),
+          quoting_status_id: urlToId(quotingId)
+        })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const status = await response.json()
+    expect(status.quote.state).toBe('revoked')
+    expect(getQueue().publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: SEND_QUOTE_REVOKE_JOB_NAME,
+        data: expect.objectContaining({
+          actorId: ACTOR1_ID,
+          quotingActorId: REMOTE_QUOTER_ID,
+          stampId: stampUri
+        })
+      })
+    )
+    const edge = await database.getStatusQuote({ statusId: quotingId })
+    expect(edge?.state).toBe('revoked')
+  })
+
+  it('is idempotent for an already-revoked quote', async () => {
+    const { quotedId, quotingId } = await seedAcceptedQuote(
+      'idempotent',
+      REMOTE_QUOTER_ID,
+      `${ACTOR1_ID}/quote_authorizations/revoke-2`
+    )
+    await database.updateStatusQuoteState({
+      statusId: quotingId,
+      state: 'revoked'
+    })
+
+    const response = await POST(
+      revokeRequest(urlToId(quotedId), urlToId(quotingId)),
+      {
+        params: Promise.resolve({
+          id: urlToId(quotedId),
+          quoting_status_id: urlToId(quotingId)
+        })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const status = await response.json()
+    expect(status.quote.state).toBe('revoked')
+  })
+
+  it('does not federate when the accepted quote has no hosted stamp', async () => {
+    const { quotedId, quotingId } = await seedAcceptedQuote(
+      'no-stamp',
+      ACTOR2_ID,
+      null
+    )
+
+    const response = await POST(
+      revokeRequest(urlToId(quotedId), urlToId(quotingId)),
+      {
+        params: Promise.resolve({
+          id: urlToId(quotedId),
+          quoting_status_id: urlToId(quotingId)
+        })
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(getQueue().publish).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the caller does not own the quoted status', async () => {
+    const quotedId = `${ACTOR2_ID}/statuses/revoke-not-mine`
+    await database.createNote({
+      id: quotedId,
+      url: quotedId,
+      actorId: ACTOR2_ID,
+      text: 'not my post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const quotingId = `${REMOTE_QUOTER_ID}/statuses/revoke-not-mine-quoting`
+    await database.createNote({
+      id: quotingId,
+      url: quotingId,
+      actorId: REMOTE_QUOTER_ID,
+      text: 'quoting',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createStatusQuote({
+      statusId: quotingId,
+      quotedStatusId: quotedId,
+      state: 'accepted'
+    })
+
+    const response = await POST(
+      revokeRequest(urlToId(quotedId), urlToId(quotingId)),
+      {
+        params: Promise.resolve({
+          id: urlToId(quotedId),
+          quoting_status_id: urlToId(quotingId)
+        })
+      }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('returns 404 when no quote edge links the two statuses', async () => {
+    const quotedId = `${ACTOR1_ID}/statuses/revoke-no-edge`
+    await database.createNote({
+      id: quotedId,
+      url: quotedId,
+      actorId: ACTOR1_ID,
+      text: 'my post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+
+    const response = await POST(
+      revokeRequest(
+        urlToId(quotedId),
+        urlToId(`${REMOTE_QUOTER_ID}/statuses/x`)
+      ),
+      {
+        params: Promise.resolve({
+          id: urlToId(quotedId),
+          quoting_status_id: urlToId(`${REMOTE_QUOTER_ID}/statuses/x`)
+        })
+      }
+    )
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/app/api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke/route.ts
+++ b/app/api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke/route.ts
@@ -1,0 +1,89 @@
+import { revokeStatusQuoteFromUserInput } from '@/lib/actions/revokeStatusQuote'
+import { OAuthGuardAnyScope } from '@/lib/services/guards/OAuthGuard'
+import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_403,
+  ERROR_500,
+  apiCorsError,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+  quoting_status_id: string
+}
+
+// POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke — the quoted
+// author withdraws approval of a quote of their status. 403 unless the caller
+// owns the quoted status; 404 when no quote edge links the two ids.
+export const POST = traceApiRoute(
+  'revokeStatusQuote',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:statuses']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const { id, quoting_status_id: quotingStatusIdParam } = await params
+      if (!id || !quotingStatusIdParam) {
+        return apiCorsError(req, CORS_HEADERS, 404)
+      }
+      const quotedStatusId = idToUrl(id)
+      const quotingStatusId = idToUrl(quotingStatusIdParam)
+
+      const result = await revokeStatusQuoteFromUserInput({
+        currentActor,
+        quotedStatusId,
+        quotingStatusId,
+        database
+      })
+      if (!result.ok) {
+        if (result.reason === 'forbidden') {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_403,
+            responseStatusCode: 403
+          })
+        }
+        return apiCorsError(req, CORS_HEADERS, 404)
+      }
+
+      const mastodonStatus = await getMastodonStatus(
+        database,
+        result.status,
+        currentActor.id
+      )
+      if (!mastodonStatus) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_500,
+          responseStatusCode: 500
+        })
+      }
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: mastodonStatus
+      })
+    }
+  ),
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return {
+        statusId: params?.id || 'unknown',
+        quotingStatusId: params?.quoting_status_id || 'unknown'
+      }
+    }
+  }
+)

--- a/app/api/v1/statuses/[id]/quotes/route.test.ts
+++ b/app/api/v1/statuses/[id]/quotes/route.test.ts
@@ -1,0 +1,157 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
+import { ACTOR3_ID } from '@/lib/stub/seed/actor3'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { urlToId } from '@/lib/utils/urlToId'
+
+import { GET } from './route'
+
+const mockGetServerSession = vi.fn()
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: () => mockGetServerSession()
+}))
+
+let mockDatabase: ReturnType<typeof getTestSQLDatabase> | null = null
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => mockDatabase
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    get: vi.fn().mockReturnValue(undefined)
+  })
+}))
+
+vi.mock('better-auth/oauth2', () => ({
+  verifyAccessToken: vi.fn()
+}))
+
+vi.mock('@/lib/config', () => ({
+  getBaseURL: vi.fn().mockReturnValue('https://llun.test'),
+  getConfig: vi.fn().mockReturnValue({
+    allowEmails: [],
+    host: 'llun.test',
+    secretPhase: 'test-secret'
+  })
+}))
+
+describe('GET /api/v1/statuses/[id]/quotes', () => {
+  const database = getTestSQLDatabase()
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    mockDatabase = database
+  })
+
+  afterAll(async () => {
+    if (!database) return
+    mockDatabase = null
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetServerSession.mockResolvedValue(null)
+  })
+
+  const createQuotingStatus = async (
+    quotingId: string,
+    actorId: string,
+    quotedStatusId: string,
+    state: 'accepted' | 'pending' | 'rejected'
+  ) => {
+    await database.createNote({
+      id: quotingId,
+      url: quotingId,
+      actorId,
+      text: 'a quoting post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createStatusQuote({
+      statusId: quotingId,
+      quotedStatusId,
+      state
+    })
+  }
+
+  it('lists accepted quotes of a status, excluding non-accepted edges', async () => {
+    const quotedId = `${ACTOR1_ID}/statuses/quotes-target-1`
+    await database.createNote({
+      id: quotedId,
+      url: quotedId,
+      actorId: ACTOR1_ID,
+      text: 'quote me',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    const acceptedQuoteId = `${ACTOR2_ID}/statuses/quotes-accepted-1`
+    await createQuotingStatus(acceptedQuoteId, ACTOR2_ID, quotedId, 'accepted')
+    const pendingQuoteId = `${ACTOR3_ID}/statuses/quotes-pending-1`
+    await createQuotingStatus(pendingQuoteId, ACTOR3_ID, quotedId, 'pending')
+
+    const req = new NextRequest(
+      `https://llun.test/api/v1/statuses/${urlToId(quotedId)}/quotes`
+    )
+    const response = await GET(req, {
+      params: Promise.resolve({ id: urlToId(quotedId) })
+    })
+
+    expect(response.status).toBe(200)
+    const statuses = (await response.json()) as { id: string }[]
+    expect(statuses.map((status) => status.id)).toEqual([
+      urlToId(acceptedQuoteId)
+    ])
+  })
+
+  it('404s when the quoted status does not exist', async () => {
+    const req = new NextRequest(
+      'https://llun.test/api/v1/statuses/does-not-exist/quotes'
+    )
+    const response = await GET(req, {
+      params: Promise.resolve({ id: 'does-not-exist' })
+    })
+    expect(response.status).toBe(404)
+  })
+
+  it('paginates with limit and emits a next Link header when more remain', async () => {
+    const quotedId = `${ACTOR1_ID}/statuses/quotes-target-2`
+    await database.createNote({
+      id: quotedId,
+      url: quotedId,
+      actorId: ACTOR1_ID,
+      text: 'popular post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await createQuotingStatus(
+      `${ACTOR2_ID}/statuses/quotes-page-a`,
+      ACTOR2_ID,
+      quotedId,
+      'accepted'
+    )
+    await createQuotingStatus(
+      `${ACTOR3_ID}/statuses/quotes-page-b`,
+      ACTOR3_ID,
+      quotedId,
+      'accepted'
+    )
+
+    const req = new NextRequest(
+      `https://llun.test/api/v1/statuses/${urlToId(quotedId)}/quotes?limit=1`
+    )
+    const response = await GET(req, {
+      params: Promise.resolve({ id: urlToId(quotedId) })
+    })
+
+    expect(response.status).toBe(200)
+    const statuses = (await response.json()) as { id: string }[]
+    expect(statuses).toHaveLength(1)
+    expect(response.headers.get('Link')).toContain('max_id=')
+  })
+})

--- a/app/api/v1/statuses/[id]/quotes/route.test.ts
+++ b/app/api/v1/statuses/[id]/quotes/route.test.ts
@@ -109,6 +109,49 @@ describe('GET /api/v1/statuses/[id]/quotes', () => {
     ])
   })
 
+  it('excludes quoting statuses the viewer cannot read (no visibility leak)', async () => {
+    const quotedId = `${ACTOR1_ID}/statuses/quotes-visibility-target`
+    await database.createNote({
+      id: quotedId,
+      url: quotedId,
+      actorId: ACTOR1_ID,
+      text: 'public post',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    // A public accepted quote — always visible.
+    const publicQuoteId = `${ACTOR2_ID}/statuses/quotes-visible-public`
+    await createQuotingStatus(publicQuoteId, ACTOR2_ID, quotedId, 'accepted')
+    // A followers-only accepted quote — must NOT leak to an anonymous viewer.
+    const privateQuoteId = `${ACTOR3_ID}/statuses/quotes-followers-only`
+    await database.createNote({
+      id: privateQuoteId,
+      url: privateQuoteId,
+      actorId: ACTOR3_ID,
+      text: 'secret quote',
+      to: [`${ACTOR3_ID}/followers`],
+      cc: []
+    })
+    await database.createStatusQuote({
+      statusId: privateQuoteId,
+      quotedStatusId: quotedId,
+      state: 'accepted'
+    })
+
+    const req = new NextRequest(
+      `https://llun.test/api/v1/statuses/${urlToId(quotedId)}/quotes`
+    )
+    const response = await GET(req, {
+      params: Promise.resolve({ id: urlToId(quotedId) })
+    })
+
+    expect(response.status).toBe(200)
+    const statuses = (await response.json()) as { id: string }[]
+    const ids = statuses.map((status) => status.id)
+    expect(ids).toContain(urlToId(publicQuoteId))
+    expect(ids).not.toContain(urlToId(privateQuoteId))
+  })
+
   it('404s when the quoted status does not exist', async () => {
     const req = new NextRequest(
       'https://llun.test/api/v1/statuses/does-not-exist/quotes'

--- a/app/api/v1/statuses/[id]/quotes/route.ts
+++ b/app/api/v1/statuses/[id]/quotes/route.ts
@@ -3,13 +3,16 @@ import { z } from 'zod'
 import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
 import { buildAccountCursorLinkHeader } from '@/lib/services/mastodon/accountCursorLinkHeader'
 import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
-import { getReadableStatus } from '@/lib/services/statusRouteAccess'
+import {
+  filterReadableStatuses,
+  getReadableStatus
+} from '@/lib/services/statusRouteAccess'
 import { Scope } from '@/lib/types/database/operations'
 import { clampedLimit } from '@/lib/utils/clampedLimit'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { apiCorsError, apiResponse, defaultOptions } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
-import { idToUrl } from '@/lib/utils/urlToId'
+import { idToUrl, urlToId } from '@/lib/utils/urlToId'
 
 const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
 
@@ -75,20 +78,30 @@ export const GET = traceApiRoute(
         statusIds: pageIds,
         currentActorId: currentActor?.id
       })
-      const mastodonStatuses = await getMastodonStatuses(
+      // getStatusesByIds does not enforce read visibility on its own — a quoting
+      // status can be followers-only or direct, so drop the ones this viewer
+      // cannot read before serializing (batched follower-state check, no N+1).
+      const readableStatuses = await filterReadableStatuses({
         database,
         statuses,
+        currentActor: currentActor ?? null
+      })
+      const mastodonStatuses = await getMastodonStatuses(
+        database,
+        readableStatuses,
         currentActor?.id
       )
 
+      // Pagination cursors advance over the raw DB page (pre-filter) so a
+      // filtered-out quoting status never causes the next page to skip or repeat;
+      // a page may simply render fewer than `limit` items.
       const paginationLink = buildAccountCursorLinkHeader({
         req,
         limit,
-        items: mastodonStatuses,
+        items: statuses,
         hasNext: hasOverflow,
         hasPrev: Boolean(maxId || sinceId),
-        // Mastodon status ids are already the urlToId-encoded form.
-        toCursor: (status) => status.id
+        toCursor: (status) => urlToId(status.id)
       })
 
       return apiResponse({

--- a/app/api/v1/statuses/[id]/quotes/route.ts
+++ b/app/api/v1/statuses/[id]/quotes/route.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { buildAccountCursorLinkHeader } from '@/lib/services/mastodon/accountCursorLinkHeader'
+import { getMastodonStatuses } from '@/lib/services/mastodon/getMastodonStatus'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
+import { Scope } from '@/lib/types/database/operations'
+import { clampedLimit } from '@/lib/utils/clampedLimit'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { apiCorsError, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+// Mastodon caps this at 40, default 20.
+const QuerySchema = z.object({
+  limit: clampedLimit(40, 20),
+  max_id: z.string().min(1).optional(),
+  since_id: z.string().min(1).optional()
+})
+
+// GET /api/v1/statuses/:id/quotes — the accepted quotes of a status, newest
+// first. Only `accepted` edges are listed (pending/rejected/revoked/deleted are
+// never public). 404 when the quoted status is not visible to the caller.
+export const GET = traceApiRoute(
+  'getStatusQuotes',
+  OptionalOAuthGuard<Params>(
+    [Scope.enum.read, Scope.enum['read:statuses']],
+    async (req, context) => {
+      const { database, currentActor, params } = context
+      const encodedStatusId = (await params).id
+      if (!encodedStatusId) return apiCorsError(req, CORS_HEADERS, 404)
+      const statusId = idToUrl(encodedStatusId)
+
+      const status = await getReadableStatus({
+        database,
+        statusId,
+        currentActor,
+        withReplies: false
+      })
+      if (!status) return apiCorsError(req, CORS_HEADERS, 404)
+
+      const query = QuerySchema.safeParse(
+        Object.fromEntries(new URL(req.url).searchParams)
+      )
+      if (!query.success) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: { error: 'Invalid request' },
+          responseStatusCode: 400
+        })
+      }
+      const { limit, max_id: maxId, since_id: sinceId } = query.data
+
+      // Fetch one extra to detect an older page for the `next` link.
+      const quotingIds = await database.getQuotingStatusIds({
+        quotedStatusId: statusId,
+        state: 'accepted',
+        limit: limit + 1,
+        maxId: maxId ? idToUrl(maxId) : undefined,
+        sinceId: sinceId ? idToUrl(sinceId) : undefined
+      })
+      const hasOverflow = quotingIds.length > limit
+      const pageIds = quotingIds.slice(0, limit)
+
+      const statuses = await database.getStatusesByIds({
+        statusIds: pageIds,
+        currentActorId: currentActor?.id
+      })
+      const mastodonStatuses = await getMastodonStatuses(
+        database,
+        statuses,
+        currentActor?.id
+      )
+
+      const paginationLink = buildAccountCursorLinkHeader({
+        req,
+        limit,
+        items: mastodonStatuses,
+        hasNext: hasOverflow,
+        hasPrev: Boolean(maxId || sinceId),
+        // Mastodon status ids are already the urlToId-encoded form.
+        toCursor: (status) => status.id
+      })
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: mastodonStatuses,
+        additionalHeaders: paginationLink ? [['Link', paginationLink]] : []
+      })
+    },
+    { matchMode: 'any' }
+  ),
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { statusId: params?.id || 'unknown' }
+    }
+  }
+)

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -241,6 +241,36 @@ describe('POST /api/v1/statuses', () => {
     expect(response.status).toBe(404)
   })
 
+  it('defaults an omitted quote_approval_policy to the actor setting', async () => {
+    await database.updateActor({
+      actorId: ACTOR1_ID,
+      defaultQuotePolicy: 'followers'
+    })
+    try {
+      const response = await POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({ status: 'inherits my default quote policy' }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+
+      expect(response.status).toBe(200)
+      const mastodonStatus = await response.json()
+      expect(mastodonStatus.quote_approval.automatic).toEqual(['followers'])
+    } finally {
+      // Restore the public default so later tests keep their expectations.
+      await database.updateActor({
+        actorId: ACTOR1_ID,
+        defaultQuotePolicy: 'public'
+      })
+    }
+  })
+
   it('attaches form media_ids[] to the created status', async () => {
     const media = await database.createMedia({
       actorId: ACTOR1_ID,

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -406,13 +406,22 @@ export const POST = traceApiRoute(
             quotedStatusId = quotedUrl
           }
 
+          // Default an omitted quote_approval_policy to the actor's configured
+          // default (Mastodon 4.5 posting:default:quote_policy). A concrete
+          // request value always wins; omitted falls back to the actor setting,
+          // then to the per-status visibility default at consumption.
+          const quoteApprovalPolicy =
+            note.quote_approval_policy ??
+            (await database.getActorSettings({ actorId: currentActor.id }))
+              ?.defaultQuotePolicy
+
           status = await createNoteFromUserInput({
             currentActor,
             text: note.status,
             summary: note.spoiler_text,
             replyNoteId: note.in_reply_to_id,
             quotedStatusId,
-            quoteApprovalPolicy: note.quote_approval_policy,
+            quoteApprovalPolicy,
             visibility: note.visibility,
             attachments,
             sensitive: note.sensitive,

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,6 +13,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Boost / Repost** — Share other users' posts (with undo)
 - ✅ **Like / Favorite** — React to posts (with undo)
 - ✅ **Polls** — Create, vote on, and view poll results (single and multiple choice)
+- ✅ **Quote posts (Mastodon 4.5)** — Quote another post with the full FEP-044f consent handshake (`QuoteRequest` → `Accept` + a hosted `QuoteAuthorization` stamp; revocation is a `Delete` of the stamp), a per-post quote-approval policy (`public` / `followers` / `nobody`) with a per-account default, and inbound interop with Fedibird (`quoteUri`) and Misskey (`_misskey_quote`) quotes (rendered as unapproved until a stamp verifies)
 - ✅ **Multiple actors per account** — Create and switch between multiple handles under one account (e.g., `@user@domain.tld` and `@ride@domain.tld`)
 - ✅ **Multi-domain support** — Different domains for different actors
 - ✅ **Account blocks** — Block or unblock remote accounts and list blocked accounts
@@ -65,6 +66,7 @@ This document tracks the implemented and planned features for Activity.next.
 
 - ✅ **Mastodon API v1/v2** — Compatible with Mastodon client applications (including iOS clients); statuses, accounts, and media endpoints are fully Mastodon-compatible
 - ✅ **Mastodon-compatible status actions** — Favourite, reblog, bookmark, pin, context, history, translate, and relationship endpoints
+- ✅ **Quote posts API (Mastodon 4.5)** — `quoted_status_id` + `quote_approval_policy` on `POST /api/v1/statuses`, the `quote` sub-entity and `quote_approval` on the Status entity, `GET /api/v1/statuses/:id/quotes`, `POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke`, `PUT /api/v1/statuses/:id/interaction_policy`, and the `posting:default:quote_policy` preference / `source[quote_policy]` on `update_credentials`
 - ✅ **Granular OAuth scopes** — Fine-grained scope enforcement and client-credentials app tokens
 - ✅ **Search** — Search accounts, hashtags, and statuses via `/api/v2/search` (status search backed by a full-text index)
 - ✅ **Lists** — Create and manage timeline lists, their members, replies policy, and exclusive flag

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -140,6 +140,26 @@ product or security decision, not a gap to be closed.
   same millisecond share it — which is harmless because clients key the list on
   the (unique) `group_key`, not on this field.
 
+- **Quote approval is consent-gated (FEP-044f) and has no manual-approval
+  queue.** Quote posts (Mastodon 4.5) are supported end to end — `quoted_status_id`
+  and `quote_approval_policy` on `POST /api/v1/statuses`, the `quote` sub-entity
+  and `quote_approval` on the Status entity, `GET /api/v1/statuses/:id/quotes`,
+  `POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke`, and
+  `PUT /api/v1/statuses/:id/interaction_policy` — with a few deliberate limits.
+  Approval is driven by the FEP-044f handshake (`QuoteRequest` → `Accept` + a
+  hosted `QuoteAuthorization` stamp; revocation is a `Delete` of that stamp), so
+  the policy vocabulary is `public` / `followers` / `nobody` and `quote_approval.manual`
+  is always empty (there is no held-for-review queue). For a `followers`-policy
+  status, `quote_approval.current_user` reports `unknown` to a non-author viewer —
+  the follower-relationship refinement is deferred. Legacy Fedibird (`quoteUri`)
+  and Misskey (`_misskey_quote`) quotes carry no stamp, so they are stored and
+  rendered as unapproved (`pending`) rather than as embedded quotes, matching
+  Mastodon 4.5's treatment of stamp-less quotes. Revocation v1 delivers the stamp
+  `Delete` to the quoting author's server only, not to every prior recipient.
+  Changing a status's quote policy via `PUT …/interaction_policy` is not treated
+  as an edit (it never sets `edited_at`). Configured under `lib/services/quotes/`,
+  `lib/actions/*Quote*`, and `app/api/v1/statuses/[id]/quotes|interaction_policy`.
+
 ## Not planned
 
 These endpoints are not implemented and are not currently on the roadmap. They
@@ -181,6 +201,9 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
   remove/revoke) while keeping the pre-final `title`/`topic`/`visibility`
   vocabulary, bulk `account_ids` mutations, the per-member approve consent
   endpoint, and account-id addressing as documented extensions.
+- **Hosted quote-authorization stamps** — `GET /users/:username/quote_authorizations/:id`
+  serves the FEP-044f `QuoteAuthorization` object for an approved quote; it 404s
+  once the quote is revoked (the edge is no longer `accepted`).
 - **Remote statuses** — `/api/v1/accounts/:id/remote-statuses` exposes cached
   remote posts for an actor.
 - **Admin CRUD extras** — custom emoji, domain allow/deny lists (with import),

--- a/lib/actions/revokeStatusQuote.ts
+++ b/lib/actions/revokeStatusQuote.ts
@@ -1,0 +1,96 @@
+import { Database } from '@/lib/database/types'
+import { SEND_QUOTE_REVOKE_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status, getOriginalStatus } from '@/lib/types/domain/status'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { getSpan } from '@/lib/utils/trace'
+
+interface RevokeStatusQuoteFromUserInput {
+  currentActor: Actor
+  // The quoted status ([id]) — the caller must be its author.
+  quotedStatusId: string
+  // The quoting status ([quoting_status_id]) whose quote edge is revoked.
+  quotingStatusId: string
+  database: Database
+}
+
+export type RevokeStatusQuoteResult =
+  | { ok: true; status: Status }
+  | { ok: false; reason: 'forbidden' | 'not_found' }
+
+/**
+ * Quoted author revokes their approval of a quote of their status (Mastodon
+ * `POST /statuses/:id/quotes/:quoting_status_id/revoke`). Author-only. Flips the
+ * edge to `revoked` (idempotent; the stamp route stops serving once non-accepted)
+ * and, when a hosted stamp exists, delivers a FEP-044f Delete of it to the
+ * quoting author's inbox. Returns the quoting status with `quote.state:
+ * 'revoked'`.
+ */
+export const revokeStatusQuoteFromUserInput = async ({
+  currentActor,
+  quotedStatusId,
+  quotingStatusId,
+  database
+}: RevokeStatusQuoteFromUserInput): Promise<RevokeStatusQuoteResult> => {
+  const span = getSpan('actions', 'revokeStatusQuoteFromUser', {
+    quotedStatusId,
+    quotingStatusId
+  })
+
+  const quotedStatus = await database.getStatus({
+    statusId: quotedStatusId,
+    withReplies: false
+  })
+  if (!quotedStatus) {
+    span.end()
+    return { ok: false, reason: 'not_found' }
+  }
+  if (getOriginalStatus(quotedStatus).actorId !== currentActor.id) {
+    span.end()
+    return { ok: false, reason: 'forbidden' }
+  }
+
+  // The edge must exist and actually link these two statuses.
+  const edge = await database.getStatusQuote({ statusId: quotingStatusId })
+  if (!edge || edge.quotedStatusId !== quotedStatusId) {
+    span.end()
+    return { ok: false, reason: 'not_found' }
+  }
+
+  // One-way state machine: accepted -> revoked; already-revoked is a no-op
+  // (idempotent). `authorizationUri` is preserved so we can still address the
+  // Delete below.
+  await database.updateStatusQuoteState({
+    statusId: quotingStatusId,
+    state: 'revoked'
+  })
+
+  const quotingStatus = await database.getStatus({
+    statusId: quotingStatusId,
+    withReplies: false
+  })
+  if (!quotingStatus) {
+    span.end()
+    return { ok: false, reason: 'not_found' }
+  }
+
+  // Federate the stamp revocation to the quoting author (best-effort; v1
+  // notifies the quoting server only, not every prior recipient). Only when a
+  // hosted stamp was actually issued and the quoter is a different actor.
+  const quotingActorId = getOriginalStatus(quotingStatus).actorId
+  if (edge.authorizationUri && quotingActorId !== currentActor.id) {
+    await getQueue().publish({
+      id: getHashFromString(`${edge.authorizationUri}#revoke`),
+      name: SEND_QUOTE_REVOKE_JOB_NAME,
+      data: {
+        actorId: currentActor.id,
+        quotingActorId,
+        stampId: edge.authorizationUri
+      }
+    })
+  }
+
+  span.end()
+  return { ok: true, status: quotingStatus }
+}

--- a/lib/actions/updateStatusInteractionPolicy.ts
+++ b/lib/actions/updateStatusInteractionPolicy.ts
@@ -1,0 +1,72 @@
+import { Database } from '@/lib/database/types'
+import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import { getQueue } from '@/lib/services/queue'
+import { Actor } from '@/lib/types/domain/actor'
+import {
+  QuoteApprovalPolicy,
+  Status,
+  StatusType
+} from '@/lib/types/domain/status'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+import { getSpan } from '@/lib/utils/trace'
+
+interface UpdateStatusInteractionPolicyFromUserInput {
+  statusId: string
+  currentActor: Actor
+  quoteApprovalPolicy: QuoteApprovalPolicy
+  publish?: boolean
+  status?: Status
+  database: Database
+}
+
+/**
+ * Set who may quote a status (Mastodon `PUT /statuses/:id/interaction_policy`).
+ * Author-only. Rewrites `quoteApprovalPolicy` in the content blob WITHOUT
+ * recording an edit (no status_history / no `edited_at` bump — see
+ * `updateStatusQuoteApprovalPolicy`), then re-federates the note so the
+ * advertised `interactionPolicy.canQuote` refreshes. Returns the updated status,
+ * or null when the caller is not the local author of a Note/Poll.
+ */
+export const updateStatusInteractionPolicyFromUserInput = async ({
+  statusId,
+  currentActor,
+  quoteApprovalPolicy,
+  publish = true,
+  status: preloadedStatus,
+  database
+}: UpdateStatusInteractionPolicyFromUserInput): Promise<Status | null> => {
+  const span = getSpan('actions', 'updateStatusInteractionPolicyFromUser', {
+    statusId
+  })
+  const status = preloadedStatus ?? (await database.getStatus({ statusId }))
+  if (
+    !status ||
+    status.id !== statusId ||
+    status.actorId !== currentActor.id ||
+    (status.type !== StatusType.enum.Note &&
+      status.type !== StatusType.enum.Poll)
+  ) {
+    span.end()
+    return null
+  }
+
+  const updatedStatus = await database.updateStatusQuoteApprovalPolicy({
+    statusId,
+    quoteApprovalPolicy
+  })
+  if (!updatedStatus) {
+    span.end()
+    return null
+  }
+
+  if (publish) {
+    await getQueue().publish({
+      id: getHashFromString(`${statusId}#interaction-policy`),
+      name: SEND_UPDATE_NOTE_JOB_NAME,
+      data: { actorId: currentActor.id, statusId }
+    })
+  }
+
+  span.end()
+  return updatedStatus
+}

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -340,6 +340,44 @@ export const sendQuoteReject = async ({
     }
   )
 
+interface SendQuoteRevokeParams {
+  currentActor: Actor
+  inbox: string
+  // The hosted QuoteAuthorization stamp id being revoked.
+  stampId: string
+}
+export const sendQuoteRevoke = async ({
+  currentActor,
+  inbox,
+  stampId
+}: SendQuoteRevokeParams) =>
+  getTracer().startActiveSpan(
+    'activities.sendQuoteRevoke',
+    { attributes: { actorId: currentActor.id, inbox } },
+    async (span) => {
+      // FEP-044f revocation is a Delete of the QuoteAuthorization stamp. The
+      // receiver matches it by stamp id and requires the sender to be the
+      // stamp's issuer (the quoted author), so we sign as currentActor.
+      const activity = {
+        '@context': QUOTE_ACTIVITY_CONTEXT,
+        id: `${stampId}#delete`,
+        type: 'Delete',
+        actor: currentActor.id,
+        object: { id: stampId, type: 'QuoteAuthorization' }
+      }
+      const statusCode = await postActivityToInbox({
+        span,
+        inbox,
+        currentActor,
+        activity,
+        logPrefix: 'sendQuoteRevoke',
+        silenceTimeout: true
+      })
+      span.end()
+      return statusCode
+    }
+  )
+
 interface SendAnnounceParams {
   currentActor: Actor
   inbox: string

--- a/lib/database/sql/actor.test.ts
+++ b/lib/database/sql/actor.test.ts
@@ -936,6 +936,7 @@ describe('ActorDatabase', () => {
             note: '',
             privacy: 'public',
             sensitive: false,
+            quote_policy: 'public',
             attribution_domains: []
           },
 

--- a/lib/database/sql/actor.ts
+++ b/lib/database/sql/actor.ts
@@ -324,6 +324,7 @@ const getMastodonAccountFromSQLActor = ({
       privacy: settings.defaultPrivacy ?? 'public',
       sensitive: settings.defaultSensitive ?? false,
       language: settings.defaultLanguage ?? 'en',
+      quote_policy: settings.defaultQuotePolicy ?? 'public',
       attribution_domains: settings.attributionDomains ?? [],
       follow_requests_count: 0
     },
@@ -848,6 +849,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
     defaultPrivacy,
     defaultSensitive,
     defaultLanguage,
+    defaultQuotePolicy,
     postLineLimit,
     readingExpandMedia,
     readingExpandSpoilers,
@@ -895,6 +897,7 @@ export const ActorSQLDatabaseMixin = (database: Knex): SQLActorDatabase => ({
       ...(defaultPrivacy !== undefined ? { defaultPrivacy } : null),
       ...(defaultSensitive !== undefined ? { defaultSensitive } : null),
       ...(defaultLanguage !== undefined ? { defaultLanguage } : null),
+      ...(defaultQuotePolicy !== undefined ? { defaultQuotePolicy } : null),
       ...(postLineLimit !== undefined ? { postLineLimit } : null),
       ...(readingExpandMedia !== undefined ? { readingExpandMedia } : null),
       ...(readingExpandSpoilers !== undefined

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -74,7 +74,8 @@ import {
   StatusEditRevision,
   UpdateNoteParams,
   UpdateNoteVisibilityParams,
-  UpdatePollParams
+  UpdatePollParams,
+  UpdateStatusQuoteApprovalPolicyParams
 } from '@/lib/types/database/operations'
 import { getActorProfile } from '@/lib/types/domain/actor'
 import { Attachment, isFitnessAttachment } from '@/lib/types/domain/attachment'
@@ -3390,9 +3391,32 @@ export const StatusSQLDatabaseMixin = (
     }
   }
 
+  async function updateStatusQuoteApprovalPolicy({
+    statusId,
+    quoteApprovalPolicy
+  }: UpdateStatusQuoteApprovalPolicyParams): Promise<Status | null> {
+    const existingStatus = await database('statuses')
+      .where('id', statusId)
+      .first()
+    if (!existingStatus) return null
+
+    // Rewrite only the quote-approval policy inside the content blob, preserving
+    // every other key. Deliberately NOT a status edit: no status_history row and
+    // no updatedAt bump, so `edited_at` never flips (Mastodon treats an
+    // interaction-policy change as a non-edit).
+    const data = getCompatibleJSON(existingStatus.content)
+    const content = { ...data, quoteApprovalPolicy }
+    await database('statuses')
+      .where('id', statusId)
+      .update({ content: JSON.stringify(content) })
+
+    return getStatus({ statusId })
+  }
+
   return {
     createNote,
     updateNote,
+    updateStatusQuoteApprovalPolicy,
     updateNoteVisibility,
     createAnnounce,
     createPoll,

--- a/lib/jobs/index.ts
+++ b/lib/jobs/index.ts
@@ -40,6 +40,7 @@ import {
   SEND_QUOTE_ACCEPT_JOB_NAME,
   SEND_QUOTE_REJECT_JOB_NAME,
   SEND_QUOTE_REQUEST_JOB_NAME,
+  SEND_QUOTE_REVOKE_JOB_NAME,
   SEND_UNBLOCK_JOB_NAME,
   SEND_UNDO_ANNOUNCE_JOB_NAME,
   SEND_UNDO_FOLLOW_JOB_NAME,
@@ -57,6 +58,7 @@ import { sendNoteJob } from './sendNoteJob'
 import { sendQuoteAcceptJob } from './sendQuoteAcceptJob'
 import { sendQuoteRejectJob } from './sendQuoteRejectJob'
 import { sendQuoteRequestJob } from './sendQuoteRequestJob'
+import { sendQuoteRevokeJob } from './sendQuoteRevokeJob'
 import { sendUnblockJob } from './sendUnblockJob'
 import { sendUndoAnnounceJob } from './sendUndoAnnounceJob'
 import { sendUndoFollowJob } from './sendUndoFollowJob'
@@ -90,6 +92,7 @@ export const JOBS: Record<string, JobHandle> = {
   [SEND_QUOTE_REQUEST_JOB_NAME]: sendQuoteRequestJob,
   [SEND_QUOTE_ACCEPT_JOB_NAME]: sendQuoteAcceptJob,
   [SEND_QUOTE_REJECT_JOB_NAME]: sendQuoteRejectJob,
+  [SEND_QUOTE_REVOKE_JOB_NAME]: sendQuoteRevokeJob,
   [HANDLE_QUOTE_REQUEST_JOB_NAME]: handleQuoteRequestJob,
   [SEND_UPDATE_NOTE_JOB_NAME]: sendUpdateNoteJob,
   [SEND_UNDO_ANNOUNCE_JOB_NAME]: sendUndoAnnounceJob,

--- a/lib/jobs/names.ts
+++ b/lib/jobs/names.ts
@@ -26,6 +26,7 @@ export const GENERATE_FITNESS_ROUTE_HEATMAP_JOB_NAME =
 export const SEND_QUOTE_REQUEST_JOB_NAME = 'SendQuoteRequestJob'
 export const SEND_QUOTE_ACCEPT_JOB_NAME = 'SendQuoteAcceptJob'
 export const SEND_QUOTE_REJECT_JOB_NAME = 'SendQuoteRejectJob'
+export const SEND_QUOTE_REVOKE_JOB_NAME = 'SendQuoteRevokeJob'
 export const HANDLE_QUOTE_REQUEST_JOB_NAME = 'HandleQuoteRequestJob'
 export const FETCH_REMOTE_STATUS_JOB_NAME = 'FetchRemoteStatusJob'
 export const PUBLISH_SCHEDULED_STATUS_JOB_NAME = 'PublishScheduledStatusJob'

--- a/lib/jobs/sendQuoteRevokeJob.ts
+++ b/lib/jobs/sendQuoteRevokeJob.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+import { sendQuoteRevoke } from '@/lib/activities'
+import { getActorPerson } from '@/lib/activities/getActorPerson'
+import { createJobHandle } from '@/lib/jobs/createJobHandle'
+import { SEND_QUOTE_REVOKE_JOB_NAME } from '@/lib/jobs/names'
+import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { JobHandle } from '@/lib/services/queue/type'
+import { getTracer } from '@/lib/utils/trace'
+
+export const JobData = z.object({
+  // The quoted author revoking their approval (signs the Delete).
+  actorId: z.string(),
+  // The quoting note's author, whose inbox receives the stamp Delete.
+  quotingActorId: z.string(),
+  // The hosted QuoteAuthorization stamp id being revoked.
+  stampId: z.string()
+})
+
+// Quoted-author side: withdraw a previously-issued QuoteAuthorization by
+// delivering a Delete of the stamp to the quoting author's inbox (FEP-044f).
+export const sendQuoteRevokeJob: JobHandle = createJobHandle(
+  SEND_QUOTE_REVOKE_JOB_NAME,
+  async (database, message) => {
+    await getTracer().startActiveSpan('sendQuoteRevokeJob', async (span) => {
+      const { actorId, quotingActorId, stampId } = JobData.parse(message.data)
+
+      if (!(await canFederateWithDomain(database, quotingActorId))) {
+        span.end()
+        return
+      }
+
+      const [currentActor, signingActor] = await Promise.all([
+        database.getActorFromId({ id: actorId }),
+        getFederationSigningActor(database)
+      ])
+      if (!currentActor) {
+        span.end()
+        return
+      }
+
+      const person = await getActorPerson({
+        actorId: quotingActorId,
+        signingActor
+      })
+      const inbox = person?.inbox ?? `${quotingActorId}/inbox`
+
+      await sendQuoteRevoke({ currentActor, inbox, stampId })
+
+      span.end()
+    })
+  }
+)

--- a/lib/services/accounts/updateCredentialsHandler.ts
+++ b/lib/services/accounts/updateCredentialsHandler.ts
@@ -11,6 +11,7 @@ import { headerHost } from '@/lib/services/guards/headerHost'
 import { saveMedia } from '@/lib/services/medias'
 import { MediaSchema } from '@/lib/services/medias/types'
 import { Scope } from '@/lib/types/database/operations'
+import { QuoteApprovalPolicy } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
 import { apiResponse } from '@/lib/utils/response'
@@ -52,7 +53,8 @@ const UpdateCredentialsRequest = z.object({
     .object({
       privacy: z.enum(['public', 'unlisted', 'private', 'direct']).optional(),
       sensitive: z.union([z.boolean(), z.string()]).optional(),
-      language: z.string().max(20).optional()
+      language: z.string().max(20).optional(),
+      quote_policy: QuoteApprovalPolicy.optional()
     })
     .optional()
 })
@@ -300,6 +302,9 @@ export const updateCredentialsHandler = (
           : null),
         ...(source?.language !== undefined
           ? { defaultLanguage: source.language }
+          : null),
+        ...(source?.quote_policy !== undefined
+          ? { defaultQuotePolicy: source.quote_policy }
           : null),
         ...(iconUrl !== undefined ? { iconUrl } : null),
         ...(headerImageUrl !== undefined ? { headerImageUrl } : null),

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -131,6 +131,7 @@ export type UpdateActorParams = {
   defaultPrivacy?: 'public' | 'unlisted' | 'private' | 'direct'
   defaultSensitive?: boolean
   defaultLanguage?: string
+  defaultQuotePolicy?: 'public' | 'followers' | 'nobody'
   postLineLimit?: PostLineLimit
   // Mastodon `reading:*` preferences surfaced by /api/v1/preferences.
   readingExpandMedia?: 'default' | 'show_all' | 'hide_all'
@@ -503,6 +504,10 @@ export type UpdateNoteParams = Pick<CreateNoteParams, 'text' | 'summary'> &
     language?: string | null
   }
 
+export type UpdateStatusQuoteApprovalPolicyParams = BaseStatusParams & {
+  quoteApprovalPolicy: QuoteApprovalPolicy
+}
+
 export type UpdateNoteVisibilityParams = BaseStatusParams & {
   to: string[]
   cc: string[]
@@ -773,6 +778,11 @@ export interface StatusDatabase {
   createAnnounce(params: CreateAnnounceParams): Promise<Status>
   createPoll(params: CreatePollParams): Promise<Status>
   updateNote(params: UpdateNoteParams): Promise<Status | null>
+  // Rewrites the status's quote-approval policy in the content blob without
+  // recording an edit (no status_history append, no edited_at bump).
+  updateStatusQuoteApprovalPolicy(
+    params: UpdateStatusQuoteApprovalPolicyParams
+  ): Promise<Status | null>
   updateNoteVisibility(
     params: UpdateNoteVisibilityParams
   ): Promise<Status | null>

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -33,6 +33,9 @@ export interface ActorSettings {
   defaultPrivacy?: 'public' | 'unlisted' | 'private' | 'direct'
   defaultSensitive?: boolean
   defaultLanguage?: string
+  // Default `quote_approval_policy` for new statuses (Mastodon 4.5
+  // `posting:default:quote_policy` / `source[quote_policy]`).
+  defaultQuotePolicy?: 'public' | 'followers' | 'nobody'
   postLineLimit?: PostLineLimit
   // Mastodon `reading:*` preferences surfaced by /api/v1/preferences.
   readingExpandMedia?: 'default' | 'show_all' | 'hide_all'

--- a/lib/types/mastodon/account/source.ts
+++ b/lib/types/mastodon/account/source.ts
@@ -5,6 +5,11 @@ import { Visibility } from '@/lib/types/mastodon/visibility'
 
 import { Field } from './field'
 
+// Inlined to keep this leaf schema free of a domain-type import cycle
+// (lib/types/domain/status pulls in mastodon types). Kept in lockstep with
+// QuoteApprovalPolicy in lib/types/domain/status.ts.
+const QuotePolicy = z.enum(['public', 'followers', 'nobody'])
+
 export const Source = z.object({
   note: z.string().describe('Profile bio, in plain-text instead of in HTML'),
   fields: Field.array().describe('Metadata about the account'),
@@ -17,6 +22,10 @@ export const Source = z.object({
   language: z
     .string()
     .describe('The default posting language for new statuses'),
+  // Mastodon 4.5 default quote-approval policy for new statuses.
+  quote_policy: QuotePolicy.optional().describe(
+    'The default quote approval policy to be used for new statuses.'
+  ),
   attribution_domains: z
     .string()
     .array()


### PR DESCRIPTION
## Epic 4.1c — Quote management API + preferences

Third PR of the Mastodon 4.5 quote-posts epic, on top of the merged 4.1a (data model + inbound federation, #1236) and 4.1b (outbound QuoteRequest/Accept/Reject handshake, #1239).

### New endpoints
- **`GET /api/v1/statuses/:id/quotes`** — the accepted quotes of a status, newest-first (`read`/`read:statuses`; 404 when the status isn't visible to the caller; `max_id`/`since_id`/`limit` (cap 40) with `Link` pagination).
- **`POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke`** — the quoted author withdraws approval (`write`/`write:statuses`; 403 unless they own the quoted status; 404 without a linking edge). Flips the edge to `revoked` (the hosted stamp then 404s) and delivers a FEP-044f `Delete` of the stamp to the quoting author's inbox via a new `SendQuoteRevokeJob`. Idempotent for an already-revoked quote.
- **`PUT /api/v1/statuses/:id/interaction_policy`** — the author sets `quote_approval_policy`. Rewrites the content-blob policy **without recording an edit** (no `status_history`, `edited_at` never flips — regression-tested) and re-federates so the advertised `interactionPolicy.canQuote` refreshes.

### Preferences & credentials
- `posting:default:quote_policy` added to `GET /api/v1/preferences`.
- `source[quote_policy]` accepted by `PATCH /api/v1/accounts/update_credentials` (and JSON `source.quote_policy`), persisted as `ActorSettings.defaultQuotePolicy` and echoed in the account `source`.
- `POST /api/v1/statuses` defaults an omitted `quote_approval_policy` to that per-account setting.

### Notes
- **No migration** — `defaultQuotePolicy` lives in the existing `actors.settings` JSON blob.
- The `followers`-policy `quote_approval.current_user` refinement (needs a batched follow-relationship lookup to avoid an N+1 in timeline serialization) is **deferred** and documented in `docs/mastodon-api-compatibility.md`.
- Docs updated in this landing PR: `docs/features.md` (quote posts) and `docs/mastodon-api-compatibility.md` (divergences + the hosted-stamp extension).

### Verification
- Gate green on the rebased tree: `prettier:check` ✓, `lint` 0 errors ✓, `build` ✓, **6519 tests** ✓.
- New tests: quotes list (filter/pagination/404), revoke (federate/idempotent/no-stamp/403/404), interaction_policy (policy set + `edited_at` stays null + enqueue + 403 + 422), preferences + update_credentials `quote_policy`, POST default-from-setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)