### PR TITLE
fix: draw the fitness route hover highlight as a dot on every map provider

### DIFF
--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -551,6 +551,52 @@ describe('FitnessStatusDetail', () => {
     ).toBeInTheDocument()
   })
 
+  it('keeps the privacy notice dismissed when its own file is selected again', async () => {
+    // The dismissal is scoped to the acknowledged file, so reloading that file's
+    // route must not resurrect the notice. Deriving it during render is what
+    // guarantees that: the reset used to live in an effect keyed on the
+    // `routeSegments` identity, and a passive effect runs a task *after* the
+    // commit that revealed the notice — late enough to land after the user's tap
+    // and undo it. That race is what made this suite flake on CI.
+    mockGetFitnessFilesByStatus.mockResolvedValue([
+      buildFitnessFile({ id: 'fit-1', fileName: 'ride-morning.gpx' }),
+      buildFitnessFile({
+        id: 'fit-2',
+        fileName: 'ride-evening.gpx',
+        isPrimary: false,
+        activityStartTime: Date.parse('2026-05-27T18:00:00Z')
+      })
+    ])
+    mockGetFitnessRouteData.mockResolvedValue(routeDataWithHiddenSegments)
+
+    renderDetail()
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Dismiss notice: green segments are hidden from other viewers'
+      })
+    )
+    const select = await screen.findByLabelText('Activity file')
+
+    fireEvent.change(select, { target: { value: 'fit-2' } })
+    expect(
+      await screen.findByText('Green segments are hidden from other viewers')
+    ).toBeInTheDocument()
+
+    fireEvent.change(select, { target: { value: 'fit-1' } })
+    // Wait for fit-1's route to be re-fetched and committed — that commit is
+    // exactly where the old reset fired.
+    await waitFor(() =>
+      expect(mockGetFitnessRouteData).toHaveBeenCalledTimes(3)
+    )
+    await act(async () => {})
+
+    expect(await screen.findByText('file 1 of 2')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Green segments are hidden from other viewers')
+    ).not.toBeInTheDocument()
+  })
+
   it('surfaces an error banner when route data fails to load', async () => {
     mockGetFitnessRouteData.mockRejectedValue(new Error('boom'))
 

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -37,6 +37,14 @@ import {
 } from '@/lib/client'
 import { ActivityRouteMapKit } from '@/lib/components/fitness/ActivityRouteMapKit'
 import { findRouteSampleForElapsed } from '@/lib/components/fitness/mapGeometry'
+import {
+  ROUTE_HIGHLIGHT_CORE_COLOR,
+  ROUTE_HIGHLIGHT_CORE_RADIUS_PX,
+  ROUTE_HIGHLIGHT_HALO_COLOR,
+  ROUTE_HIGHLIGHT_HALO_OPACITY,
+  ROUTE_HIGHLIGHT_HALO_RADIUS_PX,
+  ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR
+} from '@/lib/components/fitness/routeHighlightMarker'
 import { BrandedDeviceLink } from '@/lib/components/posts/BrandedDeviceLink'
 import { BookmarkButton } from '@/lib/components/posts/actions/bookmark-button'
 import { LikeButton } from '@/lib/components/posts/actions/like-button'
@@ -1032,14 +1040,16 @@ const ActivityMapPanel: FC<{
             }
           })
 
+          // Geometry and colours come from the shared highlight-marker module so
+          // the Apple MapKit annotation draws the identical dot.
           map.addLayer({
             id: 'activity-active-point-ring',
             type: 'circle',
             source: MAP_ACTIVE_POINT_SOURCE_ID,
             paint: {
-              'circle-radius': 8,
-              'circle-color': '#ffffff',
-              'circle-opacity': 0.95
+              'circle-radius': ROUTE_HIGHLIGHT_HALO_RADIUS_PX,
+              'circle-color': ROUTE_HIGHLIGHT_HALO_COLOR,
+              'circle-opacity': ROUTE_HIGHLIGHT_HALO_OPACITY
             }
           })
 
@@ -1048,12 +1058,12 @@ const ActivityMapPanel: FC<{
             type: 'circle',
             source: MAP_ACTIVE_POINT_SOURCE_ID,
             paint: {
-              'circle-radius': 4.5,
+              'circle-radius': ROUTE_HIGHLIGHT_CORE_RADIUS_PX,
               'circle-color': [
                 'case',
                 ['==', ['get', 'isHiddenByPrivacy'], true],
-                '#16a34a',
-                '#1d4ed8'
+                ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR,
+                ROUTE_HIGHLIGHT_CORE_COLOR
               ]
             }
           })

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -857,6 +857,8 @@ const ChartPanel: FC<{
 
 const ActivityMapPanel: FC<{
   mapAttachment?: Attachment
+  /** Activity file the route belongs to — the scope of a notice dismissal. */
+  fitnessFileId?: string | null
   routeSamples: FitnessRouteSample[]
   routeSegments: FitnessRouteSegment[]
   highlightedElapsedSeconds?: number | null
@@ -866,6 +868,7 @@ const ActivityMapPanel: FC<{
   onOpenMap?: () => void
 }> = ({
   mapAttachment,
+  fitnessFileId = null,
   routeSamples,
   routeSegments,
   highlightedElapsedSeconds = null,
@@ -879,8 +882,20 @@ const ActivityMapPanel: FC<{
   const [mapLoadError, setMapLoadError] = useState<string | null>(null)
   // The privacy notice is an acknowledgement, not a persistent legend — tapping
   // it clears it so it stops covering the map.
-  const [isPrivacyNoticeDismissed, setIsPrivacyNoticeDismissed] =
-    useState(false)
+  //
+  // The dismissal records WHICH activity file was acknowledged rather than a
+  // bare boolean, because the panel is not keyed per file: switching files in an
+  // aggregated post swaps the route underneath the same instance, and a carried
+  // -over dismissal would leave the next route drawing green segments with no
+  // explanation. Deriving it during render (instead of resetting the flag from
+  // an effect keyed on `routeSegments`) is what makes that safe — a passive
+  // effect runs a task *after* the commit that showed the notice, so it could
+  // land after the user's tap and silently resurrect a notice they just closed.
+  const [dismissedNoticeFileId, setDismissedNoticeFileId] = useState<
+    string | null
+  >(null)
+  const isPrivacyNoticeDismissed =
+    fitnessFileId !== null && dismissedNoticeFileId === fitnessFileId
   const drawableRouteSegments = useMemo(
     () => routeSegments.filter((segment) => segment.samples.length >= 2),
     [routeSegments]
@@ -893,14 +908,6 @@ const ActivityMapPanel: FC<{
     () => drawableRouteSegments.some((segment) => segment.isHiddenByPrivacy),
     [drawableRouteSegments]
   )
-
-  // The panel is not keyed per file, so switching activity files in an
-  // aggregated post swaps `routeSegments` underneath the same instance. Without
-  // this reset a dismissal would carry over and the next file would draw green
-  // segments with no explanation.
-  useEffect(() => {
-    setIsPrivacyNoticeDismissed(false)
-  }, [routeSegments])
 
   // Keyed on the descriptor's fields (not its object identity) so an inline prop
   // literal doesn't tear the map down on every parent render. Apple renders
@@ -1228,7 +1235,7 @@ const ActivityMapPanel: FC<{
           {hasHiddenPrivacySegments && !isPrivacyNoticeDismissed ? (
             <button
               type="button"
-              onClick={() => setIsPrivacyNoticeDismissed(true)}
+              onClick={() => setDismissedNoticeFileId(fitnessFileId)}
               aria-label="Dismiss notice: green segments are hidden from other viewers"
               className="absolute bottom-3 left-3 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-green-300 bg-background/95 px-3 py-2 text-xs font-medium text-green-700 shadow-sm hover:bg-muted dark:border-green-900 dark:text-green-400"
             >
@@ -2090,6 +2097,7 @@ export const FitnessStatusDetail: FC<Props> = ({
             {shouldRenderMapPanel && (
               <ActivityMapPanel
                 mapAttachment={mapAttachment}
+                fitnessFileId={fitness?.id ?? null}
                 routeSamples={routeSamples}
                 routeSegments={routeSegments}
                 mapProvider={mapProvider}
@@ -2143,6 +2151,7 @@ export const FitnessStatusDetail: FC<Props> = ({
             {shouldRenderMapPanel && (
               <ActivityMapPanel
                 mapAttachment={mapAttachment}
+                fitnessFileId={fitness?.id ?? null}
                 routeSamples={routeSamples}
                 routeSegments={routeSegments}
                 highlightedElapsedSeconds={highlightedElapsedSeconds}

--- a/lib/components/fitness/ActivityRouteMapKit.test.tsx
+++ b/lib/components/fitness/ActivityRouteMapKit.test.tsx
@@ -159,6 +159,43 @@ describe('ActivityRouteMapKit', () => {
     expect(mockLoadMapKitModule).toHaveBeenCalledTimes(1)
   })
 
+  it('draws the hover highlight as a centred dot rather than a pin', async () => {
+    const double = createMapKitTestDouble()
+    mockLoadMapKitModule.mockImplementation((() =>
+      Promise.resolve(double.mapkit)) as never)
+    const markerAnnotation = vi.spyOn(double.mapkit, 'MarkerAnnotation')
+    const hiddenSamples = routeSamples.map((sample) => ({
+      ...sample,
+      isHiddenByPrivacy: true
+    }))
+
+    render(
+      <ActivityRouteMapKit
+        routeSegments={[{ isHiddenByPrivacy: true, samples: hiddenSamples }]}
+        routeSamples={hiddenSamples}
+        highlightedElapsedSeconds={120}
+        onUnavailable={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(double.annotations).toHaveLength(1))
+    // Apple's teardrop pin is anchored by its tip, so it covers the map above
+    // the sample instead of marking it — the GL surfaces draw a dot on the point.
+    expect(markerAnnotation).not.toHaveBeenCalled()
+
+    const element = double.annotations[0].element
+    expect(element).not.toBeNull()
+    // Zero-sized anchor: MapKit's bottom-centre anchoring lands on its centre.
+    expect(element?.style.width).toBe('0px')
+    expect(element?.style.height).toBe('0px')
+
+    const [halo, core] = Array.from(element?.children ?? []) as HTMLElement[]
+    expect(halo.style.width).toBe('16px')
+    expect(halo.style.backgroundColor).toBe('rgb(255, 255, 255)')
+    // Green because the hovered sample sits on a privacy-hidden segment.
+    expect(core.style.backgroundColor).toBe('rgb(22, 163, 74)')
+  })
+
   it('rebuilds the route overlays when the route data changes', async () => {
     const double = createMapKitTestDouble()
     mockLoadMapKitModule.mockImplementation((() =>

--- a/lib/components/fitness/ActivityRouteMapKit.tsx
+++ b/lib/components/fitness/ActivityRouteMapKit.tsx
@@ -15,6 +15,7 @@ import {
   boundsToRegion,
   loadMapKitSurface
 } from '@/lib/components/fitness/mapkitSurface'
+import { createRouteHighlightElement } from '@/lib/components/fitness/routeHighlightMarker'
 
 // Mirrors the GL activity route paint: orange for the shared trace, green for the
 // segments hidden from other viewers by a privacy location.
@@ -28,8 +29,6 @@ const HIDDEN_ROUTE_STYLE = {
   lineWidth: 4,
   strokeOpacity: 0.95
 }
-const ACTIVE_MARKER_COLOR = '#1d4ed8'
-const ACTIVE_HIDDEN_MARKER_COLOR = '#16a34a'
 // MapKit zooms by shrinking/growing the region span; these mirror the GL buttons.
 const ZOOM_IN_FACTOR = 0.5
 const ZOOM_OUT_FACTOR = 2
@@ -85,8 +84,9 @@ export interface ActivityRouteMapKitProps {
 
 /**
  * Apple MapKit JS sibling of the GL `ActivityMapPanel` map: the activity route as
- * `PolylineOverlay`s plus a `MarkerAnnotation` that follows the chart hover. Zoom
- * controls drive `setRegionAnimated` because MapKit has no `zoomIn`/`zoomOut`.
+ * `PolylineOverlay`s plus a custom dot annotation that follows the chart hover.
+ * Zoom controls drive `setRegionAnimated` because MapKit has no
+ * `zoomIn`/`zoomOut`.
  */
 export const ActivityRouteMapKit: FC<ActivityRouteMapKitProps> = ({
   routeSegments,
@@ -235,13 +235,16 @@ export const ActivityRouteMapKit: FC<ActivityRouteMapKitProps> = ({
     }
     if (!activeSample) return
 
-    const marker = new mapkit.MarkerAnnotation(
+    // A custom annotation, not a `MarkerAnnotation`: Apple's teardrop pin is
+    // anchored by its tip, so it renders above the sample it marks instead of on
+    // it. The shared dot element matches the GL circle layers exactly.
+    const isHiddenByPrivacy = Boolean(activeSample.isHiddenByPrivacy)
+    const marker = new mapkit.Annotation(
       new mapkit.Coordinate(activeSample.lat, activeSample.lng),
-      {
-        color: activeSample.isHiddenByPrivacy
-          ? ACTIVE_HIDDEN_MARKER_COLOR
-          : ACTIVE_MARKER_COLOR
-      }
+      () => createRouteHighlightElement(isHiddenByPrivacy),
+      // The dot is a chart-hover follower: it should neither animate in on every
+      // move nor become selectable.
+      { animates: false, enabled: false }
     )
     map.addAnnotation(marker)
     markerRef.current = marker

--- a/lib/components/fitness/mapkitSurface.ts
+++ b/lib/components/fitness/mapkitSurface.ts
@@ -95,6 +95,19 @@ export interface MapKitSurfaceModule {
     coordinate: MapKitCoordinate,
     options?: Record<string, unknown>
   ) => MapKitAnnotation
+  /**
+   * Custom annotation: MapKit renders whatever element the factory returns,
+   * anchored by that element's bottom centre — unlike `MarkerAnnotation`, which
+   * always draws Apple's teardrop pin.
+   */
+  Annotation: new (
+    coordinate: MapKitCoordinate,
+    factory: (
+      coordinate: MapKitCoordinate,
+      options: Record<string, unknown>
+    ) => HTMLElement,
+    options?: Record<string, unknown>
+  ) => MapKitAnnotation
   Coordinate: new (latitude: number, longitude: number) => MapKitCoordinate
   CoordinateSpan: new (
     latitudeDelta: number,

--- a/lib/components/fitness/mapkitTestDouble.ts
+++ b/lib/components/fitness/mapkitTestDouble.ts
@@ -49,7 +49,13 @@ export class TestOverlay {
 export class TestAnnotation {
   constructor(
     readonly coordinate: MapKitCoordinate,
-    readonly options: ConstructorOptions
+    readonly options: ConstructorOptions,
+    /**
+     * The element a custom `mapkit.Annotation` factory produced. `null` for a
+     * `MarkerAnnotation`, whose teardrop pin MapKit draws itself — so this is
+     * also what distinguishes the two annotation kinds in assertions.
+     */
+    readonly element: HTMLElement | null = null
   ) {}
 }
 
@@ -245,6 +251,24 @@ export const createMapKitTestDouble = (): MapKitTestDouble => {
       annotations.push(annotation)
       return annotation
     } as unknown as MapKitSurfaceModule['MarkerAnnotation'],
+    Annotation: function Annotation(
+      coordinate: MapKitCoordinate,
+      factory: (
+        coordinate: MapKitCoordinate,
+        options: ConstructorOptions
+      ) => HTMLElement,
+      options: ConstructorOptions = {}
+    ) {
+      // MapKit calls the factory itself when it attaches the annotation; calling
+      // it here is what lets a test assert on the rendered marker element.
+      const annotation = new TestAnnotation(
+        coordinate,
+        options,
+        factory(coordinate, options)
+      )
+      annotations.push(annotation)
+      return annotation
+    } as unknown as MapKitSurfaceModule['Annotation'],
     Coordinate: function Coordinate(latitude: number, longitude: number) {
       return { latitude, longitude }
     } as unknown as MapKitSurfaceModule['Coordinate'],

--- a/lib/components/fitness/routeHighlightMarker.test.ts
+++ b/lib/components/fitness/routeHighlightMarker.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  ROUTE_HIGHLIGHT_CORE_COLOR,
+  ROUTE_HIGHLIGHT_CORE_RADIUS_PX,
+  ROUTE_HIGHLIGHT_HALO_COLOR,
+  ROUTE_HIGHLIGHT_HALO_OPACITY,
+  ROUTE_HIGHLIGHT_HALO_RADIUS_PX,
+  ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR,
+  createRouteHighlightElement,
+  getRouteHighlightCoreColor
+} from './routeHighlightMarker'
+
+const dotsOf = (element: HTMLElement) =>
+  Array.from(element.children) as HTMLElement[]
+
+describe('getRouteHighlightCoreColor', () => {
+  it.each([
+    {
+      description: 'blue on a shared segment',
+      isHiddenByPrivacy: false,
+      expected: ROUTE_HIGHLIGHT_CORE_COLOR
+    },
+    {
+      description: 'green on a privacy-hidden segment',
+      isHiddenByPrivacy: true,
+      expected: ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR
+    }
+  ])('returns $description', ({ isHiddenByPrivacy, expected }) => {
+    expect(getRouteHighlightCoreColor(isHiddenByPrivacy)).toBe(expected)
+  })
+})
+
+describe('createRouteHighlightElement', () => {
+  it('anchors a zero-sized node so MapKit centres the dot on the coordinate', () => {
+    // MapKit positions a custom annotation by its element's bottom centre; on a
+    // zero-sized element that is the element's own origin, which is what keeps
+    // the marker on the route sample instead of floating above it like the pin.
+    const element = createRouteHighlightElement(false)
+
+    expect(element.style.width).toBe('0px')
+    expect(element.style.height).toBe('0px')
+    expect(element.style.position).toBe('relative')
+    expect(element.style.pointerEvents).toBe('none')
+
+    for (const dot of dotsOf(element)) {
+      expect(dot.style.position).toBe('absolute')
+      expect(dot.style.left).toBe('0px')
+      expect(dot.style.top).toBe('0px')
+      expect(dot.style.transform).toBe('translate(-50%, -50%)')
+      expect(dot.style.borderRadius).toBe('50%')
+    }
+  })
+
+  it('draws the halo and the core as siblings matching the GL circle layers', () => {
+    const [halo, core] = dotsOf(createRouteHighlightElement(false))
+
+    expect(halo.style.width).toBe(`${ROUTE_HIGHLIGHT_HALO_RADIUS_PX * 2}px`)
+    expect(halo.style.height).toBe(`${ROUTE_HIGHLIGHT_HALO_RADIUS_PX * 2}px`)
+    expect(halo.style.backgroundColor).toBe('rgb(255, 255, 255)')
+    expect(ROUTE_HIGHLIGHT_HALO_COLOR).toBe('#ffffff')
+    expect(halo.style.opacity).toBe(String(ROUTE_HIGHLIGHT_HALO_OPACITY))
+
+    expect(core.style.width).toBe(`${ROUTE_HIGHLIGHT_CORE_RADIUS_PX * 2}px`)
+    expect(core.style.height).toBe(`${ROUTE_HIGHLIGHT_CORE_RADIUS_PX * 2}px`)
+    // A sibling, not a child of the halo — nesting would multiply the halo's
+    // opacity into the core and wash it out.
+    expect(core.parentElement).not.toBe(halo)
+    expect(core.style.opacity).toBe('')
+  })
+
+  it('colours the core green for a privacy-hidden sample', () => {
+    const [, core] = dotsOf(createRouteHighlightElement(true))
+
+    expect(core.style.backgroundColor).toBe('rgb(22, 163, 74)')
+    expect(ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR).toBe('#16a34a')
+  })
+})

--- a/lib/components/fitness/routeHighlightMarker.ts
+++ b/lib/components/fitness/routeHighlightMarker.ts
@@ -1,0 +1,83 @@
+/**
+ * The marker the fitness activity map drops on the route while the analysis
+ * charts are hovered.
+ *
+ * Every provider draws the same thing — a white halo with a coloured core,
+ * centred exactly on the hovered route sample — so the geometry and colours live
+ * here and are read by both surfaces: the GL circle layers (Mapbox /
+ * OpenFreeMap) and the Apple MapKit annotation. Apple used to render a
+ * `MarkerAnnotation` instead, whose teardrop pin is anchored by its tip and so
+ * covers the map *above* the point it marks; the highlight therefore sat visibly
+ * off-route on Apple maps only.
+ */
+
+/** GL paints circles by radius; the DOM dot derives its diameters from these. */
+export const ROUTE_HIGHLIGHT_HALO_RADIUS_PX = 8
+export const ROUTE_HIGHLIGHT_CORE_RADIUS_PX = 4.5
+export const ROUTE_HIGHLIGHT_HALO_COLOR = '#ffffff'
+export const ROUTE_HIGHLIGHT_HALO_OPACITY = 0.95
+/** Blue on the shared trace, green on segments hidden by a privacy location. */
+export const ROUTE_HIGHLIGHT_CORE_COLOR = '#1d4ed8'
+export const ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR = '#16a34a'
+
+export const getRouteHighlightCoreColor = (isHiddenByPrivacy: boolean) =>
+  isHiddenByPrivacy
+    ? ROUTE_HIGHLIGHT_HIDDEN_CORE_COLOR
+    : ROUTE_HIGHLIGHT_CORE_COLOR
+
+const createDot = (diameterPx: number, color: string) => {
+  const dot = document.createElement('div')
+  dot.style.position = 'absolute'
+  dot.style.left = '0px'
+  dot.style.top = '0px'
+  dot.style.width = `${diameterPx}px`
+  dot.style.height = `${diameterPx}px`
+  dot.style.borderRadius = '50%'
+  dot.style.backgroundColor = color
+  // Pull the dot back by half its own size so its centre — not its top-left
+  // corner — lands on the anchor's origin.
+  dot.style.transform = 'translate(-50%, -50%)'
+  return dot
+}
+
+/**
+ * Build the element Apple MapKit renders for a custom (`mapkit.Annotation`)
+ * highlight marker.
+ *
+ * MapKit anchors an annotation element by its BOTTOM CENTRE, which is what makes
+ * a naively-sized element float above the coordinate — the same offset the pin
+ * had. The returned node is therefore a zero-sized anchor with the halo and core
+ * translated onto its origin: on a zero-sized box the bottom centre, the centre
+ * and the origin are all the same point, so the dot lands on the sample without
+ * an `anchorOffset` correction (and so without `DOMPoint`, which jsdom does not
+ * implement) — and it stays centred whichever corner MapKit anchors by.
+ *
+ * The halo and core are siblings rather than nested so the halo's opacity does
+ * not wash out the core, matching the two independent GL circle layers.
+ */
+export const createRouteHighlightElement = (
+  isHiddenByPrivacy: boolean
+): HTMLElement => {
+  const anchor = document.createElement('div')
+  anchor.style.position = 'relative'
+  anchor.style.width = '0px'
+  anchor.style.height = '0px'
+  // Both dots live outside a zero-sized box, so nothing may clip them.
+  anchor.style.overflow = 'visible'
+  // A hover follower is decoration: it must never swallow map gestures.
+  anchor.style.pointerEvents = 'none'
+
+  const halo = createDot(
+    ROUTE_HIGHLIGHT_HALO_RADIUS_PX * 2,
+    ROUTE_HIGHLIGHT_HALO_COLOR
+  )
+  halo.style.opacity = String(ROUTE_HIGHLIGHT_HALO_OPACITY)
+
+  const core = createDot(
+    ROUTE_HIGHLIGHT_CORE_RADIUS_PX * 2,
+    getRouteHighlightCoreColor(isHiddenByPrivacy)
+  )
+
+  anchor.append(halo, core)
+  return anchor
+}

--- a/lib/utils/mapkit.ts
+++ b/lib/utils/mapkit.ts
@@ -96,6 +96,11 @@ export interface MapKitModule {
     options?: unknown
   ) => unknown
   MarkerAnnotation: new (coordinate: unknown, options?: unknown) => unknown
+  Annotation: new (
+    coordinate: unknown,
+    factory: (coordinate: never, options: never) => HTMLElement,
+    options?: unknown
+  ) => unknown
   CoordinateRegion: new (center: unknown, span: unknown) => unknown
   CoordinateSpan: new (
     latitudeDelta: number,


### PR DESCRIPTION
Hovering the analysis charts on a fitness activity highlights the matching point on the route map. On Mapbox and OpenFreeMap that highlight is a small dot sitting on the route; on Apple Maps it was a teardrop **pin**. A pin is anchored by its *tip*, so its body covered the map **above** the sample rather than marking it — the same hover pointed at two visibly different places depending on which provider the instance renders with.

## What changed

`ActivityRouteMapKit` now builds a custom `mapkit.Annotation` instead of a `MarkerAnnotation`, and draws the same white halo + coloured core the GL circle layers do (blue on the shared trace, green on a segment hidden by a privacy location).

The geometry and colours moved out of the two components into a shared `lib/components/fitness/routeHighlightMarker.ts`, read by both the GL `activity-active-point-*` layers in `FitnessStatusDetail` and the MapKit element. They were duplicated literals before — `8` / `4.5` / `#ffffff` / `#1d4ed8` / `#16a34a` written out twice — so the two surfaces could drift apart silently. Now a change to the dot is a change to one module.

### Why the element is zero-sized

MapKit anchors a custom annotation's element by its **bottom centre**, which is exactly what made the pin sit high. So the factory returns a `0×0` anchor with the halo and core absolutely positioned and pulled back onto its origin by `translate(-50%, -50%)`.

On a zero-sized box the bottom centre, the centre and the top-left origin are all the *same point* — so the dot lands on the coordinate under any of MapKit's anchoring conventions, and needs no `anchorOffset` correction (and therefore no `DOMPoint`, which jsdom does not implement). The halo and core are siblings rather than nested, so the halo's `0.95` opacity does not wash the core out; that mirrors the two independent GL circle layers.

The annotation is created with `animates: false` (a hover follower should not drop in on every mouse move) and `enabled: false` (it is decoration, not something to select). The element itself is `pointer-events: none` so it can never swallow a map gesture.

## Browser verification

Apple MapKit needs a real Apple Developer MapKit key, which no local checkout has, so the marker was verified in a browser against a live MapLibre map instead — importing **the shipped module**, and positioning it with MapKit's own anchoring rule (`maplibregl.Marker` with `anchor: 'bottom'` puts the element's bottom centre on the coordinate, exactly as MapKit does). Three panes over the same route and the same "hovered" sample:

1. the GL circle layers as `FitnessStatusDetail` paints them (the reference),
2. `createRouteHighlightElement`, bottom-centre anchored,
3. a bottom-anchored teardrop pin — the old behaviour.

Panes 1 and 2 render an identical dot centred on the route vertex; pane 3 shows the pin's body covering the map above it, with the vertex hidden under the tip. Measured in pane 2: element `0×0`, anchor point `(640.66, 215.39)`, halo centre `(640.66, 215.39)`, core centre `(640.66, 215.39)` — offset from the anchor `dx 0, dy 0`, with halo `16px` and core `9px` as the shared constants specify.

## Tests

- `lib/components/fitness/routeHighlightMarker.test.ts` — new: the zero-sized anchor, the halo/core diameters and colours, halo-and-core-as-siblings, and the per-privacy-state core colour.
- `lib/components/fitness/ActivityRouteMapKit.test.tsx` — new case asserting the hover highlight is the dot element and that `MarkerAnnotation` is never constructed.
- The MapKit test double gained `Annotation`; it calls the factory and records the produced element, which is also what distinguishes a custom annotation from a pin in assertions.

`yarn run prettier --write .` → `yarn lint` (0 errors) → `yarn build` → `yarn test` (746 files, 7833 tests) all green.

## Not in this PR

`PrivacyZoneMapKit` has the same mismatch — it drops a `MarkerAnnotation` pin where its GL twin in `FitnessPrivacyLocationSettings` draws a green circle. It is a different surface (placing a privacy zone, not following a chart hover), so it is left alone here; the shared module is the obvious place to fix it from if you want that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also here: the CI flake this PR tripped over

The first CI run failed on `FitnessStatusDetail.test.tsx > brings the privacy notice back when another activity file is selected` — at its **first** assertion, with the just-dismissed notice still in the document. Unrelated to the marker change (the same test file was already known to flake), so it is fixed here rather than left to keep blocking PRs.

`ActivityMapPanel` reset the dismissal from an effect keyed on the `routeSegments` **array identity**:

```js
useEffect(() => { setIsPrivacyNoticeDismissed(false) }, [routeSegments])
```

A passive effect runs a task *after* the commit that revealed the notice, and RTL's `findBy*` resolves on the DOM mutation with the act environment disabled — so the effect can still be pending when the test clicks the notice away, and then lands afterwards and puts it back. Same shape as the `waitFor` race fixed in #1331. Once that happens the `waitFor` can never pass; it just retries to timeout.

The dismissal now records **which activity file** was acknowledged and is derived during render, so there is no effect left to race:

```js
const isPrivacyNoticeDismissed =
  fitnessFileId !== null && dismissedNoticeFileId === fitnessFileId
```

Selecting a different file still shows the notice for the new route (that behaviour is unchanged and still tested). What changes is that reloading the *acknowledged* file's route no longer resurrects it — which is also the better behaviour: a background refetch should not re-nag about something the viewer already closed.

The new test `keeps the privacy notice dismissed when its own file is selected again` covers exactly that, and it discriminates: it **fails** against the old identity-keyed reset and passes with the derived state.
