### PR TITLE
Bump version to v1.123.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activities.next",
-  "version": "1.123.4",
+  "version": "1.123.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated version bump to v1.123.5.

This PR batches unreleased commits on main and applies the highest required bump.

- Bump type: `patch`
- Base tag: `v1.123.4`
- Base main SHA: `9eb3af460006f76147ccab3134b7db867a6de72e`
- Included commits: `11`

The merged bump commit will still be tagged by `.github/workflows/tag-version.yml`.
