### PR TITLE
fix: stop node-gyp building better-sqlite3 so the Docker image builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,11 @@
   "engines": {
     "node": "24.x"
   },
+  "dependenciesMeta": {
+    "better-sqlite3": {
+      "built": false
+    }
+  },
   "resolutions": {
     "postcss": "8.5.22",
     "sharp": "^0.35.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4432,6 +4432,9 @@ __metadata:
     web-push: "npm:^3.6.7"
     yauzl: "npm:^3.4.0"
     zod: "npm:^4.4.3"
+  dependenciesMeta:
+    better-sqlite3:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Fixes the `Package` workflow, which has been failing on `main` since #1308 merged:

```
ERROR: process "/bin/sh -c yarn install --immutable" did not complete successfully: exit code: 1
```

The trigger was the `better-sqlite3` 12 → 13 bump in that PR — but not the version itself.

**v12** shipped an `install` script (`prebuild-install || node-gyp rebuild`) that downloaded a prebuilt binary. **v13** moved to N-API, dropped that script, and ships prebuilt binaries inside the npm tarball instead — while still carrying a `binding.gyp`. Yarn builds any package that has a `binding.gyp` and no install script, so it now invokes node-gyp, and `node:24-alpine` has no Python toolchain:

```
YN0009: better-sqlite3@npm:13.0.1 couldn't be built successfully (exit code 1)
gyp ERR! find Python checking if "python3" can be used
gyp ERR! find Python - executable path is ""
```

Compiling was never what actually loaded. `lib/binding.js` resolves `prebuilds/<platform>-<arch>.node` first and only falls back to `build/Release`; on macOS the gyp step "succeeds" and leaves no `.node` behind at all. So the fix declares the package as not-built and lets the shipped prebuild do its job:

```json
"dependenciesMeta": {
  "better-sqlite3": { "built": false }
}
```

That also makes install behave identically on macOS, CI, and Alpine, and removes a native compile from every Docker build.

## Verification

Reproduced and fixed against the real `node:24-alpine` image, not inferred.

| Case | Result |
| --- | --- |
| **Control** — `main`'s `package.json` + `yarn.lock` on `node:24-alpine` | Reproduces CI exactly: `YN0009 … couldn't be built successfully`, `gyp ERR! find Python` |
| **Fixed** — this branch, `linux/arm64` | Install completes; `better-sqlite3` no longer appears in yarn's build list; in-container query returns `sqlite 3.53.3` |
| **Fixed** — this branch, `linux/amd64` (the arch that failed in CI) | Same, via emulation |
| **Full image**, all stages | Builds end to end; boots; `GET /` → 200; `GET /api/nodeinfo/2.0` returns data read from SQLite; no errors in the container log |
| Runtime image contents | `node_modules/better-sqlite3/prebuilds/linuxmusl-arm64.node` present — the standalone tracer picks the prebuild up the same way it previously picked up `build/Release` |

`linuxmusl-x64.node` and `linuxmusl-arm64.node` both ship in the tarball, and musl is detected at runtime via `glibcVersionRuntime`, so the correct binary is chosen inside the container rather than at build time.

Locally: `yarn install --immutable` clean, the Dockerfile's exact migrate step (`yarn knex migrate:latest --disable-transactions`) applies all 141 migrations to a throwaway SQLite file, `yarn lint` 0 errors, `yarn build` ✓, `yarn test` 712 files / 6835 tests passed.

## Trade-off

Platforms outside better-sqlite3's six shipped prebuild targets (`darwin` / `linux` / `linuxmusl` / `win32` × `x64` / `arm64`) no longer fall back to compiling from source. Both published image architectures and every supported development platform are covered; an exotic self-host target would need `yarn rebuild better-sqlite3` or the `built: false` entry removed locally.

## Follow-up worth considering (not in this PR)

`Package` only triggers on `push` to `main`, so no pull request ever builds the Docker image — which is exactly why this reached `main` with CI fully green. Adding an image build (build stage only, no push) to `ci.yml` would catch this class of failure at review time. Left out here because it adds CI minutes to every PR, which is a call for the maintainer.

## Checklist

- [x] `yarn run prettier --write .`, `yarn lint`, `yarn build`, and `yarn test` all pass locally, run in that order
- [x] Docs updated: n/a — no command, env var, route, script, or convention changed
- [x] If migrations changed: n/a — no migrations touched
- [x] `version` in `package.json` is untouched (CI bumps it from commit prefixes)
- [x] No production or operational SQL in this description
