### PR TITLE
Bump version to v1.123.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.1",
+  "version": "1.123.2",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.2.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.1`
- Base main SHA: `44ac307f1ad1b3ae8f70f59afcafce16254af387`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
