### PR TITLE
Bump version to v1.123.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.122.3",
+  "version": "1.123.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.0.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `minor`
- Base tag: `v1.122.3`
- Base main SHA: `8910e91ef1a2ae69b29851452e36542955e614de`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
