### PR TITLE
Bump version to v1.113.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.113.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.112.0`
- Base main SHA: `4ad0daeac73e1c25d195a3750f0d525a84fb9d9a`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
