### PR TITLE
Bump version to v1.120.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.120.0",
+  "version": "1.120.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.120.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.120.0`
- Base main SHA: `f4150168e6a58696cca2be4787f1161bbcb5c9f6`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
