### PR TITLE
Bump version to v1.116.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.116.0",
+  "version": "1.116.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.116.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.116.0`
- Base main SHA: `bd78d6a1562c7d59f5805281ea18ba07b16eeced`
- Included commits: `4`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
