### PR TITLE
minor: resolve followers-policy quote_approval.current_user (Epic 4.1f)

### DIFF
--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -150,8 +150,11 @@ product or security decision, not a gap to be closed.
   hosted `QuoteAuthorization` stamp; revocation is a `Delete` of that stamp), so
   the policy vocabulary is `public` / `followers` / `nobody` and `quote_approval.manual`
   is always empty (there is no held-for-review queue). For a `followers`-policy
-  status, `quote_approval.current_user` reports `unknown` to a non-author viewer —
-  the follower-relationship refinement is deferred. Legacy Fedibird (`quoteUri`)
+  status, `quote_approval.current_user` reflects the follower relationship — a
+  non-author viewer sees `automatic` when they are an accepted follower of the
+  author and `denied` otherwise (an anonymous viewer still sees `unknown`); the
+  verdict is resolved in one batched follow query per page, so it adds no N+1.
+  Legacy Fedibird (`quoteUri`)
   and Misskey (`_misskey_quote`) quotes carry no stamp, so they are stored and
   rendered as unapproved (`pending`) rather than as embedded quotes, matching
   Mastodon 4.5's treatment of stamp-less quotes. Revocation v1 delivers the stamp

--- a/lib/services/mastodon/getMastodonStatus.test.ts
+++ b/lib/services/mastodon/getMastodonStatus.test.ts
@@ -1795,21 +1795,39 @@ describe('getMastodonStatus', () => {
         expectedCurrentUser: 'denied'
       },
       {
-        description: 'followers policy, non-author viewer',
+        // ACTOR2 does not have an accepted follow of ACTOR1 (seed), so a
+        // followers-policy status by ACTOR1 denies quoting to ACTOR2.
+        description: 'followers policy, non-follower viewer',
         policy: 'followers' as const,
         viewer: ACTOR2_ID,
         expectedAutomatic: ['followers'],
-        expectedCurrentUser: 'unknown'
+        expectedCurrentUser: 'denied'
+      },
+      {
+        // ACTOR3 has an accepted follow of ACTOR2 (seed), so a followers-policy
+        // status by ACTOR2 automatically approves quoting for ACTOR3.
+        description: 'followers policy, accepted-follower viewer',
+        author: ACTOR2_ID,
+        policy: 'followers' as const,
+        viewer: ACTOR3_ID,
+        expectedAutomatic: ['followers'],
+        expectedCurrentUser: 'automatic'
       }
     ])(
       'emits quote_approval for $description',
-      async ({ policy, viewer, expectedAutomatic, expectedCurrentUser }) => {
+      async ({
+        author = ACTOR1_ID,
+        policy,
+        viewer,
+        expectedAutomatic,
+        expectedCurrentUser
+      }) => {
         counter += 1
-        const id = `${ACTOR1_ID}/statuses/mq-approval-${counter}`
+        const id = `${author}/statuses/mq-approval-${counter}`
         await database.createNote({
           id,
           url: id,
-          actorId: ACTOR1_ID,
+          actorId: author,
           text: 'approval',
           to: [ACTIVITY_STREAM_PUBLIC],
           cc: [],
@@ -1824,6 +1842,39 @@ describe('getMastodonStatus', () => {
         })
       }
     )
+
+    it('resolves followers-policy current_user with a single batched follow query', async () => {
+      // Three followers-policy statuses by ACTOR2; ACTOR3 is an accepted
+      // follower of ACTOR2 (seed), so all three report current_user
+      // 'automatic'. The follow relationship must be resolved in ONE batched
+      // getAcceptedFollowTargetActorIds call across the whole page (no N+1).
+      const statuses: Status[] = []
+      for (let i = 0; i < 3; i += 1) {
+        counter += 1
+        const id = `${ACTOR2_ID}/statuses/mq-approval-batch-${counter}`
+        await database.createNote({
+          id,
+          url: id,
+          actorId: ACTOR2_ID,
+          text: 'approval batch',
+          to: [ACTIVITY_STREAM_PUBLIC],
+          cc: [],
+          quoteApprovalPolicy: 'followers'
+        })
+        statuses.push((await database.getStatus({ statusId: id })) as Status)
+      }
+
+      const spy = vi.spyOn(database, 'getAcceptedFollowTargetActorIds')
+      const results = await getMastodonStatuses(database, statuses, ACTOR3_ID)
+
+      expect(results).toHaveLength(3)
+      for (const result of results) {
+        expect(
+          (result.quote_approval as { current_user: string }).current_user
+        ).toBe('automatic')
+      }
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
 
     it('batch-prefetches quoted statuses with a single getStatusesByIds call', async () => {
       const quotingStatuses: Status[] = []

--- a/lib/services/mastodon/getMastodonStatus.ts
+++ b/lib/services/mastodon/getMastodonStatus.ts
@@ -6,6 +6,7 @@ import { canActorReadStatus } from '@/lib/services/statusAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
 import { getMastodonAttachment } from '@/lib/types/domain/attachment'
+import { FollowStatus } from '@/lib/types/domain/follow'
 import {
   QuoteApprovalPolicy,
   Status,
@@ -74,6 +75,12 @@ interface GetMastodonStatusOptions {
   // Memoizes thread-root resolution (statusId → rootId) across a batch render so
   // a thread's shared ancestors are walked once rather than once per status.
   conversationRootCache?: Map<string, string>
+  // Batched accepted-follow state (quoted-author actorId → viewer follows them)
+  // for the followers-policy quote_approval.current_user verdict, resolved once
+  // per page in getMastodonStatuses so no per-status follow lookup is needed.
+  // Mirrors getFollowerStateByActorId in statusRouteAccess. A missing entry
+  // falls back to a single per-status follow lookup.
+  quoteFollowerStateByActorId?: ReadonlyMap<string, boolean>
 }
 
 const getMastodonAccount = (
@@ -249,6 +256,25 @@ const addStatusQuoteIds = (status: Status, statusIds: Set<string>) => {
   }
 }
 
+// Collect the authors whose followers-policy statuses the viewer might quote, so
+// the batched quote_approval verdict can resolve accepted-follow state for the
+// whole page in one query. Only followers-policy statuses authored by someone
+// other than the viewer need a follow lookup (self / public / nobody are decided
+// without one).
+const addQuoteFollowerCandidateAuthorId = (
+  status: Status,
+  currentActorId: string,
+  authorIds: Set<string>
+) => {
+  const target =
+    status.type === StatusType.enum.Announce ? status.originalStatus : status
+  if (!target || target.type === StatusType.enum.Announce) return
+  if (target.actorId === currentActorId) return
+  if (getEffectiveQuoteApprovalPolicy(target) === 'followers') {
+    authorIds.add(target.actorId)
+  }
+}
+
 const getQuotedStatus = async (
   database: Database,
   statusId: string,
@@ -292,13 +318,37 @@ const QUOTE_POLICY_AUTOMATIC_AUDIENCE: Record<QuoteApprovalPolicy, string[]> = {
   nobody: []
 }
 
-// Build the `quote_approval` object for a non-Announce status. `current_user`
-// is the viewer's standing; the follower-relationship refinement for the
-// `followers` policy lands with canQuoteStatus in a later PR, so an
-// unauthenticated or follower viewer sees `unknown` there.
-const getQuoteApproval = (
+// Whether `viewerActorId` has an accepted follow of `authorId`, sourced from the
+// batched map when present (getMastodonStatuses populates it for the whole page)
+// and otherwise from a single follow lookup — mirroring canActorReadSingleStatus
+// in statusAccess. A merely-requested follow does not count.
+const isAcceptedFollowerOf = async (
+  database: Database,
+  viewerActorId: string,
+  authorId: string,
+  options?: GetMastodonStatusOptions
+): Promise<boolean> => {
+  const prefetched = options?.quoteFollowerStateByActorId?.get(authorId)
+  if (prefetched !== undefined) return prefetched
+
+  const follow = await database.getAcceptedOrRequestedFollow({
+    actorId: viewerActorId,
+    targetActorId: authorId
+  })
+  return follow?.status === FollowStatus.enum.Accepted
+}
+
+// Build the `quote_approval` object for a non-Announce status. `current_user` is
+// the viewer's standing, matching canQuoteStatus: self / `public` → `automatic`,
+// `nobody` → `denied`, and for `followers` → `automatic` iff the viewer is an
+// accepted follower of the author, else `denied`. Block relationships (which
+// already gate the status's visibility, per canActorReadStatus's block-free hot
+// path) are not re-checked here. An anonymous viewer is always `unknown`.
+const getQuoteApproval = async (
+  database: Database,
   status: StatusNote | StatusPoll,
-  currentActorId?: string
+  currentActorId?: string,
+  options?: GetMastodonStatusOptions
 ) => {
   const policy = getEffectiveQuoteApprovalPolicy(status)
   const automatic = QUOTE_POLICY_AUTOMATIC_AUDIENCE[policy]
@@ -307,7 +357,15 @@ const getQuoteApproval = (
   else if (currentActorId === status.actorId) currentUser = 'automatic'
   else if (policy === 'public') currentUser = 'automatic'
   else if (policy === 'nobody') currentUser = 'denied'
-  else currentUser = 'unknown'
+  else {
+    const isFollower = await isAcceptedFollowerOf(
+      database,
+      currentActorId,
+      status.actorId,
+      options
+    )
+    currentUser = isFollower ? 'automatic' : 'denied'
+  }
   return { automatic, manual: [] as string[], current_user: currentUser }
 }
 
@@ -543,7 +601,12 @@ export const getMastodonStatus = async (
   }
 
   const quoteDepth = options?.quoteDepth ?? 0
-  const quoteApproval = getQuoteApproval(status, currentActorId)
+  const quoteApproval = await getQuoteApproval(
+    database,
+    status,
+    currentActorId,
+    options
+  )
 
   let quote:
     | { state: string; quoted_status: Mastodon.Status | null }
@@ -739,8 +802,47 @@ export const getMastodonStatuses = async (
     }
   }
 
+  // Resolve accepted-follow state once for every followers-policy author on the
+  // page (top-level statuses, their reblog originals, and embedded quoted
+  // statuses) so the quote_approval.current_user verdict needs no per-status
+  // follow lookup. Mirrors getFollowerStateByActorId in statusRouteAccess.
+  const quoteFollowerCandidateAuthorIds = new Set<string>()
+  if (currentActorId) {
+    for (const status of safeStatuses) {
+      addQuoteFollowerCandidateAuthorId(
+        status,
+        currentActorId,
+        quoteFollowerCandidateAuthorIds
+      )
+    }
+    for (const quotedStatus of quotedStatuses) {
+      addQuoteFollowerCandidateAuthorId(
+        quotedStatus,
+        currentActorId,
+        quoteFollowerCandidateAuthorIds
+      )
+    }
+  }
+  const quoteFollowerTargetActorIds = [...quoteFollowerCandidateAuthorIds]
+  const acceptedQuoteFollowTargetActorIds =
+    currentActorId && quoteFollowerTargetActorIds.length > 0
+      ? new Set(
+          await database.getAcceptedFollowTargetActorIds({
+            actorId: currentActorId,
+            targetActorIds: quoteFollowerTargetActorIds
+          })
+        )
+      : new Set<string>()
+  const quoteFollowerStateByActorId = new Map(
+    quoteFollowerTargetActorIds.map(
+      (actorId) =>
+        [actorId, acceptedQuoteFollowTargetActorIds.has(actorId)] as const
+    )
+  )
+
   const options: GetMastodonStatusOptions = {
     ...inputOptions,
+    quoteFollowerStateByActorId,
     pinnedStatusIds:
       inputOptions.pinnedStatusIds ?? new Set<string>(pinnedStatusIds),
     mutedConversationRootIds:


### PR DESCRIPTION
## Summary

Epic 4.1f follow-up (item 1 of 5): implement the deferred **follower-relationship refinement** for `quote_approval.current_user` on the Mastodon Status entity.

Previously, a `followers`-policy status reported `quote_approval.current_user: "unknown"` to any non-author viewer. Now it reflects the real verdict from the shared quote policy (`lib/services/quotes/canQuoteStatus.ts`):

- author / `public` policy → `automatic`
- `nobody` policy → `denied`
- `followers` policy, non-author viewer → `automatic` **iff** the viewer is an *accepted* follower of the author, else `denied`
- anonymous viewer → `unknown` (unchanged)

## Batching (no N+1)

The verdict is resolved for the whole page in **one** `getAcceptedFollowTargetActorIds` query inside `getMastodonStatuses`, mirroring `getFollowerStateByActorId` in `lib/services/statusRouteAccess.ts`. Candidate authors are collected from top-level statuses, their reblog originals, and embedded quoted statuses. The single-status path (`getMastodonStatus` called directly) falls back to one follow lookup, mirroring `canActorReadSingleStatus`.

Block relationships are **not** re-checked here: they already gate the status's visibility (`canActorReadStatus` is block-free in this same hot path), so a status reaching serialization for a viewer has no block between them.

## Tests

- Updated the table-driven `quote_approval` test: `followers` non-follower viewer → `denied`; added an accepted-follower viewer → `automatic` case.
- Added a batched-path test asserting three followers-policy statuses resolve `automatic` for an accepted follower with a **single** `getAcceptedFollowTargetActorIds` call (no N+1).

## Gate

`prettier:check`, `yarn lint` (0 errors), `yarn build`, `yarn test` (6548 passed) all green locally.

## Docs

Updated the quote divergence note in `docs/mastodon-api-compatibility.md`.

## Notes

No migration. Pure serialization refinement of an existing Mastodon API field (`quote_approval.current_user`); not a web-UI surface, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)