### PR TITLE
fix: store a caller-supplied thumbnail on the S3 media driver

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -254,8 +254,11 @@ change doesn't touch.
 - **The two storage drivers must answer the same input identically.**
   `LocalFileStorage` and `S3FileStorage` are edited one at a time and drift
   silently — an uploaded `thumbnail` was stored by one and dropped by the other
-  for as long as both existed, so the same upload federated a different
-  `meta.small` per backend. Shared policy belongs in a module both import
+  for as long as both existed, so the same upload answered with a different
+  `meta.small`/`preview_url` per backend (the upload-response entity only;
+  `getMastodonAttachment` hardcodes `preview_url: null` and the AP `Document`
+  has no thumbnail field, so nothing federated). Shared policy belongs in a
+  module both import
   (`medias/thumbnailInput` validates a supplied thumbnail; `medias/fileName`
   handles supplied names), and a change to one driver's `saveFile` needs the
   matching test in **both** `localFile.test.ts` and `S3StorageFile.test.ts`.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -251,6 +251,20 @@ change doesn't touch.
   `thumbnail.*` describes the **stored** WebP (`outputInfo`). Know which one a
   change reads: only the latter moves when the encode pipeline changes, and only
   the latter feeds `meta.small`.
+- **The two storage drivers must answer the same input identically.**
+  `LocalFileStorage` and `S3FileStorage` are edited one at a time and drift
+  silently — an uploaded `thumbnail` was stored by one and dropped by the other
+  for as long as both existed, so the same upload federated a different
+  `meta.small` per backend. Shared policy belongs in a module both import
+  (`medias/thumbnailInput` validates a supplied thumbnail; `medias/fileName`
+  handles supplied names), and a change to one driver's `saveFile` needs the
+  matching test in **both** `localFile.test.ts` and `S3StorageFile.test.ts`.
+- **A stored file with no `medias` row is unreachable**, so whatever fails
+  after a write must reclaim it — only `scripts/maintenance/cleanupMediaStorage.ts`
+  can find it otherwise. Equally, do not report a storage failure as a
+  `MediaValidationError`: that is a 422 the client will not retry, and
+  `handleSyncMediaUpload` deliberately logs nothing for it. Validate input
+  first, then let a genuine fault stay a logged 500.
 
 ## Docs hygiene
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,8 +181,10 @@ and both storage drivers treat it identically: it is re-encoded and stored the
 same way, recorded on the media row from the **stored** file's size and
 dimensions (so it is metered against the account's storage usage), and surfaced
 as the attachment's `meta.small` and `preview_url`. For a video it replaces the
-frame the server would otherwise extract; without one, a video still gets that
-extracted frame and an image gets no thumbnail at all.
+extracted frame — the frame is extracted either way, so it saves no work — while
+without one a video keeps that frame and an image gets no thumbnail at all. A
+thumbnail that is not an image is refused before anything is stored, so an
+unusable one cannot leave an orphaned original behind.
 
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,11 +183,14 @@ dimensions (so it is metered against the account's storage usage), and surfaced
 as the attachment's `meta.small` and `preview_url`. For a video it replaces the
 extracted frame — the frame is extracted either way, so it saves no work — while
 without one a video keeps that frame and an image gets no thumbnail at all. A
-supplied thumbnail is client input, so both drivers validate it — declared type
-and actual bytes — through the same module before anything is stored, and
-unusable input is a 422 with nothing written. Should storing it fail after that,
-the original stored alongside it is reclaimed: a `medias` row is the only handle
-anything has on a stored path, so a file written without one is unreachable.
+supplied thumbnail is client input, so both drivers validate it through the same
+module: the declared type and a header parse before anything is stored, and — if
+storing it fails anyway, as a truncated image only can once the encoder reaches
+the missing bytes — a full decode to decide what went wrong. Unusable input is a
+422; a storage fault keeps its own error and stays a logged 500. Either way the
+original stored alongside it is reclaimed, because a `medias` row is the only
+handle anything has on a stored path and a file written without one is
+unreachable.
 
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,10 +183,11 @@ dimensions (so it is metered against the account's storage usage), and surfaced
 as the attachment's `meta.small` and `preview_url`. For a video it replaces the
 extracted frame — the frame is extracted either way, so it saves no work — while
 without one a video keeps that frame and an image gets no thumbnail at all. A
-thumbnail that is not an image is refused before anything is stored; one that
-merely claims to be an image is caught by the encoder instead, and the original
-it arrived with is reclaimed rather than left orphaned. Either way the upload
-answers 422, not 500.
+supplied thumbnail is client input, so both drivers validate it — declared type
+and actual bytes — through the same module before anything is stored, and
+unusable input is a 422 with nothing written. Should storing it fail after that,
+the original stored alongside it is reclaimed: a `medias` row is the only handle
+anything has on a stored path, so a file written without one is unreachable.
 
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,6 +176,14 @@ and `PATCH /api/v1/profile`), custom emojis, thumbnail replacement
 and the fitness import jobs — which cover both the route maps the server
 generates and the arbitrary-sized activity photos it fetches from Strava.
 
+The sync upload endpoint also accepts an optional `thumbnail` beside the file,
+and both storage drivers treat it identically: it is re-encoded and stored the
+same way, recorded on the media row from the **stored** file's size and
+dimensions (so it is metered against the account's storage usage), and surfaced
+as the attachment's `meta.small` and `preview_url`. For a video it replaces the
+frame the server would otherwise extract; without one, a video still gets that
+extracted frame and an image gets no thumbnail at all.
+
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs
 straight to the bucket. `uploadAttachment` (`lib/client.ts`) tries this first

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,12 +183,10 @@ dimensions (so it is metered against the account's storage usage), and surfaced
 as the attachment's `meta.small` and `preview_url`. For a video it replaces the
 extracted frame — the frame is extracted either way, so it saves no work — while
 without one a video keeps that frame and an image gets no thumbnail at all. A
-supplied thumbnail is client input, so both drivers validate it through the same
-module: the declared type and a header parse before anything is stored, and — if
-storing it fails anyway, as a truncated image only can once the encoder reaches
-the missing bytes — a full decode to decide what went wrong. Unusable input is a
-422; a storage fault keeps its own error and stays a logged 500. Either way the
-original stored alongside it is reclaimed, because a `medias` row is the only
+supplied thumbnail is client input, so both drivers validate it the same way and
+before anything is stored: unusable input is a 422 with nothing written, while a
+storage fault keeps its own error and stays a logged 500. Whatever fails after
+the first write reclaims what it stored, because a `medias` row is the only
 handle anything has on a stored path and a file written without one is
 unreachable.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,8 +183,10 @@ dimensions (so it is metered against the account's storage usage), and surfaced
 as the attachment's `meta.small` and `preview_url`. For a video it replaces the
 extracted frame — the frame is extracted either way, so it saves no work — while
 without one a video keeps that frame and an image gets no thumbnail at all. A
-thumbnail that is not an image is refused before anything is stored, so an
-unusable one cannot leave an orphaned original behind.
+thumbnail that is not an image is refused before anything is stored; one that
+merely claims to be an image is caught by the encoder instead, and the original
+it arrived with is reclaimed rather than left orphaned. Either way the upload
+answers 422, not 500.
 
 **Presigned direct-to-S3** stores the bytes exactly as uploaded — original
 format, no re-encode, no server-side dimension cap — because the browser PUTs

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -22,6 +22,7 @@ import {
 import { MediaValidationError } from '@/lib/services/medias/errors'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
 import { extractVideoMeta } from '@/lib/services/medias/extractVideoMeta'
+import { getQuotaLimit } from '@/lib/services/medias/quota'
 import { getMaxMediaUploadSize } from '@/lib/services/medias/uploadSizeLimit'
 import { Actor } from '@/lib/types/domain/actor'
 import { StreamByteLimitError } from '@/lib/utils/streamLimit'
@@ -600,9 +601,9 @@ describe('S3FileStorage saveFile with a video', () => {
     )
   })
 
-  // The image and video branches share one `createMedia` call, but only the
-  // image branch reaches it through `_uploadImageToS3`, so it needs its own
-  // coverage.
+  // The image and video branches share one `createMedia` call, but the
+  // original's path and metadata come from a different helper in each, so the
+  // image branch needs its own coverage.
   it('stores a sanitized original file name for an image', async () => {
     database.createMedia.mockResolvedValue({
       id: 'media-2',
@@ -650,21 +651,29 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
   // deletes its temp file as soon as `send` resolves, so an image stream has to
   // be drained inside the mock.
   let uploads: { key: string; body: Buffer }[]
+  let deletedKeys: string[]
 
   beforeEach(() => {
     vi.clearAllMocks()
     uploads = []
+    deletedKeys = []
     ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
       function () {
         return { send } as unknown as S3Client
       }
     )
     send.mockImplementation(async (command) => {
+      if (command instanceof DeleteObjectCommand) {
+        deletedKeys.push(String(command.input.Key))
+        return {}
+      }
       if (!(command instanceof PutObjectCommand)) {
         throw new Error('Unexpected command')
       }
       const { Key, Body } = command.input
       const chunks: Buffer[] = []
+      // A video is uploaded as a Buffer and an image as a stream. `for await`
+      // over a Buffer walks it byte by byte, so the two need separate handling.
       if (Buffer.isBuffer(Body)) {
         chunks.push(Body)
       } else {
@@ -838,6 +847,47 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     ).rejects.toThrow(MediaValidationError)
     expect(uploads).toHaveLength(0)
     expect(database.createMedia).not.toHaveBeenCalled()
+  })
+
+  // `createMedia` meters the thumbnail's bytes too, so the pre-check has to
+  // reserve for them — otherwise an upload that fits only without its thumbnail
+  // is accepted and leaves the account over its quota.
+  it('counts the thumbnail against the account quota', async () => {
+    const file = await createPngFile(800, 600)
+    const thumbnail = await createPngFile(400, 300)
+    // Exactly enough room for the original on its own.
+    database.getStorageUsageForAccount.mockResolvedValue(
+      getQuotaLimit() - file.size
+    )
+
+    await expect(
+      createStorage().saveFile(actor, { file, thumbnail })
+    ).rejects.toThrow(MediaValidationError)
+    expect(uploads).toHaveLength(0)
+    // The same upload without the thumbnail still fits, so the thumbnail's
+    // bytes are what tipped it over.
+    await expect(
+      createStorage().saveFile(actor, { file })
+    ).resolves.toBeTruthy()
+  })
+
+  // The declared type is only a claim, and sharp is the real arbiter — so the
+  // guard above cannot be the whole story. By the time sharp rejects, the
+  // original is already in the bucket and no `medias` row will ever reference
+  // it.
+  it('reclaims the stored original when the thumbnail is not a readable image', async () => {
+    const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
+      type: 'image/png'
+    })
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail
+      })
+    ).rejects.toThrow(MediaValidationError)
+    expect(database.createMedia).not.toHaveBeenCalled()
+    expect(deletedKeys).toEqual([uploaded('original').key])
   })
 
   it('stores no thumbnail for an image uploaded without one', async () => {

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -849,6 +849,19 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     expect(database.createMedia).not.toHaveBeenCalled()
   })
 
+  // The dedicated thumbnail endpoint (PUT /api/v1/media/:id) has to answer the
+  // same bytes the same way — it used to reach sharp unguarded and 500.
+  it('refuses unreadable bytes on the standalone thumbnail path', async () => {
+    const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
+      type: 'image/png'
+    })
+
+    await expect(
+      createStorage().saveThumbnail(actor, thumbnail)
+    ).rejects.toThrow(MediaValidationError)
+    expect(uploads).toHaveLength(0)
+  })
+
   // `createMedia` meters the thumbnail's bytes too, so the pre-check has to
   // reserve for them — otherwise an upload that fits only without its thumbnail
   // is accepted and leaves the account over its quota.
@@ -872,10 +885,10 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
   })
 
   // The declared type is only a claim, and sharp is the real arbiter — so the
-  // guard above cannot be the whole story. By the time sharp rejects, the
-  // original is already in the bucket and no `medias` row will ever reference
-  // it.
-  it('reclaims the stored original when the thumbnail is not a readable image', async () => {
+  // type guard above cannot be the whole story. Validating the bytes up front
+  // is what keeps this a 422 with nothing stored, rather than a 500 with an
+  // original in the bucket that no `medias` row will ever reference.
+  it('refuses unreadable thumbnail bytes before storing anything', async () => {
     const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
       type: 'image/png'
     })
@@ -886,8 +899,51 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
         thumbnail
       })
     ).rejects.toThrow(MediaValidationError)
+    expect(uploads).toHaveLength(0)
     expect(database.createMedia).not.toHaveBeenCalled()
-    expect(deletedKeys).toEqual([uploaded('original').key])
+  })
+
+  // What is left after that check is a storage fault, not bad input: it must
+  // keep its own error — a logged 500, not a 422 telling the caller its
+  // perfectly good thumbnail was rejected — while still reclaiming the original.
+  it('reclaims the stored original when the thumbnail upload fails', async () => {
+    const failure = new Error('S3 unavailable')
+    let puts = 0
+    send.mockImplementation(async (command) => {
+      if (command instanceof DeleteObjectCommand) {
+        deletedKeys.push(String(command.input.Key))
+        return {}
+      }
+      puts += 1
+      // The second PutObject is the thumbnail; the original is already stored.
+      if (puts === 2) throw failure
+      uploads.push({ key: String(command.input.Key), body: Buffer.alloc(0) })
+      return {}
+    })
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createPngFile(400, 300)
+      })
+    ).rejects.toThrow(failure)
+    expect(database.createMedia).not.toHaveBeenCalled()
+    expect(deletedKeys).toEqual([uploads[0].key])
+  })
+
+  // A row is the only handle anything else has on these paths, so without one
+  // both stored objects are unreachable.
+  it('reclaims both stored objects when the media row cannot be created', async () => {
+    database.createMedia.mockResolvedValue(null as never)
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createPngFile(400, 300)
+      })
+    ).rejects.toThrow('Fail to store media')
+    expect(deletedKeys).toEqual(uploads.map((upload) => upload.key))
+    expect(deletedKeys).toHaveLength(2)
   })
 
   it('stores no thumbnail for an image uploaded without one', async () => {
@@ -901,33 +957,42 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     )
   })
 
-  it('prefers a caller-supplied thumbnail over the extracted video frame', async () => {
+  it.each([
+    {
+      description:
+        'prefers a caller-supplied thumbnail over the extracted video frame',
+      suppliedThumbnail: { width: 400, height: 300 },
+      storedThumbnail: { width: 400, height: 300 }
+    },
+    {
+      description:
+        'falls back to the extracted video frame when no thumbnail is supplied',
+      suppliedThumbnail: null,
+      // The mocked `extractVideoImage` frame.
+      storedThumbnail: { width: 1, height: 1 }
+    }
+  ])('$description', async ({ suppliedThumbnail, storedThumbnail }) => {
     const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
       type: 'video/mp4'
     })
 
     await createStorage().saveFile(actor, {
       file,
-      thumbnail: await createPngFile(400, 300)
+      ...(suppliedThumbnail
+        ? {
+            thumbnail: await createPngFile(
+              suppliedThumbnail.width,
+              suppliedThumbnail.height
+            )
+          }
+        : null)
     })
 
-    // The video plus one thumbnail — the 1x1 preview frame is not uploaded.
+    // The video plus exactly one thumbnail — the losing source is not uploaded.
     expect(uploads).toHaveLength(2)
     await expect(
       sharp(uploaded('thumbnail').body).metadata()
-    ).resolves.toMatchObject({ width: 400, height: 300 })
-  })
-
-  it('falls back to the extracted video frame when no thumbnail is supplied', async () => {
-    const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
-      type: 'video/mp4'
-    })
-
-    await createStorage().saveFile(actor, { file })
-
-    await expect(
-      sharp(uploaded('thumbnail').body).metadata()
-    ).resolves.toMatchObject({ width: 1, height: 1 })
+    ).resolves.toMatchObject(storedThumbnail)
   })
 })
 

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -627,6 +627,192 @@ describe('S3FileStorage saveFile with a video', () => {
   })
 })
 
+// Regression: the image branch called `createMedia` with no `thumbnail` key at
+// all, so a client that uploaded one (MediaSchema accepts it, and
+// handleSyncMediaUpload passes it straight through) got it stored on a
+// filesystem instance and silently dropped on an object-storage one — the same
+// upload produced a different `meta.small`/`preview_url` per backend. The video
+// branch had the matching gap: it always used the extracted frame and ignored a
+// caller-supplied thumbnail. Mirrors `localFile.test.ts`.
+describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
+  const send = vi.fn()
+  const actor = { id: 'actor-1', account: { id: 'account-1' } } as Actor
+  const database = {
+    createMedia: vi.fn(),
+    getActorFromId: vi.fn(),
+    getStorageUsageForAccount: vi.fn(),
+    getFitnessStorageUsageForAccount: vi.fn()
+  } as unknown as jest.Mocked<Database>
+
+  // Every PutObjectCommand with the bytes it actually uploaded. The storage
+  // deletes its temp file as soon as `send` resolves, so an image stream has to
+  // be drained inside the mock.
+  let uploads: { key: string; body: Buffer }[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    uploads = []
+    ;(S3Client as jest.MockedClass<typeof S3Client>).mockImplementation(
+      function () {
+        return { send } as unknown as S3Client
+      }
+    )
+    send.mockImplementation(async (command) => {
+      if (!(command instanceof PutObjectCommand)) {
+        throw new Error('Unexpected command')
+      }
+      const { Key, Body } = command.input
+      const chunks: Buffer[] = []
+      if (Buffer.isBuffer(Body)) {
+        chunks.push(Body)
+      } else {
+        for await (const chunk of Body as Readable) {
+          chunks.push(Buffer.from(chunk))
+        }
+      }
+      uploads.push({ key: String(Key), body: Buffer.concat(chunks) })
+      return {}
+    })
+    database.getActorFromId.mockResolvedValue(actor)
+    database.getStorageUsageForAccount.mockResolvedValue(0)
+    database.getFitnessStorageUsageForAccount.mockResolvedValue(0)
+    database.createMedia.mockImplementation((async (params: unknown) => ({
+      id: 'media-1',
+      actorId: actor.id,
+      ...(params as object)
+    })) as never)
+    vi.mocked(extractVideoMeta).mockResolvedValue({
+      streams: [{ codec_type: 'video', width: 10, height: 10 }],
+      format: { format_name: 'mov,mp4,m4a,3gp,3g2,mj2' }
+    })
+    vi.mocked(extractVideoImage).mockResolvedValue(ONE_PIXEL_PNG)
+  })
+
+  const createStorage = () =>
+    new S3FileStorage(
+      {
+        type: MediaStorageType.ObjectStorage,
+        bucket: 'bucket',
+        region: 'us-east-1',
+        endpoint: 'https://s3.example.com'
+      },
+      'llun.test',
+      database
+    )
+
+  const createPngFile = async (width: number, height: number) => {
+    const buffer = await sharp({
+      create: { width, height, channels: 3, background: '#3366cc' }
+    })
+      .png()
+      .toBuffer()
+    return new File([new Uint8Array(buffer)], 'route-map.png', {
+      type: 'image/png'
+    })
+  }
+
+  // Thumbnails are uploaded under the same prefix as the original, suffixed
+  // `-thumbnail`, so each helper has to pick out the object it means.
+  const uploaded = (kind: 'original' | 'thumbnail') => {
+    const match = uploads.find(
+      (upload) =>
+        upload.key.endsWith('-thumbnail.webp') === (kind === 'thumbnail')
+    )
+    if (!match) {
+      throw new Error(
+        `No uploaded ${kind} in [${uploads.map((upload) => upload.key).join(', ')}]`
+      )
+    }
+    return match
+  }
+
+  it('uploads a caller-supplied thumbnail alongside the image', async () => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600),
+      thumbnail: await createPngFile(400, 300)
+    })
+
+    expect(uploads).toHaveLength(2)
+    await expect(
+      sharp(uploaded('thumbnail').body).metadata()
+    ).resolves.toMatchObject({ width: 400, height: 300, format: 'webp' })
+  })
+
+  // `thumbnail.bytes` is metered: `createMedia` adds it to the account's usage
+  // counter, so it has to describe the stored WebP (`outputInfo`) rather than
+  // the uploaded PNG.
+  it('records the stored thumbnail on the media row', async () => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600),
+      thumbnail: await createPngFile(400, 300)
+    })
+
+    const thumbnail = uploaded('thumbnail')
+    expect(database.createMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thumbnail: {
+          path: thumbnail.key,
+          bytes: thumbnail.body.length,
+          mimeType: 'image/webp',
+          metaData: { width: 400, height: 300 }
+        }
+      })
+    )
+  })
+
+  it('reports the stored thumbnail as meta.small on the attachment', async () => {
+    const attachment = await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600),
+      thumbnail: await createPngFile(400, 300)
+    })
+
+    expect(attachment?.meta.small).toMatchObject({ width: 400, height: 300 })
+    expect(attachment?.preview_url).toBe(
+      `https://llun.test/api/v1/files/${uploaded('thumbnail').key}`
+    )
+  })
+
+  it('stores no thumbnail for an image uploaded without one', async () => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600)
+    })
+
+    expect(uploads).toHaveLength(1)
+    expect(database.createMedia).toHaveBeenCalledWith(
+      expect.not.objectContaining({ thumbnail: expect.anything() })
+    )
+  })
+
+  it('prefers a caller-supplied thumbnail over the extracted video frame', async () => {
+    const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
+      type: 'video/mp4'
+    })
+
+    await createStorage().saveFile(actor, {
+      file,
+      thumbnail: await createPngFile(400, 300)
+    })
+
+    // The video plus one thumbnail — the 1x1 preview frame is not uploaded.
+    expect(uploads).toHaveLength(2)
+    await expect(
+      sharp(uploaded('thumbnail').body).metadata()
+    ).resolves.toMatchObject({ width: 400, height: 300 })
+  })
+
+  it('falls back to the extracted video frame when no thumbnail is supplied', async () => {
+    const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
+      type: 'video/mp4'
+    })
+
+    await createStorage().saveFile(actor, { file })
+
+    await expect(
+      sharp(uploaded('thumbnail').body).metadata()
+    ).resolves.toMatchObject({ width: 1, height: 1 })
+  })
+})
+
 describe('S3FileStorage getFile', () => {
   const send = vi.fn()
   const database = {} as unknown as jest.Mocked<Database>

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -722,6 +722,20 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     })
   }
 
+  // A PNG with an intact header and a missing body: it passes the cheap header
+  // check and only fails once the encoder reaches the bytes that are not there.
+  const createTruncatedPngFile = async (width: number, height: number) => {
+    const file = await createPngFile(width, height)
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    return new File(
+      [bytes.subarray(0, Math.floor(bytes.length * 0.6))],
+      'cut.png',
+      {
+        type: 'image/png'
+      }
+    )
+  }
+
   // Thumbnails are uploaded under the same prefix as the original, suffixed
   // `-thumbnail`, so each helper has to pick out the object it means.
   const uploaded = (kind: 'original' | 'thumbnail') => {
@@ -929,6 +943,44 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     ).rejects.toThrow(failure)
     expect(database.createMedia).not.toHaveBeenCalled()
     expect(deletedKeys).toEqual([uploads[0].key])
+  })
+
+  // `metadata()` reads the header, so this is the input the up-front check
+  // cannot catch — it reaches the encoder, and without the classifier in the
+  // catch the caller would get a logged 500 for its own corrupt bytes.
+  it('refuses a truncated thumbnail and reclaims the stored original', async () => {
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createTruncatedPngFile(400, 300)
+      })
+    ).rejects.toThrow(MediaValidationError)
+    expect(database.createMedia).not.toHaveBeenCalled()
+    expect(deletedKeys).toEqual([uploaded('original').key])
+  })
+
+  it('refuses truncated bytes on the standalone thumbnail path', async () => {
+    await expect(
+      createStorage().saveThumbnail(
+        actor,
+        await createTruncatedPngFile(400, 300)
+      )
+    ).rejects.toThrow(MediaValidationError)
+  })
+
+  // The row is written last, so a database failure leaves both objects stored
+  // and unreferenced — the same reclaim as a missing row.
+  it('reclaims both stored objects when the media row write fails', async () => {
+    database.createMedia.mockRejectedValue(new Error('deadlock detected'))
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createPngFile(400, 300)
+      })
+    ).rejects.toThrow('deadlock detected')
+    expect(deletedKeys).toEqual(uploads.map((upload) => upload.key))
+    expect(deletedKeys).toHaveLength(2)
   })
 
   // A row is the only handle anything else has on these paths, so without one

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -19,6 +19,7 @@ import {
   MAX_HEIGHT,
   MAX_WIDTH
 } from '@/lib/services/medias/constants'
+import { MediaValidationError } from '@/lib/services/medias/errors'
 import { extractVideoImage } from '@/lib/services/medias/extractVideoImage'
 import { extractVideoMeta } from '@/lib/services/medias/extractVideoMeta'
 import { getMaxMediaUploadSize } from '@/lib/services/medias/uploadSizeLimit'
@@ -599,8 +600,9 @@ describe('S3FileStorage saveFile with a video', () => {
     )
   })
 
-  // `saveFile`'s image branch is a separate `createMedia` call from the video
-  // branch above, so it needs its own coverage.
+  // The image and video branches share one `createMedia` call, but only the
+  // image branch reaches it through `_uploadImageToS3`, so it needs its own
+  // coverage.
   it('stores a sanitized original file name for an image', async () => {
     database.createMedia.mockResolvedValue({
       id: 'media-2',
@@ -760,6 +762,32 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     )
   })
 
+  // Both fixtures above sit inside the 4000x4000 box, where the input and the
+  // stored file have the same dimensions — so only an above-cap thumbnail
+  // distinguishes `outputInfo` from the input `metaData`. Reporting the input's
+  // dimensions is the bug #1334 fixed on the original's side.
+  it('records an above-cap thumbnail at the dimensions it was stored at', async () => {
+    await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600),
+      thumbnail: await createPngFile(MAX_WIDTH + 200, (MAX_HEIGHT + 200) / 2)
+    })
+
+    expect(database.createMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thumbnail: expect.objectContaining({
+          metaData: { width: MAX_WIDTH, height: MAX_HEIGHT / 2 }
+        })
+      })
+    )
+    await expect(
+      sharp(uploaded('thumbnail').body).metadata()
+    ).resolves.toMatchObject({ width: MAX_WIDTH, height: MAX_HEIGHT / 2 })
+    // The original is bounded independently and is well inside the box.
+    await expect(
+      sharp(uploaded('original').body).metadata()
+    ).resolves.toMatchObject({ width: 800, height: 600 })
+  })
+
   it('reports the stored thumbnail as meta.small on the attachment', async () => {
     const attachment = await createStorage().saveFile(actor, {
       file: await createPngFile(800, 600),
@@ -770,6 +798,46 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     expect(attachment?.preview_url).toBe(
       `https://llun.test/api/v1/files/${uploaded('thumbnail').key}`
     )
+  })
+
+  // `description` and `focus` are spread into the same `createMedia` call the
+  // thumbnail is, so the refactor that unified the two branches could have
+  // dropped them without any other test noticing.
+  it('keeps the description and focus alongside the thumbnail', async () => {
+    const attachment = await createStorage().saveFile(actor, {
+      file: await createPngFile(800, 600),
+      thumbnail: await createPngFile(400, 300),
+      description: 'A blue square',
+      focus: { x: 0.5, y: -0.25 }
+    })
+
+    expect(database.createMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'A blue square',
+        focus: { x: 0.5, y: -0.25 }
+      })
+    )
+    expect(attachment?.description).toBe('A blue square')
+    expect(attachment?.meta.focus).toEqual({ x: 0.5, y: -0.25 })
+  })
+
+  // `MediaSchema.thumbnail` accepts every ACCEPTED_FILE_TYPES entry, videos
+  // included. Reaching sharp with one rejects with a plain Error — a 500, not
+  // the 422 every other bad upload gets — and by then the original is already
+  // in the bucket with no `medias` row to reclaim it by.
+  it('refuses a thumbnail that is not an image before storing anything', async () => {
+    const thumbnail = new File([Buffer.from('video-bytes')], 'clip.mp4', {
+      type: 'video/mp4'
+    })
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail
+      })
+    ).rejects.toThrow(MediaValidationError)
+    expect(uploads).toHaveLength(0)
+    expect(database.createMedia).not.toHaveBeenCalled()
   })
 
   it('stores no thumbnail for an image uploaded without one', async () => {

--- a/lib/services/medias/S3StorageFile.test.ts
+++ b/lib/services/medias/S3StorageFile.test.ts
@@ -898,25 +898,6 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     ).resolves.toBeTruthy()
   })
 
-  // The declared type is only a claim, and sharp is the real arbiter — so the
-  // type guard above cannot be the whole story. Validating the bytes up front
-  // is what keeps this a 422 with nothing stored, rather than a 500 with an
-  // original in the bucket that no `medias` row will ever reference.
-  it('refuses unreadable thumbnail bytes before storing anything', async () => {
-    const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
-      type: 'image/png'
-    })
-
-    await expect(
-      createStorage().saveFile(actor, {
-        file: await createPngFile(800, 600),
-        thumbnail
-      })
-    ).rejects.toThrow(MediaValidationError)
-    expect(uploads).toHaveLength(0)
-    expect(database.createMedia).not.toHaveBeenCalled()
-  })
-
   // What is left after that check is a storage fault, not bad input: it must
   // keep its own error — a logged 500, not a 422 telling the caller its
   // perfectly good thumbnail was rejected — while still reclaiming the original.
@@ -945,18 +926,18 @@ describe('S3FileStorage saveFile with a caller-supplied thumbnail', () => {
     expect(deletedKeys).toEqual([uploads[0].key])
   })
 
-  // `metadata()` reads the header, so this is the input the up-front check
-  // cannot catch — it reaches the encoder, and without the classifier in the
-  // catch the caller would get a logged 500 for its own corrupt bytes.
-  it('refuses a truncated thumbnail and reclaims the stored original', async () => {
+  // The case a header parse would let through: the driver has to decode the
+  // thumbnail fully before it stores the original, or the encoder is the first
+  // thing to notice and the caller gets a 500 for its own corrupt bytes.
+  it('refuses a truncated thumbnail before storing anything', async () => {
     await expect(
       createStorage().saveFile(actor, {
         file: await createPngFile(800, 600),
         thumbnail: await createTruncatedPngFile(400, 300)
       })
     ).rejects.toThrow(MediaValidationError)
+    expect(uploads).toHaveLength(0)
     expect(database.createMedia).not.toHaveBeenCalled()
-    expect(deletedKeys).toEqual([uploaded('original').key])
   })
 
   it('refuses truncated bytes on the standalone thumbnail path', async () => {

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -39,6 +39,11 @@ import {
 import { getMediaFileUrl } from '@/lib/services/medias/mediaFileUrl'
 import { checkQuotaAvailable } from '@/lib/services/medias/quota'
 import {
+  assertReadableImageBytes,
+  assertReadableThumbnail,
+  getUploadQuotaReservation
+} from '@/lib/services/medias/thumbnailInput'
+import {
   ImageRenditionOutput,
   MediaSchema,
   MediaStorage,
@@ -406,22 +411,18 @@ export class S3FileStorage implements MediaStorage {
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
       return null
     }
-    // `MediaSchema.thumbnail` is a `FileSchema`, which accepts every entry of
-    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an obviously
-    // unusable one here, before anything is uploaded. The declared type is only
-    // a claim, so this is the cheap half of the check; sharp is the real
-    // arbiter, and the catch below covers what it rejects.
-    if (media.thumbnail && !media.thumbnail.type.startsWith('image')) {
-      throw new MediaValidationError('Thumbnail must be an image')
+    // Validate the thumbnail before anything is uploaded, so unusable bytes
+    // cannot leave a stored original behind.
+    if (media.thumbnail) {
+      await assertReadableThumbnail(media.thumbnail)
     }
 
-    // Check quota before saving. `createMedia` meters the thumbnail's stored
-    // bytes too, so reserve for it here — the uploaded file is larger than the
-    // WebP it becomes, which errs on the safe side.
+    // Check quota before saving; the reservation covers the thumbnail, whose
+    // stored bytes `createMedia` meters too.
     const quotaCheck = await checkQuotaAvailable(
       this._database,
       actor,
-      file.size + (media.thumbnail?.size ?? 0)
+      getUploadQuotaReservation(media)
     )
     if (!quotaCheck.available) {
       throw new MediaValidationError(
@@ -449,14 +450,11 @@ export class S3FileStorage implements MediaStorage {
           : null
     } catch (error) {
       // The original is already uploaded and no `medias` row will reference it,
-      // so reclaim it before the failure propagates.
+      // so reclaim it before the failure propagates. The error passes through
+      // untouched: the thumbnail's bytes were validated before any of this ran,
+      // so whatever failed here is ours — a storage fault that has to stay a
+      // logged 500, not be relabelled as the caller's bad input.
       await this.deleteFile(path).catch(() => false)
-      // Bytes that merely claim to be an image reach sharp and reject with a
-      // plain Error, which surfaces as a 500; that is invalid input, so report
-      // it as the 422 the rest of the upload path returns.
-      if (media.thumbnail) {
-        throw new MediaValidationError('Thumbnail is not a readable image')
-      }
       throw error
     }
     const storedMedia = await this._database.createMedia({
@@ -489,6 +487,11 @@ export class S3FileStorage implements MediaStorage {
       ...(media.focus ? { focus: media.focus } : null)
     })
     if (!storedMedia) {
+      // Same reclaim as above — without a row, nothing can find these again.
+      await this.deleteFile(path).catch(() => false)
+      if (thumbnail) {
+        await this.deleteFile(thumbnail.path).catch(() => false)
+      }
       throw new Error('Fail to store media')
     }
     return this._getSaveFileOutput(storedMedia)
@@ -499,6 +502,9 @@ export class S3FileStorage implements MediaStorage {
     file: File
   ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
+    // Same validation saveFile applies, so the dedicated thumbnail endpoint
+    // answers unreadable bytes with the same 422 rather than a 500.
+    await assertReadableImageBytes(file)
 
     // Enforce the account quota like saveFile, so a thumbnail replacement can't
     // push usage past the limit.

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -406,6 +406,14 @@ export class S3FileStorage implements MediaStorage {
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
       return null
     }
+    // `MediaSchema.thumbnail` is a `FileSchema`, which accepts every entry of
+    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an unusable one
+    // here, before anything is uploaded: reaching sharp with it rejects with a
+    // plain Error, which is a 500 rather than a 422 and leaves the already
+    // stored original behind with no `medias` row to reclaim it by.
+    if (media.thumbnail && !media.thumbnail.type.startsWith('image')) {
+      throw new MediaValidationError('Thumbnail must be an image')
+    }
 
     // Check quota before saving
     const quotaCheck = await checkQuotaAvailable(
@@ -422,10 +430,10 @@ export class S3FileStorage implements MediaStorage {
     const { path, metaData, previewImage } = file.type.startsWith('video')
       ? await this._uploadVideoToS3(currentTime, file)
       : await this._uploadImageToS3(currentTime, file)
-    // Same precedence as the local driver: a caller-supplied thumbnail wins
-    // over a frame extracted from a video, and video preview extraction can
-    // fail (no decodable frame), so only fall back to the preview when we
-    // actually have one — sharp(null) would throw.
+    // Same precedence as the local driver: a caller-supplied thumbnail wins,
+    // and a video otherwise falls back to the frame extracted from it. The
+    // image arm is what makes `previewImage` null here — a video whose frame
+    // cannot be decoded rejects rather than resolving null.
     const thumbnail = media.thumbnail
       ? await this._uploadImageToS3(currentTime, media.thumbnail, {
           isThumbnail: true

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -419,54 +419,22 @@ export class S3FileStorage implements MediaStorage {
       )
     }
 
-    if (file.type.startsWith('video')) {
-      const { path, metaData, previewImage } = await this._uploadVideoToS3(
-        currentTime,
-        file
-      )
-      // Video preview extraction can fail (no decodable frame); only build a
-      // thumbnail when we actually have a preview image to avoid sharp(null).
-      const thumbnail = previewImage
+    const { path, metaData, previewImage } = file.type.startsWith('video')
+      ? await this._uploadVideoToS3(currentTime, file)
+      : await this._uploadImageToS3(currentTime, file)
+    // Same precedence as the local driver: a caller-supplied thumbnail wins
+    // over a frame extracted from a video, and video preview extraction can
+    // fail (no decodable frame), so only fall back to the preview when we
+    // actually have one — sharp(null) would throw.
+    const thumbnail = media.thumbnail
+      ? await this._uploadImageToS3(currentTime, media.thumbnail, {
+          isThumbnail: true
+        })
+      : previewImage
         ? await this._uploadImageBufferToS3(currentTime, previewImage, {
             isThumbnail: true
           })
         : null
-      const storedMedia = await this._database.createMedia({
-        actorId: actor.id,
-        original: {
-          path,
-          bytes: file.size,
-          mimeType: file.type,
-          metaData: {
-            width: metaData.width ?? 0,
-            height: metaData.height ?? 0
-          },
-          fileName: sanitizeStoredFileName(file.name)
-        },
-        ...(thumbnail
-          ? {
-              // Use the resized image's actual size/dimensions (outputInfo).
-              thumbnail: {
-                path: thumbnail.path,
-                bytes: thumbnail.outputInfo.size,
-                mimeType: thumbnail.contentType,
-                metaData: {
-                  width: thumbnail.outputInfo.width,
-                  height: thumbnail.outputInfo.height
-                }
-              }
-            }
-          : null),
-        ...(media.description ? { description: media.description } : null),
-        ...(media.focus ? { focus: media.focus } : null)
-      })
-      if (!storedMedia) {
-        throw new Error('Fail to store media')
-      }
-      return this._getSaveFileOutput(storedMedia)
-    }
-
-    const { metaData, path } = await this._uploadImageToS3(currentTime, file)
     const storedMedia = await this._database.createMedia({
       actorId: actor.id,
       original: {
@@ -479,6 +447,20 @@ export class S3FileStorage implements MediaStorage {
         },
         fileName: sanitizeStoredFileName(file.name)
       },
+      ...(thumbnail
+        ? {
+            // Use the resized image's actual size/dimensions (outputInfo).
+            thumbnail: {
+              path: thumbnail.path,
+              bytes: thumbnail.outputInfo.size,
+              mimeType: thumbnail.contentType,
+              metaData: {
+                width: thumbnail.outputInfo.width,
+                height: thumbnail.outputInfo.height
+              }
+            }
+          }
+        : null),
       ...(media.description ? { description: media.description } : null),
       ...(media.focus ? { focus: media.focus } : null)
     })
@@ -633,7 +615,17 @@ export class S3FileStorage implements MediaStorage {
     } finally {
       await fs.unlink(tempFilePath).catch(() => undefined)
     }
-    return { image: resizedImage, metaData, outputInfo, path, contentType }
+    // `previewImage` is always null here — it only exists so an image and a
+    // video upload share one result shape in `saveFile`, as they do in the
+    // local driver.
+    return {
+      image: resizedImage,
+      metaData,
+      outputInfo,
+      path,
+      contentType,
+      previewImage: null
+    }
   }
 
   private async _uploadVideoToS3(currentTime: number, file: File) {

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -41,10 +41,7 @@ import {
   checkQuotaAvailable,
   getUploadQuotaReservation
 } from '@/lib/services/medias/quota'
-import {
-  assertReadableThumbnail,
-  assertThumbnailDecodable
-} from '@/lib/services/medias/thumbnailInput'
+import { readValidThumbnail } from '@/lib/services/medias/thumbnailInput'
 import {
   ImageRenditionOutput,
   MediaSchema,
@@ -413,14 +410,14 @@ export class S3FileStorage implements MediaStorage {
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
       return null
     }
-    // Validate the thumbnail before anything is uploaded, so unusable bytes
-    // cannot leave a stored original behind.
-    if (media.thumbnail) {
-      await assertReadableThumbnail(media.thumbnail)
-    }
+    // Read and validate the thumbnail before anything is uploaded, so unusable
+    // bytes cannot leave a stored original behind.
+    const thumbnailBuffer = media.thumbnail
+      ? await readValidThumbnail(media.thumbnail)
+      : null
 
-    // Check quota before saving; the reservation covers the thumbnail, whose
-    // stored bytes `createMedia` meters too.
+    // Check quota before saving; see `getUploadQuotaReservation` for why the
+    // thumbnail's share of it is an estimate.
     const quotaCheck = await checkQuotaAvailable(
       this._database,
       actor,
@@ -435,30 +432,23 @@ export class S3FileStorage implements MediaStorage {
     const { path, metaData, previewImage } = file.type.startsWith('video')
       ? await this._uploadVideoToS3(currentTime, file)
       : await this._uploadImageToS3(currentTime, file)
-    // Same precedence as the local driver: a caller-supplied thumbnail wins,
-    // and a video otherwise falls back to the frame extracted from it. The
-    // image arm is what makes `previewImage` null here — a video whose frame
-    // cannot be decoded rejects rather than resolving null.
+    // Same precedence as the local driver: a caller-supplied thumbnail wins, and
+    // a video otherwise falls back to the frame extracted from it. `previewImage`
+    // is null for an image upload — a video whose frame cannot be decoded
+    // rejects rather than resolving null.
+    const thumbnailSource = thumbnailBuffer ?? previewImage
     let thumbnail
     try {
-      thumbnail = media.thumbnail
-        ? await this._uploadImageToS3(currentTime, media.thumbnail, {
+      thumbnail = thumbnailSource
+        ? await this._uploadImageBufferToS3(currentTime, thumbnailSource, {
             isThumbnail: true
           })
-        : previewImage
-          ? await this._uploadImageBufferToS3(currentTime, previewImage, {
-              isThumbnail: true
-            })
-          : null
+        : null
     } catch (error) {
+      // The thumbnail's bytes were validated above, so this is a storage fault
+      // of ours: keep the error — it has to stay a logged 500, not a 422 the
+      // client will not retry — but put the original back first.
       await this._reclaimStored(path)
-      // Tell the caller's bad bytes apart from a fault of ours: an image whose
-      // body is truncated passes the header check up front and only fails once
-      // the encoder reaches the missing bytes. Anything else keeps its own
-      // error and stays a logged 500, not a 422 the client will not retry.
-      if (media.thumbnail) {
-        await assertThumbnailDecodable(media.thumbnail)
-      }
       throw error
     }
 
@@ -509,6 +499,9 @@ export class S3FileStorage implements MediaStorage {
     file: File
   ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
+    // Same validation saveFile applies, so the dedicated thumbnail endpoint
+    // answers unusable bytes with the same 422 rather than a 500.
+    const buffer = await readValidThumbnail(file)
 
     // Enforce the account quota like saveFile, so a thumbnail replacement can't
     // push usage past the limit.
@@ -525,19 +518,13 @@ export class S3FileStorage implements MediaStorage {
 
     // Use the stored image's actual size/dimensions (outputInfo), not the input
     // image's metadata.
-    let stored
-    try {
-      stored = await this._uploadImageToS3(Date.now(), file, {
+    const { outputInfo, path, contentType } = await this._uploadImageBufferToS3(
+      Date.now(),
+      buffer,
+      {
         isThumbnail: true
-      })
-    } catch (error) {
-      // The same split saveFile makes: bytes that will not decode are the
-      // caller's 422, anything else is ours and stays a logged 500. Nothing is
-      // stored before this, so there is nothing to reclaim.
-      await assertThumbnailDecodable(file)
-      throw error
-    }
-    const { outputInfo, path, contentType } = stored
+      }
+    )
     return {
       path,
       bytes: outputInfo.size,
@@ -590,11 +577,11 @@ export class S3FileStorage implements MediaStorage {
 
   // A stored path is reachable only through its `medias` row, so anything that
   // fails before that row exists has to take the files back out.
-  private async _reclaimStored(...paths: (string | undefined)[]) {
+  private async _reclaimStored(originalPath: string, thumbnailPath?: string) {
     await Promise.all(
-      paths
-        .filter((path) => path !== undefined)
-        .map((path) => this.deleteFile(path).catch(() => false))
+      [originalPath, thumbnailPath]
+        .filter((stored) => stored !== undefined)
+        .map((stored) => this.deleteFile(stored).catch(() => false))
     )
   }
 

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -37,11 +37,13 @@ import {
   getImageOutputFormatDetail
 } from '@/lib/services/medias/imageOutputFormat'
 import { getMediaFileUrl } from '@/lib/services/medias/mediaFileUrl'
-import { checkQuotaAvailable } from '@/lib/services/medias/quota'
 import {
-  assertReadableImageBytes,
-  assertReadableThumbnail,
+  checkQuotaAvailable,
   getUploadQuotaReservation
+} from '@/lib/services/medias/quota'
+import {
+  assertReadableThumbnail,
+  assertThumbnailDecodable
 } from '@/lib/services/medias/thumbnailInput'
 import {
   ImageRenditionOutput,
@@ -449,49 +451,54 @@ export class S3FileStorage implements MediaStorage {
             })
           : null
     } catch (error) {
-      // The original is already uploaded and no `medias` row will reference it,
-      // so reclaim it before the failure propagates. The error passes through
-      // untouched: the thumbnail's bytes were validated before any of this ran,
-      // so whatever failed here is ours — a storage fault that has to stay a
-      // logged 500, not be relabelled as the caller's bad input.
-      await this.deleteFile(path).catch(() => false)
+      await this._reclaimStored(path)
+      // Tell the caller's bad bytes apart from a fault of ours: an image whose
+      // body is truncated passes the header check up front and only fails once
+      // the encoder reaches the missing bytes. Anything else keeps its own
+      // error and stays a logged 500, not a 422 the client will not retry.
+      if (media.thumbnail) {
+        await assertThumbnailDecodable(media.thumbnail)
+      }
       throw error
     }
-    const storedMedia = await this._database.createMedia({
-      actorId: actor.id,
-      original: {
-        path,
-        bytes: file.size,
-        mimeType: file.type,
-        metaData: {
-          width: metaData.width ?? 0,
-          height: metaData.height ?? 0
+
+    let storedMedia
+    try {
+      storedMedia = await this._database.createMedia({
+        actorId: actor.id,
+        original: {
+          path,
+          bytes: file.size,
+          mimeType: file.type,
+          metaData: {
+            width: metaData.width ?? 0,
+            height: metaData.height ?? 0
+          },
+          fileName: sanitizeStoredFileName(file.name)
         },
-        fileName: sanitizeStoredFileName(file.name)
-      },
-      ...(thumbnail
-        ? {
-            // Use the resized image's actual size/dimensions (outputInfo).
-            thumbnail: {
-              path: thumbnail.path,
-              bytes: thumbnail.outputInfo.size,
-              mimeType: thumbnail.contentType,
-              metaData: {
-                width: thumbnail.outputInfo.width,
-                height: thumbnail.outputInfo.height
+        ...(thumbnail
+          ? {
+              // Use the resized image's actual size/dimensions (outputInfo).
+              thumbnail: {
+                path: thumbnail.path,
+                bytes: thumbnail.outputInfo.size,
+                mimeType: thumbnail.contentType,
+                metaData: {
+                  width: thumbnail.outputInfo.width,
+                  height: thumbnail.outputInfo.height
+                }
               }
             }
-          }
-        : null),
-      ...(media.description ? { description: media.description } : null),
-      ...(media.focus ? { focus: media.focus } : null)
-    })
+          : null),
+        ...(media.description ? { description: media.description } : null),
+        ...(media.focus ? { focus: media.focus } : null)
+      })
+    } catch (error) {
+      await this._reclaimStored(path, thumbnail?.path)
+      throw error
+    }
     if (!storedMedia) {
-      // Same reclaim as above — without a row, nothing can find these again.
-      await this.deleteFile(path).catch(() => false)
-      if (thumbnail) {
-        await this.deleteFile(thumbnail.path).catch(() => false)
-      }
+      await this._reclaimStored(path, thumbnail?.path)
       throw new Error('Fail to store media')
     }
     return this._getSaveFileOutput(storedMedia)
@@ -502,9 +509,6 @@ export class S3FileStorage implements MediaStorage {
     file: File
   ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
-    // Same validation saveFile applies, so the dedicated thumbnail endpoint
-    // answers unreadable bytes with the same 422 rather than a 500.
-    await assertReadableImageBytes(file)
 
     // Enforce the account quota like saveFile, so a thumbnail replacement can't
     // push usage past the limit.
@@ -521,11 +525,19 @@ export class S3FileStorage implements MediaStorage {
 
     // Use the stored image's actual size/dimensions (outputInfo), not the input
     // image's metadata.
-    const { outputInfo, path, contentType } = await this._uploadImageToS3(
-      Date.now(),
-      file,
-      { isThumbnail: true }
-    )
+    let stored
+    try {
+      stored = await this._uploadImageToS3(Date.now(), file, {
+        isThumbnail: true
+      })
+    } catch (error) {
+      // The same split saveFile makes: bytes that will not decode are the
+      // caller's 422, anything else is ours and stays a logged 500. Nothing is
+      // stored before this, so there is nothing to reclaim.
+      await assertThumbnailDecodable(file)
+      throw error
+    }
+    const { outputInfo, path, contentType } = stored
     return {
       path,
       bytes: outputInfo.size,
@@ -574,6 +586,16 @@ export class S3FileStorage implements MediaStorage {
         height: outputInfo.height
       }
     }
+  }
+
+  // A stored path is reachable only through its `medias` row, so anything that
+  // fails before that row exists has to take the files back out.
+  private async _reclaimStored(...paths: (string | undefined)[]) {
+    await Promise.all(
+      paths
+        .filter((path) => path !== undefined)
+        .map((path) => this.deleteFile(path).catch(() => false))
+    )
   }
 
   private async _uploadImageToS3(

--- a/lib/services/medias/S3StorageFile.ts
+++ b/lib/services/medias/S3StorageFile.ts
@@ -407,19 +407,21 @@ export class S3FileStorage implements MediaStorage {
       return null
     }
     // `MediaSchema.thumbnail` is a `FileSchema`, which accepts every entry of
-    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an unusable one
-    // here, before anything is uploaded: reaching sharp with it rejects with a
-    // plain Error, which is a 500 rather than a 422 and leaves the already
-    // stored original behind with no `medias` row to reclaim it by.
+    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an obviously
+    // unusable one here, before anything is uploaded. The declared type is only
+    // a claim, so this is the cheap half of the check; sharp is the real
+    // arbiter, and the catch below covers what it rejects.
     if (media.thumbnail && !media.thumbnail.type.startsWith('image')) {
       throw new MediaValidationError('Thumbnail must be an image')
     }
 
-    // Check quota before saving
+    // Check quota before saving. `createMedia` meters the thumbnail's stored
+    // bytes too, so reserve for it here — the uploaded file is larger than the
+    // WebP it becomes, which errs on the safe side.
     const quotaCheck = await checkQuotaAvailable(
       this._database,
       actor,
-      file.size
+      file.size + (media.thumbnail?.size ?? 0)
     )
     if (!quotaCheck.available) {
       throw new MediaValidationError(
@@ -434,15 +436,29 @@ export class S3FileStorage implements MediaStorage {
     // and a video otherwise falls back to the frame extracted from it. The
     // image arm is what makes `previewImage` null here — a video whose frame
     // cannot be decoded rejects rather than resolving null.
-    const thumbnail = media.thumbnail
-      ? await this._uploadImageToS3(currentTime, media.thumbnail, {
-          isThumbnail: true
-        })
-      : previewImage
-        ? await this._uploadImageBufferToS3(currentTime, previewImage, {
+    let thumbnail
+    try {
+      thumbnail = media.thumbnail
+        ? await this._uploadImageToS3(currentTime, media.thumbnail, {
             isThumbnail: true
           })
-        : null
+        : previewImage
+          ? await this._uploadImageBufferToS3(currentTime, previewImage, {
+              isThumbnail: true
+            })
+          : null
+    } catch (error) {
+      // The original is already uploaded and no `medias` row will reference it,
+      // so reclaim it before the failure propagates.
+      await this.deleteFile(path).catch(() => false)
+      // Bytes that merely claim to be an image reach sharp and reject with a
+      // plain Error, which surfaces as a 500; that is invalid input, so report
+      // it as the 422 the rest of the upload path returns.
+      if (media.thumbnail) {
+        throw new MediaValidationError('Thumbnail is not a readable image')
+      }
+      throw error
+    }
     const storedMedia = await this._database.createMedia({
       actorId: actor.id,
       original: {

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -642,28 +642,10 @@ describe('LocalFileStorage.saveFile with a caller-supplied thumbnail', () => {
     ).resolves.toBeTruthy()
   })
 
-  // The declared type is only a claim, and sharp is the real arbiter — so the
-  // type guard above cannot be the whole story. Validating the bytes up front
-  // is what keeps this a 422 with nothing stored.
-  it('refuses unreadable thumbnail bytes before storing anything', async () => {
-    const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
-      type: 'image/png'
-    })
-
-    await expect(
-      createStorage().saveFile(actor, {
-        file: await createPngFile(800, 600),
-        thumbnail
-      })
-    ).rejects.toThrow(MediaValidationError)
-    expect(database.createMedia).not.toHaveBeenCalled()
-    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
-  })
-
-  // `metadata()` reads the header, so this is the input the up-front check
-  // cannot catch — it reaches the encoder, and without the classifier in the
-  // catch the caller would get a logged 500 for its own corrupt bytes.
-  it('refuses a truncated thumbnail and reclaims the stored original', async () => {
+  // The case a header parse would let through: the driver has to decode the
+  // thumbnail fully before it stores the original, or the encoder is the first
+  // thing to notice and the caller gets a 500 for its own corrupt bytes.
+  it('refuses a truncated thumbnail before storing anything', async () => {
     await expect(
       createStorage().saveFile(actor, {
         file: await createPngFile(800, 600),

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -574,6 +574,20 @@ describe('LocalFileStorage.saveFile with a caller-supplied thumbnail', () => {
     })
   }
 
+  // A PNG with an intact header and a missing body: it passes the cheap header
+  // check and only fails once the encoder reaches the bytes that are not there.
+  const createTruncatedPngFile = async (width: number, height: number) => {
+    const file = await createPngFile(width, height)
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    return new File(
+      [bytes.subarray(0, Math.floor(bytes.length * 0.6))],
+      'cut.png',
+      {
+        type: 'image/png'
+      }
+    )
+  }
+
   // The dedicated thumbnail endpoint (PUT /api/v1/media/:id) has to answer the
   // same bytes the same way — it used to reach sharp unguarded and 500.
   it('refuses unreadable bytes on the standalone thumbnail path', async () => {
@@ -643,6 +657,44 @@ describe('LocalFileStorage.saveFile with a caller-supplied thumbnail', () => {
       })
     ).rejects.toThrow(MediaValidationError)
     expect(database.createMedia).not.toHaveBeenCalled()
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+  })
+
+  // `metadata()` reads the header, so this is the input the up-front check
+  // cannot catch — it reaches the encoder, and without the classifier in the
+  // catch the caller would get a logged 500 for its own corrupt bytes.
+  it('refuses a truncated thumbnail and reclaims the stored original', async () => {
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createTruncatedPngFile(400, 300)
+      })
+    ).rejects.toThrow(MediaValidationError)
+    expect(database.createMedia).not.toHaveBeenCalled()
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+  })
+
+  it('refuses truncated bytes on the standalone thumbnail path', async () => {
+    await expect(
+      createStorage().saveThumbnail(
+        actor,
+        await createTruncatedPngFile(400, 300)
+      )
+    ).rejects.toThrow(MediaValidationError)
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+  })
+
+  // The row is written last, so a database failure leaves both files stored and
+  // unreferenced — the same reclaim as a missing row.
+  it('reclaims both stored files when the media row write fails', async () => {
+    database.createMedia.mockRejectedValue(new Error('deadlock detected'))
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createPngFile(400, 300)
+      })
+    ).rejects.toThrow('deadlock detected')
     await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
   })
 

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -458,4 +458,74 @@ describe('LocalFileStorage.saveFile with a video', () => {
       .path
     expect(storedPath).toMatch(/^[0-9a-f]{16}\.mp4$/)
   })
+
+  const createPngFile = async (width: number, height: number) => {
+    const buffer = await sharp({
+      create: { width, height, channels: 3, background: '#3366cc' }
+    })
+      .png()
+      .toBuffer()
+    return new File([new Uint8Array(buffer)], 'route-map.png', {
+      type: 'image/png'
+    })
+  }
+
+  const readStoredThumbnail = async () => {
+    const files = await fs.readdir(mediaRoot)
+    const match = files.find((file) => file.endsWith('-thumbnail.webp'))
+    if (!match) throw new Error(`No stored thumbnail in [${files.join(', ')}]`)
+    return sharp(await fs.readFile(path.join(mediaRoot, match))).metadata()
+  }
+
+  // Which of the two thumbnail sources wins was untested on this driver, so the
+  // precedence could be inverted here — reintroducing exactly the bug the S3
+  // driver had — with nothing failing.
+  it('prefers a caller-supplied thumbnail over the extracted video frame', async () => {
+    const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
+      type: 'video/mp4'
+    })
+
+    await createStorage().saveFile(actor, {
+      file,
+      thumbnail: await createPngFile(400, 300)
+    })
+
+    // 400x300 rather than the 1x1 extracted frame.
+    await expect(readStoredThumbnail()).resolves.toMatchObject({
+      width: 400,
+      height: 300
+    })
+  })
+
+  it('falls back to the extracted video frame when no thumbnail is supplied', async () => {
+    const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
+      type: 'video/mp4'
+    })
+
+    await createStorage().saveFile(actor, { file })
+
+    await expect(readStoredThumbnail()).resolves.toMatchObject({
+      width: 1,
+      height: 1
+    })
+  })
+
+  // `MediaSchema.thumbnail` accepts every ACCEPTED_FILE_TYPES entry, videos
+  // included. Reaching sharp with one rejects with a plain Error — a 500, not
+  // the 422 every other bad upload gets — and by then the original is already
+  // written with no `medias` row to reclaim it by.
+  it('refuses a thumbnail that is not an image before storing anything', async () => {
+    const thumbnail = new File([Buffer.from('video-bytes')], 'clip.mp4', {
+      type: 'video/mp4'
+    })
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail
+      })
+    ).rejects.toThrow(MediaValidationError)
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+    expect(database.createMedia).not.toHaveBeenCalled()
+  })
 })

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -518,6 +518,74 @@ describe('LocalFileStorage.saveFile with a video', () => {
     await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(2)
     await expect(readStoredThumbnail()).resolves.toMatchObject(stored)
   })
+})
+
+// Mirrors `S3StorageFile.test.ts`'s block of the same name: a thumbnail
+// uploaded beside the file is client input on both drivers, and the two must
+// answer it identically.
+describe('LocalFileStorage.saveFile with a caller-supplied thumbnail', () => {
+  let tempDir: string
+  let mediaRoot: string
+
+  const actor = { id: 'actor-1', account: { id: 'account-1' } } as Actor
+
+  const database = {
+    createMedia: vi.fn(),
+    getActorFromId: vi.fn(),
+    getFitnessStorageUsageForAccount: vi.fn(),
+    getStorageUsageForAccount: vi.fn()
+  } as unknown as jest.Mocked<Database>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'activities-media-'))
+    mediaRoot = path.join(tempDir, 'media')
+    await fs.mkdir(mediaRoot)
+
+    database.getActorFromId.mockResolvedValue(actor)
+    database.getStorageUsageForAccount.mockResolvedValue(0)
+    database.getFitnessStorageUsageForAccount.mockResolvedValue(0)
+    database.createMedia.mockImplementation((async (params: unknown) => ({
+      id: 'media-1',
+      actorId: actor.id,
+      ...(params as object)
+    })) as never)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  const createStorage = () =>
+    new LocalFileStorage(
+      { type: MediaStorageType.LocalFile, path: mediaRoot },
+      'llun.test',
+      database
+    )
+
+  const createPngFile = async (width: number, height: number) => {
+    const buffer = await sharp({
+      create: { width, height, channels: 3, background: '#3366cc' }
+    })
+      .png()
+      .toBuffer()
+    return new File([new Uint8Array(buffer)], 'route-map.png', {
+      type: 'image/png'
+    })
+  }
+
+  // The dedicated thumbnail endpoint (PUT /api/v1/media/:id) has to answer the
+  // same bytes the same way — it used to reach sharp unguarded and 500.
+  it('refuses unreadable bytes on the standalone thumbnail path', async () => {
+    const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
+      type: 'image/png'
+    })
+
+    await expect(
+      createStorage().saveThumbnail(actor, thumbnail)
+    ).rejects.toThrow(MediaValidationError)
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+  })
 
   // `MediaSchema.thumbnail` accepts every ACCEPTED_FILE_TYPES entry, videos
   // included. Reaching sharp with one rejects with a plain Error — a 500, not
@@ -561,8 +629,9 @@ describe('LocalFileStorage.saveFile with a video', () => {
   })
 
   // The declared type is only a claim, and sharp is the real arbiter — so the
-  // guard above cannot be the whole story.
-  it('reclaims the stored original when the thumbnail is not a readable image', async () => {
+  // type guard above cannot be the whole story. Validating the bytes up front
+  // is what keeps this a 422 with nothing stored.
+  it('refuses unreadable thumbnail bytes before storing anything', async () => {
     const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
       type: 'image/png'
     })
@@ -574,6 +643,20 @@ describe('LocalFileStorage.saveFile with a video', () => {
       })
     ).rejects.toThrow(MediaValidationError)
     expect(database.createMedia).not.toHaveBeenCalled()
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+  })
+
+  // A row is the only handle anything else has on these paths, so without one
+  // both stored files are unreachable.
+  it('reclaims both stored files when the media row cannot be created', async () => {
+    database.createMedia.mockResolvedValue(null as never)
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail: await createPngFile(400, 300)
+      })
+    ).rejects.toThrow('Fail to store media')
     await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
   })
 })

--- a/lib/services/medias/localFile.test.ts
+++ b/lib/services/medias/localFile.test.ts
@@ -12,6 +12,7 @@ import { Actor } from '@/lib/types/domain/actor'
 import { MAX_HEIGHT, MAX_WIDTH } from './constants'
 import { MediaValidationError } from './errors'
 import { LocalFileStorage } from './localFile'
+import { getQuotaLimit } from './quota'
 
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
@@ -407,6 +408,24 @@ describe('LocalFileStorage.saveFile with a video', () => {
       database
     )
 
+  const createPngFile = async (width: number, height: number) => {
+    const buffer = await sharp({
+      create: { width, height, channels: 3, background: '#3366cc' }
+    })
+      .png()
+      .toBuffer()
+    return new File([new Uint8Array(buffer)], 'route-map.png', {
+      type: 'image/png'
+    })
+  }
+
+  const readStoredThumbnail = async () => {
+    const files = await fs.readdir(mediaRoot)
+    const match = files.find((file) => file.endsWith('-thumbnail.webp'))
+    if (!match) throw new Error(`No stored thumbnail in [${files.join(', ')}]`)
+    return sharp(await fs.readFile(path.join(mediaRoot, match))).metadata()
+  }
+
   // A guard, not a regression: this driver always built its path from a
   // generated prefix plus an extension, and `path.extname` can never return a
   // separator, so a supplied name never reached the path here. The traversal
@@ -459,55 +478,45 @@ describe('LocalFileStorage.saveFile with a video', () => {
     expect(storedPath).toMatch(/^[0-9a-f]{16}\.mp4$/)
   })
 
-  const createPngFile = async (width: number, height: number) => {
-    const buffer = await sharp({
-      create: { width, height, channels: 3, background: '#3366cc' }
-    })
-      .png()
-      .toBuffer()
-    return new File([new Uint8Array(buffer)], 'route-map.png', {
-      type: 'image/png'
-    })
-  }
-
-  const readStoredThumbnail = async () => {
-    const files = await fs.readdir(mediaRoot)
-    const match = files.find((file) => file.endsWith('-thumbnail.webp'))
-    if (!match) throw new Error(`No stored thumbnail in [${files.join(', ')}]`)
-    return sharp(await fs.readFile(path.join(mediaRoot, match))).metadata()
-  }
-
   // Which of the two thumbnail sources wins was untested on this driver, so the
   // precedence could be inverted here — reintroducing exactly the bug the S3
-  // driver had — with nothing failing.
-  it('prefers a caller-supplied thumbnail over the extracted video frame', async () => {
+  // driver had — with nothing failing. The file count matters as much as the
+  // dimensions: a variant that writes both and then picks one leaves the loser
+  // on disk with no `medias` row to reclaim it by.
+  it.each([
+    {
+      description:
+        'prefers a caller-supplied thumbnail over the extracted video frame',
+      suppliedThumbnail: { width: 400, height: 300 },
+      stored: { width: 400, height: 300 }
+    },
+    {
+      description:
+        'falls back to the extracted video frame when no thumbnail is supplied',
+      suppliedThumbnail: null,
+      // The mocked `extractVideoImage` frame.
+      stored: { width: 1, height: 1 }
+    }
+  ])('$description', async ({ suppliedThumbnail, stored }) => {
     const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
       type: 'video/mp4'
     })
 
     await createStorage().saveFile(actor, {
       file,
-      thumbnail: await createPngFile(400, 300)
+      ...(suppliedThumbnail
+        ? {
+            thumbnail: await createPngFile(
+              suppliedThumbnail.width,
+              suppliedThumbnail.height
+            )
+          }
+        : null)
     })
 
-    // 400x300 rather than the 1x1 extracted frame.
-    await expect(readStoredThumbnail()).resolves.toMatchObject({
-      width: 400,
-      height: 300
-    })
-  })
-
-  it('falls back to the extracted video frame when no thumbnail is supplied', async () => {
-    const file = new File([Buffer.from('video-bytes')], 'clip.mp4', {
-      type: 'video/mp4'
-    })
-
-    await createStorage().saveFile(actor, { file })
-
-    await expect(readStoredThumbnail()).resolves.toMatchObject({
-      width: 1,
-      height: 1
-    })
+    // The video plus exactly one thumbnail — the losing source is not written.
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(2)
+    await expect(readStoredThumbnail()).resolves.toMatchObject(stored)
   })
 
   // `MediaSchema.thumbnail` accepts every ACCEPTED_FILE_TYPES entry, videos
@@ -527,5 +536,44 @@ describe('LocalFileStorage.saveFile with a video', () => {
     ).rejects.toThrow(MediaValidationError)
     await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
     expect(database.createMedia).not.toHaveBeenCalled()
+  })
+
+  // `createMedia` meters the thumbnail's bytes too, so the pre-check has to
+  // reserve for them — otherwise an upload that fits only without its thumbnail
+  // is accepted and leaves the account over its quota.
+  it('counts the thumbnail against the account quota', async () => {
+    const file = await createPngFile(800, 600)
+    const thumbnail = await createPngFile(400, 300)
+    // Exactly enough room for the original on its own.
+    database.getStorageUsageForAccount.mockResolvedValue(
+      getQuotaLimit() - file.size
+    )
+
+    await expect(
+      createStorage().saveFile(actor, { file, thumbnail })
+    ).rejects.toThrow(MediaValidationError)
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
+    // The same upload without the thumbnail still fits, so the thumbnail's
+    // bytes are what tipped it over.
+    await expect(
+      createStorage().saveFile(actor, { file })
+    ).resolves.toBeTruthy()
+  })
+
+  // The declared type is only a claim, and sharp is the real arbiter — so the
+  // guard above cannot be the whole story.
+  it('reclaims the stored original when the thumbnail is not a readable image', async () => {
+    const thumbnail = new File([Buffer.from('not-an-image')], 'evil.png', {
+      type: 'image/png'
+    })
+
+    await expect(
+      createStorage().saveFile(actor, {
+        file: await createPngFile(800, 600),
+        thumbnail
+      })
+    ).rejects.toThrow(MediaValidationError)
+    expect(database.createMedia).not.toHaveBeenCalled()
+    await expect(fs.readdir(mediaRoot)).resolves.toHaveLength(0)
   })
 })

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -24,10 +24,7 @@ import {
 } from './imageOutputFormat'
 import { getMediaFileUrl } from './mediaFileUrl'
 import { checkQuotaAvailable, getUploadQuotaReservation } from './quota'
-import {
-  assertReadableThumbnail,
-  assertThumbnailDecodable
-} from './thumbnailInput'
+import { readValidThumbnail } from './thumbnailInput'
 import {
   ImageRenditionOutput,
   MediaSchema,
@@ -136,14 +133,14 @@ export class LocalFileStorage implements MediaStorage {
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
       return null
     }
-    // Validate the thumbnail before anything is written, so unusable bytes
-    // cannot leave a stored original behind.
-    if (media.thumbnail) {
-      await assertReadableThumbnail(media.thumbnail)
-    }
+    // Read and validate the thumbnail before anything is written, so unusable
+    // bytes cannot leave a stored original behind.
+    const thumbnailBuffer = media.thumbnail
+      ? await readValidThumbnail(media.thumbnail)
+      : null
 
-    // Check quota before saving; the reservation covers the thumbnail, whose
-    // stored bytes `createMedia` meters too.
+    // Check quota before saving; see `getUploadQuotaReservation` for why the
+    // thumbnail's share of it is an estimate.
     const quotaCheck = await checkQuotaAvailable(
       this._database,
       actor,
@@ -158,22 +155,19 @@ export class LocalFileStorage implements MediaStorage {
     const { path, metaData, previewImage } = file.type.startsWith('video')
       ? await this._saveVideoFile(file)
       : await this._saveImageFile(file)
+    // A caller-supplied thumbnail wins; a video otherwise falls back to the
+    // frame extracted from it.
+    const thumbnailSource = thumbnailBuffer ?? previewImage
     let thumbnail
     try {
-      thumbnail = media.thumbnail
-        ? await this._saveImageFile(media.thumbnail, { isThumbnail: true })
-        : previewImage
-          ? await this._saveImageBuffer(previewImage, { isThumbnail: true })
-          : null
+      thumbnail = thumbnailSource
+        ? await this._saveImageBuffer(thumbnailSource, { isThumbnail: true })
+        : null
     } catch (error) {
+      // The thumbnail's bytes were validated above, so this is a storage fault
+      // of ours: keep the error — it has to stay a logged 500, not a 422 the
+      // client will not retry — but put the original back first.
       await this._reclaimStored(path)
-      // Tell the caller's bad bytes apart from a fault of ours: an image whose
-      // body is truncated passes the header check up front and only fails once
-      // the encoder reaches the missing bytes. Anything else keeps its own
-      // error and stays a logged 500, not a 422 the client will not retry.
-      if (media.thumbnail) {
-        await assertThumbnailDecodable(media.thumbnail)
-      }
       throw error
     }
     let storedMedia
@@ -226,6 +220,10 @@ export class LocalFileStorage implements MediaStorage {
     file: File
   ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
+    // Same validation saveFile applies, so the dedicated thumbnail endpoint
+    // answers unusable bytes with the same 422 rather than a 500.
+    const buffer = await readValidThumbnail(file)
+
     // Enforce the account quota like saveFile, so a thumbnail replacement can't
     // push usage past the limit.
     const quotaCheck = await checkQuotaAvailable(
@@ -241,17 +239,10 @@ export class LocalFileStorage implements MediaStorage {
 
     // Use the stored image's actual size/dimensions (outputInfo), not the input
     // image's metadata.
-    let stored
-    try {
-      stored = await this._saveImageFile(file, { isThumbnail: true })
-    } catch (error) {
-      // The same split saveFile makes: bytes that will not decode are the
-      // caller's 422, anything else is ours and stays a logged 500. Nothing is
-      // stored before this, so there is nothing to reclaim.
-      await assertThumbnailDecodable(file)
-      throw error
-    }
-    const { outputInfo, path, contentType } = stored
+    const { outputInfo, path, contentType } = await this._saveImageBuffer(
+      buffer,
+      { isThumbnail: true }
+    )
     return {
       path,
       bytes: outputInfo.size,
@@ -302,11 +293,11 @@ export class LocalFileStorage implements MediaStorage {
 
   // A stored path is reachable only through its `medias` row, so anything that
   // fails before that row exists has to take the files back out.
-  private async _reclaimStored(...paths: (string | undefined)[]) {
+  private async _reclaimStored(originalPath: string, thumbnailPath?: string) {
     await Promise.all(
-      paths
-        .filter((path) => path !== undefined)
-        .map((path) => this.deleteFile(path).catch(() => false))
+      [originalPath, thumbnailPath]
+        .filter((stored) => stored !== undefined)
+        .map((stored) => this.deleteFile(stored).catch(() => false))
     )
   }
 

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -25,6 +25,11 @@ import {
 import { getMediaFileUrl } from './mediaFileUrl'
 import { checkQuotaAvailable } from './quota'
 import {
+  assertReadableImageBytes,
+  assertReadableThumbnail,
+  getUploadQuotaReservation
+} from './thumbnailInput'
+import {
   ImageRenditionOutput,
   MediaSchema,
   MediaStorage,
@@ -132,22 +137,18 @@ export class LocalFileStorage implements MediaStorage {
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
       return null
     }
-    // `MediaSchema.thumbnail` is a `FileSchema`, which accepts every entry of
-    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an obviously
-    // unusable one here, before anything is written. The declared type is only
-    // a claim, so this is the cheap half of the check; sharp is the real
-    // arbiter, and the catch below covers what it rejects.
-    if (media.thumbnail && !media.thumbnail.type.startsWith('image')) {
-      throw new MediaValidationError('Thumbnail must be an image')
+    // Validate the thumbnail before anything is written, so unusable bytes
+    // cannot leave a stored original behind.
+    if (media.thumbnail) {
+      await assertReadableThumbnail(media.thumbnail)
     }
 
-    // Check quota before saving. `createMedia` meters the thumbnail's stored
-    // bytes too, so reserve for it here — the uploaded file is larger than the
-    // WebP it becomes, which errs on the safe side.
+    // Check quota before saving; the reservation covers the thumbnail, whose
+    // stored bytes `createMedia` meters too.
     const quotaCheck = await checkQuotaAvailable(
       this._database,
       actor,
-      file.size + (media.thumbnail?.size ?? 0)
+      getUploadQuotaReservation(media)
     )
     if (!quotaCheck.available) {
       throw new MediaValidationError(
@@ -167,14 +168,11 @@ export class LocalFileStorage implements MediaStorage {
           : null
     } catch (error) {
       // The original is already written and no `medias` row will reference it,
-      // so reclaim it before the failure propagates.
+      // so reclaim it before the failure propagates. The error passes through
+      // untouched: the thumbnail's bytes were validated before any of this ran,
+      // so whatever failed here is ours — a storage fault that has to stay a
+      // logged 500, not be relabelled as the caller's bad input.
       await this.deleteFile(path).catch(() => false)
-      // Bytes that merely claim to be an image reach sharp and reject with a
-      // plain Error, which surfaces as a 500; that is invalid input, so report
-      // it as the 422 the rest of the upload path returns.
-      if (media.thumbnail) {
-        throw new MediaValidationError('Thumbnail is not a readable image')
-      }
       throw error
     }
     const storedMedia = await this._database.createMedia({
@@ -209,6 +207,11 @@ export class LocalFileStorage implements MediaStorage {
     })
 
     if (!storedMedia) {
+      // Same reclaim as above — without a row, nothing can find these again.
+      await this.deleteFile(path).catch(() => false)
+      if (thumbnail) {
+        await this.deleteFile(thumbnail.path).catch(() => false)
+      }
       throw new Error('Fail to store media')
     }
 
@@ -220,6 +223,9 @@ export class LocalFileStorage implements MediaStorage {
     file: File
   ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
+    // Same validation saveFile applies, so the dedicated thumbnail endpoint
+    // answers unreadable bytes with the same 422 rather than a 500.
+    await assertReadableImageBytes(file)
 
     // Enforce the account quota like saveFile, so a thumbnail replacement can't
     // push usage past the limit.

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -133,19 +133,21 @@ export class LocalFileStorage implements MediaStorage {
       return null
     }
     // `MediaSchema.thumbnail` is a `FileSchema`, which accepts every entry of
-    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an unusable one
-    // here, before anything is written: reaching sharp with it rejects with a
-    // plain Error, which is a 500 rather than a 422 and leaves the already
-    // stored original behind with no `medias` row to reclaim it by.
+    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an obviously
+    // unusable one here, before anything is written. The declared type is only
+    // a claim, so this is the cheap half of the check; sharp is the real
+    // arbiter, and the catch below covers what it rejects.
     if (media.thumbnail && !media.thumbnail.type.startsWith('image')) {
       throw new MediaValidationError('Thumbnail must be an image')
     }
 
-    // Check quota before saving
+    // Check quota before saving. `createMedia` meters the thumbnail's stored
+    // bytes too, so reserve for it here — the uploaded file is larger than the
+    // WebP it becomes, which errs on the safe side.
     const quotaCheck = await checkQuotaAvailable(
       this._database,
       actor,
-      file.size
+      file.size + (media.thumbnail?.size ?? 0)
     )
     if (!quotaCheck.available) {
       throw new MediaValidationError(
@@ -156,11 +158,25 @@ export class LocalFileStorage implements MediaStorage {
     const { path, metaData, previewImage } = file.type.startsWith('video')
       ? await this._saveVideoFile(file)
       : await this._saveImageFile(file)
-    const thumbnail = media.thumbnail
-      ? await this._saveImageFile(media.thumbnail, { isThumbnail: true })
-      : previewImage
-        ? await this._saveImageBuffer(previewImage, { isThumbnail: true })
-        : null
+    let thumbnail
+    try {
+      thumbnail = media.thumbnail
+        ? await this._saveImageFile(media.thumbnail, { isThumbnail: true })
+        : previewImage
+          ? await this._saveImageBuffer(previewImage, { isThumbnail: true })
+          : null
+    } catch (error) {
+      // The original is already written and no `medias` row will reference it,
+      // so reclaim it before the failure propagates.
+      await this.deleteFile(path).catch(() => false)
+      // Bytes that merely claim to be an image reach sharp and reject with a
+      // plain Error, which surfaces as a 500; that is invalid input, so report
+      // it as the 422 the rest of the upload path returns.
+      if (media.thumbnail) {
+        throw new MediaValidationError('Thumbnail is not a readable image')
+      }
+      throw error
+    }
     const storedMedia = await this._database.createMedia({
       actorId: actor.id,
       original: {

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -23,11 +23,10 @@ import {
   getImageOutputFormatDetail
 } from './imageOutputFormat'
 import { getMediaFileUrl } from './mediaFileUrl'
-import { checkQuotaAvailable } from './quota'
+import { checkQuotaAvailable, getUploadQuotaReservation } from './quota'
 import {
-  assertReadableImageBytes,
   assertReadableThumbnail,
-  getUploadQuotaReservation
+  assertThumbnailDecodable
 } from './thumbnailInput'
 import {
   ImageRenditionOutput,
@@ -167,51 +166,55 @@ export class LocalFileStorage implements MediaStorage {
           ? await this._saveImageBuffer(previewImage, { isThumbnail: true })
           : null
     } catch (error) {
-      // The original is already written and no `medias` row will reference it,
-      // so reclaim it before the failure propagates. The error passes through
-      // untouched: the thumbnail's bytes were validated before any of this ran,
-      // so whatever failed here is ours — a storage fault that has to stay a
-      // logged 500, not be relabelled as the caller's bad input.
-      await this.deleteFile(path).catch(() => false)
+      await this._reclaimStored(path)
+      // Tell the caller's bad bytes apart from a fault of ours: an image whose
+      // body is truncated passes the header check up front and only fails once
+      // the encoder reaches the missing bytes. Anything else keeps its own
+      // error and stays a logged 500, not a 422 the client will not retry.
+      if (media.thumbnail) {
+        await assertThumbnailDecodable(media.thumbnail)
+      }
       throw error
     }
-    const storedMedia = await this._database.createMedia({
-      actorId: actor.id,
-      original: {
-        path,
-        bytes: file.size,
-        mimeType: file.type,
-        metaData: {
-          width: metaData.width ?? 0,
-          height: metaData.height ?? 0
+    let storedMedia
+    try {
+      storedMedia = await this._database.createMedia({
+        actorId: actor.id,
+        original: {
+          path,
+          bytes: file.size,
+          mimeType: file.type,
+          metaData: {
+            width: metaData.width ?? 0,
+            height: metaData.height ?? 0
+          },
+          fileName: sanitizeStoredFileName(file.name)
         },
-        fileName: sanitizeStoredFileName(file.name)
-      },
-      ...(thumbnail
-        ? {
-            // Use the resized image's actual size/dimensions (outputInfo), not
-            // the input image's metadata.
-            thumbnail: {
-              path: thumbnail.path,
-              bytes: thumbnail.outputInfo.size,
-              mimeType: thumbnail.contentType,
-              metaData: {
-                width: thumbnail.outputInfo.width,
-                height: thumbnail.outputInfo.height
+        ...(thumbnail
+          ? {
+              // Use the resized image's actual size/dimensions (outputInfo), not
+              // the input image's metadata.
+              thumbnail: {
+                path: thumbnail.path,
+                bytes: thumbnail.outputInfo.size,
+                mimeType: thumbnail.contentType,
+                metaData: {
+                  width: thumbnail.outputInfo.width,
+                  height: thumbnail.outputInfo.height
+                }
               }
             }
-          }
-        : null),
-      ...(media.description ? { description: media.description } : null),
-      ...(media.focus ? { focus: media.focus } : null)
-    })
+          : null),
+        ...(media.description ? { description: media.description } : null),
+        ...(media.focus ? { focus: media.focus } : null)
+      })
+    } catch (error) {
+      await this._reclaimStored(path, thumbnail?.path)
+      throw error
+    }
 
     if (!storedMedia) {
-      // Same reclaim as above — without a row, nothing can find these again.
-      await this.deleteFile(path).catch(() => false)
-      if (thumbnail) {
-        await this.deleteFile(thumbnail.path).catch(() => false)
-      }
+      await this._reclaimStored(path, thumbnail?.path)
       throw new Error('Fail to store media')
     }
 
@@ -223,10 +226,6 @@ export class LocalFileStorage implements MediaStorage {
     file: File
   ): Promise<ThumbnailStorageOutput | null> {
     if (!file.type.startsWith('image')) return null
-    // Same validation saveFile applies, so the dedicated thumbnail endpoint
-    // answers unreadable bytes with the same 422 rather than a 500.
-    await assertReadableImageBytes(file)
-
     // Enforce the account quota like saveFile, so a thumbnail replacement can't
     // push usage past the limit.
     const quotaCheck = await checkQuotaAvailable(
@@ -242,9 +241,17 @@ export class LocalFileStorage implements MediaStorage {
 
     // Use the stored image's actual size/dimensions (outputInfo), not the input
     // image's metadata.
-    const { outputInfo, path, contentType } = await this._saveImageFile(file, {
-      isThumbnail: true
-    })
+    let stored
+    try {
+      stored = await this._saveImageFile(file, { isThumbnail: true })
+    } catch (error) {
+      // The same split saveFile makes: bytes that will not decode are the
+      // caller's 422, anything else is ours and stays a logged 500. Nothing is
+      // stored before this, so there is nothing to reclaim.
+      await assertThumbnailDecodable(file)
+      throw error
+    }
+    const { outputInfo, path, contentType } = stored
     return {
       path,
       bytes: outputInfo.size,
@@ -291,6 +298,16 @@ export class LocalFileStorage implements MediaStorage {
         height: outputInfo.height
       }
     }
+  }
+
+  // A stored path is reachable only through its `medias` row, so anything that
+  // fails before that row exists has to take the files back out.
+  private async _reclaimStored(...paths: (string | undefined)[]) {
+    await Promise.all(
+      paths
+        .filter((path) => path !== undefined)
+        .map((path) => this.deleteFile(path).catch(() => false))
+    )
   }
 
   private async _saveImageFile(

--- a/lib/services/medias/localFile.ts
+++ b/lib/services/medias/localFile.ts
@@ -132,6 +132,14 @@ export class LocalFileStorage implements MediaStorage {
     if (!file.type.startsWith('image') && !file.type.startsWith('video')) {
       return null
     }
+    // `MediaSchema.thumbnail` is a `FileSchema`, which accepts every entry of
+    // ACCEPTED_FILE_TYPES — video and audio included. Refuse an unusable one
+    // here, before anything is written: reaching sharp with it rejects with a
+    // plain Error, which is a 500 rather than a 422 and leaves the already
+    // stored original behind with no `medias` row to reclaim it by.
+    if (media.thumbnail && !media.thumbnail.type.startsWith('image')) {
+      throw new MediaValidationError('Thumbnail must be an image')
+    }
 
     // Check quota before saving
     const quotaCheck = await checkQuotaAvailable(

--- a/lib/services/medias/quota.ts
+++ b/lib/services/medias/quota.ts
@@ -3,6 +3,7 @@ import { Database } from '@/lib/database/types'
 import { Actor } from '@/lib/types/domain/actor'
 
 import { DEFAULT_QUOTA_PER_ACCOUNT } from './constants'
+import type { MediaSchema } from './types'
 
 export const getQuotaLimit = (): number => {
   const config = getConfig()
@@ -41,3 +42,12 @@ export const checkQuotaAvailable = async (
   const available = used + requiredBytes <= limit
   return { available, used, limit }
 }
+
+// What one upload should reserve. `createMedia` meters the original's UPLOADED
+// bytes plus the thumbnail's STORED bytes, so this is best-effort rather than
+// exact: a lossy JPEG can re-encode into a near-lossless WebP larger than it
+// arrived as. Reserving nothing for the thumbnail was worse — an upload that
+// fits only without it was accepted and left the account over its quota. The
+// original under-counts the same way, and always has.
+export const getUploadQuotaReservation = (media: MediaSchema) =>
+  media.file.size + (media.thumbnail?.size ?? 0)

--- a/lib/services/medias/thumbnailInput.test.ts
+++ b/lib/services/medias/thumbnailInput.test.ts
@@ -1,10 +1,7 @@
 import sharp from 'sharp'
 
 import { MediaValidationError } from './errors'
-import {
-  assertReadableThumbnail,
-  assertThumbnailDecodable
-} from './thumbnailInput'
+import { readValidThumbnail } from './thumbnailInput'
 
 const createPng = async (width = 40, height = 30) =>
   sharp({ create: { width, height, channels: 3, background: '#3366cc' } })
@@ -14,20 +11,22 @@ const createPng = async (width = 40, height = 30) =>
 const asFile = (bytes: Uint8Array, type = 'image/png', name = 'thumb.png') =>
   new File([bytes], name, { type })
 
-describe('assertReadableThumbnail', () => {
-  it('accepts a real image', async () => {
-    await expect(
-      assertReadableThumbnail(asFile(await createPng()))
-    ).resolves.toBeUndefined()
+describe('readValidThumbnail', () => {
+  it('returns the bytes of a real image', async () => {
+    const png = await createPng()
+
+    await expect(readValidThumbnail(asFile(png))).resolves.toEqual(png)
   })
 
   it.each([
     {
+      // Real image bytes, declared as a video. Only the declared-type guard
+      // rejects this — the decode below is perfectly happy with it — and it is
+      // the check that keeps `saveFile` consistent with `saveThumbnail`, which
+      // refuses a non-image type outright.
       description: 'rejects a declared type that is not an image',
-      file: () =>
-        new File([Buffer.from('video-bytes')], 'clip.mp4', {
-          type: 'video/mp4'
-        })
+      file: async () =>
+        new File([await createPng()], 'clip.mp4', { type: 'video/mp4' })
     },
     {
       description: 'rejects bytes that are not an image at all',
@@ -36,42 +35,21 @@ describe('assertReadableThumbnail', () => {
     {
       description: 'rejects an empty file',
       file: () => asFile(Buffer.alloc(0))
+    },
+    {
+      description: 'rejects an image whose body is truncated',
+      file: async () => {
+        // The case a header parse cannot catch: `sharp().metadata()` reports
+        // 400x300 for this, and only the full decode rejects it. Without that,
+        // the encoder is the first thing to notice — by which point the
+        // original is stored and the failure looks like ours.
+        const png = await createPng(400, 300)
+        return asFile(png.subarray(0, Math.floor(png.length * 0.6)))
+      }
     }
   ])('$description', async ({ file }) => {
-    await expect(assertReadableThumbnail(file())).rejects.toThrow(
+    await expect(readValidThumbnail(await file())).rejects.toThrow(
       MediaValidationError
     )
-  })
-
-  // The reason `assertThumbnailDecodable` has to exist: this check reads the
-  // header, so an image whose body was cut short passes it and only fails later,
-  // in the encoder. Anything that changes this to a full decode should delete
-  // the second function rather than leave both.
-  it('accepts a truncated image, which only a full decode catches', async () => {
-    const png = await createPng(400, 300)
-    const truncated = asFile(png.subarray(0, Math.floor(png.length * 0.6)))
-
-    await expect(assertReadableThumbnail(truncated)).resolves.toBeUndefined()
-    await expect(assertThumbnailDecodable(truncated)).rejects.toThrow(
-      MediaValidationError
-    )
-  })
-})
-
-describe('assertThumbnailDecodable', () => {
-  it('accepts a real image', async () => {
-    await expect(
-      assertThumbnailDecodable(asFile(await createPng()))
-    ).resolves.toBeUndefined()
-  })
-
-  // It classifies bytes, so it must not care about the declared type — the
-  // caller has already decided whether that mattered.
-  it('accepts a real image regardless of the declared type', async () => {
-    await expect(
-      assertThumbnailDecodable(
-        asFile(await createPng(), 'image/jpeg', 'mislabelled.jpg')
-      )
-    ).resolves.toBeUndefined()
   })
 })

--- a/lib/services/medias/thumbnailInput.test.ts
+++ b/lib/services/medias/thumbnailInput.test.ts
@@ -1,0 +1,77 @@
+import sharp from 'sharp'
+
+import { MediaValidationError } from './errors'
+import {
+  assertReadableThumbnail,
+  assertThumbnailDecodable
+} from './thumbnailInput'
+
+const createPng = async (width = 40, height = 30) =>
+  sharp({ create: { width, height, channels: 3, background: '#3366cc' } })
+    .png()
+    .toBuffer()
+
+const asFile = (bytes: Uint8Array, type = 'image/png', name = 'thumb.png') =>
+  new File([bytes], name, { type })
+
+describe('assertReadableThumbnail', () => {
+  it('accepts a real image', async () => {
+    await expect(
+      assertReadableThumbnail(asFile(await createPng()))
+    ).resolves.toBeUndefined()
+  })
+
+  it.each([
+    {
+      description: 'rejects a declared type that is not an image',
+      file: () =>
+        new File([Buffer.from('video-bytes')], 'clip.mp4', {
+          type: 'video/mp4'
+        })
+    },
+    {
+      description: 'rejects bytes that are not an image at all',
+      file: () => asFile(Buffer.from('not-an-image'))
+    },
+    {
+      description: 'rejects an empty file',
+      file: () => asFile(Buffer.alloc(0))
+    }
+  ])('$description', async ({ file }) => {
+    await expect(assertReadableThumbnail(file())).rejects.toThrow(
+      MediaValidationError
+    )
+  })
+
+  // The reason `assertThumbnailDecodable` has to exist: this check reads the
+  // header, so an image whose body was cut short passes it and only fails later,
+  // in the encoder. Anything that changes this to a full decode should delete
+  // the second function rather than leave both.
+  it('accepts a truncated image, which only a full decode catches', async () => {
+    const png = await createPng(400, 300)
+    const truncated = asFile(png.subarray(0, Math.floor(png.length * 0.6)))
+
+    await expect(assertReadableThumbnail(truncated)).resolves.toBeUndefined()
+    await expect(assertThumbnailDecodable(truncated)).rejects.toThrow(
+      MediaValidationError
+    )
+  })
+})
+
+describe('assertThumbnailDecodable', () => {
+  it('accepts a real image', async () => {
+    await expect(
+      assertThumbnailDecodable(asFile(await createPng()))
+    ).resolves.toBeUndefined()
+  })
+
+  // It classifies bytes, so it must not care about the declared type — the
+  // caller has already decided whether that mattered.
+  it('accepts a real image regardless of the declared type', async () => {
+    await expect(
+      assertThumbnailDecodable(
+        asFile(await createPng(), 'image/jpeg', 'mislabelled.jpg')
+      )
+    ).resolves.toBeUndefined()
+  })
+})

--- a/lib/services/medias/thumbnailInput.ts
+++ b/lib/services/medias/thumbnailInput.ts
@@ -1,40 +1,30 @@
-import sharp, { type Sharp } from 'sharp'
+import sharp from 'sharp'
 
 import { MediaValidationError } from './errors'
-
-const assertPasses = async (
-  file: File,
-  check: (image: Sharp) => Promise<unknown>
-) => {
-  try {
-    await check(sharp(Buffer.from(await file.arrayBuffer())))
-  } catch {
-    throw new MediaValidationError('Thumbnail is not a readable image')
-  }
-}
 
 // A thumbnail is unvalidated client input on every path that accepts one:
 // `FileSchema` checks the declared type against ACCEPTED_FILE_TYPES, which
 // includes video and audio, and a declared type is only a claim in any case.
-// Both storage drivers validate through here so the answer cannot differ by
+// Both storage drivers read one through here so the answer cannot differ by
 // backend — that divergence is what this module exists to prevent.
 //
-// `metadata()` parses the header rather than decoding pixels, so this is cheap
-// enough to run before anything is stored: bytes that are not an image at all
-// are refused with nothing written.
-export const assertReadableThumbnail = async (thumbnail: File) => {
+// Returns the bytes, so the caller stores them without reading the file again.
+export const readValidThumbnail = async (thumbnail: File): Promise<Buffer> => {
   if (!thumbnail.type.startsWith('image')) {
     throw new MediaValidationError('Thumbnail must be an image')
   }
-  await assertPasses(thumbnail, (image) => image.metadata())
-}
-
-// A full decode, for classifying a failure that happened while storing. An
-// image whose header is intact but whose body is truncated passes the check
-// above and only fails when the encoder reaches the missing bytes — this is
-// what tells that apart from a storage fault of ours, which must keep its own
-// error and stay a logged 500 rather than becoming a 422 the client will not
-// retry.
-export const assertThumbnailDecodable = async (thumbnail: File) => {
-  await assertPasses(thumbnail, (image) => image.stats())
+  const buffer = Buffer.from(await thumbnail.arrayBuffer())
+  try {
+    // A full decode, not the cheaper `metadata()`: that parses the header, so
+    // an image whose body is truncated passes it and fails only once the
+    // encoder reaches the bytes that are not there — by which point the
+    // original is stored and the failure is indistinguishable from a storage
+    // fault of ours. Deciding it here keeps unusable input a 422 with nothing
+    // written, and leaves every failure after it a genuine 500. It costs about
+    // a sixth of the encode it precedes.
+    await sharp(buffer).stats()
+  } catch {
+    throw new MediaValidationError('Thumbnail is not a readable image')
+  }
+  return buffer
 }

--- a/lib/services/medias/thumbnailInput.ts
+++ b/lib/services/medias/thumbnailInput.ts
@@ -1,0 +1,39 @@
+import sharp from 'sharp'
+
+import { MediaValidationError } from './errors'
+import type { MediaSchema } from './types'
+
+// Checks that bytes claiming to be an image actually are one. `metadata()`
+// parses the header rather than decoding pixels, so this is cheap enough to run
+// before anything is stored — which is the point: an unreadable thumbnail must
+// be a 422 rather than a 500 with a stored original left behind, and a failure
+// after this point must stay recognisable as a storage failure of ours rather
+// than being reported as the caller's fault.
+export const assertReadableImageBytes = async (file: File) => {
+  try {
+    await sharp(Buffer.from(await file.arrayBuffer())).metadata()
+  } catch {
+    throw new MediaValidationError('Thumbnail is not a readable image')
+  }
+}
+
+// A thumbnail is unvalidated client input on every path that accepts one:
+// `FileSchema` checks the declared type against ACCEPTED_FILE_TYPES, which
+// includes video and audio, and a declared type is only a claim in any case.
+// Both storage drivers validate it through here so the answer cannot differ by
+// backend — that divergence is what this module exists to prevent.
+export const assertReadableThumbnail = async (thumbnail: File) => {
+  if (!thumbnail.type.startsWith('image')) {
+    throw new MediaValidationError('Thumbnail must be an image')
+  }
+  await assertReadableImageBytes(thumbnail)
+}
+
+// `createMedia` meters the original's UPLOADED bytes plus the thumbnail's
+// STORED bytes, so this is a best-effort reservation, not an exact one: a lossy
+// JPEG can re-encode into a near-lossless WebP larger than it arrived as.
+// Reserving nothing was worse — an upload that fits only without its thumbnail
+// was accepted and left the account over its quota. The original under-counts
+// the same way, and always has.
+export const getUploadQuotaReservation = (media: MediaSchema) =>
+  media.file.size + (media.thumbnail?.size ?? 0)

--- a/lib/services/medias/thumbnailInput.ts
+++ b/lib/services/medias/thumbnailInput.ts
@@ -1,17 +1,13 @@
-import sharp from 'sharp'
+import sharp, { type Sharp } from 'sharp'
 
 import { MediaValidationError } from './errors'
-import type { MediaSchema } from './types'
 
-// Checks that bytes claiming to be an image actually are one. `metadata()`
-// parses the header rather than decoding pixels, so this is cheap enough to run
-// before anything is stored — which is the point: an unreadable thumbnail must
-// be a 422 rather than a 500 with a stored original left behind, and a failure
-// after this point must stay recognisable as a storage failure of ours rather
-// than being reported as the caller's fault.
-export const assertReadableImageBytes = async (file: File) => {
+const assertPasses = async (
+  file: File,
+  check: (image: Sharp) => Promise<unknown>
+) => {
   try {
-    await sharp(Buffer.from(await file.arrayBuffer())).metadata()
+    await check(sharp(Buffer.from(await file.arrayBuffer())))
   } catch {
     throw new MediaValidationError('Thumbnail is not a readable image')
   }
@@ -20,20 +16,25 @@ export const assertReadableImageBytes = async (file: File) => {
 // A thumbnail is unvalidated client input on every path that accepts one:
 // `FileSchema` checks the declared type against ACCEPTED_FILE_TYPES, which
 // includes video and audio, and a declared type is only a claim in any case.
-// Both storage drivers validate it through here so the answer cannot differ by
+// Both storage drivers validate through here so the answer cannot differ by
 // backend — that divergence is what this module exists to prevent.
+//
+// `metadata()` parses the header rather than decoding pixels, so this is cheap
+// enough to run before anything is stored: bytes that are not an image at all
+// are refused with nothing written.
 export const assertReadableThumbnail = async (thumbnail: File) => {
   if (!thumbnail.type.startsWith('image')) {
     throw new MediaValidationError('Thumbnail must be an image')
   }
-  await assertReadableImageBytes(thumbnail)
+  await assertPasses(thumbnail, (image) => image.metadata())
 }
 
-// `createMedia` meters the original's UPLOADED bytes plus the thumbnail's
-// STORED bytes, so this is a best-effort reservation, not an exact one: a lossy
-// JPEG can re-encode into a near-lossless WebP larger than it arrived as.
-// Reserving nothing was worse — an upload that fits only without its thumbnail
-// was accepted and left the account over its quota. The original under-counts
-// the same way, and always has.
-export const getUploadQuotaReservation = (media: MediaSchema) =>
-  media.file.size + (media.thumbnail?.size ?? 0)
+// A full decode, for classifying a failure that happened while storing. An
+// image whose header is intact but whose body is truncated passes the check
+// above and only fails when the encoder reaches the missing bytes — this is
+// what tells that apart from a storage fault of ours, which must keep its own
+// error and stay a logged 500 rather than becoming a 422 the client will not
+// retry.
+export const assertThumbnailDecodable = async (thumbnail: File) => {
+  await assertPasses(thumbnail, (image) => image.stats())
+}


### PR DESCRIPTION
## Summary

`S3FileStorage.saveFile` handled `media.thumbnail` only in its **video** branch, where it built one from the extracted preview frame. The **image** branch called `createMedia` with no `thumbnail` key at all, so a thumbnail uploaded beside an image was silently discarded.

`MediaSchema` accepts an optional `thumbnail` and `handleSyncMediaUpload` passes the parsed schema straight through, so the same `POST /api/v1/media` request produced a different `meta.small` and `preview_url` depending on which storage backend the instance runs: stored on a filesystem instance, dropped on an object-storage one. (Upload-response only — `getMastodonAttachment` hardcodes `preview_url: null` and the ActivityPub `Document` has no thumbnail field, so nothing federated.)

The video branch had the matching half of the gap — it always used the extracted frame and ignored a caller-supplied thumbnail, which the local driver prefers.

Five rounds of sub-agent review turned this from "store the thumbnail on S3 too" into "both drivers answer a supplied thumbnail identically, and neither leaves a stored file behind when it can't". The review comments record what each round found.

## What changed

**`lib/services/medias/S3StorageFile.ts`** — the image and video branches share one `createMedia` call with the local driver's precedence: a caller-supplied thumbnail wins → else a video's extracted preview frame → else no thumbnail. The stored thumbnail is recorded from `outputInfo` (the stored WebP), so `meta.small` and the metered `thumbnail.bytes` describe what actually landed in the bucket. `_uploadImageBufferToS3` returns `previewImage: null` so an image and a video upload share one result shape, exactly as `_saveImageBuffer` does locally.

**`lib/services/medias/thumbnailInput.ts`** (new) — a supplied thumbnail is unvalidated client input, and both drivers read one through `readValidThumbnail` so the answer cannot differ by backend. It checks the declared type (`FileSchema` accepts video and audio too) and fully decodes the bytes — `sharp().stats()`, not the cheaper `metadata()`, which parses only the header and so lets a truncated image through to the encoder, where the failure is no longer distinguishable from a storage fault. It runs before anything is stored and returns the bytes, so the drivers store them without reading the file again.

**`lib/services/medias/localFile.ts`** — same validation, same quota reservation, same reclaim. Its behaviour changes too: it previously fed an unvalidated thumbnail straight to sharp.

**Reclaim on failure, both drivers** — a `medias` row is the only handle anything has on a stored path, so a file written without one is reachable only by `scripts/maintenance/cleanupMediaStorage.ts`. Whatever fails between the first write and the row now takes the files back out: a thumbnail that fails to store, `createMedia` rejecting, and `createMedia` returning null. The error itself is never relabelled — a storage fault stays a logged 500 rather than becoming a 422 the client will not retry.

**Quota** — `getUploadQuotaReservation` (in `medias/quota`) reserves `file.size + thumbnail.size`, since `createMedia` meters `original.bytes + thumbnail.bytes`. Best-effort rather than exact: a lossy JPEG can re-encode into a *larger* near-lossless WebP, so this can still under-reserve — `original.bytes` under-counts the same way and always has. Reserving nothing was strictly worse: an upload that fits only without its thumbnail was accepted and left the account over quota. This tightens acceptance slightly — an upload at the quota edge carrying a thumbnail now 422s where it previously succeeded.

**`saveThumbnail`** (`PUT|PATCH /api/v1/media/:id`) uses the same validation, so the dedicated thumbnail endpoint answers with 422 what it used to 500 on.

**Docs** — `docs/architecture.md` gains a paragraph on thumbnail handling in the media-storage section; `REVIEW.md` records the two invariants this surfaced (the drivers must answer identically; a write that loses its row must be reclaimed, not relabelled as client error).

## Testing

`thumbnailInput.test.ts` pins the validator directly, including the two inputs that isolate each half of it: real image bytes declared `video/mp4` (only the type guard rejects it) and a truncated PNG (only the full decode does).

Both drivers carry a `saveFile with a caller-supplied thumbnail` block covering: the thumbnail is stored at its own dimensions under a `-thumbnail` key; `createMedia` records path/bytes/mimeType/metaData from the *stored* file; the attachment reports `meta.small`/`preview_url`; an above-cap thumbnail (the only case that distinguishes `outputInfo` from the input metadata); `description`/`focus` survive the unified call; the quota reservation; a non-image thumbnail; a truncated one; and reclaim on both `createMedia` failure modes. The S3 block additionally injects a storage failure to pin that the original is reclaimed and the error is not relabelled. Video precedence is a table on both drivers. Coverage is not identical between the two files — some cases exist only where they can be driven, and the S3 block is the superset.

Every assertion was mutation-checked: reverting each behaviour in turn — `outputInfo`→`metaData`, dropping the `description`/`focus` spreads, dropping the type guard, `stats()`→`metadata()`, removing each reclaim, inverting the precedence on either driver — fails exactly the tests that cover it and nothing else. The type-guard mutation initially failed *nothing*, which is why that test exists.

Gate: `prettier --write .`, `eslint .` (0 errors), `next build`, `vitest run` — **738 files / 7623 tests passed**.

No UI surface: the observable change is the Mastodon attachment JSON and the upload status codes, which the tests assert.

## Notes

- Found during review of #1334, which deliberately did not widen its scope; re-verified as still valid after #1332 and #1337 merged.
- Out of scope, filed separately: `LocalFileStorage._saveVideoFile` writes the video into the media root and *then* runs `extractVideoImage`, so an ffmpeg failure orphans the video — the same class of leak this PR fixes elsewhere, on a path it does not touch (the S3 driver extracts before its PUT and has no such gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)