### PR TITLE
minor: add the status reaction write API and outbound federation

### DIFF
--- a/app/(timeline)/settings/notifications/page.tsx
+++ b/app/(timeline)/settings/notifications/page.tsx
@@ -49,6 +49,11 @@ const notificationTypes: {
     description: 'Someone reblogs your post'
   },
   {
+    key: 'emoji_reaction',
+    label: 'Reactions',
+    description: 'Someone reacts to your post with an emoji'
+  },
+  {
     key: 'activity_import',
     label: 'Fitness Activity Imported',
     description:

--- a/app/api/v1/accounts/email-notifications/route.test.ts
+++ b/app/api/v1/accounts/email-notifications/route.test.ts
@@ -171,6 +171,33 @@ describe('POST /api/v1/accounts/email-notifications', () => {
     )
   })
 
+  it('persists emoji_reaction so the email master toggle can stay off', async () => {
+    // The settings page drives BOTH the Email and Push columns from one
+    // `notificationTypes` list. A key this schema does not declare is stripped
+    // silently, and the master toggle is recomputed as
+    // `some((nt) => stored[nt.key] !== false)` — so a missing key reads back as
+    // enabled and switching the whole Email channel off never sticks.
+    const req = new NextRequest(
+      'http://localhost/api/v1/accounts/email-notifications',
+      {
+        method: 'POST',
+        body: JSON.stringify({ emoji_reaction: false }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://llun.test'
+        }
+      }
+    )
+    const res = await POST(req, { params: Promise.resolve({}) })
+
+    expect(res.status).toBe(200)
+    expect(mockDb.updateActor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailNotifications: { emoji_reaction: false }
+      })
+    )
+  })
+
   it('returns 403 when targeting an actor not owned by current user', async () => {
     const req = new NextRequest(
       'http://localhost/api/v1/accounts/email-notifications',

--- a/app/api/v1/accounts/email-notifications/route.ts
+++ b/app/api/v1/accounts/email-notifications/route.ts
@@ -11,6 +11,7 @@ const EmailNotificationSettingsRequest = z.object({
   mention: z.boolean().optional(),
   reply: z.boolean().optional(),
   reblog: z.boolean().optional(),
+  emoji_reaction: z.boolean().optional(),
   activity_import: z.boolean().optional(),
   actorId: z.string().optional()
 })

--- a/app/api/v1/accounts/push-notifications/route.ts
+++ b/app/api/v1/accounts/push-notifications/route.ts
@@ -11,6 +11,7 @@ const PushNotificationSettingsRequest = z.object({
   mention: z.boolean().optional(),
   reply: z.boolean().optional(),
   reblog: z.boolean().optional(),
+  emoji_reaction: z.boolean().optional(),
   activity_import: z.boolean().optional(),
   actorId: z.string().optional()
 })

--- a/app/api/v1/pleroma/statuses/[id]/reactions/[emoji]/route.ts
+++ b/app/api/v1/pleroma/statuses/[id]/reactions/[emoji]/route.ts
@@ -1,0 +1,82 @@
+import {
+  OAuthGuardAnyScope,
+  OptionalOAuthGuard,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import { getStatusReactionList } from '@/lib/services/reactions/getStatusReactionList'
+import {
+  reactionRouteAttributes,
+  reactionWriteHandler
+} from '@/lib/services/reactions/reactionRouteHandlers'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+// Pleroma/Akkoma dialect — the primary reaction surface, and the one with real
+// deployed client support (Husky, the Megalodon family). Not core Mastodon API.
+const CORS_HEADERS = [
+  HttpMethod.enum.OPTIONS,
+  HttpMethod.enum.GET,
+  HttpMethod.enum.PUT,
+  HttpMethod.enum.DELETE
+]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+const guardOptions = { errorResponse: corsErrorResponse(CORS_HEADERS) }
+const WRITE_SCOPES = [Scope.enum.write, Scope.enum['write:favourites']]
+
+interface Params {
+  id: string
+  emoji: string
+}
+
+export const GET = traceApiRoute(
+  'getStatusReactionsByEmoji',
+  OptionalOAuthGuard<Params>(
+    [Scope.enum.read, Scope.enum['read:statuses']],
+    async (req, { database, currentActor, params }) => {
+      const { id, emoji } = await params
+      const reactions = await getStatusReactionList({
+        database,
+        currentActor,
+        statusId: idToUrl(id),
+        name: emoji
+      })
+      if (!reactions) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      return apiResponse({ req, allowedMethods: CORS_HEADERS, data: reactions })
+    },
+    guardOptions
+  ),
+  { addAttributes: reactionRouteAttributes }
+)
+
+export const PUT = traceApiRoute(
+  'addStatusReaction',
+  OAuthGuardAnyScope<Params>(
+    WRITE_SCOPES,
+    reactionWriteHandler('react', CORS_HEADERS),
+    guardOptions
+  ),
+  { addAttributes: reactionRouteAttributes }
+)
+
+export const DELETE = traceApiRoute(
+  'removeStatusReaction',
+  OAuthGuardAnyScope<Params>(
+    WRITE_SCOPES,
+    reactionWriteHandler('unreact', CORS_HEADERS),
+    guardOptions
+  ),
+  { addAttributes: reactionRouteAttributes }
+)

--- a/app/api/v1/pleroma/statuses/[id]/reactions/[emoji]/route.ts
+++ b/app/api/v1/pleroma/statuses/[id]/reactions/[emoji]/route.ts
@@ -56,7 +56,9 @@ export const GET = traceApiRoute(
 
       return apiResponse({ req, allowedMethods: CORS_HEADERS, data: reactions })
     },
-    guardOptions
+    // `any`, so a token holding only the granular `read:statuses` is accepted;
+    // the guard otherwise defaults to requiring every listed scope.
+    { ...guardOptions, matchMode: 'any' }
   ),
   { addAttributes: reactionRouteAttributes }
 )

--- a/app/api/v1/pleroma/statuses/[id]/reactions/route.ts
+++ b/app/api/v1/pleroma/statuses/[id]/reactions/route.ts
@@ -1,0 +1,52 @@
+import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import { getStatusReactionList } from '@/lib/services/reactions/getStatusReactionList'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { ERROR_404, apiResponse, defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+// Pleroma/Akkoma dialect, auth optional — an anonymous reader sees the same
+// rollups with `me: false`. Not core Mastodon API.
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.GET]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+}
+
+export const GET = traceApiRoute(
+  'getStatusReactions',
+  OptionalOAuthGuard<Params>(
+    [Scope.enum.read, Scope.enum['read:statuses']],
+    async (req, { database, currentActor, params }) => {
+      const statusId = idToUrl((await params).id)
+      const reactions = await getStatusReactionList({
+        database,
+        currentActor,
+        statusId
+      })
+      if (!reactions) {
+        return apiResponse({
+          req,
+          allowedMethods: CORS_HEADERS,
+          data: ERROR_404,
+          responseStatusCode: 404
+        })
+      }
+
+      return apiResponse({
+        req,
+        allowedMethods: CORS_HEADERS,
+        data: reactions
+      })
+    }
+  ),
+  {
+    addAttributes: async (_req, context) => {
+      const params = await context.params
+      return { statusId: params?.id || 'unknown' }
+    }
+  }
+)

--- a/app/api/v1/pleroma/statuses/[id]/reactions/route.ts
+++ b/app/api/v1/pleroma/statuses/[id]/reactions/route.ts
@@ -1,4 +1,7 @@
-import { OptionalOAuthGuard } from '@/lib/services/guards/OAuthGuard'
+import {
+  OptionalOAuthGuard,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
 import { getStatusReactionList } from '@/lib/services/reactions/getStatusReactionList'
 import { Scope } from '@/lib/types/database/operations'
 import { HttpMethod } from '@/lib/utils/http-headers'
@@ -41,7 +44,11 @@ export const GET = traceApiRoute(
         allowedMethods: CORS_HEADERS,
         data: reactions
       })
-    }
+    },
+    // `any`, so a token holding only the granular `read:statuses` is accepted;
+    // the guard otherwise defaults to requiring every listed scope. The CORS
+    // error responder keeps guard-level 401/403 readable cross-origin.
+    { errorResponse: corsErrorResponse(CORS_HEADERS), matchMode: 'any' }
   ),
   {
     addAttributes: async (_req, context) => {

--- a/app/api/v1/push/subscription/types.ts
+++ b/app/api/v1/push/subscription/types.ts
@@ -31,6 +31,7 @@ const ALERT_KEYS: (keyof PushAlerts)[] = [
   'update',
   'quote',
   'quoted_update',
+  'pleroma:emoji_reaction',
   'admin.sign_up',
   'admin.report'
 ]

--- a/app/api/v1/routeScopeWiring.test.ts
+++ b/app/api/v1/routeScopeWiring.test.ts
@@ -34,6 +34,23 @@ vi.mock('@/lib/utils/traceApiRoute', () => ({
 // guarded methods (deduped). Kept independent of the route source so a wrong
 // literal is caught.
 const EXPECTED: Array<{ module: string; scopes: string[] }> = [
+  // status emoji reactions (ecosystem dialects, one store)
+  {
+    module: '@/app/api/v1/pleroma/statuses/[id]/reactions/[emoji]/route',
+    scopes: ['read', 'read:statuses', 'write', 'write:favourites']
+  },
+  {
+    module: '@/app/api/v1/pleroma/statuses/[id]/reactions/route',
+    scopes: ['read', 'read:statuses']
+  },
+  {
+    module: '@/app/api/v1/statuses/[id]/react/[name]/route',
+    scopes: ['write', 'write:favourites']
+  },
+  {
+    module: '@/app/api/v1/statuses/[id]/unreact/[name]/route',
+    scopes: ['write', 'write:favourites']
+  },
   // account actions
   {
     module: '@/app/api/v1/accounts/[id]/follow/route',

--- a/app/api/v1/routeScopeWiring.test.ts
+++ b/app/api/v1/routeScopeWiring.test.ts
@@ -253,6 +253,16 @@ const MULTI_METHOD: Array<{
   methods: Record<string, string[]>
 }> = [
   {
+    // Reads and writes on one reaction URL: a GET<->mutation scope swap here
+    // would pass the flattened EXPECTED assertion above.
+    module: '@/app/api/v1/pleroma/statuses/[id]/reactions/[emoji]/route',
+    methods: {
+      GET: ['read', 'read:statuses'],
+      PUT: ['write', 'write:favourites'],
+      DELETE: ['write', 'write:favourites']
+    }
+  },
+  {
     module: '@/app/api/v1/notifications/route',
     methods: {
       GET: ['read', 'read:notifications'],

--- a/app/api/v1/statuses/[id]/react/[name]/route.ts
+++ b/app/api/v1/statuses/[id]/react/[name]/route.ts
@@ -1,0 +1,33 @@
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import {
+  reactionRouteAttributes,
+  reactionWriteHandler
+} from '@/lib/services/reactions/reactionRouteHandlers'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+// glitch-soc dialect — a thin alias over the same service as the Pleroma route,
+// so the two surfaces can never disagree. Not core Mastodon API.
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+  name: string
+}
+
+export const POST = traceApiRoute(
+  'reactStatus',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:favourites']],
+    reactionWriteHandler('react', CORS_HEADERS),
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
+  ),
+  { addAttributes: reactionRouteAttributes }
+)

--- a/app/api/v1/statuses/[id]/unreact/[name]/route.ts
+++ b/app/api/v1/statuses/[id]/unreact/[name]/route.ts
@@ -1,0 +1,33 @@
+import {
+  OAuthGuardAnyScope,
+  corsErrorResponse
+} from '@/lib/services/guards/OAuthGuard'
+import {
+  reactionRouteAttributes,
+  reactionWriteHandler
+} from '@/lib/services/reactions/reactionRouteHandlers'
+import { Scope } from '@/lib/types/database/operations'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { defaultOptions } from '@/lib/utils/response'
+import { traceApiRoute } from '@/lib/utils/traceApiRoute'
+
+// glitch-soc dialect — a thin alias over the same service as the Pleroma route,
+// so the two surfaces can never disagree. Not core Mastodon API.
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.POST]
+
+export const OPTIONS = defaultOptions(CORS_HEADERS)
+
+interface Params {
+  id: string
+  name: string
+}
+
+export const POST = traceApiRoute(
+  'unreactStatus',
+  OAuthGuardAnyScope<Params>(
+    [Scope.enum.write, Scope.enum['write:favourites']],
+    reactionWriteHandler('unreact', CORS_HEADERS),
+    { errorResponse: corsErrorResponse(CORS_HEADERS) }
+  ),
+  { addAttributes: reactionRouteAttributes }
+)

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,7 +46,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Push notifications** — Web Push subscriptions with VAPID configuration
 - ✅ **Unread count** — Badge showing unread notification count
 
-- 🚧 **Status emoji reactions** — Inbound federation and storage have shipped: a reaction from Pleroma/Akkoma (`EmojiReact`) or the Misskey family (a `Like` carrying `content`/`_misskey_reaction`) is stored as a reaction rather than a favourite and is served on every status as `pleroma.emoji_reactions` and `reactions`. The write API, outbound federation, and the picker UI are still landing
+- 🚧 **Status emoji reactions** — React to a post with a unicode emoji or an instance custom emoji, separately from favouriting it. Reactions federate both ways: inbound from Pleroma/Akkoma (`EmojiReact`) and the Misskey family (a `Like` carrying `content`/`_misskey_reaction`), outbound as a Misskey-style `Like` that vanilla Mastodon shows as a favourite. Served on every status as `pleroma.emoji_reactions` and `reactions`, with `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` (plus glitch-soc `react`/`unreact` aliases) to write them. The picker UI is still landing
 
 ### Storage & Media
 

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -277,6 +277,19 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
   favourite arrives as a `❤` reaction and a later reaction replaces it (their
   one-per-user rule). Reacting never favourites the post locally.
 
+  One consequence needs care on removal: Mastodon resolves `Undo{Like}` by
+  _(account, status)_, not by activity id, and it stored the reaction as a
+  favourite. So retracting a reaction would delete the recipient-side favourite
+  — including a genuine one the actor had also made, since Mastodon dedups the
+  two into a single row. The `Undo` is therefore **withheld when the actor still
+  favourites the status**: the favourite is the state that should survive, and
+  the reaction is already gone locally either way.
+
+  Reacting to a boost applies the reaction to the **boosted post**, matching how
+  the rollups are serialized (an `Announce` wrapper reports no reactions of its
+  own; they appear on `reblog`). A reaction past the per-actor cap of 8 answers
+  `422` rather than a 200 that silently stored nothing.
+
   Known limitation: reactions are capped at 8 distinct emoji per actor per
   status, but the number of _distinct_ emoji on a status is not capped, and the
   rollups are serialized in full (twice — once per dialect) on every status.

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -277,13 +277,15 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
   favourite arrives as a `❤` reaction and a later reaction replaces it (their
   one-per-user rule). Reacting never favourites the post locally.
 
-  One consequence needs care on removal: Mastodon resolves `Undo{Like}` by
-  _(account, status)_, not by activity id, and it stored the reaction as a
-  favourite. So retracting a reaction would delete the recipient-side favourite
-  — including a genuine one the actor had also made, since Mastodon dedups the
-  two into a single row. The `Undo` is therefore **withheld when the actor still
-  favourites the status**: the favourite is the state that should survive, and
-  the reaction is already gone locally either way.
+  Removal is where the single-shape compromise bites. A reaction-native
+  receiver (Misskey family, Pleroma/Akkoma, another Activity.next) resolves the
+  `Undo` by reaction content and removes exactly that emoji. Vanilla Mastodon
+  resolves `Undo{Like}` by _(account, status)_ against the one favourite our
+  reaction degraded into, so it can also clear a genuine favourite or the
+  stand-in for another of your reactions. The `Undo` is sent regardless: the
+  Mastodon-side effect is cosmetic on a server that never rendered the reaction
+  and is recoverable by re-favouriting, whereas withholding it would leave the
+  reaction stuck visible forever on exactly the servers that do render it.
 
   Reacting to a boost applies the reaction to the **boosted post**, matching how
   the rollups are serialized (an `Announce` wrapper reports no reactions of its

--- a/docs/mastodon-api-compatibility.md
+++ b/docs/mastodon-api-compatibility.md
@@ -242,10 +242,40 @@ are not part of the Mastodon API and are safe for Mastodon clients to ignore.
   Reactions arrive as their own notification type, `pleroma:emoji_reaction`,
   which carries an extra `emoji` field; `types[]`/`exclude_types[]` accept that
   name. None of this is core Mastodon API, and vanilla clients ignore all of it.
+  The write endpoints are the Pleroma/Akkoma dialect, with the glitch-soc pair
+  as thin aliases over the same service and store, so the two can never
+  disagree. All take `write` or `write:favourites`; the reads take `read` or
+  `read:statuses` and accept anonymous callers (`me` is then always false):
+
+  | Endpoint                                                     | Dialect           |
+  | ------------------------------------------------------------ | ----------------- |
+  | `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` | Pleroma (primary) |
+  | `GET /api/v1/pleroma/statuses/:id/reactions`                 | Pleroma           |
+  | `GET /api/v1/pleroma/statuses/:id/reactions/:emoji`          | Pleroma           |
+  | `POST /api/v1/statuses/:id/react/:name`                      | glitch-soc        |
+  | `POST /api/v1/statuses/:id/unreact/:name`                    | glitch-soc        |
+
+  The write endpoints return the affected `Status`; the reads return
+  `{name, count, me, url, static_url, accounts}` in first-reaction order. A
+  reaction this instance originates must be a **single emoji grapheme** or a
+  shortcode naming an enabled local custom emoji — anything else is `422`. That
+  is stricter than what is accepted inbound, deliberately: we have to be able to
+  render and federate what we send.
+
   Inbound federation accepts both dialects at the per-user **and** shared
   inboxes: the litepub `EmojiReact` of FEP-c0e0 and a Misskey-style `Like`
   carrying `content`/`_misskey_reaction`, plus the `Undo` of either. A **plain**
   `Like` (no reaction content) remains an ordinary favourite.
+
+  **Outbound, a reaction is emitted as a Misskey-style `Like`** — the emoji on
+  both `content` and `_misskey_reaction`, plus an `Emoji` tag for a custom one —
+  because that is the only spelling every server family renders something for.
+  The consequence is worth stating plainly: **on vanilla Mastodon your reaction
+  arrives as a favourite.** Mastodon has no `EmojiReact` handler at all and
+  drops that activity silently, while its `Like` handler ignores `content`, so a
+  visible favourite is strictly better than nothing. On the Misskey family a
+  favourite arrives as a `❤` reaction and a later reaction replaces it (their
+  one-per-user rule). Reacting never favourites the post locally.
 
   Known limitation: reactions are capped at 8 distinct emoji per actor per
   status, but the number of _distinct_ emoji on a status is not capped, and the

--- a/lib/actions/emojiReaction.test.ts
+++ b/lib/actions/emojiReaction.test.ts
@@ -1,7 +1,6 @@
 import {
   emojiReactionRequest,
   getReactionContent,
-  getReactionGroupKey,
   undoEmojiReactionRequest
 } from '@/lib/actions/emojiReaction'
 import {
@@ -9,6 +8,7 @@ import {
   getTestDatabaseTable
 } from '@/lib/database/testUtils'
 import { Database } from '@/lib/database/types'
+import { getReactionGroupKey } from '@/lib/services/reactions/reactionGroupKey'
 import { seedDatabase } from '@/lib/stub/database'
 import { DatabaseSeed } from '@/lib/stub/scenarios/database'
 import { EmojiReact, Like } from '@/lib/types/activitypub'
@@ -59,45 +59,6 @@ describe('getReactionContent', () => {
     }
   ])('$description', ({ activity, expected }) => {
     expect(getReactionContent(activity)).toEqual(expected)
-  })
-})
-
-describe('getReactionGroupKey', () => {
-  const shortStatusId = 'https://remote.test/users/alice/statuses/1'
-
-  it('keeps the readable form while it fits the column', () => {
-    expect(getReactionGroupKey(shortStatusId, '🔥')).toBe(
-      `emoji_reaction:${shortStatusId}:🔥`
-    )
-  })
-
-  it.each([
-    {
-      description: 'a long status id',
-      statusId: `https://remote.test/users/alice/statuses/${'s'.repeat(300)}`,
-      name: '🔥'
-    },
-    {
-      description: 'a long reaction name',
-      statusId: shortStatusId,
-      name: `${'x'.repeat(60)}@${'d'.repeat(180)}`
-    }
-  ])(
-    'falls back to a bounded digest for $description',
-    ({ statusId, name }) => {
-      const groupKey = getReactionGroupKey(statusId, name)
-      // notifications.groupKey is varchar(255); Postgres rejects an overflow and
-      // SQLite silently accepts it, so the bound has to hold here.
-      expect(groupKey.length).toBeLessThanOrEqual(255)
-      expect(getReactionGroupKey(statusId, name)).toBe(groupKey)
-    }
-  )
-
-  it('gives different groups to different reactions on one status', () => {
-    const statusId = `https://remote.test/users/alice/statuses/${'s'.repeat(300)}`
-    expect(getReactionGroupKey(statusId, '🔥')).not.toBe(
-      getReactionGroupKey(statusId, '🎉')
-    )
   })
 })
 

--- a/lib/actions/emojiReaction.ts
+++ b/lib/actions/emojiReaction.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
+import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
 import { getReactionGroupKey } from '@/lib/services/reactions/reactionGroupKey'
 import {
@@ -228,7 +229,7 @@ export const emojiReactionRequest = async ({
     return
   }
 
-  await createNotificationWithPolicy(database, {
+  const notification = await createNotificationWithPolicy(database, {
     actorId: status.actorId,
     type: NotificationType.enum.emoji_reaction,
     sourceActorId: activity.actor,
@@ -236,6 +237,33 @@ export const emojiReactionRequest = async ({
     reactionName: name,
     groupKey: getReactionGroupKey(status.id, name)
   })
+  if (!notification || notification.filtered) return
+
+  // Fan out the push alert, mirroring `likeRequest`. Without this an inbound
+  // federated reaction records a notification row but never reaches the
+  // recipient's device — so the whole reaction push path would only ever fire
+  // for a local actor reacting to a local post. Fire-and-forget: alert delivery
+  // must not fail the inbound activity. No email content: there is no reaction
+  // email template yet, and sendNotificationAlerts only mails events with one.
+  database
+    .getActorFromId({ id: activity.actor })
+    .then((sourceActor) => {
+      if (!sourceActor) return
+      sendNotificationAlerts({
+        database,
+        actorId: status.actorId,
+        sourceActorId: activity.actor,
+        sourceActor,
+        statusId: status.id,
+        events: [
+          {
+            type: NotificationType.enum.emoji_reaction,
+            notificationId: notification.id
+          }
+        ]
+      })
+    })
+    .catch(() => undefined)
 }
 
 /**

--- a/lib/actions/emojiReaction.ts
+++ b/lib/actions/emojiReaction.ts
@@ -4,14 +4,13 @@ import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
+import { getReactionGroupKey } from '@/lib/services/reactions/reactionGroupKey'
 import {
-  MAX_NOTIFICATION_GROUP_KEY_LENGTH,
   MAX_REACTION_NAME_LENGTH,
   MAX_STORED_REACTION_NAME_LENGTH
 } from '@/lib/services/statuses/reactionLimits'
 import { EmojiReact, Like } from '@/lib/types/activitypub'
 import { NotificationType } from '@/lib/types/database/operations'
-import { getHashFromString } from '@/lib/utils/getHashFromString'
 import { logger } from '@/lib/utils/logger'
 
 // A reaction-bearing activity is either a litepub `EmojiReact` (Pleroma/Akkoma,
@@ -193,20 +192,6 @@ const getReactionEmojiUrl = ({
 
 const getReactionTarget = (activity: ReactionActivity) =>
   typeof activity.object === 'string' ? activity.object : activity.object.id
-
-/**
- * Groups an actor's reaction notifications per (status, emoji). Both parts are
- * remote-controlled and unbounded-ish — the status id is a URL and the name can
- * be a full `shortcode@domain` — so the readable form is used only while it fits
- * the varchar(255) column, with a digest of the same inputs as the overflow
- * fallback. The digest is deterministic, so a group stays stable across
- * deliveries either way.
- */
-export const getReactionGroupKey = (statusId: string, name: string) => {
-  const groupKey = `emoji_reaction:${statusId}:${name}`
-  if (groupKey.length <= MAX_NOTIFICATION_GROUP_KEY_LENGTH) return groupKey
-  return `emoji_reaction:${getHashFromString(`${statusId}:${name}`)}`
-}
 
 /**
  * Store an inbound emoji reaction. A reaction is never a favourite: it writes no

--- a/lib/activities/index.ts
+++ b/lib/activities/index.ts
@@ -13,6 +13,14 @@ import { getActorPerson } from '@/lib/activities/getActorPerson'
 import { compactActivityPub } from '@/lib/activities/jsonld'
 import { LikeStatus } from '@/lib/activities/likeAction'
 import { QUOTE_ACTIVITY_CONTEXT } from '@/lib/activities/quoteContext'
+import {
+  REACTION_CONTEXT,
+  ReactionActivity,
+  UndoReactionActivity,
+  getReactionContent,
+  getReactionEmojiTag,
+  reactionActivityId
+} from '@/lib/activities/reactionActivity'
 import { RejectFollow } from '@/lib/activities/rejectFollow'
 import { UndoBlock } from '@/lib/activities/undoBlock'
 import { UndoFollow } from '@/lib/activities/undoFollow'
@@ -29,6 +37,7 @@ import {
 } from '@/lib/types/activitypub/activities'
 import { Actor } from '@/lib/types/domain/actor'
 import { Block as DomainBlock } from '@/lib/types/domain/block'
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
 import { Follow } from '@/lib/types/domain/follow'
 import { Relay } from '@/lib/types/domain/relay'
 import {
@@ -930,6 +939,94 @@ export const sendLike = async ({ currentActor, status }: LikeParams) =>
         currentActor,
         activity,
         logPrefix: 'sendLike'
+      })
+      span.end()
+    }
+  )
+
+interface ReactionParams {
+  currentActor: Actor
+  status: Status
+  // The stored reaction name: a unicode emoji, or a local custom-emoji
+  // shortcode whose row is passed alongside so the Emoji tag can be rendered.
+  reaction: string
+  customEmoji: CustomEmojiData | null
+}
+
+const buildReactionActivity = ({
+  currentActor,
+  status,
+  reaction,
+  customEmoji
+}: ReactionParams): ReactionActivity => {
+  const content = getReactionContent(reaction, customEmoji)
+  const emojiTag = getReactionEmojiTag(customEmoji)
+  return {
+    '@context': REACTION_CONTEXT,
+    id: reactionActivityId(currentActor.id, status.id, reaction, statusIdHash),
+    type: 'Like',
+    actor: currentActor.id,
+    object: status.id,
+    // Misskey sets both; `content` is what every other family reads.
+    content,
+    _misskey_reaction: content,
+    ...(emojiTag ? { tag: [emojiTag] } : {})
+  }
+}
+
+export const sendReaction = async (params: ReactionParams) =>
+  getTracer().startActiveSpan(
+    'activities.sendReaction',
+    {
+      attributes: {
+        actorId: params.currentActor.id,
+        statusId: params.status.id
+      }
+    },
+    async (span) => {
+      const { currentActor, status } = params
+      if (!status.actor) return
+
+      await postActivityToInbox({
+        span,
+        inbox: status.actor.inboxUrl,
+        currentActor,
+        activity: buildReactionActivity(params),
+        logPrefix: 'sendReaction'
+      })
+      span.end()
+    }
+  )
+
+export const sendUndoReaction = async (params: ReactionParams) =>
+  getTracer().startActiveSpan(
+    'activities.sendUndoReaction',
+    {
+      attributes: {
+        actorId: params.currentActor.id,
+        statusId: params.status.id
+      }
+    },
+    async (span) => {
+      const { currentActor, status } = params
+      if (!status.actor) return
+
+      const reactionActivity = buildReactionActivity(params)
+      const activity: UndoReactionActivity = {
+        '@context': REACTION_CONTEXT,
+        id: `${reactionActivity.id}/undo`,
+        type: 'Undo',
+        actor: currentActor.id,
+        // Embed the reaction verbatim: Misskey undoes the rendered Like, and a
+        // receiver needs the content to know which reaction is being retracted.
+        object: reactionActivity
+      }
+      await postActivityToInbox({
+        span,
+        inbox: status.actor.inboxUrl,
+        currentActor,
+        activity,
+        logPrefix: 'sendUndoReaction'
       })
       span.end()
     }

--- a/lib/activities/reactionActivity.test.ts
+++ b/lib/activities/reactionActivity.test.ts
@@ -1,0 +1,98 @@
+import {
+  REACTION_CONTEXT,
+  getReactionContent,
+  getReactionEmojiTag,
+  reactionActivityId
+} from '@/lib/activities/reactionActivity'
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
+
+const customEmoji: CustomEmojiData = {
+  id: 'emoji-1',
+  shortcode: 'blobcat',
+  url: 'https://test.llun.dev/emojis/blobcat.gif',
+  staticUrl: 'https://test.llun.dev/emojis/blobcat.png',
+  category: null,
+  visibleInPicker: true,
+  disabled: false,
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000
+}
+
+describe('REACTION_CONTEXT', () => {
+  it('declares the terms a Misskey-style reaction needs', () => {
+    // Receivers only read `_misskey_reaction` and the `Emoji` tag when the
+    // context defines them; dropping either silently degrades the reaction.
+    expect(REACTION_CONTEXT[0]).toBe('https://www.w3.org/ns/activitystreams')
+    expect(REACTION_CONTEXT[1]).toEqual({
+      misskey: 'https://misskey-hub.net/ns#',
+      _misskey_reaction: 'misskey:_misskey_reaction',
+      toot: 'http://joinmastodon.org/ns#',
+      Emoji: 'toot:Emoji'
+    })
+  })
+})
+
+describe('reactionActivityId', () => {
+  const hash = (value: string) => `h(${value})`
+  const actorId = 'https://test.llun.dev/users/alice'
+  const statusId = 'https://remote.test/users/bob/statuses/1'
+
+  it('is distinct per reaction on one status', () => {
+    expect(reactionActivityId(actorId, statusId, '🔥', hash)).not.toBe(
+      reactionActivityId(actorId, statusId, '🎉', hash)
+    )
+  })
+
+  it('is distinct from the favourite Like id for the same status', () => {
+    // sendLike uses `${actor}#likes/${hash(statusId)}`. A receiver that dedups
+    // by activity id must never conflate a favourite with a reaction, or an Undo
+    // would retract the wrong one.
+    expect(reactionActivityId(actorId, statusId, '🔥', hash)).not.toBe(
+      `${actorId}#likes/${hash(statusId)}`
+    )
+  })
+
+  it('is stable for the same inputs', () => {
+    expect(reactionActivityId(actorId, statusId, '🔥', hash)).toBe(
+      reactionActivityId(actorId, statusId, '🔥', hash)
+    )
+  })
+})
+
+describe('getReactionContent', () => {
+  it.each([
+    {
+      description: 'wraps a custom emoji in colons',
+      reaction: 'blobcat',
+      emoji: customEmoji,
+      expected: ':blobcat:'
+    },
+    {
+      description: 'emits a unicode emoji as itself',
+      reaction: '🔥',
+      emoji: null,
+      expected: '🔥'
+    }
+  ])('$description', ({ reaction, emoji, expected }) => {
+    expect(getReactionContent(reaction, emoji)).toBe(expected)
+  })
+})
+
+describe('getReactionEmojiTag', () => {
+  it('renders the Misskey Emoji tag shape for a custom emoji', () => {
+    expect(getReactionEmojiTag(customEmoji)).toEqual({
+      id: 'https://test.llun.dev/emojis/blobcat',
+      type: 'Emoji',
+      name: ':blobcat:',
+      updated: expect.toBeString(),
+      icon: {
+        type: 'Image',
+        url: 'https://test.llun.dev/emojis/blobcat.gif'
+      }
+    })
+  })
+
+  it('emits no tag for a unicode reaction', () => {
+    expect(getReactionEmojiTag(null)).toBeNull()
+  })
+})

--- a/lib/activities/reactionActivity.ts
+++ b/lib/activities/reactionActivity.ts
@@ -1,0 +1,102 @@
+import { getConfig } from '@/lib/config'
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
+import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
+
+// Outbound reactions are emitted in the Misskey shape — a `Like` carrying the
+// emoji on both `content` and `_misskey_reaction`, plus an `Emoji` tag for a
+// custom one — because it is the only spelling every server family renders
+// something for:
+//
+// - Misskey / Firefish / Sharkey read it natively.
+// - Pleroma / Akkoma rewrite a `Like` with `content` into their own
+//   `EmojiReact`.
+// - Vanilla Mastodon has no `EmojiReact` handler at all and drops it silently,
+//   but its `Like` handler ignores `content` — so the reaction degrades to a
+//   plain favourite instead of vanishing.
+//
+// That degradation is the deliberate trade-off: the alternative (emitting
+// FEP-c0e0 `EmojiReact`, which is cleaner) is invisible to most of the network.
+export const REACTION_CONTEXT = [
+  'https://www.w3.org/ns/activitystreams',
+  {
+    misskey: 'https://misskey-hub.net/ns#',
+    _misskey_reaction: 'misskey:_misskey_reaction',
+    toot: 'http://joinmastodon.org/ns#',
+    Emoji: 'toot:Emoji'
+  }
+]
+
+export interface ReactionEmojiTag {
+  id: string
+  type: 'Emoji'
+  name: string
+  updated: string
+  icon: {
+    type: 'Image'
+    mediaType?: string
+    url: string
+  }
+}
+
+export interface ReactionActivity {
+  '@context': typeof REACTION_CONTEXT
+  id: string
+  type: 'Like'
+  actor: string
+  object: string
+  content: string
+  _misskey_reaction: string
+  tag?: ReactionEmojiTag[]
+}
+
+export interface UndoReactionActivity {
+  '@context': typeof REACTION_CONTEXT
+  id: string
+  type: 'Undo'
+  actor: string
+  object: ReactionActivity
+}
+
+/**
+ * The activity id for one (actor, status, reaction). It must be distinct per
+ * reaction *and* distinct from the favourite `Like` id the same actor may send
+ * for the same status — otherwise a receiver that dedups by id would treat a
+ * favourite and a reaction as the same activity, and an `Undo` could retract
+ * the wrong one.
+ */
+export const reactionActivityId = (
+  actorId: string,
+  statusId: string,
+  reaction: string,
+  hash: (value: string) => string
+) => `${actorId}#emoji-reactions/${hash(statusId)}/${hash(reaction)}`
+
+/**
+ * How the reaction is written on the wire: a custom emoji travels colon-wrapped
+ * (`:blobcat:`), a unicode emoji as itself.
+ */
+export const getReactionContent = (
+  reaction: string,
+  customEmoji: CustomEmojiData | null
+) => (customEmoji ? `:${customEmoji.shortcode}:` : reaction)
+
+/**
+ * The `Emoji` tag describing a local custom emoji, in Misskey's `renderEmoji`
+ * shape, so receivers can display the image rather than the bare shortcode.
+ * Unicode reactions carry no tag.
+ */
+export const getReactionEmojiTag = (
+  customEmoji: CustomEmojiData | null
+): ReactionEmojiTag | null => {
+  if (!customEmoji) return null
+  return {
+    id: `https://${getConfig().host}/emojis/${customEmoji.shortcode}`,
+    type: 'Emoji',
+    name: `:${customEmoji.shortcode}:`,
+    updated: getISOTimeUTC(customEmoji.updatedAt),
+    icon: {
+      type: 'Image',
+      url: customEmoji.url
+    }
+  }
+}

--- a/lib/database/sql/pushSubscription.test.ts
+++ b/lib/database/sql/pushSubscription.test.ts
@@ -584,3 +584,24 @@ describe('PushSubscription Database', () => {
     })
   })
 })
+
+describe('pleroma:emoji_reaction alert default', () => {
+  it('resolves to true for a stored row that predates the key', () => {
+    // normalizeAlerts fills a missing key from DEFAULT_PUSH_ALERTS, so a false
+    // default would permanently suppress reaction pushes for every subscription
+    // created before the key existed.
+    const alerts = parseStoredAlerts(
+      JSON.stringify({ mention: true, favourite: false })
+    )
+
+    expect(alerts['pleroma:emoji_reaction']).toBeTrue()
+  })
+
+  it('honours an explicit opt-out', () => {
+    const alerts = parseStoredAlerts(
+      JSON.stringify({ 'pleroma:emoji_reaction': false })
+    )
+
+    expect(alerts['pleroma:emoji_reaction']).toBeFalse()
+  })
+})

--- a/lib/database/sql/pushSubscription.ts
+++ b/lib/database/sql/pushSubscription.ts
@@ -42,7 +42,13 @@ export const DEFAULT_PUSH_ALERTS: PushAlerts = {
   update: false,
   quote: false,
   quoted_update: false,
-  'pleroma:emoji_reaction': false,
+  // Deliberately true, unlike every Mastodon-documented flag above.
+  // `pleroma:emoji_reaction` is an ecosystem extension that no Mastodon client
+  // will ever request, and `normalizeAlerts` resolves a key absent from a
+  // stored row to this default — so `false` would permanently suppress reaction
+  // pushes for every subscription that predates the key, i.e. all of them. An
+  // Akkoma-aware client that explicitly sets it false is still honoured.
+  'pleroma:emoji_reaction': true,
   'admin.sign_up': false,
   'admin.report': false
 }

--- a/lib/database/sql/pushSubscription.ts
+++ b/lib/database/sql/pushSubscription.ts
@@ -42,6 +42,7 @@ export const DEFAULT_PUSH_ALERTS: PushAlerts = {
   update: false,
   quote: false,
   quoted_update: false,
+  'pleroma:emoji_reaction': false,
   'admin.sign_up': false,
   'admin.report': false
 }
@@ -61,6 +62,7 @@ export const ALL_PUSH_ALERTS_ENABLED: PushAlerts = {
   update: true,
   quote: true,
   quoted_update: true,
+  'pleroma:emoji_reaction': true,
   'admin.sign_up': true,
   'admin.report': true
 }

--- a/lib/services/notifications/pushNotification.ts
+++ b/lib/services/notifications/pushNotification.ts
@@ -29,6 +29,7 @@ const NOTIFICATION_TYPE_TO_ALERT: Partial<
   reblog: 'reblog',
   quote: 'quote',
   quoted_update: 'quoted_update',
+  emoji_reaction: 'pleroma:emoji_reaction',
   activity_import: 'status'
 }
 
@@ -115,6 +116,11 @@ const getNotificationContent = (
       return {
         title: 'Quoted',
         body: `${displayName} quoted your post`
+      }
+    case 'emoji_reaction':
+      return {
+        title: 'Reaction',
+        body: `${displayName} reacted to your post`
       }
     case 'quoted_update':
       return {

--- a/lib/services/reactions/getStatusReactionList.test.ts
+++ b/lib/services/reactions/getStatusReactionList.test.ts
@@ -1,0 +1,123 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import { getStatusReactionList } from '@/lib/services/reactions/getStatusReactionList'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { Actor } from '@/lib/types/domain/actor'
+
+describe('getStatusReactionList', () => {
+  const database = getTestSQLDatabase()
+  const statusId = `${ACTOR1_ID}/statuses/post-1`
+  let author: Actor
+  let reactor: Actor
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    author = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    reactor = (await database.getActorFromUsername({
+      username: seedActor2.username,
+      domain: seedActor2.domain
+    })) as Actor
+
+    await database.createStatusReaction({
+      statusId,
+      actorId: ACTOR1_ID,
+      name: '🔥'
+    })
+    await database.createStatusReaction({
+      statusId,
+      actorId: ACTOR2_ID,
+      name: '🔥'
+    })
+    await database.createStatusReaction({
+      statusId,
+      actorId: ACTOR2_ID,
+      name: '🎉'
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  it('returns every reaction with its accounts', async () => {
+    const reactions = await getStatusReactionList({
+      database,
+      currentActor: author,
+      statusId
+    })
+
+    expect(reactions).toHaveLength(2)
+    const fire = reactions?.find((entry) => entry.name === '🔥')
+    expect(fire).toMatchObject({ name: '🔥', count: 2, me: true })
+    expect(fire?.accounts).toHaveLength(2)
+  })
+
+  it('restricts to one emoji when given a name', async () => {
+    const reactions = await getStatusReactionList({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🎉'
+    })
+
+    expect(reactions).toHaveLength(1)
+    expect(reactions?.[0]).toMatchObject({ name: '🎉', count: 1, me: true })
+    expect(reactions?.[0].accounts).toHaveLength(1)
+  })
+
+  it('reports me false for an anonymous reader', async () => {
+    const reactions = await getStatusReactionList({
+      database,
+      currentActor: null,
+      statusId
+    })
+
+    expect(reactions?.every((entry) => entry.me === false)).toBeTrue()
+  })
+
+  it('resolves accounts whose url is a profile url rather than the actor uri', async () => {
+    // Some actors serve `/@name` as their `url`; keying the account map on
+    // `url` alone drops them and the reactor silently disappears.
+    const accounts = await database.getMastodonActorsFromIds({
+      ids: [ACTOR1_ID, ACTOR2_ID]
+    })
+    vi.spyOn(database, 'getMastodonActorsFromIds').mockResolvedValueOnce(
+      accounts.map((account) => ({ ...account, url: 'https://llun.test/@x' }))
+    )
+
+    const reactions = await getStatusReactionList({
+      database,
+      currentActor: author,
+      statusId
+    })
+
+    expect(
+      reactions?.find((entry) => entry.name === '🔥')?.accounts
+    ).toHaveLength(2)
+  })
+
+  it('returns null for a status that cannot be read', async () => {
+    const reactions = await getStatusReactionList({
+      database,
+      currentActor: author,
+      statusId: 'https://nonexistent.status/id'
+    })
+
+    expect(reactions).toBeNull()
+  })
+
+  it('returns an empty list for a status with no reactions', async () => {
+    const reactions = await getStatusReactionList({
+      database,
+      currentActor: author,
+      statusId: `${ACTOR1_ID}/statuses/post-2`
+    })
+
+    expect(reactions).toEqual([])
+  })
+})

--- a/lib/services/reactions/getStatusReactionList.ts
+++ b/lib/services/reactions/getStatusReactionList.ts
@@ -1,7 +1,9 @@
 import { Database } from '@/lib/database/types'
+import { normalizeStoredReactionName } from '@/lib/services/reactions/reactionName'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
+import { idToUrl } from '@/lib/utils/urlToId'
 
 // The Pleroma/Akkoma `GET .../reactions` entry: the rollup a Status already
 // carries, plus the accounts behind it. Not core Mastodon API.
@@ -33,26 +35,49 @@ export const getStatusReactionList = async ({
   })
   if (!status) return null
 
+  // The `:emoji` URL segment is free text, and the write path stores a custom
+  // emoji colon-free — so normalise identically here or `GET .../reactions/:x:`
+  // would find nothing that `PUT .../reactions/:x:` had just created.
+  const storedName = name ? normalizeStoredReactionName(name) : undefined
+
   const [rollups, reactors] = await Promise.all([
     database.getStatusReactionRollups({
       statusIds: [statusId],
       currentActorId: currentActor?.id
     }),
-    database.getStatusReactionActors({ statusId, ...(name ? { name } : {}) })
+    database.getStatusReactionActors({
+      statusId,
+      ...(storedName ? { name: storedName } : {})
+    })
   ])
 
-  const selected = name
-    ? rollups.filter((rollup) => rollup.name === name)
+  const selected = storedName
+    ? rollups.filter((rollup) => rollup.name === storedName)
     : rollups
   if (selected.length === 0) return []
 
   // One batched account lookup for the whole page rather than one per reaction.
+  const requestedActorIds = [...new Set(reactors.map((r) => r.actorId))]
+  const requestedActorIdSet = new Set(requestedActorIds)
   const accounts = await database.getMastodonActorsFromIds({
-    ids: [...new Set(reactors.map((reactor) => reactor.actorId))]
+    ids: requestedActorIds
   })
-  const accountByUrl = new Map(
-    accounts.map((account) => [account.url, account])
-  )
+  // Key by the actor URI decoded from the opaque `account.id`, falling back to
+  // `account.url` — for some actors `url` is a profile URL (`/@name`) rather
+  // than the actor URI, and keying on it alone drops them. Mirrors how
+  // getMastodonStatuses builds its account cache.
+  const accountByActorId = new Map<string, Mastodon.Account>()
+  for (const account of accounts) {
+    const decodedActorId =
+      typeof account.id === 'string' ? idToUrl(account.id) : ''
+    if (requestedActorIdSet.has(decodedActorId)) {
+      accountByActorId.set(decodedActorId, account)
+      continue
+    }
+    if (requestedActorIdSet.has(account.url)) {
+      accountByActorId.set(account.url, account)
+    }
+  }
 
   return selected.map((rollup) => ({
     name: rollup.name,
@@ -64,7 +89,7 @@ export const getStatusReactionList = async ({
     // actor we can no longer resolve is dropped rather than nulled.
     accounts: reactors
       .filter((reactor) => reactor.name === rollup.name)
-      .map((reactor) => accountByUrl.get(reactor.actorId))
+      .map((reactor) => accountByActorId.get(reactor.actorId))
       .filter((account): account is Mastodon.Account => Boolean(account))
   }))
 }

--- a/lib/services/reactions/getStatusReactionList.ts
+++ b/lib/services/reactions/getStatusReactionList.ts
@@ -1,0 +1,70 @@
+import { Database } from '@/lib/database/types'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
+import { Mastodon } from '@/lib/types/activitypub'
+import { Actor } from '@/lib/types/domain/actor'
+
+// The Pleroma/Akkoma `GET .../reactions` entry: the rollup a Status already
+// carries, plus the accounts behind it. Not core Mastodon API.
+export interface StatusReactionWithAccounts {
+  name: string
+  count: number
+  me: boolean
+  url: string | null
+  static_url: string | null
+  accounts: Mastodon.Account[]
+}
+
+export const getStatusReactionList = async ({
+  database,
+  currentActor,
+  statusId,
+  name
+}: {
+  database: Database
+  currentActor: Actor | null
+  statusId: string
+  name?: string
+}): Promise<StatusReactionWithAccounts[] | null> => {
+  const status = await getReadableStatus({
+    database,
+    statusId,
+    currentActor,
+    withReplies: false
+  })
+  if (!status) return null
+
+  const [rollups, reactors] = await Promise.all([
+    database.getStatusReactionRollups({
+      statusIds: [statusId],
+      currentActorId: currentActor?.id
+    }),
+    database.getStatusReactionActors({ statusId, ...(name ? { name } : {}) })
+  ])
+
+  const selected = name
+    ? rollups.filter((rollup) => rollup.name === name)
+    : rollups
+  if (selected.length === 0) return []
+
+  // One batched account lookup for the whole page rather than one per reaction.
+  const accounts = await database.getMastodonActorsFromIds({
+    ids: [...new Set(reactors.map((reactor) => reactor.actorId))]
+  })
+  const accountByUrl = new Map(
+    accounts.map((account) => [account.url, account])
+  )
+
+  return selected.map((rollup) => ({
+    name: rollup.name,
+    count: rollup.count,
+    me: rollup.me,
+    url: rollup.url,
+    static_url: rollup.staticUrl,
+    // Reactors are returned oldest-first, matching the rollup ordering. An
+    // actor we can no longer resolve is dropped rather than nulled.
+    accounts: reactors
+      .filter((reactor) => reactor.name === rollup.name)
+      .map((reactor) => accountByUrl.get(reactor.actorId))
+      .filter((account): account is Mastodon.Account => Boolean(account))
+  }))
+}

--- a/lib/services/reactions/reactStatus.test.ts
+++ b/lib/services/reactions/reactStatus.test.ts
@@ -359,72 +359,50 @@ describe('unreactStatus', () => {
       expect(mockSendUndoReaction).toHaveBeenCalledTimes(1)
     })
 
-    it('withholds the Undo while the actor still holds another reaction', async () => {
-      // A Like-only receiver collapsed both of our reaction Likes into a single
-      // favourite, so undoing one would delete the representation of the other.
+    it.each([
+      {
+        description: 'the actor still holds another reaction',
+        setup: async () => {
+          await reactStatus({
+            database,
+            currentActor: reactor,
+            statusId: remoteStatusId,
+            name: '\u{1F30E}'
+          })
+        }
+      },
+      {
+        description: 'the actor also favourited the status',
+        setup: async () => {
+          await database.createLike({
+            actorId: reactor.id,
+            statusId: remoteStatusId
+          })
+        }
+      }
+    ])('still sends the Undo when $description', async ({ setup }) => {
+      // A reaction-native receiver resolves the Undo by reaction content, so
+      // withholding it would leave this emoji visible there forever. That
+      // matters more than the favourite a Like-only receiver may also clear —
+      // it never rendered the reaction in the first place.
       await reactStatus({
         database,
         currentActor: reactor,
         statusId: remoteStatusId,
-        name: '🌍'
+        name: '\u{1F30D}'
       })
-      await reactStatus({
-        database,
-        currentActor: reactor,
-        statusId: remoteStatusId,
-        name: '🌎'
-      })
-      vi.clearAllMocks()
-
-      await unreactStatus({
-        database,
-        currentActor: reactor,
-        statusId: remoteStatusId,
-        name: '🌍'
-      })
-      expect(mockSendUndoReaction).not.toHaveBeenCalled()
-
-      // Retracting the last one has nothing left to represent, so it goes out.
-      await unreactStatus({
-        database,
-        currentActor: reactor,
-        statusId: remoteStatusId,
-        name: '🌎'
-      })
-      expect(mockSendUndoReaction).toHaveBeenCalledTimes(1)
-    })
-
-    it('withholds the Undo when the actor also favourited the status', async () => {
-      // A vanilla-Mastodon receiver resolves Undo{Like} by (account, status),
-      // and our reaction Like landed there as a favourite. Sending the Undo
-      // would destroy the genuine favourite the actor still holds.
-      await reactStatus({
-        database,
-        currentActor: reactor,
-        statusId: remoteStatusId,
-        name: '📡'
-      })
-      await database.createLike({
-        actorId: reactor.id,
-        statusId: remoteStatusId
-      })
+      await setup()
       vi.clearAllMocks()
 
       const result = await unreactStatus({
         database,
         currentActor: reactor,
         statusId: remoteStatusId,
-        name: '📡'
+        name: '\u{1F30D}'
       })
 
       expect(result).toMatchObject({ changed: true })
-      expect(mockSendUndoReaction).not.toHaveBeenCalled()
-      // The reaction is still gone locally — only the outbound Undo is withheld.
-      expect(
-        (
-          await database.getStatusReactionActors({ statusId: remoteStatusId })
-        ).map((entry) => entry.name)
-      ).not.toContain('📡')
+      expect(mockSendUndoReaction).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/lib/services/reactions/reactStatus.test.ts
+++ b/lib/services/reactions/reactStatus.test.ts
@@ -359,6 +359,41 @@ describe('unreactStatus', () => {
       expect(mockSendUndoReaction).toHaveBeenCalledTimes(1)
     })
 
+    it('withholds the Undo while the actor still holds another reaction', async () => {
+      // A Like-only receiver collapsed both of our reaction Likes into a single
+      // favourite, so undoing one would delete the representation of the other.
+      await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '🌍'
+      })
+      await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '🌎'
+      })
+      vi.clearAllMocks()
+
+      await unreactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '🌍'
+      })
+      expect(mockSendUndoReaction).not.toHaveBeenCalled()
+
+      // Retracting the last one has nothing left to represent, so it goes out.
+      await unreactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '🌎'
+      })
+      expect(mockSendUndoReaction).toHaveBeenCalledTimes(1)
+    })
+
     it('withholds the Undo when the actor also favourited the status', async () => {
       // A vanilla-Mastodon receiver resolves Undo{Like} by (account, status),
       // and our reaction Like landed there as a favourite. Sending the Undo

--- a/lib/services/reactions/reactStatus.test.ts
+++ b/lib/services/reactions/reactStatus.test.ts
@@ -223,38 +223,39 @@ describe('reactStatus', () => {
     ).toMatchObject({ ok: true, changed: false })
   })
 
-  it('does not notify or federate when nothing changed', async () => {
-    const statusId = `${ACTOR2_ID}/statuses/post-2`
+  it('does not federate again when nothing changed', async () => {
+    // Must use a REMOTE-authored status: on a local self-authored one the
+    // federation and notification branches are both skipped anyway, so the
+    // assertions would hold even with the `changed` guard removed.
+    const remoteStatusId = `${EXTERNAL_ACTOR1}/statuses/unchanged-1`
+    await database.createNote({
+      id: remoteStatusId,
+      url: remoteStatusId,
+      actorId: EXTERNAL_ACTOR1,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'Remote post'
+    })
+
     const first = await reactStatus({
       database,
       currentActor: reactor,
-      statusId,
+      statusId: remoteStatusId,
       name: '🙌'
     })
-    expect(first).toMatchObject({ changed: true })
-
-    vi.clearAllMocks()
-    const before = await database.getNotifications({
-      actorId: reactor.id,
-      limit: 50,
-      types: [NotificationType.enum.emoji_reaction]
-    })
+    expect(first).toMatchObject({ ok: true, changed: true })
+    expect(mockSendReaction).toHaveBeenCalledTimes(1)
 
     const repeat = await reactStatus({
       database,
       currentActor: reactor,
-      statusId,
+      statusId: remoteStatusId,
       name: '🙌'
     })
 
     expect(repeat).toMatchObject({ ok: true, changed: false })
-    expect(mockSendReaction).not.toHaveBeenCalled()
-    const after = await database.getNotifications({
-      actorId: reactor.id,
-      limit: 50,
-      types: [NotificationType.enum.emoji_reaction]
-    })
-    expect(after).toHaveLength(before.length)
+    // Still once: a redelivered reaction must not re-post to the remote inbox.
+    expect(mockSendReaction).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/lib/services/reactions/reactStatus.test.ts
+++ b/lib/services/reactions/reactStatus.test.ts
@@ -1,0 +1,277 @@
+import { getTestSQLDatabase } from '@/lib/database/testUtils'
+import {
+  reactStatus,
+  unreactStatus
+} from '@/lib/services/reactions/reactStatus'
+import { seedDatabase } from '@/lib/stub/database'
+import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
+import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { NotificationType } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+
+const mockSendReaction = vi.fn()
+const mockSendUndoReaction = vi.fn()
+
+vi.mock('@/lib/activities', () => ({
+  sendReaction: (...params: unknown[]) => mockSendReaction(...params),
+  sendUndoReaction: (...params: unknown[]) => mockSendUndoReaction(...params)
+}))
+
+describe('reactStatus', () => {
+  const database = getTestSQLDatabase()
+  let reactor: Actor
+  let author: Actor
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    reactor = (await database.getActorFromUsername({
+      username: seedActor2.username,
+      domain: seedActor2.domain
+    })) as Actor
+    author = (await database.getActorFromUsername({
+      username: seedActor1.username,
+      domain: seedActor1.domain
+    })) as Actor
+    await database.createCustomEmoji({
+      shortcode: 'partyparrot',
+      url: 'https://test.llun.dev/emojis/partyparrot.gif',
+      staticUrl: 'https://test.llun.dev/emojis/partyparrot.png'
+    })
+    await database.createCustomEmoji({
+      shortcode: 'retired',
+      url: 'https://test.llun.dev/emojis/retired.gif',
+      staticUrl: 'https://test.llun.dev/emojis/retired.png',
+      disabled: true
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('stores a unicode reaction and reports the change', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/post-1`
+    const result = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🔥'
+    })
+
+    expect(result).toMatchObject({ ok: true, changed: true })
+    const rollups = await database.getStatusReactionRollups({
+      statusIds: [statusId],
+      currentActorId: reactor.id
+    })
+    expect(rollups).toContainEqual(
+      expect.objectContaining({ name: '🔥', count: 1, me: true })
+    )
+  })
+
+  it('never records a reaction as a favourite', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/post-2`
+    await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🎉'
+    })
+
+    expect(
+      await database.isActorLikedStatus({ statusId, actorId: reactor.id })
+    ).toBeFalse()
+    expect(await database.getLikeCount({ statusId })).toBe(0)
+  })
+
+  it('stores a local custom emoji by its bare shortcode', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/post-3`
+    const result = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: ':partyparrot:'
+    })
+
+    expect(result).toMatchObject({ ok: true, changed: true })
+    const rollups = await database.getStatusReactionRollups({
+      statusIds: [statusId]
+    })
+    // Stored colon-free so the rollup resolves the image live from customEmojis.
+    expect(rollups).toContainEqual(
+      expect.objectContaining({
+        name: 'partyparrot',
+        url: 'https://test.llun.dev/emojis/partyparrot.gif'
+      })
+    )
+  })
+
+  it.each([
+    { description: 'a shortcode with no matching emoji', name: ':nosuch:' },
+    { description: 'a disabled custom emoji', name: ':retired:' },
+    { description: 'two emoji', name: '🔥🔥' },
+    { description: 'arbitrary text', name: 'not an emoji' },
+    {
+      description: 'a remote namespaced shortcode',
+      name: 'blobcat@remote.test'
+    }
+  ])('rejects $description as invalid-emoji', async ({ name }) => {
+    const result = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId: `${ACTOR1_ID}/statuses/post-1`,
+      name
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'invalid-emoji' })
+  })
+
+  it('reports not-found for a status that does not exist', async () => {
+    const result = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId: 'https://nonexistent.status/id',
+      name: '🔥'
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'not-found' })
+  })
+
+  it('notifies the author of a local status instead of federating', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/post-1`
+    await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '💜'
+    })
+
+    const notifications = await database.getNotifications({
+      actorId: author.id,
+      limit: 20,
+      types: [NotificationType.enum.emoji_reaction]
+    })
+    expect(
+      notifications.some((entry) => entry.reactionName === '💜')
+    ).toBeTrue()
+    // A local author has no remote inbox — federating would post to ourselves.
+    expect(mockSendReaction).not.toHaveBeenCalled()
+  })
+
+  it('does not notify or federate when nothing changed', async () => {
+    const statusId = `${ACTOR2_ID}/statuses/post-2`
+    const first = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🙌'
+    })
+    expect(first).toMatchObject({ changed: true })
+
+    vi.clearAllMocks()
+    const before = await database.getNotifications({
+      actorId: reactor.id,
+      limit: 50,
+      types: [NotificationType.enum.emoji_reaction]
+    })
+
+    const repeat = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🙌'
+    })
+
+    expect(repeat).toMatchObject({ ok: true, changed: false })
+    expect(mockSendReaction).not.toHaveBeenCalled()
+    const after = await database.getNotifications({
+      actorId: reactor.id,
+      limit: 50,
+      types: [NotificationType.enum.emoji_reaction]
+    })
+    expect(after).toHaveLength(before.length)
+  })
+})
+
+describe('unreactStatus', () => {
+  const database = getTestSQLDatabase()
+  let reactor: Actor
+
+  beforeAll(async () => {
+    await database.migrate()
+    await seedDatabase(database)
+    reactor = (await database.getActorFromUsername({
+      username: seedActor2.username,
+      domain: seedActor2.domain
+    })) as Actor
+    await database.createCustomEmoji({
+      shortcode: 'partyparrot',
+      url: 'https://test.llun.dev/emojis/partyparrot.gif',
+      staticUrl: 'https://test.llun.dev/emojis/partyparrot.png'
+    })
+  })
+
+  afterAll(async () => {
+    await database.destroy()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('removes exactly the named reaction', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/post-1`
+    await reactStatus({ database, currentActor: reactor, statusId, name: '🔥' })
+    await reactStatus({ database, currentActor: reactor, statusId, name: '💧' })
+
+    const result = await unreactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🔥'
+    })
+
+    expect(result).toMatchObject({ ok: true, changed: true })
+    const reactors = await database.getStatusReactionActors({ statusId })
+    expect(reactors.map((entry) => entry.name)).toEqual(['💧'])
+  })
+
+  it.each([
+    { description: 'colon-wrapped', name: ':partyparrot:' },
+    { description: 'bare', name: 'partyparrot' }
+  ])('removes a custom emoji written $description', async ({ name }) => {
+    const statusId = `${ACTOR1_ID}/statuses/post-2`
+    await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: ':partyparrot:'
+    })
+
+    const result = await unreactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name
+    })
+
+    expect(result).toMatchObject({ changed: true })
+    expect(await database.getStatusReactionActors({ statusId })).toEqual([])
+  })
+
+  it('reports no change when the reaction was not there', async () => {
+    const result = await unreactStatus({
+      database,
+      currentActor: reactor,
+      statusId: `${ACTOR1_ID}/statuses/post-3`,
+      name: '🛸'
+    })
+
+    expect(result).toMatchObject({ ok: true, changed: false })
+    expect(mockSendUndoReaction).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/reactions/reactStatus.test.ts
+++ b/lib/services/reactions/reactStatus.test.ts
@@ -406,6 +406,62 @@ describe('unreactStatus', () => {
     })
   })
 
+  it('still removes a reaction after the status stops being readable', async () => {
+    // The author narrows a public post to followers-only afterwards. Refusing
+    // would leave the reaction counted in everyone else's rollups forever.
+    const statusId = `${ACTOR1_ID}/statuses/narrowed-1`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      to: [ACTIVITY_STREAM_PUBLIC],
+      cc: [],
+      text: 'Public then narrowed'
+    })
+    await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🔒'
+    })
+    await database.updateNoteVisibility({
+      statusId,
+      to: [`${ACTOR1_ID}/followers`],
+      cc: []
+    })
+
+    const result = await unreactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🔒'
+    })
+
+    expect(result).toMatchObject({ ok: true, changed: true })
+    expect(await database.getStatusReactionActors({ statusId })).toEqual([])
+  })
+
+  it('reports not-found for an unreadable status the actor never reacted to', async () => {
+    const statusId = `${ACTOR1_ID}/statuses/narrowed-2`
+    await database.createNote({
+      id: statusId,
+      url: statusId,
+      actorId: ACTOR1_ID,
+      to: [`${ACTOR1_ID}/followers`],
+      cc: [],
+      text: 'Never readable'
+    })
+
+    const result = await unreactStatus({
+      database,
+      currentActor: reactor,
+      statusId,
+      name: '🔒'
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'not-found' })
+  })
+
   it('reports no change when the reaction was not there', async () => {
     const result = await unreactStatus({
       database,

--- a/lib/services/reactions/reactStatus.test.ts
+++ b/lib/services/reactions/reactStatus.test.ts
@@ -3,11 +3,14 @@ import {
   reactStatus,
   unreactStatus
 } from '@/lib/services/reactions/reactStatus'
+import { MAX_REACTIONS_PER_ACTOR } from '@/lib/services/statuses/reactionLimits'
 import { seedDatabase } from '@/lib/stub/database'
 import { ACTOR1_ID, seedActor1 } from '@/lib/stub/seed/actor1'
 import { ACTOR2_ID, seedActor2 } from '@/lib/stub/seed/actor2'
+import { EXTERNAL_ACTOR1 } from '@/lib/stub/seed/external1'
 import { NotificationType } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 const mockSendReaction = vi.fn()
 const mockSendUndoReaction = vi.fn()
@@ -162,6 +165,64 @@ describe('reactStatus', () => {
     expect(mockSendReaction).not.toHaveBeenCalled()
   })
 
+  it('reacts to the boosted post rather than the boost wrapper', async () => {
+    // The serializer renders an Announce wrapper with empty reactions by design,
+    // so a reaction stored against the wrapper would be invisible everywhere.
+    const announceId = `${ACTOR2_ID}/statuses/announce-1`
+    const boostedId = `${ACTOR1_ID}/statuses/post-3`
+
+    const result = await reactStatus({
+      database,
+      currentActor: reactor,
+      statusId: announceId,
+      name: '🛰️'
+    })
+
+    expect(result).toMatchObject({ ok: true, changed: true })
+    expect(
+      (await database.getStatusReactionActors({ statusId: boostedId })).map(
+        (entry) => entry.name
+      )
+    ).toContain('🛰️')
+    expect(
+      await database.getStatusReactionActors({ statusId: announceId })
+    ).toEqual([])
+  })
+
+  it('reports cap-reached instead of silently dropping the reaction', async () => {
+    const statusId = `${ACTOR2_ID}/statuses/reply-1`
+    const names = ['🍎', '🍊', '🍋', '🍉', '🍇', '🍓', '🍒', '🥝']
+    expect(names).toHaveLength(MAX_REACTIONS_PER_ACTOR)
+    for (const name of names) {
+      const result = await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId,
+        name
+      })
+      expect(result).toMatchObject({ ok: true, changed: true })
+    }
+
+    expect(
+      await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId,
+        name: '🍍'
+      })
+    ).toEqual({ ok: false, reason: 'cap-reached' })
+
+    // A reaction already held stays idempotent rather than reporting the cap.
+    expect(
+      await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId,
+        name: '🍎'
+      })
+    ).toMatchObject({ ok: true, changed: false })
+  })
+
   it('does not notify or federate when nothing changed', async () => {
     const statusId = `${ACTOR2_ID}/statuses/post-2`
     const first = await reactStatus({
@@ -261,6 +322,74 @@ describe('unreactStatus', () => {
 
     expect(result).toMatchObject({ changed: true })
     expect(await database.getStatusReactionActors({ statusId })).toEqual([])
+  })
+
+  describe('federating the retraction', () => {
+    const remoteStatusId = `${EXTERNAL_ACTOR1}/statuses/remote-1`
+
+    beforeAll(async () => {
+      // EXTERNAL_ACTOR1 is already seeded by seedDatabase.
+      await database.createNote({
+        id: remoteStatusId,
+        url: remoteStatusId,
+        actorId: EXTERNAL_ACTOR1,
+        to: [ACTIVITY_STREAM_PUBLIC],
+        cc: [],
+        text: 'Remote post'
+      })
+    })
+
+    it('sends the Undo for a remote status', async () => {
+      await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '🔭'
+      })
+
+      const result = await unreactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '🔭'
+      })
+
+      expect(result).toMatchObject({ changed: true })
+      expect(mockSendUndoReaction).toHaveBeenCalledTimes(1)
+    })
+
+    it('withholds the Undo when the actor also favourited the status', async () => {
+      // A vanilla-Mastodon receiver resolves Undo{Like} by (account, status),
+      // and our reaction Like landed there as a favourite. Sending the Undo
+      // would destroy the genuine favourite the actor still holds.
+      await reactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '📡'
+      })
+      await database.createLike({
+        actorId: reactor.id,
+        statusId: remoteStatusId
+      })
+      vi.clearAllMocks()
+
+      const result = await unreactStatus({
+        database,
+        currentActor: reactor,
+        statusId: remoteStatusId,
+        name: '📡'
+      })
+
+      expect(result).toMatchObject({ changed: true })
+      expect(mockSendUndoReaction).not.toHaveBeenCalled()
+      // The reaction is still gone locally — only the outbound Undo is withheld.
+      expect(
+        (
+          await database.getStatusReactionActors({ statusId: remoteStatusId })
+        ).map((entry) => entry.name)
+      ).not.toContain('📡')
+    })
   })
 
   it('reports no change when the reaction was not there', async () => {

--- a/lib/services/reactions/reactStatus.ts
+++ b/lib/services/reactions/reactStatus.ts
@@ -199,26 +199,23 @@ export const unreactStatus = async ({
     name: storedName
   })
   if (changed && !target.isLocalActor) {
-    // A vanilla-Mastodon receiver resolves `Undo{Like}` by (account, status),
-    // not by activity id, and it collapsed everything we sent for this status —
-    // every reaction Like plus any real favourite — into ONE favourite row.
-    // Sending the Undo would therefore delete the representation of whatever is
-    // left. Withhold it while anything should still be represented there; the
-    // reaction is already gone locally either way.
-    const [stillFavourited, remaining] = await Promise.all([
-      database.isActorLikedStatus({
-        statusId: target.id,
-        actorId: currentActor.id
-      }),
-      database.getStatusReactionRollups({
-        statusIds: [target.id],
-        currentActorId: currentActor.id
-      })
-    ])
-    if (stillFavourited || remaining.some((rollup) => rollup.me)) {
-      return { ok: true, changed, status }
-    }
-
+    // The Undo always goes out, even though on a Like-only receiver it can clear
+    // more than the one reaction. One activity shape serves two Undo semantics
+    // and they cannot both be satisfied without per-instance software detection
+    // (rejected in the epic design):
+    //
+    // - Reaction-native receivers (Misskey family, Pleroma/Akkoma, other
+    //   activities.next instances) resolve the Undo by reaction content, so they
+    //   remove exactly this emoji — and if we withhold it the reaction stays
+    //   visible there FOREVER, with nothing the user can do about it.
+    // - Vanilla Mastodon resolves it by (account, status) against the single
+    //   favourite our reaction degraded into, so it may also clear a genuine
+    //   favourite or the stand-in for another reaction.
+    //
+    // Sending wins: the second case is a cosmetic artifact on a server that
+    // never rendered the reaction at all, and the user can re-favourite.
+    // Withholding would be a permanent, unrecoverable bug on exactly the servers
+    // this feature exists for.
     const shortcode = getCustomEmojiShortcode(storedName)
     const customEmoji = shortcode
       ? await database.getCustomEmojiByShortcode(shortcode)

--- a/lib/services/reactions/reactStatus.ts
+++ b/lib/services/reactions/reactStatus.ts
@@ -5,13 +5,15 @@ import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotific
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
 import {
   getCustomEmojiShortcode,
-  isUnicodeEmojiReaction
+  isUnicodeEmojiReaction,
+  normalizeStoredReactionName
 } from '@/lib/services/reactions/reactionName'
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
+import { MAX_REACTIONS_PER_ACTOR } from '@/lib/services/statuses/reactionLimits'
 import { NotificationType } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
-import { Status } from '@/lib/types/domain/status'
+import { Status, getOriginalStatus } from '@/lib/types/domain/status'
 
 import { getReactionGroupKey } from './reactionGroupKey'
 
@@ -30,6 +32,10 @@ export type ReactStatusResult =
   // Not something this instance can render or federate: not a single emoji
   // grapheme, and not a shortcode naming an enabled local custom emoji.
   | { ok: false; reason: 'invalid-emoji' }
+  // The actor already holds MAX_REACTIONS_PER_ACTOR distinct reactions here.
+  // Reported rather than silently dropped: the storage layer would no-op, and
+  // the client would see a 200 whose Status does not contain its reaction.
+  | { ok: false; reason: 'cap-reached' }
 
 type ResolvedReaction = { name: string; customEmoji: CustomEmojiData | null }
 
@@ -127,8 +133,29 @@ export const reactStatus = async ({
   const resolved = await resolveLocalReaction(database, name)
   if (!resolved) return { ok: false, reason: 'invalid-emoji' }
 
+  // Reacting to a boost reacts to the post it boosts. The serializer renders an
+  // Announce wrapper with empty reactions by design (they belong to the
+  // original, and surface on `reblog`), so storing against the wrapper would
+  // federate a reaction that is then invisible on every Status entity.
+  const target = getOriginalStatus(status)
+
+  // The storage layer drops a reaction past the cap silently, which would make
+  // this look like a success that did nothing. Check first so the caller gets a
+  // real error. Racy under concurrency, but the cap is advisory anyway.
+  const existing = await database.getStatusReactionRollups({
+    statusIds: [target.id],
+    currentActorId: currentActor.id
+  })
+  const mine = existing.filter((rollup) => rollup.me)
+  if (
+    mine.length >= MAX_REACTIONS_PER_ACTOR &&
+    !mine.some((rollup) => rollup.name === resolved.name)
+  ) {
+    return { ok: false, reason: 'cap-reached' }
+  }
+
   const changed = await database.createStatusReaction({
-    statusId,
+    statusId: target.id,
     actorId: currentActor.id,
     name: resolved.name
   })
@@ -138,7 +165,7 @@ export const reactStatus = async ({
     await announceReaction({
       database,
       currentActor,
-      status,
+      status: target,
       reaction: resolved.name,
       customEmoji: resolved.customEmoji
     })
@@ -163,21 +190,36 @@ export const unreactStatus = async ({
 
   // Removal accepts whatever is stored rather than re-validating: an emoji that
   // was legal when it was added must stay removable after an admin disables it.
-  const shortcode = getCustomEmojiShortcode(name)
-  const storedName = isUnicodeEmojiReaction(name) ? name : (shortcode ?? name)
+  const storedName = normalizeStoredReactionName(name)
+  const target = getOriginalStatus(status)
 
   const changed = await database.deleteStatusReaction({
-    statusId,
+    statusId: target.id,
     actorId: currentActor.id,
     name: storedName
   })
-  if (changed && !status.isLocalActor) {
+  if (changed && !target.isLocalActor) {
+    // A vanilla-Mastodon receiver resolves `Undo{Like}` by (account, status),
+    // not by activity id — and it stored our reaction Like as a favourite. If
+    // the actor also genuinely favourited this status, sending the Undo would
+    // destroy that favourite there. Withhold it: the favourite is the state
+    // that should survive, and the reaction is already gone locally.
+    if (
+      await database.isActorLikedStatus({
+        statusId: target.id,
+        actorId: currentActor.id
+      })
+    ) {
+      return { ok: true, changed, status }
+    }
+
+    const shortcode = getCustomEmojiShortcode(storedName)
     const customEmoji = shortcode
       ? await database.getCustomEmojiByShortcode(shortcode)
       : null
     await sendUndoReaction({
       currentActor,
-      status,
+      status: target,
       reaction: storedName,
       customEmoji
     })

--- a/lib/services/reactions/reactStatus.ts
+++ b/lib/services/reactions/reactStatus.ts
@@ -1,0 +1,187 @@
+import { sendReaction, sendUndoReaction } from '@/lib/activities'
+import { Database } from '@/lib/database/types'
+import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
+import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
+import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
+import {
+  getCustomEmojiShortcode,
+  isUnicodeEmojiReaction
+} from '@/lib/services/reactions/reactionName'
+import { getReadableStatus } from '@/lib/services/statusRouteAccess'
+import { NotificationType } from '@/lib/types/database/operations'
+import { Actor } from '@/lib/types/domain/actor'
+import { CustomEmojiData } from '@/lib/types/domain/customEmoji'
+import { Status } from '@/lib/types/domain/status'
+
+import { getReactionGroupKey } from './reactionGroupKey'
+
+interface ReactStatusParams {
+  database: Database
+  currentActor: Actor
+  statusId: string
+  name: string
+}
+
+export type ReactStatusResult =
+  | { ok: true; changed: boolean; status: Status }
+  // The status does not exist, or the actor cannot read it. Both answer 404 so
+  // an unreadable status is indistinguishable from a missing one.
+  | { ok: false; reason: 'not-found' }
+  // Not something this instance can render or federate: not a single emoji
+  // grapheme, and not a shortcode naming an enabled local custom emoji.
+  | { ok: false; reason: 'invalid-emoji' }
+
+type ResolvedReaction = { name: string; customEmoji: CustomEmojiData | null }
+
+/**
+ * Resolve what a locally-authored reaction is allowed to be. Inbound federation
+ * is deliberately liberal, but a reaction we originate has to round-trip: a
+ * unicode emoji is stored as itself, a shortcode only when it names an enabled
+ * custom emoji on this instance (which is also what supplies the outbound
+ * `Emoji` tag). A `shortcode@domain` reference is rejected — this instance
+ * cannot vouch for another's emoji.
+ */
+const resolveLocalReaction = async (
+  database: Database,
+  name: string
+): Promise<ResolvedReaction | null> => {
+  if (isUnicodeEmojiReaction(name)) return { name, customEmoji: null }
+
+  const shortcode = getCustomEmojiShortcode(name)
+  if (!shortcode) return null
+
+  const customEmoji = await database.getCustomEmojiByShortcode(shortcode)
+  if (!customEmoji || customEmoji.disabled) return null
+  return { name: customEmoji.shortcode, customEmoji }
+}
+
+// A reaction on a status this instance hosts notifies the author directly; one
+// on a remote status federates to its author's inbox. The two are exclusive:
+// federating to a local author would post to our own inbox, and the inbound
+// handler would then find the reaction already stored and skip the notification.
+const announceReaction = async ({
+  database,
+  currentActor,
+  status,
+  reaction,
+  customEmoji
+}: {
+  database: Database
+  currentActor: Actor
+  status: Status
+  reaction: string
+  customEmoji: CustomEmojiData | null
+}) => {
+  if (!status.isLocalActor) {
+    await sendReaction({ currentActor, status, reaction, customEmoji })
+    return
+  }
+
+  if (
+    !(await shouldCreateNotification(database, status.actorId, currentActor.id))
+  ) {
+    return
+  }
+
+  const notification = await createNotificationWithPolicy(database, {
+    actorId: status.actorId,
+    type: NotificationType.enum.emoji_reaction,
+    sourceActorId: currentActor.id,
+    statusId: status.id,
+    reactionName: reaction,
+    groupKey: getReactionGroupKey(status.id, reaction)
+  })
+  if (!notification || notification.filtered) return
+
+  // Already fire-and-forget internally: alert delivery must never fail the
+  // reaction itself.
+  sendNotificationAlerts({
+    database,
+    actorId: status.actorId,
+    sourceActorId: currentActor.id,
+    sourceActor: currentActor,
+    statusId: status.id,
+    events: [
+      {
+        type: NotificationType.enum.emoji_reaction,
+        notificationId: notification.id
+      }
+    ]
+  })
+}
+
+export const reactStatus = async ({
+  database,
+  currentActor,
+  statusId,
+  name
+}: ReactStatusParams): Promise<ReactStatusResult> => {
+  const status = await getReadableStatus({
+    database,
+    statusId,
+    currentActor,
+    withReplies: false
+  })
+  if (!status) return { ok: false, reason: 'not-found' }
+
+  const resolved = await resolveLocalReaction(database, name)
+  if (!resolved) return { ok: false, reason: 'invalid-emoji' }
+
+  const changed = await database.createStatusReaction({
+    statusId,
+    actorId: currentActor.id,
+    name: resolved.name
+  })
+  // Re-reacting with the same emoji, or reacting past the per-status cap,
+  // changes nothing — so it must not re-federate or re-notify either.
+  if (changed) {
+    await announceReaction({
+      database,
+      currentActor,
+      status,
+      reaction: resolved.name,
+      customEmoji: resolved.customEmoji
+    })
+  }
+
+  return { ok: true, changed, status }
+}
+
+export const unreactStatus = async ({
+  database,
+  currentActor,
+  statusId,
+  name
+}: ReactStatusParams): Promise<ReactStatusResult> => {
+  const status = await getReadableStatus({
+    database,
+    statusId,
+    currentActor,
+    withReplies: false
+  })
+  if (!status) return { ok: false, reason: 'not-found' }
+
+  // Removal accepts whatever is stored rather than re-validating: an emoji that
+  // was legal when it was added must stay removable after an admin disables it.
+  const shortcode = getCustomEmojiShortcode(name)
+  const storedName = isUnicodeEmojiReaction(name) ? name : (shortcode ?? name)
+
+  const changed = await database.deleteStatusReaction({
+    statusId,
+    actorId: currentActor.id,
+    name: storedName
+  })
+  if (changed && !status.isLocalActor) {
+    const customEmoji = shortcode
+      ? await database.getCustomEmojiByShortcode(shortcode)
+      : null
+    await sendUndoReaction({
+      currentActor,
+      status,
+      reaction: storedName,
+      customEmoji
+    })
+  }
+
+  return { ok: true, changed, status }
+}

--- a/lib/services/reactions/reactStatus.ts
+++ b/lib/services/reactions/reactStatus.ts
@@ -200,16 +200,22 @@ export const unreactStatus = async ({
   })
   if (changed && !target.isLocalActor) {
     // A vanilla-Mastodon receiver resolves `Undo{Like}` by (account, status),
-    // not by activity id — and it stored our reaction Like as a favourite. If
-    // the actor also genuinely favourited this status, sending the Undo would
-    // destroy that favourite there. Withhold it: the favourite is the state
-    // that should survive, and the reaction is already gone locally.
-    if (
-      await database.isActorLikedStatus({
+    // not by activity id, and it collapsed everything we sent for this status —
+    // every reaction Like plus any real favourite — into ONE favourite row.
+    // Sending the Undo would therefore delete the representation of whatever is
+    // left. Withhold it while anything should still be represented there; the
+    // reaction is already gone locally either way.
+    const [stillFavourited, remaining] = await Promise.all([
+      database.isActorLikedStatus({
         statusId: target.id,
         actorId: currentActor.id
+      }),
+      database.getStatusReactionRollups({
+        statusIds: [target.id],
+        currentActorId: currentActor.id
       })
-    ) {
+    ])
+    if (stillFavourited || remaining.some((rollup) => rollup.me)) {
       return { ok: true, changed, status }
     }
 

--- a/lib/services/reactions/reactStatus.ts
+++ b/lib/services/reactions/reactStatus.ts
@@ -180,18 +180,42 @@ export const unreactStatus = async ({
   statusId,
   name
 }: ReactStatusParams): Promise<ReactStatusResult> => {
-  const status = await getReadableStatus({
+  const readableStatus = await getReadableStatus({
     database,
     statusId,
     currentActor,
     withReplies: false
   })
+  // A status readable when the actor reacted may since have narrowed its
+  // audience (the author edits its visibility, or an accepted follow goes away).
+  // Refusing here would trap the reaction forever: it keeps counting in every
+  // viewer's rollups and, for a remote post, is never retracted upstream — the
+  // same unrecoverable-for-the-user shape that made us always send the Undo.
+  // Holding the row is itself proof the actor could read the status at the time,
+  // so fall back on ownership, exactly as unfavourite/unbookmark/unreblog do.
+  const status =
+    readableStatus ??
+    (await database.getStatus({
+      statusId,
+      withReplies: false,
+      currentActorId: currentActor.id
+    }))
   if (!status) return { ok: false, reason: 'not-found' }
 
   // Removal accepts whatever is stored rather than re-validating: an emoji that
   // was legal when it was added must stay removable after an admin disables it.
   const storedName = normalizeStoredReactionName(name)
   const target = getOriginalStatus(status)
+
+  if (!readableStatus) {
+    const own = await database.getStatusReactionRollups({
+      statusIds: [target.id],
+      currentActorId: currentActor.id
+    })
+    if (!own.some((rollup) => rollup.me && rollup.name === storedName)) {
+      return { ok: false, reason: 'not-found' }
+    }
+  }
 
   const changed = await database.deleteStatusReaction({
     statusId: target.id,

--- a/lib/services/reactions/reactionGroupKey.test.ts
+++ b/lib/services/reactions/reactionGroupKey.test.ts
@@ -1,0 +1,40 @@
+import { getReactionGroupKey } from '@/lib/services/reactions/reactionGroupKey'
+
+describe('getReactionGroupKey', () => {
+  const shortStatusId = 'https://remote.test/users/alice/statuses/1'
+
+  it('keeps the readable form while it fits the column', () => {
+    expect(getReactionGroupKey(shortStatusId, '🔥')).toBe(
+      `emoji_reaction:${shortStatusId}:🔥`
+    )
+  })
+
+  it.each([
+    {
+      description: 'a long status id',
+      statusId: `https://remote.test/users/alice/statuses/${'s'.repeat(300)}`,
+      name: '🔥'
+    },
+    {
+      description: 'a long reaction name',
+      statusId: shortStatusId,
+      name: `${'x'.repeat(60)}@${'d'.repeat(180)}`
+    }
+  ])(
+    'falls back to a bounded digest for $description',
+    ({ statusId, name }) => {
+      const groupKey = getReactionGroupKey(statusId, name)
+      // notifications.groupKey is varchar(255); Postgres rejects an overflow and
+      // SQLite silently accepts it, so the bound has to hold here.
+      expect(groupKey.length).toBeLessThanOrEqual(255)
+      expect(getReactionGroupKey(statusId, name)).toBe(groupKey)
+    }
+  )
+
+  it('gives different groups to different reactions on one status', () => {
+    const statusId = `https://remote.test/users/alice/statuses/${'s'.repeat(300)}`
+    expect(getReactionGroupKey(statusId, '🔥')).not.toBe(
+      getReactionGroupKey(statusId, '🎉')
+    )
+  })
+})

--- a/lib/services/reactions/reactionGroupKey.ts
+++ b/lib/services/reactions/reactionGroupKey.ts
@@ -1,0 +1,16 @@
+import { MAX_NOTIFICATION_GROUP_KEY_LENGTH } from '@/lib/services/statuses/reactionLimits'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+
+/**
+ * Groups an actor's reaction notifications per (status, emoji). Both parts are
+ * remote-controlled and unbounded-ish — the status id is a URL and the name can
+ * be a full `shortcode@domain` — so the readable form is used only while it fits
+ * the varchar(255) column, with a digest of the same inputs as the overflow
+ * fallback. The digest is deterministic, so a group stays stable across
+ * deliveries either way.
+ */
+export const getReactionGroupKey = (statusId: string, name: string) => {
+  const groupKey = `emoji_reaction:${statusId}:${name}`
+  if (groupKey.length <= MAX_NOTIFICATION_GROUP_KEY_LENGTH) return groupKey
+  return `emoji_reaction:${getHashFromString(`${statusId}:${name}`)}`
+}

--- a/lib/services/reactions/reactionName.test.ts
+++ b/lib/services/reactions/reactionName.test.ts
@@ -1,0 +1,61 @@
+import {
+  getCustomEmojiShortcode,
+  isUnicodeEmojiReaction
+} from '@/lib/services/reactions/reactionName'
+
+describe('isUnicodeEmojiReaction', () => {
+  it.each([
+    { description: 'a plain emoji', value: '🔥' },
+    { description: 'an emoji with a variation selector', value: '❤️' },
+    { description: 'a skin-toned emoji', value: '👍🏽' },
+    { description: 'a flag (regional indicator pair)', value: '🇹🇭' },
+    { description: 'a ZWJ family sequence', value: '👨‍👩‍👧‍👦' },
+    { description: 'a keycap', value: '1️⃣' }
+  ])('accepts $description', ({ value }) => {
+    expect(isUnicodeEmojiReaction(value)).toBeTrue()
+  })
+
+  it.each([
+    { description: 'two emoji', value: '🔥🔥' },
+    { description: 'an empty string', value: '' },
+    { description: 'a bare letter', value: 'a' },
+    { description: 'a bare digit', value: '5' },
+    { description: 'a shortcode', value: 'partyparrot' },
+    { description: 'a colon-wrapped shortcode', value: ':partyparrot:' },
+    { description: 'an emoji with trailing text', value: '🔥x' }
+  ])('rejects $description', ({ value }) => {
+    expect(isUnicodeEmojiReaction(value)).toBeFalse()
+  })
+})
+
+describe('getCustomEmojiShortcode', () => {
+  it.each([
+    {
+      description: 'a colon-wrapped shortcode',
+      value: ':blobcat:',
+      expected: 'blobcat'
+    },
+    { description: 'a bare shortcode', value: 'blobcat', expected: 'blobcat' },
+    {
+      description: 'a shortcode with digits and underscores',
+      value: ':blob_cat_2:',
+      expected: 'blob_cat_2'
+    }
+  ])('reads $description', ({ value, expected }) => {
+    expect(getCustomEmojiShortcode(value)).toBe(expected)
+  })
+
+  it.each([
+    { description: 'a unicode emoji', value: '🔥' },
+    { description: 'an empty string', value: '' },
+    { description: 'bare colons', value: '::' },
+    {
+      description: 'a remote namespaced shortcode',
+      value: 'blobcat@remote.test'
+    },
+    { description: 'a shortcode with a space', value: 'blob cat' },
+    { description: 'a shortcode with a hyphen', value: 'blob-cat' }
+  ])('returns null for $description', ({ value }) => {
+    expect(getCustomEmojiShortcode(value)).toBeNull()
+  })
+})

--- a/lib/services/reactions/reactionName.ts
+++ b/lib/services/reactions/reactionName.ts
@@ -1,0 +1,49 @@
+// Reaction-name handling for *local* writes.
+//
+// Inbound federation stays deliberately liberal (senders disagree about what a
+// reaction may be, and storage is opaque — see lib/actions/emojiReaction), but a
+// reaction this instance originates has to be something we can actually render
+// and federate, so it is validated here before it is stored.
+
+// One grapheme cluster is the unit a reaction is measured in: a flag is a
+// regional-indicator pair, a family is several code points joined by ZWJ, and a
+// skin-toned hand carries a modifier — all a single user-perceived character.
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: 'grapheme'
+})
+
+// A keycap (`1\u{FE0F}\u{20E3}`) is built from an ASCII digit plus the enclosing
+// combiner, so none of the emoji properties match it — match the combiner
+// itself. It can only appear inside a keycap sequence, and the single-grapheme
+// check above already rules out a bare digit.
+const EMOJI_CODE_POINT =
+  /\p{Extended_Pictographic}|\p{Emoji_Presentation}|\p{Regional_Indicator}|\u{20E3}/u
+
+/**
+ * Whether `value` is a single emoji grapheme — the unicode half of what a
+ * reaction may be. Rejects plain letters and digits (which are `Emoji` but not
+ * `Emoji_Presentation`, and are how a shortcode is spelled) and anything longer
+ * than one grapheme.
+ */
+export const isUnicodeEmojiReaction = (value: string): boolean => {
+  const graphemes = [...graphemeSegmenter.segment(value)]
+  if (graphemes.length !== 1) return false
+  return EMOJI_CODE_POINT.test(value)
+}
+
+// A custom-emoji reference, written either `:shortcode:` or bare. Matches the
+// shortcode grammar the admin emoji form and the picker use.
+const SHORTCODE = /^[A-Za-z0-9_]+$/
+
+/**
+ * The custom-emoji shortcode `value` names, or null when it is not a shortcode
+ * reference. Colons are stripped: they are how the emoji is *written*, never how
+ * it is stored.
+ */
+export const getCustomEmojiShortcode = (value: string): string | null => {
+  const shortcode =
+    value.startsWith(':') && value.endsWith(':') && value.length > 2
+      ? value.slice(1, -1)
+      : value
+  return SHORTCODE.test(shortcode) ? shortcode : null
+}

--- a/lib/services/reactions/reactionName.ts
+++ b/lib/services/reactions/reactionName.ts
@@ -47,3 +47,15 @@ export const getCustomEmojiShortcode = (value: string): string | null => {
       : value
   return SHORTCODE.test(shortcode) ? shortcode : null
 }
+
+/**
+ * The form a reaction is *stored* in, for callers that receive one as free text
+ * (a URL segment, an inbound activity). Colons are stripped from a shortcode;
+ * anything else is passed through untouched so an unknown or remote name still
+ * matches what is on the row.
+ */
+export const normalizeStoredReactionName = (value: string): string => {
+  const trimmed = value.trim()
+  if (isUnicodeEmojiReaction(trimmed)) return trimmed
+  return getCustomEmojiShortcode(trimmed) ?? trimmed
+}

--- a/lib/services/reactions/reactionRouteHandlers.test.ts
+++ b/lib/services/reactions/reactionRouteHandlers.test.ts
@@ -1,0 +1,137 @@
+import { NextRequest } from 'next/server'
+
+import { Database } from '@/lib/database/types'
+import { reactionWriteHandler } from '@/lib/services/reactions/reactionRouteHandlers'
+import { Actor } from '@/lib/types/domain/actor'
+import { HttpMethod } from '@/lib/utils/http-headers'
+
+const mockReactStatus = vi.fn()
+const mockUnreactStatus = vi.fn()
+const mockRefetchedStatusResponse = vi.fn()
+
+vi.mock('@/lib/services/reactions/reactStatus', () => ({
+  reactStatus: (...params: unknown[]) => mockReactStatus(...params),
+  unreactStatus: (...params: unknown[]) => mockUnreactStatus(...params)
+}))
+
+vi.mock('@/lib/services/mastodon/statusActionResponse', () => ({
+  refetchedStatusResponse: (...params: unknown[]) =>
+    mockRefetchedStatusResponse(...params)
+}))
+
+const CORS_HEADERS = [HttpMethod.enum.OPTIONS, HttpMethod.enum.PUT]
+const database = {} as Database
+const currentActor = { id: 'https://test.llun.dev/users/alice' } as Actor
+
+const request = () =>
+  new NextRequest('https://test.llun.dev/api/v1/pleroma/statuses/x/reactions/y')
+
+const invoke = (
+  mode: 'react' | 'unreact',
+  params: { id: string; emoji?: string; name?: string }
+) =>
+  reactionWriteHandler(mode, CORS_HEADERS)(request(), {
+    database,
+    currentActor,
+    params: Promise.resolve(params)
+  })
+
+describe('reactionWriteHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockReactStatus.mockResolvedValue({ ok: true, changed: true })
+    mockUnreactStatus.mockResolvedValue({ ok: true, changed: true })
+    mockRefetchedStatusResponse.mockResolvedValue(
+      new Response(null, { status: 200 })
+    )
+  })
+
+  // The Pleroma dialect names the segment `emoji`, glitch-soc names it `name`.
+  // Both must reach the same service with the same arguments — that is the whole
+  // point of serving two dialects over one store.
+  it.each([
+    {
+      description: 'the pleroma :emoji segment',
+      params: { id: 'status-1', emoji: '🔥' }
+    },
+    {
+      description: 'the glitch :name segment',
+      params: { id: 'status-1', name: '🔥' }
+    }
+  ])('reacts through $description', async ({ params }) => {
+    const response = await invoke('react', params)
+
+    expect(response.status).toBe(200)
+    expect(mockReactStatus).toHaveBeenCalledWith({
+      database,
+      currentActor,
+      statusId: expect.stringContaining('status-1'),
+      name: '🔥'
+    })
+    expect(mockUnreactStatus).not.toHaveBeenCalled()
+  })
+
+  it('routes unreact to unreactStatus', async () => {
+    await invoke('unreact', { id: 'status-1', emoji: '🔥' })
+
+    expect(mockUnreactStatus).toHaveBeenCalledTimes(1)
+    expect(mockReactStatus).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      description: 'an unreadable or missing status',
+      reason: 'not-found',
+      expected: 404
+    },
+    {
+      description: 'an emoji this instance cannot render',
+      reason: 'invalid-emoji',
+      expected: 422
+    }
+  ])('answers $expected for $description', async ({ reason, expected }) => {
+    mockReactStatus.mockResolvedValue({ ok: false, reason })
+
+    const response = await invoke('react', { id: 'status-1', emoji: '🔥' })
+
+    expect(response.status).toBe(expected)
+    expect(mockRefetchedStatusResponse).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      description: 'an empty segment',
+      params: { id: 'status-1', emoji: '   ' }
+    },
+    {
+      description: 'an over-long segment',
+      params: { id: 'status-1', emoji: 'x'.repeat(200) }
+    },
+    { description: 'a missing segment', params: { id: 'status-1' } }
+  ])(
+    'answers 422 for $description without calling the service',
+    async ({ params }) => {
+      const response = await invoke('react', params)
+
+      expect(response.status).toBe(422)
+      expect(mockReactStatus).not.toHaveBeenCalled()
+    }
+  )
+
+  it('returns the refetched status so the caller sees its own reaction', async () => {
+    await invoke('react', { id: 'status-1', emoji: '🔥' })
+
+    expect(mockRefetchedStatusResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ database, currentActor })
+    )
+  })
+
+  it('still returns the status when nothing changed', async () => {
+    mockReactStatus.mockResolvedValue({ ok: true, changed: false })
+
+    const response = await invoke('react', { id: 'status-1', emoji: '🔥' })
+
+    expect(response.status).toBe(200)
+    expect(mockRefetchedStatusResponse).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/services/reactions/reactionRouteHandlers.ts
+++ b/lib/services/reactions/reactionRouteHandlers.ts
@@ -57,6 +57,7 @@ export const reactionWriteHandler =
     })
 
     if (!result.ok) {
+      // `invalid-emoji` and `cap-reached` are both unprocessable input.
       return apiCorsError(
         req,
         corsHeaders,

--- a/lib/services/reactions/reactionRouteHandlers.ts
+++ b/lib/services/reactions/reactionRouteHandlers.ts
@@ -1,0 +1,84 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { Database } from '@/lib/database/types'
+import { refetchedStatusResponse } from '@/lib/services/mastodon/statusActionResponse'
+import {
+  reactStatus,
+  unreactStatus
+} from '@/lib/services/reactions/reactStatus'
+import { MAX_REACTION_NAME_LENGTH } from '@/lib/services/statuses/reactionLimits'
+import { Actor } from '@/lib/types/domain/actor'
+import { HttpMethod } from '@/lib/utils/http-headers'
+import { apiCorsError } from '@/lib/utils/response'
+import { idToUrl } from '@/lib/utils/urlToId'
+
+// Next's App Router already percent-decodes a dynamic segment, so this is the
+// emoji/shortcode itself — do not decode it again.
+export const ReactionSegment = z
+  .string()
+  .trim()
+  .min(1)
+  .max(MAX_REACTION_NAME_LENGTH)
+
+/**
+ * Shared body of every reaction write route. The Pleroma (`PUT`/`DELETE`) and
+ * glitch-soc (`POST react`/`unreact`) dialects differ only in their URL and
+ * method — they run the same service over the same store, so the two can never
+ * report different state.
+ */
+export const reactionWriteHandler =
+  (mode: 'react' | 'unreact', corsHeaders: HttpMethod[]) =>
+  async (
+    req: NextRequest,
+    {
+      database,
+      currentActor,
+      params
+    }: {
+      database: Database
+      currentActor: Actor
+      params: Promise<{ id: string; emoji?: string; name?: string }>
+    }
+  ) => {
+    const { id, emoji, name } = await params
+    if (!id) return apiCorsError(req, corsHeaders, 404)
+
+    const segment = ReactionSegment.safeParse(emoji ?? name)
+    if (!segment.success) return apiCorsError(req, corsHeaders, 422)
+
+    const statusId = idToUrl(id)
+    const act = mode === 'react' ? reactStatus : unreactStatus
+    const result = await act({
+      database,
+      currentActor,
+      statusId,
+      name: segment.data
+    })
+
+    if (!result.ok) {
+      return apiCorsError(
+        req,
+        corsHeaders,
+        result.reason === 'not-found' ? 404 : 422
+      )
+    }
+
+    // Both dialects answer with the affected Status, refetched so the caller
+    // sees its own reaction reflected in the rollups.
+    return refetchedStatusResponse({
+      req,
+      database,
+      currentActor,
+      statusId,
+      allowedMethods: corsHeaders
+    })
+  }
+
+export const reactionRouteAttributes = async (
+  _req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) => {
+  const params = await context.params
+  return { statusId: params?.id || 'unknown' }
+}

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -3294,6 +3294,8 @@ export type PushAlerts = {
   update: boolean
   quote: boolean
   quoted_update: boolean
+  // Ecosystem dialect (Akkoma parity), not a core Mastodon alert key.
+  'pleroma:emoji_reaction': boolean
   'admin.sign_up': boolean
   'admin.report': boolean
 }


### PR DESCRIPTION
Epic 5.1, PR 2 of 3. 5.1a ([#1320](https://github.com/llun/activities.next/pull/1320)) stored reactions and accepted them inbound; this makes them writable and sends them out. The picker UI is 5.1c.

## The write path

`reactStatus` / `unreactStatus` (`lib/services/reactions/reactStatus.ts`) resolve the status through `getReadableStatus`, validate, write, and — **only when the write actually changed state** — federate or notify. That gate is why 5.1a made `createStatusReaction`/`deleteStatusReaction` report whether they stored anything: a redelivered or capped reaction must not re-federate or re-notify.

**A locally-authored status notifies its author directly instead of federating.** This deliberately departs from how favourites work. `sendLike` posts to `status.actor.inboxUrl` unconditionally, so a local favourite notifies via a self-POST that comes back through our own inbox — but that cannot work for reactions: the inbound handler would find the reaction already stored, `changed` would be false, and the notification would be skipped. Federation and local notification are therefore exclusive here.

## Validation is stricter locally than inbound — on purpose

Inbound federation stays liberal (senders disagree about what a reaction may be, and storage is opaque). A reaction *we* originate has to round-trip, so it must be either:

- a **single emoji grapheme**, measured with `Intl.Segmenter` so a flag (regional-indicator pair), a ZWJ family, a skin-toned hand and a keycap each count as one — a bare letter or digit does not; or
- a **shortcode naming an enabled custom emoji on this instance**, which is also what supplies the outbound `Emoji` tag.

Anything else is `422`, including `shortcode@domain`: this instance cannot vouch for another's emoji. Removal deliberately skips revalidation so an emoji stays removable after an admin disables it.

## Routes — two dialects, one store

| Endpoint | Dialect | Scopes |
|---|---|---|
| `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` | Pleroma (primary) | `write` \| `write:favourites` |
| `GET /api/v1/pleroma/statuses/:id/reactions` | Pleroma | `read` \| `read:statuses`, auth optional |
| `GET /api/v1/pleroma/statuses/:id/reactions/:emoji` | Pleroma | `read` \| `read:statuses`, auth optional |
| `POST /api/v1/statuses/:id/react/:name` | glitch-soc | `write` \| `write:favourites` |
| `POST /api/v1/statuses/:id/unreact/:name` | glitch-soc | `write` \| `write:favourites` |

All five run one shared `reactionWriteHandler` over one service, so the dialects cannot drift; a parity test asserts the Pleroma `:emoji` segment and the glitch `:name` segment reach the service identically. Writes return the refetched `Status` so the caller sees its own reaction; reads return `{name, count, me, url, static_url, accounts}` in first-reaction order, with one batched account lookup rather than one per reaction. All four modules are registered in `routeScopeWiring.test.ts`.

## Outbound

`sendReaction`/`sendUndoReaction` emit the **Misskey shape** — a `Like` with the emoji on both `content` and `_misskey_reaction`, plus an `Emoji` tag for a custom one. That is the only spelling every family renders something for: Misskey/Firefish/Sharkey read it natively, Pleroma/Akkoma rewrite it into their own `EmojiReact`, and vanilla Mastodon — which has no `EmojiReact` handler at all and drops that activity silently — ignores `content` on a `Like` and shows a **favourite**.

That degradation is the deliberate trade-off, and it is now stated plainly in the compat doc: **reacting from here shows up as a favourite to someone on vanilla Mastodon.** The alternative (emitting FEP-c0e0 `EmojiReact`, which is cleaner) would be invisible to most of the network.

The activity id is `#emoji-reactions/<md5 status>/<md5 reaction>` — distinct per reaction *and* distinct from `sendLike`'s `#likes/<md5 status>`, so a receiver that dedups by activity id can never conflate a favourite with a reaction, or have an `Undo` retract the wrong one. Tests assert exactly that.

## Deviations from the plan

1. **`getReactionGroupKey` moved** from `lib/actions/emojiReaction.ts` to `lib/services/reactions/reactionGroupKey.ts` (with its tests), so the inbound action and the local service share one implementation instead of a service importing an action.
2. **`getStatusReactionActors` gained no pagination.** The plan's GET contract does not specify any, and Pleroma's does not either; a status with very many reactors returns them all. Related to the per-status rollup limitation already recorded in the compat doc, and best revisited together.
3. **Grouped notifications** deliberately left alone: `emoji_reaction` is not in `DEFAULT_GROUPABLE_TYPES` (Mastodon groups only favourite/reblog/follow by default), so reactions only reach the v2 grouped path when a client opts in with `grouped_types[]`.

## Verification

`prettier --write .` → `eslint .` (0 errors, 31 pre-existing warnings) → `next build` → `vitest run`: **721 files / 7043 tests green**.

No UI in this PR, so no screenshots — the picker and chips land in 5.1c, which is where browser verification belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
