### PR TITLE
fix: align inline fitness post card with design system

### DIFF
--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -1035,13 +1035,97 @@ describe('Post', () => {
     // not the old "Distance: <value>" inline text).
     expect(screen.getByText('Distance')).toBeInTheDocument()
     expect(screen.getByText('11.4 km')).toBeInTheDocument()
+    expect(screen.getByText('Duration')).toBeInTheDocument()
+    expect(screen.getByText('2:38:00')).toBeInTheDocument()
+    // A run activity surfaces Pace (not Avg speed) via getFitnessPaceOrSpeed.
+    expect(screen.getByText('Pace')).toBeInTheDocument()
     expect(screen.getByText('Elevation')).toBeInTheDocument()
     expect(screen.getByText('964 m')).toBeInTheDocument()
     // Recording device footer links to the brand.
     expect(screen.getByRole('link', { name: 'Fenix 7' })).toBeInTheDocument()
-    // The old inline treatment is gone.
-    expect(screen.queryByText('Fitness')).not.toBeInTheDocument()
+    // Screen-reader label replaces the dropped visible "Fitness" text.
+    expect(screen.getByText('Fitness activity')).toBeInTheDocument()
+    // The old inline "Distance: <value>" treatment is gone.
     expect(screen.queryByText(/Distance:/)).not.toBeInTheDocument()
+  })
+
+  it('surfaces Avg speed (not Pace) for a cycling activity', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            totalDistanceMeters: 26200,
+            totalDurationSeconds: 3822,
+            activityType: 'ride'
+          }
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Avg speed')).toBeInTheDocument()
+    expect(screen.getByText('24.7 km/h')).toBeInTheDocument()
+    expect(screen.queryByText('Pace')).not.toBeInTheDocument()
+  })
+
+  it('drops stat cells whose metric the file does not provide', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            // Only distance is present: no duration/elevation, and pace/speed
+            // needs both distance and duration, so those cells are dropped.
+            totalDistanceMeters: 5000
+          }
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Distance')).toBeInTheDocument()
+    expect(screen.getByText('5.00 km')).toBeInTheDocument()
+    expect(screen.queryByText('Duration')).not.toBeInTheDocument()
+    expect(screen.queryByText('Elevation')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pace')).not.toBeInTheDocument()
+    expect(screen.queryByText('Avg speed')).not.toBeInTheDocument()
+  })
+
+  it('omits the stat grid entirely when no metrics are available but still shows the device', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            // Completed, but nothing measurable parsed out of the file.
+            deviceManufacturer: 'garmin',
+            deviceName: 'Fenix 7'
+          }
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    // No stat grid at all.
+    expect(screen.queryByText('Distance')).not.toBeInTheDocument()
+    expect(screen.queryByText('Duration')).not.toBeInTheDocument()
+    expect(screen.queryByText('Elevation')).not.toBeInTheDocument()
+    // The file row and the decoupled device footer still render.
+    expect(screen.getByText('strava-123.tcx')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Fenix 7' })).toBeInTheDocument()
   })
 
   describe('Translate gating', () => {

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -1004,6 +1004,46 @@ describe('Post', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('renders the labeled stat grid, type pill, and device for a completed fitness file', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentTime={currentTime}
+        status={{
+          ...status,
+          summary: null,
+          fitness: {
+            ...fitnessBase,
+            fileType: 'fit',
+            fileName: '2025-05-27-skitour.fit',
+            totalDistanceMeters: 11400,
+            totalDurationSeconds: 9480,
+            elevationGainMeters: 964,
+            activityType: 'run',
+            deviceManufacturer: 'garmin',
+            deviceName: 'Fenix 7'
+          }
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    // File name and lowercase type pill.
+    expect(screen.getByText('2025-05-27-skitour.fit')).toBeInTheDocument()
+    expect(screen.getByText('fit')).toBeInTheDocument()
+    // Stats render as labeled cells (label and value are separate elements,
+    // not the old "Distance: <value>" inline text).
+    expect(screen.getByText('Distance')).toBeInTheDocument()
+    expect(screen.getByText('11.4 km')).toBeInTheDocument()
+    expect(screen.getByText('Elevation')).toBeInTheDocument()
+    expect(screen.getByText('964 m')).toBeInTheDocument()
+    // Recording device footer links to the brand.
+    expect(screen.getByRole('link', { name: 'Fenix 7' })).toBeInTheDocument()
+    // The old inline treatment is gone.
+    expect(screen.queryByText('Fitness')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Distance:/)).not.toBeInTheDocument()
+  })
+
   describe('Translate gating', () => {
     beforeEach(() => {
       ;(getTranslationCapability as jest.Mock).mockResolvedValue({

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -200,6 +200,9 @@ export const Post: FC<PostProps> = (props) => {
         <div className="mt-2 max-w-full rounded-lg border bg-background p-3 text-xs">
           <div className="flex max-w-full items-center gap-2">
             <Activity className="size-4 shrink-0 text-primary" />
+            {/* The visible "Fitness" label was dropped in the redesign; keep the
+                activity semantic for screen readers. */}
+            <span className="sr-only">Fitness activity</span>
             <a
               href={fitnessFile.url}
               target="_blank"

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -139,6 +139,22 @@ export const Post: FC<PostProps> = (props) => {
     activityType: fitnessFile?.activityType
   })
   const fitnessSourceUrl = normalizeFitnessSourceUrl(fitnessFile?.sourceUrl)
+  const fitnessDeviceLabel = getDeviceDisplayLabel(
+    fitnessFile?.deviceName,
+    fitnessFile?.deviceManufacturer
+  )
+  // Labeled stat cells for the 4-up grid, in the design's order, dropping any
+  // metric the file doesn't provide.
+  const fitnessStats = [
+    { label: 'Distance', value: fitnessDistance },
+    { label: 'Duration', value: fitnessDuration },
+    fitnessPaceOrSpeed
+      ? { label: fitnessPaceOrSpeed.label, value: fitnessPaceOrSpeed.value }
+      : null,
+    { label: 'Elevation', value: fitnessElevation }
+  ].filter((stat): stat is { label: string; value: string } =>
+    Boolean(stat?.value)
+  )
   const isOwner =
     Boolean(actualStatus.isLocalActor) &&
     props.currentActor?.id === actualStatus.actorId
@@ -181,22 +197,19 @@ export const Post: FC<PostProps> = (props) => {
         )}
       </TranslateContent>
       {fitnessFile ? (
-        <div className="mt-2 max-w-full rounded-md border bg-muted/30 px-3 py-2 text-xs">
+        <div className="mt-2 max-w-full rounded-lg border bg-background p-3 text-xs">
           <div className="flex max-w-full items-center gap-2">
-            <Activity className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="shrink-0 font-medium text-muted-foreground">
-              Fitness
-            </span>
+            <Activity className="size-4 shrink-0 text-primary" />
             <a
               href={fitnessFile.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="truncate text-foreground underline-offset-2 hover:underline"
+              className="truncate font-mono text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
               title={fitnessFile.fileName}
             >
               {fitnessFile.fileName}
             </a>
-            <span className="shrink-0 text-muted-foreground uppercase">
+            <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
               {fitnessFile.fileType}
             </span>
           </div>
@@ -225,48 +238,28 @@ export const Post: FC<PostProps> = (props) => {
             )
           ) : null}
 
-          {isFitnessCompleted ? (
-            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
-              {fitnessDistance ? (
-                <span>
-                  Distance:{' '}
-                  <strong className="text-foreground">{fitnessDistance}</strong>
-                </span>
-              ) : null}
-              {fitnessDuration ? (
-                <span>
-                  Duration:{' '}
-                  <strong className="text-foreground">{fitnessDuration}</strong>
-                </span>
-              ) : null}
-              {fitnessPaceOrSpeed ? (
-                <span>
-                  {fitnessPaceOrSpeed.label}:{' '}
-                  <strong className="text-foreground">
-                    {fitnessPaceOrSpeed.value}
-                  </strong>
-                </span>
-              ) : null}
-              {fitnessElevation ? (
-                <span>
-                  Elevation:{' '}
-                  <strong className="text-foreground">
-                    {fitnessElevation}
-                  </strong>
-                </span>
-              ) : null}
-              {getDeviceDisplayLabel(
-                fitnessFile.deviceName,
-                fitnessFile.deviceManufacturer
-              ) ? (
-                <span className="text-muted-foreground">
-                  Via:{' '}
-                  <BrandedDeviceLink
-                    deviceName={fitnessFile.deviceName}
-                    deviceManufacturer={fitnessFile.deviceManufacturer}
-                  />
-                </span>
-              ) : null}
+          {isFitnessCompleted && fitnessStats.length > 0 ? (
+            <div className="mt-2.5 grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {fitnessStats.map((stat) => (
+                <div key={stat.label} className="flex flex-col gap-0.5">
+                  <span className="text-[11px] text-muted-foreground">
+                    {stat.label}
+                  </span>
+                  <span className="text-sm font-semibold text-foreground">
+                    {stat.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {isFitnessCompleted && fitnessDeviceLabel ? (
+            <div className="mt-2 text-[11px] text-muted-foreground">
+              Via:{' '}
+              <BrandedDeviceLink
+                deviceName={fitnessFile.deviceName}
+                deviceManufacturer={fitnessFile.deviceManufacturer}
+              />
             </div>
           ) : null}
 
@@ -276,7 +269,7 @@ export const Post: FC<PostProps> = (props) => {
                 href={fitnessSourceUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
               >
                 <ExternalLink className="size-3.5 shrink-0" />
                 {getFitnessSourceLabel(fitnessSourceUrl)}


### PR DESCRIPTION
## Summary

Restyles the fitness activity card rendered inside a timeline post ([`lib/components/posts/post.tsx`](https://github.com/llun/activities.next/blob/claude/fitness-status-design-1c021f/lib/components/posts/post.tsx)) to match the design system's `FitnessChip` spec (`ui_kits/web/FitnessChip.jsx` in the "Activities.next Design System" project). This is the inline card in the post/feed — **not** the completed-fitness detail page (`FitnessStatusDetail.tsx`, unchanged).

### Changes
- **Card**: `rounded-lg border` on `bg-background` (was a `bg-muted/30` gray tint) — a theme-aware white that lifts off the framed timeline card (`bg-card`) and stays correct in dark mode.
- **Header row**: orange `Activity` icon (`text-primary`), a **monospace** muted file-name link, and a right-aligned **rounded pill** for the file type. Removes the old "Fitness" word label and the `uppercase` type text.
- **Stats**: a labeled **4-up grid** (Distance / Duration / Pace|Speed / Elevation — label over value) instead of the old inline "Distance: **value**" spans. The pace/speed label stays derived from `getFitnessPaceOrSpeed`.
- **Device**: moved to its own `Via: <device>` footer line (still via `BrandedDeviceLink`).

No activity-title row: the design's `fitness.title` will be handled in the design; `StatusFitnessFile` has no title field and `fitness.description` is left untouched by the chip.

The processing, failed/retry, and "View on Strava" source-link branches are unchanged.

## Testing
- `yarn run prettier --write .`, `yarn lint` (0 errors), `yarn build` (exit 0), `yarn test` (**688 files / 6572 tests passed**) — all green.
- Updated `post.test.tsx` to assert the new labeled stat grid, type pill, and device link, and that the old inline "Distance:" / "Fitness" markup is gone.
- **Browser-verified** locally (SQLite mock data) in **light and dark mode** across three variants: full card with a branded device, a card with a Strava source link, and a card with a plain (unknown-brand) device.

## Notes
- Number formatting is unchanged (existing formatters): Duration renders `H:MM:SS`, and the metric is `Pace` (run/walk/hike/swim) or `Avg speed` otherwise — so it may differ from a design mock that hardcodes `2h 38m` / `312 m/h`. Out of scope for this restyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)