### PR TITLE
fix: plot the activity graphs at Strava's resolution and make the elevation profile scrub

### DIFF
--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -52,6 +52,26 @@ vi.mock('@/lib/components/posts/media', () => ({
   Media: () => <div data-testid="media" />
 }))
 
+// The MapKit surface is the one map path that is a component rather than an
+// imperative GL handle, so it is where a test can read back the instant the
+// page is asking the map to highlight.
+vi.mock('@/lib/components/fitness/ActivityRouteMapKit', () => ({
+  ActivityRouteMapKit: ({
+    highlightedElapsedSeconds
+  }: {
+    highlightedElapsedSeconds?: number | null
+  }) => (
+    <div
+      data-testid="route-map"
+      data-highlighted-elapsed-seconds={
+        typeof highlightedElapsedSeconds === 'number'
+          ? String(highlightedElapsedSeconds)
+          : ''
+      }
+    />
+  )
+}))
+
 vi.mock('@/lib/components/posts/post', () => ({
   Post: ({ status }: { status: { id: string } }) => (
     <div data-testid="reply-post">{status.id}</div>
@@ -737,6 +757,167 @@ describe('FitnessStatusDetail', () => {
         }
       }
     )
+
+    // A 1 Hz recording arrives as one sample per second, so a plotted point per
+    // ~51s of it — which is what the old flat 120-point cap produced — averages
+    // every short climb and sprint away. Strava draws one point per 8 samples
+    // (measured on two of its own activity Analysis pages: 5,913 -> 740 and
+    // 5,272 -> 659), so these are the ratios, not round numbers.
+    it.each([
+      { description: '5913 samples like the reference ride', raw: 5_913 },
+      { description: '5272 samples like the second ride', raw: 5_272 }
+    ])('plots $description at Strava density', async ({ raw }) => {
+      const ramp = Array.from({ length: raw }, (_, index) => index)
+      mockGetFitnessRouteData.mockResolvedValue({
+        ...routeData,
+        altitudeSeries: ramp,
+        speedSeries: ramp,
+        powerSeries: ramp,
+        heartRateSeries: ramp
+      })
+
+      const panel = await openAnalysis()
+
+      const expected = Math.round(raw / 8)
+      const pointCounts = Array.from(panel.querySelectorAll('path')).map(
+        (path) => (path.getAttribute('d') ?? '').match(/[LM]/g)?.length ?? 0
+      )
+      expect(pointCounts).toEqual([expected, expected, expected, expected])
+    })
+
+    // The ratio is clamped at both ends: a short activity never gets coarser
+    // than it already was, and a very long one never grows an unbounded path.
+    it.each([
+      {
+        description: 'floors a short recording at 120 points',
+        raw: 600,
+        expected: 120
+      },
+      {
+        description: 'caps a very long recording at 1200 points',
+        raw: 40_000,
+        expected: 1_200
+      }
+    ])('$description', async ({ raw, expected }) => {
+      const ramp = Array.from({ length: raw }, (_, index) => index)
+      mockGetFitnessRouteData.mockResolvedValue({
+        ...routeData,
+        altitudeSeries: ramp
+      })
+
+      const panel = await openAnalysis()
+
+      const [elevationPath] = Array.from(panel.querySelectorAll('path'))
+      expect(
+        (elevationPath.getAttribute('d') ?? '').match(/[LM]/g)
+      ).toHaveLength(expected)
+    })
+
+    // Downsampling is a bin average, so a series shorter than the floor has to
+    // survive untouched — otherwise a two-minute activity would be resampled
+    // for no reason and its samples would stop lining up with the map.
+    it('leaves a series shorter than the floor at its own resolution', async () => {
+      const panel = await openAnalysis()
+
+      const [elevationPath] = Array.from(panel.querySelectorAll('path'))
+      expect(
+        (elevationPath.getAttribute('d') ?? '').match(/[LM]/g)
+      ).toHaveLength(routeData.altitudeSeries?.length ?? 0)
+    })
+  })
+
+  describe('overview elevation profile', () => {
+    // Same contract as the analysis stack, on the summary card: drag it and it
+    // reports the elevation under the pointer and moves the highlight on the
+    // map above it. It used to be a static picture.
+    const hoverElevation = (clientX: number) => {
+      const profile = screen.getByTestId('overview-elevation-profile')
+      const [plot] = Array.from(profile.querySelectorAll('svg'))
+      plot.getBoundingClientRect = () => ({ left: 100, width: 400 }) as DOMRect
+      fireEvent.mouseMove(plot, { clientX })
+      return plot
+    }
+
+    const renderOverview = async () => {
+      renderDetail()
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('overview-elevation-profile')
+        ).toBeInTheDocument()
+      )
+    }
+
+    it('reports the elevation under the pointer while it is dragged', async () => {
+      await renderOverview()
+
+      expect(screen.queryAllByTestId('chart-hover-value')).toHaveLength(0)
+
+      // A quarter of the way across => 450s of a 1800s ride => sample index 1
+      // of the [10, 24, 40, 55, 48, 30] fixture.
+      const plot = hoverElevation(200)
+
+      const [readout] = screen.getAllByTestId('chart-hover-value')
+      expect(readout).toHaveTextContent(/^24m$/)
+      // The card header carries the instant, so the value has a time to belong
+      // to without a second readout chip.
+      expect(screen.getByText(/7:30 · 120 m gain/)).toBeInTheDocument()
+
+      fireEvent.mouseLeave(plot)
+      expect(screen.queryAllByTestId('chart-hover-value')).toHaveLength(0)
+      expect(screen.getByText(/^120 m gain$/)).toBeInTheDocument()
+    })
+
+    it('scrubs on touch as well as on hover', async () => {
+      await renderOverview()
+
+      const profile = screen.getByTestId('overview-elevation-profile')
+      const [plot] = Array.from(profile.querySelectorAll('svg'))
+      plot.getBoundingClientRect = () => ({ left: 100, width: 400 }) as DOMRect
+
+      fireEvent.touchStart(plot, { touches: [{ clientX: 200 }] })
+      expect(screen.getAllByTestId('chart-hover-value')[0]).toHaveTextContent(
+        /^24m$/
+      )
+
+      fireEvent.touchEnd(plot)
+      expect(screen.queryAllByTestId('chart-hover-value')).toHaveLength(0)
+    })
+
+    // The whole point of the scrub is the map, and the map only follows a
+    // highlight the Overview's own panel is given — the prop used to be passed
+    // on the Analysis section's panel alone, so the profile could report a
+    // value with nothing moving beside it.
+    it('follows the scrubbed instant on the map above it', async () => {
+      renderDetail({ mapProvider: { type: 'apple' } })
+      await waitFor(() =>
+        expect(screen.getByTestId('route-map')).toBeInTheDocument()
+      )
+
+      expect(screen.getByTestId('route-map')).toHaveAttribute(
+        'data-highlighted-elapsed-seconds',
+        ''
+      )
+
+      hoverElevation(200)
+
+      // A quarter of the way across a 1800s ride.
+      expect(screen.getByTestId('route-map')).toHaveAttribute(
+        'data-highlighted-elapsed-seconds',
+        '450'
+      )
+    })
+
+    it('drops the highlight when the section changes', async () => {
+      await renderOverview()
+
+      hoverElevation(200)
+      expect(screen.getAllByTestId('chart-hover-value')).not.toHaveLength(0)
+
+      const menu = await openSectionMenu()
+      fireEvent.click(within(menu).getByRole('menuitem', { name: 'Analysis' }))
+
+      expect(screen.queryAllByTestId('chart-hover-value')).toHaveLength(0)
+    })
   })
 
   it('shows the multi-file activity switcher when several files are aggregated', async () => {

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -765,7 +765,13 @@ describe('FitnessStatusDetail', () => {
     // 5,272 -> 659), so these are the ratios, not round numbers.
     it.each([
       { description: '5913 samples like the reference ride', raw: 5_913 },
-      { description: '5272 samples like the second ride', raw: 5_272 }
+      { description: '5272 samples like the second ride', raw: 5_272 },
+      // Just above where the 120-point floor stops binding (it binds below 956
+      // samples), so this case pins the RATIO rather than the clamp — the two
+      // rows above would still pass if the ratio were replaced by any cap of
+      // their own value, and the floor case below passes even against the old
+      // flat 120.
+      { description: '1000 samples just past the floor', raw: 1_000 }
     ])('plots $description at Strava density', async ({ raw }) => {
       const ramp = Array.from({ length: raw }, (_, index) => index)
       mockGetFitnessRouteData.mockResolvedValue({
@@ -859,12 +865,16 @@ describe('FitnessStatusDetail', () => {
       const [readout] = screen.getAllByTestId('chart-hover-value')
       expect(readout).toHaveTextContent(/^24m$/)
       // The card header carries the instant, so the value has a time to belong
-      // to without a second readout chip.
-      expect(screen.getByText(/7:30 · 120 m gain/)).toBeInTheDocument()
+      // to without a second readout chip. It REPLACES the gain rather than
+      // prefixing it: at 320px a prefixed "1:18:29 · 455 m gain" outgrows the
+      // heading row and wraps it to two lines, which moves the chart under the
+      // finger that is dragging it.
+      expect(screen.getByText('7:30')).toBeInTheDocument()
+      expect(screen.queryByText(/120 m gain/)).not.toBeInTheDocument()
 
       fireEvent.mouseLeave(plot)
       expect(screen.queryAllByTestId('chart-hover-value')).toHaveLength(0)
-      expect(screen.getByText(/^120 m gain$/)).toBeInTheDocument()
+      expect(screen.getByText('120 m gain')).toBeInTheDocument()
     })
 
     it('scrubs on touch as well as on hover', async () => {

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.test.tsx
@@ -877,6 +877,23 @@ describe('FitnessStatusDetail', () => {
       expect(screen.getByText('120 m gain')).toBeInTheDocument()
     })
 
+    // Four ticks, not the helper's default six. `justify-between` gives the
+    // label row no way to wrap, and six H:MM:SS labels are wider than this
+    // card's 212px content box at the 320px reflow target — so they ran
+    // together into one unbroken string of digits and, past ~5h, crossed the
+    // card's own border, which a Card has no `overflow-hidden` to clip. The
+    // 10:00/20:00 pair is what distinguishes this from the six-tick set.
+    it('labels its time axis with four ticks, which fit the card at 320px', async () => {
+      await renderOverview()
+
+      const profile = screen.getByTestId('overview-elevation-profile')
+      const labels = Array.from(profile.lastElementChild?.children ?? []).map(
+        (label) => label.textContent
+      )
+
+      expect(labels).toEqual(['0:00', '10:00', '20:00', '30:00'])
+    })
+
     it('scrubs on touch as well as on hover', async () => {
       await renderOverview()
 

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -908,8 +908,8 @@ const ElevationProfileChart: FC<{
     () => getSeriesMinMax(values),
     [values]
   )
-  // Memoized because the series is now plotted at full Strava-like density:
-  // rebuilding a 2,000-point path string on every pointer move would be the one
+  // Memoized because the series is now plotted at Strava's density: rebuilding
+  // a path string of up to 1,200 points on every pointer move would be the one
   // expensive thing a scrub does.
   const line = useMemo(
     () => buildChartPath(values, width, height, minValue, maxValue),
@@ -919,8 +919,16 @@ const ElevationProfileChart: FC<{
     () => `${line} L ${width.toFixed(2)} ${height} L 0 ${height} Z`,
     [line, height]
   )
+  // Four ticks, not the helper's default six. This card is narrower than the
+  // Analysis panel (a `p-5` Card inside the same column, so 212px of content at
+  // the 320px reflow target against that panel's 220px) and `justify-between`
+  // gives a label row no way to wrap: six H:MM:SS labels need 222px and six
+  // HH:MM:SS labels 239px, so anything past ~2h30 rendered as one unbroken run
+  // of digits and anything past ~5h crossed the card's own border, since a Card
+  // has no `overflow-hidden` to clip it the way that panel does. Four labels
+  // are 167px / 195px, which still leaves real gaps at 320px.
   const xLabels = useMemo(
-    () => (durationSeconds ? buildXAxisLabels(durationSeconds) : null),
+    () => (durationSeconds ? buildXAxisLabels(durationSeconds, 4) : null),
     [durationSeconds]
   )
   const scrub = useChartScrub({
@@ -2561,15 +2569,19 @@ export const FitnessStatusDetail: FC<Props> = ({
                 <SectionTitle
                   icon={Mountain}
                   right={
-                    <span className="text-xs tabular-nums text-muted-foreground">
-                      {/* The scrubbed instant replaces nothing — it is added
-                          in front of the gain, so the card keeps reporting the
-                          activity's own headline number while the pointer
-                          reports where on it you are. */}
-                      {highlightedElapsedLabel
-                        ? `${highlightedElapsedLabel} · `
-                        : ''}
-                      {Math.max(0, Math.round(elevationGainMeters))} m gain
+                    <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+                      {/* The scrubbed instant REPLACES the gain rather than
+                          prefixing it, the same way the Analysis card swaps its
+                          hover hint for "Selected time". Prefixing made this
+                          slot grow past the heading row's width at the 320px
+                          reflow target, and `formatFitnessDuration` widens from
+                          M:SS to H:MM:SS at exactly 3600s — so dragging across
+                          the one-hour mark wrapped the row to two lines and
+                          pushed the chart 8px down under the user's own finger,
+                          then snapped back when they lifted it. The gain is the
+                          resting state and returns the moment the scrub ends. */}
+                      {highlightedElapsedLabel ??
+                        `${Math.max(0, Math.round(elevationGainMeters))} m gain`}
                     </span>
                   }
                 >

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -943,10 +943,11 @@ const ElevationProfileChart: FC<{
   // Worked at 11px tabular-nums, where "0:00" is ~24px and one "H:MM:SS" label
   // ~42px (a five-hour ride, the point at which every tick but the first has
   // taken the wider form): six labels need 24 + 5x42 = 234px against 212px,
-  // while four need 24 + 3x42 = 150px and keep ~20px between each. A ten-hour
-  // ride widens every label again to ~49px, which is 269px at six ticks and a
-  // still-comfortable 171px at four. Pinned by a test, since the failure is
-  // silent — nothing errors, the labels just merge.
+  // while four need 24 + 3x42 = 150px and keep ~20px between each. Going longer
+  // adds little: `formatFitnessDuration` does not zero-pad the hour, so a
+  // ten-hour ride widens only the labels that reach two digits (~49px) — 241px
+  // at six ticks, a still-comfortable 157px at four. Pinned by a test, since
+  // the failure is silent — nothing errors, the labels just merge.
   const xLabels = useMemo(
     () => (durationSeconds ? buildXAxisLabels(durationSeconds, 4) : null),
     [durationSeconds]

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -26,7 +26,16 @@ import {
   X
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { FC, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  FC,
+  type MouseEvent,
+  ReactNode,
+  type TouchEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import {
   type FitnessRouteSample,
@@ -82,6 +91,33 @@ import {
 } from '@/lib/utils/mapProvider'
 import { htmlToPlainText } from '@/lib/utils/text/htmlToPlainText'
 
+const clampNumber = (value: number, min: number, max: number) => {
+  return Math.max(min, Math.min(max, value))
+}
+
+// How densely a chart series is plotted, as samples-per-drawn-point.
+//
+// The series used to be flattened to a fixed 120 points, which is what made
+// every graph on this page read as a smoothed cartoon of the activity beside
+// the same ride on Strava: a 1h44 recording arrives as 6,123 one-second
+// samples, so each of those 120 bins averaged ~51 seconds — roughly 370 m of a
+// 44 km ride — and every short climb, descent and sprint inside a bin was
+// averaged flat.
+//
+// 8 is Strava's own ratio, read off two of its activity Analysis pages rather
+// than guessed: it ships the whole stream to the browser and draws exactly one
+// point per 8 of them (5,913 samples -> 740 drawn; 5,272 -> 659). A fixed point
+// COUNT would not reproduce that — it is a density, so a longer recording gets
+// proportionally more points rather than being squeezed into the same budget.
+const ANALYSIS_SAMPLES_PER_POINT = 8
+// Floors and ceilings on that ratio. The floor keeps a short activity at least
+// as detailed as it was before this change (a 10-minute 1 Hz recording is 600
+// samples, which Strava's ratio alone would draw as 75 points); the ceiling
+// bounds the path strings — memoized, so a hover never rebuilds them — for a
+// recording long enough that the ratio would otherwise run away.
+const ANALYSIS_SERIES_MIN_POINTS = 120
+const ANALYSIS_SERIES_MAX_POINTS = 1_200
+
 const downsampleSeries = (series: number[], targetCount: number) => {
   if (series.length <= targetCount) return series
   const ratio = series.length / targetCount
@@ -94,6 +130,20 @@ const downsampleSeries = (series: number[], targetCount: number) => {
     result.push(sum / chunk.length)
   }
   return result
+}
+
+// Reduce one raw series to the point count Strava would draw it at. An empty
+// series stays empty — a chart with no data is not rendered at all.
+const plotAtStravaDensity = (series: number[]) => {
+  if (series.length === 0) return []
+  return downsampleSeries(
+    series,
+    clampNumber(
+      Math.round(series.length / ANALYSIS_SAMPLES_PER_POINT),
+      ANALYSIS_SERIES_MIN_POINTS,
+      ANALYSIS_SERIES_MAX_POINTS
+    )
+  )
 }
 
 interface Props {
@@ -332,10 +382,6 @@ const MAP_ACTIVE_POINT_SOURCE_ID = 'activity-active-point'
 // matching RouteHeatmapMap.
 const MAP_LOAD_TIMEOUT_MS = 20_000
 
-const clampNumber = (value: number, min: number, max: number) => {
-  return Math.max(min, Math.min(max, value))
-}
-
 const normalizeRouteSample = (
   sample: FitnessRouteSample
 ): FitnessRouteSample => {
@@ -485,6 +531,226 @@ const buildXAxisLabels = (durationSeconds: number, tickCount = 6) => {
   return labels
 }
 
+interface ChartScrubOptions {
+  values: number[]
+  width: number
+  height: number
+  minValue: number
+  maxValue: number
+  durationSeconds?: number
+  highlightedElapsedSeconds?: number | null
+  onHighlightElapsedSeconds?: (elapsedSeconds: number | null) => void
+}
+
+// Everything a chart needs to follow the pointer: whether it can, where the
+// highlighted sample sits in plot coordinates, and the DOM handlers that turn a
+// pointer or a finger into an elapsed time.
+//
+// This lives in one hook because two visually different charts now share the
+// behaviour — the Analysis stack's line panels and the Overview's filled
+// elevation profile. Keeping the geometry beside the handlers is what stops the
+// dot from drifting off the line: both read the same `getChartXPosition` /
+// `getChartYPosition` projection the path was drawn with.
+const useChartScrub = ({
+  values,
+  width,
+  height,
+  minValue,
+  maxValue,
+  durationSeconds,
+  highlightedElapsedSeconds = null,
+  onHighlightElapsedSeconds
+}: ChartScrubOptions) => {
+  const canScrub =
+    typeof onHighlightElapsedSeconds === 'function' &&
+    typeof durationSeconds === 'number' &&
+    durationSeconds > 0 &&
+    values.length > 0
+
+  // One nullable object rather than three parallel nullable fields plus an
+  // `isHighlighted` boolean: a boolean beside them narrows nothing, so every
+  // consumer had to re-assert that x, y and value were numbers before it could
+  // pass them anywhere typed.
+  const highlightedIndex =
+    canScrub && typeof highlightedElapsedSeconds === 'number'
+      ? clampNumber(
+          Math.round(
+            (highlightedElapsedSeconds / durationSeconds) * (values.length - 1)
+          ),
+          0,
+          values.length - 1
+        )
+      : null
+  const highlight =
+    highlightedIndex === null
+      ? null
+      : {
+          value: values[highlightedIndex],
+          x: getChartXPosition(highlightedIndex, values.length, width),
+          y: getChartYPosition(
+            values[highlightedIndex],
+            height,
+            minValue,
+            maxValue
+          )
+        }
+
+  // One scrub for pointer and touch alike: both report a viewport x, and the
+  // instant it lands on is the same either way.
+  const scrubToClientX = (clientX: number | undefined, plot: SVGSVGElement) => {
+    if (!canScrub || !onHighlightElapsedSeconds) return
+    if (typeof clientX !== 'number') return
+    const bounds = plot.getBoundingClientRect()
+    const ratio = clampNumber(
+      (clientX - bounds.left) / Math.max(bounds.width, 1),
+      0,
+      1
+    )
+    onHighlightElapsedSeconds(ratio * durationSeconds)
+  }
+
+  const clearScrub = () => {
+    if (!canScrub || !onHighlightElapsedSeconds) return
+    onHighlightElapsedSeconds(null)
+  }
+
+  const plotHandlers = {
+    onMouseMove: (event: MouseEvent<SVGSVGElement>) => {
+      scrubToClientX(event.clientX, event.currentTarget)
+    },
+    onMouseLeave: clearScrub,
+    onTouchStart: (event: TouchEvent<SVGSVGElement>) => {
+      scrubToClientX(event.touches[0]?.clientX, event.currentTarget)
+    },
+    onTouchMove: (event: TouchEvent<SVGSVGElement>) => {
+      scrubToClientX(event.touches[0]?.clientX, event.currentTarget)
+    },
+    onTouchEnd: (event: TouchEvent<SVGSVGElement>) => {
+      // A tap is followed by compatibility `mousemove`/`mousedown`/…
+      // at the same point, and that `mousemove` would re-enter the scrub
+      // the moment this clears it — leaving the readout stuck on, because
+      // no `mouseleave` follows a touch. Preventing the default suppresses
+      // that whole compat sequence; the chart has no click behaviour to
+      // lose, and a drag never gets here stuck anyway because movement
+      // past the tap slop suppresses the compat events on its own.
+      // Guarded on `cancelable`: once a scroll is underway Chrome keeps
+      // dispatching `touchend` with `cancelable: false` rather than
+      // switching to `touchcancel`, and calling this on one of those is a
+      // no-op that logs a warning on every vertical swipe that started on
+      // a chart — which is most of them, under four stacked full-width
+      // charts.
+      if (event.cancelable) event.preventDefault()
+      clearScrub()
+    },
+    onTouchCancel: clearScrub
+  }
+
+  // A vertical swipe still scrolls the page and a pinch still zooms; only the
+  // horizontal drag is claimed, for scrubbing. Both of the other two have to be
+  // named explicitly — `touch-pan-y` on its own compiles to exactly
+  // `touch-action: pan-y`, which drops pinch-zoom, and blocking magnification
+  // over a stack of charts takes it away in the one place a low-vision reader
+  // most wants it.
+  const plotClassName = canScrub
+    ? 'cursor-crosshair touch-pan-y touch-pinch-zoom'
+    : undefined
+
+  return {
+    canScrub,
+    highlight,
+    plotClassName,
+    plotHandlers
+  }
+}
+
+// The dot pinned to the highlighted sample plus the value chip beside it,
+// shared by every scrubbable chart so the two never drift apart.
+const ChartHoverMarker: FC<{
+  x: number
+  y: number
+  width: number
+  height: number
+  value: number
+  unit: string
+  fractionDigits: number
+  dotClassName?: string
+}> = ({ x, y, width, height, value, unit, fractionDigits, dotClassName }) => {
+  // The readout sits beside the dot and flips to its left near the right edge.
+  // The threshold is a fraction of the viewBox while the chip is a fixed pixel
+  // width, so the two only agree above some container width. At the 320px
+  // reflow target the plot is 220px and the chip is ~77px for the widest value
+  // these series realistically produce ("13.5 km/h"), against a budget of that
+  // 220px PLUS this panel's own 16px right padding — the `overflow-hidden` is
+  // on the merged panel outside it. So the design kit's 0.72 lands 12px past
+  // what will be shown, and anything at or below 0.66 fits. 0.62 keeps a margin
+  // for a longer value or a wider font, at the cost of flipping sooner than the
+  // kit does in a desktop column, where there is still room to the right.
+  const shouldFlipReadout = x / width > 0.62
+
+  return (
+    <>
+      {/* The dot is HTML, not an SVG `circle`: `preserveAspectRatio="none"`
+          scales x and y independently, so a circle renders as an ellipse that
+          is half again as wide as it is tall in a desktop column and nearly
+          twice as tall as wide on a phone. Positioned by the same percentage
+          mapping as the readout — exact under that same `none`. */}
+      <span
+        aria-hidden="true"
+        data-testid="chart-hover-dot"
+        className={cn(
+          'pointer-events-none absolute z-10 size-[11px] -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background',
+          dotClassName ?? 'bg-sky-500'
+        )}
+        style={{
+          left: `${(x / width) * 100}%`,
+          top: `${(y / height) * 100}%`
+        }}
+      />
+      {/* Value readout pinned to the hover dot. Percentage positioning works
+          because `preserveAspectRatio="none"` maps the viewBox linearly onto
+          the rendered box; the vertical clamp keeps it inside the plot when
+          the sample sits against the top or bottom of the scale.
+          `aria-hidden` because it is the running commentary on a pointer
+          gesture: the numbers it shows are already in the panel header's
+          "Scale …", and a screen reader would otherwise meet a bare figure
+          with no context, attached to a control it cannot drive.
+          Keeping it inside the panel is the flip threshold's job, not a
+          `max-width`'s — the chip is clipped by where it is positioned, and
+          a cap wide enough to never truncate the text is also too wide to
+          ever bind. */}
+      <div
+        aria-hidden="true"
+        data-testid="chart-hover-value"
+        className="pointer-events-none absolute z-20 flex items-baseline gap-1 rounded-md border bg-background px-2 py-1 shadow-sm"
+        style={{
+          left: `${(x / width) * 100}%`,
+          top: `${clampNumber((y / height) * 100, 8, 92)}%`,
+          transform: shouldFlipReadout
+            ? 'translate(calc(-100% - 12px), -50%)'
+            : 'translate(12px, -50%)'
+        }}
+      >
+        <span className="text-sm font-semibold leading-none tabular-nums text-foreground">
+          {formatChartValue(value, fractionDigits)}
+        </span>
+        <span className="text-[10px] leading-none text-muted-foreground">
+          {unit}
+        </span>
+        <span
+          aria-hidden="true"
+          className={cn(
+            'absolute top-1/2 size-2 bg-background',
+            shouldFlipReadout
+              ? '-right-[4.5px] border-r border-t'
+              : '-left-[4.5px] border-b border-l'
+          )}
+          style={{ transform: 'translateY(-50%) rotate(45deg)' }}
+        />
+      </div>
+    </>
+  )
+}
+
 const Card: FC<{
   className?: string
   children: ReactNode
@@ -619,53 +885,126 @@ const SectionNav: FC<{
   )
 }
 
-const ElevationProfileChart: FC<{ values: number[]; height?: number }> = ({
+// The Overview's filled elevation profile. Visually it is its own thing — the
+// orange area fill under a heavier line, sized for a summary card — but it
+// scrubs exactly like the Analysis stack does, off the same `useChartScrub`
+// hook and the same shared marker, so dragging it reports the elevation under
+// the pointer and moves the highlight on the map above it.
+const ElevationProfileChart: FC<{
+  values: number[]
+  height?: number
+  durationSeconds?: number
+  highlightedElapsedSeconds?: number | null
+  onHighlightElapsedSeconds?: (elapsedSeconds: number | null) => void
+}> = ({
   values,
-  height = 130
+  height = 130,
+  durationSeconds,
+  highlightedElapsedSeconds = null,
+  onHighlightElapsedSeconds
 }) => {
   const width = 800
-  const { minValue, maxValue } = getSeriesMinMax(values)
-  const line = buildChartPath(values, width, height, minValue, maxValue)
-  const area = `${line} L ${width.toFixed(2)} ${height} L 0 ${height} Z`
+  const { minValue, maxValue } = useMemo(
+    () => getSeriesMinMax(values),
+    [values]
+  )
+  // Memoized because the series is now plotted at full Strava-like density:
+  // rebuilding a 2,000-point path string on every pointer move would be the one
+  // expensive thing a scrub does.
+  const line = useMemo(
+    () => buildChartPath(values, width, height, minValue, maxValue),
+    [values, height, minValue, maxValue]
+  )
+  const area = useMemo(
+    () => `${line} L ${width.toFixed(2)} ${height} L 0 ${height} Z`,
+    [line, height]
+  )
+  const xLabels = useMemo(
+    () => (durationSeconds ? buildXAxisLabels(durationSeconds) : null),
+    [durationSeconds]
+  )
+  const scrub = useChartScrub({
+    values,
+    width,
+    height,
+    minValue,
+    maxValue,
+    durationSeconds,
+    highlightedElapsedSeconds,
+    onHighlightElapsedSeconds
+  })
 
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
-      className="block w-full"
-      style={{ height }}
-    >
-      <defs>
-        <linearGradient
-          id="fitness-elevation-gradient"
-          x1="0"
-          y1="0"
-          x2="0"
-          y2="1"
+    <div data-testid="overview-elevation-profile">
+      <div className="relative" style={{ height }}>
+        <svg
+          viewBox={`0 0 ${width} ${height}`}
+          preserveAspectRatio="none"
+          className={cn('block h-full w-full', scrub.plotClassName)}
+          {...scrub.plotHandlers}
         >
-          <stop offset="0" stopColor="hsl(24 95% 46%)" stopOpacity="0.28" />
-          <stop offset="1" stopColor="hsl(24 95% 46%)" stopOpacity="0.02" />
-        </linearGradient>
-      </defs>
-      <line
-        x1={0}
-        y1={height / 2}
-        x2={width}
-        y2={height / 2}
-        className="stroke-border"
-        strokeWidth={1}
-        strokeDasharray="4 4"
-      />
-      <path d={area} fill="url(#fitness-elevation-gradient)" />
-      <path
-        d={line}
-        fill="none"
-        className="stroke-primary"
-        strokeWidth={2.5}
-        strokeLinejoin="round"
-        vectorEffect="non-scaling-stroke"
-      />
-    </svg>
+          <defs>
+            <linearGradient
+              id="fitness-elevation-gradient"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop offset="0" stopColor="hsl(24 95% 46%)" stopOpacity="0.28" />
+              <stop offset="1" stopColor="hsl(24 95% 46%)" stopOpacity="0.02" />
+            </linearGradient>
+          </defs>
+          <line
+            x1={0}
+            y1={height / 2}
+            x2={width}
+            y2={height / 2}
+            className="stroke-border"
+            strokeWidth={1}
+            strokeDasharray="4 4"
+          />
+          <path d={area} fill="url(#fitness-elevation-gradient)" />
+          <path
+            d={line}
+            fill="none"
+            className="stroke-primary"
+            strokeWidth={2.5}
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+          {scrub.highlight ? (
+            <line
+              x1={scrub.highlight.x}
+              y1={0}
+              x2={scrub.highlight.x}
+              y2={height}
+              vectorEffect="non-scaling-stroke"
+              className="stroke-primary stroke-[1.5] opacity-60"
+            />
+          ) : null}
+        </svg>
+        {scrub.highlight ? (
+          <ChartHoverMarker
+            x={scrub.highlight.x}
+            y={scrub.highlight.y}
+            width={width}
+            height={height}
+            value={scrub.highlight.value}
+            unit="m"
+            fractionDigits={0}
+            dotClassName="bg-primary"
+          />
+        ) : null}
+      </div>
+      {xLabels && (
+        <div className="mt-2 flex justify-between text-[11px] tabular-nums text-muted-foreground">
+          {xLabels.map((label, index) => (
+            <span key={index}>{label}</span>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -771,66 +1110,16 @@ const ChartPanel: FC<{
     () => (durationSeconds ? buildXAxisLabels(durationSeconds) : null),
     [durationSeconds]
   )
-  const canHoverMapPoint =
-    typeof onHighlightElapsedSeconds === 'function' &&
-    typeof durationSeconds === 'number' &&
-    durationSeconds > 0 &&
-    values.length > 0
-  const highlightedIndex =
-    canHoverMapPoint && typeof highlightedElapsedSeconds === 'number'
-      ? clampNumber(
-          Math.round(
-            (highlightedElapsedSeconds / durationSeconds) * (values.length - 1)
-          ),
-          0,
-          values.length - 1
-        )
-      : null
-  const highlightedValue =
-    typeof highlightedIndex === 'number' ? values[highlightedIndex] : null
-  const highlightedX =
-    typeof highlightedIndex === 'number'
-      ? getChartXPosition(highlightedIndex, values.length, width)
-      : null
-  const highlightedY =
-    typeof highlightedValue === 'number'
-      ? getChartYPosition(highlightedValue, height, minValue, maxValue)
-      : null
-  // The readout sits beside the dot and flips to its left near the right edge.
-  // The threshold is a fraction of the viewBox while the chip is a fixed pixel
-  // width, so the two only agree above some container width. At the 320px
-  // reflow target the plot is 220px and the chip is ~77px for the widest value
-  // these series realistically produce ("13.5 km/h"), against a budget of that
-  // 220px PLUS this panel's own 16px right padding — the `overflow-hidden` is
-  // on the merged panel outside it. So the design kit's 0.72 lands 12px past
-  // what will be shown, and anything at or below 0.66 fits. 0.62 keeps a margin
-  // for a longer value or a wider font, at the cost of flipping sooner than the
-  // kit does in a desktop column, where there is still room to the right.
-  const shouldFlipReadout =
-    typeof highlightedX === 'number' && highlightedX / width > 0.62
-  const isHighlighted =
-    typeof highlightedX === 'number' &&
-    typeof highlightedY === 'number' &&
-    typeof highlightedValue === 'number'
-
-  // One scrub for pointer and touch alike: both report a viewport x, and the
-  // instant it lands on is the same either way.
-  const scrubToClientX = (clientX: number | undefined, plot: SVGSVGElement) => {
-    if (!canHoverMapPoint || !onHighlightElapsedSeconds) return
-    if (typeof clientX !== 'number') return
-    const bounds = plot.getBoundingClientRect()
-    const ratio = clampNumber(
-      (clientX - bounds.left) / Math.max(bounds.width, 1),
-      0,
-      1
-    )
-    onHighlightElapsedSeconds(ratio * durationSeconds)
-  }
-
-  const clearScrub = () => {
-    if (!canHoverMapPoint || !onHighlightElapsedSeconds) return
-    onHighlightElapsedSeconds(null)
-  }
+  const scrub = useChartScrub({
+    values,
+    width,
+    height,
+    minValue,
+    maxValue,
+    durationSeconds,
+    highlightedElapsedSeconds,
+    onHighlightElapsedSeconds
+  })
 
   // No border or rounding of its own: every chart is a row of the one bordered
   // panel the Analysis section stacks them into, so a border here would draw a
@@ -865,44 +1154,8 @@ const ChartPanel: FC<{
         <svg
           viewBox={`0 0 ${width} ${height}`}
           preserveAspectRatio="none"
-          className={cn(
-            'block h-full w-full',
-            // A vertical swipe still scrolls the page and a pinch still zooms;
-            // only the horizontal drag is claimed, for scrubbing. Both of the
-            // other two have to be named explicitly — `touch-pan-y` on its own
-            // compiles to exactly `touch-action: pan-y`, which drops
-            // pinch-zoom, and blocking magnification over a stack of charts
-            // takes it away in the one place a low-vision reader most wants it.
-            canHoverMapPoint && 'cursor-crosshair touch-pan-y touch-pinch-zoom'
-          )}
-          onMouseMove={(event) => {
-            scrubToClientX(event.clientX, event.currentTarget)
-          }}
-          onMouseLeave={clearScrub}
-          onTouchStart={(event) => {
-            scrubToClientX(event.touches[0]?.clientX, event.currentTarget)
-          }}
-          onTouchMove={(event) => {
-            scrubToClientX(event.touches[0]?.clientX, event.currentTarget)
-          }}
-          onTouchEnd={(event) => {
-            // A tap is followed by compatibility `mousemove`/`mousedown`/…
-            // at the same point, and that `mousemove` would re-enter the scrub
-            // the moment this clears it — leaving the readout stuck on, because
-            // no `mouseleave` follows a touch. Preventing the default suppresses
-            // that whole compat sequence; the chart has no click behaviour to
-            // lose, and a drag never gets here stuck anyway because movement
-            // past the tap slop suppresses the compat events on its own.
-            // Guarded on `cancelable`: once a scroll is underway Chrome keeps
-            // dispatching `touchend` with `cancelable: false` rather than
-            // switching to `touchcancel`, and calling this on one of those is a
-            // no-op that logs a warning on every vertical swipe that started on
-            // a chart — which is most of them, under four stacked full-width
-            // charts.
-            if (event.cancelable) event.preventDefault()
-            clearScrub()
-          }}
-          onTouchCancel={clearScrub}
+          className={cn('block h-full w-full', scrub.plotClassName)}
+          {...scrub.plotHandlers}
         >
           <path
             d={path}
@@ -910,11 +1163,11 @@ const ChartPanel: FC<{
             vectorEffect="non-scaling-stroke"
             className={cn('stroke-[2]', strokeClassName ?? 'stroke-sky-500')}
           />
-          {isHighlighted ? (
+          {scrub.highlight ? (
             <line
-              x1={highlightedX}
+              x1={scrub.highlight.x}
               y1={0}
-              x2={highlightedX}
+              x2={scrub.highlight.x}
               y2={height}
               vectorEffect="non-scaling-stroke"
               className={cn(
@@ -924,67 +1177,17 @@ const ChartPanel: FC<{
             />
           ) : null}
         </svg>
-        {/* The dot is HTML, not an SVG `circle`: `preserveAspectRatio="none"`
-            scales x and y independently, so a circle renders as an ellipse that
-            is half again as wide as it is tall in a desktop column and nearly
-            twice as tall as wide on a phone. Positioned by the same percentage
-            mapping as the readout — exact under that same `none`. */}
-        {isHighlighted ? (
-          <span
-            aria-hidden="true"
-            data-testid="chart-hover-dot"
-            className={cn(
-              'pointer-events-none absolute z-10 size-[11px] -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background',
-              dotClassName ?? 'bg-sky-500'
-            )}
-            style={{
-              left: `${(highlightedX / width) * 100}%`,
-              top: `${(highlightedY / height) * 100}%`
-            }}
+        {scrub.highlight ? (
+          <ChartHoverMarker
+            x={scrub.highlight.x}
+            y={scrub.highlight.y}
+            width={width}
+            height={height}
+            value={scrub.highlight.value}
+            unit={unit}
+            fractionDigits={fractionDigits}
+            dotClassName={dotClassName}
           />
-        ) : null}
-        {/* Value readout pinned to the hover dot. Percentage positioning works
-            because `preserveAspectRatio="none"` maps the viewBox linearly onto
-            the rendered box; the vertical clamp keeps it inside the plot when
-            the sample sits against the top or bottom of the scale.
-            `aria-hidden` because it is the running commentary on a pointer
-            gesture: the numbers it shows are already in the panel header's
-            "Scale …", and a screen reader would otherwise meet a bare figure
-            with no context, attached to a control it cannot drive.
-            Keeping it inside the panel is the flip threshold's job, not a
-            `max-width`'s — the chip is clipped by where it is positioned, and
-            a cap wide enough to never truncate the text is also too wide to
-            ever bind. */}
-        {isHighlighted ? (
-          <div
-            aria-hidden="true"
-            data-testid="chart-hover-value"
-            className="pointer-events-none absolute z-20 flex items-baseline gap-1 rounded-md border bg-background px-2 py-1 shadow-sm"
-            style={{
-              left: `${(highlightedX / width) * 100}%`,
-              top: `${clampNumber((highlightedY / height) * 100, 8, 92)}%`,
-              transform: shouldFlipReadout
-                ? 'translate(calc(-100% - 12px), -50%)'
-                : 'translate(12px, -50%)'
-            }}
-          >
-            <span className="text-sm font-semibold leading-none tabular-nums text-foreground">
-              {formatChartValue(highlightedValue, fractionDigits)}
-            </span>
-            <span className="text-[10px] leading-none text-muted-foreground">
-              {unit}
-            </span>
-            <span
-              aria-hidden="true"
-              className={cn(
-                'absolute top-1/2 size-2 bg-background',
-                shouldFlipReadout
-                  ? '-right-[4.5px] border-r border-t'
-                  : '-left-[4.5px] border-b border-l'
-              )}
-              style={{ transform: 'translateY(-50%) rotate(45deg)' }}
-            />
-          </div>
         ) : null}
       </div>
       {xLabels && (
@@ -1708,10 +1911,12 @@ export const FitnessStatusDetail: FC<Props> = ({
     }
   }, [fitness?.id])
 
+  // Both Overview (its elevation profile) and Analysis (its graph stack) scrub
+  // the same instant onto the same map, so leaving a section always drops the
+  // highlight: the pointer is no longer over any chart, and a crosshair left
+  // standing on a section you have just switched away from reads as a fault.
   useEffect(() => {
-    if (activeSection !== 'analysis') {
-      setHighlightedElapsedSeconds(null)
-    }
+    setHighlightedElapsedSeconds(null)
   }, [activeSection])
 
   const distanceMeters = fitness?.totalDistanceMeters ?? 0
@@ -1784,14 +1989,10 @@ export const FitnessStatusDetail: FC<Props> = ({
 
   const activitySeries = useMemo(() => {
     return {
-      heartRate:
-        heartRateChartSeries.length > 0
-          ? downsampleSeries(heartRateChartSeries, 120)
-          : [],
-      power: powerSeries.length > 0 ? downsampleSeries(powerSeries, 120) : [],
-      speed: speedSeries.length > 0 ? downsampleSeries(speedSeries, 120) : [],
-      elevation:
-        altitudeSeries.length > 0 ? downsampleSeries(altitudeSeries, 120) : []
+      heartRate: plotAtStravaDensity(heartRateChartSeries),
+      power: plotAtStravaDensity(powerSeries),
+      speed: plotAtStravaDensity(speedSeries),
+      elevation: plotAtStravaDensity(altitudeSeries)
     }
   }, [heartRateChartSeries, powerSeries, speedSeries, altitudeSeries])
   const { minValue: elevationMin, maxValue: elevationMax } = useMemo(
@@ -2329,6 +2530,7 @@ export const FitnessStatusDetail: FC<Props> = ({
                 fitnessFileId={fitness?.id ?? null}
                 routeSamples={routeSamples}
                 routeSegments={routeSegments}
+                highlightedElapsedSeconds={highlightedElapsedSeconds}
                 mapProvider={mapProvider}
                 routeDataError={routeDataError}
                 isRouteDataLoading={isRouteDataLoading}
@@ -2359,14 +2561,26 @@ export const FitnessStatusDetail: FC<Props> = ({
                 <SectionTitle
                   icon={Mountain}
                   right={
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {/* The scrubbed instant replaces nothing — it is added
+                          in front of the gain, so the card keeps reporting the
+                          activity's own headline number while the pointer
+                          reports where on it you are. */}
+                      {highlightedElapsedLabel
+                        ? `${highlightedElapsedLabel} · `
+                        : ''}
                       {Math.max(0, Math.round(elevationGainMeters))} m gain
                     </span>
                   }
                 >
                   Elevation
                 </SectionTitle>
-                <ElevationProfileChart values={activitySeries.elevation} />
+                <ElevationProfileChart
+                  values={activitySeries.elevation}
+                  durationSeconds={durationSeconds}
+                  highlightedElapsedSeconds={highlightedElapsedSeconds}
+                  onHighlightElapsedSeconds={setHighlightedElapsedSeconds}
+                />
               </Card>
             )}
           </div>

--- a/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
+++ b/app/(timeline)/[actor]/[status]/FitnessStatusDetail.tsx
@@ -677,14 +677,23 @@ const ChartHoverMarker: FC<{
 }> = ({ x, y, width, height, value, unit, fractionDigits, dotClassName }) => {
   // The readout sits beside the dot and flips to its left near the right edge.
   // The threshold is a fraction of the viewBox while the chip is a fixed pixel
-  // width, so the two only agree above some container width. At the 320px
-  // reflow target the plot is 220px and the chip is ~77px for the widest value
-  // these series realistically produce ("13.5 km/h"), against a budget of that
-  // 220px PLUS this panel's own 16px right padding — the `overflow-hidden` is
-  // on the merged panel outside it. So the design kit's 0.72 lands 12px past
-  // what will be shown, and anything at or below 0.66 fits. 0.62 keeps a margin
-  // for a longer value or a wider font, at the cost of flipping sooner than the
-  // kit does in a desktop column, where there is still room to the right.
+  // width, so the two only agree above some container width, and the binding
+  // case is the narrowest host at the 320px reflow target.
+  //
+  // Derived for the Analysis stack, where the plot is 220px and the chip is
+  // ~77px for the widest value those series realistically produce
+  // ("13.5 km/h"), against a budget of that 220px plus the panel's own 16px
+  // right padding: the design kit's 0.72 lands 12px past what will be shown,
+  // anything at or below 0.66 fits, and 0.62 keeps a margin for a longer value
+  // or a wider font — at the cost of flipping sooner than the kit does in a
+  // desktop column, where there is still room to the right.
+  //
+  // Re-checked for the Overview elevation card, which is the other host and a
+  // tighter one: a `Card` has no `overflow-hidden` to clip a chip that escapes,
+  // and its plot is 212px rather than 220px. It is still safe, because its chip
+  // is also smaller ("1234 m" is ~67px against that 77px), so the right edge
+  // lands at 0.62 x 212 + 12 + 67 = 210px — inside the 212px plot, before
+  // touching the card's 20px padding. Re-derive BOTH if this moves.
   const shouldFlipReadout = x / width > 0.62
 
   return (
@@ -711,9 +720,13 @@ const ChartHoverMarker: FC<{
           the rendered box; the vertical clamp keeps it inside the plot when
           the sample sits against the top or bottom of the scale.
           `aria-hidden` because it is the running commentary on a pointer
-          gesture: the numbers it shows are already in the panel header's
-          "Scale …", and a screen reader would otherwise meet a bare figure
-          with no context, attached to a control it cannot drive.
+          gesture, which a screen reader would otherwise meet as a bare figure
+          with no context, attached to a control it cannot drive. Note the
+          Analysis panel also prints the same range in its "Scale …" header
+          while the elevation card does not, so on that card the scrubbed
+          value is genuinely pointer-only — the same gap the charts already
+          have for a keyboard user, and a follow-up rather than something this
+          chip should paper over with a live region.
           Keeping it inside the panel is the flip threshold's job, not a
           `max-width`'s — the chip is clipped by where it is positioned, and
           a cap wide enough to never truncate the text is also too wide to
@@ -921,12 +934,19 @@ const ElevationProfileChart: FC<{
   )
   // Four ticks, not the helper's default six. This card is narrower than the
   // Analysis panel (a `p-5` Card inside the same column, so 212px of content at
-  // the 320px reflow target against that panel's 220px) and `justify-between`
-  // gives a label row no way to wrap: six H:MM:SS labels need 222px and six
-  // HH:MM:SS labels 239px, so anything past ~2h30 rendered as one unbroken run
-  // of digits and anything past ~5h crossed the card's own border, since a Card
-  // has no `overflow-hidden` to clip it the way that panel does. Four labels
-  // are 167px / 195px, which still leaves real gaps at 320px.
+  // the 320px reflow target against that panel's 220px), `justify-between`
+  // gives a label row no way to wrap, and a Card has no `overflow-hidden` to
+  // clip a row that outgrows it the way that panel does — so an over-wide row
+  // here runs its labels together into one unbroken string of digits and then
+  // crosses the card's own border.
+  //
+  // Worked at 11px tabular-nums, where "0:00" is ~24px and one "H:MM:SS" label
+  // ~42px (a five-hour ride, the point at which every tick but the first has
+  // taken the wider form): six labels need 24 + 5x42 = 234px against 212px,
+  // while four need 24 + 3x42 = 150px and keep ~20px between each. A ten-hour
+  // ride widens every label again to ~49px, which is 269px at six ticks and a
+  // still-comfortable 171px at four. Pinned by a test, since the failure is
+  // silent — nothing errors, the labels just merge.
   const xLabels = useMemo(
     () => (durationSeconds ? buildXAxisLabels(durationSeconds, 4) : null),
     [durationSeconds]


### PR DESCRIPTION
## Problem

Two things the fitness activity page did worse than Strava, both reported against
[this ride](https://llun.social/@ride@llun.social/3501fbf9202d15eafe969430dcef0f478e82e0423656746277d0f2083993307b).

**1. The graphs were a smoothed cartoon of the activity.** Every analysis series was flattened to a fixed **120 points**. That ride's `route-data` payload carries **6,123 one-second samples**, so each bin averaged **~51 seconds — roughly 370 m of a 44 km ride** — and every short climb, descent and sprint inside a bin was averaged flat.

**2. The Overview's "Elevation" card was a static picture.** The Analysis stack already scrubbed (crosshair, value readout, map highlight); the summary card had none of it.

## What Strava actually does

Measured in the browser on two of the user's own activity Analysis pages rather than guessed. Strava ships the **whole** stream to the client and draws **one point per 8 samples**:

| Strava activity | stream samples | points drawn | ratio |
| --- | --- | --- | --- |
| [19517478683](https://www.strava.com/activities/19517478683/analysis) | 5,913 | 740 | 8.0 |
| [19487466238](https://www.strava.com/activities/19487466238/analysis) | 5,272 | 659 | 8.0 |

That is a **density**, not a count — which is why a fixed cap of any size would not reproduce it. A longer recording gets proportionally more points instead of being squeezed into the same budget.

## Changes

**Resolution** — `plotAtStravaDensity` replaces the flat `120`: one drawn point per 8 samples, clamped to `[120, 1200]`. The floor keeps a short activity at least as detailed as it already was (a 10-minute 1 Hz recording is 600 samples, which the bare ratio would draw as 75 points); the ceiling bounds the generated path strings — memoized, so a hover never rebuilds them — for a recording long enough that the ratio would run away.

**Scrubbable elevation profile** — the Overview card now behaves exactly like the Analysis stack: drag it and it reports the elevation under the pointer, draws the crosshair, and moves the highlight on the map above it. Time-axis labels were added underneath so a drag has something to read against, and the card header shows the scrubbed instant in front of the gain (`1:18:29 · 455 m gain`) rather than replacing it.

Rather than copy the Analysis panel's behaviour, the geometry + handlers were lifted into a shared **`useChartScrub`** hook and a shared **`ChartHoverMarker`**, which `ChartPanel` and `ElevationProfileChart` both consume — that keeps the dot on the line, since both now read the identical `getChartXPosition`/`getChartYPosition` projection the path is drawn with. `ChartPanel` gets ~110 lines shorter as a result. The hook returns the highlight as **one nullable object** rather than three parallel nullable fields plus an `isHighlighted` boolean, so consumers narrow properly instead of re-asserting `as number`.

Two wiring fixes the scrub needed: the Overview's `ActivityMapPanel` was never given `highlightedElapsedSeconds` (only Analysis was), and the highlight is now dropped on **every** section change, so no crosshair is left standing on a section you have switched away from.

## Verification

Built a 6,200-sample 1 Hz TCX, uploaded it to a local SQLite instance, and checked the rendered SVG:

- Analysis graphs: **775 points each** (6,200 / 8) — was 120. Matches Strava's ratio.
- Overview elevation profile: **775 points**, and dragging it shows `82 m` at `1:18:29` with the blue highlight dot tracking along the route on the map.
- Leaving the section clears the crosshair.

`prettier` → `lint` → `build` → `test` all green (**746 files, 7,859 tests**).

### New regression tests

- The Strava ratio, asserted at both measured sample counts (5,913 → 740 and 5,272 → 659) rather than at round numbers.
- Both clamp ends, and that a series below the floor is left at its own resolution.
- The Overview profile reports the value under the pointer, on hover and on touch.
- **The map actually follows the scrub** — `ActivityRouteMapKit` is mocked so the test can read back the elapsed seconds the page hands the map. This is the assertion that would have caught the missing prop.
- The highlight is dropped on a section change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)