### PR TITLE
fix: stop the status detail card clipping post overlays

### DIFF
--- a/app/(timeline)/[actor]/[status]/Header.tsx
+++ b/app/(timeline)/[actor]/[status]/Header.tsx
@@ -5,31 +5,16 @@ import { useRouter } from 'next/navigation'
 import { FC } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
-import { cn } from '@/lib/utils'
 
 interface Props {
   isFitnessDashboard?: boolean
-  /**
-   * Extra classes for the header bar. The conversation card no longer clips its
-   * children (post overlays have to escape it), so that card rounds this — its
-   * first child — itself.
-   */
-  className?: string
 }
 
-export const Header: FC<Props> = ({
-  isFitnessDashboard = false,
-  className
-}) => {
+export const Header: FC<Props> = ({ isFitnessDashboard = false }) => {
   const router = useRouter()
 
   return (
-    <div
-      className={cn(
-        'sticky top-0 z-10 flex items-center gap-3 border-b bg-background/90 px-5 py-3 backdrop-blur',
-        className
-      )}
-    >
+    <div className="sticky top-0 z-10 flex items-center gap-3 border-b bg-background/90 px-5 py-3 backdrop-blur">
       <Button
         variant="ghost"
         size="icon"

--- a/app/(timeline)/[actor]/[status]/Header.tsx
+++ b/app/(timeline)/[actor]/[status]/Header.tsx
@@ -5,16 +5,31 @@ import { useRouter } from 'next/navigation'
 import { FC } from 'react'
 
 import { Button } from '@/lib/components/ui/button'
+import { cn } from '@/lib/utils'
 
 interface Props {
   isFitnessDashboard?: boolean
+  /**
+   * Extra classes for the header bar. The conversation card no longer clips its
+   * children (post overlays have to escape it), so that card rounds this — its
+   * first child — itself.
+   */
+  className?: string
 }
 
-export const Header: FC<Props> = ({ isFitnessDashboard = false }) => {
+export const Header: FC<Props> = ({
+  isFitnessDashboard = false,
+  className
+}) => {
   const router = useRouter()
 
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-3 border-b bg-background/90 px-5 py-3 backdrop-blur">
+    <div
+      className={cn(
+        'sticky top-0 z-10 flex items-center gap-3 border-b bg-background/90 px-5 py-3 backdrop-blur',
+        className
+      )}
+    >
       <Button
         variant="ghost"
         size="icon"

--- a/app/(timeline)/[actor]/[status]/page.layout.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.layout.test.tsx
@@ -36,7 +36,10 @@ vi.mock('@/lib/database', async () => ({
   getDatabase: vi.fn(() => ({
     getStatus: mockGetStatus,
     getStatusReplies: mockGetStatusReplies,
-    getAcceptedOrRequestedFollow: mockGetAcceptedOrRequestedFollow
+    getAcceptedOrRequestedFollow: mockGetAcceptedOrRequestedFollow,
+    // Without this the page's settings read throws and every test logs an
+    // error while quietly exercising the env/default fallback path.
+    getAllServerSettings: vi.fn(async () => [])
   }))
 }))
 
@@ -151,17 +154,23 @@ describe('Conversation card chrome', () => {
     })
   })
 
-  // The card wraps posts, and a post's non-portalled overlays have to escape
-  // it: the edit-history panel opens upward from the action row and is taller
-  // than the space above the focused post, and the action-row error tooltips
-  // hang below their row. `Posts` dropped `overflow-hidden` for the same
+  // The card wraps posts, and the edit-history panel — which is not portalled
+  // — opens upward out of it. `Posts` dropped `overflow-hidden` for the same
   // reason. Clipping here was what a comment on this card wrongly claimed was
-  // already gone, so pin the class off rather than trusting the comment.
+  // already gone, so pin it off rather than trusting the comment.
   it('does not clip its children, so post overlays can escape it', async () => {
     const card = await renderPage()
 
     expect(card).toHaveClass('rounded-2xl')
-    expect(card).not.toHaveClass('overflow-hidden')
+    // Reject every clip, not just `overflow-hidden`: `overflow-x-hidden` would
+    // force the computed `overflow-y` to `auto`, re-clipping the panel
+    // vertically while an assertion naming only `overflow-hidden` passed.
+    // `overflow-x-clip` is the one form that does not clip the other axis, but
+    // it is also not needed here, so the simplest guard is to allow none.
+    const clipping = Array.from(card.classList).filter((name) =>
+      name.startsWith('overflow-')
+    )
+    expect(clipping).toEqual([])
   })
 
   // Nothing clips for the rounded corners any more, so the child that meets
@@ -213,6 +222,31 @@ describe('Conversation card chrome', () => {
     // The ancestor chain now sits above the focused post, so it takes the
     // corners and the post must not keep them.
     expect(rowFor('parent')).toHaveClass('rounded-t-2xl')
+    expect(rowFor('focused')).not.toHaveClass('rounded-t-2xl')
+  })
+
+  // With a single ancestor, `index === 0` and `index === previouses.length - 1`
+  // are the same row, so a chain of two is what distinguishes the topmost
+  // ancestor from the one nearest the focused post. The chain runs up to three.
+  it('rounds only the topmost ancestor when the chain is longer than one', async () => {
+    const focused = buildNote({ id: 'focused', reply: 'parent' })
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockImplementation(
+      async ({ statusId }: { statusId: string }) =>
+        statusId === 'parent'
+          ? buildNote({ id: 'parent', reply: 'grandparent' })
+          : buildNote({ id: 'grandparent' })
+    )
+
+    await renderPage()
+
+    expect(rowFor('grandparent')).toHaveClass('rounded-t-2xl')
+    expect(rowFor('parent')).not.toHaveClass('rounded-t-2xl')
     expect(rowFor('focused')).not.toHaveClass('rounded-t-2xl')
   })
 

--- a/app/(timeline)/[actor]/[status]/page.layout.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.layout.test.tsx
@@ -154,23 +154,41 @@ describe('Conversation card chrome', () => {
     })
   })
 
+  // Collects every clip between the card and a post, inclusive of both. The
+  // panel opens upward *out of the post*, so a clip anywhere on that path cuts
+  // it off — checking only the card left "move the class down one level" as a
+  // green mutation. Matches on the prefix rather than `overflow-hidden` alone
+  // because `overflow-x-hidden` forces the computed `overflow-y` to `auto`,
+  // which re-clips the panel vertically. `overflow-visible`/`overflow-x-clip`
+  // would be rejected too; neither is needed here, so allowing none is the
+  // simplest honest guard.
+  const clipsBetween = (card: HTMLElement, statusId: string) => {
+    const found: string[] = []
+    let node: HTMLElement | null = screen.getByTestId(`status-${statusId}`)
+    while (node && node !== card.parentElement) {
+      found.push(
+        ...Array.from(node.classList).filter((name) =>
+          name.startsWith('overflow-')
+        )
+      )
+      node = node.parentElement
+    }
+    return found
+  }
+
   // The card wraps posts, and the edit-history panel — which is not portalled
   // — opens upward out of it. `Posts` dropped `overflow-hidden` for the same
   // reason. Clipping here was what a comment on this card wrongly claimed was
   // already gone, so pin it off rather than trusting the comment.
   it('does not clip its children, so post overlays can escape it', async () => {
+    // Signed in on purpose: a logged-out viewer gets no action row at all, so
+    // there is no overlay to clip and the assertion would be vacuous.
+    mockGetActorFromSession.mockResolvedValue(buildViewer())
+
     const card = await renderPage()
 
     expect(card).toHaveClass('rounded-2xl')
-    // Reject every clip, not just `overflow-hidden`: `overflow-x-hidden` would
-    // force the computed `overflow-y` to `auto`, re-clipping the panel
-    // vertically while an assertion naming only `overflow-hidden` passed.
-    // `overflow-x-clip` is the one form that does not clip the other axis, but
-    // it is also not needed here, so the simplest guard is to allow none.
-    const clipping = Array.from(card.classList).filter((name) =>
-      name.startsWith('overflow-')
-    )
-    expect(clipping).toEqual([])
+    expect(clipsBetween(card, 'focused')).toEqual([])
   })
 
   // Nothing clips for the rounded corners any more, so the child that meets

--- a/app/(timeline)/[actor]/[status]/page.layout.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.layout.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import '@testing-library/jest-dom'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 import { getServerAuthSession } from '@/lib/services/auth/getSession'
 import { Actor } from '@/lib/types/domain/actor'
@@ -166,12 +166,27 @@ describe('Conversation card chrome', () => {
 
   // Nothing clips for the rounded corners any more, so the child that meets
   // them has to round itself or its square background bleeds past the border.
-  it('rounds the header, its topmost child, for a signed-in viewer', async () => {
+  // Exactly one child may do so — a second would notch a rounded row into the
+  // middle of the card.
+  // `StatusBox` is mocked to a bare testid div, so the row that carries the
+  // radius is its parent. Anchoring on the status rather than a child index
+  // keeps the assertion meaningful if the card gains another child.
+  const rowFor = (statusId: string) =>
+    screen.getByTestId(`status-${statusId}`).parentElement
+
+  it('rounds the header wrapper, its topmost child, for a signed-in viewer', async () => {
     mockGetActorFromSession.mockResolvedValue(buildViewer())
 
     const card = await renderPage()
 
+    // The wrapper, not the header itself: `Header` is `sticky top-0`, so it
+    // has to keep a clipping ancestor or it starts detaching mid-scroll and
+    // carries the corners out over the posts.
     expect(card.firstElementChild).toHaveClass('rounded-t-2xl')
+    expect(card.firstElementChild).toHaveClass('overflow-hidden')
+    // The header takes the corners, so the post below it must not — even
+    // though it is the topmost *post* and would take them when logged out.
+    expect(rowFor('focused')).not.toHaveClass('rounded-t-2xl')
   })
 
   it('rounds the focused post instead when logged out, which has no header', async () => {
@@ -180,7 +195,7 @@ describe('Conversation card chrome', () => {
     // The logged-out branch leads with an `sr-only` heading, which is out of
     // flow and paints nothing — the post below it is what meets the corners.
     expect(card.firstElementChild).toHaveClass('sr-only')
-    expect(card.children[1]).toHaveClass('rounded-t-2xl')
+    expect(rowFor('focused')).toHaveClass('rounded-t-2xl')
   })
 
   it('rounds the first ancestor row when logged out and the post is a reply', async () => {
@@ -193,14 +208,33 @@ describe('Conversation card chrome', () => {
     })
     mockGetStatus.mockResolvedValue(buildNote({ id: 'parent' }))
 
-    const card = await renderPage()
+    await renderPage()
 
     // The ancestor chain now sits above the focused post, so it takes the
     // corners and the post must not keep them.
-    expect(card.children[1]).toHaveClass('rounded-t-2xl')
-    expect(card.children[1]).toContainElement(
-      card.querySelector('[data-testid="status-parent"]')
-    )
-    expect(card.children[2]).not.toHaveClass('rounded-t-2xl')
+    expect(rowFor('parent')).toHaveClass('rounded-t-2xl')
+    expect(rowFor('focused')).not.toHaveClass('rounded-t-2xl')
+  })
+
+  // Both rounding rules are guarded on the viewer being logged out, because a
+  // signed-in viewer gets the header above everything. Without this, deleting
+  // either guard leaves the suite green while shipping a rounded row notched
+  // into the middle of the card.
+  it('rounds neither the ancestor row nor the post for a signed-in viewer', async () => {
+    mockGetActorFromSession.mockResolvedValue(buildViewer())
+    const focused = buildNote({ id: 'focused', reply: 'parent' })
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(buildNote({ id: 'parent' }))
+
+    const card = await renderPage()
+
+    expect(card.firstElementChild).toHaveClass('rounded-t-2xl')
+    expect(rowFor('parent')).not.toHaveClass('rounded-t-2xl')
+    expect(rowFor('focused')).not.toHaveClass('rounded-t-2xl')
   })
 })

--- a/app/(timeline)/[actor]/[status]/page.layout.test.tsx
+++ b/app/(timeline)/[actor]/[status]/page.layout.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+
+import { getServerAuthSession } from '@/lib/services/auth/getSession'
+import { Actor } from '@/lib/types/domain/actor'
+import { Status } from '@/lib/types/domain/status'
+import { ACTIVITY_STREAM_PUBLIC } from '@/lib/utils/activitystream'
+import { getActorFromSession } from '@/lib/utils/getActorFromSession'
+
+import Page from './page'
+import { resolveStatusFromPath } from './resolveStatusFromPath'
+
+vi.mock('next/navigation', async () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  }),
+  useRouter: vi.fn(() => ({ back: vi.fn(), push: vi.fn(), refresh: vi.fn() }))
+}))
+
+vi.mock('@/lib/config', async () => ({
+  getConfig: vi.fn(() => ({
+    host: 'activities.local',
+    fitnessStorage: undefined,
+    mediaStorage: undefined
+  }))
+}))
+
+const mockGetStatus = vi.fn()
+const mockGetStatusReplies = vi.fn()
+const mockGetAcceptedOrRequestedFollow = vi.fn()
+
+vi.mock('@/lib/database', async () => ({
+  getDatabase: vi.fn(() => ({
+    getStatus: mockGetStatus,
+    getStatusReplies: mockGetStatusReplies,
+    getAcceptedOrRequestedFollow: mockGetAcceptedOrRequestedFollow
+  }))
+}))
+
+vi.mock('@/lib/services/auth/getSession', async () => ({
+  getServerAuthSession: vi.fn()
+}))
+
+vi.mock('@/lib/services/queue', async () => ({
+  getQueue: vi.fn()
+}))
+
+vi.mock('@/lib/utils/getActorFromSession', async () => ({
+  getActorFromSession: vi.fn()
+}))
+
+vi.mock('@/lib/config/mapProvider', async () => ({
+  getMapProviderConfig: vi.fn(() => ({ type: 'osm' })),
+  getPublicMapProvider: vi.fn(() => ({ type: 'osm' }))
+}))
+
+vi.mock('./resolveStatusFromPath', async () => ({
+  ...(await vi.importActual('./resolveStatusFromPath')),
+  resolveStatusFromPath: vi.fn()
+}))
+
+vi.mock('./RemoteStatusLoading', async () => ({
+  RemoteStatusLoading: () => null
+}))
+
+vi.mock('./StatusBox', async () => ({
+  StatusBox: ({ status }: { status: { id: string } }) => (
+    <div data-testid={`status-${status.id}`} />
+  )
+}))
+
+const mockResolveStatusFromPath = vi.mocked(resolveStatusFromPath)
+const mockGetServerAuthSession = vi.mocked(getServerAuthSession)
+const mockGetActorFromSession = vi.mocked(getActorFromSession)
+
+const AUTHOR_ID = 'https://activities.local/users/anna'
+const VIEWER_ID = 'https://activities.local/users/viewer'
+
+const buildNote = (overrides: Partial<Status> = {}): Status =>
+  ({
+    id: 'note-id',
+    type: 'Note',
+    actorId: AUTHOR_ID,
+    actor: null,
+    url: `${AUTHOR_ID}/statuses/note-id`,
+    text: 'body',
+    reply: '',
+    replies: [],
+    to: [ACTIVITY_STREAM_PUBLIC],
+    cc: [],
+    edits: [],
+    isLocalActor: true,
+    isActorLiked: false,
+    isActorBookmarked: false,
+    actorAnnounceStatusId: null,
+    totalLikes: 0,
+    totalShares: 0,
+    attachments: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }) as unknown as Status
+
+const buildViewer = (): Actor =>
+  ({
+    id: VIEWER_ID,
+    type: 'Person',
+    username: 'viewer',
+    domain: 'activities.local',
+    followersUrl: `${VIEWER_ID}/followers`,
+    inboxUrl: `${VIEWER_ID}/inbox`,
+    sharedInboxUrl: 'https://activities.local/inbox',
+    publicKey: 'public-key',
+    followingCount: 0,
+    followersCount: 0,
+    statusCount: 0,
+    lastStatusAt: null,
+    createdAt: 1,
+    updatedAt: 1
+  }) as unknown as Actor
+
+const renderPage = async () => {
+  const element = await Page({
+    params: Promise.resolve({
+      actor: '@anna@activities.local',
+      status: 'hash'
+    })
+  })
+  const { container } = render(element)
+  return container.firstElementChild as HTMLElement
+}
+
+describe('Conversation card chrome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetStatus.mockReset()
+    mockGetServerAuthSession.mockResolvedValue(null)
+    mockGetActorFromSession.mockResolvedValue(null)
+    mockGetStatusReplies.mockResolvedValue([])
+
+    const focused = buildNote({ id: 'focused' })
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+  })
+
+  // The card wraps posts, and a post's non-portalled overlays have to escape
+  // it: the edit-history panel opens upward from the action row and is taller
+  // than the space above the focused post, and the action-row error tooltips
+  // hang below their row. `Posts` dropped `overflow-hidden` for the same
+  // reason. Clipping here was what a comment on this card wrongly claimed was
+  // already gone, so pin the class off rather than trusting the comment.
+  it('does not clip its children, so post overlays can escape it', async () => {
+    const card = await renderPage()
+
+    expect(card).toHaveClass('rounded-2xl')
+    expect(card).not.toHaveClass('overflow-hidden')
+  })
+
+  // Nothing clips for the rounded corners any more, so the child that meets
+  // them has to round itself or its square background bleeds past the border.
+  it('rounds the header, its topmost child, for a signed-in viewer', async () => {
+    mockGetActorFromSession.mockResolvedValue(buildViewer())
+
+    const card = await renderPage()
+
+    expect(card.firstElementChild).toHaveClass('rounded-t-2xl')
+  })
+
+  it('rounds the focused post instead when logged out, which has no header', async () => {
+    const card = await renderPage()
+
+    // The logged-out branch leads with an `sr-only` heading, which is out of
+    // flow and paints nothing — the post below it is what meets the corners.
+    expect(card.firstElementChild).toHaveClass('sr-only')
+    expect(card.children[1]).toHaveClass('rounded-t-2xl')
+  })
+
+  it('rounds the first ancestor row when logged out and the post is a reply', async () => {
+    const focused = buildNote({ id: 'focused', reply: 'parent' })
+    mockResolveStatusFromPath.mockResolvedValue({
+      status: focused,
+      statusId: 'focused',
+      fullStatusId: focused.url,
+      isStatusHash: true
+    })
+    mockGetStatus.mockResolvedValue(buildNote({ id: 'parent' }))
+
+    const card = await renderPage()
+
+    // The ancestor chain now sits above the focused post, so it takes the
+    // corners and the post must not keep them.
+    expect(card.children[1]).toHaveClass('rounded-t-2xl')
+    expect(card.children[1]).toContainElement(
+      card.querySelector('[data-testid="status-parent"]')
+    )
+    expect(card.children[2]).not.toHaveClass('rounded-t-2xl')
+  })
+})

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -343,7 +343,9 @@ const Page: FC<Props> = async ({ params }) => {
         // edits the panel runs past the top edge. A reply pushes it down by up
         // to three ancestor rows, which buys room but does not settle it — a
         // post edited enough times to fill the list still overruns a short
-        // chain.
+        // chain. The panel's *horizontal* fit is its own problem and already
+        // solved — it anchors to the action row so it tracks the post's width
+        // — so this class governs the vertical overrun only.
         // The reaction picker and the ⋯ menu's *popover* are not why — both
         // portal to the document body, so no ancestor's overflow reaches them
         // (`PostMenu`'s own error tooltip is not portalled, but it hangs

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -333,23 +333,34 @@ const Page: FC<Props> = async ({ params }) => {
         // to the signed-in card to keep the spacing consistent across both.
         currentActorProfile && 'mt-4',
         // No `overflow-hidden`: this card contains posts, and a post's
-        // non-portaled overlays (the reaction picker) would be clipped by it —
-        // the same reason `Posts` dropped it.
-        'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
+        // non-portalled overlays would be clipped by it — the same reason
+        // `Posts` dropped it. The edit-history panel opens upward from the
+        // action row (`bottom-full`, up to 25rem tall) and the focused post
+        // sits close enough to this card's top edge for it to run past; the
+        // action-row error tooltips hang below their row. The reaction picker
+        // and the ⋯ menu are *not* why — both portal to the document body, so
+        // no ancestor's overflow can reach them. The children that meet the
+        // rounded corners round themselves instead.
+        'rounded-2xl border bg-background/80 shadow-sm'
       )}
     >
       {currentActorProfile ? (
-        <Header isFitnessDashboard={false} />
+        <Header isFitnessDashboard={false} className="rounded-t-2xl" />
       ) : (
         // Logged-out view has no back-button chrome (matching the web-public
         // design), but keep a top-level heading for the document outline.
         <h1 className="sr-only">Post</h1>
       )}
 
-      {previouses.reverse().map((item) => (
+      {previouses.reverse().map((item, index) => (
         <div
           key={item.id}
-          className="border-b border-l-4 border-l-primary/20 bg-muted/30"
+          className={cn(
+            'border-b border-l-4 border-l-primary/20 bg-muted/30',
+            // A logged-out view renders no `Header`, so the first ancestor row
+            // is what meets the card's rounded top corners.
+            !currentActorProfile && index === 0 && 'rounded-t-2xl'
+          )}
         >
           <StatusBox
             host={host}
@@ -361,7 +372,14 @@ const Page: FC<Props> = async ({ params }) => {
         </div>
       ))}
 
-      <div className="border-b bg-background">
+      <div
+        className={cn(
+          'border-b bg-background',
+          // …and with neither a `Header` nor an ancestor chain above it, the
+          // focused post is the topmost child instead.
+          !currentActorProfile && previouses.length === 0 && 'rounded-t-2xl'
+        )}
+      >
         <StatusBox
           host={host}
           mapProvider={mapProvider}

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -340,9 +340,10 @@ const Page: FC<Props> = async ({ params }) => {
         // and the only viewer who gets an action row at all is a signed-in
         // one, whose focused post sits directly below the back-button bar
         // whenever the post is not a reply. So on a short post with a few
-        // edits the panel runs past the top edge. (A reply pushes it down by
-        // up to three ancestor rows, which is room enough — the no-ancestor
-        // case is the one that clips, and it is the common one.)
+        // edits the panel runs past the top edge. A reply pushes it down by up
+        // to three ancestor rows, which buys room but does not settle it — a
+        // post edited enough times to fill the list still overruns a short
+        // chain.
         // The reaction picker and the ⋯ menu's *popover* are not why — both
         // portal to the document body, so no ancestor's overflow reaches them
         // (`PostMenu`'s own error tooltip is not portalled, but it hangs

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -334,18 +334,38 @@ const Page: FC<Props> = async ({ params }) => {
         currentActorProfile && 'mt-4',
         // No `overflow-hidden`: this card contains posts, and a post's
         // non-portalled overlays would be clipped by it — the same reason
-        // `Posts` dropped it. The edit-history panel opens upward from the
-        // action row (`bottom-full`, up to 25rem tall) and the focused post
-        // sits close enough to this card's top edge for it to run past; the
-        // action-row error tooltips hang below their row. The reaction picker
-        // and the ⋯ menu are *not* why — both portal to the document body, so
-        // no ancestor's overflow can reach them. The children that meet the
-        // rounded corners round themselves instead.
+        // `Posts` dropped it. The one that reaches this card's edge is the
+        // edit-history panel: it opens *upward* from the action row
+        // (`bottom-full`, ~360px — a 2.5rem header over a `max-h-80` list),
+        // and the only viewer who gets an action row at all is a signed-in
+        // one, whose focused post sits just below the back-button bar. So the
+        // panel runs past the top edge on any short post with a few edits.
+        // The reaction picker and the ⋯ menu's *popover* are not why — both
+        // portal to the document body, so no ancestor's overflow reaches them
+        // (`PostMenu`'s own error tooltip is not portalled, but it hangs
+        // `top-full` mid-card, nowhere near an edge).
+        //
+        // Only the top corners need compensating: the children that meet them
+        // round themselves. The last child is always the replies wrapper or
+        // the "No replies yet" block, neither of which paints a background —
+        // append a background-painting child last and the bottom corners will
+        // need the same treatment.
         'rounded-2xl border bg-background/80 shadow-sm'
       )}
     >
       {currentActorProfile ? (
-        <Header isFitnessDashboard={false} className="rounded-t-2xl" />
+        // The clip moves onto a wrapper around the header rather than onto the
+        // header itself, and it is deliberately still a clip. Rounding the
+        // header directly would work only while it is at rest: `Header` is
+        // `sticky top-0`, and the card's `overflow-hidden` was the scroll
+        // container pinning it — with that gone the header would start
+        // detaching and would carry two transparent corner notches out over
+        // the posts. Keeping a clipping box here preserves the header's
+        // scrollport, so its behaviour is unchanged by this PR, and clipping
+        // is safe on this subtree alone because the header holds no overlays.
+        <div className="overflow-hidden rounded-t-2xl">
+          <Header isFitnessDashboard={false} />
+        </div>
       ) : (
         // Logged-out view has no back-button chrome (matching the web-public
         // design), but keep a top-level heading for the document outline.

--- a/app/(timeline)/[actor]/[status]/page.tsx
+++ b/app/(timeline)/[actor]/[status]/page.tsx
@@ -338,8 +338,11 @@ const Page: FC<Props> = async ({ params }) => {
         // edit-history panel: it opens *upward* from the action row
         // (`bottom-full`, ~360px — a 2.5rem header over a `max-h-80` list),
         // and the only viewer who gets an action row at all is a signed-in
-        // one, whose focused post sits just below the back-button bar. So the
-        // panel runs past the top edge on any short post with a few edits.
+        // one, whose focused post sits directly below the back-button bar
+        // whenever the post is not a reply. So on a short post with a few
+        // edits the panel runs past the top edge. (A reply pushes it down by
+        // up to three ancestor rows, which is room enough — the no-ancestor
+        // case is the one that clips, and it is the common one.)
         // The reaction picker and the ⋯ menu's *popover* are not why — both
         // portal to the document body, so no ancestor's overflow reaches them
         // (`PostMenu`'s own error tooltip is not portalled, but it hangs
@@ -354,15 +357,23 @@ const Page: FC<Props> = async ({ params }) => {
       )}
     >
       {currentActorProfile ? (
-        // The clip moves onto a wrapper around the header rather than onto the
-        // header itself, and it is deliberately still a clip. Rounding the
-        // header directly would work only while it is at rest: `Header` is
-        // `sticky top-0`, and the card's `overflow-hidden` was the scroll
-        // container pinning it — with that gone the header would start
-        // detaching and would carry two transparent corner notches out over
-        // the posts. Keeping a clipping box here preserves the header's
-        // scrollport, so its behaviour is unchanged by this PR, and clipping
-        // is safe on this subtree alone because the header holds no overlays.
+        // Rounds the header by clipping a wrapper rather than by putting the
+        // radius on the header itself, because `Header` is `sticky top-0` and
+        // the radius has to survive it.
+        //
+        // That `sticky` has never actually engaged: an ancestor with
+        // `overflow: hidden` is the scrollport for a sticky descendant, and
+        // both of this file's `Header` call sites had one (the fitness card
+        // still does). Dropping this card's clip would have made the viewport
+        // the scrollport and started the bar detaching mid-scroll for the
+        // first time — carrying two transparent corner notches out over the
+        // posts, since `background` and `backdrop-filter` both clip to the
+        // radius. A wrapper exactly the header's height keeps the sticky inert
+        // as it has always been, and clipping is free here because, unlike the
+        // rest of the card, this subtree holds no overlays.
+        //
+        // So the header still does not stick, on either call site. Whether it
+        // should is a live question, but it is not this change's to answer.
         <div className="overflow-hidden rounded-t-2xl">
           <Header isFitnessDashboard={false} />
         </div>

--- a/lib/components/posts/actions/edit-history-button.tsx
+++ b/lib/components/posts/actions/edit-history-button.tsx
@@ -66,9 +66,14 @@ export const EditHistoryButton: FC<Props> = ({
           // post's right edge on every surface. Anchored to the trigger it
           // would start wherever the trigger sits — which moves with the
           // engagement counts beside it, now that the actions are packed at the
-          // post's left edge — and a post's card clips whatever hangs outside
-          // it. Below `md` the panel is viewport-fixed instead, so the post's
-          // own width stops mattering.
+          // post's left edge — and a card that clips cuts off whatever hangs
+          // outside it. Not all of them do: `Posts` and the status detail card
+          // dropped `overflow-hidden` so this panel can escape *upward*, which
+          // `bottom-full` needs and which staying inside the post's width
+          // cannot buy. The fitness header card still clips, so the horizontal
+          // fit here cannot lean on the ancestor either way. Below `md` the
+          // panel is viewport-fixed instead, so the post's own width stops
+          // mattering.
           className="absolute bottom-full right-0 z-20 mb-2 w-[25rem] rounded-lg border bg-background shadow-lg max-md:fixed max-md:inset-x-4 max-md:bottom-20 max-md:max-h-[calc(100vh-7rem)] max-md:w-auto"
           onClick={(e) => e.stopPropagation()}
         >

--- a/lib/components/posts/actions/reaction-button.test.tsx
+++ b/lib/components/posts/actions/reaction-button.test.tsx
@@ -254,10 +254,13 @@ describe('ReactionButton', () => {
       name: 'Choose a reaction'
     })
 
-    // Every card that wraps posts clips its children for rounded corners, and
-    // the panel is far taller than the space inside them. Portalling it to the
+    // Cards that wrap posts clip their children for rounded corners, and the
+    // panel is far taller than the space inside them. Portalling it to the
     // document root is what stops that, so pin it: an `absolute` child of the
-    // chip row was clipped on four separate surfaces before this.
+    // chip row was clipped on four separate surfaces before this. Some of
+    // those cards have since dropped `overflow-hidden` for the sake of the
+    // non-portalled edit-history panel, but the picker must not depend on
+    // that — the fitness header card still clips, and any new card may.
     expect(container.contains(picker)).toBe(false)
     expect(document.body.contains(picker)).toBe(true)
     // Viewport-positioned, not positioned against an ancestor in the post.


### PR DESCRIPTION
## The contradiction

The conversation card on the status detail page carried `overflow-hidden` **directly beneath a comment saying it did not**:

```tsx
// No `overflow-hidden`: this card contains posts, and a post's
// non-portaled overlays (the reaction picker) would be clipped by it —
// the same reason `Posts` dropped it.
'overflow-hidden rounded-2xl border bg-background/80 shadow-sm'
```

`git log -L` shows the comment arrived in #1330 (the reaction-picker PR) as an addition to a line that already had the class — stale intent, never applied. This predates #1368, but that ancestor is exactly what clipped the edit-history panel there, so anyone debugging a clipped overlay would read the comment and rule out the element actually doing the clipping.

## Which side was right

**The conclusion, not the reason.**

The reason was false. `ReactionPicker` `createPortal`s to `document.body`, pinned by an assertion in `reaction-button.test.tsx`. The ⋯ menu's popover is a Radix portal too. Neither can be reached by an ancestor's overflow.

The conclusion was still correct, for a different overlay. `Posts` did drop the class, citing "edit-history panel, inline error bubbles" — and `EditHistoryButton` renders `absolute bottom-full`, ~360px tall (a 2.5rem header over a `max-h-80` list), opening **upward**. The only viewer who gets an action row at all is a signed-in one, whose focused post sits just below the back-button bar — so on a short post with a few edits the panel runs past the card's top edge.

## Changes

- **`page.tsx`** — drop `overflow-hidden` from the card; rewrite the comment to name the one overlay that actually reaches this edge, and to record explicitly what is *not* a reason (the picker and the menu popover portal; `PostMenu`'s non-portalled tooltip hangs mid-card).
- Children meeting the rounded corners now round themselves: the header wrapper when signed in, the first ancestor row or the focused post when logged out. That branch leads with an out-of-flow `sr-only` heading, so a `first:` selector would target the wrong element.
- **Sticky header.** Removing the clip also removed the scroll container pinning `Header`'s `sticky top-0`, which would have started detaching mid-scroll for the first time — carrying two transparent corner notches out over the posts, since `background` and `backdrop-filter` both clip to the radius. The clip therefore moves onto a **wrapper around the header** rather than being deleted outright: that subtree holds no overlays, so clipping costs nothing, and it restores the scrollport exactly. **This PR makes no sticky-behavior change.**
- **`edit-history-button.tsx` / `reaction-button.test.tsx`** — both claimed "every card that wraps a post clips it", which this change falsifies. Corrected.
- **`page.layout.test.tsx`** (new) — pins the class off and pins which child carries the radius in each branch.

## Verification

Measured, not assumed. Header top minus card top at `scrollY 900`, with `main` given the same `overflow-x-clip` as the real layout:

| variant | offset | |
|---|---|---|
| `overflow-hidden` on the card (main) | 1px | inert |
| radius on the header, no clip | 422px | detached, corner notches |
| clip on a header wrapper (adopted) | 1px | identical to main |

Corner rendering checked at 6× zoom: the fix is pixel-identical to main, and a control with the top child left square shows the white nub that appears otherwise — so the rounding additions are load-bearing.

Tests are mutation-checked. Four independent mutations are each caught: dropping either `!currentActorProfile` guard, dropping `previouses.length === 0`, and dropping `overflow-hidden` from the header wrapper.

Gates: prettier ✅ · lint ✅ (0 errors) · build ✅ · test ✅ 749 files / 8019 tests.

## Known-unfixed, on a different surface

The **fitness dashboard** card is *not* fixed here, and my earlier claim that it "doesn't need this change" was wrong. Review found the clipper there is not the outer card but an inner one at `FitnessStatusDetail.tsx:2752`, which wraps both `<Actions>` and its `EditHistoryButton`. Two overlays are clipped **today**:

- **Action-row errors are effectively invisible** — `absolute right-0 top-full mt-1` on a row that is the last child of the footer strip, so the box starts ~10px above the card's bottom border. A failed ⋯ → Delete on a fitness post shows the user nothing.
- **Edit history is cut off on desktop** — the ~360px panel opens upward into a ~230px body. `max-md:fixed` spares mobile.

Both are pre-existing and live in a different ~2900-line component with its own large test file, so they are tracked separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)