### PR TITLE
Bump version to v1.108.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.108.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.107.0`
- Base main SHA: `4887ff1dc2c1c634d46a63d0c67cc8a20e8e3dc2`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
