### PR TITLE
fix: dispatch s3 media storage type in saveMedia

### DIFF
--- a/lib/services/medias/index.test.ts
+++ b/lib/services/medias/index.test.ts
@@ -7,8 +7,9 @@ import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 
 import * as S3FileStorage from './S3StorageFile'
-import { deleteMediaFile, saveMediaImageRendition } from './index'
+import { deleteMediaFile, saveMedia, saveMediaImageRendition } from './index'
 import * as LocalFileStorage from './localFile'
+import { MediaSchema } from './types'
 
 vi.mock('fs', () => ({
   promises: {
@@ -35,15 +36,20 @@ const mockUnlink = fs.unlink as jest.MockedFunction<typeof fs.unlink>
 const mockS3Send = vi.fn()
 const mockDeleteFile = vi.fn()
 const mockSaveImageRendition = vi.fn()
+// saveFile is mocked per driver so a test can tell which storage was reached.
+const mockLocalSaveFile = vi.fn()
+const mockS3SaveFile = vi.fn()
 
 // Mock the storage getStorage methods
 const mockLocalStorage = {
   deleteFile: mockDeleteFile,
-  saveImageRendition: mockSaveImageRendition
+  saveImageRendition: mockSaveImageRendition,
+  saveFile: mockLocalSaveFile
 }
 const mockS3Storage = {
   deleteFile: mockDeleteFile,
-  saveImageRendition: mockSaveImageRendition
+  saveImageRendition: mockSaveImageRendition,
+  saveFile: mockS3SaveFile
 }
 
 vi.spyOn(LocalFileStorage.LocalFileStorage, 'getStorage').mockReturnValue(
@@ -64,6 +70,8 @@ describe('Media Storage Service', () => {
     vi.clearAllMocks()
     mockDeleteFile.mockReset()
     mockSaveImageRendition.mockReset()
+    mockLocalSaveFile.mockReset()
+    mockS3SaveFile.mockReset()
     ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
       function () {
         return {
@@ -71,6 +79,66 @@ describe('Media Storage Service', () => {
         } as unknown as S3Client
       }
     )
+  })
+
+  describe('saveMedia', () => {
+    const actor = { id: 'actor-1' } as Actor
+    const media: MediaSchema = {
+      file: new File(['jpeg'], 'photo.jpg', { type: 'image/jpeg' })
+    }
+    const saveFileOutput = { id: 'media-1' }
+
+    // Both S3-backed config types must reach the S3 driver: `s3` used to fall
+    // through to the `default` branch, so every synchronous upload on an
+    // instance configured with it was rejected with a 422.
+    it.each([
+      {
+        description: 'delegates s3 storage to the s3 driver',
+        mediaStorage: { type: MediaStorageType.S3Storage, bucket: 'bucket' }
+      },
+      {
+        description: 'delegates object storage to the s3 driver',
+        mediaStorage: { type: MediaStorageType.ObjectStorage, bucket: 'bucket' }
+      }
+    ])('$description', async ({ mediaStorage }) => {
+      mockGetConfig.mockReturnValue({
+        mediaStorage,
+        host: 'llun.test'
+      } as unknown as ReturnType<typeof getConfig>)
+      mockS3SaveFile.mockResolvedValue(saveFileOutput)
+
+      const result = await saveMedia(mockDatabase, actor, media)
+
+      expect(result).toEqual(saveFileOutput)
+      expect(mockS3SaveFile).toHaveBeenCalledWith(actor, media)
+      expect(mockLocalSaveFile).not.toHaveBeenCalled()
+    })
+
+    it('delegates local file storage to the local driver', async () => {
+      mockGetConfig.mockReturnValue({
+        mediaStorage: { type: MediaStorageType.LocalFile, path: '/tmp/media' },
+        host: 'llun.test'
+      } as unknown as ReturnType<typeof getConfig>)
+      mockLocalSaveFile.mockResolvedValue(saveFileOutput)
+
+      const result = await saveMedia(mockDatabase, actor, media)
+
+      expect(result).toEqual(saveFileOutput)
+      expect(mockLocalSaveFile).toHaveBeenCalledWith(actor, media)
+      expect(mockS3SaveFile).not.toHaveBeenCalled()
+    })
+
+    it('returns null when no storage is configured', async () => {
+      mockGetConfig.mockReturnValue({
+        host: 'llun.test'
+      } as unknown as ReturnType<typeof getConfig>)
+
+      const result = await saveMedia(mockDatabase, actor, media)
+
+      expect(result).toBeNull()
+      expect(mockLocalSaveFile).not.toHaveBeenCalled()
+      expect(mockS3SaveFile).not.toHaveBeenCalled()
+    })
   })
 
   describe('deleteMediaFile', () => {

--- a/lib/services/medias/index.ts
+++ b/lib/services/medias/index.ts
@@ -25,6 +25,7 @@ export const saveMedia = async (
         media
       )
     }
+    case MediaStorageType.S3Storage:
     case MediaStorageType.ObjectStorage: {
       return S3FileStorage.getStorage(mediaStorage, host, database).saveFile(
         actor,


### PR DESCRIPTION
## Summary

`saveMedia` in `lib/services/medias/index.ts` switched on `mediaStorage?.type` but handled only `MediaStorageType.LocalFile` and `MediaStorageType.ObjectStorage` — it was missing `MediaStorageType.S3Storage` (`'s3'`). Every other dispatcher in the same file (`saveMediaThumbnail`, `saveMediaImageRendition`, `getPresignedUrl`, `completePresignedMediaUpload`, `getMedia`, `deleteMediaFile`) already lists `case MediaStorageType.S3Storage:` alongside `ObjectStorage`.

`'s3'` is a fully supported value: `getMediaStorageConfig` accepts `ACTIVITIES_MEDIA_STORAGE_TYPE=s3` and builds a `MediaStorageS3Config` from it, and the docs (`docs/environment-variables.md`, `docs/setup.md`, `docs/maintenance.md`, `.env.example`) list it as a peer of `object` with no stated limitation.

**Impact:** on an instance configured with `ACTIVITIES_MEDIA_STORAGE_TYPE=s3`, `saveMedia` fell through to `default: return null`, and `handleSyncMediaUpload` converts that null into a 422 — so `POST /api/v1/media` and `POST /api/v2/media` rejected **every** synchronous upload, while thumbnails, image renditions, presigned uploads and reads all kept working. That asymmetry is what made it easy to miss.

## Changes

- `lib/services/medias/index.ts` — add the missing `case MediaStorageType.S3Storage:` above `ObjectStorage` so both S3-backed config types route to `S3FileStorage.getStorage(...).saveFile(...)`.
- `lib/services/medias/index.test.ts` — new `describe('saveMedia', …)` block. `saveFile` is mocked **per driver** (`mockLocalSaveFile` / `mockS3SaveFile`) rather than shared like the existing `deleteFile` mocks, so each case pins *which* storage was reached instead of only that something was called:
  - table-driven `it.each` over `s3` and `object` → the S3 driver receives `(actor, media)` and the local driver is untouched
  - `fs` → the local driver, S3 untouched
  - no storage configured → `null`, neither driver called

## Testing

The regression test was confirmed to fail without the fix — stashing the one-line change makes `'delegates s3 storage to the s3 driver'` fail with `expected null to deeply equal { id: 'media-1' }`, which is exactly the null `handleSyncMediaUpload` was turning into a 422.

Full gate, run in order, all green:

- `yarn run prettier --write .` — no files reformatted beyond the two changed
- `yarn lint` — 0 errors (31 pre-existing `no-explicit-any` warnings, untouched)
- `yarn build` — clean
- `yarn test` — 737 files / 7579 tests passed

## Notes

- No migration, no schema-dump change, no config or environment-variable change.
- No docs update needed: the docs already document `s3` and `object` as equivalent backends, so this restores documented behavior rather than changing it.
- No UI surface, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)