### PR TITLE
Bump version to v1.121.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.120.1",
+  "version": "1.121.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.121.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.120.1`
- Base main SHA: `0ff4ba305aa3e96fdf312db693244666f14f02bc`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
