### PR TITLE
minor: quoted_update notifications for edited quoted posts (Epic 4.1f)

### DIFF
--- a/app/(timeline)/notifications/notificationConfig.ts
+++ b/app/(timeline)/notifications/notificationConfig.ts
@@ -4,6 +4,7 @@ import {
   Heart,
   Library,
   type LucideIcon,
+  PencilLine,
   Quote,
   Repeat2,
   Reply,
@@ -88,6 +89,12 @@ export const NOTIFICATION_TYPE_CONFIG: Record<
     badgeClassName:
       'bg-[hsl(142_60%_36%/0.12)] text-[hsl(142_60%_36%)] dark:bg-[hsl(142_60%_45%/0.16)] dark:text-[hsl(142_55%_60%)]',
     verb: 'quoted your post',
+    kind: 'status'
+  },
+  quoted_update: {
+    icon: PencilLine,
+    badgeClassName: PRIMARY_BADGE,
+    verb: 'edited a post you quoted',
     kind: 'status'
   },
   activity_import: {

--- a/docs/features.md
+++ b/docs/features.md
@@ -40,7 +40,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Main timeline** — Home feed with posts from followed accounts
 - ✅ **Favorites page** — Browse posts you've favorited
 - ✅ **List timelines** — Per-list timelines honoring replies policy, exclusive lists, and block/mute/keyword filtering
-- ✅ **Notifications** — Like, follow, mention, reblog, follow request, and collection (added-to-collection / collection-update) notifications
+- ✅ **Notifications** — Like, follow, mention, reblog, follow request, quote (someone quoted your post), quote-update (a post you quoted was edited), and collection (added-to-collection / collection-update) notifications
 - ✅ **Notification grouping** — Group similar notifications together
 - ✅ **Email notifications** — Configurable email alerts for each notification type
 - ✅ **Push notifications** — Web Push subscriptions with VAPID configuration

--- a/lib/actions/updateNote.test.ts
+++ b/lib/actions/updateNote.test.ts
@@ -8,6 +8,7 @@ import * as timelinesService from '@/lib/services/timelines'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { seedActor2 } from '@/lib/stub/seed/actor2'
 import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
@@ -23,6 +24,10 @@ vi.mock('@/lib/services/queue', () => ({
 
 vi.mock('@/lib/services/timelines', () => ({
   addStatusToTimelines: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/lib/services/notifications/sendNotificationAlerts', () => ({
+  sendNotificationAlerts: vi.fn()
 }))
 
 describe('Update note action', () => {
@@ -188,6 +193,101 @@ describe('Update note action', () => {
         status
       )
       expect(getQueue().publish).not.toHaveBeenCalled()
+    })
+
+    it('notifies local authors of accepted quotes when the status is edited', async () => {
+      if (!actor1) fail('Actor1 is required')
+      const actor2 = (await database.getActorFromUsername({
+        username: seedActor2.username,
+        domain: seedActor2.domain
+      })) as Actor
+      const quotedId = `${actor1.id}/statuses/quoted-update-edit`
+      await database.createNote({
+        id: quotedId,
+        url: quotedId,
+        actorId: actor1.id,
+        text: 'quoted',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const quotingId = `${actor2.id}/statuses/quoted-update-quoting`
+      await database.createNote({
+        id: quotingId,
+        url: quotingId,
+        actorId: actor2.id,
+        text: 'quoting',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createStatusQuote({
+        statusId: quotingId,
+        quotedStatusId: quotedId,
+        state: 'accepted'
+      })
+
+      await updateNoteFromUserInput({
+        statusId: quotedId,
+        currentActor: actor1,
+        database,
+        text: 'quoted (edited)'
+      })
+
+      const notifications = await database.getNotifications({
+        actorId: actor2.id,
+        limit: 100,
+        types: ['quoted_update']
+      })
+      expect(
+        notifications.filter((n) => n.statusId === quotingId)
+      ).toHaveLength(1)
+    })
+
+    it('does not notify quoters when publish is false', async () => {
+      if (!actor1) fail('Actor1 is required')
+      const actor2 = (await database.getActorFromUsername({
+        username: seedActor2.username,
+        domain: seedActor2.domain
+      })) as Actor
+      const quotedId = `${actor1.id}/statuses/quoted-update-draft`
+      await database.createNote({
+        id: quotedId,
+        url: quotedId,
+        actorId: actor1.id,
+        text: 'quoted',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      const quotingId = `${actor2.id}/statuses/quoted-update-draft-quoting`
+      await database.createNote({
+        id: quotingId,
+        url: quotingId,
+        actorId: actor2.id,
+        text: 'quoting',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.createStatusQuote({
+        statusId: quotingId,
+        quotedStatusId: quotedId,
+        state: 'accepted'
+      })
+
+      await updateNoteFromUserInput({
+        statusId: quotedId,
+        currentActor: actor1,
+        database,
+        summary: 'Draft warning',
+        publish: false
+      })
+
+      const notifications = await database.getNotifications({
+        actorId: actor2.id,
+        limit: 100,
+        types: ['quoted_update']
+      })
+      expect(
+        notifications.filter((n) => n.statusId === quotingId)
+      ).toHaveLength(0)
     })
   })
 })

--- a/lib/actions/updateNote.ts
+++ b/lib/actions/updateNote.ts
@@ -2,6 +2,7 @@ import { persistEmojiTagsForStatus } from '@/lib/actions/createNote'
 import { Database } from '@/lib/database/types'
 import { SEND_UPDATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
 import { persistDetectedLanguage } from '@/lib/services/language-detection'
+import { notifyQuotedStatusUpdate } from '@/lib/services/notifications/notifyQuotedStatusUpdate'
 import { getQueue } from '@/lib/services/queue'
 import { addStatusToTimelines } from '@/lib/services/timelines'
 import { Actor } from '@/lib/types/domain/actor'
@@ -86,6 +87,15 @@ export const updateNoteFromUserInput = async ({
         actorId: currentActor.id,
         statusId
       }
+    })
+
+    // Notify the authors of accepted quotes of this status that a post they
+    // quoted was edited. Only published (federated) edits notify quoters.
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: statusId,
+      sourceActorId: currentActor.id,
+      sourceActor: currentActor
     })
   }
 

--- a/lib/database/sql/statusQuote.test.ts
+++ b/lib/database/sql/statusQuote.test.ts
@@ -346,6 +346,47 @@ describe('StatusQuoteDatabase', () => {
       expect(beforeLast).not.toContain(all[all.length - 1])
     })
 
+    it('paginates quoting status ids with offset', async () => {
+      const quotedStatusId = uniqueId('offset-target')
+      for (let i = 0; i < 5; i += 1) {
+        await database.createStatusQuote({
+          statusId: `${ACTOR1_ID}/statuses/offset-${i}-${randomUUID()}`,
+          quotedStatusId,
+          state: 'accepted'
+        })
+      }
+
+      const all = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted',
+        limit: 5
+      })
+      expect(all).toHaveLength(5)
+
+      const page1 = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted',
+        limit: 2,
+        offset: 0
+      })
+      const page2 = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted',
+        limit: 2,
+        offset: 2
+      })
+      const page3 = await database.getQuotingStatusIds({
+        quotedStatusId,
+        state: 'accepted',
+        limit: 2,
+        offset: 4
+      })
+
+      // Offset pages tile the full ordered list with no gaps or repeats.
+      expect([...page1, ...page2, ...page3]).toEqual(all)
+      expect(page3).toHaveLength(1)
+    })
+
     it('returns an empty page when the cursor id does not exist', async () => {
       const quotedStatusId = uniqueId('cursor-missing-target')
       await database.createStatusQuote({

--- a/lib/database/sql/statusQuote.ts
+++ b/lib/database/sql/statusQuote.ts
@@ -182,12 +182,14 @@ export const StatusQuoteSQLDatabaseMixin = (
       state,
       limit = 20,
       maxId,
-      sinceId
+      sinceId,
+      offset
     }: GetQuotingStatusIdsParams): Promise<string[]> {
       const query = database<StatusQuoteRow>('status_quotes')
         .where('quotedStatusId', quotedStatusId)
         .limit(limit)
       if (state) query.where('state', state)
+      if (offset) query.offset(offset)
 
       // Keyset pagination over (createdAt, statusId), newest first. The cursor
       // ids reference the quoting status id (the PK of this table).

--- a/lib/jobs/updateNoteJob.test.ts
+++ b/lib/jobs/updateNoteJob.test.ts
@@ -7,7 +7,11 @@ import { updateNoteJob } from '@/lib/jobs/updateNoteJob'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { MockMastodonActivityPubNote } from '@/lib/stub/note'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
+import { Actor } from '@/lib/types/domain/actor'
 import { Status, StatusType } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 enableFetchMocks()
 
@@ -231,5 +235,55 @@ describe('updateNoteJob', () => {
     expect(status.id).toEqual(image.id)
     expect(status.text).toEqual('<p>Beautiful sunset with filters</p>')
     expect(status.type).toEqual(StatusType.enum.Note)
+  })
+
+  it('notifies local authors of accepted quotes when an inbound edit updates the quoted status', async () => {
+    // A remote status our user quoted is edited elsewhere and arrives as an
+    // inbound Update; the local quoting author should get a quoted_update.
+    const quotedRemoteId = `${EXTERNAL_ACTOR1}/statuses/inbound-quoted-update`
+    const note = MockMastodonActivityPubNote({
+      id: quotedRemoteId,
+      from: EXTERNAL_ACTOR1,
+      content: '<p>original</p>'
+    })
+    await createNoteJob(database, {
+      id: 'id',
+      name: CREATE_NOTE_JOB_NAME,
+      data: note
+    })
+
+    const actor1 = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    const quotingId = `${actor1.id}/statuses/inbound-quoted-update-quoting`
+    await database.createNote({
+      id: quotingId,
+      url: quotingId,
+      actorId: actor1.id,
+      text: 'quoting',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createStatusQuote({
+      statusId: quotingId,
+      quotedStatusId: quotedRemoteId,
+      state: 'accepted'
+    })
+
+    await updateNoteJob(database, {
+      id: 'id',
+      name: UPDATE_NOTE_JOB_NAME,
+      data: { ...note, content: '<p>edited</p>' }
+    })
+
+    const notifications = await database.getNotifications({
+      actorId: actor1.id,
+      limit: 100,
+      types: ['quoted_update']
+    })
+    expect(notifications.filter((n) => n.statusId === quotingId)).toHaveLength(
+      1
+    )
   })
 })

--- a/lib/jobs/updateNoteJob.test.ts
+++ b/lib/jobs/updateNoteJob.test.ts
@@ -286,4 +286,57 @@ describe('updateNoteJob', () => {
       1
     )
   })
+
+  it('does not notify quoters for a metadata-only inbound Update (unchanged content)', async () => {
+    // A metadata-only federated Update (e.g. an interaction/quote-policy or
+    // visibility change) carries unchanged content and must not spam quoters
+    // with a false "edited a post you quoted" notification.
+    const quotedRemoteId = `${EXTERNAL_ACTOR1}/statuses/inbound-metadata-only`
+    const note = MockMastodonActivityPubNote({
+      id: quotedRemoteId,
+      from: EXTERNAL_ACTOR1,
+      content: '<p>unchanged</p>'
+    })
+    await createNoteJob(database, {
+      id: 'id',
+      name: CREATE_NOTE_JOB_NAME,
+      data: note
+    })
+
+    const actor1 = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    const quotingId = `${actor1.id}/statuses/inbound-metadata-only-quoting`
+    await database.createNote({
+      id: quotingId,
+      url: quotingId,
+      actorId: actor1.id,
+      text: 'quoting',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    await database.createStatusQuote({
+      statusId: quotingId,
+      quotedStatusId: quotedRemoteId,
+      state: 'accepted'
+    })
+
+    // Same content as the original — only metadata would differ in a real
+    // policy/visibility Update.
+    await updateNoteJob(database, {
+      id: 'id',
+      name: UPDATE_NOTE_JOB_NAME,
+      data: { ...note }
+    })
+
+    const notifications = await database.getNotifications({
+      actorId: actor1.id,
+      limit: 100,
+      types: ['quoted_update']
+    })
+    expect(notifications.filter((n) => n.statusId === quotingId)).toHaveLength(
+      0
+    )
+  })
 })

--- a/lib/jobs/updateNoteJob.ts
+++ b/lib/jobs/updateNoteJob.ts
@@ -7,6 +7,7 @@ import {
   getSummary
 } from '@/lib/activities/note'
 import { persistDetectedLanguage } from '@/lib/services/language-detection'
+import { notifyQuotedStatusUpdate } from '@/lib/services/notifications/notifyQuotedStatusUpdate'
 import {
   ArticleContent,
   ImageContent,
@@ -75,6 +76,14 @@ export const updateNoteJob = createJobHandle(
       statusId: note.id,
       text,
       html: true
+    })
+
+    // A remote status our users may have quoted was edited elsewhere; notify the
+    // local authors of accepted quotes of it. The edit's author is the source.
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: note.id,
+      sourceActorId: existingStatus.actorId
     })
   }
 )

--- a/lib/jobs/updateNoteJob.ts
+++ b/lib/jobs/updateNoteJob.ts
@@ -61,6 +61,16 @@ export const updateNoteJob = createJobHandle(
     // value when the update carries no locale (updateNote treats `undefined`
     // as "keep").
     const language = getLanguage(note) ?? undefined
+
+    // Only a change to the readable content (text/summary) notifies quoters. A
+    // metadata-only Update — interaction/quote policy, visibility, or a
+    // re-federated quote-approval stamp — carries unchanged content, and
+    // updateNote records a history revision unconditionally, so compare before
+    // updating to avoid false "edited a post you quoted" notifications.
+    const contentChanged =
+      text !== existingStatus.text ||
+      (summary || '') !== (existingStatus.summary || '')
+
     await database.updateNote({
       statusId: note.id,
       summary,
@@ -79,11 +89,15 @@ export const updateNoteJob = createJobHandle(
     })
 
     // A remote status our users may have quoted was edited elsewhere; notify the
-    // local authors of accepted quotes of it. The edit's author is the source.
-    await notifyQuotedStatusUpdate({
-      database,
-      quotedStatusId: note.id,
-      sourceActorId: existingStatus.actorId
-    })
+    // local authors of accepted quotes of it, but only for a real content edit
+    // (a metadata-only Update must not spam quoters). The edit's author is the
+    // source.
+    if (contentChanged) {
+      await notifyQuotedStatusUpdate({
+        database,
+        quotedStatusId: note.id,
+        sourceActorId: existingStatus.actorId
+      })
+    }
   }
 )

--- a/lib/services/notifications/getMastodonNotification.ts
+++ b/lib/services/notifications/getMastodonNotification.ts
@@ -17,6 +17,7 @@ type MastodonNotificationType =
   | 'status'
   | 'reblog'
   | 'quote'
+  | 'quoted_update'
   | 'follow'
   | 'follow_request'
   | 'favourite'
@@ -59,6 +60,8 @@ const mapNotificationType = (
       return 'reblog'
     case 'quote':
       return 'quote'
+    case 'quoted_update':
+      return 'quoted_update'
     case 'follow':
       return 'follow'
     case 'follow_request':

--- a/lib/services/notifications/notificationTypeMapping.test.ts
+++ b/lib/services/notifications/notificationTypeMapping.test.ts
@@ -1,4 +1,5 @@
 import {
+  internalTypeToMastodon,
   mastodonTypeToInternal,
   mastodonTypesToInternal
 } from './notificationTypeMapping'
@@ -20,10 +21,28 @@ describe('mastodonTypeToInternal', () => {
     expect(mastodonTypeToInternal('mention')).toEqual(['mention', 'reply'])
   })
 
+  it('maps quote to quote', () => {
+    expect(mastodonTypeToInternal('quote')).toEqual(['quote'])
+  })
+
+  it('maps quoted_update to quoted_update', () => {
+    expect(mastodonTypeToInternal('quoted_update')).toEqual(['quoted_update'])
+  })
+
   it('passes unknown types through unchanged', () => {
     expect(mastodonTypeToInternal('follow')).toEqual(['follow'])
     expect(mastodonTypeToInternal('follow_request')).toEqual(['follow_request'])
     expect(mastodonTypeToInternal('poll')).toEqual(['poll'])
+  })
+})
+
+describe('internalTypeToMastodon', () => {
+  it('maps quote to quote', () => {
+    expect(internalTypeToMastodon('quote')).toBe('quote')
+  })
+
+  it('maps quoted_update to quoted_update', () => {
+    expect(internalTypeToMastodon('quoted_update')).toBe('quoted_update')
   })
 })
 

--- a/lib/services/notifications/notificationTypeMapping.ts
+++ b/lib/services/notifications/notificationTypeMapping.ts
@@ -38,6 +38,8 @@ export const mastodonTypeToInternal = (type: string): NotificationType[] => {
       return [NotificationType.enum.mention, NotificationType.enum.reply]
     case 'quote':
       return [NotificationType.enum.quote]
+    case 'quoted_update':
+      return [NotificationType.enum.quoted_update]
     default:
       return [type as NotificationType]
   }
@@ -56,6 +58,7 @@ export type MastodonNotificationType =
   | 'status'
   | 'reblog'
   | 'quote'
+  | 'quoted_update'
   | 'follow'
   | 'follow_request'
   | 'favourite'
@@ -82,6 +85,8 @@ export const internalTypeToMastodon = (
       return 'reblog'
     case 'quote':
       return 'quote'
+    case 'quoted_update':
+      return 'quoted_update'
     case 'follow':
       return 'follow'
     case 'follow_request':

--- a/lib/services/notifications/notifyQuotedStatusUpdate.test.ts
+++ b/lib/services/notifications/notifyQuotedStatusUpdate.test.ts
@@ -1,0 +1,190 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
+import { seedDatabase } from '@/lib/stub/database'
+import { seedActor1 } from '@/lib/stub/seed/actor1'
+import { seedActor2 } from '@/lib/stub/seed/actor2'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
+import { Actor } from '@/lib/types/domain/actor'
+import { QuoteState } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+import {
+  QUOTING_STATUS_PAGE_SIZE,
+  notifyQuotedStatusUpdate
+} from './notifyQuotedStatusUpdate'
+
+vi.mock('@/lib/services/notifications/sendNotificationAlerts', () => ({
+  sendNotificationAlerts: vi.fn()
+}))
+
+describe('notifyQuotedStatusUpdate', () => {
+  const database = getTestSQLDatabase()
+  const mockSendNotificationAlerts =
+    sendNotificationAlerts as jest.MockedFunction<typeof sendNotificationAlerts>
+  // actor1 authors (and edits) the quoted status; actor2 is a local quoter.
+  let actor1: Actor
+  let actor2: Actor
+  let counter = 0
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    actor1 = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    actor2 = (await database.getActorFromUsername({
+      username: seedActor2.username,
+      domain: seedActor2.domain
+    })) as Actor
+  })
+
+  afterAll(async () => {
+    if (database) await database.destroy()
+  })
+
+  beforeEach(() => {
+    mockSendNotificationAlerts.mockClear()
+  })
+
+  const createStatus = async (actorId: string, label: string) => {
+    counter += 1
+    const id = `${actorId}/statuses/qu-${label}-${counter}`
+    await database.createNote({
+      id,
+      url: id,
+      actorId,
+      text: label,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: []
+    })
+    return id
+  }
+
+  const createQuote = async (
+    quotingActorId: string,
+    quotedStatusId: string,
+    state: QuoteState = 'accepted'
+  ) => {
+    const quotingStatusId = await createStatus(quotingActorId, 'quoting')
+    await database.createStatusQuote({
+      statusId: quotingStatusId,
+      quotedStatusId,
+      state
+    })
+    return quotingStatusId
+  }
+
+  const quotedUpdateNotificationsFor = (actorId: string) =>
+    database.getNotifications({
+      actorId,
+      limit: 500,
+      types: ['quoted_update']
+    })
+
+  it('notifies a local quoting author when the quoted status is updated', async () => {
+    const quotedId = await createStatus(actor1.id, 'quoted')
+    const quotingId = await createQuote(actor2.id, quotedId)
+
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: quotedId,
+      sourceActorId: actor1.id,
+      sourceActor: actor1
+    })
+
+    const notifications = await quotedUpdateNotificationsFor(actor2.id)
+    expect(notifications.filter((n) => n.statusId === quotingId)).toHaveLength(
+      1
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockSendNotificationAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: actor2.id,
+        sourceActorId: actor1.id,
+        statusId: quotingId,
+        events: expect.arrayContaining([
+          expect.objectContaining({ type: 'quoted_update' })
+        ])
+      })
+    )
+  })
+
+  it('does not notify a remote quoting author', async () => {
+    const quotedId = await createStatus(actor1.id, 'quoted')
+    const quotingId = await createQuote(EXTERNAL_ACTOR1, quotedId)
+
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: quotedId,
+      sourceActorId: actor1.id,
+      sourceActor: actor1
+    })
+
+    const notifications = await quotedUpdateNotificationsFor(EXTERNAL_ACTOR1)
+    expect(notifications.filter((n) => n.statusId === quotingId)).toHaveLength(
+      0
+    )
+  })
+
+  it('does not notify the editor about their own quote', async () => {
+    const quotedId = await createStatus(actor1.id, 'quoted')
+    const quotingId = await createQuote(actor1.id, quotedId)
+
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: quotedId,
+      sourceActorId: actor1.id,
+      sourceActor: actor1
+    })
+
+    const notifications = await quotedUpdateNotificationsFor(actor1.id)
+    expect(notifications.filter((n) => n.statusId === quotingId)).toHaveLength(
+      0
+    )
+  })
+
+  it.each([
+    { state: 'pending' as const },
+    { state: 'rejected' as const },
+    { state: 'revoked' as const },
+    { state: 'deleted' as const }
+  ])('does not notify for a $state quote edge', async ({ state }) => {
+    const quotedId = await createStatus(actor1.id, 'quoted')
+    const quotingId = await createQuote(actor2.id, quotedId, state)
+
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: quotedId,
+      sourceActorId: actor1.id,
+      sourceActor: actor1
+    })
+
+    const notifications = await quotedUpdateNotificationsFor(actor2.id)
+    expect(notifications.filter((n) => n.statusId === quotingId)).toHaveLength(
+      0
+    )
+  })
+
+  it('enumerates every accepted quoter past the pagination page size', async () => {
+    const quotedId = await createStatus(actor1.id, 'quoted')
+    const quotingIds: string[] = []
+    for (let i = 0; i < QUOTING_STATUS_PAGE_SIZE + 3; i += 1) {
+      quotingIds.push(await createQuote(actor2.id, quotedId))
+    }
+
+    await notifyQuotedStatusUpdate({
+      database,
+      quotedStatusId: quotedId,
+      sourceActorId: actor1.id,
+      sourceActor: actor1
+    })
+
+    const notifications = await quotedUpdateNotificationsFor(actor2.id)
+    const notifiedStatusIds = new Set(notifications.map((n) => n.statusId))
+    for (const quotingId of quotingIds) {
+      expect(notifiedStatusIds.has(quotingId)).toBe(true)
+    }
+  })
+})

--- a/lib/services/notifications/notifyQuotedStatusUpdate.ts
+++ b/lib/services/notifications/notifyQuotedStatusUpdate.ts
@@ -1,0 +1,97 @@
+import { Database } from '@/lib/database/types'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
+import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
+import { NotificationType } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { getOriginalStatus } from '@/lib/types/domain/status'
+
+// How many accepted quote edges to enumerate per page. getQuotingStatusIds
+// keyset-pages over (createdAt, statusId), so a status quoted more than this
+// many times is covered by looping with the maxId cursor.
+export const QUOTING_STATUS_PAGE_SIZE = 40
+
+interface NotifyQuotedStatusUpdateParams {
+  database: Database
+  // The status that was edited (the quoted status).
+  quotedStatusId: string
+  // The actor who edited it (the quoted status's author) — the notification
+  // source and the self-quote guard's excluded recipient.
+  sourceActorId: string
+  // Optional pre-resolved source actor, forwarded to sendNotificationAlerts so
+  // it does not re-fetch (mirrors the createNote quote producer).
+  sourceActor?: Actor
+}
+
+/**
+ * Notify the authors of accepted quotes OF an edited status that a post they
+ * quoted was updated. Mirrors the `quote` notification producer in createNote
+ * but in the inverse direction: enumerate every `accepted` quote edge whose
+ * `quotedStatusId` is the edited status and notify each LOCAL quoting author
+ * (remote quoters learn of the edit via the federated Update, so they get no
+ * stored notification). The editor's own quote of their status is skipped.
+ *
+ * Delivery is best-effort: the per-recipient `sendNotificationAlerts` call is
+ * fire-and-forget (it handles its own errors) so alerting never fails the edit.
+ */
+export const notifyQuotedStatusUpdate = async ({
+  database,
+  quotedStatusId,
+  sourceActorId,
+  sourceActor
+}: NotifyQuotedStatusUpdateParams): Promise<void> => {
+  let maxId: string | undefined
+  for (;;) {
+    const quotingStatusIds = await database.getQuotingStatusIds({
+      quotedStatusId,
+      state: 'accepted',
+      limit: QUOTING_STATUS_PAGE_SIZE,
+      ...(maxId ? { maxId } : {})
+    })
+    if (quotingStatusIds.length === 0) break
+
+    // Hydrate the page in one query rather than one lookup per quoter.
+    const quotingStatuses = await database.getStatusesByIds({
+      statusIds: quotingStatusIds,
+      withReplies: false
+    })
+
+    for (const quotingStatus of quotingStatuses) {
+      // Only local quoting authors get a stored notification.
+      if (!quotingStatus.isLocalActor) continue
+
+      const quotingActorId = getOriginalStatus(quotingStatus).actorId
+      // Skip the editor's own quote of their status (self-quote guard, mirroring
+      // createNote's quotedAuthorId !== currentActor.id).
+      if (quotingActorId === sourceActorId) continue
+
+      const notification = await createNotificationWithPolicy(database, {
+        actorId: quotingActorId,
+        type: NotificationType.enum.quoted_update,
+        sourceActorId,
+        // Attach the recipient's own quote post (matching how the `quote`
+        // producer attaches the quoting status), so the notification renders it
+        // and the conversation-mute check keys off it.
+        statusId: quotingStatus.id,
+        groupKey: `quoted_update:${quotedStatusId}`
+      })
+      if (notification && !notification.filtered) {
+        sendNotificationAlerts({
+          database,
+          actorId: quotingActorId,
+          sourceActorId,
+          ...(sourceActor ? { sourceActor } : {}),
+          statusId: quotingStatus.id,
+          events: [
+            {
+              type: NotificationType.enum.quoted_update,
+              notificationId: notification.id
+            }
+          ]
+        })
+      }
+    }
+
+    if (quotingStatusIds.length < QUOTING_STATUS_PAGE_SIZE) break
+    maxId = quotingStatusIds[quotingStatusIds.length - 1]
+  }
+}

--- a/lib/services/notifications/notifyQuotedStatusUpdate.ts
+++ b/lib/services/notifications/notifyQuotedStatusUpdate.ts
@@ -5,9 +5,10 @@ import { NotificationType } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { getOriginalStatus } from '@/lib/types/domain/status'
 
-// How many accepted quote edges to enumerate per page. getQuotingStatusIds
-// keyset-pages over (createdAt, statusId), so a status quoted more than this
-// many times is covered by looping with the maxId cursor.
+// How many accepted quote edges to enumerate per page. The producer sweeps by
+// offset (not the maxId keyset cursor) so a full sweep is not truncated if a
+// quoting post is deleted mid-enumeration — an offset references no deletable
+// row, whereas a keyset cursor row could vanish and end the loop early.
 export const QUOTING_STATUS_PAGE_SIZE = 40
 
 interface NotifyQuotedStatusUpdateParams {
@@ -39,13 +40,13 @@ export const notifyQuotedStatusUpdate = async ({
   sourceActorId,
   sourceActor
 }: NotifyQuotedStatusUpdateParams): Promise<void> => {
-  let maxId: string | undefined
+  let offset = 0
   for (;;) {
     const quotingStatusIds = await database.getQuotingStatusIds({
       quotedStatusId,
       state: 'accepted',
       limit: QUOTING_STATUS_PAGE_SIZE,
-      ...(maxId ? { maxId } : {})
+      offset
     })
     if (quotingStatusIds.length === 0) break
 
@@ -92,6 +93,6 @@ export const notifyQuotedStatusUpdate = async ({
     }
 
     if (quotingStatusIds.length < QUOTING_STATUS_PAGE_SIZE) break
-    maxId = quotingStatusIds[quotingStatusIds.length - 1]
+    offset += QUOTING_STATUS_PAGE_SIZE
   }
 }

--- a/lib/services/notifications/pushNotification.ts
+++ b/lib/services/notifications/pushNotification.ts
@@ -28,6 +28,7 @@ const NOTIFICATION_TYPE_TO_ALERT: Partial<
   reply: 'mention',
   reblog: 'reblog',
   quote: 'quote',
+  quoted_update: 'quoted_update',
   activity_import: 'status'
 }
 
@@ -114,6 +115,11 @@ const getNotificationContent = (
       return {
         title: 'Quoted',
         body: `${displayName} quoted your post`
+      }
+    case 'quoted_update':
+      return {
+        title: 'Quote updated',
+        body: `${displayName} edited a post you quoted`
       }
     default:
       return {

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -3066,6 +3066,9 @@ export const NotificationType = z.enum([
   'reblog',
   // Mastodon 4.5 quote posts: someone quoted the recipient's status.
   'quote',
+  // A status the recipient quoted (an accepted quote edge) was edited by its
+  // author. Mirrors the Mastodon push alert key of the same name.
+  'quoted_update',
   'activity_import',
   // Mastodon 4.6 Collections: a member was added to a collection
   // (`added_to_collection`) or a collection they're in had its metadata changed

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -2840,6 +2840,10 @@ export type GetQuotingStatusIdsParams = {
   limit?: number
   maxId?: string | null
   sinceId?: string | null
+  // Row offset for sequential enumeration (e.g. notifying every quoter). Unlike
+  // the maxId keyset cursor, an offset does not reference a deletable row, so a
+  // full sweep is not truncated if a quoting post is deleted mid-enumeration.
+  offset?: number
 }
 
 export interface StatusQuoteDatabase {

--- a/lib/types/database/rows.ts
+++ b/lib/types/database/rows.ts
@@ -49,6 +49,7 @@ export interface ActorSettings {
     reply?: boolean
     reblog?: boolean
     quote?: boolean
+    quoted_update?: boolean
     activity_import?: boolean
     added_to_collection?: boolean
     collection_update?: boolean
@@ -61,6 +62,7 @@ export interface ActorSettings {
     reply?: boolean
     reblog?: boolean
     quote?: boolean
+    quoted_update?: boolean
     activity_import?: boolean
     added_to_collection?: boolean
     collection_update?: boolean


### PR DESCRIPTION
## Summary

Epic 4.1f follow-up (item 2 of 5): produce the **`quoted_update`** notification. The internal `PushAlerts`/push-subscription groundwork already declared a `quoted_update` flag but nothing produced it. Now, when a status is edited, the authors of **accepted** quotes OF that status are notified that a post they quoted was updated — the inverse direction of the existing `quote` producer.

## What's wired

- **New internal `NotificationType` `quoted_update`** (matches the existing `PushAlerts` / `ALERT_KEYS` naming — distinct from Mastodon's `update` reblog-edit alert), threaded through:
  - `notificationTypeMapping` (`mastodonTypeToInternal` / `internalTypeToMastodon`)
  - `getMastodonNotification` (`mapNotificationType`)
  - `pushNotification` (`NOTIFICATION_TYPE_TO_ALERT` toggle + push title/body)
  - the notifications UI config (`NOTIFICATION_TYPE_CONFIG` — exhaustive `Record<NotificationType,…>`)
  - `ActorSettings` email/push notification setting shapes (`rows.ts`)
- **New producer `lib/services/notifications/notifyQuotedStatusUpdate.ts`**: enumerates every `accepted` quote edge of the edited status via `getQuotingStatusIds` (**paged past the default limit of 20** to cover all quoters), hydrates each page in one `getStatusesByIds` call (no per-quoter N+1), and notifies only **local** quoting authors (remote quoters learn of the edit via the federated `Update`). Skips the editor's own quote. Uses `createNotificationWithPolicy` + fire-and-forget `sendNotificationAlerts`, exactly like the `quote` producer.
- **Hooked into both edit paths**: `updateNoteFromUserInput` (local edit, gated on `publish` so only federated edits notify) and `updateNoteJob` (inbound remote `Update`).

## Design notes

- The `quoted_update` **statusId** is the recipient's own quote post (matching how the `quote` producer attaches the quoting status), so the notification renders it and the conversation-mute check keys off it. **groupKey** is `quoted_update:<quotedStatusId>` (one group per edited status).
- The `PUT …/interaction_policy` endpoint does **not** go through `updateNoteFromUserInput`, so a quote-policy change (which must not bump `edited_at`) never fires this notification.
- **No migration** — `notifications.type` is an unconstrained `varchar`.

## Tests

- `notifyQuotedStatusUpdate.test.ts` (new): notifies a local quoter; skips remote quoters; skips the editor's self-quote; only `accepted` edges (table-driven over pending/rejected/revoked/deleted); enumerates every quoter **past the pagination page size**.
- `notificationTypeMapping.test.ts`: `quote`/`quoted_update` both directions.
- `updateNote.test.ts`: local edit notifies quoters; `publish:false` does not.
- `updateNoteJob.test.ts`: inbound remote edit notifies the local quoter.

## Gate

`prettier:check`, `yarn lint` (0 errors), `yarn build`, `yarn test` (6561 passed) all green locally.

## Docs

Updated the notifications entry in `docs/features.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)