### PR TITLE
Bump version to v1.116.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.115.1",
+  "version": "1.116.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.116.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.115.1`
- Base main SHA: `944735cdb37a0a00bf52902051f1362b9844d480`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
