### PR TITLE
Bump version to v1.111.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.110.0",
+  "version": "1.111.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.111.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.110.0`
- Base main SHA: `ee65625caca80a0c9d20f02b1c3861c166f788c7`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
