### PR TITLE
Bump version to v1.119.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.118.0",
+  "version": "1.119.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.119.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.118.0`
- Base main SHA: `079eb2f8bd5a300a96a4ffbaa8be65a6a12c50ec`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
