### PR TITLE
Bump version to v1.117.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.116.1",
+  "version": "1.117.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.117.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.116.1`
- Base main SHA: `8783f1b334db24bcc8e462906c332a5552f7d2ab`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
