### PR TITLE
Bump version to v1.113.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.113.3",
+  "version": "1.113.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.113.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.113.3`
- Base main SHA: `39903a0d600252b8d298ae8cfebcfd195d0739ec`
- Included commits: `6`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
