### PR TITLE
minor: quote-compose action + embedded quote card (Epic 4.1e)

### DIFF
--- a/app/(timeline)/MainPageTimeline.tsx
+++ b/app/(timeline)/MainPageTimeline.tsx
@@ -16,7 +16,12 @@ import { ActorProfile } from '@/lib/types/domain/actor'
 import { EditableStatus, Status } from '@/lib/types/domain/status'
 import { cn } from '@/lib/utils'
 
-import { clearAction, editAction, statusActionReducer } from './reducer'
+import {
+  clearAction,
+  editAction,
+  quoteAction,
+  statusActionReducer
+} from './reducer'
 
 interface MainPageTimelineProps {
   host: string
@@ -57,6 +62,11 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
 
   const onEdit = (status: EditableStatus) => {
     dispatchStatusAction(editAction(status))
+    window.scrollTo({ top: 0 })
+  }
+
+  const onQuote = (status: Status) => {
+    dispatchStatusAction(quoteAction(status))
     window.scrollTo({ top: 0 })
   }
 
@@ -196,8 +206,10 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
           profile={profile}
           replyStatus={statusActionState.replyStatus}
           editStatus={statusActionState.editStatus}
+          quotedStatus={statusActionState.quoteStatus}
           isMediaUploadEnabled={isMediaUploadEnabled}
           onDiscardReply={() => dispatchStatusAction(clearAction())}
+          onDiscardQuote={() => dispatchStatusAction(clearAction())}
           onDiscardEdit={() => dispatchStatusAction(clearAction())}
           onPostCreated={(status: Status) => {
             setCurrentStatuses((previousValue) => [status, ...previousValue])
@@ -226,6 +238,7 @@ export const MainPageTimeline: FC<MainPageTimelineProps> = ({
             postLineLimit={postLineLimit}
             onReplyCreated={onReplyCreated}
             onEdit={onEdit}
+            onQuote={onQuote}
             onPostDeleted={onPostDeleted}
           />
         ) : isLoadingMoreStatuses || isRefreshing ? (

--- a/app/(timeline)/reducer.test.ts
+++ b/app/(timeline)/reducer.test.ts
@@ -1,0 +1,40 @@
+import { EditableStatus, Status } from '@/lib/types/domain/status'
+
+import {
+  clearAction,
+  editAction,
+  quoteAction,
+  replyAction,
+  statusActionReducer
+} from './reducer'
+
+const status = { id: 'https://llun.test/users/a/statuses/1' } as Status
+
+describe('statusActionReducer', () => {
+  it('sets quoteStatus (and only that) on a quote action', () => {
+    const next = statusActionReducer(
+      { replyStatus: status },
+      quoteAction(status)
+    )
+    expect(next).toEqual({ quoteStatus: status })
+  })
+
+  it('sets replyStatus on a reply action', () => {
+    expect(statusActionReducer({}, replyAction(status))).toEqual({
+      replyStatus: status
+    })
+  })
+
+  it('sets editStatus on an edit action', () => {
+    const editable = status as unknown as EditableStatus
+    expect(statusActionReducer({}, editAction(editable))).toEqual({
+      editStatus: editable
+    })
+  })
+
+  it('clears all pending actions on clear', () => {
+    expect(statusActionReducer({ quoteStatus: status }, clearAction())).toEqual(
+      {}
+    )
+  })
+})

--- a/app/(timeline)/reducer.ts
+++ b/app/(timeline)/reducer.ts
@@ -14,18 +14,26 @@ export const editAction = (status: EditableStatus) => ({
 })
 export type EditAction = ReturnType<typeof editAction>
 
+export const quoteAction = (status: Status) => ({
+  type: 'quote' as const,
+  status
+})
+export type QuoteAction = ReturnType<typeof quoteAction>
+
 export const clearAction = () => ({ type: 'clear' as const })
 export type ClearAction = ReturnType<typeof clearAction>
 
 export const statusActionReducer: Reducer<
-  { replyStatus?: Status; editStatus?: EditableStatus },
-  ReplyAction | EditAction | ClearAction
+  { replyStatus?: Status; editStatus?: EditableStatus; quoteStatus?: Status },
+  ReplyAction | EditAction | QuoteAction | ClearAction
 > = (state, action) => {
   switch (action.type) {
     case 'edit':
       return { editStatus: action.status }
     case 'reply':
       return { replyStatus: action.status }
+    case 'quote':
+      return { quoteStatus: action.status }
     default: {
       return {}
     }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -891,6 +891,20 @@ export const getStatusQuotes = async ({
   }
 }
 
+// Fetch a single status by id (Mastodon shape). Returns null when the status is
+// not found OR not readable by the caller (the route 404s in both cases), so a
+// quote card never renders content the viewer isn't allowed to see.
+export const getStatusById = async (
+  statusId: string
+): Promise<MastodonStatus | null> => {
+  const response = await fetch(`/api/v1/statuses/${urlToId(statusId)}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' }
+  })
+  if (response.status !== 200) return null
+  return (await response.json()) as MastodonStatus
+}
+
 export const revokeStatusQuote = async ({
   quotedStatusId,
   quotingStatusId

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -291,6 +291,39 @@ describe('PostBox edit media', () => {
     })
   })
 
+  it('disables the poll toggle while composing a quote (mutually exclusive)', async () => {
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Add poll' })).toBeDisabled()
+  })
+
   it('keeps a new post with media enabled when text is cleared', async () => {
     render(
       <PostBox

--- a/lib/components/post-box/post-box.test.tsx
+++ b/lib/components/post-box/post-box.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/client'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
-import { EditableStatus, StatusType } from '@/lib/types/domain/status'
+import { EditableStatus, Status, StatusType } from '@/lib/types/domain/status'
 
 import { PostBox } from './post-box'
 
@@ -242,6 +242,51 @@ describe('PostBox edit media', () => {
             })
           ]
         })
+      )
+    })
+  })
+
+  it('shows the quoted preview and sends quotedStatus when composing a quote', async () => {
+    const quotedStatus = {
+      id: 'https://activities.local/users/bob/statuses/1',
+      actorId: 'https://activities.local/users/bob',
+      actor: {
+        id: 'https://activities.local/users/bob',
+        username: 'bob',
+        domain: 'activities.local',
+        name: 'Bob'
+      },
+      type: StatusType.enum.Note,
+      text: 'quote me please',
+      tags: [],
+      to: [],
+      cc: []
+    } as unknown as Status
+
+    render(
+      <PostBox
+        host="activities.local"
+        profile={profile}
+        quotedStatus={quotedStatus}
+        onDiscardReply={vi.fn()}
+        onDiscardQuote={vi.fn()}
+        onPostCreated={vi.fn()}
+        onPostUpdated={vi.fn()}
+        onDiscardEdit={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Quoting')).toBeInTheDocument()
+
+    const textbox = screen.getByPlaceholderText('What is on your mind?')
+    fireEvent.change(textbox, { target: { value: 'my commentary' } })
+    const postButton = screen.getByRole('button', { name: 'Post' })
+    await waitFor(() => expect(postButton).toBeEnabled())
+    fireEvent.click(postButton)
+
+    await waitFor(() => {
+      expect(createNoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'my commentary', quotedStatus })
       )
     })
   })

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -351,6 +351,16 @@ export const PostBox: FC<Props> = ({
     }
   }, [])
 
+  // Quote and poll are mutually exclusive (a quote post cannot carry a poll).
+  // If a poll is open when a quote is started, close it so the poll create
+  // branch can never run with a quote (which would drop the quote and leak the
+  // quoted status onto the next post).
+  useEffect(() => {
+    if (quotedStatus && postExtensionRef.current.poll.showing) {
+      dispatch(setPollVisibility(false))
+    }
+  }, [quotedStatus])
+
   useEffect(() => {
     textRef.current = text
   }, [text])
@@ -1108,8 +1118,16 @@ export const PostBox: FC<Props> = ({
                 postExtension.poll.showing ? 'Remove poll' : 'Add poll'
               }
               aria-pressed={postExtension.poll.showing}
-              disabled={isPosting}
-              title={postExtension.poll.showing ? 'Remove poll' : 'Add poll'}
+              // A quote post cannot carry a poll (they are mutually exclusive,
+              // like media); disable the toggle while quoting.
+              disabled={isPosting || Boolean(quotedStatus)}
+              title={
+                quotedStatus
+                  ? 'A quote post cannot include a poll'
+                  : postExtension.poll.showing
+                    ? 'Remove poll'
+                    : 'Add poll'
+              }
               className={cn(
                 postExtension.poll.showing
                   ? 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'

--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -58,6 +58,7 @@ import { processStatusTextContent } from '@/lib/utils/text/processStatusText'
 import { EmojiPickerButton } from './emoji-picker-button'
 import { Duration, PollChoices } from './poll-choices'
 import { QuoteApprovalPolicySelector } from './quote-approval-policy-selector'
+import { QuotedPreview } from './quoted-preview'
 import {
   DEFAULT_STATE,
   addAttachment,
@@ -89,8 +90,10 @@ interface Props {
   profile: ActorProfile
   replyStatus?: Status
   editStatus?: EditableStatus
+  quotedStatus?: Status
   isMediaUploadEnabled?: boolean
   onDiscardReply: () => void
+  onDiscardQuote?: () => void
   onPostCreated: (status: Status, attachments: Attachment[]) => void
   onPostUpdated: (status: Status) => void
   onDiscardEdit: () => void
@@ -300,10 +303,12 @@ export const PostBox: FC<Props> = ({
   profile,
   replyStatus,
   editStatus,
+  quotedStatus,
   isMediaUploadEnabled,
   onPostCreated,
   onPostUpdated,
   onDiscardReply,
+  onDiscardQuote,
   onDiscardEdit
 }) => {
   const [allowPost, setAllowPost] = useState<boolean>(false)
@@ -663,6 +668,7 @@ export const PostBox: FC<Props> = ({
         message,
         contentWarning,
         replyStatus,
+        quotedStatus,
         attachments,
         fitnessFileId,
         visibility: postExtension.visibility,
@@ -697,6 +703,10 @@ export const PostBox: FC<Props> = ({
   const onCloseReply = () => {
     onDiscardReply()
     setText('')
+  }
+
+  const onCloseQuote = () => {
+    onDiscardQuote?.()
   }
 
   const onRemoveAttachment = (attachmentIndex: number) => {
@@ -956,6 +966,11 @@ export const PostBox: FC<Props> = ({
               host={host}
               status={replyStatus}
               onClose={onCloseReply}
+            />
+            <QuotedPreview
+              host={host}
+              status={quotedStatus}
+              onClose={onCloseQuote}
             />
             {postExtension.contentWarningVisible ? (
               <input

--- a/lib/components/post-box/quoted-preview.tsx
+++ b/lib/components/post-box/quoted-preview.tsx
@@ -1,0 +1,65 @@
+import { X } from 'lucide-react'
+import { FC } from 'react'
+
+import { ActorInfo } from '@/lib/components/posts/actor'
+import { Button } from '@/lib/components/ui/button'
+import { Status } from '@/lib/types/domain/status'
+import { cn } from '@/lib/utils'
+import { cleanClassName } from '@/lib/utils/text/cleanClassName'
+import { processStatusText } from '@/lib/utils/text/processStatusText'
+
+interface Props {
+  host: string
+  status?: Status
+  onClose?: () => void
+  className?: string
+}
+
+// Composer preview of the status being quoted, mirroring ReplyPreview. Pinned
+// under the textarea so the author sees what they're quoting before posting.
+export const QuotedPreview: FC<Props> = ({
+  host,
+  status,
+  onClose,
+  className
+}) => {
+  if (!status) return null
+
+  const previewText = processStatusText(host, status)
+  const parsedPreview = previewText ? cleanClassName(previewText) : null
+
+  return (
+    <section
+      className={cn(
+        'rounded-xl border border-border/60 border-l-4 border-l-primary/40 bg-muted/20 px-3 py-2',
+        className
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="font-medium">Quoting</span>
+            <div className="text-sm text-foreground">
+              <ActorInfo actor={status.actor} actorId={status.actorId || ''} />
+            </div>
+          </div>
+          <div className="mt-1 text-sm text-muted-foreground leading-relaxed line-clamp-2 break-words [&_a]:text-sky-600 dark:[&_a]:text-sky-400 [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-sky-700 dark:[&_a:hover]:text-sky-300 [&_p]:inline [&_p]:after:content-['_'] [&_br]:hidden">
+            {parsedPreview ?? (
+              <span className="italic">No content preview</span>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onClose?.()}
+          aria-label="Dismiss quote"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/lib/components/posts/actions/actions.tsx
+++ b/lib/components/posts/actions/actions.tsx
@@ -27,6 +27,7 @@ export const Actions: FC<Props> = ({
   showActions = false,
   onReply,
   onEdit,
+  onQuote,
   onShowEdits,
   onPostDeleted,
   onBookmarkChanged,
@@ -94,6 +95,7 @@ export const Actions: FC<Props> = ({
         canEdit={canEdit}
         onReply={onReply}
         onEdit={onEdit}
+        onQuote={onQuote}
         onPostDeleted={onPostDeleted}
       />
     </div>

--- a/lib/components/posts/actions/post-menu.test.tsx
+++ b/lib/components/posts/actions/post-menu.test.tsx
@@ -169,6 +169,31 @@ describe('PostMenu', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('offers a Quote action when onQuote is provided and fires it', async () => {
+    const onQuote = vi.fn()
+    render(
+      <PostMenu
+        status={otherStatus}
+        isOwner={false}
+        canEdit={false}
+        onQuote={onQuote}
+      />
+    )
+
+    const menu = await openMenu()
+    const quoteItem = within(menu).getByRole('menuitem', { name: 'Quote post' })
+    fireEvent.click(quoteItem)
+    expect(onQuote).toHaveBeenCalledWith(otherStatus)
+  })
+
+  it('omits the Quote action when onQuote is not provided', async () => {
+    render(<PostMenu status={otherStatus} isOwner={false} canEdit={false} />)
+    const menu = await openMenu()
+    expect(
+      within(menu).queryByRole('menuitem', { name: 'Quote post' })
+    ).not.toBeInTheDocument()
+  })
+
   it('shows relationship actions for another actor’s post', async () => {
     render(<PostMenu status={otherStatus} isOwner={false} canEdit={false} />)
 

--- a/lib/components/posts/actions/post-menu.tsx
+++ b/lib/components/posts/actions/post-menu.tsx
@@ -96,6 +96,7 @@ interface Props {
   canEdit: boolean
   onReply?: (status: Status) => void
   onEdit?: (status: EditableStatus) => void
+  onQuote?: (status: Status) => void
   onPostDeleted?: (status: Status) => void
 }
 
@@ -112,6 +113,7 @@ export const PostMenu: FC<Props> = ({
   canEdit,
   onReply,
   onEdit,
+  onQuote,
   onPostDeleted
 }) => {
   const router = useRouter()
@@ -280,6 +282,15 @@ export const PostMenu: FC<Props> = ({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-60">
+          {onQuote ? (
+            <>
+              <DropdownMenuItem onSelect={() => onQuote(status)}>
+                <MessageSquareQuote className="size-4" />
+                Quote post
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          ) : null}
           {isOwner ? (
             <>
               {canEdit ? (

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -35,6 +35,7 @@ import { CollapsibleContent } from './collapsible-content'
 import { ContentWarning } from './content-warning'
 import { FitnessProcessingProgress } from './fitness-processing-progress'
 import { Poll } from './poll'
+import { QuoteCard } from './quote-card'
 import { ReadOnlyStats } from './read-only-stats'
 import { RetryFitnessButton } from './retry-fitness-button'
 import { TranslateContent } from './translate-content'
@@ -55,6 +56,7 @@ export interface PostProps {
   showReadOnlyStats?: boolean
   onReply?: (status: Status) => void
   onEdit?: (status: EditableStatus) => void
+  onQuote?: (status: Status) => void
   onPostDeleted?: (status: Status) => void
   onBookmarkChanged?: (
     status: StatusNote | StatusPoll,
@@ -290,6 +292,9 @@ export const Post: FC<PostProps> = (props) => {
         currentActorId={props.currentActor?.id}
       />
       <Attachments status={actualStatus} onMediaSelected={onShowAttachment} />
+      {actualStatus.quote ? (
+        <QuoteCard quote={actualStatus.quote} currentTime={props.currentTime} />
+      ) : null}
     </TranslationProvider>
   )
 

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -43,6 +43,7 @@ interface Props {
   onReply?: (status: Status) => void
   onReplyCreated?: (status: Status, attachments: Attachment[]) => void
   onEdit?: (status: EditableStatus) => void
+  onQuote?: (status: Status) => void
   onPostDeleted?: (status: Status) => void
   onBookmarkChanged?: (
     status: StatusNote | StatusPoll,
@@ -65,6 +66,7 @@ export const Posts: FC<Props> = ({
   onReply,
   onReplyCreated,
   onEdit,
+  onQuote,
   onPostDeleted,
   onBookmarkChanged,
   onLikeChanged
@@ -140,6 +142,7 @@ export const Posts: FC<Props> = ({
               postLineLimit={postLineLimit}
               onReply={handleReply}
               onEdit={onEdit}
+              onQuote={onQuote}
               onPostDeleted={onPostDeleted}
               onBookmarkChanged={onBookmarkChanged}
               onLikeChanged={onLikeChanged}

--- a/lib/components/posts/quote-card.test.tsx
+++ b/lib/components/posts/quote-card.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { StatusQuote } from '@/lib/types/domain/status'
+import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
+
+import { QuoteCard } from './quote-card'
+
+const { mockGetStatusById } = vi.hoisted(() => ({
+  mockGetStatusById: vi.fn()
+}))
+vi.mock('@/lib/client', () => ({
+  getStatusById: mockGetStatusById
+}))
+
+const CURRENT_TIME = Date.parse('2026-07-18T00:00:00.000Z')
+
+const quote = (overrides: Partial<StatusQuote> = {}): StatusQuote => ({
+  quotedStatusId: 'https://remote.example/users/bob/statuses/1',
+  state: 'accepted',
+  authorizationUri: null,
+  ...overrides
+})
+
+const mastodonStatus = (): MastodonStatus =>
+  ({
+    id: 'https://remote.example/users/bob/statuses/1',
+    url: 'https://remote.example/@bob/1',
+    uri: 'https://remote.example/users/bob/statuses/1',
+    content: '<p>the quoted content</p>',
+    created_at: '2026-07-17T23:30:00.000Z',
+    account: {
+      acct: 'bob@remote.example',
+      username: 'bob',
+      display_name: 'Bob',
+      avatar: 'https://remote.example/avatars/bob.png',
+      url: 'https://remote.example/@bob'
+    }
+  }) as unknown as MastodonStatus
+
+describe('QuoteCard', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the quoted post preview for an accepted quote', async () => {
+    mockGetStatusById.mockResolvedValue(mastodonStatus())
+    render(<QuoteCard quote={quote()} currentTime={CURRENT_TIME} />)
+
+    expect(await screen.findByText('the quoted content')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+    expect(screen.getByText('@bob@remote.example')).toBeInTheDocument()
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://remote.example/@bob/1')
+  })
+
+  it('shows an unavailable tombstone when the quoted post is not readable', async () => {
+    mockGetStatusById.mockResolvedValue(null)
+    render(<QuoteCard quote={quote()} currentTime={CURRENT_TIME} />)
+
+    expect(
+      await screen.findByText('This quoted post is unavailable')
+    ).toBeInTheDocument()
+  })
+
+  it.each([
+    { state: 'pending', text: 'Quote pending approval' },
+    { state: 'rejected', text: 'This quote was declined' },
+    { state: 'revoked', text: 'This quote was withdrawn' },
+    { state: 'deleted', text: 'The quoted post is no longer available' }
+  ] as const)(
+    'renders the $state tombstone without fetching',
+    async ({ state, text }) => {
+      render(<QuoteCard quote={quote({ state })} currentTime={CURRENT_TIME} />)
+      expect(screen.getByText(text)).toBeInTheDocument()
+      await waitFor(() => expect(mockGetStatusById).not.toHaveBeenCalled())
+    }
+  )
+})

--- a/lib/components/posts/quote-card.test.tsx
+++ b/lib/components/posts/quote-card.test.tsx
@@ -64,6 +64,15 @@ describe('QuoteCard', () => {
     ).toBeInTheDocument()
   })
 
+  it('falls back to the unavailable tombstone when the fetch rejects', async () => {
+    mockGetStatusById.mockRejectedValue(new Error('network down'))
+    render(<QuoteCard quote={quote()} currentTime={CURRENT_TIME} />)
+
+    expect(
+      await screen.findByText('This quoted post is unavailable')
+    ).toBeInTheDocument()
+  })
+
   it.each([
     { state: 'pending', text: 'Quote pending approval' },
     { state: 'rejected', text: 'This quote was declined' },

--- a/lib/components/posts/quote-card.tsx
+++ b/lib/components/posts/quote-card.tsx
@@ -54,11 +54,19 @@ export const QuoteCard: FC<Props> = ({ quote, currentTime, className }) => {
     if (quote.state !== 'accepted') return
     let active = true
     setLoaded(false)
-    getStatusById(quote.quotedStatusId).then((status) => {
-      if (!active) return
-      setQuotedStatus(status)
-      setLoaded(true)
-    })
+    getStatusById(quote.quotedStatusId)
+      .then((status) => {
+        if (!active) return
+        setQuotedStatus(status)
+        setLoaded(true)
+      })
+      .catch(() => {
+        // A rejected fetch (offline, aborted, bad body) falls back to the
+        // unavailable tombstone instead of sticking on the loading state.
+        if (!active) return
+        setQuotedStatus(null)
+        setLoaded(true)
+      })
     return () => {
       active = false
     }

--- a/lib/components/posts/quote-card.tsx
+++ b/lib/components/posts/quote-card.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { formatDistance } from 'date-fns'
+import { Quote } from 'lucide-react'
+import { FC, useEffect, useState } from 'react'
+
+import { getStatusById } from '@/lib/client'
+import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar'
+import { QuoteState, StatusQuote } from '@/lib/types/domain/status'
+import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
+import { cn } from '@/lib/utils'
+import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
+
+interface Props {
+  quote: StatusQuote
+  // Epoch ms from the server (hydration rule: never Date.now() in client render).
+  currentTime: number
+  className?: string
+}
+
+// Non-accepted edges never embed content; render a state-specific tombstone.
+const TOMBSTONE_TEXT: Record<Exclude<QuoteState, 'accepted'>, string> = {
+  pending: 'Quote pending approval',
+  rejected: 'This quote was declined',
+  revoked: 'This quote was withdrawn',
+  deleted: 'The quoted post is no longer available'
+}
+
+const Tombstone: FC<{ text: string; className?: string }> = ({
+  text,
+  className
+}) => (
+  <div
+    className={cn(
+      'mt-2 flex items-center gap-2 rounded-xl border border-dashed border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground italic',
+      className
+    )}
+  >
+    <Quote className="size-4 shrink-0" />
+    <span>{text}</span>
+  </div>
+)
+
+// Embedded card for a quoted post. For an `accepted` edge it lazily fetches the
+// quoted status (the API 404s when the viewer may not see it, so unreadable
+// quotes fall back to the unavailable tombstone rather than leaking content).
+// Depth is bounded at 1: the fetched quoted status is rendered as a compact
+// plain-text preview, never with its own nested quote card.
+export const QuoteCard: FC<Props> = ({ quote, currentTime, className }) => {
+  const [quotedStatus, setQuotedStatus] = useState<MastodonStatus | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (quote.state !== 'accepted') return
+    let active = true
+    setLoaded(false)
+    getStatusById(quote.quotedStatusId).then((status) => {
+      if (!active) return
+      setQuotedStatus(status)
+      setLoaded(true)
+    })
+    return () => {
+      active = false
+    }
+  }, [quote.state, quote.quotedStatusId])
+
+  if (quote.state !== 'accepted') {
+    return (
+      <Tombstone text={TOMBSTONE_TEXT[quote.state]} className={className} />
+    )
+  }
+
+  if (!loaded) {
+    return (
+      <div
+        className={cn(
+          'mt-2 rounded-xl border border-border/60 bg-muted/10 px-3 py-2 text-sm text-muted-foreground',
+          className
+        )}
+        aria-busy="true"
+      >
+        Loading quoted post…
+      </div>
+    )
+  }
+
+  if (!quotedStatus) {
+    return (
+      <Tombstone text="This quoted post is unavailable" className={className} />
+    )
+  }
+
+  const account = quotedStatus.account
+  const preview = htmlToPlainText(quotedStatus.content)
+  const relativeTime = formatDistance(
+    new Date(quotedStatus.created_at),
+    currentTime
+  )
+
+  return (
+    <a
+      href={quotedStatus.url || quote.quotedStatusId}
+      className={cn(
+        'mt-2 block rounded-xl border border-border/60 border-l-4 border-l-primary/40 bg-muted/20 px-3 py-2 transition-colors hover:bg-muted/40',
+        className
+      )}
+    >
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Avatar className="size-5">
+          <AvatarImage src={account.avatar} alt="" />
+          <AvatarFallback>
+            {(account.display_name || account.username || '?')
+              .charAt(0)
+              .toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <span className="font-medium text-foreground">
+          {account.display_name || account.username}
+        </span>
+        <span className="truncate">@{account.acct}</span>
+        <span aria-hidden>·</span>
+        <span className="shrink-0">{relativeTime}</span>
+      </div>
+      <div className="mt-1 line-clamp-3 text-sm text-foreground/90 break-words">
+        {preview || (
+          <span className="italic text-muted-foreground">
+            No content preview
+          </span>
+        )}
+      </div>
+    </a>
+  )
+}


### PR DESCRIPTION
## Epic 4.1e — Quote-compose action + embedded quote card

Completes the two pieces deferred from 4.1d (#1251), finishing the Mastodon 4.5 quote-posts UI. **Browser-verified end to end** (screenshots below).

### Quote-compose action
- A **"Quote post"** item in the status menu (`PostMenu`), shown when an `onQuote` handler is provided, opens the composer with the quoted status pinned in a new `QuotedPreview`. Posting sends `quoted_status_id` through `createNote` (the outbox path authorizes it via `resolveQuoteForCreate`, shipped in 4.1d).
- Wiring: new `quoteAction`/`quoteStatus` in the timeline `statusActionReducer`; `onQuote` drilled `Posts → Post → Actions → PostMenu`; `MainPageTimeline` feeds `quotedStatus` to the `PostBox`.

### Embedded quote card
- `Post` renders `status.quote` as a `QuoteCard`. For an **accepted** edge it lazily fetches the quoted status via a new `getStatusById` client function — the status route **404s when the viewer may not see it**, so unreadable quotes fall back to an "unavailable" tombstone rather than leaking content. `pending`/`rejected`/`revoked`/`deleted` render state-specific tombstones.
- **Depth bounded at 1**: the fetched quoted status is a compact plain-text preview (`htmlToPlainText`, so no `dangerouslySetInnerHTML`), never a nested card. Relative time uses the server-provided `currentTime` (no `Date.now()` in client render).
- **No hot-path DB change**: the card reads the already-hydrated domain edge and fetches content client-side through the existing, readability-enforcing route — avoiding a recursion-sensitive change to the timeline hydration path.

### Verification
- Gate green: `prettier:check` ✓, `lint` 0 errors ✓, `build` ✓, **6544 tests** ✓ (new: reducer `quoteAction`, PostMenu Quote item, PostBox quote passthrough + `QuotedPreview`, `QuoteCard` accepted/unavailable/tombstone matrix).
- **Browser-verified** on the local SQLite stack: opened a post's menu → "Quote post" → composer showed the "Quoting" preview → posted → the new status rendered an embedded quote card with the quoted author, timestamp, and content.

With this, Epic 4.1 (quote posts) is feature-complete: compose a quote, choose/change who can quote, revoke, federate (FEP-044f), and see rendered quote cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)