### PR TITLE
fix: stop the env-block builder emitting placeholders as values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,11 @@ ACTIVITIES_SECRET_PHASE=
 # ============================================================================
 # Required for media uploads (images, etc.)
 # Without this, media uploads are disabled.
+#
+# Leave the whole block commented out to disable uploads. Do NOT set a variable
+# to an empty value instead: a blank required value (e.g. a bare
+# ACTIVITIES_MEDIA_STORAGE_PATH=) is rejected and disables storage with a
+# warning, rather than being ignored.
 
 # Storage type: fs (local), s3, object (S3-compatible)
 # ACTIVITIES_MEDIA_STORAGE_TYPE=fs
@@ -154,6 +159,11 @@ ACTIVITIES_SECRET_PHASE=
 # OPTIONAL - Fitness File Storage Configuration
 # ============================================================================
 # Falls back to media storage config if not set separately.
+#
+# The same blank-value rule applies to _PATH / _BUCKET / _REGION here: leave a
+# variable commented out rather than setting it to an empty value. (An empty
+# ACTIVITIES_FITNESS_STORAGE_TYPE= is different — it selects the media-storage
+# fallback, exactly as leaving it unset does.)
 
 # ACTIVITIES_FITNESS_STORAGE_TYPE=fs
 # ACTIVITIES_FITNESS_STORAGE_PATH=./uploads/fitness

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -75,6 +75,22 @@ inert — nothing typed into it is submitted, stored, or sent anywhere, and the
 server still only reads those values from the environment at boot, so a change
 needs a restart.
 
+A required variable you have not filled in is listed in the block carrying a
+value only when the example is itself a correct one to keep — today that is just
+`ACTIVITIES_MEDIA_STORAGE_PATH=./uploads` — and empty otherwise (`NAME=`), never
+its example. The example belongs to the input beside it: a block that carried
+examples as values could be pasted verbatim and boot a real configuration out of
+them, pointing a live instance's uploads at a bucket the operator does not own.
+Note that `./uploads` is a default of the builder's field, not of the variable:
+none of the storage variables has an app-level default, so omitting a required
+one from your `.env` fails config validation rather than falling back. An
+**optional** variable is left out of the block entirely until you type something
+into it, which is why `ACTIVITIES_MEDIA_STORAGE_ENDPOINT` does not appear by
+default.
+
+An emitted `NAME=` is inert because a blank required value is rejected rather
+than accepted — see [Media Storage](#media-storage) below for that rule.
+
 ## Core Configuration
 
 | Variable                         | Required | Description                                                                                                                                                                                                                                            |
@@ -205,6 +221,15 @@ Required for media uploads (images and video in posts). If no media storage is c
 
 `ACTIVITIES_MEDIA_STORAGE_PATH`, `ACTIVITIES_MEDIA_STORAGE_BUCKET`, and `ACTIVITIES_MEDIA_STORAGE_REGION` are required for their storage type and have no default. Surrounding whitespace is trimmed, and a value that is **set but empty** (or whitespace only) is treated as **not configured**: the app logs a warning and leaves media storage disabled instead of starting a broken backend. An empty `ACTIVITIES_MEDIA_STORAGE_PATH` would otherwise resolve to the application's working directory, and an empty bucket or region would only fail later inside the AWS SDK.
 
+If you have been running with a blank media path, treat it as a **credential exposure**, not merely a misconfiguration. `GET /api/v1/files/<path>` reads straight off the storage root with no database lookup — it only checks that the path stays inside the root and that the extension maps to a known MIME type — so with the root set to the working directory, any file in the application checkout with a recognised extension was readable without authentication. `.env`, `.env.local` and `*.sqlite3` happen not to map to a MIME type and so were not readable, but that is not an all-clear; plenty of secret-bearing files do map, including:
+
+- a legacy root `config.json` (`application/json`), which on older instances held the whole configuration: `secretPhase`, database credentials, and auth and email secrets (S3 credentials were never in it — those come from the AWS SDK chain);
+- `backups/production-archives/*.tar.gz` (`application/gzip`), the default output directory of `scripts/backup/productionArchive.ts` — a full database and media archive;
+- key material such as `.p8` (the Apple Maps signing key), `.pem`, `.crt`, `.p12` and `.pfx`;
+- `.conf`, `.ini`, `.toml` and `.txt`, plus source files (`.ts`, `.js`, `.json`, `.md`, `.yml`, `.sql`).
+
+Audit what was sitting in the application directory and rotate anything reachable from that list, rather than assuming only source code leaked.
+
 Leaving one of them **unset** while its storage type is configured is different, and still a hard startup failure — unless another required variable for the same storage type is blank, which disables storage before validation runs.
 
 The rule covers those three value variables, not `ACTIVITIES_MEDIA_STORAGE_TYPE`, which is neither trimmed nor blank-checked: a padded `' fs '` is simply an unrecognised type. An unrecognised type — and a type left unset while other `ACTIVITIES_MEDIA_STORAGE_*` variables are set — disables media storage with a warning naming the variable.
@@ -223,6 +248,8 @@ The rule covers those three value variables, not `ACTIVITIES_MEDIA_STORAGE_TYPE`
 S3 credentials are not `ACTIVITIES_*` variables: the AWS SDK resolves them from its standard chain, so set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (or leave them unset when the host already supplies an IAM role or instance profile).
 
 > Upgrade note: If you previously set `ACTIVITIES_MEDIA_STORAGE_HOSTNAME` or `ACTIVITIES_FITNESS_STORAGE_HOSTNAME` to a MinIO, Cloudflare R2, DigitalOcean Spaces, or other S3-compatible API endpoint, move that value to the matching `*_STORAGE_ENDPOINT` variable. `*_STORAGE_HOSTNAME` is for a public hostname/CDN origin, not for S3 API operations or browser presigned uploads.
+
+> Upgrade note: An instance that was running with a **blank** required storage variable (most likely `ACTIVITIES_MEDIA_STORAGE_TYPE=fs` with an empty `ACTIVITIES_MEDIA_STORAGE_PATH=`) had a working-looking media backend rooted at the process working directory. That configuration now disables media and fitness storage: uploads stop, and every existing media URL serves the "media removed" placeholder. The signal is a pair of boot warnings — `ACTIVITIES_MEDIA_STORAGE_PATH is set but empty; media storage will be disabled` and the matching `… fitness storage will be disabled` — so grep for `is set but empty` after upgrading. To recover, set a real path and move your existing files into it. They are loose in the directory the app was started from, named `<16 hex characters><extension>`: `.webp` for stored images, `-thumbnail.webp` for their thumbnails, `.jpg` for the JPEG renditions generated for email, and `.mp4`/`.webm` for video attachments — so move all of those, not just the `.webp` files. Fitness activity files were not loose in that directory: the fallback defaulted the empty path to `uploads`, so move `./uploads/fitness/` into `<new path>/fitness/` as well, or every `.fit`/`.gpx`/`.tcx` and imported Strava `.zip` archive goes missing. Route maps and their email JPEGs are **not** in there — they go through media storage, so they are among the loose files and the first move already covers them. Set the path even if you do not want media storage: leaving the `ACTIVITIES_MEDIA_STORAGE_*` variables unset entirely is the supported way to turn uploads off.
 
 ## Fitness File Storage
 

--- a/lib/components/admin/settings/EnvBlockBuilder.test.tsx
+++ b/lib/components/admin/settings/EnvBlockBuilder.test.tsx
@@ -10,6 +10,8 @@ import {
   within
 } from '@testing-library/react'
 
+import { ENV_TEMPLATE_AREAS } from '@/lib/config/environmentTemplates'
+
 import { EnvBlockBuilder } from './EnvBlockBuilder'
 
 const STORAGE_AREA = 'Media storage — filesystem or S3'
@@ -80,8 +82,8 @@ describe('EnvBlockBuilder', () => {
     const area = activeArea(STORAGE_AREA)
 
     // A variable name appears once as the field's help and once more in the
-    // preview. Required variables carry their placeholder as a visible to-do;
-    // the optional endpoint is absent from the block entirely.
+    // preview. Required variables are listed empty as a visible to-do; the
+    // optional endpoint is absent from the block entirely.
     expect(area.getAllByText('ACTIVITIES_MEDIA_STORAGE_BUCKET')).toHaveLength(2)
     expect(area.getAllByText('ACTIVITIES_MEDIA_STORAGE_ENDPOINT')).toHaveLength(
       1
@@ -210,4 +212,130 @@ describe('EnvBlockBuilder', () => {
       'media.example.social'
     )
   })
+
+  // The invariant that keeps an unfilled block from booting a real
+  // configuration, checked against the string the COPY button actually writes
+  // — the preview's textContent has no newlines, so scraping it cannot see
+  // individual lines at all, and splitting it yields one concatenated blob that
+  // can only ever observe the last value.
+  //
+  // A placeholder is the *input's* example; emitting it as the value produced
+  // lines an operator could paste verbatim and have work.
+  // `ACTIVITIES_MEDIA_STORAGE_BUCKET=media.example.social` would point a live
+  // instance's uploads at a bucket nobody involved owns. A `defaultValue` is
+  // the exception and is emitted, because it is a correct value rather than an
+  // example.
+  describe.each(
+    ENV_TEMPLATE_AREAS.flatMap((area) =>
+      area.choices.map((choice) => ({
+        area: area.value,
+        label: area.label,
+        choice: choice.value,
+        selectorName: area.selectorName,
+        selectorLabel: area.selectorLabel,
+        fields: choice.fields
+      }))
+    )
+  )(
+    '$area/$choice block',
+    ({ area, label, choice, selectorName, selectorLabel, fields }) => {
+      const copiedBlock = async (typed?: Record<string, string>) => {
+        render(<EnvBlockBuilder />)
+        selectArea(area)
+        const scope = activeArea(label)
+        // The descriptor's own label, not a regex guess: a third area, or a field
+        // ever labelled "Endpoint type", would break or double-match a pattern.
+        fireEvent.change(scope.getByLabelText(selectorLabel), {
+          target: { value: choice }
+        })
+        for (const [fieldLabel, value] of Object.entries(typed ?? {})) {
+          fireEvent.change(scope.getByLabelText(fieldLabel), {
+            target: { value }
+          })
+        }
+        fireEvent.click(scope.getByRole('button', { name: 'Copy .env block' }))
+        await waitFor(() => expect(writeText).toHaveBeenCalled())
+        return writeText.mock.calls.at(-1)![0] as string
+      }
+
+      const required = fields.filter((field) => !field.optional)
+
+      it('lists every required variable and no optional one', async () => {
+        const block = await copiedBlock()
+        const names = block.split('\n').map((line) => line.split('=')[0])
+
+        for (const field of required) expect(names).toContain(field.name)
+        for (const field of fields.filter((f) => f.optional)) {
+          expect(names).not.toContain(field.name)
+        }
+        expect(names).toContain(selectorName)
+        // Guards the vacuous pass: an empty block satisfies every "not present"
+        // assertion above on its own.
+        expect(names.filter(Boolean).length).toBe(required.length + 1)
+      })
+
+      // A placeholder may only reach the block when it is *also* the field's
+      // declared default — i.e. a correct value that happens to double as the
+      // example, like `./uploads`. Anything else is someone else's bucket, token
+      // or key. `environmentTemplates.test.ts` pins which fields are allowed that
+      // exemption, by name and value, so this skip cannot be widened silently.
+      it.each(fields.map((field) => ({ field })))(
+        'never emits $field.name as its placeholder',
+        async ({ field }) => {
+          const block = await copiedBlock()
+          const line = block
+            .split('\n')
+            .find((candidate) => candidate.startsWith(`${field.name}=`))
+          if (!line || field.defaultValue === field.placeholder) return
+          expect(line.slice(field.name.length + 1)).not.toBe(field.placeholder)
+        }
+      )
+
+      it('leaves an unfilled required variable empty unless it has a default', async () => {
+        const block = await copiedBlock()
+
+        for (const field of required) {
+          const line = block
+            .split('\n')
+            // The non-null assertion is load-bearing: softening it to `?.` would
+            // make this test pass vacuously for a variable missing from the
+            // block entirely. That case must throw.
+            .find((candidate) => candidate.startsWith(`${field.name}=`))!
+          expect(line.slice(field.name.length + 1)).toBe(
+            field.defaultValue ?? ''
+          )
+        }
+      })
+
+      // The third branch of `value || field.defaultValue || ''`. Without this a
+      // field that HAS a default is never typed into anywhere in the suite, so
+      // reordering to `field.defaultValue || value` — which silently discards
+      // everything the admin types into "Media directory" — stays green.
+      it.each(required.map((field) => ({ field })))(
+        'emits what was typed into $field.name, over any default',
+        async ({ field }) => {
+          const typedValue = `/typed/${field.name.toLowerCase()}`
+          const block = await copiedBlock({ [field.label]: typedValue })
+
+          expect(block).toContain(`${field.name}=${typedValue}`)
+        }
+      )
+
+      // Trimming runs before the `||`, so whitespace is not a value and the
+      // default (or emptiness) must win — never `NAME=   `.
+      it.each(required.map((field) => ({ field })))(
+        'treats a whitespace-only $field.name as unfilled',
+        async ({ field }) => {
+          const block = await copiedBlock({ [field.label]: '   ' })
+          const line = block
+            .split('\n')
+            .find((candidate) => candidate.startsWith(`${field.name}=`))!
+
+          expect(line.slice(field.name.length + 1)).toBe(
+            field.defaultValue ?? ''
+          )
+        }
+      )
+    }
+  )
 })

--- a/lib/components/admin/settings/EnvBlockBuilder.tsx
+++ b/lib/components/admin/settings/EnvBlockBuilder.tsx
@@ -146,12 +146,26 @@ const EnvAreaBuilder: FC<{ area: EnvTemplateArea }> = ({ area }) => {
     const fieldLines = choice.fields.flatMap<EnvBlockLine>((field) => {
       const value = (values[field.name] ?? '').trim()
       // An optional variable only belongs in the block once it has a value; a
-      // required one carries its placeholder as a visible to-do.
+      // required one is always listed as a visible to-do, carrying its
+      // `defaultValue` if it has one and otherwise nothing at all.
+      //
+      // Never its placeholder. A placeholder is an example for the input beside
+      // it, and pasting one as a value boots a real configuration out of it:
+      // `ACTIVITIES_MEDIA_STORAGE_BUCKET=media.example.social` would point a
+      // live instance's uploads at a bucket the operator does not own.
+      //
+      // `NAME=` is inert instead: a blank required value is rejected by both
+      // storage resolvers (`requiredStorageValue` in lib/config/storageValue),
+      // which disable that storage and warn, and the map provider falls back to
+      // keyless OpenStreetMap. Note "rejected", not "treated as unset" — an
+      // UNSET required value is passed through to `Config.parse`, where
+      // `z.string()` rejects it and the whole config fails to load. Blank
+      // disables one backend; missing stops the app.
       if (field.optional && !value) return []
       return [
         {
           name: field.name,
-          value: value || field.placeholder,
+          value: value || field.defaultValue || '',
           masked: Boolean(field.secret && value)
         }
       ]

--- a/lib/config/environmentTemplates.test.ts
+++ b/lib/config/environmentTemplates.test.ts
@@ -1,0 +1,81 @@
+import { ENV_TEMPLATE_AREAS, EnvTemplateField } from './environmentTemplates'
+
+const fieldsOf = (): { area: string; field: EnvTemplateField }[] =>
+  ENV_TEMPLATE_AREAS.flatMap((area) =>
+    area.choices.flatMap((choice) =>
+      choice.fields.map((field) => ({ area: area.value, field }))
+    )
+  )
+
+describe('ENV_TEMPLATE_AREAS', () => {
+  it('gives every field a unique variable name within its choice', () => {
+    for (const area of ENV_TEMPLATE_AREAS) {
+      for (const choice of area.choices) {
+        // The selector is in the set too: a field colliding with it emits two
+        // lines for one variable, which the block's line-count guard in
+        // EnvBlockBuilder.test.tsx cannot distinguish from a correct block.
+        const names = [
+          area.selectorName,
+          ...choice.fields.map((field) => field.name)
+        ]
+        expect(new Set(names).size).toBe(names.length)
+      }
+    }
+  })
+
+  it.each(fieldsOf())('gives $area/$field.name a placeholder', ({ field }) => {
+    // The placeholder is the input's example. It is deliberately NOT what the
+    // generated block carries — see the emptiness invariant in
+    // EnvBlockBuilder.test.tsx, which is what keeps an unfilled block from
+    // booting a real configuration.
+    expect(field.placeholder.trim()).not.toBe('')
+  })
+
+  // `defaultValue` is the one way a value reaches the generated block without
+  // being typed, so it is also the one way a placeholder could be smuggled back
+  // in — the leak invariant in EnvBlockBuilder.test.tsx skips a field whose
+  // default IS its placeholder, which is correct for `./uploads` and would be a
+  // silent hole for anything else. Pin the exact set, and the exact values.
+  //
+  // Adding `defaultValue: 'media.example.social'` to the bucket descriptor
+  // would otherwise ship a copy-pasteable bucket the operator does not own,
+  // with every other test still green.
+  const DEFAULTS_BY_NAME: Record<string, string> = {
+    ACTIVITIES_MEDIA_STORAGE_PATH: './uploads'
+  }
+
+  it('declares a default only where one is expected, with the expected value', () => {
+    const withDefaults = fieldsOf().filter(({ field }) => field.defaultValue)
+
+    expect(
+      Object.fromEntries(
+        withDefaults.map(({ field }) => [field.name, field.defaultValue])
+      )
+    ).toEqual(DEFAULTS_BY_NAME)
+  })
+
+  // The filesystem block is the one an operator can paste and run as-is, and
+  // that only holds while its required variables carry real defaults. Without
+  // one, `ACTIVITIES_MEDIA_STORAGE_PATH=` disables media and fitness storage
+  // outright (both resolvers reject a blank value — before that guard it
+  // resolved to the process CWD and served the application directory). Note
+  // "reject", not "treat as unset": an unset value is passed through and fails
+  // config validation, which stops the app rather than one backend.
+  it('keeps the filesystem storage block runnable with nothing typed', () => {
+    const storage = ENV_TEMPLATE_AREAS.find((area) => area.value === 'storage')
+    if (!storage) throw new Error('storage area is missing')
+    const fs = storage.choices.find((choice) => choice.value === 'fs')
+    if (!fs) throw new Error('fs choice is missing')
+
+    expect(fs.fields.length).toBeGreaterThan(0)
+    for (const field of fs.fields.filter((candidate) => !candidate.optional)) {
+      expect(field.defaultValue).toBeTruthy()
+    }
+  })
+
+  it('names every variable in the ACTIVITIES_ or AWS_ namespace', () => {
+    for (const { field } of fieldsOf()) {
+      expect(field.name).toMatch(/^(ACTIVITIES|AWS)_/)
+    }
+  })
+})

--- a/lib/config/environmentTemplates.ts
+++ b/lib/config/environmentTemplates.ts
@@ -15,9 +15,19 @@ export interface EnvTemplateField {
   // Environment variable this input fills in.
   name: string
   label: string
+  // Example shown *in the input*. Never emitted into the generated block: an
+  // example that reached a `.env` verbatim would be a working configuration
+  // built out of values the operator does not own (see EnvBlockBuilder).
   placeholder: string
+  // A genuinely correct value the operator can keep, emitted into the block
+  // when nothing is typed. Only where the example is itself a correct value —
+  // an illustrative one is not. This is a default of the field, not of the
+  // variable: the resolvers have no app-level defaults, and omitting a required
+  // variable entirely fails config validation.
+  defaultValue?: string
   // Left out of the generated block until the admin types a value. Required
-  // fields always appear, carrying their placeholder as a visible to-do.
+  // fields always appear, carrying their `defaultValue` if they have one and
+  // otherwise empty, as a visible to-do.
   optional?: boolean
   // Masked in the preview, included verbatim when copied.
   secret?: boolean
@@ -59,6 +69,11 @@ const MEDIA_STORAGE_FILESYSTEM_FIELDS: EnvTemplateField[] = [
     name: 'ACTIVITIES_MEDIA_STORAGE_PATH',
     label: 'Media directory',
     placeholder: './uploads',
+    // The one placeholder that is also a correct value, so it is also the one
+    // that belongs in the block untyped: `ACTIVITIES_MEDIA_STORAGE_PATH=` is
+    // rejected by both storage resolvers, which would leave the filesystem
+    // block — the block an operator can otherwise paste and run — inert.
+    defaultValue: './uploads',
     wide: true
   }
 ]

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -11,6 +11,18 @@ import { proxy, config as proxyConfig } from './proxy'
 const STATIC_IMPORT_PATTERN =
   /(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g
 const FILESYSTEM_MODULES = new Set(['fs', 'node:fs', 'path', 'node:path'])
+// Node-only modules that are not filesystem APIs but must stay out of the
+// middleware bundle all the same. `lib/utils/logger` calls `pino({…})` at
+// module top level and package.json declares no `sideEffects`, so it cannot be
+// tree-shaken away: one import anywhere in this graph drags pino, its
+// serializers and sonic-boom into middleware.js. This has already happened
+// once, from a storage helper parked in lib/config/utils (which proxy.ts
+// reaches via lib/config/host), with a green build and no warning — the only
+// visible trace was 264 extra files in middleware.js.nft.json.
+//
+// lib/config/storageValue.ts states this constraint in prose as its reason for
+// existing; this is what enforces it.
+const NODE_ONLY_MODULES = new Set(['pino', '@/lib/utils/logger'])
 const SOURCE_EXTENSIONS = ['', '.ts', '.tsx', '.js', '.mjs']
 
 const resolveSourcePath = (rawPath: string): string | null => {
@@ -344,7 +356,12 @@ describe('proxy', () => {
     )
   })
 
-  it('keeps the proxy static import graph free of filesystem modules', () => {
+  // Walk proxy.ts's static import graph, reporting every disallowed specifier
+  // reached and the files visited on the way. The visited set is returned so a
+  // caller can prove the walk got somewhere: if module resolution ever breaks,
+  // it collapses to proxy.ts alone and every "no violations" assertion below
+  // passes while guarding nothing.
+  const walkProxyImportGraph = (disallowed: Set<string>) => {
     const rootDirectory = originalCwd
     const visited = new Set<string>()
     const pending = [path.join(rootDirectory, 'proxy.ts')]
@@ -357,7 +374,7 @@ describe('proxy', () => {
 
       const source = fs.readFileSync(currentFile, 'utf-8')
       for (const specifier of getStaticImportSpecifiers(source)) {
-        if (FILESYSTEM_MODULES.has(specifier)) {
+        if (disallowed.has(specifier)) {
           violations.push(
             `${path.relative(rootDirectory, currentFile)} imports ${specifier}`
           )
@@ -373,6 +390,25 @@ describe('proxy', () => {
       }
     }
 
-    expect(violations).toEqual([])
-  })
+    return { violations, visited }
+  }
+
+  // Both guards exist because the middleware bundle must stay free of Node-only
+  // dependencies: filesystem APIs break under the Edge runtime, and the logger
+  // drags pino in wholesale (see NODE_ONLY_MODULES).
+  it.each([
+    { description: 'filesystem modules', disallowed: FILESYSTEM_MODULES },
+    { description: 'the logger', disallowed: NODE_ONLY_MODULES }
+  ])(
+    'keeps the proxy static import graph free of $description',
+    ({ disallowed }) => {
+      const { violations, visited } = walkProxyImportGraph(disallowed)
+
+      // lib/config/utils.ts is where the logger leaked in from once, reached
+      // via lib/config/host. Asserting the walk still gets there is what stops
+      // a resolution failure from turning both guards green and inert.
+      expect(visited).toContain(path.join(originalCwd, 'lib/config/utils.ts'))
+      expect(violations).toEqual([])
+    }
+  )
 })


### PR DESCRIPTION
## The bug

The admin **Configure environment** builder (Admin → Posts & media) filled a required field's value from its **placeholder** when nothing had been typed:

```ts
value: value || field.placeholder
```

A placeholder is an example for the input beside it. Emitting it as a value meant an admin could open the builder, click **Copy .env block**, paste, restart, and boot a real configuration out of values they do not own. With nothing typed:

| Choice | Block before | Block after |
| --- | --- | --- |
| `storage/s3` | `..._BUCKET=media.example.social`<br>`..._REGION=eu-central-1` | `..._BUCKET=`<br>`..._REGION=` |
| `storage/fs` | `..._PATH=./uploads` | `..._PATH=./uploads` (unchanged — a real value) |
| `maps/mapbox` | `..._MAPBOX_ACCESS_TOKEN=pk.eyJ1Ijoi…` | `..._MAPBOX_ACCESS_TOKEN=` |
| `maps/apple` | fake team id, key id and PEM | all three empty |

## The change

Splits the two ideas `placeholder` was carrying, in `lib/config/environmentTemplates.ts`:

- `placeholder` — an example, shown in the input, **never** emitted into the block.
- `defaultValue` (new, optional) — a genuinely correct value the operator can keep, which **is** emitted.

A required field with nothing typed emits `NAME=<defaultValue>` if it has one and `NAME=` otherwise; optional fields are unchanged (omitted until given a value). Only `ACTIVITIES_MEDIA_STORAGE_PATH` carries a `defaultValue` (`./uploads`), which keeps the filesystem block pasteable as-is. It is a default of the *field*, not of the variable — no storage variable has an app-level default.

### Relationship to #1344

`NAME=` is only inert if the resolvers reject a blank value. This branch originally carried its own implementation of that guard; **#1344 landed it independently and goes further** (the `getEffectiveFitnessStorageConfig` fallback, the `cleanupMediaStorage.ts` refusal). On rebase that duplicate was dropped in favour of main's — the two implementations had independently converged on the same `requiredStorageValue(name, subject)` shape and the same leaf-module placement, so there was nothing left to reconcile.

Two things are kept from this branch's review rounds because main lacks them:

**A guard for the boundary #1344 relies on.** `lib/config/storageValue.ts` exists precisely because `lib/config/utils.ts` is reachable from `proxy.ts` — but nothing enforced that. Putting a logger import there passes lint, build and every test while dragging **264 pino files** into `middleware.js` (`lib/utils/logger` calls `pino({…})` at module top level and there is no `sideEffects` field, so it cannot be tree-shaken). `proxy.test.ts` now fails on `pino` / `@/lib/utils/logger` anywhere in the proxy's static import graph, reusing the existing walk, and both cases assert the walk still reaches `lib/config/utils.ts` so a resolution failure cannot make them vacuous. Verified by reintroducing the exact import.

**What a CWD-rooted media path actually exposed.** `GET /api/v1/files/<path>` reads off the storage root with no database lookup — only a containment check and a MIME-type check — so a legacy root `config.json` (`secretPhase`, database credentials), `backups/production-archives/*.tar.gz`, and `.p8`/`.pem`/`.p12` key material were readable unauthenticated. Affected operators need to **rotate**, not just re-point a variable. There is an upgrade note for instances that were running that way, since they lose media and fitness storage with only a boot warning to say so. `.env.example` also gets the blank-value note #1344 explicitly left undone.

## Tests

The invariant is asserted against **the string the copy button actually writes**, not the preview's `textContent` — the preview renders each line as a `<div>`, so `textContent` has no newlines and splitting it yields one concatenated blob that can only observe the last value of a block.

It sweeps **every area and every choice** (`fs`, `s3`, `osm`, `mapbox`, `apple`), asserting per choice:

1. every required variable is present, with a matching line count — so an emptied block cannot pass vacuously;
2. no field's placeholder appears as a value;
3. an unfilled required field is exactly its `defaultValue ?? ''`;
4. a typed value beats the default, and a whitespace-only one does not.

`environmentTemplates.test.ts` separately pins the permitted defaults **by name and value**, since assertion 2 must skip a field whose default *is* its placeholder — correct for `./uploads`, a silent hole for anything else.

**Every assertion was proved by mutation.**

## Verification

- `yarn run prettier --write .` → `yarn lint` (0 errors) → `yarn build` → `yarn test` (742 files, 7757 tests) all green on the rebased tree.
- `middleware.js.nft.json` re-checked after the rebase: zero pino entries.
- All five area/choice blocks verified in a real browser against a local SQLite instance with a mock admin, plus a typed value correctly overriding `./uploads`.
