### PR TITLE
none: expand the .env.example blank-storage-value note

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,18 @@ ACTIVITIES_SECRET_PHASE=
 # to an empty value instead: a blank required value (e.g. a bare
 # ACTIVITIES_MEDIA_STORAGE_PATH=) is rejected and disables storage with a
 # warning, rather than being ignored.
+#
+# That rule covers ACTIVITIES_MEDIA_STORAGE_PATH, _BUCKET and _REGION, which are
+# required for their storage type and have no default. Surrounding whitespace is
+# trimmed, so a whitespace-only value counts as blank. Leaving one of them unset
+# while the storage type is configured is different: that is still a hard
+# startup failure (unless another required variable for the same type is blank,
+# which disables storage before validation runs).
+#
+# ACTIVITIES_MEDIA_STORAGE_TYPE is not covered — it is neither trimmed nor
+# blank-checked, so a padded ' fs ' is simply an unrecognised type. An
+# unrecognised type, and a type left unset while other ACTIVITIES_MEDIA_STORAGE_*
+# variables are set, disables media storage with a warning naming the variable.
 
 # Storage type: fs (local), s3, object (S3-compatible)
 # ACTIVITIES_MEDIA_STORAGE_TYPE=fs
@@ -164,6 +176,16 @@ ACTIVITIES_SECRET_PHASE=
 # variable commented out rather than setting it to an empty value. (An empty
 # ACTIVITIES_FITNESS_STORAGE_TYPE= is different — it selects the media-storage
 # fallback, exactly as leaving it unset does.)
+#
+# That fallback applies the rule to the ACTIVITIES_MEDIA_STORAGE_* variables it
+# reads, so a blank ACTIVITIES_MEDIA_STORAGE_PATH no longer falls through to
+# uploads/fitness under the application's working directory.
+#
+# Setting ACTIVITIES_FITNESS_STORAGE_TYPE to a non-empty value opts out of the
+# media-storage fallback entirely. If the type is set but unusable — a blank
+# required value, or a type this app does not recognise — fitness storage is
+# disabled and a warning names the variable; it does not quietly write fitness
+# files into the media bucket.
 
 # ACTIVITIES_FITNESS_STORAGE_TYPE=fs
 # ACTIVITIES_FITNESS_STORAGE_PATH=./uploads/fitness


### PR DESCRIPTION
Rebased onto `main` after #1345 landed.

#1345 added a short operator-facing note in both storage blocks of `.env.example` — the same two spots this PR targets, which is where the conflict came from. That wording is kept as the lead; this PR adds the parts of the rule it does not carry, so `.env.example` matches the **Media Storage** and **Fitness File Storage** sections of `docs/environment-variables.md`.

### What #1345 already says

> Leave the whole block commented out to disable uploads. Do NOT set a variable to an empty value instead: a blank required value (e.g. a bare `ACTIVITIES_MEDIA_STORAGE_PATH=`) is rejected and disables storage with a warning, rather than being ignored.

### What this adds

- Whitespace is trimmed, so a **whitespace-only** value counts as blank.
- Leaving a required variable **unset** while its storage type is set is the *opposite* outcome from leaving it blank, and is still a hard startup failure. This is the distinction most likely to bite an operator, and neither note carried it.
- `ACTIVITIES_MEDIA_STORAGE_TYPE` is outside the rule — neither trimmed nor blank-checked, so a padded `' fs '` is just an unrecognised type. An unrecognised or unset type disables media storage with a warning naming the variable.
- The media-storage fallback applies the rule to the `ACTIVITIES_MEDIA_STORAGE_*` variables it reads, so a blank media path no longer falls through to `uploads/fitness` under the working directory.
- A **non-empty** `ACTIVITIES_FITNESS_STORAGE_TYPE` opts out of that fallback entirely; a set-but-unusable type disables fitness storage rather than quietly writing fitness files into the media bucket.

### Verification

Comments only — no code or behaviour change. Every claim was checked against `lib/config/storageValue.ts`, `lib/config/mediaStorage.ts` and `lib/config/fitnessStorage.ts`, none of which #1345 touched.

- `yarn run prettier --write .` — no reformatting
- `yarn lint` — 0 errors (31 pre-existing warnings)
- `yarn build` — exit 0
- `yarn test` — 742 files, 7757 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)