### PR TITLE
Bump version to v1.114.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.113.5",
+  "version": "1.114.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.114.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.113.5`
- Base main SHA: `e812d94f8469baed3180b100de570bf12a00b7bb`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
