### PR TITLE
fix: show read-only engagement counts to logged-out hashtag and collection viewers

### DIFF
--- a/app/(timeline)/collections/[id]/CollectionDetail.test.tsx
+++ b/app/(timeline)/collections/[id]/CollectionDetail.test.tsx
@@ -263,25 +263,31 @@ describe('CollectionDetail', () => {
     expect(screen.queryByText('Ada')).not.toBeInTheDocument()
   })
 
-  it('shows read-only engagement stats for logged-out viewers', () => {
-    render(<CollectionDetail {...baseProps} isOwner={false} />)
-
-    const feed = screen.getByTestId('posts')
-    expect(feed).toHaveAttribute('data-show-actions', 'false')
-    expect(feed).toHaveAttribute('data-read-only-stats', 'true')
-  })
-
-  it('enables interactive actions and hides read-only stats when signed in', () => {
+  it.each([
+    {
+      description: 'shows read-only engagement stats for logged-out viewers',
+      currentActor: undefined,
+      showActions: 'false',
+      readOnlyStats: 'true'
+    },
+    {
+      description:
+        'enables interactive actions and hides read-only stats when signed in',
+      currentActor: {} as ActorProfile,
+      showActions: 'true',
+      readOnlyStats: 'false'
+    }
+  ])('$description', ({ currentActor, showActions, readOnlyStats }) => {
     render(
       <CollectionDetail
         {...baseProps}
         isOwner={false}
-        currentActor={{} as ActorProfile}
+        currentActor={currentActor}
       />
     )
 
     const feed = screen.getByTestId('posts')
-    expect(feed).toHaveAttribute('data-show-actions', 'true')
-    expect(feed).toHaveAttribute('data-read-only-stats', 'false')
+    expect(feed).toHaveAttribute('data-show-actions', showActions)
+    expect(feed).toHaveAttribute('data-read-only-stats', readOnlyStats)
   })
 })

--- a/app/(timeline)/collections/[id]/CollectionDetail.test.tsx
+++ b/app/(timeline)/collections/[id]/CollectionDetail.test.tsx
@@ -37,10 +37,26 @@ vi.mock('@/lib/components/page-header', () => ({
 }))
 
 // Render the status ids so tests can assert WHICH feed (owner vs public, and
-// appended pages) is on screen, not just the count.
+// appended pages) is on screen, not just the count. The showActions /
+// showReadOnlyStats flags are surfaced as data attributes (not child nodes) so
+// the `posts()` textContent helper keeps returning just the status ids.
 vi.mock('@/lib/components/posts/posts', () => ({
-  Posts: ({ statuses }: { statuses: Status[] }) => (
-    <div data-testid="posts">{statuses.map((s) => s.id).join(',')}</div>
+  Posts: ({
+    statuses,
+    showActions,
+    showReadOnlyStats
+  }: {
+    statuses: Status[]
+    showActions?: boolean
+    showReadOnlyStats?: boolean
+  }) => (
+    <div
+      data-testid="posts"
+      data-show-actions={String(Boolean(showActions))}
+      data-read-only-stats={String(Boolean(showReadOnlyStats))}
+    >
+      {statuses.map((s) => s.id).join(',')}
+    </div>
   )
 }))
 
@@ -245,5 +261,27 @@ describe('CollectionDetail', () => {
     // Public viewers see only the approved roster.
     expect(screen.getByText('Ben')).toBeInTheDocument()
     expect(screen.queryByText('Ada')).not.toBeInTheDocument()
+  })
+
+  it('shows read-only engagement stats for logged-out viewers', () => {
+    render(<CollectionDetail {...baseProps} isOwner={false} />)
+
+    const feed = screen.getByTestId('posts')
+    expect(feed).toHaveAttribute('data-show-actions', 'false')
+    expect(feed).toHaveAttribute('data-read-only-stats', 'true')
+  })
+
+  it('enables interactive actions and hides read-only stats when signed in', () => {
+    render(
+      <CollectionDetail
+        {...baseProps}
+        isOwner={false}
+        currentActor={{} as ActorProfile}
+      />
+    )
+
+    const feed = screen.getByTestId('posts')
+    expect(feed).toHaveAttribute('data-show-actions', 'true')
+    expect(feed).toHaveAttribute('data-read-only-stats', 'false')
   })
 })

--- a/app/(timeline)/collections/[id]/CollectionDetail.tsx
+++ b/app/(timeline)/collections/[id]/CollectionDetail.tsx
@@ -344,6 +344,7 @@ export const CollectionDetail: FC<CollectionDetailProps> = ({
           statuses={currentStatuses}
           currentActor={currentActor}
           showActions={Boolean(currentActor)}
+          showReadOnlyStats={!currentActor}
           isMediaUploadEnabled={isMediaUploadEnabled}
           postLineLimit={postLineLimit}
           onPostDeleted={removeStatus}

--- a/app/(timeline)/tags/[tag]/HashtagTimeline.test.tsx
+++ b/app/(timeline)/tags/[tag]/HashtagTimeline.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { Status } from '@/lib/types/domain/status'
+
+import { HashtagTimeline } from './HashtagTimeline'
+
+vi.mock('@/lib/client', () => ({
+  getHashtagTimeline: vi.fn()
+}))
+
+// Surface the showActions / showReadOnlyStats flags as data attributes so the
+// tests can assert the logged-in vs logged-out engagement row without pulling
+// in the real Posts tree.
+vi.mock('@/lib/components/posts/posts', () => ({
+  Posts: ({
+    statuses,
+    showActions,
+    showReadOnlyStats
+  }: {
+    statuses: Status[]
+    showActions?: boolean
+    showReadOnlyStats?: boolean
+  }) => (
+    <div
+      data-testid="posts"
+      data-show-actions={String(Boolean(showActions))}
+      data-read-only-stats={String(Boolean(showReadOnlyStats))}
+    >
+      {statuses.map((s) => s.id).join(',')}
+    </div>
+  )
+}))
+
+vi.mock('@/lib/components/scroll-to-top-button', () => ({
+  ScrollToTopButton: () => null
+}))
+
+vi.mock('@/lib/components/posts/useLoadMoreOnVisible', () => ({
+  useLoadMoreOnVisible: () => ({
+    loadMoreRef: vi.fn(),
+    isLoadMoreVisible: false
+  })
+}))
+
+const statuses = [{ id: 'status-1' }] as unknown as Status[]
+
+const baseProps = {
+  tag: 'fediverse',
+  host: 'llun.social',
+  statuses,
+  postCount: 1,
+  currentTime: 1_700_000_000_000
+}
+
+describe('HashtagTimeline', () => {
+  it('shows read-only engagement stats for logged-out viewers', () => {
+    render(<HashtagTimeline {...baseProps} />)
+
+    const feed = screen.getByTestId('posts')
+    expect(feed).toHaveAttribute('data-show-actions', 'false')
+    expect(feed).toHaveAttribute('data-read-only-stats', 'true')
+  })
+
+  it('enables interactive actions and hides read-only stats when signed in', () => {
+    render(<HashtagTimeline {...baseProps} currentActor={{} as ActorProfile} />)
+
+    const feed = screen.getByTestId('posts')
+    expect(feed).toHaveAttribute('data-show-actions', 'true')
+    expect(feed).toHaveAttribute('data-read-only-stats', 'false')
+  })
+})

--- a/app/(timeline)/tags/[tag]/HashtagTimeline.test.tsx
+++ b/app/(timeline)/tags/[tag]/HashtagTimeline.test.tsx
@@ -58,19 +58,25 @@ const baseProps = {
 }
 
 describe('HashtagTimeline', () => {
-  it('shows read-only engagement stats for logged-out viewers', () => {
-    render(<HashtagTimeline {...baseProps} />)
+  it.each([
+    {
+      description: 'shows read-only engagement stats for logged-out viewers',
+      currentActor: undefined,
+      showActions: 'false',
+      readOnlyStats: 'true'
+    },
+    {
+      description:
+        'enables interactive actions and hides read-only stats when signed in',
+      currentActor: {} as ActorProfile,
+      showActions: 'true',
+      readOnlyStats: 'false'
+    }
+  ])('$description', ({ currentActor, showActions, readOnlyStats }) => {
+    render(<HashtagTimeline {...baseProps} currentActor={currentActor} />)
 
     const feed = screen.getByTestId('posts')
-    expect(feed).toHaveAttribute('data-show-actions', 'false')
-    expect(feed).toHaveAttribute('data-read-only-stats', 'true')
-  })
-
-  it('enables interactive actions and hides read-only stats when signed in', () => {
-    render(<HashtagTimeline {...baseProps} currentActor={{} as ActorProfile} />)
-
-    const feed = screen.getByTestId('posts')
-    expect(feed).toHaveAttribute('data-show-actions', 'true')
-    expect(feed).toHaveAttribute('data-read-only-stats', 'false')
+    expect(feed).toHaveAttribute('data-show-actions', showActions)
+    expect(feed).toHaveAttribute('data-read-only-stats', readOnlyStats)
   })
 })

--- a/app/(timeline)/tags/[tag]/HashtagTimeline.tsx
+++ b/app/(timeline)/tags/[tag]/HashtagTimeline.tsx
@@ -123,6 +123,7 @@ export const HashtagTimeline: FC<HashtagTimelineProps> = ({
           statuses={currentStatuses}
           currentActor={currentActor}
           showActions={Boolean(currentActor)}
+          showReadOnlyStats={!currentActor}
           isMediaUploadEnabled={isMediaUploadEnabled}
           postLineLimit={postLineLimit}
           onPostDeleted={onPostDeleted}


### PR DESCRIPTION
## Summary

Logged-out visitors on the **hashtag timeline** (`/tags/[tag]`) and **collection detail** (`/collections/[id]`) pages saw posts with **no engagement row at all**, while the logged-out **profile feed** (`ActorTimelines`) and the **landing feed** both render a non-interactive reply/boost/like row. Both pages already support logged-out viewers (`currentActor` is optional; the server pages pass `actor ? getActorProfile(actor) : undefined` with no sign-in redirect) and correctly set `showActions={Boolean(currentActor)}` — they just never passed `showReadOnlyStats`.

This is a pre-existing display gap (not introduced by #1283) that surfaced during that PR's review.

## Fix

Pass `showReadOnlyStats={!currentActor}` to `<Posts>` in both surfaces, mirroring the established pattern:

- `ActorTimelines` → `showReadOnlyStats={!showActions}`
- `LandingPublicFeed` → `showReadOnlyStats`

`Post` only renders the read-only row when `showReadOnlyStats && !showActions`, so signed-in users are unaffected — they keep the interactive action buttons.

```diff
   showActions={Boolean(currentActor)}
+  showReadOnlyStats={!currentActor}
   isMediaUploadEnabled={isMediaUploadEnabled}
```

## Tests

Added regression tests mirroring `ActorTimelines`' logged-out vs signed-in cases:

- **New** `HashtagTimeline.test.tsx` (2 tests)
- **Extended** `CollectionDetail.test.tsx` `Posts` mock + 2 tests

Each asserts `showReadOnlyStats=true` / `showActions=false` when logged out, and the inverse when a `currentActor` is present.

## Verification

`prettier --write` → `lint` (0 errors) → `build` → `test` (**691 files, 6624 tests**) all green.

Manually verified in a browser against a local SQLite instance, on this branch (rebased onto #1283):

| | Hashtag `/tags/sunset` | Collection `/collections/…` |
|---|---|---|
| **Logged out** | ✅ read-only row (reply · boost · ♥ counts) | ✅ read-only row on member post |
| **Signed in** | ✅ interactive buttons, no read-only row | ✅ (same shared wiring) |

Also confirmed via cookie-free SSR request that the logged-out HTML contains the `aria-label="Engagement"` read-only row (2 on the hashtag page, 1 on the collection page) and **zero** interactive action controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
