### PR TITLE
Bump version to v1.122.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.121.1",
+  "version": "1.122.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.122.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.121.1`
- Base main SHA: `a3ac55273d8a07aaa06ce2a545a496d9b1507237`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
