### PR TITLE
fix: actor icon links to profile; name/handle/arrow open the actor list

### DIFF
--- a/lib/components/actor-switcher/ActorSwitcher.test.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { ActorSwitcher } from './ActorSwitcher'
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    refresh: vi.fn()
+  }))
+}))
+
+vi.mock('./AddActorDialog', () => ({
+  AddActorDialog: () => null
+}))
+
+const alice = {
+  id: 'actor-1',
+  username: 'alice',
+  domain: 'activities.local',
+  name: 'Alice'
+}
+const bob = {
+  id: 'actor-2',
+  username: 'bob',
+  domain: 'activities.local',
+  name: 'Bob'
+}
+
+const profileHref = '/@alice@activities.local'
+
+describe('ActorSwitcher', () => {
+  describe('with a single actor', () => {
+    it('renders the whole row as a link to the profile', () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice]} />)
+
+      const link = screen.getByRole('link')
+      expect(link).toHaveAttribute('href', profileHref)
+      expect(link).toHaveTextContent('Alice')
+      expect(link).toHaveTextContent('@alice@activities.local')
+    })
+
+    it('does not render the actor-list dropdown trigger', () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice]} />)
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('does not render the chevron arrow', () => {
+      const { container } = render(
+        <ActorSwitcher currentActor={alice} actors={[alice]} />
+      )
+
+      expect(
+        container.querySelector('.lucide-chevron-down')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('with multiple actors', () => {
+    it('links only the avatar icon to the profile', () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      const iconLink = screen.getByRole('link', {
+        name: "View Alice's profile"
+      })
+      expect(iconLink).toHaveAttribute('href', profileHref)
+    })
+
+    it('renders the name/handle/arrow as the dropdown trigger, not a link', () => {
+      render(<ActorSwitcher currentActor={alice} actors={[alice, bob]} />)
+
+      // The identity + chevron open the menu via a button trigger — they are
+      // not part of the profile link, so clicking them switches actors rather
+      // than navigating.
+      const trigger = screen.getByRole('button')
+      expect(trigger).toHaveTextContent('Alice')
+      expect(trigger).toHaveTextContent('@alice@activities.local')
+      expect(trigger.querySelector('.lucide-chevron-down')).toBeInTheDocument()
+
+      // Only the avatar is a link; the identity text is inside the button.
+      const profileLinks = screen
+        .getAllByRole('link')
+        .filter((link) => link.getAttribute('href') === profileHref)
+      expect(profileLinks).toHaveLength(1)
+      expect(profileLinks[0]).not.toHaveTextContent('Alice')
+    })
+  })
+})

--- a/lib/components/actor-switcher/ActorSwitcher.tsx
+++ b/lib/components/actor-switcher/ActorSwitcher.tsx
@@ -91,38 +91,68 @@ export function ActorSwitcher({ currentActor, actors }: ActorSwitcherProps) {
     window.location.reload()
   }
 
+  const hasMultipleActors = actors.length > 1
+  const profileHref = `/@${currentActor.username}@${currentActor.domain}`
+  const displayName = currentActor.name || currentActor.username
+
+  const avatar = (
+    <Avatar className="h-10 w-10 shrink-0">
+      {currentActor.iconUrl && <AvatarImage src={currentActor.iconUrl} />}
+      <AvatarFallback className="bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+        {getAvatarInitial(currentActor.username)}
+      </AvatarFallback>
+    </Avatar>
+  )
+
+  const identity = (
+    <div className="flex-1 overflow-hidden">
+      <p className="text-sm font-medium truncate">{displayName}</p>
+      <p className="text-xs text-muted-foreground truncate">
+        {getHandle(currentActor)}
+      </p>
+    </div>
+  )
+
+  // With a single actor there is nothing to switch to, so the whole row is just
+  // a link to the profile: no dropdown and no chevron. (Adding another actor
+  // remains available under Settings → Actors.)
+  if (!hasMultipleActors) {
+    return (
+      <Link
+        href={profileHref}
+        className="flex items-center gap-3 rounded-lg p-2 cursor-pointer hover:bg-muted transition-colors w-full overflow-hidden"
+      >
+        {avatar}
+        {identity}
+      </Link>
+    )
+  }
+
+  // With multiple actors the icon links to the profile while the name, handle,
+  // and chevron open the actor list. The avatar link is a sibling of the
+  // dropdown trigger (not nested inside it) so clicking the icon navigates
+  // instead of opening the menu.
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <div className="flex items-center gap-3 rounded-lg p-2 cursor-pointer hover:bg-muted transition-colors w-full">
-            <Link
-              href={`/@${currentActor.username}@${currentActor.domain}`}
-              className="flex items-center gap-3 flex-1 overflow-hidden"
-              onClick={(e) => e.stopPropagation()}
+        <div className="flex items-center gap-3 rounded-lg p-2 hover:bg-muted transition-colors w-full">
+          <Link
+            href={profileHref}
+            aria-label={`View ${displayName}'s profile`}
+            className="shrink-0 rounded-full cursor-pointer"
+          >
+            {avatar}
+          </Link>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="flex flex-1 items-center gap-3 overflow-hidden text-left cursor-pointer"
             >
-              <Avatar className="h-10 w-10">
-                {currentActor.iconUrl && (
-                  <AvatarImage src={currentActor.iconUrl} />
-                )}
-                <AvatarFallback className="bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300">
-                  {getAvatarInitial(currentActor.username)}
-                </AvatarFallback>
-              </Avatar>
-              <div className="flex-1 overflow-hidden">
-                <p className="text-sm font-medium truncate">
-                  {currentActor.name || currentActor.username}
-                </p>
-                <p className="text-xs text-muted-foreground truncate">
-                  {getHandle(currentActor)}
-                </p>
-              </div>
-            </Link>
-            {actors.length > 1 && (
-              <ChevronDown className="h-4 w-4 text-muted-foreground" />
-            )}
-          </div>
-        </DropdownMenuTrigger>
+              {identity}
+              <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+            </button>
+          </DropdownMenuTrigger>
+        </div>
         <DropdownMenuContent align="start" className="w-[280px]">
           {actors.map((actor) => {
             const isPendingDeletion = actor.deletionStatus === 'scheduled'


### PR DESCRIPTION
## Summary

Fixes the sidebar actor switcher so that **clicking the actor icon goes to the actor's profile page**, while the **name, handle, and arrow open the actor list**.

Previously the entire row was the dropdown trigger, with the avatar/name/handle wrapped in a `Link` that called `stopPropagation` on `click`. Radix opens the menu on **`pointerdown`**, which fires before the link's `click` handler — so clicking the avatar opened the actor list instead of navigating to the profile.

## Behavior

| Element | Multiple actors | Single actor |
| --- | --- | --- |
| **Icon (avatar)** | → actor profile page | → actor profile page |
| **Name / handle / arrow** | open the actor list menu | → actor profile page |
| **Arrow (chevron)** | shown | **hidden** |

- The avatar is now a `Link` rendered as a **sibling** of the dropdown trigger (not nested inside it), so clicking the icon reliably navigates instead of opening the menu.
- With a **single actor** there is nothing to switch to, so the whole row is just a link to the profile — no dropdown, no chevron. Adding another actor remains available under **Settings → Actors** (the "Add actor" button there is unchanged).
- The chevron renders only when the account has **more than one actor**.

## Changes

- `lib/components/actor-switcher/ActorSwitcher.tsx` — restructured the trigger; split the avatar link from the name/handle/arrow trigger; single-actor path renders a plain profile link.
- `lib/components/actor-switcher/ActorSwitcher.test.tsx` — new tests covering both the single-actor (plain link, no trigger, no chevron) and multiple-actor (icon links to profile; name/handle/arrow is the dropdown trigger with chevron) structures.

## Verification

Local gate (Node 24): `prettier --write .`, `yarn lint` (0 errors), `yarn build`, and `yarn test` (**6592 tests pass**) all green. New unit tests: 5 pass.

Verified in a real browser (local SQLite dev + mock user) while signed in:

- **Single actor** — the sidebar row is a single `<a href="/@testuser@localhost:3000">` with **no chevron** and no `aria-haspopup`.
- **Multiple actors** (added a second actor "runner" via Settings → Actors):
  - The **avatar icon** is a separate `<a aria-label="View runner's profile" href="/@runner@localhost:3000">` — clicking it **navigates to the profile page**.
  - The **name/handle/arrow** is a `<button aria-haspopup="menu">` with the chevron — clicking it **opens the actor list** (testuser, runner ✓, + Add another actor).

## Notes

- No migrations, no API changes, no new dependencies. Patch-level change (`fix:`).
