### PR TITLE
minor: quote-policy UI controls + quote client functions (Epic 4.1d)

### DIFF
--- a/app/api/v1/accounts/outbox/route.test.ts
+++ b/app/api/v1/accounts/outbox/route.test.ts
@@ -6,6 +6,7 @@ import { DELETE, POST } from './route'
 
 const mockCreateNoteFromUserInput = vi.fn()
 const mockCreatePollFromUserInput = vi.fn()
+const mockResolveQuoteForCreate = vi.fn()
 const mockGetServerSession = vi.fn()
 vi.mock('@/lib/actions/createNote', () => ({
   createNoteFromUserInput: (...args: unknown[]) =>
@@ -14,6 +15,10 @@ vi.mock('@/lib/actions/createNote', () => ({
 vi.mock('@/lib/actions/createPoll', () => ({
   createPollFromUserInput: (...args: unknown[]) =>
     mockCreatePollFromUserInput(...args)
+}))
+vi.mock('@/lib/services/quotes/resolveQuoteForCreate', () => ({
+  resolveQuoteForCreate: (...args: unknown[]) =>
+    mockResolveQuoteForCreate(...args)
 }))
 
 vi.mock('@/lib/services/auth/getSession', () => ({
@@ -43,6 +48,12 @@ describe('POST /api/v1/accounts/outbox', () => {
     })
     mockCreatePollFromUserInput.mockReset()
     mockCreatePollFromUserInput.mockResolvedValue({ id: 'poll-status' })
+    mockResolveQuoteForCreate.mockReset()
+    mockResolveQuoteForCreate.mockResolvedValue({
+      ok: true,
+      quotedStatusId: undefined,
+      quoteApprovalPolicy: undefined
+    })
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
@@ -84,6 +95,86 @@ describe('POST /api/v1/accounts/outbox', () => {
     await expect(res.json()).resolves.toEqual({
       error: 'Unprocessable entity'
     })
+  })
+
+  it('passes an authorized quote through to the create action', async () => {
+    mockResolveQuoteForCreate.mockResolvedValueOnce({
+      ok: true,
+      quotedStatusId: 'https://llun.test/users/alice/statuses/1',
+      quoteApprovalPolicy: 'followers'
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts/outbox', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'note',
+        message: 'quoting you',
+        quotedStatusId: 'https://llun.test/users/alice/statuses/1',
+        quoteApprovalPolicy: 'followers'
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://test.llun.dev'
+      }
+    })
+
+    await POST(req, { params: Promise.resolve({}) })
+
+    // The route authorized the quote (resolveQuoteForCreate ok) and forwarded
+    // the resolved target + policy to the create action.
+    expect(mockCreateNoteFromUserInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quotedStatusId: 'https://llun.test/users/alice/statuses/1',
+        quoteApprovalPolicy: 'followers'
+      })
+    )
+  })
+
+  it('returns 404 when the quote target is not found or unreadable', async () => {
+    mockResolveQuoteForCreate.mockResolvedValueOnce({
+      ok: false,
+      reason: 'not_found'
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts/outbox', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'note',
+        message: 'quoting a hidden post',
+        quotedStatusId: 'https://llun.test/users/alice/statuses/secret'
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://test.llun.dev'
+      }
+    })
+
+    const res = await POST(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(404)
+    expect(mockCreateNoteFromUserInput).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 when the quote policy denies the caller', async () => {
+    mockResolveQuoteForCreate.mockResolvedValueOnce({
+      ok: false,
+      reason: 'denied'
+    })
+    const req = new NextRequest('http://localhost/api/v1/accounts/outbox', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'note',
+        message: 'quoting a no-quote post',
+        quotedStatusId: 'https://llun.test/users/alice/statuses/nobody'
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://test.llun.dev'
+      }
+    })
+
+    const res = await POST(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(422)
+    expect(mockCreateNoteFromUserInput).not.toHaveBeenCalled()
   })
 
   it('returns 422 when a poll request fails validation in the action', async () => {

--- a/app/api/v1/accounts/outbox/route.ts
+++ b/app/api/v1/accounts/outbox/route.ts
@@ -7,6 +7,7 @@ import { createNoteFromUserInput } from '@/lib/actions/createNote'
 import { createPollFromUserInput } from '@/lib/actions/createPoll'
 import { deleteStatusFromUserInput } from '@/lib/actions/deleteStatus'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { resolveQuoteForCreate } from '@/lib/services/quotes/resolveQuoteForCreate'
 import { toActivityPubObject } from '@/lib/types/domain/status'
 import { HttpMethod } from '@/lib/utils/http-headers'
 import { logger } from '@/lib/utils/logger'
@@ -54,8 +55,28 @@ export const POST = traceApiRoute(
             replyStatus,
             attachments,
             fitnessFileId,
+            quotedStatusId: quotedStatusIdInput,
+            quoteApprovalPolicy: requestedQuotePolicy,
             visibility
           } = request
+          // Authorize the quote target (if any) and default the new status's
+          // quote policy, mirroring POST /api/v1/statuses.
+          const quoteResolution = await resolveQuoteForCreate({
+            database,
+            currentActor,
+            quotedStatusId: quotedStatusIdInput,
+            requestedPolicy: requestedQuotePolicy
+          })
+          if (!quoteResolution.ok) {
+            return apiResponse({
+              req,
+              allowedMethods: CORS_HEADERS,
+              data:
+                quoteResolution.reason === 'not_found' ? ERROR_404 : ERROR_422,
+              responseStatusCode:
+                quoteResolution.reason === 'not_found' ? 404 : 422
+            })
+          }
           const status = await createNoteFromUserInput({
             currentActor,
             text: message,
@@ -63,6 +84,8 @@ export const POST = traceApiRoute(
             replyNoteId: replyStatus?.id,
             attachments,
             fitnessFileId,
+            quotedStatusId: quoteResolution.quotedStatusId,
+            quoteApprovalPolicy: quoteResolution.quoteApprovalPolicy,
             visibility,
             database
           })

--- a/app/api/v1/accounts/outbox/types.ts
+++ b/app/api/v1/accounts/outbox/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { SecondsToDurationText } from '@/lib/components/post-box/poll-choices'
 import { PostBoxAttachment } from '@/lib/types/domain/attachment'
-import { Status } from '@/lib/types/domain/status'
+import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 export const CreateNoteRequest = z.object({
@@ -12,6 +12,10 @@ export const CreateNoteRequest = z.object({
   replyStatus: Status.optional(),
   attachments: PostBoxAttachment.array().optional(),
   fitnessFileId: z.string().optional(),
+  // The canonical URL id of the status this note quotes (FEP-044f), if any.
+  quotedStatusId: z.string().optional(),
+  // Who may quote the new status; omitted defaults to the actor's setting.
+  quoteApprovalPolicy: QuoteApprovalPolicy.optional(),
   visibility: z
     .enum(['public', 'unlisted', 'private', 'direct'])
     .optional() as z.ZodOptional<z.ZodType<MastodonVisibility>>

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -12,7 +12,7 @@ import {
 } from '@/lib/types/domain/attachment'
 import type { AdminCustomEmoji } from '@/lib/types/domain/customEmoji'
 import type { FilterAction, FilterContext } from '@/lib/types/domain/filter'
-import { Status } from '@/lib/types/domain/status'
+import { QuoteApprovalPolicy, Status } from '@/lib/types/domain/status'
 import type { Account as MastodonAccount } from '@/lib/types/mastodon/account'
 import type { Relationship as MastodonRelationship } from '@/lib/types/mastodon/account/relationship'
 import type { AdminAccount } from '@/lib/types/mastodon/admin/account'
@@ -39,6 +39,8 @@ export interface CreateNoteParams {
   message: string
   contentWarning?: string
   replyStatus?: Status
+  quotedStatus?: Status
+  quoteApprovalPolicy?: QuoteApprovalPolicy
   attachments?: PostBoxAttachment[]
   fitnessFileId?: string
   visibility?: MastodonVisibility
@@ -47,6 +49,8 @@ export const createNote = async ({
   message,
   contentWarning,
   replyStatus,
+  quotedStatus,
+  quoteApprovalPolicy,
   attachments = [],
   fitnessFileId,
   visibility
@@ -71,6 +75,8 @@ export const createNote = async ({
       contentWarning,
       attachments,
       fitnessFileId,
+      quotedStatusId: quotedStatus?.id,
+      quoteApprovalPolicy,
       visibility
     })
   })
@@ -825,6 +831,116 @@ export const getBlocks = async ({
     accounts: (await response.json()) as MastodonAccount[],
     nextMaxId: getCursorFromLinkHeader(linkHeader, 'next'),
     prevMinId: getCursorFromLinkHeader(linkHeader, 'prev')
+  }
+}
+
+// Reads a specific cursor query param from a rel in the Link header. The quotes
+// endpoint paginates with max_id (next) / since_id (prev) rather than min_id.
+const getLinkCursor = (
+  linkHeader: string | null,
+  rel: string,
+  param: string
+) => {
+  if (!linkHeader) return null
+  const link = linkHeader
+    .split(',')
+    .map((item) => item.trim())
+    .find((item) => item.endsWith(`rel="${rel}"`))
+  const url = link?.match(/<([^>]+)>/)?.[1]
+  if (!url) return null
+  return new URL(url).searchParams.get(param)
+}
+
+export interface GetStatusQuotesParams {
+  statusId: string
+  limit?: number
+  maxId?: string
+  sinceId?: string
+}
+export interface GetStatusQuotesResult {
+  statuses: MastodonStatus[]
+  nextMaxId: string | null
+  prevSinceId: string | null
+}
+export const getStatusQuotes = async ({
+  statusId,
+  limit,
+  maxId,
+  sinceId
+}: GetStatusQuotesParams): Promise<GetStatusQuotesResult> => {
+  const url = new URL(
+    `${window.origin}/api/v1/statuses/${urlToId(statusId)}/quotes`
+  )
+  if (limit) url.searchParams.set('limit', `${limit}`)
+  if (maxId) url.searchParams.set('max_id', maxId)
+  if (sinceId) url.searchParams.set('since_id', sinceId)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (response.status !== 200) {
+    return { statuses: [], nextMaxId: null, prevSinceId: null }
+  }
+
+  const linkHeader = response.headers.get('Link')
+  return {
+    statuses: (await response.json()) as MastodonStatus[],
+    nextMaxId: getLinkCursor(linkHeader, 'next', 'max_id'),
+    prevSinceId: getLinkCursor(linkHeader, 'prev', 'since_id')
+  }
+}
+
+export const revokeStatusQuote = async ({
+  quotedStatusId,
+  quotingStatusId
+}: {
+  quotedStatusId: string
+  quotingStatusId: string
+}): Promise<MastodonStatus | null> => {
+  const response = await fetch(
+    `/api/v1/statuses/${urlToId(quotedStatusId)}/quotes/${urlToId(quotingStatusId)}/revoke`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+  )
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonStatus
+}
+
+export const updateStatusInteractionPolicy = async ({
+  statusId,
+  quoteApprovalPolicy
+}: {
+  statusId: string
+  quoteApprovalPolicy: QuoteApprovalPolicy
+}): Promise<MastodonStatus | null> => {
+  const response = await fetch(
+    `/api/v1/statuses/${urlToId(statusId)}/interaction_policy`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quote_approval_policy: quoteApprovalPolicy })
+    }
+  )
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonStatus
+}
+
+// The default quote-approval policy for new statuses (Mastodon 4.5
+// posting:default:quote_policy). Falls back to 'public' on any failure.
+export const getDefaultQuotePolicy = async (): Promise<QuoteApprovalPolicy> => {
+  try {
+    const response = await fetch('/api/v1/preferences', {
+      method: 'GET',
+      headers: { Accept: 'application/json' }
+    })
+    if (response.status !== 200) return 'public'
+    const preferences = (await response.json()) as Record<string, unknown>
+    const policy = preferences['posting:default:quote_policy']
+    return QuoteApprovalPolicy.safeParse(policy).success
+      ? (policy as QuoteApprovalPolicy)
+      : 'public'
+  } catch {
+    return 'public'
   }
 }
 

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/lib/client', () => ({
   createPoll: vi.fn(),
   deleteFitnessFile: vi.fn(),
   getCustomEmojis: vi.fn().mockResolvedValue([]),
+  getDefaultQuotePolicy: vi.fn().mockResolvedValue('public'),
   updateNote: vi.fn(),
   uploadAttachment: vi.fn(),
   uploadFitnessFile: vi.fn()
@@ -233,6 +234,7 @@ describe('PostBox edit media', () => {
       expect(createNoteMock).toHaveBeenCalledWith(
         expect.objectContaining({
           message: '',
+          quoteApprovalPolicy: 'public',
           attachments: [
             expect.objectContaining({
               id: 'uploaded-media',

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -22,6 +22,7 @@ import {
   createPoll,
   deleteFitnessFile,
   getCustomEmojis,
+  getDefaultQuotePolicy,
   updateNote,
   uploadAttachment,
   uploadFitnessFile
@@ -40,6 +41,7 @@ import {
 } from '@/lib/types/domain/attachment'
 import {
   EditableStatus,
+  QuoteApprovalPolicy,
   Status,
   StatusNote,
   StatusType
@@ -55,6 +57,7 @@ import { processStatusTextContent } from '@/lib/utils/text/processStatusText'
 
 import { EmojiPickerButton } from './emoji-picker-button'
 import { Duration, PollChoices } from './poll-choices'
+import { QuoteApprovalPolicySelector } from './quote-approval-policy-selector'
 import {
   DEFAULT_STATE,
   addAttachment,
@@ -71,6 +74,7 @@ import {
   setPollDurationInSeconds,
   setPollType,
   setPollVisibility,
+  setQuoteApprovalPolicy,
   setVisibility,
   statusExtensionReducer,
   updateAttachment
@@ -321,10 +325,26 @@ export const PostBox: FC<Props> = ({
     DEFAULT_STATE
   )
   const postExtensionRef = useRef(postExtension)
+  // The actor's default quote policy (Mastodon posting:default:quote_policy),
+  // fetched once and re-applied after each post so it stays sticky across the
+  // resetExtension() that follows a successful create.
+  const defaultQuotePolicyRef = useRef<QuoteApprovalPolicy>('public')
 
   useEffect(() => {
     postExtensionRef.current = postExtension
   }, [postExtension])
+
+  useEffect(() => {
+    let active = true
+    getDefaultQuotePolicy().then((policy) => {
+      if (!active) return
+      defaultQuotePolicyRef.current = policy
+      dispatch(setQuoteApprovalPolicy(policy))
+    })
+    return () => {
+      active = false
+    }
+  }, [])
 
   useEffect(() => {
     textRef.current = text
@@ -645,12 +665,16 @@ export const PostBox: FC<Props> = ({
         replyStatus,
         attachments,
         fitnessFileId,
-        visibility: postExtension.visibility
+        visibility: postExtension.visibility,
+        quoteApprovalPolicy: postExtension.quoteApprovalPolicy
       })
 
       const { status, attachments: storedAttachments } = response
       onPostCreated(status, storedAttachments)
       dispatch(resetExtension())
+      // resetExtension() drops the policy back to the DEFAULT_STATE 'public';
+      // re-apply the actor's configured default so it stays sticky.
+      dispatch(setQuoteApprovalPolicy(defaultQuotePolicyRef.current))
 
       setText('')
       setIsPosting(false)
@@ -1112,6 +1136,11 @@ export const PostBox: FC<Props> = ({
               onVisibilityChange={(visibility) =>
                 dispatch(setVisibility(visibility))
               }
+              disabled={isPosting}
+            />
+            <QuoteApprovalPolicySelector
+              value={postExtension.quoteApprovalPolicy}
+              onChange={(policy) => dispatch(setQuoteApprovalPolicy(policy))}
               disabled={isPosting}
             />
             <Button

--- a/lib/components/post-box/quote-approval-policy-selector.test.tsx
+++ b/lib/components/post-box/quote-approval-policy-selector.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { QuoteApprovalPolicySelector } from './quote-approval-policy-selector'
+
+describe('QuoteApprovalPolicySelector', () => {
+  it('shows the current policy label on the trigger', () => {
+    render(<QuoteApprovalPolicySelector value="followers" onChange={vi.fn()} />)
+    expect(
+      screen.getByRole('button', { name: /followers can quote/i })
+    ).toBeInTheDocument()
+  })
+
+  it('invokes onChange with the picked policy', async () => {
+    const onChange = vi.fn()
+    render(<QuoteApprovalPolicySelector value="public" onChange={onChange} />)
+
+    // Radix dropdowns open from the keyboard in jsdom (matching the pattern
+    // used by the post-menu / section-nav dropdown tests).
+    fireEvent.keyDown(
+      screen.getByRole('button', { name: /anyone can quote/i }),
+      { key: 'ArrowDown' }
+    )
+    const option = await screen.findByRole('menuitemradio', {
+      name: /no one can quote/i
+    })
+    fireEvent.click(option)
+
+    expect(onChange).toHaveBeenCalledWith('nobody')
+  })
+})

--- a/lib/components/post-box/quote-approval-policy-selector.tsx
+++ b/lib/components/post-box/quote-approval-policy-selector.tsx
@@ -1,0 +1,123 @@
+import {
+  Ban,
+  Check,
+  ChevronDown,
+  Globe,
+  type LucideIcon,
+  Users
+} from 'lucide-react'
+import { FC } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/lib/components/ui/dropdown-menu'
+import { QuoteApprovalPolicy } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  value: QuoteApprovalPolicy
+  onChange: (policy: QuoteApprovalPolicy) => void
+  disabled?: boolean
+}
+
+const QUOTE_POLICY_OPTIONS: {
+  value: QuoteApprovalPolicy
+  label: string
+  Icon: LucideIcon
+  description: string
+}[] = [
+  {
+    value: 'public',
+    label: 'Anyone can quote',
+    Icon: Globe,
+    description: 'Everyone may quote this post'
+  },
+  {
+    value: 'followers',
+    label: 'Followers can quote',
+    Icon: Users,
+    description: 'Only your followers may quote this post'
+  },
+  {
+    value: 'nobody',
+    label: 'No one can quote',
+    Icon: Ban,
+    description: 'No one may quote this post'
+  }
+]
+
+// Composer control mirroring VisibilitySelector: pick who may quote the post
+// being written (Mastodon 4.5 quote_approval_policy).
+export const QuoteApprovalPolicySelector: FC<Props> = ({
+  value,
+  onChange,
+  disabled
+}) => {
+  const currentOption =
+    QUOTE_POLICY_OPTIONS.find((opt) => opt.value === value) ||
+    QUOTE_POLICY_OPTIONS[0]
+  const CurrentIcon = currentOption.Icon
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          title={currentOption.label}
+          aria-label={`Set who can quote, current: ${currentOption.label}`}
+          className="gap-1.5 px-2.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          <CurrentIcon className="size-4" />
+          <span>{currentOption.label}</span>
+          <ChevronDown className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        {QUOTE_POLICY_OPTIONS.map((option) => {
+          const active = option.value === value
+          const { Icon } = option
+          return (
+            <DropdownMenuItem
+              key={option.value}
+              role="menuitemradio"
+              aria-checked={active}
+              onSelect={() => onChange(option.value)}
+              className={cn(
+                'flex cursor-pointer items-start gap-2.5',
+                active &&
+                  'bg-primary/10 text-primary focus:bg-primary/15 focus:text-primary'
+              )}
+            >
+              <Icon
+                className={cn(
+                  'mt-0.5 size-4',
+                  active ? 'text-primary' : 'text-muted-foreground'
+                )}
+              />
+              <span className="min-w-0 flex-1">
+                <span
+                  className={cn('block font-medium', active && 'text-primary')}
+                >
+                  {option.label}
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+              {active ? (
+                <Check className="mt-0.5 ml-auto size-4 text-primary" />
+              ) : null}
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/lib/components/post-box/reducers.ts
+++ b/lib/components/post-box/reducers.ts
@@ -2,6 +2,7 @@ import { Reducer } from 'react'
 
 import { MAX_ATTACHMENTS } from '@/lib/services/medias/constants'
 import { PostBoxAttachment } from '@/lib/types/domain/attachment'
+import { QuoteApprovalPolicy } from '@/lib/types/domain/status'
 import { MastodonVisibility } from '@/lib/utils/getVisibility'
 
 import { Choice, DEFAULT_DURATION, Duration } from './poll-choices'
@@ -17,6 +18,8 @@ interface StatusExtension {
     pollType: 'oneOf' | 'anyOf'
   }
   visibility: MastodonVisibility
+  // Who may quote the post being composed (Mastodon 4.5 quote_approval_policy).
+  quoteApprovalPolicy: QuoteApprovalPolicy
   fitnessFile?: {
     file: File
     uploading: boolean
@@ -106,6 +109,14 @@ export const setVisibility = (visibility: MastodonVisibility) => ({
 })
 type ActionSetVisibility = ReturnType<typeof setVisibility>
 
+export const setQuoteApprovalPolicy = (
+  quoteApprovalPolicy: QuoteApprovalPolicy
+) => ({
+  type: 'setQuoteApprovalPolicy' as const,
+  quoteApprovalPolicy
+})
+type ActionSetQuoteApprovalPolicy = ReturnType<typeof setQuoteApprovalPolicy>
+
 export const setFitnessFile = (file: File) => ({
   type: 'setFitnessFile' as const,
   file
@@ -143,6 +154,7 @@ type Actions =
   | ActionUpdateAttachment
   | ActionRemoveAttachment
   | ActionSetVisibility
+  | ActionSetQuoteApprovalPolicy
   | ActionSetFitnessFile
   | ActionSetFitnessFileUploading
   | ActionSetFitnessFileUploaded
@@ -165,7 +177,8 @@ export const DEFAULT_STATE: StatusExtension = {
     durationInSeconds: DEFAULT_DURATION,
     pollType: 'oneOf'
   },
-  visibility: 'public'
+  visibility: 'public',
+  quoteApprovalPolicy: 'public'
 }
 
 export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
@@ -314,6 +327,12 @@ export const statusExtensionReducer: Reducer<StatusExtension, Actions> = (
       return {
         ...state,
         visibility: action.visibility
+      }
+    }
+    case 'setQuoteApprovalPolicy': {
+      return {
+        ...state,
+        quoteApprovalPolicy: action.quoteApprovalPolicy
       }
     }
     case 'setFitnessFile': {

--- a/lib/components/posts/actions/post-menu.test.tsx
+++ b/lib/components/posts/actions/post-menu.test.tsx
@@ -37,7 +37,8 @@ vi.mock('@/lib/client', () => ({
   unblock: vi.fn(),
   createReport: vi.fn(),
   deleteStatus: vi.fn(),
-  updateStatusVisibility: vi.fn()
+  updateStatusVisibility: vi.fn(),
+  updateStatusInteractionPolicy: vi.fn()
 }))
 
 const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
@@ -153,6 +154,9 @@ describe('PostMenu', () => {
     ).toBeInTheDocument()
     expect(
       within(menu).getByRole('menuitem', { name: 'Change visibility' })
+    ).toBeInTheDocument()
+    expect(
+      within(menu).getByRole('menuitem', { name: 'Change who can quote' })
     ).toBeInTheDocument()
     expect(
       within(menu).getByRole('menuitem', { name: 'Copy link to post' })

--- a/lib/components/posts/actions/post-menu.tsx
+++ b/lib/components/posts/actions/post-menu.tsx
@@ -9,11 +9,13 @@ import {
   Link as LinkIcon,
   Lock,
   Mail,
+  MessageSquareQuote,
   MoreHorizontal,
   Pencil,
   Trash2,
   TriangleAlert,
   Unlock,
+  Users,
   VolumeX
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -23,6 +25,7 @@ import {
   getRelationship,
   unblock,
   unmute,
+  updateStatusInteractionPolicy,
   updateStatusVisibility
 } from '@/lib/client'
 import { getActorIdMention } from '@/lib/components/posts/actor'
@@ -36,8 +39,10 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/lib/components/ui/dropdown-menu'
+import { getEffectiveQuoteApprovalPolicy } from '@/lib/services/quotes/quotePolicy'
 import {
   EditableStatus,
+  QuoteApprovalPolicy,
   Status,
   StatusNote,
   StatusPoll
@@ -65,6 +70,20 @@ const VISIBILITY_OPTIONS: {
     icon: <Lock className="size-4" />
   },
   { value: 'direct', label: 'Direct', icon: <Mail className="size-4" /> }
+]
+
+const QUOTE_POLICY_OPTIONS: {
+  value: QuoteApprovalPolicy
+  label: string
+  icon: ReactNode
+}[] = [
+  { value: 'public', label: 'Anyone', icon: <Globe className="size-4" /> },
+  {
+    value: 'followers',
+    label: 'Followers',
+    icon: <Users className="size-4" />
+  },
+  { value: 'nobody', label: 'No one', icon: <Ban className="size-4" /> }
 ]
 
 type ActiveDialog = 'mute' | 'block' | 'report' | 'delete' | null
@@ -121,6 +140,10 @@ export const PostMenu: FC<Props> = ({
     getVisibility(status.to, status.cc)
   )
   const [visibilitySaving, setVisibilitySaving] = useState(false)
+  const [quotePolicy, setQuotePolicy] = useState<QuoteApprovalPolicy>(
+    getEffectiveQuoteApprovalPolicy(status)
+  )
+  const [quotePolicySaving, setQuotePolicySaving] = useState(false)
 
   useEffect(() => {
     if (!copied) return
@@ -178,6 +201,25 @@ export const PostMenu: FC<Props> = ({
     if (!success) {
       setVisibility(previous)
       setActionError("Couldn't change post visibility. Please try again.")
+    }
+  }
+
+  const handleQuotePolicyChange = async (next: QuoteApprovalPolicy) => {
+    if (next === quotePolicy || quotePolicySaving) return
+    const previous = quotePolicy
+    setQuotePolicy(next)
+    setQuotePolicySaving(true)
+    setActionError(null)
+    const updated = await updateStatusInteractionPolicy({
+      statusId: status.id,
+      quoteApprovalPolicy: next
+    })
+    setQuotePolicySaving(false)
+    if (!updated) {
+      setQuotePolicy(previous)
+      setActionError(
+        "Couldn't change who can quote this post. Please try again."
+      )
     }
   }
 
@@ -267,6 +309,29 @@ export const PostMenu: FC<Props> = ({
                       {option.icon}
                       <span className="flex-1">{option.label}</span>
                       {option.value === visibility ? (
+                        <Check className="size-4 text-primary" />
+                      ) : null}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <MessageSquareQuote className="size-4" />
+                  Change who can quote
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-52">
+                  {QUOTE_POLICY_OPTIONS.map((option) => (
+                    <DropdownMenuItem
+                      key={option.value}
+                      disabled={quotePolicySaving}
+                      onSelect={() => {
+                        void handleQuotePolicyChange(option.value)
+                      }}
+                    >
+                      {option.icon}
+                      <span className="flex-1">{option.label}</span>
+                      {option.value === quotePolicy ? (
                         <Check className="size-4 text-primary" />
                       ) : null}
                     </DropdownMenuItem>

--- a/lib/services/quotes/resolveQuoteForCreate.test.ts
+++ b/lib/services/quotes/resolveQuoteForCreate.test.ts
@@ -1,0 +1,115 @@
+import type { Database } from '@/lib/database/types'
+import { resolveQuoteForCreate } from '@/lib/services/quotes/resolveQuoteForCreate'
+import type { Actor } from '@/lib/types/domain/actor'
+
+const { mockCanActorReadStatus, mockCanQuoteStatus } = vi.hoisted(() => ({
+  mockCanActorReadStatus: vi.fn(),
+  mockCanQuoteStatus: vi.fn()
+}))
+
+vi.mock('@/lib/services/statusAccess', () => ({
+  canActorReadStatus: mockCanActorReadStatus
+}))
+vi.mock('@/lib/services/quotes/canQuoteStatus', () => ({
+  canQuoteStatus: mockCanQuoteStatus
+}))
+
+const currentActor = { id: 'https://llun.test/users/me' } as Actor
+const QUOTED_URL = 'https://llun.test/users/alice/statuses/1'
+
+const makeDatabase = (
+  overrides: Partial<{
+    quotedStatus: unknown
+    defaultQuotePolicy: 'public' | 'followers' | 'nobody' | undefined
+  }> = {}
+): Database =>
+  ({
+    getStatus: vi
+      .fn()
+      .mockResolvedValue(
+        'quotedStatus' in overrides
+          ? overrides.quotedStatus
+          : { id: QUOTED_URL, actorId: 'https://llun.test/users/alice' }
+      ),
+    getActorSettings: vi
+      .fn()
+      .mockResolvedValue({ defaultQuotePolicy: overrides.defaultQuotePolicy })
+  }) as unknown as Database
+
+describe('resolveQuoteForCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCanActorReadStatus.mockResolvedValue(true)
+    mockCanQuoteStatus.mockResolvedValue('automatic')
+  })
+
+  it('resolves the quoted status id and defaults the policy from the actor setting', async () => {
+    const database = makeDatabase({ defaultQuotePolicy: 'followers' })
+    const result = await resolveQuoteForCreate({
+      database,
+      currentActor,
+      quotedStatusId: QUOTED_URL
+    })
+    expect(result).toEqual({
+      ok: true,
+      quotedStatusId: QUOTED_URL,
+      quoteApprovalPolicy: 'followers'
+    })
+  })
+
+  it('prefers an explicit requested policy over the actor default', async () => {
+    const database = makeDatabase({ defaultQuotePolicy: 'followers' })
+    const result = await resolveQuoteForCreate({
+      database,
+      currentActor,
+      quotedStatusId: QUOTED_URL,
+      requestedPolicy: 'nobody'
+    })
+    expect(result).toMatchObject({ ok: true, quoteApprovalPolicy: 'nobody' })
+  })
+
+  it('returns ok with no quoted id and the default policy when nothing is quoted', async () => {
+    const database = makeDatabase({ defaultQuotePolicy: 'public' })
+    const result = await resolveQuoteForCreate({
+      database,
+      currentActor
+    })
+    expect(result).toEqual({
+      ok: true,
+      quotedStatusId: undefined,
+      quoteApprovalPolicy: 'public'
+    })
+  })
+
+  it('returns not_found when the quoted status does not exist', async () => {
+    const database = makeDatabase({ quotedStatus: null })
+    const result = await resolveQuoteForCreate({
+      database,
+      currentActor,
+      quotedStatusId: QUOTED_URL
+    })
+    expect(result).toEqual({ ok: false, reason: 'not_found' })
+  })
+
+  it('returns not_found when the quoted status is not readable by the caller', async () => {
+    mockCanActorReadStatus.mockResolvedValue(false)
+    const database = makeDatabase()
+    const result = await resolveQuoteForCreate({
+      database,
+      currentActor,
+      quotedStatusId: QUOTED_URL
+    })
+    expect(result).toEqual({ ok: false, reason: 'not_found' })
+  })
+
+  it('returns denied when the quote policy denies the caller', async () => {
+    mockCanQuoteStatus.mockResolvedValue('denied')
+    const database = makeDatabase()
+    const result = await resolveQuoteForCreate({
+      database,
+      currentActor,
+      quotedStatusId: QUOTED_URL
+    })
+    expect(result).toEqual({ ok: false, reason: 'denied' })
+  })
+})

--- a/lib/services/quotes/resolveQuoteForCreate.ts
+++ b/lib/services/quotes/resolveQuoteForCreate.ts
@@ -1,0 +1,72 @@
+import { Database } from '@/lib/database/types'
+import { canQuoteStatus } from '@/lib/services/quotes/canQuoteStatus'
+import { canActorReadStatus } from '@/lib/services/statusAccess'
+import { Actor } from '@/lib/types/domain/actor'
+import { QuoteApprovalPolicy } from '@/lib/types/domain/status'
+
+type ResolveQuoteForCreateParams = {
+  database: Database
+  currentActor: Actor
+  // The canonical quoted status URL id (callers that receive an opaque/encoded
+  // id must decode it with idToUrl first), if any.
+  quotedStatusId?: string
+  // The client-supplied quote_approval_policy for the NEW status, if any.
+  requestedPolicy?: QuoteApprovalPolicy
+}
+
+export type ResolveQuoteForCreateResult =
+  | {
+      ok: true
+      // Canonical quoted status URL id (undefined when nothing is quoted).
+      quotedStatusId?: string
+      // Effective policy for the new status: the requested value, else the
+      // actor's default (undefined leaves the per-status visibility fallback).
+      quoteApprovalPolicy?: QuoteApprovalPolicy
+    }
+  | { ok: false; reason: 'not_found' | 'denied' }
+
+/**
+ * Shared quote authorization + policy defaulting for the status-create paths.
+ * When a quote target is supplied it must be readable by the caller (else
+ * `not_found`) and its author's policy must permit the quote (else `denied`),
+ * mirroring `POST /api/v1/statuses`. The new status's own quote-approval policy
+ * defaults to the actor's `defaultQuotePolicy` when the caller omits it.
+ */
+export const resolveQuoteForCreate = async ({
+  database,
+  currentActor,
+  quotedStatusId: quotedStatusIdInput,
+  requestedPolicy
+}: ResolveQuoteForCreateParams): Promise<ResolveQuoteForCreateResult> => {
+  let quotedStatusId: string | undefined
+  if (quotedStatusIdInput) {
+    const quotedStatus = await database.getStatus({
+      statusId: quotedStatusIdInput,
+      withReplies: false
+    })
+    if (
+      !quotedStatus ||
+      !(await canActorReadStatus({
+        database,
+        status: quotedStatus,
+        currentActor
+      }))
+    ) {
+      return { ok: false, reason: 'not_found' }
+    }
+    const verdict = await canQuoteStatus({
+      database,
+      quotedStatus,
+      quotingActorId: currentActor.id
+    })
+    if (verdict === 'denied') return { ok: false, reason: 'denied' }
+    quotedStatusId = quotedStatusIdInput
+  }
+
+  const quoteApprovalPolicy =
+    requestedPolicy ??
+    (await database.getActorSettings({ actorId: currentActor.id }))
+      ?.defaultQuotePolicy
+
+  return { ok: true, quotedStatusId, quoteApprovalPolicy }
+}


### PR DESCRIPTION
## Epic 4.1d — Quote UI (client functions + quote-policy controls)

Final PR of the Mastodon 4.5 quote-posts epic, on top of merged 4.1a (#1236), 4.1b (#1239), and 4.1c (#1249).

### Client functions (`lib/client.ts`)
- `getStatusQuotes`, `revokeStatusQuote`, `updateStatusInteractionPolicy`, `getDefaultQuotePolicy`, and `quoted_status_id`/`quote_approval_policy` passthrough on `createNote`.
- New shared `resolveQuoteForCreate` service authorizes a quote target (`not_found`/`denied`) and defaults the new status's policy from the actor setting; the outbox create path now carries + authorizes quotes (mirrors `POST /api/v1/statuses`).

### Quote-policy authoring UI (design-system components, browser-verified)
- **Composer**: a `QuoteApprovalPolicySelector` in the post-box toolbar (Anyone / Followers / No one), seeded from `posting:default:quote_policy` and kept sticky across posts; the chosen policy flows through `createNote`.
- **Status menu (own posts)**: a "Change who can quote" submenu calling `updateStatusInteractionPolicy`, preselected from `getEffectiveQuoteApprovalPolicy`, with optimistic update + rollback (mirrors "Change visibility").

### Verification
- Gate green: `prettier:check` ✓, `lint` 0 errors ✓, `build` ✓, **6531 tests** ✓ (new: `resolveQuoteForCreate`, outbox quote passthrough, `QuoteApprovalPolicySelector`, post-box policy passthrough, post-menu "Change who can quote").
- **Browser-verified** on the local SQLite stack (mock user): the composer selector renders and its dropdown shows all three policies with the correct default/active state (screenshots below).

### Deferred follow-up (documented, not in this PR)
Two pieces are intentionally left for a focused follow-up because each carries risk/scope disproportionate to a safe landing here:
- **"Quote this post" compose action** — opening the composer with a pinned quoted-status preview needs the timeline `statusActionReducer` + an `onQuote` prop drilled through `Post`/`Actions`/`PostMenu` across ~7 components. The create side is already wired (`createNote` accepts `quotedStatus`; the outbox authorizes it), so this is UI plumbing only.
- **Embedded quote card rendering** — the web UI renders the *domain* `Status`, whose `quote` edge carries no embedded quoted status; a full card needs a batched, downgrade-aware hydration in the hot `getStatusesByIds` path (mirroring the Mastodon serializer). Deferred to avoid a rushed change to the timeline hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)