### PR TITLE
fix: redesign notification emails to match the design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,18 +262,12 @@ section-navigation patterns; pick by section type.
 Emails go through one shared skeleton, so a design or copy change lands in one
 place instead of eleven.
 
-> **Migration in progress — this describes the target, not the whole tree yet.**
-> Only the four account/security emails are on the shared layout:
-> `verifyEmail.ts`, `changeEmail.ts`, `resetPassword.ts`, `actorDeleted.ts`.
-> The seven notification templates — `follow.ts`, `followRequest.ts`, `like.ts`,
-> `mention.ts`, `reply.ts`, `reblog.ts`, `activityImport.ts` — still export the
-> old `getSubject`/`getTextContent`/`getHTMLContent` trio, write raw markup, and
-> hand-maintain both media. Their links are broken in two different ways:
-> `like`/`mention`/`reply`/`reblog` build a local status URL from a hardcoded
-> `https://${config.host}`, while `follow`/`followRequest` link the **remote**
-> `actor.id` directly instead of the local profile page (`activityImport` has no
-> link at all). They are being migrated, not grandfathered: apply the rules below
-> to any template you touch, and do not copy the old shape into a new one.
+> **Migration in progress — one template left.** Ten of the eleven are on the
+> shared layout. Only `activityImport.ts` still exports the old
+> `getSubject`/`getTextContent`/`getHTMLContent` trio and writes raw markup —
+> and nothing sends it, so it is dead code until the fitness import wiring
+> lands. Apply the rules below when migrating it, and do not copy the old shape
+> into a new template.
 
 - **One module per email** in `lib/services/email/templates/`, exporting a single
   `build<Name>Email(params): RenderedEmail` (`{ subject, text, html }`). **Never

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -169,14 +169,11 @@ change doesn't touch.
 
 ## Emails
 
-- **Migration in progress.** Only the four account/security emails
-  (`verifyEmail`, `changeEmail`, `resetPassword`, `actorDeleted`) are on the
-  shared layout. The seven notification templates still use the old
-  `getSubject`/`getTextContent`/`getHTMLContent` trio with raw markup, and their
-  links are wrong in two different ways: `like`/`mention`/`reply`/`reblog`
-  hardcode `https://${config.host}`, while `follow`/`followRequest` link the
-  remote `actor.id` rather than the local profile. Apply the rules below to any
-  template a change touches; don't copy the old shape into a new one.
+- **Migration in progress — one template left.** Ten of eleven are on the shared
+  layout; only `activityImport.ts` still uses the old
+  `getSubject`/`getTextContent`/`getHTMLContent` trio, and nothing sends it.
+  Apply the rules below when migrating it; don't copy the old shape into a new
+  template.
 - Every migrated email is built by a `build<Name>Email(params): RenderedEmail`
   module in `lib/services/email/templates/`. No subject/HTML/text literals at a
   call site.
@@ -194,9 +191,9 @@ change doesn't touch.
   omission does not fail loudly: the template throws, the catch swallows it, and
   the test passes while the email silently stops sending. This has bitten twice.
 - Template changes are verified by rendering:
-  `./scripts/mock/renderEmailPreviews.ts` (see `docs/maintenance.md`). It covers
-  only the four migrated templates — a PR migrating another must add it to
-  `buildPreviews()`, and fixtures must be production-shaped (43-char codes).
+  `./scripts/mock/renderEmailPreviews.ts` (see `docs/maintenance.md`). A PR
+  migrating a template must add it to `buildPreviews()`, and fixtures must be
+  production-shaped (43-char codes).
 - Outlook-only properties (`mso-padding-alt` on both the button cell and its
   anchor, `mso-hide:all`, the MSO ghost table pinning the column to 600px) are
   load-bearing and invisible in a browser. Don't drop them as dead style.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -129,8 +129,8 @@ Creates a test user for development/testing:
 
 Renders email templates to standalone HTML files so a template change can be
 checked visually. Covers the templates listed in `buildPreviews()` — currently
-the four account/security emails; the notification templates are not on the
-shared layout yet. Emails are not pages, so there is no dev-server route to open —
+every email except the fitness activity import, which is not on the shared
+layout yet. Emails are not pages, so there is no dev-server route to open —
 this is the visual verification step for anything under
 `lib/services/email/templates/`.
 

--- a/lib/actions/acceptFollowRequest.test.ts
+++ b/lib/actions/acceptFollowRequest.test.ts
@@ -3,11 +3,7 @@ import { enableFetchMocks } from 'jest-fetch-mock'
 import { acceptFollowRequest } from '@/lib/actions/acceptFollowRequest'
 import { AcceptFollow } from '@/lib/activities/acceptFollow'
 import { getTestSQLDatabase } from '@/lib/database/testUtils'
-import {
-  getHTMLContent,
-  getSubject,
-  getTextContent
-} from '@/lib/services/email/templates/follow'
+import { buildFollowEmail } from '@/lib/services/email/templates/follow'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { mockRequests } from '@/lib/stub/activities'
 import { seedDatabase } from '@/lib/stub/database'
@@ -92,7 +88,9 @@ describe('Accept follow action', () => {
         followId: followRequest.id
       })
       const actor5 = await database.getActorFromId({ id: ACTOR5_ID })
+      const actor1 = await database.getActorFromId({ id: ACTOR1_ID })
       if (!actor5) fail('Actor5 should be exists')
+      if (!actor1) fail('Actor1 should be exists')
       expect(acceptedRequest?.status).toEqual(FollowStatus.enum.Accepted)
 
       expect(sendNotificationAlerts).toHaveBeenCalledWith(
@@ -104,9 +102,9 @@ describe('Accept follow action', () => {
               type: NotificationType.enum.follow,
               emailContent: expect.objectContaining({
                 recipientEmail: 'test1@llun.test',
-                subject: getSubject(actor5),
-                text: getTextContent(actor5),
-                html: getHTMLContent(actor5)
+                // The recipient is threaded through so the footer can name the
+                // account whose notification settings control this email.
+                ...buildFollowEmail({ recipient: actor1, actor: actor5 })
               })
             }
           ]

--- a/lib/actions/acceptFollowRequest.ts
+++ b/lib/actions/acceptFollowRequest.ts
@@ -1,11 +1,7 @@
 import { AcceptFollow } from '@/lib/activities/acceptFollow'
 import { Database } from '@/lib/database/types'
 import { SEND_UNDO_FOLLOW_JOB_NAME } from '@/lib/jobs/names'
-import {
-  getHTMLContent,
-  getSubject,
-  getTextContent
-} from '@/lib/services/email/templates/follow'
+import { buildFollowEmail } from '@/lib/services/email/templates/follow'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { getQueue } from '@/lib/services/queue'
 import { NotificationType } from '@/lib/types/database/operations'
@@ -80,9 +76,7 @@ export const acceptFollowRequest = async ({
           type: NotificationType.enum.follow,
           emailContent: {
             recipientEmail: targetActor.account.email,
-            subject: getSubject(actor),
-            text: getTextContent(actor),
-            html: getHTMLContent(actor)
+            ...buildFollowEmail({ recipient: targetActor, actor })
           }
         }
       ]

--- a/lib/actions/announce.ts
+++ b/lib/actions/announce.ts
@@ -2,11 +2,7 @@ import crypto from 'crypto'
 
 import { Database } from '@/lib/database/types'
 import { SEND_ANNOUNCE_JOB_NAME } from '@/lib/jobs/names'
-import {
-  getHTMLContent,
-  getSubject,
-  getTextContent
-} from '@/lib/services/email/templates/reblog'
+import { buildBoostEmail } from '@/lib/services/email/templates/reblog'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
@@ -127,9 +123,11 @@ export const userAnnounce = async ({
                   emailContent: targetActor?.account
                     ? {
                         recipientEmail: targetActor.account.email,
-                        subject: getSubject(currentActor),
-                        text: getTextContent(currentActor, editableStatus),
-                        html: getHTMLContent(currentActor, editableStatus)
+                        ...buildBoostEmail({
+                          recipient: targetActor,
+                          actor: currentActor,
+                          status: editableStatus
+                        })
                       }
                     : undefined
                 }

--- a/lib/actions/createFollower.ts
+++ b/lib/actions/createFollower.ts
@@ -2,16 +2,8 @@ import { recordActorIfNeeded } from '@/lib/actions/utils'
 import { acceptFollow, rejectFollow } from '@/lib/activities'
 import { FollowRequest } from '@/lib/activities/followAction'
 import { Database } from '@/lib/database/types'
-import {
-  getHTMLContent as getFollowHTMLContent,
-  getSubject as getFollowSubject,
-  getTextContent as getFollowTextContent
-} from '@/lib/services/email/templates/follow'
-import {
-  getHTMLContent as getFollowRequestHTMLContent,
-  getSubject as getFollowRequestSubject,
-  getTextContent as getFollowRequestTextContent
-} from '@/lib/services/email/templates/followRequest'
+import { buildFollowEmail } from '@/lib/services/email/templates/follow'
+import { buildFollowRequestEmail } from '@/lib/services/email/templates/followRequest'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { followGroupKey } from '@/lib/services/notifications/followGrouping'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
@@ -89,9 +81,10 @@ export const createFollower = async ({
             emailContent: targetActor.account
               ? {
                   recipientEmail: targetActor.account.email,
-                  subject: getFollowRequestSubject(followerActor),
-                  text: getFollowRequestTextContent(followerActor),
-                  html: getFollowRequestHTMLContent(followerActor)
+                  ...buildFollowRequestEmail({
+                    recipient: targetActor,
+                    actor: followerActor
+                  })
                 }
               : undefined
           }
@@ -134,9 +127,10 @@ export const createFollower = async ({
             emailContent: targetActor.account
               ? {
                   recipientEmail: targetActor.account.email,
-                  subject: getFollowSubject(followerActor),
-                  text: getFollowTextContent(followerActor),
-                  html: getFollowHTMLContent(followerActor)
+                  ...buildFollowEmail({
+                    recipient: targetActor,
+                    actor: followerActor
+                  })
                 }
               : undefined
           }

--- a/lib/actions/createNote.ts
+++ b/lib/actions/createNote.ts
@@ -6,16 +6,8 @@ import {
   SEND_NOTE_JOB_NAME,
   SEND_QUOTE_REQUEST_JOB_NAME
 } from '@/lib/jobs/names'
-import {
-  getHTMLContent as getMentionHTMLContent,
-  getSubject as getMentionSubject,
-  getTextContent as getMentionTextContent
-} from '@/lib/services/email/templates/mention'
-import {
-  getHTMLContent as getReplyHTMLContent,
-  getSubject as getReplySubject,
-  getTextContent as getReplyTextContent
-} from '@/lib/services/email/templates/reply'
+import { buildMentionEmail } from '@/lib/services/email/templates/mention'
+import { buildReplyEmail } from '@/lib/services/email/templates/reply'
 import { persistDetectedLanguage } from '@/lib/services/language-detection'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
@@ -702,9 +694,11 @@ export const createNoteFromUserInput = async ({
               emailContent: targetActor?.account
                 ? {
                     recipientEmail: targetActor.account.email,
-                    subject: getReplySubject(currentActor),
-                    text: getReplyTextContent(status),
-                    html: getReplyHTMLContent(status)
+                    ...buildReplyEmail({
+                      recipient: targetActor,
+                      actor: currentActor,
+                      status
+                    })
                   }
                 : undefined
             }
@@ -740,9 +734,11 @@ export const createNoteFromUserInput = async ({
                 emailContent: targetActor?.account
                   ? {
                       recipientEmail: targetActor.account.email,
-                      subject: getMentionSubject(currentActor),
-                      text: getMentionTextContent(status),
-                      html: getMentionHTMLContent(status)
+                      ...buildMentionEmail({
+                        recipient: targetActor,
+                        actor: currentActor,
+                        status
+                      })
                     }
                   : undefined
               }

--- a/lib/actions/like.ts
+++ b/lib/actions/like.ts
@@ -1,10 +1,6 @@
 import { LikeStatus } from '@/lib/activities/likeAction'
 import { Database } from '@/lib/database/types'
-import {
-  getHTMLContent,
-  getSubject,
-  getTextContent
-} from '@/lib/services/email/templates/like'
+import { buildLikeEmail } from '@/lib/services/email/templates/like'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import { sendNotificationAlerts } from '@/lib/services/notifications/sendNotificationAlerts'
 import { shouldCreateNotification } from '@/lib/services/notifications/shouldNotify'
@@ -65,9 +61,11 @@ export const likeRequest = async ({
                 emailContent: targetActor?.account
                   ? {
                       recipientEmail: targetActor.account.email,
-                      subject: getSubject(sourceActor),
-                      text: getTextContent(sourceActor, editableStatus),
-                      html: getHTMLContent(sourceActor, editableStatus)
+                      ...buildLikeEmail({
+                        recipient: targetActor,
+                        actor: sourceActor,
+                        status: editableStatus
+                      })
                     }
                   : undefined
               }

--- a/lib/services/email/layout/actorDisplay.test.ts
+++ b/lib/services/email/layout/actorDisplay.test.ts
@@ -1,0 +1,161 @@
+import { ActorProfile } from '@/lib/types/domain/actor'
+
+import {
+  getDisplayName,
+  getInitials,
+  getMonogramColor,
+  getShortName,
+  toQuoteAuthor
+} from './actorDisplay'
+import { MONOGRAM_PALETTE } from './theme'
+
+const actor = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  followersUrl: 'https://remote.example.com/users/ben/followers',
+  inboxUrl: 'https://remote.example.com/users/ben/inbox',
+  sharedInboxUrl: 'https://remote.example.com/inbox',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+describe('getDisplayName', () => {
+  it.each([
+    {
+      description: 'uses the profile name when it is set',
+      name: 'Ben Carter',
+      expected: 'Ben Carter'
+    },
+    {
+      description: 'falls back to the username when the name is missing',
+      name: undefined,
+      expected: 'ben'
+    },
+    {
+      description: 'falls back to the username when the name is blank',
+      name: '   ',
+      expected: 'ben'
+    },
+    {
+      description: 'trims surrounding whitespace from the name',
+      name: '  Ben Carter  ',
+      expected: 'Ben Carter'
+    }
+  ])('$description', ({ name, expected }) => {
+    expect(getDisplayName(actor({ name }))).toBe(expected)
+  })
+})
+
+describe('getShortName', () => {
+  it.each([
+    {
+      description: 'takes the first word of a multi-word name',
+      name: 'Ben Carter',
+      expected: 'Ben'
+    },
+    {
+      description: 'returns a single-word name unchanged',
+      name: 'Maythee',
+      expected: 'Maythee'
+    },
+    {
+      description: 'collapses repeated spaces between words',
+      name: 'Ben    Carter',
+      expected: 'Ben'
+    },
+    {
+      description: 'falls back to the username when the name is missing',
+      name: undefined,
+      expected: 'ben'
+    }
+  ])('$description', ({ name, expected }) => {
+    expect(getShortName(actor({ name }))).toBe(expected)
+  })
+})
+
+describe('getInitials', () => {
+  it.each([
+    {
+      description: 'uses the first two characters of a single-word name',
+      displayName: 'Maythee',
+      expected: 'MA'
+    },
+    {
+      description: 'uses the initials of the first two words',
+      displayName: 'Ben Carter',
+      expected: 'BC'
+    },
+    {
+      description: 'ignores words after the second',
+      displayName: 'Ben Michael Carter',
+      expected: 'BM'
+    },
+    {
+      description: 'uppercases a lowercase name',
+      displayName: 'anna',
+      expected: 'AN'
+    },
+    {
+      description: 'returns a single character for a one-character name',
+      displayName: 'A',
+      expected: 'A'
+    },
+    {
+      description: 'returns a placeholder for an empty name',
+      displayName: '',
+      expected: '?'
+    },
+    {
+      description: 'returns a placeholder for a whitespace-only name',
+      displayName: '   ',
+      expected: '?'
+    },
+    {
+      description: 'keeps a non-Latin character whole',
+      displayName: 'ปกรณ์',
+      expected: 'ปก'
+    },
+    {
+      description: 'does not split an astral-plane character',
+      displayName: '😀 Carter',
+      expected: '😀C'
+    }
+  ])('$description', ({ displayName, expected }) => {
+    expect(getInitials(displayName)).toBe(expected)
+  })
+})
+
+describe('getMonogramColor', () => {
+  it('returns a colour from the palette', () => {
+    expect(MONOGRAM_PALETTE).toContain(getMonogramColor('@ben@example.com'))
+  })
+
+  it('returns the same colour for the same handle', () => {
+    expect(getMonogramColor('@ben@example.com')).toBe(
+      getMonogramColor('@ben@example.com')
+    )
+  })
+
+  it('spreads different handles across more than one colour', () => {
+    const colors = new Set(
+      Array.from({ length: 40 }, (_, index) =>
+        getMonogramColor(`@user${index}@example.com`)
+      )
+    )
+    expect(colors.size).toBeGreaterThan(1)
+  })
+})
+
+describe('toQuoteAuthor', () => {
+  it('pairs the display name with the fully qualified handle', () => {
+    expect(toQuoteAuthor(actor({ name: 'Ben Carter' }))).toEqual({
+      displayName: 'Ben Carter',
+      handle: '@ben@remote.example.com'
+    })
+  })
+})

--- a/lib/services/email/layout/actorDisplay.ts
+++ b/lib/services/email/layout/actorDisplay.ts
@@ -1,0 +1,69 @@
+import { ActorProfile, getMention } from '@/lib/types/domain/actor'
+import { getHashFromString } from '@/lib/utils/getHashFromString'
+
+import { MONOGRAM_PALETTE } from './theme'
+
+/** The two strings the quoted-actor row in an email renders. */
+export interface QuoteAuthor {
+  readonly displayName: string
+  readonly handle: string
+}
+
+type NamedActor = Pick<ActorProfile, 'name' | 'username'>
+
+const getWords = (value: string) => value.trim().split(/\s+/).filter(Boolean)
+
+/** Full display name: the profile name when set, otherwise the bare username. */
+export const getDisplayName = (actor: NamedActor): string =>
+  actor.name?.trim() || actor.username
+
+/**
+ * The short form used in headlines — "Ben Carter" becomes "Ben", so a subject
+ * line reads "Ben boosted your post" rather than restating the whole name.
+ */
+export const getShortName = (actor: NamedActor): string => {
+  const displayName = getDisplayName(actor)
+  return getWords(displayName)[0] ?? displayName
+}
+
+/**
+ * Two-letter monogram for the avatar circle: initials of the first two words
+ * ("Ben Carter" -> "BC"), or the first two characters of a single-word name
+ * ("Maythee" -> "MA").
+ *
+ * This deliberately differs from the web `Avatar` component, which emits a
+ * single letter for a one-word name. The email circle is a fixed 24px with no
+ * image fallback, and one letter reads as a typo at that size.
+ *
+ * Iterates with `Array.from` so an astral-plane first character (emoji, many
+ * CJK extensions) is taken whole instead of being split at a surrogate pair.
+ */
+export const getInitials = (displayName: string): string => {
+  const words = getWords(displayName)
+  if (words.length === 0) return '?'
+  if (words.length === 1) {
+    return Array.from(words[0]).slice(0, 2).join('').toUpperCase()
+  }
+  return words
+    .slice(0, 2)
+    .map((word) => Array.from(word)[0])
+    .join('')
+    .toUpperCase()
+}
+
+/**
+ * Deterministic monogram fill, keyed on the full `@user@domain` handle so the
+ * same person is the same colour in every email they appear in.
+ */
+export const getMonogramColor = (handle: string): string => {
+  // Slice 8 hex chars (max 0xffffffff) so the parse stays inside a safe integer.
+  const index =
+    parseInt(getHashFromString(handle).slice(0, 8), 16) %
+    MONOGRAM_PALETTE.length
+  return MONOGRAM_PALETTE[index]
+}
+
+export const toQuoteAuthor = (actor: ActorProfile): QuoteAuthor => ({
+  displayName: getDisplayName(actor),
+  handle: getMention(actor, true)
+})

--- a/lib/services/email/layout/blocks.test.ts
+++ b/lib/services/email/layout/blocks.test.ts
@@ -1,4 +1,13 @@
-import { button, fallbackUrl, headline, label, note, paragraph } from './blocks'
+import {
+  button,
+  fallbackUrl,
+  headline,
+  label,
+  note,
+  paragraph,
+  quote
+} from './blocks'
+import { MONOGRAM_PALETTE } from './theme'
 
 const XSS = '"><script>alert(1)</script>'
 
@@ -171,5 +180,60 @@ describe('note', () => {
 
   it('lets an over-long unbroken word wrap instead of overflowing the card', () => {
     expect(note('a').html).toContain('word-wrap:break-word')
+  })
+})
+
+describe('quote', () => {
+  const author = { displayName: 'Ben Carter', handle: '@ben@example.com' }
+
+  it('renders the monogram, display name and handle', () => {
+    const { html } = quote({ author })
+    expect(html).toContain('>BC</td>')
+    expect(html).toContain('>Ben Carter</td>')
+    expect(html).toContain('>@ben@example.com</td>')
+  })
+
+  it('gives the monogram a colour from the palette', () => {
+    const { html } = quote({ author })
+    const bgcolor = html.match(
+      /bgcolor="(#[0-9a-f]{6})" style="width:24px/
+    )?.[1]
+    expect(MONOGRAM_PALETTE).toContain(bgcolor)
+  })
+
+  it('renders the actor row alone when there is no body', () => {
+    const { html, text } = quote({ author })
+    expect(html).not.toContain('margin-top:8px')
+    expect(text).toBe('Ben Carter (@ben@example.com)')
+  })
+
+  it('renders a pre-sanitized body below the actor row', () => {
+    const { html, text } = quote({
+      author,
+      body: { html: '<p>Hello <b>there</b></p>', text: 'Hello there' }
+    })
+    expect(html).toContain('<p>Hello <b>there</b></p>')
+    expect(text).toBe('Ben Carter (@ben@example.com)\nHello there')
+  })
+
+  it('escapes the display name and handle', () => {
+    const { html } = quote({ author: { displayName: XSS, handle: XSS } })
+    expect(html).not.toContain(XSS)
+    expect(html).not.toContain('<script')
+  })
+
+  it('emits the body html verbatim because it is already sanitized', () => {
+    // The single unescaped slot in the layout. It is the caller's job to have
+    // run getStatusBody first; this asserts the contract rather than a bug.
+    const { html } = quote({
+      author,
+      body: { html: '<a href="https://example.com/x">link</a>', text: 'link' }
+    })
+    expect(html).toContain('<a href="https://example.com/x">link</a>')
+  })
+
+  it('lets a long unbroken body word wrap', () => {
+    const { html } = quote({ author, body: { html: 'x', text: 'x' } })
+    expect(html).toContain('word-wrap:break-word')
   })
 })

--- a/lib/services/email/layout/blocks.ts
+++ b/lib/services/email/layout/blocks.ts
@@ -1,14 +1,21 @@
 import { escapeHtml } from '@/lib/utils/text/escapeHtml'
 
+import { QuoteAuthor, getInitials, getMonogramColor } from './actorDisplay'
 import {
+  BORDER,
   BORDER_SUBTLE,
   BUTTON_BACKGROUND,
   BUTTON_TEXT,
   FONT_STACK,
+  INSET_BACKGROUND,
   RADIUS_BUTTON,
+  RADIUS_FULL,
+  RADIUS_INSET,
   TEXT,
   TEXT_BODY,
-  TEXT_MUTED
+  TEXT_CHROME,
+  TEXT_MUTED,
+  TEXT_STRONG
 } from './theme'
 
 /**
@@ -172,3 +179,53 @@ export const note = (content: InlineContent): EmailBlock => ({
   html: `<p style="margin:20px 0 0;padding-top:16px;border-top:1px solid ${BORDER_SUBTLE};font-family:${FONT_STACK};font-size:13px;line-height:1.6;color:${TEXT_MUTED};word-wrap:break-word;">${renderInlineHtml(content)}</p>`,
   text: renderInlineText(content)
 })
+
+/**
+ * A post body that has ALREADY been through the sanitize/markdown pipeline.
+ *
+ * This is the one and only value the layout emits without escaping, which is
+ * why it is a named type rather than a bare string: a plain `string` parameter
+ * would make it far too easy to hand raw remote text straight into the HTML.
+ * Build it with `getStatusBody`, never by hand.
+ */
+export interface SanitizedBody {
+  readonly html: string
+  readonly text: string
+}
+
+/**
+ * The muted inset card quoting an actor — their monogram, display name and
+ * handle, optionally over the post body.
+ *
+ * `follow`/`followRequest` pass no body (the actor row is the whole point);
+ * `like`/`boost` quote the RECIPIENT's own post, `mention`/`reply` the sender's.
+ */
+export const quote = (options: {
+  author: QuoteAuthor
+  body?: SanitizedBody
+}): EmailBlock => {
+  const { author, body } = options
+  const initials = getInitials(author.displayName)
+  const monogram = getMonogramColor(author.handle)
+
+  const bodyHtml = body
+    ? `<div style="margin-top:8px;font-family:${FONT_STACK};font-size:14px;line-height:1.6;color:${TEXT_BODY};word-wrap:break-word;">${body.html}</div>`
+    : ''
+
+  return {
+    html:
+      `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px;"><tr>` +
+      `<td bgcolor="${INSET_BACKGROUND}" style="background-color:${INSET_BACKGROUND};border:1px solid ${BORDER};border-radius:${RADIUS_INSET};padding:14px 16px;">` +
+      `<table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>` +
+      // line-height equal to the height is what centres the initials vertically
+      // in Outlook, which ignores flex and vertical-align on a coloured box.
+      `<td width="24" height="24" align="center" bgcolor="${monogram}" style="width:24px;height:24px;border-radius:${RADIUS_FULL};color:${BUTTON_TEXT};font-family:${FONT_STACK};font-size:10px;font-weight:600;line-height:24px;">${escapeHtml(initials)}</td>` +
+      `<td style="padding-left:8px;font-family:${FONT_STACK};font-size:14px;font-weight:600;color:${TEXT_STRONG};white-space:nowrap;">${escapeHtml(author.displayName)}</td>` +
+      `<td style="padding-left:6px;font-family:${FONT_STACK};font-size:13px;color:${TEXT_CHROME};">${escapeHtml(author.handle)}</td>` +
+      `</tr></table>${bodyHtml}` +
+      `</td></tr></table>`,
+    text: body
+      ? `${author.displayName} (${author.handle})\n${body.text}`
+      : `${author.displayName} (${author.handle})`
+  }
+}

--- a/lib/services/email/layout/theme.ts
+++ b/lib/services/email/layout/theme.ts
@@ -17,6 +17,8 @@ export const FONT_STACK =
 export const PAGE_BACKGROUND = '#f4f4f4'
 /** The single card holding the message body. */
 export const CARD_BACKGROUND = '#fdfdfd'
+/** Inset blocks: quoted posts, and the fitness stat card once it lands. */
+export const INSET_BACKGROUND = '#f5f5f5'
 
 export const BORDER = '#e5e5e5'
 /** Lighter rule used only for the in-card "if you didn't request this" divider. */
@@ -39,5 +41,15 @@ export const BUTTON_TEXT = '#ffffff'
 export const CONTENT_WIDTH = 600
 
 export const RADIUS_CARD = '12px'
+export const RADIUS_INSET = '8px'
 export const RADIUS_BUTTON = '6px'
 export const RADIUS_FULL = '9999px'
+
+// Monogram fills for the quoted-actor avatar. Picked deterministically from the
+// actor's handle so the same person is always the same colour across emails.
+export const MONOGRAM_PALETTE = [
+  '#a855f7',
+  '#6366f1',
+  '#ea580c',
+  '#14b8a6'
+] as const

--- a/lib/services/email/templates/emailDesign.test.ts
+++ b/lib/services/email/templates/emailDesign.test.ts
@@ -164,6 +164,18 @@ const actorlessHostileStatus = {
   actor: undefined
 } as unknown as EditableStatus
 
+/**
+ * The same hostile body from a LOCAL author. This branch runs markdown, which
+ * does not sanitize, so it needs its own coverage — a suite whose fixtures are
+ * all remote silently never exercises it, which is exactly how the missing
+ * sanitize step survived review once already.
+ */
+const localHostileStatus = {
+  ...hostileStatus,
+  isLocalActor: true,
+  text: 'Hi <img src="https://tracker.evil.example/p.gif" onerror="alert(1)"><script>alert(2)</script><style>body{display:none}</style>'
+} as unknown as EditableStatus
+
 const count = (haystack: string, needle: string) =>
   haystack.split(needle).length - 1
 
@@ -316,6 +328,52 @@ describe('email design conformance', () => {
       // remote-controlled status.url. The button builder must refuse it.
       expect(email.html).not.toContain('javascript:')
       expect(count(email.html, 'bgcolor="#E66A0F"')).toBe(0)
+    }
+  )
+
+  it.each([
+    {
+      description: 'mention',
+      email: buildMentionEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: localHostileStatus
+      })
+    },
+    {
+      description: 'reply',
+      email: buildReplyEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: localHostileStatus
+      })
+    },
+    {
+      description: 'like',
+      email: buildLikeEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: localHostileStatus
+      })
+    },
+    {
+      description: 'boost',
+      email: buildBoostEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: localHostileStatus
+      })
+    }
+  ])(
+    '$description strips raw html from a LOCAL author post body',
+    ({ email }) => {
+      // The markdown branch does not sanitize on its own, so a local author
+      // could otherwise plant a tracking pixel or a layout-breaking <style>
+      // in another user's inbox.
+      expect(email.html).not.toContain('<script')
+      expect(email.html).not.toContain('<style>body')
+      expect(email.html).not.toContain('onerror')
+      expect(email.html).not.toContain('tracker.evil.example')
     }
   )
 })

--- a/lib/services/email/templates/emailDesign.test.ts
+++ b/lib/services/email/templates/emailDesign.test.ts
@@ -1,0 +1,321 @@
+import { RenderedEmail } from '@/lib/services/email/types'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { EditableStatus, StatusType } from '@/lib/types/domain/status'
+
+import { buildActorDeletedEmail } from './actorDeleted'
+import { buildChangeEmail } from './changeEmail'
+import { buildFollowEmail } from './follow'
+import { buildFollowRequestEmail } from './followRequest'
+import { buildLikeEmail } from './like'
+import { buildMentionEmail } from './mention'
+import { buildBoostEmail } from './reblog'
+import { buildReplyEmail } from './reply'
+import { buildResetPasswordEmail } from './resetPassword'
+import { buildVerifyEmail } from './verifyEmail'
+
+// Every string slot carries a hostile sentinel, so a template that forgets to
+// escape one fails here rather than in someone's inbox.
+const XSS = '"><script>alert(1)</script>'
+// A real code is 43-char base64url; a short placeholder would not exercise the
+// wrapping rules the layout applies to long links.
+const CODE = 'Yk3nQ8xR2vL7pT1wZ0aB5cD9eF4gH6jK8mN2qS5tU7x'
+const HOST = 'test.llun.dev'
+
+const hostileActor: ActorProfile = {
+  id: `javascript:alert(1)`,
+  username: XSS,
+  domain: XSS,
+  name: XSS,
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000
+}
+
+const hostileStatus = {
+  id: XSS,
+  // The nastiest input in the set: remote actors control this, and it is the
+  // fallback getEmailStatusUrl returns when no local path can be derived.
+  url: 'javascript:alert(1)',
+  actorId: hostileActor.id,
+  actor: hostileActor,
+  isLocalActor: false,
+  type: StatusType.enum.Note,
+  text: `${XSS}<img src=x onerror=alert(1)>`,
+  summary: '',
+  to: [],
+  cc: [],
+  tags: [],
+  attachments: [],
+  replies: [],
+  createdAt: 1000
+} as unknown as EditableStatus
+
+interface Case {
+  description: string
+  email: RenderedEmail
+  /** actor-deleted is the only email with no call to action. */
+  buttons: number
+  footer: 'notification' | 'account'
+}
+
+const cases: Case[] = [
+  {
+    description: 'verify email',
+    email: buildVerifyEmail({ recipientEmail: XSS, verificationCode: CODE }),
+    buttons: 1,
+    footer: 'account'
+  },
+  {
+    description: 'change email',
+    email: buildChangeEmail({ recipientEmail: XSS, emailChangeCode: CODE }),
+    buttons: 1,
+    footer: 'account'
+  },
+  {
+    description: 'reset password',
+    email: buildResetPasswordEmail({
+      recipientEmail: XSS,
+      passwordResetCode: CODE
+    }),
+    buttons: 1,
+    footer: 'account'
+  },
+  {
+    description: 'actor deleted',
+    email: buildActorDeletedEmail({
+      recipient: hostileActor,
+      recipientEmail: XSS,
+      contactEmail: XSS
+    }),
+    buttons: 0,
+    footer: 'account'
+  },
+  {
+    description: 'follow',
+    email: buildFollowEmail({
+      recipient: hostileActor,
+      actor: hostileActor
+    }),
+    buttons: 1,
+    footer: 'notification'
+  },
+  {
+    description: 'follow request',
+    email: buildFollowRequestEmail({
+      recipient: hostileActor,
+      actor: hostileActor
+    }),
+    buttons: 1,
+    footer: 'notification'
+  },
+  {
+    description: 'mention',
+    email: buildMentionEmail({
+      recipient: hostileActor,
+      actor: hostileActor,
+      status: hostileStatus
+    }),
+    // One, not zero: the hostile actor still yields a derivable local path, so
+    // getEmailStatusUrl never reaches its status.url fallback. The refusal of a
+    // javascript: url is covered separately below, with an actor-less status.
+    buttons: 1,
+    footer: 'notification'
+  },
+  {
+    description: 'reply',
+    email: buildReplyEmail({
+      recipient: hostileActor,
+      actor: hostileActor,
+      status: hostileStatus
+    }),
+    buttons: 1,
+    footer: 'notification'
+  },
+  {
+    description: 'like',
+    email: buildLikeEmail({
+      recipient: hostileActor,
+      actor: hostileActor,
+      status: hostileStatus
+    }),
+    buttons: 1,
+    footer: 'notification'
+  },
+  {
+    description: 'boost',
+    email: buildBoostEmail({
+      recipient: hostileActor,
+      actor: hostileActor,
+      status: hostileStatus
+    }),
+    buttons: 1,
+    footer: 'notification'
+  }
+]
+
+/** A status with no actor, so getEmailStatusUrl falls back to its raw url. */
+const actorlessHostileStatus = {
+  ...hostileStatus,
+  actor: undefined
+} as unknown as EditableStatus
+
+const count = (haystack: string, needle: string) =>
+  haystack.split(needle).length - 1
+
+describe('email design conformance', () => {
+  it.each(cases)('$description renders a well-formed document', ({ email }) => {
+    expect(email.html.startsWith('<!doctype html>')).toBe(true)
+    expect(email.html).toContain('<html lang="en">')
+    expect(email.html.trimEnd().endsWith('</html>')).toBe(true)
+    expect(email.html).toContain('<body')
+  })
+
+  it.each(cases)(
+    '$description declares the email head metadata',
+    ({ email }) => {
+      expect(email.html).toContain('<meta charset="utf-8">')
+      expect(email.html).toContain('name="color-scheme"')
+      expect(email.html).toContain('name="format-detection"')
+    }
+  )
+
+  it.each(cases)('$description uses one fluid 600px column', ({ email }) => {
+    expect(email.html).toContain(
+      'style="width:100%;max-width:600px;table-layout:fixed;"'
+    )
+    // The Outlook ghost table, which cannot use max-width.
+    expect(email.html).toContain('<!--[if mso]><table role="presentation"')
+  })
+
+  it.each(cases)(
+    '$description hides a preheader from the body',
+    ({ email }) => {
+      expect(email.html).toContain('mso-hide:all')
+      expect(email.html).toContain('&zwnj;&nbsp;'.repeat(30))
+    }
+  )
+
+  it.each(cases)(
+    '$description titles the document with its subject',
+    ({ email }) => {
+      expect(email.html).toContain('<title>')
+      expect(email.subject.length).toBeGreaterThan(0)
+    }
+  )
+
+  it.each(cases)(
+    '$description renders the expected number of call-to-action buttons',
+    ({ email, buttons }) => {
+      expect(count(email.html, 'bgcolor="#E66A0F"')).toBe(buttons)
+    }
+  )
+
+  it.each(cases)(
+    '$description uses the $footer footer',
+    ({ email, footer }) => {
+      if (footer === 'notification') {
+        expect(email.html).toContain('Manage email notifications')
+        expect(email.html).toContain(`https://${HOST}/settings/notifications`)
+      } else {
+        expect(email.html).toContain('This email was sent to')
+        expect(email.html).not.toContain('Manage email notifications')
+      }
+    }
+  )
+
+  it.each(cases)('$description escapes every hostile input', ({ email }) => {
+    // Assert on the sentinel itself, not on `"><`, which occurs legitimately at
+    // every tag boundary.
+    expect(email.html).not.toContain(XSS)
+    expect(email.html).not.toContain('<script')
+    expect(email.html).not.toContain('onerror=')
+  })
+
+  it.each(cases)('$description emits no dangerous url', ({ email }) => {
+    expect(email.html).not.toContain('javascript:')
+    expect(email.html).not.toContain('data:text/html')
+  })
+
+  it.each(cases)('$description emits no relative href or src', ({ email }) => {
+    // A mail client has no origin to resolve one against.
+    expect(email.html).not.toMatch(/(?:href|src)="\/(?!\/)/)
+  })
+
+  it.each(cases)('$description inlines all styling', ({ email }) => {
+    expect(email.html).not.toContain('class="')
+    // Exactly one <style>: the MSO font conditional.
+    expect(count(email.html, '<style')).toBe(1)
+  })
+
+  it.each(cases)(
+    '$description leaves no unresolved template value',
+    ({ email }) => {
+      for (const rendered of [email.html, email.text, email.subject]) {
+        expect(rendered).not.toContain('${')
+        expect(rendered).not.toContain('undefined')
+        expect(rendered).not.toContain('NaN')
+        expect(rendered).not.toContain('[object Object]')
+      }
+    }
+  )
+
+  it.each(cases)('$description ships a usable plain-text part', ({ email }) => {
+    expect(email.text.length).toBeGreaterThan(0)
+    // Assert no LAYOUT markup leaked into the text alternative. A bare `<` is
+    // deliberately NOT the test: these fixtures put one in the display name,
+    // and a literal angle bracket in a text/plain body is correct — it is a
+    // character the user typed, not markup.
+    expect(email.text).not.toMatch(
+      /<\/?(?:table|tr|td|div|p|a|span|h1|img|body|html|strong)[\s/>]/i
+    )
+    expect(email.text).not.toContain('style="')
+  })
+
+  it.each([
+    {
+      description: 'mention',
+      email: buildMentionEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: actorlessHostileStatus
+      })
+    },
+    {
+      description: 'reply',
+      email: buildReplyEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: actorlessHostileStatus
+      })
+    },
+    {
+      description: 'like',
+      email: buildLikeEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: actorlessHostileStatus
+      })
+    },
+    {
+      description: 'boost',
+      email: buildBoostEmail({
+        recipient: hostileActor,
+        actor: hostileActor,
+        status: actorlessHostileStatus
+      })
+    }
+  ])(
+    '$description drops the button rather than link a hostile status url',
+    ({ email }) => {
+      // With no actor there is no local path, so getEmailStatusUrl returns the
+      // remote-controlled status.url. The button builder must refuse it.
+      expect(email.html).not.toContain('javascript:')
+      expect(count(email.html, 'bgcolor="#E66A0F"')).toBe(0)
+    }
+  )
+})

--- a/lib/services/email/templates/follow.test.ts
+++ b/lib/services/email/templates/follow.test.ts
@@ -1,42 +1,69 @@
-import { Actor } from '@/lib/types/domain/actor'
+import { ActorProfile } from '@/lib/types/domain/actor'
 
-import { getHTMLContent, getSubject, getTextContent } from './follow'
+import { buildFollowEmail } from './follow'
 
-describe('follow email template', () => {
-  const mockActor: Actor = {
-    id: 'https://remote.example.com/users/follower',
-    username: 'follower',
-    domain: 'remote.example.com',
-    name: 'Follower User',
-    createdAt: Date.now(),
-    statusesCount: 0,
-    followersCount: 0,
-    followingCount: 0
-  }
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
 
-  describe('getSubject', () => {
-    it('returns subject with actor username and host', () => {
-      const result = getSubject(mockActor)
-      // Uses config host from test config
-      expect(result).toMatch(/@follower is following you in/)
-    })
+const actor = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  name: 'Ben Carter',
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+const recipient = actor({
+  id: `${BASE_URL}/users/anna`,
+  username: 'anna',
+  domain: HOST,
+  name: 'Anna'
+})
+
+describe('buildFollowEmail', () => {
+  const build = () => buildFollowEmail({ recipient, actor: actor() })
+
+  it('keeps the subject the codebase already used', () => {
+    expect(build().subject).toBe(`@ben is following you in ${HOST}`)
   })
 
-  describe('getTextContent', () => {
-    it('returns text content with username and id', () => {
-      const result = getTextContent(mockActor)
-      expect(result).toEqual(
-        'follower (https://remote.example.com/users/follower) is following you'
-      )
-    })
+  it('uses the short name in the headline', () => {
+    expect(build().html).toContain('Ben is following you')
   })
 
-  describe('getHTMLContent', () => {
-    it('returns HTML content with linked actor', () => {
-      const result = getHTMLContent(mockActor)
-      expect(result).toEqual(
-        '<p><a href="https://remote.example.com/users/follower">follower</a> is following you</p>'
-      )
+  it('quotes the follower with their handle', () => {
+    const { html } = build()
+    expect(html).toContain('>Ben Carter</td>')
+    expect(html).toContain('>@ben@remote.example.com</td>')
+  })
+
+  it('links the local profile rather than the remote actor id', () => {
+    const { html } = build()
+    expect(html).toContain(`href="${BASE_URL}/@ben@remote.example.com"`)
+    // The old template linked actor.id, dropping the reader on another server.
+    expect(html).not.toContain('href="https://remote.example.com/users/ben"')
+  })
+
+  it('uses the notification footer naming new followers', () => {
+    const { html } = build()
+    expect(html).toContain('email notifications for new followers')
+    expect(html).toContain(`@anna@${HOST}`)
+    expect(html).toContain(`${BASE_URL}/settings/notifications`)
+  })
+
+  it('escapes a hostile display name', () => {
+    const { html } = buildFollowEmail({
+      recipient,
+      actor: actor({ name: '"><script>alert(1)</script>' })
     })
+    expect(html).not.toContain('<script')
   })
 })

--- a/lib/services/email/templates/follow.ts
+++ b/lib/services/email/templates/follow.ts
@@ -1,15 +1,44 @@
 import { getConfig } from '@/lib/config'
-import { Actor } from '@/lib/types/domain/actor'
+import {
+  getShortName,
+  toQuoteAuthor
+} from '@/lib/services/email/layout/actorDisplay'
+import { button, headline, quote } from '@/lib/services/email/layout/blocks'
+import { renderEmail } from '@/lib/services/email/layout/renderEmail'
+import { RenderedEmail } from '@/lib/services/email/types'
+import { ActorProfile, getMention } from '@/lib/types/domain/actor'
 
-export const getSubject = (actor: Actor) =>
-  `@${actor.username} is following you in ${getConfig().host}`
+import { getEmailActorUrl } from './statusUrl'
 
-export const getTextContent = (actor: Actor) =>
-  `
-${actor.username} (${actor.id}) is following you
-`.trim()
+export interface FollowEmailParams {
+  /** The actor being followed — receives this email. */
+  recipient: ActorProfile
+  /** The new follower. */
+  actor: ActorProfile
+}
 
-export const getHTMLContent = (actor: Actor) =>
-  `
-<p><a href="${actor.id}">${actor.username}</a> is following you</p>
-`.trim()
+/** Someone started following you, or you accepted their follow request. */
+export const buildFollowEmail = ({
+  recipient,
+  actor
+}: FollowEmailParams): RenderedEmail => {
+  const author = toQuoteAuthor(actor)
+
+  return renderEmail({
+    subject: `@${actor.username} is following you in ${getConfig().host}`,
+    preheader: `${author.displayName} (${author.handle}) is now following you.`,
+    blocks: [
+      headline(`${getShortName(actor)} is following you`),
+      quote({ author }),
+      // The LOCAL profile page, not actor.id. The previous template linked the
+      // remote actor URI, which drops the reader on another server with no
+      // session and no follow button.
+      button({ label: 'View profile', url: getEmailActorUrl(author.handle) })
+    ],
+    footer: {
+      kind: 'notification',
+      eventLabel: 'new followers',
+      handle: getMention(recipient, true)
+    }
+  })
+}

--- a/lib/services/email/templates/followRequest.test.ts
+++ b/lib/services/email/templates/followRequest.test.ts
@@ -1,41 +1,51 @@
-import { Actor } from '@/lib/types/domain/actor'
+import { ActorProfile } from '@/lib/types/domain/actor'
 
-import { getHTMLContent, getSubject, getTextContent } from './followRequest'
+import { buildFollowRequestEmail } from './followRequest'
 
-describe('followRequest email template', () => {
-  const mockActor: Actor = {
-    id: 'https://remote.example.com/users/requester',
-    username: 'requester',
-    domain: 'remote.example.com',
-    name: 'Requester User',
-    createdAt: Date.now(),
-    statusesCount: 0,
-    followersCount: 0,
-    followingCount: 0
-  }
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
 
-  describe('getSubject', () => {
-    it('returns subject with actor username and host', () => {
-      const result = getSubject(mockActor)
-      expect(result).toMatch(/@requester wants to follow you in/)
-    })
+const actor = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  name: 'Ben Carter',
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+const recipient = actor({
+  id: `${BASE_URL}/users/anna`,
+  username: 'anna',
+  domain: HOST,
+  name: 'Anna'
+})
+
+describe('buildFollowRequestEmail', () => {
+  const build = () => buildFollowRequestEmail({ recipient, actor: actor() })
+
+  it('keeps the subject the codebase already used', () => {
+    expect(build().subject).toBe(`@ben wants to follow you in ${HOST}`)
   })
 
-  describe('getTextContent', () => {
-    it('returns text content with username and id', () => {
-      const result = getTextContent(mockActor)
-      expect(result).toEqual(
-        'requester (https://remote.example.com/users/requester) has requested to follow you'
-      )
-    })
+  it('explains why approval is needed', () => {
+    expect(build().text).toContain('Your account approves followers manually')
   })
 
-  describe('getHTMLContent', () => {
-    it('returns HTML content with linked actor', () => {
-      const result = getHTMLContent(mockActor)
-      expect(result).toEqual(
-        '<p><a href="https://remote.example.com/users/requester">requester</a> has requested to follow you</p>'
-      )
-    })
+  it('sends the reader to notifications where the controls are', () => {
+    const { html } = build()
+    expect(html).toContain(`href="${BASE_URL}/notifications"`)
+    expect(html).toContain('>Review request</a>')
+  })
+
+  it('uses the notification footer naming follow requests', () => {
+    expect(build().html).toContain('email notifications for follow requests')
   })
 })

--- a/lib/services/email/templates/followRequest.ts
+++ b/lib/services/email/templates/followRequest.ts
@@ -1,15 +1,51 @@
-import { getConfig } from '@/lib/config'
-import { Actor } from '@/lib/types/domain/actor'
+import { getBaseURL, getConfig } from '@/lib/config'
+import {
+  getShortName,
+  toQuoteAuthor
+} from '@/lib/services/email/layout/actorDisplay'
+import {
+  button,
+  headline,
+  paragraph,
+  quote
+} from '@/lib/services/email/layout/blocks'
+import { renderEmail } from '@/lib/services/email/layout/renderEmail'
+import { RenderedEmail } from '@/lib/services/email/types'
+import { ActorProfile, getMention } from '@/lib/types/domain/actor'
 
-export const getSubject = (actor: Actor) =>
-  `@${actor.username} wants to follow you in ${getConfig().host}`
+export interface FollowRequestEmailParams {
+  /** The locked account being asked — receives this email. */
+  recipient: ActorProfile
+  /** The actor requesting to follow. */
+  actor: ActorProfile
+}
 
-export const getTextContent = (actor: Actor) =>
-  `
-${actor.username} (${actor.id}) has requested to follow you
-`.trim()
+/** Someone asked to follow a manually-approved account. */
+export const buildFollowRequestEmail = ({
+  recipient,
+  actor
+}: FollowRequestEmailParams): RenderedEmail => {
+  const author = toQuoteAuthor(actor)
 
-export const getHTMLContent = (actor: Actor) =>
-  `
-<p><a href="${actor.id}">${actor.username}</a> has requested to follow you</p>
-`.trim()
+  return renderEmail({
+    subject: `@${actor.username} wants to follow you in ${getConfig().host}`,
+    preheader: `${author.displayName} (${author.handle}) has requested to follow you.`,
+    blocks: [
+      headline(`${getShortName(actor)} wants to follow you`),
+      paragraph(
+        'Your account approves followers manually. Review this request to approve or reject it.'
+      ),
+      quote({ author }),
+      // Notifications, not the profile: the approve/reject controls live there.
+      button({
+        label: 'Review request',
+        url: `${getBaseURL()}/notifications`
+      })
+    ],
+    footer: {
+      kind: 'notification',
+      eventLabel: 'follow requests',
+      handle: getMention(recipient, true)
+    }
+  })
+}

--- a/lib/services/email/templates/like.test.ts
+++ b/lib/services/email/templates/like.test.ts
@@ -1,73 +1,100 @@
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { EditableStatus, StatusType } from '@/lib/types/domain/status'
 
-import { getHTMLContent, getSubject, getTextContent } from './like'
+import { buildLikeEmail } from './like'
 
-describe('like email template', () => {
-  const mockActor: ActorProfile = {
-    id: 'https://remote.example.com/users/liker',
-    username: 'liker',
-    domain: 'remote.example.com',
-    name: 'Liker User',
-    createdAt: Date.now(),
-    statusesCount: 0,
-    followersCount: 0,
-    followingCount: 0
-  }
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
 
-  const mockStatus: EditableStatus = {
-    id: 'https://test.llun.dev/statuses/123',
-    url: 'https://test.llun.dev/@user/123',
-    actorId: 'https://test.llun.dev/users/user',
-    actor: {
-      id: 'https://test.llun.dev/users/user',
-      username: 'user',
-      domain: 'test.llun.dev',
-      name: 'Test User',
-      createdAt: Date.now(),
-      statusesCount: 0,
-      followersCount: 0,
-      followingCount: 0
-    },
+const profile = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  name: 'Ben Carter',
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+const recipient = profile({
+  id: `${BASE_URL}/users/anna`,
+  username: 'anna',
+  domain: HOST,
+  name: 'Anna'
+})
+
+const status = (overrides: Partial<EditableStatus> = {}): EditableStatus =>
+  ({
+    id: `${BASE_URL}/statuses/1`,
+    url: `${BASE_URL}/@anna/1`,
+    actorId: `${BASE_URL}/users/anna`,
+    actor: recipient,
+    isLocalActor: true,
     type: StatusType.enum.Note,
-    text: 'This is my awesome post!',
+    text: 'Morning run done',
     summary: '',
     to: [],
     cc: [],
     tags: [],
     attachments: [],
     replies: [],
-    createdAt: Date.now()
-  }
+    createdAt: 1000,
+    ...overrides
+  }) as EditableStatus
 
-  describe('getSubject', () => {
-    it('returns subject with actor username and host', () => {
-      const result = getSubject(mockActor)
-      // Uses config host from test config
-      expect(result).toMatch(/@liker liked your post in/)
-    })
+const build = (overrides = {}) =>
+  buildLikeEmail({
+    recipient,
+    actor: profile(),
+    status: status(),
+    ...overrides
   })
 
-  describe('getTextContent', () => {
-    it('returns text content with local URL and message', () => {
-      const result = getTextContent(mockActor, mockStatus)
-      // Should include the actor who liked
-      expect(result).toContain('@liker@remote.example.com liked your post')
-      expect(result).toContain('Your post: This is my awesome post!')
-      // Should use local server URL (test.llun.dev from mock config)
-      expect(result).toContain('View this post on your server:')
-      expect(result).toContain('test.llun.dev/@user')
-    })
+describe('buildLikeEmail', () => {
+  it('keeps the subject the codebase already used', () => {
+    expect(build().subject).toBe(`@ben liked your post in ${HOST}`)
   })
 
-  describe('getHTMLContent', () => {
-    it('returns HTML content with message and local URL', () => {
-      const result = getHTMLContent(mockActor, mockStatus)
-      expect(result).toContain('@liker@remote.example.com liked your post')
-      expect(result).toContain('<p>This is my awesome post!</p>')
-      // Should link to local server, not remote
-      expect(result).toContain('View this post on your server')
-      expect(result).toContain('test.llun.dev/@user')
+  it('uses the short name in the headline', () => {
+    expect(build().html).toContain('Ben liked your post')
+  })
+
+  it('labels the quote as the recipient own post', () => {
+    const { html } = build()
+    expect(html).toContain('>Your post:</p>')
+    expect(html).toContain('>Anna</td>')
+    expect(html).toContain(`>@anna@${HOST}</td>`)
+  })
+
+  it('includes the post body in both media', () => {
+    const { html, text } = build()
+    expect(html).toContain('Morning run done')
+    expect(text).toContain('Morning run done')
+  })
+
+  it('links the post on the recipient own server', () => {
+    const { html } = build()
+    expect(html).toContain(`href="${BASE_URL}/@anna@${HOST}/`)
+    expect(html).toContain('>View post</a>')
+  })
+
+  it('uses the notification footer naming likes', () => {
+    expect(build().html).toContain('email notifications for likes')
+  })
+
+  it('does not emit raw remote post markup', () => {
+    const { html } = build({
+      status: status({
+        text: '<script>alert(1)</script>hi',
+        isLocalActor: false
+      })
     })
+    expect(html).not.toContain('<script')
   })
 })

--- a/lib/services/email/templates/like.ts
+++ b/lib/services/email/templates/like.ts
@@ -1,41 +1,53 @@
 import { getConfig } from '@/lib/config'
+import {
+  getShortName,
+  toQuoteAuthor
+} from '@/lib/services/email/layout/actorDisplay'
+import {
+  button,
+  headline,
+  label,
+  quote
+} from '@/lib/services/email/layout/blocks'
+import { renderEmail } from '@/lib/services/email/layout/renderEmail'
+import { RenderedEmail } from '@/lib/services/email/types'
 import { ActorProfile, getMention } from '@/lib/types/domain/actor'
 import { EditableStatus } from '@/lib/types/domain/status'
 
-export const getSubject = (actor: ActorProfile) =>
-  `@${actor.username} liked your post in ${getConfig().host}`
+import { getStatusBody } from './statusBody'
+import { getEmailStatusUrl } from './statusUrl'
 
-const getLocalStatusUrl = (status: EditableStatus): string => {
-  if (!status.actor) {
-    return status.url
-  }
-  const config = getConfig()
-  const actorMention = getMention(status.actor, true)
-  const encodedStatusId = encodeURIComponent(status.id)
-  return `https://${config.host}/${actorMention}/${encodedStatusId}`
+export interface LikeEmailParams {
+  /** The post's author — receives this email. */
+  recipient: ActorProfile
+  /** Who liked it. */
+  actor: ActorProfile
+  status: EditableStatus
 }
 
-export const getTextContent = (actor: ActorProfile, status: EditableStatus) => {
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = getMention(actor, true)
-
-  return `
-${actorMention} liked your post.
-
-Your post: ${status.text}
-
-View this post on your server: ${localUrl}
-`.trim()
-}
-
-export const getHTMLContent = (actor: ActorProfile, status: EditableStatus) => {
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = getMention(actor, true)
-
-  return `
-<h3>${actorMention} liked your post</h3>
-<p><strong>Your post:</strong></p>
-<p>${status.text}</p>
-<p><a href="${localUrl}">View this post on your server</a></p>
-`.trim()
-}
+/** Someone liked your post. The quote block shows the recipient's own post. */
+export const buildLikeEmail = ({
+  recipient,
+  actor,
+  status
+}: LikeEmailParams): RenderedEmail =>
+  renderEmail({
+    subject: `@${actor.username} liked your post in ${getConfig().host}`,
+    preheader: `${getShortName(actor)} liked your post.`,
+    blocks: [
+      headline(`${getShortName(actor)} liked your post`),
+      label('Your post:'),
+      quote({
+        // The recipient wrote the post being liked, so quote them — falling
+        // back to the recipient when the status carries no actor.
+        author: toQuoteAuthor(status.actor ?? recipient),
+        body: getStatusBody(status)
+      }),
+      button({ label: 'View post', url: getEmailStatusUrl(status) })
+    ],
+    footer: {
+      kind: 'notification',
+      eventLabel: 'likes',
+      handle: getMention(recipient, true)
+    }
+  })

--- a/lib/services/email/templates/mention.test.ts
+++ b/lib/services/email/templates/mention.test.ts
@@ -1,91 +1,84 @@
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { EditableStatus, StatusType } from '@/lib/types/domain/status'
 
-import { getHTMLContent, getSubject, getTextContent } from './mention'
+import { buildMentionEmail } from './mention'
 
-describe('mention email template', () => {
-  const mockActor: ActorProfile = {
-    id: 'https://remote.example.com/users/mentioner',
-    username: 'mentioner',
-    domain: 'remote.example.com',
-    name: 'Mentioner User',
-    createdAt: Date.now(),
-    statusesCount: 0,
-    followersCount: 0,
-    followingCount: 0
-  }
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
 
-  const mockStatus: EditableStatus = {
-    id: 'https://remote.example.com/statuses/123',
-    url: 'https://remote.example.com/@mentioner/123',
-    actorId: mockActor.id,
-    actor: mockActor,
+const profile = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  name: 'Ben Carter',
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+const recipient = profile({
+  id: `${BASE_URL}/users/anna`,
+  username: 'anna',
+  domain: HOST,
+  name: 'Anna'
+})
+
+const status = (overrides: Partial<EditableStatus> = {}): EditableStatus =>
+  ({
+    id: `${BASE_URL}/statuses/1`,
+    url: `${BASE_URL}/@anna/1`,
+    actorId: `${BASE_URL}/users/anna`,
+    actor: recipient,
+    isLocalActor: true,
     type: StatusType.enum.Note,
-    text: 'Hey @user@test.example.com check this out!',
+    text: 'Morning run done',
     summary: '',
     to: [],
     cc: [],
     tags: [],
     attachments: [],
     replies: [],
-    createdAt: Date.now()
-  }
+    createdAt: 1000,
+    ...overrides
+  }) as EditableStatus
 
-  describe('getSubject', () => {
-    it('returns subject with actor username and host', () => {
-      const result = getSubject(mockActor)
-      // Uses config host from test config
-      expect(result).toMatch(/@mentioner mentions you in/)
-    })
+const sender = profile()
+const senderStatus = status({
+  actor: sender,
+  actorId: sender.id,
+  isLocalActor: false,
+  text: 'hey @anna have you tried this'
+})
+
+const build = () =>
+  buildMentionEmail({ recipient, actor: sender, status: senderStatus })
+
+describe('buildMentionEmail', () => {
+  it('keeps the subject the codebase already used', () => {
+    expect(build().subject).toBe(`@ben mentions you in ${HOST}`)
   })
 
-  describe('getTextContent', () => {
-    it('returns text content with local URL and message', () => {
-      const result = getTextContent(mockStatus)
-      // Should link to local server, not remote
-      expect(result).toContain('@mentioner@remote.example.com mentioned you')
-      expect(result).toContain(
-        'Message: Hey @user@test.example.com check this out!'
-      )
-      // Should use local server URL (test.llun.dev from mock config)
-      expect(result).toContain('View this post on your server:')
-      expect(result).toContain('test.llun.dev/@mentioner@remote.example.com')
-    })
+  it('uses the short name in the headline', () => {
+    expect(build().html).toContain('Ben mentioned you in a post')
   })
 
-  describe('getHTMLContent', () => {
-    it('returns HTML content with message and local URL for remote actor', () => {
-      const result = getHTMLContent(mockStatus)
-      expect(result).toContain('@mentioner@remote.example.com mentioned you')
-      expect(result).toContain(
-        '<div>Hey @user@test.example.com check this out!</div>'
-      )
-      // Should link to local server, not remote
-      expect(result).toContain('View this post on your server')
-      expect(result).toContain('test.llun.dev/@mentioner@remote.example.com')
-    })
+  it('quotes the sender, not the recipient', () => {
+    const { html } = build()
+    expect(html).toContain('>Ben Carter</td>')
+    expect(html).toContain('>@ben@remote.example.com</td>')
+  })
 
-    it('converts markdown to HTML for local actor status', () => {
-      const localStatus: EditableStatus = {
-        ...mockStatus,
-        isLocalActor: true,
-        text: 'Line one\nLine two\nLine three'
-      }
-      const result = getHTMLContent(localStatus)
-      expect(result).toContain(
-        '<div><p>Line one<br>Line two<br>Line three</p></div>'
-      )
-    })
+  it('carries no label because the post is the subject of the email', () => {
+    expect(build().html).not.toContain('>Your post:</p>')
+  })
 
-    it('sanitizes remote actor HTML in email', () => {
-      const remoteStatus: EditableStatus = {
-        ...mockStatus,
-        isLocalActor: false,
-        text: '<p>Hello</p><script>alert("xss")</script>'
-      }
-      const result = getHTMLContent(remoteStatus)
-      expect(result).not.toContain('<script>')
-      expect(result).toContain('<p>Hello</p>')
-    })
+  it('uses the notification footer naming mentions', () => {
+    expect(build().html).toContain('email notifications for mentions')
   })
 })

--- a/lib/services/email/templates/mention.ts
+++ b/lib/services/email/templates/mention.ts
@@ -1,47 +1,45 @@
 import { getConfig } from '@/lib/config'
+import {
+  getShortName,
+  toQuoteAuthor
+} from '@/lib/services/email/layout/actorDisplay'
+import { button, headline, quote } from '@/lib/services/email/layout/blocks'
+import { renderEmail } from '@/lib/services/email/layout/renderEmail'
+import { RenderedEmail } from '@/lib/services/email/types'
 import { ActorProfile, getMention } from '@/lib/types/domain/actor'
 import { EditableStatus } from '@/lib/types/domain/status'
-import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
-import { sanitizeText } from '@/lib/utils/text/sanitizeText'
 
-export const getSubject = (actor: ActorProfile) =>
-  `@${actor.username} mentions you in ${getConfig().host}`
+import { getStatusBody } from './statusBody'
+import { getEmailStatusUrl } from './statusUrl'
 
-const getLocalStatusUrl = (status: EditableStatus): string => {
-  if (!status.actor) {
-    return status.url
-  }
-  const config = getConfig()
-  const actorMention = getMention(status.actor, true)
-  const encodedStatusId = encodeURIComponent(status.id)
-  return `https://${config.host}/${actorMention}/${encodedStatusId}`
+export interface MentionEmailParams {
+  /** The mentioned actor — receives this email. */
+  recipient: ActorProfile
+  /** Who wrote the post. */
+  actor: ActorProfile
+  status: EditableStatus
 }
 
-export const getTextContent = (status: EditableStatus) => {
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = status.actor ? getMention(status.actor, true) : 'Unknown'
-
-  return `
-${actorMention} mentioned you in a post.
-
-Message: ${status.text}
-
-View this post on your server: ${localUrl}
-`.trim()
-}
-
-export const getHTMLContent = (status: EditableStatus) => {
-  const config = getConfig()
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = status.actor ? getMention(status.actor, true) : 'Unknown'
-  const messageHtml = status.isLocalActor
-    ? convertMarkdownText(config.host)(status.text)
-    : sanitizeText(status.text)
-
-  return `
-<h3>${actorMention} mentioned you in a post</h3>
-<p><strong>Message:</strong></p>
-<div>${messageHtml}</div>
-<p><a href="${localUrl}">View this post on your server</a></p>
-`.trim()
-}
+/** Someone mentioned you. The quote block shows THEIR post, not yours. */
+export const buildMentionEmail = ({
+  recipient,
+  actor,
+  status
+}: MentionEmailParams): RenderedEmail =>
+  renderEmail({
+    subject: `@${actor.username} mentions you in ${getConfig().host}`,
+    preheader: `${getShortName(actor)} mentioned you in a post.`,
+    blocks: [
+      headline(`${getShortName(actor)} mentioned you in a post`),
+      quote({
+        author: toQuoteAuthor(status.actor ?? actor),
+        body: getStatusBody(status)
+      }),
+      button({ label: 'View post', url: getEmailStatusUrl(status) })
+    ],
+    footer: {
+      kind: 'notification',
+      eventLabel: 'mentions',
+      handle: getMention(recipient, true)
+    }
+  })

--- a/lib/services/email/templates/reblog.test.ts
+++ b/lib/services/email/templates/reblog.test.ts
@@ -1,77 +1,74 @@
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { EditableStatus, StatusType } from '@/lib/types/domain/status'
 
-import { getHTMLContent, getSubject, getTextContent } from './reblog'
+import { buildBoostEmail } from './reblog'
 
-describe('reblog email template', () => {
-  const mockActor: ActorProfile = {
-    id: 'https://remote.example.com/users/reblogger',
-    username: 'reblogger',
-    domain: 'remote.example.com',
-    name: 'Reblogger User',
-    createdAt: Date.now(),
-    statusesCount: 0,
-    followersCount: 0,
-    followingCount: 0
-  }
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
 
-  const mockStatus: EditableStatus = {
-    id: 'https://test.llun.dev/statuses/123',
-    url: 'https://test.llun.dev/@user/123',
-    actorId: 'https://test.llun.dev/users/user',
-    actor: {
-      id: 'https://test.llun.dev/users/user',
-      username: 'user',
-      domain: 'test.llun.dev',
-      name: 'Test User',
-      createdAt: Date.now(),
-      statusesCount: 0,
-      followersCount: 0,
-      followingCount: 0
-    },
+const profile = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  name: 'Ben Carter',
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+const recipient = profile({
+  id: `${BASE_URL}/users/anna`,
+  username: 'anna',
+  domain: HOST,
+  name: 'Anna'
+})
+
+const status = (overrides: Partial<EditableStatus> = {}): EditableStatus =>
+  ({
+    id: `${BASE_URL}/statuses/1`,
+    url: `${BASE_URL}/@anna/1`,
+    actorId: `${BASE_URL}/users/anna`,
+    actor: recipient,
+    isLocalActor: true,
     type: StatusType.enum.Note,
-    text: 'This is my awesome post!',
+    text: 'Morning run done',
     summary: '',
     to: [],
     cc: [],
     tags: [],
     attachments: [],
     replies: [],
-    createdAt: Date.now()
-  }
+    createdAt: 1000,
+    ...overrides
+  }) as EditableStatus
 
-  describe('getSubject', () => {
-    it('returns subject with actor username and host', () => {
-      const result = getSubject(mockActor)
-      // Uses config host from test config
-      expect(result).toMatch(/@reblogger reblogged your post in/)
-    })
+const build = () =>
+  buildBoostEmail({ recipient, actor: profile(), status: status() })
+
+describe('buildBoostEmail', () => {
+  it('says boosted, matching the product vocabulary', () => {
+    expect(build().subject).toBe(`@ben boosted your post in ${HOST}`)
+    expect(build().html).toContain('Ben boosted your post')
   })
 
-  describe('getTextContent', () => {
-    it('returns text content with local URL and message', () => {
-      const result = getTextContent(mockActor, mockStatus)
-      // Should include the actor who reblogged
-      expect(result).toContain(
-        '@reblogger@remote.example.com reblogged your post'
-      )
-      expect(result).toContain('Your post: This is my awesome post!')
-      // Should use local server URL (test.llun.dev from mock config)
-      expect(result).toContain('View this post on your server:')
-      expect(result).toContain('test.llun.dev/@user')
-    })
+  it('no longer says reblogged anywhere in the user-facing copy', () => {
+    const { subject, html, text } = build()
+    expect(subject).not.toContain('reblog')
+    expect(html).not.toContain('reblog')
+    expect(text).not.toContain('reblog')
   })
 
-  describe('getHTMLContent', () => {
-    it('returns HTML content with message and local URL', () => {
-      const result = getHTMLContent(mockActor, mockStatus)
-      expect(result).toContain(
-        '@reblogger@remote.example.com reblogged your post'
-      )
-      expect(result).toContain('<p>This is my awesome post!</p>')
-      // Should link to local server, not remote
-      expect(result).toContain('View this post on your server')
-      expect(result).toContain('test.llun.dev/@user')
-    })
+  it('labels the quote as the recipient own post', () => {
+    expect(build().html).toContain('>Your post:</p>')
+  })
+
+  it('uses the notification footer naming boosts', () => {
+    expect(build().html).toContain('email notifications for boosts')
   })
 })

--- a/lib/services/email/templates/reblog.ts
+++ b/lib/services/email/templates/reblog.ts
@@ -1,41 +1,61 @@
 import { getConfig } from '@/lib/config'
+import {
+  getShortName,
+  toQuoteAuthor
+} from '@/lib/services/email/layout/actorDisplay'
+import {
+  button,
+  headline,
+  label,
+  quote
+} from '@/lib/services/email/layout/blocks'
+import { renderEmail } from '@/lib/services/email/layout/renderEmail'
+import { RenderedEmail } from '@/lib/services/email/types'
 import { ActorProfile, getMention } from '@/lib/types/domain/actor'
 import { EditableStatus } from '@/lib/types/domain/status'
 
-export const getSubject = (actor: ActorProfile) =>
-  `@${actor.username} reblogged your post in ${getConfig().host}`
+import { getStatusBody } from './statusBody'
+import { getEmailStatusUrl } from './statusUrl'
 
-const getLocalStatusUrl = (status: EditableStatus): string => {
-  if (!status.actor) {
-    return status.url
-  }
-  const config = getConfig()
-  const actorMention = getMention(status.actor, true)
-  const encodedStatusId = encodeURIComponent(status.id)
-  return `https://${config.host}/${actorMention}/${encodedStatusId}`
+export interface BoostEmailParams {
+  /** The post's author — receives this email. */
+  recipient: ActorProfile
+  /** Who boosted it. */
+  actor: ActorProfile
+  status: EditableStatus
 }
 
-export const getTextContent = (actor: ActorProfile, status: EditableStatus) => {
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = getMention(actor, true)
-
-  return `
-${actorMention} reblogged your post.
-
-Your post: ${status.text}
-
-View this post on your server: ${localUrl}
-`.trim()
-}
-
-export const getHTMLContent = (actor: ActorProfile, status: EditableStatus) => {
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = getMention(actor, true)
-
-  return `
-<h3>${actorMention} reblogged your post</h3>
-<p><strong>Your post:</strong></p>
-<p>${status.text}</p>
-<p><a href="${localUrl}">View this post on your server</a></p>
-`.trim()
-}
+/**
+ * Someone boosted your post. The quote block shows the recipient's own post.
+ *
+ * User-facing copy says "boosted"; the internal vocabulary stays "reblog" —
+ * `NotificationType.reblog`, the stored value, and the Mastodon API field are
+ * the fediverse wire term and must not move. That is also why this file keeps
+ * its name: it preserves the 1:1 mapping between module and notification type
+ * that the other templates have.
+ */
+export const buildBoostEmail = ({
+  recipient,
+  actor,
+  status
+}: BoostEmailParams): RenderedEmail =>
+  renderEmail({
+    subject: `@${actor.username} boosted your post in ${getConfig().host}`,
+    preheader: `${getShortName(actor)} boosted your post.`,
+    blocks: [
+      headline(`${getShortName(actor)} boosted your post`),
+      label('Your post:'),
+      quote({
+        // The recipient wrote the post being boosted, so quote them — falling
+        // back to the recipient when the status carries no actor.
+        author: toQuoteAuthor(status.actor ?? recipient),
+        body: getStatusBody(status)
+      }),
+      button({ label: 'View post', url: getEmailStatusUrl(status) })
+    ],
+    footer: {
+      kind: 'notification',
+      eventLabel: 'boosts',
+      handle: getMention(recipient, true)
+    }
+  })

--- a/lib/services/email/templates/reply.test.ts
+++ b/lib/services/email/templates/reply.test.ts
@@ -1,70 +1,80 @@
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { EditableStatus, StatusType } from '@/lib/types/domain/status'
 
-import { getHTMLContent, getSubject, getTextContent } from './reply'
+import { buildReplyEmail } from './reply'
 
-describe('reply email template', () => {
-  const mockActor: ActorProfile = {
-    id: 'https://remote.example.com/users/replier',
-    username: 'replier',
-    domain: 'remote.example.com',
-    name: 'Replier User',
-    createdAt: Date.now(),
-    statusesCount: 0,
-    followersCount: 0,
-    followingCount: 0
-  }
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
 
-  const mockStatus: EditableStatus = {
-    id: 'https://remote.example.com/statuses/456',
-    url: 'https://remote.example.com/@replier/456',
-    actorId: 'https://remote.example.com/users/replier',
-    actor: {
-      id: 'https://remote.example.com/users/replier',
-      username: 'replier',
-      domain: 'remote.example.com',
-      name: 'Replier User',
-      createdAt: Date.now(),
-      statusesCount: 0,
-      followersCount: 0,
-      followingCount: 0
-    },
+const profile = (overrides: Partial<ActorProfile> = {}): ActorProfile => ({
+  id: 'https://remote.example.com/users/ben',
+  username: 'ben',
+  domain: 'remote.example.com',
+  name: 'Ben Carter',
+  followersUrl: '',
+  inboxUrl: '',
+  sharedInboxUrl: '',
+  followingCount: 0,
+  followersCount: 0,
+  statusCount: 0,
+  lastStatusAt: null,
+  createdAt: 1000,
+  ...overrides
+})
+
+const recipient = profile({
+  id: `${BASE_URL}/users/anna`,
+  username: 'anna',
+  domain: HOST,
+  name: 'Anna'
+})
+
+const status = (overrides: Partial<EditableStatus> = {}): EditableStatus =>
+  ({
+    id: `${BASE_URL}/statuses/1`,
+    url: `${BASE_URL}/@anna/1`,
+    actorId: `${BASE_URL}/users/anna`,
+    actor: recipient,
+    isLocalActor: true,
     type: StatusType.enum.Note,
-    text: 'This is a reply to your post!',
+    text: 'Morning run done',
     summary: '',
     to: [],
     cc: [],
     tags: [],
     attachments: [],
     replies: [],
-    createdAt: Date.now()
-  }
+    createdAt: 1000,
+    ...overrides
+  }) as EditableStatus
 
-  describe('getSubject', () => {
-    it('returns subject with actor username and host', () => {
-      const result = getSubject(mockActor)
-      expect(result).toMatch(/@replier replied to your post in/)
-    })
+const sender = profile()
+const replyStatus = status({
+  actor: sender,
+  actorId: sender.id,
+  isLocalActor: false,
+  text: 'This is brilliant'
+})
+
+const build = () =>
+  buildReplyEmail({ recipient, actor: sender, status: replyStatus })
+
+describe('buildReplyEmail', () => {
+  it('keeps the subject the codebase already used', () => {
+    expect(build().subject).toBe(`@ben replied to your post in ${HOST}`)
   })
 
-  describe('getTextContent', () => {
-    it('returns text content with message and local URL', () => {
-      const result = getTextContent(mockStatus)
-      expect(result).toContain(
-        '@replier@remote.example.com replied to your post'
-      )
-      expect(result).toContain('Reply: This is a reply to your post!')
-      expect(result).toContain('View this post on your server:')
-    })
+  it('labels the quote as the reply', () => {
+    const { html } = build()
+    expect(html).toContain('>Reply:</p>')
+    expect(html).toContain('This is brilliant')
   })
 
-  describe('getHTMLContent', () => {
-    it('returns HTML content with message and local URL', () => {
-      const result = getHTMLContent(mockStatus)
-      expect(result).toContain(
-        '@replier@remote.example.com replied to your post'
-      )
-      expect(result).toContain('View this post on your server')
-    })
+  it('quotes the replier, not the recipient', () => {
+    expect(build().html).toContain('>@ben@remote.example.com</td>')
+  })
+
+  it('uses the notification footer naming replies', () => {
+    expect(build().html).toContain('email notifications for replies')
   })
 })

--- a/lib/services/email/templates/reply.ts
+++ b/lib/services/email/templates/reply.ts
@@ -1,50 +1,52 @@
 import { getConfig } from '@/lib/config'
+import {
+  getShortName,
+  toQuoteAuthor
+} from '@/lib/services/email/layout/actorDisplay'
+import {
+  button,
+  headline,
+  label,
+  quote
+} from '@/lib/services/email/layout/blocks'
+import { renderEmail } from '@/lib/services/email/layout/renderEmail'
+import { RenderedEmail } from '@/lib/services/email/types'
 import { ActorProfile, getMention } from '@/lib/types/domain/actor'
 import { EditableStatus } from '@/lib/types/domain/status'
-import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
-import { sanitizeText } from '@/lib/utils/text/sanitizeText'
 
-export const getSubject = (actor: ActorProfile) =>
-  `@${actor.username} replied to your post in ${getConfig().host}`
+import { getStatusBody } from './statusBody'
+import { getEmailStatusUrl } from './statusUrl'
 
-const getLocalStatusUrl = (status: EditableStatus): string => {
-  const config = getConfig()
-  if (status.url.startsWith(`https://${config.host}`)) {
-    return status.url
-  }
-  if (!status.actor) {
-    return status.url
-  }
-  const actorMention = getMention(status.actor, true)
-  const encodedStatusId = encodeURIComponent(status.id)
-  return `https://${config.host}/${actorMention}/${encodedStatusId}`
+export interface ReplyEmailParams {
+  /** The actor replied to — receives this email. */
+  recipient: ActorProfile
+  /** Who replied. */
+  actor: ActorProfile
+  /** The reply itself, not the post it answers. */
+  status: EditableStatus
 }
 
-export const getTextContent = (status: EditableStatus) => {
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = status.actor ? getMention(status.actor, true) : 'Unknown'
-
-  return `
-${actorMention} replied to your post.
-
-Reply: ${status.text}
-
-View this post on your server: ${localUrl}
-`.trim()
-}
-
-export const getHTMLContent = (status: EditableStatus) => {
-  const config = getConfig()
-  const localUrl = getLocalStatusUrl(status)
-  const actorMention = status.actor ? getMention(status.actor, true) : 'Unknown'
-  const messageHtml = status.isLocalActor
-    ? convertMarkdownText(config.host)(status.text)
-    : sanitizeText(status.text)
-
-  return `
-<h3>${actorMention} replied to your post</h3>
-<p><strong>Reply:</strong></p>
-<div>${messageHtml}</div>
-<p><a href="${localUrl}">View this post on your server</a></p>
-`.trim()
-}
+/** Someone replied to your post. The quote block shows their reply. */
+export const buildReplyEmail = ({
+  recipient,
+  actor,
+  status
+}: ReplyEmailParams): RenderedEmail =>
+  renderEmail({
+    subject: `@${actor.username} replied to your post in ${getConfig().host}`,
+    preheader: `${getShortName(actor)} replied to your post.`,
+    blocks: [
+      headline(`${getShortName(actor)} replied to your post`),
+      label('Reply:'),
+      quote({
+        author: toQuoteAuthor(status.actor ?? actor),
+        body: getStatusBody(status)
+      }),
+      button({ label: 'View post', url: getEmailStatusUrl(status) })
+    ],
+    footer: {
+      kind: 'notification',
+      eventLabel: 'replies',
+      handle: getMention(recipient, true)
+    }
+  })

--- a/lib/services/email/templates/statusBody.test.ts
+++ b/lib/services/email/templates/statusBody.test.ts
@@ -1,0 +1,70 @@
+import { EditableStatus, StatusType } from '@/lib/types/domain/status'
+
+import { getStatusBody } from './statusBody'
+
+const BASE_URL = 'https://test.llun.dev'
+
+const status = (overrides: Partial<EditableStatus> = {}): EditableStatus =>
+  ({
+    id: `${BASE_URL}/statuses/1`,
+    url: `${BASE_URL}/@user/1`,
+    actorId: `${BASE_URL}/users/user`,
+    type: StatusType.enum.Note,
+    text: 'hello',
+    summary: '',
+    to: [],
+    cc: [],
+    tags: [],
+    attachments: [],
+    replies: [],
+    createdAt: 1000,
+    ...overrides
+  }) as EditableStatus
+
+describe('getStatusBody', () => {
+  it('absolutizes the relative hashtag link convertMarkdownText emits', () => {
+    const { html } = getStatusBody(
+      status({ text: 'a #tag here', isLocalActor: true })
+    )
+    // The whole point: `/tags/tag` has no origin to resolve against in an inbox.
+    expect(html).not.toMatch(/href="\/(?!\/)/)
+    expect(html).toContain(`href="${BASE_URL}/tags/tag"`)
+  })
+
+  it('absolutizes a relative href that survives sanitizeText on the remote path', () => {
+    const { html } = getStatusBody(
+      status({ text: '<a href="/foo">x</a>', isLocalActor: false })
+    )
+    expect(html).toContain(`href="${BASE_URL}/foo"`)
+  })
+
+  it('leaves a protocol-relative url alone because it points at another origin', () => {
+    const { html } = getStatusBody(
+      status({ text: '<a href="//evil.example/x">x</a>', isLocalActor: false })
+    )
+    expect(html).not.toContain(`${BASE_URL}//evil.example`)
+  })
+
+  it('leaves an already absolute url alone', () => {
+    const { html } = getStatusBody(
+      status({ text: '<a href="https://other.test/x">x</a>' })
+    )
+    expect(html).toContain('href="https://other.test/x"')
+  })
+
+  it('strips markup from the plain-text twin', () => {
+    const { text } = getStatusBody(
+      status({ text: '<p>Hello <b>there</b></p>', isLocalActor: false })
+    )
+    expect(text).not.toContain('<')
+    expect(text).toContain('Hello')
+    expect(text).toContain('there')
+  })
+
+  it('does not let a remote script tag through', () => {
+    const { html } = getStatusBody(
+      status({ text: '<script>alert(1)</script>hi', isLocalActor: false })
+    )
+    expect(html).not.toContain('<script')
+  })
+})

--- a/lib/services/email/templates/statusBody.test.ts
+++ b/lib/services/email/templates/statusBody.test.ts
@@ -61,10 +61,30 @@ describe('getStatusBody', () => {
     expect(text).toContain('there')
   })
 
-  it('does not let a remote script tag through', () => {
+  it.each([
+    { description: 'a local author', isLocalActor: true },
+    { description: 'a remote author', isLocalActor: false }
+  ])('strips raw html from $description', ({ isLocalActor }) => {
+    // The local branch runs markdown, which does NOT sanitize — marked has
+    // shipped no sanitizer since v5. Without an unconditional sanitize step a
+    // local user could plant a tracking pixel or a layout-breaking <style> in
+    // someone else's inbox, and quote() emits this value unescaped.
     const { html } = getStatusBody(
-      status({ text: '<script>alert(1)</script>hi', isLocalActor: false })
+      status({
+        text: 'Hi <img src="https://tracker.evil.example/p.gif" onerror="alert(1)"><script>alert(2)</script><style>body{display:none}</style>',
+        isLocalActor
+      })
     )
     expect(html).not.toContain('<script')
+    expect(html).not.toContain('<style')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('tracker.evil.example')
+  })
+
+  it('still renders markdown for a local author', () => {
+    const { html } = getStatusBody(
+      status({ text: 'a **bold** word', isLocalActor: true })
+    )
+    expect(html).toContain('<strong>bold</strong>')
   })
 })

--- a/lib/services/email/templates/statusBody.ts
+++ b/lib/services/email/templates/statusBody.ts
@@ -46,3 +46,12 @@ export const getStatusBody = (status: EditableStatus): SanitizedBody => {
   const html = absolutizeLinks(sanitizeText(rendered))
   return { html, text: htmlToPlainText(html) }
 }
+
+// Deliberately stops where the web pipeline continues: processStatusTextContent
+// also runs convertEmojisToImages and sanitizeTrustedStatusText. Custom emoji
+// therefore stay as literal `:shortcode:` text in an email rather than becoming
+// <img> tags — which is the better degradation, since mail clients block remote
+// images by default and a row of broken-image icons reads worse than the
+// shortcode. Everything else the renderer emits survives unchanged: hashtag and
+// mention links keep their class/rel, headings and images are dropped to text
+// exactly as they are on the web, because both paths share sanitizeText.

--- a/lib/services/email/templates/statusBody.ts
+++ b/lib/services/email/templates/statusBody.ts
@@ -1,0 +1,39 @@
+import { getBaseURL, getConfig } from '@/lib/config'
+import { SanitizedBody } from '@/lib/services/email/layout/blocks'
+import { EditableStatus } from '@/lib/types/domain/status'
+import { convertMarkdownText } from '@/lib/utils/text/convertMarkdownText'
+import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
+import { sanitizeText } from '@/lib/utils/text/sanitizeText'
+
+// Rewrites root-relative hrefs to absolute ones. A mail client has no origin to
+// resolve them against, so `/tags/x` is simply a dead link in an inbox.
+//
+// convertMarkdownText emits exactly that for every hashtag
+// (`<a href="/tags/foo" …>`), which is why the mention and reply emails have
+// been shipping dead hashtag links. sanitizeText also permits a schemeless href
+// on the remote path, so both pipelines need this.
+//
+// Only `href="/…"` is rewritten, never `href="//…"` — a protocol-relative URL
+// points at another origin entirely and must not be silently re-homed.
+const absolutizeLinks = (html: string): string =>
+  html.replace(
+    /(\s(?:href|src)=")\/(?!\/)/g,
+    (_match, attribute: string) => `${attribute}${getBaseURL()}/`
+  )
+
+/**
+ * Render a status body for an email: HTML through the same sanitize/markdown
+ * pipeline the web UI uses, plus the plain-text twin derived from it.
+ *
+ * The text side is derived rather than hand-written because the source is
+ * already HTML — the previous templates printed `status.text` raw into the text
+ * part, which for a remote actor meant a wall of markup.
+ */
+export const getStatusBody = (status: EditableStatus): SanitizedBody => {
+  const html = absolutizeLinks(
+    status.isLocalActor
+      ? convertMarkdownText(getConfig().host)(status.text)
+      : sanitizeText(status.text)
+  )
+  return { html, text: htmlToPlainText(html) }
+}

--- a/lib/services/email/templates/statusBody.ts
+++ b/lib/services/email/templates/statusBody.ts
@@ -30,10 +30,19 @@ const absolutizeLinks = (html: string): string =>
  * part, which for a remote actor meant a wall of markup.
  */
 export const getStatusBody = (status: EditableStatus): SanitizedBody => {
-  const html = absolutizeLinks(
-    status.isLocalActor
-      ? convertMarkdownText(getConfig().host)(status.text)
-      : sanitizeText(status.text)
-  )
+  // Markdown for a local author, then sanitize ALWAYS — the same order as
+  // processStatusTextContent, which is what the web UI renders through.
+  //
+  // These must not become an either/or. `marked` has shipped no sanitizer since
+  // v5, so running only the markdown step lets a local author put raw HTML
+  // straight into another user's inbox: a tracking pixel (read receipt plus IP),
+  // a <style> block that hides the real card, or arbitrary anchor markup for
+  // phishing. `quote()` emits this value unescaped, so sanitizing here is the
+  // only thing standing between a post body and the recipient's mail client.
+  const rendered = status.isLocalActor
+    ? convertMarkdownText(getConfig().host)(status.text)
+    : status.text
+  // Absolutize after sanitizing, so only hrefs that survived it are rewritten.
+  const html = absolutizeLinks(sanitizeText(rendered))
   return { html, text: htmlToPlainText(html) }
 }

--- a/lib/services/email/templates/statusUrl.test.ts
+++ b/lib/services/email/templates/statusUrl.test.ts
@@ -1,0 +1,63 @@
+import { Status, StatusType } from '@/lib/types/domain/status'
+
+import { getEmailActorUrl, getEmailStatusUrl } from './statusUrl'
+
+const HOST = 'test.llun.dev'
+const BASE_URL = `https://${HOST}`
+
+const remoteStatus = {
+  id: 'https://remote.example.com/statuses/9',
+  url: 'https://remote.example.com/@rin/9',
+  actorId: 'https://remote.example.com/users/rin',
+  actor: {
+    id: 'https://remote.example.com/users/rin',
+    username: 'rin',
+    domain: 'remote.example.com',
+    followersUrl: '',
+    inboxUrl: '',
+    sharedInboxUrl: '',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1000
+  },
+  isLocalActor: false,
+  type: StatusType.enum.Note,
+  text: 'hi',
+  summary: '',
+  to: [],
+  cc: [],
+  tags: [],
+  attachments: [],
+  replies: [],
+  createdAt: 1000
+} as unknown as Status
+
+describe('getEmailStatusUrl', () => {
+  it('points a remote status at the recipient own server, not the origin', () => {
+    const url = getEmailStatusUrl(remoteStatus)
+    expect(url.startsWith(`${BASE_URL}/`)).toBe(true)
+    expect(url).toContain('@rin@remote.example.com')
+    expect(url).not.toContain('remote.example.com/@rin/9')
+  })
+
+  it('uses the configured scheme rather than assuming https', () => {
+    // getBaseURL() honours ACTIVITIES_INSECURE_AUTH; the four copies this
+    // replaces hardcoded https://${config.host}.
+    expect(getEmailStatusUrl(remoteStatus).startsWith(BASE_URL)).toBe(true)
+  })
+
+  it('falls back to the status url when no path can be derived', () => {
+    const actorless = { ...remoteStatus, actor: undefined } as unknown as Status
+    expect(getEmailStatusUrl(actorless)).toBe(remoteStatus.url)
+  })
+})
+
+describe('getEmailActorUrl', () => {
+  it('builds a local profile url from a handle', () => {
+    expect(getEmailActorUrl('@rin@remote.example.com')).toBe(
+      `${BASE_URL}/@rin@remote.example.com`
+    )
+  })
+})

--- a/lib/services/email/templates/statusUrl.test.ts
+++ b/lib/services/email/templates/statusUrl.test.ts
@@ -1,4 +1,4 @@
-import { Status, StatusType } from '@/lib/types/domain/status'
+import { EditableStatus, StatusType } from '@/lib/types/domain/status'
 
 import { getEmailActorUrl, getEmailStatusUrl } from './statusUrl'
 
@@ -32,7 +32,7 @@ const remoteStatus = {
   attachments: [],
   replies: [],
   createdAt: 1000
-} as unknown as Status
+} as unknown as EditableStatus
 
 describe('getEmailStatusUrl', () => {
   it('points a remote status at the recipient own server, not the origin', () => {
@@ -49,7 +49,10 @@ describe('getEmailStatusUrl', () => {
   })
 
   it('falls back to the status url when no path can be derived', () => {
-    const actorless = { ...remoteStatus, actor: undefined } as unknown as Status
+    const actorless = {
+      ...remoteStatus,
+      actor: undefined
+    } as unknown as EditableStatus
     expect(getEmailStatusUrl(actorless)).toBe(remoteStatus.url)
   })
 })

--- a/lib/services/email/templates/statusUrl.ts
+++ b/lib/services/email/templates/statusUrl.ts
@@ -1,0 +1,26 @@
+import { getBaseURL } from '@/lib/config'
+import { Status } from '@/lib/types/domain/status'
+import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
+
+/**
+ * Absolute URL of a status on the RECIPIENT's own server, so the link resolves
+ * for them whether the post is local or remote.
+ *
+ * Replaces four near-identical private copies (one of which had drifted) that
+ * each hardcoded `https://${config.host}` — wrong on an
+ * `ACTIVITIES_INSECURE_AUTH=true` deployment. Built on `getStatusDetailPath` so
+ * email links are byte-identical to the ones the web UI renders.
+ *
+ * Falls back to `status.url` when the status has no actor and no path can be
+ * derived. That value is remote-controlled, so callers must pass it through the
+ * layout's URL check rather than emitting it directly — `button` and
+ * `fallbackUrl` already do.
+ */
+export const getEmailStatusUrl = (status: Status): string => {
+  const path = getStatusDetailPath(status)
+  return path ? `${getBaseURL()}${path}` : status.url
+}
+
+/** Absolute URL of an actor's profile on the recipient's own server. */
+export const getEmailActorUrl = (handle: string): string =>
+  `${getBaseURL()}/${handle}`

--- a/lib/services/email/templates/statusUrl.ts
+++ b/lib/services/email/templates/statusUrl.ts
@@ -1,5 +1,5 @@
 import { getBaseURL } from '@/lib/config'
-import { Status } from '@/lib/types/domain/status'
+import { EditableStatus } from '@/lib/types/domain/status'
 import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
 
 /**
@@ -15,8 +15,12 @@ import { getStatusDetailPath } from '@/lib/utils/getStatusDetailPath'
  * derived. That value is remote-controlled, so callers must pass it through the
  * layout's URL check rather than emitting it directly — `button` and
  * `fallbackUrl` already do.
+ *
+ * Takes `EditableStatus` rather than the wider `Status`: only a Note or a Poll
+ * carries a `url`, and an Announce is never what a notification email quotes —
+ * the call sites unwrap to the original status first.
  */
-export const getEmailStatusUrl = (status: Status): string => {
+export const getEmailStatusUrl = (status: EditableStatus): string => {
   const path = getStatusDetailPath(status)
   return path ? `${getBaseURL()}${path}` : status.url
 }

--- a/lib/services/notifications/sendNotificationAlerts.ts
+++ b/lib/services/notifications/sendNotificationAlerts.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@/lib/config'
 import { Database } from '@/lib/database/types'
 import { sendMail } from '@/lib/services/email'
+import { RenderedEmail } from '@/lib/services/email/types'
 import { NotificationType } from '@/lib/types/database/operations'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
@@ -9,11 +10,13 @@ import { shouldSendEmailForNotification } from './emailNotificationSettings'
 import { sendPushNotification } from './pushNotification'
 import { shouldSendPushForNotification } from './pushNotificationSettings'
 
-export interface EmailContent {
+/**
+ * A rendered template plus its destination. Defined in terms of
+ * {@link RenderedEmail} so a call site can spread a `build*Email()` result
+ * straight in, and so the two stay in step if the template contract changes.
+ */
+export type EmailContent = RenderedEmail & {
   recipientEmail: string
-  subject: string
-  text: string
-  html: string
 }
 
 export interface NotificationEvent {

--- a/lib/services/timelines/mentionNotification.ts
+++ b/lib/services/timelines/mentionNotification.ts
@@ -1,16 +1,8 @@
 import { SpanStatusCode } from '@opentelemetry/api'
 
 import { getConfig } from '@/lib/config'
-import {
-  getHTMLContent as getMentionHTMLContent,
-  getSubject as getMentionSubject,
-  getTextContent as getMentionTextContent
-} from '@/lib/services/email/templates/mention'
-import {
-  getHTMLContent as getReplyHTMLContent,
-  getSubject as getReplySubject,
-  getTextContent as getReplyTextContent
-} from '@/lib/services/email/templates/reply'
+import { buildMentionEmail } from '@/lib/services/email/templates/mention'
+import { buildReplyEmail } from '@/lib/services/email/templates/reply'
 import { createNotificationWithPolicy } from '@/lib/services/notifications/createNotificationWithPolicy'
 import {
   NotificationEvent,
@@ -119,9 +111,11 @@ export const notifyRemoteReplyAndMention = async ({
               if (config.email && account && status.actor) {
                 replyEvent.emailContent = {
                   recipientEmail: account.email,
-                  subject: getReplySubject(status.actor),
-                  text: getReplyTextContent(status),
-                  html: getReplyHTMLContent(status)
+                  ...buildReplyEmail({
+                    recipient: currentActor,
+                    actor: status.actor,
+                    status
+                  })
                 }
               }
               alertEvents.push(replyEvent)
@@ -180,9 +174,11 @@ export const notifyRemoteReplyAndMention = async ({
           if (config.email && account && status.actor) {
             mentionEvent.emailContent = {
               recipientEmail: account.email,
-              subject: getMentionSubject(status.actor),
-              text: getMentionTextContent(status),
-              html: getMentionHTMLContent(status)
+              ...buildMentionEmail({
+                recipient: currentActor,
+                actor: status.actor,
+                status
+              })
             }
           }
           alertEvents.push(mentionEvent)

--- a/scripts/mock/renderEmailPreviews.ts
+++ b/scripts/mock/renderEmailPreviews.ts
@@ -79,6 +79,10 @@ const maythee = fixtureActor('maythee', 'mastodon.social', 'Maythee')
 const ben = fixtureActor('ben', 'llun.social', 'Ben Carter')
 const rin = fixtureActor('rin', 'pixelfed.social', 'Rin')
 
+// Only the fields the templates actually read are populated — a full
+// EditableStatus carries ~30 more (edits, reply, quote state, visibility, …)
+// that no email touches. Cast through `unknown` for that reason, matching the
+// test fixtures; a preview does not need a faithful database row.
 const fixtureStatus = (
   actor: ActorProfile,
   text: string,
@@ -99,7 +103,7 @@ const fixtureStatus = (
     attachments: [],
     replies: [],
     createdAt: 1_700_000_000_000
-  }) as EditableStatus
+  }) as unknown as EditableStatus
 
 const annaPost = fixtureStatus(
   anna,

--- a/scripts/mock/renderEmailPreviews.ts
+++ b/scripts/mock/renderEmailPreviews.ts
@@ -5,8 +5,9 @@
  * this is how a template change gets a real visual check before it ships.
  *
  * NOTE: covers only the templates listed in buildPreviews() below — currently
- * the four account/security emails. The seven notification templates are not on
- * the shared layout yet; add each one here in the PR that migrates it.
+ * the four account/security emails and the six notification emails. The fitness
+ * activity-import email is not on the shared layout yet; add it here in the PR
+ * that migrates it.
  *
  * Pure function calls with fixture data — no database is opened, no network
  * request is made, and no mail is sent. Only `getConfig()`/`getBaseURL()` are
@@ -33,10 +34,17 @@ import path from 'path'
 
 import { buildActorDeletedEmail } from '@/lib/services/email/templates/actorDeleted'
 import { buildChangeEmail } from '@/lib/services/email/templates/changeEmail'
+import { buildFollowEmail } from '@/lib/services/email/templates/follow'
+import { buildFollowRequestEmail } from '@/lib/services/email/templates/followRequest'
+import { buildLikeEmail } from '@/lib/services/email/templates/like'
+import { buildMentionEmail } from '@/lib/services/email/templates/mention'
+import { buildBoostEmail } from '@/lib/services/email/templates/reblog'
+import { buildReplyEmail } from '@/lib/services/email/templates/reply'
 import { buildResetPasswordEmail } from '@/lib/services/email/templates/resetPassword'
 import { buildVerifyEmail } from '@/lib/services/email/templates/verifyEmail'
 import { RenderedEmail } from '@/lib/services/email/types'
 import { ActorProfile } from '@/lib/types/domain/actor'
+import { EditableStatus, StatusType } from '@/lib/types/domain/status'
 import { escapeHtml } from '@/lib/utils/text/escapeHtml'
 
 const RECIPIENT = 'anna@example.com'
@@ -65,6 +73,39 @@ const fixtureActor = (
   lastStatusAt: Date.now(),
   createdAt: Date.now()
 })
+
+const anna = fixtureActor('anna', 'llun.social', 'Anna')
+const maythee = fixtureActor('maythee', 'mastodon.social', 'Maythee')
+const ben = fixtureActor('ben', 'llun.social', 'Ben Carter')
+const rin = fixtureActor('rin', 'pixelfed.social', 'Rin')
+
+const fixtureStatus = (
+  actor: ActorProfile,
+  text: string,
+  id: string
+): EditableStatus =>
+  ({
+    id: `https://${actor.domain}/statuses/${id}`,
+    url: `https://${actor.domain}/@${actor.username}/${id}`,
+    actorId: actor.id,
+    actor,
+    isLocalActor: actor.domain === 'llun.social',
+    type: StatusType.enum.Note,
+    text,
+    summary: '',
+    to: [],
+    cc: [],
+    tags: [],
+    attachments: [],
+    replies: [],
+    createdAt: 1_700_000_000_000
+  }) as EditableStatus
+
+const annaPost = fixtureStatus(
+  anna,
+  'Morning run done — 8.2 km along the river. The new shoes are holding up surprisingly well. #running',
+  'note-88101'
+)
 
 interface Preview {
   slug: string
@@ -105,6 +146,52 @@ const buildPreviews = (): Preview[] => [
       recipientEmail: RECIPIENT,
       contactEmail: 'admin@llun.social'
     })
+  },
+  {
+    slug: 'follow',
+    group: 'Notifications',
+    email: buildFollowEmail({ recipient: anna, actor: maythee })
+  },
+  {
+    slug: 'follow-request',
+    group: 'Notifications',
+    email: buildFollowRequestEmail({ recipient: anna, actor: ben })
+  },
+  {
+    slug: 'mention',
+    group: 'Notifications',
+    email: buildMentionEmail({
+      recipient: anna,
+      actor: maythee,
+      status: fixtureStatus(
+        maythee,
+        '@anna have you tried the new Garmin Connect sync yet? Curious how it handles multi-sport days.',
+        'note-88213'
+      )
+    })
+  },
+  {
+    slug: 'reply',
+    group: 'Notifications',
+    email: buildReplyEmail({
+      recipient: anna,
+      actor: rin,
+      status: fixtureStatus(
+        rin,
+        'This is brilliant — federated fitness is genuinely the dream. Adding it to my instance tonight.',
+        'note-88214'
+      )
+    })
+  },
+  {
+    slug: 'like',
+    group: 'Notifications',
+    email: buildLikeEmail({ recipient: anna, actor: maythee, status: annaPost })
+  },
+  {
+    slug: 'boost',
+    group: 'Notifications',
+    email: buildBoostEmail({ recipient: anna, actor: ben, status: annaPost })
   }
 ]
 


### PR DESCRIPTION
## Summary

Second of three PRs bringing every email in line with the approved [Email templates](https://claude.ai/design/p/a61009c5-7207-4e18-8d2b-a0cace8d672b?file=ui_kits%2Fweb%2Femails.html) design. Builds on the shared layout from #1322.

Moves the six notification emails — follow, follow request, mention, reply, like, boost — onto that layout. **Ten of eleven templates are now migrated**; only the fitness activity import remains, and nothing sends it (PR 3).

## Defects fixed

These templates were the worst of the set. Four separate problems, all live:

- **Every hashtag link was dead.** `convertMarkdownText` renders hashtags as `<a href="/tags/foo">`. A mail client has no origin to resolve that against, so every hashtag in a mention or reply email pointed nowhere. New `absolutizeLinks` rewrites root-relative hrefs on both the markdown and sanitize paths — deliberately *not* protocol-relative `//host` URLs, which point at another origin and must not be silently re-homed.
- **`like` and `reblog` injected raw remote markup.** Both interpolated `status.text` straight into the HTML with no sanitizing. Only `mention`/`reply` had the pipeline; now all four share it.
- **`follow`/`followRequest` linked the remote `actor.id`**, dropping the reader on another server with no session and no follow button. They now link the local profile.
- **Four templates hardcoded `https://${config.host}`** in duplicated `getLocalStatusUrl` copies (one had drifted). Consolidated into `getEmailStatusUrl`, built on `getStatusDetailPath` so an email link is byte-identical to the web UI's.

The plain-text part was also printing `status.text` raw — for a remote actor, a wall of markup. It is now derived from the sanitized HTML.

## Copy change

`reblog.ts` says **"boosted"** in subject and body, per the design. Internal vocabulary is untouched — `NotificationType.reblog`, the stored value and the Mastodon API field are the fediverse wire term. The file keeps its name to preserve the 1:1 module↔notification-type mapping.

> Known, deliberate inconsistency: Settings still reads "Reblogs" while the email says "boosted". That label was scoped out.

## What changed

- `layout/actorDisplay.ts` — short name, two-letter monogram, stable per-handle colour (held back from #1322 as it had no consumer there)
- `layout/blocks.ts` — the `quote` builder, and `SanitizedBody`: the one value the layout emits unescaped, a named type precisely so a bare string can't be handed in by accident
- `templates/statusUrl.ts`, `templates/statusBody.ts` — the two shared helpers
- Six templates rewritten to `build*Email(): RenderedEmail`
- The recipient threaded through **9 call sites** (all already had it in scope — no extra DB reads); `EmailContent` is now `RenderedEmail & { recipientEmail }`

## Testing

`prettier --check` clean · `eslint` 0 errors · `next build` exit 0 · **7242 tests passed (725 files)**

New `emailDesign.test.ts` — one table-driven conformance suite over all ten templates, rendered with a fixture whose every string slot carries a hostile sentinel: document shape, fluid column + Outlook ghost table, preheader, button count, footer variant, and that no hostile input, `javascript:` url, relative href or unresolved template value survives. **134 assertions.**

Two assertions there are deliberately narrower than the obvious version, both because the obvious one produces false failures:
- it asserts the sentinel never appears **verbatim**, rather than that `"><` is absent — that sequence occurs at every legitimate tag boundary
- the plain-text check looks for **layout markup**, not a bare `<` — the fixtures put one in the display name, and a literal angle bracket in a `text/plain` body is a character, not a tag

Writing the suite also corrected an assumption of mine: I expected the hostile fixtures to yield **zero** buttons via the `javascript:` fallback. They yield one — the hostile actor still produces a derivable local path, so `getEmailStatusUrl` never reaches its fallback. The refusal is now covered by a separate case using an actor-less status, which is the only way to reach it.

## Verification

Rendered all ten templates and checked them in a browser. Confirmed in the DOM that the boost email's `#running` hashtag now resolves to `https://llun.social/tags/running` — **zero relative links in the document**.

> Same caveat as #1322: the Outlook-specific work (ghost table, `mso-padding-alt`, `mso-hide:all`) is invisible in a browser by construction and wants one real send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
