### PR TITLE
Bump version to v1.121.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.121.0",
+  "version": "1.121.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.121.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.121.0`
- Base main SHA: `26edcf91512035d3124fefe73c7f8d89365c5f7f`
- Included commits: `8`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
