### PR TITLE
fix: save media on s3 storage type

### DIFF
--- a/lib/services/medias/index.test.ts
+++ b/lib/services/medias/index.test.ts
@@ -8,16 +8,6 @@ import * as mediaStorageService from './index'
 import * as LocalFileStorage from './localFile'
 import { MediaSchema, PresigedMediaInput } from './types'
 
-const {
-  completePresignedMediaUpload,
-  deleteMediaFile,
-  getMedia,
-  getPresignedUrl,
-  saveMedia,
-  saveMediaImageRendition,
-  saveMediaThumbnail
-} = mediaStorageService
-
 vi.mock('@/lib/config')
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
@@ -113,77 +103,87 @@ const S3_STORAGE_TYPES = [
 const NON_DELEGATING_EXPORTS = ['PresignedUploadValidationError']
 
 interface MediaStorageFunctionCase {
-  name: string
+  name: keyof typeof mediaStorageService
   /** Method on the resolved storage driver the function must delegate to. */
   method: keyof StorageMock
-  expectedArguments: unknown[]
+  /**
+   * Arguments after `database`. Every function in this module hands these
+   * straight to its driver method, so the harness both invokes the export with
+   * them and asserts the driver received them. A future function that reshapes
+   * its arguments fails loudly here rather than needing a silent second field.
+   */
+  callArguments: unknown[]
   /** Storage types the function delegates for; the rest fall back. */
   supportedTypes: MediaStorageType[]
   /** Value returned when no driver handles the configured storage type. */
   fallbackValue: null | false
-  call: () => Promise<unknown>
 }
 
 const MEDIA_STORAGE_FUNCTIONS: MediaStorageFunctionCase[] = [
   {
     name: 'saveMedia',
     method: 'saveFile',
-    expectedArguments: [actor, media],
+    callArguments: [actor, media],
     supportedTypes: ALL_STORAGE_TYPES,
-    fallbackValue: null,
-    call: () => saveMedia(mockDatabase, actor, media)
+    fallbackValue: null
   },
   {
     name: 'saveMediaThumbnail',
     method: 'saveThumbnail',
-    expectedArguments: [actor, file],
+    callArguments: [actor, file],
     supportedTypes: ALL_STORAGE_TYPES,
-    fallbackValue: null,
-    call: () => saveMediaThumbnail(mockDatabase, actor, file)
+    fallbackValue: null
   },
   {
     name: 'saveMediaImageRendition',
     method: 'saveImageRendition',
-    expectedArguments: [actor, file, 'jpeg'],
+    callArguments: [actor, file, 'jpeg'],
     supportedTypes: ALL_STORAGE_TYPES,
-    fallbackValue: null,
-    call: () => saveMediaImageRendition(mockDatabase, actor, file, 'jpeg')
+    fallbackValue: null
   },
   {
     name: 'getPresignedUrl',
     method: 'getPresigedForSaveFileUrl',
-    expectedArguments: [actor, presignedInput],
+    callArguments: [actor, presignedInput],
     // Presigned uploads go straight to the bucket, so local file storage has
     // nothing to sign.
     supportedTypes: S3_STORAGE_TYPES,
-    fallbackValue: null,
-    call: () => getPresignedUrl(mockDatabase, actor, presignedInput)
+    fallbackValue: null
   },
   {
     name: 'completePresignedMediaUpload',
     method: 'completePresignedUpload',
-    expectedArguments: [actor, 'media-1'],
+    callArguments: [actor, 'media-1'],
     supportedTypes: S3_STORAGE_TYPES,
-    fallbackValue: null,
-    call: () => completePresignedMediaUpload(mockDatabase, actor, 'media-1')
+    fallbackValue: null
   },
   {
     name: 'getMedia',
     method: 'getFile',
-    expectedArguments: ['medias/test.jpg'],
+    callArguments: ['medias/test.jpg'],
     supportedTypes: ALL_STORAGE_TYPES,
-    fallbackValue: null,
-    call: () => getMedia(mockDatabase, 'medias/test.jpg')
+    fallbackValue: null
   },
   {
     name: 'deleteMediaFile',
     method: 'deleteFile',
-    expectedArguments: ['medias/test.jpg'],
+    callArguments: ['medias/test.jpg'],
     supportedTypes: ALL_STORAGE_TYPES,
-    fallbackValue: false,
-    call: () => deleteMediaFile(mockDatabase, 'medias/test.jpg')
+    fallbackValue: false
   }
 ]
+
+/**
+ * Invokes the live export named by the row. Looking the function up by `name`
+ * rather than capturing it in a per-row closure is what keeps a copy-pasted row
+ * honest: a row labelled one function cannot end up exercising another.
+ */
+const invoke = (mediaFunction: MediaStorageFunctionCase) => {
+  const exported = mediaStorageService[mediaFunction.name] as (
+    ...args: unknown[]
+  ) => Promise<unknown>
+  return exported(mockDatabase, ...mediaFunction.callArguments)
+}
 
 const configureStorage = (mediaStorage: unknown) => {
   mockGetConfig.mockReturnValue({
@@ -212,10 +212,10 @@ describe('Media Storage Service', () => {
   })
 
   // The delegation matrix below only protects what it enumerates, and an
-  // `it.each([])` registers zero tests without failing. Without these guards the
-  // matrix can silently shrink: dropping a STORAGE_CONFIGS entry, adding a
-  // fourth MediaStorageType, or exporting an eighth function all leave a green
-  // suite that no longer covers the case this file exists to catch.
+  // `it.each([])` registers zero tests without failing, so the matrix can
+  // silently shrink: exporting an eighth function, dropping a STORAGE_CONFIGS
+  // entry, or adding a fourth MediaStorageType would each leave a green suite
+  // that no longer covers the case this file exists to catch.
   describe('matrix coverage', () => {
     it('describes every function exported from the module', () => {
       const exported = Object.keys(mediaStorageService).filter(
@@ -237,12 +237,14 @@ describe('Media Storage Service', () => {
       expect(exercised.sort()).toEqual(Object.values(MediaStorageType).sort())
     })
 
-    it('declares at least one supported storage type per function', () => {
-      const withoutSupportedTypes = MEDIA_STORAGE_FUNCTIONS.filter(
-        (mediaFunction) => mediaFunction.supportedTypes.length === 0
-      ).map((mediaFunction) => mediaFunction.name)
-
-      expect(withoutSupportedTypes).toEqual([])
+    // Without this, a new enum member is auto-classified as unsupported: adding
+    // it to STORAGE_CONFIGS alone turns the previous guard green again while
+    // every function merely asserts that returning null for it is correct —
+    // which is precisely the silent-null bug this file exists to catch.
+    it('treats every configurable storage type as supported by default', () => {
+      expect([...ALL_STORAGE_TYPES].sort()).toEqual(
+        Object.values(MediaStorageType).sort()
+      )
     })
   })
 
@@ -267,7 +269,7 @@ describe('Media Storage Service', () => {
           : S3FileStorage.S3FileStorage.getStorage
       expectedStorage[mediaFunction.method].mockResolvedValue(DELEGATED_RESULT)
 
-      const result = await mediaFunction.call()
+      const result = await invoke(mediaFunction)
 
       expect(result).toBe(DELEGATED_RESULT)
       expect(expectedGetStorage).toHaveBeenCalledWith(
@@ -276,7 +278,7 @@ describe('Media Storage Service', () => {
         mockDatabase
       )
       expect(expectedStorage[mediaFunction.method]).toHaveBeenCalledWith(
-        ...mediaFunction.expectedArguments
+        ...mediaFunction.callArguments
       )
       expect(otherStorage[mediaFunction.method]).not.toHaveBeenCalled()
     })
@@ -287,7 +289,7 @@ describe('Media Storage Service', () => {
         async (storage) => {
           configureStorage(storage.mediaStorage)
 
-          const result = await mediaFunction.call()
+          const result = await invoke(mediaFunction)
 
           expect(result).toBe(mediaFunction.fallbackValue)
           expect(localStorageMock[mediaFunction.method]).not.toHaveBeenCalled()
@@ -299,7 +301,7 @@ describe('Media Storage Service', () => {
     it('returns the fallback value when no storage is configured', async () => {
       configureStorage(undefined)
 
-      const result = await mediaFunction.call()
+      const result = await invoke(mediaFunction)
 
       expect(result).toBe(mediaFunction.fallbackValue)
       expect(localStorageMock[mediaFunction.method]).not.toHaveBeenCalled()
@@ -315,7 +317,10 @@ describe('Media Storage Service', () => {
     it('returns false when the driver reports the deletion failed', async () => {
       localStorageMock.deleteFile.mockResolvedValue(false)
 
-      const result = await deleteMediaFile(mockDatabase, 'medias/test.jpg')
+      const result = await mediaStorageService.deleteMediaFile(
+        mockDatabase,
+        'medias/test.jpg'
+      )
 
       expect(result).toBe(false)
       // Without this the assertion above cannot tell a driver that returned
@@ -328,7 +333,10 @@ describe('Media Storage Service', () => {
     it('passes the path through unchanged', async () => {
       localStorageMock.deleteFile.mockResolvedValue(true)
 
-      await deleteMediaFile(mockDatabase, 'medias/file with spaces.jpg')
+      await mediaStorageService.deleteMediaFile(
+        mockDatabase,
+        'medias/file with spaces.jpg'
+      )
 
       expect(localStorageMock.deleteFile).toHaveBeenCalledWith(
         'medias/file with spaces.jpg'

--- a/lib/services/medias/index.test.ts
+++ b/lib/services/medias/index.test.ts
@@ -4,7 +4,11 @@ import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 
 import * as S3FileStorage from './S3StorageFile'
-import {
+import * as mediaStorageService from './index'
+import * as LocalFileStorage from './localFile'
+import { MediaSchema, PresigedMediaInput } from './types'
+
+const {
   completePresignedMediaUpload,
   deleteMediaFile,
   getMedia,
@@ -12,9 +16,7 @@ import {
   saveMedia,
   saveMediaImageRendition,
   saveMediaThumbnail
-} from './index'
-import * as LocalFileStorage from './localFile'
-import { MediaSchema, PresigedMediaInput } from './types'
+} = mediaStorageService
 
 vi.mock('@/lib/config')
 vi.mock('@/lib/utils/logger', () => ({
@@ -105,6 +107,10 @@ const S3_STORAGE_TYPES = [
   MediaStorageType.S3Storage,
   MediaStorageType.ObjectStorage
 ]
+
+// Re-exported error class rather than a storage-delegating function, so it is
+// the one export the matrix below does not describe.
+const NON_DELEGATING_EXPORTS = ['PresignedUploadValidationError']
 
 interface MediaStorageFunctionCase {
   name: string
@@ -205,6 +211,41 @@ describe('Media Storage Service', () => {
     )
   })
 
+  // The delegation matrix below only protects what it enumerates, and an
+  // `it.each([])` registers zero tests without failing. Without these guards the
+  // matrix can silently shrink: dropping a STORAGE_CONFIGS entry, adding a
+  // fourth MediaStorageType, or exporting an eighth function all leave a green
+  // suite that no longer covers the case this file exists to catch.
+  describe('matrix coverage', () => {
+    it('describes every function exported from the module', () => {
+      const exported = Object.keys(mediaStorageService).filter(
+        (name) => !NON_DELEGATING_EXPORTS.includes(name)
+      )
+
+      expect(exported.sort()).toEqual(
+        MEDIA_STORAGE_FUNCTIONS.map(
+          (mediaFunction) => mediaFunction.name
+        ).sort()
+      )
+    })
+
+    it('exercises every configurable storage type', () => {
+      const exercised = STORAGE_CONFIGS.map(
+        (storage) => storage.mediaStorage.type
+      )
+
+      expect(exercised.sort()).toEqual(Object.values(MediaStorageType).sort())
+    })
+
+    it('declares at least one supported storage type per function', () => {
+      const withoutSupportedTypes = MEDIA_STORAGE_FUNCTIONS.filter(
+        (mediaFunction) => mediaFunction.supportedTypes.length === 0
+      ).map((mediaFunction) => mediaFunction.name)
+
+      expect(withoutSupportedTypes).toEqual([])
+    })
+  })
+
   describe.each(MEDIA_STORAGE_FUNCTIONS)('$name', (mediaFunction) => {
     const supported = STORAGE_CONFIGS.filter((storage) =>
       mediaFunction.supportedTypes.includes(storage.mediaStorage.type)
@@ -277,6 +318,11 @@ describe('Media Storage Service', () => {
       const result = await deleteMediaFile(mockDatabase, 'medias/test.jpg')
 
       expect(result).toBe(false)
+      // Without this the assertion above cannot tell a driver that returned
+      // false from the `default` branch, which returns false too.
+      expect(localStorageMock.deleteFile).toHaveBeenCalledWith(
+        'medias/test.jpg'
+      )
     })
 
     it('passes the path through unchanged', async () => {

--- a/lib/services/medias/index.test.ts
+++ b/lib/services/medias/index.test.ts
@@ -1,22 +1,21 @@
-import { S3Client } from '@aws-sdk/client-s3'
-import { promises as fs } from 'fs'
-
 import { getConfig } from '@/lib/config'
 import { MediaStorageType } from '@/lib/config/mediaStorage'
 import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 
 import * as S3FileStorage from './S3StorageFile'
-import { deleteMediaFile, saveMediaImageRendition } from './index'
+import {
+  completePresignedMediaUpload,
+  deleteMediaFile,
+  getMedia,
+  getPresignedUrl,
+  saveMedia,
+  saveMediaImageRendition,
+  saveMediaThumbnail
+} from './index'
 import * as LocalFileStorage from './localFile'
+import { MediaSchema, PresigedMediaInput } from './types'
 
-vi.mock('fs', () => ({
-  promises: {
-    unlink: vi.fn()
-  }
-}))
-
-vi.mock('@aws-sdk/client-s3')
 vi.mock('@/lib/config')
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
@@ -31,249 +30,263 @@ vi.mock('@/lib/services/medias/localFile')
 vi.mock('@/lib/services/medias/S3StorageFile')
 
 const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
-const mockUnlink = fs.unlink as jest.MockedFunction<typeof fs.unlink>
-const mockS3Send = vi.fn()
-const mockDeleteFile = vi.fn()
-const mockSaveImageRendition = vi.fn()
 
-// Mock the storage getStorage methods
-const mockLocalStorage = {
-  deleteFile: mockDeleteFile,
-  saveImageRendition: mockSaveImageRendition
-}
-const mockS3Storage = {
-  deleteFile: mockDeleteFile,
-  saveImageRendition: mockSaveImageRendition
+const HOST = 'llun.test'
+const DELEGATED_RESULT = { delegated: true }
+
+const mockDatabase = {} as unknown as Database
+const actor = { id: 'actor-1' } as Actor
+const file = new File(['image'], 'image.png', { type: 'image/png' })
+const media = { file } as MediaSchema
+const presignedInput = {
+  fileName: 'image.png',
+  checksum: 'a'.repeat(40),
+  width: 100,
+  height: 100,
+  contentType: 'image/png',
+  size: 1024
+} as PresigedMediaInput
+
+const createStorageMock = () => ({
+  isPresigedSupported: vi.fn(),
+  saveFile: vi.fn(),
+  saveThumbnail: vi.fn(),
+  saveImageRendition: vi.fn(),
+  getPresigedForSaveFileUrl: vi.fn(),
+  completePresignedUpload: vi.fn(),
+  getFile: vi.fn(),
+  deleteFile: vi.fn()
+})
+type StorageMock = ReturnType<typeof createStorageMock>
+
+let localStorageMock: StorageMock
+let s3StorageMock: StorageMock
+
+/**
+ * Every storage type an operator can configure. `saveMedia` used to omit the
+ * 's3' case and silently returned null on every save — avatars, custom emojis
+ * and fitness route maps all disappeared without an error — so the delegation
+ * matrix below runs each exported function against all three types rather than
+ * trusting one representative.
+ */
+const STORAGE_CONFIGS = [
+  {
+    description: 'local file storage',
+    driver: 'local' as const,
+    mediaStorage: { type: MediaStorageType.LocalFile, path: '/tmp/media' }
+  },
+  {
+    description: 's3 storage',
+    driver: 's3' as const,
+    mediaStorage: {
+      type: MediaStorageType.S3Storage,
+      bucket: 'test-bucket',
+      region: 'us-west-2'
+    }
+  },
+  {
+    description: 'object storage',
+    driver: 's3' as const,
+    mediaStorage: {
+      type: MediaStorageType.ObjectStorage,
+      bucket: 'test-bucket',
+      region: 'us-east-1',
+      endpoint: 'https://s3.example.com'
+    }
+  }
+]
+
+const ALL_STORAGE_TYPES = [
+  MediaStorageType.LocalFile,
+  MediaStorageType.S3Storage,
+  MediaStorageType.ObjectStorage
+]
+const S3_STORAGE_TYPES = [
+  MediaStorageType.S3Storage,
+  MediaStorageType.ObjectStorage
+]
+
+interface MediaStorageFunctionCase {
+  name: string
+  /** Method on the resolved storage driver the function must delegate to. */
+  method: keyof StorageMock
+  expectedArguments: unknown[]
+  /** Storage types the function delegates for; the rest fall back. */
+  supportedTypes: MediaStorageType[]
+  /** Value returned when no driver handles the configured storage type. */
+  fallbackValue: null | false
+  call: () => Promise<unknown>
 }
 
-vi.spyOn(LocalFileStorage.LocalFileStorage, 'getStorage').mockReturnValue(
-  mockLocalStorage as unknown as ReturnType<
-    typeof LocalFileStorage.LocalFileStorage.getStorage
-  >
-)
-vi.spyOn(S3FileStorage.S3FileStorage, 'getStorage').mockReturnValue(
-  mockS3Storage as unknown as ReturnType<
-    typeof S3FileStorage.S3FileStorage.getStorage
-  >
-)
+const MEDIA_STORAGE_FUNCTIONS: MediaStorageFunctionCase[] = [
+  {
+    name: 'saveMedia',
+    method: 'saveFile',
+    expectedArguments: [actor, media],
+    supportedTypes: ALL_STORAGE_TYPES,
+    fallbackValue: null,
+    call: () => saveMedia(mockDatabase, actor, media)
+  },
+  {
+    name: 'saveMediaThumbnail',
+    method: 'saveThumbnail',
+    expectedArguments: [actor, file],
+    supportedTypes: ALL_STORAGE_TYPES,
+    fallbackValue: null,
+    call: () => saveMediaThumbnail(mockDatabase, actor, file)
+  },
+  {
+    name: 'saveMediaImageRendition',
+    method: 'saveImageRendition',
+    expectedArguments: [actor, file, 'jpeg'],
+    supportedTypes: ALL_STORAGE_TYPES,
+    fallbackValue: null,
+    call: () => saveMediaImageRendition(mockDatabase, actor, file, 'jpeg')
+  },
+  {
+    name: 'getPresignedUrl',
+    method: 'getPresigedForSaveFileUrl',
+    expectedArguments: [actor, presignedInput],
+    // Presigned uploads go straight to the bucket, so local file storage has
+    // nothing to sign.
+    supportedTypes: S3_STORAGE_TYPES,
+    fallbackValue: null,
+    call: () => getPresignedUrl(mockDatabase, actor, presignedInput)
+  },
+  {
+    name: 'completePresignedMediaUpload',
+    method: 'completePresignedUpload',
+    expectedArguments: [actor, 'media-1'],
+    supportedTypes: S3_STORAGE_TYPES,
+    fallbackValue: null,
+    call: () => completePresignedMediaUpload(mockDatabase, actor, 'media-1')
+  },
+  {
+    name: 'getMedia',
+    method: 'getFile',
+    expectedArguments: ['medias/test.jpg'],
+    supportedTypes: ALL_STORAGE_TYPES,
+    fallbackValue: null,
+    call: () => getMedia(mockDatabase, 'medias/test.jpg')
+  },
+  {
+    name: 'deleteMediaFile',
+    method: 'deleteFile',
+    expectedArguments: ['medias/test.jpg'],
+    supportedTypes: ALL_STORAGE_TYPES,
+    fallbackValue: false,
+    call: () => deleteMediaFile(mockDatabase, 'medias/test.jpg')
+  }
+]
+
+const configureStorage = (mediaStorage: unknown) => {
+  mockGetConfig.mockReturnValue({
+    mediaStorage,
+    host: HOST
+  } as unknown as ReturnType<typeof getConfig>)
+}
 
 describe('Media Storage Service', () => {
-  const mockDatabase = {} as unknown as Database
-
   beforeEach(() => {
     vi.clearAllMocks()
-    mockDeleteFile.mockReset()
-    mockSaveImageRendition.mockReset()
-    ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
-      function () {
-        return {
-          send: mockS3Send
-        } as unknown as S3Client
-      }
+
+    localStorageMock = createStorageMock()
+    s3StorageMock = createStorageMock()
+
+    vi.spyOn(LocalFileStorage.LocalFileStorage, 'getStorage').mockReturnValue(
+      localStorageMock as unknown as ReturnType<
+        typeof LocalFileStorage.LocalFileStorage.getStorage
+      >
+    )
+    vi.spyOn(S3FileStorage.S3FileStorage, 'getStorage').mockReturnValue(
+      s3StorageMock as unknown as ReturnType<
+        typeof S3FileStorage.S3FileStorage.getStorage
+      >
     )
   })
 
-  describe('deleteMediaFile', () => {
-    describe('LocalFile storage', () => {
-      beforeEach(() => {
-        mockGetConfig.mockReturnValue({
-          mediaStorage: {
-            type: MediaStorageType.LocalFile,
-            path: '/tmp/media'
-          },
-          host: 'https://example.com'
-        } as unknown as ReturnType<typeof getConfig>)
-      })
+  describe.each(MEDIA_STORAGE_FUNCTIONS)('$name', (mediaFunction) => {
+    const supported = STORAGE_CONFIGS.filter((storage) =>
+      mediaFunction.supportedTypes.includes(storage.mediaStorage.type)
+    )
+    const unsupported = STORAGE_CONFIGS.filter(
+      (storage) =>
+        !mediaFunction.supportedTypes.includes(storage.mediaStorage.type)
+    )
 
-      it('deletes file from local filesystem', async () => {
-        mockDeleteFile.mockResolvedValue(true)
+    it.each(supported)('delegates to $description', async (storage) => {
+      configureStorage(storage.mediaStorage)
+      const [expectedStorage, otherStorage] =
+        storage.driver === 'local'
+          ? [localStorageMock, s3StorageMock]
+          : [s3StorageMock, localStorageMock]
+      const expectedGetStorage =
+        storage.driver === 'local'
+          ? LocalFileStorage.LocalFileStorage.getStorage
+          : S3FileStorage.S3FileStorage.getStorage
+      expectedStorage[mediaFunction.method].mockResolvedValue(DELEGATED_RESULT)
 
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
+      const result = await mediaFunction.call()
 
-        expect(result).toBe(true)
-        expect(mockDeleteFile).toHaveBeenCalledWith('media/test.jpg')
-      })
-
-      it('returns true when file does not exist (ENOENT)', async () => {
-        mockDeleteFile.mockResolvedValue(true)
-
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
-
-        expect(result).toBe(true)
-        expect(mockDeleteFile).toHaveBeenCalled()
-      })
-
-      it('returns false when deletion fails with other error', async () => {
-        mockDeleteFile.mockResolvedValue(false)
-
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
-
-        expect(result).toBe(false)
-        expect(mockDeleteFile).toHaveBeenCalled()
-      })
-
-      it('handles paths with special characters', async () => {
-        mockDeleteFile.mockResolvedValue(true)
-
-        await deleteMediaFile(mockDatabase, 'media/file with spaces.jpg')
-
-        expect(mockDeleteFile).toHaveBeenCalledWith(
-          'media/file with spaces.jpg'
-        )
-      })
+      expect(result).toBe(DELEGATED_RESULT)
+      expect(expectedGetStorage).toHaveBeenCalledWith(
+        storage.mediaStorage,
+        HOST,
+        mockDatabase
+      )
+      expect(expectedStorage[mediaFunction.method]).toHaveBeenCalledWith(
+        ...mediaFunction.expectedArguments
+      )
+      expect(otherStorage[mediaFunction.method]).not.toHaveBeenCalled()
     })
 
-    describe('S3Storage', () => {
-      beforeEach(() => {
-        mockGetConfig.mockReturnValue({
-          mediaStorage: {
-            type: MediaStorageType.S3Storage,
-            bucket: 'test-bucket',
-            region: 'us-west-2',
-            accessKeyId: 'test-key',
-            secretAccessKey: 'test-secret'
-          },
-          host: 'https://example.com'
-        } as unknown as ReturnType<typeof getConfig>)
-      })
+    if (unsupported.length > 0) {
+      it.each(unsupported)(
+        'returns the fallback value for $description',
+        async (storage) => {
+          configureStorage(storage.mediaStorage)
 
-      it('deletes file from S3', async () => {
-        mockDeleteFile.mockResolvedValue(true)
+          const result = await mediaFunction.call()
 
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
+          expect(result).toBe(mediaFunction.fallbackValue)
+          expect(localStorageMock[mediaFunction.method]).not.toHaveBeenCalled()
+          expect(s3StorageMock[mediaFunction.method]).not.toHaveBeenCalled()
+        }
+      )
+    }
 
-        expect(result).toBe(true)
-        expect(mockDeleteFile).toHaveBeenCalledWith('media/test.jpg')
-      })
+    it('returns the fallback value when no storage is configured', async () => {
+      configureStorage(undefined)
 
-      it('returns true when file does not exist (NoSuchKey)', async () => {
-        mockDeleteFile.mockResolvedValue(true)
+      const result = await mediaFunction.call()
 
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
-
-        expect(result).toBe(true)
-        expect(mockDeleteFile).toHaveBeenCalled()
-      })
-
-      it('returns false when deletion fails with other error', async () => {
-        mockDeleteFile.mockResolvedValue(false)
-
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
-
-        expect(result).toBe(false)
-        expect(mockDeleteFile).toHaveBeenCalled()
-      })
-
-      it('handles paths with special characters', async () => {
-        mockDeleteFile.mockResolvedValue(true)
-
-        await deleteMediaFile(mockDatabase, 'media/file%20with%20spaces.jpg')
-
-        expect(mockDeleteFile).toHaveBeenCalledWith(
-          'media/file%20with%20spaces.jpg'
-        )
-      })
-    })
-
-    describe('ObjectStorage', () => {
-      beforeEach(() => {
-        mockGetConfig.mockReturnValue({
-          mediaStorage: {
-            type: MediaStorageType.ObjectStorage,
-            bucket: 'test-bucket',
-            region: 'us-east-1',
-            endpoint: 'https://s3.example.com',
-            accessKeyId: 'test-key',
-            secretAccessKey: 'test-secret'
-          },
-          host: 'https://example.com'
-        } as unknown as ReturnType<typeof getConfig>)
-      })
-
-      it('deletes file from object storage', async () => {
-        mockDeleteFile.mockResolvedValue(true)
-
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
-
-        expect(result).toBe(true)
-        expect(mockDeleteFile).toHaveBeenCalled()
-      })
-
-      it('returns true when file does not exist', async () => {
-        mockDeleteFile.mockResolvedValue(true)
-
-        const result = await deleteMediaFile(mockDatabase, 'media/test.jpg')
-
-        expect(result).toBe(true)
-      })
-    })
-
-    describe('No storage configured', () => {
-      beforeEach(() => {
-        mockGetConfig.mockReturnValue({
-          host: 'https://example.com'
-        } as unknown as ReturnType<typeof getConfig>)
-      })
-
-      it('returns false when no storage is configured', async () => {
-        const result = await deleteMediaFile(mockDatabase, '/media/test.jpg')
-
-        expect(result).toBe(false)
-        expect(mockUnlink).not.toHaveBeenCalled()
-        expect(mockS3Send).not.toHaveBeenCalled()
-      })
+      expect(result).toBe(mediaFunction.fallbackValue)
+      expect(localStorageMock[mediaFunction.method]).not.toHaveBeenCalled()
+      expect(s3StorageMock[mediaFunction.method]).not.toHaveBeenCalled()
     })
   })
 
-  describe('saveMediaImageRendition', () => {
-    const actor = { id: 'actor-1' } as Actor
-    const file = new File(['png'], 'route-map.png', { type: 'image/png' })
-
-    it.each([
-      {
-        description: 'delegates to local file storage',
-        mediaStorage: { type: MediaStorageType.LocalFile, path: '/tmp/media' }
-      },
-      {
-        description: 'delegates to s3 storage',
-        mediaStorage: { type: MediaStorageType.S3Storage, bucket: 'bucket' }
-      },
-      {
-        description: 'delegates to object storage',
-        mediaStorage: { type: MediaStorageType.ObjectStorage, bucket: 'bucket' }
-      }
-    ])('$description', async ({ mediaStorage }) => {
-      mockGetConfig.mockReturnValue({
-        mediaStorage,
-        host: 'llun.test'
-      } as unknown as ReturnType<typeof getConfig>)
-      mockSaveImageRendition.mockResolvedValue({ path: 'medias/map.jpg' })
-
-      const result = await saveMediaImageRendition(
-        mockDatabase,
-        actor,
-        file,
-        'jpeg'
-      )
-
-      expect(result).toEqual({ path: 'medias/map.jpg' })
-      expect(mockSaveImageRendition).toHaveBeenCalledWith(actor, file, 'jpeg')
+  describe('deleteMediaFile', () => {
+    beforeEach(() => {
+      configureStorage({ type: MediaStorageType.LocalFile, path: '/tmp/media' })
     })
 
-    it('returns null when no storage is configured', async () => {
-      mockGetConfig.mockReturnValue({
-        host: 'llun.test'
-      } as unknown as ReturnType<typeof getConfig>)
+    it('returns false when the driver reports the deletion failed', async () => {
+      localStorageMock.deleteFile.mockResolvedValue(false)
 
-      const result = await saveMediaImageRendition(
-        mockDatabase,
-        actor,
-        file,
-        'jpeg'
+      const result = await deleteMediaFile(mockDatabase, 'medias/test.jpg')
+
+      expect(result).toBe(false)
+    })
+
+    it('passes the path through unchanged', async () => {
+      localStorageMock.deleteFile.mockResolvedValue(true)
+
+      await deleteMediaFile(mockDatabase, 'medias/file with spaces.jpg')
+
+      expect(localStorageMock.deleteFile).toHaveBeenCalledWith(
+        'medias/file with spaces.jpg'
       )
-
-      expect(result).toBeNull()
-      expect(mockSaveImageRendition).not.toHaveBeenCalled()
     })
   })
 })

--- a/lib/services/medias/index.ts
+++ b/lib/services/medias/index.ts
@@ -25,6 +25,7 @@ export const saveMedia = async (
         media
       )
     }
+    case MediaStorageType.S3Storage:
     case MediaStorageType.ObjectStorage: {
       return S3FileStorage.getStorage(mediaStorage, host, database).saveFile(
         actor,


### PR DESCRIPTION
## Summary

`saveMedia`'s switch on `mediaStorage?.type` in `lib/services/medias/index.ts` handled only `MediaStorageType.LocalFile` (`'fs'`) and `MediaStorageType.ObjectStorage` (`'object'`), then fell through to `default: return null`. It omitted `MediaStorageType.S3Storage` (`'s3'`) — a documented, supported value: it appears in `docs/environment-variables.md` and `docs/setup.md`, and `MediaStorageS3Config` in `lib/config/mediaStorage.ts` accepts both `'object'` and `'s3'`.

`saveMedia` was the **only** function in that module with the gap. `saveMediaThumbnail`, `saveMediaImageRendition`, `getPresignedUrl`, `completePresignedMediaUpload`, `getMedia`, and `deleteMediaFile` all list `S3Storage` alongside `ObjectStorage`. I swept the rest of the repo for the same pattern — `lib/services/fitness-files/index.ts`, `scripts/maintenance/cleanupMediaStorage.ts`, and `scripts/backup/productionArchive.ts` all pair the two types correctly.

## Impact

On an instance configured with `ACTIVITIES_MEDIA_STORAGE_TYPE=s3`, every server-side image save silently returned `null`:

- `lib/jobs/processFitnessFileJob.ts` logged `Failed to store generated route map image` and still marked the import `'completed'`, so every fitness post permanently lost its map with no user-visible signal.
- `lib/services/accounts/updateCredentialsHandler.ts` does `if (saved) …`, so an avatar/header change returned HTTP 200 while silently keeping the old image.
- `lib/services/medias/handleSyncMediaUpload.ts` returned a bare 422 "Validation failed" for what was actually a server misconfiguration.
- `app/api/v1/admin/custom_emojis/route.ts` dropped custom emoji uploads.
- `lib/jobs/importStravaArchiveJob.ts`, `lib/jobs/importStravaActivityJob.ts`, and `lib/jobs/regenerateFitnessMapsJob.ts` lost their stored media.

Deployments on `'fs'` or `'object'` were unaffected, which is why this went unnoticed.

## Changes

**`lib/services/medias/index.ts`** — one line, falling through to the same `S3FileStorage` branch as `ObjectStorage`, matching every other function in the file.

**`lib/services/medias/index.test.ts`** — the omission survived because the test file only exercised all three storage types for `deleteMediaFile`. Replaced the duplicated per-storage blocks with a delegation matrix: `describe.each` over all seven exported functions x `it.each` over all three storage types. Each case asserts that the expected driver's `getStorage` was called with `(mediaStorage, host, database)`, that the right method received the right arguments, that the return value passes through, and — the part that catches an omission — that the *other* driver was never touched.

`getPresignedUrl` / `completePresignedMediaUpload` declare only the S3 types as supported, so local file storage is asserted to hit the fallback rather than silently counting as coverage. Each function also gets a no-storage-configured case with its own fallback value (`null`, or `false` for `deleteMediaFile`).

This replaced four hand-duplicated `deleteMediaFile` blocks that were near-identical pass-through assertions against a mocked driver (the "returns true when file does not exist (ENOENT)" case never reached any filesystem). The two genuinely distinct ones — false pass-through and path-unchanged — are kept. The now-unused `fs` and `@aws-sdk/client-s3` mocks went with them, since both storage modules are auto-mocked and neither was ever reachable.

## Verification

Confirmed the new matrix actually catches the bug: stashing the source fix and re-running produces exactly one failure, `saveMedia > delegates to 's3 storage'` — expected `{delegated: true}`, received `null`.

Definition of Done gate, in order:

- `yarn run prettier --write .` — no files changed beyond the two touched
- `yarn lint` — 0 errors (31 pre-existing warnings, none in `medias/`)
- `yarn build` — passed
- `yarn test` — 737 files, 7590 tests, all passing (30 in this file, up from 15)

No docs are made stale — this restores the behavior `docs/environment-variables.md` and `docs/setup.md` already describe. No migration, and no UI change, so no browser verification applies.

Found during review of #1334, which deliberately did not widen its scope; re-verified as still valid after #1332 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)