### PR TITLE
Bump version to v1.123.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.2",
+  "version": "1.123.3",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.3.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.2`
- Base main SHA: `7946221ecd53978075736efe3316ed14756dabc0`
- Included commits: `2`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
