### PR TITLE
Bump version to v1.114.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.114.0",
+  "version": "1.114.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.114.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.114.0`
- Base main SHA: `188cbec65d1e659ff94caed83c087e6ca0f0e510`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
