### PR TITLE
minor: advertise Mastodon 4.5 quote support via instance api_versions (Epic 4.1f)

### DIFF
--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -148,7 +148,19 @@ describe('GET /api/v2/instance', () => {
       { src: 'https://llun.test/icon-192.png', size: '192x192' },
       { src: 'https://llun.test/icon-512.png', size: '512x512' }
     ])
-    expect(body.api_versions).toEqual({ mastodon: 2 })
+    expect(body.api_versions).toEqual({ mastodon: 7 })
+  })
+
+  it('advertises Mastodon 4.5 quote support via api_versions without a streaming capability', async () => {
+    const response = await GET(
+      new NextRequest('https://llun.test/api/v2/instance'),
+      params
+    )
+    const body = await response.json()
+    // Mastodon clients gate quote authoring on api_versions.mastodon >= 7 (4.5).
+    expect(body.api_versions.mastodon).toBeGreaterThanOrEqual(7)
+    // Streaming stays un-advertised so clients fall back to REST polling.
+    expect(body.configuration.urls.streaming).toBe('')
   })
 
   it('serves streaming and vapid configuration', async () => {

--- a/docs/features.md
+++ b/docs/features.md
@@ -66,7 +66,7 @@ This document tracks the implemented and planned features for Activity.next.
 
 - ✅ **Mastodon API v1/v2** — Compatible with Mastodon client applications (including iOS clients); statuses, accounts, and media endpoints are fully Mastodon-compatible
 - ✅ **Mastodon-compatible status actions** — Favourite, reblog, bookmark, pin, context, history, translate, and relationship endpoints
-- ✅ **Quote posts API (Mastodon 4.5)** — `quoted_status_id` + `quote_approval_policy` on `POST /api/v1/statuses`, the `quote` sub-entity and `quote_approval` on the Status entity, `GET /api/v1/statuses/:id/quotes`, `POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke`, `PUT /api/v1/statuses/:id/interaction_policy`, and the `posting:default:quote_policy` preference / `source[quote_policy]` on `update_credentials`
+- ✅ **Quote posts API (Mastodon 4.5)** — `quoted_status_id` + `quote_approval_policy` on `POST /api/v1/statuses`, the `quote` sub-entity and `quote_approval` on the Status entity, `GET /api/v1/statuses/:id/quotes`, `POST /api/v1/statuses/:id/quotes/:quoting_status_id/revoke`, `PUT /api/v1/statuses/:id/interaction_policy`, and the `posting:default:quote_policy` preference / `source[quote_policy]` on `update_credentials`; quote support is advertised to clients via `api_versions.mastodon: 7` on `GET /api/v2/instance`
 - ✅ **Granular OAuth scopes** — Fine-grained scope enforcement and client-credentials app tokens
 - ✅ **Search** — Search accounts, hashtags, and statuses via `/api/v2/search` (status search backed by a full-text index)
 - ✅ **Lists** — Create and manage timeline lists, their members, replies policy, and exclusive flag

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -162,9 +162,16 @@ product or security decision, not a gap to be closed.
   recipient of the quoting note, so third-party servers that saw the quote honor
   the revocation (FEP-044f); every copy stays signed by the quoted author, which
   is what the receiving side requires. Changing a status's quote policy via
-  `PUT …/interaction_policy` is not treated
-  as an edit (it never sets `edited_at`). Configured under `lib/services/quotes/`,
-  `lib/actions/*Quote*`, and `app/api/v1/statuses/[id]/quotes|interaction_policy`.
+  `PUT …/interaction_policy` is not treated as an edit (it never sets
+  `edited_at`). The v2 instance entity advertises `api_versions.mastodon: 7` so
+  Mastodon 4.5 clients enable their quote UI (streaming stays unadvertised —
+  `configuration.urls.streaming` is empty, so no streaming capability is
+  claimed). Quote cards render only for **stored** statuses: a live
+  remote-profile view (`getActorPosts` / `fromNote`, which builds unstored
+  ephemeral statuses that carry no quote edge) omits quote rendering — those
+  posts show their quote once actually ingested and stored. Configured under
+  `lib/services/quotes/`, `lib/actions/*Quote*`, and
+  `app/api/v1/statuses/[id]/quotes|interaction_policy`.
 
 ## Not planned
 

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -26,7 +26,11 @@ export const MIN_SCHEDULED_STATUS_AHEAD_MS = 5 * 60 * 1000
 export const SCHEDULED_AT_TOO_SOON_ERROR =
   'Validation failed: Scheduled at must be at least 5 minutes in the future'
 
-// Advertised in the v2 instance entity (api_versions.mastodon). Mastodon 4.3
-// introduced the field with value 2; this server implements the 4.3-era API
-// surface, so advertise 2 and bump only alongside newer API features.
-export const MASTODON_INSTANCE_API_VERSION = 2
+// Advertised in the v2 instance entity (api_versions.mastodon). Mastodon exposes
+// this as a single monotonic integer bumped per release (4.3 → 2, 4.4 → 6,
+// 4.5 → 7, 4.6 → 10). Mastodon 4.5 introduced quote posts and its client guide
+// gates quote authoring on api_versions.mastodon >= 7, so this server — which
+// implements the 4.5 quote-post surface — advertises 7. Streaming stays
+// unadvertised (configuration.urls.streaming is empty), so no streaming
+// capability is claimed.
+export const MASTODON_INSTANCE_API_VERSION = 7


### PR DESCRIPTION
Epic 4.1f items 4 & 5. Item 4: bump MASTODON_INSTANCE_API_VERSION 2->7 so /api/v2/instance reports api_versions.mastodon:7 (Mastodon 4.5 clients gate quote authoring on >=7). Streaming stays unadvertised (streaming:''). Item 5 (ephemeral remote quotes): DEFER+documented. Tests+gate green (6566). No migration.