### PR TITLE
Bump version to v1.117.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.117.0",
+  "version": "1.117.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.117.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.117.0`
- Base main SHA: `7a0625254c9ffcdf5287d49735d0f638a6af5bc0`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
