### PR TITLE
Bump version to v1.117.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.117.1",
+  "version": "1.117.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.117.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.117.1`
- Base main SHA: `502d7ec49a56fd0ea029144857316f7dd6311620`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
