### PR TITLE
minor: add the status reaction picker and chips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,8 +348,12 @@ consistency is enforced by keeping the wiring in one place rather than per page.
   change visibility / who-can-quote, delete-own; mute / block / report for other
   actors; copy link; open original) and wires reply/quote/edit itself. `Post`
   also renders the emoji **reaction row** (chips + picker) as a sibling directly
-  above that action row, gated on the same `showActions` + `currentActor` pair —
-  reactions are **not** favourites and never touch the like button's state. A page
+  above that action row. It follows the same `showActions` + `currentActor` gate,
+  but degrades rather than disappearing: a reader who cannot react (logged out,
+  `showActions={false}`, or a remote custom emoji this instance cannot react
+  with) still sees the chips as read-only labels, and only the picker and the
+  toggling are withheld. Reactions are **not** favourites and never touch the
+  like button's state. A page
   must **not** pass per-status action callbacks (`onReply`, `onQuote`, `onEdit`)
   and must **not** hide individual actions — that per-page drift is exactly what
   this consolidation removed (profiles used to lack Quote/Edit; six feeds had a
@@ -381,7 +385,10 @@ consistency is enforced by keeping the wiring in one place rather than per page.
 - The bespoke fitness activity detail (`FitnessStatusDetail`) and the
   notification snippet (`StatusNotification`) are intentionally separate
   presentations and are outside this contract; everything else goes through
-  `Posts`/`Post`.
+  `Posts`/`Post`. The fitness detail composes its own action row, so it renders
+  `ReactionRow` explicitly — a post's reactions must be visible and addable
+  wherever its action row is, and that page is the one surface that has to opt
+  in by hand.
 
 ## Better-auth Plugin Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,10 @@ consistency is enforced by keeping the wiring in one place rather than per page.
 - **The action set is owned by `Posts`, not by pages.** `Posts` renders the full
   action row (reply, boost, like, bookmark) plus the `⋯` menu (quote, edit-own,
   change visibility / who-can-quote, delete-own; mute / block / report for other
-  actors; copy link; open original) and wires reply/quote/edit itself. A page
+  actors; copy link; open original) and wires reply/quote/edit itself. `Post`
+  also renders the emoji **reaction row** (chips + picker) as a sibling directly
+  above that action row, gated on the same `showActions` + `currentActor` pair —
+  reactions are **not** favourites and never touch the like button's state. A page
   must **not** pass per-status action callbacks (`onReply`, `onQuote`, `onEdit`)
   and must **not** hide individual actions — that per-page drift is exactly what
   this consolidation removed (profiles used to lack Quote/Edit; six feeds had a
@@ -366,8 +369,10 @@ consistency is enforced by keeping the wiring in one place rather than per page.
 - **Pages supply only optional data-sync callbacks** for their own feed state:
   `onStatusCreated` (a reply/quote was created — prepend it if it belongs in this
   feed, otherwise ignore), `onPostUpdated` (an edit — replace the status in
-  place), `onPostDeleted`, `onLikeChanged`, `onBookmarkChanged`. These mutate the
-  page's own `statuses` copy; they never decide which actions are shown.
+  place), `onPostDeleted`, `onLikeChanged`, `onBookmarkChanged`,
+  `onReactionsChanged` (the emoji-reaction rollups for a status changed). These
+  mutate the page's own `statuses` copy; they never decide which actions are
+  shown.
 - **Read-only or logged-out surfaces** pass `showActions={false}` (optionally
   with `showReadOnlyStats` to show non-interactive engagement counts instead — as
   the logged-out landing feed and logged-out profile do). That is the _only_

--- a/app/(timeline)/[actor]/ActorTimelines.tsx
+++ b/app/(timeline)/[actor]/ActorTimelines.tsx
@@ -22,6 +22,7 @@ import {
   StatusPoll,
   StatusType
 } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 
 import { ActorMediaGallery } from './ActorMediaGallery'
 
@@ -230,6 +231,22 @@ export const ActorTimelines: FC<Props> = ({
     []
   )
 
+  // Reactions have to be synced alongside likes and bookmarks: those handlers
+  // replace the status object in this page's own copy, which re-renders the
+  // reaction row from its (now stale) `reactions` prop and would otherwise
+  // revert a chip the viewer just added.
+  const handleReactionsChanged = useCallback(
+    (status: StatusNote | StatusPoll, reactions: StatusReaction[]) => {
+      setCurrentStatuses((previousStatuses) =>
+        updateMatchingStatus(previousStatuses, status.id, (target) => ({
+          ...target,
+          reactions
+        }))
+      )
+    },
+    []
+  )
+
   const loadMoreStatuses = useCallback(async () => {
     const nextPageUrl = currentStatusPagination.nextPageUrl
     if (isLoadingRef.current || !nextPageUrl) return
@@ -331,6 +348,7 @@ export const ActorTimelines: FC<Props> = ({
         onPostDeleted={handlePostDeleted}
         onLikeChanged={handleLikeChanged}
         onBookmarkChanged={handleBookmarkChanged}
+        onReactionsChanged={handleReactionsChanged}
       />
     ) : (
       <EmptyState>{emptyMessage}</EmptyState>

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -46,6 +46,7 @@ import { RepostButton } from '@/lib/components/posts/actions/repost-button'
 import { ActorAvatar } from '@/lib/components/posts/actor'
 import { Media } from '@/lib/components/posts/media'
 import { Post } from '@/lib/components/posts/post'
+import { ReactionRow } from '@/lib/components/posts/reaction-row'
 import { StatusReplyBox } from '@/lib/components/posts/status-reply-box'
 import { Button } from '@/lib/components/ui/button'
 import {
@@ -1958,6 +1959,20 @@ export const FitnessStatusDetail: FC<Props> = ({
             )}
           </div>
         </div>
+
+        {/* Reactions belong to the post, so they sit above the action bar here as
+            they do in `Post`. This page composes its own action row instead of
+            using `Posts`, so the row has to be added explicitly — without it a
+            fitness post is the one surface where an existing reaction is
+            invisible and no new one can be added. */}
+        {(currentActor || (status.reactions?.length ?? 0) > 0) && (
+          <div className="border-t px-4 pt-2.5">
+            <ReactionRow
+              currentActor={currentActor ?? undefined}
+              status={status}
+            />
+          </div>
+        )}
 
         <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-t px-4 py-2.5">
           {sourceHref ? (

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -204,6 +204,9 @@ const Page: FC<Props> = async ({ params }) => {
     replies = await database.getStatusReplies({
       statusId,
       url: statusUrl,
+      // Separate from the visibility filter below: this is the viewer whose
+      // like, bookmark and reaction state each reply is hydrated with.
+      currentActorId: currentActor?.id,
       ...(currentActor
         ? { visibleToActorId: currentActor.id }
         : { publicOnly: true })

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -285,7 +285,10 @@ const Page: FC<Props> = async ({ params }) => {
           // which already supplies its own top padding, so only the signed-in
           // surface needs this gap.
           currentActorProfile && 'mt-4',
-          'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
+          // No `overflow-hidden`: this card contains posts, and a post's
+          // non-portaled overlays (the reaction picker) would be clipped by it —
+          // the same reason `Posts` dropped it.
+          'rounded-2xl border bg-background/80 shadow-sm'
         )}
       >
         {currentActorProfile ? (
@@ -332,7 +335,10 @@ const Page: FC<Props> = async ({ params }) => {
         // logged-out `PublicShell` already provides its own, so scope the gap
         // to the signed-in card to keep the spacing consistent across both.
         currentActorProfile && 'mt-4',
-        'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
+        // No `overflow-hidden`: this card contains posts, and a post's
+        // non-portaled overlays (the reaction picker) would be clipped by it —
+        // the same reason `Posts` dropped it.
+        'rounded-2xl border bg-background/80 shadow-sm'
       )}
     >
       {currentActorProfile ? (

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -285,10 +285,7 @@ const Page: FC<Props> = async ({ params }) => {
           // which already supplies its own top padding, so only the signed-in
           // surface needs this gap.
           currentActorProfile && 'mt-4',
-          // No `overflow-hidden`: this card contains posts, and a post's
-          // non-portaled overlays (the reaction picker) would be clipped by it —
-          // the same reason `Posts` dropped it.
-          'rounded-2xl border bg-background/80 shadow-sm'
+          'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
         )}
       >
         {currentActorProfile ? (
@@ -338,7 +335,7 @@ const Page: FC<Props> = async ({ params }) => {
         // No `overflow-hidden`: this card contains posts, and a post's
         // non-portaled overlays (the reaction picker) would be clipped by it —
         // the same reason `Posts` dropped it.
-        'rounded-2xl border bg-background/80 shadow-sm'
+        'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
       )}
     >
       {currentActorProfile ? (

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -230,7 +230,11 @@ const Page: FC<Props> = async ({ params }) => {
   if (status.type !== StatusType.enum.Announce && status.reply) {
     let replyStatus = await database.getStatus({
       statusId: status.reply,
-      withReplies: false
+      withReplies: false,
+      // Ancestors render the same interactive chips as the focused status, so
+      // they need the same viewer — otherwise one post shows its reaction
+      // highlighted on the timeline and unhighlighted as a thread ancestor.
+      currentActorId: currentActor?.id
     })
     while (previouses.length < 3 && replyStatus) {
       // `getStatus` does no visibility filtering, so without this guard a public
@@ -257,7 +261,8 @@ const Page: FC<Props> = async ({ params }) => {
       }
       replyStatus = await database.getStatus({
         statusId: replyStatus.reply,
-        withReplies: false
+        withReplies: false,
+        currentActorId: currentActor?.id
       })
     }
   }

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -79,7 +79,8 @@ const Page: FC<Props> = async ({ params }) => {
   const resolvedStatus = await resolveStatusFromPath({
     database,
     actorParam: actor,
-    statusParam
+    statusParam,
+    currentActorId: currentActor?.id
   })
   if (!resolvedStatus) return notFound()
 

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
@@ -81,6 +81,28 @@ describe('resolveStatusFromPath', () => {
     })
   })
 
+  it('hydrates a hash route for the signed-in viewer too', async () => {
+    const database = createDatabase()
+    database.getStatusFromUrlHash.mockResolvedValueOnce(originalStatus)
+    const viewerId = 'https://remote.example/users/viewer'
+
+    await resolveStatusFromPath({
+      database,
+      actorParam: '@original@remote.example',
+      statusParam: statusHash,
+      currentActorId: viewerId
+    })
+
+    // The hash route lands on the same detail page as the id route, so it has
+    // to hydrate the viewer's own state the same way — otherwise their emoji
+    // reaction renders as "Add" on exactly one of the two URLs for one post.
+    expect(database.getStatusFromUrlHash).toHaveBeenCalledWith({
+      urlHash: statusHash,
+      actorId: originalActorId,
+      currentActorId: viewerId
+    })
+  })
+
   it('resolves a hash route from the scoped actor lookup', async () => {
     const database = createDatabase()
     database.getStatusFromUrlHash.mockResolvedValueOnce(originalStatus)

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.test.ts
@@ -59,6 +59,28 @@ describe('resolveStatusFromPath', () => {
     getStatus: vi.fn().mockResolvedValue(null)
   })
 
+  it('hydrates the focused status for the signed-in viewer', async () => {
+    const database = createDatabase()
+    database.getStatus.mockResolvedValueOnce(originalStatus)
+    const viewerId = 'https://remote.example/users/viewer'
+
+    await resolveStatusFromPath({
+      database,
+      actorParam: '@original@remote.example',
+      statusParam: '123',
+      currentActorId: viewerId
+    })
+
+    // Without the viewer id the focused status resolves with no like, bookmark
+    // or reaction state, so the viewer's own emoji reaction renders as "Add" on
+    // the one surface where the chips are interactive.
+    expect(database.getStatus).toHaveBeenCalledWith({
+      statusId: 'https://remote.example/users/original/statuses/123',
+      withReplies: false,
+      currentActorId: viewerId
+    })
+  })
+
   it('resolves a hash route from the scoped actor lookup', async () => {
     const database = createDatabase()
     database.getStatusFromUrlHash.mockResolvedValueOnce(originalStatus)

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
@@ -78,12 +78,14 @@ export const resolveStatusFromPath = async ({
   if (isStatusHash) {
     status = await database.getStatusFromUrlHash({
       urlHash: decodedStatusParam,
-      actorId: actorIdFromPath
+      actorId: actorIdFromPath,
+      currentActorId
     })
 
     if (!status && actorIdFromPath) {
       const unscopedStatus = await database.getStatusFromUrlHash({
-        urlHash: decodedStatusParam
+        urlHash: decodedStatusParam,
+        currentActorId
       })
 
       if (unscopedStatus) {

--- a/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
+++ b/app/(timeline)/[actor]/[status]/resolveStatusFromPath.ts
@@ -8,6 +8,9 @@ interface ResolveStatusFromPathParams {
   >
   actorParam: string
   statusParam: string
+  // The signed-in viewer, so the focused status is hydrated with their own
+  // like/bookmark/reaction state. Omitted for anonymous readers.
+  currentActorId?: string
 }
 
 interface ResolveStatusFromPathResult {
@@ -43,7 +46,8 @@ const getStatusForPathActor = (status: Status, actorId: string) => {
 export const resolveStatusFromPath = async ({
   database,
   actorParam,
-  statusParam
+  statusParam,
+  currentActorId
 }: ResolveStatusFromPathParams): Promise<ResolveStatusFromPathResult | null> => {
   const decodedActor = decodePathParam(actorParam)
   const decodedStatusParam = decodePathParam(statusParam)
@@ -91,13 +95,15 @@ export const resolveStatusFromPath = async ({
   if (!status && !isStatusHash) {
     status = await database.getStatus({
       statusId: fullStatusId,
-      withReplies: false
+      withReplies: false,
+      currentActorId
     })
   }
 
   if (!status && !isStatusHash && !isFullStatusUrl) {
     status = await database.getStatus({
       statusId: decodedStatusParam,
+      currentActorId,
       withReplies: false
     })
   }

--- a/app/(timeline)/[actor]/getProfileData.ts
+++ b/app/(timeline)/[actor]/getProfileData.ts
@@ -28,6 +28,10 @@ type ProfileData = {
 
 type ProfileDataOptions = {
   statusPageUrl?: string
+  // The signed-in viewer. Hydration only — it decides the like/bookmark/reaction
+  // state on the returned statuses, not which statuses are returned (that stays
+  // governed by the profile's own visibility rules).
+  currentActorId?: string
 }
 
 export const getProfileData = async (
@@ -51,7 +55,10 @@ export const getProfileData = async (
       followersCount,
       hasFitnessData
     ] = await Promise.all([
-      database.getActorStatuses({ actorId: persistedActor.id }),
+      database.getActorStatuses({
+        actorId: persistedActor.id,
+        currentActorId: options.currentActorId
+      }),
       database.getActorStatusesCount({ actorId: persistedActor.id }),
       database.getAttachmentsForActor({ actorId: persistedActor.id }),
       database.getActorFollowingCount({ actorId: persistedActor.id }),

--- a/app/(timeline)/[actor]/page.tsx
+++ b/app/(timeline)/[actor]/page.tsx
@@ -69,7 +69,8 @@ const Page: FC<Props> = async ({ params }) => {
   const actorProfile = await getProfileData(
     database,
     decodedActorHandle,
-    isLoggedIn
+    isLoggedIn,
+    { currentActorId: currentActor?.id }
   )
   if (!actorProfile) {
     return notFound()

--- a/app/(timeline)/collections/[id]/page.tsx
+++ b/app/(timeline)/collections/[id]/page.tsx
@@ -121,6 +121,10 @@ const Page = async ({ params }: PageProps) => {
       })
     : ((await database.getPublicCollectionTimeline({
         id,
+        // Hydration only — the public projection still decides which statuses
+        // are here. A signed-in visitor gets interactive chips and buttons, so
+        // they have to reflect that visitor's own state.
+        currentActorId: viewer?.id,
         limit: FEED_PAGE_LIMIT
       })) ?? [])
 

--- a/app/(timeline)/favorites/FavoritesTimeline.tsx
+++ b/app/(timeline)/favorites/FavoritesTimeline.tsx
@@ -17,6 +17,7 @@ import {
   StatusType,
   getOriginalStatus
 } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 
 const MAX_EMPTY_FAVOURITE_CONTINUATIONS = 5
 
@@ -77,6 +78,16 @@ export const FavoritesTimeline: FC<FavoritesTimelineProps> = ({
 
   const onLikeChanged = (status: StatusNote | StatusPoll, isLiked: boolean) => {
     if (!isLiked) removeStatus(status)
+  }
+
+  // Keep this page's copy in step with a reaction the viewer just added, so a
+  // later edit (which replaces the status object) doesn't re-render the reaction
+  // row from a stale `reactions` prop and drop the chip.
+  const onReactionsChanged = (
+    status: StatusNote | StatusPoll,
+    reactions: StatusReaction[]
+  ) => {
+    updateStatus({ ...status, reactions })
   }
 
   const loadMoreStatuses = useCallback(async () => {
@@ -149,6 +160,7 @@ export const FavoritesTimeline: FC<FavoritesTimelineProps> = ({
           onPostDeleted={removeStatus}
           onPostUpdated={updateStatus}
           onLikeChanged={onLikeChanged}
+          onReactionsChanged={onReactionsChanged}
         />
       ) : (
         <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground shadow-sm">

--- a/app/(timeline)/fitness/page.tsx
+++ b/app/(timeline)/fitness/page.tsx
@@ -87,7 +87,12 @@ const Page: FC = async () => {
   )
   const loadedStatuses = await Promise.all(
     statusIds.map((statusId) =>
-      database.getStatus({ statusId }).catch(() => null)
+      database
+        // This page is signed-in only, and these statuses render the same
+        // interactive chips as everywhere else — without the viewer their
+        // reaction (and like/bookmark) state reads false.
+        .getStatus({ statusId, currentActorId: currentActor.id })
+        .catch(() => null)
     )
   )
   const statuses = loadedStatuses.filter(

--- a/app/(timeline)/tags/[tag]/page.tsx
+++ b/app/(timeline)/tags/[tag]/page.tsx
@@ -50,9 +50,10 @@ const Page = async ({ params }: PageProps) => {
     fetchBatch: ({ maxStatusId, limit }) =>
       database.getStatusesByHashtag({
         hashtag: tag,
-        // Hydration only (this timeline is public either way): without it the
-        // viewer's own like, bookmark and reaction state reads false on the
-        // server-rendered page while the client-paginated pages have it.
+        // Hydration only — this timeline is public either way. The load-more
+        // endpoint (app/api/v1/tags/[tag]/route.ts) passes the same viewer, so
+        // page 1 and the pages appended after it agree about the viewer's own
+        // like, bookmark and reaction state.
         currentActorId: actor?.id,
         limit,
         maxStatusId: maxStatusId ?? undefined

--- a/app/(timeline)/tags/[tag]/page.tsx
+++ b/app/(timeline)/tags/[tag]/page.tsx
@@ -50,6 +50,10 @@ const Page = async ({ params }: PageProps) => {
     fetchBatch: ({ maxStatusId, limit }) =>
       database.getStatusesByHashtag({
         hashtag: tag,
+        // Hydration only (this timeline is public either way): without it the
+        // viewer's own like, bookmark and reaction state reads false on the
+        // server-rendered page while the client-paginated pages have it.
+        currentActorId: actor?.id,
         limit,
         maxStatusId: maxStatusId ?? undefined
       })

--- a/app/api/v1/collections/[id]/feed/route.ts
+++ b/app/api/v1/collections/[id]/feed/route.ts
@@ -41,78 +41,85 @@ export const GET = traceApiRoute(
   'getPublicCollectionFeed',
   OptionalOAuthGuard<Params>(
     [Scope.enum.read],
-    timelineErrorBoundary(CORS_HEADERS, async (req, { database, params }) => {
-      const { id } = await params
-      const url = new URL(req.url)
-      const format = url.searchParams.get('format')
-      const parsedQuery = parseTimelineQuery(url.searchParams)
-      if (!parsedQuery.ok) {
+    timelineErrorBoundary(
+      CORS_HEADERS,
+      async (req, { database, currentActor, params }) => {
+        const { id } = await params
+        const url = new URL(req.url)
+        const format = url.searchParams.get('format')
+        const parsedQuery = parseTimelineQuery(url.searchParams)
+        if (!parsedQuery.ok) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_400,
+            responseStatusCode: 400
+          })
+        }
+        const limit = parsedQuery.query.limit
+        const maxStatusId = parsedQuery.query.maxStatusId
+        const minStatusId =
+          parsedQuery.query.minStatusId ?? parsedQuery.query.sinceStatusId
+
+        const statuses = await database.getPublicCollectionTimeline({
+          id,
+          // Load-more for the same feed the page rendered, so it hydrates for the
+          // same viewer — otherwise their own state flips to un-acted partway
+          // down one scroll.
+          currentActorId: currentActor?.id,
+          limit,
+          maxStatusId,
+          minStatusId
+        })
+        if (statuses === null) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: ERROR_404,
+            responseStatusCode: 404
+          })
+        }
+
+        // The activities.next web app renders the public feed with the same
+        // domain-shaped <Posts> path as the list/collection timelines, so it asks
+        // for the internal format. The default (Mastodon entities + Link headers)
+        // stays the public, client-compatible response.
+        if (format === TimelineFormat.enum.activities_next) {
+          return apiResponse({
+            req,
+            allowedMethods: CORS_HEADERS,
+            data: {
+              statuses: statuses.map((item) => cleanJson(item)),
+              nextMaxStatusId:
+                statuses.length > 0 ? statuses[statuses.length - 1].id : null,
+              prevMinStatusId: statuses.length > 0 ? statuses[0].id : null
+            }
+          })
+        }
+
+        const mastodonStatuses = await getMastodonStatuses(database, statuses)
+
+        const host = headerHost(req.headers)
+        const firstStatus = statuses[0]
+        const lastStatus = statuses[statuses.length - 1]
+        const nextLink = lastStatus
+          ? `<https://${host}/api/v1/collections/${id}/feed?limit=${limit}&max_id=${urlToId(lastStatus.id)}>; rel="next"`
+          : null
+        const prevLink = firstStatus
+          ? `<https://${host}/api/v1/collections/${id}/feed?limit=${limit}&min_id=${urlToId(firstStatus.id)}>; rel="prev"`
+          : null
+        const links = [nextLink, prevLink].filter(Boolean).join(', ')
+
         return apiResponse({
           req,
           allowedMethods: CORS_HEADERS,
-          data: ERROR_400,
-          responseStatusCode: 400
+          data: mastodonStatuses,
+          additionalHeaders: [
+            ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
+          ]
         })
       }
-      const limit = parsedQuery.query.limit
-      const maxStatusId = parsedQuery.query.maxStatusId
-      const minStatusId =
-        parsedQuery.query.minStatusId ?? parsedQuery.query.sinceStatusId
-
-      const statuses = await database.getPublicCollectionTimeline({
-        id,
-        limit,
-        maxStatusId,
-        minStatusId
-      })
-      if (statuses === null) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: ERROR_404,
-          responseStatusCode: 404
-        })
-      }
-
-      // The activities.next web app renders the public feed with the same
-      // domain-shaped <Posts> path as the list/collection timelines, so it asks
-      // for the internal format. The default (Mastodon entities + Link headers)
-      // stays the public, client-compatible response.
-      if (format === TimelineFormat.enum.activities_next) {
-        return apiResponse({
-          req,
-          allowedMethods: CORS_HEADERS,
-          data: {
-            statuses: statuses.map((item) => cleanJson(item)),
-            nextMaxStatusId:
-              statuses.length > 0 ? statuses[statuses.length - 1].id : null,
-            prevMinStatusId: statuses.length > 0 ? statuses[0].id : null
-          }
-        })
-      }
-
-      const mastodonStatuses = await getMastodonStatuses(database, statuses)
-
-      const host = headerHost(req.headers)
-      const firstStatus = statuses[0]
-      const lastStatus = statuses[statuses.length - 1]
-      const nextLink = lastStatus
-        ? `<https://${host}/api/v1/collections/${id}/feed?limit=${limit}&max_id=${urlToId(lastStatus.id)}>; rel="next"`
-        : null
-      const prevLink = firstStatus
-        ? `<https://${host}/api/v1/collections/${id}/feed?limit=${limit}&min_id=${urlToId(firstStatus.id)}>; rel="prev"`
-        : null
-      const links = [nextLink, prevLink].filter(Boolean).join(', ')
-
-      return apiResponse({
-        req,
-        allowedMethods: CORS_HEADERS,
-        data: mastodonStatuses,
-        additionalHeaders: [
-          ...(links.length > 0 ? [['Link', links] as [string, string]] : [])
-        ]
-      })
-    }),
+    ),
     { errorResponse: corsErrorResponse(CORS_HEADERS) }
   )
 )

--- a/app/api/v1/tags/[tag]/route.test.ts
+++ b/app/api/v1/tags/[tag]/route.test.ts
@@ -96,7 +96,9 @@ describe('GET /api/v1/tags/:tag', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(Array.isArray(body.statuses)).toBe(true)
-    expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalled()
+    expect(mockDatabase.getStatusesByHashtag).toHaveBeenCalledWith(
+      expect.objectContaining({ currentActorId: expect.any(String) })
+    )
   })
 
   it('includes the seven-day usage history in the Tag entity', async () => {

--- a/app/api/v1/tags/[tag]/route.ts
+++ b/app/api/v1/tags/[tag]/route.ts
@@ -108,6 +108,11 @@ export const GET = traceApiRoute(
         fetchBatch: ({ maxStatusId, limit }) =>
           database.getStatusesByHashtag({
             hashtag: tag,
+            // This is the load-more endpoint behind the web hashtag page, so it
+            // must hydrate for the same viewer the server-rendered first page
+            // did — otherwise the viewer's own reaction, like, bookmark and
+            // boost state flip to false halfway down one scroll.
+            currentActorId: currentActor?.id,
             limit,
             maxStatusId: maxStatusId ?? undefined
           })

--- a/app/api/v2/search/route.ts
+++ b/app/api/v2/search/route.ts
@@ -344,7 +344,15 @@ const getResolvedStatus = async ({
     (await database.getStatus({
       statusId: query,
       currentActorId: currentActor.id
-    })) ?? (await database.getStatusFromUrl({ url: query }))
+    })) ??
+    // The url lookup is the one that actually fires for a pasted permalink (a
+    // status's `url` is never its `id`), so it needs the same viewer as the id
+    // lookup above — otherwise the resolved hit renders with no reaction, like
+    // or bookmark state while the indexed hits beside it render with it.
+    (await database.getStatusFromUrl({
+      url: query,
+      currentActorId: currentActor.id
+    }))
 
   const status =
     localStatus ??

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,7 +46,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Push notifications** — Web Push subscriptions with VAPID configuration
 - ✅ **Unread count** — Badge showing unread notification count
 
-- ✅ **Status emoji reactions** — React to any post with a unicode emoji or an instance custom emoji, separately from favouriting it. Chips under each post show who reacted with what, and a picker adds your own. Reactions federate both ways: inbound from Pleroma/Akkoma (`EmojiReact`) and the Misskey family (a `Like` carrying `content`/`_misskey_reaction`), outbound as a Misskey-style `Like` that vanilla Mastodon shows as a favourite. Served on every status as `pleroma.emoji_reactions` and `reactions`, with `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` (plus glitch-soc `react`/`unreact` aliases)
+- ✅ **Status emoji reactions** — React to any post with a unicode emoji or an instance custom emoji, separately from favouriting it. Chips under each post show each emoji with its count (yours highlighted), and a picker adds your own; the accounts behind a reaction are available from the API rather than the chips. Reactions federate both ways: inbound from Pleroma/Akkoma (`EmojiReact`) and the Misskey family (a `Like` carrying `content`/`_misskey_reaction`), outbound as a Misskey-style `Like` that vanilla Mastodon shows as a favourite. Served on every status as `pleroma.emoji_reactions` and `reactions`, with `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` (plus glitch-soc `react`/`unreact` aliases)
 
 ### Storage & Media
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,7 +46,7 @@ This document tracks the implemented and planned features for Activity.next.
 - ✅ **Push notifications** — Web Push subscriptions with VAPID configuration
 - ✅ **Unread count** — Badge showing unread notification count
 
-- 🚧 **Status emoji reactions** — React to a post with a unicode emoji or an instance custom emoji, separately from favouriting it. Reactions federate both ways: inbound from Pleroma/Akkoma (`EmojiReact`) and the Misskey family (a `Like` carrying `content`/`_misskey_reaction`), outbound as a Misskey-style `Like` that vanilla Mastodon shows as a favourite. Served on every status as `pleroma.emoji_reactions` and `reactions`, with `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` (plus glitch-soc `react`/`unreact` aliases) to write them. The picker UI is still landing
+- ✅ **Status emoji reactions** — React to any post with a unicode emoji or an instance custom emoji, separately from favouriting it. Chips under each post show who reacted with what, and a picker adds your own. Reactions federate both ways: inbound from Pleroma/Akkoma (`EmojiReact`) and the Misskey family (a `Like` carrying `content`/`_misskey_reaction`), outbound as a Misskey-style `Like` that vanilla Mastodon shows as a favourite. Served on every status as `pleroma.emoji_reactions` and `reactions`, with `PUT`/`DELETE /api/v1/pleroma/statuses/:id/reactions/:emoji` (plus glitch-soc `react`/`unreact` aliases)
 
 ### Storage & Media
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -468,8 +468,39 @@ export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
 }
 
 /**
+ * The outcome of a reaction write. A 4xx that the user cannot retry away (the
+ * per-actor cap, an emoji this instance rejects) carries the server's own
+ * message so the row can say what actually went wrong instead of inviting a
+ * retry that will always fail the same way.
+ */
+export type ReactionUpdateResult =
+  | { ok: true; reactions: MastodonStatusReaction[] }
+  | { ok: false; error?: string }
+
+const toReactionUpdateResult = async (
+  response: Response
+): Promise<ReactionUpdateResult> => {
+  if (!response.ok) {
+    // 4xx is a verdict on the request itself; 5xx and network faults are
+    // transient, and get the caller's generic retry copy.
+    if (response.status >= 400 && response.status < 500) {
+      const body = await response.json().catch(() => null)
+      const error = (body as { error?: unknown } | null)?.error
+      if (typeof error === 'string' && error.length > 0)
+        return { ok: false, error }
+    }
+    return { ok: false }
+  }
+  const status = (await response.json()) as MastodonStatus
+  return {
+    ok: true,
+    reactions: status.pleroma?.emoji_reactions ?? status.reactions ?? []
+  }
+}
+
+/**
  * Adds the current actor's emoji reaction to a status and returns the updated
- * reaction rollups, or null on failure so the caller can revert its optimistic
+ * reaction rollups, or a failure the caller can use to revert its optimistic
  * chip. `name` is a unicode emoji or a local custom-emoji shortcode.
  *
  * Uses the Pleroma/Akkoma dialect, which is the primary reaction surface (the
@@ -480,9 +511,7 @@ export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
 export const reactToStatus = async ({
   statusId,
   name
-}: DefaultStatusParams & { name: string }): Promise<
-  MastodonStatusReaction[] | null
-> => {
+}: DefaultStatusParams & { name: string }): Promise<ReactionUpdateResult> => {
   const response = await fetch(
     `/api/v1/pleroma/statuses/${urlToId(statusId)}/reactions/${encodeURIComponent(name)}`,
     {
@@ -492,21 +521,17 @@ export const reactToStatus = async ({
       }
     }
   )
-  if (!response.ok) return null
-  const status = (await response.json()) as MastodonStatus
-  return status.pleroma?.emoji_reactions ?? status.reactions ?? []
+  return toReactionUpdateResult(response)
 }
 
 /**
  * Removes the current actor's emoji reaction from a status and returns the
- * updated rollups, or null on failure.
+ * updated rollups, or a failure the caller can use to revert.
  */
 export const unreactFromStatus = async ({
   statusId,
   name
-}: DefaultStatusParams & { name: string }): Promise<
-  MastodonStatusReaction[] | null
-> => {
+}: DefaultStatusParams & { name: string }): Promise<ReactionUpdateResult> => {
   const response = await fetch(
     `/api/v1/pleroma/statuses/${urlToId(statusId)}/reactions/${encodeURIComponent(name)}`,
     {
@@ -516,9 +541,7 @@ export const unreactFromStatus = async ({
       }
     }
   )
-  if (!response.ok) return null
-  const status = (await response.json()) as MastodonStatus
-  return status.pleroma?.emoji_reactions ?? status.reactions ?? []
+  return toReactionUpdateResult(response)
 }
 
 export const bookmarkStatus = async ({ statusId }: DefaultStatusParams) => {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -27,6 +27,7 @@ import type { ListEntity } from '@/lib/types/mastodon/list'
 import type { MediaAttachment } from '@/lib/types/mastodon/mediaAttachment'
 import type { PreviewCard } from '@/lib/types/mastodon/previewCard'
 import type { Status as MastodonStatus } from '@/lib/types/mastodon/status'
+import type { StatusReaction as MastodonStatusReaction } from '@/lib/types/mastodon/statusReaction'
 import type { Tag } from '@/lib/types/mastodon/tag'
 import type { Translation } from '@/lib/types/mastodon/translation'
 import { normalizeActorId } from '@/lib/utils/activitypub'
@@ -464,6 +465,60 @@ export const likeStatus = async ({ statusId }: DefaultStatusParams) => {
     }
   )
   return response.status === 200
+}
+
+/**
+ * Adds the current actor's emoji reaction to a status and returns the updated
+ * reaction rollups, or null on failure so the caller can revert its optimistic
+ * chip. `name` is a unicode emoji or a local custom-emoji shortcode.
+ *
+ * Uses the Pleroma/Akkoma dialect, which is the primary reaction surface (the
+ * glitch-soc `react`/`unreact` routes are aliases over the same store). This is
+ * an ecosystem extension, not core Mastodon API.
+ * @see https://docs.akkoma.dev/stable/development/API/pleroma_api/
+ */
+export const reactToStatus = async ({
+  statusId,
+  name
+}: DefaultStatusParams & { name: string }): Promise<
+  MastodonStatusReaction[] | null
+> => {
+  const response = await fetch(
+    `/api/v1/pleroma/statuses/${urlToId(statusId)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  if (!response.ok) return null
+  const status = (await response.json()) as MastodonStatus
+  return status.pleroma?.emoji_reactions ?? status.reactions ?? []
+}
+
+/**
+ * Removes the current actor's emoji reaction from a status and returns the
+ * updated rollups, or null on failure.
+ */
+export const unreactFromStatus = async ({
+  statusId,
+  name
+}: DefaultStatusParams & { name: string }): Promise<
+  MastodonStatusReaction[] | null
+> => {
+  const response = await fetch(
+    `/api/v1/pleroma/statuses/${urlToId(statusId)}/reactions/${encodeURIComponent(name)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  if (!response.ok) return null
+  const status = (await response.json()) as MastodonStatus
+  return status.pleroma?.emoji_reactions ?? status.reactions ?? []
 }
 
 export const bookmarkStatus = async ({ statusId }: DefaultStatusParams) => {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -481,13 +481,22 @@ const toReactionUpdateResult = async (
   response: Response
 ): Promise<ReactionUpdateResult> => {
   if (!response.ok) {
-    // 4xx is a verdict on the request itself; 5xx and network faults are
-    // transient, and get the caller's generic retry copy.
-    if (response.status >= 400 && response.status < 500) {
-      const body = await response.json().catch(() => null)
-      const error = (body as { error?: unknown } | null)?.error
-      if (typeof error === 'string' && error.length > 0)
-        return { ok: false, error }
+    // Only a 422 the route deliberately marked with a `reason` carries copy
+    // meant for a person. Every other 4xx answers with the bare HTTP reason
+    // phrase ('Unauthorized', 'Not Found'), which must never be shown as if it
+    // explained the failure — those fall through to the caller's own wording.
+    if (response.status === 422) {
+      const body = (await response.json().catch(() => null)) as {
+        error?: unknown
+        reason?: unknown
+      } | null
+      if (
+        typeof body?.reason === 'string' &&
+        typeof body.error === 'string' &&
+        body.error.length > 0
+      ) {
+        return { ok: false, error: body.error }
+      }
     }
     return { ok: false }
   }

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -62,7 +62,10 @@ vi.mock('@/lib/client', () => ({
   getFitnessProcessingState: vi.fn().mockResolvedValue(null),
   getTranslationCapability: vi.fn(),
   getTranslationLanguages: vi.fn(),
-  translateStatus: vi.fn()
+  translateStatus: vi.fn(),
+  reactToStatus: vi.fn(),
+  unreactFromStatus: vi.fn(),
+  getCustomEmojis: vi.fn().mockResolvedValue([])
 }))
 
 const currentTime = new Date('2026-04-26T10:00:00.000Z').getTime()
@@ -405,6 +408,50 @@ describe('Post', () => {
     expect(
       screen.queryByRole('link', { name: '@hackers.pub' })
     ).not.toBeInTheDocument()
+  })
+
+  it('renders the reaction row above the action row for a signed-in viewer', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        showActions
+        status={{
+          ...status,
+          reactions: [
+            { name: '🔥', count: 2, me: true, url: null, static_url: null }
+          ]
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText('Remove 🔥 reaction')).toHaveTextContent('2')
+    expect(screen.getByLabelText('Add reaction')).toBeInTheDocument()
+  })
+
+  it('renders reaction chips read-only when the post shows no actions', () => {
+    render(
+      <Post
+        host="activities.local"
+        currentActor={status.actor ?? undefined}
+        currentTime={currentTime}
+        showActions={false}
+        status={{
+          ...status,
+          reactions: [
+            { name: '🔥', count: 2, me: false, url: null, static_url: null }
+          ]
+        }}
+        onShowAttachment={vi.fn()}
+      />
+    )
+
+    // The chip is still readable, but nothing on the row can be actioned —
+    // `showActions={false}` withholds the actor from the reaction row too.
+    expect(screen.getByLabelText('🔥 reaction, 2')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Add reaction')).not.toBeInTheDocument()
   })
 
   it('renders the primary action row plus an overflow menu, with owner authoring actions consolidated into the menu', () => {

--- a/lib/components/posts/post.test.tsx
+++ b/lib/components/posts/post.test.tsx
@@ -427,8 +427,17 @@ describe('Post', () => {
       />
     )
 
-    expect(screen.getByLabelText('Remove 🔥 reaction')).toHaveTextContent('2')
+    const chip = screen.getByLabelText('Remove 🔥 reaction, 2')
+    expect(chip).toHaveTextContent('2')
     expect(screen.getByLabelText('Add reaction')).toBeInTheDocument()
+
+    // Ordering is the point of the name: chips belong to the post, so they sit
+    // between the content and the action row, not below it.
+    const likeButton = screen.getByLabelText(/^Like/)
+    expect(
+      chip.compareDocumentPosition(likeButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
   })
 
   it('renders reaction chips read-only when the post shows no actions', () => {
@@ -450,7 +459,9 @@ describe('Post', () => {
 
     // The chip is still readable, but nothing on the row can be actioned —
     // `showActions={false}` withholds the actor from the reaction row too.
-    expect(screen.getByLabelText('🔥 reaction, 2')).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: '🔥 reaction, 2' })
+    ).toBeInTheDocument()
     expect(screen.queryByLabelText('Add reaction')).not.toBeInTheDocument()
   })
 

--- a/lib/components/posts/post.tsx
+++ b/lib/components/posts/post.tsx
@@ -12,6 +12,7 @@ import {
   StatusPoll,
   StatusType
 } from '@/lib/types/domain/status'
+import type { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 import {
   formatFitnessDistance,
   formatFitnessDuration,
@@ -36,6 +37,7 @@ import { ContentWarning } from './content-warning'
 import { FitnessProcessingProgress } from './fitness-processing-progress'
 import { Poll } from './poll'
 import { QuoteCard } from './quote-card'
+import { ReactionRow } from './reaction-row'
 import { ReadOnlyStats } from './read-only-stats'
 import { RetryFitnessButton } from './retry-fitness-button'
 import { TranslateContent } from './translate-content'
@@ -63,6 +65,10 @@ export interface PostProps {
     isBookmarked: boolean
   ) => void
   onLikeChanged?: (status: StatusNote | StatusPoll, isLiked: boolean) => void
+  onReactionsChanged?: (
+    status: StatusNote | StatusPoll,
+    reactions: StatusReaction[]
+  ) => void
   onOpenStatus?: (status: Status) => void
   onShowAttachment: OnMediaSelectedHandle
   collapsible?: boolean
@@ -349,6 +355,16 @@ export const Post: FC<PostProps> = (props) => {
           )}
 
           <div>
+            {/* Chips sit between the content and the action row: they belong to
+                the post, not to the actions, and a logged-out reader still sees
+                them (read-only) while the action row is hidden. An Announce
+                wrapper carries no reactions of its own — they live on the
+                boosted status, which is what `getActualStatus` resolves to. */}
+            <ReactionRow
+              currentActor={props.showActions ? props.currentActor : undefined}
+              status={actualStatus}
+              onReactionsChanged={props.onReactionsChanged}
+            />
             <Actions {...props} />
             {props.showReadOnlyStats && !props.showActions && (
               <ReadOnlyStats status={status} />

--- a/lib/components/posts/posts.tsx
+++ b/lib/components/posts/posts.tsx
@@ -8,6 +8,7 @@ import { PostLineLimit } from '@/lib/types/database/rows'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { Attachment } from '@/lib/types/domain/attachment'
 import { Status, StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 import { cn } from '@/lib/utils'
 import { getStatusDetailPathClient } from '@/lib/utils/getStatusDetailPathClient'
 import { getActualStatus } from '@/lib/utils/text/processStatusText'
@@ -51,6 +52,10 @@ interface Props {
     isBookmarked: boolean
   ) => void
   onLikeChanged?: (status: StatusNote | StatusPoll, isLiked: boolean) => void
+  onReactionsChanged?: (
+    status: StatusNote | StatusPoll,
+    reactions: StatusReaction[]
+  ) => void
 }
 
 export const Posts: FC<Props> = ({
@@ -68,7 +73,8 @@ export const Posts: FC<Props> = ({
   onPostUpdated,
   onPostDeleted,
   onBookmarkChanged,
-  onLikeChanged
+  onLikeChanged,
+  onReactionsChanged
 }) => {
   const router = useRouter()
   const [modalMedias, setModalMedias] = useState<{
@@ -152,6 +158,7 @@ export const Posts: FC<Props> = ({
                 onPostDeleted={onPostDeleted}
                 onBookmarkChanged={onBookmarkChanged}
                 onLikeChanged={onLikeChanged}
+                onReactionsChanged={onReactionsChanged}
                 onOpenStatus={openStatus}
                 onShowAttachment={(allMedias, index) => {
                   setModalMedias({ medias: allMedias, initialSelection: index })

--- a/lib/components/posts/reaction-picker.tsx
+++ b/lib/components/posts/reaction-picker.tsx
@@ -1,7 +1,15 @@
 'use client'
 
 import { Search, Sticker } from 'lucide-react'
-import { FC, useEffect, useMemo, useState } from 'react'
+import {
+  FC,
+  RefObject,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState
+} from 'react'
+import { createPortal } from 'react-dom'
 
 import { getCustomEmojis } from '@/lib/client'
 import {
@@ -58,6 +66,67 @@ const loadCustomEmojis = (): Promise<CustomEmojiOption[]> => {
 interface ReactionPickerProps {
   onPick: (name: string) => void
   onClose: () => void
+  // The button the picker hangs off. Its viewport rect anchors the panel.
+  anchorRef: RefObject<HTMLButtonElement | null>
+}
+
+const PANEL_WIDTH = 288
+const VIEWPORT_MARGIN = 8
+
+// The panel is rendered in a portal at the document root and positioned from
+// the trigger's viewport rect. It used to be an `absolute` child of the chip
+// row, which meant ANY ancestor with `overflow-hidden` clipped it — and the
+// cards that wrap posts have it for their rounded corners. That was fixed
+// container-by-container three times and kept reappearing somewhere else (the
+// status detail cards, the fitness header card, the search results section,
+// the collection detail card), so the panel now escapes them all by
+// construction.
+const usePanelPosition = (
+  anchorRef: RefObject<HTMLButtonElement | null>,
+  panel: HTMLElement | null
+) => {
+  const [position, setPosition] = useState<{
+    top: number
+    left: number
+  } | null>(null)
+
+  useLayoutEffect(() => {
+    const place = () => {
+      const anchor = anchorRef.current
+      if (!anchor) return
+      const rect = anchor.getBoundingClientRect()
+      const height = panel?.offsetHeight ?? 0
+
+      // Below the trigger by default; above it when there isn't room, which is
+      // reachable either way because the panel is viewport-positioned.
+      const below = rect.bottom + VIEWPORT_MARGIN
+      const fitsBelow = below + height <= window.innerHeight - VIEWPORT_MARGIN
+      const top = fitsBelow
+        ? below
+        : Math.max(VIEWPORT_MARGIN, rect.top - VIEWPORT_MARGIN - height)
+
+      // Clamp right edge first, then left — doing it the other way round lets a
+      // viewport narrower than the panel produce a negative left, pushing the
+      // panel off-screen instead of pinning it to the margin.
+      const left = Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(rect.left, window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN)
+      )
+      setPosition({ top, left })
+    }
+
+    place()
+    // Scrolling or resizing moves the trigger, so follow it rather than leaving
+    // the panel stranded. `capture` catches scrolls in any ancestor.
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+  }, [anchorRef, panel])
+
+  return position
 }
 
 /**
@@ -68,12 +137,15 @@ interface ReactionPickerProps {
  */
 export const ReactionPicker: FC<ReactionPickerProps> = ({
   onPick,
-  onClose
+  onClose,
+  anchorRef
 }) => {
   const [query, setQuery] = useState('')
   const [customEmojis, setCustomEmojis] = useState<CustomEmojiOption[]>([])
   const [tab, setTab] = useState(EMOJI_GROUPS[0].id)
+  const [panel, setPanel] = useState<HTMLDivElement | null>(null)
   const hasCustom = customEmojis.length > 0
+  const position = usePanelPosition(anchorRef, panel)
 
   useEffect(() => {
     let active = true
@@ -146,21 +218,24 @@ export const ReactionPicker: FC<ReactionPickerProps> = ({
       : []
   }, [query, tab, customEmojis])
 
-  return (
+  const content = (
     <>
       {/* Outside-click overlay. aria-hidden keeps this full-viewport target out
           of the accessibility tree. */}
       <div className="fixed inset-0 z-30" aria-hidden onClick={onClose} />
       <div
+        ref={setPanel}
         role="dialog"
         aria-label="Choose a reaction"
-        // Opens downward (like the composer's emoji picker) rather than upward.
-        // Upward it needs ~330px of clear space above the chip row, which the
-        // status detail page does not have — the focused post sits ~170px from
-        // the top of its card, so the panel's head was clipped away by the
-        // card's overflow, and block-start overflow can never be scrolled back
-        // into view.
-        className="bg-background absolute top-full left-0 z-40 mt-2 w-72 overflow-hidden rounded-xl border shadow-lg"
+        className="bg-background fixed z-40 w-72 overflow-hidden rounded-xl border shadow-lg"
+        style={{
+          top: position?.top ?? 0,
+          left: position?.left ?? 0,
+          // Hidden for the first paint only, while the panel is measured: it
+          // has no height until it is in the DOM, so its placement cannot be
+          // computed any earlier.
+          visibility: position ? 'visible' : 'hidden'
+        }}
       >
         <div className="border-b p-2.5">
           <div className="relative">
@@ -232,4 +307,9 @@ export const ReactionPicker: FC<ReactionPickerProps> = ({
       </div>
     </>
   )
+
+  // Portalled to the document root so no ancestor's overflow can clip it.
+  return typeof document === 'undefined'
+    ? content
+    : createPortal(content, document.body)
 }

--- a/lib/components/posts/reaction-picker.tsx
+++ b/lib/components/posts/reaction-picker.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { Search, Sticker } from 'lucide-react'
+import { FC, useEffect, useMemo, useState } from 'react'
+
+import { getCustomEmojis } from '@/lib/client'
+import {
+  EMOJI_GROUPS,
+  searchSystemEmojis
+} from '@/lib/components/post-box/emoji-data'
+import { Input } from '@/lib/components/ui/input'
+import { cn } from '@/lib/utils'
+
+import type { CustomEmojiOption } from './reaction-row'
+
+// A reaction is one emoji, so the picker returns the *name to store* rather than
+// text to insert at a caret: a unicode character as itself, a custom emoji as its
+// bare shortcode (the API accepts either spelling; bare matches what is stored).
+type PickerItem =
+  | { kind: 'custom'; key: string; name: string; label: string; url: string }
+  | { kind: 'system'; key: string; name: string; label: string; char: string }
+
+const ItemGlyph: FC<{ item: PickerItem }> = ({ item }) =>
+  item.kind === 'custom' ? (
+    <img
+      src={item.url}
+      alt={item.label}
+      className="h-[22px] w-[22px] object-contain"
+    />
+  ) : (
+    <span style={{ fontSize: 20, lineHeight: 1 }}>{item.char}</span>
+  )
+
+// The instance's custom emoji, fetched at most once per page load. Threading
+// them as a prop would touch every surface that renders a post (~30 files),
+// which is exactly the prop-drilling AGENTS.md warns against for instance-wide
+// values; the picker is also the only consumer, and only once it is opened.
+let customEmojiRequest: Promise<CustomEmojiOption[]> | null = null
+
+const loadCustomEmojis = (): Promise<CustomEmojiOption[]> => {
+  if (!customEmojiRequest) {
+    customEmojiRequest = getCustomEmojis()
+      .then((emojis) =>
+        emojis
+          .filter((emoji) => emoji.visible_in_picker)
+          .map((emoji) => ({ shortcode: emoji.shortcode, url: emoji.url }))
+      )
+      // A failure degrades to unicode-only rather than breaking the picker, and
+      // is not cached so the next open retries.
+      .catch(() => {
+        customEmojiRequest = null
+        return []
+      })
+  }
+  return customEmojiRequest
+}
+
+interface ReactionPickerProps {
+  onPick: (name: string) => void
+  onClose: () => void
+}
+
+/**
+ * The emoji picker for post reactions. Reuses the post-box picker's data layer
+ * (`EMOJI_GROUPS` + `searchSystemEmojis` + the instance's custom emoji) rather
+ * than duplicating an emoji table, but returns a reaction name instead of
+ * inserting text.
+ */
+export const ReactionPicker: FC<ReactionPickerProps> = ({
+  onPick,
+  onClose
+}) => {
+  const [query, setQuery] = useState('')
+  const [customEmojis, setCustomEmojis] = useState<CustomEmojiOption[]>([])
+  const [tab, setTab] = useState(EMOJI_GROUPS[0].id)
+  const hasCustom = customEmojis.length > 0
+
+  useEffect(() => {
+    let active = true
+    loadCustomEmojis().then((emojis) => {
+      if (active) setCustomEmojis(emojis)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  // Escape closes the picker, matching the post-box picker and the announcement
+  // reaction picker.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const tabs = useMemo(
+    () => [
+      ...(hasCustom
+        ? [{ id: 'custom', name: 'Custom', kind: 'icon' as const }]
+        : []),
+      ...EMOJI_GROUPS.map((group) => ({
+        id: group.id,
+        name: group.name,
+        kind: 'emoji' as const,
+        glyph: group.icon
+      }))
+    ],
+    [hasCustom]
+  )
+
+  const items = useMemo<PickerItem[]>(() => {
+    const toCustom = (emoji: CustomEmojiOption): PickerItem => ({
+      kind: 'custom',
+      key: `c:${emoji.shortcode}`,
+      name: emoji.shortcode,
+      label: `:${emoji.shortcode}:`,
+      url: emoji.url
+    })
+    const trimmed = query.trim().toLowerCase()
+    if (trimmed) {
+      return [
+        ...customEmojis
+          .filter((emoji) => emoji.shortcode.toLowerCase().includes(trimmed))
+          .map(toCustom),
+        ...searchSystemEmojis(trimmed).map((emoji) => ({
+          kind: 'system' as const,
+          key: `s:${emoji.char}`,
+          name: emoji.char,
+          label: emoji.name,
+          char: emoji.char
+        }))
+      ]
+    }
+    if (tab === 'custom') return customEmojis.map(toCustom)
+    const group = EMOJI_GROUPS.find((candidate) => candidate.id === tab)
+    return group
+      ? group.emojis.map((emoji) => ({
+          kind: 'system' as const,
+          key: `s:${emoji.char}`,
+          name: emoji.char,
+          label: emoji.name,
+          char: emoji.char
+        }))
+      : []
+  }, [query, tab, customEmojis])
+
+  return (
+    <>
+      {/* Outside-click overlay. aria-hidden keeps this full-viewport target out
+          of the accessibility tree. */}
+      <div className="fixed inset-0 z-30" aria-hidden onClick={onClose} />
+      <div
+        role="dialog"
+        aria-label="Choose a reaction"
+        className="bg-background absolute bottom-9 left-0 z-40 w-72 overflow-hidden rounded-xl border shadow-lg"
+      >
+        <div className="border-b p-2.5">
+          <div className="relative">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+            <Input
+              autoFocus
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search emoji"
+              aria-label="Search emoji"
+              className="h-9 pl-8"
+            />
+          </div>
+        </div>
+
+        {!query.trim() && (
+          <div className="no-scrollbar flex items-center gap-0.5 overflow-x-auto px-2 pt-1.5">
+            {tabs.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                title={entry.name}
+                aria-label={entry.name}
+                aria-pressed={entry.id === tab}
+                onClick={() => setTab(entry.id)}
+                className={cn(
+                  'focus-visible:ring-ring inline-flex size-8 shrink-0 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none',
+                  entry.id === tab
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-muted'
+                )}
+              >
+                {entry.kind === 'icon' ? (
+                  <Sticker className="size-4" />
+                ) : (
+                  <span style={{ fontSize: 18, lineHeight: 1 }}>
+                    {entry.glyph}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="max-h-[200px] overflow-y-auto px-2 py-2">
+          {items.length === 0 ? (
+            <p className="text-muted-foreground py-6 text-center text-sm">
+              {query.trim()
+                ? `Nothing matches “${query.trim()}”`
+                : 'No custom emoji on this instance yet.'}
+            </p>
+          ) : (
+            <div className="grid grid-cols-7 gap-1">
+              {items.map((item) => (
+                <button
+                  key={item.key}
+                  type="button"
+                  title={item.label}
+                  aria-label={`React with ${item.label}`}
+                  onClick={() => onPick(item.name)}
+                  className="hover:bg-muted focus-visible:ring-ring inline-flex aspect-square w-full items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  <ItemGlyph item={item} />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/lib/components/posts/reaction-picker.tsx
+++ b/lib/components/posts/reaction-picker.tsx
@@ -154,7 +154,13 @@ export const ReactionPicker: FC<ReactionPickerProps> = ({
       <div
         role="dialog"
         aria-label="Choose a reaction"
-        className="bg-background absolute bottom-9 left-0 z-40 w-72 overflow-hidden rounded-xl border shadow-lg"
+        // Opens downward (like the composer's emoji picker) rather than upward.
+        // Upward it needs ~330px of clear space above the chip row, which the
+        // status detail page does not have — the focused post sits ~170px from
+        // the top of its card, so the panel's head was clipped away by the
+        // card's overflow, and block-start overflow can never be scrolled back
+        // into view.
+        className="bg-background absolute top-full left-0 z-40 mt-2 w-72 overflow-hidden rounded-xl border shadow-lg"
       >
         <div className="border-b p-2.5">
           <div className="relative">

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -72,7 +72,7 @@ describe('ReactionRow', () => {
 
   it('adds a reaction optimistically and reconciles with the server', async () => {
     const served: StatusReaction[] = [{ ...fire, count: 3, me: true }]
-    mockReactToStatus.mockResolvedValue(served)
+    mockReactToStatus.mockResolvedValue({ ok: true, reactions: served })
     const onReactionsChanged = vi.fn()
     const status = statusWith([fire])
 
@@ -99,7 +99,10 @@ describe('ReactionRow', () => {
   })
 
   it('removes the viewer own reaction', async () => {
-    mockUnreactFromStatus.mockResolvedValue([{ ...fire, count: 1, me: false }])
+    mockUnreactFromStatus.mockResolvedValue({
+      ok: true,
+      reactions: [{ ...fire, count: 1, me: false }]
+    })
 
     render(
       <ReactionRow
@@ -114,7 +117,7 @@ describe('ReactionRow', () => {
   })
 
   it('reverts the chip and shows an error when the request fails', async () => {
-    mockReactToStatus.mockResolvedValue(null)
+    mockReactToStatus.mockResolvedValue({ ok: false })
 
     render(
       <ReactionRow currentActor={currentActor} status={statusWith([fire])} />
@@ -126,6 +129,24 @@ describe('ReactionRow', () => {
     )
     // Reverted: back to the un-pressed chip with its original count.
     expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('2')
+  })
+
+  it('shows the server message instead of a retry prompt when it refuses', async () => {
+    mockReactToStatus.mockResolvedValue({
+      ok: false,
+      error: 'You can only add 8 reactions to a post.'
+    })
+
+    render(
+      <ReactionRow currentActor={currentActor} status={statusWith([fire])} />
+    )
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reaction-error')).toHaveTextContent(
+        'You can only add 8 reactions to a post.'
+      )
+    )
   })
 
   it('renders a custom emoji as an image and a unicode one as text', () => {
@@ -152,11 +173,15 @@ describe('ReactionRow', () => {
     expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('🔥')
   })
 
-  it('renders read-only chips without an add button for a logged-out reader', () => {
+  it('renders read-only chips for a logged-out reader without any control', () => {
     render(<ReactionRow status={statusWith([fire])} />)
 
-    expect(screen.getByLabelText('Add 🔥 reaction')).toBeDisabled()
-    expect(screen.queryByLabelText('Add reaction')).not.toBeInTheDocument()
+    // Readable, but not a control: a disabled button would drop the count out
+    // of the tab order and grey it out for everyone who cannot react.
+    const chip = screen.getByLabelText('🔥 reaction, 2')
+    expect(chip).toHaveTextContent('2')
+    expect(chip.tagName).toBe('SPAN')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('renders nothing for a logged-out reader on a post with no reactions', () => {
@@ -166,7 +191,10 @@ describe('ReactionRow', () => {
   })
 
   it('opens the picker and reacts with the chosen emoji', async () => {
-    mockReactToStatus.mockResolvedValue([{ ...fire, count: 1, me: true }])
+    mockReactToStatus.mockResolvedValue({
+      ok: true,
+      reactions: [{ ...fire, count: 1, me: true }]
+    })
 
     render(<ReactionRow currentActor={currentActor} status={statusWith([])} />)
     fireEvent.click(screen.getByLabelText('Add reaction'))

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -211,6 +211,32 @@ describe('ReactionRow', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('never truncates away the viewer own reaction', () => {
+    // 12 older reactions fill the row; the viewer's own is the 13th and, being
+    // newest, sorts last in the rollups.
+    const crowd: StatusReaction[] = Array.from({ length: 12 }, (_, index) => ({
+      name: `e${index}`,
+      count: 1,
+      me: false,
+      url: `https://llun.test/e${index}.gif`,
+      static_url: `https://llun.test/e${index}.png`
+    }))
+
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([...crowd, { ...fire, count: 1, me: true }])}
+      />
+    )
+
+    // Visible, and one of the older chips gives up its slot instead.
+    expect(screen.getByLabelText('Remove 🔥 reaction, 1')).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText('Add e11 reaction, 1')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('+1')).toBeInTheDocument()
+  })
+
   it('shows a remote custom emoji reaction without offering to join it', () => {
     render(
       <ReactionRow

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -446,6 +446,94 @@ describe('ReactionRow', () => {
     await waitFor(() => expect(trigger).toHaveFocus())
   })
 
+  it('renders the picker outside the post so no ancestor can clip it', async () => {
+    const { container } = render(
+      <div style={{ overflow: 'hidden' }}>
+        <ReactionRow currentActor={currentActor} status={statusWith([])} />
+      </div>
+    )
+    fireEvent.click(screen.getByLabelText('Add reaction'))
+
+    const picker = await screen.findByRole('dialog', {
+      name: 'Choose a reaction'
+    })
+
+    // Every card that wraps posts clips its children for rounded corners, and
+    // the panel is far taller than the space inside them. Portalling it to the
+    // document root is what stops that, so pin it: an `absolute` child of the
+    // chip row was clipped on four separate surfaces before this.
+    expect(container.contains(picker)).toBe(false)
+    expect(document.body.contains(picker)).toBe(true)
+    // Viewport-positioned, not positioned against an ancestor in the post.
+    expect(picker.className).toContain('fixed')
+  })
+
+  it.each([
+    {
+      description: 'below the trigger when there is room',
+      viewport: { width: 1280, height: 720 },
+      anchor: { top: 100, bottom: 128, left: 400 },
+      expected: { top: '136px', left: '400px' }
+    },
+    {
+      description: 'pinned to the margin on a viewport narrower than the panel',
+      viewport: { width: 280, height: 720 },
+      anchor: { top: 100, bottom: 128, left: 200 },
+      // Clamping the right edge before the left would yield a negative offset
+      // here (280 - 288 - 8), pushing the panel off-screen.
+      expected: { top: '136px', left: '8px' }
+    },
+    {
+      description: 'clamped left when the trigger sits near the right edge',
+      viewport: { width: 1280, height: 720 },
+      anchor: { top: 100, bottom: 128, left: 1200 },
+      expected: { top: '136px', left: '984px' }
+    }
+  ])(
+    'positions the picker $description',
+    async ({ viewport, anchor, expected }) => {
+      const originalWidth = window.innerWidth
+      const originalHeight = window.innerHeight
+      Object.defineProperty(window, 'innerWidth', {
+        value: viewport.width,
+        configurable: true
+      })
+      Object.defineProperty(window, 'innerHeight', {
+        value: viewport.height,
+        configurable: true
+      })
+
+      render(
+        <ReactionRow currentActor={currentActor} status={statusWith([])} />
+      )
+      const trigger = screen.getByLabelText('Add reaction')
+      trigger.getBoundingClientRect = () =>
+        ({
+          ...anchor,
+          right: anchor.left + 28,
+          width: 28,
+          height: 28
+        }) as DOMRect
+
+      fireEvent.click(trigger)
+      const picker = await screen.findByRole('dialog', {
+        name: 'Choose a reaction'
+      })
+
+      expect(picker.style.top).toBe(expected.top)
+      expect(picker.style.left).toBe(expected.left)
+
+      Object.defineProperty(window, 'innerWidth', {
+        value: originalWidth,
+        configurable: true
+      })
+      Object.defineProperty(window, 'innerHeight', {
+        value: originalHeight,
+        configurable: true
+      })
+    }
+  )
+
   it('opens the picker and reacts with the chosen emoji', async () => {
     mockReactToStatus.mockResolvedValue({
       ok: true,

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -344,7 +344,7 @@ describe('ReactionRow', () => {
     expect(screen.getByLabelText('Remove 🔥 reaction, 2')).toBeInTheDocument()
   })
 
-  it('disables every chip while a reaction write is in flight', async () => {
+  it('marks every chip busy while a reaction write is in flight', async () => {
     let resolveRequest: (value: unknown) => void = () => {}
     mockReactToStatus.mockReturnValue(
       new Promise((resolve) => {
@@ -361,14 +361,56 @@ describe('ReactionRow', () => {
     fireEvent.click(screen.getByLabelText('Add 🔥 reaction, 2'))
 
     // Overlapping writes would race on the full rollups the response carries,
-    // so the row refuses a second interaction visibly rather than silently.
-    expect(screen.getByLabelText('Add 🎉 reaction, 1')).toBeDisabled()
-    expect(screen.getByLabelText('Add reaction')).toBeDisabled()
+    // so the row refuses a second interaction visibly rather than silently —
+    // via aria-disabled, not `disabled`, which would blur the control the user
+    // just activated and drop keyboard focus to <body>.
+    const other = screen.getByLabelText('Add 🎉 reaction, 1')
+    const trigger = screen.getByLabelText('Add reaction')
+    expect(other).toHaveAttribute('aria-disabled', 'true')
+    expect(trigger).toHaveAttribute('aria-disabled', 'true')
+    expect(other).toBeEnabled()
+    expect(trigger).toBeEnabled()
+
+    // Busy means inert, not merely styled.
+    fireEvent.click(other)
+    expect(mockReactToStatus).toHaveBeenCalledTimes(1)
 
     resolveRequest({ ok: true, reactions: [{ ...fire, count: 3, me: true }] })
     await waitFor(() =>
-      expect(screen.getByLabelText('Remove 🔥 reaction, 3')).toBeEnabled()
+      expect(screen.getByLabelText('Remove 🔥 reaction, 3')).toHaveAttribute(
+        'aria-disabled',
+        'false'
+      )
     )
+  })
+
+  it('keeps focus on the trigger across a picker-driven reaction', async () => {
+    let resolveRequest: (value: unknown) => void = () => {}
+    mockReactToStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      })
+    )
+
+    render(<ReactionRow currentActor={currentActor} status={statusWith([])} />)
+    const trigger = screen.getByLabelText('Add reaction')
+    fireEvent.click(trigger)
+    await screen.findByRole('dialog', { name: 'Choose a reaction' })
+
+    const firstEmoji = screen
+      .getAllByRole('button')
+      .find((button) =>
+        button.getAttribute('aria-label')?.startsWith('React with')
+      )
+    fireEvent.click(firstEmoji as HTMLElement)
+
+    // The trigger is focused by onPick and must STAY focused while the write is
+    // in flight — disabling it here would blur it and reset the user's tab
+    // position to the top of the document.
+    await waitFor(() => expect(trigger).toHaveFocus())
+    resolveRequest({ ok: true, reactions: [{ ...fire, count: 1, me: true }] })
+    await waitFor(() => expect(mockReactToStatus).toHaveBeenCalledTimes(1))
+    expect(trigger).toHaveFocus()
   })
 
   it('returns focus to the trigger when the picker closes', async () => {

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -178,7 +178,9 @@ describe('ReactionRow', () => {
 
     // Readable, but not a control: a disabled button would drop the count out
     // of the tab order and grey it out for everyone who cannot react.
-    const chip = screen.getByLabelText('🔥 reaction, 2')
+    // Exposed as an image with the emoji in its label: the glyph is aria-hidden,
+    // so the label is the only thing that names which reaction this count is for.
+    const chip = screen.getByRole('img', { name: '🔥 reaction, 2' })
     expect(chip).toHaveTextContent('2')
     expect(chip.tagName).toBe('SPAN')
     expect(screen.queryByRole('button')).not.toBeInTheDocument()

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -52,8 +52,8 @@ describe('ReactionRow', () => {
       />
     )
 
-    expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('2')
-    expect(screen.getByLabelText('Add 🎉 reaction')).toHaveTextContent('1')
+    expect(screen.getByLabelText('Add 🔥 reaction, 2')).toHaveTextContent('2')
+    expect(screen.getByLabelText('Add 🎉 reaction, 1')).toHaveTextContent('1')
   })
 
   it('marks the viewer own reaction as pressed', () => {
@@ -64,14 +64,26 @@ describe('ReactionRow', () => {
       />
     )
 
-    expect(screen.getByLabelText('Remove 🔥 reaction')).toHaveAttribute(
+    expect(screen.getByLabelText('Remove 🔥 reaction, 2')).toHaveAttribute(
       'aria-pressed',
       'true'
     )
   })
 
   it('adds a reaction optimistically and reconciles with the server', async () => {
-    const served: StatusReaction[] = [{ ...fire, count: 3, me: true }]
+    // Deliberately NOT the optimistic guess (which would be count 3, me true,
+    // url null): a serve-shaped value proves setReactions used the response and
+    // not its own prediction.
+    const served: StatusReaction[] = [
+      { ...fire, count: 7, me: true },
+      {
+        name: 'partyparrot',
+        count: 1,
+        me: false,
+        url: 'https://llun.test/e.gif',
+        static_url: 'https://llun.test/e.png'
+      }
+    ]
     mockReactToStatus.mockResolvedValue({ ok: true, reactions: served })
     const onReactionsChanged = vi.fn()
     const status = statusWith([fire])
@@ -83,10 +95,12 @@ describe('ReactionRow', () => {
         onReactionsChanged={onReactionsChanged}
       />
     )
-    fireEvent.click(screen.getByLabelText('Add 🔥 reaction'))
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction, 2'))
 
-    // Optimistic flip happens before the request resolves.
-    expect(screen.getByLabelText('Remove 🔥 reaction')).toHaveTextContent('3')
+    // Optimistic flip happens before the request resolves: the guess is +1.
+    expect(screen.getByLabelText('Remove 🔥 reaction, 3')).toHaveTextContent(
+      '3'
+    )
     await waitFor(() =>
       expect(mockReactToStatus).toHaveBeenCalledWith({
         statusId: status.id,
@@ -96,6 +110,11 @@ describe('ReactionRow', () => {
     await waitFor(() =>
       expect(onReactionsChanged).toHaveBeenCalledWith(status, served)
     )
+    // Reconciled to the server's rollups, not the optimistic guess.
+    expect(screen.getByLabelText('Remove 🔥 reaction, 7')).toHaveTextContent(
+      '7'
+    )
+    expect(screen.getByAltText('partyparrot')).toBeInTheDocument()
   })
 
   it('removes the viewer own reaction', async () => {
@@ -110,7 +129,7 @@ describe('ReactionRow', () => {
         status={statusWith([{ ...fire, count: 2, me: true }])}
       />
     )
-    fireEvent.click(screen.getByLabelText('Remove 🔥 reaction'))
+    fireEvent.click(screen.getByLabelText('Remove 🔥 reaction, 2'))
 
     await waitFor(() => expect(mockUnreactFromStatus).toHaveBeenCalledTimes(1))
     expect(mockReactToStatus).not.toHaveBeenCalled()
@@ -122,13 +141,13 @@ describe('ReactionRow', () => {
     render(
       <ReactionRow currentActor={currentActor} status={statusWith([fire])} />
     )
-    fireEvent.click(screen.getByLabelText('Add 🔥 reaction'))
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction, 2'))
 
     await waitFor(() =>
       expect(screen.getByTestId('reaction-error')).toBeInTheDocument()
     )
     // Reverted: back to the un-pressed chip with its original count.
-    expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('2')
+    expect(screen.getByLabelText('Add 🔥 reaction, 2')).toHaveTextContent('2')
   })
 
   it('shows the server message instead of a retry prompt when it refuses', async () => {
@@ -140,7 +159,7 @@ describe('ReactionRow', () => {
     render(
       <ReactionRow currentActor={currentActor} status={statusWith([fire])} />
     )
-    fireEvent.click(screen.getByLabelText('Add 🔥 reaction'))
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction, 2'))
 
     await waitFor(() =>
       expect(screen.getByTestId('reaction-error')).toHaveTextContent(
@@ -170,7 +189,7 @@ describe('ReactionRow', () => {
       'src',
       'https://llun.test/emojis/partyparrot.gif'
     )
-    expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('🔥')
+    expect(screen.getByLabelText('Add 🔥 reaction, 2')).toHaveTextContent('🔥')
   })
 
   it('renders read-only chips for a logged-out reader without any control', () => {
@@ -190,6 +209,152 @@ describe('ReactionRow', () => {
     const { container } = render(<ReactionRow status={statusWith([])} />)
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows a remote custom emoji reaction without offering to join it', () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([
+          {
+            name: 'partyparrot@remote.example',
+            count: 3,
+            me: false,
+            // A resolvable url — the chip is still not joinable, because the
+            // name is namespaced to another instance.
+            url: 'https://remote.example/e.gif',
+            static_url: 'https://remote.example/e.png'
+          }
+        ])}
+      />
+    )
+
+    // The write path only accepts a unicode emoji or one of this instance's own
+    // shortcodes, so a button here would 422 on every click.
+    const chip = screen.getByRole('img', {
+      name: 'partyparrot@remote.example reaction, 3'
+    })
+    expect(chip.tagName).toBe('SPAN')
+    expect(
+      screen.getByAltText('partyparrot@remote.example')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/Add partyparrot@remote\.example reaction/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a disabled local custom emoji read-only', () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([
+          // No url: the rollup resolves urls only for enabled local emoji, so a
+          // shortcode with none is one this instance can no longer react with.
+          { name: 'retired', count: 4, me: false, url: null, static_url: null }
+        ])}
+      />
+    )
+
+    expect(
+      screen.getByRole('img', { name: 'retired reaction, 4' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/Add retired reaction/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps an enabled local custom emoji joinable', () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([
+          {
+            name: 'partyparrot',
+            count: 1,
+            me: false,
+            url: 'https://llun.test/e.gif',
+            static_url: 'https://llun.test/e.png'
+          }
+        ])}
+      />
+    )
+
+    expect(screen.getByLabelText('Add partyparrot reaction, 1')).toBeEnabled()
+  })
+
+  it('adds rather than removes when the picker returns an existing reaction', async () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([{ ...fire, me: true }])}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('Add reaction'))
+    await screen.findByRole('dialog', { name: 'Choose a reaction' })
+
+    // 🔥 is not in the default tab, so search for it — the same way a user
+    // reaching for a specific emoji would.
+    fireEvent.change(screen.getByLabelText('Search emoji'), {
+      target: { value: 'fire' }
+    })
+    const alreadyReacted = screen
+      .getAllByRole('button')
+      .find(
+        (button) =>
+          button.getAttribute('aria-label')?.startsWith('React with') &&
+          button.textContent === '🔥'
+      )
+    expect(alreadyReacted).toBeDefined()
+    fireEvent.click(alreadyReacted as HTMLElement)
+
+    // "React with 🔥" must never undo a 🔥 the viewer already added.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Choose a reaction' })
+      ).not.toBeInTheDocument()
+    )
+    expect(mockUnreactFromStatus).not.toHaveBeenCalled()
+    expect(mockReactToStatus).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Remove 🔥 reaction, 2')).toBeInTheDocument()
+  })
+
+  it('disables every chip while a reaction write is in flight', async () => {
+    let resolveRequest: (value: unknown) => void = () => {}
+    mockReactToStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      })
+    )
+
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([fire, { ...fire, name: '🎉', count: 1 }])}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction, 2'))
+
+    // Overlapping writes would race on the full rollups the response carries,
+    // so the row refuses a second interaction visibly rather than silently.
+    expect(screen.getByLabelText('Add 🎉 reaction, 1')).toBeDisabled()
+    expect(screen.getByLabelText('Add reaction')).toBeDisabled()
+
+    resolveRequest({ ok: true, reactions: [{ ...fire, count: 3, me: true }] })
+    await waitFor(() =>
+      expect(screen.getByLabelText('Remove 🔥 reaction, 3')).toBeEnabled()
+    )
+  })
+
+  it('returns focus to the trigger when the picker closes', async () => {
+    render(<ReactionRow currentActor={currentActor} status={statusWith([])} />)
+    const trigger = screen.getByLabelText('Add reaction')
+    fireEvent.click(trigger)
+
+    await screen.findByRole('dialog', { name: 'Choose a reaction' })
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    // Otherwise a keyboard user's focus is dumped on <body>.
+    await waitFor(() => expect(trigger).toHaveFocus())
   })
 
   it('opens the picker and reacts with the chosen emoji', async () => {

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -413,6 +413,27 @@ describe('ReactionRow', () => {
     expect(trigger).toHaveFocus()
   })
 
+  it('moves focus to the trigger when removing the last reaction unmounts its chip', async () => {
+    mockUnreactFromStatus.mockResolvedValue({ ok: true, reactions: [] })
+
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([{ ...fire, count: 1, me: true }])}
+      />
+    )
+    const chip = screen.getByLabelText('Remove 🔥 reaction, 1')
+    chip.focus()
+    fireEvent.click(chip)
+
+    // The chip is gone because the reaction is gone — but focus has to land
+    // somewhere deliberate rather than on <body>.
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/🔥 reaction/)).not.toBeInTheDocument()
+    )
+    expect(screen.getByLabelText('Add reaction')).toHaveFocus()
+  })
+
   it('returns focus to the trigger when the picker closes', async () => {
     render(<ReactionRow currentActor={currentActor} status={statusWith([])} />)
     const trigger = screen.getByLabelText('Add reaction')

--- a/lib/components/posts/reaction-row.test.tsx
+++ b/lib/components/posts/reaction-row.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { ReactionRow } from '@/lib/components/posts/reaction-row'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { StatusNote } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
+
+const mockReactToStatus = vi.fn()
+const mockUnreactFromStatus = vi.fn()
+
+vi.mock('@/lib/client', () => ({
+  reactToStatus: (...params: unknown[]) => mockReactToStatus(...params),
+  unreactFromStatus: (...params: unknown[]) => mockUnreactFromStatus(...params),
+  getCustomEmojis: () => Promise.resolve([])
+}))
+
+const currentActor = {
+  id: 'https://llun.test/users/me',
+  username: 'me'
+} as ActorProfile
+
+const statusWith = (reactions: StatusReaction[]) =>
+  ({
+    id: 'https://llun.test/users/author/statuses/1',
+    type: 'Note',
+    actorId: 'https://llun.test/users/author',
+    reactions
+  }) as unknown as StatusNote
+
+const fire: StatusReaction = {
+  name: '🔥',
+  count: 2,
+  me: false,
+  url: null,
+  static_url: null
+}
+
+describe('ReactionRow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a chip per reaction with its count', () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([fire, { ...fire, name: '🎉', count: 1 }])}
+      />
+    )
+
+    expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('2')
+    expect(screen.getByLabelText('Add 🎉 reaction')).toHaveTextContent('1')
+  })
+
+  it('marks the viewer own reaction as pressed', () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([{ ...fire, me: true }])}
+      />
+    )
+
+    expect(screen.getByLabelText('Remove 🔥 reaction')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('adds a reaction optimistically and reconciles with the server', async () => {
+    const served: StatusReaction[] = [{ ...fire, count: 3, me: true }]
+    mockReactToStatus.mockResolvedValue(served)
+    const onReactionsChanged = vi.fn()
+    const status = statusWith([fire])
+
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={status}
+        onReactionsChanged={onReactionsChanged}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction'))
+
+    // Optimistic flip happens before the request resolves.
+    expect(screen.getByLabelText('Remove 🔥 reaction')).toHaveTextContent('3')
+    await waitFor(() =>
+      expect(mockReactToStatus).toHaveBeenCalledWith({
+        statusId: status.id,
+        name: '🔥'
+      })
+    )
+    await waitFor(() =>
+      expect(onReactionsChanged).toHaveBeenCalledWith(status, served)
+    )
+  })
+
+  it('removes the viewer own reaction', async () => {
+    mockUnreactFromStatus.mockResolvedValue([{ ...fire, count: 1, me: false }])
+
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([{ ...fire, count: 2, me: true }])}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('Remove 🔥 reaction'))
+
+    await waitFor(() => expect(mockUnreactFromStatus).toHaveBeenCalledTimes(1))
+    expect(mockReactToStatus).not.toHaveBeenCalled()
+  })
+
+  it('reverts the chip and shows an error when the request fails', async () => {
+    mockReactToStatus.mockResolvedValue(null)
+
+    render(
+      <ReactionRow currentActor={currentActor} status={statusWith([fire])} />
+    )
+    fireEvent.click(screen.getByLabelText('Add 🔥 reaction'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reaction-error')).toBeInTheDocument()
+    )
+    // Reverted: back to the un-pressed chip with its original count.
+    expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('2')
+  })
+
+  it('renders a custom emoji as an image and a unicode one as text', () => {
+    render(
+      <ReactionRow
+        currentActor={currentActor}
+        status={statusWith([
+          fire,
+          {
+            name: 'partyparrot',
+            count: 1,
+            me: false,
+            url: 'https://llun.test/emojis/partyparrot.gif',
+            static_url: 'https://llun.test/emojis/partyparrot.png'
+          }
+        ])}
+      />
+    )
+
+    expect(screen.getByAltText('partyparrot')).toHaveAttribute(
+      'src',
+      'https://llun.test/emojis/partyparrot.gif'
+    )
+    expect(screen.getByLabelText('Add 🔥 reaction')).toHaveTextContent('🔥')
+  })
+
+  it('renders read-only chips without an add button for a logged-out reader', () => {
+    render(<ReactionRow status={statusWith([fire])} />)
+
+    expect(screen.getByLabelText('Add 🔥 reaction')).toBeDisabled()
+    expect(screen.queryByLabelText('Add reaction')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for a logged-out reader on a post with no reactions', () => {
+    const { container } = render(<ReactionRow status={statusWith([])} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('opens the picker and reacts with the chosen emoji', async () => {
+    mockReactToStatus.mockResolvedValue([{ ...fire, count: 1, me: true }])
+
+    render(<ReactionRow currentActor={currentActor} status={statusWith([])} />)
+    fireEvent.click(screen.getByLabelText('Add reaction'))
+
+    const picker = await screen.findByRole('dialog', {
+      name: 'Choose a reaction'
+    })
+    expect(picker).toBeInTheDocument()
+
+    const firstEmoji = screen
+      .getAllByRole('button')
+      .find((button) =>
+        button.getAttribute('aria-label')?.startsWith('React with')
+      )
+    expect(firstEmoji).toBeDefined()
+    fireEvent.click(firstEmoji as HTMLElement)
+
+    await waitFor(() => expect(mockReactToStatus).toHaveBeenCalledTimes(1))
+  })
+})

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -309,6 +309,7 @@ export const ReactionRow: FC<ReactionRowProps> = ({
       )}
       {isPicking && (
         <ReactionPicker
+          anchorRef={pickerTriggerRef}
           // Focus goes back to the trigger on close, so dismissing the picker
           // with Escape or an outside click does not dump a keyboard user on
           // <body>. On a pick the chip that appears is the natural next target,

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -166,6 +166,11 @@ export const ReactionRow: FC<ReactionRowProps> = ({
           return (
             <span
               key={reaction.name}
+              // `role="img"` so the label is authoritative: the glyph itself is
+              // aria-hidden, and aria-label on a generic span is not reliably
+              // announced, which would leave a screen reader reading just the
+              // count with no idea which emoji it belongs to.
+              role="img"
               className={chipClass(reaction.me, false)}
               aria-label={`${reaction.name} reaction, ${reaction.count}`}
             >

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { SmilePlus } from 'lucide-react'
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useRef, useState } from 'react'
 
 import { reactToStatus, unreactFromStatus } from '@/lib/client'
 import { useDismissingError } from '@/lib/components/posts/actions/actionButtonShared'
+import { isUnicodeEmojiReaction } from '@/lib/services/reactions/reactionName'
 import { ActorProfile } from '@/lib/types/domain/actor'
 import { StatusNote, StatusPoll } from '@/lib/types/domain/status'
 import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
@@ -19,6 +20,21 @@ const formatCount = (count: number): string => (count > 99 ? '99+' : `${count}`)
 // The rollups arrive in first-reaction order, so the oldest — which is also the
 // most established — stay visible.
 const MAX_VISIBLE_CHIPS = 12
+
+// The write path accepts a unicode emoji or one of THIS instance's enabled
+// shortcodes — nothing else. So a chip is only offered as a control when the
+// viewer could actually succeed:
+//   • unicode                        → always
+//   • local shortcode, still enabled → the rollup carries a url (the rollup
+//     query resolves urls only for non-disabled local emoji)
+//   • local shortcode, disabled/gone → no url, so withheld
+//   • remote `shortcode@domain`      → namespaced, never locally reactable
+// Own reactions stay actionable regardless, so a reaction is always removable.
+const canJoinReaction = (reaction: StatusReaction): boolean => {
+  if (reaction.me) return true
+  if (isUnicodeEmojiReaction(reaction.name)) return true
+  return !reaction.name.includes('@') && Boolean(reaction.url)
+}
 
 const chipClass = (mine: boolean, interactive = true) =>
   cn(
@@ -75,19 +91,38 @@ export const ReactionRow: FC<ReactionRowProps> = ({
   )
   const [pendingName, setPendingName] = useState<string | null>(null)
   const [isPicking, setIsPicking] = useState(false)
+  const pickerTriggerRef = useRef<HTMLButtonElement>(null)
   const [error, setError] = useDismissingError()
 
+  // Read inside the resync effect without being one of its dependencies: making
+  // it a dependency would re-run the effect when a write settles and overwrite
+  // the server's rollups with the (still stale) prop.
+  const pendingNameRef = useRef<string | null>(null)
+  pendingNameRef.current = pendingName
+
   useEffect(() => {
+    // A write in flight owns the local state: resyncing from the prop mid-flight
+    // would discard the optimistic chip, then be overwritten by the server's
+    // rollups a moment later, flickering the count.
+    if (pendingNameRef.current) return
     setReactions(status.reactions ?? [])
     setError(null)
   }, [status.id, status.reactions, setError])
 
-  const toggle = async (name: string) => {
+  const toggle = async (name: string, intent: 'toggle' | 'add' = 'toggle') => {
+    // Single-flight: each response carries the status's full authoritative
+    // rollups, so two overlapping writes would race and the loser's chip would
+    // vanish. Every chip is disabled while one is pending, so this guard is a
+    // backstop rather than a silent refusal.
     if (!currentActor || pendingName) return
 
     const previous = reactions
     const existing = previous.find((reaction) => reaction.name === name)
-    const removing = Boolean(existing?.me)
+    // A chip toggles; a pick from the picker only ever adds. Routing a pick
+    // through the toggle would make "React with 🔥" *remove* a 🔥 the viewer had
+    // already added — the opposite of what the item says it does.
+    if (intent === 'add' && existing?.me) return
+    const removing = intent === 'toggle' && Boolean(existing?.me)
 
     // Optimistic: bump or drop the chip, then reconcile with the server's
     // authoritative rollups (which also carry the custom-emoji urls).
@@ -158,11 +193,12 @@ export const ReactionRow: FC<ReactionRowProps> = ({
           </>
         )
 
-        // A reader who cannot react gets a plain, readable chip rather than a
-        // disabled button: a disabled control drops out of the tab order and
-        // renders greyed out, which would hide the counts from keyboard and
-        // screen-reader users on every logged-out surface.
-        if (!currentActor) {
+        // A chip nobody can act on — a logged-out reader, or a remote custom
+        // emoji this instance cannot react with — is a plain, readable chip
+        // rather than a disabled button: a disabled control drops out of the tab
+        // order and renders greyed out, hiding the count from keyboard and
+        // screen-reader users.
+        if (!currentActor || !canJoinReaction(reaction)) {
           return (
             <span
               key={reaction.name}
@@ -183,9 +219,12 @@ export const ReactionRow: FC<ReactionRowProps> = ({
           <button
             key={reaction.name}
             type="button"
-            disabled={pendingName === reaction.name}
+            // Every chip is disabled while a write is in flight: the response
+            // carries the whole status's rollups, so overlapping writes would
+            // race and lose one of the two changes.
+            disabled={pendingName !== null}
             aria-pressed={reaction.me}
-            aria-label={`${reaction.me ? 'Remove' : 'Add'} ${reaction.name} reaction`}
+            aria-label={`${reaction.me ? 'Remove' : 'Add'} ${reaction.name} reaction, ${reaction.count}`}
             className={chipClass(reaction.me)}
             onClick={(event) => {
               event.stopPropagation()
@@ -203,7 +242,9 @@ export const ReactionRow: FC<ReactionRowProps> = ({
       )}
       {currentActor && (
         <button
+          ref={pickerTriggerRef}
           type="button"
+          disabled={pendingName !== null}
           aria-label="Add reaction"
           aria-haspopup="dialog"
           aria-expanded={isPicking}
@@ -218,10 +259,18 @@ export const ReactionRow: FC<ReactionRowProps> = ({
       )}
       {isPicking && (
         <ReactionPicker
-          onClose={() => setIsPicking(false)}
+          // Focus goes back to the trigger on close, so dismissing the picker
+          // with Escape or an outside click does not dump a keyboard user on
+          // <body>. On a pick the chip that appears is the natural next target,
+          // but the trigger is still the element that was activated.
+          onClose={() => {
+            setIsPicking(false)
+            pickerTriggerRef.current?.focus()
+          }}
           onPick={(name) => {
             setIsPicking(false)
-            void toggle(name)
+            pickerTriggerRef.current?.focus()
+            void toggle(name, 'add')
           }}
         />
       )}

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -180,6 +180,12 @@ export const ReactionRow: FC<ReactionRowProps> = ({
               { name, count: 1, me: true, url: null, static_url: null }
             ]
     )
+    // Removing the last of a reaction unmounts the chip the user just activated.
+    // That is correct — they deleted it — but a keyboard user would be dropped
+    // on <body>, so move focus to the adjacent picker trigger first.
+    if (removing && existing?.count === 1) {
+      pickerTriggerRef.current?.focus()
+    }
     setPendingName(name)
     try {
       const result = removing

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { SmilePlus } from 'lucide-react'
+import { FC, useEffect, useState } from 'react'
+
+import { reactToStatus, unreactFromStatus } from '@/lib/client'
+import { useDismissingError } from '@/lib/components/posts/actions/actionButtonShared'
+import { ActorProfile } from '@/lib/types/domain/actor'
+import { StatusNote, StatusPoll } from '@/lib/types/domain/status'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
+import { cn } from '@/lib/utils'
+
+import { ReactionPicker } from './reaction-picker'
+
+// Counts of 100+ collapse to "99+", matching the announcement reaction chips.
+const formatCount = (count: number): string => (count > 99 ? '99+' : `${count}`)
+
+// A hot post can accumulate more distinct emoji than a row can usefully show.
+// The rollups arrive in first-reaction order, so the oldest — which is also the
+// most established — stay visible.
+const MAX_VISIBLE_CHIPS = 12
+
+const chipClass = (mine: boolean) =>
+  cn(
+    'flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-[13px] transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+    mine
+      ? 'border-primary/45 bg-primary/10 text-primary'
+      : 'border-border bg-background text-foreground hover:bg-muted'
+  )
+
+// A custom emoji renders as its image; a unicode emoji and a custom emoji whose
+// image we could not vouch for (a remote `name@domain` with no trusted url) both
+// render as text.
+const ReactionGlyph: FC<{ reaction: StatusReaction }> = ({ reaction }) =>
+  reaction.url ? (
+    <img
+      src={reaction.url}
+      alt={reaction.name}
+      className="max-h-[18px] max-w-[18px] object-contain"
+    />
+  ) : (
+    <span aria-hidden="true">{reaction.name}</span>
+  )
+
+interface ReactionRowProps {
+  currentActor?: ActorProfile
+  status: StatusNote | StatusPoll
+  onReactionsChanged?: (
+    status: StatusNote | StatusPoll,
+    reactions: StatusReaction[]
+  ) => void
+}
+
+export interface CustomEmojiOption {
+  shortcode: string
+  url: string
+}
+
+/**
+ * The reaction chips under a post, plus the picker that adds one. Rendered by
+ * `Post` for every surface, so a reaction behaves identically everywhere — the
+ * same rule the rest of the action row follows.
+ *
+ * Reactions are NOT favourites: this row never touches the like button's state.
+ */
+export const ReactionRow: FC<ReactionRowProps> = ({
+  currentActor,
+  status,
+  onReactionsChanged
+}) => {
+  const [reactions, setReactions] = useState<StatusReaction[]>(
+    status.reactions ?? []
+  )
+  const [pendingName, setPendingName] = useState<string | null>(null)
+  const [isPicking, setIsPicking] = useState(false)
+  const [error, setError] = useDismissingError()
+
+  useEffect(() => {
+    setReactions(status.reactions ?? [])
+    setError(null)
+  }, [status.id, status.reactions, setError])
+
+  const toggle = async (name: string) => {
+    if (!currentActor || pendingName) return
+
+    const previous = reactions
+    const existing = previous.find((reaction) => reaction.name === name)
+    const removing = Boolean(existing?.me)
+
+    // Optimistic: bump or drop the chip, then reconcile with the server's
+    // authoritative rollups (which also carry the custom-emoji urls).
+    setReactions(
+      removing
+        ? previous
+            .map((reaction) =>
+              reaction.name === name
+                ? { ...reaction, me: false, count: reaction.count - 1 }
+                : reaction
+            )
+            .filter((reaction) => reaction.count > 0)
+        : existing
+          ? previous.map((reaction) =>
+              reaction.name === name
+                ? { ...reaction, me: true, count: reaction.count + 1 }
+                : reaction
+            )
+          : [
+              ...previous,
+              { name, count: 1, me: true, url: null, static_url: null }
+            ]
+    )
+    setPendingName(name)
+    try {
+      const updated = removing
+        ? await unreactFromStatus({ statusId: status.id, name })
+        : await reactToStatus({ statusId: status.id, name })
+      if (!updated) {
+        setReactions(previous)
+        setError(
+          removing
+            ? 'Failed to remove reaction. Please try again.'
+            : 'Failed to add reaction. Please try again.'
+        )
+        return
+      }
+      setReactions(updated)
+      onReactionsChanged?.(status, updated)
+    } catch {
+      setReactions(previous)
+      setError('Failed to update reaction. Please try again.')
+    } finally {
+      setPendingName(null)
+    }
+  }
+
+  // Nothing to show and nothing to do: a logged-out reader on an unreacted post
+  // gets no empty row.
+  if (reactions.length === 0 && !currentActor) return null
+
+  const visible = reactions.slice(0, MAX_VISIBLE_CHIPS)
+  const hiddenCount = reactions.length - visible.length
+
+  return (
+    <div className="relative mt-2 flex flex-wrap items-center gap-1.5">
+      {visible.map((reaction) => (
+        <button
+          key={reaction.name}
+          type="button"
+          disabled={!currentActor || pendingName === reaction.name}
+          aria-pressed={reaction.me}
+          aria-label={`${reaction.me ? 'Remove' : 'Add'} ${reaction.name} reaction`}
+          className={chipClass(reaction.me)}
+          onClick={(event) => {
+            event.stopPropagation()
+            void toggle(reaction.name)
+          }}
+        >
+          <ReactionGlyph reaction={reaction} />
+          <span className="text-xs font-medium tabular-nums">
+            {formatCount(reaction.count)}
+          </span>
+        </button>
+      ))}
+      {hiddenCount > 0 && (
+        <span className="text-muted-foreground text-xs tabular-nums">
+          +{hiddenCount}
+        </span>
+      )}
+      {currentActor && (
+        <button
+          type="button"
+          aria-label="Add reaction"
+          aria-haspopup="dialog"
+          aria-expanded={isPicking}
+          className="border-border bg-background text-muted-foreground hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors"
+          onClick={(event) => {
+            event.stopPropagation()
+            setIsPicking((value) => !value)
+          }}
+        >
+          <SmilePlus className="size-3.5" />
+        </button>
+      )}
+      {isPicking && (
+        <ReactionPicker
+          onClose={() => setIsPicking(false)}
+          onPick={(name) => {
+            setIsPicking(false)
+            void toggle(name)
+          }}
+        />
+      )}
+      {error && (
+        <span
+          className="text-destructive w-full text-xs"
+          role="alert"
+          data-testid="reaction-error"
+        >
+          {error}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -111,20 +111,24 @@ export const ReactionRow: FC<ReactionRowProps> = ({
     )
     setPendingName(name)
     try {
-      const updated = removing
+      const result = removing
         ? await unreactFromStatus({ statusId: status.id, name })
         : await reactToStatus({ statusId: status.id, name })
-      if (!updated) {
+      if (!result.ok) {
         setReactions(previous)
+        // The server's own message when it rejected the request outright (the
+        // per-actor cap, an emoji this instance won't take) — "try again" would
+        // be a lie there, since the same request always fails the same way.
         setError(
-          removing
-            ? 'Failed to remove reaction. Please try again.'
-            : 'Failed to add reaction. Please try again.'
+          result.error ??
+            (removing
+              ? 'Failed to remove reaction. Please try again.'
+              : 'Failed to add reaction. Please try again.')
         )
         return
       }
-      setReactions(updated)
-      onReactionsChanged?.(status, updated)
+      setReactions(result.reactions)
+      onReactionsChanged?.(status, result.reactions)
     } catch {
       setReactions(previous)
       setError('Failed to update reaction. Please try again.')
@@ -142,25 +146,49 @@ export const ReactionRow: FC<ReactionRowProps> = ({
 
   return (
     <div className="relative mt-2 flex flex-wrap items-center gap-1.5">
-      {visible.map((reaction) => (
-        <button
-          key={reaction.name}
-          type="button"
-          disabled={!currentActor || pendingName === reaction.name}
-          aria-pressed={reaction.me}
-          aria-label={`${reaction.me ? 'Remove' : 'Add'} ${reaction.name} reaction`}
-          className={chipClass(reaction.me)}
-          onClick={(event) => {
-            event.stopPropagation()
-            void toggle(reaction.name)
-          }}
-        >
-          <ReactionGlyph reaction={reaction} />
-          <span className="text-xs font-medium tabular-nums">
-            {formatCount(reaction.count)}
-          </span>
-        </button>
-      ))}
+      {visible.map((reaction) => {
+        const body = (
+          <>
+            <ReactionGlyph reaction={reaction} />
+            <span className="text-xs font-medium tabular-nums">
+              {formatCount(reaction.count)}
+            </span>
+          </>
+        )
+
+        // A reader who cannot react gets a plain, readable chip rather than a
+        // disabled button: a disabled control drops out of the tab order and
+        // renders greyed out, which would hide the counts from keyboard and
+        // screen-reader users on every logged-out surface.
+        if (!currentActor) {
+          return (
+            <span
+              key={reaction.name}
+              className={chipClass(reaction.me)}
+              aria-label={`${reaction.name} reaction, ${reaction.count}`}
+            >
+              {body}
+            </span>
+          )
+        }
+
+        return (
+          <button
+            key={reaction.name}
+            type="button"
+            disabled={pendingName === reaction.name}
+            aria-pressed={reaction.me}
+            aria-label={`${reaction.me ? 'Remove' : 'Add'} ${reaction.name} reaction`}
+            className={chipClass(reaction.me)}
+            onClick={(event) => {
+              event.stopPropagation()
+              void toggle(reaction.name)
+            }}
+          >
+            {body}
+          </button>
+        )
+      })}
       {hiddenCount > 0 && (
         <span className="text-muted-foreground text-xs tabular-nums">
           +{hiddenCount}

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -30,6 +30,35 @@ const MAX_VISIBLE_CHIPS = 12
 //   • local shortcode, disabled/gone → no url, so withheld
 //   • remote `shortcode@domain`      → namespaced, never locally reactable
 // Own reactions stay actionable regardless, so a reaction is always removable.
+// Rollups arrive oldest-first, so on a post that already carries
+// MAX_VISIBLE_CHIPS distinct emoji a brand-new reaction sorts last and would be
+// truncated away — the viewer would add one and see nothing change but the
+// overflow counter. The viewer's own reactions are therefore never truncated;
+// the remaining slots go to the rest, still oldest-first. (The per-actor cap is
+// well below MAX_VISIBLE_CHIPS, so a viewer's own chips can never fill the row.)
+const selectVisibleReactions = (
+  reactions: StatusReaction[]
+): StatusReaction[] => {
+  if (reactions.length <= MAX_VISIBLE_CHIPS) return reactions
+
+  const mineCount = reactions.reduce(
+    (total, reaction) => total + (reaction.me ? 1 : 0),
+    0
+  )
+  let remainingSlots = Math.max(0, MAX_VISIBLE_CHIPS - mineCount)
+  const visible: StatusReaction[] = []
+  for (const reaction of reactions) {
+    if (reaction.me) {
+      visible.push(reaction)
+      continue
+    }
+    if (remainingSlots === 0) continue
+    remainingSlots -= 1
+    visible.push(reaction)
+  }
+  return visible
+}
+
 const canJoinReaction = (reaction: StatusReaction): boolean => {
   if (reaction.me) return true
   if (isUnicodeEmojiReaction(reaction.name)) return true
@@ -178,7 +207,12 @@ export const ReactionRow: FC<ReactionRowProps> = ({
   // gets no empty row.
   if (reactions.length === 0 && !currentActor) return null
 
-  const visible = reactions.slice(0, MAX_VISIBLE_CHIPS)
+  // Rollups arrive oldest-first, so on a post that already has MAX_VISIBLE_CHIPS
+  // distinct emoji a brand-new reaction sorts last and would be truncated away —
+  // the viewer would add one and see nothing change but the overflow counter.
+  // The viewer's own reactions are therefore never truncated; the remaining
+  // slots go to the others, still oldest-first.
+  const visible = selectVisibleReactions(reactions)
   const hiddenCount = reactions.length - visible.length
 
   return (

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -20,12 +20,14 @@ const formatCount = (count: number): string => (count > 99 ? '99+' : `${count}`)
 // most established — stay visible.
 const MAX_VISIBLE_CHIPS = 12
 
-const chipClass = (mine: boolean) =>
+const chipClass = (mine: boolean, interactive = true) =>
   cn(
     'flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-[13px] transition-colors disabled:cursor-not-allowed disabled:opacity-50',
     mine
       ? 'border-primary/45 bg-primary/10 text-primary'
-      : 'border-border bg-background text-foreground hover:bg-muted'
+      : 'border-border bg-background text-foreground',
+    // No hover affordance on a chip that cannot be clicked.
+    !mine && interactive && 'hover:bg-muted'
   )
 
 // A custom emoji renders as its image; a unicode emoji and a custom emoji whose
@@ -164,7 +166,7 @@ export const ReactionRow: FC<ReactionRowProps> = ({
           return (
             <span
               key={reaction.name}
-              className={chipClass(reaction.me)}
+              className={chipClass(reaction.me, false)}
               aria-label={`${reaction.name} reaction, ${reaction.count}`}
             >
               {body}

--- a/lib/components/posts/reaction-row.tsx
+++ b/lib/components/posts/reaction-row.tsx
@@ -65,9 +65,14 @@ const canJoinReaction = (reaction: StatusReaction): boolean => {
   return !reaction.name.includes('@') && Boolean(reaction.url)
 }
 
-const chipClass = (mine: boolean, interactive = true) =>
+const chipClass = (mine: boolean, interactive = true, busy = false) =>
   cn(
-    'flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-[13px] transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+    'flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-[13px] transition-colors',
+    // Busy rather than `disabled`: a disabled control is blurred by the browser
+    // and drops out of the tab order, which would throw a keyboard user back to
+    // <body> mid-interaction. aria-disabled conveys the same state to assistive
+    // tech while keeping focus where the user put it.
+    busy && 'cursor-not-allowed opacity-50',
     mine
       ? 'border-primary/45 bg-primary/10 text-primary'
       : 'border-border bg-background text-foreground',
@@ -253,13 +258,14 @@ export const ReactionRow: FC<ReactionRowProps> = ({
           <button
             key={reaction.name}
             type="button"
-            // Every chip is disabled while a write is in flight: the response
+            // Every chip goes busy while a write is in flight: the response
             // carries the whole status's rollups, so overlapping writes would
-            // race and lose one of the two changes.
-            disabled={pendingName !== null}
+            // race and lose one of the two changes. `aria-disabled` rather than
+            // `disabled` so the button the user just activated keeps focus.
+            aria-disabled={pendingName !== null}
             aria-pressed={reaction.me}
             aria-label={`${reaction.me ? 'Remove' : 'Add'} ${reaction.name} reaction, ${reaction.count}`}
-            className={chipClass(reaction.me)}
+            className={chipClass(reaction.me, true, pendingName !== null)}
             onClick={(event) => {
               event.stopPropagation()
               void toggle(reaction.name)
@@ -278,13 +284,17 @@ export const ReactionRow: FC<ReactionRowProps> = ({
         <button
           ref={pickerTriggerRef}
           type="button"
-          disabled={pendingName !== null}
+          aria-disabled={pendingName !== null}
           aria-label="Add reaction"
           aria-haspopup="dialog"
           aria-expanded={isPicking}
-          className="border-border bg-background text-muted-foreground hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors"
+          className={cn(
+            'border-border bg-background text-muted-foreground hover:bg-muted flex h-7 w-7 items-center justify-center rounded-full border transition-colors',
+            pendingName !== null && 'cursor-not-allowed opacity-50'
+          )}
           onClick={(event) => {
             event.stopPropagation()
+            if (pendingName) return
             setIsPicking((value) => !value)
           }}
         >

--- a/lib/database/sql/collection.ts
+++ b/lib/database/sql/collection.ts
@@ -207,6 +207,7 @@ const readCollectionFeed = async ({
   collectionSeq,
   projection,
   ownerActorId,
+  viewerActorId,
   limit,
   maxStatusId,
   minStatusId
@@ -219,6 +220,7 @@ const readCollectionFeed = async ({
   collectionSeq: string | number
   projection: 'owner' | 'public'
   ownerActorId: string
+  viewerActorId?: string
   limit: number
   maxStatusId?: string | null
   minStatusId?: string | null
@@ -304,11 +306,14 @@ const readCollectionFeed = async ({
   const rows = await query
   const statusIds = rows.map((row) => row.id as string)
   if (statusIds.length === 0) return []
-  // Owner projection hydrates the owner's action state; the public projection
-  // is anonymous (no viewer), so action state is intentionally un-acted.
+  // `projection` chose WHICH statuses this feed contains; the viewer decides
+  // whose action state they carry. Those are separate concerns: a public feed
+  // read by a signed-in visitor still renders interactive chips and buttons, so
+  // hydrating it anonymously would show that visitor their own reaction, like
+  // and bookmark as un-acted.
   return getStatusesByIds(
     statusIds,
-    projection === 'owner' ? ownerActorId : undefined
+    viewerActorId ?? (projection === 'owner' ? ownerActorId : undefined)
   )
 }
 
@@ -865,6 +870,7 @@ export const CollectionSQLDatabaseMixin = (
     id,
     actorId,
     projection = 'owner',
+    currentActorId,
     limit = PER_PAGE_LIMIT,
     maxStatusId,
     minStatusId
@@ -877,6 +883,7 @@ export const CollectionSQLDatabaseMixin = (
       collectionSeq: seq,
       projection,
       ownerActorId: actorId,
+      viewerActorId: currentActorId ?? actorId,
       limit,
       maxStatusId,
       minStatusId
@@ -885,6 +892,7 @@ export const CollectionSQLDatabaseMixin = (
 
   async getPublicCollectionTimeline({
     id,
+    currentActorId,
     limit = PER_PAGE_LIMIT,
     maxStatusId,
     minStatusId
@@ -909,6 +917,7 @@ export const CollectionSQLDatabaseMixin = (
       collectionSeq: collection.seq,
       projection: 'public',
       ownerActorId: collection.ownerActorId,
+      viewerActorId: currentActorId,
       limit,
       maxStatusId,
       minStatusId

--- a/lib/database/sql/index.test.ts
+++ b/lib/database/sql/index.test.ts
@@ -220,7 +220,10 @@ describe('getSQLDatabase', () => {
       likeDatabase,
       bookmarkDatabase,
       mediaDatabase,
-      statusDetectedLanguageDatabase
+      statusDetectedLanguageDatabase,
+      expect.objectContaining({
+        getStatusReactionRollups: expect.any(Function)
+      })
     )
     expect(timelineMixinMock).toHaveBeenCalledWith(knexDatabase, statusDatabase)
   })

--- a/lib/database/sql/index.ts
+++ b/lib/database/sql/index.ts
@@ -103,7 +103,8 @@ export const getSQLDatabase = (database: Knex): Database => {
     likeDatabase,
     bookmarkDatabase,
     mediaDatabase,
-    statusDetectedLanguageDatabase
+    statusDetectedLanguageDatabase,
+    statusReactionDatabase
   )
   const listDatabase = ListSQLDatabaseMixin(
     database,

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -432,6 +432,36 @@ describe('StatusDatabase', () => {
           }
         })
 
+        it('resolves the viewer own boost from the batch on a list path', async () => {
+          // actorAnnounceStatusId is the boost button's state. It used to be
+          // looked up per status (fully hydrating an Announce just to read its
+          // id); it now comes from the same batch as likes and bookmarks, so
+          // the list path must still report it correctly.
+          const announceId = await database.createAnnounce({
+            id: `${extraActorId}/statuses/announce-batch-test`,
+            actorId: extraActorId,
+            cc: [],
+            to: [ACTIVITY_STREAM_PUBLIC],
+            originalStatusId: reactedStatusId
+          })
+
+          try {
+            const actorStatuses = await database.getActorStatuses({
+              actorId: primaryActorId,
+              currentActorId: extraActorId
+            })
+            const boosted = actorStatuses.find(
+              (status) => status.id === reactedStatusId
+            ) as StatusNote
+
+            expect(boosted.actorAnnounceStatusId).toEqual(announceId?.id)
+          } finally {
+            await database.deleteStatus({
+              statusId: `${extraActorId}/statuses/announce-batch-test`
+            })
+          }
+        })
+
         it('hydrates rollups for the replies under a status', async () => {
           const replies = await database.getStatusReplies({
             statusId: statuses.primary.post,

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -358,6 +358,72 @@ describe('StatusDatabase', () => {
         })
       })
 
+      describe('emoji reaction hydration', () => {
+        const reactedStatusId = statuses.primary.post
+
+        afterEach(async () => {
+          await database.deleteStatusReaction({
+            statusId: reactedStatusId,
+            actorId: extraActorId,
+            name: '🔥'
+          })
+          await database.deleteStatusReaction({
+            statusId: reactedStatusId,
+            actorId: replyAuthorId,
+            name: '🔥'
+          })
+        })
+
+        it('hydrates rollups onto a single status with the viewer own flag', async () => {
+          await database.createStatusReaction({
+            statusId: reactedStatusId,
+            actorId: extraActorId,
+            name: '🔥'
+          })
+          await database.createStatusReaction({
+            statusId: reactedStatusId,
+            actorId: replyAuthorId,
+            name: '🔥'
+          })
+
+          const status = (await database.getStatus({
+            statusId: reactedStatusId,
+            withReplies: false,
+            currentActorId: extraActorId
+          })) as StatusNote
+
+          expect(status.reactions).toEqual([
+            { name: '🔥', count: 2, me: true, url: null, static_url: null }
+          ])
+        })
+
+        it('hydrates rollups for every status a list returns', async () => {
+          await database.createStatusReaction({
+            statusId: reactedStatusId,
+            actorId: extraActorId,
+            name: '🔥'
+          })
+
+          // getActorStatuses batches its rollups, so the reacted status carries
+          // them and every other status in the page resolves to an empty array
+          // from the same batch rather than a per-status query.
+          const actorStatuses = await database.getActorStatuses({
+            actorId: primaryActorId,
+            visibleToActorId: extraActorId
+          })
+          const reacted = actorStatuses.find(
+            (status) => status.id === reactedStatusId
+          ) as StatusNote
+
+          expect(reacted.reactions).toEqual([
+            { name: '🔥', count: 1, me: true, url: null, static_url: null }
+          ])
+          for (const status of actorStatuses) {
+            expect(status.reactions).toBeDefined()
+          }
+        })
+      })
+
       it('returns status with replies', async () => {
         const status = (await database.getStatus({
           statusId: statuses.primary.post,

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -352,6 +352,7 @@ describe('StatusDatabase', () => {
           isLocalActor: true,
           totalLikes: 0,
           totalShares: 0,
+          reactions: [],
           attachments: [],
           tags: []
         })

--- a/lib/database/sql/status.test.ts
+++ b/lib/database/sql/status.test.ts
@@ -409,7 +409,10 @@ describe('StatusDatabase', () => {
           // from the same batch rather than a per-status query.
           const actorStatuses = await database.getActorStatuses({
             actorId: primaryActorId,
-            visibleToActorId: extraActorId
+            // The hydration viewer, deliberately NOT `visibleToActorId` — that
+            // one is the visibility filter and passing a viewer there would
+            // change which statuses come back.
+            currentActorId: extraActorId
           })
           const reacted = actorStatuses.find(
             (status) => status.id === reactedStatusId
@@ -418,8 +421,49 @@ describe('StatusDatabase', () => {
           expect(reacted.reactions).toEqual([
             { name: '🔥', count: 1, me: true, url: null, static_url: null }
           ])
+          // Every other status in the page resolves to an empty array from the
+          // same batch. `toEqual([])` rather than `toBeDefined()`: the per-status
+          // fallback would also leave these defined, so only the exact value
+          // distinguishes a seeded batch from a fallback query.
           for (const status of actorStatuses) {
-            expect(status.reactions).toBeDefined()
+            if (status.id === reactedStatusId) continue
+            if (status.type === StatusType.enum.Announce) continue
+            expect(status.reactions).toEqual([])
+          }
+        })
+
+        it('hydrates rollups for the replies under a status', async () => {
+          const replies = await database.getStatusReplies({
+            statusId: statuses.primary.post,
+            currentActorId: extraActorId
+          })
+          expect(replies.length).toBeGreaterThan(0)
+
+          const target = replies[0]
+          await database.createStatusReaction({
+            statusId: target.id,
+            actorId: extraActorId,
+            name: '🎯'
+          })
+
+          try {
+            const hydrated = await database.getStatusReplies({
+              statusId: statuses.primary.post,
+              currentActorId: extraActorId
+            })
+            const reacted = hydrated.find(
+              (reply) => reply.id === target.id
+            ) as StatusNote
+
+            expect(reacted.reactions).toEqual([
+              { name: '🎯', count: 1, me: true, url: null, static_url: null }
+            ])
+          } finally {
+            await database.deleteStatusReaction({
+              statusId: target.id,
+              actorId: extraActorId,
+              name: '🎯'
+            })
           }
         })
       })

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -3397,14 +3397,17 @@ export const StatusSQLDatabaseMixin = (
       .increment('totalVotes', 1)
   }
 
-  async function getStatusFromUrl({ url }: GetStatusFromUrlParams) {
+  async function getStatusFromUrl({
+    url,
+    currentActorId
+  }: GetStatusFromUrlParams) {
     const status = await database('statuses')
       .where('urlHash', getStatusUrlHash(url))
       .andWhere('url', url)
       .first<{ id: string }>('id')
 
     if (status?.id) {
-      return getStatus({ statusId: status.id })
+      return getStatus({ statusId: status.id, currentActorId })
     }
 
     return null

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -72,6 +72,7 @@ import {
   StatusDatabase,
   StatusDetectedLanguageDatabase,
   StatusEditRevision,
+  StatusReactionDatabase,
   UpdateNoteParams,
   UpdateNoteVisibilityParams,
   UpdatePollParams,
@@ -90,6 +91,7 @@ import {
   StatusType
 } from '@/lib/types/domain/status'
 import { Tag } from '@/lib/types/domain/tag'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 import { normalizeActorId } from '@/lib/utils/activitypub'
 import { getAttachmentMediaPath } from '@/lib/utils/getAttachmentMediaPath'
 import { getHashFromString } from '@/lib/utils/getHashFromString'
@@ -144,6 +146,11 @@ type StatusHydrationContext = {
   // Pre-batched quote edges, keyed by the quoting statusId. Viewer-independent;
   // the viewer-relative downgrades happen later in the Mastodon serializer.
   quoteEdges?: Map<string, StatusQuote>
+  // Pre-batched emoji-reaction rollups, keyed by statusId. Viewer-RELATIVE (the
+  // `me` flag), so it is only populated once per page and reused rather than
+  // re-queried per status. An absent entry means "the batch did not cover this
+  // status", which falls back to a single lookup.
+  reactionRollups?: Map<string, StatusReaction[]>
 }
 
 export const buildPubliclyReadableStatusIdsQuery = ({
@@ -252,7 +259,8 @@ export const StatusSQLDatabaseMixin = (
   likeDatabase: LikeDatabase,
   bookmarkDatabase: BookmarkDatabase,
   mediaDatabase: MediaDatabase,
-  statusDetectedLanguageDatabase: StatusDetectedLanguageDatabase
+  statusDetectedLanguageDatabase: StatusDetectedLanguageDatabase,
+  statusReactionDatabase: StatusReactionDatabase
 ): StatusDatabase => {
   const applyPublicReadableStatusFilter = ({
     query,
@@ -550,6 +558,9 @@ export const StatusSQLDatabaseMixin = (
       tags: [],
       replies: [],
       totalLikes: 0,
+      // A status this instance just created has no reactions yet; declare it so
+      // the freshly-created shape matches the hydrated one.
+      reactions: [],
       isActorLiked: false,
       isActorBookmarked: false,
       actorAnnounceStatusId: null,
@@ -985,6 +996,9 @@ export const StatusSQLDatabaseMixin = (
       replies: [],
       choices: [],
       totalLikes: 0,
+      // A status this instance just created has no reactions yet; declare it so
+      // the freshly-created shape matches the hydrated one.
+      reactions: [],
       isActorLiked: false,
       isActorBookmarked: false,
       actorAnnounceStatusId: null,
@@ -1612,34 +1626,59 @@ export const StatusSQLDatabaseMixin = (
     // per-status query in getStatusWithAttachmentsFromData. Run it in the
     // same Promise.all as the bookmark/like queries below rather than
     // sequentially, so all three independent batched lookups overlap.
-    const [detectedLanguages, quoteEdges, bookmarkRows, likeRows] =
-      await Promise.all([
-        hasHydrationStatusIds
-          ? statusDetectedLanguageDatabase.getDetectedLanguages({
-              statusIds: [...hydrationStatusIds]
-            })
-          : Promise.resolve({}),
-        // Quote edges are viewer-independent, so batch them for every fetch (as
-        // with detected languages) rather than falling back to a per-status
-        // query in getStatusWithAttachmentsFromData.
-        hasHydrationStatusIds
-          ? getStatusQuoteEdges([...hydrationStatusIds])
-          : Promise.resolve(new Map<string, StatusQuote>()),
-        currentActorId && hasHydrationStatusIds
-          ? database('bookmarks')
-              .where('actorId', currentActorId)
-              .whereIn('statusId', [...hydrationStatusIds])
-              .select<{ statusId: string }[]>('statusId')
-          : Promise.resolve([]),
-        currentActorId && hasHydrationStatusIds
-          ? database('likes')
-              .where('actorId', currentActorId)
-              .whereIn('statusId', [...hydrationStatusIds])
-              .select<{ statusId: string }[]>('statusId')
-          : Promise.resolve([])
-      ])
+    const [
+      detectedLanguages,
+      quoteEdges,
+      bookmarkRows,
+      likeRows,
+      reactionRollups
+    ] = await Promise.all([
+      hasHydrationStatusIds
+        ? statusDetectedLanguageDatabase.getDetectedLanguages({
+            statusIds: [...hydrationStatusIds]
+          })
+        : Promise.resolve({}),
+      // Quote edges are viewer-independent, so batch them for every fetch (as
+      // with detected languages) rather than falling back to a per-status
+      // query in getStatusWithAttachmentsFromData.
+      hasHydrationStatusIds
+        ? getStatusQuoteEdges([...hydrationStatusIds])
+        : Promise.resolve(new Map<string, StatusQuote>()),
+      currentActorId && hasHydrationStatusIds
+        ? database('bookmarks')
+            .where('actorId', currentActorId)
+            .whereIn('statusId', [...hydrationStatusIds])
+            .select<{ statusId: string }[]>('statusId')
+        : Promise.resolve([]),
+      currentActorId && hasHydrationStatusIds
+        ? database('likes')
+            .where('actorId', currentActorId)
+            .whereIn('statusId', [...hydrationStatusIds])
+            .select<{ statusId: string }[]>('statusId')
+        : Promise.resolve([]),
+      hasHydrationStatusIds
+        ? statusReactionDatabase.getStatusReactionRollups({
+            statusIds: [...hydrationStatusIds],
+            currentActorId
+          })
+        : Promise.resolve([])
+    ])
     hydrationContext.detectedLanguages = detectedLanguages
     hydrationContext.quoteEdges = quoteEdges
+    // Seed every requested id, including those with no reactions, so a
+    // reaction-less status resolves from the batch instead of re-querying.
+    hydrationContext.reactionRollups = new Map(
+      [...hydrationStatusIds].map((statusId) => [statusId, []])
+    )
+    for (const rollup of reactionRollups) {
+      hydrationContext.reactionRollups.get(rollup.statusId)?.push({
+        name: rollup.name,
+        count: rollup.count,
+        me: rollup.me,
+        url: rollup.url,
+        static_url: rollup.staticUrl
+      })
+    }
     if (currentActorId) {
       hydrationContext.bookmarkedStatusIds = new Set(
         bookmarkRows.map((row) => row.statusId)
@@ -2842,7 +2881,8 @@ export const StatusSQLDatabaseMixin = (
       edits,
       fitnessFile,
       detectedLanguage,
-      quoteEdge
+      quoteEdge,
+      reactions
     ] = await Promise.all([
       mediaDatabase.getAttachments({ statusId: data.id }),
       getTags({ statusId: data.id }),
@@ -2898,7 +2938,26 @@ export const StatusSQLDatabaseMixin = (
       // status's edge directly (mirrors the detected-language fallback).
       hydrationContext?.quoteEdges
         ? (hydrationContext.quoteEdges.get(data.id) ?? null)
-        : getStatusQuoteEdgeForData(data.id)
+        : getStatusQuoteEdgeForData(data.id),
+      // Reaction rollups: the pre-batched map when the page covered this status,
+      // otherwise a single lookup (single-status routes). `has` rather than a
+      // truthiness check, so a reaction-less status resolves from the batch.
+      hydrationContext?.reactionRollups?.has(data.id)
+        ? (hydrationContext.reactionRollups.get(data.id) ?? [])
+        : statusReactionDatabase
+            .getStatusReactionRollups({
+              statusIds: [data.id],
+              currentActorId
+            })
+            .then((rollups) =>
+              rollups.map((rollup) => ({
+                name: rollup.name,
+                count: rollup.count,
+                me: rollup.me,
+                url: rollup.url,
+                static_url: rollup.staticUrl
+              }))
+            )
     ])
 
     const repliesNote = (
@@ -2945,6 +3004,7 @@ export const StatusSQLDatabaseMixin = (
         : {}),
       totalLikes,
       totalShares,
+      reactions,
       isActorLiked: isActorLikedStatusResult,
       isActorBookmarked: isActorBookmarkedStatusResult,
       actorAnnounceStatusId: actorAnnounceStatus?.id ?? null,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -139,6 +139,10 @@ const publicRecipientStatusIds = (database: Knex) =>
 type StatusHydrationContext = {
   bookmarkedStatusIds?: Set<string>
   likedStatusIds?: Set<string>
+  // originalStatusId -> the viewer's own Announce id for it. Only the id is
+  // ever consumed, so this batches what would otherwise be a per-status lookup
+  // that fully hydrates an Announce just to read `.id` off it.
+  announcedStatusIds?: Map<string, string>
   // Pre-batched content-detected languages, keyed by statusId. Viewer-
   // independent (unlike the like/bookmark sets above), so callers populate it
   // for any timeline page regardless of whether a viewer is signed in.
@@ -1253,7 +1257,7 @@ export const StatusSQLDatabaseMixin = (
     currentActorId?: string
   ): Promise<Pick<
     StatusHydrationContext,
-    'likedStatusIds' | 'bookmarkedStatusIds'
+    'likedStatusIds' | 'bookmarkedStatusIds' | 'announcedStatusIds'
   > | null> {
     // No viewer means no viewer state to resolve, and the consumer must be left
     // with the fields UNSET — it reads an unset field as "not batched, look this
@@ -1264,9 +1268,9 @@ export const StatusSQLDatabaseMixin = (
     // A viewer with nothing to look up still gets empty sets rather than null:
     // returning null here would mark the page as un-batched and send every row
     // back to a per-status query.
-    const [bookmarkRows, likeRows] =
+    const [bookmarkRows, likeRows, announceRows] =
       statusIds.length === 0
-        ? [[], []]
+        ? [[], [], []]
         : await Promise.all([
             database('bookmarks')
               .where('actorId', currentActorId)
@@ -1275,11 +1279,22 @@ export const StatusSQLDatabaseMixin = (
             database('likes')
               .where('actorId', currentActorId)
               .whereIn('statusId', statusIds)
-              .select<{ statusId: string }[]>('statusId')
+              .select<{ statusId: string }[]>('statusId'),
+            database('statuses')
+              .where('type', StatusType.enum.Announce)
+              .where('actorId', currentActorId)
+              .whereIn('originalStatusId', statusIds)
+              .select<{ id: string; originalStatusId: string }[]>(
+                'id',
+                'originalStatusId'
+              )
           ])
     return {
       bookmarkedStatusIds: new Set(bookmarkRows.map((row) => row.statusId)),
-      likedStatusIds: new Set(likeRows.map((row) => row.statusId))
+      likedStatusIds: new Set(likeRows.map((row) => row.statusId)),
+      announcedStatusIds: new Map(
+        announceRows.map((row) => [row.originalStatusId, row.id] as const)
+      )
     }
   }
 
@@ -2917,7 +2932,7 @@ export const StatusSQLDatabaseMixin = (
       totalShares,
       isActorLikedStatusResult,
       isActorBookmarkedStatusResult,
-      actorAnnounceStatus,
+      actorAnnounceStatusId,
       edits,
       fitnessFile,
       detectedLanguage,
@@ -2953,10 +2968,12 @@ export const StatusSQLDatabaseMixin = (
             })
         : false,
       currentActorId
-        ? getActorAnnounceStatus({
-            statusId: data.id,
-            actorId: currentActorId
-          })
+        ? hydrationContext.announcedStatusIds
+          ? (hydrationContext.announcedStatusIds.get(data.id) ?? null)
+          : getActorAnnouncedStatusId({
+              originalStatusId: data.id,
+              actorId: currentActorId
+            })
         : null,
       database('status_history').where('statusId', data.id),
       // A status can carry several fitness files (e.g. the same ride merged
@@ -3047,7 +3064,7 @@ export const StatusSQLDatabaseMixin = (
       reactions,
       isActorLiked: isActorLikedStatusResult,
       isActorBookmarked: isActorBookmarkedStatusResult,
-      actorAnnounceStatusId: actorAnnounceStatus?.id ?? null,
+      actorAnnounceStatusId,
       isLocalActor: Boolean(actor?.account),
       attachments: orderedAttachments,
       tags,

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1244,6 +1244,35 @@ export const StatusSQLDatabaseMixin = (
     return context
   }
 
+  // The viewer's own like/bookmark state for a page of statuses, batched. Every
+  // list path that hydrates for a viewer uses this: passing a `currentActorId`
+  // into per-status hydration without it turns on a like lookup, a bookmark
+  // lookup and an announce lookup *per row*.
+  async function buildViewerHydration(
+    statusIds: string[],
+    currentActorId?: string
+  ): Promise<Pick<
+    StatusHydrationContext,
+    'likedStatusIds' | 'bookmarkedStatusIds'
+  > | null> {
+    if (!currentActorId || statusIds.length === 0) return null
+
+    const [bookmarkRows, likeRows] = await Promise.all([
+      database('bookmarks')
+        .where('actorId', currentActorId)
+        .whereIn('statusId', statusIds)
+        .select<{ statusId: string }[]>('statusId'),
+      database('likes')
+        .where('actorId', currentActorId)
+        .whereIn('statusId', statusIds)
+        .select<{ statusId: string }[]>('statusId')
+    ])
+    return {
+      bookmarkedStatusIds: new Set(bookmarkRows.map((row) => row.statusId)),
+      likedStatusIds: new Set(likeRows.map((row) => row.statusId))
+    }
+  }
+
   async function getStatusReplies({
     statusId,
     url,
@@ -1281,21 +1310,24 @@ export const StatusSQLDatabaseMixin = (
     // Batch detected-language and quote-edge hydration so this doesn't N+1 one
     // query per reply (mirroring getStatusesByIds).
     const hydrationStatusIds = await collectHydrationStatusIds(statuses)
-    const [detectedLanguages, quoteEdges, reactionRollups] = await Promise.all([
-      hydrationStatusIds.size > 0
-        ? statusDetectedLanguageDatabase.getDetectedLanguages({
-            statusIds: [...hydrationStatusIds]
-          })
-        : Promise.resolve({}),
-      hydrationStatusIds.size > 0
-        ? getStatusQuoteEdges([...hydrationStatusIds])
-        : Promise.resolve(new Map<string, StatusQuote>()),
-      buildReactionRollupContext([...hydrationStatusIds], currentActorId)
-    ])
+    const [detectedLanguages, quoteEdges, reactionRollups, viewerHydration] =
+      await Promise.all([
+        hydrationStatusIds.size > 0
+          ? statusDetectedLanguageDatabase.getDetectedLanguages({
+              statusIds: [...hydrationStatusIds]
+            })
+          : Promise.resolve({}),
+        hydrationStatusIds.size > 0
+          ? getStatusQuoteEdges([...hydrationStatusIds])
+          : Promise.resolve(new Map<string, StatusQuote>()),
+        buildReactionRollupContext([...hydrationStatusIds], currentActorId),
+        buildViewerHydration([...hydrationStatusIds], currentActorId)
+      ])
     const hydrationContext: StatusHydrationContext = {
       detectedLanguages,
       quoteEdges,
-      reactionRollups
+      reactionRollups,
+      ...(viewerHydration ?? {})
     }
     const statusesWithAttachments = (
       await Promise.all(
@@ -1523,21 +1555,24 @@ export const StatusSQLDatabaseMixin = (
     // query per status (mirroring getStatusesByIds) — actor status lists back
     // profile pages and the Mastodon accounts/:id/statuses endpoint.
     const hydrationStatusIds = await collectHydrationStatusIds(statuses)
-    const [detectedLanguages, quoteEdges, reactionRollups] = await Promise.all([
-      hydrationStatusIds.size > 0
-        ? statusDetectedLanguageDatabase.getDetectedLanguages({
-            statusIds: [...hydrationStatusIds]
-          })
-        : Promise.resolve({}),
-      hydrationStatusIds.size > 0
-        ? getStatusQuoteEdges([...hydrationStatusIds])
-        : Promise.resolve(new Map<string, StatusQuote>()),
-      buildReactionRollupContext([...hydrationStatusIds], currentActorId)
-    ])
+    const [detectedLanguages, quoteEdges, reactionRollups, viewerHydration] =
+      await Promise.all([
+        hydrationStatusIds.size > 0
+          ? statusDetectedLanguageDatabase.getDetectedLanguages({
+              statusIds: [...hydrationStatusIds]
+            })
+          : Promise.resolve({}),
+        hydrationStatusIds.size > 0
+          ? getStatusQuoteEdges([...hydrationStatusIds])
+          : Promise.resolve(new Map<string, StatusQuote>()),
+        buildReactionRollupContext([...hydrationStatusIds], currentActorId),
+        buildViewerHydration([...hydrationStatusIds], currentActorId)
+      ])
     const hydrationContext: StatusHydrationContext = {
       detectedLanguages,
       quoteEdges,
-      reactionRollups
+      reactionRollups,
+      ...(viewerHydration ?? {})
     }
     const statusesWithAttachments = (
       await Promise.all(
@@ -1661,49 +1696,26 @@ export const StatusSQLDatabaseMixin = (
     // per-status query in getStatusWithAttachmentsFromData. Run it in the
     // same Promise.all as the bookmark/like queries below rather than
     // sequentially, so all three independent batched lookups overlap.
-    const [
-      detectedLanguages,
-      quoteEdges,
-      bookmarkRows,
-      likeRows,
-      reactionRollups
-    ] = await Promise.all([
-      hasHydrationStatusIds
-        ? statusDetectedLanguageDatabase.getDetectedLanguages({
-            statusIds: [...hydrationStatusIds]
-          })
-        : Promise.resolve({}),
-      // Quote edges are viewer-independent, so batch them for every fetch (as
-      // with detected languages) rather than falling back to a per-status
-      // query in getStatusWithAttachmentsFromData.
-      hasHydrationStatusIds
-        ? getStatusQuoteEdges([...hydrationStatusIds])
-        : Promise.resolve(new Map<string, StatusQuote>()),
-      currentActorId && hasHydrationStatusIds
-        ? database('bookmarks')
-            .where('actorId', currentActorId)
-            .whereIn('statusId', [...hydrationStatusIds])
-            .select<{ statusId: string }[]>('statusId')
-        : Promise.resolve([]),
-      currentActorId && hasHydrationStatusIds
-        ? database('likes')
-            .where('actorId', currentActorId)
-            .whereIn('statusId', [...hydrationStatusIds])
-            .select<{ statusId: string }[]>('statusId')
-        : Promise.resolve([]),
-      buildReactionRollupContext([...hydrationStatusIds], currentActorId)
-    ])
+    const [detectedLanguages, quoteEdges, reactionRollups, viewerHydration] =
+      await Promise.all([
+        hasHydrationStatusIds
+          ? statusDetectedLanguageDatabase.getDetectedLanguages({
+              statusIds: [...hydrationStatusIds]
+            })
+          : Promise.resolve({}),
+        // Quote edges are viewer-independent, so batch them for every fetch (as
+        // with detected languages) rather than falling back to a per-status
+        // query in getStatusWithAttachmentsFromData.
+        hasHydrationStatusIds
+          ? getStatusQuoteEdges([...hydrationStatusIds])
+          : Promise.resolve(new Map<string, StatusQuote>()),
+        buildReactionRollupContext([...hydrationStatusIds], currentActorId),
+        buildViewerHydration([...hydrationStatusIds], currentActorId)
+      ])
     hydrationContext.detectedLanguages = detectedLanguages
     hydrationContext.quoteEdges = quoteEdges
     hydrationContext.reactionRollups = reactionRollups
-    if (currentActorId) {
-      hydrationContext.bookmarkedStatusIds = new Set(
-        bookmarkRows.map((row) => row.statusId)
-      )
-      hydrationContext.likedStatusIds = new Set(
-        likeRows.map((row) => row.statusId)
-      )
-    }
+    Object.assign(hydrationContext, viewerHydration ?? {})
     const statusMap = new Map(
       statuses.map((statusData) => [statusData.id, statusData] as const)
     )

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1249,7 +1249,8 @@ export const StatusSQLDatabaseMixin = (
     url,
     limit,
     publicOnly = false,
-    visibleToActorId
+    visibleToActorId,
+    currentActorId
   }: GetStatusRepliesParams) {
     let query = database('statuses')
       .where((builder) => {
@@ -1289,10 +1290,7 @@ export const StatusSQLDatabaseMixin = (
       hydrationStatusIds.size > 0
         ? getStatusQuoteEdges([...hydrationStatusIds])
         : Promise.resolve(new Map<string, StatusQuote>()),
-      buildReactionRollupContext(
-        [...hydrationStatusIds],
-        visibleToActorId ?? undefined
-      )
+      buildReactionRollupContext([...hydrationStatusIds], currentActorId)
     ])
     const hydrationContext: StatusHydrationContext = {
       detectedLanguages,
@@ -1304,7 +1302,7 @@ export const StatusSQLDatabaseMixin = (
         statuses.map((item) =>
           getStatusWithAttachmentsFromData(
             item,
-            undefined,
+            currentActorId,
             undefined,
             hydrationContext
           )
@@ -1368,6 +1366,7 @@ export const StatusSQLDatabaseMixin = (
 
   async function getActorStatuses({
     actorId,
+    currentActorId,
     minStatusId,
     maxStatusId,
     limit = PER_PAGE_LIMIT,
@@ -1533,10 +1532,7 @@ export const StatusSQLDatabaseMixin = (
       hydrationStatusIds.size > 0
         ? getStatusQuoteEdges([...hydrationStatusIds])
         : Promise.resolve(new Map<string, StatusQuote>()),
-      buildReactionRollupContext(
-        [...hydrationStatusIds],
-        visibleToActorId ?? undefined
-      )
+      buildReactionRollupContext([...hydrationStatusIds], currentActorId)
     ])
     const hydrationContext: StatusHydrationContext = {
       detectedLanguages,
@@ -1548,7 +1544,7 @@ export const StatusSQLDatabaseMixin = (
         statuses.map((item) =>
           getStatusWithAttachmentsFromData(
             item,
-            undefined,
+            currentActorId,
             undefined,
             hydrationContext
           )
@@ -2644,6 +2640,7 @@ export const StatusSQLDatabaseMixin = (
 
   async function getStatusesByHashtag({
     hashtag,
+    currentActorId,
     limit = PER_PAGE_LIMIT,
     minStatusId,
     maxStatusId,
@@ -2762,7 +2759,7 @@ export const StatusSQLDatabaseMixin = (
     const rows = await query
     const statusIds = rows.map((row: { id: string }) => row.id)
     if (statusIds.length === 0) return []
-    return getStatusesByIds({ statusIds })
+    return getStatusesByIds({ statusIds, currentActorId })
   }
 
   async function getHashtagCounter({
@@ -3376,7 +3373,8 @@ export const StatusSQLDatabaseMixin = (
 
   async function getStatusFromUrlHash({
     urlHash,
-    actorId
+    actorId,
+    currentActorId
   }: GetStatusFromUrlHashParams) {
     const query = database('statuses').where('urlHash', urlHash)
     if (actorId) {
@@ -3386,7 +3384,7 @@ export const StatusSQLDatabaseMixin = (
     const status = await query.first()
     if (!status) return null
 
-    return getStatusWithAttachmentsFromData(status)
+    return getStatusWithAttachmentsFromData(status, currentActorId)
   }
 
   async function getActorAnnouncedStatusId({

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1255,18 +1255,28 @@ export const StatusSQLDatabaseMixin = (
     StatusHydrationContext,
     'likedStatusIds' | 'bookmarkedStatusIds'
   > | null> {
-    if (!currentActorId || statusIds.length === 0) return null
+    // No viewer means no viewer state to resolve, and the consumer must be left
+    // with the fields UNSET — it reads an unset field as "not batched, look this
+    // status up individually", which is the correct behaviour for anonymous
+    // reads (where the lookup is skipped outright).
+    if (!currentActorId) return null
 
-    const [bookmarkRows, likeRows] = await Promise.all([
-      database('bookmarks')
-        .where('actorId', currentActorId)
-        .whereIn('statusId', statusIds)
-        .select<{ statusId: string }[]>('statusId'),
-      database('likes')
-        .where('actorId', currentActorId)
-        .whereIn('statusId', statusIds)
-        .select<{ statusId: string }[]>('statusId')
-    ])
+    // A viewer with nothing to look up still gets empty sets rather than null:
+    // returning null here would mark the page as un-batched and send every row
+    // back to a per-status query.
+    const [bookmarkRows, likeRows] =
+      statusIds.length === 0
+        ? [[], []]
+        : await Promise.all([
+            database('bookmarks')
+              .where('actorId', currentActorId)
+              .whereIn('statusId', statusIds)
+              .select<{ statusId: string }[]>('statusId'),
+            database('likes')
+              .where('actorId', currentActorId)
+              .whereIn('statusId', statusIds)
+              .select<{ statusId: string }[]>('statusId')
+          ])
     return {
       bookmarkedStatusIds: new Set(bookmarkRows.map((row) => row.statusId)),
       likedStatusIds: new Set(likeRows.map((row) => row.statusId))

--- a/lib/database/sql/status.ts
+++ b/lib/database/sql/status.ts
@@ -1215,6 +1215,35 @@ export const StatusSQLDatabaseMixin = (
     })
   }
 
+  // Batched emoji-reaction rollups for a page of statuses, in the shape the
+  // domain Status carries. Every hydration site uses this so none of them falls
+  // back to the per-status lookup — that fallback exists for single-status
+  // routes, not for list paths.
+  async function buildReactionRollupContext(
+    statusIds: string[],
+    currentActorId?: string
+  ): Promise<Map<string, StatusReaction[]>> {
+    const context = new Map<string, StatusReaction[]>(
+      statusIds.map((statusId) => [statusId, []])
+    )
+    if (statusIds.length === 0) return context
+
+    const rollups = await statusReactionDatabase.getStatusReactionRollups({
+      statusIds,
+      currentActorId
+    })
+    for (const rollup of rollups) {
+      context.get(rollup.statusId)?.push({
+        name: rollup.name,
+        count: rollup.count,
+        me: rollup.me,
+        url: rollup.url,
+        static_url: rollup.staticUrl
+      })
+    }
+    return context
+  }
+
   async function getStatusReplies({
     statusId,
     url,
@@ -1251,7 +1280,7 @@ export const StatusSQLDatabaseMixin = (
     // Batch detected-language and quote-edge hydration so this doesn't N+1 one
     // query per reply (mirroring getStatusesByIds).
     const hydrationStatusIds = await collectHydrationStatusIds(statuses)
-    const [detectedLanguages, quoteEdges] = await Promise.all([
+    const [detectedLanguages, quoteEdges, reactionRollups] = await Promise.all([
       hydrationStatusIds.size > 0
         ? statusDetectedLanguageDatabase.getDetectedLanguages({
             statusIds: [...hydrationStatusIds]
@@ -1259,11 +1288,16 @@ export const StatusSQLDatabaseMixin = (
         : Promise.resolve({}),
       hydrationStatusIds.size > 0
         ? getStatusQuoteEdges([...hydrationStatusIds])
-        : Promise.resolve(new Map<string, StatusQuote>())
+        : Promise.resolve(new Map<string, StatusQuote>()),
+      buildReactionRollupContext(
+        [...hydrationStatusIds],
+        visibleToActorId ?? undefined
+      )
     ])
     const hydrationContext: StatusHydrationContext = {
       detectedLanguages,
-      quoteEdges
+      quoteEdges,
+      reactionRollups
     }
     const statusesWithAttachments = (
       await Promise.all(
@@ -1490,7 +1524,7 @@ export const StatusSQLDatabaseMixin = (
     // query per status (mirroring getStatusesByIds) — actor status lists back
     // profile pages and the Mastodon accounts/:id/statuses endpoint.
     const hydrationStatusIds = await collectHydrationStatusIds(statuses)
-    const [detectedLanguages, quoteEdges] = await Promise.all([
+    const [detectedLanguages, quoteEdges, reactionRollups] = await Promise.all([
       hydrationStatusIds.size > 0
         ? statusDetectedLanguageDatabase.getDetectedLanguages({
             statusIds: [...hydrationStatusIds]
@@ -1498,11 +1532,16 @@ export const StatusSQLDatabaseMixin = (
         : Promise.resolve({}),
       hydrationStatusIds.size > 0
         ? getStatusQuoteEdges([...hydrationStatusIds])
-        : Promise.resolve(new Map<string, StatusQuote>())
+        : Promise.resolve(new Map<string, StatusQuote>()),
+      buildReactionRollupContext(
+        [...hydrationStatusIds],
+        visibleToActorId ?? undefined
+      )
     ])
     const hydrationContext: StatusHydrationContext = {
       detectedLanguages,
-      quoteEdges
+      quoteEdges,
+      reactionRollups
     }
     const statusesWithAttachments = (
       await Promise.all(
@@ -1656,29 +1695,11 @@ export const StatusSQLDatabaseMixin = (
             .whereIn('statusId', [...hydrationStatusIds])
             .select<{ statusId: string }[]>('statusId')
         : Promise.resolve([]),
-      hasHydrationStatusIds
-        ? statusReactionDatabase.getStatusReactionRollups({
-            statusIds: [...hydrationStatusIds],
-            currentActorId
-          })
-        : Promise.resolve([])
+      buildReactionRollupContext([...hydrationStatusIds], currentActorId)
     ])
     hydrationContext.detectedLanguages = detectedLanguages
     hydrationContext.quoteEdges = quoteEdges
-    // Seed every requested id, including those with no reactions, so a
-    // reaction-less status resolves from the batch instead of re-querying.
-    hydrationContext.reactionRollups = new Map(
-      [...hydrationStatusIds].map((statusId) => [statusId, []])
-    )
-    for (const rollup of reactionRollups) {
-      hydrationContext.reactionRollups.get(rollup.statusId)?.push({
-        name: rollup.name,
-        count: rollup.count,
-        me: rollup.me,
-        url: rollup.url,
-        static_url: rollup.staticUrl
-      })
-    }
+    hydrationContext.reactionRollups = reactionRollups
     if (currentActorId) {
       hydrationContext.bookmarkedStatusIds = new Set(
         bookmarkRows.map((row) => row.statusId)

--- a/lib/database/sql/timeline.test.ts
+++ b/lib/database/sql/timeline.test.ts
@@ -76,6 +76,54 @@ describe('TimelineDatabase', () => {
           }
         }, 15000)
 
+        it('hydrates reaction rollups for the timeline owner', async () => {
+          const sender = 'https://llun.dev/users/timeline-reactor'
+          await database.createFollow({
+            actorId: TEST_ID_MAIN,
+            targetActorId: sender,
+            status: FollowStatus.enum.Accepted,
+            inbox: `${TEST_ID_MAIN}/inbox`,
+            sharedInbox: `${TEST_ID_MAIN}/inbox`
+          })
+
+          const statusId = `${sender}/statuses/reacted-post`
+          const status = await database.createNote({
+            id: statusId,
+            url: statusId,
+            actorId: sender,
+            text: 'Reacted post',
+            to: [ACTIVITY_STREAM_PUBLIC],
+            cc: [TEST_ID_MAIN]
+          })
+          await addStatusToTimelines(database, status)
+          await database.createStatusReaction({
+            statusId,
+            actorId: TEST_ID_MAIN,
+            name: '🔥'
+          })
+
+          try {
+            const statuses = await database.getTimeline({
+              timeline: Timeline.MAIN,
+              actorId: TEST_ID_MAIN
+            })
+            const reacted = statuses.find((item) => item.id === statusId)
+
+            // The home timeline hydrates in one batch keyed on the timeline's
+            // own actor, so the viewer's reaction comes back flagged as theirs
+            // rather than needing a per-status lookup.
+            expect(reacted?.reactions).toEqual([
+              { name: '🔥', count: 1, me: true, url: null, static_url: null }
+            ])
+          } finally {
+            await database.deleteStatusReaction({
+              statusId,
+              actorId: TEST_ID_MAIN,
+              name: '🔥'
+            })
+          }
+        })
+
         it('does not repeat statuses when paginating with out-of-order insertion', async () => {
           const TEST_ID_PAGINATE = `https://${TEST_DOMAIN}/users/timeline-paginate`
           await database.createAccount({

--- a/lib/database/sql/timeline.ts
+++ b/lib/database/sql/timeline.ts
@@ -9,7 +9,6 @@ import {
   GetTimelineParams,
   TimelineDatabase
 } from '@/lib/types/database/operations'
-import { Status } from '@/lib/types/domain/status'
 import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
 
 export const TimelineSQLDatabaseMixin = (
@@ -261,19 +260,17 @@ export const TimelineSQLDatabaseMixin = (
         // Ascending (min_id) rows come back oldest-first; flip to newest-first.
         if (ascending) statusesId.reverse()
 
-        const statuses: Array<Status | null> = []
-        for (const { statusId } of statusesId) {
-          // Keep status hydration sequential; each status load fans out more DB
-          // work and parallelizing the outer loop can overflow RSC async tracing.
-          statuses.push(
-            await statusDatabase.getStatus({
-              statusId,
-              currentActorId: actorId
-            })
-          )
-        }
-
-        return statuses.filter((status): status is Status => !!status)
+        // One batched hydration rather than a status-at-a-time loop: this is the
+        // busiest page in the app, and the per-status path re-queries detected
+        // languages, quote edges, bookmarks, likes and reaction rollups once per
+        // row. getStatusesByIds returns them in the ids' order, so the timeline
+        // ordering established above is preserved. (The loop this replaces was
+        // sequential to avoid a parallel fan-out overflowing RSC async tracing;
+        // a single batched call does not fan out at all.)
+        return statusDatabase.getStatusesByIds({
+          statusIds: statusesId.map(({ statusId }) => statusId),
+          currentActorId: actorId
+        })
       }
       default: {
         return []

--- a/lib/services/reactions/getStatusReactionList.ts
+++ b/lib/services/reactions/getStatusReactionList.ts
@@ -3,6 +3,7 @@ import { normalizeStoredReactionName } from '@/lib/services/reactions/reactionNa
 import { getReadableStatus } from '@/lib/services/statusRouteAccess'
 import { Mastodon } from '@/lib/types/activitypub'
 import { Actor } from '@/lib/types/domain/actor'
+import { getOriginalStatus } from '@/lib/types/domain/status'
 import { idToUrl } from '@/lib/utils/urlToId'
 
 // The Pleroma/Akkoma `GET .../reactions` entry: the rollup a Status already
@@ -35,6 +36,11 @@ export const getStatusReactionList = async ({
   })
   if (!status) return null
 
+  // Reactions are stored against the boosted post, never the boost — so read
+  // them back from the same target the write path used, or reacting through a
+  // boost's id would store a row that a GET on that same id cannot see.
+  const targetStatusId = getOriginalStatus(status).id
+
   // The `:emoji` URL segment is free text, and the write path stores a custom
   // emoji colon-free — so normalise identically here or `GET .../reactions/:x:`
   // would find nothing that `PUT .../reactions/:x:` had just created.
@@ -42,11 +48,11 @@ export const getStatusReactionList = async ({
 
   const [rollups, reactors] = await Promise.all([
     database.getStatusReactionRollups({
-      statusIds: [statusId],
+      statusIds: [targetStatusId],
       currentActorId: currentActor?.id
     }),
     database.getStatusReactionActors({
-      statusId,
+      statusId: targetStatusId,
       ...(storedName ? { name: storedName } : {})
     })
   ])

--- a/lib/services/reactions/reactionRouteHandlers.test.ts
+++ b/lib/services/reactions/reactionRouteHandlers.test.ts
@@ -88,6 +88,11 @@ describe('reactionWriteHandler', () => {
       description: 'an emoji this instance cannot render',
       reason: 'invalid-emoji',
       expected: 422
+    },
+    {
+      description: 'a viewer already at the per-actor cap',
+      reason: 'cap-reached',
+      expected: 422
     }
   ])('answers $expected for $description', async ({ reason, expected }) => {
     mockReactStatus.mockResolvedValue({ ok: false, reason })
@@ -97,6 +102,30 @@ describe('reactionWriteHandler', () => {
     expect(response.status).toBe(expected)
     expect(mockRefetchedStatusResponse).not.toHaveBeenCalled()
   })
+
+  it.each([
+    {
+      reason: 'cap-reached',
+      error: 'You can only add 8 reactions to a post.'
+    },
+    {
+      reason: 'invalid-emoji',
+      error: 'That emoji cannot be used as a reaction.'
+    }
+  ])(
+    'explains a $reason refusal in the response body',
+    async ({ reason, error }) => {
+      mockReactStatus.mockResolvedValue({ ok: false, reason })
+
+      const response = await invoke('react', { id: 'status-1', emoji: '🔥' })
+      const body = await response.json()
+
+      // The client shows `error` to the user verbatim, and only does so when
+      // `reason` is present — that marker is what separates this from the bare
+      // `{ error: 'Unprocessable entity' }` every other 4xx returns.
+      expect(body).toEqual({ error, reason })
+    }
+  )
 
   it.each([
     {

--- a/lib/services/reactions/reactionRouteHandlers.ts
+++ b/lib/services/reactions/reactionRouteHandlers.ts
@@ -7,10 +7,13 @@ import {
   reactStatus,
   unreactStatus
 } from '@/lib/services/reactions/reactStatus'
-import { MAX_REACTION_NAME_LENGTH } from '@/lib/services/statuses/reactionLimits'
+import {
+  MAX_REACTIONS_PER_ACTOR,
+  MAX_REACTION_NAME_LENGTH
+} from '@/lib/services/statuses/reactionLimits'
 import { Actor } from '@/lib/types/domain/actor'
 import { HttpMethod } from '@/lib/utils/http-headers'
-import { apiCorsError } from '@/lib/utils/response'
+import { apiCorsError, apiResponse } from '@/lib/utils/response'
 import { idToUrl } from '@/lib/utils/urlToId'
 
 // Next's App Router already percent-decodes a dynamic segment, so this is the
@@ -57,12 +60,26 @@ export const reactionWriteHandler =
     })
 
     if (!result.ok) {
-      // `invalid-emoji` and `cap-reached` are both unprocessable input.
-      return apiCorsError(
+      if (result.reason === 'not-found') {
+        return apiCorsError(req, corsHeaders, 404)
+      }
+
+      // `invalid-emoji` and `cap-reached` are both unprocessable input, and
+      // both are permanent for this request — the client shows the message
+      // rather than inviting a retry that would fail identically. Mastodon's
+      // own errors carry a human-readable `error` string, so this stays in
+      // dialect.
+      return apiResponse({
         req,
-        corsHeaders,
-        result.reason === 'not-found' ? 404 : 422
-      )
+        allowedMethods: corsHeaders,
+        data: {
+          error:
+            result.reason === 'cap-reached'
+              ? `You can only add ${MAX_REACTIONS_PER_ACTOR} reactions to a post.`
+              : 'That emoji cannot be used as a reaction.'
+        },
+        responseStatusCode: 422
+      })
     }
 
     // Both dialects answer with the affected Status, refetched so the caller

--- a/lib/services/reactions/reactionRouteHandlers.ts
+++ b/lib/services/reactions/reactionRouteHandlers.ts
@@ -76,7 +76,11 @@ export const reactionWriteHandler =
           error:
             result.reason === 'cap-reached'
               ? `You can only add ${MAX_REACTIONS_PER_ACTOR} reactions to a post.`
-              : 'That emoji cannot be used as a reaction.'
+              : 'That emoji cannot be used as a reaction.',
+          // Marks `error` as copy written for a person, so a client can show it
+          // as-is. Without it a client cannot tell this apart from the generic
+          // `{ error: 'Unprocessable entity' }` every other 4xx returns.
+          reason: result.reason
         },
         responseStatusCode: 422
       })

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -553,6 +553,8 @@ export type GetStatusRepliesParams = BaseStatusParams & {
   limit?: number
   publicOnly?: boolean
   visibleToActorId?: string | null
+  // Hydration-only viewer; see GetActorStatusesParams.
+  currentActorId?: string
 }
 export type GetStatusEditHistoryParams = BaseStatusParams
 // A single superseded revision of a status (a row in `status_history`). `text`
@@ -579,6 +581,10 @@ export type GetStatusFromUrlParams = {
 export type GetStatusFromUrlHashParams = {
   urlHash: string
   actorId?: string
+  // The signed-in viewer, so the returned status carries their own like,
+  // bookmark and reaction state — the hash route lands on the same status
+  // detail page as the id route and must hydrate it the same way.
+  currentActorId?: string
 }
 
 export type GetActorAnnouncedStatusIdParams = {
@@ -625,6 +631,11 @@ export type GetActorStatusesCountParams = {
 }
 export type GetActorStatusesParams = {
   actorId: string
+  // The signed-in viewer, for hydration only: it decides the like, bookmark and
+  // reaction state carried on the returned statuses. `visibleToActorId` below is
+  // the separate *visibility filter* and must not be conflated with it — a
+  // viewer id passed there changes which statuses come back.
+  currentActorId?: string
   minStatusId?: string | null
   maxStatusId?: string | null
   limit?: number
@@ -702,6 +713,10 @@ export type DeleteStatusTagsByTypeParams = {
 }
 export type GetStatusesByHashtagParams = {
   hashtag: string
+  // The signed-in viewer. Hydration only — it decides the like/bookmark/reaction
+  // state on the returned statuses and never which statuses are returned (a tag
+  // timeline is public by definition).
+  currentActorId?: string
   limit?: number
   minStatusId?: string
   maxStatusId?: string

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -577,6 +577,11 @@ export type DeleteStatusParams = BaseStatusParams & {
 
 export type GetStatusFromUrlParams = {
   url: string
+  // The signed-in viewer, so the resolved status carries their own like,
+  // bookmark and reaction state. A status's `url` is its web permalink, which
+  // is never equal to its `id`, so this lookup — not the id lookup beside it —
+  // is what a pasted link actually resolves through.
+  currentActorId?: string
 }
 export type GetStatusFromUrlHashParams = {
   urlHash: string

--- a/lib/types/database/operations.ts
+++ b/lib/types/database/operations.ts
@@ -1607,12 +1607,20 @@ export type GetCollectionTimelineParams = {
   // getPublicCollectionTimeline instead.
   actorId: string
   projection?: 'owner' | 'public'
+  // Hydration-only viewer; see GetPublicCollectionTimelineParams. Defaults to
+  // the owner, so the owner's own public preview still shows their state.
+  currentActorId?: string
   limit?: number
   maxStatusId?: string | null
   minStatusId?: string | null
 }
 export type GetPublicCollectionTimelineParams = {
   id: string
+  // The signed-in reader, for hydration only. `projection` decides WHICH
+  // statuses this feed contains; this decides whose like/bookmark/reaction
+  // state they carry. A public feed rendered for a signed-in viewer still shows
+  // interactive controls, so those controls must reflect that viewer.
+  currentActorId?: string
   limit?: number
   maxStatusId?: string | null
   minStatusId?: string | null

--- a/lib/types/domain/status.ts
+++ b/lib/types/domain/status.ts
@@ -24,6 +24,7 @@ import {
 } from '@/lib/types/domain/attachment'
 import { PollChoice } from '@/lib/types/domain/pollChoice'
 import { Tag, getEmojiFromTag, getMentionFromTag } from '@/lib/types/domain/tag'
+import { StatusReaction } from '@/lib/types/mastodon/statusReaction'
 import { getISOTimeUTC } from '@/lib/utils/getISOTimeUTC'
 
 export const StatusType = z.enum(['Note', 'Announce', 'Poll'])
@@ -141,6 +142,12 @@ export const StatusNote = StatusBase.extend({
   isActorBookmarked: z.boolean(),
   totalLikes: z.number(),
   totalShares: z.number().default(0),
+  // Emoji-reaction rollups in first-reaction order, with `me` relative to the
+  // viewer. Hydrated alongside the like/bookmark state so the shared Post
+  // components can render chips without a per-post request. Optional rather than
+  // defaulted: a defaulted array is required on the *output* type, which would
+  // force every existing status literal and fixture to declare it.
+  reactions: StatusReaction.array().optional(),
 
   attachments: Attachment.array(),
   tags: Tag.array(),


### PR DESCRIPTION
Epic 5.1, PR 3 of 3. [#1320](https://github.com/llun/activities.next/pull/1320) stored reactions and accepted them inbound; [#1324](https://github.com/llun/activities.next/pull/1324) made them writable and federated them out. This puts them on screen.

## Reactions had to reach the domain Status

5.1a added rollups to the **Mastodon** `Status` entity, but the shared `Post` components render a **domain** `Status` — which had no reactions. Fetching per post from the client would have been one request per rendered post, so instead the rollups now hydrate onto the domain status through the existing batch seam next to the like/bookmark state: **one extra grouped query per timeline page**, with a single-status fallback for the detail routes (the same `has`-vs-`get` contract `statusMetricsCache` uses).

`reactions` is `.optional()` rather than `.default([])` on purpose — a zod default is *required* on the output type, which would have forced every existing status literal and fixture in the repo to declare it. Freshly-created statuses do declare `reactions: []` so the created shape matches the hydrated one.

## The UI

- **`ReactionRow`** sits between the post content and the action row, rendered by `Post` — so reactions look and behave identically on every surface, per the **Status Posts & Actions** rule, with no per-page wiring. Optimistic toggle that reverts on failure and reconciles against the server's authoritative rollups; `aria-pressed` chips; a custom emoji renders as its image and a unicode one (or a remote emoji whose image we could not vouch for) as text; a `+N` overflow once a post collects more chips than a row can usefully carry.
- **`ReactionPicker`** reuses the post-box picker's data layer (`EMOJI_GROUPS`, `searchSystemEmojis`, the instance custom emoji) rather than duplicating an emoji table, and returns a reaction *name* instead of caret text. It loads the custom emoji itself, memoized once per page load — threading them as a prop would touch every surface that renders a post, which is the prop-drilling `AGENTS.md` warns against for instance-wide values.
- A logged-out reader sees existing chips read-only with no picker, and a post with no reactions renders nothing at all for them.
- All calls go through new `lib/client.ts` helpers (`reactToStatus`, `unreactFromStatus`); no component calls `fetch` directly.

## Browser verification

Ran against a throwaway local SQLite database on port 3044 with the sanctioned mock user. Note: `.env.local` is unreadable in this environment, so rather than trust it I passed the local SQLite config **inline**, which wins over `dotenv-flow` — the resolved target was provably `./dev-reactions.sqlite3`.

Verified end to end, signed in as `testuser@localhost:3044`:

1. Reaction rows render on every post (7 add buttons on the timeline); `GET /api/v1/custom_emojis` fires once and returns 200.
2. The picker opens with `aria-expanded="true"` and 30 emoji — screenshot below.
3. Picking one issues `PUT /api/v1/pleroma/statuses/apurl_…/reactions/%F0%9F%98%83` → **200**, and the chip renders as `😃 1` with `aria-pressed="true"` in the "mine" style.
4. The database holds exactly one row: the correct status URL, actor, `name: 😃`, `url: NULL` (unicode).
5. **The chip survives a full page reload** with `me: true` — which is the real proof the new server-side domain hydration works.
6. Toggling the chip off deletes the row (`select count(*)` → 0).
7. A self-reaction creates **no** notification, as designed.

One thing worth recording for anyone repeating this: `scripts/mock/createMockStatuses.ts` seeds statuses with **bare UUID ids** rather than ActivityPub URLs, so `urlToId` cannot round-trip them and any status-addressed API 404s on them — including the pre-existing favourite route. Verification therefore used a post created through the app, which gets a proper `apurl_` id. Not a defect in this PR, but it will bite the next person who tests a status-addressed endpoint against mock data.

I could not attach the screenshots to this description (the Browser pane returned blank captures on the image-heavy timeline, and there is no upload path from the CLI); the picker and chip screenshots were captured locally and the functional evidence above is the substantive verification.

## Verification

`prettier --write .` → `eslint .` (0 errors, 31 pre-existing warnings) → `next build` → `vitest run`: **732 files / 7333 tests green**, including 9 new jsdom tests for the row.

Two existing expectations were updated rather than worked around: the mixin-wiring test now asserts the new `statusReactionDatabase` argument, and `createNote`'s timeline assertion passes because freshly-created statuses now declare `reactions: []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
