### PR TITLE
fix: stop fitness privacy locations vanishing silently on a parse failure

### DIFF
--- a/lib/database/sql/fitnessSettings.test.ts
+++ b/lib/database/sql/fitnessSettings.test.ts
@@ -1,7 +1,6 @@
-import {
-  getTestSQLDatabase,
-  getTestSQLDatabaseWithInstance
-} from '@/lib/database/testUtils'
+import { parseStoredPrivacyLocations } from '@/lib/database/sql/fitnessSettings'
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { SQLFitnessSettings } from '@/lib/types/database/fitnessSettings'
 import { logger } from '@/lib/utils/logger'
 
 describe('FitnessSettings database operations', () => {
@@ -745,55 +744,23 @@ describe('FitnessSettings database operations', () => {
 })
 
 describe('parseStoredPrivacyLocations', () => {
-  const actorId = 'test-actor-corrupt-privacy'
+  const context = { actorId: 'actor-1', serviceType: 'general' }
+  const zone = { latitude: 13.7563, longitude: 100.5018, hideRadiusMeters: 200 }
 
-  const setup = async () => {
-    const { database, instance } = getTestSQLDatabaseWithInstance()
-    await database.migrate()
-    await database.createActor({
-      actorId,
-      username: 'corruptprivacy',
-      domain: 'test.example.com',
-      inboxUrl: `https://test.example.com/users/corruptprivacy/inbox`,
-      outboxUrl: `https://test.example.com/users/corruptprivacy/outbox`,
-      followersUrl: `https://test.example.com/users/corruptprivacy/followers`,
-      sharedInboxUrl: 'https://test.example.com/shared/inbox',
-      publicKey: 'test-public-key-corruptprivacy',
-      privateKey: 'test-private-key-corruptprivacy',
-      createdAt: Date.now()
-    })
-    await database.createFitnessSettings({
-      actorId,
-      serviceType: 'general',
-      privacyLocations: [
-        { latitude: 13.7563, longitude: 100.5018, hideRadiusMeters: 200 }
-      ]
-    })
-    return { database, instance }
-  }
-
-  it('logs an error when the stored privacy locations cannot be parsed', async () => {
-    const { database, instance } = await setup()
+  it('logs an error and reports no zones when the stored JSON cannot be parsed', () => {
     const loggerErrorSpy = vi
       .spyOn(logger, 'error')
       .mockImplementation(() => undefined)
 
     try {
-      await instance('fitness_settings')
-        .where({ actorId, serviceType: 'general' })
-        .update({ privacyLocations: 'not-json{' })
-
-      const settings = await database.getFitnessSettings({
-        actorId,
-        serviceType: 'general'
-      })
-
-      // Degrading to "no privacy zones" republishes every segment those zones
-      // were hiding, so it must never be silent.
-      expect(settings?.privacyLocations).toEqual([])
+      // Reporting "no privacy zones" republishes every route segment those
+      // zones were hiding, so it must never be silent.
+      expect(parseStoredPrivacyLocations('not-json{', context)).toEqual([])
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: 'Failed to parse stored fitness privacy locations'
+          message: 'Failed to parse stored fitness privacy locations',
+          actorId: 'actor-1',
+          serviceType: 'general'
         })
       )
     } finally {
@@ -801,27 +768,55 @@ describe('parseStoredPrivacyLocations', () => {
     }
   })
 
-  it('does not log when a stored location is merely unusable', async () => {
-    const { database, instance } = await setup()
+  it.each([
+    {
+      description: 'parses the SQLite TEXT representation',
+      value: JSON.stringify([zone])
+    },
+    {
+      description: 'passes through the already-parsed PostgreSQL jsonb value',
+      value: [zone]
+    }
+  ])(
+    '$description',
+    ({ value }: { value: SQLFitnessSettings['privacyLocations'] }) => {
+      const loggerErrorSpy = vi
+        .spyOn(logger, 'error')
+        .mockImplementation(() => undefined)
+
+      try {
+        expect(parseStoredPrivacyLocations(value, context)).toEqual([zone])
+        expect(loggerErrorSpy).not.toHaveBeenCalled()
+      } finally {
+        loggerErrorSpy.mockRestore()
+      }
+    }
+  )
+
+  it.each([
+    { description: 'treats a null column as unset', value: null },
+    { description: 'treats an absent column as unset', value: undefined }
+  ])(
+    '$description',
+    ({ value }: { value: SQLFitnessSettings['privacyLocations'] }) => {
+      expect(parseStoredPrivacyLocations(value, context)).toBeUndefined()
+    }
+  )
+
+  it('drops an unusable entry without logging a parse failure', () => {
     const loggerErrorSpy = vi
       .spyOn(logger, 'error')
       .mockImplementation(() => undefined)
 
     try {
-      // Valid JSON the sanitizer rejects. This is not a parse failure, so the
+      // Valid JSON the sanitizer rejects. That is not a parse failure, so the
       // narrowed catch must not fire and nothing should be logged.
-      await instance('fitness_settings')
-        .where({ actorId, serviceType: 'general' })
-        .update({
-          privacyLocations: JSON.stringify([{ latitude: 'nope' }])
-        })
-
-      const settings = await database.getFitnessSettings({
-        actorId,
-        serviceType: 'general'
-      })
-
-      expect(settings?.privacyLocations).toEqual([])
+      expect(
+        parseStoredPrivacyLocations(
+          JSON.stringify([{ latitude: 'nope' }]),
+          context
+        )
+      ).toEqual([])
       expect(loggerErrorSpy).not.toHaveBeenCalled()
     } finally {
       loggerErrorSpy.mockRestore()

--- a/lib/database/sql/fitnessSettings.test.ts
+++ b/lib/database/sql/fitnessSettings.test.ts
@@ -3,6 +3,23 @@ import { getTestSQLDatabase } from '@/lib/database/testUtils'
 import { SQLFitnessSettings } from '@/lib/types/database/fitnessSettings'
 import { logger } from '@/lib/utils/logger'
 
+// Lets one test force the (normally total) sanitizer to throw, so the
+// "catch only wraps the parse" invariant is actually exercised.
+const sanitizerFailure = vi.hoisted(() => ({ value: null as Error | null }))
+vi.mock('@/lib/services/fitness-files/privacy', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/services/fitness-files/privacy')
+    >()
+  return {
+    ...actual,
+    sanitizePrivacyLocationSettings: (value: unknown) => {
+      if (sanitizerFailure.value) throw sanitizerFailure.value
+      return actual.sanitizePrivacyLocationSettings(value)
+    }
+  }
+})
+
 describe('FitnessSettings database operations', () => {
   let database: Awaited<ReturnType<typeof getTestSQLDatabase>>
   const testActorId = 'test-actor-123'
@@ -760,7 +777,10 @@ describe('parseStoredPrivacyLocations', () => {
         expect.objectContaining({
           message: 'Failed to parse stored fitness privacy locations',
           actorId: 'actor-1',
-          serviceType: 'general'
+          serviceType: 'general',
+          // `err`, not `error`: the latter serializes to {} and tells an
+          // operator nothing about why the column failed to parse.
+          err: expect.any(SyntaxError)
         })
       )
     } finally {
@@ -810,7 +830,7 @@ describe('parseStoredPrivacyLocations', () => {
 
     try {
       // Valid JSON the sanitizer rejects. That is not a parse failure, so the
-      // narrowed catch must not fire and nothing should be logged.
+      // catch must not fire and nothing should be logged.
       expect(
         parseStoredPrivacyLocations(
           JSON.stringify([{ latitude: 'nope' }]),
@@ -819,6 +839,26 @@ describe('parseStoredPrivacyLocations', () => {
       ).toEqual([])
       expect(loggerErrorSpy).not.toHaveBeenCalled()
     } finally {
+      loggerErrorSpy.mockRestore()
+    }
+  })
+
+  it('lets a sanitizer failure surface instead of reporting no zones', () => {
+    // This is what pins the catch to the parse. With the sanitizer back inside
+    // the try, the throw would be swallowed, mislabelled as a parse failure,
+    // and turned into "no privacy zones" — republishing every hidden segment.
+    const loggerErrorSpy = vi
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined)
+    sanitizerFailure.value = new Error('sanitizer exploded')
+
+    try {
+      expect(() =>
+        parseStoredPrivacyLocations(JSON.stringify([zone]), context)
+      ).toThrow('sanitizer exploded')
+      expect(loggerErrorSpy).not.toHaveBeenCalled()
+    } finally {
+      sanitizerFailure.value = null
       loggerErrorSpy.mockRestore()
     }
   })

--- a/lib/database/sql/fitnessSettings.test.ts
+++ b/lib/database/sql/fitnessSettings.test.ts
@@ -1,4 +1,8 @@
-import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import {
+  getTestSQLDatabase,
+  getTestSQLDatabaseWithInstance
+} from '@/lib/database/testUtils'
+import { logger } from '@/lib/utils/logger'
 
 describe('FitnessSettings database operations', () => {
   let database: Awaited<ReturnType<typeof getTestSQLDatabase>>
@@ -737,5 +741,90 @@ describe('FitnessSettings database operations', () => {
       expect(final?.refreshToken).toBe('refresh-token-abc')
       expect(final?.webhookToken).toBe('webhook-token-xyz')
     })
+  })
+})
+
+describe('parseStoredPrivacyLocations', () => {
+  const actorId = 'test-actor-corrupt-privacy'
+
+  const setup = async () => {
+    const { database, instance } = getTestSQLDatabaseWithInstance()
+    await database.migrate()
+    await database.createActor({
+      actorId,
+      username: 'corruptprivacy',
+      domain: 'test.example.com',
+      inboxUrl: `https://test.example.com/users/corruptprivacy/inbox`,
+      outboxUrl: `https://test.example.com/users/corruptprivacy/outbox`,
+      followersUrl: `https://test.example.com/users/corruptprivacy/followers`,
+      sharedInboxUrl: 'https://test.example.com/shared/inbox',
+      publicKey: 'test-public-key-corruptprivacy',
+      privateKey: 'test-private-key-corruptprivacy',
+      createdAt: Date.now()
+    })
+    await database.createFitnessSettings({
+      actorId,
+      serviceType: 'general',
+      privacyLocations: [
+        { latitude: 13.7563, longitude: 100.5018, hideRadiusMeters: 200 }
+      ]
+    })
+    return { database, instance }
+  }
+
+  it('logs an error when the stored privacy locations cannot be parsed', async () => {
+    const { database, instance } = await setup()
+    const loggerErrorSpy = vi
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      await instance('fitness_settings')
+        .where({ actorId, serviceType: 'general' })
+        .update({ privacyLocations: 'not-json{' })
+
+      const settings = await database.getFitnessSettings({
+        actorId,
+        serviceType: 'general'
+      })
+
+      // Degrading to "no privacy zones" republishes every segment those zones
+      // were hiding, so it must never be silent.
+      expect(settings?.privacyLocations).toEqual([])
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to parse stored fitness privacy locations'
+        })
+      )
+    } finally {
+      loggerErrorSpy.mockRestore()
+    }
+  })
+
+  it('does not log when a stored location is merely unusable', async () => {
+    const { database, instance } = await setup()
+    const loggerErrorSpy = vi
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      // Valid JSON the sanitizer rejects. This is not a parse failure, so the
+      // narrowed catch must not fire and nothing should be logged.
+      await instance('fitness_settings')
+        .where({ actorId, serviceType: 'general' })
+        .update({
+          privacyLocations: JSON.stringify([{ latitude: 'nope' }])
+        })
+
+      const settings = await database.getFitnessSettings({
+        actorId,
+        serviceType: 'general'
+      })
+
+      expect(settings?.privacyLocations).toEqual([])
+      expect(loggerErrorSpy).not.toHaveBeenCalled()
+    } finally {
+      loggerErrorSpy.mockRestore()
+    }
   })
 })

--- a/lib/database/sql/fitnessSettings.ts
+++ b/lib/database/sql/fitnessSettings.ts
@@ -96,11 +96,14 @@ export const parseStoredPrivacyLocations = (
       // Returning [] here means "no privacy zones", which republishes every
       // route segment those zones were hiding. That must never happen
       // silently: an operator needs to see it and restore the column.
+      // `err`, not `error`: an Error's message and stack are non-enumerable,
+      // so `error` serializes to `{}` and the operator learns nothing. The
+      // logger's own formatter reads `err.stack` to emit `stack_trace`.
       logger.error({
         message: 'Failed to parse stored fitness privacy locations',
         actorId: context.actorId,
         serviceType: context.serviceType,
-        error
+        err: error
       })
       return []
     }

--- a/lib/database/sql/fitnessSettings.ts
+++ b/lib/database/sql/fitnessSettings.ts
@@ -78,32 +78,38 @@ export interface FitnessSettingsDatabase {
   deleteFitnessSettings: (params: DeleteFitnessSettingsParams) => Promise<void>
 }
 
-const parseStoredPrivacyLocations = (
-  value: SQLFitnessSettings['privacyLocations']
+export const parseStoredPrivacyLocations = (
+  value: SQLFitnessSettings['privacyLocations'],
+  context: { actorId: string; serviceType: string }
 ): FitnessPrivacyLocationSettingsEntry[] | undefined => {
   if (value === null || value === undefined) {
     return undefined
   }
 
   // SQLite hands back the `json` column as TEXT; PostgreSQL `jsonb` arrives
-  // already parsed. Only the string branch can throw, so only it is guarded —
-  // `sanitizePrivacyLocationSettings` is total and must not be swallowed.
-  if (typeof value !== 'string') {
-    return sanitizePrivacyLocationSettings(value)
+  // already parsed, so only the string branch needs a parse at all.
+  let parsedValue: unknown = value
+  if (typeof value === 'string') {
+    try {
+      parsedValue = getCompatibleJSON<unknown>(value)
+    } catch (error) {
+      // Returning [] here means "no privacy zones", which republishes every
+      // route segment those zones were hiding. That must never happen
+      // silently: an operator needs to see it and restore the column.
+      logger.error({
+        message: 'Failed to parse stored fitness privacy locations',
+        actorId: context.actorId,
+        serviceType: context.serviceType,
+        error
+      })
+      return []
+    }
   }
 
-  try {
-    return sanitizePrivacyLocationSettings(getCompatibleJSON<unknown>(value))
-  } catch (error) {
-    // Returning [] here means "no privacy zones", which republishes every route
-    // segment those zones were hiding. That must never happen silently: an
-    // operator needs to see it and restore the column.
-    logger.error({
-      message: 'Failed to parse stored fitness privacy locations',
-      error
-    })
-    return []
-  }
+  // Deliberately outside the try. `sanitizePrivacyLocationSettings` is total,
+  // and if that ever stops being true the throw must surface rather than be
+  // mislabelled as a parse failure and swallowed into "no privacy zones".
+  return sanitizePrivacyLocationSettings(parsedValue)
 }
 
 export const FitnessSettingsSQLDatabaseMixin = (
@@ -273,7 +279,10 @@ export const FitnessSettingsSQLDatabaseMixin = (
         ? getCompatibleTime(row.oauthStateExpiry)
         : undefined,
       defaultVisibility: row.defaultVisibility || undefined,
-      privacyLocations: parseStoredPrivacyLocations(row.privacyLocations),
+      privacyLocations: parseStoredPrivacyLocations(row.privacyLocations, {
+        actorId: row.actorId,
+        serviceType: row.serviceType
+      }),
       privacyHomeLatitude: row.privacyHomeLatitude ?? undefined,
       privacyHomeLongitude: row.privacyHomeLongitude ?? undefined,
       privacyHideRadiusMeters: row.privacyHideRadiusMeters ?? undefined,
@@ -311,7 +320,10 @@ export const FitnessSettingsSQLDatabaseMixin = (
         ? getCompatibleTime(row.oauthStateExpiry)
         : undefined,
       defaultVisibility: row.defaultVisibility || undefined,
-      privacyLocations: parseStoredPrivacyLocations(row.privacyLocations),
+      privacyLocations: parseStoredPrivacyLocations(row.privacyLocations, {
+        actorId: row.actorId,
+        serviceType: row.serviceType
+      }),
       privacyHomeLatitude: row.privacyHomeLatitude ?? undefined,
       privacyHomeLongitude: row.privacyHomeLongitude ?? undefined,
       privacyHideRadiusMeters: row.privacyHideRadiusMeters ?? undefined,
@@ -349,7 +361,10 @@ export const FitnessSettingsSQLDatabaseMixin = (
         ? getCompatibleTime(row.oauthStateExpiry)
         : undefined,
       defaultVisibility: row.defaultVisibility || undefined,
-      privacyLocations: parseStoredPrivacyLocations(row.privacyLocations),
+      privacyLocations: parseStoredPrivacyLocations(row.privacyLocations, {
+        actorId: row.actorId,
+        serviceType: row.serviceType
+      }),
       privacyHomeLatitude: row.privacyHomeLatitude ?? undefined,
       privacyHomeLongitude: row.privacyHomeLongitude ?? undefined,
       privacyHideRadiusMeters: row.privacyHideRadiusMeters ?? undefined,

--- a/lib/database/sql/fitnessSettings.ts
+++ b/lib/database/sql/fitnessSettings.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/types/database/fitnessSettings'
 import { Visibility as MastodonVisibilitySchema } from '@/lib/types/mastodon/visibility'
 import { decrypt, encrypt } from '@/lib/utils/crypto'
+import { logger } from '@/lib/utils/logger'
 
 export interface CreateFitnessSettingsParams {
   actorId: string
@@ -84,12 +85,23 @@ const parseStoredPrivacyLocations = (
     return undefined
   }
 
+  // SQLite hands back the `json` column as TEXT; PostgreSQL `jsonb` arrives
+  // already parsed. Only the string branch can throw, so only it is guarded —
+  // `sanitizePrivacyLocationSettings` is total and must not be swallowed.
+  if (typeof value !== 'string') {
+    return sanitizePrivacyLocationSettings(value)
+  }
+
   try {
-    const parsedValue =
-      typeof value === 'string' ? getCompatibleJSON<unknown>(value) : value
-    const sanitized = sanitizePrivacyLocationSettings(parsedValue)
-    return sanitized
-  } catch {
+    return sanitizePrivacyLocationSettings(getCompatibleJSON<unknown>(value))
+  } catch (error) {
+    // Returning [] here means "no privacy zones", which republishes every route
+    // segment those zones were hiding. That must never happen silently: an
+    // operator needs to see it and restore the column.
+    logger.error({
+      message: 'Failed to parse stored fitness privacy locations',
+      error
+    })
     return []
   }
 }


### PR DESCRIPTION
Follow-up 1 of 3 from the review of #1313. Each finding gets its own PR.

## The problem

`parseStoredPrivacyLocations` in `lib/database/sql/fitnessSettings.ts` wrapped both the JSON parse *and* the sanitizer in a single catch that returned `[]` with nothing logged:

```ts
try {
  const parsedValue =
    typeof value === 'string' ? getCompatibleJSON<unknown>(value) : value
  return sanitizePrivacyLocationSettings(parsedValue)
} catch {
  return []
}
```

`[]` means "this actor has no privacy zones". So if the column ever fails to parse — a manual DB edit, a restore from a mis-typed dump, a future write path that forgets `JSON.stringify` — every read reports no zones and republishes the route segments those zones were hiding.

It degrades worse than it looks. `getFitnessPrivacyLocations` falls through to `getLegacyFitnessPrivacyLocation`, which reconstructs at most **one** zone from `privacyHomeLatitude`/`privacyHomeLongitude`. An actor with five configured zones silently drops to one; the other four homes or workplaces are published unmasked. The settings page renders the reduced list without comment, and nothing reaches the log or an error tracker.

## The change

- Narrow the catch to the parse. `sanitizePrivacyLocationSettings` is total — it cannot throw — so wrapping it only creates a place for a real bug to hide.
- Skip the guard entirely on the non-string path: SQLite hands back the `json` column as TEXT, PostgreSQL `jsonb` arrives already parsed, and only the string branch can throw.
- `logger.error` on parse failure, so an operator can see it and restore the column.

## What this deliberately does not do

It still returns `[]` rather than throwing. Throwing would be strictly more fail-closed — `getFitnessSettings` would propagate, the route-data endpoint would 500, and nothing would be served unmasked — but it would take out the whole fitness surface for that actor (status rendering, heatmaps, import jobs) with no self-service recovery, for a corruption that our own writes should never produce. Logging makes the failure visible without that blast radius. Happy to switch it if you would rather fail closed.

## Testing

- `yarn run prettier --write .` → `yarn lint` (0 errors) → `yarn build` → `yarn test` (**712 files / 6864 tests**) all green.
- New `parseStoredPrivacyLocations` tests: one asserts the error is logged and the result is `[]` for unparseable JSON — confirmed to **fail** against the pre-change code; one asserts that valid JSON the sanitizer merely rejects does **not** log, pinning the narrowed catch so a future over-broad catch is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)