### PR TITLE
minor: add "Who can quote" default to settings preferences

### DIFF
--- a/app/(timeline)/settings/preferences/page.tsx
+++ b/app/(timeline)/settings/preferences/page.tsx
@@ -30,6 +30,7 @@ const Page = async () => {
     <PreferencesSettings
       initialPreferences={{
         visibility: settings?.defaultPrivacy ?? 'public',
+        quotePolicy: settings?.defaultQuotePolicy ?? 'public',
         sensitive: settings?.defaultSensitive ?? false,
         language: settings?.defaultLanguage ?? 'en',
         expandMedia: settings?.readingExpandMedia ?? 'default',

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2540,6 +2540,8 @@ export const updatePushNotifications = async (
 export interface PreferencesInput {
   // Posting defaults — saved through the standard Mastodon credential endpoint.
   visibility: 'public' | 'unlisted' | 'private' | 'direct'
+  // Default quote-approval policy for new public/unlisted posts (Mastodon 4.5).
+  quotePolicy: QuoteApprovalPolicy
   sensitive: boolean
   language: string
   // Reading preferences — saved through the web-internal endpoint.
@@ -2568,6 +2570,7 @@ export const updatePreferences = async (
     body: JSON.stringify({
       source: {
         privacy: preferences.visibility,
+        quote_policy: preferences.quotePolicy,
         sensitive: preferences.sensitive,
         language: preferences.language
       }

--- a/lib/components/settings/PreferencesSettings.test.tsx
+++ b/lib/components/settings/PreferencesSettings.test.tsx
@@ -56,6 +56,18 @@ describe('PreferencesSettings', () => {
     )
   })
 
+  it('reflects the initial quote policy in the select', () => {
+    render(
+      <PreferencesSettings
+        initialPreferences={{ ...initialPreferences, quotePolicy: 'nobody' }}
+      />
+    )
+
+    expect(
+      (screen.getByLabelText('Who can quote') as HTMLSelectElement).value
+    ).toBe('nobody')
+  })
+
   it('disables Save until a preference changes', () => {
     render(<PreferencesSettings initialPreferences={initialPreferences} />)
 

--- a/lib/components/settings/PreferencesSettings.test.tsx
+++ b/lib/components/settings/PreferencesSettings.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/client', () => ({
 
 const initialPreferences: PreferencesInput = {
   visibility: 'public',
+  quotePolicy: 'public',
   sensitive: false,
   language: 'en',
   expandMedia: 'default',
@@ -36,7 +37,23 @@ describe('PreferencesSettings', () => {
     expect(screen.getByText('Posting defaults')).toBeInTheDocument()
     expect(screen.getByText('Reading')).toBeInTheDocument()
     expect(screen.getByLabelText('Posting privacy')).toBeInTheDocument()
+    expect(screen.getByLabelText('Who can quote')).toBeInTheDocument()
     expect(screen.getByLabelText('Posting language')).toBeInTheDocument()
+  })
+
+  it('saves the changed quote policy', async () => {
+    render(<PreferencesSettings initialPreferences={initialPreferences} />)
+
+    fireEvent.change(screen.getByLabelText('Who can quote'), {
+      target: { value: 'followers' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() =>
+      expect(mockUpdatePreferences).toHaveBeenCalledWith(
+        expect.objectContaining({ quotePolicy: 'followers' })
+      )
+    )
   })
 
   it('disables Save until a preference changes', () => {

--- a/lib/components/settings/PreferencesSettings.tsx
+++ b/lib/components/settings/PreferencesSettings.tsx
@@ -12,6 +12,7 @@ import { Switch } from '@/lib/components/ui/switch'
 import { cn } from '@/lib/utils'
 
 type PostingVisibility = PreferencesInput['visibility']
+type QuotePolicy = PreferencesInput['quotePolicy']
 type ExpandMedia = PreferencesInput['expandMedia']
 
 const VISIBILITIES: { value: PostingVisibility; label: string }[] = [
@@ -25,6 +26,12 @@ const VISIBILITIES: { value: PostingVisibility; label: string }[] = [
   // by a Mastodon client). Listing it keeps the select from silently rewriting a
   // stored `direct` default to a different value on save.
   { value: 'direct', label: 'Direct — only people mentioned' }
+]
+
+const QUOTE_POLICIES: { value: QuotePolicy; label: string }[] = [
+  { value: 'public', label: 'Anyone can quote' },
+  { value: 'followers', label: 'Followers can quote' },
+  { value: 'nobody', label: 'No one can quote' }
 ]
 
 const LANGUAGES: { value: string; label: string }[] = [
@@ -180,6 +187,27 @@ export const PreferencesSettings: FC<Props> = ({ initialPreferences }) => {
               </option>
             ))}
           </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="posting-quote-policy">Who can quote</Label>
+          <Select
+            id="posting-quote-policy"
+            value={preferences.quotePolicy}
+            onChange={(event) =>
+              update('quotePolicy', event.target.value as QuotePolicy)
+            }
+          >
+            {QUOTE_POLICIES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+          <p className="text-[0.8rem] text-muted-foreground">
+            Applies to new public and unlisted posts; quotes of restricted posts
+            always need your approval.
+          </p>
         </div>
 
         <div className="space-y-2">


### PR DESCRIPTION
## Summary

Adds the **"Who can quote"** default to Settings → Preferences, matching the design in `PreferencesKit.jsx`. It surfaces the already-existing default quote-approval policy (`ActorSettings.defaultQuotePolicy`) in the web UI — previously it could only be set through a third-party Mastodon client.

The dropdown sits between *Posting privacy* and *Posting language* with options:

| Label | Value |
| --- | --- |
| Anyone can quote | `public` |
| Followers can quote | `followers` |
| No one can quote | `nobody` |

…and the design's help text: *"Applies to new public and unlisted posts; quotes of restricted posts always need your approval."*

## What changed

- **`lib/components/settings/PreferencesSettings.tsx`** — new "Who can quote" `Select` + `QUOTE_POLICIES` options.
- **`lib/client.ts`** — `quotePolicy` added to `PreferencesInput`; `updatePreferences` now sends `source[quote_policy]` in the `PATCH /api/v1/accounts/update_credentials` write.
- **`app/(timeline)/settings/preferences/page.tsx`** — seeds the field from `settings.defaultQuotePolicy` (falls back to `public`).
- **`lib/components/settings/PreferencesSettings.test.tsx`** — field added to the fixture + a test asserting the changed policy is saved.

The backend read (`GET /api/v1/preferences`) and write (`update_credentials` → `updateActorSettings`) paths already existed and were tested; this PR is the web UI + client plumbing only. No migration (settings is a JSON column).

## Scope

Only the quote option. The design's two Reading toggles (*Group boosts*, *Slow mode*) were intentionally left out — they have no backend field or timeline behavior yet, so they'd be dead controls.

## Testing

- `yarn run prettier --write .` · `yarn lint` (0 errors) · `yarn build` · `yarn test` (**6593 passed**) — all green.
- **Manual browser (local SQLite + mock user):** the dropdown renders in the correct position; changing it to *Followers can quote* → **Save** → **full page reload** shows *Followers can quote* still selected, confirming the value persists through the DB and is read back server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
