### PR TITLE
Bump version to v1.113.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.113.1",
+  "version": "1.113.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.113.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.113.1`
- Base main SHA: `634358a1dd409981512aca090611bce2414f2033`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
