### PR TITLE
Bump version to v1.120.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.119.0",
+  "version": "1.120.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.120.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.119.0`
- Base main SHA: `725677a2de81ffeeef18cded261f81b79e0119ff`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
