### PR TITLE
fix: stop upscaling stored images to the 4000x4000 cap

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -221,6 +221,18 @@ change doesn't touch.
   is separately `vi.mock`'d. (Some review bots wrongly flag `vi.importMock` as
   non-existent — it is a valid, documented Vitest API.)
 
+## Stored media
+
+- Stored-image resizes go through `STORED_IMAGE_RESIZE_OPTIONS`
+  (`lib/services/medias/constants.ts`), never an inline `{ fit: 'inside' }`.
+  sharp's `fit: 'inside'` **enlarges** by default, so a bare
+  `MAX_WIDTH`/`MAX_HEIGHT` box is an upscale, not a cap — it inflates every
+  stored image below the cap, silently, with no error and no test failure.
+- `original.metaData`/`original.bytes` describe the **uploaded** file, while
+  `thumbnail.*` describes the **stored** WebP (`outputInfo`). Know which one a
+  change reads: only the latter moves when the encode pipeline changes, and only
+  the latter feeds `meta.small`.
+
 ## Docs hygiene
 
 - `docs/` is durable, general-purpose reference only. No implementation plans,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,14 +160,22 @@ Media files (images and video) and fitness files (.fit, .gpx, .tcx) support mult
 - **S3** — Amazon S3
 - **Object storage** — Any S3-compatible service (MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
 
-Uploaded images (originals, thumbnails, and generated fitness route maps) are
-re-encoded to WebP and bounded by a 4000x4000 pixel box. That box is a **cap,
-not a target**: an image already inside it is stored at its own dimensions and
-is never upscaled. Images stored before this became true were enlarged to fill
-the box, so older rows can be several times larger than their source and carry
-dimensions the source never had. They are still served correctly and are left
-as-is — nothing re-encodes them — so an instance's media directory may hold a
-mix of both until those attachments are deleted.
+Every stored image — uploaded originals, their thumbnails, avatars, headers,
+custom emojis, and generated fitness route maps — is re-encoded to WebP and
+bounded by a 4000x4000 pixel box. That box is a **cap, not a target**: an image
+already inside it is stored at its own dimensions and is never upscaled.
+
+Images that predate that rule were enlarged on disk to fill the box. The
+`medias` row was not: `original.metaData` and `original.bytes` are read from the
+uploaded file, so they always described the source. An affected attachment
+therefore **serves a file several times larger than the dimensions and byte
+count it advertises**, and per-account storage usage under-counts it — a query
+for oversized rows will not find these. Only thumbnails recorded the enlarged
+numbers (`thumbnail.metaData`/`thumbnail.bytes`, surfaced as `meta.small`), so
+those over-counted usage instead.
+
+Nothing re-encodes existing media, so an instance's storage keeps both shapes
+until the affected attachments are deleted.
 
 ## Database Schema (Simplified)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,10 +167,13 @@ of the surface the user is on — the same picker can take either.
 **Server-side write** (`saveMedia` / `saveMediaThumbnail` in
 `lib/services/medias/`) re-encodes to WebP and bounds the result by a 4000x4000
 pixel box. That box is a **cap, not a target**: an image already inside it is
-stored at its own dimensions and is never upscaled. This runs for the sync
-upload endpoint, the Mastodon-API multipart avatar/header
-(`PATCH /api/v1/accounts/update_credentials`), custom emojis, and the fitness
-route maps the server generates itself.
+stored at its own dimensions and is never upscaled. This runs whenever the
+server itself holds the bytes: the sync upload endpoint, the Mastodon-API
+multipart avatar/header handler (`PATCH /api/v1/accounts/update_credentials`
+and `PATCH /api/v1/profile`), custom emojis, thumbnail replacement
+(`PUT /api/v1/media/:id`), and the fitness import jobs — which cover both the
+route maps the server generates and the arbitrary-sized activity photos it
+fetches from Strava.
 
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,15 @@ Media files (images and video) and fitness files (.fit, .gpx, .tcx) support mult
 - **S3** — Amazon S3
 - **Object storage** — Any S3-compatible service (MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
 
+Uploaded images (originals, thumbnails, and generated fitness route maps) are
+re-encoded to WebP and bounded by a 4000x4000 pixel box. That box is a **cap,
+not a target**: an image already inside it is stored at its own dimensions and
+is never upscaled. Images stored before this became true were enlarged to fill
+the box, so older rows can be several times larger than their source and carry
+dimensions the source never had. They are still served correctly and are left
+as-is — nothing re-encodes them — so an instance's media directory may hold a
+mix of both until those attachments are deleted.
+
 ## Database Schema (Simplified)
 
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,16 +164,17 @@ An image reaches storage by one of two routes, and only one of them processes
 the bytes. Which route a given upload takes is a property of the mechanism, not
 of the surface the user is on — the same picker can take either.
 
-**Server-side write** (`saveMedia` / `saveMediaThumbnail` in
-`lib/services/medias/`) re-encodes to WebP and bounds the result by a 4000x4000
+**Server-side write** (`saveMedia`, `saveMediaThumbnail` and
+`saveMediaImageRendition` in `lib/services/medias/`) re-encodes the image — WebP
+unless the caller asks for another format — and bounds the result by a 4000x4000
 pixel box. That box is a **cap, not a target**: an image already inside it is
 stored at its own dimensions and is never upscaled. This runs whenever the
 server itself holds the bytes: the sync upload endpoint, the Mastodon-API
 multipart avatar/header handler (`PATCH /api/v1/accounts/update_credentials`
 and `PATCH /api/v1/profile`), custom emojis, thumbnail replacement
-(`PUT /api/v1/media/:id`), and the fitness import jobs — which cover both the
-route maps the server generates and the arbitrary-sized activity photos it
-fetches from Strava.
+(`PUT /api/v1/media/:id`), the JPEG route-map copy the import email points at,
+and the fitness import jobs — which cover both the route maps the server
+generates and the arbitrary-sized activity photos it fetches from Strava.
 
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,28 +160,36 @@ Media files (images and video) and fitness files (.fit, .gpx, .tcx) support mult
 - **S3** — Amazon S3
 - **Object storage** — Any S3-compatible service (MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
 
-Images that the **server** writes — anything through `saveMedia` /
-`saveMediaThumbnail`, which covers avatars, headers, custom emojis, generated
-fitness route maps, and any upload posted to the sync upload endpoint — are
-re-encoded to WebP and bounded by a 4000x4000 pixel box. That box is a **cap,
-not a target**: an image already inside it is stored at its own dimensions and
-is never upscaled.
+An image reaches storage by one of two routes, and only one of them processes
+the bytes. Which route a given upload takes is a property of the mechanism, not
+of the surface the user is on — the same picker can take either.
 
-The **presigned direct-to-S3** path is the exception, and it is what the web
-composer prefers whenever object storage is configured: the browser PUTs
-straight to the bucket, so those bytes are stored exactly as uploaded — original
-format, no re-encode, no server-side dimension cap. The only cap there is the
-browser-side canvas resize in `lib/utils/resizeImage.ts`, which a non-browser
-API client does not run.
+**Server-side write** (`saveMedia` / `saveMediaThumbnail` in
+`lib/services/medias/`) re-encodes to WebP and bounds the result by a 4000x4000
+pixel box. That box is a **cap, not a target**: an image already inside it is
+stored at its own dimensions and is never upscaled. This runs for the sync
+upload endpoint, the Mastodon-API multipart avatar/header
+(`PATCH /api/v1/accounts/update_credentials`), custom emojis, and the fitness
+route maps the server generates itself.
 
-Images that predate that rule were enlarged on disk to fill the box. The
-`medias` row was not: `original.metaData` and `original.bytes` are read from the
-uploaded file, so they always described the source. An affected attachment
-therefore **serves a file several times larger than the dimensions and byte
-count it advertises**, and per-account storage usage under-counts it — a query
-for oversized rows will not find these. Only thumbnails recorded the enlarged
-numbers (`thumbnail.metaData`/`thumbnail.bytes`, surfaced as `meta.small`), so
-those over-counted usage instead.
+**Presigned direct-to-S3** stores the bytes exactly as uploaded — original
+format, no re-encode, no server-side dimension cap — because the browser PUTs
+straight to the bucket. `uploadAttachment` (`lib/client.ts`) tries this first
+and only falls back to the sync endpoint when the instance has no object
+storage, so on an S3/object instance it is what the post composer _and_ the
+Settings/Account avatar and header pickers actually use. The only cap there is
+the browser-side canvas resize in `lib/utils/resizeImage.ts`, which a
+non-browser API client never runs.
+
+Images written by the server-side route before the cap became downscale-only
+were enlarged on disk to fill the box. The `medias` row was not:
+`original.metaData` and `original.bytes` are read from the uploaded file, so
+they always described the source. An affected attachment therefore **serves a
+file several times larger than the dimensions and byte count it advertises**,
+and per-account storage usage under-counts it — a query for oversized rows will
+not find these. Only thumbnails recorded the enlarged numbers
+(`thumbnail.metaData`/`thumbnail.bytes`, surfaced as `meta.small`), so those
+over-counted usage instead.
 
 Nothing re-encodes existing media, so an instance's storage keeps both shapes
 until the affected attachments are deleted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,10 +160,19 @@ Media files (images and video) and fitness files (.fit, .gpx, .tcx) support mult
 - **S3** — Amazon S3
 - **Object storage** — Any S3-compatible service (MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
 
-Every stored image — uploaded originals, their thumbnails, avatars, headers,
-custom emojis, and generated fitness route maps — is re-encoded to WebP and
-bounded by a 4000x4000 pixel box. That box is a **cap, not a target**: an image
-already inside it is stored at its own dimensions and is never upscaled.
+Images that the **server** writes — anything through `saveMedia` /
+`saveMediaThumbnail`, which covers avatars, headers, custom emojis, generated
+fitness route maps, and any upload posted to the sync upload endpoint — are
+re-encoded to WebP and bounded by a 4000x4000 pixel box. That box is a **cap,
+not a target**: an image already inside it is stored at its own dimensions and
+is never upscaled.
+
+The **presigned direct-to-S3** path is the exception, and it is what the web
+composer prefers whenever object storage is configured: the browser PUTs
+straight to the bucket, so those bytes are stored exactly as uploaded — original
+format, no re-encode, no server-side dimension cap. The only cap there is the
+browser-side canvas resize in `lib/utils/resizeImage.ts`, which a non-browser
+API client does not run.
 
 Images that predate that rule were enlarged on disk to fill the box. The
 `medias` row was not: `original.metaData` and `original.bytes` are read from the

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -508,14 +508,14 @@ describe('S3FileStorage saveFile image sizing', () => {
     getFitnessStorageUsageForAccount: vi.fn()
   } as unknown as jest.Mocked<Database>
 
-  // The uploaded WebP, captured off the PutObjectCommand body. The storage
+  // The uploaded WebPs, captured off each PutObjectCommand body. The storage
   // deletes its temp file as soon as `send` resolves, so the stream has to be
   // drained inside the mock.
-  let uploadedBody: Buffer | null
+  let uploadedBodies: Buffer[]
 
   beforeEach(() => {
     vi.clearAllMocks()
-    uploadedBody = null
+    uploadedBodies = []
     ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
       function () {
         return { send } as unknown as S3Client
@@ -527,7 +527,7 @@ describe('S3FileStorage saveFile image sizing', () => {
         for await (const chunk of command.input.Body as Readable) {
           chunks.push(Buffer.from(chunk))
         }
-        uploadedBody = Buffer.concat(chunks)
+        uploadedBodies.push(Buffer.concat(chunks))
         return {}
       }
       throw new Error('Unexpected command')
@@ -568,35 +568,47 @@ describe('S3FileStorage saveFile image sizing', () => {
   }
 
   const readUploadedImage = async () => {
-    expect(uploadedBody).not.toBeNull()
-    return sharp(uploadedBody as Buffer).metadata()
+    expect(uploadedBodies).toHaveLength(1)
+    return sharp(uploadedBodies[0]).metadata()
   }
 
-  // Regression: `fit: 'inside'` enlarges by default, so every image below the
-  // 4000x4000 cap was upscaled to fill it before being uploaded.
-  it('uploads an image below the cap at its original dimensions', async () => {
-    const attachment = await createStorage().saveFile(actor, {
-      file: await createPngFile(800, 600)
+  // Regression: `fit: 'inside'` enlarges by default, so the MAX_WIDTH/MAX_HEIGHT
+  // box was an upscale rather than a cap. Asserting on the uploaded bytes is
+  // what catches it: `original.metaData` is read from the INPUT image, so it
+  // reported the source dimensions either way.
+  it.each([
+    {
+      description: 'uploads an image below the cap at its own dimensions',
+      source: { width: 800, height: 600 },
+      uploaded: { width: 800, height: 600 }
+    },
+    {
+      description: 'scales an image above the cap down to fit',
+      source: { width: MAX_WIDTH + 200, height: (MAX_HEIGHT + 200) / 2 },
+      uploaded: { width: MAX_WIDTH, height: MAX_HEIGHT / 2 }
+    }
+  ])('$description', async ({ source, uploaded }) => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(source.width, source.height)
     })
 
-    await expect(readUploadedImage()).resolves.toMatchObject({
-      width: 800,
-      height: 600
-    })
-    expect(attachment?.meta.original).toMatchObject({
-      width: 800,
-      height: 600
-    })
+    await expect(readUploadedImage()).resolves.toMatchObject(uploaded)
   })
 
-  it('scales an image above the cap down to fit', async () => {
-    await createStorage().saveFile(actor, {
-      file: await createPngFile(MAX_WIDTH + 200, (MAX_HEIGHT + 200) / 2)
-    })
+  // The thumbnail path is where the upscale reached the database: unlike the
+  // original, the returned `metaData`/`bytes` come from `outputInfo` — the
+  // stored WebP — so an upscaled thumbnail was reported as 4000x3000 in the
+  // Mastodon attachment's `meta.small` and charged to the account's quota.
+  it('records the thumbnail dimensions actually uploaded', async () => {
+    const thumbnail = await createStorage().saveThumbnail(
+      actor,
+      await createPngFile(800, 600)
+    )
 
+    expect(thumbnail?.metaData).toEqual({ width: 800, height: 600 })
     await expect(readUploadedImage()).resolves.toMatchObject({
-      width: MAX_WIDTH,
-      height: MAX_HEIGHT / 2
+      width: 800,
+      height: 600
     })
   })
 })

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -11,7 +11,11 @@ import { Readable } from 'stream'
 import { MediaStorageType } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
 import { S3FileStorage } from '@/lib/services/medias/S3StorageFile'
-import { MAX_FILE_SIZE } from '@/lib/services/medias/constants'
+import {
+  MAX_FILE_SIZE,
+  MAX_HEIGHT,
+  MAX_WIDTH
+} from '@/lib/services/medias/constants'
 import { getMaxMediaUploadSize } from '@/lib/services/medias/uploadSizeLimit'
 import { Actor } from '@/lib/types/domain/actor'
 import { StreamByteLimitError } from '@/lib/utils/streamLimit'
@@ -491,5 +495,108 @@ describe('S3FileStorage image output format', () => {
       url: `https://llun.test/api/v1/files/${putObjectInput().Key}`
     })
     expect(database.createMedia).not.toHaveBeenCalled()
+  })
+})
+
+describe('S3FileStorage saveFile image sizing', () => {
+  const send = vi.fn()
+  const actor = { id: 'actor-1' } as Actor
+  const database = {
+    createMedia: vi.fn(),
+    getActorFromId: vi.fn(),
+    getStorageUsageForAccount: vi.fn(),
+    getFitnessStorageUsageForAccount: vi.fn()
+  } as unknown as jest.Mocked<Database>
+
+  // The uploaded WebP, captured off the PutObjectCommand body. The storage
+  // deletes its temp file as soon as `send` resolves, so the stream has to be
+  // drained inside the mock.
+  let uploadedBody: Buffer | null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    uploadedBody = null
+    ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+      function () {
+        return { send } as unknown as S3Client
+      }
+    )
+    send.mockImplementation(async (command) => {
+      if (command instanceof PutObjectCommand) {
+        const chunks: Buffer[] = []
+        for await (const chunk of command.input.Body as Readable) {
+          chunks.push(Buffer.from(chunk))
+        }
+        uploadedBody = Buffer.concat(chunks)
+        return {}
+      }
+      throw new Error('Unexpected command')
+    })
+    database.getActorFromId.mockResolvedValue({
+      id: 'actor-1',
+      account: { id: 'account-1' }
+    } as never)
+    database.getStorageUsageForAccount.mockResolvedValue(0)
+    database.getFitnessStorageUsageForAccount.mockResolvedValue(0)
+    database.createMedia.mockImplementation((async (params: unknown) => ({
+      id: 'media-1',
+      ...(params as object)
+    })) as never)
+  })
+
+  const createStorage = () =>
+    new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+  const createPngFile = async (width: number, height: number) => {
+    const buffer = await sharp({
+      create: { width, height, channels: 3, background: '#3366cc' }
+    })
+      .png()
+      .toBuffer()
+    return new File([new Uint8Array(buffer)], 'route-map.png', {
+      type: 'image/png'
+    })
+  }
+
+  const readUploadedImage = async () => {
+    expect(uploadedBody).not.toBeNull()
+    return sharp(uploadedBody as Buffer).metadata()
+  }
+
+  // Regression: `fit: 'inside'` enlarges by default, so every image below the
+  // 4000x4000 cap was upscaled to fill it before being uploaded.
+  it('uploads an image below the cap at its original dimensions', async () => {
+    const attachment = await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600)
+    })
+
+    await expect(readUploadedImage()).resolves.toMatchObject({
+      width: 800,
+      height: 600
+    })
+    expect(attachment?.meta.original).toMatchObject({
+      width: 800,
+      height: 600
+    })
+  })
+
+  it('scales an image above the cap down to fit', async () => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(MAX_WIDTH + 200, (MAX_HEIGHT + 200) / 2)
+    })
+
+    await expect(readUploadedImage()).resolves.toMatchObject({
+      width: MAX_WIDTH,
+      height: MAX_HEIGHT / 2
+    })
   })
 })

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -17,9 +17,9 @@ import sharp from 'sharp'
 import { MediaStorageS3Config } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
 import {
-  IMAGE_RESIZE_OPTIONS,
   MAX_HEIGHT,
-  MAX_WIDTH
+  MAX_WIDTH,
+  STORED_IMAGE_RESIZE_OPTIONS
 } from '@/lib/services/medias/constants'
 import { MediaValidationError } from '@/lib/services/medias/errors'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
@@ -583,7 +583,7 @@ export class S3FileStorage implements MediaStorage {
 
     const resizedImage = encodeImageOutput(
       sharp(buffer)
-        .resize(MAX_WIDTH, MAX_HEIGHT, IMAGE_RESIZE_OPTIONS)
+        .resize(MAX_WIDTH, MAX_HEIGHT, STORED_IMAGE_RESIZE_OPTIONS)
         .rotate(),
       imageFormat
     )

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -16,7 +16,11 @@ import sharp from 'sharp'
 
 import { MediaStorageS3Config } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
-import { MAX_HEIGHT, MAX_WIDTH } from '@/lib/services/medias/constants'
+import {
+  IMAGE_RESIZE_OPTIONS,
+  MAX_HEIGHT,
+  MAX_WIDTH
+} from '@/lib/services/medias/constants'
 import { MediaValidationError } from '@/lib/services/medias/errors'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
 import { extractVideoMeta } from '@/lib/services/medias/extractVideoMeta'
@@ -578,7 +582,9 @@ export class S3FileStorage implements MediaStorage {
     const { extension, contentType } = getImageOutputFormatDetail(imageFormat)
 
     const resizedImage = encodeImageOutput(
-      sharp(buffer).resize(MAX_WIDTH, MAX_HEIGHT, { fit: 'inside' }).rotate(),
+      sharp(buffer)
+        .resize(MAX_WIDTH, MAX_HEIGHT, IMAGE_RESIZE_OPTIONS)
+        .rotate(),
       imageFormat
     )
 

--- a/lib/services/medias/constants.ts
+++ b/lib/services/medias/constants.ts
@@ -19,7 +19,7 @@ export const MAX_HEIGHT = 4000
 // 800x600 route map (39 KB PNG) was stored as a 4000x3000 WebP of 271 KB, a
 // size no surface ever displays. Matches `lib/utils/resizeImage.ts`, which the
 // browser upload path already applies as a downscale-only cap.
-export const IMAGE_RESIZE_OPTIONS = {
+export const STORED_IMAGE_RESIZE_OPTIONS = {
   fit: 'inside',
   withoutEnlargement: true
 } as const

--- a/lib/services/medias/constants.ts
+++ b/lib/services/medias/constants.ts
@@ -9,6 +9,21 @@ export const MAX_CONFIGURABLE_FILE_SIZE = 1_073_741_824
 export const MAX_ATTACHMENTS = 10
 export const MAX_WIDTH = 4000
 export const MAX_HEIGHT = 4000
+
+// sharp resize options shared by every stored-image pipeline (LocalFileStorage
+// and S3FileStorage), kept in one place so the two cannot drift apart.
+//
+// `withoutEnlargement` is load-bearing: sharp's `fit: 'inside'` ENLARGES by
+// default, so without it the MAX_WIDTH/MAX_HEIGHT box stops being a cap and
+// becomes an upscale — every image below 4000x4000 was blown up to fill it. An
+// 800x600 route map (39 KB PNG) was stored as a 4000x3000 WebP of 271 KB, a
+// size no surface ever displays. Matches `lib/utils/resizeImage.ts`, which the
+// browser upload path already applies as a downscale-only cap.
+export const IMAGE_RESIZE_OPTIONS = {
+  fit: 'inside',
+  withoutEnlargement: true
+} as const
+
 // Default quota per account is 1GB (1,073,741,824 bytes)
 export const DEFAULT_QUOTA_PER_ACCOUNT = 1_073_741_824
 

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -268,39 +268,69 @@ describe('LocalFileStorage.saveFile image sizing', () => {
     })
   }
 
-  const readStoredImage = async () => {
+  // Thumbnails are written alongside the original as `<prefix>-thumbnail.webp`,
+  // so each helper has to pick out the file it means.
+  const readStored = async (kind: 'original' | 'thumbnail') => {
     const files = await fs.readdir(mediaRoot)
-    expect(files).toHaveLength(1)
-    return sharp(await fs.readFile(path.join(mediaRoot, files[0]))).metadata()
+    const match = files.find(
+      (file) => file.endsWith('-thumbnail.webp') === (kind === 'thumbnail')
+    )
+    if (!match) throw new Error(`No stored ${kind} in [${files.join(', ')}]`)
+    return sharp(await fs.readFile(path.join(mediaRoot, match))).metadata()
   }
 
-  // Regression: `fit: 'inside'` enlarges by default, so every image below the
-  // 4000x4000 cap was upscaled to fill it — an 800x600 route map was stored as
-  // a 4000x3000 WebP roughly 7x the source's bytes, and no surface ever
-  // displayed it at that size.
-  it('stores an image below the cap at its original dimensions', async () => {
-    const attachment = await createStorage().saveFile(actor, {
-      file: await createPngFile(800, 600)
+  const readStoredImage = () => readStored('original')
+
+  // Regression: `fit: 'inside'` enlarges by default, so the MAX_WIDTH/MAX_HEIGHT
+  // box was an upscale rather than a cap — an 800x600 route map was stored as a
+  // 4000x3000 WebP, at a size no surface ever displays. Asserting on the bytes
+  // actually written is what catches it: `original.metaData` is read from the
+  // INPUT image, so it reported 800x600 either way.
+  it.each([
+    {
+      description: 'stores an image below the cap at its own dimensions',
+      source: { width: 800, height: 600 },
+      stored: { width: 800, height: 600 }
+    },
+    {
+      description: 'scales an image above the cap down to fit',
+      source: { width: MAX_WIDTH + 200, height: (MAX_HEIGHT + 200) / 2 },
+      stored: { width: MAX_WIDTH, height: MAX_HEIGHT / 2 }
+    }
+  ])('$description', async ({ source, stored }) => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(source.width, source.height)
     })
 
-    await expect(readStoredImage()).resolves.toMatchObject({
-      width: 800,
-      height: 600
-    })
-    expect(attachment?.meta.original).toMatchObject({
+    await expect(readStoredImage()).resolves.toMatchObject(stored)
+  })
+
+  // The thumbnail path is where the upscale reached the database: unlike the
+  // original, `thumbnail.metaData`/`bytes` come from `outputInfo` — the stored
+  // WebP — so an upscaled thumbnail was reported as 4000x3000 in the Mastodon
+  // attachment's `meta.small` and charged to the account's storage quota.
+  it('records the thumbnail dimensions actually stored', async () => {
+    const thumbnail = await createStorage().saveThumbnail(
+      actor,
+      await createPngFile(800, 600)
+    )
+
+    expect(thumbnail?.metaData).toEqual({ width: 800, height: 600 })
+    await expect(readStored('thumbnail')).resolves.toMatchObject({
       width: 800,
       height: 600
     })
   })
 
-  it('scales an image above the cap down to fit', async () => {
-    await createStorage().saveFile(actor, {
-      file: await createPngFile(MAX_WIDTH + 200, (MAX_HEIGHT + 200) / 2)
+  it('reports the stored thumbnail as meta.small on the attachment', async () => {
+    const attachment = await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600),
+      thumbnail: await createPngFile(400, 300)
     })
 
-    await expect(readStoredImage()).resolves.toMatchObject({
-      width: MAX_WIDTH,
-      height: MAX_HEIGHT / 2
+    expect(attachment?.meta.small).toMatchObject({
+      width: 400,
+      height: 300
     })
   })
 })

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -7,6 +7,7 @@ import { MediaStorageType } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 
+import { MAX_HEIGHT, MAX_WIDTH } from './constants'
 import { MediaValidationError } from './errors'
 import { LocalFileStorage } from './localFile'
 
@@ -208,5 +209,98 @@ describe('LocalFileStorage image output format', () => {
       createStorage().saveImageRendition(actor, await createPngFile(), 'jpeg')
     ).rejects.toThrow(MediaValidationError)
     expect(await fs.readdir(mediaRoot)).toEqual([])
+  })
+})
+
+describe('LocalFileStorage.saveFile image sizing', () => {
+  let tempDir: string
+  let mediaRoot: string
+
+  const actor = { id: 'actor-1' } as Actor
+
+  const database = {
+    createMedia: vi.fn(),
+    getActorFromId: vi.fn(),
+    getStorageUsageForAccount: vi.fn(),
+    getFitnessStorageUsageForAccount: vi.fn()
+  } as unknown as jest.Mocked<Database>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'activities-media-'))
+    mediaRoot = path.join(tempDir, 'media')
+    await fs.mkdir(mediaRoot)
+
+    database.getActorFromId.mockResolvedValue({
+      id: 'actor-1',
+      account: { id: 'account-1' }
+    } as never)
+    database.getStorageUsageForAccount.mockResolvedValue(0)
+    database.getFitnessStorageUsageForAccount.mockResolvedValue(0)
+    database.createMedia.mockImplementation((async (params: unknown) => ({
+      id: 'media-1',
+      ...(params as object)
+    })) as never)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  const createStorage = () =>
+    new LocalFileStorage(
+      {
+        type: MediaStorageType.LocalFile,
+        path: mediaRoot
+      },
+      'llun.test',
+      database
+    )
+
+  const createPngFile = async (width: number, height: number) => {
+    const buffer = await sharp({
+      create: { width, height, channels: 3, background: '#3366cc' }
+    })
+      .png()
+      .toBuffer()
+    return new File([new Uint8Array(buffer)], 'route-map.png', {
+      type: 'image/png'
+    })
+  }
+
+  const readStoredImage = async () => {
+    const files = await fs.readdir(mediaRoot)
+    expect(files).toHaveLength(1)
+    return sharp(await fs.readFile(path.join(mediaRoot, files[0]))).metadata()
+  }
+
+  // Regression: `fit: 'inside'` enlarges by default, so every image below the
+  // 4000x4000 cap was upscaled to fill it — an 800x600 route map was stored as
+  // a 4000x3000 WebP roughly 7x the source's bytes, and no surface ever
+  // displayed it at that size.
+  it('stores an image below the cap at its original dimensions', async () => {
+    const attachment = await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600)
+    })
+
+    await expect(readStoredImage()).resolves.toMatchObject({
+      width: 800,
+      height: 600
+    })
+    expect(attachment?.meta.original).toMatchObject({
+      width: 800,
+      height: 600
+    })
+  })
+
+  it('scales an image above the cap down to fit', async () => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(MAX_WIDTH + 200, (MAX_HEIGHT + 200) / 2)
+    })
+
+    await expect(readStoredImage()).resolves.toMatchObject({
+      width: MAX_WIDTH,
+      height: MAX_HEIGHT / 2
+    })
   })
 })

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -10,7 +10,7 @@ import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 
-import { MAX_HEIGHT, MAX_WIDTH } from './constants'
+import { IMAGE_RESIZE_OPTIONS, MAX_HEIGHT, MAX_WIDTH } from './constants'
 import { MediaValidationError } from './errors'
 import { extractVideoImage } from './extractVideoImage'
 import { extractVideoMeta } from './extractVideoMeta'
@@ -291,7 +291,7 @@ export class LocalFileStorage implements MediaStorage {
     const filePath = path.resolve(process.cwd(), uploadPath, filename)
     const resizedImage = encodeImageOutput(
       sharp(imageBuffer)
-        .resize(MAX_WIDTH, MAX_HEIGHT, { fit: 'inside' })
+        .resize(MAX_WIDTH, MAX_HEIGHT, IMAGE_RESIZE_OPTIONS)
         .rotate(),
       format
     )

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -10,7 +10,7 @@ import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 import { logger } from '@/lib/utils/logger'
 
-import { IMAGE_RESIZE_OPTIONS, MAX_HEIGHT, MAX_WIDTH } from './constants'
+import { MAX_HEIGHT, MAX_WIDTH, STORED_IMAGE_RESIZE_OPTIONS } from './constants'
 import { MediaValidationError } from './errors'
 import { extractVideoImage } from './extractVideoImage'
 import { extractVideoMeta } from './extractVideoMeta'
@@ -291,7 +291,7 @@ export class LocalFileStorage implements MediaStorage {
     const filePath = path.resolve(process.cwd(), uploadPath, filename)
     const resizedImage = encodeImageOutput(
       sharp(imageBuffer)
-        .resize(MAX_WIDTH, MAX_HEIGHT, IMAGE_RESIZE_OPTIONS)
+        .resize(MAX_WIDTH, MAX_HEIGHT, STORED_IMAGE_RESIZE_OPTIONS)
         .rotate(),
       format
     )


### PR DESCRIPTION
## Summary

`sharp`'s `fit: 'inside'` **enlarges by default** (`withoutEnlargement` is
false), so the image pipeline in both storage drivers

```ts
sharp(buffer).resize(MAX_WIDTH, MAX_HEIGHT, { fit: 'inside' }).rotate()
```

was not applying a 4000×4000 cap — it was an **upscale**. Every image the server
wrote below 4000×4000 was blown up to fill the box.

This adds `withoutEnlargement: true` through a single shared
`STORED_IMAGE_RESIZE_OPTIONS` constant, so the two duplicated call sites
(`lib/services/medias/localFile.ts`, `lib/services/medias/S3StorageFile.ts`)
cannot drift apart again. Images **above** the cap are still scaled down exactly
as before.

Noticed while adding the JPEG twin of the route map for the import email
(#1332), which deliberately kept the twin on the same pipeline rather than
widening that PR's scope.

## Measured impact

Stored WebP for representative sources, before vs. after. Measured on detailed,
non-flat content — a flat fill compresses to nothing at any size and would
understate this badly:

| Source | Before | After | Ratio |
| --- | --- | --- | --- |
| 64×64 custom emoji | 4000×4000, 1,040,740 B | 64×64, 4,144 B | 251× |
| 400×400 avatar | 4000×4000, 4,248,906 B | 400×400, 133,998 B | 32× |
| 800×600 route map | 4000×3000, 276,096 B | 800×600, 11,862 B | 23× |
| 1600×1200 photo | 4000×3000, 2,862,224 B | 1600×1200, 1,546,542 B | 1.9× |
| 3024×4032 photo (over the cap) | 3000×4000, unchanged | 3000×4000, unchanged | 1× |

## Scope: which uploads this affects

Only the **server-side write** path (`saveMedia` / `saveMediaThumbnail`) runs
sharp at all. That covers the sync upload endpoint, the Mastodon-API multipart
avatar/header handler, custom emojis, thumbnail replacement, and the fitness
import jobs — both the route maps the server generates and the arbitrary-sized
activity photos pulled from Strava.

The **presigned direct-to-S3** path never touched sharp and is unchanged. On an
object-storage instance that is what the web composer and the Settings/Account
image pickers actually use, so this fix does not reach them. `docs/architecture.md`
now documents that split, since it was not written down anywhere.

## Behaviour changes

- **New uploads on the server-side path** are stored at their own dimensions
  when they fit the cap.
- **Thumbnails** (`saveThumbnail`, and `saveFile` with a thumbnail) record
  `bytes`/`metaData` from `outputInfo` — the real stored file — so `meta.small`
  stops reporting upscaled dimensions and the per-account quota counter stops
  being charged for them.
- **`meta.original` is unchanged.** It is read from the *input* image, so it
  always reported the source dimensions. What changes is that the stored file
  now agrees with it.
- **Existing stored media is untouched.** Nothing re-encodes it. Re-encoding
  stored user media would rewrite paths, bytes and the quota counter for no
  display benefit, so this PR does not attempt it. Note the recorded row was
  never inflated for originals — only the file on disk was — so an affected
  attachment serves a file several times larger than the size it advertises, and
  a query for oversized rows will not find it. That is now written down in
  `docs/architecture.md`.

## Tests

New regression tests drive both storage drivers end to end and assert the
**actual stored bytes**, not the recorded metadata — the local driver reads the
file back out of its media root, the S3 driver drains the `PutObjectCommand`
body. Coverage per driver: below-cap (stored at source dimensions), above-cap
(still scaled down to fit), and the thumbnail path, which is where the upscale
reached the database.

All five below-cap assertions fail without `withoutEnlargement`, with the exact
upscale signature (`4000x3000` where `800x600` is expected). The two above-cap
cases stay green, so they independently guard the cap itself.

No pre-existing test asserted post-resize dimensions, so nothing else needed
updating.

## Verification

- [x] `yarn run prettier --write .`
- [x] `yarn lint` — 0 errors (31 pre-existing warnings, none in touched files)
- [x] `yarn build`
- [x] `yarn test` — 732 files, 7376 tests passing

No UI change, so no screenshots: this alters bytes on disk, not rendering.

## Follow-ups (deliberately not in this PR)

- `medias.original.bytes` is the **input file's** size while the stored file is
  the re-encoded WebP, so the quota counter for originals has never matched
  actual disk usage in either direction.
- `medias.original.metaData` is read from the input image, so an upload **above**
  the cap still reports pre-downscale dimensions (an 8000×4000 upload stores
  4000×2000 but reports 8000×4000). The thumbnail path already uses `outputInfo`
  for exactly this reason.
- `saveMedia` in `lib/services/medias/index.ts` omits `MediaStorageType.S3Storage`
  from its switch and returns `null` for it, unlike every other function in that
  file. On an instance configured with the documented `s3` type, every
  server-side image save silently no-ops.
- `S3FileStorage.saveFile`'s image branch ignores `media.thumbnail` entirely,
  while `LocalFileStorage` handles it — a client-supplied thumbnail is dropped on
  object storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
