### PR TITLE
Bump version to v1.113.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.113.0",
+  "version": "1.113.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.113.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.113.0`
- Base main SHA: `496330e4eac63fb94c984e8a7e3dddc1d31bdddf`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
