### PR TITLE
Bump version to v1.123.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.0",
+  "version": "1.123.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.1.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.0`
- Base main SHA: `79d8bb14eb5623bd5bc2707a51af834912269176`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
