### PR TITLE
Bump version to v1.114.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.114.3",
+  "version": "1.114.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.114.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.114.3`
- Base main SHA: `3f09a975792b5479eca6905f34046df0668c887b`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
