### PR TITLE
Bump version to v1.113.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.113.4",
+  "version": "1.113.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.113.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.113.4`
- Base main SHA: `340497064d8d76b8f6f66ac9a5faf8d2fe044da9`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
