### PR TITLE
chore: raise Node heap limit for CI test job to prevent OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
         run: yarn test
         env:
           TEST_DATABASE_TYPE: sqlite
+          # Raise the V8 heap ceiling for the Vitest workers. The full suite
+          # peaks just above Node's default ~4 GB old-space limit and
+          # intermittently crashed a worker fork with "JavaScript heap out of
+          # memory" (all tests still passed). ubuntu-latest has 16 GB RAM, so
+          # 8 GB per process is safe. Workers inherit NODE_OPTIONS from this env.
+          NODE_OPTIONS: --max-old-space-size=8192
 
   # Drift gate for the committed SQLite reference schema dump. The Vitest
   # suite builds every test database from migrations/schema.sqlite.sql (via


### PR DESCRIPTION
## Summary

The `All Tests` CI job runs the full Vitest suite (~6,586 tests) with Node's default old-space heap limit (~4 GB). The suite peaks just above that ceiling, so a Vitest worker fork intermittently crashes with `FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory` at teardown. **All tests pass** (`689 passed (690)`, `6586 passed`); only the worker crash flips the required check to red, blocking merges (it hit the open dependabot PRs #1274 and #1270 repeatedly).

## Fix

Add `NODE_OPTIONS=--max-old-space-size=8192` to the `Run all tests` step so the Vitest fork workers inherit an 8 GB heap ceiling. `ubuntu-latest` runners have 16 GB RAM, so 8 GB per process is safe.

## Scope / notes

- `.github/`-only change → **no version bump**.
- Self-validating: this PR's own `All Tests` run exercises the new heap limit.
- No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)