### PR TITLE
minor: add database-backed admin server settings

### DIFF
--- a/app/(nosidebar)/auth/signin/page.tsx
+++ b/app/(nosidebar)/auth/signin/page.tsx
@@ -15,6 +15,7 @@ import {
 import { getBaseURL, getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { getActorFromSession } from '@/lib/utils/getActorFromSession'
 import { Booleanish } from '@/lib/utils/zodBooleanish'
 
@@ -74,7 +75,10 @@ const Page: FC<Props> = async ({ searchParams }) => {
     return redirect(actor ? target : '/')
   }
 
-  const { auth, serviceName, registrationOpen } = getConfig()
+  const { auth, serviceName } = getConfig()
+  const {
+    registrations: { open: registrationOpen }
+  } = await getResolvedServerSettings(database)
   const credentialEnabled = auth?.enableCredential !== false
 
   // Use an absolute URL on the configured host (ACTIVITIES_HOST) so the logo

--- a/app/(nosidebar)/auth/signup/page.tsx
+++ b/app/(nosidebar)/auth/signup/page.tsx
@@ -14,9 +14,9 @@ import {
 } from '@/lib/components/ui/card'
 import { Input } from '@/lib/components/ui/input'
 import { Label } from '@/lib/components/ui/label'
-import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
@@ -29,7 +29,7 @@ const Page: FC = async () => {
 
   // When the server has closed registration there is no sign-up to show; send
   // visitors to the landing, whose auth card explains registration is closed.
-  if (!getConfig().registrationOpen) {
+  if (!(await getResolvedServerSettings(database)).registrations.open) {
     return redirect('/')
   }
 

--- a/app/(timeline)/PublicTopBar.tsx
+++ b/app/(timeline)/PublicTopBar.tsx
@@ -1,16 +1,18 @@
 import Link from 'next/link'
-import { FC } from 'react'
 
 import { Logo } from '@/lib/components/layout/logo'
 import { Button } from '@/lib/components/ui/button'
-import { getBaseURL, getConfig } from '@/lib/config'
+import { getBaseURL } from '@/lib/config'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 // Public top bar shown to logged-out visitors in place of the app nav sidebar:
 // a slim sticky bar with the brand logo and Sign in / Create account links to
 // the real auth routes, matching the web-public design. The "Create account"
 // CTA is hidden when the server has closed registration.
-export const PublicTopBar: FC = () => {
-  const { registrationOpen } = getConfig()
+export const PublicTopBar = async () => {
+  const {
+    registrations: { open: registrationOpen }
+  } = await getResolvedServerSettings()
   // Absolute logo URL on the canonical origin (ACTIVITIES_HOST) so it resolves
   // even when this page is served on a CDN alias domain, matching PublicFooter.
   const logoSrc = new URL('/logo-nav.png', getBaseURL()).toString()

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -10,6 +10,7 @@ import { FETCH_REMOTE_STATUS_JOB_NAME } from '@/lib/jobs/names'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { getFederationSigningActor } from '@/lib/services/federation/getFederationSigningActor'
 import { getQueue } from '@/lib/services/queue'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import {
   canActorReadStatus,
   isStatusPubliclyReadable
@@ -59,10 +60,13 @@ export const generateMetadata = async ({
 }
 
 const Page: FC<Props> = async ({ params }) => {
-  const { host, mediaStorage, registrationOpen } = getConfig()
+  const { host, mediaStorage } = getConfig()
   const mapProvider = getPublicMapProvider()
   const database = getDatabase()
   if (!database) throw new Error('Database is not available')
+  const {
+    registrations: { open: registrationOpen }
+  } = await getResolvedServerSettings(database)
 
   const session = await getServerAuthSession()
   const currentActor = await getActorFromSession(database, session)

--- a/app/(timeline)/admin/federation/page.tsx
+++ b/app/(timeline)/admin/federation/page.tsx
@@ -16,6 +16,7 @@ import {
   deleteDomainBlockAction,
   importKnownDomainBlocklistAction
 } from '@/app/(timeline)/admin/federation/actions'
+import { FederationPolicyForm } from '@/lib/components/admin/settings/FederationPolicyForm'
 import { PageHeader } from '@/lib/components/page-header'
 import { Button } from '@/lib/components/ui/button'
 import { Checkbox } from '@/lib/components/ui/checkbox'
@@ -27,6 +28,7 @@ import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { KNOWN_DOMAIN_BLOCKLIST_SOURCES } from '@/lib/services/federation/blocklistSources'
+import { getServerSettingsView } from '@/lib/services/serverSettings'
 import { cn } from '@/lib/utils'
 import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
 
@@ -175,7 +177,11 @@ const Page = async ({ searchParams }: Props) => {
   const isErrorStatus = status ? ERROR_STATUSES.has(status) : false
   const sourceCounts = new Map(Object.entries(stats.sourceCounts))
   const config = getConfig()
-  const federationMode = config.federationMode ?? 'open'
+  const { settings, locks } = await getServerSettingsView(database)
+  const federationMode = settings.federation.mode
+  // Trusted media domains stay env-configured (they feed the Edge-runtime CSP),
+  // so they are shown read-only in the policy form.
+  const mediaDomains = config.allowMediaDomains ?? []
   const hasPreviousBlocks = blockOffset > 0
   const hasNextBlocks =
     blocks.length > 0 &&
@@ -233,6 +239,12 @@ const Page = async ({ searchParams }: Props) => {
           <p className="text-2xl font-bold">{stats.sourceBlocks}</p>
         </div>
       </div>
+
+      <FederationPolicyForm
+        settings={settings}
+        locks={locks}
+        mediaDomains={mediaDomains}
+      />
 
       <section className="rounded-xl border bg-background/80 p-5 shadow-sm">
         <div className="mb-4 flex items-center justify-between gap-4">

--- a/app/(timeline)/admin/instance/page.tsx
+++ b/app/(timeline)/admin/instance/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation'
+
+import { InstanceSettingsForm } from '@/lib/components/admin/settings/InstanceSettingsForm'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getServerSettingsView } from '@/lib/services/serverSettings'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const { settings, locks } = await getServerSettingsView(database)
+  return <InstanceSettingsForm settings={settings} locks={locks} />
+}
+
+export default Page

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -6,6 +6,7 @@ import {
   Flag,
   Globe,
   Hash,
+  Image,
   Megaphone,
   Rss,
   Scale,
@@ -43,6 +44,12 @@ const tabs: SectionNavTab[] = [
   // Server settings — DB-backed instance policy, grouped under "Settings" below
   // the moderation tools and above System.
   { name: 'Instance', url: '/admin/instance', icon: Server, group: 'Settings' },
+  {
+    name: 'Posts & media',
+    url: '/admin/posts',
+    icon: Image,
+    group: 'Settings'
+  },
   { name: 'System', url: '/admin/system', icon: Settings }
 ]
 

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -9,6 +9,7 @@ import {
   Megaphone,
   Rss,
   Scale,
+  Server,
   Settings,
   Smile,
   Users
@@ -39,6 +40,9 @@ const tabs: SectionNavTab[] = [
   { name: 'Federation', url: '/admin/federation', icon: Globe },
   { name: 'Relays', url: '/admin/relays', icon: Rss },
   { name: 'Custom emojis', url: '/admin/emojis', icon: Smile },
+  // Server settings — DB-backed instance policy, grouped under "Settings" below
+  // the moderation tools and above System.
+  { name: 'Instance', url: '/admin/instance', icon: Server, group: 'Settings' },
   { name: 'System', url: '/admin/system', icon: Settings }
 ]
 

--- a/app/(timeline)/admin/layout.tsx
+++ b/app/(timeline)/admin/layout.tsx
@@ -8,6 +8,7 @@ import {
   Hash,
   Image,
   Megaphone,
+  Network,
   Rss,
   Scale,
   Server,
@@ -50,6 +51,7 @@ const tabs: SectionNavTab[] = [
     icon: Image,
     group: 'Settings'
   },
+  { name: 'Network', url: '/admin/network', icon: Network, group: 'Settings' },
   { name: 'System', url: '/admin/system', icon: Settings }
 ]
 

--- a/app/(timeline)/admin/network/page.tsx
+++ b/app/(timeline)/admin/network/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation'
+
+import { NetworkSettingsForm } from '@/lib/components/admin/settings/NetworkSettingsForm'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getServerSettingsView } from '@/lib/services/serverSettings'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const { settings, locks } = await getServerSettingsView(database)
+  return <NetworkSettingsForm settings={settings} locks={locks} />
+}
+
+export default Page

--- a/app/(timeline)/admin/posts/page.tsx
+++ b/app/(timeline)/admin/posts/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from 'next/navigation'
+
+import { PostsMediaSettingsForm } from '@/lib/components/admin/settings/PostsMediaSettingsForm'
+import { getConfig } from '@/lib/config'
+import { MediaStorageType } from '@/lib/config/mediaStorage'
+import { getDatabase } from '@/lib/database'
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getServerSettingsView } from '@/lib/services/serverSettings'
+import { getAdminFromSession } from '@/lib/utils/getAdminFromSession'
+
+export const dynamic = 'force-dynamic'
+
+const STORAGE_LABELS: Record<MediaStorageType, string> = {
+  [MediaStorageType.LocalFile]: 'Local filesystem',
+  [MediaStorageType.ObjectStorage]: 'Object storage',
+  [MediaStorageType.S3Storage]: 'S3-compatible storage'
+}
+
+const Page = async () => {
+  const database = getDatabase()
+  if (!database) throw new Error('Failed to load database')
+
+  const session = await getServerAuthSession()
+  const admin = await getAdminFromSession(database, session)
+  if (!admin) return redirect('/')
+
+  const config = getConfig()
+  const storageBackend = config.mediaStorage
+    ? STORAGE_LABELS[config.mediaStorage.type]
+    : 'Local filesystem (default)'
+
+  const { settings, locks } = await getServerSettingsView(database)
+  return (
+    <PostsMediaSettingsForm
+      settings={settings}
+      locks={locks}
+      storageBackend={storageBackend}
+    />
+  )
+}
+
+export default Page

--- a/app/(timeline)/page.tsx
+++ b/app/(timeline)/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import {
   getFilteredStatusPage,
   getFilteredTimelinePage
@@ -30,11 +31,14 @@ export const metadata: Metadata = {
 }
 
 const Page = async () => {
-  const { host, serviceName, mediaStorage, registrationOpen } = getConfig()
+  const { host, serviceName, mediaStorage } = getConfig()
   const database = getDatabase()
   if (!database) {
     throw new Error('Fail to load database')
   }
+  const {
+    registrations: { open: registrationOpen }
+  } = await getResolvedServerSettings(database)
 
   const session = await getServerAuthSession()
   const actor = await getActorFromSession(database, session)

--- a/app/api/v1/accounts/route.test.ts
+++ b/app/api/v1/accounts/route.test.ts
@@ -2,11 +2,12 @@ import knex from 'knex'
 import { NextRequest } from 'next/server'
 
 import { GET as verifyCredentials } from '@/app/api/v1/accounts/verify_credentials/route'
-import { getConfig } from '@/lib/config'
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { Database } from '@/lib/database/types'
 import { registerAccount } from '@/lib/services/accounts/registerAccount'
 import { hashToken } from '@/lib/services/guards/OAuthGuard'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { Scope } from '@/lib/types/database/operations'
 
 import { GET, POST } from './route'
@@ -24,6 +25,16 @@ vi.mock('@/lib/config', () => ({
 vi.mock('@/lib/services/accounts/registerAccount', () => ({
   registerAccount: vi.fn()
 }))
+
+vi.mock('@/lib/services/serverSettings', () => ({
+  getResolvedServerSettings: vi.fn()
+}))
+
+// Registration open/closed is resolved from server settings.
+const settingsWith = (open: boolean) => ({
+  ...structuredClone(DEFAULT_SERVER_SETTINGS),
+  registrations: { open, allowEmails: [] }
+})
 
 vi.mock('@/lib/services/auth/getSession', () => ({
   getServerAuthSession: vi.fn().mockResolvedValue(null)
@@ -57,6 +68,7 @@ const mastodonAccount = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(getResolvedServerSettings).mockResolvedValue(settingsWith(true))
 })
 
 describe('GET /api/v1/accounts', () => {
@@ -145,11 +157,9 @@ describe('POST /api/v1/accounts (web form / non-bearer)', () => {
   })
 
   it('rejects web sign-up with 403 when registration is closed', async () => {
-    vi.mocked(getConfig).mockReturnValueOnce({
-      host: 'llun.test',
-      allowEmails: [],
-      registrationOpen: false
-    } as never)
+    vi.mocked(getResolvedServerSettings).mockResolvedValueOnce(
+      settingsWith(false)
+    )
     const createAccount = vi.fn()
     mockDatabase = { ...(mockDatabase as object), createAccount }
     const req = new NextRequest('http://localhost/api/v1/accounts', {
@@ -166,11 +176,9 @@ describe('POST /api/v1/accounts (web form / non-bearer)', () => {
   })
 
   it('returns 403 for closed registration even when the body is invalid', async () => {
-    vi.mocked(getConfig).mockReturnValueOnce({
-      host: 'llun.test',
-      allowEmails: [],
-      registrationOpen: false
-    } as never)
+    vi.mocked(getResolvedServerSettings).mockResolvedValueOnce(
+      settingsWith(false)
+    )
     const createAccount = vi.fn()
     mockDatabase = { ...(mockDatabase as object), createAccount }
     // Deliberately malformed/schema-invalid body — missing required fields.
@@ -484,12 +492,9 @@ describe('POST /api/v1/accounts with a Bearer app token', () => {
   })
 
   it('returns 403 for closed registration before parsing the body', async () => {
-    vi.mocked(getConfig).mockReturnValueOnce({
-      host: 'llun.test',
-      allowEmails: [],
-      registrationOpen: false,
-      secretPhase: 'test-secret'
-    } as never)
+    vi.mocked(getResolvedServerSettings).mockResolvedValueOnce(
+      settingsWith(false)
+    )
     // Malformed body (missing required fields): a closed server must still
     // answer 403 without reaching schema validation or registerAccount().
     const res = await postRegister(APP_TOKEN, 'garbage=1')

--- a/app/api/v1/accounts/route.ts
+++ b/app/api/v1/accounts/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
-import { getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { localizeAccounts } from '@/lib/services/accounts/localizeAccount'
 import { registerAccount } from '@/lib/services/accounts/registerAccount'
@@ -13,6 +12,7 @@ import {
 import { getRedirectUrl } from '@/lib/services/guards/getRedirectUrl'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import { issueAccessToken } from '@/lib/services/oauth/issueAccessToken'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -129,7 +129,7 @@ const registerViaApi = OAuthAppGuard(
     // runs as a before_action) and the web-form path. registerAccount() also
     // re-checks registrationOpen, so the registration_closed result branch below
     // remains a defensive fallback.
-    if (!getConfig().registrationOpen) {
+    if (!(await getResolvedServerSettings(database)).registrations.open) {
       return apiResponse({
         req,
         allowedMethods: CORS_HEADERS,
@@ -285,7 +285,7 @@ export const POST = traceApiRoute(
     // registerAccount() also checks registrationOpen so it is safe to call as a
     // standalone service; the registration_closed branch in the result handler
     // below is a defensive fallback for that standalone-caller scenario.
-    if (!getConfig().registrationOpen) {
+    if (!(await getResolvedServerSettings(database)).registrations.open) {
       return apiResponse({
         req: request,
         allowedMethods: CORS_HEADERS,

--- a/app/api/v1/actors/domains/route.test.ts
+++ b/app/api/v1/actors/domains/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 
@@ -70,20 +71,33 @@ describe('GET /api/v1/actors/domains', () => {
   })
 
   it('returns allowActorDomains when it is set', async () => {
-    mockGetConfig.mockReturnValue({
-      host: 'llun.test',
-      allowEmails: [],
-      allowActorDomains: ['domain1.test', 'domain2.test', 'llun.test']
+    mockGetConfig.mockReturnValue({ host: 'llun.test', allowEmails: [] })
+    // allowActorDomains is a database-backed federation setting.
+    await database.setServerSetting({
+      key: 'federation.allowActorDomains',
+      value: ['domain1.test', 'domain2.test', 'llun.test']
     })
+    invalidateServerSettingsCache(database)
 
-    const response = await GET(createRequest(), {
-      params: Promise.resolve({})
-    })
+    try {
+      const response = await GET(createRequest(), {
+        params: Promise.resolve({})
+      })
 
-    const data = await response.json()
-    expect(response.status).toBe(200)
-    expect(data.domains).toEqual(['domain1.test', 'domain2.test', 'llun.test'])
-    expect(data.host).toBe('llun.test')
+      const data = await response.json()
+      expect(response.status).toBe(200)
+      expect(data.domains).toEqual([
+        'domain1.test',
+        'domain2.test',
+        'llun.test'
+      ])
+      expect(data.host).toBe('llun.test')
+    } finally {
+      await database.deleteServerSetting({
+        key: 'federation.allowActorDomains'
+      })
+      invalidateServerSettingsCache(database)
+    }
   })
 
   it('returns host from config', async () => {

--- a/app/api/v1/actors/domains/route.ts
+++ b/app/api/v1/actors/domains/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getConfig } from '@/lib/config'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { apiResponse } from '@/lib/utils/response'
 import { traceApiRoute } from '@/lib/utils/traceApiRoute'
 
@@ -9,8 +10,9 @@ export const GET = traceApiRoute(
   'getActorDomains',
   AuthenticatedGuard(async (req: NextRequest) => {
     const config = getConfig()
-    const allowedDomains = config.allowActorDomains?.length
-      ? config.allowActorDomains
+    const { federation } = await getResolvedServerSettings()
+    const allowedDomains = federation.allowActorDomains.length
+      ? federation.allowActorDomains
       : [config.host]
 
     return apiResponse({

--- a/app/api/v1/actors/route.test.ts
+++ b/app/api/v1/actors/route.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { FEDERATION_SIGNING_ACTOR_USERNAME } from '@/lib/services/federation/instanceActor'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
 import { seedDatabase } from '@/lib/stub/database'
 import { seedActor1 } from '@/lib/stub/seed/actor1'
 
@@ -73,20 +74,29 @@ describe('POST /api/v1/actors', () => {
     })
 
   it('uses the requested domain when it is allowed', async () => {
-    mockGetConfig.mockReturnValue({
-      host: 'llun.test',
-      allowEmails: [],
-      allowActorDomains: ['allowed.test', 'llun.test']
+    mockGetConfig.mockReturnValue({ host: 'llun.test', allowEmails: [] })
+    // allowActorDomains is a database-backed federation setting.
+    await database.setServerSetting({
+      key: 'federation.allowActorDomains',
+      value: ['allowed.test', 'llun.test']
     })
+    invalidateServerSettingsCache(database)
 
-    const response = await POST(
-      createRequest({ username: 'newactor-allowed', domain: 'allowed.test' }),
-      { params: Promise.resolve({}) }
-    )
+    try {
+      const response = await POST(
+        createRequest({ username: 'newactor-allowed', domain: 'allowed.test' }),
+        { params: Promise.resolve({}) }
+      )
 
-    const data = await response.json()
-    expect(response.status).toBe(200)
-    expect(data.domain).toBe('allowed.test')
+      const data = await response.json()
+      expect(response.status).toBe(200)
+      expect(data.domain).toBe('allowed.test')
+    } finally {
+      await database.deleteServerSetting({
+        key: 'federation.allowActorDomains'
+      })
+      invalidateServerSettingsCache(database)
+    }
   })
 
   it('falls back to the current actor domain when none is provided', async () => {

--- a/app/api/v1/actors/route.ts
+++ b/app/api/v1/actors/route.ts
@@ -6,6 +6,7 @@ import { getConfig } from '@/lib/config'
 import { isFederationSigningActorUsername } from '@/lib/services/federation/instanceActor'
 import { AuthenticatedGuard } from '@/lib/services/guards/AuthenticatedGuard'
 import { headerHost } from '@/lib/services/guards/headerHost'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import {
   HTTP_STATUS,
   apiErrorResponse,
@@ -75,10 +76,11 @@ export const POST = traceApiRoute(
 
     const { username } = parsed.data
     const config = getConfig()
+    const { federation } = await getResolvedServerSettings()
     const domain =
       parsed.data.domain ?? currentActor.domain ?? headerHost(req.headers)
-    const allowedDomains = config.allowActorDomains?.length
-      ? config.allowActorDomains
+    const allowedDomains = federation.allowActorDomains.length
+      ? federation.allowActorDomains
       : [config.host]
 
     if (!allowedDomains.includes(domain)) {

--- a/app/api/v1/admin/server_settings/route.test.ts
+++ b/app/api/v1/admin/server_settings/route.test.ts
@@ -1,0 +1,141 @@
+import { NextRequest } from 'next/server'
+
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { Database } from '@/lib/database/types'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
+
+import { GET, PATCH } from './route'
+
+const holder = vi.hoisted(() => ({
+  db: null as Database | null
+}))
+
+vi.mock('@/lib/database', () => ({
+  getDatabase: () => holder.db
+}))
+
+vi.mock('@/lib/services/auth/getSession', () => ({
+  getServerAuthSession: vi
+    .fn()
+    .mockResolvedValue({ user: { email: 'admin@test.llun.dev' } })
+}))
+
+vi.mock('@/lib/utils/getAdminFromSession', () => ({
+  getAdminFromSession: vi
+    .fn()
+    .mockResolvedValue({ id: 'admin', defaultActorId: null })
+}))
+
+vi.mock('@/lib/config', () => ({
+  getBaseURL: () => 'https://test.llun.dev',
+  getConfig: () => ({
+    host: 'test.llun.dev',
+    allowEmails: [],
+    trustedHosts: []
+  })
+}))
+
+const ORIGIN = 'https://test.llun.dev'
+const URL_PATH = `${ORIGIN}/api/v1/admin/server_settings`
+const ENV_KEYS = ['ACTIVITIES_SERVICE_NAME']
+
+const patchRequest = (body: unknown) =>
+  new NextRequest(URL_PATH, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Origin: ORIGIN },
+    body: JSON.stringify(body)
+  })
+
+describe('/api/v1/admin/server_settings', () => {
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(async () => {
+    savedEnv = {}
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+    holder.db = getTestSQLDatabase()
+    await holder.db.migrate()
+  })
+
+  afterEach(async () => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key]
+      else process.env[key] = savedEnv[key]
+    }
+    await holder.db?.destroy()
+  })
+
+  it('returns resolved settings and lock metadata', async () => {
+    const response = await GET(new NextRequest(URL_PATH), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.settings.posts.maxCharacters).toBe(500)
+    expect(data.settings.federation.mode).toBe('open')
+    expect(data.locks['posts.maxCharacters'].locked).toBe(false)
+  })
+
+  it('persists a valid PATCH and returns the updated view', async () => {
+    const response = await PATCH(
+      patchRequest({ 'posts.maxCharacters': 1500 }),
+      {
+        params: Promise.resolve({})
+      }
+    )
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.settings.posts.maxCharacters).toBe(1500)
+    await expect(
+      holder.db?.getServerSetting({ key: 'posts.maxCharacters' })
+    ).resolves.toMatchObject({ value: 1500 })
+  })
+
+  it('rejects an invalid value with 422 and writes nothing', async () => {
+    const response = await PATCH(patchRequest({ 'posts.maxCharacters': -1 }), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+
+    const data = await response.json()
+    expect(data.rejected).toContainEqual({
+      key: 'posts.maxCharacters',
+      reason: 'invalid'
+    })
+    await expect(
+      holder.db?.getServerSetting({ key: 'posts.maxCharacters' })
+    ).resolves.toBeNull()
+  })
+
+  it('rejects writes to an env-locked field with 422', async () => {
+    process.env.ACTIVITIES_SERVICE_NAME = 'Env Name'
+    invalidateServerSettingsCache(holder.db)
+
+    const response = await PATCH(patchRequest({ 'instance.name': 'Changed' }), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(422)
+
+    const data = await response.json()
+    expect(data.rejected).toContainEqual({
+      key: 'instance.name',
+      reason: 'locked'
+    })
+  })
+
+  it('forbids a non-admin caller with 403', async () => {
+    const { getAdminFromSession } = await vi.importMock<
+      typeof import('@/lib/utils/getAdminFromSession')
+    >('@/lib/utils/getAdminFromSession')
+    getAdminFromSession.mockResolvedValueOnce(null)
+
+    const response = await GET(new NextRequest(URL_PATH), {
+      params: Promise.resolve({})
+    })
+    expect(response.status).toBe(403)
+  })
+})

--- a/app/api/v1/admin/server_settings/route.ts
+++ b/app/api/v1/admin/server_settings/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from 'next/server'
+
+import { AdminApiGuard } from '@/lib/services/guards/AdminApiGuard'
+import {
+  getServerSettingsView,
+  updateServerSettings
+} from '@/lib/services/serverSettings'
+import { getRequestBody } from '@/lib/utils/getRequestBody'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import {
+  ERROR_400,
+  HTTP_STATUS,
+  apiResponse,
+  defaultOptions
+} from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+// Read/write the database-backed server settings. Same-origin admin surface
+// (the admin settings pages) — guarded by the admin role + the aggregate
+// admin:read / admin:write scopes; env-pinned fields are reported locked and
+// reject writes.
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PATCH
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+export const GET = traceApiRoute(
+  'adminGetServerSettings',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    const view = await getServerSettingsView(database)
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { settings: view.settings, locks: view.locks }
+    })
+  })
+)
+
+export const PATCH = traceApiRoute(
+  'adminUpdateServerSettings',
+  AdminApiGuard(CORS_HEADERS, async (req: NextRequest, { database }) => {
+    let body: Record<string, unknown>
+    try {
+      body = await getRequestBody(req)
+    } catch {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: ERROR_400,
+        responseStatusCode: HTTP_STATUS.BAD_REQUEST
+      })
+    }
+
+    const result = await updateServerSettings(database, body)
+    if (!result.applied) {
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: {
+          error: 'Some settings could not be saved',
+          rejected: result.rejected
+        },
+        responseStatusCode: HTTP_STATUS.UNPROCESSABLE_ENTITY
+      })
+    }
+
+    return apiResponse({
+      req,
+      allowedMethods: CORS_HEADERS,
+      data: { settings: result.view.settings, locks: result.view.locks }
+    })
+  })
+)

--- a/app/api/v1/emails/confirmations/route.test.ts
+++ b/app/api/v1/emails/confirmations/route.test.ts
@@ -1,13 +1,25 @@
 import knex from 'knex'
 import { NextRequest } from 'next/server'
 
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
 import { getSQLDatabase } from '@/lib/database/sql'
 import { Database } from '@/lib/database/types'
 import { hashToken } from '@/lib/services/guards/OAuthGuard'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { Scope } from '@/lib/types/database/operations'
 
 import { POST } from './route'
+
+vi.mock('@/lib/services/serverSettings', () => ({
+  getResolvedServerSettings: vi.fn()
+}))
+
+// The email allow-list is resolved from server settings.
+const settingsWithAllowEmails = (allowEmails: string[]) => ({
+  ...structuredClone(DEFAULT_SERVER_SETTINGS),
+  registrations: { open: true, allowEmails }
+})
 
 const mockGetServerSession = vi.fn()
 vi.mock('@/lib/services/auth/getSession', () => ({
@@ -103,6 +115,9 @@ describe('POST /api/v1/emails/confirmations', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWithAllowEmails([])
+    )
     mockGetServerSession.mockResolvedValue({
       user: { email: seedActor1.email }
     })
@@ -215,10 +230,12 @@ describe('POST /api/v1/emails/confirmations', () => {
   it('allows a new email whose case differs from the allow-list entry', async () => {
     mockGetConfig.mockReturnValue({
       host: 'llun.test',
-      allowEmails: [seedActor1.email, 'Allowed@LLUN.test'],
       allowActorDomains: [],
       email: { serviceFromAddress: 'noreply@llun.test' }
     })
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWithAllowEmails([seedActor1.email, 'Allowed@LLUN.test'])
+    )
 
     const response = await POST(makeRequest({ email: 'allowed@llun.test' }), {
       params: Promise.resolve({})
@@ -236,10 +253,12 @@ describe('POST /api/v1/emails/confirmations', () => {
     // actor); only the requested new address is absent from it.
     mockGetConfig.mockReturnValue({
       host: 'llun.test',
-      allowEmails: [seedActor1.email],
       allowActorDomains: [],
       email: { serviceFromAddress: 'noreply@llun.test' }
     })
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWithAllowEmails([seedActor1.email])
+    )
 
     const response = await POST(makeRequest({ email: 'blocked@llun.test' }), {
       params: Promise.resolve({})
@@ -437,6 +456,9 @@ describe('POST /api/v1/emails/confirmations with a Bearer token', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWithAllowEmails([])
+    )
     mockDatabase = apiDatabase
     mockKnex = apiKnex
     mockGetConfig.mockReturnValue({

--- a/app/api/v1/emails/confirmations/route.ts
+++ b/app/api/v1/emails/confirmations/route.ts
@@ -8,13 +8,13 @@
 // requires a `write` scope, rather than the cookie-only AuthenticatedGuard.
 import { z } from 'zod'
 
-import { getConfig } from '@/lib/config'
 import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
 import {
   OAuthGuardAnyScope,
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { Scope } from '@/lib/types/database/operations'
 import { getRequestBody } from '@/lib/utils/getRequestBody'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -109,8 +109,8 @@ export const POST = traceApiRoute(
       if (newEmail && newEmail !== account.email) {
         // Honor the server's allow-list so the email param can't be used to
         // sidestep the same restriction enforced at registration.
-        const { allowEmails } = getConfig()
-        if (!isEmailAllowed(allowEmails, newEmail)) {
+        const { registrations } = await getResolvedServerSettings(database)
+        if (!isEmailAllowed(registrations.allowEmails, newEmail)) {
           return apiResponse({
             req,
             allowedMethods: CORS_HEADERS,

--- a/app/api/v1/instance/route.test.ts
+++ b/app/api/v1/instance/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import type { Config } from '@/lib/config'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { MAX_STORED_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
 
 import { GET } from './route'
 
@@ -131,6 +132,31 @@ describe('GET /api/v1/instance', () => {
     expect(body.registrations).toBe(true)
     expect(body.rules).toEqual([{ id: rule.id, text: 'No spam', hint: '' }])
     expect(body.contact_account).toBeNull()
+  })
+
+  it('reflects database-backed server settings', async () => {
+    await database.setServerSetting({
+      key: 'registrations.open',
+      value: false
+    })
+    await database.setServerSetting({
+      key: 'posts.maxCharacters',
+      value: 2000
+    })
+    invalidateServerSettingsCache(database)
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v1/instance'),
+        params
+      )
+      const body = await response.json()
+      expect(body.registrations).toBe(false)
+      expect(body.configuration.statuses.max_characters).toBe(2000)
+    } finally {
+      await database.deleteServerSetting({ key: 'registrations.open' })
+      await database.deleteServerSetting({ key: 'posts.maxCharacters' })
+      invalidateServerSettingsCache(database)
+    }
   })
 
   it('advertises the stored media ceiling as max_media_attachments', async () => {

--- a/app/api/v1/instance/route.ts
+++ b/app/api/v1/instance/route.ts
@@ -3,19 +3,14 @@ import { NextRequest } from 'next/server'
 import { buildBaseURL, getConfig } from '@/lib/config'
 import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
-import {
-  MAX_PINNED_STATUSES,
-  MAX_STORED_MEDIA_ATTACHMENTS
-} from '@/lib/services/mastodon/constants'
+import { MAX_PINNED_STATUSES } from '@/lib/services/mastodon/constants'
 import {
   getInstanceContactAccount,
   getInstanceContactEmail,
   getInstanceStats
 } from '@/lib/services/mastodon/instance'
-import {
-  ACCEPTED_FILE_TYPES,
-  MAX_FILE_SIZE
-} from '@/lib/services/medias/constants'
+import { ACCEPTED_FILE_TYPES } from '@/lib/services/medias/constants'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { InstanceRuleData } from '@/lib/types/database/operations'
 import { Rule } from '@/lib/types/mastodon/rule'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -49,19 +44,19 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
     }
   }
 
-  const [stats, contactAccount] = await Promise.all([
+  const [stats, contactAccount, serverSettings] = await Promise.all([
     getInstanceStats(database, config.host),
-    getInstanceContactAccount(database)
+    getInstanceContactAccount(database),
+    getResolvedServerSettings(database)
   ])
 
   const data = {
     uri: domain,
-    title: config.serviceName ?? 'Activities.next',
-    short_description:
-      config.serviceDescription ?? 'Personal activity pub server with Next.js',
-    description:
-      config.serviceDescription ?? 'Personal activity pub server with Next.js',
-    email: getInstanceContactEmail(config),
+    title: serverSettings.instance.name,
+    short_description: serverSettings.instance.description,
+    description: serverSettings.instance.description,
+    email:
+      serverSettings.instance.contactEmail || getInstanceContactEmail(config),
     version: VERSION,
     // No streaming API: the documented key is present but empty so clients
     // treat streaming as unavailable and fall back to polling.
@@ -74,14 +69,14 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
       domain_count: stats.domainCount
     },
     thumbnail: `${baseUrl}/logo.png`,
-    languages: config.languages,
-    registrations: config.registrationOpen,
+    languages: serverSettings.instance.languages,
+    registrations: serverSettings.registrations.open,
     approval_required: false,
     invites_enabled: false,
     configuration: {
       statuses: {
-        max_characters: 500,
-        max_media_attachments: MAX_STORED_MEDIA_ATTACHMENTS,
+        max_characters: serverSettings.posts.maxCharacters,
+        max_media_attachments: serverSettings.posts.maxMediaAttachments,
         characters_reserved_per_url: 23
       },
       accounts: {
@@ -89,17 +84,17 @@ export const GET = traceApiRoute('getInstance', async (req: NextRequest) => {
       },
       media_attachments: {
         supported_mime_types: ACCEPTED_FILE_TYPES,
-        image_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
+        image_size_limit: serverSettings.media.maxFileSize,
         image_matrix_limit: 16777216,
-        video_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
+        video_size_limit: serverSettings.media.maxFileSize,
         video_frame_rate_limit: 60,
         video_matrix_limit: 2304000
       },
       polls: {
-        max_options: 4,
-        max_characters_per_option: 50,
-        min_expiration: 300,
-        max_expiration: 2629746
+        max_options: serverSettings.polls.maxOptions,
+        max_characters_per_option: serverSettings.polls.maxCharactersPerOption,
+        min_expiration: serverSettings.polls.minExpirationSeconds,
+        max_expiration: serverSettings.polls.maxExpirationSeconds
       }
     },
     contact_account: contactAccount,

--- a/app/api/v1/statuses/[id]/route.test.ts
+++ b/app/api/v1/statuses/[id]/route.test.ts
@@ -12,6 +12,7 @@ import {
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { deleteMediaFile } from '@/lib/services/medias'
 import { getQueue } from '@/lib/services/queue'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
 import { TEST_DOMAIN } from '@/lib/stub/const'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
@@ -1609,6 +1610,44 @@ describe('GET /api/v1/statuses/[id]', () => {
         })
       ])
       expect(getQueue().publish).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects an edit over the configured character limit with 422', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { email: seedActor1.email }
+      })
+      const statusId = `${ACTOR1_ID}/statuses/api-edit-length-limit`
+      await database.createNote({
+        id: statusId,
+        url: statusId,
+        actorId: ACTOR1_ID,
+        text: 'Short',
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: []
+      })
+      await database.setServerSetting({ key: 'posts.maxCharacters', value: 10 })
+      invalidateServerSettingsCache(database)
+
+      try {
+        const response = await PUT(
+          new NextRequest(
+            `https://llun.test/api/v1/statuses/${urlToId(statusId)}`,
+            {
+              method: 'PUT',
+              body: JSON.stringify({ status: 'x'.repeat(11) }),
+              headers: {
+                'Content-Type': 'application/json',
+                Origin: 'https://llun.test'
+              }
+            }
+          ),
+          { params: Promise.resolve({ id: urlToId(statusId) }) }
+        )
+        expect(response.status).toBe(422)
+      } finally {
+        await database.deleteServerSetting({ key: 'posts.maxCharacters' })
+        invalidateServerSettingsCache(database)
+      }
     })
 
     it('stores more media than the federation cap and federates only the first few', async () => {

--- a/app/api/v1/statuses/[id]/route.ts
+++ b/app/api/v1/statuses/[id]/route.ts
@@ -13,17 +13,17 @@ import {
   OptionalOAuthGuard
 } from '@/lib/services/guards/OAuthGuard'
 import {
-  MAX_POLL_EXPIRATION_SECONDS,
-  MAX_POLL_OPTIONS,
-  MAX_POLL_OPTION_CHARS,
   MAX_STORED_MEDIA_ATTACHMENTS,
-  MIN_POLL_EXPIRATION_SECONDS,
-  MIN_POLL_OPTIONS
+  MIN_POLL_OPTIONS,
+  POLL_OPTIONS_CEILING,
+  POLL_OPTION_CHARS_CEILING
 } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { deleteMediaFile } from '@/lib/services/medias'
 import { FocusSchema } from '@/lib/services/medias/types'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
+import { validateStatusContentLimits } from '@/lib/services/statuses/contentLimits'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
 import { Scope } from '@/lib/types/database/operations'
@@ -133,15 +133,10 @@ const EditMediaAttributeSchema = z.object({
 // edit semantics).
 const EditPollSchema = z.object({
   options: z
-    .array(z.string().trim().min(1).max(MAX_POLL_OPTION_CHARS))
+    .array(z.string().trim().min(1).max(POLL_OPTION_CHARS_CEILING))
     .min(MIN_POLL_OPTIONS)
-    .max(MAX_POLL_OPTIONS),
-  expires_in: z.coerce
-    .number()
-    .int()
-    .min(MIN_POLL_EXPIRATION_SECONDS)
-    .max(MAX_POLL_EXPIRATION_SECONDS)
-    .optional(),
+    .max(POLL_OPTIONS_CEILING),
+  expires_in: z.coerce.number().int().positive().optional(),
   multiple: Booleanish.optional(),
   hide_totals: Booleanish.optional()
 })
@@ -192,6 +187,19 @@ export const PUT = traceApiRoute(
           })
         }
         const changes = parsed.data
+
+        // Enforce the admin-configured status/poll limits (server settings).
+        const serverSettings = await getResolvedServerSettings(database)
+        const limitError = validateStatusContentLimits(changes, serverSettings)
+        if (limitError) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: { error: limitError },
+            responseStatusCode: 422
+          })
+        }
+
         const mediaAttributes = changes.media_attributes
         const mediaIds =
           changes.media_ids === undefined

--- a/app/api/v1/statuses/route.test.ts
+++ b/app/api/v1/statuses/route.test.ts
@@ -11,6 +11,7 @@ import {
   SCHEDULED_AT_TOO_SOON_ERROR
 } from '@/lib/services/mastodon/constants'
 import { getQueue } from '@/lib/services/queue'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID } from '@/lib/stub/seed/actor2'
@@ -573,6 +574,78 @@ describe('POST /api/v1/statuses', () => {
       { title: 'Green', votes_count: 0 },
       { title: 'Blue', votes_count: 0 }
     ])
+  })
+
+  it('rejects a status over the configured character limit with 422', async () => {
+    await database.setServerSetting({ key: 'posts.maxCharacters', value: 10 })
+    invalidateServerSettingsCache(database)
+    try {
+      const response = await POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({ status: 'x'.repeat(11) }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+      expect(response.status).toBe(422)
+    } finally {
+      await database.deleteServerSetting({ key: 'posts.maxCharacters' })
+      invalidateServerSettingsCache(database)
+    }
+  })
+
+  it('accepts a longer status when the character limit is raised', async () => {
+    await database.setServerSetting({
+      key: 'posts.maxCharacters',
+      value: 5000
+    })
+    invalidateServerSettingsCache(database)
+    try {
+      const response = await POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({ status: 'x'.repeat(1000) }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+      expect(response.status).toBe(200)
+    } finally {
+      await database.deleteServerSetting({ key: 'posts.maxCharacters' })
+      invalidateServerSettingsCache(database)
+    }
+  })
+
+  it('rejects a poll with more options than the configured limit with 422', async () => {
+    await database.setServerSetting({ key: 'polls.maxOptions', value: 2 })
+    invalidateServerSettingsCache(database)
+    try {
+      const response = await POST(
+        new NextRequest('https://llun.test/api/v1/statuses', {
+          method: 'POST',
+          body: JSON.stringify({
+            status: 'Pick one',
+            poll: { options: ['a', 'b', 'c'], expires_in: 3600 }
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Origin: 'https://llun.test'
+          }
+        }),
+        { params: Promise.resolve({}) }
+      )
+      expect(response.status).toBe(422)
+    } finally {
+      await database.deleteServerSetting({ key: 'polls.maxOptions' })
+      invalidateServerSettingsCache(database)
+    }
   })
 
   it('creates a poll from flattened form poll params', async () => {

--- a/app/api/v1/statuses/route.ts
+++ b/app/api/v1/statuses/route.ts
@@ -10,19 +10,19 @@ import {
   corsErrorResponse
 } from '@/lib/services/guards/OAuthGuard'
 import {
-  MAX_POLL_EXPIRATION_SECONDS,
-  MAX_POLL_OPTIONS,
-  MAX_POLL_OPTION_CHARS,
   MAX_STORED_MEDIA_ATTACHMENTS,
-  MIN_POLL_EXPIRATION_SECONDS,
   MIN_POLL_OPTIONS,
   MIN_SCHEDULED_STATUS_AHEAD_MS,
+  POLL_OPTIONS_CEILING,
+  POLL_OPTION_CHARS_CEILING,
   SCHEDULED_AT_TOO_SOON_ERROR
 } from '@/lib/services/mastodon/constants'
 import { getMastodonStatus } from '@/lib/services/mastodon/getMastodonStatus'
 import { getQueue } from '@/lib/services/queue'
 import { canQuoteStatus } from '@/lib/services/quotes/canQuoteStatus'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { canActorReadStatus } from '@/lib/services/statusAccess'
+import { validateStatusContentLimits } from '@/lib/services/statuses/contentLimits'
 import { getAttachmentsFromMediaIds } from '@/lib/services/statuses/mediaIds'
 import { parseStatusRequestBody } from '@/lib/services/statuses/parseStatusRequestBody'
 import {
@@ -63,16 +63,15 @@ export const OPTIONS = defaultOptions(CORS_HEADERS)
 
 const VisibilitySchema = z.enum(['public', 'unlisted', 'private', 'direct'])
 
+// The precise option-count/length/expiry bounds are the admin-configured poll
+// settings, enforced at runtime after parsing (see validateStatusContentLimits).
+// The schema only applies the structural floor and absolute safety ceilings.
 const PollSchema = z.object({
   options: z
-    .array(z.string().trim().min(1).max(MAX_POLL_OPTION_CHARS))
+    .array(z.string().trim().min(1).max(POLL_OPTION_CHARS_CEILING))
     .min(MIN_POLL_OPTIONS)
-    .max(MAX_POLL_OPTIONS),
-  expires_in: z.coerce
-    .number()
-    .int()
-    .min(MIN_POLL_EXPIRATION_SECONDS)
-    .max(MAX_POLL_EXPIRATION_SECONDS),
+    .max(POLL_OPTIONS_CEILING),
+  expires_in: z.coerce.number().int().positive(),
   multiple: Booleanish.optional().default(false),
   hide_totals: Booleanish.optional().default(false)
 })
@@ -178,6 +177,18 @@ export const POST = traceApiRoute(
             req,
             allowedMethods: CORS_HEADERS,
             data: ERROR_422,
+            responseStatusCode: 422
+          })
+        }
+
+        // Enforce the admin-configured status/poll limits (server settings).
+        const serverSettings = await getResolvedServerSettings(database)
+        const limitError = validateStatusContentLimits(note, serverSettings)
+        if (limitError) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: { error: limitError },
             responseStatusCode: 422
           })
         }

--- a/app/api/v2/instance/route.test.ts
+++ b/app/api/v2/instance/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import type { Config } from '@/lib/config'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { MAX_STORED_MEDIA_ATTACHMENTS } from '@/lib/services/mastodon/constants'
+import { invalidateServerSettingsCache } from '@/lib/services/serverSettings'
 
 import { GET } from './route'
 
@@ -205,24 +206,51 @@ describe('GET /api/v2/instance', () => {
       registrationOpen: false
     }
   ])('$description', async ({ registrationOpen }) => {
-    const config =
-      await vi.importMock<typeof import('@/lib/config')>('@/lib/config')
-    vi.mocked(config.getConfig).mockReturnValue({
-      ...baseConfig,
-      registrationOpen
-    } as unknown as Config)
-
-    const response = await GET(
-      new NextRequest('https://llun.test/api/v2/instance'),
-      params
-    )
-    const body = await response.json()
-    expect(body.registrations).toEqual({
-      enabled: registrationOpen,
-      approval_required: false,
-      message: null,
-      url: null
+    // Registration state is resolved from server settings (env -> db ->
+    // default), so drive it through a stored setting rather than getConfig.
+    await database.setServerSetting({
+      key: 'registrations.open',
+      value: registrationOpen
     })
+    invalidateServerSettingsCache(database)
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v2/instance'),
+        params
+      )
+      const body = await response.json()
+      expect(body.registrations).toEqual({
+        enabled: registrationOpen,
+        approval_required: false,
+        message: null,
+        url: null
+      })
+    } finally {
+      await database.deleteServerSetting({ key: 'registrations.open' })
+      invalidateServerSettingsCache(database)
+    }
+  })
+
+  it('echoes database-backed post and poll limits in configuration', async () => {
+    await database.setServerSetting({
+      key: 'posts.maxCharacters',
+      value: 1000
+    })
+    await database.setServerSetting({ key: 'polls.maxOptions', value: 6 })
+    invalidateServerSettingsCache(database)
+    try {
+      const response = await GET(
+        new NextRequest('https://llun.test/api/v2/instance'),
+        params
+      )
+      const body = await response.json()
+      expect(body.configuration.statuses.max_characters).toBe(1000)
+      expect(body.configuration.polls.max_options).toBe(6)
+    } finally {
+      await database.deleteServerSetting({ key: 'posts.maxCharacters' })
+      await database.deleteServerSetting({ key: 'polls.maxOptions' })
+      invalidateServerSettingsCache(database)
+    }
   })
 
   it('returns empty rules instead of failing when the database is unavailable', async () => {

--- a/app/api/v2/instance/route.ts
+++ b/app/api/v2/instance/route.ts
@@ -5,18 +5,15 @@ import { getDatabase } from '@/lib/database'
 import { headerHost } from '@/lib/services/guards/headerHost'
 import {
   MASTODON_INSTANCE_API_VERSION,
-  MAX_PINNED_STATUSES,
-  MAX_STORED_MEDIA_ATTACHMENTS
+  MAX_PINNED_STATUSES
 } from '@/lib/services/mastodon/constants'
 import {
   getInstanceContactAccount,
   getInstanceContactEmail,
   getInstanceStats
 } from '@/lib/services/mastodon/instance'
-import {
-  ACCEPTED_FILE_TYPES,
-  MAX_FILE_SIZE
-} from '@/lib/services/medias/constants'
+import { ACCEPTED_FILE_TYPES } from '@/lib/services/medias/constants'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { isTranslationEnabled } from '@/lib/services/translation'
 import { InstanceRuleData } from '@/lib/types/database/operations'
 import { Rule } from '@/lib/types/mastodon/rule'
@@ -52,21 +49,20 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
       })
     }
   }
-  const [stats, contactAccount] = await Promise.all([
+  const [stats, contactAccount, serverSettings] = await Promise.all([
     getInstanceStats(database, config.host),
-    getInstanceContactAccount(database)
+    getInstanceContactAccount(database),
+    getResolvedServerSettings(database)
   ])
   return apiResponse({
     req,
     allowedMethods: CORS_HEADERS,
     data: {
       domain,
-      title: config.serviceName ?? 'Activities.next',
+      title: serverSettings.instance.name,
       version: VERSION,
       source_url: 'https://github.com/llun/activities.next',
-      description:
-        config.serviceDescription ??
-        'Personal activity pub server with Next.js',
+      description: serverSettings.instance.description,
       usage: {
         users: {
           active_month: stats.activeMonth
@@ -83,7 +79,7 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
         { src: `${baseUrl}/icon-192.png`, size: '192x192' },
         { src: `${baseUrl}/icon-512.png`, size: '512x512' }
       ],
-      languages: config.languages,
+      languages: serverSettings.instance.languages,
       api_versions: {
         mastodon: MASTODON_INSTANCE_API_VERSION
       },
@@ -102,36 +98,39 @@ export const GET = traceApiRoute('getInstanceV2', async (req: NextRequest) => {
           max_pinned_statuses: MAX_PINNED_STATUSES
         },
         statuses: {
-          max_characters: 500,
-          max_media_attachments: MAX_STORED_MEDIA_ATTACHMENTS,
+          max_characters: serverSettings.posts.maxCharacters,
+          max_media_attachments: serverSettings.posts.maxMediaAttachments,
           characters_reserved_per_url: 23
         },
         media_attachments: {
           supported_mime_types: ACCEPTED_FILE_TYPES,
-          image_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
+          image_size_limit: serverSettings.media.maxFileSize,
           image_matrix_limit: 33177600,
-          video_size_limit: config.mediaStorage?.maxFileSize ?? MAX_FILE_SIZE,
+          video_size_limit: serverSettings.media.maxFileSize,
           video_frame_rate_limit: 120,
           video_matrix_limit: 8294400
         },
         polls: {
-          max_options: 4,
-          max_characters_per_option: 50,
-          min_expiration: 300,
-          max_expiration: 2629746
+          max_options: serverSettings.polls.maxOptions,
+          max_characters_per_option:
+            serverSettings.polls.maxCharactersPerOption,
+          min_expiration: serverSettings.polls.minExpirationSeconds,
+          max_expiration: serverSettings.polls.maxExpirationSeconds
         },
         translation: {
           enabled: isTranslationEnabled()
         }
       },
       registrations: {
-        enabled: config.registrationOpen,
+        enabled: serverSettings.registrations.open,
         approval_required: false,
         message: null,
         url: null
       },
       contact: {
-        email: getInstanceContactEmail(config),
+        email:
+          serverSettings.instance.contactEmail ||
+          getInstanceContactEmail(config),
         account: contactAccount
       },
       rules: rules.map((rule): Rule => ({

--- a/app/u/heatmaps/[token]/page.tsx
+++ b/app/u/heatmaps/[token]/page.tsx
@@ -2,10 +2,11 @@ import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { FC } from 'react'
 
-import { getBaseURL, getConfig } from '@/lib/config'
+import { getBaseURL } from '@/lib/config'
 import { getPublicMapProvider } from '@/lib/config/mapProvider'
 import { getDatabase } from '@/lib/database'
 import { toPublicHeatmap } from '@/lib/services/fitness-files/publicHeatmap'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 import { SharedHeatmapPage } from './SharedHeatmapPage'
 import { buildSharedHeatmapView } from './sharedHeatmapView'
@@ -79,14 +80,16 @@ const Page: FC<PageProps> = async ({ params }) => {
     token
   })
 
-  const config = getConfig()
+  const {
+    registrations: { open: registrationOpen }
+  } = await getResolvedServerSettings(database)
   const mapProvider = getPublicMapProvider()
 
   return (
     <SharedHeatmapPage
       view={view}
       mapProvider={mapProvider}
-      signupOpen={config.registrationOpen}
+      signupOpen={registrationOpen}
       signinUrl="/auth/signin"
       signupUrl="/auth/signup"
     />

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -8,6 +8,32 @@ This document lists all environment variables supported by Activity.next.
 
 Application configuration is provided through environment variables. Root-level `config.json` files are ignored; migrate any previous file settings to the corresponding `ACTIVITIES_*` or `OTEL_EXPORTER_*` variables listed below. Application config is read at runtime, so Docker/standalone builds do not need real `ACTIVITIES_*` or `OTEL_EXPORTER_*` values at build time. Environment variables read outside app config, such as `NODE_ENV`, `BUILD_STANDALONE`, `NEXT_TELEMETRY_DISABLED`, and `LOG_LEVEL`, still apply.
 
+## Database-backed server settings (env → database → default)
+
+Some instance policy is also editable at runtime from the admin area
+(**Admin → Instance / Posts & media / Network**, and the **Federation** tab),
+stored in the `server_settings` table. Each such value is resolved with the
+precedence **environment variable → database → built-in default**: an
+environment variable always wins and locks the field in the admin UI with a
+"Set by environment" badge, so removing the variable is what hands control back
+to the admin form. Clients read the resolved values from `/api/v1/instance` and
+`/api/v2/instance`, and the create/edit status APIs enforce the resolved
+post/poll limits.
+
+The variables that pin an admin-editable setting are:
+`ACTIVITIES_SERVICE_NAME`, `ACTIVITIES_SERVICE_DESCRIPTION`,
+`ACTIVITIES_LANGUAGES`, `ACTIVITIES_REGISTRATION_OPEN`,
+`ACTIVITIES_ALLOW_EMAILS`, `ACTIVITIES_MEDIA_STORAGE_MAX_FILE_SIZE`,
+`ACTIVITIES_REQUEST_TIMEOUT`, `ACTIVITIES_REQUEST_RETRY`,
+`ACTIVITIES_REQUEST_MAX_RESPONSE_SIZE_BYTES`, `ACTIVITIES_FEDERATION_MODE`, and
+`ACTIVITIES_ALLOW_ACTOR_DOMAINS`. Post size and poll limits have no environment
+variable and are database-or-default only. `ACTIVITIES_ALLOW_MEDIA_DOMAINS` and
+the `ACTIVITIES_MEDIA_STORAGE_*` backend stay environment-only (they feed the
+Edge-runtime CSP and storage infrastructure) and are shown read-only in the
+admin UI. When no `ACTIVITIES_REQUEST_*` variable is set, the outbound request
+timeout default is `4000` ms (the documented config default), unifying the
+previous 10000 ms request-wrapper fallback.
+
 ## Core Configuration
 
 | Variable                         | Required | Description                                                                                                                                                                                                                                            |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -30,9 +30,9 @@ The variables that pin an admin-editable setting are:
 variable and are database-or-default only. `ACTIVITIES_ALLOW_MEDIA_DOMAINS` and
 the `ACTIVITIES_MEDIA_STORAGE_*` backend stay environment-only (they feed the
 Edge-runtime CSP and storage infrastructure) and are shown read-only in the
-admin UI. When no `ACTIVITIES_REQUEST_*` variable is set, the outbound request
-timeout default is `4000` ms (the documented config default), unifying the
-previous 10000 ms request-wrapper fallback.
+admin UI. On a multi-instance deployment, an admin's save takes effect on other
+instances within a short cache window rather than instantly; an environment
+variable, when set, always wins regardless.
 
 ## Core Configuration
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -100,6 +100,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Docker support** — Official container image at `ghcr.io/llun/activities.next`
 - ✅ **Vercel deployment** — Deploy as a serverless Next.js application
 - ✅ **Federation controls** — Admin allow/block rules, import for domain blocks, and allowlist mode
+- ✅ **Database-backed server settings** — Edit instance identity, registrations, post/poll/upload limits, and federation policy from the admin area, resolved `env → database → default` (an environment variable wins and locks the field). See [Environment Variables](environment-variables.md#database-backed-server-settings-env--database--default)
 
 ## In Progress
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,4 +1,5 @@
 import { Duration } from '@/lib/components/post-box/poll-choices'
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
 import type { AdminAnnouncement } from '@/lib/services/announcements/adminAnnouncement'
 import { PresignedUrlOutput } from '@/lib/services/medias/types'
 import type { AdminRule } from '@/lib/services/rules/adminRule'
@@ -3410,6 +3411,40 @@ export const adminDeleteCustomEmoji = async (id: string): Promise<void> => {
     method: 'DELETE'
   })
   if (!response.ok) throw new Error('Failed to delete custom emoji')
+}
+
+// Database-backed admin server settings. Resolved values plus per-field lock
+// metadata (env-pinned fields are locked and reject writes).
+export interface AdminServerSettingsResponse {
+  settings: ResolvedServerSettings
+  locks: Record<string, { locked: boolean; envVar?: string }>
+}
+
+export const getAdminServerSettings =
+  async (): Promise<AdminServerSettingsResponse> => {
+    const response = await fetch('/api/v1/admin/server_settings', {
+      headers: { Accept: 'application/json' }
+    })
+    if (!response.ok) throw new Error('Failed to load server settings')
+    return (await response.json()) as AdminServerSettingsResponse
+  }
+
+// Partial { key: value } patch. Env-locked, unknown, or invalid keys are
+// rejected server-side and nothing is written; the thrown message surfaces to
+// the form.
+export const updateAdminServerSettings = async (
+  patch: Record<string, unknown>
+): Promise<AdminServerSettingsResponse> => {
+  const response = await fetch('/api/v1/admin/server_settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch)
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => null)
+    throw new Error(error?.error ?? 'Failed to save server settings')
+  }
+  return (await response.json()) as AdminServerSettingsResponse
 }
 
 // Lists (https://docs.joinmastodon.org/methods/lists/).

--- a/lib/components/admin/settings/EnvLockBadge.tsx
+++ b/lib/components/admin/settings/EnvLockBadge.tsx
@@ -1,0 +1,27 @@
+import { Lock } from 'lucide-react'
+import { FC } from 'react'
+
+// Amber "Set by environment" badge shown on a field whose value is pinned by an
+// ACTIVITIES_* environment variable. env beats database, always — so the field
+// renders read-only until the variable is removed.
+export const EnvLockBadge: FC<{ envVar?: string }> = ({ envVar }) => (
+  <span
+    title={envVar}
+    className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-950/60 dark:text-amber-300"
+  >
+    <Lock className="h-3 w-3" aria-hidden />
+    Set by environment
+  </span>
+)
+
+// The help line for a locked field, naming the variable that pins it.
+export const LockedFieldHelp: FC<{ envVar?: string }> = ({ envVar }) =>
+  envVar ? (
+    <>
+      Pinned by{' '}
+      <code className="rounded bg-muted px-1 py-px font-mono text-[11px]">
+        {envVar}
+      </code>{' '}
+      — unset it to manage this here.
+    </>
+  ) : null

--- a/lib/components/admin/settings/FederationPolicyForm.test.tsx
+++ b/lib/components/admin/settings/FederationPolicyForm.test.tsx
@@ -31,7 +31,7 @@ const settingsWith = (
     maxOptions: 4,
     maxCharactersPerOption: 50,
     minExpirationSeconds: 300,
-    maxExpirationSeconds: 2629746
+    maxExpirationSeconds: 2678400
   },
   media: { maxFileSize: 209715200 },
   network: {

--- a/lib/components/admin/settings/FederationPolicyForm.test.tsx
+++ b/lib/components/admin/settings/FederationPolicyForm.test.tsx
@@ -86,7 +86,7 @@ describe('FederationPolicyForm', () => {
     expect(mediaField).toBeDisabled()
     expect(mediaField).toHaveValue('files.mastodon.social')
     expect(
-      screen.getByText('ACTIVITIES_ALLOW_MEDIA_DOMAINS')
+      screen.getByText(/ACTIVITIES_ALLOW_MEDIA_DOMAINS/)
     ).toBeInTheDocument()
   })
 

--- a/lib/components/admin/settings/FederationPolicyForm.test.tsx
+++ b/lib/components/admin/settings/FederationPolicyForm.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import { FederationPolicyForm } from './FederationPolicyForm'
+import type { ServerSettingLocks } from './InstanceSettingsForm'
+
+const mockUpdate = vi.fn()
+
+vi.mock('@/lib/client', () => ({
+  updateAdminServerSettings: (patch: Record<string, unknown>) =>
+    mockUpdate(patch)
+}))
+
+const settingsWith = (
+  federation: ResolvedServerSettings['federation']
+): ResolvedServerSettings => ({
+  instance: {
+    name: 'llun.social',
+    description: '',
+    contactEmail: '',
+    languages: ['en']
+  },
+  registrations: { open: true, allowEmails: [] },
+  posts: { maxCharacters: 500, maxMediaAttachments: 20 },
+  polls: {
+    maxOptions: 4,
+    maxCharactersPerOption: 50,
+    minExpirationSeconds: 300,
+    maxExpirationSeconds: 2629746
+  },
+  media: { maxFileSize: 209715200 },
+  network: {
+    requestTimeoutMs: 4000,
+    requestRetries: 1,
+    maxResponseSizeBytes: 2097152
+  },
+  federation
+})
+
+const renderForm = (
+  federation: ResolvedServerSettings['federation'] = {
+    mode: 'open',
+    allowActorDomains: []
+  },
+  locks: ServerSettingLocks = {},
+  mediaDomains: string[] = ['files.mastodon.social']
+) =>
+  render(
+    <FederationPolicyForm
+      settings={settingsWith(federation)}
+      locks={locks}
+      mediaDomains={mediaDomains}
+    />
+  )
+
+describe('FederationPolicyForm', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue({
+      settings: settingsWith({ mode: 'open', allowActorDomains: [] }),
+      locks: {}
+    })
+  })
+
+  it('hides the allowed-servers field in open mode', () => {
+    renderForm()
+    expect(screen.queryByLabelText('Allowed servers')).not.toBeInTheDocument()
+  })
+
+  it('reveals the allowed-servers field when switched to allowlist', () => {
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Mode'), {
+      target: { value: 'allowlist' }
+    })
+    expect(screen.getByLabelText('Allowed servers')).toBeInTheDocument()
+  })
+
+  it('shows trusted media domains read-only and env-pinned', () => {
+    renderForm()
+    const mediaField = screen.getByLabelText('Trusted media domains')
+    expect(mediaField).toBeDisabled()
+    expect(mediaField).toHaveValue('files.mastodon.social')
+    expect(
+      screen.getByText('ACTIVITIES_ALLOW_MEDIA_DOMAINS')
+    ).toBeInTheDocument()
+  })
+
+  it('saves the mode change', async () => {
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Mode'), {
+      target: { value: 'allowlist' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ 'federation.mode': 'allowlist' })
+      )
+    )
+  })
+
+  it('locks the mode select when pinned by env', () => {
+    renderForm(
+      { mode: 'allowlist', allowActorDomains: ['mastodon.social'] },
+      {
+        'federation.mode': {
+          locked: true,
+          envVar: 'ACTIVITIES_FEDERATION_MODE'
+        }
+      }
+    )
+    expect(screen.getByLabelText('Mode')).toBeDisabled()
+    expect(screen.getByText('ACTIVITIES_FEDERATION_MODE')).toBeInTheDocument()
+  })
+})

--- a/lib/components/admin/settings/FederationPolicyForm.tsx
+++ b/lib/components/admin/settings/FederationPolicyForm.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { FC } from 'react'
+
+import { Select } from '@/lib/components/ui/select'
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import type { ServerSettingLocks } from './InstanceSettingsForm'
+import { LinesTextarea } from './LinesTextarea'
+import { SaveBar } from './SaveBar'
+import { SettingsField } from './SettingsField'
+import { SettingsSection } from './SettingsSection'
+import { useServerSettingsForm } from './useServerSettingsForm'
+
+interface FederationPolicyFormProps {
+  settings: ResolvedServerSettings
+  locks: ServerSettingLocks
+  // Trusted media domains stay env-configured: they feed the CSP built in the
+  // Edge runtime, which cannot read the database. Shown read-only.
+  mediaDomains: string[]
+}
+
+const FEDERATION_KEYS = ['federation.mode', 'federation.allowActorDomains']
+
+export const FederationPolicyForm: FC<FederationPolicyFormProps> = ({
+  settings,
+  locks,
+  mediaDomains
+}) => {
+  const { values, setValue, isDirty, statusFor, saveSection } =
+    useServerSettingsForm({
+      'federation.mode': settings.federation.mode,
+      'federation.allowActorDomains': settings.federation.allowActorDomains
+    })
+
+  const lock = (key: string) => locks[key] ?? { locked: false }
+  const status = statusFor('federation')
+  const mode = values['federation.mode'] as 'open' | 'allowlist'
+
+  return (
+    <SettingsSection
+      title="Federation policy"
+      description="Who this instance federates with by default. Per-domain blocks below still apply."
+      footer={
+        <SaveBar
+          dirty={isDirty(FEDERATION_KEYS)}
+          saving={status.saving}
+          saved={status.saved}
+          error={status.error}
+          onSave={() => saveSection('federation', FEDERATION_KEYS)}
+        />
+      }
+    >
+      <SettingsField
+        label="Mode"
+        htmlFor="federation-mode"
+        locked={lock('federation.mode').locked}
+        envVar={lock('federation.mode').envVar}
+      >
+        <Select
+          id="federation-mode"
+          value={mode}
+          disabled={lock('federation.mode').locked}
+          onChange={(event) => setValue('federation.mode', event.target.value)}
+        >
+          <option value="open">Open — federate with any server</option>
+          <option value="allowlist">
+            Allowlist — only servers listed below
+          </option>
+        </Select>
+      </SettingsField>
+
+      {mode === 'allowlist' && (
+        <SettingsField
+          label="Allowed servers"
+          htmlFor="federation-actor-domains"
+          help="One domain per line. Actors elsewhere are ignored."
+          locked={lock('federation.allowActorDomains').locked}
+          envVar={lock('federation.allowActorDomains').envVar}
+        >
+          <LinesTextarea
+            id="federation-actor-domains"
+            value={values['federation.allowActorDomains'] as string[]}
+            disabled={lock('federation.allowActorDomains').locked}
+            onChange={(next) => setValue('federation.allowActorDomains', next)}
+          />
+        </SettingsField>
+      )}
+
+      <SettingsField
+        label="Trusted media domains"
+        htmlFor="federation-media-domains"
+        locked
+        envVar="ACTIVITIES_ALLOW_MEDIA_DOMAINS"
+      >
+        <LinesTextarea
+          id="federation-media-domains"
+          value={mediaDomains}
+          disabled
+          rows={2}
+          onChange={() => {}}
+        />
+      </SettingsField>
+    </SettingsSection>
+  )
+}

--- a/lib/components/admin/settings/FederationPolicyForm.tsx
+++ b/lib/components/admin/settings/FederationPolicyForm.tsx
@@ -91,7 +91,7 @@ export const FederationPolicyForm: FC<FederationPolicyFormProps> = ({
         label="Trusted media domains"
         htmlFor="federation-media-domains"
         locked
-        envVar="ACTIVITIES_ALLOW_MEDIA_DOMAINS"
+        help="Configured in the environment; the ACTIVITIES_ALLOW_MEDIA_DOMAINS variable feeds the Content-Security-Policy and cannot be managed here."
       >
         <LinesTextarea
           id="federation-media-domains"

--- a/lib/components/admin/settings/InstanceSettingsForm.test.tsx
+++ b/lib/components/admin/settings/InstanceSettingsForm.test.tsx
@@ -90,4 +90,41 @@ describe('InstanceSettingsForm', () => {
     expect(screen.getByText('Set by environment')).toBeInTheDocument()
     expect(screen.getByText('ACTIVITIES_SERVICE_NAME')).toBeInTheDocument()
   })
+
+  it('surfaces the server error message when a save fails', async () => {
+    mockUpdate.mockRejectedValueOnce(
+      new Error('Some settings could not be saved')
+    )
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Instance name'), {
+      target: { value: 'New Name' }
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Update' })[0])
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Some settings could not be saved')
+      ).toBeInTheDocument()
+    )
+    // Still dirty (the value was not adopted), so Update stays enabled.
+    expect(screen.getAllByRole('button', { name: 'Update' })[0]).toBeEnabled()
+  })
+
+  it('adopts the server-resolved values and clears dirty after a save', async () => {
+    mockUpdate.mockResolvedValueOnce({
+      settings: {
+        ...baseSettings,
+        instance: { ...baseSettings.instance, name: 'New Name' }
+      },
+      locks: {}
+    })
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Instance name'), {
+      target: { value: 'New Name' }
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Update' })[0])
+
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument())
+    expect(screen.getAllByRole('button', { name: 'Update' })[0]).toBeDisabled()
+  })
 })

--- a/lib/components/admin/settings/InstanceSettingsForm.test.tsx
+++ b/lib/components/admin/settings/InstanceSettingsForm.test.tsx
@@ -35,7 +35,7 @@ const baseSettings: ResolvedServerSettings = {
     maxOptions: 4,
     maxCharactersPerOption: 50,
     minExpirationSeconds: 300,
-    maxExpirationSeconds: 2629746
+    maxExpirationSeconds: 2678400
   },
   media: { maxFileSize: 209715200 },
   network: {

--- a/lib/components/admin/settings/InstanceSettingsForm.test.tsx
+++ b/lib/components/admin/settings/InstanceSettingsForm.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import {
+  InstanceSettingsForm,
+  ServerSettingLocks
+} from './InstanceSettingsForm'
+
+const mockUpdate = vi.fn()
+
+vi.mock('@/lib/client', () => ({
+  updateAdminServerSettings: (patch: Record<string, unknown>) =>
+    mockUpdate(patch)
+}))
+
+vi.mock('@/lib/components/page-header', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>
+}))
+
+const baseSettings: ResolvedServerSettings = {
+  instance: {
+    name: 'llun.social',
+    description: 'A friendly place.',
+    contactEmail: 'admin@llun.social',
+    languages: ['en', 'th']
+  },
+  registrations: { open: true, allowEmails: ['anna@llun.dev'] },
+  posts: { maxCharacters: 500, maxMediaAttachments: 20 },
+  polls: {
+    maxOptions: 4,
+    maxCharactersPerOption: 50,
+    minExpirationSeconds: 300,
+    maxExpirationSeconds: 2629746
+  },
+  media: { maxFileSize: 209715200 },
+  network: {
+    requestTimeoutMs: 4000,
+    requestRetries: 1,
+    maxResponseSizeBytes: 2097152
+  },
+  federation: { mode: 'open', allowActorDomains: [] }
+}
+
+const renderForm = (locks: ServerSettingLocks = {}) =>
+  render(<InstanceSettingsForm settings={baseSettings} locks={locks} />)
+
+describe('InstanceSettingsForm', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue({ settings: baseSettings, locks: {} })
+  })
+
+  it('renders the initial values', () => {
+    renderForm()
+    expect(screen.getByLabelText('Instance name')).toHaveValue('llun.social')
+    expect(screen.getByText('English')).toBeInTheDocument()
+    expect(screen.getByText('ไทย')).toBeInTheDocument()
+    expect(screen.getByText('Registrations are open')).toBeInTheDocument()
+  })
+
+  it('saves only the edited instance-details keys', async () => {
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Instance name'), {
+      target: { value: 'New Name' }
+    })
+
+    // Two sections → two Update buttons; details is the first.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Update' })[0])
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ 'instance.name': 'New Name' })
+      )
+    )
+    // Registration keys are not part of the details patch.
+    const patch = mockUpdate.mock.calls[0][0]
+    expect(patch).not.toHaveProperty('registrations.open')
+  })
+
+  it('disables an env-locked field and shows the badge', () => {
+    renderForm({
+      'instance.name': { locked: true, envVar: 'ACTIVITIES_SERVICE_NAME' }
+    })
+    expect(screen.getByLabelText('Instance name')).toBeDisabled()
+    expect(screen.getByText('Set by environment')).toBeInTheDocument()
+    expect(screen.getByText('ACTIVITIES_SERVICE_NAME')).toBeInTheDocument()
+  })
+})

--- a/lib/components/admin/settings/InstanceSettingsForm.tsx
+++ b/lib/components/admin/settings/InstanceSettingsForm.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
+import { Input } from '@/lib/components/ui/input'
+import { Switch } from '@/lib/components/ui/switch'
+import { Textarea } from '@/lib/components/ui/textarea'
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import { LanguagesPicker } from './LanguagesPicker'
+import { LinesTextarea } from './LinesTextarea'
+import { SaveBar } from './SaveBar'
+import { ControlRow, SettingsField } from './SettingsField'
+import { SettingsSection } from './SettingsSection'
+import { useServerSettingsForm } from './useServerSettingsForm'
+
+export type ServerSettingLocks = Record<
+  string,
+  { locked: boolean; envVar?: string }
+>
+
+interface InstanceSettingsFormProps {
+  settings: ResolvedServerSettings
+  locks: ServerSettingLocks
+}
+
+const DETAILS_KEYS = [
+  'instance.name',
+  'instance.description',
+  'instance.contactEmail',
+  'instance.languages'
+]
+const REGISTRATION_KEYS = ['registrations.open', 'registrations.allowEmails']
+
+export const InstanceSettingsForm: FC<InstanceSettingsFormProps> = ({
+  settings,
+  locks
+}) => {
+  const { values, setValue, isDirty, statusFor, saveSection } =
+    useServerSettingsForm({
+      'instance.name': settings.instance.name,
+      'instance.description': settings.instance.description,
+      'instance.contactEmail': settings.instance.contactEmail,
+      'instance.languages': settings.instance.languages,
+      'registrations.open': settings.registrations.open,
+      'registrations.allowEmails': settings.registrations.allowEmails
+    })
+
+  const lock = (key: string) => locks[key] ?? { locked: false }
+  const detailsStatus = statusFor('details')
+  const registrationStatus = statusFor('registrations')
+  const registrationOpen = values['registrations.open'] as boolean
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Instance"
+        description="Who this instance is and who may join. Values pinned by an environment variable are locked until the variable is removed."
+      />
+
+      <SettingsSection
+        title="Instance details"
+        description="Public information shown on the about page and in the API."
+        footer={
+          <SaveBar
+            dirty={isDirty(DETAILS_KEYS)}
+            saving={detailsStatus.saving}
+            saved={detailsStatus.saved}
+            error={detailsStatus.error}
+            onSave={() => saveSection('details', DETAILS_KEYS)}
+          />
+        }
+      >
+        <SettingsField
+          label="Instance name"
+          htmlFor="instance-name"
+          locked={lock('instance.name').locked}
+          envVar={lock('instance.name').envVar}
+        >
+          <Input
+            id="instance-name"
+            value={values['instance.name'] as string}
+            disabled={lock('instance.name').locked}
+            onChange={(event) => setValue('instance.name', event.target.value)}
+          />
+        </SettingsField>
+
+        <SettingsField
+          label="Short description"
+          htmlFor="instance-description"
+          help="Shown in the instance picker and previews."
+          locked={lock('instance.description').locked}
+          envVar={lock('instance.description').envVar}
+        >
+          <Textarea
+            id="instance-description"
+            rows={3}
+            value={values['instance.description'] as string}
+            disabled={lock('instance.description').locked}
+            onChange={(event) =>
+              setValue('instance.description', event.target.value)
+            }
+          />
+        </SettingsField>
+
+        <SettingsField
+          label="Contact email"
+          htmlFor="instance-contact"
+          help="Published in the instance API as the admin contact."
+          locked={lock('instance.contactEmail').locked}
+          envVar={lock('instance.contactEmail').envVar}
+        >
+          <Input
+            id="instance-contact"
+            type="email"
+            value={values['instance.contactEmail'] as string}
+            disabled={lock('instance.contactEmail').locked}
+            onChange={(event) =>
+              setValue('instance.contactEmail', event.target.value)
+            }
+          />
+        </SettingsField>
+
+        <SettingsField
+          label="Languages"
+          help="Primary languages of this instance, advertised for search and trends. The first one is the default."
+          locked={lock('instance.languages').locked}
+          envVar={lock('instance.languages').envVar}
+        >
+          <LanguagesPicker
+            value={values['instance.languages'] as string[]}
+            disabled={lock('instance.languages').locked}
+            onChange={(next) => setValue('instance.languages', next)}
+          />
+        </SettingsField>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Registrations"
+        description="Control who can create an account on this instance."
+        footer={
+          <SaveBar
+            dirty={isDirty(REGISTRATION_KEYS)}
+            saving={registrationStatus.saving}
+            saved={registrationStatus.saved}
+            error={registrationStatus.error}
+            onSave={() => saveSection('registrations', REGISTRATION_KEYS)}
+          />
+        }
+      >
+        <ControlRow
+          label={
+            registrationOpen
+              ? 'Registrations are open'
+              : 'Registrations are closed'
+          }
+          description={
+            registrationOpen
+              ? 'Anyone with an allowed email can sign up.'
+              : 'New sign-ups are rejected; existing accounts are unaffected.'
+          }
+          htmlFor="registrations-open"
+          locked={lock('registrations.open').locked}
+          envVar={lock('registrations.open').envVar}
+        >
+          <Switch
+            id="registrations-open"
+            checked={registrationOpen}
+            disabled={lock('registrations.open').locked}
+            onCheckedChange={(checked) =>
+              setValue('registrations.open', checked)
+            }
+          />
+        </ControlRow>
+
+        <SettingsField
+          label="Allowed email addresses"
+          htmlFor="registrations-allow-emails"
+          help="One address per line. Leave empty to allow any email."
+          locked={lock('registrations.allowEmails').locked}
+          envVar={lock('registrations.allowEmails').envVar}
+        >
+          <LinesTextarea
+            id="registrations-allow-emails"
+            value={values['registrations.allowEmails'] as string[]}
+            disabled={lock('registrations.allowEmails').locked}
+            onChange={(next) => setValue('registrations.allowEmails', next)}
+          />
+        </SettingsField>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/lib/components/admin/settings/LanguagesPicker.tsx
+++ b/lib/components/admin/settings/LanguagesPicker.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { Plus, Search, X } from 'lucide-react'
+import { FC, useEffect, useRef, useState } from 'react'
+
+// A curated set of instance languages (code + endonym). Scales past a handful of
+// toggles: selected languages render as removable chips, and new ones come from
+// a searchable picker rather than one giant toggle wall.
+export const LANGUAGE_OPTIONS: [string, string][] = [
+  ['en', 'English'],
+  ['de', 'Deutsch'],
+  ['th', 'ไทย'],
+  ['ja', '日本語'],
+  ['fr', 'Français'],
+  ['es', 'Español'],
+  ['pt', 'Português'],
+  ['it', 'Italiano'],
+  ['nl', 'Nederlands'],
+  ['sv', 'Svenska'],
+  ['da', 'Dansk'],
+  ['nb', 'Norsk bokmål'],
+  ['fi', 'Suomi'],
+  ['pl', 'Polski'],
+  ['cs', 'Čeština'],
+  ['uk', 'Українська'],
+  ['tr', 'Türkçe'],
+  ['ar', 'العربية'],
+  ['hi', 'हिन्दी'],
+  ['zh', '中文'],
+  ['ko', '한국어'],
+  ['vi', 'Tiếng Việt'],
+  ['id', 'Bahasa Indonesia']
+]
+
+const labelForCode = (code: string) =>
+  LANGUAGE_OPTIONS.find(([value]) => value === code)?.[1] ?? code
+
+interface LanguagesPickerProps {
+  value: string[]
+  onChange: (value: string[]) => void
+  disabled?: boolean
+}
+
+export const LanguagesPicker: FC<LanguagesPickerProps> = ({
+  value,
+  onChange,
+  disabled
+}) => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  const normalizedQuery = query.toLowerCase()
+  const remaining = LANGUAGE_OPTIONS.filter(
+    ([code, name]) =>
+      !value.includes(code) &&
+      (name.toLowerCase().includes(normalizedQuery) ||
+        code.includes(normalizedQuery))
+  )
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {value.map((code) => (
+        <span
+          key={code}
+          className="inline-flex items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 py-1 pl-3 pr-1.5 text-sm font-medium text-primary"
+        >
+          {labelForCode(code)}
+          {!disabled && (
+            <button
+              type="button"
+              aria-label={`Remove ${labelForCode(code)}`}
+              onClick={() => onChange(value.filter((c) => c !== code))}
+              className="flex h-4 w-4 items-center justify-center rounded-full transition-colors hover:bg-primary/20"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </span>
+      ))}
+
+      {value.length === 0 && disabled && (
+        <span className="text-sm text-muted-foreground">
+          No languages configured
+        </span>
+      )}
+
+      {!disabled && (
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => {
+              setOpen((current) => !current)
+              setQuery('')
+            }}
+            className="inline-flex items-center gap-1.5 rounded-full border border-dashed px-3 py-1 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/60"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add language
+          </button>
+          {open && (
+            <>
+              {/* Click-away layer. */}
+              <div
+                className="fixed inset-0 z-30"
+                aria-hidden
+                onClick={() => setOpen(false)}
+              />
+              <div className="absolute left-0 top-9 z-40 w-60 rounded-xl border bg-background shadow-lg">
+                <div className="border-b p-2">
+                  <div className="flex items-center gap-2 rounded-md bg-muted px-2.5 py-1.5">
+                    <Search className="h-3.5 w-3.5 text-muted-foreground" />
+                    <input
+                      ref={inputRef}
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                      placeholder="Search languages"
+                      aria-label="Search languages"
+                      className="w-full bg-transparent text-sm outline-none"
+                    />
+                  </div>
+                </div>
+                <div className="max-h-52 overflow-y-auto p-1">
+                  {remaining.length === 0 ? (
+                    <p className="px-3 py-4 text-center text-sm text-muted-foreground">
+                      No matches
+                    </p>
+                  ) : (
+                    remaining.map(([code, name]) => (
+                      <button
+                        key={code}
+                        type="button"
+                        onClick={() => {
+                          onChange([...value, code])
+                          setOpen(false)
+                          setQuery('')
+                        }}
+                        className="flex w-full items-center justify-between rounded-lg px-3 py-1.5 text-left text-sm transition-colors hover:bg-muted"
+                      >
+                        <span>{name}</span>
+                        <span className="font-mono text-[11px] text-muted-foreground">
+                          {code}
+                        </span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/components/admin/settings/LinesTextarea.tsx
+++ b/lib/components/admin/settings/LinesTextarea.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { FC, useEffect, useRef, useState } from 'react'
+
+import { Textarea } from '@/lib/components/ui/textarea'
+import { cn } from '@/lib/utils'
+
+// Edits a string[] as one value per line. Keeps a local text buffer so typing
+// (including blank lines) stays smooth, and only emits trimmed, non-empty
+// lines. Re-syncs the buffer when the external value changes to something the
+// buffer did not produce (e.g. after a save normalizes or reorders the list).
+interface LinesTextareaProps {
+  id?: string
+  value: string[]
+  onChange: (value: string[]) => void
+  disabled?: boolean
+  rows?: number
+  placeholder?: string
+  className?: string
+  'aria-label'?: string
+}
+
+const sameLines = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((item, index) => item === b[index])
+
+export const LinesTextarea: FC<LinesTextareaProps> = ({
+  id,
+  value,
+  onChange,
+  disabled,
+  rows = 3,
+  placeholder,
+  className,
+  'aria-label': ariaLabel
+}) => {
+  const [text, setText] = useState(() => value.join('\n'))
+  const lastEmitted = useRef<string[]>(value)
+
+  useEffect(() => {
+    if (!sameLines(value, lastEmitted.current)) {
+      setText(value.join('\n'))
+      lastEmitted.current = value
+    }
+  }, [value])
+
+  const handleChange = (next: string) => {
+    setText(next)
+    const lines = next
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+    lastEmitted.current = lines
+    onChange(lines)
+  }
+
+  return (
+    <Textarea
+      id={id}
+      value={text}
+      onChange={(event) => handleChange(event.target.value)}
+      disabled={disabled}
+      rows={rows}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      className={cn('font-mono text-[13px]', className)}
+    />
+  )
+}

--- a/lib/components/admin/settings/NetworkSettingsForm.test.tsx
+++ b/lib/components/admin/settings/NetworkSettingsForm.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import type { ServerSettingLocks } from './InstanceSettingsForm'
+import { NetworkSettingsForm } from './NetworkSettingsForm'
+
+const mockUpdate = vi.fn()
+
+vi.mock('@/lib/client', () => ({
+  updateAdminServerSettings: (patch: Record<string, unknown>) =>
+    mockUpdate(patch)
+}))
+
+vi.mock('@/lib/components/page-header', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>
+}))
+
+const baseSettings: ResolvedServerSettings = {
+  instance: {
+    name: 'llun.social',
+    description: '',
+    contactEmail: '',
+    languages: ['en']
+  },
+  registrations: { open: true, allowEmails: [] },
+  posts: { maxCharacters: 500, maxMediaAttachments: 20 },
+  polls: {
+    maxOptions: 4,
+    maxCharactersPerOption: 50,
+    minExpirationSeconds: 300,
+    maxExpirationSeconds: 2629746
+  },
+  media: { maxFileSize: 209715200 },
+  network: {
+    requestTimeoutMs: 4000,
+    requestRetries: 1,
+    maxResponseSizeBytes: 2097152
+  },
+  federation: { mode: 'open', allowActorDomains: [] }
+}
+
+const renderForm = (locks: ServerSettingLocks = {}) =>
+  render(<NetworkSettingsForm settings={baseSettings} locks={locks} />)
+
+describe('NetworkSettingsForm', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue({ settings: baseSettings, locks: {} })
+  })
+
+  it('renders initial request tuning values', () => {
+    renderForm()
+    expect(screen.getByLabelText('Timeout')).toHaveValue(4000)
+    expect(screen.getByLabelText('Retries')).toHaveValue(1)
+    expect(screen.getByLabelText('Response size cap')).toHaveValue(2)
+  })
+
+  it('saves the edited timeout', async () => {
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Timeout'), {
+      target: { value: '8000' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ 'network.requestTimeoutMs': 8000 })
+      )
+    )
+  })
+
+  it('disables an env-locked field and shows the badge', () => {
+    renderForm({
+      'network.requestTimeoutMs': {
+        locked: true,
+        envVar: 'ACTIVITIES_REQUEST_TIMEOUT'
+      }
+    })
+    expect(screen.getByLabelText('Timeout')).toBeDisabled()
+    expect(screen.getByText('ACTIVITIES_REQUEST_TIMEOUT')).toBeInTheDocument()
+  })
+})

--- a/lib/components/admin/settings/NetworkSettingsForm.test.tsx
+++ b/lib/components/admin/settings/NetworkSettingsForm.test.tsx
@@ -33,7 +33,7 @@ const baseSettings: ResolvedServerSettings = {
     maxOptions: 4,
     maxCharactersPerOption: 50,
     minExpirationSeconds: 300,
-    maxExpirationSeconds: 2629746
+    maxExpirationSeconds: 2678400
   },
   media: { maxFileSize: 209715200 },
   network: {

--- a/lib/components/admin/settings/NetworkSettingsForm.tsx
+++ b/lib/components/admin/settings/NetworkSettingsForm.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import type { ServerSettingLocks } from './InstanceSettingsForm'
+import { NumberField } from './NumberField'
+import { SaveBar } from './SaveBar'
+import { SettingsField } from './SettingsField'
+import { SettingsSection } from './SettingsSection'
+import { useServerSettingsForm } from './useServerSettingsForm'
+
+const BYTES_PER_MB = 1024 * 1024
+
+interface NetworkSettingsFormProps {
+  settings: ResolvedServerSettings
+  locks: ServerSettingLocks
+}
+
+const NETWORK_KEYS = [
+  'network.requestTimeoutMs',
+  'network.requestRetries',
+  'network.maxResponseSizeBytes'
+]
+
+export const NetworkSettingsForm: FC<NetworkSettingsFormProps> = ({
+  settings,
+  locks
+}) => {
+  const { values, setValue, isDirty, statusFor, saveSection } =
+    useServerSettingsForm({
+      'network.requestTimeoutMs': settings.network.requestTimeoutMs,
+      'network.requestRetries': settings.network.requestRetries,
+      'network.maxResponseSizeBytes': settings.network.maxResponseSizeBytes
+    })
+
+  const lock = (key: string) => locks[key] ?? { locked: false }
+  const status = statusFor('network')
+  const responseBytes = values['network.maxResponseSizeBytes'] as number
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Network"
+        description="How this server talks to the rest of the network. Integrations like translation and maps are configured in the environment."
+      />
+
+      <SettingsSection
+        title="Advanced — outbound requests"
+        description="How this server talks to other servers. Defaults are fine for almost everyone."
+        footer={
+          <SaveBar
+            dirty={isDirty(NETWORK_KEYS)}
+            saving={status.saving}
+            saved={status.saved}
+            error={status.error}
+            onSave={() => saveSection('network', NETWORK_KEYS)}
+          />
+        }
+      >
+        <div className="grid gap-4 sm:grid-cols-3">
+          <SettingsField
+            label="Timeout"
+            htmlFor="network-timeout"
+            locked={lock('network.requestTimeoutMs').locked}
+            envVar={lock('network.requestTimeoutMs').envVar}
+          >
+            <NumberField
+              id="network-timeout"
+              value={values['network.requestTimeoutMs'] as number}
+              min={1}
+              suffix="ms"
+              disabled={lock('network.requestTimeoutMs').locked}
+              onChange={(next) => setValue('network.requestTimeoutMs', next)}
+            />
+          </SettingsField>
+
+          <SettingsField
+            label="Retries"
+            htmlFor="network-retries"
+            locked={lock('network.requestRetries').locked}
+            envVar={lock('network.requestRetries').envVar}
+          >
+            <NumberField
+              id="network-retries"
+              value={values['network.requestRetries'] as number}
+              min={0}
+              max={20}
+              suffix="attempts"
+              disabled={lock('network.requestRetries').locked}
+              onChange={(next) => setValue('network.requestRetries', next)}
+            />
+          </SettingsField>
+
+          <SettingsField
+            label="Response size cap"
+            htmlFor="network-response-cap"
+            locked={lock('network.maxResponseSizeBytes').locked}
+            envVar={lock('network.maxResponseSizeBytes').envVar}
+          >
+            <NumberField
+              id="network-response-cap"
+              value={Math.round(responseBytes / BYTES_PER_MB)}
+              min={1}
+              suffix="MB"
+              disabled={lock('network.maxResponseSizeBytes').locked}
+              onChange={(next) =>
+                setValue(
+                  'network.maxResponseSizeBytes',
+                  Math.round(next * BYTES_PER_MB)
+                )
+              }
+            />
+          </SettingsField>
+        </div>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/lib/components/admin/settings/NumberField.tsx
+++ b/lib/components/admin/settings/NumberField.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { FC, ReactNode, useEffect, useRef, useState } from 'react'
+
+import { Input } from '@/lib/components/ui/input'
+
+// A numeric input with an optional trailing unit. Keeps a local text buffer so
+// clearing/retyping stays smooth, and only emits finite numbers. Re-syncs the
+// buffer when the external value changes to one the buffer did not produce
+// (e.g. after a save).
+interface NumberFieldProps {
+  id?: string
+  value: number
+  onChange: (value: number) => void
+  disabled?: boolean
+  suffix?: ReactNode
+  min?: number
+  max?: number
+}
+
+export const NumberField: FC<NumberFieldProps> = ({
+  id,
+  value,
+  onChange,
+  disabled,
+  suffix,
+  min,
+  max
+}) => {
+  const [text, setText] = useState(() => String(value))
+  const lastEmitted = useRef(value)
+
+  useEffect(() => {
+    if (value !== lastEmitted.current) {
+      setText(String(value))
+      lastEmitted.current = value
+    }
+  }, [value])
+
+  const handleChange = (raw: string) => {
+    setText(raw)
+    if (raw.trim() === '') return
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) {
+      lastEmitted.current = parsed
+      onChange(parsed)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        id={id}
+        type="number"
+        inputMode="numeric"
+        value={text}
+        min={min}
+        max={max}
+        disabled={disabled}
+        onChange={(event) => handleChange(event.target.value)}
+        className="w-40"
+      />
+      {suffix && (
+        <span className="text-sm text-muted-foreground">{suffix}</span>
+      )}
+    </div>
+  )
+}

--- a/lib/components/admin/settings/PostsMediaSettingsForm.test.tsx
+++ b/lib/components/admin/settings/PostsMediaSettingsForm.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import type { ServerSettingLocks } from './InstanceSettingsForm'
+import { PostsMediaSettingsForm } from './PostsMediaSettingsForm'
+
+const mockUpdate = vi.fn()
+
+vi.mock('@/lib/client', () => ({
+  updateAdminServerSettings: (patch: Record<string, unknown>) =>
+    mockUpdate(patch)
+}))
+
+vi.mock('@/lib/components/page-header', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>
+}))
+
+const baseSettings: ResolvedServerSettings = {
+  instance: {
+    name: 'llun.social',
+    description: '',
+    contactEmail: '',
+    languages: ['en']
+  },
+  registrations: { open: true, allowEmails: [] },
+  posts: { maxCharacters: 500, maxMediaAttachments: 20 },
+  polls: {
+    maxOptions: 4,
+    maxCharactersPerOption: 50,
+    minExpirationSeconds: 300,
+    maxExpirationSeconds: 2629746
+  },
+  media: { maxFileSize: 209715200 },
+  network: {
+    requestTimeoutMs: 4000,
+    requestRetries: 1,
+    maxResponseSizeBytes: 2097152
+  },
+  federation: { mode: 'open', allowActorDomains: [] }
+}
+
+const renderForm = (locks: ServerSettingLocks = {}) =>
+  render(
+    <PostsMediaSettingsForm
+      settings={baseSettings}
+      locks={locks}
+      storageBackend="S3-compatible storage"
+    />
+  )
+
+describe('PostsMediaSettingsForm', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue({ settings: baseSettings, locks: {} })
+  })
+
+  it('renders initial post and media values', () => {
+    renderForm()
+    expect(screen.getByLabelText('Post size')).toHaveValue(500)
+    expect(screen.getByLabelText('Upload size limit')).toHaveValue(200)
+    expect(screen.getByLabelText('Storage backend')).toHaveValue(
+      'S3-compatible storage'
+    )
+  })
+
+  it('saves the edited post limits', async () => {
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Post size'), {
+      target: { value: '1000' }
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Update' })[0])
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ 'posts.maxCharacters': 1000 })
+      )
+    )
+  })
+
+  it('converts the upload limit from MB to bytes on save', async () => {
+    renderForm()
+    fireEvent.change(screen.getByLabelText('Upload size limit'), {
+      target: { value: '50' }
+    })
+    // Media is the third section.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Update' })[2])
+
+    await waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ 'media.maxFileSize': 50 * 1024 * 1024 })
+      )
+    )
+  })
+
+  it('always shows the storage backend as read-only and env-pinned', () => {
+    renderForm()
+    expect(screen.getByLabelText('Storage backend')).toBeDisabled()
+    expect(screen.getByText('Set by environment')).toBeInTheDocument()
+  })
+})

--- a/lib/components/admin/settings/PostsMediaSettingsForm.test.tsx
+++ b/lib/components/admin/settings/PostsMediaSettingsForm.test.tsx
@@ -33,7 +33,7 @@ const baseSettings: ResolvedServerSettings = {
     maxOptions: 4,
     maxCharactersPerOption: 50,
     minExpirationSeconds: 300,
-    maxExpirationSeconds: 2629746
+    maxExpirationSeconds: 2678400
   },
   media: { maxFileSize: 209715200 },
   network: {

--- a/lib/components/admin/settings/PostsMediaSettingsForm.tsx
+++ b/lib/components/admin/settings/PostsMediaSettingsForm.tsx
@@ -39,8 +39,8 @@ const MIN_EXPIRATION_OPTIONS = [
 ]
 const MAX_EXPIRATION_OPTIONS = [
   { value: '604800', label: '7 days' },
-  { value: '2629746', label: '1 month' },
-  { value: '7889238', label: '3 months' }
+  { value: '2678400', label: '1 month' },
+  { value: '8035200', label: '3 months' }
 ]
 
 // Keep an out-of-preset stored value selectable so the select never silently

--- a/lib/components/admin/settings/PostsMediaSettingsForm.tsx
+++ b/lib/components/admin/settings/PostsMediaSettingsForm.tsx
@@ -1,0 +1,259 @@
+'use client'
+
+import { FC } from 'react'
+
+import { PageHeader } from '@/lib/components/page-header'
+import { Input } from '@/lib/components/ui/input'
+import { Select } from '@/lib/components/ui/select'
+import type { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+import type { ServerSettingLocks } from './InstanceSettingsForm'
+import { NumberField } from './NumberField'
+import { SaveBar } from './SaveBar'
+import { SettingsField } from './SettingsField'
+import { SettingsSection } from './SettingsSection'
+import { useServerSettingsForm } from './useServerSettingsForm'
+
+const BYTES_PER_MB = 1024 * 1024
+
+interface PostsMediaSettingsFormProps {
+  settings: ResolvedServerSettings
+  locks: ServerSettingLocks
+  // Human label for the (env-configured) storage backend, shown read-only.
+  storageBackend: string
+}
+
+const POSTS_KEYS = ['posts.maxCharacters', 'posts.maxMediaAttachments']
+const POLL_KEYS = [
+  'polls.maxOptions',
+  'polls.maxCharactersPerOption',
+  'polls.minExpirationSeconds',
+  'polls.maxExpirationSeconds'
+]
+const MEDIA_KEYS = ['media.maxFileSize']
+
+const MIN_EXPIRATION_OPTIONS = [
+  { value: '300', label: '5 minutes' },
+  { value: '1800', label: '30 minutes' },
+  { value: '3600', label: '1 hour' }
+]
+const MAX_EXPIRATION_OPTIONS = [
+  { value: '604800', label: '7 days' },
+  { value: '2629746', label: '1 month' },
+  { value: '7889238', label: '3 months' }
+]
+
+// Keep an out-of-preset stored value selectable so the select never silently
+// rewrites it.
+const withCurrent = (
+  options: { value: string; label: string }[],
+  current: string
+) =>
+  options.some((option) => option.value === current)
+    ? options
+    : [{ value: current, label: `${current} seconds` }, ...options]
+
+export const PostsMediaSettingsForm: FC<PostsMediaSettingsFormProps> = ({
+  settings,
+  locks,
+  storageBackend
+}) => {
+  const { values, setValue, isDirty, statusFor, saveSection } =
+    useServerSettingsForm({
+      'posts.maxCharacters': settings.posts.maxCharacters,
+      'posts.maxMediaAttachments': settings.posts.maxMediaAttachments,
+      'polls.maxOptions': settings.polls.maxOptions,
+      'polls.maxCharactersPerOption': settings.polls.maxCharactersPerOption,
+      'polls.minExpirationSeconds': settings.polls.minExpirationSeconds,
+      'polls.maxExpirationSeconds': settings.polls.maxExpirationSeconds,
+      'media.maxFileSize': settings.media.maxFileSize
+    })
+
+  const lock = (key: string) => locks[key] ?? { locked: false }
+  const postsStatus = statusFor('posts')
+  const pollsStatus = statusFor('polls')
+  const mediaStatus = statusFor('media')
+
+  const maxCharacters = values['posts.maxCharacters'] as number
+  const uploadBytes = values['media.maxFileSize'] as number
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Posts & media"
+        description="Limits for posts, polls, and uploads. Advertised via the instance API so apps follow along."
+      />
+
+      <SettingsSection
+        title="Posts"
+        description="Limits for new posts, advertised to apps via the instance API."
+        footer={
+          <SaveBar
+            dirty={isDirty(POSTS_KEYS)}
+            saving={postsStatus.saving}
+            saved={postsStatus.saved}
+            error={postsStatus.error}
+            onSave={() => saveSection('posts', POSTS_KEYS)}
+          />
+        }
+      >
+        <SettingsField
+          label="Post size"
+          htmlFor="posts-max-characters"
+          help={`New posts and edits are capped at ${maxCharacters.toLocaleString()} characters. Links always count as 23.`}
+        >
+          <NumberField
+            id="posts-max-characters"
+            value={maxCharacters}
+            min={1}
+            suffix="characters"
+            onChange={(next) => setValue('posts.maxCharacters', next)}
+          />
+        </SettingsField>
+
+        <SettingsField
+          label="Media per post"
+          htmlFor="posts-max-media"
+          help="Up to 20. The fediverse still only ever sees the first 4."
+        >
+          <NumberField
+            id="posts-max-media"
+            value={values['posts.maxMediaAttachments'] as number}
+            min={1}
+            max={20}
+            suffix="attachments"
+            onChange={(next) => setValue('posts.maxMediaAttachments', next)}
+          />
+        </SettingsField>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Polls"
+        description="Shape of polls people can attach to posts."
+        footer={
+          <SaveBar
+            dirty={isDirty(POLL_KEYS)}
+            saving={pollsStatus.saving}
+            saved={pollsStatus.saved}
+            error={pollsStatus.error}
+            onSave={() => saveSection('polls', POLL_KEYS)}
+          />
+        }
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SettingsField label="Choices per poll" htmlFor="polls-max-options">
+            <NumberField
+              id="polls-max-options"
+              value={values['polls.maxOptions'] as number}
+              min={2}
+              max={50}
+              suffix="choices"
+              onChange={(next) => setValue('polls.maxOptions', next)}
+            />
+          </SettingsField>
+
+          <SettingsField
+            label="Characters per choice"
+            htmlFor="polls-max-chars"
+          >
+            <NumberField
+              id="polls-max-chars"
+              value={values['polls.maxCharactersPerOption'] as number}
+              min={1}
+              suffix="characters"
+              onChange={(next) =>
+                setValue('polls.maxCharactersPerOption', next)
+              }
+            />
+          </SettingsField>
+
+          <SettingsField label="Shortest duration" htmlFor="polls-min-expiry">
+            <Select
+              id="polls-min-expiry"
+              value={String(values['polls.minExpirationSeconds'])}
+              onChange={(event) =>
+                setValue(
+                  'polls.minExpirationSeconds',
+                  Number(event.target.value)
+                )
+              }
+            >
+              {withCurrent(
+                MIN_EXPIRATION_OPTIONS,
+                String(values['polls.minExpirationSeconds'])
+              ).map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+          </SettingsField>
+
+          <SettingsField label="Longest duration" htmlFor="polls-max-expiry">
+            <Select
+              id="polls-max-expiry"
+              value={String(values['polls.maxExpirationSeconds'])}
+              onChange={(event) =>
+                setValue(
+                  'polls.maxExpirationSeconds',
+                  Number(event.target.value)
+                )
+              }
+            >
+              {withCurrent(
+                MAX_EXPIRATION_OPTIONS,
+                String(values['polls.maxExpirationSeconds'])
+              ).map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+          </SettingsField>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Media"
+        description="Upload policy. The storage backend itself is infrastructure and stays in the environment."
+        footer={
+          <SaveBar
+            dirty={isDirty(MEDIA_KEYS)}
+            saving={mediaStatus.saving}
+            saved={mediaStatus.saved}
+            error={mediaStatus.error}
+            onSave={() => saveSection('media', MEDIA_KEYS)}
+          />
+        }
+      >
+        <SettingsField
+          label="Upload size limit"
+          htmlFor="media-max-file-size"
+          help="Applies to images and video alike; existing media is never touched."
+          locked={lock('media.maxFileSize').locked}
+          envVar={lock('media.maxFileSize').envVar}
+        >
+          <NumberField
+            id="media-max-file-size"
+            value={Math.round(uploadBytes / BYTES_PER_MB)}
+            min={1}
+            suffix="MB per file"
+            disabled={lock('media.maxFileSize').locked}
+            onChange={(next) =>
+              setValue('media.maxFileSize', Math.round(next * BYTES_PER_MB))
+            }
+          />
+        </SettingsField>
+
+        <SettingsField
+          label="Storage backend"
+          htmlFor="media-storage-backend"
+          locked
+          envVar="ACTIVITIES_MEDIA_STORAGE_*"
+        >
+          <Input id="media-storage-backend" value={storageBackend} disabled />
+        </SettingsField>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/lib/components/admin/settings/PostsMediaSettingsForm.tsx
+++ b/lib/components/admin/settings/PostsMediaSettingsForm.tsx
@@ -249,7 +249,7 @@ export const PostsMediaSettingsForm: FC<PostsMediaSettingsFormProps> = ({
           label="Storage backend"
           htmlFor="media-storage-backend"
           locked
-          envVar="ACTIVITIES_MEDIA_STORAGE_*"
+          help="Infrastructure configured in the environment (the ACTIVITIES_MEDIA_STORAGE_* variables); it cannot be managed here."
         >
           <Input id="media-storage-backend" value={storageBackend} disabled />
         </SettingsField>

--- a/lib/components/admin/settings/SaveBar.tsx
+++ b/lib/components/admin/settings/SaveBar.tsx
@@ -1,0 +1,40 @@
+import { FC } from 'react'
+
+import { Button } from '@/lib/components/ui/button'
+
+// The per-section save footer: an inline error, an "Unsaved changes" hint, a
+// transient "Saved" badge, and the Update button (disabled until the section is
+// dirty). Rendered inside a SettingsSection footer. Dirty wins over Saved so a
+// fresh edit never claims the section is already saved.
+interface SaveBarProps {
+  dirty: boolean
+  saving: boolean
+  saved: boolean
+  error?: string | null
+  onSave: () => void
+  label?: string
+}
+
+export const SaveBar: FC<SaveBarProps> = ({
+  dirty,
+  saving,
+  saved,
+  error,
+  onSave,
+  label = 'Update'
+}) => (
+  <>
+    {error && <p className="text-sm text-destructive">{error}</p>}
+    {!error && dirty && (
+      <span className="text-sm text-muted-foreground">Unsaved changes</span>
+    )}
+    {!error && !dirty && saved && (
+      <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+        Saved
+      </span>
+    )}
+    <Button onClick={onSave} disabled={saving || !dirty}>
+      {saving ? 'Saving…' : label}
+    </Button>
+  </>
+)

--- a/lib/components/admin/settings/SettingsField.tsx
+++ b/lib/components/admin/settings/SettingsField.tsx
@@ -1,0 +1,76 @@
+import { FC, ReactNode } from 'react'
+
+import { Label } from '@/lib/components/ui/label'
+
+import { EnvLockBadge, LockedFieldHelp } from './EnvLockBadge'
+
+// A labelled settings field: label (+ env-lock badge when pinned), the control,
+// and a help line. When locked, the help is replaced by the "pinned by <var>"
+// explanation.
+interface SettingsFieldProps {
+  label: ReactNode
+  htmlFor?: string
+  help?: ReactNode
+  locked?: boolean
+  envVar?: string
+  children: ReactNode
+}
+
+export const SettingsField: FC<SettingsFieldProps> = ({
+  label,
+  htmlFor,
+  help,
+  locked,
+  envVar,
+  children
+}) => {
+  const helpContent =
+    locked && envVar ? <LockedFieldHelp envVar={envVar} /> : help
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Label htmlFor={htmlFor}>{label}</Label>
+        {locked && <EnvLockBadge envVar={envVar} />}
+      </div>
+      {children}
+      {helpContent && (
+        <p className="text-[0.8rem] text-muted-foreground">{helpContent}</p>
+      )}
+    </div>
+  )
+}
+
+// A label/description on the left with a control (usually a Switch) on the
+// right. Mirrors the settings ControlRow, plus an optional env-lock badge.
+interface ControlRowProps {
+  label: ReactNode
+  description?: ReactNode
+  htmlFor?: string
+  locked?: boolean
+  envVar?: string
+  children: ReactNode
+}
+
+export const ControlRow: FC<ControlRowProps> = ({
+  label,
+  description,
+  htmlFor,
+  locked,
+  envVar,
+  children
+}) => (
+  <div className="flex items-center justify-between gap-4">
+    <div className="min-w-0 space-y-0.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Label htmlFor={htmlFor} className="cursor-pointer">
+          {label}
+        </Label>
+        {locked && <EnvLockBadge envVar={envVar} />}
+      </div>
+      {description && (
+        <p className="text-[0.8rem] text-muted-foreground">{description}</p>
+      )}
+    </div>
+    <div className="shrink-0">{children}</div>
+  </div>
+)

--- a/lib/components/admin/settings/SettingsSection.tsx
+++ b/lib/components/admin/settings/SettingsSection.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode } from 'react'
+
+// The section-card shell shared by every admin settings form, matching the
+// settings-page pattern (rounded-2xl border, muted description, footer slot for
+// the save bar).
+interface SettingsSectionProps {
+  title?: ReactNode
+  description?: ReactNode
+  footer?: ReactNode
+  children: ReactNode
+}
+
+export const SettingsSection: FC<SettingsSectionProps> = ({
+  title,
+  description,
+  footer,
+  children
+}) => (
+  <section className="space-y-4 rounded-2xl border bg-background/80 p-6 shadow-sm">
+    {(title || description) && (
+      <div className="space-y-1">
+        {title && <h2 className="text-lg font-semibold">{title}</h2>}
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+    )}
+    {children}
+    {footer && (
+      <div className="flex items-center justify-end gap-3 pt-1">{footer}</div>
+    )}
+  </section>
+)

--- a/lib/components/admin/settings/index.ts
+++ b/lib/components/admin/settings/index.ts
@@ -1,0 +1,5 @@
+export { EnvLockBadge, LockedFieldHelp } from './EnvLockBadge'
+export { LanguagesPicker, LANGUAGE_OPTIONS } from './LanguagesPicker'
+export { SaveBar } from './SaveBar'
+export { ControlRow, SettingsField } from './SettingsField'
+export { SettingsSection } from './SettingsSection'

--- a/lib/components/admin/settings/index.ts
+++ b/lib/components/admin/settings/index.ts
@@ -1,6 +1,7 @@
 export { EnvLockBadge, LockedFieldHelp } from './EnvLockBadge'
 export { LanguagesPicker, LANGUAGE_OPTIONS } from './LanguagesPicker'
 export { LinesTextarea } from './LinesTextarea'
+export { NumberField } from './NumberField'
 export { SaveBar } from './SaveBar'
 export { ControlRow, SettingsField } from './SettingsField'
 export { SettingsSection } from './SettingsSection'

--- a/lib/components/admin/settings/index.ts
+++ b/lib/components/admin/settings/index.ts
@@ -1,5 +1,8 @@
 export { EnvLockBadge, LockedFieldHelp } from './EnvLockBadge'
 export { LanguagesPicker, LANGUAGE_OPTIONS } from './LanguagesPicker'
+export { LinesTextarea } from './LinesTextarea'
 export { SaveBar } from './SaveBar'
 export { ControlRow, SettingsField } from './SettingsField'
 export { SettingsSection } from './SettingsSection'
+export { useServerSettingsForm } from './useServerSettingsForm'
+export type { SectionStatus } from './useServerSettingsForm'

--- a/lib/components/admin/settings/settings.test.tsx
+++ b/lib/components/admin/settings/settings.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { EnvLockBadge } from './EnvLockBadge'
+import { LanguagesPicker } from './LanguagesPicker'
+import { SettingsField } from './SettingsField'
+
+describe('EnvLockBadge', () => {
+  it('names the pinning variable in its tooltip', () => {
+    render(<EnvLockBadge envVar="ACTIVITIES_SERVICE_NAME" />)
+    const badge = screen.getByText('Set by environment')
+    expect(badge).toHaveAttribute('title', 'ACTIVITIES_SERVICE_NAME')
+  })
+})
+
+describe('SettingsField', () => {
+  it('shows the help text when unlocked', () => {
+    render(
+      <SettingsField label="Instance name" help="Shown on the about page.">
+        <input />
+      </SettingsField>
+    )
+    expect(screen.getByText('Shown on the about page.')).toBeInTheDocument()
+    expect(screen.queryByText('Set by environment')).not.toBeInTheDocument()
+  })
+
+  it('shows the env badge and pinned help when locked', () => {
+    render(
+      <SettingsField
+        label="Instance name"
+        help="Shown on the about page."
+        locked
+        envVar="ACTIVITIES_SERVICE_NAME"
+      >
+        <input />
+      </SettingsField>
+    )
+    expect(screen.getByText('Set by environment')).toBeInTheDocument()
+    expect(screen.getByText('ACTIVITIES_SERVICE_NAME')).toBeInTheDocument()
+    // The locked help replaces the normal help.
+    expect(
+      screen.queryByText('Shown on the about page.')
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe('LanguagesPicker', () => {
+  it('renders a chip per selected language', () => {
+    render(<LanguagesPicker value={['en', 'th']} onChange={vi.fn()} />)
+    expect(screen.getByText('English')).toBeInTheDocument()
+    expect(screen.getByText('ไทย')).toBeInTheDocument()
+  })
+
+  it('removes a language via its chip button', () => {
+    const onChange = vi.fn()
+    render(<LanguagesPicker value={['en', 'th']} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove English' }))
+    expect(onChange).toHaveBeenCalledWith(['th'])
+  })
+
+  it('adds a language through the searchable picker', () => {
+    const onChange = vi.fn()
+    render(<LanguagesPicker value={['en']} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add language/i }))
+    fireEvent.change(screen.getByPlaceholderText('Search languages'), {
+      target: { value: 'deutsch' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Deutsch/ }))
+
+    expect(onChange).toHaveBeenCalledWith(['en', 'de'])
+  })
+
+  it('hides the add and remove controls when disabled', () => {
+    render(<LanguagesPicker value={['en']} onChange={vi.fn()} disabled />)
+    expect(screen.getByText('English')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /add language/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Remove English' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/lib/components/admin/settings/useServerSettingsForm.ts
+++ b/lib/components/admin/settings/useServerSettingsForm.ts
@@ -1,0 +1,99 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+import {
+  AdminServerSettingsResponse,
+  updateAdminServerSettings
+} from '@/lib/client'
+
+// A settings form keyed by dotted setting keys (e.g. `instance.name`). Sections
+// save independently: each SaveBar drives its own saving/saved/error status and
+// patches only its keys, matching the design where every section has its own
+// Update button.
+
+type Values = Record<string, unknown>
+
+export interface SectionStatus {
+  saving: boolean
+  saved: boolean
+  error: string | null
+}
+
+const IDLE: SectionStatus = { saving: false, saved: false, error: null }
+
+const getByPath = (source: unknown, path: string): unknown =>
+  path
+    .split('.')
+    .reduce<unknown>(
+      (value, key) =>
+        value == null ? undefined : (value as Record<string, unknown>)[key],
+      source
+    )
+
+const valuesEqual = (a: unknown, b: unknown) =>
+  JSON.stringify(a) === JSON.stringify(b)
+
+export const useServerSettingsForm = (initial: Values) => {
+  const [values, setValues] = useState<Values>(initial)
+  const [baseline, setBaseline] = useState<Values>(initial)
+  const [statuses, setStatuses] = useState<Record<string, SectionStatus>>({})
+
+  const setValue = useCallback((key: string, value: unknown) => {
+    setValues((current) => ({ ...current, [key]: value }))
+  }, [])
+
+  const isDirty = useCallback(
+    (keys: string[]) =>
+      keys.some((key) => !valuesEqual(values[key], baseline[key])),
+    [values, baseline]
+  )
+
+  const statusFor = useCallback(
+    (id: string): SectionStatus => statuses[id] ?? IDLE,
+    [statuses]
+  )
+
+  const saveSection = useCallback(
+    async (id: string, keys: string[]) => {
+      setStatuses((current) => ({
+        ...current,
+        [id]: { saving: true, saved: false, error: null }
+      }))
+
+      const patch: Values = {}
+      keys.forEach((key) => {
+        patch[key] = values[key]
+      })
+
+      try {
+        const result: AdminServerSettingsResponse =
+          await updateAdminServerSettings(patch)
+        // Adopt the server-resolved values (e.g. normalized emails) as both the
+        // live value and the new baseline so the section reads as saved.
+        const resolved: Values = {}
+        keys.forEach((key) => {
+          resolved[key] = getByPath(result.settings, key)
+        })
+        setValues((current) => ({ ...current, ...resolved }))
+        setBaseline((current) => ({ ...current, ...resolved }))
+        setStatuses((current) => ({
+          ...current,
+          [id]: { saving: false, saved: true, error: null }
+        }))
+      } catch (error) {
+        setStatuses((current) => ({
+          ...current,
+          [id]: {
+            saving: false,
+            saved: false,
+            error: error instanceof Error ? error.message : 'Failed to save'
+          }
+        }))
+      }
+    },
+    [values]
+  )
+
+  return { values, setValue, isDirty, statusFor, saveSection }
+}

--- a/lib/components/section-nav-dropdown.test.tsx
+++ b/lib/components/section-nav-dropdown.test.tsx
@@ -74,4 +74,33 @@ describe('SectionNavDropdown', () => {
       within(menu).getByRole('menuitem', { name: 'Overview' })
     ).not.toHaveAttribute('aria-current')
   })
+
+  it('renders a group heading before a run of grouped tabs', async () => {
+    ;(usePathname as jest.Mock).mockReturnValue('/admin')
+    const groupedTabs: SectionNavTab[] = [
+      { name: 'Overview', url: '/admin', icon: Activity },
+      {
+        name: 'Instance',
+        url: '/admin/instance',
+        icon: Globe,
+        group: 'Settings'
+      },
+      { name: 'Network', url: '/admin/network', icon: Lock, group: 'Settings' }
+    ]
+    render(<SectionNavDropdown label="Admin" tabs={groupedTabs} />)
+
+    const nav = screen.getByRole('navigation', { name: 'Admin' })
+    fireEvent.keyDown(within(nav).getByRole('button'), { key: 'ArrowDown' })
+
+    const menu = await screen.findByRole('menu')
+    // The group label renders once, and the grouped items remain menu items.
+    expect(within(menu).getByText('Settings')).toBeInTheDocument()
+    expect(
+      within(menu).getByRole('menuitem', { name: 'Instance' })
+    ).toHaveAttribute('href', '/admin/instance')
+    expect(
+      within(menu).getByRole('menuitem', { name: 'Network' })
+    ).toBeInTheDocument()
+    expect(within(menu).getByRole('separator')).toBeInTheDocument()
+  })
 })

--- a/lib/components/section-nav-dropdown.tsx
+++ b/lib/components/section-nav-dropdown.tsx
@@ -3,13 +3,15 @@
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { FC } from 'react'
+import { FC, Fragment } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/lib/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
@@ -18,6 +20,10 @@ export interface SectionNavTab {
   name: string
   url: string
   icon: LucideIcon
+  // Optional heading a run of tabs sits under. Contiguous tabs sharing a group
+  // render below a separator + label (e.g. admin's "Settings" group); tabs
+  // without a group render as a plain list, exactly as before.
+  group?: string
 }
 
 interface SectionNavDropdownProps {
@@ -66,26 +72,40 @@ export const SectionNavDropdown: FC<SectionNavDropdownProps> = ({
           align="start"
           className="w-[--radix-dropdown-menu-trigger-width]"
         >
-          {tabs.map((tab) => {
+          {tabs.map((tab, index) => {
             const isActive = tab.url === activeTab.url
+            // Start a labelled group when this tab begins a new run under a
+            // group heading (the previous tab had a different or no group).
+            const startsGroup =
+              tab.group !== undefined && tab.group !== tabs[index - 1]?.group
             return (
-              <DropdownMenuItem key={tab.url} asChild>
-                <Link
-                  href={tab.url}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={cn(
-                    'flex w-full items-center gap-2',
-                    // The design system's signature active state: a 10% orange
-                    // wash plus orange text. The wash is a non-color-dependent
-                    // cue alongside aria-current, so the state doesn't rely on
-                    // the orange text alone.
-                    isActive && 'bg-primary/10 font-medium text-primary'
-                  )}
-                >
-                  <tab.icon className="h-4 w-4" />
-                  {tab.name}
-                </Link>
-              </DropdownMenuItem>
+              <Fragment key={tab.url}>
+                {startsGroup && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {tab.group}
+                    </DropdownMenuLabel>
+                  </>
+                )}
+                <DropdownMenuItem asChild>
+                  <Link
+                    href={tab.url}
+                    aria-current={isActive ? 'page' : undefined}
+                    className={cn(
+                      'flex w-full items-center gap-2',
+                      // The design system's signature active state: a 10% orange
+                      // wash plus orange text. The wash is a non-color-dependent
+                      // cue alongside aria-current, so the state doesn't rely on
+                      // the orange text alone.
+                      isActive && 'bg-primary/10 font-medium text-primary'
+                    )}
+                  >
+                    <tab.icon className="h-4 w-4" />
+                    {tab.name}
+                  </Link>
+                </DropdownMenuItem>
+              </Fragment>
             )
           })}
         </DropdownMenuContent>

--- a/lib/config/serverSettings.test.ts
+++ b/lib/config/serverSettings.test.ts
@@ -1,0 +1,76 @@
+import { SERVER_SETTING_FIELDS_BY_KEY } from './serverSettings'
+
+const readEnvFor = (key: string) => SERVER_SETTING_FIELDS_BY_KEY[key].readEnv()
+
+const ENV_KEYS = [
+  'ACTIVITIES_REQUEST_TIMEOUT',
+  'ACTIVITIES_REGISTRATION_OPEN',
+  'ACTIVITIES_FEDERATION_MODE',
+  'ACTIVITIES_ALLOW_EMAILS',
+  'ACTIVITIES_LANGUAGES'
+]
+
+describe('server settings registry env parsers', () => {
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    savedEnv = {}
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key]
+      else process.env[key] = savedEnv[key]
+    }
+  })
+
+  it('parses numeric env vars with parseInt, matching getConfig', () => {
+    // parseInt (not Number) is what getConfig's getOptionalInteger uses.
+    process.env.ACTIVITIES_REQUEST_TIMEOUT = '5000ms'
+    expect(readEnvFor('network.requestTimeoutMs')).toBe(5000)
+    process.env.ACTIVITIES_REQUEST_TIMEOUT = '500.9'
+    expect(readEnvFor('network.requestTimeoutMs')).toBe(500)
+    process.env.ACTIVITIES_REQUEST_TIMEOUT = ''
+    expect(readEnvFor('network.requestTimeoutMs')).toBeUndefined()
+    process.env.ACTIVITIES_REQUEST_TIMEOUT = 'abc'
+    expect(readEnvFor('network.requestTimeoutMs')).toBeUndefined()
+  })
+
+  it('returns undefined for an unset variable (unlocked)', () => {
+    expect(readEnvFor('network.requestTimeoutMs')).toBeUndefined()
+    expect(readEnvFor('registrations.open')).toBeUndefined()
+    expect(readEnvFor('federation.mode')).toBeUndefined()
+  })
+
+  it('reads registration-open as false only for the literal "false"', () => {
+    process.env.ACTIVITIES_REGISTRATION_OPEN = 'false'
+    expect(readEnvFor('registrations.open')).toBe(false)
+    process.env.ACTIVITIES_REGISTRATION_OPEN = 'true'
+    expect(readEnvFor('registrations.open')).toBe(true)
+    process.env.ACTIVITIES_REGISTRATION_OPEN = 'anything'
+    expect(readEnvFor('registrations.open')).toBe(true)
+  })
+
+  it('reads federation mode strictly and ignores an invalid value', () => {
+    process.env.ACTIVITIES_FEDERATION_MODE = 'allowlist'
+    expect(readEnvFor('federation.mode')).toBe('allowlist')
+    process.env.ACTIVITIES_FEDERATION_MODE = 'open'
+    expect(readEnvFor('federation.mode')).toBe('open')
+    process.env.ACTIVITIES_FEDERATION_MODE = ''
+    expect(readEnvFor('federation.mode')).toBe('open')
+    // A typo must not silently coerce to the more permissive 'open'.
+    process.env.ACTIVITIES_FEDERATION_MODE = 'allowlst'
+    expect(readEnvFor('federation.mode')).toBeUndefined()
+  })
+
+  it('normalizes allowed emails and parses languages from JSON', () => {
+    process.env.ACTIVITIES_ALLOW_EMAILS = '["A@Example.com"]'
+    expect(readEnvFor('registrations.allowEmails')).toEqual(['a@example.com'])
+    process.env.ACTIVITIES_LANGUAGES = '["en","th"]'
+    expect(readEnvFor('instance.languages')).toEqual(['en', 'th'])
+  })
+})

--- a/lib/config/serverSettings.ts
+++ b/lib/config/serverSettings.ts
@@ -31,7 +31,10 @@ export const DEFAULT_MAX_STATUS_CHARACTERS = 500
 // advertised the Mastodon literal 2629746 while enforcing this constant).
 export const DEFAULT_MAX_POLL_EXPIRATION_SECONDS = MAX_POLL_EXPIRATION_SECONDS
 
-const DEFAULT_REQUEST_TIMEOUT_MS = 4000
+// Matches the outbound request wrapper's effective default when no
+// ACTIVITIES_REQUEST_* variable is set (lib/utils/request.ts previously fell
+// back to 10000 in that common case), so the unconfigured timeout is unchanged.
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000
 const DEFAULT_REQUEST_RETRIES = 1
 const DEFAULT_MAX_RESPONSE_SIZE_BYTES = 2 * 1024 * 1024
 
@@ -124,9 +127,13 @@ const readEnvBooleanDefaultTrue = (name: string) => (): boolean | undefined =>
 
 const readEnvNumber = (name: string) => (): number | undefined => {
   const raw = process.env[name]
-  if (raw === undefined) return undefined
-  const parsed = Number(raw)
-  return Number.isFinite(parsed) ? parsed : undefined
+  // Mirror getConfig()'s parsing exactly (getOptionalInteger / mediaStorage use
+  // parseInt base 10): an empty value is "unset", and `parseInt` (not `Number`)
+  // is what determines the pinned value so `5000ms`/`5e3`/`500.9` resolve the
+  // same way here as in getConfig().
+  if (raw === undefined || raw === '') return undefined
+  const parsed = parseInt(raw, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
 }
 
 const readEnvStringArray = (name: string) => (): string[] | undefined =>
@@ -143,7 +150,13 @@ const readEnvFederationMode =
   (name: string) => (): 'open' | 'allowlist' | undefined => {
     const raw = process.env[name]
     if (raw === undefined) return undefined
-    return raw === 'allowlist' ? 'allowlist' : 'open'
+    if (raw === 'allowlist') return 'allowlist'
+    // getConfig() treats an empty value as the 'open' default. Any other,
+    // non-empty value is rejected by getConfig()'s strict enum at startup, so it
+    // is unreachable here; fall through to database/default rather than silently
+    // coercing a typo to the more permissive 'open'.
+    if (raw === '' || raw === 'open') return 'open'
+    return undefined
   }
 
 /* -------------------------------- registry -------------------------------- */

--- a/lib/config/serverSettings.ts
+++ b/lib/config/serverSettings.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import {
+  MAX_POLL_EXPIRATION_SECONDS,
   MAX_POLL_OPTION_CHARS,
   MAX_STORED_MEDIA_ATTACHMENTS,
   MIN_POLL_EXPIRATION_SECONDS
@@ -25,9 +26,10 @@ export type ServerSettingTab = 'instance' | 'posts' | 'network' | 'federation'
 // can fall back to it before the resolved value is threaded in.
 export const DEFAULT_MAX_STATUS_CHARACTERS = 500
 
-// Mastodon's canonical maximum poll expiration (seconds ~= 1 month). Matches the
-// value the instance API has always advertised.
-export const DEFAULT_MAX_POLL_EXPIRATION_SECONDS = 2629746
+// Maximum poll expiration (~1 month). Uses the value the create/edit routes
+// actually enforce, so advertising and enforcement agree (the routes previously
+// advertised the Mastodon literal 2629746 while enforcing this constant).
+export const DEFAULT_MAX_POLL_EXPIRATION_SECONDS = MAX_POLL_EXPIRATION_SECONDS
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 4000
 const DEFAULT_REQUEST_RETRIES = 1

--- a/lib/config/serverSettings.ts
+++ b/lib/config/serverSettings.ts
@@ -1,0 +1,399 @@
+import { z } from 'zod'
+
+import {
+  MAX_POLL_OPTION_CHARS,
+  MAX_STORED_MEDIA_ATTACHMENTS,
+  MIN_POLL_EXPIRATION_SECONDS
+} from '@/lib/services/mastodon/constants'
+import { MAX_FILE_SIZE } from '@/lib/services/medias/constants'
+import { normalizeEmail } from '@/lib/utils/normalizeEmail'
+
+import { getEnvironmentList } from './utils'
+
+// The database-backed server settings registry. Each field maps a value that
+// today lives in an ACTIVITIES_* env var or a hardcoded constant to a
+// database-backed setting resolved by env -> database -> default. Env reads and
+// env-var name constants stay in lib/config (see AGENTS.md); the resolver in
+// lib/services/serverSettings combines this registry with the database.
+
+// Which admin tab a field belongs to. Drives grouping in the admin UI/API; note
+// it is coarser than the dotted key prefix (registrations.* live on the
+// Instance tab; polls.*/media.* live on the Posts & media tab).
+export type ServerSettingTab = 'instance' | 'posts' | 'network' | 'federation'
+
+// The public default for the maximum status length. Kept here so the composer
+// can fall back to it before the resolved value is threaded in.
+export const DEFAULT_MAX_STATUS_CHARACTERS = 500
+
+// Mastodon's canonical maximum poll expiration (seconds ~= 1 month). Matches the
+// value the instance API has always advertised.
+export const DEFAULT_MAX_POLL_EXPIRATION_SECONDS = 2629746
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 4000
+const DEFAULT_REQUEST_RETRIES = 1
+const DEFAULT_MAX_RESPONSE_SIZE_BYTES = 2 * 1024 * 1024
+
+// The fully-resolved settings shape consumers read. Grouped by concern; the
+// dotted registry keys below write into these paths.
+export interface ResolvedServerSettings {
+  instance: {
+    name: string
+    description: string
+    contactEmail: string
+    languages: string[]
+  }
+  registrations: {
+    open: boolean
+    allowEmails: string[]
+  }
+  posts: {
+    maxCharacters: number
+    maxMediaAttachments: number
+  }
+  polls: {
+    maxOptions: number
+    maxCharactersPerOption: number
+    minExpirationSeconds: number
+    maxExpirationSeconds: number
+  }
+  media: {
+    maxFileSize: number
+  }
+  network: {
+    requestTimeoutMs: number
+    requestRetries: number
+    maxResponseSizeBytes: number
+  }
+  federation: {
+    mode: 'open' | 'allowlist'
+    allowActorDomains: string[]
+  }
+}
+
+// The default values, mirroring today's env defaults and hardcoded constants.
+// A field is only served from the database when its env var is absent; when an
+// env var is present it wins and locks the field.
+export const DEFAULT_SERVER_SETTINGS: ResolvedServerSettings = {
+  instance: {
+    name: 'Activities.next',
+    description: 'Personal activity pub server with Next.js',
+    contactEmail: '',
+    languages: ['en']
+  },
+  registrations: {
+    open: true,
+    allowEmails: []
+  },
+  posts: {
+    maxCharacters: DEFAULT_MAX_STATUS_CHARACTERS,
+    maxMediaAttachments: MAX_STORED_MEDIA_ATTACHMENTS
+  },
+  polls: {
+    maxOptions: 4,
+    maxCharactersPerOption: MAX_POLL_OPTION_CHARS,
+    minExpirationSeconds: MIN_POLL_EXPIRATION_SECONDS,
+    maxExpirationSeconds: DEFAULT_MAX_POLL_EXPIRATION_SECONDS
+  },
+  media: {
+    maxFileSize: MAX_FILE_SIZE
+  },
+  network: {
+    requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    requestRetries: DEFAULT_REQUEST_RETRIES,
+    maxResponseSizeBytes: DEFAULT_MAX_RESPONSE_SIZE_BYTES
+  },
+  federation: {
+    mode: 'open',
+    allowActorDomains: []
+  }
+}
+
+/* ------------------------------- env readers ------------------------------ */
+// Each reader returns the parsed value when the variable is present, or
+// undefined when it is not (so the resolver falls through to the database, then
+// the default). The parsing mirrors getConfig() so an env-pinned setting keeps
+// exactly the value it has today.
+
+const readEnvString = (name: string) => (): string | undefined =>
+  process.env[name]
+
+const readEnvBooleanDefaultTrue = (name: string) => (): boolean | undefined =>
+  process.env[name] === undefined ? undefined : process.env[name] !== 'false'
+
+const readEnvNumber = (name: string) => (): number | undefined => {
+  const raw = process.env[name]
+  if (raw === undefined) return undefined
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const readEnvStringArray = (name: string) => (): string[] | undefined =>
+  process.env[name] === undefined
+    ? undefined
+    : getEnvironmentList(name, { onInvalidList: 'empty' })
+
+const readEnvNormalizedEmails = (name: string) => (): string[] | undefined =>
+  process.env[name] === undefined
+    ? undefined
+    : getEnvironmentList(name, { onInvalidList: 'empty' }).map(normalizeEmail)
+
+const readEnvFederationMode =
+  (name: string) => (): 'open' | 'allowlist' | undefined => {
+    const raw = process.env[name]
+    if (raw === undefined) return undefined
+    return raw === 'allowlist' ? 'allowlist' : 'open'
+  }
+
+/* -------------------------------- registry -------------------------------- */
+
+export interface ServerSettingField {
+  // Dotted storage key, e.g. `posts.maxCharacters`.
+  key: string
+  // Admin tab the field is shown on.
+  group: ServerSettingTab
+  // The env var that pins (locks) this field when present, for the badge.
+  envVar?: string
+  // Validates database and admin-supplied values.
+  schema: z.ZodType
+  // Reads the env override, or undefined when the variable is unset.
+  readEnv: () => unknown
+  // Reads/writes the field within a resolved settings object.
+  get: (settings: ResolvedServerSettings) => unknown
+  set: (settings: ResolvedServerSettings, value: unknown) => void
+}
+
+// Typed field factory: keeps each definition strongly typed while the registry
+// stores them behind the erased ServerSettingField shape.
+const field = <V>(def: {
+  key: string
+  group: ServerSettingTab
+  envVar?: string
+  schema: z.ZodType<V>
+  readEnv: () => V | undefined
+  get: (settings: ResolvedServerSettings) => V
+  set: (settings: ResolvedServerSettings, value: V) => void
+}): ServerSettingField => def as unknown as ServerSettingField
+
+const nameSchema = z.string().trim().max(255)
+const descriptionSchema = z.string().trim().max(5000)
+const emailSchema = z.string().trim().max(255)
+const languagesSchema = z.array(z.string().trim().min(2).max(15)).max(100)
+const allowEmailsSchema = z
+  .array(z.string().trim().max(255))
+  .max(1000)
+  .transform((emails) => emails.map(normalizeEmail))
+const domainsSchema = z.array(z.string().trim().max(255)).max(1000)
+
+export const SERVER_SETTING_FIELDS: ServerSettingField[] = [
+  // Instance identity
+  field<string>({
+    key: 'instance.name',
+    group: 'instance',
+    envVar: 'ACTIVITIES_SERVICE_NAME',
+    schema: nameSchema,
+    readEnv: readEnvString('ACTIVITIES_SERVICE_NAME'),
+    get: (s) => s.instance.name,
+    set: (s, v) => {
+      s.instance.name = v
+    }
+  }),
+  field<string>({
+    key: 'instance.description',
+    group: 'instance',
+    envVar: 'ACTIVITIES_SERVICE_DESCRIPTION',
+    schema: descriptionSchema,
+    readEnv: readEnvString('ACTIVITIES_SERVICE_DESCRIPTION'),
+    get: (s) => s.instance.description,
+    set: (s, v) => {
+      s.instance.description = v
+    }
+  }),
+  field<string>({
+    key: 'instance.contactEmail',
+    group: 'instance',
+    // No env var: contact email has no dedicated variable today.
+    schema: emailSchema,
+    readEnv: () => undefined,
+    get: (s) => s.instance.contactEmail,
+    set: (s, v) => {
+      s.instance.contactEmail = v
+    }
+  }),
+  field<string[]>({
+    key: 'instance.languages',
+    group: 'instance',
+    envVar: 'ACTIVITIES_LANGUAGES',
+    schema: languagesSchema,
+    readEnv: readEnvStringArray('ACTIVITIES_LANGUAGES'),
+    get: (s) => s.instance.languages,
+    set: (s, v) => {
+      s.instance.languages = v
+    }
+  }),
+
+  // Registrations
+  field<boolean>({
+    key: 'registrations.open',
+    group: 'instance',
+    envVar: 'ACTIVITIES_REGISTRATION_OPEN',
+    schema: z.boolean(),
+    readEnv: readEnvBooleanDefaultTrue('ACTIVITIES_REGISTRATION_OPEN'),
+    get: (s) => s.registrations.open,
+    set: (s, v) => {
+      s.registrations.open = v
+    }
+  }),
+  field<string[]>({
+    key: 'registrations.allowEmails',
+    group: 'instance',
+    envVar: 'ACTIVITIES_ALLOW_EMAILS',
+    schema: allowEmailsSchema,
+    readEnv: readEnvNormalizedEmails('ACTIVITIES_ALLOW_EMAILS'),
+    get: (s) => s.registrations.allowEmails,
+    set: (s, v) => {
+      s.registrations.allowEmails = v
+    }
+  }),
+
+  // Posts & media
+  field<number>({
+    key: 'posts.maxCharacters',
+    group: 'posts',
+    schema: z.number().int().min(1).max(100000),
+    readEnv: () => undefined,
+    get: (s) => s.posts.maxCharacters,
+    set: (s, v) => {
+      s.posts.maxCharacters = v
+    }
+  }),
+  field<number>({
+    key: 'posts.maxMediaAttachments',
+    group: 'posts',
+    // Bounded by the stored-media safety ceiling; the setting drives the value
+    // advertised to clients, not the hard create-route cap.
+    schema: z.number().int().min(1).max(MAX_STORED_MEDIA_ATTACHMENTS),
+    readEnv: () => undefined,
+    get: (s) => s.posts.maxMediaAttachments,
+    set: (s, v) => {
+      s.posts.maxMediaAttachments = v
+    }
+  }),
+
+  // Polls
+  field<number>({
+    key: 'polls.maxOptions',
+    group: 'posts',
+    schema: z.number().int().min(2).max(50),
+    readEnv: () => undefined,
+    get: (s) => s.polls.maxOptions,
+    set: (s, v) => {
+      s.polls.maxOptions = v
+    }
+  }),
+  field<number>({
+    key: 'polls.maxCharactersPerOption',
+    group: 'posts',
+    schema: z.number().int().min(1).max(1000),
+    readEnv: () => undefined,
+    get: (s) => s.polls.maxCharactersPerOption,
+    set: (s, v) => {
+      s.polls.maxCharactersPerOption = v
+    }
+  }),
+  field<number>({
+    key: 'polls.minExpirationSeconds',
+    group: 'posts',
+    schema: z.number().int().min(60),
+    readEnv: () => undefined,
+    get: (s) => s.polls.minExpirationSeconds,
+    set: (s, v) => {
+      s.polls.minExpirationSeconds = v
+    }
+  }),
+  field<number>({
+    key: 'polls.maxExpirationSeconds',
+    group: 'posts',
+    schema: z.number().int().min(300),
+    readEnv: () => undefined,
+    get: (s) => s.polls.maxExpirationSeconds,
+    set: (s, v) => {
+      s.polls.maxExpirationSeconds = v
+    }
+  }),
+
+  // Media upload
+  field<number>({
+    key: 'media.maxFileSize',
+    group: 'posts',
+    envVar: 'ACTIVITIES_MEDIA_STORAGE_MAX_FILE_SIZE',
+    schema: z.number().int().min(1),
+    readEnv: readEnvNumber('ACTIVITIES_MEDIA_STORAGE_MAX_FILE_SIZE'),
+    get: (s) => s.media.maxFileSize,
+    set: (s, v) => {
+      s.media.maxFileSize = v
+    }
+  }),
+
+  // Network — outbound requests
+  field<number>({
+    key: 'network.requestTimeoutMs',
+    group: 'network',
+    envVar: 'ACTIVITIES_REQUEST_TIMEOUT',
+    schema: z.number().int().min(1),
+    readEnv: readEnvNumber('ACTIVITIES_REQUEST_TIMEOUT'),
+    get: (s) => s.network.requestTimeoutMs,
+    set: (s, v) => {
+      s.network.requestTimeoutMs = v
+    }
+  }),
+  field<number>({
+    key: 'network.requestRetries',
+    group: 'network',
+    envVar: 'ACTIVITIES_REQUEST_RETRY',
+    schema: z.number().int().min(0).max(20),
+    readEnv: readEnvNumber('ACTIVITIES_REQUEST_RETRY'),
+    get: (s) => s.network.requestRetries,
+    set: (s, v) => {
+      s.network.requestRetries = v
+    }
+  }),
+  field<number>({
+    key: 'network.maxResponseSizeBytes',
+    group: 'network',
+    envVar: 'ACTIVITIES_REQUEST_MAX_RESPONSE_SIZE_BYTES',
+    schema: z.number().int().min(1),
+    readEnv: readEnvNumber('ACTIVITIES_REQUEST_MAX_RESPONSE_SIZE_BYTES'),
+    get: (s) => s.network.maxResponseSizeBytes,
+    set: (s, v) => {
+      s.network.maxResponseSizeBytes = v
+    }
+  }),
+
+  // Federation policy
+  field<'open' | 'allowlist'>({
+    key: 'federation.mode',
+    group: 'federation',
+    envVar: 'ACTIVITIES_FEDERATION_MODE',
+    schema: z.enum(['open', 'allowlist']),
+    readEnv: readEnvFederationMode('ACTIVITIES_FEDERATION_MODE'),
+    get: (s) => s.federation.mode,
+    set: (s, v) => {
+      s.federation.mode = v
+    }
+  }),
+  field<string[]>({
+    key: 'federation.allowActorDomains',
+    group: 'federation',
+    envVar: 'ACTIVITIES_ALLOW_ACTOR_DOMAINS',
+    schema: domainsSchema,
+    readEnv: readEnvStringArray('ACTIVITIES_ALLOW_ACTOR_DOMAINS'),
+    get: (s) => s.federation.allowActorDomains,
+    set: (s, v) => {
+      s.federation.allowActorDomains = v
+    }
+  })
+]
+
+// Lookup by key for the admin write path.
+export const SERVER_SETTING_FIELDS_BY_KEY: Record<string, ServerSettingField> =
+  Object.fromEntries(SERVER_SETTING_FIELDS.map((f) => [f.key, f]))

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -37,6 +37,7 @@ import { ReportSQLDatabaseMixin } from '@/lib/database/sql/report'
 import { ScheduledStatusSQLDatabaseMixin } from '@/lib/database/sql/scheduledStatus'
 import { SearchSQLDatabaseMixin } from '@/lib/database/sql/search'
 import { ServerFilterSQLDatabaseMixin } from '@/lib/database/sql/serverFilter'
+import { ServerSettingSQLDatabaseMixin } from '@/lib/database/sql/serverSetting'
 import { StatusSQLDatabaseMixin } from '@/lib/database/sql/status'
 import { StatusDetectedLanguageSQLDatabaseMixin } from '@/lib/database/sql/statusDetectedLanguage'
 import { StatusMuteSQLDatabaseMixin } from '@/lib/database/sql/statusMute'
@@ -75,6 +76,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     StatusDetectedLanguageSQLDatabaseMixin(database)
   const filterDatabase = FilterSQLDatabaseMixin(database)
   const serverFilterDatabase = ServerFilterSQLDatabaseMixin(database)
+  const serverSettingDatabase = ServerSettingSQLDatabaseMixin(database)
   const followerDatabase = FollowerSQLDatabaseMixin(database, actorDatabase)
   const followedTagDatabase = FollowedTagSQLDatabaseMixin(database)
   const instanceActivityDatabase = InstanceActivitySQLDatabaseMixin(database)
@@ -162,6 +164,7 @@ export const getSQLDatabase = (database: Knex): Database => {
     ...listDatabase,
     ...filterDatabase,
     ...serverFilterDatabase,
+    ...serverSettingDatabase,
     ...followerDatabase,
     ...followedTagDatabase,
     ...likeDatabase,

--- a/lib/database/sql/serverSetting.test.ts
+++ b/lib/database/sql/serverSetting.test.ts
@@ -97,6 +97,30 @@ describe('ServerSettingDatabase', () => {
       ).resolves.toBe(false)
     })
 
+    it('upserts a batch of settings in one call', async () => {
+      await database.setServerSettings([
+        { key: 'batch.one', value: 1 },
+        { key: 'batch.two', value: ['a', 'b'] }
+      ])
+
+      await expect(
+        database.getServerSetting({ key: 'batch.one' })
+      ).resolves.toMatchObject({ value: 1 })
+      await expect(
+        database.getServerSetting({ key: 'batch.two' })
+      ).resolves.toMatchObject({ value: ['a', 'b'] })
+
+      // A second batch overwrites existing keys.
+      await database.setServerSettings([{ key: 'batch.one', value: 2 }])
+      await expect(
+        database.getServerSetting({ key: 'batch.one' })
+      ).resolves.toMatchObject({ value: 2 })
+    })
+
+    it('accepts an empty batch as a no-op', async () => {
+      await expect(database.setServerSettings([])).resolves.toBeUndefined()
+    })
+
     it('stores a boolean value distinctly from its string form', async () => {
       await database.setServerSetting({
         key: 'registrations.open',

--- a/lib/database/sql/serverSetting.test.ts
+++ b/lib/database/sql/serverSetting.test.ts
@@ -1,0 +1,110 @@
+import {
+  databaseBeforeAll,
+  getTestDatabaseTable
+} from '@/lib/database/testUtils'
+
+describe('ServerSettingDatabase', () => {
+  const table = getTestDatabaseTable()
+
+  beforeAll(async () => {
+    await databaseBeforeAll(table)
+  })
+
+  afterAll(async () => {
+    await Promise.all(table.map((item) => item[1].destroy()))
+  })
+
+  describe.each(table)('%s', (_, database) => {
+    it('returns null for a setting that was never stored', async () => {
+      await expect(
+        database.getServerSetting({ key: 'missing.setting' })
+      ).resolves.toBeNull()
+    })
+
+    it('stores and reads back a setting value', async () => {
+      const stored = await database.setServerSetting({
+        key: 'posts.maxCharacters',
+        value: 1000
+      })
+
+      expect(stored).toMatchObject({ key: 'posts.maxCharacters', value: 1000 })
+      expect(stored.createdAt).toBeGreaterThan(0)
+      expect(stored.updatedAt).toBeGreaterThan(0)
+
+      await expect(
+        database.getServerSetting({ key: 'posts.maxCharacters' })
+      ).resolves.toMatchObject({ key: 'posts.maxCharacters', value: 1000 })
+    })
+
+    it('round-trips non-scalar JSON values', async () => {
+      await database.setServerSetting({
+        key: 'instance.languages',
+        value: ['en', 'th']
+      })
+
+      const row = await database.getServerSetting({ key: 'instance.languages' })
+      expect(row?.value).toEqual(['en', 'th'])
+    })
+
+    it('upserts an existing key, overwriting value and keeping createdAt', async () => {
+      const first = await database.setServerSetting({
+        key: 'network.requestTimeoutMs',
+        value: 4000
+      })
+      const second = await database.setServerSetting({
+        key: 'network.requestTimeoutMs',
+        value: 8000
+      })
+
+      expect(second.value).toBe(8000)
+      expect(second.createdAt).toBe(first.createdAt)
+      await expect(
+        database.getServerSetting({ key: 'network.requestTimeoutMs' })
+      ).resolves.toMatchObject({ value: 8000 })
+    })
+
+    it('lists every stored setting ordered by key', async () => {
+      await database.setServerSetting({ key: 'zeta.setting', value: 'z' })
+      await database.setServerSetting({ key: 'alpha.setting', value: 'a' })
+
+      const all = await database.getAllServerSettings()
+      const keys = all.map((setting) => setting.key)
+      const alphaIndex = keys.indexOf('alpha.setting')
+      const zetaIndex = keys.indexOf('zeta.setting')
+
+      expect(alphaIndex).toBeGreaterThanOrEqual(0)
+      expect(zetaIndex).toBeGreaterThan(alphaIndex)
+      expect([...keys]).toEqual([...keys].sort())
+    })
+
+    it('deletes a stored setting and reports removal', async () => {
+      await database.setServerSetting({
+        key: 'federation.mode',
+        value: 'allowlist'
+      })
+
+      await expect(
+        database.deleteServerSetting({ key: 'federation.mode' })
+      ).resolves.toBe(true)
+      await expect(
+        database.getServerSetting({ key: 'federation.mode' })
+      ).resolves.toBeNull()
+    })
+
+    it('returns false when deleting a key that does not exist', async () => {
+      await expect(
+        database.deleteServerSetting({ key: 'never.stored' })
+      ).resolves.toBe(false)
+    })
+
+    it('stores a boolean value distinctly from its string form', async () => {
+      await database.setServerSetting({
+        key: 'registrations.open',
+        value: false
+      })
+
+      const row = await database.getServerSetting({ key: 'registrations.open' })
+      expect(row?.value).toBe(false)
+    })
+  })
+})

--- a/lib/database/sql/serverSetting.ts
+++ b/lib/database/sql/serverSetting.ts
@@ -1,0 +1,71 @@
+import { Knex } from 'knex'
+
+import { getCompatibleTime } from '@/lib/database/sql/utils/getCompatibleTime'
+import {
+  DeleteServerSettingParams,
+  GetServerSettingParams,
+  ServerSettingData,
+  ServerSettingDatabase,
+  SetServerSettingParams
+} from '@/lib/types/database/operations'
+
+type SQLServerSetting = {
+  key: string
+  value: string
+  createdAt: number | Date | string
+  updatedAt: number | Date | string
+}
+
+const toServerSetting = (row: SQLServerSetting): ServerSettingData => ({
+  key: row.key,
+  value: JSON.parse(row.value),
+  createdAt: getCompatibleTime(row.createdAt),
+  updatedAt: getCompatibleTime(row.updatedAt)
+})
+
+export const ServerSettingSQLDatabaseMixin = (
+  database: Knex
+): ServerSettingDatabase => ({
+  async getServerSetting({ key }: GetServerSettingParams) {
+    const row = await database<SQLServerSetting>('server_settings')
+      .where({ key })
+      .first()
+    return row ? toServerSetting(row) : null
+  },
+
+  async getAllServerSettings() {
+    const rows = await database<SQLServerSetting>('server_settings').orderBy(
+      'key',
+      'asc'
+    )
+    return rows.map(toServerSetting)
+  },
+
+  async setServerSetting({ key, value }: SetServerSettingParams) {
+    const currentTime = new Date()
+    // JSON-encode so the single text column round-trips any value shape
+    // (string, number, boolean, string[]). Upsert keeps the original
+    // createdAt while overwriting value + updatedAt.
+    const serialized = JSON.stringify(value)
+    await database('server_settings')
+      .insert({
+        key,
+        value: serialized,
+        createdAt: currentTime,
+        updatedAt: currentTime
+      })
+      .onConflict('key')
+      .merge({ value: serialized, updatedAt: currentTime })
+
+    // The row is guaranteed to exist after the upsert.
+    const row = (await database<SQLServerSetting>('server_settings')
+      .where({ key })
+      .first()) as SQLServerSetting
+    return toServerSetting(row)
+  },
+
+  async deleteServerSetting({ key }: DeleteServerSettingParams) {
+    const deleted = await database('server_settings').where({ key }).delete()
+    return deleted > 0
+  }
+})

--- a/lib/database/sql/serverSetting.ts
+++ b/lib/database/sql/serverSetting.ts
@@ -64,6 +64,27 @@ export const ServerSettingSQLDatabaseMixin = (
     return toServerSetting(row)
   },
 
+  async setServerSettings(entries: SetServerSettingParams[]) {
+    if (entries.length === 0) return
+    // Upsert the whole batch in one transaction so a mid-batch failure rolls
+    // back — the admin PATCH is genuinely all-or-nothing.
+    const currentTime = new Date()
+    await database.transaction(async (trx) => {
+      for (const { key, value } of entries) {
+        const serialized = JSON.stringify(value)
+        await trx('server_settings')
+          .insert({
+            key,
+            value: serialized,
+            createdAt: currentTime,
+            updatedAt: currentTime
+          })
+          .onConflict('key')
+          .merge({ value: serialized, updatedAt: currentTime })
+      }
+    })
+  },
+
   async deleteServerSetting({ key }: DeleteServerSettingParams) {
     const deleted = await database('server_settings').where({ key }).delete()
     return deleted > 0

--- a/lib/database/types.ts
+++ b/lib/database/types.ts
@@ -39,6 +39,7 @@ import {
   ScheduledStatusDatabase,
   SearchDatabase,
   ServerFilterDatabase,
+  ServerSettingDatabase,
   StatusDatabase,
   StatusDetectedLanguageDatabase,
   StatusMuteDatabase,
@@ -71,6 +72,7 @@ export type Database = AccountDatabase &
   FollowedTagDatabase &
   FilterDatabase &
   ServerFilterDatabase &
+  ServerSettingDatabase &
   BookmarkDatabase &
   CustomEmojiDatabase &
   DirectConversationDatabase &

--- a/lib/services/accounts/registerAccount.test.ts
+++ b/lib/services/accounts/registerAccount.test.ts
@@ -1,5 +1,7 @@
 import { getConfig } from '@/lib/config'
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
 import { Database } from '@/lib/database/types'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 import { registerAccount } from './registerAccount'
 
@@ -20,6 +22,17 @@ vi.mock('@/lib/services/email', async () => ({
   sendMail: vi.fn().mockResolvedValue(undefined)
 }))
 
+vi.mock('@/lib/services/serverSettings', () => ({
+  getResolvedServerSettings: vi.fn()
+}))
+
+// Registration open/allow-list are resolved from server settings; build a
+// resolved object varying only those fields.
+const settingsWith = (registrations: {
+  open: boolean
+  allowEmails: string[]
+}) => ({ ...structuredClone(DEFAULT_SERVER_SETTINGS), registrations })
+
 type MockDatabase = Pick<
   Database,
   'isAccountExists' | 'isUsernameExists' | 'createAccount'
@@ -33,6 +46,9 @@ beforeEach(() => {
   // getConfig(), so use a stable mockReturnValue (not mockReturnValueOnce) that
   // every call within a single registration resolves to.
   vi.mocked(getConfig).mockReturnValue(DEFAULT_CONFIG as never)
+  vi.mocked(getResolvedServerSettings).mockResolvedValue(
+    settingsWith({ open: true, allowEmails: [] })
+  )
   mockDatabase = {
     isAccountExists: vi.fn().mockResolvedValue(false),
     isUsernameExists: vi.fn().mockResolvedValue(false),
@@ -42,13 +58,9 @@ beforeEach(() => {
 
 describe('registerAccount', () => {
   it('returns registration_closed when registration is disabled', async () => {
-    vi.mocked(getConfig).mockReturnValue({
-      host: 'llun.test',
-      allowEmails: [],
-      registrationOpen: false,
-      secretPhase: 'test-secret',
-      email: null
-    } as never)
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWith({ open: false, allowEmails: [] })
+    )
 
     const result = await registerAccount({
       database: mockDatabase as unknown as Database,
@@ -62,13 +74,9 @@ describe('registerAccount', () => {
   })
 
   it('returns email_not_allowed when email is not on the allow-list', async () => {
-    vi.mocked(getConfig).mockReturnValue({
-      host: 'llun.test',
-      allowEmails: ['allowed@example.com'],
-      registrationOpen: true,
-      secretPhase: 'test-secret',
-      email: null
-    } as never)
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWith({ open: true, allowEmails: ['allowed@example.com'] })
+    )
 
     const result = await registerAccount({
       database: mockDatabase as unknown as Database,
@@ -371,13 +379,9 @@ describe('registerAccount', () => {
   })
 
   it('blocks an email not on the allow-list regardless of case', async () => {
-    vi.mocked(getConfig).mockReturnValue({
-      host: 'llun.test',
-      allowEmails: ['allowed@example.com'],
-      registrationOpen: true,
-      secretPhase: 'test-secret-phase-for-unit-tests-only',
-      email: null
-    } as never)
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      settingsWith({ open: true, allowEmails: ['allowed@example.com'] })
+    )
 
     const result = await registerAccount({
       database: mockDatabase as unknown as Database,

--- a/lib/services/accounts/registerAccount.ts
+++ b/lib/services/accounts/registerAccount.ts
@@ -5,6 +5,7 @@ import { getConfig } from '@/lib/config'
 import { isUniqueConstraintError } from '@/lib/database/sql/utils/isUniqueConstraintError'
 import { Database } from '@/lib/database/types'
 import { sendConfirmationEmail } from '@/lib/services/accounts/sendConfirmationEmail'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { getLocalActorId } from '@/lib/utils/activitypubId'
 import { logger } from '@/lib/utils/logger'
 import { isEmailAllowed, normalizeEmail } from '@/lib/utils/normalizeEmail'
@@ -37,8 +38,9 @@ export const registerAccount = async ({
   name
 }: RegisterAccountParams): Promise<RegisterAccountResult> => {
   const config = getConfig()
+  const settings = await getResolvedServerSettings(database)
 
-  if (!config.registrationOpen) {
+  if (!settings.registrations.open) {
     return { type: 'registration_closed' }
   }
 
@@ -47,9 +49,9 @@ export const registerAccount = async ({
   // same canonical (lowercased) address — even when this service is called
   // directly rather than through the request schema. See normalizeEmail.
   const email = normalizeEmail(rawEmail)
-  const { host: domain, allowEmails } = config
+  const domain = config.host
 
-  if (!isEmailAllowed(allowEmails, email)) {
+  if (!isEmailAllowed(settings.registrations.allowEmails, email)) {
     return { type: 'email_not_allowed' }
   }
 

--- a/lib/services/federation/domainPolicy.test.ts
+++ b/lib/services/federation/domainPolicy.test.ts
@@ -1,4 +1,6 @@
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
 import { Database } from '@/lib/database/types'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 import {
   canFederateWithDomain,
@@ -11,6 +13,24 @@ const mockGetConfig = vi.fn()
 vi.mock('@/lib/config', () => ({
   getConfig: () => mockGetConfig()
 }))
+
+vi.mock('@/lib/services/serverSettings', () => ({
+  getResolvedServerSettings: vi.fn()
+}))
+
+// The host stays env-configured; the federation mode + actor allow-list are
+// resolved from server settings.
+const mockFederation = ({
+  host = 'local.test',
+  mode = 'open' as 'open' | 'allowlist',
+  allowActorDomains = [] as string[]
+} = {}) => {
+  mockGetConfig.mockReturnValue({ host })
+  vi.mocked(getResolvedServerSettings).mockResolvedValue({
+    ...structuredClone(DEFAULT_SERVER_SETTINGS),
+    federation: { mode, allowActorDomains }
+  })
+}
 
 const createDatabase = (params: { blocks?: string[]; allows?: string[] }) => {
   const findBlock = (domain: string) =>
@@ -62,11 +82,7 @@ const createDatabase = (params: { blocks?: string[]; allows?: string[] }) => {
 
 describe('domainPolicy', () => {
   beforeEach(() => {
-    mockGetConfig.mockReturnValue({
-      host: 'local.test',
-      allowActorDomains: [],
-      federationMode: 'open'
-    })
+    mockFederation()
   })
 
   it('rejects suspended blocked domains in open federation mode', async () => {
@@ -81,11 +97,7 @@ describe('domainPolicy', () => {
   })
 
   it('requires allow entries in allowlist mode', async () => {
-    mockGetConfig.mockReturnValue({
-      host: 'local.test',
-      allowActorDomains: [],
-      federationMode: 'allowlist'
-    })
+    mockFederation({ mode: 'allowlist' })
     const database = createDatabase({ allows: ['trusted.test'] })
 
     await expect(
@@ -97,11 +109,7 @@ describe('domainPolicy', () => {
   })
 
   it('always allows local actor domains', async () => {
-    mockGetConfig.mockReturnValue({
-      host: 'local.test',
-      allowActorDomains: ['alias.test'],
-      federationMode: 'allowlist'
-    })
+    mockFederation({ mode: 'allowlist', allowActorDomains: ['alias.test'] })
     const database = createDatabase({})
 
     await expect(isDomainAllowed(database, 'alias.test')).resolves.toBe(true)
@@ -110,24 +118,25 @@ describe('domainPolicy', () => {
     ).resolves.toBe(true)
   })
 
-  it('treats only exact local domains and configured wildcards as local', () => {
-    mockGetConfig.mockReturnValue({
-      host: 'local.test',
-      allowActorDomains: ['alias.test', '*.trusted.test'],
-      federationMode: 'open'
-    })
+  it('treats only exact local domains and configured wildcards as local', async () => {
+    mockFederation({ allowActorDomains: ['alias.test', '*.trusted.test'] })
+    const database = createDatabase({})
 
-    expect(isLocalFederationDomain('https://local.test/users/a')).toBe(true)
-    expect(isLocalFederationDomain('https://evil.local.test/users/a')).toBe(
-      false
-    )
-    expect(isLocalFederationDomain('https://alias.test/users/a')).toBe(true)
-    expect(isLocalFederationDomain('https://sub.alias.test/users/a')).toBe(
-      false
-    )
-    expect(isLocalFederationDomain('https://sub.trusted.test/users/a')).toBe(
-      true
-    )
+    await expect(
+      isLocalFederationDomain(database, 'https://local.test/users/a')
+    ).resolves.toBe(true)
+    await expect(
+      isLocalFederationDomain(database, 'https://evil.local.test/users/a')
+    ).resolves.toBe(false)
+    await expect(
+      isLocalFederationDomain(database, 'https://alias.test/users/a')
+    ).resolves.toBe(true)
+    await expect(
+      isLocalFederationDomain(database, 'https://sub.alias.test/users/a')
+    ).resolves.toBe(false)
+    await expect(
+      isLocalFederationDomain(database, 'https://sub.trusted.test/users/a')
+    ).resolves.toBe(true)
   })
 
   it('filters URLs with a batched block lookup', async () => {
@@ -149,11 +158,7 @@ describe('domainPolicy', () => {
   })
 
   it('filters URLs with batched allow lookups in allowlist mode', async () => {
-    mockGetConfig.mockReturnValue({
-      host: 'local.test',
-      allowActorDomains: [],
-      federationMode: 'allowlist'
-    })
+    mockFederation({ mode: 'allowlist' })
     const database = createDatabase({ allows: ['trusted.test'] })
 
     await expect(

--- a/lib/services/federation/domainPolicy.ts
+++ b/lib/services/federation/domainPolicy.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 import {
   FederationMode,
@@ -11,24 +12,49 @@ import {
 export const getDomainFromUrl = (value: string): string | null =>
   normalizeDomain(value)
 
-export const getFederationMode = (): FederationMode =>
-  getConfig().federationMode ?? 'open'
+// The federation mode and actor allow-list are database-backed settings
+// (env -> database -> default). Resolve them once per operation; the resolver
+// caches per database instance so hot paths (inbox verification, delivery
+// fan-out) do not pay a database read per call.
+const getFederationPolicy = async (
+  database: Database
+): Promise<{ mode: FederationMode; allowActorDomains: string[] }> => {
+  const { federation } = await getResolvedServerSettings(database)
+  return {
+    mode: federation.mode,
+    allowActorDomains: federation.allowActorDomains
+  }
+}
 
-export const isLocalFederationDomain = (value: string): boolean => {
+// Pure local-domain check against the configured host (env-only) plus the
+// resolved actor allow-list. Kept synchronous so it can run inside per-domain
+// loops without awaiting the resolver each time.
+const isLocalDomain = (value: string, allowActorDomains: string[]): boolean => {
   const domain = getDomainFromUrl(value)
   if (!domain) return false
 
-  const config = getConfig()
-  const host = normalizeDomain(config.host)
+  const host = normalizeDomain(getConfig().host)
   if (domain === host) return true
 
-  return (config.allowActorDomains ?? []).some((localDomain) => {
+  return allowActorDomains.some((localDomain) => {
     const normalized = normalizeDomain(localDomain)
     if (!normalized) return false
     if (normalized.startsWith('*.'))
       return domainMatchesRule(domain, normalized)
     return domain === normalized
   })
+}
+
+export const getFederationMode = async (
+  database: Database
+): Promise<FederationMode> => (await getFederationPolicy(database)).mode
+
+export const isLocalFederationDomain = async (
+  database: Database,
+  value: string
+): Promise<boolean> => {
+  const { allowActorDomains } = await getFederationPolicy(database)
+  return isLocalDomain(value, allowActorDomains)
 }
 
 export const isDomainBlocked = async (
@@ -48,7 +74,9 @@ export const isDomainAllowed = async (
 ): Promise<boolean> => {
   const domain = getDomainFromUrl(value)
   if (!domain) return false
-  if (isLocalFederationDomain(domain)) return true
+
+  const { allowActorDomains } = await getFederationPolicy(database)
+  if (isLocalDomain(domain, allowActorDomains)) return true
 
   return Boolean(await database.getDomainAllowForDomain(domain))
 }
@@ -59,12 +87,14 @@ export const canFederateWithDomain = async (
 ): Promise<boolean> => {
   const domain = getDomainFromUrl(value)
   if (!domain) return false
-  if (isLocalFederationDomain(domain)) return true
+
+  const { mode, allowActorDomains } = await getFederationPolicy(database)
+  if (isLocalDomain(domain, allowActorDomains)) return true
 
   if (await isDomainBlocked(database, domain)) return false
 
-  if (getFederationMode() === 'allowlist') {
-    return isDomainAllowed(database, domain)
+  if (mode === 'allowlist') {
+    return Boolean(await database.getDomainAllowForDomain(domain))
   }
 
   return true
@@ -74,12 +104,13 @@ const getFederationDecisionsForDomains = async (
   database: Database,
   domains: string[]
 ): Promise<Map<string, boolean>> => {
+  const { mode, allowActorDomains } = await getFederationPolicy(database)
   const uniqueDomains = [...new Set(domains)]
   const decisions = new Map<string, boolean>()
   const remoteDomains: string[] = []
 
   for (const domain of uniqueDomains) {
-    if (isLocalFederationDomain(domain)) {
+    if (isLocalDomain(domain, allowActorDomains)) {
       decisions.set(domain, true)
     } else {
       remoteDomains.push(domain)
@@ -96,7 +127,7 @@ const getFederationDecisionsForDomains = async (
     return !isBlocked
   })
 
-  if (getFederationMode() !== 'allowlist' || unblockedDomains.length === 0) {
+  if (mode !== 'allowlist' || unblockedDomains.length === 0) {
     return decisions
   }
 

--- a/lib/services/mastodon/constants.ts
+++ b/lib/services/mastodon/constants.ts
@@ -21,6 +21,13 @@ export const MAX_POLL_OPTION_CHARS = 50
 export const MIN_POLL_EXPIRATION_SECONDS = 5 * 60
 export const MAX_POLL_EXPIRATION_SECONDS = 60 * 60 * 24 * 31
 
+// Absolute safety ceilings for the poll create/edit request schema. The
+// admin-configured poll limits (server settings) are enforced at runtime and
+// never exceed these, so the schema stays bounded regardless of settings while
+// still allowing an admin to raise the limits above the Mastodon defaults.
+export const POLL_OPTIONS_CEILING = 50
+export const POLL_OPTION_CHARS_CEILING = 1000
+
 // Mastodon rejects a scheduled_at less than five minutes in the future.
 export const MIN_SCHEDULED_STATUS_AHEAD_MS = 5 * 60 * 1000
 export const SCHEDULED_AT_TOO_SOON_ERROR =

--- a/lib/services/serverSettings/index.test.ts
+++ b/lib/services/serverSettings/index.test.ts
@@ -132,6 +132,74 @@ describe('server settings resolver', () => {
     await database.destroy()
   })
 
+  it('re-reads the database after the cache TTL expires', async () => {
+    const database = await freshDatabase()
+    const spy = vi.spyOn(database, 'getAllServerSettings')
+
+    await getResolvedServerSettings(database)
+    await getResolvedServerSettings(database)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    vi.useFakeTimers()
+    try {
+      vi.advanceTimersByTime(60_000)
+      await getResolvedServerSettings(database)
+      expect(spy).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+    spy.mockRestore()
+    await database.destroy()
+  })
+
+  it('falls back to env + defaults when the settings read fails with no prior cache', async () => {
+    const database = await freshDatabase()
+    const spy = vi
+      .spyOn(database, 'getAllServerSettings')
+      .mockRejectedValue(new Error('database unavailable'))
+    process.env.ACTIVITIES_SERVICE_NAME = 'Env Name'
+    invalidateServerSettingsCache(database)
+
+    const settings = await getResolvedServerSettings(database)
+    // Env override still applies; everything else is the registry default.
+    expect(settings.instance.name).toBe('Env Name')
+    expect(settings.registrations.open).toBe(
+      DEFAULT_SERVER_SETTINGS.registrations.open
+    )
+
+    spy.mockRestore()
+    await database.destroy()
+  })
+
+  it('keeps serving the last-known-good stored value when a later read fails', async () => {
+    const database = await freshDatabase()
+    await database.setServerSetting({ key: 'registrations.open', value: false })
+    invalidateServerSettingsCache(database)
+    // Prime the cache with the stored (closed) value.
+    await expect(getResolvedServerSettings(database)).resolves.toMatchObject({
+      registrations: { open: false }
+    })
+
+    vi.useFakeTimers()
+    try {
+      // Expire the cache, then make the re-read fail.
+      vi.advanceTimersByTime(60_000)
+      const spy = vi
+        .spyOn(database, 'getAllServerSettings')
+        .mockRejectedValue(new Error('database unavailable'))
+
+      // Must serve the stale stored value (closed), not revert to the
+      // permissive default (open).
+      const settings = await getResolvedServerSettings(database)
+      expect(settings.registrations.open).toBe(false)
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    } finally {
+      vi.useRealTimers()
+    }
+    await database.destroy()
+  })
+
   describe('updateServerSettings', () => {
     it('writes valid values and reflects them immediately', async () => {
       const database = await freshDatabase()

--- a/lib/services/serverSettings/index.test.ts
+++ b/lib/services/serverSettings/index.test.ts
@@ -1,0 +1,205 @@
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import {
+  getResolvedServerSettings,
+  getServerSettingsView,
+  invalidateServerSettingsCache,
+  updateServerSettings
+} from '@/lib/services/serverSettings'
+
+const ENV_KEYS = [
+  'ACTIVITIES_SERVICE_NAME',
+  'ACTIVITIES_SERVICE_DESCRIPTION',
+  'ACTIVITIES_LANGUAGES',
+  'ACTIVITIES_REGISTRATION_OPEN',
+  'ACTIVITIES_ALLOW_EMAILS',
+  'ACTIVITIES_MEDIA_STORAGE_MAX_FILE_SIZE',
+  'ACTIVITIES_REQUEST_TIMEOUT',
+  'ACTIVITIES_REQUEST_RETRY',
+  'ACTIVITIES_REQUEST_MAX_RESPONSE_SIZE_BYTES',
+  'ACTIVITIES_FEDERATION_MODE',
+  'ACTIVITIES_ALLOW_ACTOR_DOMAINS'
+]
+
+const freshDatabase = async () => {
+  const database = getTestSQLDatabase()
+  await database.migrate()
+  return database
+}
+
+describe('server settings resolver', () => {
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    savedEnv = {}
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key]
+      else process.env[key] = savedEnv[key]
+    }
+  })
+
+  it('returns registry defaults with no env and no stored rows', async () => {
+    const database = await freshDatabase()
+    await expect(getResolvedServerSettings(database)).resolves.toEqual(
+      DEFAULT_SERVER_SETTINGS
+    )
+    await database.destroy()
+  })
+
+  it('serves a stored database value over the default', async () => {
+    const database = await freshDatabase()
+    await database.setServerSetting({ key: 'posts.maxCharacters', value: 1000 })
+    invalidateServerSettingsCache(database)
+
+    const settings = await getResolvedServerSettings(database)
+    expect(settings.posts.maxCharacters).toBe(1000)
+    await database.destroy()
+  })
+
+  it('lets an env override win over a stored value and locks the field', async () => {
+    const database = await freshDatabase()
+    await database.setServerSetting({ key: 'instance.name', value: 'DB Name' })
+    process.env.ACTIVITIES_SERVICE_NAME = 'Env Name'
+    invalidateServerSettingsCache(database)
+
+    const view = await getServerSettingsView(database)
+    expect(view.settings.instance.name).toBe('Env Name')
+    expect(view.locks['instance.name']).toEqual({
+      locked: true,
+      envVar: 'ACTIVITIES_SERVICE_NAME'
+    })
+    await database.destroy()
+  })
+
+  it('marks fields without an env override as unlocked', async () => {
+    const database = await freshDatabase()
+    const view = await getServerSettingsView(database)
+    expect(view.locks['instance.name'].locked).toBe(false)
+    expect(view.locks['posts.maxCharacters'].locked).toBe(false)
+    await database.destroy()
+  })
+
+  it('ignores an invalid stored value and falls back to the default', async () => {
+    const database = await freshDatabase()
+    await database.setServerSetting({ key: 'posts.maxCharacters', value: -5 })
+    invalidateServerSettingsCache(database)
+
+    const settings = await getResolvedServerSettings(database)
+    expect(settings.posts.maxCharacters).toBe(
+      DEFAULT_SERVER_SETTINGS.posts.maxCharacters
+    )
+    await database.destroy()
+  })
+
+  it('parses env values the way getConfig does', async () => {
+    const database = await freshDatabase()
+    process.env.ACTIVITIES_REGISTRATION_OPEN = 'false'
+    process.env.ACTIVITIES_LANGUAGES = '["en","th"]'
+    process.env.ACTIVITIES_ALLOW_EMAILS = '["A@Example.com"]'
+    process.env.ACTIVITIES_FEDERATION_MODE = 'allowlist'
+    process.env.ACTIVITIES_REQUEST_TIMEOUT = '8000'
+    invalidateServerSettingsCache(database)
+
+    const settings = await getResolvedServerSettings(database)
+    expect(settings.registrations.open).toBe(false)
+    expect(settings.instance.languages).toEqual(['en', 'th'])
+    expect(settings.registrations.allowEmails).toEqual(['a@example.com'])
+    expect(settings.federation.mode).toBe('allowlist')
+    expect(settings.network.requestTimeoutMs).toBe(8000)
+    await database.destroy()
+  })
+
+  it('caches within the TTL and re-reads after invalidation', async () => {
+    const database = await freshDatabase()
+    const spy = vi.spyOn(database, 'getAllServerSettings')
+
+    await getResolvedServerSettings(database)
+    await getResolvedServerSettings(database)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    invalidateServerSettingsCache(database)
+    await getResolvedServerSettings(database)
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    spy.mockRestore()
+    await database.destroy()
+  })
+
+  describe('updateServerSettings', () => {
+    it('writes valid values and reflects them immediately', async () => {
+      const database = await freshDatabase()
+      const result = await updateServerSettings(database, {
+        'posts.maxCharacters': 2000,
+        'network.requestRetries': 3
+      })
+
+      expect(result.applied).toBe(true)
+      expect(result.rejected).toEqual([])
+      expect(result.view.settings.posts.maxCharacters).toBe(2000)
+      expect(result.view.settings.network.requestRetries).toBe(3)
+      await database.destroy()
+    })
+
+    it('rejects the whole patch when a key is env-locked and writes nothing', async () => {
+      const database = await freshDatabase()
+      process.env.ACTIVITIES_SERVICE_NAME = 'Env Name'
+      invalidateServerSettingsCache(database)
+
+      const result = await updateServerSettings(database, {
+        'instance.name': 'Should Not Save',
+        'posts.maxCharacters': 900
+      })
+
+      expect(result.applied).toBe(false)
+      expect(result.rejected).toContainEqual({
+        key: 'instance.name',
+        reason: 'locked'
+      })
+
+      invalidateServerSettingsCache(database)
+      const settings = await getResolvedServerSettings(database)
+      expect(settings.posts.maxCharacters).toBe(
+        DEFAULT_SERVER_SETTINGS.posts.maxCharacters
+      )
+      await database.destroy()
+    })
+
+    it('rejects unknown keys and invalid values', async () => {
+      const database = await freshDatabase()
+      const result = await updateServerSettings(database, {
+        'nope.key': 1,
+        'posts.maxCharacters': -3
+      })
+
+      expect(result.applied).toBe(false)
+      expect(result.rejected).toEqual(
+        expect.arrayContaining([
+          { key: 'nope.key', reason: 'unknown' },
+          { key: 'posts.maxCharacters', reason: 'invalid' }
+        ])
+      )
+      await database.destroy()
+    })
+
+    it('normalizes allowed emails on write', async () => {
+      const database = await freshDatabase()
+      const result = await updateServerSettings(database, {
+        'registrations.allowEmails': ['User@Example.COM', ' second@x.test ']
+      })
+
+      expect(result.applied).toBe(true)
+      expect(result.view.settings.registrations.allowEmails).toEqual([
+        'user@example.com',
+        'second@x.test'
+      ])
+      await database.destroy()
+    })
+  })
+})

--- a/lib/services/serverSettings/index.ts
+++ b/lib/services/serverSettings/index.ts
@@ -132,8 +132,11 @@ export const getServerSettingsView = async (
         'serverSettings: failed to read stored settings; serving cached values or env/defaults',
       error: error instanceof Error ? error.message : String(error)
     })
-    if (entry) return entry.view
-    const view = buildView(new Map())
+    // Re-cache the served view briefly (whether the stale last-known-good entry
+    // or the env/defaults fallback) so a sustained outage does not re-read the
+    // failing database — and re-log — on every request; recovery stays bounded
+    // to FAILURE_CACHE_TTL_MS.
+    const view = entry ? entry.view : buildView(new Map())
     writeCache(database, view, now + FAILURE_CACHE_TTL_MS)
     return view
   }

--- a/lib/services/serverSettings/index.ts
+++ b/lib/services/serverSettings/index.ts
@@ -8,14 +8,25 @@ import {
 import { getDatabase } from '@/lib/database'
 import { Database } from '@/lib/database/types'
 import { ServerSettingValue } from '@/lib/types/database/operations'
+import { logger } from '@/lib/utils/logger'
 
 // Resolves database-backed server settings using env -> database -> default
 // precedence. An env var always wins and locks its field; otherwise a stored
 // database row wins; otherwise the registry default applies. Resolved values
 // are cached per database instance with a short TTL so hot paths (inbox
 // verification, outbound request fan-out) do not pay a database read per call.
+//
+// The TTL also bounds how long another instance/pod serves a stale value after
+// an admin saves: an admin's own write invalidates the local cache immediately,
+// but on a multi-instance deployment other instances converge within one TTL.
+// Keep it short so a security-tightening change (closing registration, enabling
+// an allowlist) propagates promptly.
 
-const CACHE_TTL_MS = 30_000
+const CACHE_TTL_MS = 15_000
+// A read failure caches env + defaults only briefly, so the resolver recovers
+// within seconds once the database is healthy again instead of serving the
+// fallback for a full TTL.
+const FAILURE_CACHE_TTL_MS = 2_000
 
 export interface ServerSettingLock {
   locked: boolean
@@ -48,23 +59,13 @@ type CacheEntry = { view: ServerSettingsView; expiresAt: number }
 const cacheByDatabase = new WeakMap<Database, CacheEntry>()
 let nullDatabaseCache: CacheEntry | null = null
 
-const resolve = async (
-  database: Database | null
-): Promise<ServerSettingsView> => {
+// Build the resolved view from the already-read stored rows (no I/O):
+// default -> database (valid rows only) -> env (wins and locks the field).
+const buildView = (
+  storedByKey: Map<string, ServerSettingValue>
+): ServerSettingsView => {
   const settings = structuredClone(DEFAULT_SERVER_SETTINGS)
   const locks: Record<string, ServerSettingLock> = {}
-
-  let storedByKey = new Map<string, ServerSettingValue>()
-  if (database) {
-    try {
-      const rows = await database.getAllServerSettings()
-      storedByKey = new Map(rows.map((row) => [row.key, row.value]))
-    } catch {
-      // A settings read failure must never take down a request path; fall back
-      // to env + defaults.
-      storedByKey = new Map()
-    }
-  }
 
   for (const settingField of SERVER_SETTING_FIELDS) {
     // Database value wins over the default, when present and still valid.
@@ -78,32 +79,24 @@ const resolve = async (
     const envValue = settingField.readEnv()
     if (envValue !== undefined) {
       settingField.set(settings, envValue)
-      locks[settingField.key] = {
-        locked: true,
-        envVar: settingField.envVar
-      }
+      locks[settingField.key] = { locked: true, envVar: settingField.envVar }
     } else {
-      locks[settingField.key] = {
-        locked: false,
-        envVar: settingField.envVar
-      }
+      locks[settingField.key] = { locked: false, envVar: settingField.envVar }
     }
   }
 
   return { settings, locks }
 }
 
-const readCache = (database: Database | null, now: number) => {
-  const entry = database ? cacheByDatabase.get(database) : nullDatabaseCache
-  return entry && entry.expiresAt > now ? entry.view : null
-}
+const readCacheEntry = (database: Database | null): CacheEntry | null =>
+  (database ? cacheByDatabase.get(database) : nullDatabaseCache) ?? null
 
 const writeCache = (
   database: Database | null,
   view: ServerSettingsView,
-  now: number
+  expiresAt: number
 ) => {
-  const entry: CacheEntry = { view, expiresAt: now + CACHE_TTL_MS }
+  const entry: CacheEntry = { view, expiresAt }
   if (database) cacheByDatabase.set(database, entry)
   else nullDatabaseCache = entry
 }
@@ -113,11 +106,40 @@ export const getServerSettingsView = async (
   database: Database | null = getDatabase()
 ): Promise<ServerSettingsView> => {
   const now = Date.now()
-  const cached = readCache(database, now)
-  if (cached) return cached
+  const entry = readCacheEntry(database)
+  if (entry && entry.expiresAt > now) return entry.view
 
-  const view = await resolve(database)
-  writeCache(database, view, now)
+  // No configured database: env + defaults only.
+  if (!database) {
+    const view = buildView(new Map())
+    writeCache(null, view, now + CACHE_TTL_MS)
+    return view
+  }
+
+  let storedByKey: Map<string, ServerSettingValue>
+  try {
+    const rows = await database.getAllServerSettings()
+    storedByKey = new Map(rows.map((row) => [row.key, row.value]))
+  } catch (error) {
+    // A settings read failure must never take down a request path, but it must
+    // also not silently revert an admin's stored policy (a closed registration,
+    // an allowlist) to the permissive default. Prefer the last-known-good cached
+    // view even if it has expired; only when there is none fall back to env +
+    // defaults, cached briefly so recovery is fast. Always log so the fallback
+    // window is observable.
+    logger.error({
+      message:
+        'serverSettings: failed to read stored settings; serving cached values or env/defaults',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    if (entry) return entry.view
+    const view = buildView(new Map())
+    writeCache(database, view, now + FAILURE_CACHE_TTL_MS)
+    return view
+  }
+
+  const view = buildView(storedByKey)
+  writeCache(database, view, now + CACHE_TTL_MS)
   return view
 }
 
@@ -135,9 +157,11 @@ export const invalidateServerSettingsCache = (
   else nullDatabaseCache = null
 }
 
-// Applies a partial { key: value } patch atomically: every entry is validated
-// against its registry schema and rejected if the key is unknown, env-locked,
-// or fails validation. When anything is rejected, nothing is written.
+// Applies a partial { key: value } patch: every entry is validated against its
+// registry schema and rejected if the key is unknown, env-locked, or fails
+// validation. When anything is rejected, nothing is written. Accepted entries
+// are persisted in a single transaction, so a mid-batch database failure rolls
+// back and the patch is genuinely all-or-nothing.
 export const updateServerSettings = async (
   database: Database,
   patch: Record<string, unknown>
@@ -168,10 +192,13 @@ export const updateServerSettings = async (
     return { view, rejected, applied: false }
   }
 
-  for (const { key, value } of validated) {
-    await database.setServerSetting({ key, value })
+  try {
+    await database.setServerSettings(validated)
+  } finally {
+    // Invalidate even if the write threw so the cache never masks the persisted
+    // state (a rolled-back transaction leaves the stored values unchanged).
+    invalidateServerSettingsCache(database)
   }
-  invalidateServerSettingsCache(database)
   const updated = await getServerSettingsView(database)
   return { view: updated, rejected: [], applied: true }
 }

--- a/lib/services/serverSettings/index.ts
+++ b/lib/services/serverSettings/index.ts
@@ -1,0 +1,189 @@
+import {
+  DEFAULT_SERVER_SETTINGS,
+  ResolvedServerSettings,
+  SERVER_SETTING_FIELDS,
+  SERVER_SETTING_FIELDS_BY_KEY,
+  ServerSettingTab
+} from '@/lib/config/serverSettings'
+import { getDatabase } from '@/lib/database'
+import { Database } from '@/lib/database/types'
+import { ServerSettingValue } from '@/lib/types/database/operations'
+
+// Resolves database-backed server settings using env -> database -> default
+// precedence. An env var always wins and locks its field; otherwise a stored
+// database row wins; otherwise the registry default applies. Resolved values
+// are cached per database instance with a short TTL so hot paths (inbox
+// verification, outbound request fan-out) do not pay a database read per call.
+
+const CACHE_TTL_MS = 30_000
+
+export interface ServerSettingLock {
+  locked: boolean
+  envVar?: string
+}
+
+export interface ServerSettingsView {
+  settings: ResolvedServerSettings
+  locks: Record<string, ServerSettingLock>
+}
+
+export type ServerSettingRejectionReason = 'unknown' | 'locked' | 'invalid'
+
+export interface ServerSettingRejection {
+  key: string
+  reason: ServerSettingRejectionReason
+}
+
+export interface ServerSettingUpdateResult {
+  view: ServerSettingsView
+  rejected: ServerSettingRejection[]
+  applied: boolean
+}
+
+type CacheEntry = { view: ServerSettingsView; expiresAt: number }
+
+// Cache is keyed by the database instance so the production singleton is cached
+// while each test's throwaway database resolves independently. A null database
+// (no configured backend) has its own slot.
+const cacheByDatabase = new WeakMap<Database, CacheEntry>()
+let nullDatabaseCache: CacheEntry | null = null
+
+const resolve = async (
+  database: Database | null
+): Promise<ServerSettingsView> => {
+  const settings = structuredClone(DEFAULT_SERVER_SETTINGS)
+  const locks: Record<string, ServerSettingLock> = {}
+
+  let storedByKey = new Map<string, ServerSettingValue>()
+  if (database) {
+    try {
+      const rows = await database.getAllServerSettings()
+      storedByKey = new Map(rows.map((row) => [row.key, row.value]))
+    } catch {
+      // A settings read failure must never take down a request path; fall back
+      // to env + defaults.
+      storedByKey = new Map()
+    }
+  }
+
+  for (const settingField of SERVER_SETTING_FIELDS) {
+    // Database value wins over the default, when present and still valid.
+    const storedValue = storedByKey.get(settingField.key)
+    if (storedValue !== undefined) {
+      const parsed = settingField.schema.safeParse(storedValue)
+      if (parsed.success) settingField.set(settings, parsed.data)
+    }
+
+    // Env override wins over everything and locks the field.
+    const envValue = settingField.readEnv()
+    if (envValue !== undefined) {
+      settingField.set(settings, envValue)
+      locks[settingField.key] = {
+        locked: true,
+        envVar: settingField.envVar
+      }
+    } else {
+      locks[settingField.key] = {
+        locked: false,
+        envVar: settingField.envVar
+      }
+    }
+  }
+
+  return { settings, locks }
+}
+
+const readCache = (database: Database | null, now: number) => {
+  const entry = database ? cacheByDatabase.get(database) : nullDatabaseCache
+  return entry && entry.expiresAt > now ? entry.view : null
+}
+
+const writeCache = (
+  database: Database | null,
+  view: ServerSettingsView,
+  now: number
+) => {
+  const entry: CacheEntry = { view, expiresAt: now + CACHE_TTL_MS }
+  if (database) cacheByDatabase.set(database, entry)
+  else nullDatabaseCache = entry
+}
+
+// Full resolved settings + lock metadata for the admin UI/API. Cached.
+export const getServerSettingsView = async (
+  database: Database | null = getDatabase()
+): Promise<ServerSettingsView> => {
+  const now = Date.now()
+  const cached = readCache(database, now)
+  if (cached) return cached
+
+  const view = await resolve(database)
+  writeCache(database, view, now)
+  return view
+}
+
+// The resolved values consumers read (limits, policy, identity). Cached.
+export const getResolvedServerSettings = async (
+  database: Database | null = getDatabase()
+): Promise<ResolvedServerSettings> =>
+  (await getServerSettingsView(database)).settings
+
+// Drops the cached view so the next read reflects a fresh env/database state.
+export const invalidateServerSettingsCache = (
+  database: Database | null = getDatabase()
+) => {
+  if (database) cacheByDatabase.delete(database)
+  else nullDatabaseCache = null
+}
+
+// Applies a partial { key: value } patch atomically: every entry is validated
+// against its registry schema and rejected if the key is unknown, env-locked,
+// or fails validation. When anything is rejected, nothing is written.
+export const updateServerSettings = async (
+  database: Database,
+  patch: Record<string, unknown>
+): Promise<ServerSettingUpdateResult> => {
+  const view = await getServerSettingsView(database)
+  const validated: { key: string; value: ServerSettingValue }[] = []
+  const rejected: ServerSettingRejection[] = []
+
+  for (const [key, value] of Object.entries(patch)) {
+    const settingField = SERVER_SETTING_FIELDS_BY_KEY[key]
+    if (!settingField) {
+      rejected.push({ key, reason: 'unknown' })
+      continue
+    }
+    if (view.locks[key]?.locked) {
+      rejected.push({ key, reason: 'locked' })
+      continue
+    }
+    const parsed = settingField.schema.safeParse(value)
+    if (!parsed.success) {
+      rejected.push({ key, reason: 'invalid' })
+      continue
+    }
+    validated.push({ key, value: parsed.data as ServerSettingValue })
+  }
+
+  if (rejected.length > 0) {
+    return { view, rejected, applied: false }
+  }
+
+  for (const { key, value } of validated) {
+    await database.setServerSetting({ key, value })
+  }
+  invalidateServerSettingsCache(database)
+  const updated = await getServerSettingsView(database)
+  return { view: updated, rejected: [], applied: true }
+}
+
+// Field metadata (key, tab, env var) for the admin API to describe each field.
+export const getServerSettingFieldsMeta = (): {
+  key: string
+  group: ServerSettingTab
+  envVar?: string
+}[] =>
+  SERVER_SETTING_FIELDS.map(({ key, group, envVar }) => ({
+    key,
+    group,
+    envVar
+  }))

--- a/lib/services/statuses/contentLimits.test.ts
+++ b/lib/services/statuses/contentLimits.test.ts
@@ -1,0 +1,90 @@
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
+
+import { validateStatusContentLimits } from './contentLimits'
+
+const settingsWith = (
+  overrides: Partial<{
+    maxCharacters: number
+    maxOptions: number
+    maxCharactersPerOption: number
+    minExpirationSeconds: number
+    maxExpirationSeconds: number
+  }> = {}
+) => ({
+  ...structuredClone(DEFAULT_SERVER_SETTINGS),
+  posts: {
+    ...DEFAULT_SERVER_SETTINGS.posts,
+    maxCharacters: overrides.maxCharacters ?? 500
+  },
+  polls: {
+    maxOptions: overrides.maxOptions ?? 4,
+    maxCharactersPerOption: overrides.maxCharactersPerOption ?? 50,
+    minExpirationSeconds: overrides.minExpirationSeconds ?? 300,
+    maxExpirationSeconds: overrides.maxExpirationSeconds ?? 2678400
+  }
+})
+
+describe('validateStatusContentLimits', () => {
+  it('accepts text within the character limit', () => {
+    expect(
+      validateStatusContentLimits({ status: 'hello' }, settingsWith())
+    ).toBeNull()
+  })
+
+  it('rejects text over the resolved character limit', () => {
+    const result = validateStatusContentLimits(
+      { status: 'x'.repeat(11) },
+      settingsWith({ maxCharacters: 10 })
+    )
+    expect(result).toBe('Text character limit of 10 exceeded')
+  })
+
+  it('allows a longer post when the limit is raised', () => {
+    expect(
+      validateStatusContentLimits(
+        { status: 'x'.repeat(1000) },
+        settingsWith({ maxCharacters: 5000 })
+      )
+    ).toBeNull()
+  })
+
+  it('rejects a poll with too many options', () => {
+    const result = validateStatusContentLimits(
+      { poll: { options: ['a', 'b', 'c', 'd', 'e'], expires_in: 3600 } },
+      settingsWith({ maxOptions: 4 })
+    )
+    expect(result).toBe('Poll cannot have more than 4 options')
+  })
+
+  it('accepts more poll options when the limit is raised', () => {
+    expect(
+      validateStatusContentLimits(
+        { poll: { options: ['a', 'b', 'c', 'd', 'e', 'f'], expires_in: 3600 } },
+        settingsWith({ maxOptions: 6 })
+      )
+    ).toBeNull()
+  })
+
+  it('rejects a poll option over the per-option character limit', () => {
+    const result = validateStatusContentLimits(
+      { poll: { options: ['ok', 'x'.repeat(51)], expires_in: 3600 } },
+      settingsWith({ maxCharactersPerOption: 50 })
+    )
+    expect(result).toBe('Poll option character limit of 50 exceeded')
+  })
+
+  it('rejects a poll expiry outside the resolved range', () => {
+    expect(
+      validateStatusContentLimits(
+        { poll: { options: ['a', 'b'], expires_in: 60 } },
+        settingsWith({ minExpirationSeconds: 300 })
+      )
+    ).toBe('Poll expiration is out of range')
+    expect(
+      validateStatusContentLimits(
+        { poll: { options: ['a', 'b'], expires_in: 9999999 } },
+        settingsWith({ maxExpirationSeconds: 2678400 })
+      )
+    ).toBe('Poll expiration is out of range')
+  })
+})

--- a/lib/services/statuses/contentLimits.ts
+++ b/lib/services/statuses/contentLimits.ts
@@ -1,0 +1,46 @@
+import { ResolvedServerSettings } from '@/lib/config/serverSettings'
+
+export interface StatusContentToValidate {
+  status?: string
+  // expires_in is optional on edit (omitted keeps the current expiry), so the
+  // expiry range is only checked when a value is provided.
+  poll?: { options: string[]; expires_in?: number } | null
+}
+
+// Enforces the admin-configured status/poll limits (server settings) after the
+// request schema has validated structure. Returns a Mastodon-style error
+// message when the text or poll exceeds a resolved limit, or null when within
+// limits. Shared by the create and edit routes so the two cannot drift.
+export const validateStatusContentLimits = (
+  content: StatusContentToValidate,
+  settings: ResolvedServerSettings
+): string | null => {
+  const text = content.status ?? ''
+  if (text.length > settings.posts.maxCharacters) {
+    return `Text character limit of ${settings.posts.maxCharacters} exceeded`
+  }
+
+  const poll = content.poll
+  if (poll) {
+    const { polls } = settings
+    if (poll.options.length > polls.maxOptions) {
+      return `Poll cannot have more than ${polls.maxOptions} options`
+    }
+    if (
+      poll.options.some(
+        (option) => option.length > polls.maxCharactersPerOption
+      )
+    ) {
+      return `Poll option character limit of ${polls.maxCharactersPerOption} exceeded`
+    }
+    if (
+      poll.expires_in !== undefined &&
+      (poll.expires_in < polls.minExpirationSeconds ||
+        poll.expires_in > polls.maxExpirationSeconds)
+    ) {
+      return 'Poll expiration is out of range'
+    }
+  }
+
+  return null
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1953,6 +1953,40 @@ export interface InstanceRuleDatabase {
 }
 
 // ============================================================================
+// Server Setting Database
+// ============================================================================
+
+// A single database-backed instance server setting, stored as one key/value
+// row. `key` is the registry key (e.g. `posts.maxCharacters`) and `value` is
+// the decoded JSON value. `createdAt`/`updatedAt` are epoch milliseconds in the
+// domain shape regardless of the backend's timestamp storage. The env ->
+// database -> default resolver overlays these rows onto env/default values.
+export type ServerSettingValue = string | number | boolean | string[] | null
+
+export type ServerSettingData = {
+  key: string
+  value: ServerSettingValue
+  createdAt: number
+  updatedAt: number
+}
+
+export type GetServerSettingParams = { key: string }
+export type SetServerSettingParams = { key: string; value: ServerSettingValue }
+export type DeleteServerSettingParams = { key: string }
+
+export interface ServerSettingDatabase {
+  getServerSetting(
+    params: GetServerSettingParams
+  ): Promise<ServerSettingData | null>
+  // Every stored setting row, ordered by key ascending.
+  getAllServerSettings(): Promise<ServerSettingData[]>
+  // Upsert; overwrites value and bumps updatedAt, returning the stored row.
+  setServerSetting(params: SetServerSettingParams): Promise<ServerSettingData>
+  // True when a row was removed.
+  deleteServerSetting(params: DeleteServerSettingParams): Promise<boolean>
+}
+
+// ============================================================================
 // Relay Database
 // ============================================================================
 

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1982,6 +1982,8 @@ export interface ServerSettingDatabase {
   getAllServerSettings(): Promise<ServerSettingData[]>
   // Upsert; overwrites value and bumps updatedAt, returning the stored row.
   setServerSetting(params: SetServerSettingParams): Promise<ServerSettingData>
+  // Upsert several settings in a single transaction (all-or-nothing).
+  setServerSettings(params: SetServerSettingParams[]): Promise<void>
   // True when a row was removed.
   deleteServerSetting(params: DeleteServerSettingParams): Promise<boolean>
 }

--- a/lib/utils/getActorFromSession.test.ts
+++ b/lib/utils/getActorFromSession.test.ts
@@ -1,9 +1,10 @@
-import { getConfig } from '@/lib/config'
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
 import { Database } from '@/lib/database/types'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { getAccountFromSession } from '@/lib/utils/getActorFromSession'
 
-vi.mock('@/lib/config', () => ({
-  getConfig: vi.fn()
+vi.mock('@/lib/services/serverSettings', () => ({
+  getResolvedServerSettings: vi.fn()
 }))
 
 vi.mock('next/headers', () => ({
@@ -15,8 +16,11 @@ const account = { id: 'account-1', email: 'user@example.com' }
 const databaseWith = (getAccountFromEmail: jest.Mock) =>
   ({ getAccountFromEmail }) as unknown as Database
 
-const mockConfig = (allowEmails: string[]) => {
-  vi.mocked(getConfig).mockReturnValue({ allowEmails } as never)
+const mockAllowEmails = (allowEmails: string[]) => {
+  vi.mocked(getResolvedServerSettings).mockResolvedValue({
+    ...structuredClone(DEFAULT_SERVER_SETTINGS),
+    registrations: { open: true, allowEmails }
+  })
 }
 
 describe('getAccountFromSession', () => {
@@ -25,7 +29,7 @@ describe('getAccountFromSession', () => {
   })
 
   it('returns null when there is no signed-in email', async () => {
-    mockConfig([])
+    mockAllowEmails([])
     const getAccountFromEmail = vi.fn()
     const result = await getAccountFromSession(
       databaseWith(getAccountFromEmail),
@@ -36,7 +40,7 @@ describe('getAccountFromSession', () => {
   })
 
   it('allows any signed-in email when the allowlist is empty', async () => {
-    mockConfig([])
+    mockAllowEmails([])
     const getAccountFromEmail = vi.fn().mockResolvedValue(account)
     const result = await getAccountFromSession(
       databaseWith(getAccountFromEmail),
@@ -59,7 +63,7 @@ describe('getAccountFromSession', () => {
   ])(
     'allows the account when $description',
     async ({ allowEmails, sessionEmail }) => {
-      mockConfig(allowEmails)
+      mockAllowEmails(allowEmails)
       const getAccountFromEmail = vi.fn().mockResolvedValue(account)
       const result = await getAccountFromSession(
         databaseWith(getAccountFromEmail),
@@ -71,7 +75,7 @@ describe('getAccountFromSession', () => {
   )
 
   it('blocks an email that is not in the allowlist regardless of case', async () => {
-    mockConfig(['allowed@example.com'])
+    mockAllowEmails(['allowed@example.com'])
     const getAccountFromEmail = vi.fn()
     const result = await getAccountFromSession(
       databaseWith(getAccountFromEmail),

--- a/lib/utils/getActorFromSession.ts
+++ b/lib/utils/getActorFromSession.ts
@@ -1,8 +1,8 @@
 import { cookies } from 'next/headers'
 import { cache } from 'react'
 
-import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { isEmailAllowed } from '@/lib/utils/normalizeEmail'
 
 export interface AuthSession {
@@ -30,8 +30,8 @@ export const getAccountFromSession = async (
 ) => {
   if (!session?.user?.email) return null
 
-  const config = getConfig()
-  if (!isEmailAllowed(config.allowEmails, session.user.email)) {
+  const settings = await getResolvedServerSettings(database)
+  if (!isEmailAllowed(settings.registrations.allowEmails, session.user.email)) {
     return null
   }
 

--- a/lib/utils/request.test.ts
+++ b/lib/utils/request.test.ts
@@ -1,8 +1,14 @@
 import fetchMock, { enableFetchMocks } from 'jest-fetch-mock'
 
 import { getConfig } from '@/lib/config'
+import { DEFAULT_SERVER_SETTINGS } from '@/lib/config/serverSettings'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 
 import { request } from './request'
+
+vi.mock('@/lib/services/serverSettings', () => ({
+  getResolvedServerSettings: vi.fn()
+}))
 
 vi.mock('got', async () => {
   type GotMockOptions = {
@@ -96,6 +102,9 @@ describe('request utility', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
     mockGetConfig.mockReturnValue(defaultConfig)
+    vi.mocked(getResolvedServerSettings).mockResolvedValue(
+      structuredClone(DEFAULT_SERVER_SETTINGS)
+    )
   })
 
   describe('request', () => {
@@ -492,6 +501,34 @@ describe('request utility', () => {
         statusCode: 200
       })
       expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries using the database-backed retry count', async () => {
+      vi.useFakeTimers()
+      vi.mocked(getResolvedServerSettings).mockResolvedValue({
+        ...structuredClone(DEFAULT_SERVER_SETTINGS),
+        network: {
+          requestTimeoutMs: 4000,
+          requestRetries: 2,
+          maxResponseSizeBytes: 2 * 1024 * 1024
+        }
+      })
+      const error = Object.assign(new Error('connection reset'), {
+        code: 'ECONNRESET'
+      })
+      fetchMock.mockRejectOnce(error)
+      fetchMock.mockRejectOnce(error)
+      fetchMock.mockResponseOnce('ok', { status: 200 })
+
+      const responsePromise = request({ url: 'https://example.com/api/test' })
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await expect(responsePromise).resolves.toMatchObject({
+        body: 'ok',
+        statusCode: 200
+      })
+      // Initial attempt plus the two database-backed retries.
+      expect(fetchMock).toHaveBeenCalledTimes(3)
     })
 
     it('preserves configured null retry noise', async () => {

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -1,7 +1,7 @@
 import { getConfig } from '@/lib/config'
+import { getResolvedServerSettings } from '@/lib/services/serverSettings'
 import { getHeaderValue } from '@/lib/utils/getHeaderValue'
 import {
-  DEFAULT_SAFE_REMOTE_FETCH_MAX_BODY_BYTES,
   SafeRemoteFetchHeaderBuilderRequest,
   SafeRemoteFetchHeaderSource,
   SafeRemoteFetchMethod,
@@ -11,8 +11,6 @@ import { waitFor } from '@/lib/utils/waitFor'
 import packageJson from '@/package.json'
 
 const USER_AGENT = `activities.next/${packageJson.version}`
-const DEFAULT_RESPONSE_TIMEOUT = 10000
-const MAX_RETRY_LIMIT = 1
 const DEFAULT_RETRY_NOISE = 100
 const RETRY_BACKOFF_LIMIT = 30_000
 const RETRYABLE_METHODS = new Set([
@@ -63,7 +61,7 @@ export interface RequestResult {
   body: string
 }
 
-const getRequestOptions = ({
+const getRequestOptions = async ({
   method = 'GET',
   headers,
   body,
@@ -73,21 +71,20 @@ const getRequestOptions = ({
   maxResponseSize
 }: Omit<RequestOptions, 'url'>) => {
   const config = getConfig()
-  const retryLimit = config.request?.numberOfRetry ?? MAX_RETRY_LIMIT
+  // Timeout, retries, and the response-size cap are database-backed settings
+  // (env -> database -> default). retryNoise stays an env-only knob.
+  const { network } = await getResolvedServerSettings()
+  const retryLimit = network.requestRetries
   const configRetryNoise = config.request?.retryNoise
   const configuredRetryNoise =
     typeof configRetryNoise === 'number' || configRetryNoise === null
       ? configRetryNoise
       : DEFAULT_RETRY_NOISE
-  const defaultResponseTimeout =
-    responseTimeout ||
-    config.request?.timeoutInMilliseconds ||
-    DEFAULT_RESPONSE_TIMEOUT
+  const defaultResponseTimeout = responseTimeout || network.requestTimeoutMs
   const maxBodyBytes =
     typeof maxResponseSize === 'number'
       ? maxResponseSize
-      : (config.request?.maxResponseSizeInBytes ??
-        DEFAULT_SAFE_REMOTE_FETCH_MAX_BODY_BYTES)
+      : network.maxResponseSizeBytes
 
   return {
     body,
@@ -190,7 +187,7 @@ export const request = async ({
   retryNoise,
   maxResponseSize
 }: RequestOptions): Promise<RequestResult> => {
-  const options = getRequestOptions({
+  const options = await getRequestOptions({
     method,
     headers,
     body,

--- a/migrations/20260723000000_add_server_settings.js
+++ b/migrations/20260723000000_add_server_settings.js
@@ -1,0 +1,29 @@
+/**
+ * Stores database-backed instance server settings as key/value rows. Backs the
+ * admin server-settings pages (Instance, Posts & media, Network) and the
+ * federation-policy block. Each row is one setting: `key` is the registry key
+ * (e.g. `posts.maxCharacters`) and `value` holds its JSON-encoded value.
+ *
+ * The env -> database -> default resolver reads these rows; when the matching
+ * environment variable is set it still wins and locks the field, so a row here
+ * is only consulted for settings that are not pinned by the environment.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = async (knex) => {
+  await knex.schema.createTable('server_settings', (table) => {
+    table.string('key').primary()
+    table.text('value').notNullable()
+    table.timestamp('createdAt').notNullable()
+    table.timestamp('updatedAt').notNullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = async (knex) => {
+  await knex.schema.dropTableIfExists('server_settings')
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -902,6 +902,13 @@ CREATE TABLE public.server_filters (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE public.server_settings (
+    key character varying(255) NOT NULL,
+    value text NOT NULL,
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL
+);
+
 CREATE TABLE public.sessions (
     id character varying(255) NOT NULL,
     "accountId" character varying(255),
@@ -1407,6 +1414,9 @@ ALTER TABLE ONLY public.server_filter_keywords
 
 ALTER TABLE ONLY public.server_filters
     ADD CONSTRAINT server_filters_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.server_settings
+    ADD CONSTRAINT server_settings_pkey PRIMARY KEY (key);
 
 ALTER TABLE ONLY public.sessions
     ADD CONSTRAINT sessions_pkey PRIMARY KEY (id);

--- a/migrations/schema.sqlite.sql
+++ b/migrations/schema.sqlite.sql
@@ -245,3 +245,4 @@ CREATE INDEX `status_quotes_authorization_idx` on `status_quotes` (`authorizatio
 CREATE TABLE `moderation_actions` (`id` varchar(255), `targetActorId` varchar(255) not null, `moderatorAccountId` varchar(255) not null, `moderatorActorId` varchar(255) null, `action` varchar(32) not null, `reportId` varchar(255) null, `text` text not null default '', `createdAt` datetime default CURRENT_TIMESTAMP, primary key (`id`));
 CREATE INDEX `moderation_actions_target_idx` on `moderation_actions` (`targetActorId`, `createdAt`);
 CREATE INDEX `moderation_actions_report_idx` on `moderation_actions` (`reportId`);
+CREATE TABLE `server_settings` (`key` varchar(255), `value` text not null, `createdAt` datetime not null, `updatedAt` datetime not null, primary key (`key`));


### PR DESCRIPTION
## Summary

Moves instance server settings out of `ACTIVITIES_*` environment variables and hardcoded constants into a database-backed settings layer that admins can edit from the UI, resolved by **`env → database → default`** precedence: an environment variable always wins and locks the field with a "Set by environment" badge, so removing the variable hands control back to the admin form.

Implements the `ui_kits/web/admin-settings.html` design (Activities.next Design System).

### What's included

- **New `server_settings` table** + `ServerSettingDatabase` operations (both reference schema dumps regenerated).
- **Registry + resolver** (`lib/config/serverSettings.ts` + `lib/services/serverSettings/`): typed settings with per-field lock metadata, atomic validated writes, and a per-database TTL cache so hot paths (inbox verification, outbound requests) don't pay a DB read per call.
- **Admin API** `GET`/`PATCH /api/v1/admin/server_settings` + `lib/client.ts` helpers.
- **Three new admin tabs** in a "Settings" group of the admin dropdown (before System):
  - **Instance** — name, description, contact email, languages; registrations open + allowed emails.
  - **Posts & media** — post size, media per post, poll limits, upload size limit, read-only storage backend.
  - **Network** — outbound request timeout, retries, response-size cap.
- **Federation policy block** on the existing Federation tab (mode, allowed actor domains; trusted media domains shown read-only since they feed the Edge-runtime CSP).
- **Consumers rewired to the resolver**: `/api/v1` + `/api/v2/instance`, registration (signup/signin/landing/status/heatmap pages, `registerAccount`, accounts + email-confirmation APIs, `getAccountFromSession`), federation domain policy, outbound request tuning, and **new** server-side status-length + poll-limit enforcement on the create/edit status APIs.

### Precedence & notable decisions

- `env → database → default`. Env-pinned fields are read-only in the UI.
- Poll `max_expiration` default is aligned to the enforced constant (`2678400`s) so advertising and enforcement agree at the default; poll schemas keep only a structural floor + absolute safety ceilings so an admin can raise limits above the Mastodon defaults.
- The unconfigured outbound-request timeout unifies to the documented config-schema default (`4000` ms) instead of the request wrapper's ad-hoc `10000` ms.
- Maintenance mode is intentionally out of scope (deferred; enforcement touches auth + federation).

## Commits

16 small, independently-green commits (data layer → registry/resolver → admin API → shared UI → grouped nav → one commit per tab → federation block → one consumer subsystem per commit → docs). See the commit list.

## Verification

Full local browser walk-through as an admin (SQLite): all four surfaces render correctly, and editing **Instance name → "My Test Instance"** persisted to `server_settings` and `GET /api/v2/instance` echoed `"title": "My Test Instance"` — confirming the admin UI → PATCH → DB → resolver → instance API chain end to end. Screenshots of the Instance, Posts & media, Network, and Federation-policy surfaces are attached in the review thread.

- `yarn run prettier --write .` → clean
- `yarn lint` → 0 errors
- `yarn build` → compiles
- `yarn test` → **702 files, 6701 tests passing**
- Both schema dumps regenerated (SQLite drift-check clean).

## Follow-ups (deliberately out of this PR)

These are already advertised via the instance API and enforced server-side / via env, so they're refinements rather than gaps:

- Make the built-in web composer's character counter reflect a non-default post-size limit (needs instance-config threading into the composer).
- Read the resolved upload-size cap in the media upload path (currently a synchronous Zod refine reading env config; the value is advertised via the instance API and the env-configured case already works).
- Maintenance mode (store + enforce).
- DB-backing trusted media domains (blocked on Edge-runtime CSP reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
