### PR TITLE
Bump version to v1.115.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.114.4",
+  "version": "1.115.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.115.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.114.4`
- Base main SHA: `9d71069bf91eb9bdc7fca84052d3ba53ef5dee31`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
