### PR TITLE
chore(deps): bump @radix-ui/react-dialog from 1.1.18 to 1.1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@date-fns/utc": "^2.1.1",
     "@opentelemetry/api": "^1.9.1",
     "@radix-ui/react-avatar": "^1.2.1",
-    "@radix-ui/react-dialog": "^1.1.18",
+    "@radix-ui/react-dialog": "^1.1.20",
     "@radix-ui/react-dropdown-menu": "^2.1.21",
     "@radix-ui/react-label": "^2.1.11",
     "@radix-ui/react-progress": "^1.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,22 +2423,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.1.18":
-  version: 1.1.18
-  resolution: "@radix-ui/react-dialog@npm:1.1.18"
+"@radix-ui/react-dialog@npm:^1.1.20":
+  version: 1.1.20
+  resolution: "@radix-ui/react-dialog@npm:1.1.20"
   dependencies:
-    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/primitive": "npm:1.1.6"
     "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.4"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.14"
+    "@radix-ui/react-context": "npm:1.2.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.16"
     "@radix-ui/react-focus-guards": "npm:1.1.4"
-    "@radix-ui/react-focus-scope": "npm:1.1.11"
+    "@radix-ui/react-focus-scope": "npm:1.1.13"
     "@radix-ui/react-id": "npm:1.1.2"
-    "@radix-ui/react-portal": "npm:1.1.13"
-    "@radix-ui/react-presence": "npm:1.1.6"
+    "@radix-ui/react-portal": "npm:1.1.14"
+    "@radix-ui/react-presence": "npm:1.1.8"
     "@radix-ui/react-primitive": "npm:2.1.7"
     "@radix-ui/react-slot": "npm:1.3.0"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.4"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.2"
     aria-hidden: "npm:^1.2.4"
     react-remove-scroll: "npm:^2.7.2"
   peerDependencies:
@@ -2451,7 +2452,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10c0/679ffabf212dc481cfdeec114044b7ead8f3879ecc0e1c025025ec6dba303a824f6221dfe254eb94b4c7b31cfaf0d18be0047c65479608274b044e498b0fafca
+  checksum: 10c0/c6bd301f5214ddff69ef6c91fc25530dda955dc8495b5245edb2bd3da17cdd99b4583c03e3c216a5f5cd8526023ca6600e7891ec91d414f3c535cc67f831d5ad
   languageName: node
   linkType: hard
 
@@ -2549,27 +2550,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/0447a97a2672ad04fa73e0af3a09adafa1e85327c43cec2ae7267daa8544c9e6ef3136fbadcbdd3e28bf1ff0864537241c159e26cf5800b7698e5e69772e7ed3
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-scope@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.11"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.3"
-    "@radix-ui/react-primitive": "npm:2.1.7"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/e773dfbe4c3907067db4d96082bf9a4dad730ad7396dc181f09fc79e054c4a7382dee6a3b948efef97904ae0387dc81b7733e479af69f5a22de2649c99847561
   languageName: node
   linkType: hard
 
@@ -4948,7 +4928,7 @@ __metadata:
     "@next/eslint-plugin-next": "npm:^16.2.10"
     "@opentelemetry/api": "npm:^1.9.1"
     "@radix-ui/react-avatar": "npm:^1.2.1"
-    "@radix-ui/react-dialog": "npm:^1.1.18"
+    "@radix-ui/react-dialog": "npm:^1.1.20"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.21"
     "@radix-ui/react-label": "npm:^2.1.11"
     "@radix-ui/react-progress": "npm:^1.1.12"


### PR DESCRIPTION
Supersedes #1270.

Dependabot's #1270 conflicted with #1274 (react-dropdown-menu 2.1.21) on the `@radix-ui` block of `package.json`/`yarn.lock`, and Dependabot refused to rebase it (its branch had non-Dependabot commits from earlier `update-branch` calls). This PR reapplies the same bump cleanly on top of current `main` with a regenerated, consistent lockfile (`yarn install`): `@radix-ui/react-dialog` `^1.1.18` → `^1.1.20`; dropdown-menu stays `2.1.21`; shared transitives deduped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)