### PR TITLE
fix: resolve inbound remote quotes with valid FEP-044f stamps (Epic 4.1f)

### DIFF
--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -154,7 +154,12 @@ product or security decision, not a gap to be closed.
   non-author viewer sees `automatic` when they are an accepted follower of the
   author and `denied` otherwise (an anonymous viewer still sees `unknown`); the
   verdict is resolved in one batched follow query per page, so it adds no N+1.
-  Legacy Fedibird (`quoteUri`)
+  An inbound quote that arrives with a valid `quoteAuthorization` stamp is
+  accepted even when the quoted post is not already stored locally: the quoted
+  note is fetched (instance-signed, like the boost path) so the stamp can be
+  verified against its author and the quote card can embed the content. Fetching
+  only makes the author knowable — the stamp's three-field match against that
+  author is still what grants approval. Legacy Fedibird (`quoteUri`)
   and Misskey (`_misskey_quote`) quotes carry no stamp, so they are stored and
   rendered as unapproved (`pending`) rather than as embedded quotes, matching
   Mastodon 4.5's treatment of stamp-less quotes. Revoking approval fans the stamp

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -3,10 +3,15 @@ import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { createNoteJob } from '@/lib/jobs/createNoteJob'
 import { CREATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
+import {
+  buildQuoteAuthorizationObject,
+  buildQuoteAuthorizationUri
+} from '@/lib/services/quotes/quoteAuthorization'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
 import { MockImageDocument } from '@/lib/stub/imageDocument'
 import { MockLitepubNote, MockMastodonActivityPubNote } from '@/lib/stub/note'
+import { MockActivityPubPerson } from '@/lib/stub/person'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
 import { Actor } from '@/lib/types/domain/actor'
@@ -865,6 +870,214 @@ describe('createNoteJob', () => {
       // The duplicate returned early (existing status), so createStatusQuote was
       // not called again and the sentinel survives.
       expect(edge?.authorizationUri).toBe('https://llun.test/sentinel')
+    })
+
+    it('fetches the quoted note and accepts a stamped quote whose target is not stored locally', async () => {
+      // Mastodon 4.5 quotes reference a post we usually do not already store. A
+      // valid FEP-044f stamp still proves approval, so createNoteJob must fetch
+      // the quoted note (instance-signed, like the boost path) so the stamp
+      // verifies against the quoted author and the quote card can load the
+      // content — instead of leaving every remote quote stuck as `pending`.
+      const quotedAuthorId = 'https://somewhere.test/users/quotedauthor'
+      const quotedStatusId = `${quotedAuthorId}/statuses/quoted-remote-accepted`
+      const quotingNoteId = `${ACTOR2_ID}/statuses/quoting-remote-accepted`
+      const stampUri = buildQuoteAuthorizationUri(quotedAuthorId, quotingNoteId)
+      const stampBody = JSON.stringify(
+        buildQuoteAuthorizationObject({
+          stampUri,
+          attributedTo: quotedAuthorId,
+          interactingObject: quotingNoteId,
+          interactionTarget: quotedStatusId
+        })
+      )
+
+      fetchMock.mockResponse(async (req) => {
+        const { pathname } = new URL(req.url)
+        if (pathname.includes('/quote_authorizations/')) {
+          return { status: 200, body: stampBody }
+        }
+        if (pathname.includes('/statuses/')) {
+          const from = req.url.slice(0, req.url.indexOf('/statuses'))
+          return {
+            status: 200,
+            body: JSON.stringify(
+              MockMastodonActivityPubNote({
+                id: req.url,
+                from,
+                content: 'quoted remote status',
+                withContext: true
+              })
+            )
+          }
+        }
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockActivityPubPerson({ id: req.url, url: req.url })
+          )
+        }
+      })
+
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: quotingNoteId,
+          from: ACTOR2_ID,
+          content: 'cross-author remote quote'
+        }),
+        quote: quotedStatusId,
+        quoteAuthorization: stampUri
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-remote-accepted',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: ACTOR2_ID
+      })
+
+      // The quoted post is fetched and stored locally so the card can load it.
+      await expect(
+        database.getStatus({ statusId: quotedStatusId })
+      ).resolves.not.toBeNull()
+
+      // With the quoted author now known, the valid stamp verifies to accepted.
+      const edge = await database.getStatusQuote({ statusId: quotingNoteId })
+      expect(edge).toMatchObject({
+        quotedStatusId,
+        state: 'accepted'
+      })
+      expect(edge?.authorizationUri).toBe(stampUri)
+    })
+
+    it('leaves a stamped remote quote pending when the quoted note cannot be fetched', async () => {
+      // The quoted server is unreachable, so we never learn the author and the
+      // stamp cannot be validated. The quote must degrade to pending (never crash
+      // or trust the stamp blindly).
+      const quotedAuthorId = 'https://somewhere.test/users/unreachable'
+      const quotedStatusId = `${quotedAuthorId}/statuses/quoted-unreachable`
+      const quotingNoteId = `${ACTOR2_ID}/statuses/quoting-unreachable`
+      const stampUri = buildQuoteAuthorizationUri(quotedAuthorId, quotingNoteId)
+
+      fetchMock.mockResponse(async (req) => {
+        const { pathname } = new URL(req.url)
+        if (pathname.includes('/statuses/quoted-unreachable')) {
+          return { status: 404, body: '' }
+        }
+        if (pathname.includes('/quote_authorizations/')) {
+          return {
+            status: 200,
+            body: JSON.stringify(
+              buildQuoteAuthorizationObject({
+                stampUri,
+                attributedTo: quotedAuthorId,
+                interactingObject: quotingNoteId,
+                interactionTarget: quotedStatusId
+              })
+            )
+          }
+        }
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockActivityPubPerson({ id: req.url, url: req.url })
+          )
+        }
+      })
+
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: quotingNoteId,
+          from: ACTOR2_ID,
+          content: 'quote of an unreachable post'
+        }),
+        quote: quotedStatusId,
+        quoteAuthorization: stampUri
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-unreachable',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: ACTOR2_ID
+      })
+
+      await expect(
+        database.getStatus({ statusId: quotedStatusId })
+      ).resolves.toBeNull()
+      const edge = await database.getStatusQuote({ statusId: quotingNoteId })
+      expect(edge).toMatchObject({ quotedStatusId, state: 'pending' })
+    })
+
+    it('still rejects a forged stamp after fetching the quoted note (fetching grants no trust)', async () => {
+      // The stamp is hosted under the quoted author's authority but names a
+      // different issuer. Fetching the quoted note only makes the author
+      // knowable; the exact-actor check must still reject the forgery.
+      const quotedAuthorId = 'https://somewhere.test/users/victim'
+      const quotedStatusId = `${quotedAuthorId}/statuses/quoted-forged-remote`
+      const quotingNoteId = `${ACTOR2_ID}/statuses/quoting-forged-remote`
+      const stampUri = buildQuoteAuthorizationUri(quotedAuthorId, quotingNoteId)
+      const forgedStampBody = JSON.stringify(
+        buildQuoteAuthorizationObject({
+          stampUri,
+          attributedTo: 'https://somewhere.test/users/impostor',
+          interactingObject: quotingNoteId,
+          interactionTarget: quotedStatusId
+        })
+      )
+
+      fetchMock.mockResponse(async (req) => {
+        const { pathname } = new URL(req.url)
+        if (pathname.includes('/quote_authorizations/')) {
+          return { status: 200, body: forgedStampBody }
+        }
+        if (pathname.includes('/statuses/')) {
+          const from = req.url.slice(0, req.url.indexOf('/statuses'))
+          return {
+            status: 200,
+            body: JSON.stringify(
+              MockMastodonActivityPubNote({
+                id: req.url,
+                from,
+                content: 'victim status',
+                withContext: true
+              })
+            )
+          }
+        }
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockActivityPubPerson({ id: req.url, url: req.url })
+          )
+        }
+      })
+
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: quotingNoteId,
+          from: ACTOR2_ID,
+          content: 'quote with forged remote stamp'
+        }),
+        quote: quotedStatusId,
+        quoteAuthorization: stampUri
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-forged-remote',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: ACTOR2_ID
+      })
+
+      // The quoted note was fetched and stored so the card could load it...
+      await expect(
+        database.getStatus({ statusId: quotedStatusId })
+      ).resolves.not.toBeNull()
+      // ...but the forged stamp does not verify, so the edge stays pending and
+      // the attacker-supplied stamp uri is not persisted.
+      const edge = await database.getStatusQuote({ statusId: quotingNoteId })
+      expect(edge).toMatchObject({ quotedStatusId, state: 'pending' })
+      expect(edge?.authorizationUri).toBeNull()
     })
   })
 })

--- a/lib/jobs/createNoteJob.test.ts
+++ b/lib/jobs/createNoteJob.test.ts
@@ -1,5 +1,6 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
+import { QUOTE_ACTIVITY_CONTEXT } from '@/lib/activities/quoteContext'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { createNoteJob } from '@/lib/jobs/createNoteJob'
 import { CREATE_NOTE_JOB_NAME } from '@/lib/jobs/names'
@@ -1078,6 +1079,238 @@ describe('createNoteJob', () => {
       const edge = await database.getStatusQuote({ statusId: quotingNoteId })
       expect(edge).toMatchObject({ quotedStatusId, state: 'pending' })
       expect(edge?.authorizationUri).toBeNull()
+    })
+
+    it('does not fetch a not-locally-stored quote target when there is no stamp', async () => {
+      // Only stamped quotes are worth resolving; a stamp-less quote whose target
+      // is not stored must stay pending WITHOUT fetching, so we never fan out a
+      // fetch on every inbound quote.
+      const quotedStatusId =
+        'https://somewhere.test/users/stampless/statuses/quoted-stampless'
+      const quotingNoteId = `${ACTOR2_ID}/statuses/quoting-stampless-remote`
+
+      fetchMock.mockResponse(async () => {
+        throw new Error(
+          'no remote fetch expected for a stamp-less remote quote'
+        )
+      })
+
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: quotingNoteId,
+          from: ACTOR2_ID,
+          content: 'stamp-less remote quote'
+        }),
+        quote: quotedStatusId
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-stampless-remote',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: ACTOR2_ID
+      })
+
+      await expect(
+        database.getStatus({ statusId: quotedStatusId })
+      ).resolves.toBeNull()
+      const edge = await database.getStatusQuote({ statusId: quotingNoteId })
+      expect(edge).toMatchObject({ quotedStatusId, state: 'pending' })
+    })
+
+    it('bounds quote resolution to a single hop (a fetched quoted note does not chase its own quote)', async () => {
+      // A quotes B (stamped); the fetched B is itself a stamped quote of C. The
+      // recursive store must NOT fetch C, so an attacker-controlled chain cannot
+      // drive unbounded recursive fetches.
+      const authorB = 'https://somewhere.test/users/chain-b'
+      const bId = `${authorB}/statuses/chain-b`
+      const authorC = 'https://somewhere.test/users/chain-c'
+      const cId = `${authorC}/statuses/chain-c`
+      const quotingA = `${ACTOR2_ID}/statuses/quoting-a-chain`
+      const stampAB = buildQuoteAuthorizationUri(authorB, quotingA)
+      const stampBC = buildQuoteAuthorizationUri(authorC, bId)
+
+      fetchMock.mockResponse(async (req) => {
+        const { pathname } = new URL(req.url)
+        if (req.url === stampAB) {
+          return {
+            status: 200,
+            body: JSON.stringify(
+              buildQuoteAuthorizationObject({
+                stampUri: stampAB,
+                attributedTo: authorB,
+                interactingObject: quotingA,
+                interactionTarget: bId
+              })
+            )
+          }
+        }
+        // B is itself a stamped quote of C (quote terms carried on a real quote
+        // context so they survive compaction on fetch).
+        if (req.url === bId) {
+          return {
+            status: 200,
+            body: JSON.stringify({
+              '@context': QUOTE_ACTIVITY_CONTEXT,
+              ...MockMastodonActivityPubNote({
+                id: bId,
+                from: authorB,
+                content: 'note b quotes c'
+              }),
+              quote: cId,
+              quoteAuthorization: stampBC
+            })
+          }
+        }
+        // C's note and the B->C stamp are BOTH served successfully: without the
+        // single-hop bound, resolving B would fetch + store C (and accept B->C),
+        // which the assertions below detect as a regression.
+        if (req.url === stampBC) {
+          return {
+            status: 200,
+            body: JSON.stringify(
+              buildQuoteAuthorizationObject({
+                stampUri: stampBC,
+                attributedTo: authorC,
+                interactingObject: bId,
+                interactionTarget: cId
+              })
+            )
+          }
+        }
+        if (pathname.includes('/statuses/')) {
+          const from = req.url.slice(0, req.url.indexOf('/statuses'))
+          return {
+            status: 200,
+            body: JSON.stringify(
+              MockMastodonActivityPubNote({
+                id: req.url,
+                from,
+                content: 'note c',
+                withContext: true
+              })
+            )
+          }
+        }
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockActivityPubPerson({ id: req.url, url: req.url })
+          )
+        }
+      })
+
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: quotingA,
+          from: ACTOR2_ID,
+          content: 'a quotes b'
+        }),
+        quote: bId,
+        quoteAuthorization: stampAB
+      }
+
+      await createNoteJob(database, {
+        id: 'quote-a-chain',
+        name: CREATE_NOTE_JOB_NAME,
+        data: note,
+        verifiedSenderActorId: ACTOR2_ID
+      })
+
+      // A -> B resolved and accepted (B fetched + stored, valid stamp).
+      const edgeA = await database.getStatusQuote({ statusId: quotingA })
+      expect(edgeA).toMatchObject({ quotedStatusId: bId, state: 'accepted' })
+      await expect(
+        database.getStatus({ statusId: bId })
+      ).resolves.not.toBeNull()
+      // B's own quote target C was never fetched (single-hop), so B -> C stays
+      // pending and C is not stored.
+      await expect(database.getStatus({ statusId: cId })).resolves.toBeNull()
+      const edgeB = await database.getStatusQuote({ statusId: bId })
+      expect(edgeB).toMatchObject({ quotedStatusId: cId, state: 'pending' })
+    })
+
+    it('does not orphan the quoting note when the quoted author domain is blocked', async () => {
+      // Fetching the quoted note runs assertActorCanFederate for the quoted
+      // author, which throws for a blocked domain. That must not abort ingestion
+      // of the quoting note (which is already stored) — the edge degrades to
+      // pending and the note is fully processed.
+      const authorId = 'https://blocked-quote.test/users/blockedauthor'
+      const quotedStatusId = `${authorId}/statuses/quoted-blocked`
+      const quotingNoteId = `${ACTOR2_ID}/statuses/quoting-blocked-target`
+      const stampUri = buildQuoteAuthorizationUri(authorId, quotingNoteId)
+      await database.createDomainBlock({
+        domain: 'blocked-quote.test',
+        severity: 'suspend'
+      })
+
+      fetchMock.mockResponse(async (req) => {
+        const { pathname } = new URL(req.url)
+        if (pathname.includes('/quote_authorizations/')) {
+          return {
+            status: 200,
+            body: JSON.stringify(
+              buildQuoteAuthorizationObject({
+                stampUri,
+                attributedTo: authorId,
+                interactingObject: quotingNoteId,
+                interactionTarget: quotedStatusId
+              })
+            )
+          }
+        }
+        if (pathname.includes('/statuses/')) {
+          const from = req.url.slice(0, req.url.indexOf('/statuses'))
+          return {
+            status: 200,
+            body: JSON.stringify(
+              MockMastodonActivityPubNote({
+                id: req.url,
+                from,
+                content: 'blocked-domain quoted status',
+                withContext: true
+              })
+            )
+          }
+        }
+        return {
+          status: 200,
+          body: JSON.stringify(
+            MockActivityPubPerson({ id: req.url, url: req.url })
+          )
+        }
+      })
+
+      const note = {
+        ...MockMastodonActivityPubNote({
+          id: quotingNoteId,
+          from: ACTOR2_ID,
+          content: 'quote of a blocked-domain post'
+        }),
+        quote: quotedStatusId,
+        quoteAuthorization: stampUri
+      }
+
+      // The blocked-domain fetch must be swallowed, not thrown.
+      await expect(
+        createNoteJob(database, {
+          id: 'quote-blocked-target',
+          name: CREATE_NOTE_JOB_NAME,
+          data: note,
+          verifiedSenderActorId: ACTOR2_ID
+        })
+      ).resolves.not.toThrow()
+
+      // The quoting note is not orphaned: it keeps a pending quote edge and the
+      // quoted post is not stored.
+      await expect(
+        database.getStatus({ statusId: quotingNoteId })
+      ).resolves.not.toBeNull()
+      await expect(
+        database.getStatus({ statusId: quotedStatusId })
+      ).resolves.toBeNull()
+      const edge = await database.getStatusQuote({ statusId: quotingNoteId })
+      expect(edge).toMatchObject({ quotedStatusId, state: 'pending' })
     })
   })
 })

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -4,6 +4,7 @@ import {
   assertActorCanFederate,
   recordActorIfNeeded
 } from '@/lib/actions/utils'
+import { getNote } from '@/lib/activities'
 import {
   BaseNote,
   getAttachments,
@@ -14,6 +15,7 @@ import {
   getSummary,
   getTags
 } from '@/lib/activities/note'
+import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { persistDetectedLanguage } from '@/lib/services/language-detection'
 import { verifyRemoteQuote } from '@/lib/services/quotes/verifyRemoteQuote'
 import { addStatusToTimelines } from '@/lib/services/timelines'
@@ -132,10 +134,36 @@ export const createNoteJob = createJobHandle(
     // degrades to `pending` and never drops the note.
     const quotedStatusId = getQuoteTargetId(note)
     if (quotedStatusId) {
-      const quotedStatus = await database.getStatus({
+      let quotedStatus = await database.getStatus({
         statusId: quotedStatusId,
         withReplies: false
       })
+      // A Mastodon 4.5 quote references a post we usually do not already store.
+      // When the note carries a FEP-044f authorization stamp, fetch the quoted
+      // note (instance-signed, mirroring the boost path in createAnnounceJob) and
+      // store it so verifyRemoteQuote can confirm the quoted author and the quote
+      // card can load the content. Without this, every remote quote is stuck as a
+      // `pending` tombstone even when it was legitimately approved. Fetching only
+      // makes the author knowable — the stamp is still validated below, so a
+      // fetch never grants trust on its own.
+      if (!quotedStatus && note.quoteAuthorization) {
+        const signingActor = await getFederationSigningActor(database)
+        const fetchedQuotedNote = await getNote({
+          statusId: quotedStatusId,
+          signingActor
+        })
+        if (fetchedQuotedNote) {
+          await createNoteJob(database, {
+            id: fetchedQuotedNote.id,
+            name: CREATE_NOTE_JOB_NAME,
+            data: fetchedQuotedNote
+          })
+          quotedStatus = await database.getStatus({
+            statusId: quotedStatusId,
+            withReplies: false
+          })
+        }
+      }
       const state = await verifyRemoteQuote({
         database,
         note,

--- a/lib/jobs/createNoteJob.ts
+++ b/lib/jobs/createNoteJob.ts
@@ -32,6 +32,7 @@ import {
   normalizeActorId,
   toRecipientArray
 } from '@/lib/utils/activitypub'
+import { logger } from '@/lib/utils/logger'
 
 import { createJobHandle } from './createJobHandle'
 import { CREATE_NOTE_JOB_NAME } from './names'
@@ -146,21 +147,43 @@ export const createNoteJob = createJobHandle(
       // `pending` tombstone even when it was legitimately approved. Fetching only
       // makes the author knowable — the stamp is still validated below, so a
       // fetch never grants trust on its own.
-      if (!quotedStatus && note.quoteAuthorization) {
-        const signingActor = await getFederationSigningActor(database)
-        const fetchedQuotedNote = await getNote({
-          statusId: quotedStatusId,
-          signingActor
-        })
-        if (fetchedQuotedNote) {
-          await createNoteJob(database, {
-            id: fetchedQuotedNote.id,
-            name: CREATE_NOTE_JOB_NAME,
-            data: fetchedQuotedNote
-          })
-          quotedStatus = await database.getStatus({
+      //
+      // `skipQuoteResolution` bounds this to a single hop: the quoted note is
+      // stored WITHOUT chasing its own quote target, so an attacker-controlled
+      // chain of quoting notes (A quotes B quotes C …) cannot drive unbounded
+      // recursive fetches. Wrapped in try/catch so any failure (e.g. the quoted
+      // author's domain is federation-blocked, or a store error) leaves
+      // `quotedStatus` null and degrades the edge to `pending` rather than
+      // throwing and orphaning this note (the "never drops the note" invariant).
+      if (
+        !quotedStatus &&
+        note.quoteAuthorization &&
+        !message.skipQuoteResolution
+      ) {
+        try {
+          const signingActor = await getFederationSigningActor(database)
+          const fetchedQuotedNote = await getNote({
             statusId: quotedStatusId,
-            withReplies: false
+            signingActor
+          })
+          if (fetchedQuotedNote) {
+            await createNoteJob(database, {
+              id: fetchedQuotedNote.id,
+              name: CREATE_NOTE_JOB_NAME,
+              data: fetchedQuotedNote,
+              skipQuoteResolution: true
+            })
+            quotedStatus = await database.getStatus({
+              statusId: quotedStatusId,
+              withReplies: false
+            })
+          }
+        } catch (error) {
+          logger.warn({
+            message:
+              'Failed to fetch quoted note for inbound quote; leaving the edge pending',
+            quotedStatusId,
+            error: error instanceof Error ? error.message : String(error)
           })
         }
       }

--- a/lib/services/queue/type.ts
+++ b/lib/services/queue/type.ts
@@ -10,6 +10,12 @@ export interface JobMessage {
   // delaySeconds, so delayed jobs (e.g. scheduled statuses) only fire under a
   // real queue like QStash.
   delaySeconds?: number
+  // Internal, in-process only (never published to the queue): set when
+  // createNoteJob is invoked recursively to store a note it fetched as a quote
+  // target. It bounds inbound quote resolution to a single hop, so an
+  // attacker-controlled chain of quoting notes cannot drive unbounded recursive
+  // fetches. See createNoteJob's quote-resolution block.
+  skipQuoteResolution?: boolean
 }
 
 export interface Queue {


### PR DESCRIPTION
## Summary

Fixes quote posts that rendered as a **"Quote pending approval"** tombstone instead of the embedded quote card shown in the design. When such a quote is also boosted, it shows up as **"Boosted by …"** over a broken/pending quote — which is the "quote status that shows Boosted by at the top and different from the design" in the report.

## Root cause

`verifyRemoteQuote` returns `pending` whenever the quoted post is **not already stored locally** — it needs the quoted author's id to validate the FEP-044f `quoteAuthorization` stamp, and that id was only read from a locally-stored quoted status (`lib/services/quotes/verifyRemoteQuote.ts:104` bails before fetching the stamp). Instances rarely already store the quoted post (e.g. someone quoting a `@Techmeme` post you don't follow), so virtually **every** inbound remote quote was stuck `pending` and rendered as a tombstone.

Confirmed against the live instance: `paul@tapbots.social`'s quote of a Techmeme post carries a **valid** `quoteAuthorization` stamp hosted on `techhub.social`, and Techmeme's policy is `canQuote.automaticApproval: Public` — yet llun.dev rendered it as `pending` because Techmeme's post isn't stored locally.

## Fix

`createNoteJob` now fetches the quoted note (instance-signed, mirroring the boost path in `createAnnounceJob`) and stores it when the quoting note carries a `quoteAuthorization` stamp. The quoted author is then knowable, the stamp verifies, the edge becomes `accepted`, and the quote card can load the quoted content.

**Security invariant preserved:** fetching only makes the author *knowable*; the FEP-044f three-field stamp check (`attributedTo`/`interactingObject`/`interactionTarget` + same-authority) still gates approval. A forged or mismatched stamp stays `pending` and its uri is not persisted (covered by a new test). The fetch is gated on a stamp being present, so stamp-less Fedibird/Misskey quotes keep their existing `pending` behavior and we don't fetch on every quote.

## Scope note

The **"Boosted by …"** header itself is a genuine boost of a quote (e.g. `mishari@mastodon.in.th` boosted paul's quote), which correctly matches the design's boost rows — so it is intentionally unchanged. This PR fixes the quote *content* not rendering, which is the actual divergence from the design.

## Testing

- New integration tests in `lib/jobs/createNoteJob.test.ts`:
  - stamped remote quote whose target isn't stored locally → fetched + stored + `accepted`;
  - unreachable quoted note → graceful `pending` (no crash, not stored);
  - forged stamp after fetching the note → still `pending`, stamp uri not persisted.
- `prettier --write .` → `lint` (0 errors) → `build` → `test` (**6574 tests**) all green.
- Verified separately in a local browser that an `accepted` quote renders exactly like the design's card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
