### PR TITLE
minor: fan quote-revocation Delete out to all prior recipients (Epic 4.1f)

### DIFF
--- a/app/api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke/route.test.ts
+++ b/app/api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke/route.test.ts
@@ -145,6 +145,7 @@ describe('POST /api/v1/statuses/[id]/quotes/[quoting_status_id]/revoke', () => {
         data: expect.objectContaining({
           actorId: ACTOR1_ID,
           quotingActorId: REMOTE_QUOTER_ID,
+          quotingStatusId: quotingId,
           stampId: stampUri
         })
       })

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -157,9 +157,12 @@ product or security decision, not a gap to be closed.
   Legacy Fedibird (`quoteUri`)
   and Misskey (`_misskey_quote`) quotes carry no stamp, so they are stored and
   rendered as unapproved (`pending`) rather than as embedded quotes, matching
-  Mastodon 4.5's treatment of stamp-less quotes. Revocation v1 delivers the stamp
-  `Delete` to the quoting author's server only, not to every prior recipient.
-  Changing a status's quote policy via `PUT …/interaction_policy` is not treated
+  Mastodon 4.5's treatment of stamp-less quotes. Revoking approval fans the stamp
+  `Delete` out to the quoting author's inbox **and** every named (`to`/`cc`)
+  recipient of the quoting note, so third-party servers that saw the quote honor
+  the revocation (FEP-044f); every copy stays signed by the quoted author, which
+  is what the receiving side requires. Changing a status's quote policy via
+  `PUT …/interaction_policy` is not treated
   as an edit (it never sets `edited_at`). Configured under `lib/services/quotes/`,
   `lib/actions/*Quote*`, and `app/api/v1/statuses/[id]/quotes|interaction_policy`.
 

--- a/lib/actions/revokeStatusQuote.ts
+++ b/lib/actions/revokeStatusQuote.ts
@@ -24,8 +24,8 @@ export type RevokeStatusQuoteResult =
  * `POST /statuses/:id/quotes/:quoting_status_id/revoke`). Author-only. Flips the
  * edge to `revoked` (idempotent; the stamp route stops serving once non-accepted)
  * and, when a hosted stamp exists, delivers a FEP-044f Delete of it to the
- * quoting author's inbox. Returns the quoting status with `quote.state:
- * 'revoked'`.
+ * quoting author's inbox and every named recipient of the quoting note. Returns
+ * the quoting status with `quote.state: 'revoked'`.
  */
 export const revokeStatusQuoteFromUserInput = async ({
   currentActor,
@@ -75,9 +75,10 @@ export const revokeStatusQuoteFromUserInput = async ({
     return { ok: false, reason: 'not_found' }
   }
 
-  // Federate the stamp revocation to the quoting author (best-effort; v1
-  // notifies the quoting server only, not every prior recipient). Only when a
-  // hosted stamp was actually issued and the quoter is a different actor.
+  // Federate the stamp revocation (best-effort). The job fans the Delete out to
+  // the quoting author's inbox and every named recipient of the quoting note, so
+  // every server that saw the quote honors the revocation (FEP-044f). Only when
+  // a hosted stamp was actually issued and the quoter is a different actor.
   const quotingActorId = getOriginalStatus(quotingStatus).actorId
   if (edge.authorizationUri && quotingActorId !== currentActor.id) {
     await getQueue().publish({
@@ -86,6 +87,7 @@ export const revokeStatusQuoteFromUserInput = async ({
       data: {
         actorId: currentActor.id,
         quotingActorId,
+        quotingStatusId,
         stampId: edge.authorizationUri
       }
     })

--- a/lib/jobs/sendQuoteRevokeJob.test.ts
+++ b/lib/jobs/sendQuoteRevokeJob.test.ts
@@ -1,0 +1,136 @@
+import { sendQuoteRevoke } from '@/lib/activities'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SEND_QUOTE_REVOKE_JOB_NAME } from '@/lib/jobs/names'
+import { sendQuoteRevokeJob } from '@/lib/jobs/sendQuoteRevokeJob'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID } from '@/lib/stub/seed/actor1'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+
+vi.mock('@/lib/activities', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/activities')>()),
+  sendQuoteRevoke: vi.fn().mockResolvedValue(undefined)
+}))
+
+// Resolve any actor's inbox to <actorId>/inbox without a network fetch.
+vi.mock('@/lib/activities/getActorPerson', () => ({
+  getActorPerson: vi.fn(({ actorId }: { actorId: string }) =>
+    Promise.resolve({ inbox: `${actorId}/inbox` })
+  )
+}))
+
+vi.mock('@/lib/services/federation/getFederationSigningActor', () => ({
+  getFederationSigningActor: vi.fn().mockResolvedValue(null)
+}))
+
+const REMOTE_QUOTER_ID = 'https://remote.example/users/quoter'
+const MENTIONED_ACTOR_ID = 'https://mention.example/users/bob'
+const MENTIONED_SHARED_INBOX = 'https://mention.example/inbox'
+const STAMP_ID = `${ACTOR1_ID}/quote_authorizations/fanout`
+
+describe('sendQuoteRevokeJob', () => {
+  const database = getTestSQLDatabase()
+  const mockSendQuoteRevoke = sendQuoteRevoke as jest.MockedFunction<
+    typeof sendQuoteRevoke
+  >
+  let counter = 0
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    await database.createActor({
+      actorId: REMOTE_QUOTER_ID,
+      username: 'quoter',
+      domain: 'remote.example',
+      followersUrl: `${REMOTE_QUOTER_ID}/followers`,
+      inboxUrl: `${REMOTE_QUOTER_ID}/inbox`,
+      sharedInboxUrl: 'https://remote.example/inbox',
+      publicKey: 'public-key',
+      createdAt: Date.now()
+    })
+    await database.createActor({
+      actorId: MENTIONED_ACTOR_ID,
+      username: 'bob',
+      domain: 'mention.example',
+      followersUrl: `${MENTIONED_ACTOR_ID}/followers`,
+      inboxUrl: `${MENTIONED_ACTOR_ID}/inbox`,
+      sharedInboxUrl: MENTIONED_SHARED_INBOX,
+      publicKey: 'public-key',
+      createdAt: Date.now()
+    })
+  })
+
+  afterAll(async () => {
+    if (database) await database.destroy()
+  })
+
+  beforeEach(() => {
+    mockSendQuoteRevoke.mockClear()
+  })
+
+  const seedQuoting = async (cc: string[]) => {
+    counter += 1
+    const quotingStatusId = `${REMOTE_QUOTER_ID}/statuses/revoke-fanout-${counter}`
+    await database.createNote({
+      id: quotingStatusId,
+      url: quotingStatusId,
+      actorId: REMOTE_QUOTER_ID,
+      text: 'quoting you',
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc
+    })
+    return quotingStatusId
+  }
+
+  const runJob = (quotingStatusId?: string) =>
+    sendQuoteRevokeJob(database, {
+      id: 'revoke-job',
+      name: SEND_QUOTE_REVOKE_JOB_NAME,
+      data: {
+        actorId: ACTOR1_ID,
+        quotingActorId: REMOTE_QUOTER_ID,
+        ...(quotingStatusId ? { quotingStatusId } : {}),
+        stampId: STAMP_ID
+      }
+    })
+
+  const sentInboxes = () =>
+    mockSendQuoteRevoke.mock.calls.map((c) => c[0].inbox)
+
+  it('fans the stamp Delete out to the quoting note recipients and the quoting author', async () => {
+    const quotingStatusId = await seedQuoting([MENTIONED_ACTOR_ID])
+
+    await runJob(quotingStatusId)
+
+    const inboxes = sentInboxes()
+    expect(inboxes).toContain(`${REMOTE_QUOTER_ID}/inbox`)
+    expect(inboxes).toContain(MENTIONED_SHARED_INBOX)
+  })
+
+  it('signs every fanned-out Delete as the quoted author', async () => {
+    const quotingStatusId = await seedQuoting([MENTIONED_ACTOR_ID])
+
+    await runJob(quotingStatusId)
+
+    expect(mockSendQuoteRevoke).toHaveBeenCalled()
+    for (const call of mockSendQuoteRevoke.mock.calls) {
+      expect(call[0].currentActor.id).toBe(ACTOR1_ID)
+      expect(call[0].stampId).toBe(STAMP_ID)
+    }
+  })
+
+  it('delivers only to the quoting author when the note has no other recipients', async () => {
+    const quotingStatusId = await seedQuoting([])
+
+    await runJob(quotingStatusId)
+
+    const inboxes = sentInboxes()
+    expect(inboxes).toEqual([`${REMOTE_QUOTER_ID}/inbox`])
+  })
+
+  it('falls back to author-only delivery when no quotingStatusId is provided', async () => {
+    await runJob()
+
+    const inboxes = sentInboxes()
+    expect(inboxes).toEqual([`${REMOTE_QUOTER_ID}/inbox`])
+  })
+})

--- a/lib/jobs/sendQuoteRevokeJob.ts
+++ b/lib/jobs/sendQuoteRevokeJob.ts
@@ -6,47 +6,91 @@ import { createJobHandle } from '@/lib/jobs/createJobHandle'
 import { SEND_QUOTE_REVOKE_JOB_NAME } from '@/lib/jobs/names'
 import { canFederateWithDomain } from '@/lib/services/federation/domainPolicy'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
+import { getExplicitRecipientInboxes } from '@/lib/services/federation/statusDelivery'
 import { JobHandle } from '@/lib/services/queue/type'
+import { logger } from '@/lib/utils/logger'
 import { getTracer } from '@/lib/utils/trace'
 
 export const JobData = z.object({
   // The quoted author revoking their approval (signs the Delete).
   actorId: z.string(),
-  // The quoting note's author, whose inbox receives the stamp Delete.
+  // The quoting note's author, whose inbox always receives the stamp Delete.
   quotingActorId: z.string(),
+  // The quoting note whose named (to/cc) recipients also receive the Delete so
+  // every server that saw the quote honors the revocation (FEP-044f). Optional
+  // for backward compatibility with jobs queued before fan-out (author-only).
+  quotingStatusId: z.string().optional(),
   // The hosted QuoteAuthorization stamp id being revoked.
   stampId: z.string()
 })
 
 // Quoted-author side: withdraw a previously-issued QuoteAuthorization by
-// delivering a Delete of the stamp to the quoting author's inbox (FEP-044f).
+// delivering a Delete of the stamp (FEP-044f). The Delete is fanned out to the
+// quoting author's inbox AND every named (to/cc) recipient of the quoting note,
+// so any third-party server that received the quote un-approves it. Every copy
+// is signed by the quoted author (`currentActor`), which is exactly what the
+// receiving side (deleteObjectJob) requires: it revokes only when the Delete's
+// verified sender is the quoted status's own author. The signer must never
+// change per destination.
 export const sendQuoteRevokeJob: JobHandle = createJobHandle(
   SEND_QUOTE_REVOKE_JOB_NAME,
   async (database, message) => {
     await getTracer().startActiveSpan('sendQuoteRevokeJob', async (span) => {
-      const { actorId, quotingActorId, stampId } = JobData.parse(message.data)
+      const { actorId, quotingActorId, quotingStatusId, stampId } =
+        JobData.parse(message.data)
 
       if (!(await canFederateWithDomain(database, quotingActorId))) {
         span.end()
         return
       }
 
-      const [currentActor, signingActor] = await Promise.all([
+      const [currentActor, signingActor, quotingStatus] = await Promise.all([
         database.getActorFromId({ id: actorId }),
-        getFederationSigningActor(database)
+        getFederationSigningActor(database),
+        quotingStatusId
+          ? database.getStatus({
+              statusId: quotingStatusId,
+              withReplies: false
+            })
+          : Promise.resolve(null)
       ])
       if (!currentActor) {
         span.end()
         return
       }
 
+      // The quoting author's own inbox is always delivered (their server
+      // propagates to its follower audience, which we cannot enumerate).
       const person = await getActorPerson({
         actorId: quotingActorId,
         signingActor
       })
-      const inbox = person?.inbox ?? `${quotingActorId}/inbox`
+      const authorInbox = person?.inbox ?? `${quotingActorId}/inbox`
 
-      await sendQuoteRevoke({ currentActor, inbox, stampId })
+      // Plus the quoting note's named third-party recipients.
+      const recipientInboxes = quotingStatus
+        ? await getExplicitRecipientInboxes({
+            database,
+            currentActor,
+            status: quotingStatus
+          })
+        : []
+
+      const inboxes = [...new Set([authorInbox, ...recipientInboxes])]
+
+      await Promise.all(
+        inboxes.map(async (inbox) => {
+          try {
+            await sendQuoteRevoke({ currentActor, inbox, stampId })
+          } catch (error) {
+            logger.error({
+              message: 'Failed to send quote revoke',
+              inbox,
+              error: error instanceof Error ? error.message : String(error)
+            })
+          }
+        })
+      )
 
       span.end()
     })

--- a/lib/services/federation/statusDelivery.test.ts
+++ b/lib/services/federation/statusDelivery.test.ts
@@ -4,7 +4,10 @@ import { Actor } from '@/lib/types/domain/actor'
 import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
-import { getFederatedStatusDeliveryInboxes } from './statusDelivery'
+import {
+  getExplicitRecipientInboxes,
+  getFederatedStatusDeliveryInboxes
+} from './statusDelivery'
 
 vi.mock('@/lib/activities/getActorPerson', () => ({
   getActorPerson: vi.fn()
@@ -212,5 +215,62 @@ describe('getFederatedStatusDeliveryInboxes', () => {
     })
 
     expect(maxActiveLookups).toBeLessThanOrEqual(8)
+  })
+})
+
+describe('getExplicitRecipientInboxes', () => {
+  beforeEach(() => {
+    vi.mocked(getActorPerson).mockResolvedValue(null)
+  })
+
+  it('returns only named remote recipients, never followers or relays', async () => {
+    const currentActor = makeActor('https://local.test/users/alice', {
+      privateKey: 'private-key'
+    })
+    const remoteActor = makeActor('https://remote.test/users/bob')
+    const localRecipient = makeActor('https://local.test/users/carol', {
+      privateKey: 'private-key'
+    })
+    const getFollowersInbox = vi
+      .fn()
+      .mockResolvedValue(['https://follower.example/inbox'])
+    const getAcceptedRelays = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'r1', inboxUrl: 'https://relay.example/inbox', state: 'accepted' }
+      ])
+    const database = makeDatabase({
+      getFollowersInbox,
+      getAcceptedRelays,
+      getActorsFromIds: vi.fn(async ({ ids }) =>
+        ids
+          .map((id) => {
+            if (id === remoteActor.id) return remoteActor
+            if (id === localRecipient.id) return localRecipient
+            return null
+          })
+          .filter((actor): actor is Actor => actor !== null)
+      )
+    })
+
+    // A public + followers audience would expand followers/relays in
+    // getFederatedStatusDeliveryInboxes; getExplicitRecipientInboxes must not.
+    const inboxes = await getExplicitRecipientInboxes({
+      database,
+      currentActor,
+      status: makeStatus({
+        to: [
+          ACTIVITY_STREAM_PUBLIC,
+          `${currentActor.id}/followers`,
+          currentActor.id,
+          remoteActor.id,
+          localRecipient.id
+        ]
+      })
+    })
+
+    expect(inboxes).toEqual([remoteActor.sharedInboxUrl])
+    expect(getFollowersInbox).not.toHaveBeenCalled()
+    expect(getAcceptedRelays).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/federation/statusDelivery.ts
+++ b/lib/services/federation/statusDelivery.ts
@@ -95,6 +95,35 @@ const getRemoteActorInboxes = async ({
   return [...cachedInboxes, ...fetchedInboxes]
 }
 
+// The remote inboxes of a status's explicitly-named (to/cc) recipients only —
+// no follower or relay expansion. Used to fan a stamp revocation out to the
+// quoting note's named third-party recipients (FEP-044f), where the follower/
+// relay branches of getFederatedStatusDeliveryInboxes would incorrectly key off
+// the signer (the quoted author) rather than the quoting note's audience. Local
+// recipients and the signer itself are excluded, and the result is domain-policy
+// filtered.
+export const getExplicitRecipientInboxes = async ({
+  database,
+  currentActor,
+  status
+}: {
+  database: Database
+  currentActor: Actor
+  status: Status
+}) => {
+  const explicitRecipientActorIds = getExplicitRecipientActorIds(status).filter(
+    (actorId) => actorId !== currentActor.id
+  )
+  const recipientInboxes = await getRemoteActorInboxes({
+    database,
+    actorIds: explicitRecipientActorIds,
+    currentActor
+  })
+  return filterFederatedUrls(database, [
+    ...new Set(recipientInboxes.filter((inbox): inbox is string => !!inbox))
+  ])
+}
+
 export const getFederatedStatusDeliveryInboxes = async ({
   database,
   currentActor,


### PR DESCRIPTION
## Summary

Epic 4.1f follow-up (item 3 of 5): honor the FEP-044f **third-party MUST-honor** requirement for quote revocation. v1 delivered the `QuoteAuthorization` stamp `Delete` to the quoting author's inbox only; now the revoke job also fans it out to every named (`to`/`cc`) recipient of the quoting note.

## What changed

- **`getExplicitRecipientInboxes`** (new export in `lib/services/federation/statusDelivery.ts`): resolves only a status's named `to`/`cc` remote recipient inboxes — **no** follower/relay expansion. `getFederatedStatusDeliveryInboxes` keys its follower/relay branches off `currentActor`, which for a revoke is the *quoted author* (the signer), so it would reach the wrong audience. Local recipients and the signer are excluded; the result is domain-policy filtered.
- **`sendQuoteRevokeJob`**: loads the quoting note (`JobData` gains an **optional** `quotingStatusId`, for backward-compat with jobs queued before this change), unions the quoting author's inbox with the note's named recipients, dedups, and delivers to each. **Every copy stays signed by the quoted author** — exactly what the receiving `deleteObjectJob` exact-author check requires (left untouched; fan-out is safe because the signer never changes).
- **`revokeStatusQuoteFromUserInput`**: passes `quotingStatusId` in the job payload.

## Tests

- New `lib/jobs/sendQuoteRevokeJob.test.ts`: fans out to author + named recipient; signs every copy as the quoted author; author-only when no other recipients; author-only fallback when `quotingStatusId` absent.
- `statusDelivery.test.ts`: `getExplicitRecipientInboxes` returns only named remote recipients, never followers/relays.
- `revoke/route.test.ts`: asserts the job payload carries `quotingStatusId`.

## Gate

`prettier:check`, `yarn lint` (0 errors), `yarn build`, `yarn test` (6553 passed) all green locally. No migration.

## Docs

Updated the revocation divergence note in `docs/mastodon-api-compatibility.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)