### PR TITLE
Bump version to v1.122.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.122.2",
+  "version": "1.122.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.122.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.122.2`
- Base main SHA: `b313a10f73c53b657eadd568b0358bf0c02b9640`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
