### PR TITLE
fix: add missing spacing below postbox action row before attachments

### DIFF
--- a/lib/components/post-box/post-box.tsx
+++ b/lib/components/post-box/post-box.tsx
@@ -1088,7 +1088,7 @@ export const PostBox: FC<Props> = ({
           onPollTypeChange={(pollType) => dispatch(setPollType(pollType))}
           onRemove={() => dispatch(setPollVisibility(false))}
         />
-        <div className="mt-3 flex flex-wrap items-center gap-y-2 border-t pt-3">
+        <div className="mt-3 mb-3 flex flex-wrap items-center gap-y-2 border-t pt-3">
           <div className="flex flex-wrap items-center gap-1">
             <UploadMediaButton
               isMediaUploadEnabled={isMediaUploadEnabled}


### PR DESCRIPTION
## Summary
- Fixes a layout bug where attaching an image or a fitness (`.fit`/`.gpx`/`.tcx`) file to the postbox rendered the attachment preview flush against the action row, with no gap.
- The action row (`lib/components/post-box/post-box.tsx`) already used `mt-3 border-t pt-3` to create spacing *above* itself, but had no bottom margin, so nothing separated it from whatever rendered below (the fitness-file chip, the image attachment grid, or the warning message). Added `mb-3` to match.

## Test plan
- [x] `yarn run prettier --write .`
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (749 files / 8027 tests passed)
- [x] Verified in a local browser (SQLite dev DB + mock user): attached a fitness file and a real image, confirmed the gap between the action row and the attachment preview now matches the gap above the action row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)