### PR TITLE
Bump version to v1.110.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.109.0",
+  "version": "1.110.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.110.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.109.0`
- Base main SHA: `033c5b9cea5dd7fae6d4023b7882bcf28623f04f`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
