### PR TITLE
Bump version to v1.123.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.3",
+  "version": "1.123.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.4.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.3`
- Base main SHA: `ba4098312cb595def93307477d0b6c40c0c539e7`
- Included commits: `1`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
