### PR TITLE
test: de-flake the heatmap setData assertion

### DIFF
--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -1207,9 +1207,9 @@ describe('FitnessHeatmapView', () => {
       />
     )
 
-    // A gate, not a count assertion — the exact number is captured below. An
-    // exact count inside waitFor can never recover if the extra call lands
-    // before the first poll.
+    // A gate, not a count assertion — the exact number is captured below. Call
+    // counts only ever grow, so an exact count inside waitFor can never recover
+    // if an extra call lands before the count is captured below.
     await waitFor(() => {
       expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalled()
     })
@@ -1347,7 +1347,7 @@ describe('RouteHeatmapMap', () => {
       <RouteHeatmapMap
         heatmap={worldHeatmap({
           updatedAt: 3,
-          // The third point must sit off the straight line between the
+          // The interior point must sit off the straight line between the
           // endpoints: simplifySegmentsToBudget runs Douglas-Peucker at a 1m
           // tolerance, so a collinear point is dropped and the "updated"
           // geometry would be byte-identical to the original.

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -1209,7 +1209,7 @@ describe('FitnessHeatmapView', () => {
 
     // A gate, not a count assertion — the exact number is captured below. Call
     // counts only ever grow, so an exact count inside waitFor can never recover
-    // if an extra call lands before the count is captured below.
+    // if an extra call lands before waitFor's first successful check.
     await waitFor(() => {
       expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalled()
     })
@@ -1338,8 +1338,10 @@ describe('RouteHeatmapMap', () => {
     // Wait for the *initial* push before clearing, not just for the provider
     // label. The label appears in the commit that flips isMapLoaded, while the
     // first setData runs in that commit's passive effect — a later macrotask.
-    // Clearing on the label alone can therefore land between the two, leaving
-    // the initial push to arrive after the clear and inflate every later count.
+    // Clearing on the label alone can therefore land between the two, in which
+    // case the clear silently does nothing and the initial push stays in the
+    // record — which is what made the old exact-count assertion here
+    // unsatisfiable.
     await waitFor(() => expect(setData).toHaveBeenCalled())
     setData.mockClear()
 

--- a/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
+++ b/app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx
@@ -1207,8 +1207,11 @@ describe('FitnessHeatmapView', () => {
       />
     )
 
+    // A gate, not a count assertion — the exact number is captured below. An
+    // exact count inside waitFor can never recover if the extra call lands
+    // before the first poll.
     await waitFor(() => {
-      expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(1)
+      expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalled()
     })
 
     const callsAfterInitialLoad = mockGetFitnessRouteHeatmaps.mock.calls.length
@@ -1245,8 +1248,9 @@ describe('FitnessHeatmapView', () => {
       />
     )
 
+    // A gate, not a count assertion — see the sibling test above.
     await waitFor(() => {
-      expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalledTimes(1)
+      expect(mockGetFitnessRouteHeatmaps).toHaveBeenCalled()
     })
 
     const callsAfterInitialLoad = mockGetFitnessRouteHeatmaps.mock.calls.length
@@ -1331,18 +1335,27 @@ describe('RouteHeatmapMap', () => {
     const { rerender } = render(
       <RouteHeatmapMap heatmap={worldHeatmap()} mapProvider={{ type: 'osm' }} />
     )
-    await screen.findByText('OpenFreeMap')
+    // Wait for the *initial* push before clearing, not just for the provider
+    // label. The label appears in the commit that flips isMapLoaded, while the
+    // first setData runs in that commit's passive effect — a later macrotask.
+    // Clearing on the label alone can therefore land between the two, leaving
+    // the initial push to arrive after the clear and inflate every later count.
+    await waitFor(() => expect(setData).toHaveBeenCalled())
     setData.mockClear()
 
     rerender(
       <RouteHeatmapMap
         heatmap={worldHeatmap({
           updatedAt: 3,
+          // The third point must sit off the straight line between the
+          // endpoints: simplifySegmentsToBudget runs Douglas-Peucker at a 1m
+          // tolerance, so a collinear point is dropped and the "updated"
+          // geometry would be byte-identical to the original.
           segments: [
             {
               points: [
                 { lat: 52.36, lng: 4.88 },
-                { lat: 52.37, lng: 4.89 },
+                { lat: 52.37, lng: 4.91 },
                 { lat: 52.39, lng: 4.91 }
               ]
             }
@@ -1352,7 +1365,28 @@ describe('RouteHeatmapMap', () => {
       />
     )
 
-    await waitFor(() => expect(setData).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(setData).toHaveBeenCalled())
+    // Assert the payload rather than the call count: the point of the test is
+    // that the new geometry reaches the source, and a redundant extra push
+    // would be harmless.
+    expect(setData.mock.lastCall?.[0]).toMatchObject({
+      type: 'FeatureCollection',
+      features: [
+        expect.objectContaining({
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [4.88, 52.36],
+              [4.91, 52.37],
+              [4.91, 52.39]
+            ]
+          }
+        })
+      ]
+    })
+    // …and that it went to the *existing* source: the map is never rebuilt for
+    // an in-place cache update.
+    expect(mapConstructor).toHaveBeenCalledTimes(1)
   })
 
   it('renders an empty route state without loading any map provider', () => {


### PR DESCRIPTION
## Summary

`RouteHeatmapMap > pushes updated geometry to the existing source when the cache changes` is flaky in CI (always **Shard 4 of 4**) and intermittently blocks unrelated PRs:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ app/(timeline)/fitness/heatmap/FitnessHeatmapView.test.tsx:1355:41
```

**The test was wrong, not the component.**

## Root cause

The component's contract is one `setData` per `routeGeoJson` change (`lib/components/fitness/RouteHeatmapMap.tsx:373`). The "second" call is not a redundant re-render — it is the **initial** push, which the test intends to exclude with `setData.mockClear()` but never actually waits for:

- `OpenFreeMap` is rendered in the commit that flips `isMapLoaded`
- the first `setData` runs in that commit's **passive effect** — a later macrotask
- `await screen.findByText('OpenFreeMap')` can resolve between the two

When it does, `mockClear()` clears nothing, both the initial push and the rerender push land afterwards, and the count is permanently 2 — so `waitFor` can only retry until it times out.

Reproduced deterministically by observing the label outside React Testing Library's act drain: `raceAfterFind=0` → `raceAfterSettle=2`.

Evidence it is pre-existing and not caused by any particular change: the same commit SHA (`04583655b`, #1322) produced one passing and one failing CI run. Prior instances: runs `30117916423` and `30107189026`, both Shard 4.

## Second finding: the test never checked the geometry

The fixture's "updated" third point `(52.37, 4.89)` is **exactly collinear** with the endpoints, so `simplifySegmentsToBudget`'s Douglas-Peucker pass at the 1m tolerance dropped it. Dumping both payloads showed them byte-identical:

```
[[4.88,52.36],[4.91,52.39]]   // initial
[[4.88,52.36],[4.91,52.39]]   // "updated"
```

A test named *pushes updated geometry* was asserting only that `setData` fired again — it would have passed while pushing the old geometry.

## Changes

- **Wait for the initial push before clearing** (`waitFor(() => expect(setData).toHaveBeenCalled())`), so the clear can no longer race the effect it is meant to exclude. This is a logical guarantee, not a timing one.
- **Move the third fixture point off the line** so it survives simplification, and assert the **last call's payload** plus `expect(mapConstructor).toHaveBeenCalledTimes(1)` (the update went to the *existing* source, no remount) — instead of counting calls.
- The two sibling `toHaveBeenCalledTimes(1)` assertions inside `waitFor` (the polling tests) have the same shape and both immediately capture the real count afterwards, so they become `toHaveBeenCalled()` gates. The trailing `toHaveBeenCalledTimes(callsAfterInitialLoad)` is a settled assertion outside `waitFor` and is correct as-is — left alone.

No component guard was added: a redundant `setData` would be harmless and idempotent, so exactly-once is not a real invariant worth enforcing.

## Test results

- Replayed the exact CI interleaving against the new structure: `atLabel=0` (raced) yet passes, 5/5
- **20/20** clean runs of the file
- Full gate: `yarn run prettier --write .` → `yarn lint` (0 errors) → `yarn build` → `yarn test` (**731 files, 7324 tests passed**)

## Notes

Test-only change. No migrations, no config, no user-facing behavior, no docs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)