### PR TITLE
Bump version to v1.122.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.122.0",
+  "version": "1.122.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.122.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.122.0`
- Base main SHA: `e399f305370ca5bddc45dee6a53f122284d6d304`
- Included commits: `3`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
