### PR TITLE
Bump version to v1.122.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.122.1",
+  "version": "1.122.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.122.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.122.1`
- Base main SHA: `a4dc7a91f0d1c341c4f98bd6643f6b132eafa46e`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
