### PR TITLE
Bump version to v1.118.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.117.2",
+  "version": "1.118.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.118.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.117.2`
- Base main SHA: `ead39d3a127577a118f9b4c57eeb6e2b81ee4f99`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
