### PR TITLE
fix: shard CI test run into two passes to prevent heap OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,14 +85,23 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Run all tests
-        run: yarn test
+        # Run the suite in two sequential shards. Each `vitest run` process
+        # handles ~half of the ~690 test files and releases ALL memory when it
+        # exits, so peak memory per process is roughly halved. The single-process
+        # run accumulated memory across files and crashed a worker fork with
+        # "JavaScript heap out of memory" (all tests still passed); raising the
+        # heap ceiling alone only delayed it — V8's GC grew lazier and the live
+        # set climbed to ~8 GB before thrashing. Sharding keeps the working set
+        # well under the ceiling. Both shards run in this one job, so the
+        # required "All Tests" status check is unchanged.
+        run: |
+          yarn test --shard=1/2
+          yarn test --shard=2/2
         env:
           TEST_DATABASE_TYPE: sqlite
-          # Raise the V8 heap ceiling for the Vitest workers. The full suite
-          # peaks just above Node's default ~4 GB old-space limit and
-          # intermittently crashed a worker fork with "JavaScript heap out of
-          # memory" (all tests still passed). ubuntu-latest has 16 GB RAM, so
-          # 8 GB per process is safe. Workers inherit NODE_OPTIONS from this env.
+          # Headroom ceiling for the Vitest fork workers (inherited via
+          # NODE_OPTIONS). ubuntu-latest has 16 GB RAM; with sharding each
+          # process stays well below this.
           NODE_OPTIONS: --max-old-space-size=8192
 
   # Drift gate for the committed SQLite reference schema dump. The Vitest


### PR DESCRIPTION
## Problem

Raising the Node heap ceiling ([#1287](https://github.com/llun/activities.next/pull/1287)) did **not** fix the OOM. The full `vitest run` accumulates memory across its ~690 test files, and a worker fork still crashed with `FATAL ERROR: … JavaScript heap out of memory` — this time climbing to **7856 MB / 8114 MB** and GC-thrashing for ~87 minutes before dying. **All 6,586 tests pass**; only the worker crash fails the check. A larger ceiling just makes V8's GC lazier, so the live set climbs higher.

## Fix

Run the suite as **two sequential shards** in the same `All Tests` job:

```yaml
run: |
  yarn test --shard=1/2
  yarn test --shard=2/2
```

Each `vitest run` process handles ~half the files and **releases all memory when it exits**, so peak memory per process is roughly halved and stays well under the 8 GB ceiling. Because both shards run inside the one job, the required **`All Tests`** status check name is unchanged (no branch-protection change needed).

## Notes

- `.github/`-only change → **no version bump**.
- Self-validating: this PR's own `All Tests` run exercises the sharded command.
- Unblocks the open dependabot PRs #1274 and #1270, which keep failing on this flaky OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)