### PR TITLE
Bump version to v1.115.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.115.0",
+  "version": "1.115.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.115.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.115.0`
- Base main SHA: `00ea0fa15b5d69992f954cfd8675ea07fd7c1611`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
